### PR TITLE
Check if documentation links in DeltaErrors point to valid URLs

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -72,8 +72,8 @@ case class DeltaSource(
   // Deprecated. Please use `ignoreDeletes` or `ignoreChanges` from now on.
   private val ignoreFileDeletion = {
     if (options.ignoreFileDeletion) {
-      val docPage = DeltaErrors.baseDocsPath(spark.sparkContext.getConf) +
-        "/delta/delta-streaming.html#ignoring-updates-and-deletes"
+      val docPage = DeltaErrors.generateDocsLink(spark.sparkContext.getConf,
+        "/delta/delta-streaming.html#ignoring-updates-and-deletes")
       logConsole(
         s"""WARNING: The 'ignoreFileDeletion' option is deprecated. Switch to using one of
            |'ignoreDeletes' or 'ignoreChanges'. Refer to $docPage for details.

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 Databricks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import scala.sys.process.Process
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
+
+trait DeltaErrorsSuiteBase
+    extends QueryTest
+    with SharedSparkSession    with SQLTestUtils {
+
+  val MAX_URL_ACCESS_RETRIES = 3
+  val path = "/sample/path"
+  // Map of error name to the actual error message it throws
+  def errorsToTest: Map[String, Throwable] = Map(
+    "useDeltaOnOtherFormatPathException" ->
+      DeltaErrors.useDeltaOnOtherFormatPathException("operation", path, spark),
+    "useOtherFormatOnDeltaPathException" ->
+      DeltaErrors.useOtherFormatOnDeltaPathException("operation", path, path, "format", spark),
+    "createExternalTableWithoutLogException" ->
+      DeltaErrors.createExternalTableWithoutLogException(new Path(path), "tableName", spark),
+    "createExternalTableWithoutSchemaException" ->
+      DeltaErrors.createExternalTableWithoutSchemaException(new Path(path), "tableName", spark),
+    "createManagedTableWithoutSchemaException" ->
+      DeltaErrors.createManagedTableWithoutSchemaException("tableName", spark))
+
+  def otherMessagesToTest: Map[String, String] = Map(
+    "deltaFileNotFoundHint" ->
+      DeltaErrors.deltaFileNotFoundHint(
+        DeltaErrors.generateDocsLink(sparkConf, DeltaErrors.faqPath), path))
+
+  def errorMessagesToTest: Map[String, String] =
+  errorsToTest.mapValues(_.getMessage) ++ otherMessagesToTest
+
+  protected def assertValidUrl(url: String, errName: String): Unit = {
+    var response = ""
+    (1 to MAX_URL_ACCESS_RETRIES).foreach { attempt =>
+      if (attempt > 1) Thread.sleep(1000)
+      response = Process("curl -I " + url).!!
+      if (response.contains("HTTP/1.1 200 OK") || response.contains("HTTP/2 200")) {
+        return
+      }
+      fail(
+        s"""
+           |A link to the URL: '$url' is broken in the error: $errName, accessing this URL does not
+           |result in a valid response, received the following response: $response
+         """.stripMargin)
+    }
+  }
+
+  def getUrlsFromMessage(message: String): List[String] = {
+    val regexToFindUrl = "https://[^\\s]+".r
+    regexToFindUrl.findAllIn(message).toList
+  }
+
+  def testUrls() {
+    errorMessagesToTest.foreach { case (errName, message) =>
+      getUrlsFromMessage(message).foreach { url =>
+        assertValidUrl(url, errName)
+      }
+    }
+  }
+
+  test("Validate that links to docs in DeltaErrors are correct") {
+    testUrls()
+  }
+}
+
+class DeltaErrorsSuite
+  extends DeltaErrorsSuiteBase


### PR DESCRIPTION
 - New test suite to test the documentation links in `DeltaErrors`
 - `DocsPath` now has a method `generateDocsLink` which will be used to create the docs link that is passed to the error message
 - `DeltaErrorsSuiteBase` contains a list of all the error message in `DeltaErrors` that are applicable to Delta. The test accesses each link in each error message and checks to see if the HTTP response is valid for docs.delta.io.{path}