### PR TITLE
Specification for the Delta Transaction Protocol

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -165,7 +165,7 @@ The `remove` action includes a timestamp that indicates when the removal occurre
 Physical deletion of the file can happen lazily after some user-specified expiration time threshold.
 This delay allows concurrent readers to continue to execute against a stale snapshot of the data.
 A `remove` action should remain in the state of the table as a _tombstone_ until it has expired.
-A tombstone expires when the table version timestamo
+A tombstone expires when the creation timestamp of the table version file exceeds the expiration threshold added to the `remove` action timestamp.
 
 Since actions within a given Delta file are not guaranteed to be applied in order, it is not valid for multiple file operations with the same path to exist in a single version.
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1,0 +1,233 @@
+* auto-gen TOC:
+{:toc}
+
+# Overview
+Goals
+- Serializable ACID Transactions
+- Efficient operation on a variety of storage systems
+- Scalability to billions of files / partitions
+- Self describing
+- Support for incremental processing through streaming
+- Evolvable
+
+# Blob Store Requirements
+The protocol requires the following from the underlying storage system.
+In some cases where the requirements are not met, we can still correctly implement the protocol by running an extra service for that particular cloud.
+For example, while S3 does not provide mutual exclusion, we can satisfy this requirement by using a centralized commit service.
+ - Atomic File Creation - The tahoe protocol requires that delta files are created atomically in order to support atomicity of higher level operations. When atomic creation is not available this can also be satisfied by atomic rename.
+ - Mutual Exclusion - Two clients must not both succeed at creating a particular delta file, as this would violate our requirement of a single linear history.
+ - Partial Listing - We may retain an arbitrarily large number of delta log entries both for provenance information and to allow users to read old snapshots of the table. As such, for good performance, we require the blob store to allow us to list files in lexicographic order starting at a given file name.
+
+# Transaction Log Protocol
+
+## File Layout
+The log for a delta table is stored in directory on DBFS (e.g., /home/michael/data/_delta_log). This would typically be at the same location as the root of the partitioned data files, though that is not a strict requirement.  In order to modify the state of the table, a writer must append a delta file that contains an unordered list of actions.  Delta files are named using consecutive integers and are zero padded to allow for efficient ordered enumeration.
+
+```
+dbfs:/mnt/streaming/tahoe/usage/_delta_log/00000000000000000000.json
+dbfs:/mnt/streaming/tahoe/usage/_delta_log/00000000000000000001.json
+dbfs:/mnt/streaming/tahoe/usage/_delta_log/00000000000000000002.json
+```
+
+Delta files are named using consecutive numbers and the log store ensure that concurrent writers are unable to successfully write the same delta file, giving us an agreed upon linear history for the table.  The state of the table is defined as the result of replaying all of the actions in the delta log in order.
+
+- TODO: MVCC
+- TODO: Action ordering within a table version. Invalid to include multiple conflicting actions
+- TODO: Add example files w/ optional partition directories
+- TODO: Add checkpoints
+- TODO: Add last checkpoint
+- TODO: Parquet file naming. should use guids
+
+## Table State
+At a high level, the current state of the table is defined as follows:
+ - The current metadata, including: the schema of the table, a unique identifier, partition columns, and other configuration properties (i.e., if the table is append only)
+ - The files present in the table, along with metadata about those files, including: the size of the file, partition values, statistics.
+ - Tombstones, which indicate that file was recently deleted and should remain temporarily to allow for reading of stale snapshots.
+ - Applications specific transaction versions, which allow applications such as a structured streaming to make changes to the table in an idempotent manner.
+ - Protocol Version
+
+The state of the table is changed by appending a new delta file to the log for a given table. Delta files contain actions, such as adding or removing a file. Most importantly, delta files are the unit of atomicity (i.e., each delta file represents a set of actions that will all happen atomically).
+
+## Actions
+
+### Add File
+
+### Remove File
+
+A file operation adds or removes a path from the table. The AddFile operation also includes information about partition values and statistics such as file size that are useful in query planning.
+
+Files are defined to be unique by the path (and thus the same path may not exist in a table twice).  This restriction means we can update a files metadata by adding it again in a subsequent delta file. In this case, when a duplicate path is observed in a later delta, the metadata of the latest action defines the new state of the table.
+
+Relative paths are assumed to be based at the parent of the _delta_log directory.  This allows the log to work with mount points or external file operations (such as cp or mv) that move the entire collection of data.  Absolute paths are also supported, though we need to decide if this mechanism will be exposed to end users.
+
+Removal of a file also includes a timestamp that indicates when the deletion occurred.  Physical deletion of the file can happen lazily after some user specified time threshold.  This delay allows concurrent readers to continue to execute against a stale snapshot of the data.  This tombstone should be maintained in the state of the table until after the threshold has been crossed.
+
+Since actions within a given delta file are not guaranteed to be applied in order, it is not valid for multiple file operations with the same path to exist in a single delta file.
+
+The `dataChange` flag is used to indicate that an operation only rearranges existing data or adds new statistics, and does not result in a net change in the data present in the table.  This flag is useful if we want to use the transaction log as a source for a streaming query.
+
+Stats contains a json encoded set of statistics about the file.  Clients should always assume that statistics can be missing.
+
+```
+{
+  "add": {
+    "path":"date=2017-12-10/part-000...c000.gz.parquet",
+    "partitionValues":{"date":"2017-12-10"},
+    "size":841454,
+    "modificationTime":1512909768000,
+    "dataChange":true
+    "stats":"{\"numRecords\":1,\"minValues\":{\"val..."
+  }
+}
+
+{
+  "remove":{
+    "path":"part-00001-9…..snappy.parquet",
+    "deletionTimestamp":1515488792485,
+    "dataChange":false
+  }
+}
+```
+
+### Transaction Identifiers
+
+The ability to make the application of a delta file idempotent is a useful primitive.  Examples use cases include both streaming appends and directly allowing users to build fault tolerant data pipelines. These use cases are enabled by tracking a version for a user-specified application id.  For any given application id, the table state tracks the most recent version.  Modifications to this version can be atomically committed along with other actions such as appends to make them idempotent.
+
+Note that the semantics of the version number are the responsibility of the higher layer,  and the log replay should not make an assumption other than last update wins and concurrent modifications should fail. For example, the protocol does not assume monotonicity and it would be valid for the version to decrement, "undoing" a given operation.
+
+```
+{
+  "txn": {
+    "appId":"3ba13872-2d47-4e17-86a0-21afd2a22395",
+    "version":364475
+  }
+}
+```
+
+### Change Metadata
+
+Field Name | Data Type | Description
+-|-|-
+id|`GUID`|Unique identifier for this table
+name|`String`| User provided identifier for this table
+description|`String`| User provided description for this table
+format|[Format Struct](#Format-Specification)| Specification of the encoding for the files stored in the table
+schemaString|[Schema Struct](#Schema-Specification)| Schema of the table
+partitionColumns|`Array[String]`| An array containing the names of columns that the data should be partitioned by.
+
+
+The metadata of the table contains information that identifies its contents or controls how the data is read (i.e., should we use json or parquet).  The metadata of the table is defined as the metadata action found in the most recent delta that contains one.
+
+```
+{
+  "metaData":{
+    "id":"af23c9d7-fff1-4a5a-a2c8-55c59bd782aa",
+    "format":{"provider":"parquet","options":{}},
+    "schemaString":"...",
+    "partitionColumns":[],
+    "configuration":{
+      "appendOnly": "true"
+    }
+  }
+}
+```
+
+TODO: Options that are mandatory.
+
+#### Format Specification
+Field Name | Data Type | Description
+-|-|-
+provider|`String`|Name of the encoding for files in this table
+options|`Map[String, String]`|A map containing configuration options for the format
+
+In the reference implementation the provider is use to instantiate a Spark SQL [`FileFormat`](https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala). As of Spark 2.4.3 there is built-in `FileFormat` support for `parquet`, `csv`, `orc`, `json`, and `text`.
+
+However, currently, user facing APIs only allow users to create tables where `format = 'parquet'` and `options = {}`. Support for reading other formats remains both for legacy reasons and to enable possible support for other formats in the future.
+
+#### Schema Specification
+
+##### Primitive Types
+Type Name | Description
+-|-
+string| UTF-8 encoded string of characters.
+integer|4-byte signed integer. Range: -2147483648 to 2147483647.
+short| 2-byte signed integer numbers. Range: -32768 to 32767
+byte| 1-byte signed integer number. Range: -128 to 127
+float| 4-byte single-precision floating point numbers
+double| 8-byte double-precision floating point numbers
+boolean| `true` or `false`
+binary| A sequence of binary data.
+date| A calendar date, represented as a year-month-day triple without a timezone.
+timestamp| Microsecond precision timestamp without a timezone.
+
+##### Struct Types
+
+A struct is used to represent both the top level schema of the table as well as columns that are nested within another column of the table. It is encoded as a JSON object with the following fields.
+
+Field Name | Description
+-|-
+type | Always the string "struct".
+fields | An array of fields.
+
+A struct field is encoded as follows:
+
+Field Name | Description
+-|-
+name| Name of this (possibly nested) column.
+type| A string containing the name of a primitive type, a struct definition, an array definition or a map defintion.
+nullable| Boolean denoting whether this field can be null.
+metadata| A JSON map containing information about this column. Keys prefixed with `delta` are reserved for the implementation. See [TODO](#) for more information on column level metadata that must clients must handle when writing to a table.
+
+##### Array Types
+
+##### Map Types
+
+
+
+### Change Protocol Version
+
+Field Name | Data Type | Description
+-|-|-
+minReaderVersion | Int | The minimum version of the Delta read protocol that a client must implement in order to correctly *read* this table.
+minWriterVersion | Int | The minimum version of the Delta write protocol that a client must implement in order to correctly *write* this table.
+
+
+The protocol versioning action allows for a newer client to exclude older readers and/or writers.  An exclusion should be used whenever non-forward compatible changes are made to the protocol. In the case where a client is running an invalid version, an error should be thrown instructing the user to upgrade to a newer version of DBR.
+
+```
+{
+  "protocol":{
+    "minReaderVersion":1,
+    "minWriterVersion":1
+  }
+}
+```
+
+TODO: Discuss ignoring fields
+
+### Commit Provenance Information
+Commits can optionally contain additional provenance information about what higher level operation was being performed as well as who executed it.  This information can be used both when looking at the history of the table as well as when throwing a concurrent modification exception.
+```
+{
+  "commitInfo":{
+    "timestamp":1515491537026,
+    "userId":"100121",
+    "userName":"michael@databricks.com",
+    "operation":"INSERT",
+    "operationParameters":{"mode":"Append","partitionBy":"[]"},
+    "notebook":{
+      "notebookId":"4443029",
+      "notebookPath":"Users/michael@databricks.com/actions"},
+      "clusterId":"1027-202406-pooh991"
+  }  
+}
+```
+
+## Checkpoints
+As the number of delta files grows, it becomes increasingly expensive to reconstruct the current state of the table from scratch.  In order to mitigate this problem, Delta will regularly produce a checkpoint file, which contains the current state of up until some delta version. Future readers can start with this file and only read deltas that come afterwards.
+
+Note that when producing a checkpoint, it is important to first write out the delta file, ensuring that all writers agree on what the contents of the checkpoint should be.  Ensuring that checkpoints are deterministic means that we can relax the requirements on creation.  In particular, there is no need for mutual exclusion when producing a checkpoint.  If multiple writers try and create the same checkpoint, it does not matter which one wins.
+
+Metadata about the last checkpoint that was written out is stored in a file name _last_checkpoint, and includes its version and its size. This information allows repository to keep a long history of without increasing the cost of loading the current state.  Note that, as this is only an optimization, it does not cause correctness problems if _last_checkpoint is stale due to concurrent writers or eventual consistency.
+
+TODO: Invariants...

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -233,8 +233,8 @@ The protocol does not, for example, assume appId version monotonicity and it wou
 The schema of the `txn` action is as follows:
 Field Name | Data Type | Description
 -|-|-
-appId | String | A unique identifier for the application performing the transaction.
-version | Long | An application-specific numeric identifier for this transaction.
+appId | String | A unique identifier for the application performing the transaction
+version | Long | An application-specific numeric identifier for this transaction
 
 The following is an example `txn` action:
 ```
@@ -249,17 +249,17 @@ The following is an example `txn` action:
 ### Protocol Evolution
 The `protocol` action is used to set the version of the Delta protocol that is required to read or write a given table.
 Protocol versioning allows a newer client to exclude older readers and/or writers that are missing features required to correctly interpret the transaction log.
-The protocol version will be increased whenever non-forward-compatible changes are made to this specification.
-In the case where a client is running an invalid version, an error should be thrown instructing the user to upgrade to a newer version of their Delta client library.
+The _protocol version_ will be increased whenever non-forward-compatible changes are made to this specification.
+In the case where a client is running an invalid protocol version, an error should be thrown instructing the user to upgrade to a newer protocol version of their Delta client library.
 
-Since breaking changes must be accompanied by an increase in the tables protocol version, clients can assume that unrecognized fields or actions are not required to correctly interpret the transaction log.
+Since breaking changes must be accompanied by an increase in the protocol version recorded in a table, clients can assume that unrecognized fields or actions are never required in order to correctly interpret the transaction log.
 
 The schema of the `protocol` action is as follows:
 
 Field Name | Data Type | Description
 -|-|-
-minReaderVersion | Int | The minimum version of the Delta read protocol that a client must implement in order to correctly *read* this table.
-minWriterVersion | Int | The minimum version of the Delta write protocol that a client must implement in order to correctly *write* this table.
+minReaderVersion | Int | The minimum version of the Delta read protocol that a client must implement in order to correctly *read* this table
+minWriterVersion | Int | The minimum version of the Delta write protocol that a client must implement in order to correctly *write* this table
 
 The current version of the Delta protocol is:
 ```
@@ -272,10 +272,11 @@ The current version of the Delta protocol is:
 ```
 
 ### Commit Provenance Information
-Table versions can optionally contain additional provenance information about what higher level operation was being performed as well as who executed it.
+Table versions can optionally contain additional provenance information about what higher-level operation was being performed as well as who executed it.
 
-Implementations are free to store any valid JSON in the `commitInfo` action.
+Implementations are free to store any valid JSON-formatted data via the `commitInfo` action.
 
+An example of storing provenance information related to an `INSERT` operation:
 ```
 {
   "commitInfo":{
@@ -318,8 +319,8 @@ For example, it is not valid to change the partitioning of the table without als
 # Appendix
 
 ## Per-file Statistics
-`add` file actions can optionally contain statistics about the data in the file being added to the table.
-These statistics can be used for eliminating files based on query predicates or as input to query optimization.
+`add` actions can optionally contain statistics about the data in the file being added to the table.
+These statistics can be used for eliminating files based on query predicates or as inputs to query optimization.
 
 Global statistics record information about the entire file.
 The following global statistic is currently supported:
@@ -328,7 +329,7 @@ Name | Description
 -|-
 numRecords | The number of records in this file.
 
-Per column statistics record stats for each column in the file and they are encoded mirroring the schema of the actual data.
+Per-column statistics record information for each column in the file and they are encoded mirroring the schema of the actual data.
 For example, given the following data schema:
 ```
 |-- a: struct
@@ -354,9 +355,9 @@ The following per-column statistics are currently supported:
 
 Name | Description
 -|-
-nullCount | The number of null values for this column.
-minValues | A value smaller than all values present in the file for this column.
-maxValues | A value larger than all values present in the file for this colunn.
+nullCount | The number of null values for this column
+minValues | A value smaller than all values present in the file for this column
+maxValues | A value larger than all values present in the file for this colunn
 
 
 ## Schema Serialization Format
@@ -368,8 +369,8 @@ A reference implementation can be found in [the catalyst package of the Apache S
 
 Type Name | Description
 -|-
-string| UTF-8 encoded string of characters.
-integer|4-byte signed integer. Range: -2147483648 to 2147483647.
+string| UTF-8 encoded string of characters
+integer|4-byte signed integer. Range: -2147483648 to 2147483647
 short| 2-byte signed integer numbers. Range: -32768 to 32767
 byte| 1-byte signed integer number. Range: -128 to 127
 float| 4-byte single-precision floating point numbers
@@ -381,12 +382,12 @@ timestamp| Microsecond precision timestamp without a timezone.
 
 ### Struct Type
 
-A struct is used to represent both the top level schema of the table as well as struct columns that contain nested columns. A struct is encoded as a JSON object with the following fields.
+A struct is used to represent both the top-level schema of the table as well as struct columns that contain nested columns. A struct is encoded as a JSON object with the following fields:
 
 Field Name | Description
 -|-
-type | Always the string "struct".
-fields | An array of fields.
+type | Always the string "struct"
+fields | An array of fields
 
 ### Struct Field
 
@@ -394,9 +395,9 @@ A struct field represents a top level or nested column.
 
 Field Name | Description
 -|-
-name| Name of this (possibly nested) column.
-type| String containing the name of a primitive type, a struct definition, an array definition or a map definition.
-nullable| Boolean denoting whether this field can be null.
+name| Name of this (possibly nested) column
+type| String containing the name of a primitive type, a struct definition, an array definition or a map definition
+nullable| Boolean denoting whether this field can be null
 metadata| A JSON map containing information about this column. Keys prefixed with `Delta` are reserved for the implementation. See [TODO](#) for more information on column level metadata that must clients must handle when writing to a table.
 
 ### Array Type
@@ -405,9 +406,9 @@ An array stores a variable length collection of items of some type.
 
 Field Name | Description
 -|-
-type| Always the string "array".
-elementType| The type of element stored in this array represented as a string containing the name of a primitive type, a struct definition, an array definition or a map definition.
-containsNull| Boolean denoting whether this array can contain one or more null values.
+type| Always the string "array"
+elementType| The type of element stored in this array represented as a string containing the name of a primitive type, a struct definition, an array definition or a map definition
+containsNull| Boolean denoting whether this array can contain one or more null values
 
 ### Map Type
 
@@ -416,8 +417,8 @@ A map stores an arbitrary length collection of key-value pairs with a single `ke
 Field Name | Description
 -|-
 type| Always the string "map".
-keyType| The type of element used for the key of this map, represented as a string containing the name of a primitive type, a struct definition, an array definition or a map definition.
-valueType| The type of element used for the key of this map, represented as a string containing the name of a primitive type, a struct definition, an array definition or a map definition.
+keyType| The type of element used for the key of this map, represented as a string containing the name of a primitive type, a struct definition, an array definition or a map definition
+valueType| The type of element used for the key of this map, represented as a string containing the name of a primitive type, a struct definition, an array definition or a map definition
 
 ### Example
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -37,7 +37,7 @@ This document is a specification for the Delta Transaction Protocol, which bring
 - **Self describing** - all metadata for a Delta table is stored alongside the data, static tables can be copied or moved using standard tools.
 - **Support for incremental processing** - readers can tail the Delta log to determine what data has been added in a given period of time, allowing for efficient streaming.
 
-Delta supports the above by implementing MVCC using a set of data files (encoded using parquet) along with a transaction log that tracks which files are part of the table at any given version.
+Delta supports the above by implementing MVCC using a set of data files (encoded using Apache Parquet) along with a transaction log that tracks which files are part of the table at any given version.
 
 # Delta Table Specification
 A Delta table is comprised of a set of _data files_ along with a _transaction log_ that records the state of the table in a sequence of contiguous, monotonically increasing table _versions_.

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -124,7 +124,7 @@ Since it is possible that a writer will fail while writing out one or more parts
 Checkpoints for a given version must only be created after the associated delta file has been successfully written.
 
 ### Last Checkpoint File
-The Delta transaction log will often contain many (e.g. 100,000+) files.
+The Delta transaction log will often contain many (e.g. 10,000+) files.
 Listing such a large directory can be prohibitively expensive.
 The last checkpoint file can help reduce the cost of constructing the lastest snapshot of the table by providing a pointer to near the end of the log.
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1,6 +1,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-Delta Transaction Log Protocol
+# Delta Transaction Log Protocol
 
 - [Overview](#overview)
 - [Delta Table Specification](#delta-table-specification)
@@ -36,12 +36,12 @@ This document is a specification for the Delta Transaction Protocol, which bring
 
 - **Serializable ACID Writes** - multiple writers can concurrently modify a Delta table while maintaining ACID semantics.
 - **Snapshot Isolation for Reads** - readers can read a consistent snapshot of a Delta table, even in the face of concurrent writes.
-- **Scalability to billions of partitions or file** - queries against a Delta table can be planned on a single machine or in parallel.
+- **Scalability to billions of partitions or files** - queries against a Delta table can be planned on a single machine or in parallel.
 - **Self describing** - all metadata for a Delta table is stored alongside the data. This design eliminates the need to maintain a separate metastore just to read the data and also allows static tables to be copied or moved using standard filesystem tools.
 - **Support for incremental processing** - readers can tail the Delta log to determine what data has been added in a given period of time, allowing for efficient streaming.
 
 Delta's transactions are implemented using multi-version concurrency control (MVCC).
-As a table changes, Delta's MVCC algorithm  keeps multiple copies of the data around, rather than immediately replacing files that contain records that are being updated or removed.
+As a table changes, Delta's MVCC algorithm keeps multiple copies of the data around rather than immediately replacing files that contain records that are being updated or removed.
 
 Readers of the table ensure that they only see one consistent _snapshot_ of a table at time by using the _transaction log_ to selectively choose which _data files_ to process.
 
@@ -50,7 +50,7 @@ First, they optimistically write out new data files or updated copies of existin
 Then, they _commit_, creating the latest _atomic version_ of the table by adding a new entry to the log.
 In this log entry they record which data files to logically add and remove, along with changes to other metadata about the table.
 
-Data files that are no longer present in the latest version of the table can be lazily deleted by the vacuum command, after a user-specified retention period (default 7 days).
+Data files that are no longer present in the latest version of the table can be lazily deleted by the vacuum command after a user-specified retention period (default 7 days).
 
 # Delta Table Specification
 A table has a single serial history of atomic versions, which are named using contiguous, monotonically-increasing integers.
@@ -252,7 +252,7 @@ The following is an example `remove` action.
 ```
 
 ### Transaction Identifiers
-Incremental processing systems (e.g., streaming systems) that track progress using their own application-specific versions, need to record what progress has been made, in order to avoid duplicating data in the face of failures and retries during a write.
+Incremental processing systems (e.g., streaming systems) that track progress using their own application-specific versions need to record what progress has been made, in order to avoid duplicating data in the face of failures and retries during a write.
 Transaction identifiers allow this information to be recorded atomically in the transaction log of a delta table along with the other actions that modify the contents of the table.
 
 Transaction identifiers are stored in the form of `appId` `version` pairs, where `appId` is a unique identifier for the process that is modifying the table and `version` is an indication of how much progress has been made by that application.
@@ -339,12 +339,12 @@ This section documents additional requirements that writers must follow in order
  - Writers MUST never overwrite an existing log entry. When ever possible they should use atomic primitives of the underlying filesystem to ensure concurrent writers do not overwrite each others entries.
 
 ## Consistency Between Table Metadata and Data Files
- - Any column that exists in a data files present in the table MUST also be present in the metadata of the table.
+ - Any column that exists in a data file present in the table MUST also be present in the metadata of the table.
  - Values for all partition columns present in the schema MUST be present for all files in the table.
  - Columns present in the schema of the table MAY be missing from data files. Readers SHOULD fill these missing columns in with `null`.
 
 ## Delta Log Entries
-- A single long entry MUST NOT include more than one action that reconcile with each other.
+- A single log entry MUST NOT include more than one action that reconcile with each other.
   - Add / Remove actions with the same `path`
   - More than one Metadata action
   - More than one protocol action

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1,13 +1,13 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-# Delta Transaction Log Protocol
+Delta Transaction Log Protocol
 
 - [Overview](#overview)
 - [Delta Table Specification](#delta-table-specification)
   - [File Types](#file-types)
-    - [Versions](#versions)
-    - [Checkpoints](#checkpoints)
     - [Data Files](#data-files)
+    - [Delta Log Entries](#delta-log-entries)
+    - [Checkpoints](#checkpoints)
     - [Last Checkpoint File](#last-checkpoint-file)
   - [Actions](#actions)
     - [Change Metadata](#change-metadata)
@@ -18,6 +18,7 @@
     - [Commit Provenance Information](#commit-provenance-information)
 - [Appendix](#appendix)
   - [Per-file Statistics](#per-file-statistics)
+  - [Partition Value Serialization](#partition-value-serialization)
   - [Schema Serialization Format](#schema-serialization-format)
     - [Primitive Types](#primitive-types)
     - [Struct Type](#struct-type)


### PR DESCRIPTION
This PR adds a specification for the Delta Transaction Protocol. The goal of this specification is to allow other implementors to build integrations that read and write from a Delta table. This is an early draft that should contain all the information needed to correctly read from a delta table. There are TODOs later in the document, that will be fleshed out in a future PR, on the additional requirements for modifying a table.