### PR TITLE
[Minor] Rename the logical operator UpdateTable to Update

### DIFF
--- a/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
+++ b/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
@@ -55,11 +55,11 @@ trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
   protected def makeUpdateTable(
       target: DeltaTable,
       onCondition: Option[Column],
-      setColumns: Seq[(String, Column)]): UpdateTable = {
+      setColumns: Seq[(String, Column)]): Update = {
     val updateColumns = setColumns.map { x => UnresolvedAttribute.quotedString(x._1) }
     val updateExpressions = setColumns.map{ x => x._2.expr }
     val condition = onCondition.map {_.expr}
-    UpdateTable(
+    Update(
       target.toDF.queryExecution.analyzed, updateColumns, updateExpressions, condition)
   }
 
@@ -80,7 +80,7 @@ trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
 
     val update = makeUpdateTable(self, condition, setColumns)
     val resolvedUpdate =
-      UpdateTable.resolveReferences(update, tryResolveReferences(sparkSession)(_, update))
+      Update.resolveReferences(update, tryResolveReferences(sparkSession)(_, update))
     val updateCommand = PreprocessTableUpdate(sparkSession.sessionState.conf)(resolvedUpdate)
     updateCommand.run(sparkSession)
   }

--- a/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Update.scala
+++ b/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Update.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeRef
  * @param updateExpressions: the corresponding update expression if the condition is matched
  * @param condition: Only rows that match the condition will be updated
  */
-case class UpdateTable(
+case class Update(
     child: LogicalPlan,
     updateColumns: Seq[Attribute],
     updateExpressions: Seq[Expression],
@@ -40,21 +40,21 @@ case class UpdateTable(
   override def output: Seq[Attribute] = Seq.empty
 }
 
-object UpdateTable {
+object Update {
 
   /** Resolve all the references of target columns and condition using the given `resolver` */
-  def resolveReferences(update: UpdateTable, resolver: Expression => Expression): UpdateTable = {
+  def resolveReferences(update: Update, resolver: Expression => Expression): Update = {
     if (update.resolved) return update
     assert(update.child.resolved)
 
-    val UpdateTable(child, updateColumns, updateExpressions, condition) = update
+    val Update(child, updateColumns, updateExpressions, condition) = update
 
     val cleanedUpAttributes = updateColumns.map { unresolvedExpr =>
       // Keep them unresolved but use the cleaned-up name parts from the resolved
       val errMsg = s"Failed to resolve ${unresolvedExpr.sql} given columns " +
         s"[${child.output.map(_.qualifiedName).mkString(", ")}]."
       val resolveNameParts =
-        UpdateTable.getNameParts(resolver(unresolvedExpr), errMsg, update)
+        Update.getNameParts(resolver(unresolvedExpr), errMsg, update)
       UnresolvedAttribute(resolveNameParts)
     }
 

--- a/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/merge.scala
+++ b/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/merge.scala
@@ -282,7 +282,7 @@ object MergeInto {
             // If clause allows nested field to be target, then this will return the all the
             // parts of the name (e.g., "a.b" -> Seq("a", "b")). Otherwise, this will
             // return only one string.
-            val resolvedNameParts = UpdateTable.getNameParts(
+            val resolvedNameParts = Update.getNameParts(
               resolveOrFail(unresolvedAttrib, fakeTargetPlan, s"$typ clause"),
               resolutionErrorMsg,
               merge)

--- a/src/main/scala/org/apache/spark/sql/delta/PreprocessTableUpdate.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/PreprocessTableUpdate.scala
@@ -19,11 +19,11 @@ package org.apache.spark.sql.delta
 import org.apache.spark.sql.delta.commands.UpdateCommand
 
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, UnresolvedAttribute}
-import org.apache.spark.sql.catalyst.plans.logical.UpdateTable
+import org.apache.spark.sql.catalyst.plans.logical.Update
 import org.apache.spark.sql.internal.SQLConf
 
 case class PreprocessTableUpdate(conf: SQLConf) extends UpdateExpressionsSupport {
-  def apply(update: UpdateTable): UpdateCommand = {
+  def apply(update: Update): UpdateCommand = {
     val index = EliminateSubqueryAliases(update.child) match {
       case DeltaFullTable(tahoeFileIndex) =>
         tahoeFileIndex


### PR DESCRIPTION
The current `UpdateTable` has a "VerbObject" structure, which is not aligned with `Delete`. We'd better use universal naming rules for them. Another choice is `DeleteFromTable`, `UpdateTable` and `MergeIntoTable`, but I think `Delete`, `Update`, `Merge` is enough.