### PR TITLE
[WIP][HiveOnDelta]add hive-delta read

### DIFF
--- a/external/hive-delta/pom.xml
+++ b/external/hive-delta/pom.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.delta</groupId>
+    <artifactId>hive-delta</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <scala.binary.version>2.11</scala.binary.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.delta</groupId>
+            <artifactId>delta-core_2.11</artifactId>
+            <scope>provided</scope>
+            <version>0.3.1-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-exec</artifactId>
+            <version>2.3.3</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.janino</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-client-core</artifactId>
+            <version>2.7.2</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_2.11</artifactId>
+            <version>2.4.3</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>org.apache.hadoop</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.scala-tools</groupId>
+                <artifactId>maven-scala-plugin</artifactId>
+                <version>2.15.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <configuration>
+                    <shadedArtifactAttached>false</shadedArtifactAttached>
+                    <outputFile>${project.build.directory}/shaded/delta-hive_${scala.binary.version}-${project.version}.jar</outputFile>
+                    <artifactSet>
+                        <excludes>
+                            <exclude>org.apache.hadoop:*</exclude>
+                        </excludes>
+                    </artifactSet>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.codehaus.janino</pattern>
+                                    <shadedPattern>org.codehaus.janino.shaded</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.codehaus.commons.compiler</pattern>
+                                    <shadedPattern>org.codehaus.commons.compiler.shaded</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons.lang3.time</pattern>
+                                    <shadedPattern>org.apache.commons.lang3.time.shaded</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.antlr.v4.runtime</pattern>
+                                    <shadedPattern>org.antlr.v4.runtime.shaded</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/external/hive-delta/src/main/scala/io/delta/hive/DeltaInputFormat.scala
+++ b/external/hive-delta/src/main/scala/io/delta/hive/DeltaInputFormat.scala
@@ -1,11 +1,12 @@
 package io.delta.hive
 
+import java.io.IOException
+
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
 import org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat
 import org.apache.hadoop.mapred.FileInputFormat._
 import org.apache.hadoop.mapred.JobConf
 import org.apache.hadoop.mapreduce.security.TokenCache
-import java.io.IOException
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession

--- a/external/hive-delta/src/main/scala/io/delta/hive/DeltaInputFormat.scala
+++ b/external/hive-delta/src/main/scala/io/delta/hive/DeltaInputFormat.scala
@@ -1,0 +1,81 @@
+package io.delta.hive
+
+import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
+import org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat
+import org.apache.hadoop.mapred.FileInputFormat._
+import org.apache.hadoop.mapred.JobConf
+import org.apache.hadoop.mapreduce.security.TokenCache
+import java.io.IOException
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.actions.SingleAction._
+import org.apache.spark.sql.delta.sources.DeltaDataSource
+import org.apache.spark.sql.delta.{DeltaLog, DeltaTableUtils}
+
+class DeltaInputFormat extends MapredParquetInputFormat with Logging {
+  import DeltaInputFormat._
+
+  @throws[IOException]
+  override def listStatus(job: JobConf): Array[FileStatus] = {
+    val dirs = getInputPaths(job)
+    if (dirs.isEmpty) {
+      throw new IOException("No input paths specified in job")
+    } else {
+      TokenCache.obtainTokensForNamenodes(job.getCredentials, dirs, job)
+
+      // find delta root path
+      val rootPath = DeltaTableUtils.findDeltaTableRoot(spark, dirs)
+
+      // determine the version to use
+      val parameters = Map(
+        DeltaDataSource.TIME_TRAVEL_TIMESTAMP_KEY ->
+          job.get(DeltaDataSource.TIME_TRAVEL_TIMESTAMP_KEY),
+        DeltaDataSource.TIME_TRAVEL_VERSION_KEY ->
+          job.get(DeltaDataSource.TIME_TRAVEL_VERSION_KEY),
+        DeltaDataSource.TIME_TRAVEL_SOURCE_KEY ->
+          job.get(DeltaDataSource.TIME_TRAVEL_SOURCE_KEY)
+      ).filter(_._2 != null)
+
+      val (realPath, timeTravelOpt) =
+        DeltaTableUtils.getTimeTravel(spark, rootPath.toString, parameters)
+      val deltaLog = DeltaLog.forTable(spark, realPath)
+      val versionToUse = timeTravelOpt.map { tt =>
+        val (version, accessType) = DeltaTableUtils.resolveTimeTravelVersion(
+          spark.sessionState.conf, deltaLog, tt)
+        val source = tt.creationSource.getOrElse("unknown")
+        version
+      }
+      // get the snapshot of the version
+      val snapshotToUse = versionToUse.map(deltaLog.getSnapshotAt(_)).getOrElse(deltaLog.snapshot)
+
+      // get partition filters
+      val partitionFragments = dirs.map(_.toString.substring(rootPath.toString.length() + 1))
+      val partitionFilters = if (rootPath != dirs(0)) {
+        DeltaTableUtils.resolvePathFilters(deltaLog, partitionFragments)
+      } else {
+        assert(dirs.length == 1, "Not-partitioned table should only have one input dir.")
+        Nil
+      }
+
+      // selected files to Hive to be processed
+      val fs: FileSystem = rootPath.getFileSystem(job)
+      DeltaLog.filterFileList(
+        snapshotToUse.metadata.partitionColumns, snapshotToUse.allFiles.toDF(), partitionFilters)
+        .as[AddFile]
+        .collect()
+        .map { file =>
+          logDebug(s"delta file:$file is selected")
+          fs.getFileStatus(new Path(rootPath, file.path))
+        }
+    }
+  }
+}
+
+object DeltaInputFormat {
+  lazy val spark = SparkSession.builder()
+    .master("local[*]")
+    .appName("HiveOnDelta Get Files")
+    .getOrCreate()
+}

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -18,10 +18,12 @@ package org.apache.spark.sql.delta
 
 // scalastyle:off import.ordering.noEmptyLine
 import scala.util.{Failure, Success, Try}
+
 import org.apache.spark.sql.delta.files.{TahoeFileIndex, TahoeLogFileIndex}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.{DeltaDataSource, DeltaSourceUtils}
 import org.apache.hadoop.fs.Path
+
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
@@ -250,7 +252,6 @@ object DeltaTableUtils extends PredicateHelper
     }
   }
 
-
   /** Extracts whether users provided the option to time travel a relation. */
   def getTimeTravelVersion(parameters: Map[String, String]): Option[DeltaTimeTravelSpec] = {
     val caseInsensitive = CaseInsensitiveMap[String](parameters)
@@ -297,7 +298,6 @@ object DeltaTableUtils extends PredicateHelper
 
     (realPath, timeTravelByParams.orElse(timeTravelByPath))
   }
-
 
   def resolvePathFilters(deltaLog: DeltaLog, partitionFragments: Seq[String]): Seq[Expression] = {
     val snapshot = deltaLog.update()

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -17,18 +17,20 @@
 package org.apache.spark.sql.delta
 
 // scalastyle:off import.ordering.noEmptyLine
-import scala.util.Try
-
+import scala.util.{Failure, Success, Try}
 import org.apache.spark.sql.delta.files.{TahoeFileIndex, TahoeLogFileIndex}
 import org.apache.spark.sql.delta.metering.DeltaLogging
-import org.apache.spark.sql.delta.sources.DeltaSourceUtils
+import org.apache.spark.sql.delta.sources.{DeltaDataSource, DeltaSourceUtils}
 import org.apache.hadoop.fs.Path
-
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.catalyst.expressions.{Expression, PredicateHelper, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions.{And, EqualTo, Expression, Literal, PredicateHelper, SubqueryExpression}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
+import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.util.PartitionUtils
 import org.apache.spark.sql.execution.datasources.{FileIndex, HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.internal.SQLConf
 
@@ -102,6 +104,27 @@ object DeltaTableUtils extends PredicateHelper
       currentPath = currentPath.getParent()
     }
     None
+  }
+
+  /** Find the root of a Delta table from the provided paths.
+   * Maybe the paths contain several partition's path like:
+   * `Seq("/root/path/fieldOne=1/fieldTwo=2","/root/path/fieldOne=3/fieldTwo=4"`,
+   * and "/root/path" shoule be returned.
+   */
+  def findDeltaTableRoot(spark: SparkSession, paths: Seq[Path]): Path = {
+    val rootPaths = paths.map { p =>
+      DeltaTableUtils.findDeltaTableRoot(spark, p)
+        .getOrElse {
+          val fs = p.getFileSystem(spark.sessionState.newHadoopConf())
+          if (!fs.exists(p)) {
+            throw DeltaErrors.pathNotExistsException(p.getName)
+          }
+          p
+        }
+    }.distinct
+    assert(rootPaths.length <= 1, s"There are more than one delta root paths" +
+      s"${rootPaths.mkString(",")} for ${paths.mkString(",")}")
+    rootPaths.head
   }
 
   /** Whether a path should be hidden for delta-related file operations, such as Vacuum and Fsck. */
@@ -225,5 +248,84 @@ object DeltaTableUtils extends PredicateHelper
       val timestamp = tt.getTimestamp(conf.sessionLocalTimeZone)
       deltaLog.history.getActiveCommitAtTime(timestamp, false).version -> "timestamp"
     }
+  }
+
+
+  /** Extracts whether users provided the option to time travel a relation. */
+  def getTimeTravelVersion(parameters: Map[String, String]): Option[DeltaTimeTravelSpec] = {
+    val caseInsensitive = CaseInsensitiveMap[String](parameters)
+    val tsOpt = caseInsensitive.get(DeltaDataSource.TIME_TRAVEL_TIMESTAMP_KEY)
+    val versionOpt = caseInsensitive.get(DeltaDataSource.TIME_TRAVEL_VERSION_KEY)
+    val sourceOpt = caseInsensitive.get(DeltaDataSource.TIME_TRAVEL_SOURCE_KEY)
+
+    if (tsOpt.isDefined && versionOpt.isDefined) {
+      throw DeltaErrors.provideOneOfInTimeTravel
+    } else if (tsOpt.isDefined) {
+      Some(DeltaTimeTravelSpec(Some(Literal(tsOpt.get)), None, sourceOpt.orElse(Some("dfReader"))))
+    } else if (versionOpt.isDefined) {
+      val version = Try(versionOpt.get.toLong) match {
+        case Success(v) => v
+        case Failure(t) => throw new IllegalArgumentException(
+          s"${DeltaDataSource.TIME_TRAVEL_VERSION_KEY} needs to be a valid bigint value.", t)
+      }
+      Some(DeltaTimeTravelSpec(None, Some(version), sourceOpt.orElse(Some("dfReader"))))
+    } else {
+      None
+    }
+  }
+
+  /** extract time travel:
+   * First check whether users provided the option to time travel,
+   * if not, then check if the given path contains time travel syntax with the `@`
+   */
+  def getTimeTravel(
+      spark: SparkSession,
+      maybePathWithTimeTravel: String,
+      parameters: Map[String, String])
+    : (String, Option[DeltaTimeTravelSpec]) = {
+    // Handle time travel
+    val maybeTimeTravel =
+      DeltaTableUtils.extractIfPathContainsTimeTravel(spark, maybePathWithTimeTravel)
+    val (realPath, timeTravelByPath) = maybeTimeTravel.map {
+      case (p, tt) => p -> Some(tt)
+    }.getOrElse(maybePathWithTimeTravel -> None)
+    val timeTravelByParams = getTimeTravelVersion(parameters)
+
+    if (timeTravelByParams.isDefined && timeTravelByPath.isDefined) {
+      throw DeltaErrors.multipleTimeTravelSyntaxUsed
+    }
+
+    (realPath, timeTravelByParams.orElse(timeTravelByPath))
+  }
+
+
+  def resolvePathFilters(deltaLog: DeltaLog, partitionFragments: Seq[String]): Seq[Expression] = {
+    val snapshot = deltaLog.update()
+    val metadata = snapshot.metadata
+    val partitionFilters = partitionFragments.map { fragment =>
+      val partitions = try {
+        PartitionUtils.parsePathFragmentAsSeq(fragment)
+      } catch {
+        case _: ArrayIndexOutOfBoundsException =>
+          throw DeltaErrors.partitionPathParseException(fragment)
+      }
+
+      val badColumns = partitions.map(_._1).filterNot(metadata.partitionColumns.contains)
+      if (badColumns.nonEmpty) {
+        throw DeltaErrors.partitionPathInvolvesNonPartitionColumnException(badColumns, fragment)
+      }
+
+      partitions.map { case (key, value) =>
+        EqualTo(UnresolvedAttribute(key), Literal(value))
+      }.reduce(And)
+    }
+
+    import org.apache.spark.sql.delta.actions.SingleAction._
+    val files = DeltaLog.filterFileList(
+      metadata.partitionColumns, snapshot.allFiles.toDF(), partitionFilters).as[AddFile].collect()
+    if (files.length == 0) {
+      throw DeltaErrors.pathNotExistsException(partitionFragments.mkString(","))
+    }
+    partitionFilters
   }
 }


### PR DESCRIPTION
Implement HiveOnDelta Reader.
1. the HiveOnDelta subproject is put in external/hive-delta, other plugin(presto) can be put in external directory
2. Currently HiveOnDelta subproject is a independent  mvn project , maybe we should use sbt to manage it(I tried to use sbt subproject, but have not finished).
3. DeltaInputFormat is Implement , and there are some functions added in delta-core
4. DeltaInputFormat can support partition table /non-partition table , and the timetravel.
5. TestCase is not included in this WIP.
6. the schema in delta'metadata may be changed, so we should provide a tool to auto-create new external table with new schema 

```
create external table deltatblpar(region string,cnt string)
partitioned by(datee string)
row format serde 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'
stored as inputformat 'io.delta.hive.DeltaInputFormat'
outputformat 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
location 'hdfs://emr-header-1:9000/delta/events';

// add partitions
msck repair table deltatblpar;
```
<img width="594" alt="屏幕快照 2019-09-05 上午11 19 27" src="https://user-images.githubusercontent.com/12979185/64309462-1d674d80-cfcf-11e9-9bf1-9f75961b442b.png">

<img width="631" alt="屏幕快照 2019-09-05 上午11 12 46" src="https://user-images.githubusercontent.com/12979185/64309164-43402280-cfce-11e9-8132-3121c32224ea.png">

