### PR TITLE
Fix code style for the naming of variables.

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -135,9 +135,9 @@ trait Checkpoints extends DeltaLogging {
   /** Loads the checkpoint metadata from the _last_checkpoint file. */
   private def loadMetadataFromFile(tries: Int): Option[CheckpointMetaData] = {
     try {
-      val checkpointMetaData = store.read(LAST_CHECKPOINT)
+      val checkpointMetadataJson = store.read(LAST_CHECKPOINT)
       val checkpointMetadata =
-        JsonUtils.mapper.readValue[CheckpointMetaData](checkpointMetaData.head)
+        JsonUtils.mapper.readValue[CheckpointMetaData](checkpointMetadataJson.head)
       Some(checkpointMetadata)
     } catch {
       case _: FileNotFoundException =>


### PR DESCRIPTION
The naming of `checkpointMetaData` and `checkpointMetadata` is confusing.