### PR TITLE
OpType is case class

### DIFF
--- a/src/main/scala/com/databricks/spark/util/DatabricksLogging.scala
+++ b/src/main/scala/com/databricks/spark/util/DatabricksLogging.scala
@@ -31,7 +31,7 @@ object TagDefinitions {
   object TAG_OP_TYPE extends TagDefinition
 }
 
-class OpType(val typeName: String, val description: String)
+case class OpType(typeName: String, description: String)
 
 class MetricDefinition
 

--- a/src/main/scala/com/databricks/spark/util/DatabricksLogging.scala
+++ b/src/main/scala/com/databricks/spark/util/DatabricksLogging.scala
@@ -31,7 +31,7 @@ object TagDefinitions {
   object TAG_OP_TYPE extends TagDefinition
 }
 
-class OpType(typeName: String, description: String)
+class OpType(val typeName: String, val description: String)
 
 class MetricDefinition
 


### PR DESCRIPTION
This PR makes the fields of `OpType` (`typeName` and `description`) accessible so that custom logging implementations can log them.

CC: @imback82 @rapoth @suhsteve