### PR TITLE
Merge insertAll and updateAll fail in case of dotted columns

### DIFF
--- a/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/merge.scala
+++ b/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/merge.scala
@@ -26,21 +26,16 @@ import org.apache.spark.sql.types.DataType
 /**
  * Represents an action in MERGE's UPDATE or INSERT clause where a target columns is assigned the
  * value of an expression
- *
  * @param targetColNameParts The name parts of the target column. This is a sequence to support
  *                           nested fields as targets.
- * @param expr               Expression to generate the value of the target column.
+ * @param expr Expression to generate the value of the target column.
  */
 case class MergeAction(targetColNameParts: Seq[String], expr: Expression)
   extends UnaryExpression with Unevaluable {
   override def child: Expression = expr
-
   override def foldable: Boolean = false
-
   override def dataType: DataType = expr.dataType
-
   override def sql: String = s"${targetColNameParts.mkString("`", "`.`", "`")} = ${expr.sql}"
-
   override def toString: String = s"$prettyName ( $sql )"
 }
 
@@ -80,11 +75,8 @@ sealed trait MergeIntoClause extends Expression with Unevaluable {
   }
 
   override def foldable: Boolean = false
-
   override def nullable: Boolean = false
-
   override def dataType: DataType = null
-
   override def children: Seq[Expression] = condition.toSeq ++ actions
 
   /** Verify whether the expressions in the actions are of the right type */
@@ -101,14 +93,14 @@ object MergeIntoClause {
    * Convert the parsed columns names and expressions into action for MergeInto. Note:
    * - Size of column names and expressions must be the same.
    * - If the sizes are zeros and `emptySeqIsStar` is true, this function assumes
-   * that query had `*` as an action, and therefore generates a single action
-   * with `UnresolvedStar`. This will be expanded later during analysis.
+   *   that query had `*` as an action, and therefore generates a single action
+   *   with `UnresolvedStar`. This will be expanded later during analysis.
    * - Otherwise, this will convert the names and expressions to MergeActions.
    */
   def toActions(
-                 colNames: Seq[UnresolvedAttribute],
-                 exprs: Seq[Expression],
-                 isEmptySeqEqualToStar: Boolean = true): Seq[Expression] = {
+      colNames: Seq[UnresolvedAttribute],
+      exprs: Seq[Expression],
+      isEmptySeqEqualToStar: Boolean = true): Seq[Expression] = {
     assert(colNames.size == exprs.size)
     if (colNames.isEmpty && isEmptySeqEqualToStar) {
       Seq[Expression](UnresolvedStar(None))
@@ -176,25 +168,24 @@ case class MergeIntoInsertClause(condition: Option[Expression], actions: Seq[Exp
  *    - WHEN NOT MATCHED clause can have an optional condition.
  */
 case class MergeInto(
-                      target: LogicalPlan,
-                      source: LogicalPlan,
-                      condition: Expression,
-                      matchedClauses: Seq[MergeIntoMatchedClause],
-                      notMatchedClause: Option[MergeIntoInsertClause]) extends Command {
+    target: LogicalPlan,
+    source: LogicalPlan,
+    condition: Expression,
+    matchedClauses: Seq[MergeIntoMatchedClause],
+    notMatchedClause: Option[MergeIntoInsertClause]) extends Command {
 
   (matchedClauses ++ notMatchedClause).foreach(_.verifyActions())
 
   override def children: Seq[LogicalPlan] = Seq(target, source)
-
   override def output: Seq[Attribute] = Seq.empty
 }
 
 object MergeInto {
   def apply(
-             target: LogicalPlan,
-             source: LogicalPlan,
-             condition: Expression,
-             whenClauses: Seq[MergeIntoClause]): MergeInto = {
+      target: LogicalPlan,
+      source: LogicalPlan,
+      condition: Expression,
+      whenClauses: Seq[MergeIntoClause]): MergeInto = {
     val deleteClauses = whenClauses.collect { case x: MergeIntoDeleteClause => x }
     val updateClauses = whenClauses.collect { case x: MergeIntoUpdateClause => x }
     val insertClauses = whenClauses.collect { case x: MergeIntoInsertClause => x }
@@ -231,7 +222,7 @@ object MergeInto {
   }
 
   def resolveReferences(merge: MergeInto)(
-    resolveExpr: (Expression, LogicalPlan) => Expression): MergeInto = {
+      resolveExpr: (Expression, LogicalPlan) => Expression): MergeInto = {
 
     val MergeInto(target, source, condition, matchedClauses, notMatchedClause) = merge
 

--- a/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/merge.scala
+++ b/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/merge.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.catalyst.plans.logical
 
 import java.util.Locale
 
-import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.{AnalysisException, functions}
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, UnaryExpression, Unevaluable}
 import org.apache.spark.sql.types.DataType
@@ -26,16 +26,21 @@ import org.apache.spark.sql.types.DataType
 /**
  * Represents an action in MERGE's UPDATE or INSERT clause where a target columns is assigned the
  * value of an expression
+ *
  * @param targetColNameParts The name parts of the target column. This is a sequence to support
  *                           nested fields as targets.
- * @param expr Expression to generate the value of the target column.
+ * @param expr               Expression to generate the value of the target column.
  */
 case class MergeAction(targetColNameParts: Seq[String], expr: Expression)
   extends UnaryExpression with Unevaluable {
   override def child: Expression = expr
+
   override def foldable: Boolean = false
+
   override def dataType: DataType = expr.dataType
+
   override def sql: String = s"${targetColNameParts.mkString("`", "`.`", "`")} = ${expr.sql}"
+
   override def toString: String = s"$prettyName ( $sql )"
 }
 
@@ -75,8 +80,11 @@ sealed trait MergeIntoClause extends Expression with Unevaluable {
   }
 
   override def foldable: Boolean = false
+
   override def nullable: Boolean = false
+
   override def dataType: DataType = null
+
   override def children: Seq[Expression] = condition.toSeq ++ actions
 
   /** Verify whether the expressions in the actions are of the right type */
@@ -93,14 +101,14 @@ object MergeIntoClause {
    * Convert the parsed columns names and expressions into action for MergeInto. Note:
    * - Size of column names and expressions must be the same.
    * - If the sizes are zeros and `emptySeqIsStar` is true, this function assumes
-   *   that query had `*` as an action, and therefore generates a single action
-   *   with `UnresolvedStar`. This will be expanded later during analysis.
+   * that query had `*` as an action, and therefore generates a single action
+   * with `UnresolvedStar`. This will be expanded later during analysis.
    * - Otherwise, this will convert the names and expressions to MergeActions.
    */
   def toActions(
-      colNames: Seq[UnresolvedAttribute],
-      exprs: Seq[Expression],
-      isEmptySeqEqualToStar: Boolean = true): Seq[Expression] = {
+                 colNames: Seq[UnresolvedAttribute],
+                 exprs: Seq[Expression],
+                 isEmptySeqEqualToStar: Boolean = true): Seq[Expression] = {
     assert(colNames.size == exprs.size)
     if (colNames.isEmpty && isEmptySeqEqualToStar) {
       Seq[Expression](UnresolvedStar(None))
@@ -168,24 +176,25 @@ case class MergeIntoInsertClause(condition: Option[Expression], actions: Seq[Exp
  *    - WHEN NOT MATCHED clause can have an optional condition.
  */
 case class MergeInto(
-    target: LogicalPlan,
-    source: LogicalPlan,
-    condition: Expression,
-    matchedClauses: Seq[MergeIntoMatchedClause],
-    notMatchedClause: Option[MergeIntoInsertClause]) extends Command {
+                      target: LogicalPlan,
+                      source: LogicalPlan,
+                      condition: Expression,
+                      matchedClauses: Seq[MergeIntoMatchedClause],
+                      notMatchedClause: Option[MergeIntoInsertClause]) extends Command {
 
   (matchedClauses ++ notMatchedClause).foreach(_.verifyActions())
 
   override def children: Seq[LogicalPlan] = Seq(target, source)
+
   override def output: Seq[Attribute] = Seq.empty
 }
 
 object MergeInto {
   def apply(
-      target: LogicalPlan,
-      source: LogicalPlan,
-      condition: Expression,
-      whenClauses: Seq[MergeIntoClause]): MergeInto = {
+             target: LogicalPlan,
+             source: LogicalPlan,
+             condition: Expression,
+             whenClauses: Seq[MergeIntoClause]): MergeInto = {
     val deleteClauses = whenClauses.collect { case x: MergeIntoDeleteClause => x }
     val updateClauses = whenClauses.collect { case x: MergeIntoUpdateClause => x }
     val insertClauses = whenClauses.collect { case x: MergeIntoInsertClause => x }
@@ -222,7 +231,7 @@ object MergeInto {
   }
 
   def resolveReferences(merge: MergeInto)(
-      resolveExpr: (Expression, LogicalPlan) => Expression): MergeInto = {
+    resolveExpr: (Expression, LogicalPlan) => Expression): MergeInto = {
 
     val MergeInto(target, source, condition, matchedClauses, notMatchedClause) = merge
 
@@ -266,7 +275,7 @@ object MergeInto {
             // plan.
             fakeTargetPlan.output.map(_.name).map { tgtColName =>
               val resolvedExpr =
-                resolveOrFail(UnresolvedAttribute(tgtColName), fakeSourcePlan, s"$typ clause")
+                resolveOrFail(functions.expr(s"`$tgtColName`").expr, fakeSourcePlan, s"$typ clause")
               MergeAction(Seq(tgtColName), resolvedExpr)
             }
 

--- a/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
@@ -30,8 +30,8 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
 
   test("basic scala API") {
     withTable("source") {
-      append(Seq((1, 10), (2, 20)).toDF("key1", "value1"), Nil) // target
-      val source = Seq((1, 100), (3, 30)).toDF("key2", "value2") // source
+      append(Seq((1, 10), (2, 20)).toDF("key1", "value1"), Nil)  // target
+      val source = Seq((1, 100), (3, 30)).toDF("key2", "value2")  // source
 
       io.delta.tables.DeltaTable.forPath(spark, tempPath)
         .merge(source, "key1 = key2")
@@ -41,17 +41,17 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
 
       checkAnswer(
         readDeltaTable(tempPath),
-        Row(1, 100) :: // Update
-          Row(2, 20) :: // No change
-          Row(3, 30) :: // Insert
+        Row(1, 100) ::    // Update
+          Row(2, 20) ::     // No change
+          Row(3, 30) ::     // Insert
           Nil)
     }
   }
 
   test("extended scala API") {
     withTable("source") {
-      append(Seq((1, 10), (2, 20), (4, 40)).toDF("key1", "value1"), Nil) // target
-      val source = Seq((1, 100), (3, 30), (4, 41)).toDF("key2", "value2") // source
+      append(Seq((1, 10), (2, 20), (4, 40)).toDF("key1", "value1"), Nil)  // target
+      val source = Seq((1, 100), (3, 30), (4, 41)).toDF("key2", "value2")  // source
 
       io.delta.tables.DeltaTable.forPath(spark, tempPath)
         .merge(source, "key1 = key2")
@@ -62,17 +62,17 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
 
       checkAnswer(
         readDeltaTable(tempPath),
-        Row(1, 100) :: // Update
-          Row(2, 20) :: // No change
-          Row(3, 30) :: // Insert
+        Row(1, 100) ::    // Update
+          Row(2, 20) ::     // No change
+          Row(3, 30) ::     // Insert
           Nil)
     }
   }
 
   test("extended scala API with Column") {
     withTable("source") {
-      append(Seq((1, 10), (2, 20), (4, 40)).toDF("key1", "value1"), Nil) // target
-      val source = Seq((1, 100), (3, 30), (4, 41)).toDF("key2", "value2") // source
+      append(Seq((1, 10), (2, 20), (4, 40)).toDF("key1", "value1"), Nil)  // target
+      val source = Seq((1, 100), (3, 30), (4, 41)).toDF("key2", "value2")  // source
 
       io.delta.tables.DeltaTable.forPath(spark, tempPath)
         .merge(source, functions.expr("key1 = key2"))
@@ -85,9 +85,9 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
 
       checkAnswer(
         readDeltaTable(tempPath),
-        Row(1, 100) :: // Update
-          Row(2, 20) :: // No change
-          Row(3, 30) :: // Insert
+        Row(1, 100) ::    // Update
+          Row(2, 20) ::     // No change
+          Row(3, 30) ::     // Insert
           Nil)
     }
   }
@@ -107,12 +107,12 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
 
       checkAnswer(
         readDeltaTable(tempPath),
-        Row(1, 100) :: // Update
-          Row(2, 20) :: // No change
-          Row(3, 30) :: // Insert
-          Row(4, 41) :: // Update
-          Row(5, 51) :: // Update
-          Row(6, 60) :: // Insert
+        Row(1, 100) ::    // Update
+          Row(2, 20) ::     // No change
+          Row(3, 30) ::     // Insert
+          Row(4, 41) ::     // Update
+          Row(5, 51) ::     // Update
+          Row(6, 60) ::     // Insert
           Nil)
     }
   }
@@ -151,10 +151,10 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
 
     checkAnswer(
       readDeltaTable(tempPath),
-      Row(1, 10) :: // Not updated since no update clause
-        Row(2, 20) :: // No change due to merge condition
-        Row(3, 30) :: // Not updated since no update clause
-        Nil)
+      Row(1, 10) ::       // Not updated since no update clause
+      Row(2, 20) ::       // No change due to merge condition
+      Row(3, 30) ::       // Not updated since no update clause
+      Nil)
 
     // match condition should not be ignored when map is empty
     io.delta.tables.DeltaTable.forPath(spark, tempPath)
@@ -166,9 +166,9 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
 
     checkAnswer(
       readDeltaTable(tempPath),
-      Row(1, 10) :: // Neither updated, nor deleted (condition is not ignored)
-        Row(2, 20) :: // No change due to merge condition
-        Nil) // Deleted (3, 30)
+      Row(1, 10) ::     // Neither updated, nor deleted (condition is not ignored)
+      Row(2, 20) ::     // No change due to merge condition
+      Nil)              // Deleted (3, 30)
   }
 
   test("insert with empty map throws error") {
@@ -280,11 +280,11 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
   }
 
   override protected def executeMerge(
-                                       target: String,
-                                       source: String,
-                                       condition: String,
-                                       update: String,
-                                       insert: String): Unit = {
+      target: String,
+      source: String,
+      condition: String,
+      update: String,
+      insert: String): Unit = {
 
     executeMerge(
       tgt = target,
@@ -295,10 +295,10 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
   }
 
   override protected def executeMerge(
-                                       tgt: String,
-                                       src: String,
-                                       cond: String,
-                                       clauses: MergeClause*): Unit = {
+      tgt: String,
+      src: String,
+      cond: String,
+      clauses: MergeClause*): Unit = {
 
     def parse(tableNameWithAlias: String): (String, Option[String]) = {
       tableNameWithAlias.split(" ").toList match {
@@ -314,32 +314,32 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
     }
 
     def buildClause(
-                     clause: MergeClause,
-                     mergeBuilder: DeltaMergeBuilder): DeltaMergeBuilder = {
+      clause: MergeClause,
+      mergeBuilder: DeltaMergeBuilder): DeltaMergeBuilder = {
 
       if (clause.isMatched) {
         val actionBuilder: DeltaMergeMatchedActionBuilder =
           if (clause.condition != null) mergeBuilder.whenMatched(clause.condition)
           else mergeBuilder.whenMatched()
-        if (clause.action.startsWith("DELETE")) { // DELETE clause
+        if (clause.action.startsWith("DELETE")) {   // DELETE clause
           actionBuilder.delete()
-        } else { // UPDATE clause
+        } else {                                    // UPDATE clause
           val setColExprStr = clause.action.trim.stripPrefix("UPDATE SET")
-          if (setColExprStr.trim == "*") { // UPDATE SET *
+          if (setColExprStr.trim == "*") {          // UPDATE SET *
             actionBuilder.updateAll()
-          } else { // UPDATE SET x = a, y = b, z = c
+          } else {                                  // UPDATE SET x = a, y = b, z = c
             val setColExprPairs = parseUpdate(setColExprStr.split(","))
             actionBuilder.updateExpr(setColExprPairs)
           }
         }
-      } else { // INSERT clause
+      } else {                                        // INSERT clause
         val actionBuilder: DeltaMergeNotMatchedActionBuilder =
           if (clause.condition != null) mergeBuilder.whenNotMatched(clause.condition)
           else mergeBuilder.whenNotMatched()
         val valueStr = clause.action.trim.stripPrefix("INSERT")
-        if (valueStr.trim == "*") { // INSERT *
+        if (valueStr.trim == "*") {                   // INSERT *
           actionBuilder.insertAll()
-        } else { // INSERT (x, y, z) VALUES (a, b, c)
+        } else {                                      // INSERT (x, y, z) VALUES (a, b, c)
           val valueColExprsPairs = parseInsert(valueStr, Some(clause))
           actionBuilder.insertExpr(valueColExprsPairs)
         }
@@ -370,13 +370,13 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
   }
 
   override def testNestedDataSupport(name: String, namePrefix: String = "nested data support")(
-    source: String,
-    target: String,
-    update: Seq[String],
-    insert: String = null,
-    schema: StructType = null,
-    result: String = null,
-    errorStrs: Seq[String] = null): Unit = {
+      source: String,
+      target: String,
+      update: Seq[String],
+      insert: String = null,
+      schema: StructType = null,
+      result: String = null,
+      errorStrs: Seq[String] = null): Unit = {
 
     require(result == null ^ errorStrs == null, "either set the result or the error strings")
 
@@ -410,9 +410,7 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
           execMerge()
           checkAnswer(readDeltaTable(pathOrName), spark.read.json(strToJsonSeq(result).toDS))
         } else {
-          val e = intercept[AnalysisException] {
-            execMerge()
-          }
+          val e = intercept[AnalysisException] { execMerge() }
           errorStrs.foreach { s => errorContains(e.getMessage, s) }
         }
       }
@@ -430,9 +428,7 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
   }
 
   private def parseUpdate(update: Seq[String]): Map[String, String] = {
-    update.map {
-      _.split("=").toList
-    }.map {
+    update.map { _.split("=").toList }.map {
       case setCol :: setExpr :: Nil => setCol.trim -> setExpr.trim
       case _ => fail("error parsing update actions " + update)
     }.toMap
@@ -444,7 +440,6 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
         def parse(str: String): Seq[String] = {
           str.trim.stripPrefix("(").stripSuffix(")").split(",").map(_.trim)
         }
-
         val cols = parse(colsStr)
         val exprs = parse(exprsStr)
         require(cols.size == exprs.size,

--- a/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
@@ -30,8 +30,8 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
 
   test("basic scala API") {
     withTable("source") {
-      append(Seq((1, 10), (2, 20)).toDF("key1", "value1"), Nil)  // target
-      val source = Seq((1, 100), (3, 30)).toDF("key2", "value2")  // source
+      append(Seq((1, 10), (2, 20)).toDF("key1", "value1"), Nil) // target
+      val source = Seq((1, 100), (3, 30)).toDF("key2", "value2") // source
 
       io.delta.tables.DeltaTable.forPath(spark, tempPath)
         .merge(source, "key1 = key2")
@@ -41,17 +41,17 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
 
       checkAnswer(
         readDeltaTable(tempPath),
-        Row(1, 100) ::    // Update
-          Row(2, 20) ::     // No change
-          Row(3, 30) ::     // Insert
+        Row(1, 100) :: // Update
+          Row(2, 20) :: // No change
+          Row(3, 30) :: // Insert
           Nil)
     }
   }
 
   test("extended scala API") {
     withTable("source") {
-      append(Seq((1, 10), (2, 20), (4, 40)).toDF("key1", "value1"), Nil)  // target
-      val source = Seq((1, 100), (3, 30), (4, 41)).toDF("key2", "value2")  // source
+      append(Seq((1, 10), (2, 20), (4, 40)).toDF("key1", "value1"), Nil) // target
+      val source = Seq((1, 100), (3, 30), (4, 41)).toDF("key2", "value2") // source
 
       io.delta.tables.DeltaTable.forPath(spark, tempPath)
         .merge(source, "key1 = key2")
@@ -62,17 +62,17 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
 
       checkAnswer(
         readDeltaTable(tempPath),
-        Row(1, 100) ::    // Update
-          Row(2, 20) ::     // No change
-          Row(3, 30) ::     // Insert
+        Row(1, 100) :: // Update
+          Row(2, 20) :: // No change
+          Row(3, 30) :: // Insert
           Nil)
     }
   }
 
   test("extended scala API with Column") {
     withTable("source") {
-      append(Seq((1, 10), (2, 20), (4, 40)).toDF("key1", "value1"), Nil)  // target
-      val source = Seq((1, 100), (3, 30), (4, 41)).toDF("key2", "value2")  // source
+      append(Seq((1, 10), (2, 20), (4, 40)).toDF("key1", "value1"), Nil) // target
+      val source = Seq((1, 100), (3, 30), (4, 41)).toDF("key2", "value2") // source
 
       io.delta.tables.DeltaTable.forPath(spark, tempPath)
         .merge(source, functions.expr("key1 = key2"))
@@ -85,9 +85,9 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
 
       checkAnswer(
         readDeltaTable(tempPath),
-        Row(1, 100) ::    // Update
-          Row(2, 20) ::     // No change
-          Row(3, 30) ::     // Insert
+        Row(1, 100) :: // Update
+          Row(2, 20) :: // No change
+          Row(3, 30) :: // Insert
           Nil)
     }
   }
@@ -107,12 +107,35 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
 
       checkAnswer(
         readDeltaTable(tempPath),
-        Row(1, 100) ::    // Update
-          Row(2, 20) ::     // No change
-          Row(3, 30) ::     // Insert
-          Row(4, 41) ::     // Update
-          Row(5, 51) ::     // Update
-          Row(6, 60) ::     // Insert
+        Row(1, 100) :: // Update
+          Row(2, 20) :: // No change
+          Row(3, 30) :: // Insert
+          Row(4, 41) :: // Update
+          Row(5, 51) :: // Update
+          Row(6, 60) :: // Insert
+          Nil)
+    }
+  }
+
+  test("updateAll and insertAll with columns containing dot") {
+    withTable("source") {
+      append(Seq((1, 10), (2, 20), (4, 40)).toDF("key", "the.value"), Nil) // target
+      val source = Seq((1, 100), (3, 30), (4, 41)).toDF("key", "the.value") // source
+
+      io.delta.tables.DeltaTable.forPath(spark, tempPath).as("t")
+        .merge(source.as("s"), "t.key = s.key")
+        .whenMatched()
+        .updateAll()
+        .whenNotMatched()
+        .insertAll()
+        .execute()
+
+      checkAnswer(
+        readDeltaTable(tempPath),
+        Row(1, 100) :: // Update
+          Row(2, 20) :: // No change
+          Row(4, 41) :: // Update
+          Row(3, 30) :: // Insert
           Nil)
     }
   }
@@ -128,10 +151,10 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
 
     checkAnswer(
       readDeltaTable(tempPath),
-      Row(1, 10) ::       // Not updated since no update clause
-      Row(2, 20) ::       // No change due to merge condition
-      Row(3, 30) ::       // Not updated since no update clause
-      Nil)
+      Row(1, 10) :: // Not updated since no update clause
+        Row(2, 20) :: // No change due to merge condition
+        Row(3, 30) :: // Not updated since no update clause
+        Nil)
 
     // match condition should not be ignored when map is empty
     io.delta.tables.DeltaTable.forPath(spark, tempPath)
@@ -143,9 +166,9 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
 
     checkAnswer(
       readDeltaTable(tempPath),
-      Row(1, 10) ::     // Neither updated, nor deleted (condition is not ignored)
-      Row(2, 20) ::     // No change due to merge condition
-      Nil)              // Deleted (3, 30)
+      Row(1, 10) :: // Neither updated, nor deleted (condition is not ignored)
+        Row(2, 20) :: // No change due to merge condition
+        Nil) // Deleted (3, 30)
   }
 
   test("insert with empty map throws error") {
@@ -257,11 +280,11 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
   }
 
   override protected def executeMerge(
-      target: String,
-      source: String,
-      condition: String,
-      update: String,
-      insert: String): Unit = {
+                                       target: String,
+                                       source: String,
+                                       condition: String,
+                                       update: String,
+                                       insert: String): Unit = {
 
     executeMerge(
       tgt = target,
@@ -272,10 +295,10 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
   }
 
   override protected def executeMerge(
-      tgt: String,
-      src: String,
-      cond: String,
-      clauses: MergeClause*): Unit = {
+                                       tgt: String,
+                                       src: String,
+                                       cond: String,
+                                       clauses: MergeClause*): Unit = {
 
     def parse(tableNameWithAlias: String): (String, Option[String]) = {
       tableNameWithAlias.split(" ").toList match {
@@ -291,32 +314,32 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
     }
 
     def buildClause(
-      clause: MergeClause,
-      mergeBuilder: DeltaMergeBuilder): DeltaMergeBuilder = {
+                     clause: MergeClause,
+                     mergeBuilder: DeltaMergeBuilder): DeltaMergeBuilder = {
 
       if (clause.isMatched) {
         val actionBuilder: DeltaMergeMatchedActionBuilder =
           if (clause.condition != null) mergeBuilder.whenMatched(clause.condition)
           else mergeBuilder.whenMatched()
-        if (clause.action.startsWith("DELETE")) {   // DELETE clause
+        if (clause.action.startsWith("DELETE")) { // DELETE clause
           actionBuilder.delete()
-        } else {                                    // UPDATE clause
+        } else { // UPDATE clause
           val setColExprStr = clause.action.trim.stripPrefix("UPDATE SET")
-          if (setColExprStr.trim == "*") {          // UPDATE SET *
+          if (setColExprStr.trim == "*") { // UPDATE SET *
             actionBuilder.updateAll()
-          } else {                                  // UPDATE SET x = a, y = b, z = c
+          } else { // UPDATE SET x = a, y = b, z = c
             val setColExprPairs = parseUpdate(setColExprStr.split(","))
             actionBuilder.updateExpr(setColExprPairs)
           }
         }
-      } else {                                        // INSERT clause
+      } else { // INSERT clause
         val actionBuilder: DeltaMergeNotMatchedActionBuilder =
           if (clause.condition != null) mergeBuilder.whenNotMatched(clause.condition)
           else mergeBuilder.whenNotMatched()
         val valueStr = clause.action.trim.stripPrefix("INSERT")
-        if (valueStr.trim == "*") {                   // INSERT *
+        if (valueStr.trim == "*") { // INSERT *
           actionBuilder.insertAll()
-        } else {                                      // INSERT (x, y, z) VALUES (a, b, c)
+        } else { // INSERT (x, y, z) VALUES (a, b, c)
           val valueColExprsPairs = parseInsert(valueStr, Some(clause))
           actionBuilder.insertExpr(valueColExprsPairs)
         }
@@ -347,13 +370,13 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
   }
 
   override def testNestedDataSupport(name: String, namePrefix: String = "nested data support")(
-      source: String,
-      target: String,
-      update: Seq[String],
-      insert: String = null,
-      schema: StructType = null,
-      result: String = null,
-      errorStrs: Seq[String] = null): Unit = {
+    source: String,
+    target: String,
+    update: Seq[String],
+    insert: String = null,
+    schema: StructType = null,
+    result: String = null,
+    errorStrs: Seq[String] = null): Unit = {
 
     require(result == null ^ errorStrs == null, "either set the result or the error strings")
 
@@ -387,7 +410,9 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
           execMerge()
           checkAnswer(readDeltaTable(pathOrName), spark.read.json(strToJsonSeq(result).toDS))
         } else {
-          val e = intercept[AnalysisException] { execMerge() }
+          val e = intercept[AnalysisException] {
+            execMerge()
+          }
           errorStrs.foreach { s => errorContains(e.getMessage, s) }
         }
       }
@@ -405,7 +430,9 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
   }
 
   private def parseUpdate(update: Seq[String]): Map[String, String] = {
-    update.map { _.split("=").toList }.map {
+    update.map {
+      _.split("=").toList
+    }.map {
       case setCol :: setExpr :: Nil => setCol.trim -> setExpr.trim
       case _ => fail("error parsing update actions " + update)
     }.toMap
@@ -417,6 +444,7 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase {
         def parse(str: String): Seq[String] = {
           str.trim.stripPrefix("(").stripSuffix(")").split(",").map(_.trim)
         }
+
         val cols = parse(colsStr)
         val exprs = parse(exprsStr)
         require(cols.size == exprs.size,


### PR DESCRIPTION
This resolves #233 and #208.

This PR add a test to track the issue and also proposes a fix by quoting with backticks the columns coming from the target plan.