### PR TITLE
Minor code enhancements

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/schema/Invariants.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/schema/Invariants.scala
@@ -82,7 +82,7 @@ object Invariants {
             ArbitraryExpression(spark, exprString)
           case _ =>
             throw new UnsupportedOperationException(
-              "Uncrecognized invariant. Please upgrade your Spark version.")
+              "Unrecognized invariant. Please upgrade your Spark version.")
         }
         Invariant(parents :+ field.name, invariant)
     }

--- a/src/main/scala/org/apache/spark/sql/delta/storage/HDFSLogStore.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/storage/HDFSLogStore.scala
@@ -93,7 +93,7 @@ class HDFSLogStore(sparkConf: SparkConf, defaultHadoopConf: Configuration) exten
       tempPath, EnumSet.of(CREATE), CreateOpts.checksumParam(ChecksumOpt.createDisabled()))
 
     try {
-      actions.map(_ + "\n").map(_.getBytes("utf-8")).foreach(stream.write)
+      actions.map(_ + "\n").map(_.getBytes(UTF_8)).foreach(stream.write)
       stream.close()
       streamClosed = true
       try {


### PR DESCRIPTION
Includes following fixes:
- Use StandardCharsets.UTF_8 instead of “utf-8”
- Remove unnecessary return statement
- Fix typo in error message
- Fix warnings