### PR TITLE
[DOCS] Added scripts to generate api docs and API stability annotations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,7 +95,8 @@ javacOptions in(JavaUnidoc, unidoc) := Seq(
   "-public",
   "-exclude", "org:com:io.delta.execution",
   "-windowtitle", "Delta Lake " + version.value.replaceAll("-SNAPSHOT", "") + " JavaDoc",
-  "-noqualifier", "java.lang"
+  "-noqualifier", "java.lang",
+  "-tag", "return:X"
 )
 
 // Explicitly remove source files by package because these docs are not formatted correctly for Javadocs

--- a/docs/api-docs.css
+++ b/docs/api-docs.css
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Dynamically injected style for the API docs */
+
+.unstable {
+  background-color: #257080;
+}
+
+.evolving {
+  background-color: #44751E;
+}
+
+.badge {
+  font-family: Arial, san-serif;
+  float: right;
+}

--- a/docs/api-docs.js
+++ b/docs/api-docs.js
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Dynamically injected post-processing code for the API docs */
+
+$(document).ready(function() {
+  var annotations = $("dt:contains('Annotations')").next("dd").children("span.name");
+  addBadges(annotations, "Unsable", ":: Unstable ::", '<span class="unstable badge">Unstable</span>');
+  addBadges(annotations, "Evolving", ":: Evolving ::", '<span class="evolving badge">Evolving</span>');
+});
+
+function addBadges(allAnnotations, name, tag, html) {
+  var annotations = allAnnotations.filter(":contains('" + name + "')")
+  var tags = $(".cmt:contains(" + tag + ")")
+
+  // Remove identifier tags from comments
+  tags.each(function(index) {
+    var oldHTML = $(this).html();
+    var newHTML = oldHTML.replace(tag, "");
+    $(this).html(newHTML);
+  });
+
+  // Add badges to all containers
+  tags.prevAll("h4.signature")
+    .add(annotations.closest("div.fullcommenttop"))
+    .add(annotations.closest("div.fullcomment").prevAll("h4.signature"))
+    .prepend(html);
+}
+
+$(document).ready(function() {
+  var script = document.createElement('script');
+  script.type = 'text/javascript';
+  script.async = true;
+  script.onload = function(){
+    MathJax.Hub.Config({
+      displayAlign: "left",
+      tex2jax: {
+        inlineMath: [ ["$", "$"], ["\\(","\\)"] ],
+        displayMath: [ ["$$","$$"], ["\\[", "\\]"] ],
+        processEscapes: true,
+        skipTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'a']
+      }
+    });
+  };
+  script.src = ('https:' == document.location.protocol ? 'https://' : 'http://') +
+                'cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js' +
+                '?config=TeX-AMS-MML_HTMLorMML';
+  document.getElementsByTagName('head')[0].appendChild(script);
+});

--- a/docs/api-docs.js
+++ b/docs/api-docs.js
@@ -35,29 +35,13 @@ function addBadges(allAnnotations, name, tag, html) {
   });
 
   // Add badges to all containers
-  tags.prevAll("h4.signature")
+  tags
+    // Scala 2.11 docs require these
+    .prevAll("h4.signature")
     .add(annotations.closest("div.fullcommenttop"))
     .add(annotations.closest("div.fullcomment").prevAll("h4.signature"))
+    // Scala 2.12 docs require this
+    .add(tags.prevAll("span.symbol"))
+    .add(annotations.closest("div.fullcomment").prevAll("span.symbol"))
     .prepend(html);
 }
-
-$(document).ready(function() {
-  var script = document.createElement('script');
-  script.type = 'text/javascript';
-  script.async = true;
-  script.onload = function(){
-    MathJax.Hub.Config({
-      displayAlign: "left",
-      tex2jax: {
-        inlineMath: [ ["$", "$"], ["\\(","\\)"] ],
-        displayMath: [ ["$$","$$"], ["\\[", "\\]"] ],
-        processEscapes: true,
-        skipTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'a']
-      }
-    });
-  };
-  script.src = ('https:' == document.location.protocol ? 'https://' : 'http://') +
-                'cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js' +
-                '?config=TeX-AMS-MML_HTMLorMML';
-  document.getElementsByTagName('head')[0].appendChild(script);
-});

--- a/docs/api-javadocs.css
+++ b/docs/api-javadocs.css
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Dynamically injected style for the API docs */
+
+.badge {
+  font-family: Arial, san-serif;
+  float: right;
+  margin: 4px;
+  /* The following declarations are taken from the ScalaDoc template.css */
+  display: inline-block;
+  padding: 2px 4px;
+  font-size: 11.844px;
+  font-weight: bold;
+  line-height: 14px;
+  color: #ffffff;
+  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+  white-space: nowrap;
+  vertical-align: baseline;
+  background-color: #999999;
+  padding-right: 9px;
+  padding-left: 9px;
+  -webkit-border-radius: 9px;
+     -moz-border-radius: 9px;
+          border-radius: 9px;
+}
+
+.unstable {
+  background-color: #257080;
+}
+
+.evolving {
+  background-color: #44751E;
+}

--- a/docs/api-javadocs.js
+++ b/docs/api-javadocs.js
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Dynamically injected post-processing code for the API docs */
+
+$(document).ready(function() {
+  addBadges(":: Unstable ::", '<span class="unstable badge">Unstable</span>');
+  addBadges(":: Evolving ::", '<span class="evolving badge">Evolving</span>');
+});
+
+function addBadges(tag, html) {
+  var tags = $(".block:contains(" + tag + ")")
+
+  // Remove identifier tags
+  tags.each(function(index) {
+    var oldHTML = $(this).html();
+    var newHTML = oldHTML.replace(tag, "");
+    $(this).html(newHTML);
+  });
+
+  // Add html badge tags
+  tags.each(function(index) {
+    if ($(this).parent().is('td.colLast')) {
+      $(this).parent().prepend(html);
+    } else if ($(this).parent('li.blockList')
+                      .parent('ul.blockList')
+                      .parent('div.description')
+                      .parent().is('div.contentContainer')) {
+      var contentContainer = $(this).parent('li.blockList')
+                                    .parent('ul.blockList')
+                                    .parent('div.description')
+                                    .parent('div.contentContainer')
+      var header = contentContainer.prev('div.header');
+      if (header.length > 0) {
+        header.prepend(html);
+      } else {
+        contentContainer.prepend(html);
+      }
+    } else if ($(this).parent().is('li.blockList')) {
+      $(this).parent().prepend(html);
+    } else {
+      $(this).prepend(html);
+    }
+  });
+}

--- a/docs/generate_api_docs.py
+++ b/docs/generate_api_docs.py
@@ -27,7 +27,7 @@ import argparse
 def main():
     # Parse arguments
     parser = argparse.ArgumentParser()
-    parser.add_argument("--verbose", default=False)
+    parser.add_argument("-v", "--verbose", default=False, action='store_true')
     args = parser.parse_args()
     global verbose
     verbose = args.verbose
@@ -45,9 +45,6 @@ def main():
     print "## Generating ScalaDoc and JavaDoc ..."
     with WorkingDirectory(repo_root_dir):
         run_cmd(["build/sbt", ";clean;unidoc"], stream_output=verbose)
-    log("Recreating API doc directory %s" % all_api_docs_final_dir)
-    run_cmd(["rm", "-rf", all_api_docs_final_dir])
-    run_cmd(["mkdir", "-p", all_api_docs_final_dir])
 
     # Update Scala docs
     print "## Patching ScalaDoc ..."
@@ -55,9 +52,6 @@ def main():
         # Patch the js and css files
         append(docs_root_dir + "/api-docs.js", "./lib/template.js")  # append new js functions
         append(docs_root_dir + "/api-docs.css", "./lib/template.css")  # append new styles
-
-    # Copy to final location
-    run_cmd(["cp", "-r", scaladoc_gen_dir, scala_api_docs_final_dir])
 
     # Update Java docs
     print "## Patching JavaDoc ..."
@@ -96,6 +90,10 @@ def main():
         append(docs_root_dir + "/api-javadocs.css", "./stylesheet.css")  # append new styles
 
     # Copy to final location
+    log("Copying to API doc directory %s" % all_api_docs_final_dir)
+    run_cmd(["rm", "-rf", all_api_docs_final_dir])
+    run_cmd(["mkdir", "-p", all_api_docs_final_dir])
+    run_cmd(["cp", "-r", scaladoc_gen_dir, scala_api_docs_final_dir])
     run_cmd(["cp", "-r", javadoc_gen_dir, java_api_docs_final_dir])
 
     print "## API docs generated in " + all_api_docs_final_dir

--- a/docs/generate_api_docs.py
+++ b/docs/generate_api_docs.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python2
+
+#
+# DATABRICKS CONFIDENTIAL & PROPRIETARY
+# __________________
+#
+# Copyright 2019 Databricks, Inc.
+# All Rights Reserved.
+#
+# NOTICE:  All information contained herein is, and remains the property of Databricks, Inc.
+# and its suppliers, if any.  The intellectual and technical concepts contained herein are
+# proprietary to Databricks, Inc. and its suppliers and may be covered by U.S. and foreign Patents,
+# patents in process, and are protected by trade secret and/or copyright law. Dissemination, use,
+# or reproduction of this information is strictly forbidden unless prior written permission is
+# obtained from Databricks, Inc.
+#
+# If you view or obtain a copy of this information and believe Databricks, Inc. may not have
+# intended it to be made available, please promptly report it to Databricks Legal Department
+# @ legal@databricks.com.
+#
+
+import os
+import subprocess
+import argparse
+
+
+def main():
+    # Parse arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--verbose", default=False)
+    args = parser.parse_args()
+    global verbose
+    verbose = args.verbose
+
+    # Set up the directories
+    docs_root_dir = os.path.dirname(os.path.realpath(__file__))
+    repo_root_dir = os.path.dirname(docs_root_dir)
+    scaladoc_gen_dir = repo_root_dir + "/target/scala-2.12/unidoc"
+    javadoc_gen_dir = repo_root_dir + "/target/javaunidoc"
+    all_api_docs_final_dir = docs_root_dir + "/_site/api"
+    scala_api_docs_final_dir = all_api_docs_final_dir + "/scala"
+    java_api_docs_final_dir = all_api_docs_final_dir + "/java"
+
+    # Generate Java and Scala docs
+    print "## Generating ScalaDoc and JavaDoc ..."
+    with WorkingDirectory(repo_root_dir):
+        run_cmd(["build/sbt", ";clean;unidoc"], stream_output=verbose)
+    log("Recreating API doc directory %s" % all_api_docs_final_dir)
+    run_cmd(["rm", "-rf", all_api_docs_final_dir])
+    run_cmd(["mkdir", "-p", all_api_docs_final_dir])
+
+    # Update Scala docs
+    print "## Patching ScalaDoc ..."
+    with WorkingDirectory(scaladoc_gen_dir):
+        # Patch the js and css files
+        append(docs_root_dir + "/api-docs.js", "./lib/template.js")  # append new js functions
+        append(docs_root_dir + "/api-docs.css", "./lib/template.css")  # append new styles
+
+    # Copy to final location
+    run_cmd(["cp", "-r", scaladoc_gen_dir, scala_api_docs_final_dir])
+
+    # Update Java docs
+    print "## Patching JavaDoc ..."
+    with WorkingDirectory(javadoc_gen_dir):
+        # Find html files to patch
+        (_, stdout, _) = run_cmd(["find", ".", "-name", "*.html", "-mindepth", "2"])
+        log("HTML files found:\n" + stdout)
+        javadoc_files = [line for line in stdout.split('\n') if line.strip() != '']
+
+        js_script_start = '<script defer="defer" type="text/javascript" src="'
+        js_script_end = '"></script>'
+
+        # Patch the html files
+        for javadoc_file in javadoc_files:
+            # Generate relative path to js files based on how deep the html file is
+            slash_count = javadoc_file.count("/")
+            i = 1
+            path_to_js_file = ""
+            while i < slash_count:
+                path_to_js_file = path_to_js_file + "../"
+                i += 1
+
+            # Create script elements to load new js files
+            javadoc_jquery_script = js_script_start + path_to_js_file + "lib/jquery.js" + js_script_end
+            javadoc_api_docs_script = \
+                js_script_start + path_to_js_file + "lib/api-javadocs.js" + js_script_end
+            javadoc_script_elements = javadoc_jquery_script + javadoc_api_docs_script
+
+            # Add script elements to body of the html file
+            replace(javadoc_file, "</body>", javadoc_script_elements + "</body>")
+
+        # Patch the js and css files
+        run_cmd(["mkdir", "-p", "./lib"])
+        run_cmd(["cp", scaladoc_gen_dir + "/lib/jquery.js", "./lib/"])  # copy jquery from ScalaDocs
+        run_cmd(["cp", docs_root_dir + "/api-javadocs.js", "./lib/"])   # copy new js file
+        append(docs_root_dir + "/api-javadocs.css", "./stylesheet.css")  # append new styles
+
+    # Copy to final location
+    run_cmd(["cp", "-r", javadoc_gen_dir, java_api_docs_final_dir])
+
+    print "## API docs generated in " + all_api_docs_final_dir
+
+
+def run_cmd(cmd, throw_on_error=True, env=None, stream_output=False, **kwargs):
+    """Runs a command as a child process.
+
+    A convenience wrapper for running a command from a Python script.
+    Keyword arguments:
+    cmd -- the command to run, as a list of strings
+    throw_on_error -- if true, raises an Exception if the exit code of the program is nonzero
+    env -- additional environment variables to be defined when running the child process
+    stream_output -- if true, does not capture standard output and error; if false, captures these
+      streams and returns them
+
+    Note on the return value: If stream_output is true, then only the exit code is returned. If
+    stream_output is false, then a tuple of the exit code, standard output and standard error is
+    returned.
+    """
+    log("Running command %s" % str(cmd))
+    cmd_env = os.environ.copy()
+    if env:
+        cmd_env.update(env)
+
+    if stream_output:
+        child = subprocess.Popen(cmd, env=cmd_env, **kwargs)
+        exit_code = child.wait()
+        if throw_on_error and exit_code != 0:
+            raise Exception("Non-zero exitcode: %s" % exit_code)
+        return exit_code
+    else:
+        child = subprocess.Popen(
+            cmd,
+            env=cmd_env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            **kwargs)
+        (stdout, stderr) = child.communicate()
+        exit_code = child.wait()
+        if throw_on_error and exit_code is not 0:
+            raise Exception(
+                "Non-zero exitcode: %s\n\nSTDOUT:\n%s\n\nSTDERR:%s" %
+                (exit_code, stdout, stderr))
+        return (exit_code, stdout, stderr)
+
+
+def append(src, dst):
+    log("Appending %s to %s" % (src, dst))
+    fin = open(src, "r")
+    str = fin.read()
+    fin.close()
+    fout = open(dst, "a")
+    fout.write(str)
+    fout.close()
+
+
+def replace(file, pattern, replacement):
+    log("Replacing %s with %s in file %s" % (pattern, replacement, file))
+    fin = open(file, "r")
+    str = fin.read()
+    fin.close()
+    str = str.replace(pattern, replacement)
+    fout = open(file, "w")
+    fout.write(str)
+    fout.close()
+
+# pylint: disable=too-few-public-methods
+class WorkingDirectory(object):
+    def __init__(self, working_directory):
+        self.working_directory = working_directory
+        self.old_workdir = os.getcwd()
+
+    def __enter__(self):
+        os.chdir(self.working_directory)
+
+    def __exit__(self, tpe, value, traceback):
+        os.chdir(self.old_workdir)
+
+
+def log(str):
+    if verbose:
+        print str
+
+
+verbose = False
+
+if __name__ == "__main__":
+    # pylint: disable=e1120
+    main()

--- a/src/main/scala/io/delta/DeltaTable.scala
+++ b/src/main/scala/io/delta/DeltaTable.scala
@@ -20,30 +20,92 @@ import org.apache.spark.sql.delta._
 import io.delta.execution._
 import org.apache.hadoop.fs.Path
 
+import org.apache.spark.annotation.InterfaceStability._
 import org.apache.spark.sql._
 
 /**
+ * :: Evolving ::
+ *
  * Main class for programmatically interacting with Delta tables.
  * You can create DeltaTable instances using the static methods.
  * {{{
- *   DeltaTable.forPath(pathToTheDeltaTable)
+ *   DeltaTable.forPath(sparkSession, pathToTheDeltaTable)
  * }}}
  *
+ * @since 0.3.0
  */
-class DeltaTable (df: Dataset[Row]) extends DeltaTableOperations {
+class DeltaTable(df: Dataset[Row]) extends DeltaTableOperations {
 
   /**
+   * :: Evolving ::
+   *
    * Apply an alias to the DeltaTable. This is similar to `Dataset.as(alias)` or
    * SQL `tableName AS alias`.
+   *
+   * @since 0.3.0
    */
   def as(alias: String): DeltaTable = new DeltaTable(df.as(alias))
 
   /**
    * Get a DataFrame (that is, Dataset[Row]) representation of this Delta table.
+   *
+   * @since 0.3.0
    */
+  @Evolving
   def toDF: Dataset[Row] = df
+
+  /**
+   * :: Evolving ::
+   *
+   * Delete data from the table that match the given `condition`.
+   *
+   * @param condition Boolean SQL expression
+   *
+   * @since 0.3.0
+   */
+  @Evolving
+  def delete(condition: String): Unit = {
+    delete(functions.expr(condition))
+  }
+
+  /**
+   * :: Evolving ::
+   *
+   * Delete data from the table that match the given `condition`.
+   *
+   * @param condition Boolean SQL expression
+   *
+   * @since 0.3.0
+   */
+  @Evolving
+  def delete(condition: Column): Unit = {
+    executeDelete(Some(condition.expr))
+  }
+
+  /**
+   * :: Evolving ::
+   *
+   * Delete data from the table.
+   *
+   * @since 0.3.0
+   */
+  @Evolving
+  def delete(): Unit = {
+    executeDelete(None)
+  }
 }
 
+/**
+ * :: Evolving ::
+ *
+ * Companion object to create DeltaTable instances.
+ *
+ * {{{
+ *   DeltaTable.forPath(sparkSession, pathToTheDeltaTable)
+ * }}}
+ *
+ * @since 0.3.0
+ */
 object DeltaTable {
   /**
    * Create a DeltaTable for the data at the given `path`.
@@ -51,7 +113,10 @@ object DeltaTable {
    * Note: This uses the active SparkSession in the current thread to read the table data. Hence,
    * this throws error if active SparkSession has not been set, that is,
    * `SparkSession.getActiveSession()` is empty.
+   *
+   * @since 0.3.0
    */
+  @Evolving
   def forPath(path: String): DeltaTable = {
     val sparkSession = SparkSession.getActiveSession.getOrElse {
       throw new IllegalArgumentException("Could not find active SparkSession")
@@ -62,7 +127,10 @@ object DeltaTable {
   /**
    * Create a DeltaTable for the data at the given `path` using the given SparkSession to
    * read the data.
+   *
+   * @since 0.3.0
    */
+  @Evolving
   def forPath(sparkSession: SparkSession, path: String): DeltaTable = {
     if (DeltaTableUtils.isDeltaTable(sparkSession, new Path(path))) {
       new DeltaTable(sparkSession.read.format("delta").load(path))
@@ -70,5 +138,4 @@ object DeltaTable {
       throw DeltaErrors.notADeltaTableException(DeltaTableIdentifier(path = Some(path)))
     }
   }
-
 }

--- a/src/main/scala/io/delta/DeltaTable.scala
+++ b/src/main/scala/io/delta/DeltaTable.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql._
  *
  * @since 0.3.0
  */
-class DeltaTable(df: Dataset[Row]) extends DeltaTableOperations {
+class DeltaTable (df: Dataset[Row]) extends DeltaTableOperations {
 
   /**
    * :: Evolving ::
@@ -44,9 +44,12 @@ class DeltaTable(df: Dataset[Row]) extends DeltaTableOperations {
    *
    * @since 0.3.0
    */
+  @Evolving
   def as(alias: String): DeltaTable = new DeltaTable(df.as(alias))
 
   /**
+   * :: Evolving ::
+   *
    * Get a DataFrame (that is, Dataset[Row]) representation of this Delta table.
    *
    * @since 0.3.0

--- a/src/main/scala/io/delta/execution/DeltaTableOperations.scala
+++ b/src/main/scala/io/delta/execution/DeltaTableOperations.scala
@@ -20,7 +20,6 @@ import org.apache.spark.sql.delta.DeltaErrors
 import org.apache.spark.sql.delta.commands.DeleteCommand
 import io.delta.DeltaTable
 
-import org.apache.spark.sql.{functions, Column}
 import org.apache.spark.sql.catalyst.expressions.{Expression, SubqueryExpression}
 import org.apache.spark.sql.catalyst.plans.logical._
 
@@ -31,30 +30,6 @@ import org.apache.spark.sql.catalyst.plans.logical._
  *    MergeInto:
  */
 trait DeltaTableOperations { self: DeltaTable =>
-
-  /**
-   * Delete data from the table that match the given `condition`.
-   * @param condition
-   */
-  def delete(condition: String): Unit = {
-    delete(functions.expr(condition))
-  }
-
-  /**
-   * Delete data from the table that match the given `condition`.
-   * @param condition
-   */
-  def delete(condition: Column): Unit = {
-    executeDelete(Some(condition.expr))
-  }
-
-  /**
-   * Delete data from the table.
-   */
-  def delete(): Unit = {
-    executeDelete(None)
-  }
-
   protected def executeDelete(condition: Option[Expression]): Unit = {
     val sparkSession = self.toDF.sparkSession
     val delete = Delete(self.toDF.queryExecution.analyzed, condition)


### PR DESCRIPTION
- Used Spark annotations to annotate public APIs regarding their stability 
- Copied Spark scripts to patch the generated docs files to make the annotations visible
     - Additional `:: Evolving ::` is necessary for these scripts to dynamically add badges for the annotation. Without this snippet + patching, generated Java docs do not show annotations.
     - The `generate_api_docs()` script does the following. 
          1. Generates Scala and Java docs with `sbt unidoc`
          1. Patches the docs' html, js, and css to dynamically inject badges
          1. Copies the docs to a standard location `docs/_site/api/` which will be useful for publishing the API docs in the Delta docs.
- Moved public methods in DeltaTableOperations into DeltaTable because Java docs generated by unidoc incorrectly handles inherited methods in some cases. In this case, it was showing `delete` as static methods.

**Java docs**
![image](https://user-images.githubusercontent.com/663212/61239363-8fb86180-a6f3-11e9-866d-0a2852f6be74.png)

**Scala docs**
![image](https://user-images.githubusercontent.com/663212/61254509-893ce080-a719-11e9-98ff-c8239cc2ca74.png)
