### PR TITLE
Optimized insert only merge support

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
@@ -100,6 +100,9 @@ case class MergeIntoCommand(
   @transient private lazy val sc: SparkContext = SparkContext.getOrCreate()
   @transient private lazy val targetDeltaLog: DeltaLog = targetFileIndex.deltaLog
 
+  /** Whether this merge statement only inserts new data. */
+  private def isInsertOnly: Boolean = matchedClauses.isEmpty && notMatchedClause.isDefined
+
   lazy val updateClause: Option[MergeIntoUpdateClause] =
     matchedClauses.collectFirst { case u: MergeIntoUpdateClause => u }
   lazy val deleteClause: Option[MergeIntoDeleteClause] =
@@ -120,13 +123,16 @@ case class MergeIntoCommand(
     spark: SparkSession): Seq[Row] = recordDeltaOperation(targetDeltaLog, "delta.dml.merge") {
     targetDeltaLog.withNewTransaction { deltaTxn =>
       val deltaActions = {
-        val filesToRewrite =
-          recordDeltaOperation(targetDeltaLog, "delta.dml.merge.findTouchedFiles") {
-            findTouchedFiles(spark, deltaTxn)
-          }
-
-        val newWrittenFiles = writeAllChanges(spark, deltaTxn, filesToRewrite)
-        filesToRewrite.map(_.remove) ++ newWrittenFiles
+       if (isInsertOnly) {
+         writeInsertsOnlyWhenNoMatchedClauses(spark, deltaTxn)
+       } else {
+         val filesToRewrite =
+           recordDeltaOperation(targetDeltaLog, "delta.dml.merge.findTouchedFiles") {
+             findTouchedFiles(spark, deltaTxn)
+           }
+         val newWrittenFiles = writeAllChanges(spark, deltaTxn, filesToRewrite)
+         filesToRewrite.map(_.remove) ++ newWrittenFiles
+       }
       }
       deltaTxn.commit(
         deltaActions,
@@ -230,6 +236,52 @@ case class MergeIntoCommand(
     metrics("numTargetFilesAfterSkipping") += dataSkippedFiles.size
     metrics("numTargetFilesRemoved") += touchedAddFiles.size
     touchedAddFiles
+  }
+
+  /**
+   * This is an optimization of the case when there is no update clause for the merge.
+   * We perform an left anti join on the source data to find the rows to be inserted.
+   */
+  private def writeInsertsOnlyWhenNoMatchedClauses(
+      spark: SparkSession,
+      deltaTxn: OptimisticTransaction
+    ): Seq[AddFile] = withStatusCode("DELTA", s"Writing new files " +
+    s"for insert-only MERGE operation") {
+
+    // UDFs to update metrics
+    val incrSourceRowCountExpr = makeMetricUpdateUDF("numSourceRows")
+    val incrInsertedCountExpr = makeMetricUpdateUDF("numTargetRowsInserted")
+
+    val outputColNames = target.output.map(_.name)
+    val outputExprs = notMatchedClause.get.resolvedActions.map(_.expr) :+ incrInsertedCountExpr
+    val outputCols = outputExprs.zip(outputColNames).map { case (expr, name) =>
+      new Column(Alias(expr, name)())
+    }
+
+    // source DataFrame
+    val sourceDF = Dataset.ofRows(spark, source)
+      .filter(new Column(incrSourceRowCountExpr))
+      .filter(new Column(notMatchedClause.get.condition.getOrElse(Literal(true))))
+
+    // Skip data based on the merge condition
+    val conjunctivePredicates = splitConjunctivePredicates(condition)
+    val targetOnlyPredicates =
+      conjunctivePredicates.filter(_.references.subsetOf(target.outputSet))
+    val dataSkippedFiles = deltaTxn.filterFiles(targetOnlyPredicates)
+
+    // target DataFrame
+    val targetDF = Dataset.ofRows(
+      spark, buildTargetPlanWithFiles(deltaTxn, dataSkippedFiles))
+
+    val insertDf = sourceDF.join(targetDF, new Column(condition), "leftanti")
+      .select(outputCols: _*)
+
+    val newFiles = deltaTxn.writeFiles(insertDf)
+    metrics("numTargetFilesBeforeSkipping") += deltaTxn.snapshot.numOfFiles
+    metrics("numTargetFilesAfterSkipping") += dataSkippedFiles.size
+    metrics("numTargetFilesRemoved") += 0
+    metrics("numTargetFilesAdded") += newFiles.size
+    newFiles
   }
 
   /**


### PR DESCRIPTION
This PR optimizes the use case where there is no update clause in the merge but only an insert when not matched clause. This optimizes the existing implementation by performing an anti-join on the source data to insert the data instead of performing a full-outer join.

closes #246 