### PR TITLE
Fix Scaladoc of DeltaLogging.scala

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/metering/DeltaLogging.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/metering/DeltaLogging.scala
@@ -44,7 +44,7 @@ import org.apache.spark.sql.delta.util.JsonUtils
  *    that match "delta.ddl.%".
  *
  *  Underneath these functions use the standard usage log reporting defined in
- *  [[com.databricks.spark.util.UsageLogging]].
+ *  [[com.databricks.spark.util.DatabricksLogging]].
  */
 trait DeltaLogging
   extends DeltaProgressReporter


### PR DESCRIPTION
DeltaLogging's Scaladoc says that underneath it uses `com.databricks.spark.util.UsageLogging`, but I guess it's `com.databricks.spark.util.DatabricksLogging`.