### PR TITLE
Updates Scala/Python examples with 0.5.0 features

### DIFF
--- a/examples/python/streaming.py
+++ b/examples/python/streaming.py
@@ -24,7 +24,7 @@ import random
 import threading
 
 # Clear previous run delta-tables
-files = ["/tmp/delta-table", "/tmp/delta-table2", "/tmp/delta-table3"]
+files = ["/tmp/delta-table", "/tmp/delta-table2", "/tmp/delta-table3", "/tmp/delta-table4", "/tmp/delta-table5", "/tmp/checkpoint/tbl1"]
 for i in files:
     try:
         shutil.rmtree(i)
@@ -94,6 +94,31 @@ stream3.stop()
 print("########### DeltaTable after streaming upsert #########")
 deltaTable.toDF().show()
 
+# Streaming append and concurrent repartition using  data change = false
+# tbl1 is the sink and tbl2 is the source
+print("############ Streaming appends with concurrent table repartition  ##########")
+tbl1 = "/tmp/delta-table4"
+tbl2 = "/tmp/delta-table5"
+numRows = 10
+spark.range(numRows).write.mode("overwrite").format("delta").save(tbl1)
+spark.read.format("delta").load(tbl1).show()
+spark.range(numRows, numRows * 10).write.mode("overwrite").format("delta").save(tbl2)
+
+
+# Start reading tbl2 as a stream and do a streaming write to tbl1
+# Prior to Delta 0.5.0 this would throw StreamingQueryException: Detected a data update in the source table. This is currently not supported. 
+stream4 = spark.readStream.format("delta").load(tbl2).writeStream.format("delta") \
+     .option("checkpointLocation", "/tmp/checkpoint/tbl1") \
+     .outputMode("append") \
+     .start(tbl1)
+
+# repartition table while streaming job is running
+spark.read.format("delta").load(tbl2).repartition(10).write.format("delta").mode("overwrite").option("dataChange", "false").save(tbl2)
+
+stream4.awaitTermination(10)
+stream4.stop()
+print("######### After streaming write #########")
+spark.read.format("delta").load(tbl1).show()
 # cleanup
 for i in files:
     try:

--- a/examples/python/utilities.py
+++ b/examples/python/utilities.py
@@ -71,6 +71,10 @@ deltaTable.vacuum()
 print("######## Describe history for the table ######")
 deltaTable.history().show()
 
+# Generate manifest
+print("######## Generating manifest ######")
+deltaTable.generate("SYMLINK_FORMAT_MANIFEST")
+
 # SQL Vacuum
 print("####### SQL Vacuum #######")
 spark.sql("VACUUM '%s' RETAIN 169 HOURS" % "/tmp/delta-table").collect()

--- a/examples/scala/build.sbt
+++ b/examples/scala/build.sbt
@@ -23,6 +23,6 @@ version := "0.1.0"
 lazy val root = (project in file("."))
   .settings(
     name := "hello-world",
-    libraryDependencies += "io.delta" %% "delta-core" % "0.4.0",
+    libraryDependencies += "io.delta" %% "delta-core" % "0.5.0",
     libraryDependencies += "org.apache.spark" %% "spark-sql" % "2.4.3",
     resolvers += "Delta" at "https://dl.bintray.com/delta-io/delta/")

--- a/examples/scala/src/main/scala/example/Streaming.scala
+++ b/examples/scala/src/main/scala/example/Streaming.scala
@@ -133,11 +133,9 @@ object Streaming {
     spark.read.format("delta").load(tbl1).show()
 
     // Cleanup
-    FileUtils.deleteDirectory(new File(path))
-    FileUtils.deleteDirectory(new File(tbl1))
-    FileUtils.deleteDirectory(new File(tbl2))
-    FileUtils.deleteDirectory(new File("/tmp/checkpoint/tbl1"))
-    FileUtils.deleteDirectory(new File(tablePath2))
+    Seq(path, tbl1, tbl2, "/tmp/checkpoint/tbl1", tablePath2).foreach { path =>
+    	FileUtils.deleteDirectory(new File(path))
+    }
     spark.stop()
   }
 }

--- a/examples/scala/src/main/scala/example/Utilities.scala
+++ b/examples/scala/src/main/scala/example/Utilities.scala
@@ -65,6 +65,10 @@ object Utilities {
     println("Describe History for the table")
     deltaTable.history().show()
 
+    // Generate manifest
+    println("Generate Manifest files")
+    deltaTable.generate("SYMLINK_FORMAT_MANIFEST")
+
     // SQL utility commands
     println("SQL Vacuum")
     spark.sql(s"VACUUM '$path' RETAIN 169 HOURS")


### PR DESCRIPTION
Updating examples to include examples
1.  Streaming: Streaming append and concurrent repartition using `dataChange=false` 
2. Utilities: generating manifest files.

built jar and tested locally. 