### PR TITLE
Disable the automatic async log cleanup in DeltaRetentionSuite to make tests stable

### DIFF
--- a/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
@@ -36,7 +36,7 @@ class DeltaRetentionSuite extends QueryTest
   protected val testOp = Truncate()
 
   protected override def sparkConf: SparkConf = super.sparkConf
-    // Disable the log cleanup because it runs asynchronously and causes tests flaky
+    // Disable the log cleanup because it runs asynchronously and causes test flakiness
     .set("spark.databricks.delta.properties.defaults.enableExpiredLogCleanup", "false")
 
   protected def intervalStringToMillis(str: String): Long = {

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.delta.actions.{Action, AddFile, RemoveFile}
 import org.apache.spark.sql.delta.util.FileNames
 import org.apache.hadoop.fs.Path
 
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.test.SharedSQLContext
 import org.apache.spark.unsafe.types.CalendarInterval
@@ -33,6 +34,11 @@ class DeltaRetentionSuite extends QueryTest
   with SharedSQLContext {
 
   protected val testOp = Truncate()
+
+  protected override def sparkConf: SparkConf = super.sparkConf
+    // Disable the log cleanup because it runs asynchronously and causes tests flaky
+    .set("spark.databricks.delta.properties.defaults.enableExpiredLogCleanup", "false")
+
 
   protected def intervalStringToMillis(str: String): Long = {
     CalendarInterval.fromString(str).milliseconds()

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
@@ -39,7 +39,6 @@ class DeltaRetentionSuite extends QueryTest
     // Disable the log cleanup because it runs asynchronously and causes tests flaky
     .set("spark.databricks.delta.properties.defaults.enableExpiredLogCleanup", "false")
 
-
   protected def intervalStringToMillis(str: String): Long = {
     CalendarInterval.fromString(str).milliseconds()
   }


### PR DESCRIPTION
Sometimes tests in DeltaRetentionSuite fail because of the automatic async log cleanup. This PR just disables to make tests stable.