### PR TITLE
Reduce file listing parallelism for tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,6 +60,7 @@ javaOptions in Test ++= Seq(
   "-Dspark.databricks.delta.snapshotPartitions=2",
   "-Dspark.sql.shuffle.partitions=5",
   "-Ddelta.log.cacheSize=3",
+  "-Dspark.sql.sources.parallelPartitionDiscovery.parallelism=5",
   "-Xmx1024m"
 )
 


### PR DESCRIPTION
This should make Vacuum tests a lot faster. It's running 10,000 individual Spark jobs right now due to the very high setting of file parallelism setting.

cc @rahulsmahadev 