### PR TITLE
Enable doclint on Circle CI

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,7 +120,7 @@ enablePlugins(GenJavadocPlugin, JavaUnidocPlugin, ScalaUnidocPlugin)
 
 // Configure Scala unidoc
 scalacOptions in(ScalaUnidoc, unidoc) ++= Seq(
-  "-skip-packages", "org:com:io.delta.tables.execution",
+  "-skip-packages", "org:com:io.delta.sql.parser:io.delta.tables.execution",
   "-doc-title", "Delta Lake " + version.value.replaceAll("-SNAPSHOT", "") + " ScalaDoc"
 )
 
@@ -139,6 +139,7 @@ javacOptions in(JavaUnidoc, unidoc) := Seq(
 def ignoreUndocumentedPackages(packages: Seq[Seq[java.io.File]]): Seq[Seq[java.io.File]] = {
   packages
     .map(_.filterNot(_.getName.contains("$")))
+    .map(_.filterNot(_.getCanonicalPath.contains("io/delta/sql/parser")))
     .map(_.filterNot(_.getCanonicalPath.contains("io/delta/tables/execution")))
     .map(_.filterNot(_.getCanonicalPath.contains("spark")))
 }

--- a/build.sbt
+++ b/build.sbt
@@ -130,7 +130,9 @@ javacOptions in(JavaUnidoc, unidoc) := Seq(
   "-exclude", "org:com:io.delta.sql.parser:io.delta.tables.execution",
   "-windowtitle", "Delta Lake " + version.value.replaceAll("-SNAPSHOT", "") + " JavaDoc",
   "-noqualifier", "java.lang",
-  "-tag", "return:X"
+  "-tag", "return:X",
+  // `doclint` is disabled on Circle CI. Need to enable it manually to test our javadoc.
+  "-Xdoclint:all"
 )
 
 // Explicitly remove source files by package because these docs are not formatted correctly for Javadocs


### PR DESCRIPTION
Looks like `doclint` is disabled on Circle CI. See https://github.com/Debian/openjdk-8/blob/master/debian/patches/disable-doclint-by-default.patch

This PR enables it manually to test our javadoc. In addition, it also includes the private package `io.delta.sql.parser` to fix javadoc build.