### PR TITLE
Change the LogStore conf key name

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/storage/LogStore.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/storage/LogStore.scala
@@ -109,7 +109,7 @@ object LogStore extends LogStoreProvider
 }
 
 trait LogStoreProvider {
-  val logStoreClassConfKey: String = "delta.logStore.class"
+  val logStoreClassConfKey: String = "spark.delta.logStore.class"
   val defaultLogStoreClass: String = classOf[HDFSLogStore].getName
 
   def createLogStore(spark: SparkSession): LogStore = {


### PR DESCRIPTION
Right now the LogStore conf key is "delta.logStore.class", but this is not getting picked up because Spark requires spark conf to start with "spark.". So we change this to "spark.delta.logStore.class". 