### PR TITLE
Simple implementation of concurrent write for independent partitions.

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -20,7 +20,6 @@ import java.util.{HashMap, Locale}
 
 import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
 import org.apache.spark.sql.delta.metering.DeltaLogging
-
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.unsafe.types.CalendarInterval
@@ -355,4 +354,14 @@ object DeltaConfigs extends DeltaLogging {
     a => a >= -1,
     "needs to be larger than or equal to -1.")
 
+  /**
+   * Enables concurrent writes to independent delta partitions.
+   */
+  val ENABLE_CONCURRENT_PARTITIONS_WRITE = buildConfig[Boolean](
+    "enableConcurrentPartitionsWrite",
+    "false",
+    _.toBoolean,
+    _ => true,
+    "needs to be a boolean."
+  )
 }

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -614,6 +614,15 @@ abstract class DeltaConcurrentModificationException(message: String)
 }
 
 /**
+ * Thrown when a concurrent transaction has written data to conflicting partitions
+ * after the current transaction read the table.
+ */
+class ConcurrentPartitionWriteException(
+        val conflictingPartitions: Iterable[Map[String, String]],
+        conflictingCommit: Option[CommitInfo])
+  extends ConcurrentWriteException(conflictingCommit)
+
+/**
  * Thrown when a concurrent transaction has written data after the current transaction read the
  * table.
  */

--- a/src/main/scala/org/apache/spark/sql/delta/PartitionFiltering.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/PartitionFiltering.scala
@@ -16,9 +16,8 @@
 
 package org.apache.spark.sql.delta
 
-import org.apache.spark.sql.delta.actions.{AddFile, SingleAction}
+import org.apache.spark.sql.delta.actions.{AddFile, FileAction, RemoveFile, SingleAction}
 import org.apache.spark.sql.delta.stats.DeltaScan
-
 import org.apache.spark.sql.catalyst.expressions._
 
 trait PartitionFiltering {
@@ -30,15 +29,43 @@ trait PartitionFiltering {
       keepStats: Boolean = false): DeltaScan = {
     implicit val enc = SingleAction.addFileEncoder
 
-    val partitionFilters = filters.flatMap { filter =>
-      DeltaTableUtils.splitMetadataAndDataPredicates(filter, metadata.partitionColumns, spark)._1
-    }
-
     val files = DeltaLog.filterFileList(
       metadata.partitionColumns,
       allFiles.toDF(),
-      partitionFilters).as[AddFile].collect()
+      partitionFilters(filters)).as[AddFile].collect()
 
     DeltaScan(version = version, files, null, null, null)(null, null, null, null)
+  }
+
+  def partitionFilters(filters: Seq[Expression]): Seq[Expression] = filters.flatMap { filter =>
+    DeltaTableUtils.splitMetadataAndDataPredicates(filter, metadata.partitionColumns, spark)._1
+  }
+
+  def filterFileActions(
+      actions: Seq[FileAction],
+      filters: Seq[Expression]) : Seq[FileAction] = {
+    val implicits = spark.implicits
+    import implicits._
+
+    val addFileDf = actions.flatMap {
+      case a: AddFile => Some(a)
+      case _: RemoveFile => None
+    }.toDF()
+    val addFiles = DeltaLog.filterFileList(
+      metadata.partitionColumns,
+      addFileDf,
+      filters
+    ).as[AddFile].collect()
+
+    val removeFileDf = actions.flatMap {
+      case _: AddFile => None
+      case r: RemoveFile => Some(r)
+    }.toDF()
+    val removeFiles = DeltaLog.filterFileList(
+      metadata.partitionColumns,
+      removeFileDf,
+      filters
+    ).as[RemoveFile].collect()
+    addFiles ++ removeFiles
   }
 }

--- a/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -17,12 +17,13 @@
 package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.delta.DeltaOperations.Truncate
-import org.apache.spark.sql.delta.actions.{AddFile, Metadata, SetTransaction}
+import org.apache.spark.sql.delta.actions.{AddFile, Metadata, SetTransaction, Action}
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.test.SharedSparkSession
+import DeltaConfigs.ENABLE_CONCURRENT_PARTITIONS_WRITE
 
 class OptimisticTransactionSuite extends QueryTest with SharedSparkSession {
   private val addA = AddFile("a", Map.empty, 1, 1, dataChange = true)
@@ -93,6 +94,571 @@ class OptimisticTransactionSuite extends QueryTest with SharedSparkSession {
     }
   }
 
+  val A_P1 = "part=1/a"
+  val B_P1 = "part=1/b"
+  val C_P1 = "part=1/c"
+  val C_P2 = "part=2/c"
+  val D_P2 = "part=2/d"
+  val E_P3 = "part=3/e"
+  val F_P3 = "part=3/f"
+  val G_P4 = "part=4/g"
+
+  private val addA_P1 = AddFile(A_P1, Map("part" -> "1"), 1, 1, dataChange = true)
+  private val addB_P1 = AddFile(B_P1, Map("part" -> "1"), 1, 1, dataChange = true)
+  private val addC_P1 = AddFile(C_P1, Map("part" -> "1"), 1, 1, dataChange = true)
+  private val addC_P2 = AddFile(C_P2, Map("part" -> "2"), 1, 1, dataChange = true)
+  private val addD_P2 = AddFile(D_P2, Map("part" -> "2"), 1, 1, dataChange = true)
+  private val addE_P3 = AddFile(E_P3, Map("part" -> "3"), 1, 1, dataChange = true)
+  private val addF_P3 = AddFile(F_P3, Map("part" -> "3"), 1, 1, dataChange = true)
+  private val addG_P4 = AddFile(G_P4, Map("part" -> "4"), 1, 1, dataChange = true)
+
+  test("block concurrent commit when table is not configured") {
+    withLog(addA_P1 :: addD_P2 :: addD_P2.remove :: Nil) { log =>
+      val tx1 = log.startTransaction()
+      // TX1 reads A_P1
+      tx1.filterFiles(('part === 1).expr :: Nil)
+
+      val tx2 = log.startTransaction()
+      tx2.filterFiles()
+      // TX2 modifies P2
+      tx2.commit(addC_P2 :: addD_P2.remove :: Nil, Truncate())
+
+      intercept[ConcurrentWriteException] {
+        // this is safe however table was not configured for concurrent writes
+        tx1.commit(addE_P3 :: addF_P3 :: Nil, Truncate())
+      }
+    }
+  }
+
+  test("allow concurrent commit on disjoint partitions") {
+    withConcurrentLog(addA_P1 :: addD_P2 :: addE_P3 :: addD_P2.remove :: Nil) { log =>
+      val tx1 = log.startTransaction()
+      // TX1 reads P3 (but not P1)
+      val tx1Read = tx1.filterFiles(('part === 3).expr :: Nil)
+      assert(tx1Read.map(_.path) == E_P3 :: Nil)
+
+      val tx2 = log.startTransaction()
+      tx2.filterFiles()
+      // TX2 modifies only P1
+      tx2.commit(addB_P1 :: Nil, Truncate())
+
+      // free to commit because P1 modified by TX2 was not read
+      tx1.commit(addC_P2 :: addE_P3.remove :: Nil, Truncate())
+      checkAnswer(log.update().allFiles.select("path"),
+        // start (E_P3 was removed by TX1)
+        Row(A_P1) ::
+        // TX2
+        Row(B_P1) ::
+        // TX1
+        Row(C_P2) :: Nil)
+    }
+  }
+
+  test("allow concurrent commit on disjoint partitions reading all partitions") {
+    withConcurrentLog(addA_P1 :: addD_P2 :: addD_P2.remove :: Nil) { log =>
+      val tx1 = log.startTransaction()
+      // TX1 read P1
+      tx1.filterFiles(('part isin 1).expr :: Nil)
+
+      val tx2 = log.startTransaction()
+      tx2.filterFiles()
+      tx2.commit(addC_P2 :: addD_P2.remove :: Nil, Truncate())
+
+      tx1.commit(addE_P3 :: addF_P3 :: Nil, Truncate())
+
+      checkAnswer(log.update().allFiles.select("path"),
+        // start
+        Row(A_P1) ::
+        // TX2
+        Row(C_P2) ::
+        // TX1
+        Row(E_P3) :: Row(F_P3) :: Nil)
+    }
+  }
+
+  test("block concurrent commit when read was modified") {
+    withConcurrentLog(addA_P1 :: addD_P2 :: addE_P3 :: addD_P2.remove :: Nil) { log =>
+      val tx1 = log.startTransaction()
+      // TX1 reads only P1
+      val tx1Read = tx1.filterFiles(('part === 1).expr :: Nil)
+      assert(tx1Read.map(_.path) == A_P1 :: Nil)
+
+      val tx2 = log.startTransaction()
+      tx2.filterFiles()
+      // TX2 modifies only P1
+      tx2.commit(addB_P1 :: Nil, Truncate())
+
+      intercept[ConcurrentWriteException] {
+        // P1 was modified
+        tx1.commit(addC_P2 :: addE_P3 :: Nil, Truncate())
+      }
+    }
+  }
+
+  test("block concurrent commit on full table scan") {
+    withConcurrentLog(addA_P1 :: addD_P2 :: addD_P2.remove :: Nil) { log =>
+      val tx1 = log.startTransaction()
+      // TX1 full table scan
+      tx1.filterFiles()
+      tx1.filterFiles(('part === 1).expr :: Nil)
+
+      val tx2 = log.startTransaction()
+      tx2.filterFiles()
+      tx2.commit(addC_P2 :: addD_P2.remove :: Nil, Truncate())
+
+      intercept[ConcurrentWriteException] {
+        tx1.commit(addE_P3 :: addF_P3 :: Nil, Truncate())
+      }
+    }
+  }
+
+  val A_1_1 = "a=1/b=1/a"
+  val B_1_2 = "a=1/b=2/b"
+  val C_2_1 = "a=2/b=1/c"
+  val D_3_1 = "a=3/b=1/d"
+
+  val addA_1_1_nested = AddFile(A_1_1, Map("a" -> "1", "b" -> "1"),
+    1, 1, dataChange = true)
+  val addB_1_2_nested = AddFile(B_1_2, Map("a" -> "1", "b" -> "2"),
+    1, 1, dataChange = true)
+  val addC_2_1_nested = AddFile(C_2_1, Map("a" -> "2", "b" -> "1"),
+    1, 1, dataChange = true)
+  val addD_3_1_nested = AddFile(D_3_1, Map("a" -> "3", "b" -> "1"),
+    1, 1, dataChange = true)
+
+  test("allow concurrent commit on nested partitions") {
+    withConcurrentLog(addA_1_1_nested :: Nil, partitionCols = "a" :: "b" :: Nil) { log =>
+      val tx1 = log.startTransaction()
+      // TX1 reads a=1/b=1
+      val tx1Read = tx1.filterFiles(('a === 1 and 'b === 1).expr :: Nil)
+      assert(tx1Read.map(_.path) == A_1_1 :: Nil)
+
+      val tx2 = log.startTransaction()
+      tx2.filterFiles()
+      // TX2 modifies only a=1/b=2
+      tx2.commit(addB_1_2_nested :: Nil, Truncate())
+
+      // free to commit a=2/b=1
+      tx1.commit(addC_2_1_nested :: Nil, Truncate())
+      checkAnswer(log.update().allFiles.select("path"),
+        // start
+        Row(A_1_1) ::
+        // TX2
+        Row(B_1_2) ::
+        // TX1
+        Row(C_2_1) :: Nil)
+    }
+  }
+
+  test("block concurrent commit on nested partitions conflicting add") {
+    withConcurrentLog(addA_1_1_nested :: Nil, partitionCols = "a" :: "b" :: Nil) { log =>
+      val tx1 = log.startTransaction()
+      // TX1 reads a=1/b=1
+      val tx1Read = tx1.filterFiles(('a === 1 and 'b === 1).expr :: Nil)
+      assert(tx1Read.map(_.path) == A_1_1 :: Nil)
+
+      val tx2 = log.startTransaction()
+      tx2.filterFiles()
+      // TX2 modifies a=1/b=2
+      tx2.commit(addB_1_2_nested :: Nil, Truncate())
+
+      intercept[ConcurrentWriteException] {
+        val add = AddFile("a=1/b=2/x", Map("a" -> "1", "b" -> "2"),
+          1, 1, dataChange = true)
+        tx1.commit(add :: Nil, Truncate())
+      }
+    }
+  }
+
+  test("allow concurrent commit read one level in nested partitions") {
+    withConcurrentLog(addA_1_1_nested :: addB_1_2_nested :: Nil,
+      partitionCols = "a" :: "b" :: Nil) { log =>
+        val tx1 = log.startTransaction()
+        val tx1Read = tx1.filterFiles(('a === 1).expr :: Nil)
+        assert(tx1Read.map(_.path).toSet == Set(A_1_1, B_1_2))
+
+        val tx2 = log.startTransaction()
+        tx2.filterFiles()
+        // TX2 modifies only a=2/b=1
+        tx2.commit(addC_2_1_nested :: Nil, Truncate())
+
+        // free to commit a=2/b=1
+        tx1.commit(addD_3_1_nested :: Nil, Truncate())
+        checkAnswer(log.update().allFiles.select("path"),
+          // start
+          Row(A_1_1) :: Row(B_1_2) ::
+          // TX2
+          Row(C_2_1) ::
+          // TX1
+          Row(D_3_1) :: Nil)
+    }
+  }
+
+  test("block concurrent commit read one level in nested partitions") {
+    withConcurrentLog(addA_1_1_nested :: addB_1_2_nested :: Nil,
+      partitionCols = "a" :: "b" :: Nil) { log =>
+
+      val tx1 = log.startTransaction()
+      val tx1Read = tx1.filterFiles(('a === 1).expr :: Nil)
+      assert(tx1Read.map(_.path).toSet == Set(A_1_1, B_1_2))
+
+      val tx2 = log.startTransaction()
+      tx2.filterFiles()
+      // TX2 modifies a=1/b=1
+      tx2.commit(addA_1_1_nested.remove :: Nil, Truncate())
+
+      intercept[ConcurrentWriteException] {
+        // TX2 modified a=1/b1, which was read by TX1
+        tx1.commit(addD_3_1_nested :: Nil, Truncate())
+      }
+    }
+  }
+
+  test("block concurrent commit on nested partitions full table scan") {
+    withConcurrentLog(addA_1_1_nested :: Nil, partitionCols = "a" :: "b" :: Nil) { log =>
+      val tx1 = log.startTransaction()
+      // TX1 full table scan
+      tx1.filterFiles()
+
+      val tx2 = log.startTransaction()
+      tx2.filterFiles()
+      // TX2 modifies only a=1/b=2
+      tx2.commit(addB_1_2_nested :: Nil, Truncate())
+
+      intercept[ConcurrentWriteException] {
+        tx1.commit(addC_2_1_nested :: Nil, Truncate())
+      }
+    }
+  }
+
+  test("block concurrent commit on nested partitions conflicting read") {
+    withConcurrentLog(addA_1_1_nested :: Nil,
+      partitionCols = "a" :: "b" :: Nil) { log =>
+
+      val tx1 = log.startTransaction()
+      val tx1Read = tx1.filterFiles(('a >= 1 or 'b > 1).expr :: Nil)
+      assert(tx1Read.map(_.path).toSet == Set(A_1_1))
+
+      val tx2 = log.startTransaction()
+      tx2.filterFiles()
+      // TX2 modifies a=1/b=2
+      tx2.commit(addB_1_2_nested :: Nil, Truncate())
+
+      intercept[ConcurrentWriteException] {
+        // partition a=1/b=2 conflicts with our read a >= 1 or 'b > 1
+        tx1.commit(addD_3_1_nested :: Nil, Truncate())
+      }
+    }
+  }
+
+  test("block concurrent commit on nested partitions conflict add & remove") {
+    val addA_10_nested = AddFile("a=1/b=0/a", Map("a" -> "1", "b" -> "0"),
+      1, 1, dataChange = true)
+    val addB_12_nested = AddFile("a=1/b=2/b", Map("a" -> "1", "b" -> "2"),
+      1, 1, dataChange = true)
+    withConcurrentLog(addA_10_nested :: Nil) { log =>
+      val tx1 = log.startTransaction()
+      // TX1 reads a=1/b=0
+      tx1.filterFiles()
+
+      val tx2 = log.startTransaction()
+      tx2.filterFiles()
+      // TX2 modifies a=1/b=2
+      tx2.commit(addB_12_nested :: Nil, Truncate())
+
+      intercept[ConcurrentWriteException] {
+        // a=1/b=2 was manipulated by TX2
+        tx1.commit(addB_12_nested.remove :: Nil, Truncate())
+      }
+    }
+  }
+
+  test("block concurrent commit on Delete attempt and Add initially empty") {
+    withConcurrentLog(addC_P2 :: addE_P3 :: Nil) { log =>
+      val tx1 = log.startTransaction()
+      // empty read
+      val tx1Read = tx1.filterFiles(('part === 1).expr :: Nil)
+      assert(tx1Read.isEmpty)
+      // tx2 deletes "part=p1"
+      val tx2 = log.startTransaction()
+      // empty read
+      val tx2Read = tx2.filterFiles(('part === 1).expr :: Nil)
+      assert(tx2Read.isEmpty)
+
+      tx1.commit(addA_P1 :: Nil, Truncate())
+
+      intercept[ConcurrentWriteException] {
+        // tx1 modified P1 which we tried to read and could try to delete
+        tx2.commit(Seq.empty, Truncate())
+      }
+    }
+  }
+
+  test("allow concurrent commit on Delete and Add disjoint partitions initially empty") {
+    withConcurrentLog(addC_P2 :: addE_P3 :: Nil) { log =>
+      // tx1 deletes "part=p1"
+      val tx1 = log.startTransaction()
+      // empty read
+      val tx1Read = tx1.filterFiles(('part === 1).expr :: Nil)
+      assert(tx1Read.isEmpty)
+
+      // tx2 deletes "part=p1"
+      val tx2 = log.startTransaction()
+      // empty read
+      val tx2Read = tx2.filterFiles(('part === 1).expr :: Nil)
+      assert(tx2Read.isEmpty)
+
+      tx1.commit(addD_P2 :: Nil, Truncate())
+      // empty delete
+      tx2.commit(Seq.empty, Truncate())
+
+      checkAnswer(log.update().allFiles.select("path"),
+        // start
+        Row(C_P2) :: Row(E_P3) ::
+        // TX1
+        Row(D_P2) :: Nil)
+    }
+  }
+
+  test("block concurrent commit when added conflicting partitions") {
+    withConcurrentLog(addA_P1 :: Nil) { log =>
+      val tx1 = log.startTransaction()
+      tx1.filterFiles()
+
+      val tx2 = log.startTransaction()
+      tx2.filterFiles()
+      tx2.commit(addC_P2.remove :: addB_P1 :: Nil, Truncate())
+
+      intercept[ConcurrentWriteException] {
+        // P1 is manipulated in both TX1 and TX2
+        tx1.commit(addD_P2 :: Nil, Truncate())
+      }
+    }
+  }
+
+  test("block concurrent commit when delete conflicting partitions") {
+    withConcurrentLog(addC_P2 :: Nil) { log =>
+      val tx1 = log.startTransaction()
+      tx1.filterFiles()
+
+      val tx2 = log.startTransaction()
+      tx2.filterFiles()
+      tx2.commit(addA_P1.remove :: Nil, Truncate())
+
+      intercept[ConcurrentWriteException] {
+        // P1 read by TX1 was modified
+        tx1.commit(addB_P1.remove :: Nil, Truncate())
+      }
+    }
+  }
+
+  test("block concurrent replaceWhere initial empty") {
+    withConcurrentLog(addA_P1 :: Nil) { log =>
+      val tx1 = log.startTransaction()
+      // replaceWhere (part >= 2) -> empty read
+      val tx1Read = tx1.filterFiles(('part >= 2).expr :: Nil)
+      assert(tx1Read.isEmpty)
+      val tx2 = log.startTransaction()
+      // replaceWhere (part >= 2) -> empty read
+      val tx2Read = tx2.filterFiles(('part >= 2).expr :: Nil)
+      assert(tx2Read.isEmpty)
+
+      tx1.commit(addC_P2 :: Nil, Truncate())
+      intercept[ConcurrentWriteException] {
+        // Tx1 have modified P2 which conflicts with our read (part >= 2)
+        tx2.commit(addE_P3 :: Nil, Truncate())
+      }
+    }
+  }
+
+  test("allow concurrent replaceWhere disjoint partitions initial empty") {
+    withConcurrentLog(addA_P1 :: Nil) { log =>
+      val tx1 = log.startTransaction()
+      // replaceWhere (part > 2 and part <= 3) -> empty read
+      val tx1Read = tx1.filterFiles(('part > 1 and 'part <= 3).expr :: Nil)
+      assert(tx1Read.isEmpty)
+
+      val tx2 = log.startTransaction()
+      // replaceWhere (part > 3) -> empty read
+      val tx2Read = tx2.filterFiles(('part > 3).expr :: Nil)
+      assert(tx2Read.isEmpty)
+
+      tx1.commit(addC_P2 :: Nil, Truncate())
+      // P2 doesn't conflict with read predicate (part > 3)
+      tx2.commit(addG_P4 :: Nil, Truncate())
+      checkAnswer(log.update().allFiles.select("path"),
+        // start
+        Row(A_P1) ::
+        // TX1
+        Row(C_P2) ::
+        // TX2
+        Row(G_P4) :: Nil)
+    }
+  }
+
+  test("block concurrent replaceWhere NOT empty but conflicting predicate") {
+    withConcurrentLog(addA_P1 :: addG_P4 :: Nil) { log =>
+      val tx1 = log.startTransaction()
+      // replaceWhere (part <= 3) -> read P1
+      val tx1Read = tx1.filterFiles(('part <= 3).expr :: Nil)
+      assert(tx1Read.map(_.path) == A_P1 :: Nil)
+      val tx2 = log.startTransaction()
+      // replaceWhere (part >= 2) -> read P4
+      val tx2Read = tx2.filterFiles(('part >= 2).expr :: Nil)
+      assert(tx2Read.map(_.path) == G_P4 :: Nil)
+
+      tx1.commit(addA_P1.remove :: addC_P2 :: Nil, Truncate())
+      intercept[ConcurrentWriteException] {
+        // Tx1 have modified P2 which conflicts with our read (part >= 2)
+        tx2.commit(addG_P4.remove :: addE_P3 :: Nil, Truncate())
+      }
+    }
+  }
+
+  test("block concurrent commit on read and remove") {
+    withConcurrentLog(addA_P1 :: Nil) { log =>
+      val tx1 = log.startTransaction()
+      tx1.filterFiles(('part <= 3).expr :: Nil)
+
+      val tx2 = log.startTransaction()
+      tx2.filterFiles()
+      tx2.commit(addA_P1.remove :: Nil, Truncate())
+
+      intercept[ConcurrentWriteException] {
+        tx1.commit(addG_P4 :: Nil, Truncate())
+      }
+    }
+  }
+
+  test("block concurrent commit on read & add conflicting partitions") {
+    withConcurrentLog(addA_P1 :: Nil) { log =>
+      val tx1 = log.startTransaction()
+      // read P1
+      tx1.filterFiles(('part === 1).expr :: Nil)
+
+      // tx2 commits before tx1
+      val tx2 = log.startTransaction()
+      tx2.filterFiles()
+      tx2.commit(addB_P1 :: Nil, Truncate())
+
+      intercept[ConcurrentWriteException] {
+        // P1 read by TX1 was modified by TX2
+        tx1.commit(addE_P3 :: Nil, Truncate())
+      }
+    }
+  }
+
+  test("block concurrent commit on read & delete conflicting partitions") {
+    withConcurrentLog(addA_P1 :: addB_P1 :: Nil) { log =>
+      val tx1 = log.startTransaction()
+      // read P1
+      tx1.filterFiles(('part === 1).expr :: Nil)
+
+      // tx2 commits before tx1
+      val tx2 = log.startTransaction()
+      tx2.filterFiles()
+      tx2.commit(addA_P1.remove :: Nil, Truncate())
+
+      intercept[ConcurrentWriteException] {
+        // P1 read by TX1 was removed by TX2
+        tx1.commit(addE_P3 :: Nil, Truncate())
+      }
+    }
+  }
+
+  test("block 2 concurrent replaceWhere transactions") {
+    withConcurrentLog(addA_P1 :: Nil) { log =>
+      val tx1 = log.startTransaction()
+      // read P1
+      tx1.filterFiles(('part === 1).expr :: Nil)
+
+      val tx2 = log.startTransaction()
+      // read P1
+      tx2.filterFiles(('part === 1).expr :: Nil)
+
+      // tx1 commits before tx2
+      tx1.commit(addA_P1.remove :: addB_P1 :: Nil, Truncate())
+
+      intercept[ConcurrentWriteException] {
+        // P1 read & deleted by TX1 is being modified by TX2
+        tx2.commit(addA_P1.remove :: addC_P1 :: Nil, Truncate())
+      }
+    }
+  }
+
+  test("block 2 concurrent replaceWhere transactions changing partitions") {
+    withConcurrentLog(addA_P1 :: addC_P2 :: addE_P3 :: Nil) { log =>
+      val tx1 = log.startTransaction()
+      // read P3
+      tx1.filterFiles(('part === 3 or 'part === 1).expr :: Nil)
+
+      val tx2 = log.startTransaction()
+      // read P3
+      tx2.filterFiles(('part === 3 or 'part === 2).expr :: Nil)
+
+      // tx1 commits before tx2
+      tx1.commit(addA_P1.remove :: addE_P3.remove :: addB_P1 :: Nil, Truncate())
+
+      intercept[ConcurrentWriteException] {
+        // P3 read & deleted by TX1 is being modified by TX2
+        tx2.commit(addC_P2.remove :: addE_P3.remove :: addD_P2 :: Nil, Truncate())
+      }
+    }
+  }
+
+  test("block concurrent full table scan and remove") {
+    withConcurrentLog(addA_P1 :: addC_P2 :: addE_P3 :: Nil) { log =>
+      val tx1 = log.startTransaction()
+
+      val tx2 = log.startTransaction()
+      tx2.filterFiles()
+      tx2.commit(addC_P2 :: Nil, Truncate())
+
+      tx1.filterFiles(('part === 1).expr :: Nil)
+      // full table scan
+      tx1.filterFiles()
+
+      intercept[ConcurrentWriteException] {
+        tx1.commit(addA_P1.remove :: Nil, Truncate())
+      }
+    }
+  }
+
+  test("block concurrent commit mixed metadata and data predicate") {
+    withConcurrentLog(addA_P1 :: addC_P2 :: addE_P3 :: Nil) { log =>
+      val tx1 = log.startTransaction()
+
+      val tx2 = log.startTransaction()
+      tx2.filterFiles()
+      tx2.commit(addC_P2 :: Nil, Truncate())
+
+      // actually a full table scan
+      tx1.filterFiles(('part === 1 or 'year > 2019).expr :: Nil)
+
+      intercept[ConcurrentWriteException] {
+        tx1.commit(addA_P1.remove :: Nil, Truncate())
+      }
+    }
+  }
+
+  test("block concurrent read (2 scans) and add ") {
+    withConcurrentLog(addA_P1 :: addE_P3 :: Nil) { log =>
+      val tx1 = log.startTransaction()
+      tx1.filterFiles(('part === 1).expr :: Nil)
+
+      val tx2 = log.startTransaction()
+      tx2.filterFiles()
+      tx2.commit(addC_P2 :: Nil, Truncate())
+
+      tx1.filterFiles(('part > 1 and 'part < 3).expr :: Nil)
+
+      intercept[ConcurrentWriteException] {
+        // P2 added by TX2 conflicts with our read condition 'part > 1 and 'part < 3
+        tx1.commit(addA_P1.remove :: Nil, Truncate())
+      }
+    }
+  }
+
   test("allow concurrent set-txns with different app ids") {
     withTempDir { tempDir =>
       val log = DeltaLog(spark, new Path(tempDir.getCanonicalPath))
@@ -145,6 +711,32 @@ class OptimisticTransactionSuite extends QueryTest with SharedSparkSession {
       assert(fileScans.size == 1)
       assert(fileScans.head.metadata.get("PartitionCount").contains("1"))
       checkAnswer(query, Seq(Row(1, 1)))
+    }
+  }
+
+  def withConcurrentLog(actions: Seq[Action],
+                        partitionCols: Seq[String] = "part" :: Nil)
+                       (test: DeltaLog => Unit): Unit = {
+    val hasMetadata = actions.exists {
+      case _: Metadata => true
+      case _ => false
+    }
+    var actionWithMetaData = actions
+    if (!hasMetadata) {
+      actionWithMetaData = actions :+
+        Metadata(configuration = Map(ENABLE_CONCURRENT_PARTITIONS_WRITE.key -> "true"),
+          partitionColumns = partitionCols
+        )
+    }
+    withLog(actionWithMetaData)(test)
+  }
+
+  def withLog(actions: Seq[Action])(test: DeltaLog => Unit): Unit = {
+    withTempDir { tempDir =>
+      val log = DeltaLog(spark, new Path(tempDir.getCanonicalPath))
+      // Initialize the log and add data. Truncate() is just a no-op placeholder.
+      log.startTransaction().commit(actions, Truncate())
+      test(log)
     }
   }
 }

--- a/src/test/scala/org/apache/spark/sql/delta/PartitionFilteringSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/PartitionFilteringSuite.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2019 Databricks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.test.SharedSparkSession
+
+class PartitionFilteringSuite extends QueryTest with SharedSparkSession {
+  import testImplicits._
+
+  val A_P1 = "part=1/a"
+  val B_P1 = "part=1/b"
+  val C_P2 = "part=2/c"
+  val E_P3 = "part=3/e"
+  val G_P4 = "part=4/g"
+  private val addA_P1 = AddFile(A_P1, Map("part" -> "1"), 1, 1, dataChange = true)
+  private val addB_P1 = AddFile(B_P1, Map("part" -> "1"), 1, 1, dataChange = true)
+  private val addC_P2 = AddFile(C_P2, Map("part" -> "2"), 1, 1, dataChange = true)
+  private val addE_P3 = AddFile(E_P3, Map("part" -> "3"), 1, 1, dataChange = true)
+  private val addG_P4 = AddFile(G_P4, Map("part" -> "4"), 1, 1, dataChange = true)
+
+  private val rmA_P1 = addA_P1.remove
+  private val rmB_P1 = addB_P1.remove
+  private val rmC_P2 = addC_P2.remove
+  private val rmE_P3 = addE_P3.remove
+  private val rmG_P4 = addG_P4.remove
+
+  val addActions = addA_P1 :: addB_P1 :: addC_P2 :: addE_P3 :: addG_P4 :: Nil
+  val removeActions = rmA_P1 :: rmB_P1 :: rmC_P2 :: rmE_P3 :: rmG_P4 :: Nil
+
+  test("Filter AddFiles gt lt operators") {
+    withSnapshot { snapshot =>
+      val filtered = snapshot.filterFileActions(addActions,
+      ('part > 1 and 'part < 4).expr :: Nil)
+      assert(filtered == addC_P2 :: addE_P3 :: Nil)
+    }
+  }
+
+  test("Filter AddFiles eq operator") {
+    withSnapshot { snapshot =>
+      val filtered = snapshot.filterFileActions(addActions,
+        ('part === 1 or 'part === 10).expr :: Nil)
+      assert(filtered == addA_P1 :: addB_P1 :: Nil)
+    }
+  }
+
+  test("Filter RemoveFiles gt lt operators") {
+    withSnapshot { snapshot =>
+      val filtered = snapshot.filterFileActions(removeActions,
+        ('part > 1 and 'part < 4).expr :: Nil)
+      assert(filtered == rmC_P2 :: rmE_P3 :: Nil)
+    }
+  }
+
+  test("Filter RemoveFiles eq operators") {
+    withSnapshot { snapshot =>
+      val filtered = snapshot.filterFileActions(removeActions,
+        ('part === 1 or 'part === 10).expr :: Nil)
+      assert(filtered == rmA_P1 :: rmB_P1 :: Nil)
+    }
+  }
+
+  test("Filter AddFiles and RemoveFiles") {
+    withSnapshot { snapshot =>
+      val addX_P100 = AddFile("part=100/x", Map("part" -> "100"), 1, 1, dataChange = true)
+      val filtered = snapshot.filterFileActions(removeActions ++ addActions :+ addX_P100,
+        ('part < 2 or 'part >= 4).expr :: Nil)
+      assert(filtered.toSet ==
+        // 'part < 2
+        (addA_P1 :: addB_P1 :: rmA_P1 :: rmB_P1 ::
+        // 'part >= 4
+        addG_P4 :: rmG_P4 :: addX_P100 :: Nil).toSet)
+    }
+  }
+
+  test("Filter AddFiles and RemoveFiles 'in' operator") {
+    withSnapshot { snapshot =>
+      val filtered = snapshot.filterFileActions(removeActions ++ addActions,
+        ('part isin(2, 4)).expr :: Nil)
+      assert(filtered.toSet ==
+        (addC_P2 :: rmC_P2 :: addG_P4 :: rmG_P4:: Nil).toSet)
+    }
+  }
+
+  def withSnapshot(test: Snapshot => Unit): Unit = {
+    withTempDir { tempDir =>
+      val log = DeltaLog(spark, new Path(tempDir.getCanonicalPath))
+      test(log.snapshot)
+    }
+  }
+}


### PR DESCRIPTION
This is a simple extension of [Support concurrent writes](https://github.com/delta-io/delta/issues/72), which allows concurrent updates to independent partitions.

By default this feature is disabled, to enable set `enableConcurrentPartitionsWrite=true` at table level configuration (table metadata).

Typical use case for this feature is concurrent streaming with merge and compaction (repartition many small files to small amount of big files). Without this extension, one of the participants would constantly fail on `ConcurrentModificationException`.

**Algorithm principle:**

```
---- TX1: reads partition P1

- TX2: commits write on partition P2
- TX3: commits write on partition P3

---- TX1: tries to commit write on P1
```

In the current implementation P1 commit would fail with `ConcurrentWriteException` because TX1 have read data that could have been modified by TX2 and TX3 (no matter which partitions they modified).
The new implementation evaluates which partitions was modified by TX2 and TX3 and if there is no conflict (intersection) **with what TX1 was reading or is writing**, it lets the commit to happen.

This doesn't lower transaction isolation anyhow, so following 2 scenarios will fail.
Since TX1 have read P1 which was already modified by TX2, the TX1 will fail:
```
---- TX1: reads partition P1

- TX2: appends or updates or deletes anything in P1

---- TX1: tries to commit write on P2
```
Both transactions are modifying same partition, TX1 will fail:
```
---- TX1: reads partition P1

- TX2: appends or updates or deletes anything in P2

---- TX1: tries to commit write on P2
```