### PR TITLE
Try to delete leaked CRC file in HDFSLogStore due to HADOOP-16255

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/storage/HDFSLogStore.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/storage/HDFSLogStore.scala
@@ -102,7 +102,7 @@ class HDFSLogStore(sparkConf: SparkConf, defaultHadoopConf: Configuration) exten
         fc.rename(tempPath, path, renameOpt)
         renameDone = true
         // TODO: this is a workaround of HADOOP-16255 - remove this when HADOOP-16255 is resolved
-        mayRemoveCrcFile(fc, tempPath)
+        tryRemoveCrcFile(fc, tempPath)
       } catch {
         case e: org.apache.hadoop.fs.FileAlreadyExistsException =>
           throw new FileAlreadyExistsException(path.toString)
@@ -121,7 +121,7 @@ class HDFSLogStore(sparkConf: SparkConf, defaultHadoopConf: Configuration) exten
     new Path(path.getParent, s".${path.getName}.${UUID.randomUUID}.tmp")
   }
 
-  private def mayRemoveCrcFile(fc: FileContext, path: Path): Unit = {
+  private def tryRemoveCrcFile(fc: FileContext, path: Path): Unit = {
     try {
       val checksumFile = new Path(path.getParent, s".${path.getName}.crc")
       if (fc.util.exists(checksumFile)) {

--- a/src/main/scala/org/apache/spark/sql/delta/storage/HDFSLogStore.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/storage/HDFSLogStore.scala
@@ -22,6 +22,7 @@ import java.nio.file.FileAlreadyExistsException
 import java.util.{EnumSet, UUID}
 
 import scala.collection.JavaConverters._
+import scala.util.control.NonFatal
 
 import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
@@ -100,6 +101,8 @@ class HDFSLogStore(sparkConf: SparkConf, defaultHadoopConf: Configuration) exten
         val renameOpt = if (overwrite) Options.Rename.OVERWRITE else Options.Rename.NONE
         fc.rename(tempPath, path, renameOpt)
         renameDone = true
+        // TODO: this is a workaround of HADOOP-16255 - remove this when HADOOP-16255 is resolved
+        mayRemoveCrcFile(fc, tempPath)
       } catch {
         case e: org.apache.hadoop.fs.FileAlreadyExistsException =>
           throw new FileAlreadyExistsException(path.toString)
@@ -116,6 +119,18 @@ class HDFSLogStore(sparkConf: SparkConf, defaultHadoopConf: Configuration) exten
 
   private def createTempPath(path: Path): Path = {
     new Path(path.getParent, s".${path.getName}.${UUID.randomUUID}.tmp")
+  }
+
+  private def mayRemoveCrcFile(fc: FileContext, path: Path): Unit = {
+    try {
+      val checksumFile = new Path(path.getParent, s".${path.getName}.crc")
+      if (fc.util.exists(checksumFile)) {
+        // checksum file exists, deleting it
+        fc.delete(checksumFile, true)
+      }
+    } catch {
+      case NonFatal(_) => // ignore, we are removing crc file as "best-effort"
+    }
   }
 
   override def listFrom(path: Path): Iterator[FileStatus] = {

--- a/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
@@ -44,6 +44,23 @@ abstract class LogStoreSuiteBase extends QueryTest
   }
 
   test("read / write") {
+    def assertNoLeakedCrcFiles(dir: File): Unit = {
+      // crc file should not be leaked when origin file doesn't exist.
+      // The implementation of Hadoop filesystem may filter out checksum file, so
+      // listing files from local filesystem.
+      val fileNames = dir.listFiles().toSeq.filter(p => p.isFile).map(p => p.getName)
+      val crcFiles = fileNames.filter(n => n.startsWith(".") && n.endsWith(".crc"))
+      val originFileNamesForExistingCrcFiles = crcFiles.map { name =>
+        // remove first "." and last ".crc"
+        name.substring(1, name.length - 4)
+      }
+
+      // Check all origin files exist for all crc files.
+      assert(originFileNamesForExistingCrcFiles.toSet.subsetOf(fileNames.toSet),
+        s"Some of origin files for crc files don't exist - crc files: $crcFiles / " +
+          s"expected origin files: $originFileNamesForExistingCrcFiles / actual files: $fileNames")
+    }
+
     val tempDir = Utils.createTempDir()
     val store = createLogStore(spark)
 
@@ -53,6 +70,8 @@ abstract class LogStoreSuiteBase extends QueryTest
 
     assert(store.read(deltas(0)) == Seq("zero", "none"))
     assert(store.read(deltas(1)) == Seq("one"))
+
+    assertNoLeakedCrcFiles(tempDir)
   }
 
   test("detects conflict") {


### PR DESCRIPTION
Due to [HADOOP-16255](https://issues.apache.org/jira/browse/HADOOP-16255), `fc.rename` doesn't correctly rename CRC file of source file if filesystem is descendant of `ChecksumFs` (specifically `LocalFs`), which makes HDFSLogStore leak CRC files of temp files.

This patch will try to delete CRC file of source file when renaming, but just do as a "best-effort" since it's OK to leak some CRC file instead of let write fail.

Also added verification logic to check any leaked CRC files.