### PR TITLE
Fix build warnings and remove unnecessary imports

### DIFF
--- a/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
+++ b/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
@@ -19,12 +19,12 @@ package io.delta.tables.execution
 import scala.collection.Map
 
 import org.apache.spark.sql.delta.PreprocessTableUpdate
-import org.apache.spark.sql.delta.{DeltaErrors, DeltaFullTable, DeltaHistoryManager, DeltaLog}
+import org.apache.spark.sql.delta.{DeltaErrors, DeltaHistoryManager, DeltaLog}
 import org.apache.spark.sql.delta.commands.{DeleteCommand, VacuumCommand}
 import org.apache.spark.sql.delta.util.AnalysisHelper
 import io.delta.tables.DeltaTable
 
-import org.apache.spark.sql.{functions, Column, DataFrame, SparkSession}
+import org.apache.spark.sql.{functions, Column, DataFrame}
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.expressions.{Expression, SubqueryExpression}
 import org.apache.spark.sql.catalyst.plans.logical._

--- a/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/merge.scala
+++ b/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/merge.scala
@@ -20,7 +20,7 @@ import java.util.Locale
 
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis._
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, Expression, NamedExpression, UnaryExpression, Unevaluable}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, UnaryExpression, Unevaluable}
 import org.apache.spark.sql.types.DataType
 
 /**

--- a/src/main/scala/org/apache/spark/sql/delta/PreprocessTableMerge.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/PreprocessTableMerge.scala
@@ -18,7 +18,6 @@ package org.apache.spark.sql.delta
 
 import java.util.Locale
 
-import org.apache.spark.sql.delta.{DeltaErrors, DeltaFullTable}
 import org.apache.spark.sql.delta.commands.MergeIntoCommand
 
 import org.apache.spark.sql.AnalysisException

--- a/src/main/scala/org/apache/spark/sql/delta/PreprocessTableUpdate.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/PreprocessTableUpdate.scala
@@ -16,7 +16,6 @@
 
 package org.apache.spark.sql.delta
 
-import org.apache.spark.sql.delta.{DeltaErrors, DeltaFullTable}
 import org.apache.spark.sql.delta.commands.UpdateCommand
 
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, UnresolvedAttribute}

--- a/src/main/scala/org/apache/spark/sql/delta/PreprocessTableUpdate.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/PreprocessTableUpdate.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta
 import org.apache.spark.sql.delta.commands.UpdateCommand
 
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, UnresolvedAttribute}
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, UpdateTable}
+import org.apache.spark.sql.catalyst.plans.logical.UpdateTable
 import org.apache.spark.sql.internal.SQLConf
 
 case class PreprocessTableUpdate(conf: SQLConf) extends UpdateExpressionsSupport {

--- a/src/main/scala/org/apache/spark/sql/delta/UpdateExpressionsSupport.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/UpdateExpressionsSupport.scala
@@ -16,8 +16,6 @@
 
 package org.apache.spark.sql.delta
 
-import org.apache.spark.sql.delta.DeltaErrors
-
 import org.apache.spark.sql.catalyst.analysis.{CastSupport, Resolver}
 import org.apache.spark.sql.catalyst.expressions.{Alias, CreateNamedStruct, Expression, GetStructField, Literal, NamedExpression}
 import org.apache.spark.sql.types._

--- a/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
@@ -27,7 +27,6 @@ import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.functions.input_file_name
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.BooleanType
 
 /**

--- a/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
@@ -32,7 +32,6 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import org.apache.hadoop.fs.{FileSystem, Path}
 
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
-import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.{Clock, SerializableConfiguration, SystemClock}
 
 /**


### PR DESCRIPTION
`build/sbt compile` shows:
```
[info] Compiling 72 Scala sources to /tmp/delta/target/scala-2.12/classes...
[warn] /tmp/delta/src/main/scala/org/apache/spark/sql/delta/PreprocessTableMerge.scala:21: imported `DeltaErrors' is permanently hidden by definition of object DeltaErrors in package delta
[warn] import org.apache.spark.sql.delta.{DeltaErrors, DeltaFullTable}
[warn]                                    ^
[warn] /tmp/delta/src/main/scala/org/apache/spark/sql/delta/PreprocessTableMerge.scala:21: imported `DeltaFullTable' is permanently hidden by definition of object DeltaFullTable in package delta
[warn] import org.apache.spark.sql.delta.{DeltaErrors, DeltaFullTable}
[warn]                                                 ^
[warn] /tmp/delta/src/main/scala/org/apache/spark/sql/delta/PreprocessTableUpdate.scala:19: imported `DeltaErrors' is permanently hidden by definition of object DeltaErrors in package delta
[warn] import org.apache.spark.sql.delta.{DeltaErrors, DeltaFullTable}
[warn]                                    ^
[warn] /tmp/delta/src/main/scala/org/apache/spark/sql/delta/PreprocessTableUpdate.scala:19: imported `DeltaFullTable' is permanently hidden by definition of object DeltaFullTable in package delta
[warn] import org.apache.spark.sql.delta.{DeltaErrors, DeltaFullTable}
[warn]                                                 ^
[warn] /tmp/delta/src/main/scala/org/apache/spark/sql/delta/UpdateExpressionsSupport.scala:19: imported `DeltaErrors' is permanently hidden by definition of object DeltaErrors in package delta
[warn] import org.apache.spark.sql.delta.DeltaErrors
[warn]                                   ^
[warn] there were two deprecation warnings; re-run with -deprecation for details
[warn] 6 warnings found
```

Remove unnecessary imports in some other files as well.