### PR TITLE
Fix typo in DeltaTable Generate method descriptions

### DIFF
--- a/python/delta/tables.py
+++ b/python/delta/tables.py
@@ -67,7 +67,7 @@ class DeltaTable(object):
 
         :param mode: mode for the type of manifest file to be generated
                      The valid modes are as follows (not case sensitive):
-                      - "symlink_manifest_format" : This will generate manifests in symlink format
+                      - "symlink_format_manifest" : This will generate manifests in symlink format
                                                     for Presto and Athena read support.
                      See the online documentation for more information.
 

--- a/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -142,7 +142,7 @@ class DeltaTable private[tables](df: Dataset[Row], deltaLog: DeltaLog)
    *
    * @param mode Specifies the mode for the generation of the manifest.
    *             The valid modes are as follows (not case sensitive):
-   *              - "symlink_manifest_format" : This will generate manifests in symlink format
+   *              - "symlink_format_manifest" : This will generate manifests in symlink format
    *                                            for Presto and Athena read support.
    *             See the online documentation for more information.
    * @since 0.5.0


### PR DESCRIPTION
The Generate method descriptions list **symlink_manifest_format** as a valid mode, however the [Generate documentation](https://docs.delta.io/latest/delta-utility.html#generate) as well as the [DeltaGenerateCommand](https://github.com/delta-io/delta/blob/2a322facb5c57e7322302ab878eddb16ff21b5f1/src/main/scala/org/apache/spark/sql/delta/commands/DeltaGenerateCommand.scala#L66) use **symlink_format_manifest**