### PR TITLE
Add MIMA - Scala Binary Incompatability Check to sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,6 +85,23 @@ testScalastyle := scalastyle.in(Test).toTask("").value
 
 (test in Test) := ((test in Test) dependsOn testScalastyle).value
 
+/*********************
+ *  MIMA settings    *
+ *********************/
+
+(test in Test) := ((test in Test) dependsOn mimaReportBinaryIssues).value
+
+def getVersion(version: String): String = {
+    version.split("\\.").toList match {
+        case major :: minor :: rest => s"$major.$minor.0" ;
+        case _ => throw new Exception("Could not find previous version")
+    }
+}
+
+// versionString := version.value.replaceAll("-SNAPSHOT", "")
+mimaPreviousArtifacts := Set("io.delta" %% "delta-core" %  getVersion(version.value))
+mimaBinaryIssueFilters ++= MimaExcludes.ignoredABIProblems
+
 
 /*******************
  * Unidoc settings *

--- a/build.sbt
+++ b/build.sbt
@@ -98,7 +98,6 @@ def getVersion(version: String): String = {
     }
 }
 
-// versionString := version.value.replaceAll("-SNAPSHOT", "")
 mimaPreviousArtifacts := Set("io.delta" %% "delta-core" %  getVersion(version.value))
 mimaBinaryIssueFilters ++= MimaExcludes.ignoredABIProblems
 

--- a/build.sbt
+++ b/build.sbt
@@ -93,8 +93,8 @@ testScalastyle := scalastyle.in(Test).toTask("").value
 
 def getVersion(version: String): String = {
     version.split("\\.").toList match {
-        case major :: minor :: rest => s"$major.$minor.0" ;
-        case _ => throw new Exception("Could not find previous version")
+        case major :: minor :: rest => s"$major.$minor.0" 
+        case _ => throw new Exception(s"Could not find previous version for $version.")
     }
 }
 

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Databricks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.typesafe.tools.mima.core._
+import com.typesafe.tools.mima.core.ProblemFilters._
+
+/**
+ * The list of Mima errors to exclude.
+ */
+object MimaExcludes {
+  val ignoredABIProblems = Seq(
+      ProblemFilters.exclude[Problem]("org.*"),
+      ProblemFilters.exclude[Problem]("io.delta.tables.execution.*"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("io.delta.tables.DeltaTable.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("io.delta.tables.DeltaTable.executeHistory"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("io.delta.tables.DeltaTable.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("io.delta.tables.DeltaTable.deltaLog"))
+}
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -34,3 +34,5 @@ addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
+
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")


### PR DESCRIPTION
This PR adds MIMA to the build process of Delta Lake. During build process we fetch the latest release of Delta Lake and check if the new change would break any binary compatibility with the previous versions.

Note: `sbt test` would trigger MIMA check however they are not triggered with `sbt testOnly`