### PR TITLE
Fix comments in DeltaLog.createRelation

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -594,9 +594,9 @@ class DeltaLog private(
   }
 
   /**
-   * Returns a [[DataFrame]] that contains all of the data present
-   * in the table . This DataFrame will be continually updated
-   * as files are added or removed from the table. However, new [[DataFrame]]
+   * Returns a [[BaseRelation]] that contains all of the data present
+   * in the table. This relation will be continually updated
+   * as files are added or removed from the table. However, new [[BaseRelation]]
    * must be requested in order to see changes to the schema.
    */
   def createRelation(


### PR DESCRIPTION
The return type of `createRelation` should be `BaseRelation` instead of `DataFrame`.