### PR TITLE
Public Scala/Python/SQL APIs for Manifest Generation

### DIFF
--- a/python/delta/tables.py
+++ b/python/delta/tables.py
@@ -60,6 +60,21 @@ class DeltaTable(object):
         jdt = self._jdt.alias(aliasName)
         return DeltaTable(self._spark, jdt)
 
+    @since(0.5)
+    def generate(self, mode):
+        """
+        Generate manifest files for the given delta table.
+
+        :param mode: mode for the type of manifest file to be generated
+                     The valid modes are as follows (not case sensitive):
+                      - "symlink_manifest_format" : This will generate manifests in symlink format
+                                                    for Presto and Athena read support.
+                     See the online documentation for more information.
+
+        .. note:: Evolving
+        """
+        self._jdt.generate(mode)
+
     @since(0.4)
     def delete(self, condition=None):
         """

--- a/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
+++ b/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
@@ -75,6 +75,7 @@ statement
     : VACUUM (path=STRING | table=qualifiedName)
         (RETAIN number HOURS)? (DRY RUN)?                               #vacuumTable
     | (DESC | DESCRIBE) DETAIL (path=STRING | table=qualifiedName)      #describeDeltaDetail
+    | GENERATE modeName=identifier FOR TABLE table=qualifiedName        #generate
     | (DESC | DESCRIBE) HISTORY (path=STRING | table=qualifiedName)
         (LIMIT limit=INTEGER_VALUE)?                                    #describeDeltaHistory
     | CONVERT TO DELTA table=qualifiedName
@@ -124,6 +125,7 @@ nonReserved
     : VACUUM | RETAIN | HOURS | DRY | RUN
     | CONVERT | TO | DELTA | PARTITIONED | BY
     | DESC | DESCRIBE | LIMIT | DETAIL
+    | GENERATE | FOR | TABLE
     ;
 
 // Define how the keywords above should appear in a user's SQL statement.
@@ -134,6 +136,7 @@ DELTA: 'DELTA';
 DESC: 'DESC';
 DESCRIBE: 'DESCRIBE';
 DETAIL: 'DETAIL';
+GENERATE: 'GENERATE';
 DRY: 'DRY';
 HISTORY: 'HISTORY';
 HOURS: 'HOURS';
@@ -141,6 +144,8 @@ LIMIT: 'LIMIT';
 MINUS: '-';
 NOT: 'NOT' | '!';
 NULL: 'NULL';
+FOR: 'FOR';
+TABLE: 'TABLE';
 PARTITIONED: 'PARTITIONED';
 RETAIN: 'RETAIN';
 RUN: 'RUN';

--- a/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
+++ b/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
@@ -42,6 +42,7 @@ import java.util.Locale
 
 import scala.collection.JavaConverters._
 
+import org.apache.spark.sql.delta.commands.DeltaGenerateCommand
 import io.delta.sql.parser.DeltaSqlBaseParser._
 import io.delta.tables.execution.{DescribeDeltaHistoryCommand, VacuumTableCommand}
 import org.antlr.v4.runtime._
@@ -166,6 +167,12 @@ class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
       Option(ctx.path).map(string),
       Option(ctx.table).map(visitTableIdentifier),
       Option(ctx.limit).map(_.getText.toInt))
+  }
+
+  override def visitGenerate(ctx: GenerateContext): LogicalPlan = withOrigin(ctx) {
+    DeltaGenerateCommand(
+      modeName = ctx.modeName.getText,
+      tableId = visitTableIdentifier(ctx.table))
   }
 
   override def visitConvert(ctx: ConvertContext): LogicalPlan = withOrigin(ctx) {

--- a/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -138,6 +138,24 @@ class DeltaTable private[tables](df: Dataset[Row], deltaLog: DeltaLog)
   /**
    * :: Evolving ::
    *
+   * Generate a manifest for the given Delta Table
+   *
+   * @param mode Specifies the mode for the generation of the manifest.
+   *             The valid modes are as follows (not case sensitive):
+   *              - "symlink_manifest_format" : This will generate manifests in symlink format
+   *                                            for Presto and Athena read support.
+   *             See the online documentation for more information.
+   * @since 0.5.0
+   */
+  @Evolving
+  def generate(mode: String): Unit = {
+    val path = deltaLog.dataPath.toString
+    executeGenerate(s"delta.`$path`", mode)
+  }
+
+  /**
+   * :: Evolving ::
+   *
    * Delete data from the table that match the given `condition`.
    *
    * @param condition Boolean SQL expression

--- a/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
+++ b/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
@@ -19,11 +19,12 @@ package io.delta.tables.execution
 import scala.collection.Map
 
 import org.apache.spark.sql.delta.{DeltaErrors, DeltaHistoryManager, DeltaLog, PreprocessTableUpdate}
-import org.apache.spark.sql.delta.commands.{DeleteCommand, VacuumCommand}
+import org.apache.spark.sql.delta.commands.{DeleteCommand, DeltaGenerateCommand, VacuumCommand}
 import org.apache.spark.sql.delta.util.AnalysisHelper
 import io.delta.tables.DeltaTable
 
 import org.apache.spark.sql.{functions, Column, DataFrame}
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.expressions.{Expression, SubqueryExpression}
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -67,6 +68,15 @@ trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
     val history = new DeltaHistoryManager(deltaLog)
     val spark = self.toDF.sparkSession
     spark.createDataFrame(history.getHistory(limit))
+  }
+
+  protected def executeGenerate(tblIdentifier: String, mode: String): Unit = {
+    val tableId: TableIdentifier = sparkSession
+      .sessionState
+      .sqlParser
+      .parseTableIdentifier(tblIdentifier)
+    val generate = DeltaGenerateCommand(mode, tableId)
+    generate.run(sparkSession)
   }
 
   protected def executeUpdate(set: Map[String, Column], condition: Option[Column]): Unit = {

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -687,6 +687,13 @@ object DeltaErrors
     }
     new RuntimeException(errorMessage, error)
   }
+
+  def unsupportedGenerateModeException(modeName: String): Throwable = {
+    import org.apache.spark.sql.delta.commands.DeltaGenerateCommand
+    val supportedModes = DeltaGenerateCommand.modeNameToGenerationFunc.keys.toSeq.mkString(", ")
+    new IllegalArgumentException(
+      s"Specified mode '$modeName' is not supported. Supported modes are: $supportedModes")
+  }
 }
 
 /** The basic class for all Tahoe commit conflict exceptions. */

--- a/src/main/scala/org/apache/spark/sql/delta/commands/DeltaGenerateCommand.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/DeltaGenerateCommand.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 Databricks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands
+
+import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaTableIdentifier}
+import org.apache.spark.sql.delta.hooks.GenerateSymlinkManifest
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.{AnalysisException, Row, SparkSession}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
+import org.apache.spark.sql.execution.command.RunnableCommand
+
+trait DeltaGenerateCommandBase extends RunnableCommand {
+
+  protected def getPath(spark: SparkSession, tableId: TableIdentifier): Path = {
+    DeltaTableIdentifier(spark, tableId) match {
+      case Some(id) if id.path.isDefined => new Path(id.path.get)
+      case Some(id) =>
+        throw DeltaErrors.tableNotSupportedException("DELTA GENERATE")
+      case None =>
+        // This is not a Delta table.
+        val metadata = spark.sessionState.catalog.getTableMetadata(tableId)
+        new Path(metadata.location)
+    }
+  }
+}
+
+case class DeltaGenerateCommand(modeName: String, tableId: TableIdentifier)
+  extends DeltaGenerateCommandBase {
+
+  import DeltaGenerateCommand._
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    if (!modeNameToGenerationFunc.contains(modeName)) {
+      throw DeltaErrors.unsupportedGenerateModeException(modeName)
+    }
+    val tablePath = getPath(sparkSession, tableId)
+    val deltaLog = DeltaLog.forTable(sparkSession, tablePath)
+    if (deltaLog.snapshot.version < 0) {
+      throw new AnalysisException(s"Delta table not found at $tablePath.")
+    }
+    val generationFunc = modeNameToGenerationFunc(modeName)
+    generationFunc(sparkSession, deltaLog)
+    Seq.empty
+  }
+}
+
+object DeltaGenerateCommand {
+  val modeNameToGenerationFunc = CaseInsensitiveMap(
+    Map[String, (SparkSession, DeltaLog) => Unit](
+    "symlink_format_manifest" -> GenerateSymlinkManifest.generateFullManifest
+  ))
+}


### PR DESCRIPTION
Added `DeltaTable` API `generate` which can be used to generate manifest files e.g SymlinkTextInputFormat manifest.

Added
- Scala APIs and tests
- Python APIs and tests
- SQL Support and tests.

example usage
Scala:  `deltaTable.generate("symlink_format_manifest")`
Python: `deltaTable.generate("symlink_format_manifest")`
SQL: `GENERATE symlink_format_manifest FOR TABLE delta.\path`



This closes #76 


GitOrigin-RevId: a1b0285debf1becbfad4ee5491c2acbd524945b4