### PR TITLE
Update analysisException to take all parameters AnalysisException has

### DIFF
--- a/src/main/scala/io/delta/DeltaMergeBuilder.scala
+++ b/src/main/scala/io/delta/DeltaMergeBuilder.scala
@@ -63,7 +63,7 @@ case class DeltaMergeBuilder private[delta](
     val resolvedMergeInto =
       MergeInto.resolveReferences(mergePlan)(tryResolveReferences(sparkSession) _)
     if (!resolvedMergeInto.resolved) {
-      throw DeltaErrors.analysisException("Failed to resolve\n", Some(resolvedMergeInto))
+      throw DeltaErrors.analysisException("Failed to resolve\n", plan = Some(resolvedMergeInto))
     }
     // Preprocess the actions and verify
     val mergeIntoCommand = PreprocessTableMerge(sparkSession.sessionState.conf)(resolvedMergeInto)

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -81,11 +81,12 @@ object DeltaErrors
 
   def formatSchema(schema: StructType): String = schema.treeString
 
-  def analysisException(msg: String,
-                        line: Option[Int] = None,
-                        startPosition: Option[Int] = None,
-                        plan: Option[LogicalPlan] = None,
-                        cause: Option[Throwable] = None): AnalysisException = {
+  def analysisException(
+                         msg: String,
+                         line: Option[Int] = None,
+                         startPosition: Option[Int] = None,
+                         plan: Option[LogicalPlan] = None,
+                         cause: Option[Throwable] = None): AnalysisException = {
     new AnalysisException(msg, line, startPosition, plan, cause)
   }
 

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -82,11 +82,11 @@ object DeltaErrors
   def formatSchema(schema: StructType): String = schema.treeString
 
   def analysisException(
-                         msg: String,
-                         line: Option[Int] = None,
-                         startPosition: Option[Int] = None,
-                         plan: Option[LogicalPlan] = None,
-                         cause: Option[Throwable] = None): AnalysisException = {
+      msg: String,
+      line: Option[Int] = None,
+      startPosition: Option[Int] = None,
+      plan: Option[LogicalPlan] = None,
+      cause: Option[Throwable] = None): AnalysisException = {
     new AnalysisException(msg, line, startPosition, plan, cause)
   }
 

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -81,8 +81,12 @@ object DeltaErrors
 
   def formatSchema(schema: StructType): String = schema.treeString
 
-  def analysisException(msg: String, plan: Option[LogicalPlan]): AnalysisException = {
-    new AnalysisException(msg, plan = plan)
+  def analysisException(msg: String,
+                        line: Option[Int] = None,
+                        startPosition: Option[Int] = None,
+                        plan: Option[LogicalPlan] = None,
+                        cause: Option[Throwable] = None): AnalysisException = {
+    new AnalysisException(msg, line, startPosition, plan, cause)
   }
 
   def notNullInvariantException(invariant: Invariant): Throwable = {

--- a/src/main/scala/org/apache/spark/sql/delta/util/AnalysisHelper.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/util/AnalysisHelper.scala
@@ -37,7 +37,7 @@ trait AnalysisHelper {
       case _ =>
         // This is unexpected
         throw DeltaErrors.analysisException(
-          s"Could not resolve expression $expr", Option(planContainingExpr))
+          s"Could not resolve expression $expr", plan = Option(planContainingExpr))
     }
   }
 }


### PR DESCRIPTION
AnalysisException takes line, startPosition, and cause as constructor parameters in addition to message and plan -- this change updates analysisException to accept those as well. 