### PR TITLE
Add a system property for the DeltaLog cache size

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,6 +55,7 @@ javaOptions in Test ++= Seq(
   "-Dspark.ui.showConsoleProgress=false",
   "-Dspark.databricks.delta.snapshotPartitions=2",
   "-Dspark.sql.shuffle.partitions=5",
+  "-Ddelta.log.cacheSize=10",
   "-Xmx2g"
 )
 


### PR DESCRIPTION
Add "delta.log.cacheSize" system property for the DeltaLog cache size, and set it to 10 in tests to reduce the memory footprint.