### PR TITLE
Match javaOptions Heap Size in compile and test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ parallelExecution in Test := false
 
 scalacOptions ++= Seq("-target:jvm-1.8")
 
-javaOptions += "-Xmx3g"
+javaOptions += "-Xmx2g"
 
 fork in Test := true
 

--- a/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
@@ -110,26 +110,3 @@ object FakeFileSystem {
   val scheme = "fake"
   val uri = URI.create(s"$scheme:///")
 }
-
-// BEGIN-END
-/**
- * A fake AbstractFileSystem to test whether session Hadoop configuration will be picked up.
- * This is a wrapper around [[FakeFileSystem]].
- */
-class FakeAbstractFileSystem(uri: URI, conf: org.apache.hadoop.conf.Configuration)
-  extends org.apache.hadoop.fs.DelegateToFileSystem(
-    uri,
-    new FakeFileSystem,
-    conf,
-    FakeFileSystem.scheme,
-    false) {
-
-  // Implementation copied from RawLocalFs
-  import org.apache.hadoop.fs.local.LocalConfigKeys
-  import org.apache.hadoop.fs._
-
-  override def getUriDefaultPort(): Int = -1
-  override def getServerDefaults(): FsServerDefaults = LocalConfigKeys.getServerDefaults()
-  override def isValidName(src: String): Boolean = true
-}
-// END-EDGE


### PR DESCRIPTION
Match the javaOptions heap-size (xmx) in compile and test scopes.