### PR TITLE
Create a new branch for development against the Spark head snapshot.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,8 @@ crossScalaVersions := Seq("2.12.8", "2.11.12")
 
 scalaVersion := crossScalaVersions.value.head
 
-sparkVersion := "2.4.2"
+resolvers += "Apache Spark snapshot repository" at "https://repository.apache.org/content/repositories/snapshots"
+sparkVersion := "3.0.0-SNAPSHOT"
 
 libraryDependencies ++= Seq(
   // Adding test classifier seems to break transitive resolution of the core dependencies

--- a/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
+++ b/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
@@ -23,7 +23,8 @@ import org.apache.spark.sql.delta.{DeltaErrors, PreprocessTableMerge}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.util.AnalysisHelper
 
-import org.apache.spark.annotation.InterfaceStability._
+import org.apache.spark.annotation.Evolving
+import org.apache.spark.annotation.Unstable
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.plans.logical.{AnalysisHelper => _, _}

--- a/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -22,7 +22,8 @@ import org.apache.spark.sql.delta._
 import io.delta.tables.execution._
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.annotation.InterfaceStability._
+import org.apache.spark.annotation.Evolving
+import org.apache.spark.annotation.Unstable
 import org.apache.spark.sql._
 
 /**

--- a/src/test/scala/io/delta/tables/DeltaTableSuite.scala
+++ b/src/test/scala/io/delta/tables/DeltaTableSuite.scala
@@ -20,10 +20,10 @@ import java.util.Locale
 
 
 import org.apache.spark.sql.{AnalysisException, QueryTest}
-import org.apache.spark.sql.test.SharedSQLContext
+import org.apache.spark.sql.test.SharedSparkSession
 
 class DeltaTableSuite extends QueryTest
-  with SharedSQLContext {
+  with SharedSparkSession {
 
   test("forPath") {
     withTempDir { dir =>

--- a/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -19,11 +19,11 @@ package org.apache.spark.sql.delta
 import org.apache.spark.sql.delta.actions._
 
 import org.apache.spark.sql.QueryTest
-import org.apache.spark.sql.test.SharedSQLContext
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
 
 // scalastyle:off: removeFile
-class ActionSerializerSuite extends QueryTest with SharedSQLContext {
+class ActionSerializerSuite extends QueryTest with SharedSparkSession {
 
   roundTripCompare("Add",
     AddFile("test", Map.empty, 1, 1, dataChange = true))

--- a/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
@@ -23,11 +23,11 @@ import org.apache.hadoop.fs.Path
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
-import org.apache.spark.sql.test.SharedSQLContext
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.Utils
 
 abstract class DeleteSuiteBase extends QueryTest
-  with SharedSQLContext with BeforeAndAfterEach {
+  with SharedSparkSession with BeforeAndAfterEach {
 
   import testImplicits._
 

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -25,12 +25,12 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
-import org.apache.spark.sql.test.SharedSQLContext
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.Utils
 
 // scalastyle:off: removeFile
 class DeltaLogSuite extends QueryTest
-  with SharedSQLContext {
+  with SharedSparkSession {
 
   protected val testOp = Truncate()
 

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -23,11 +23,11 @@ import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.util.FileNames.deltaFile
 
 import org.apache.spark.sql.QueryTest
-import org.apache.spark.sql.test.SharedSQLContext
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
 
 trait DeltaProtocolVersionSuiteBase extends QueryTest
-    with SharedSQLContext {
+    with SharedSparkSession {
 
   private lazy val testTableSchema = spark.range(1).schema
 

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
@@ -25,13 +25,13 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.QueryTest
-import org.apache.spark.sql.test.SharedSQLContext
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.unsafe.types.CalendarInterval
 import org.apache.spark.util.ManualClock
 
 // scalastyle:off: removeFile
 class DeltaRetentionSuite extends QueryTest
-  with SharedSQLContext {
+  with SharedSparkSession {
 
   protected val testOp = Truncate()
 

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -30,11 +30,11 @@ import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRela
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.OPTIMIZER_METADATA_ONLY
-import org.apache.spark.sql.test.SharedSQLContext
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.Utils
 
 class DeltaSuite extends QueryTest
-  with SharedSQLContext {
+  with SharedSparkSession {
 
   import testImplicits._
 

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
@@ -31,11 +31,11 @@ import org.apache.commons.lang3.time.DateUtils
 import org.apache.hadoop.fs.{FileStatus, Path}
 
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
-import org.apache.spark.sql.test.SharedSQLContext
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.ManualClock
 
 class DeltaTimeTravelSuite extends QueryTest
-  with SharedSQLContext {
+  with SharedSparkSession {
 
   import testImplicits._
 

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
@@ -28,12 +28,12 @@ import org.apache.hadoop.fs.Path
 import org.scalatest.GivenWhenThen
 
 import org.apache.spark.sql.{QueryTest, SaveMode}
-import org.apache.spark.sql.test.SharedSQLContext
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.CalendarInterval
 import org.apache.spark.util.ManualClock
 
-trait DeltaVacuumSuiteBase extends QueryTest with SharedSQLContext with GivenWhenThen {
+trait DeltaVacuumSuiteBase extends QueryTest with SharedSparkSession with GivenWhenThen {
 
   test("don't delete data in a non-reservoir") {
     withEnvironment { (tempDir, clock) =>

--- a/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
@@ -22,12 +22,12 @@ import org.scalatest.Tag
 
 import org.apache.spark.sql.{AnalysisException, Column, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.execution.streaming.MemoryStream
-import org.apache.spark.sql.test.SharedSQLContext
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.Utils
 
 trait DescribeDeltaHistorySuiteBase
   extends QueryTest
-  with SharedSQLContext {
+  with SharedSparkSession {
 
   import testImplicits._
 

--- a/src/test/scala/org/apache/spark/sql/delta/EvolvabilitySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/EvolvabilitySuite.scala
@@ -26,12 +26,12 @@ import org.apache.spark.sql.{QueryTest, SparkSession}
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.functions.typedLit
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSQLContext
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.Utils
 
 class EvolvabilitySuite extends QueryTest
-  with SharedSQLContext {
+  with SharedSparkSession {
 
   import testImplicits._
 

--- a/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
@@ -25,12 +25,12 @@ import org.apache.spark.sql.delta.storage._
 import org.apache.hadoop.fs.{Path, RawLocalFileSystem}
 
 import org.apache.spark.sql.QueryTest
-import org.apache.spark.sql.test.SharedSQLContext
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.Utils
 
 abstract class LogStoreSuiteBase extends QueryTest
   with LogStoreProvider
-  with SharedSQLContext {
+  with SharedSparkSession {
 
   def logStoreClassName: String
 

--- a/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
@@ -25,13 +25,13 @@ import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSQLContext
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, MapType, StringType, StructType}
 import org.apache.spark.util.Utils
 
 abstract class MergeIntoSuiteBase
     extends QueryTest
-    with SharedSQLContext
+    with SharedSparkSession
     with BeforeAndAfterEach {
 
   import testImplicits._

--- a/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
@@ -26,13 +26,13 @@ import org.apache.hadoop.fs.Path
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
-import org.apache.spark.sql.test.SharedSQLContext
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 
 abstract class UpdateSuiteBase
   extends QueryTest
-  with SharedSQLContext
+  with SharedSparkSession
   with BeforeAndAfterEach {
   import testImplicits._
 


### PR DESCRIPTION
This will allow us to prepare in advance to use new APIs like data source v2.

Most of the diff here is classes being moved around. There's only one significant change: the PartitionCount physical plan metadata was removed, so we have to rewrite a test to use the equivalent SQL metric instead.