### PR TITLE
[WIP] Support for Manifest Generation

### DIFF
--- a/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -94,6 +94,18 @@ class DeltaTable private[tables](df: Dataset[Row], deltaLog: DeltaLog)
   /**
    * :: Evolving ::
    *
+   * Writes a manifest containing the list of data files to read for querying a delta table.
+   *
+   * @since 0.4.0
+   */
+  @Evolving
+  def generateManifest(): DataFrame = {
+    generateManifest(deltaLog, None)
+  }
+
+  /**
+   * :: Evolving ::
+   *
    * Recursively delete files and directories in the table that are not needed by the table for
    * maintaining older versions up to the given retention threshold. This method will return an
    * empty DataFrame on successful completion.
@@ -604,6 +616,7 @@ object DeltaTable {
     val sparkSession = SparkSession.getActiveSession.getOrElse {
       throw new IllegalArgumentException("Could not find active SparkSession")
     }
+
     forPath(sparkSession, path)
   }
 

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaManifest.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaManifest.scala
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2019 Databricks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.util.Utils
+
+/**
+ * Information about a manifest.
+ */
+case class DeltaManifest (path: String)
+
+/**
+ * General interface writing manifest files for a delta table.
+ */
+trait DeltaManifestWriter {
+  def write(fs: FileSystem, snapshot: Snapshot, path: String): DeltaManifest = write(
+    fs, snapshot, Some(path)
+  )
+
+  def write(fs: FileSystem, snapshot: Snapshot): DeltaManifest = write(
+    fs, snapshot, None
+  )
+
+  def write(fs: FileSystem, snapshot: Snapshot, path: Option[String]): DeltaManifest
+}
+
+/**
+ * Writes SymlinkTextInputFormat manifests.
+ */
+class SymlinkTextInputFormatWriter extends DeltaManifestWriter
+  with BaseManifestFileWriter
+  with ManifestFileWriter {
+
+  private def createManifestPath(dataPath: Path): Path = {
+    new Path(dataPath, "_symlink_format_manifest")
+  }
+
+  private def createFragmentPath(manifestPath: Path, fragment: Path): Path = {
+    new Path(new Path(manifestPath, fragment), "manifest.txt")
+  }
+
+  private def createManifestContent(dataPath: Path, files: Iterable[AddFile]): String = {
+    files
+      .map(f => new Path(dataPath, f.path))
+      .mkString("\n")
+  }
+
+  override def write(fs: FileSystem, snapshot: Snapshot, path: Option[String]): DeltaManifest = {
+    val groups = groupByPartitions(snapshot)
+    val dataPath = snapshot.deltaLog.dataPath
+    val manifestPath = path.map(new Path(_)).getOrElse(createManifestPath(dataPath))
+
+    groups
+      .foreach(e => {
+        val path = createFragmentPath(manifestPath, e._1)
+        val content = createManifestContent(dataPath, e._2)
+
+        writeFile(fs, path, content)
+      })
+
+    DeltaManifest(manifestPath.toString)
+  }
+
+}
+
+protected trait BaseManifestFileWriter {
+  protected def groupByPartitions(snapshot: Snapshot): Map[Path, Iterable[AddFile]] = {
+    snapshot.allFiles.collect().seq
+      .groupBy(r => new Path(r.path).getParent)
+  }
+}
+
+protected trait ManifestFileWriter {
+  protected def writeFile(fs: FileSystem, path: Path, content: String): Unit = {
+    var streamClosed = false
+    val stream = fs.create(path, false)
+
+    try {
+      if (!fs.exists(path.getParent)) {
+        fs.mkdirs(path.getParent)
+      }
+
+      stream.writeBytes(content)
+      stream.close()
+
+      streamClosed = true
+
+    } finally {
+      if (!streamClosed) {
+        stream.close()
+      }
+    }
+  }
+}
+
+trait ManifestWriterProvider {
+  val writerClassConfKey: String = "spark.delta.manifest.writer"
+  val defaultWriterClassName: String = classOf[SymlinkTextInputFormatWriter].getName
+
+  def createManifestWriter(spark: SparkSession): DeltaManifestWriter = {
+    val context = spark.sparkContext
+    val sparkConf = context.getConf
+
+    createManifestWriter(sparkConf)
+  }
+
+  def createManifestWriter(sparkConf: SparkConf): DeltaManifestWriter = {
+    val writerClassName = sparkConf.get(writerClassConfKey, defaultWriterClassName)
+    val writerClass = Utils.classForName(writerClassName).asInstanceOf[Class[DeltaManifestWriter]]
+
+    createManifestWriter(writerClass)
+  }
+
+  def createManifestWriter(writerClassName: String): DeltaManifestWriter = {
+    val classForName = Utils.classForName(writerClassName)
+    val writerClass = classForName.asInstanceOf[Class[DeltaManifestWriter]]
+
+    createManifestWriter(writerClass)
+  }
+
+  def createManifestWriter(writerClass: Class[DeltaManifestWriter]): DeltaManifestWriter = {
+    writerClass.getConstructor()
+      .newInstance()
+      .asInstanceOf[DeltaManifestWriter]
+  }
+}

--- a/src/main/scala/org/apache/spark/sql/delta/commands/GenerateManifestCommand.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/GenerateManifestCommand.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Databricks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands
+
+import org.apache.spark.sql.delta.{DeltaLog, DeltaManifest, DeltaManifestWriter, ManifestWriterProvider, Snapshot}
+import org.apache.spark.sql.SparkSession
+
+/**
+ * Configuration for the manifest.
+ */
+case class GenerateManifestOptions (
+   path: Option[String],
+   version: Option[Long],
+   writerClass: Option[Either[String, Class[DeltaManifestWriter]]]
+ )
+
+/**
+ * Generate manifests from a Delta table
+ */
+case class GenerateManifestCommand(
+    deltaLog: DeltaLog,
+    options: Option[GenerateManifestOptions]
+  ) extends DeltaCommand with ManifestWriterProvider{
+
+  def run(sparkSession: SparkSession): Seq[DeltaManifest] = {
+    val writer = createWriter(sparkSession, options)
+    val snapshot = createSnapshot(deltaLog, options)
+    val manifest = writer.write(deltaLog.fs, snapshot, options.flatMap(_.path))
+
+    Seq(manifest)
+  }
+
+  private def createWriter(
+    sparkSession: SparkSession,
+    options: Option[GenerateManifestOptions]
+  ): DeltaManifestWriter = options
+    .flatMap(_.writerClass)
+    .map(_ match {
+      case Left(l) => createManifestWriter(l)
+      case Right(r) => createManifestWriter(r)
+    })
+    .getOrElse(createManifestWriter(sparkSession))
+
+  private def createSnapshot(
+      deltaLog: DeltaLog,
+      options: Option[GenerateManifestOptions]
+  ): Snapshot = options
+    .flatMap(_.version)
+    .map(deltaLog.getSnapshotAt(_))
+    .getOrElse(deltaLog.snapshot)
+}

--- a/src/test/scala/io/delta/tables/DeltaTableSuite.scala
+++ b/src/test/scala/io/delta/tables/DeltaTableSuite.scala
@@ -18,9 +18,7 @@ package io.delta.tables
 
 import java.util.Locale
 
-
-import org.apache.spark.sql.{AnalysisException, QueryTest}
-import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.{AnalysisException, Dataset, QueryTest, Row}
 import org.apache.spark.sql.test.SharedSparkSession
 
 class DeltaTableSuite extends QueryTest
@@ -47,7 +45,6 @@ class DeltaTableSuite extends QueryTest
     }
   }
 
-
   test("as") {
     withTempDir { dir =>
       testData.write.format("delta").save(dir.getAbsolutePath)
@@ -69,6 +66,19 @@ class DeltaTableSuite extends QueryTest
     withTempDir { dir =>
       testData.write.format("parquet").mode("overwrite").save(dir.getAbsolutePath)
       assert(!DeltaTable.isDeltaTable(dir.getAbsolutePath))
+    }
+  }
+
+  test("generateManifest") {
+    withTempDir { dir =>
+      testData.write.format("delta").save(dir.getAbsolutePath)
+
+      val table = DeltaTable.forPath(dir.getAbsolutePath)
+      val manifest = table.generateManifest()
+      val path = manifest.head.getString(0)
+
+      assert(manifest.count() === 1)
+      assert(path === "file:" + dir + "/_symlink_format_manifest")
     }
   }
 

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaManifestSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaManifestSuite.scala
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2019 Databricks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.io.{BufferedReader, InputStreamReader}
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.Paths
+
+import org.apache.commons.io.IOUtils
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.spark.sql.{Row, _}
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.test.{SQLTestUtils, SharedSparkSession}
+import org.apache.spark.sql.types.StructType
+
+import scala.collection.JavaConverters._
+
+class DeltaManifestSuite extends QueryTest
+  with ManifestWriterProvider
+  with SharedSparkSession
+  with SQLTestUtils {
+
+  val schema = new StructType()
+    .add(StructField("id", IntegerType, false))
+    .add(StructField("type", StringType, false))
+    .add(StructField("group", StringType, false))
+    .add(StructField("value", StringType, false))
+
+  test("Support for hive SymlinkTextInputFormat manifest generation") {
+    withTempDir { tempDir =>
+      if (tempDir.exists()) {
+        assert(tempDir.delete())
+      }
+
+      val testPath = tempDir.getCanonicalPath
+      val df = createDataFrame(Seq(
+        Row(1, "t1", "g1", "t1 - g1 - 1"),
+        Row(2, "t1", "g1", "t1 - g1 - 2"),
+        Row(3, "t1", "g1", "t1 - g1 - 3"),
+        Row(4, "t1", "g2", "t1 - g2 - 4")
+      ))
+
+      df
+        .write
+        .format("delta")
+        .mode("append")
+        .save(testPath)
+
+      val writer = createManifestWriter(spark)
+      val log = DeltaLog.forTable(spark, tempDir)
+      val manifest = writer.write(log.fs, log.snapshot)
+      val manifestsPaths = listFiles(log.fs, manifest.path).map(_.toString).toSeq
+      val inputFiles = spark.read.format("delta")
+          .load(tempDir.toString)
+          .inputFiles
+          .toSeq
+
+      assert(manifestsPaths.size === 1)
+      assertManifestContains(log.fs, inputFiles, manifestsPaths.head)
+    }
+  }
+
+  test("Support for hive SymlinkTextInputFormat manifest generation multiple paths") {
+    withTempDir { tempDir =>
+      if (tempDir.exists()) {
+        assert(tempDir.delete())
+      }
+
+      val testPath = tempDir.getCanonicalPath
+      val df1 = createDataFrame(Seq(
+        Row(1, "t1", "g1", "t1 - g1 - 1"),
+        Row(2, "t1", "g1", "t1 - g1 - 2"),
+        Row(3, "t1", "g1", "t1 - g1 - 3"),
+        Row(4, "t1", "g2", "t1 - g2 - 4")
+      ))
+
+      val df2 = createDataFrame(Seq(
+        Row(5, "t2", "g2", "t2 - g2 - 5"),
+        Row(6, "t2", "g2", "t2 - g2 - 6"),
+        Row(7, "t2", "g2", "t2 - g2 - 7"),
+        Row(8, "t2", "g1", "t2 - g1 - 8")
+      ))
+
+      df1
+        .write
+        .format("delta")
+        .mode("append")
+        .save(testPath)
+
+      df2
+        .write
+        .format("delta")
+        .mode("append")
+        .save(testPath)
+
+      val writer = createManifestWriter(spark)
+      val deltaLog = DeltaLog.forTable(spark, tempDir)
+      val manifest1 = writer.write(deltaLog.fs, deltaLog.getSnapshotAt(0), tempDir + "/_manifest1")
+      val manifest2 = writer.write(deltaLog.fs, deltaLog.getSnapshotAt(1), tempDir + "/_manifest2")
+      val manifestsPaths1 = listFiles(deltaLog.fs, manifest1.path).map(_.toString).toSeq
+      val manifestsPaths2 = listFiles(deltaLog.fs, manifest2.path).map(_.toString).toSeq
+
+      val inputFiles1 = spark.read.format("delta")
+        .option("versionAsOf", 0)
+        .load(tempDir.toString)
+        .inputFiles
+        .toSeq
+
+      val inputFiles2 = spark.read.format("delta")
+        .option("versionAsOf", 1)
+        .load(tempDir.toString)
+        .inputFiles
+        .toSeq
+
+      assert(manifestsPaths1.size === 1)
+      assertManifestContains(deltaLog.fs, inputFiles1, manifestsPaths1.head)
+      assert(manifestsPaths1.head === "file:" + tempDir + "/_manifest1/manifest.txt")
+
+      assert(manifestsPaths2.size === 1)
+      assertManifestContains(deltaLog.fs, inputFiles2, manifestsPaths2.head)
+      assert(manifestsPaths2.head === "file:" + tempDir + "/_manifest2/manifest.txt")
+    }
+  }
+
+  test("Support for hive SymlinkTextInputFormat manifest generation with partitions") {
+    withTempDir { tempDir =>
+      if (tempDir.exists()) {
+        assert(tempDir.delete())
+      }
+
+      val testPath = tempDir.getCanonicalPath
+      val df = createDataFrame(Seq(
+        Row(1, "t1", "g1", "t1 - g1 - 1"),
+        Row(2, "t1", "g1", "t1 - g1 - 2"),
+        Row(3, "t1", "g1", "t1 - g1 - 3"),
+        Row(4, "t1", "g2", "t1 - g2 - 4"),
+
+        Row(5, "t2", "g2", "t2 - g2 - 5"),
+        Row(6, "t2", "g2", "t2 - g2 - 6"),
+        Row(7, "t2", "g2", "t2 - g2 - 7"),
+        Row(8, "t2", "g1", "t2 - g1 - 8")
+      ))
+
+      df
+        .write
+        .format("delta")
+        .partitionBy("type", "group")
+        .mode("append")
+        .save(testPath)
+
+      val writer = createManifestWriter(spark)
+      val log = DeltaLog.forTable(spark, tempDir)
+      val manifest = writer.write(log.fs, log.snapshot)
+      val expectedPath = "file:" + testPath + "/_symlink_format_manifest"
+      val manifestsPaths = listFiles(log.fs, manifest.path).map(_.toString).toSeq
+      val inputFiles = spark.read.format("delta")
+        .load(tempDir.toString)
+        .inputFiles
+        .toSeq
+
+      val filePartitions = inputFiles
+        .map(Paths.get(_))
+        .groupBy(_.getParent.toString.substring(testPath.length + 5))
+        .mapValues(_.map(_.toString))
+
+      assert(filePartitions.size === 4)
+      assert(manifestsPaths.size === 4)
+
+      assert(filePartitions.contains("/type=t1/group=g1"))
+      assert(filePartitions.contains("/type=t1/group=g2"))
+      assert(filePartitions.contains("/type=t2/group=g1"))
+      assert(filePartitions.contains("/type=t2/group=g2"))
+
+      assert(filePartitions("/type=t1/group=g1").size === 1)
+      assert(filePartitions("/type=t1/group=g2").size === 1)
+      assert(filePartitions("/type=t2/group=g1").size === 1)
+      assert(filePartitions("/type=t2/group=g2").size === 1)
+
+      assert(manifestsPaths.contains(expectedPath + "/type=t1/group=g1/manifest.txt"))
+      assert(manifestsPaths.contains(expectedPath + "/type=t1/group=g2/manifest.txt"))
+      assert(manifestsPaths.contains(expectedPath + "/type=t2/group=g1/manifest.txt"))
+      assert(manifestsPaths.contains(expectedPath + "/type=t2/group=g2/manifest.txt"))
+
+      assertManifestContains(
+        log.fs,
+        filePartitions("/type=t1/group=g1"),
+        expectedPath + "/type=t1/group=g1/manifest.txt"
+      )
+
+      assertManifestContains(
+        log.fs,
+        filePartitions("/type=t1/group=g2"),
+        expectedPath + "/type=t1/group=g2/manifest.txt"
+      )
+
+      assertManifestContains(
+        log.fs,
+        filePartitions("/type=t2/group=g1"),
+        expectedPath + "/type=t2/group=g1/manifest.txt"
+      )
+
+      assertManifestContains(
+        log.fs,
+        filePartitions("/type=t2/group=g2"),
+        expectedPath + "/type=t2/group=g2/manifest.txt"
+      )
+    }
+  }
+
+  def assertManifestContains(fs: FileSystem, files: Seq[String], path: String): Unit = {
+    val lines = readLines(fs, path)
+
+    assert(lines.size === files.size)
+    files.foreach(f => assert(lines.contains(f)))
+  }
+
+  def createDataFrame(rows: Seq[Row]): DataFrame = {
+    spark.createDataFrame(spark.sparkContext.parallelize(rows), schema)
+  }
+
+  def readLines(fs: FileSystem, path: String): Seq[String] = {
+    val stream = fs.open(new Path(path))
+
+    try {
+      val reader = new BufferedReader(new InputStreamReader(stream, UTF_8))
+      val lines = IOUtils.readLines(reader)
+
+      lines.asScala.map(_.trim)
+    } finally {
+      stream.close()
+    }
+  }
+
+  def listFiles(fs: FileSystem, path: String): Iterator[Path] = {
+    val inner = fs.listFiles(new Path(path), true);
+    val iterator = new Iterator[Path] {
+      def hasNext = inner.hasNext
+      def next() = inner.next().getPath
+    }
+
+    iterator
+  }
+}


### PR DESCRIPTION
Support for Manifest Generation

This is still a work in progress but i'm using something similar to generate manifest for redshift and athena
I'd like to get some feed back on the general approach before i continue going down this path

- [x] Generate SymlinkTextInputFormat
- [x] Generate Manifest for unpartitioned tables
- [x] Generate Manifest for partitioned tables
- [ ] Remove partition from manifest when a partition is removed
- [ ] Improve test coverage
- [ ] ??
 
See : https://github.com/delta-io/delta/issues/76