### PR TITLE
[ISSUE#140] Fix bug when deleting tombstones in vacuum interface

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -41,6 +41,7 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.analysis.{Resolver, UnresolvedAttribute}
 import org.apache.spark.sql.catalyst.expressions.{And, Attribute, Expression, In, InSet, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper
+import org.apache.spark.sql.delta.util.FileNames
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.sources.{BaseRelation, InsertableRelation}
 import org.apache.spark.util.{Clock, SystemClock, ThreadUtils}
@@ -536,6 +537,29 @@ class DeltaLog private(
       minFileRetentionTimestamp,
       this,
       commitTimestamp.getOrElse(-1L))
+  }
+
+  def getCurrentSnapshotWithRetentionTimestamp(minFileRetentionTimestamp: Long): Snapshot = {
+    update()
+    val deltaFiles = {
+      if (currentSnapshot.version < 0) {
+        Nil
+      } else {
+        val files = store.listFrom(FileNames.deltaFile(logPath, 0))
+          .filter(f => FileNames.isDeltaFile(f.getPath) || FileNames.isCheckpointFile(f.getPath))
+          .map(_.getPath).toSeq
+        val (_, deltas) = files.partition(f => isCheckpointFile(f))
+        deltas
+      }
+    }
+    new Snapshot(
+      logPath,
+      currentSnapshot.version,
+      None,
+      deltaFiles,
+      minFileRetentionTimestamp,
+      this,
+      -1)
   }
 
   /* ---------------------------------------- *


### PR DESCRIPTION
Fix the bug when deleting tombstones in vacuum interface.
When constructing the current snapshot for vacuum need to use retention period pass by vacuum interface instead of TOMBSTONE_RETENTION.
Add a test to illustrate this scene and test if meets expectation.