### PR TITLE
Improvements - method implementation pattern and naming convention

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -170,7 +170,7 @@ trait Checkpoints extends DeltaLogging {
   protected def findLastCompleteCheckpoint(cv: CheckpointInstance): Option[CheckpointInstance] = {
     var cur = math.max(cv.version, 0L)
     while (cur >= 0) {
-      val checkpoints = store.listFrom(checkpointPrefix(logPath, math.max(0, cur - 1000)))
+      val checkpoints = store.iteratorFrom(checkpointPrefix(logPath, math.max(0, cur - 1000)))
           .map(_.getPath)
           .filter(isCheckpointFile)
           .map(CheckpointInstance(_))

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
@@ -171,7 +171,7 @@ class DeltaHistoryManager(
    * This value must be used as a lower bound.
    */
   private def getEarliestDeltaFile: Long = {
-    val earliestVersionOpt = deltaLog.store.listFrom(FileNames.deltaFile(deltaLog.logPath, 0))
+    val earliestVersionOpt = deltaLog.store.iteratorFrom(FileNames.deltaFile(deltaLog.logPath, 0))
       .filter(f => FileNames.isDeltaFile(f.getPath))
       .take(1).toArray.headOption
     if (earliestVersionOpt.isEmpty) {
@@ -190,7 +190,7 @@ class DeltaHistoryManager(
    * commits are contiguous.
    */
   private def getEarliestReproducibleCommit: Long = {
-    val files = deltaLog.store.listFrom(FileNames.deltaFile(deltaLog.logPath, 0))
+    val files = deltaLog.store.iteratorFrom(FileNames.deltaFile(deltaLog.logPath, 0))
       .filter(f => FileNames.isDeltaFile(f.getPath) || FileNames.isCheckpointFile(f.getPath))
 
     // A map of checkpoint version and number of parts, to number of parts observed
@@ -253,7 +253,7 @@ object DeltaHistoryManager extends DeltaLogging {
       start: Long,
       end: Option[Long] = None): Array[Commit] = {
     val until = end.getOrElse(Long.MaxValue)
-    val commits = logStore.listFrom(deltaFile(logPath, start))
+    val commits = logStore.iteratorFrom(deltaFile(logPath, start))
       .filter(f => isDeltaFile(f.getPath))
       .map { fileStatus =>
         Commit(deltaVersion(fileStatus.getPath), fileStatus.getModificationTime)

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -245,7 +245,7 @@ class DeltaLog private(
         val newFiles = store
           // List from the current version since we want to get the checkpoint file for the current
           // version
-          .listFrom(checkpointPrefix(logPath, math.max(currentSnapshot.version, 0L)))
+          .iteratorFrom(checkpointPrefix(logPath, math.max(currentSnapshot.version, 0L)))
           // Pick up checkpoint files not older than the current version and delta files newer than
           // the current version
           .filter { file =>
@@ -401,7 +401,7 @@ class DeltaLog private(
    * return an empty Iterator.
    */
   def getChanges(startVersion: Long): Iterator[(Long, Seq[Action])] = {
-    val deltas = store.listFrom(deltaFile(logPath, startVersion))
+    val deltas = store.iteratorFrom(deltaFile(logPath, startVersion))
       .filter(f => isDeltaFile(f.getPath))
     deltas.map { status =>
       val p = status.getPath
@@ -499,7 +499,7 @@ class DeltaLog private(
     val checkpointVersion = lastCheckpoint.map(_.version)
     if (checkpointVersion.isEmpty) {
       val versionZeroFile = deltaFile(logPath, 0L)
-      val versionZeroFileExists = store.listFrom(versionZeroFile)
+      val versionZeroFileExists = store.iteratorFrom(versionZeroFile)
         .take(1)
         .exists(_.getPath.getName == versionZeroFile.getName)
       if (!versionZeroFileExists) {
@@ -525,7 +525,7 @@ class DeltaLog private(
   def isValid(): Boolean = {
     val expectedExistingFile = deltaFile(logPath, currentSnapshot.version)
     try {
-      store.listFrom(expectedExistingFile)
+      store.iteratorFrom(expectedExistingFile)
         .take(1)
         .exists(_.getPath.getName == expectedExistingFile.getName)
     } catch {

--- a/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
@@ -72,7 +72,7 @@ trait MetadataCleanup extends DeltaLogging {
     val latestCheckpoint = lastCheckpoint
     if (latestCheckpoint.isEmpty) return Iterator.empty
     val threshold = latestCheckpoint.get.version - 1L
-    val files = store.listFrom(deltaFile(logPath, 0))
+    val files = store.iteratorFrom(deltaFile(logPath, 0))
       .filter(f => isCheckpointFile(f.getPath) || isDeltaFile(f.getPath))
     def getVersion(filePath: Path): Long = {
       if (isCheckpointFile(filePath)) {

--- a/src/main/scala/org/apache/spark/sql/delta/storage/FileSystemLogStore.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/storage/FileSystemLogStore.scala
@@ -52,7 +52,7 @@ abstract class FileSystemLogStore(
     }
   }
 
-  override def listFrom(path: Path): Iterator[FileStatus] = {
+  override def iteratorFrom(path: Path): Iterator[FileStatus] = {
     val fs = path.getFileSystem(getHadoopConfiguration)
     if (!fs.exists(path.getParent)) {
       throw new FileNotFoundException(s"No such file or directory: ${path.getParent}")

--- a/src/main/scala/org/apache/spark/sql/delta/storage/HDFSLogStoreImpl.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/storage/HDFSLogStoreImpl.scala
@@ -118,7 +118,7 @@ class HDFSLogStoreImpl(sparkConf: SparkConf, defaultHadoopConf: Configuration) e
     new Path(path.getParent, s".${path.getName}.${UUID.randomUUID}.tmp")
   }
 
-  override def listFrom(path: Path): Iterator[FileStatus] = {
+  override def iteratorFrom(path: Path): Iterator[FileStatus] = {
     val fc = getFileContext(path)
     if (!fc.util.exists(path.getParent)) {
       throw new FileNotFoundException(s"No such file or directory: ${path.getParent}")

--- a/src/main/scala/org/apache/spark/sql/delta/storage/LocalLockingFileSystemLogStoreImpl.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/storage/LocalLockingFileSystemLogStoreImpl.scala
@@ -51,15 +51,15 @@ class LocalLockingFileSystemLogStoreImpl(
     new Path(newUri)
   }
 
-  override def listFrom(path: Path): Iterator[FileStatus] = {
+  override def iteratorFrom(path: Path): Iterator[FileStatus] = {
     val (fs, resolvedPath, _) = resolved(path)
-    listFromInternal(fs, resolvedPath)
+    iteratorFromInternal(fs, resolvedPath)
   }
 
   /**
    * Returns `FileStatus`s starting from `resolvedPath` (inclusive).
    */
-  private def listFromInternal(fs: FileSystem, resolvedPath: Path): Iterator[FileStatus] = {
+  private def iteratorFromInternal(fs: FileSystem, resolvedPath: Path): Iterator[FileStatus] = {
     if (!fs.exists(resolvedPath.getParent)) {
       throw new FileNotFoundException(s"No such file or directory: ${resolvedPath.getParent}")
     }
@@ -68,7 +68,7 @@ class LocalLockingFileSystemLogStoreImpl(
   }
 
   private def exists(fs: FileSystem, resolvedPath: Path): Boolean = {
-    listFromInternal(fs, resolvedPath)
+    iteratorFromInternal(fs, resolvedPath)
       .take(1)
       .exists(_.getPath.getName == resolvedPath.getName)
   }

--- a/src/main/scala/org/apache/spark/sql/delta/storage/LogStore.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/storage/LogStore.scala
@@ -67,13 +67,13 @@ trait LogStore {
    * List the paths in the same directory that are lexicographically greater or equal to
    * (UTF-8 sorting) the given `path`. The result should also be sorted by the file name.
    */
-  final def listFrom(path: String): Iterator[FileStatus] = listFrom(new Path(path))
+  final def iteratorFrom(path: String): Iterator[FileStatus] = iteratorFrom(new Path(path))
 
   /**
    * List the paths in the same directory that are lexicographically greater or equal to
    * (UTF-8 sorting) the given `path`. The result should also be sorted by the file name.
    */
-  def listFrom(path: Path): Iterator[FileStatus]
+  def iteratorFrom(path: Path): Iterator[FileStatus]
 
   /** Invalidate any caching that the implementation may be using */
   def invalidateCache(): Unit

--- a/src/main/scala/org/apache/spark/sql/delta/util/FileNames.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/util/FileNames.scala
@@ -43,8 +43,8 @@ object FileNames {
   /**
    * Returns the prefix of all checkpoint files for the given version.
    *
-   * Intended for use with listFrom to get all files from this version onwards. The returned Path
-   * will not exist as a file.
+   * Intended for use with iteratorFrom to get all files from this version onwards. The returned
+   * Path will not exist as a file.
    */
   def checkpointPrefix(path: Path, version: Long): Path =
     new Path(path, f"$version%020d.checkpoint")

--- a/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
@@ -55,7 +55,7 @@ abstract class LogStoreSuiteBase extends QueryTest with SharedSQLContext {
     }
   }
 
-  test("listFrom") {
+  test("iteratorFrom") {
     val tempDir = Utils.createTempDir()
     val store = createLogStore(spark)
 
@@ -66,12 +66,13 @@ abstract class LogStoreSuiteBase extends QueryTest with SharedSQLContext {
     store.write(deltas(3), Iterator("two"))
 
     assert(
-      store.listFrom(deltas(0)).map(_.getPath.getName).toArray === Seq(1, 2, 3).map(_.toString))
+      store.iteratorFrom(deltas(0)).map(_.getPath.getName).toArray === Seq(1, 2, 3).map(_.toString))
     assert(
-      store.listFrom(deltas(1)).map(_.getPath.getName).toArray === Seq(1, 2, 3).map(_.toString))
-    assert(store.listFrom(deltas(2)).map(_.getPath.getName).toArray === Seq(2, 3).map(_.toString))
-    assert(store.listFrom(deltas(3)).map(_.getPath.getName).toArray === Seq(3).map(_.toString))
-    assert(store.listFrom(deltas(4)).map(_.getPath.getName).toArray === Nil)
+      store.iteratorFrom(deltas(1)).map(_.getPath.getName).toArray === Seq(1, 2, 3).map(_.toString))
+    assert(
+      store.iteratorFrom(deltas(2)).map(_.getPath.getName).toArray === Seq(2, 3).map(_.toString))
+    assert(store.iteratorFrom(deltas(3)).map(_.getPath.getName).toArray === Seq(3).map(_.toString))
+    assert(store.iteratorFrom(deltas(4)).map(_.getPath.getName).toArray === Nil)
   }
 
   protected def testHadoopConf(expectedErrMsg: String, fsImplConfs: (String, String)*): Unit = {
@@ -81,12 +82,12 @@ abstract class LogStoreSuiteBase extends QueryTest with SharedSQLContext {
 
         // Make sure it will fail without FakeFileSystem
         val e = intercept[IOException] {
-          createLogStore(spark).listFrom(path)
+          createLogStore(spark).iteratorFrom(path)
         }
         assert(e.getMessage.contains(expectedErrMsg))
 
         withSQLConf(fsImplConfs: _*) {
-          createLogStore(spark).listFrom(path)
+          createLogStore(spark).iteratorFrom(path)
         }
       }
     }


### PR DESCRIPTION
What were proposed in this Pull Request?
* avoid mutability at the method `findLastCompleteCheckpoint` and written recursive implementation.
* method `override def listFrom(path: Path)` actually returns the `Iterator` but name is `listFrom` which should be `iteratorFrom`. I came across this, when I debug the code
```
  val checkpoints =
          store
            .listFrom(checkpointPrefix(logPath, math.max(0, cur - 1000)))
```
`.iterate` was not resolved. Which remind me the method doesn't return the `List`.

How this PR was tested?
* compiled with sbt - PASSED
* CI / CD run - PASSED

@brkyvz Request for the review.