### PR TITLE
Added ability to generate scala and java docs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -80,8 +80,12 @@ testScalastyle := scalastyle.in(Test).toTask("").value
 
 enablePlugins(GenJavadocPlugin, JavaUnidocPlugin, ScalaUnidocPlugin)
 
-scalacOptions in(ScalaUnidoc, unidoc) ++= Seq("-skip-packages", "org:com:io.delta.execution")
+scalacOptions in(ScalaUnidoc, unidoc) ++= Seq(
+  "-skip-packages", "org:com:io.delta.execution",
+  "-doc-title", "Delta Lake " + version.value.replaceAll("-SNAPSHOT", "") + " ScalaDoc"
+)
 
+// Explicitly remove source files by package because these docs are not formatted correctly
 def ignoreUndocumentedPackages(packages: Seq[Seq[java.io.File]]): Seq[Seq[java.io.File]] = {
   packages
     .map(_.filterNot(_.getName.contains("$")))
@@ -92,10 +96,10 @@ def ignoreUndocumentedPackages(packages: Seq[Seq[java.io.File]]): Seq[Seq[java.i
 unidocAllSources in(JavaUnidoc, unidoc) := ignoreUndocumentedPackages((unidocAllSources in(JavaUnidoc, unidoc)).value)
 
 javacOptions in(JavaUnidoc, unidoc) := Seq(
-  "-windowtitle", "Delta Lake " + version.value.replaceAll("-SNAPSHOT", "") + " JavaDoc",
   "-public",
-  "-noqualifier", "java.lang",
-  "-exclude", "org:com:io.delta.execution"
+  "-exclude", "org:com:io.delta.execution",
+  "-windowtitle", "Delta Lake " + version.value.replaceAll("-SNAPSHOT", "") + " JavaDoc",
+  "-noqualifier", "java.lang"
 )
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -73,6 +73,32 @@ testScalastyle := scalastyle.in(Test).toTask("").value
 
 (test in Test) := ((test in Test) dependsOn testScalastyle).value
 
+
+/*******************
+ * Unidoc settings *
+ *******************/
+
+enablePlugins(GenJavadocPlugin, JavaUnidocPlugin, ScalaUnidocPlugin)
+
+scalacOptions in(ScalaUnidoc, unidoc) ++= Seq("-skip-packages", "org:com:io.delta.execution")
+
+def ignoreUndocumentedPackages(packages: Seq[Seq[java.io.File]]): Seq[Seq[java.io.File]] = {
+  packages
+    .map(_.filterNot(_.getName.contains("$")))
+    .map(_.filterNot(_.getCanonicalPath.contains("io/delta/execution")))
+    .map(_.filterNot(_.getCanonicalPath.contains("spark")))
+}
+
+unidocAllSources in(JavaUnidoc, unidoc) := ignoreUndocumentedPackages((unidocAllSources in(JavaUnidoc, unidoc)).value)
+
+javacOptions in(JavaUnidoc, unidoc) := Seq(
+  "-windowtitle", "Delta Lake " + version.value.replaceAll("-SNAPSHOT", "") + " JavaDoc",
+  "-public",
+  "-noqualifier", "java.lang",
+  "-exclude", "org:com:io.delta.execution"
+)
+
+
 /***************************
  * Spark Packages settings *
  ***************************/

--- a/build.sbt
+++ b/build.sbt
@@ -59,6 +59,10 @@ javaOptions in Test ++= Seq(
   "-Xmx2g"
 )
 
+/** ********************
+ * ScalaStyle settings *
+ * *********************/
+
 scalastyleConfig := baseDirectory.value / "scalastyle-config.xml"
 
 lazy val compileScalastyle = taskKey[Unit]("compileScalastyle")
@@ -80,12 +84,21 @@ testScalastyle := scalastyle.in(Test).toTask("").value
 
 enablePlugins(GenJavadocPlugin, JavaUnidocPlugin, ScalaUnidocPlugin)
 
+// Configure Scala unidoc
 scalacOptions in(ScalaUnidoc, unidoc) ++= Seq(
   "-skip-packages", "org:com:io.delta.execution",
   "-doc-title", "Delta Lake " + version.value.replaceAll("-SNAPSHOT", "") + " ScalaDoc"
 )
 
-// Explicitly remove source files by package because these docs are not formatted correctly
+// Configure Java unidoc
+javacOptions in(JavaUnidoc, unidoc) := Seq(
+  "-public",
+  "-exclude", "org:com:io.delta.execution",
+  "-windowtitle", "Delta Lake " + version.value.replaceAll("-SNAPSHOT", "") + " JavaDoc",
+  "-noqualifier", "java.lang"
+)
+
+// Explicitly remove source files by package because these docs are not formatted correctly for Javadocs
 def ignoreUndocumentedPackages(packages: Seq[Seq[java.io.File]]): Seq[Seq[java.io.File]] = {
   packages
     .map(_.filterNot(_.getName.contains("$")))
@@ -93,14 +106,12 @@ def ignoreUndocumentedPackages(packages: Seq[Seq[java.io.File]]): Seq[Seq[java.i
     .map(_.filterNot(_.getCanonicalPath.contains("spark")))
 }
 
-unidocAllSources in(JavaUnidoc, unidoc) := ignoreUndocumentedPackages((unidocAllSources in(JavaUnidoc, unidoc)).value)
+unidocAllSources in(JavaUnidoc, unidoc) := {
+  ignoreUndocumentedPackages((unidocAllSources in(JavaUnidoc, unidoc)).value)
+}
 
-javacOptions in(JavaUnidoc, unidoc) := Seq(
-  "-public",
-  "-exclude", "org:com:io.delta.execution",
-  "-windowtitle", "Delta Lake " + version.value.replaceAll("-SNAPSHOT", "") + " JavaDoc",
-  "-noqualifier", "java.lang"
-)
+// Ensure unidoc is run with tests
+(test in Test) := ((test in Test) dependsOn unidoc.in(Compile)).value
 
 
 /***************************

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -32,3 +32,5 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
+
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")


### PR DESCRIPTION
Added sbt-unidoc to generate Scala and Java docs. To generate both docs, just run `build/sbt unidoc`
- Any classes not directly in `io.delta` will be ignored from the docs.
- Unidoc will be generated when testing so that we can verify that docs are never broken. The overhead of generating the docs is just a few seconds, so does not add much to test times.