### PR TITLE
Update protocol spec to clarify hidden folders

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -79,6 +79,7 @@ Data files can be stored in the root directory of the table or in any non-hidden
 By default, the reference implementation stores data files in directories that are named based on the partition values for data in that file (i.e. `part1=value1/part2=value2/...`).
 This directory format is only used to follow existing conventions and is not required by the protocol.
 Actual partition values for a file must be read from the transaction log.
+If a partition column name starts with `_` and Delta writes data files to that folder, that folder is not considered a hidden subdirectory.
 
 ### Delta Log Entries
 Delta files are stored as JSON in a directory at the root of the table named `_delta_log`, and together make up the log of all changes that have occurred to a table.


### PR DESCRIPTION
Update the protocol spec to specify that data files written by Delta to a directory beginning with `_` are not hidden.

Out of https://github.com/delta-io/delta/issues/256, @nfx pointed out an inconsistency in the protocol spec where a table partitioned on a column beginning with `_` will save data in a folder beginning with `_`, which according to the current version of the spec would make it a hidden folder.