### PR TITLE
Remove unnecessary adding packagedArtifacts to publishM2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -164,8 +164,6 @@ spIncludeMaven := true
 
 spIgnoreProvided := true
 
-packagedArtifacts in publishM2 <<= packagedArtifacts in spPublishLocal
-
 packageBin in Compile := spPackage.value
 
 sparkComponents := Seq("sql")


### PR DESCRIPTION
@tdas fixed packaging a month ago; so we shouldn't need to add spPublishLocal packagedArtifacts to publishM2 anymore. This also fixes a warning when running build/sbt.