### PR TITLE
Fix DeltaTable forPath to not accept non-delta table paths

### DIFF
--- a/src/main/scala/io/delta/DeltaTable.scala
+++ b/src/main/scala/io/delta/DeltaTable.scala
@@ -16,8 +16,9 @@
 
 package io.delta
 
-import org.apache.spark.sql.delta._
+import org.apache.hadoop.fs.Path
 
+import org.apache.spark.sql.delta._
 import org.apache.spark.sql._
 
 /**
@@ -62,7 +63,11 @@ object DeltaTable {
    * read the data.
    */
   def forPath(sparkSession: SparkSession, path: String): DeltaTable = {
-    new DeltaTable(sparkSession.read.format("delta").load(path))
+    if (DeltaTableUtils.isDeltaTable(sparkSession, new Path(path))) {
+      new DeltaTable(sparkSession.read.format("delta").load(path))
+    } else {
+      throw DeltaErrors.notADeltaTableException(new DeltaTableIdentifier(path = Some(path)))
+    }
   }
 
 }

--- a/src/main/scala/io/delta/DeltaTable.scala
+++ b/src/main/scala/io/delta/DeltaTable.scala
@@ -66,7 +66,7 @@ object DeltaTable {
     if (DeltaTableUtils.isDeltaTable(sparkSession, new Path(path))) {
       new DeltaTable(sparkSession.read.format("delta").load(path))
     } else {
-      throw DeltaErrors.notADeltaTableException(new DeltaTableIdentifier(path = Some(path)))
+      throw DeltaErrors.notADeltaTableException(DeltaTableIdentifier(path = Some(path)))
     }
   }
 

--- a/src/test/scala/io/delta/DeltaTableSuite.scala
+++ b/src/test/scala/io/delta/DeltaTableSuite.scala
@@ -37,19 +37,13 @@ class DeltaTableSuite extends QueryTest
     }
   }
 
-  test("forPath should not create a DeltaTable based on Non-Delta-Path") {
+  test("forPath should not create a DeltaTable if a non-Delta path is provided") {
     withTempDir { dir =>
       testData.write.format("parquet").mode("overwrite").save(dir.getAbsolutePath)
-
-      val e1 = intercept[AnalysisException] {
-        DeltaTable.forPath(spark, dir.getAbsolutePath)
-      }.getMessage
-      assert(e1.contains(s"`${dir.getAbsolutePath}` is not a Delta table"))
-
-      val e2 = intercept[AnalysisException] {
+      val e = intercept[AnalysisException] {
         DeltaTable.forPath(dir.getAbsolutePath)
       }.getMessage
-      assert(e2.contains(s"`${dir.getAbsolutePath}` is not a Delta table"))
+      assert(e.contains(s"`${dir.getAbsolutePath}` is not a Delta table"))
     }
   }
 

--- a/src/test/scala/io/delta/DeltaTableSuite.scala
+++ b/src/test/scala/io/delta/DeltaTableSuite.scala
@@ -37,13 +37,12 @@ class DeltaTableSuite extends QueryTest
     }
   }
 
-  test("forPath should not create a DeltaTable if a non-Delta path is provided") {
+  test("forPath - with non-Delta table path") {
+    val msg = "not a Delta table"
     withTempDir { dir =>
       testData.write.format("parquet").mode("overwrite").save(dir.getAbsolutePath)
-      val e = intercept[AnalysisException] {
-        DeltaTable.forPath(dir.getAbsolutePath)
-      }.getMessage
-      assert(e.contains(s"`${dir.getAbsolutePath}` is not a Delta table"))
+      testError(msg) { DeltaTable.forPath(spark, dir.getAbsolutePath) }
+      testError(msg) { DeltaTable.forPath(dir.getAbsolutePath) }
     }
   }
 

--- a/src/test/scala/io/delta/DeltaTableSuite.scala
+++ b/src/test/scala/io/delta/DeltaTableSuite.scala
@@ -37,6 +37,21 @@ class DeltaTableSuite extends QueryTest
     }
   }
 
+  test("forPath should not create a DeltaTable based on Non-Delta-Path") {
+    withTempDir { dir =>
+      testData.write.format("parquet").mode("overwrite").save(dir.getAbsolutePath)
+
+      val e1 = intercept[AnalysisException] {
+        DeltaTable.forPath(spark, dir.getAbsolutePath)
+      }.getMessage
+      assert(e1.contains(s"`${dir.getAbsolutePath}` is not a Delta table"))
+
+      val e2 = intercept[AnalysisException] {
+        DeltaTable.forPath(dir.getAbsolutePath)
+      }.getMessage
+      assert(e2.contains(s"`${dir.getAbsolutePath}` is not a Delta table"))
+    }
+  }
 
   test("as") {
     withTempDir { dir =>


### PR DESCRIPTION
In this PR, I added exception handling for `forPath` method in `DeltaTable.scala`.

After the change, Delta Table will make sure create instance just for "Delta Source", other sources will throw an exception.

This PR is tested by `DeltaTableSuite.scala`
