### PR TITLE
Fix wrong data when recording event in protocolWrite

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -205,7 +205,7 @@ class DeltaLog private(
     } else {
       if (asyncUpdateTask == null || asyncUpdateTask.isCompleted) {
         val jobGroup = spark.sparkContext.getLocalProperty(SparkContext.SPARK_JOB_GROUP_ID)
-          asyncUpdateTask = Future[Unit] {
+        asyncUpdateTask = Future[Unit] {
           spark.sparkContext.setLocalProperty("spark.scheduler.pool", "deltaStateUpdatePool")
           spark.sparkContext.setJobGroup(
             jobGroup,
@@ -466,7 +466,7 @@ class DeltaLog private(
         "delta.protocol.failure.write",
         data = Map(
           "clientVersion" -> Action.writerVersion,
-          "minReaderVersion" -> currentSnapshot.protocol.minWriterVersion))
+          "minWriterVersion" -> currentSnapshot.protocol.minWriterVersion))
       throw new InvalidProtocolVersionException
     }
 

--- a/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -65,7 +65,7 @@ sealed trait Action {
 /**
  * Used to block older clients from reading or writing the log when backwards
  * incompatible changes are made to the protocol. Readers and writers are
- * responsible for checking that the meet the minimum versions before performing
+ * responsible for checking that they meet the minimum versions before performing
  * any other operations.
  *
  * Since this action allows us to explicitly block older clients in the case of a

--- a/src/main/scala/org/apache/spark/sql/delta/metering/DeltaLogging.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/metering/DeltaLogging.scala
@@ -50,7 +50,7 @@ trait DeltaLogging
   with DatabricksLogging {
 
   /**
-   * Used to record the occurence of a single event or report detailed, operation specific
+   * Used to record the occurrence of a single event or report detailed, operation specific
    * statistics.
    */
   protected def recordDeltaEvent(


### PR DESCRIPTION
In `protocolWrite`, it records event with wrong data `minReaderVersion`, currently. This patch goes to fix that.

This also fixes few other typos and style.