### PR TITLE
Describe history SQL support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,7 +120,7 @@ enablePlugins(GenJavadocPlugin, JavaUnidocPlugin, ScalaUnidocPlugin)
 
 // Configure Scala unidoc
 scalacOptions in(ScalaUnidoc, unidoc) ++= Seq(
-  "-skip-packages", "org:com:io.delta.tables.execution",
+  "-skip-packages", "org:com:io.delta.sql.parser:io.delta.tables.execution",
   "-doc-title", "Delta Lake " + version.value.replaceAll("-SNAPSHOT", "") + " ScalaDoc"
 )
 
@@ -138,6 +138,7 @@ def ignoreUndocumentedPackages(packages: Seq[Seq[java.io.File]]): Seq[Seq[java.i
   packages
     .map(_.filterNot(_.getName.contains("$")))
     .map(_.filterNot(_.getCanonicalPath.contains("io/delta/tables/execution")))
+    .map(_.filterNot(_.getCanonicalPath.contains("io/delta/sql/parser")))
     .map(_.filterNot(_.getCanonicalPath.contains("spark")))
 }
 

--- a/python/delta/tests/test_sql.py
+++ b/python/delta/tests/test_sql.py
@@ -59,7 +59,7 @@ class DeltaSqlTests(PySparkTestCase):
             self.spark.sql("set spark.databricks.delta.retentionDurationCheck.enabled = true")
 
     def test_describe_history(self):
-        assert(self.spark.sql("desc history delta.`%s`" % (self.temp_file)) > 0)
+        assert(len(self.spark.sql("desc history delta.`%s`" % (self.temp_file)).collect()) > 0)
 
 
 if __name__ == "__main__":

--- a/python/delta/tests/test_sql.py
+++ b/python/delta/tests/test_sql.py
@@ -37,25 +37,30 @@ class DeltaSqlTests(PySparkTestCase):
             self.spark = SparkSession(self.sc, spark._jsparkSession.cloneSession())
         else:
             self.spark = spark
-        self.tempPath = tempfile.mkdtemp()
-        self.tempFile = os.path.join(self.tempPath, "tempFile")
+        self.temp_path = tempfile.mkdtemp()
+        self.temp_file = os.path.join(self.temp_path, "delta_sql_test_table")
+        # Create a simple Delta table inside the temp directory to test SQL commands.
+        df = self.spark.createDataFrame([('a', 1), ('b', 2), ('c', 3)], ["key", "value"])
+        df.write.format("delta").save(self.temp_file)
+        df.write.mode("overwrite").format("delta").save(self.temp_file)
 
     def tearDown(self):
         self.spark.stop()
-        shutil.rmtree(self.tempPath)
+        shutil.rmtree(self.temp_path)
         super(DeltaSqlTests, self).tearDown()
 
     def test_vacuum(self):
-        df = self.spark.createDataFrame([('a', 1), ('b', 2), ('c', 3)], ["key", "value"])
-        df.write.format("delta").save(self.tempFile)
-        df.write.mode("overwrite").format("delta").save(self.tempFile)
         self.spark.sql("set spark.databricks.delta.retentionDurationCheck.enabled = false")
         try:
-            deleted_files = self.spark.sql("VACUUM '%s' RETAIN 0 HOURS" % self.tempFile).collect()
+            deleted_files = self.spark.sql("VACUUM '%s' RETAIN 0 HOURS" % self.temp_file).collect()
             # Verify `VACUUM` did delete some data files
-            self.assertTrue(self.tempFile in deleted_files[0][0])
+            self.assertTrue(self.temp_file in deleted_files[0][0])
         finally:
             self.spark.sql("set spark.databricks.delta.retentionDurationCheck.enabled = true")
+
+    def test_describe_history(self):
+        assert(self.spark.sql("desc history delta.`%s`" % (self.temp_file)) > 0)
+
 
 if __name__ == "__main__":
     try:

--- a/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
+++ b/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
@@ -74,6 +74,8 @@ singleStatement
 statement
     : VACUUM (path=STRING | table=qualifiedName)
         (RETAIN number HOURS)? (DRY RUN)?                               #vacuumTable
+    | (DESC | DESCRIBE) HISTORY (path=STRING | table=qualifiedName)
+        (LIMIT limit=INTEGER_VALUE)?                                    #describeDeltaHistory
     | .*?                                                               #passThrough
     ;
 

--- a/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
+++ b/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
@@ -41,7 +41,7 @@ package io.delta.sql.parser
 import scala.collection.JavaConverters._
 
 import io.delta.sql.parser.DeltaSqlBaseParser._
-import io.delta.tables.execution.VacuumTableCommand
+import io.delta.tables.execution.{DescribeDeltaHistoryCommand, VacuumTableCommand}
 import org.antlr.v4.runtime._
 import org.antlr.v4.runtime.atn.PredictionMode
 import org.antlr.v4.runtime.misc.{Interval, ParseCancellationException}
@@ -147,6 +147,14 @@ class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
       Option(ctx.table).map(visitTableIdentifier),
       Option(ctx.number).map(_.getText.toDouble),
       ctx.RUN != null)
+  }
+
+  override def visitDescribeDeltaHistory(
+      ctx: DescribeDeltaHistoryContext): LogicalPlan = withOrigin(ctx) {
+    DescribeDeltaHistoryCommand(
+      Option(ctx.path).map(string),
+      Option(ctx.table).map(visitTableIdentifier),
+      Option(ctx.limit).map(_.getText.toInt))
   }
 
   override def visitSingleStatement(ctx: SingleStatementContext): LogicalPlan = withOrigin(ctx) {

--- a/src/main/scala/io/delta/tables/execution/DescribeDeltaHistoryCommand.scala
+++ b/src/main/scala/io/delta/tables/execution/DescribeDeltaHistoryCommand.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Databricks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.tables.execution
+
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.{Encoders, Row, SparkSession}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.delta.actions.CommitInfo
+import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaTableIdentifier}
+import org.apache.spark.sql.execution.command.RunnableCommand
+
+case class DescribeDeltaHistoryCommand(
+    path: Option[String],
+    table: Option[TableIdentifier],
+    limit: Option[Int]) extends RunnableCommand {
+
+  override val output: Seq[Attribute] = Encoders.product[CommitInfo].schema
+    .map(f => AttributeReference(f.name, f.dataType, f.nullable, f.metadata)())
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val basePath =
+      new Path(if (table.nonEmpty) {
+        DeltaTableIdentifier(sparkSession, table.get) match {
+          case Some(id) if id.path.isDefined => id.path.get
+          case _ => throw DeltaErrors.tableNotSupportedException("DESCRIBE DETAIL")
+        }
+      } else {
+        path.get
+      })
+
+    // Max array size
+    if (limit.exists(_ > Int.MaxValue - 8)) {
+      throw new IllegalArgumentException("Please use a limit less than Int.MaxValue - 8.")
+    }
+
+    val deltaLog = DeltaLog.forTable(sparkSession, basePath)
+    if (deltaLog.snapshot.version == -1) {
+      throw DeltaErrors.notADeltaTableException("DESCRIBE HISTORY")
+    }
+
+    import sparkSession.implicits._
+    deltaLog.history.getHistory(limit).toDF().collect().toSeq
+  }
+}


### PR DESCRIPTION
Add a `describe history` SQL command to query a table's history. Here are some examples of this command.

```
DESCRIBE HISTORY '/foo/bar'
DESCRIBE HISTORY delta.`/foo/bar` limit 3
```

Resolves https://github.com/delta-io/delta/issues/168