### PR TITLE
Add arbitrary replaceWhere functionality

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -47,6 +47,8 @@ trait DeltaWriteOptions
 
   val replaceWhere: Option[String] = options.get(REPLACE_WHERE_OPTION)
 
+  val arbitraryReplaceWhere: Option[String] = options.get(ARBITRARY_REPLACE_WHERE_OPTION)
+
   /**
    * Whether to add an adaptive shuffle before writing out the files to break skew, and coalesce
    * data into chunkier files.
@@ -119,6 +121,8 @@ object DeltaOptions {
 
   /** An option to overwrite only the data that matches predicates over partition columns. */
   val REPLACE_WHERE_OPTION = "replaceWhere"
+  /** An option to overwrite all data that matches the given predicates. */
+  val ARBITRARY_REPLACE_WHERE_OPTION = "arbitraryReplaceWhere"
   /** An option to allow automatic schema merging during a write operation. */
   val MERGE_SCHEMA_OPTION = "mergeSchema"
   /** An option to allow overwriting schema and partitioning during an overwrite write operation. */

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -47,8 +47,6 @@ trait DeltaWriteOptions
 
   val replaceWhere: Option[String] = options.get(REPLACE_WHERE_OPTION)
 
-  val arbitraryReplaceWhere: Option[String] = options.get(ARBITRARY_REPLACE_WHERE_OPTION)
-
   /**
    * Whether to add an adaptive shuffle before writing out the files to break skew, and coalesce
    * data into chunkier files.
@@ -121,8 +119,6 @@ object DeltaOptions {
 
   /** An option to overwrite only the data that matches predicates over partition columns. */
   val REPLACE_WHERE_OPTION = "replaceWhere"
-  /** An option to overwrite all data that matches the given predicates. */
-  val ARBITRARY_REPLACE_WHERE_OPTION = "arbitraryReplaceWhere"
   /** An option to allow automatic schema merging during a write operation. */
   val MERGE_SCHEMA_OPTION = "mergeSchema"
   /** An option to allow overwriting schema and partitioning during an overwrite write operation. */

--- a/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
@@ -50,7 +50,7 @@ trait DeltaCommand extends DeltaLogging {
   protected def verifyPartitionPredicates(
       spark: SparkSession,
       partitionColumns: Seq[String],
-      predicates: Seq[Expression]): Unit = {
+      predicates: Seq[Expression]): Boolean = {
 
     predicates.foreach { pred =>
       if (SubqueryExpression.hasSubquery(pred)) {
@@ -60,13 +60,12 @@ trait DeltaCommand extends DeltaLogging {
       pred.references.foreach { col =>
         val nameEquality = spark.sessionState.conf.resolver
         partitionColumns.find(f => nameEquality(f, col.name)).getOrElse {
-          throw new AnalysisException(
-            s"Predicate references non-partition column '${col.name}'. " +
-              "Only the partition columns may be referenced: " +
-              s"[${partitionColumns.mkString(", ")}]")
+          return false
         }
       }
     }
+
+    true
   }
 
   /**

--- a/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
@@ -37,7 +37,7 @@ trait DeltaCommand extends DeltaLogging {
    *
    * @throws AnalysisException if a non-partition column is referenced.
    */
-  protected def parsePartitionPredicates(
+  protected def parsePredicates(
       spark: SparkSession,
       predicate: String): Seq[Expression] = {
     try {

--- a/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -54,8 +54,7 @@ case class WriteIntoDelta(
     data: DataFrame)
   extends RunnableCommand
   with ImplicitMetadataOperation
-  with DeltaCommand
-  with PredicateHelper {
+  with DeltaCommand {
 
   override protected val canMergeSchema: Boolean = options.canMergeSchema
 

--- a/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -98,9 +98,6 @@ case class WriteIntoDelta(
     if (affectedFiles.isEmpty) {
       // no rows qualify the partition predicates
       Nil
-    } else if (otherPredicates.isEmpty) {
-      // this is the same as "replaceWhere" so just do the normal replaceWhere
-      buildReplaceWhereActions(spark, partitionColumns, Some(metadataPredicates), txn)
     } else {
 
       val affectedFileIndex = new TahoeBatchFileIndex(

--- a/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -100,7 +100,7 @@ case class WriteIntoDelta(
       Nil
     } else if (otherPredicates.isEmpty) {
       // this is the same as "replaceWhere" so just do the normal replaceWhere
-      replaceWhereActions(spark, partitionColumns, predicates, txn)
+      replaceWhereActions(spark, partitionColumns, Some(metadataPredicates), txn)
     } else {
 
       val affectedFileIndex = new TahoeBatchFileIndex(

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -932,14 +932,15 @@ class DeltaSuite extends QueryTest
         .partitionBy("value")
         .save(tempDir.getCanonicalPath)
 
-      Seq((4, 30), (5, 20)).toDF("key", "value")
+      Seq((4, 30), (5, 20), (6, 70)).toDF("key", "value")
         .write
         .format("delta")
         .mode("overwrite")
         .option(DeltaOptions.ARBITRARY_REPLACE_WHERE_OPTION, "key = 4 OR key = 5")
         .save(tempDir.getCanonicalPath)
 
-      checkDatasetUnorderly(data.toDF.as[(Int, Int)], 1 -> 10, 3 -> 10, 2 -> 20, 5 -> 20, 4 -> 30)
+      checkDatasetUnorderly(data.toDF.as[(Int, Int)],
+        1 -> 10, 3 -> 10, 2 -> 20, 5 -> 20, 4 -> 30, 6 -> 70)
     }
   }
 

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -964,6 +964,27 @@ class DeltaSuite extends QueryTest
     }
   }
 
+  test("arbitraryReplaceWhere with partition predicate only") {
+    withTempDir { tempDir =>
+      def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
+
+      Seq((1, 10), (2, 20), (3, 10), (4, 20), (4, 10)).toDF("key", "value")
+        .write
+        .format("delta")
+        .partitionBy("value")
+        .save(tempDir.getCanonicalPath)
+
+      Seq((4, 30), (5, 20)).toDF("key", "value")
+        .write
+        .format("delta")
+        .mode("overwrite")
+        .option(DeltaOptions.ARBITRARY_REPLACE_WHERE_OPTION, "value = 20")
+        .save(tempDir.getCanonicalPath)
+
+      checkDatasetUnorderly(data.toDF.as[(Int, Int)], 1 -> 10, 3 -> 10, 4 -> 10, 5 -> 20)
+    }
+  }
+
   test("arbitraryReplaceWhere with no matching predicates") {
     withTempDir { tempDir =>
       def data: DataFrame = spark.read.format("delta").load(tempDir.toString)

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -961,7 +961,8 @@ class DeltaSuite extends QueryTest
         .option(DeltaOptions.ARBITRARY_REPLACE_WHERE_OPTION, "(key = 4 AND value = 20) OR key = 5")
         .save(tempDir.getCanonicalPath)
 
-      checkDatasetUnorderly(data.toDF.as[(Int, Int)], 1 -> 10, 3 -> 10, 4 -> 10, 2 -> 20, 5 -> 20)
+      checkDatasetUnorderly(data.toDF.as[(Int, Int)],
+        1 -> 10, 3 -> 10, 4 -> 10, 2 -> 20, 5 -> 20, 4 -> 30)
     }
   }
 

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -982,7 +982,7 @@ class DeltaSuite extends QueryTest
         .option(DeltaOptions.ARBITRARY_REPLACE_WHERE_OPTION, "value = 20")
         .save(tempDir.getCanonicalPath)
 
-      checkDatasetUnorderly(data.toDF.as[(Int, Int)], 1 -> 10, 3 -> 10, 4 -> 10, 5 -> 20)
+      checkDatasetUnorderly(data.toDF.as[(Int, Int)], 1 -> 10, 3 -> 10, 4 -> 10, 4 -> 30, 5 -> 20)
     }
   }
 


### PR DESCRIPTION
**Feature Request:**
Create ability to selectively overwrite only the data that matches predicates over arbitrary columns using the same syntactical approach as `replaceWhere`.

**Requirements:**
Given a set of column and values for them from an input DataFrame, remove all rows in a target Delta table that meet that condition and replace them with the rows from the input DataFrame. Note that the record matches do not have to be unique.

**Why is this different than upsert?** With upsert existing rows are changed and new rows are inserted. This function not only requires changes and inserts, but also deletes.

**Why can’t the existing replaceWhere function be used?** replaceWhere is only good in the case of replacing complete partitions. Not individual records belonging to it.
