### PR TITLE
Refactoring DeltaTable for cleanliness

### DIFF
--- a/src/main/scala/io/delta/execution/DeltaTableOperations.scala
+++ b/src/main/scala/io/delta/execution/DeltaTableOperations.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.delta.util.AnalysisHelper
 import io.delta.DeltaTable
 
 import org.apache.spark.sql.{functions, Column, DataFrame, SparkSession}
-import org.apache.spark.sql.catalyst.analysis.EliminateSubqueryAliases
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.expressions.{Expression, SubqueryExpression}
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -65,15 +64,13 @@ trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
       target.toDF.queryExecution.analyzed, updateColumns, updateExpressions, condition)
   }
 
-  protected def executeHistory(limit: Option[Int]): DataFrame = {
+  protected def executeHistory(deltaLog: DeltaLog, limit: Option[Int]): DataFrame = {
     val history = new DeltaHistoryManager(deltaLog)
     val spark = self.toDF.sparkSession
     spark.createDataFrame(history.getHistory(limit))
   }
 
-  protected def executeUpdate(
-      set: Map[String, Column],
-      condition: Option[Column]): Unit = {
+  protected def executeUpdate(set: Map[String, Column], condition: Option[Column]): Unit = {
     val setColumns = set.map{ case (col, expr) => (col, expr) }.toSeq
 
     // Current UPDATE does not support subquery,
@@ -100,15 +97,9 @@ trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
   protected def executeVacuum(
       deltaLog: DeltaLog,
       retentionHours: Option[Double]): DataFrame = {
-    val sparkSession = self.toDF.sparkSession
     VacuumCommand.gc(sparkSession, deltaLog, false, retentionHours)
     sparkSession.emptyDataFrame
   }
 
-  protected lazy val deltaLog = (EliminateSubqueryAliases(self.toDF.queryExecution.analyzed) match {
-    case DeltaFullTable(tahoeFileIndex) =>
-      tahoeFileIndex
-  }).deltaLog
-
-  protected lazy val sparkSession: SparkSession = self.toDF.sparkSession
+  protected def sparkSession = self.toDF.sparkSession
 }

--- a/src/test/scala/org/apache/spark/sql/delta/DeleteScalaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeleteScalaSuite.scala
@@ -69,7 +69,7 @@ class DeleteScalaSuite extends DeleteSuiteBase {
         val path = tableNameOrPath.stripPrefix("delta.`").stripSuffix("`")
         io.delta.DeltaTable.forPath(spark, path)
       } else {
-        io.delta.DeltaTable(spark.table(tableNameOrPath))
+        io.delta.DeltaTable(spark.table(tableNameOrPath), DeltaLog.forTable(spark, tableNameOrPath))
       }
       optionalAlias.map(table.as(_)).getOrElse(table)
     }

--- a/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
@@ -60,7 +60,7 @@ trait DescribeDeltaHistorySuiteBase
     }
   }
 
-  test("logging and limit") {
+  testWithFlag("logging and limit") {
     val tempDir = Utils.createTempDir().toString
     Seq(1, 2, 3).toDF().write.format("delta").save(tempDir)
     Seq(4, 5, 6).toDF().write.format("delta").mode("overwrite").save(tempDir)
@@ -168,7 +168,7 @@ trait DescribeDeltaHistorySuiteBase
       Seq($"operation", $"operationParameters.predicate"))
   }
 
-  test("old and new writers") {
+  testWithFlag("old and new writers") {
     val tempDir = Utils.createTempDir().toString
     withSQLConf(DeltaSQLConf.DELTA_COMMIT_INFO_ENABLED.key -> "false") {
       Seq(1, 2, 3).toDF().write.format("delta").save(tempDir.toString)
@@ -183,7 +183,7 @@ trait DescribeDeltaHistorySuiteBase
     checkLastOperation(tempDir, Seq("WRITE", "Append"))
   }
 
-  test("order history by version") {
+  testWithFlag("order history by version") {
     val tempDir = Utils.createTempDir().toString
 
     withSQLConf(DeltaSQLConf.DELTA_COMMIT_INFO_ENABLED.key -> "false") {

--- a/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
@@ -400,7 +400,7 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
       val path = nameOrPath.stripPrefix("delta.`").stripSuffix("`")
       io.delta.DeltaTable.forPath(spark, path)
     } else {
-      io.delta.DeltaTable(spark.table(nameOrPath))
+      io.delta.DeltaTable(spark.table(nameOrPath), DeltaLog.forTable(spark, nameOrPath))
     }
   }
 

--- a/src/test/scala/org/apache/spark/sql/delta/UpdateScalaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/UpdateScalaSuite.scala
@@ -97,7 +97,7 @@ class UpdateScalaSuite extends UpdateSuiteBase {
         val path = tableNameOrPath.stripPrefix("delta.`").stripSuffix("`")
         io.delta.DeltaTable.forPath(spark, path)
       } else {
-        io.delta.DeltaTable(spark.table(tableNameOrPath))
+        io.delta.DeltaTable(spark.table(tableNameOrPath), DeltaLog.forTable(spark, tableNameOrPath))
       }
       optionalAlias.map(table.as(_)).getOrElse(table)
     }


### PR DESCRIPTION
Previously DeltaTable was only taking `Dataset[Row]` as the parameter. And was trying to figure out the DeltaLog via the analyzed plan. Moved to a cleaner approach where we pass the DeltaLog as well as a parameter.