### PR TITLE
Fix scalastyle errors of DeltaLogging.scala

### DIFF
--- a/src/main/scala/com/databricks/spark/util/DatabricksLogging.scala
+++ b/src/main/scala/com/databricks/spark/util/DatabricksLogging.scala
@@ -43,7 +43,7 @@ object MetricDefinitions {
 trait DatabricksLogging {
   // scalastyle:off println
   def logConsole(line: String): Unit = println(line)
-  // scalastyle:off on
+  // scalastyle:on println
 
   def recordUsage(
       metric: MetricDefinition,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix scalastyle errors of DeltaLogging.scala.

Change "// scalastyle:off on" to "// scalastyle:on println" to ensure the validity of grammar checks.