### PR TITLE
[SC-20936] Python API for Delta Utility Commands(Vacuum, History, ConvertToDelta)

### DIFF
--- a/python/delta/tables.py
+++ b/python/delta/tables.py
@@ -53,6 +53,62 @@ class DeltaTable(object):
         jdt = self._jdt.alias(aliasName)
         return DeltaTable(self._spark, jdt)
 
+    def vacuum(self, retentionHours=None):
+        """
+        Recursively delete files and directories in the table that are not needed by the table for
+        maintaining older versions up to the given retention threshold. This method will return an
+        empty DataFrame on successful completion. This uses the default retention period of 7
+        days.
+        :param retentionHours:
+        :return: DataFrame of the history
+
+        .. note:: Evolving
+        """
+        jdt = self._jdt
+        if retentionHours is None:
+            return DataFrame(jdt.vacuum(), self._spark._wrapped)
+        else:
+            return DataFrame(jdt.vacuum(retentionHours), self._spark._wrapped)
+
+    def history(self, limit=None):
+        """
+        Get the information of the latest `limit` commits on this table as a Spark DataFrame.
+        The information is in reverse chronological order.
+        :param limit:
+        :return: DataFrame of the history
+
+        .. note:: Evolving
+        """
+        jdt = self._jdt
+        if limit is None:
+            return DataFrame(jdt.history(), self._spark._wrapped)
+        else:
+            return DataFrame(jdt.history(limit), self._spark._wrapped)
+
+    @classmethod
+    def convertToDelta(cls, sparkSession, identifier, partitionSchema=None):
+        """
+        Create a DeltaTable from the given parquet table. Takes an existing parquet table and
+        constructs a delta transaction log in the base path of the table.
+        Note: Any changes to the table during the conversion process may not result in a consistent
+        state at the end of the conversion. Users should stop any changes to the table before the
+        conversion is started.
+
+        :param sparkSession:
+        :param identifier:
+        :param partitionSchema:
+        :return: DeltaTable
+        """
+        assert sparkSession is not None
+        if partitionSchema is None:
+            jdt = sparkSession._sc._jvm.io.delta.tables.DeltaTable.convertToDelta(
+                sparkSession._jsparkSession, identifier)
+        else:
+            jdt = sparkSession._sc._jvm.io.delta.tables.DeltaTable.convertToDelta(
+                sparkSession._jsparkSession, identifier,
+                sparkSession._jsparkSession.parseDataType(partitionSchema.json()))
+        return jdt
+
     @classmethod
     def forPath(cls, sparkSession, path):
         """

--- a/python/delta/tests/__init__.py
+++ b/python/delta/tests/__init__.py
@@ -1,0 +1,15 @@
+#
+# Copyright 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -35,7 +35,8 @@ def test(root_dir, jar_file):
         try:
             subprocess.check_output(["spark-submit", "--jars", jar_file,
                                      "--py-files", jar_file, test_file])
-        except:
+        except Exception as e:
+            print(e)
             raise Exception("Failed test %s: " % test_file)
 
 

--- a/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -98,7 +98,7 @@ class DeltaTable private[tables](df: Dataset[Row], deltaLog: DeltaLog)
    * maintaining older versions up to the given retention threshold. This method will return an
    * empty DataFrame on successful completion.
    *
-   * note: This will use the default retention period of 7 hours.
+   * note: This will use the default retention period of 7 days.
    *
    * @since 0.3.0
    */


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added Python APIs for Vacuum, ConvertToDelta and Describe History
Added unit tests for the above
Added fix to not swallow Python tests Exceptions
## How was this patch tested?
Unit tests( test_deltatable.py)


GitOrigin-RevId: 80a5d76a6ee0f316c0e36eb5565707e946e4a9bb