### PR TITLE
Optimize imports

### DIFF
--- a/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
+++ b/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
@@ -17,7 +17,6 @@
 package io.delta.sql
 
 import io.delta.sql.parser.DeltaSqlParser
-
 import org.apache.spark.sql.SparkSessionExtensions
 
 /**

--- a/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
+++ b/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
@@ -42,23 +42,20 @@ import java.util.Locale
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.sql.delta.commands.DeltaGenerateCommand
 import io.delta.sql.parser.DeltaSqlBaseParser._
 import io.delta.tables.execution.{DescribeDeltaHistoryCommand, VacuumTableCommand}
 import org.antlr.v4.runtime._
 import org.antlr.v4.runtime.atn.PredictionMode
 import org.antlr.v4.runtime.misc.{Interval, ParseCancellationException}
 import org.antlr.v4.runtime.tree._
-
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
-import org.apache.spark.sql.catalyst.parser.{ParseErrorListener, ParseException, ParserInterface}
 import org.apache.spark.sql.catalyst.parser.ParserUtils.{string, withOrigin}
+import org.apache.spark.sql.catalyst.parser.{ParseErrorListener, ParseException, ParserInterface}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.trees.Origin
-import org.apache.spark.sql.delta.commands.DescribeDeltaDetailCommand
-import org.apache.spark.sql.delta.commands.ConvertToDeltaCommand
+import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
+import org.apache.spark.sql.delta.commands.{ConvertToDeltaCommand, DeltaGenerateCommand, DescribeDeltaDetailCommand}
 import org.apache.spark.sql.types._
 
 /**

--- a/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
+++ b/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
@@ -19,14 +19,13 @@ package io.delta.tables
 import scala.collection.JavaConverters._
 import scala.collection.Map
 
-import org.apache.spark.sql.delta.{DeltaErrors, PreprocessTableMerge}
-import org.apache.spark.sql.delta.metering.DeltaLogging
-import org.apache.spark.sql.delta.util.AnalysisHelper
-
 import org.apache.spark.annotation.InterfaceStability._
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.util.AnalysisHelper
+import org.apache.spark.sql.delta.{DeltaErrors, PreprocessTableMerge}
 import org.apache.spark.sql.functions.expr
 
 /**

--- a/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -18,13 +18,12 @@ package io.delta.tables
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.sql.delta._
 import io.delta.tables.execution._
 import org.apache.hadoop.fs.Path
-
 import org.apache.spark.annotation.InterfaceStability._
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.delta._
 import org.apache.spark.sql.types.StructType
 
 /**

--- a/src/main/scala/io/delta/tables/execution/DeltaConvert.scala
+++ b/src/main/scala/io/delta/tables/execution/DeltaConvert.scala
@@ -16,7 +16,6 @@
 
 package io.delta.tables.execution
 
-import org.apache.spark.sql.delta.commands.ConvertToDeltaCommand
 import io.delta.tables.DeltaTable
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.TableIdentifier

--- a/src/main/scala/io/delta/tables/execution/DeltaConvert.scala
+++ b/src/main/scala/io/delta/tables/execution/DeltaConvert.scala
@@ -16,11 +16,10 @@
 
 package io.delta.tables.execution
 
-import org.apache.spark.sql.delta.commands.{ConvertToDeltaCommand, ConvertToDeltaCommandBase}
 import io.delta.tables.DeltaTable
-
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.delta.commands.ConvertToDeltaCommand
 import org.apache.spark.sql.types.StructType
 
 trait DeltaConvertBase {

--- a/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
+++ b/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
@@ -18,16 +18,15 @@ package io.delta.tables.execution
 
 import scala.collection.Map
 
-import org.apache.spark.sql.delta.{DeltaErrors, DeltaHistoryManager, DeltaLog, PreprocessTableUpdate}
-import org.apache.spark.sql.delta.commands.{DeleteCommand, DeltaGenerateCommand, VacuumCommand}
-import org.apache.spark.sql.delta.util.AnalysisHelper
 import io.delta.tables.DeltaTable
-
-import org.apache.spark.sql.{functions, Column, DataFrame}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.expressions.{Expression, SubqueryExpression}
 import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.delta.commands.{DeleteCommand, DeltaGenerateCommand, VacuumCommand}
+import org.apache.spark.sql.delta.util.AnalysisHelper
+import org.apache.spark.sql.delta.{DeltaErrors, DeltaHistoryManager, DeltaLog, PreprocessTableUpdate}
+import org.apache.spark.sql.{Column, DataFrame, functions}
 
 /**
  * Interface to provide the actual implementations of DeltaTable operations.

--- a/src/main/scala/io/delta/tables/execution/DescribeDeltaHistoryCommand.scala
+++ b/src/main/scala/io/delta/tables/execution/DescribeDeltaHistoryCommand.scala
@@ -17,12 +17,12 @@
 package io.delta.tables.execution
 
 import org.apache.hadoop.fs.Path
-import org.apache.spark.sql.{Encoders, Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.delta.actions.CommitInfo
 import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaTableIdentifier}
 import org.apache.spark.sql.execution.command.RunnableCommand
+import org.apache.spark.sql.{Encoders, Row, SparkSession}
 
 case class DescribeDeltaHistoryCommand(
     path: Option[String],

--- a/src/main/scala/io/delta/tables/execution/VacuumTableCommand.scala
+++ b/src/main/scala/io/delta/tables/execution/VacuumTableCommand.scala
@@ -17,13 +17,13 @@
 package io.delta.tables.execution
 
 import org.apache.hadoop.fs.Path
-import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
-import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaTableIdentifier, DeltaTableUtils}
 import org.apache.spark.sql.delta.commands.VacuumCommand
+import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaTableIdentifier, DeltaTableUtils}
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.types.StringType
+import org.apache.spark.sql.{Row, SparkSession}
 
 /**
  * The `vacuum` command implementation for Spark SQL. Example SQL:

--- a/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -21,17 +21,15 @@ import java.util.UUID
 
 import scala.util.control.NonFatal
 
-import org.apache.spark.sql.delta.actions.{Action, Metadata, SingleAction}
-import org.apache.spark.sql.delta.metering.DeltaLogging
-import org.apache.spark.sql.delta.storage.LogStore
-import org.apache.spark.sql.delta.util.DeltaFileOperations
-import org.apache.spark.sql.delta.util.FileNames._
-import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapred.{JobConf, TaskAttemptContextImpl, TaskAttemptID}
 import org.apache.hadoop.mapreduce.{Job, TaskType}
-
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.delta.actions.{Action, Metadata, SingleAction}
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.storage.LogStore
+import org.apache.spark.sql.delta.util.FileNames._
+import org.apache.spark.sql.delta.util.{DeltaFileOperations, JsonUtils}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.util.SerializableConfiguration
 

--- a/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
@@ -22,13 +22,12 @@ import java.nio.charset.StandardCharsets.UTF_8
 import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
 
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.storage.LogStore
 import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
-import org.apache.hadoop.fs.Path
-
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.streaming.CheckpointFileManager
 import org.apache.spark.util.Utils
 

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -18,10 +18,9 @@ package org.apache.spark.sql.delta
 
 import java.util.{HashMap, Locale}
 
+import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
 import org.apache.spark.sql.delta.metering.DeltaLogging
-
-import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.unsafe.types.CalendarInterval
 

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -20,21 +20,20 @@ package org.apache.spark.sql.delta
 import java.io.FileNotFoundException
 import java.util.ConcurrentModificationException
 
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.delta.actions.{CommitInfo, Metadata}
 import org.apache.spark.sql.delta.hooks.PostCommitHook
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.{Invariant, InvariantViolationException}
 import org.apache.spark.sql.delta.util.JsonUtils
-import org.apache.hadoop.fs.Path
-
-import org.apache.spark.{SparkConf, SparkEnv}
-import org.apache.spark.sql.{AnalysisException, SparkSession}
-import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
-import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.types.{DataType, StructField, StructType}
+import org.apache.spark.sql.{AnalysisException, SparkSession}
+import org.apache.spark.{SparkConf, SparkEnv}
 
 trait DocsPath {
   /**

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
@@ -22,15 +22,14 @@ import java.sql.Timestamp
 
 import scala.collection.mutable
 
+import org.apache.hadoop.fs.{FileStatus, Path}
+import org.apache.spark.SparkEnv
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.delta.actions.{Action, CommitInfo, CommitMarker}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.storage.LogStore
-import org.apache.spark.sql.delta.util.{DateTimeUtils, FileNames, TimestampFormatter}
 import org.apache.spark.sql.delta.util.FileNames._
-import org.apache.hadoop.fs.{FileStatus, Path}
-
-import org.apache.spark.SparkEnv
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.delta.util.{DateTimeUtils, FileNames, TimestampFormatter}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.SerializableConfiguration
 

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -18,14 +18,21 @@ package org.apache.spark.sql.delta
 
 // scalastyle:off import.ordering.noEmptyLine
 import java.io.{File, FileNotFoundException, IOException}
-import java.util.concurrent.{Callable, TimeUnit}
 import java.util.concurrent.locks.ReentrantLock
+import java.util.concurrent.{Callable, TimeUnit}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 import scala.util.control.NonFatal
 
 import com.databricks.spark.util.TagDefinitions._
+import com.google.common.cache.{CacheBuilder, RemovalListener, RemovalNotification}
+import org.apache.hadoop.fs.Path
+import org.apache.spark.SparkContext
+import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.analysis.{Resolver, UnresolvedAttribute}
+import org.apache.spark.sql.catalyst.expressions.{And, Attribute, Cast, Expression, Literal}
+import org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.commands.WriteIntoDelta
 import org.apache.spark.sql.delta.files.{TahoeBatchFileIndex, TahoeLogFileIndex}
@@ -33,14 +40,6 @@ import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.storage.LogStoreProvider
-import com.google.common.cache.{CacheBuilder, RemovalListener, RemovalNotification}
-import org.apache.hadoop.fs.Path
-
-import org.apache.spark.SparkContext
-import org.apache.spark.sql._
-import org.apache.spark.sql.catalyst.analysis.{Resolver, UnresolvedAttribute}
-import org.apache.spark.sql.catalyst.expressions.{And, Attribute, Cast, Expression, In, InSet, Literal}
-import org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.json.JsonFileFormat
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaLogFileIndex.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaLogFileIndex.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.delta
 
 import org.apache.hadoop.fs._
-
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.datasources.{FileFormat, FileIndex, PartitionDirectory}

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -16,11 +16,10 @@
 
 package org.apache.spark.sql.delta
 
-import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
-import org.apache.spark.sql.delta.util.JsonUtils
-
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
+import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.types.{StructField, StructType}
 

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -22,11 +22,10 @@ import java.util.regex.PatternSyntaxException
 import scala.util.Try
 import scala.util.matching.Regex
 
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.delta.DeltaOptions.{DATA_CHANGE_OPTION, MERGE_SCHEMA_OPTION, OVERWRITE_SCHEMA_OPTION}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-
-import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.internal.SQLConf
 
 

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -17,24 +17,21 @@
 package org.apache.spark.sql.delta
 
 // scalastyle:off import.ordering.noEmptyLine
-import java.util.Locale
-
 import scala.util.{Failure, Success, Try}
 
-import org.apache.spark.sql.delta.files.{TahoeFileIndex, TahoeLogFileIndex}
-import org.apache.spark.sql.delta.metering.DeltaLogging
-import org.apache.spark.sql.delta.sources.DeltaSourceUtils
 import org.apache.hadoop.fs.Path
-
-import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, SessionCatalog}
 import org.apache.spark.sql.catalyst.expressions.{Expression, PredicateHelper, SubqueryExpression}
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.delta.files.{TahoeFileIndex, TahoeLogFileIndex}
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.sources.DeltaSourceUtils
 import org.apache.spark.sql.execution.datasources.{FileIndex, HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.{AnalysisException, SparkSession}
 
 /**
  * Extractor Object for pulling out the table scan of a Delta table. It could be a full scan

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaTableIdentifier.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaTableIdentifier.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.delta
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.internal.SQLConf
 
 /**
  * An identifier for a Delta table containing one of the path or the table identifier.

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaTableIdentifier.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaTableIdentifier.scala
@@ -16,11 +16,10 @@
 
 package org.apache.spark.sql.delta
 
-import org.apache.spark.sql.delta.sources.DeltaSourceUtils
 import org.apache.hadoop.fs.Path
-
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.delta.sources.DeltaSourceUtils
 
 /**
  * An identifier for a Delta table containing one of the path or the table identifier.

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaTimeTravelSpec.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaTimeTravelSpec.scala
@@ -18,12 +18,11 @@ package org.apache.spark.sql.delta
 
 import java.sql.Timestamp
 
-import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.commons.lang3.time.FastDateFormat
-
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.expressions.{Cast, Expression, Literal, PreciseTimestampConversion}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{LongType, TimestampType}
 

--- a/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
@@ -18,10 +18,10 @@ package org.apache.spark.sql.delta
 
 import java.util.{Calendar, TimeZone}
 
-import org.apache.spark.sql.delta.DeltaHistoryManager.BufferingLogDeletionIterator
-import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.commons.lang3.time.DateUtils
 import org.apache.hadoop.fs.{FileStatus, Path}
+import org.apache.spark.sql.delta.DeltaHistoryManager.BufferingLogDeletionIterator
+import org.apache.spark.sql.delta.metering.DeltaLogging
 
 /** Cleans up expired Delta table metadata. */
 trait MetadataCleanup extends DeltaLogging {

--- a/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -25,6 +25,9 @@ import scala.collection.mutable.{ArrayBuffer, HashSet}
 import scala.util.control.NonFatal
 
 import com.databricks.spark.util.TagDefinitions.TAG_LOG_STORE_CLASS
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.delta.DeltaOperations.Operation
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.files._
@@ -32,10 +35,6 @@ import org.apache.spark.sql.delta.hooks.{GenerateSymlinkManifest, PostCommitHook
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.hadoop.fs.Path
-
-import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.datasources.parquet.ParquetSchemaConverter
 import org.apache.spark.util.{Clock, Utils}
 

--- a/src/main/scala/org/apache/spark/sql/delta/PartitionFiltering.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/PartitionFiltering.scala
@@ -16,10 +16,9 @@
 
 package org.apache.spark.sql.delta
 
+import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.delta.actions.{AddFile, SingleAction}
 import org.apache.spark.sql.delta.stats.DeltaScan
-
-import org.apache.spark.sql.catalyst.expressions._
 
 trait PartitionFiltering {
   self: Snapshot =>

--- a/src/main/scala/org/apache/spark/sql/delta/PreprocessTableMerge.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/PreprocessTableMerge.scala
@@ -18,13 +18,12 @@ package org.apache.spark.sql.delta
 
 import java.util.Locale
 
-import org.apache.spark.sql.delta.commands.MergeIntoCommand
-
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.EliminateSubqueryAliases
-import org.apache.spark.sql.catalyst.expressions.{Expression, SubqueryExpression}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
+import org.apache.spark.sql.catalyst.expressions.{Expression, SubqueryExpression}
 import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.delta.commands.MergeIntoCommand
 import org.apache.spark.sql.internal.SQLConf
 
 case class PreprocessTableMerge(conf: SQLConf) extends UpdateExpressionsSupport {

--- a/src/main/scala/org/apache/spark/sql/delta/PreprocessTableUpdate.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/PreprocessTableUpdate.scala
@@ -16,10 +16,9 @@
 
 package org.apache.spark.sql.delta
 
-import org.apache.spark.sql.delta.commands.UpdateCommand
-
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, UnresolvedAttribute}
 import org.apache.spark.sql.catalyst.plans.logical.UpdateTable
+import org.apache.spark.sql.delta.commands.UpdateCommand
 import org.apache.spark.sql.internal.SQLConf
 
 case class PreprocessTableUpdate(conf: SQLConf) extends UpdateExpressionsSupport {

--- a/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -19,17 +19,16 @@ package org.apache.spark.sql.delta
 // scalastyle:off import.ordering.noEmptyLine
 import java.net.URI
 
-import org.apache.spark.sql.delta.actions._
-import org.apache.spark.sql.delta.actions.Action.logSchema
-import org.apache.spark.sql.delta.metering.DeltaLogging
-import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.util.StateCache
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
-
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.plans.logical.Union
+import org.apache.spark.sql.delta.actions.Action.logSchema
+import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.util.StateCache
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions._

--- a/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -19,16 +19,15 @@ package org.apache.spark.sql.delta.actions
 import java.net.URI
 import java.sql.Timestamp
 
-import org.apache.spark.sql.delta.util.JsonUtils
 import com.fasterxml.jackson.annotation.{JsonIgnore, JsonInclude}
 import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.databind.{JsonSerializer, SerializerProvider}
 import com.fasterxml.jackson.databind.annotation.{JsonDeserialize, JsonSerialize}
-import org.codehaus.jackson.annotate.JsonRawValue
-
+import com.fasterxml.jackson.databind.{JsonSerializer, SerializerProvider}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.spark.sql.types.{DataType, StructType}
+import org.codehaus.jackson.annotate.JsonRawValue
 
 /** Thrown when the protocol version of a table is greater than supported by this client. */
 class InvalidProtocolVersionException extends RuntimeException(

--- a/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
@@ -22,25 +22,22 @@ import java.util.Locale
 import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 
+import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
+import org.apache.spark.SparkException
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.catalyst.expressions.Cast
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.{AddFile, CommitInfo, Metadata, Protocol}
 import org.apache.spark.sql.delta.schema.SchemaUtils
-import org.apache.spark.sql.delta.sources.{DeltaSourceUtils, DeltaSQLConf}
-import org.apache.spark.sql.delta.util.{DateFormatter, DeltaFileOperations, PartitionUtils, TimestampFormatter}
+import org.apache.spark.sql.delta.sources.{DeltaSQLConf, DeltaSourceUtils}
 import org.apache.spark.sql.delta.util.FileNames.deltaFile
-import org.apache.spark.sql.delta.util.SerializableFileStatus
-import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
-
-import org.apache.spark.SparkException
-import org.apache.spark.sql.{AnalysisException, Row, SparkSession}
-import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.catalyst.analysis.Resolver
-import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.catalyst.expressions.Cast
+import org.apache.spark.sql.delta.util._
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetToSparkSchemaConverter}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
+import org.apache.spark.sql.{AnalysisException, Row, SparkSession}
 import org.apache.spark.util.{SerializableConfiguration, Utils}
 
 /**

--- a/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -16,17 +16,16 @@
 
 package org.apache.spark.sql.delta.commands
 
-import org.apache.spark.sql.delta._
-import org.apache.spark.sql.delta.actions.Action
-import org.apache.spark.sql.delta.files.{TahoeBatchFileIndex, TahoeFileIndex}
-
-import org.apache.spark.sql.{Column, Dataset, Row, SparkSession}
 import org.apache.spark.sql.catalyst.analysis.EliminateSubqueryAliases
 import org.apache.spark.sql.catalyst.expressions.{EqualNullSafe, Expression, InputFileName, Literal, Not}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.{Delete, LogicalPlan}
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.actions.Action
+import org.apache.spark.sql.delta.files.{TahoeBatchFileIndex, TahoeFileIndex}
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.types.BooleanType
+import org.apache.spark.sql.{Column, Dataset, Row, SparkSession}
 
 /**
  * Performs a Delete based on the search condition

--- a/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
@@ -17,22 +17,19 @@
 package org.apache.spark.sql.delta.commands
 
 import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.analysis.{Analyzer, EliminateSubqueryAliases, NoSuchTableException, UnresolvedRelation}
 import org.apache.spark.sql.catalyst.expressions.{Expression, SubqueryExpression}
 import org.apache.spark.sql.catalyst.parser.ParseException
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.delta.actions.{AddFile, RemoveFile}
 import org.apache.spark.sql.delta.files.TahoeBatchFileIndex
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSourceUtils
 import org.apache.spark.sql.delta.util.DeltaFileOperations
 import org.apache.spark.sql.delta.{DeltaLog, OptimisticTransaction}
-import org.apache.spark.sql.execution.datasources.HadoopFsRelation
-import org.apache.spark.sql.{AnalysisException, SparkSession}
-import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.catalyst.analysis.{Analyzer, EliminateSubqueryAliases, NoSuchTableException, UnresolvedRelation}
-import org.apache.spark.sql.catalyst.expressions.{Expression, SubqueryExpression}
-import org.apache.spark.sql.catalyst.parser.ParseException
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
+import org.apache.spark.sql.{AnalysisException, SparkSession}
 
 /**
  * Helper trait for all delta commands.

--- a/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
@@ -16,17 +16,16 @@
 
 package org.apache.spark.sql.delta.commands
 
-import org.apache.spark.sql.delta.{DeltaLog, OptimisticTransaction}
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.catalyst.expressions.{Expression, SubqueryExpression}
+import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.delta.actions.{AddFile, RemoveFile}
 import org.apache.spark.sql.delta.files.TahoeBatchFileIndex
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.util.DeltaFileOperations
-import org.apache.hadoop.fs.Path
-
-import org.apache.spark.sql.{AnalysisException, SparkSession}
-import org.apache.spark.sql.catalyst.expressions.{Expression, SubqueryExpression}
-import org.apache.spark.sql.catalyst.parser.ParseException
+import org.apache.spark.sql.delta.{DeltaLog, OptimisticTransaction}
 import org.apache.spark.sql.execution.datasources.HadoopFsRelation
+import org.apache.spark.sql.{AnalysisException, SparkSession}
 
 /**
  * Helper trait for all delta commands.

--- a/src/main/scala/org/apache/spark/sql/delta/commands/DeltaGenerateCommand.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/DeltaGenerateCommand.scala
@@ -16,14 +16,13 @@
 
 package org.apache.spark.sql.delta.commands
 
-import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaTableIdentifier}
-import org.apache.spark.sql.delta.hooks.GenerateSymlinkManifest
 import org.apache.hadoop.fs.Path
-
-import org.apache.spark.sql.{AnalysisException, Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
+import org.apache.spark.sql.delta.hooks.GenerateSymlinkManifest
+import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaTableIdentifier}
 import org.apache.spark.sql.execution.command.RunnableCommand
+import org.apache.spark.sql.{AnalysisException, Row, SparkSession}
 
 trait DeltaGenerateCommandBase extends RunnableCommand {
 

--- a/src/main/scala/org/apache/spark/sql/delta/commands/DescribeDeltaDetailsCommandBase.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/DescribeDeltaDetailsCommandBase.scala
@@ -20,17 +20,16 @@ package org.apache.spark.sql.delta.commands
 import java.io.FileNotFoundException
 import java.sql.Timestamp
 
-import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaTableIdentifier, Snapshot}
-import org.apache.spark.sql.delta.metering.DeltaLogging
-import org.apache.spark.sql.delta.util.FileNames
 import org.apache.hadoop.fs.Path
-
-import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
 import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.util.FileNames
+import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaTableIdentifier, Snapshot}
 import org.apache.spark.sql.execution.command.RunnableCommand
+import org.apache.spark.sql.{Row, SparkSession}
 
 /** The result returned by the `describe detail` command. */
 case class TableDetail(

--- a/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
@@ -18,19 +18,18 @@ package org.apache.spark.sql.delta.commands
 
 import scala.collection.JavaConverters._
 
+import org.apache.spark.SparkContext
+import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
+import org.apache.spark.sql.catalyst.expressions.codegen._
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, Expression, Literal, PredicateHelper, UnsafeProjection}
+import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.spark.sql.delta.files._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.{AnalysisHelper, SetAccumulator}
-
-import org.apache.spark.SparkContext
-import org.apache.spark.sql._
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, Expression, Literal, PredicateHelper, UnsafeProjection}
-import org.apache.spark.sql.catalyst.expressions.codegen._
-import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
@@ -95,8 +94,8 @@ case class MergeIntoCommand(
     notMatchedClause: Option[MergeIntoInsertClause]) extends RunnableCommand
   with DeltaCommand with PredicateHelper with AnalysisHelper {
 
-  import SQLMetrics._
   import MergeIntoCommand._
+  import SQLMetrics._
 
   @transient private lazy val sc: SparkContext = SparkContext.getOrCreate()
   @transient private lazy val targetDeltaLog: DeltaLog = targetFileIndex.deltaLog

--- a/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
@@ -16,18 +16,17 @@
 
 package org.apache.spark.sql.delta.commands
 
-import org.apache.spark.sql.delta.{DeltaLog, DeltaOperations, DeltaTableUtils, OptimisticTransaction}
-import org.apache.spark.sql.delta.actions.{Action, AddFile}
-import org.apache.spark.sql.delta.files.{TahoeBatchFileIndex, TahoeFileIndex}
 import org.apache.hadoop.fs.Path
-
-import org.apache.spark.sql.{Column, Dataset, Row, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, If, Literal}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.delta.actions.{Action, AddFile}
+import org.apache.spark.sql.delta.files.{TahoeBatchFileIndex, TahoeFileIndex}
+import org.apache.spark.sql.delta.{DeltaLog, DeltaOperations, DeltaTableUtils, OptimisticTransaction}
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.functions.input_file_name
 import org.apache.spark.sql.types.BooleanType
+import org.apache.spark.sql.{Column, Dataset, Row, SparkSession}
 
 /**
  * Performs an Update using `updateExpression` on the rows that match `condition`

--- a/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
@@ -23,14 +23,13 @@ import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.{FileAction, RemoveFile}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.DeltaFileOperations
 import org.apache.spark.sql.delta.util.DeltaFileOperations.tryDeleteNonRecursive
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import org.apache.hadoop.fs.{FileSystem, Path}
-
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 import org.apache.spark.util.{Clock, SerializableConfiguration, SystemClock}
 

--- a/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -17,11 +17,10 @@
 package org.apache.spark.sql.delta.commands
 
 // scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.sql._
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.{Action, AddFile}
 import org.apache.spark.sql.delta.schema.ImplicitMetadataOperation
-
-import org.apache.spark.sql._
 import org.apache.spark.sql.execution.command.RunnableCommand
 
 /**

--- a/src/main/scala/org/apache/spark/sql/delta/files/DelayedCommitProtocol.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/files/DelayedCommitProtocol.scala
@@ -23,15 +23,14 @@ import java.util.UUID
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
 
-import org.apache.spark.sql.delta.actions.AddFile
-import org.apache.spark.sql.delta.util.{DateFormatter, PartitionUtils, TimestampFormatter}
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapreduce.{JobContext, TaskAttemptContext}
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.internal.io.FileCommitProtocol.TaskCommitMessage
 import org.apache.spark.sql.catalyst.expressions.Cast
+import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.util.{DateFormatter, PartitionUtils, TimestampFormatter}
 import org.apache.spark.sql.types.StringType
 
 /**

--- a/src/main/scala/org/apache/spark/sql/delta/files/DeltaSourceSnapshot.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/files/DeltaSourceSnapshot.scala
@@ -16,13 +16,12 @@
 
 package org.apache.spark.sql.delta.files
 
-import org.apache.spark.sql.delta.{DeltaLog, DeltaTableUtils, Snapshot}
+import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.delta.sources.IndexedFile
 import org.apache.spark.sql.delta.util.StateCache
-
-import org.apache.spark.sql.{Dataset, SparkSession}
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.delta.{DeltaLog, DeltaTableUtils, Snapshot}
 import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.{Dataset, SparkSession}
 
 /**
  * Converts a `Snapshot` into the initial set of files read when starting a new streaming query.

--- a/src/main/scala/org/apache/spark/sql/delta/files/SQLMetricsReporting.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/files/SQLMetricsReporting.scala
@@ -16,10 +16,9 @@
 
 package org.apache.spark.sql.delta.files
 
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.delta.DeltaOperations.Operation
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.metric.SQLMetric
 
 /**

--- a/src/main/scala/org/apache/spark/sql/delta/files/TahoeFileIndex.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/files/TahoeFileIndex.scala
@@ -18,14 +18,12 @@ package org.apache.spark.sql.delta.files
 
 import java.net.URI
 
-import org.apache.spark.sql.delta.{DeltaLog, Snapshot}
-import org.apache.spark.sql.delta.actions.AddFile
-import org.apache.spark.sql.delta.actions.SingleAction.addFileEncoder
-import org.apache.hadoop.fs.FileStatus
-import org.apache.hadoop.fs.Path
-
+import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{Cast, Expression, GenericInternalRow, Literal}
+import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.actions.SingleAction.addFileEncoder
+import org.apache.spark.sql.delta.{DeltaLog, Snapshot}
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.types.StructType
 

--- a/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
@@ -18,18 +18,17 @@ package org.apache.spark.sql.delta.files
 
 import scala.collection.mutable.ListBuffer
 
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.Dataset
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.hadoop.fs.Path
-
-import org.apache.spark.sql.Dataset
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.datasources.{BasicWriteJobStatsTracker, FileFormatWriter, WriteJobStatsTracker}
-import org.apache.spark.sql.types.{ArrayType, MapType, StructType}
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
 
 /**

--- a/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
@@ -16,18 +16,17 @@
 
 package org.apache.spark.sql.delta.hooks
 
-import org.apache.spark.sql.delta._
-import org.apache.spark.sql.delta.actions._
-import org.apache.spark.sql.delta.metering.DeltaLogging
-import org.apache.spark.sql.delta.storage.LogStore
-import org.apache.spark.sql.delta.util.DeltaFileOperations
 import org.apache.hadoop.fs.Path
-
 import org.apache.spark.SparkEnv
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, Concat, Expression, Literal, ScalaUDF}
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.storage.LogStore
+import org.apache.spark.sql.delta.util.DeltaFileOperations
 import org.apache.spark.sql.execution.datasources.InMemoryFileIndex
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.StringType

--- a/src/main/scala/org/apache/spark/sql/delta/hooks/PostCommitHook.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/hooks/PostCommitHook.scala
@@ -16,10 +16,9 @@
 
 package org.apache.spark.sql.delta.hooks
 
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.Action
-
-import org.apache.spark.sql.SparkSession
 
 /**
  * A hook which can be executed after a transaction. These hooks are registered to a

--- a/src/main/scala/org/apache/spark/sql/delta/metering/DeltaLogging.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/metering/DeltaLogging.scala
@@ -19,12 +19,11 @@ package org.apache.spark.sql.delta.metering
 import scala.util.Try
 import scala.util.control.NonFatal
 
-import com.databricks.spark.util.{DatabricksLogging, OpType, TagDefinition}
 import com.databricks.spark.util.MetricDefinitions.{EVENT_LOGGING_FAILURE, EVENT_TAHOE}
 import com.databricks.spark.util.TagDefinitions.{TAG_OP_TYPE, TAG_TAHOE_ID, TAG_TAHOE_PATH}
+import com.databricks.spark.util.{DatabricksLogging, OpType, TagDefinition}
 import org.apache.spark.sql.delta.DeltaLog
-import org.apache.spark.sql.delta.util.DeltaProgressReporter
-import org.apache.spark.sql.delta.util.JsonUtils
+import org.apache.spark.sql.delta.util.{DeltaProgressReporter, JsonUtils}
 
 /**
  * Convenience wrappers for logging that include delta specific options and

--- a/src/main/scala/org/apache/spark/sql/delta/schema/CheckDeltaInvariant.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/schema/CheckDeltaInvariant.scala
@@ -16,13 +16,12 @@
 
 package org.apache.spark.sql.delta.schema
 
-import org.apache.spark.sql.delta.schema.Invariants.{ArbitraryExpression, NotNull}
-
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
-import org.apache.spark.sql.catalyst.expressions.{Expression, NonSQLExpression, UnaryExpression}
-import org.apache.spark.sql.catalyst.expressions.codegen.{Block, CodegenContext, ExprCode, JavaCode, TrueLiteral}
 import org.apache.spark.sql.catalyst.expressions.codegen.Block._
+import org.apache.spark.sql.catalyst.expressions.codegen._
+import org.apache.spark.sql.catalyst.expressions.{Expression, NonSQLExpression, UnaryExpression}
+import org.apache.spark.sql.delta.schema.Invariants.{ArbitraryExpression, NotNull}
 import org.apache.spark.sql.types.{DataType, NullType}
 
 /** An expression that validates a specific invariant on a column, before writing into Delta. */

--- a/src/main/scala/org/apache/spark/sql/delta/schema/DeltaInvariantCheckerExec.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/schema/DeltaInvariantCheckerExec.scala
@@ -16,14 +16,13 @@
 
 package org.apache.spark.sql.delta.schema
 
-import org.apache.spark.sql.delta.DeltaErrors
-import org.apache.spark.sql.delta.schema.Invariants.NotNull
-
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, BindReferences, Expression, GetStructField, Literal, SortOrder}
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, BindReferences, Expression, GetStructField, Literal, SortOrder}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
+import org.apache.spark.sql.delta.DeltaErrors
+import org.apache.spark.sql.delta.schema.Invariants.NotNull
 import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.types.{NullType, StructType}
 

--- a/src/main/scala/org/apache/spark/sql/delta/schema/ImplicitMetadataOperation.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/schema/ImplicitMetadataOperation.scala
@@ -20,9 +20,8 @@ import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.Metadata
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.util.PartitionUtils
-
-import org.apache.spark.sql.{Dataset, SparkSession}
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{Dataset, SparkSession}
 
 /**
  * A trait that writers into Delta can extend to update the schema and/or partitioning of the table.

--- a/src/main/scala/org/apache/spark/sql/delta/schema/Invariants.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/schema/Invariants.scala
@@ -16,10 +16,9 @@
 
 package org.apache.spark.sql.delta.schema
 
-import org.apache.spark.sql.delta.util.JsonUtils
-
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.spark.sql.types.StructType
 
 /**

--- a/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
@@ -20,23 +20,22 @@ import scala.util.{Failure, Success, Try}
 
 // scalastyle:off import.ordering.noEmptyLine
 import com.databricks.spark.util.DatabricksLogging
-import org.apache.spark.sql.delta._
-import org.apache.spark.sql.delta.commands.WriteIntoDelta
-import org.apache.spark.sql.delta.metering.DeltaLogging
-import org.apache.spark.sql.delta.util.PartitionUtils
 import org.apache.hadoop.fs.Path
-import org.json4s.NoTypeHints
-import org.json4s.jackson.Serialization
-
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.expressions.{EqualTo, Expression, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.commands.WriteIntoDelta
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.util.PartitionUtils
 import org.apache.spark.sql.execution.streaming.{Sink, Source}
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.types.StructType
+import org.json4s.NoTypeHints
+import org.json4s.jackson.Serialization
 
 /** A DataSource V1 for integrating Delta into Spark SQL batch and Streaming APIs. */
 class DeltaDataSource

--- a/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
@@ -22,13 +22,9 @@ import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.SetTransaction
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.{ImplicitMetadataOperation, SchemaUtils}
-import org.apache.hadoop.fs.Path
-
-import org.apache.spark.SparkContext
-import org.apache.spark.sql._
 import org.apache.spark.sql.execution.SQLExecution
-import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.execution.metric.SQLMetrics.createMetric
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.execution.streaming.{Sink, StreamExecution}
 import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.types.NullType

--- a/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
@@ -16,13 +16,12 @@
 
 package org.apache.spark.sql.delta.sources
 
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql._
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.SetTransaction
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.{ImplicitMetadataOperation, SchemaUtils}
-import org.apache.hadoop.fs.Path
-
-import org.apache.spark.sql._
 import org.apache.spark.sql.execution.streaming.{Sink, StreamExecution}
 import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.types.NullType

--- a/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -21,16 +21,15 @@ import java.io.FileNotFoundException
 
 import scala.util.matching.Regex
 
-import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaOptions}
+import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.files.DeltaSourceSnapshot
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.SchemaUtils
-
-import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaOptions}
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{DataFrame, SparkSession}
 
 /**
  * A case class to help with `Dataset` operations regarding Offset indexing, representing AddFile

--- a/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceOffset.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceOffset.scala
@@ -18,10 +18,9 @@ package org.apache.spark.sql.delta.sources
 
 import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.util.JsonUtils
+import org.apache.spark.sql.execution.streaming.{Offset, SerializedOffset}
 import org.json4s._
 import org.json4s.jackson.JsonMethods.parse
-
-import org.apache.spark.sql.execution.streaming.{Offset, SerializedOffset}
 
 /**
  * Tracks how far we processed in when reading changes from the [[DeltaLog]].

--- a/src/main/scala/org/apache/spark/sql/delta/stats/DeltaScan.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/stats/DeltaScan.scala
@@ -16,10 +16,9 @@
 
 package org.apache.spark.sql.delta.stats
 
-import org.apache.spark.sql.delta.actions.AddFile
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.delta.actions.AddFile
 
 /**
  * Note: Please don't add any new constructor to this class. `jackson-module-scala` always picks up

--- a/src/main/scala/org/apache/spark/sql/delta/storage/AzureLogStore.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/storage/AzureLogStore.scala
@@ -18,7 +18,6 @@ package org.apache.spark.sql.delta.storage
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
-
 import org.apache.spark.SparkConf
 
 /**

--- a/src/main/scala/org/apache/spark/sql/delta/storage/HDFSLogStore.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/storage/HDFSLogStore.scala
@@ -26,12 +26,11 @@ import scala.util.control.NonFatal
 
 import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs._
 import org.apache.hadoop.fs.CreateFlag.CREATE
 import org.apache.hadoop.fs.Options.{ChecksumOpt, CreateOpts}
-
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.hadoop.fs._
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.{SparkConf, SparkContext}
 
 /**
  * The [[LogStore]] implementation for HDFS, which uses Hadoop [[FileContext]] API's to

--- a/src/main/scala/org/apache/spark/sql/delta/storage/HadoopFileSystemLogStore.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/storage/HadoopFileSystemLogStore.scala
@@ -26,9 +26,8 @@ import scala.collection.JavaConverters._
 import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
-
-import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.{SparkConf, SparkContext}
 
 /**
  * Default implementation of [[LogStore]] for Hadoop [[FileSystem]] implementations.

--- a/src/main/scala/org/apache/spark/sql/delta/storage/LocalLogStore.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/storage/LocalLogStore.scala
@@ -18,7 +18,6 @@ package org.apache.spark.sql.delta.storage
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-
 import org.apache.spark.SparkConf
 
 /**

--- a/src/main/scala/org/apache/spark/sql/delta/storage/LogStore.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/storage/LogStore.scala
@@ -16,14 +16,13 @@
 
 package org.apache.spark.sql.delta.storage
 
-import org.apache.spark.sql.delta.DeltaLog
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
-
-import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.util.Utils
+import org.apache.spark.{SparkConf, SparkContext}
 
 /**
  * General interface for all critical file system operations required to read and write the

--- a/src/main/scala/org/apache/spark/sql/delta/storage/S3SingleDriverLogStore.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/storage/S3SingleDriverLogStore.scala
@@ -23,13 +23,12 @@ import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.sql.delta.util.FileNames
 import com.google.common.cache.CacheBuilder
 import com.google.common.io.CountingOutputStream
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
-
 import org.apache.spark.SparkConf
+import org.apache.spark.sql.delta.util.FileNames
 
 /**
  * Single Spark-driver/JVM LogStore implementation for S3.

--- a/src/main/scala/org/apache/spark/sql/delta/util/AnalysisHelper.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/util/AnalysisHelper.scala
@@ -16,11 +16,10 @@
 
 package org.apache.spark.sql.delta.util
 
-import org.apache.spark.sql.delta.DeltaErrors
-
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.delta.DeltaErrors
 
 trait AnalysisHelper {
   import AnalysisHelper._

--- a/src/main/scala/org/apache/spark/sql/delta/util/DateTimeFormatterHelper.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/util/DateTimeFormatterHelper.scala
@@ -43,8 +43,8 @@ import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder, ResolverSt
 import java.time.temporal.{ChronoField, TemporalAccessor, TemporalQueries}
 import java.util.Locale
 
-import org.apache.spark.sql.delta.util.DateTimeFormatterHelper._
 import com.google.common.cache.CacheBuilder
+import org.apache.spark.sql.delta.util.DateTimeFormatterHelper._
 
 /**
  * Forked from [[org.apache.spark.sql.catalyst.util.DateTimeFormatterHelper]]

--- a/src/main/scala/org/apache/spark/sql/delta/util/DeltaFileOperations.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/util/DeltaFileOperations.scala
@@ -23,17 +23,16 @@ import java.util.Locale
 import scala.util.Random
 import scala.util.control.NonFatal
 
-import org.apache.spark.sql.delta.metering.DeltaLogging
-import org.apache.spark.sql.delta.storage.LogStore
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
 import org.apache.parquet.format.converter.ParquetMetadataConverter.SKIP_ROW_GROUPS
 import org.apache.parquet.hadoop.{Footer, ParquetFileReader}
-
-import org.apache.spark.{SparkEnv, TaskContext}
 import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.storage.LogStore
 import org.apache.spark.sql.{Dataset, SparkSession}
 import org.apache.spark.util.{SerializableConfiguration, ThreadUtils}
+import org.apache.spark.{SparkEnv, TaskContext}
 
 /**
  * Some utility methods on files, directories, and paths.

--- a/src/main/scala/org/apache/spark/sql/delta/util/PartitionUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/util/PartitionUtils.scala
@@ -47,7 +47,6 @@ import scala.collection.mutable.ArrayBuffer
 import scala.util.Try
 
 import org.apache.hadoop.fs.Path
-
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis._
@@ -121,7 +120,7 @@ private[delta] object PartitionUtils {
     require(columnNames.size == literals.size)
   }
 
-  import org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils.{escapePathName, unescapePathName, DEFAULT_PARTITION_NAME}
+  import org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils.{DEFAULT_PARTITION_NAME, escapePathName, unescapePathName}
 
   /**
    * Given a group of qualified paths, tries to parse them and returns a partition specification.

--- a/src/main/scala/org/apache/spark/sql/delta/util/StateCache.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/util/StateCache.scala
@@ -18,11 +18,10 @@ package org.apache.spark.sql.delta.util
 
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.spark.sql.delta.Snapshot
-
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{Dataset, SparkSession}
+import org.apache.spark.sql.delta.Snapshot
 import org.apache.spark.sql.execution.LogicalRDD
+import org.apache.spark.sql.{Dataset, SparkSession}
 import org.apache.spark.storage.StorageLevel
 
 /**

--- a/src/test/java/io/delta/tables/JavaDeltaTableSuite.java
+++ b/src/test/java/io/delta/tables/JavaDeltaTableSuite.java
@@ -16,17 +16,19 @@
 
 package io.delta.tables;
 
-import java.util.Arrays;
-import java.util.List;
-
-import org.apache.spark.sql.test.*;
-import org.apache.spark.sql.*;
-
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.QueryTest$;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.test.TestSparkSession;
 import org.apache.spark.util.Utils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class JavaDeltaTableSuite {
 

--- a/src/test/java/org/apache/spark/sql/delta/DeleteJavaSuite.java
+++ b/src/test/java/org/apache/spark/sql/delta/DeleteJavaSuite.java
@@ -16,21 +16,19 @@
 
 package test.org.apache.spark.sql.delta;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import scala.Tuple2;
-
 import io.delta.tables.DeltaTable;
+import org.apache.spark.sql.*;
+import org.apache.spark.sql.test.TestSparkSession;
+import org.apache.spark.util.Utils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import scala.Tuple2;
 
-import org.apache.spark.sql.*;
-import org.apache.spark.sql.test.TestSparkSession;
-import org.apache.spark.util.Utils;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class DeleteJavaSuite {
 

--- a/src/test/java/org/apache/spark/sql/delta/MergeIntoJavaSuite.java
+++ b/src/test/java/org/apache/spark/sql/delta/MergeIntoJavaSuite.java
@@ -16,24 +16,21 @@
 
 package test.org.apache.spark.sql.delta;
 
-import java.io.Serializable;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import scala.Tuple2;
-
 import io.delta.tables.DeltaTable;
-
 import org.apache.spark.sql.*;
+import org.apache.spark.sql.test.TestSparkSession;
 import org.apache.spark.util.Utils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import scala.Tuple2;
 
-import org.apache.spark.sql.test.TestSparkSession;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class MergeIntoJavaSuite implements Serializable {
     private transient TestSparkSession spark;

--- a/src/test/java/org/apache/spark/sql/delta/UpdateJavaSuite.java
+++ b/src/test/java/org/apache/spark/sql/delta/UpdateJavaSuite.java
@@ -16,16 +16,20 @@
 
 package test.org.apache.spark.sql.delta;
 
-import java.util.*;
-
-import scala.Tuple2;
-
 import io.delta.tables.DeltaTable;
-import org.junit.*;
-
 import org.apache.spark.sql.*;
 import org.apache.spark.sql.test.TestSparkSession;
 import org.apache.spark.util.Utils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import scala.Tuple2;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class UpdateJavaSuite {
     private transient TestSparkSession spark;

--- a/src/test/java/org/apache/spark/sql/delta/UpdateJavaSuite.java
+++ b/src/test/java/org/apache/spark/sql/delta/UpdateJavaSuite.java
@@ -21,7 +21,6 @@ import org.apache.spark.sql.*;
 import org.apache.spark.sql.test.TestSparkSession;
 import org.apache.spark.util.Utils;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import scala.Tuple2;

--- a/src/test/scala/io/delta/sql/parser/DeltaSqlParserSuite.scala
+++ b/src/test/scala/io/delta/sql/parser/DeltaSqlParserSuite.scala
@@ -17,7 +17,6 @@
 package io.delta.sql.parser
 
 import io.delta.tables.execution.VacuumTableCommand
-
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.TableIdentifier
 

--- a/src/test/scala/io/delta/tables/DeltaTableSuite.scala
+++ b/src/test/scala/io/delta/tables/DeltaTableSuite.scala
@@ -18,10 +18,8 @@ package io.delta.tables
 
 import java.util.Locale
 
-
-import org.apache.spark.sql.{AnalysisException, QueryTest}
-import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.{AnalysisException, QueryTest}
 
 class DeltaTableSuite extends QueryTest
   with SharedSparkSession {

--- a/src/test/scala/io/delta/tables/DeltaTableTestUtils.scala
+++ b/src/test/scala/io/delta/tables/DeltaTableTestUtils.scala
@@ -16,9 +16,8 @@
 
 package io.delta.tables
 
-import org.apache.spark.sql.delta.DeltaLog
-
 import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.delta.DeltaLog
 
 object DeltaTableTestUtils {
 

--- a/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -16,9 +16,8 @@
 
 package org.apache.spark.sql.delta
 
-import org.apache.spark.sql.delta.actions._
-
 import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
 

--- a/src/test/scala/org/apache/spark/sql/delta/ConvertToDeltaSuiteBase.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/ConvertToDeltaSuiteBase.scala
@@ -16,15 +16,14 @@
 
 package org.apache.spark.sql.delta
 
+import org.apache.hadoop.fs.Path
+import org.apache.spark.SparkException
+import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.delta.files.TahoeLogFileIndex
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.hadoop.fs.Path
-
-import org.apache.spark.SparkException
-import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
-import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.util.Utils
 
 abstract class ConvertToDeltaSuiteBase extends QueryTest

--- a/src/test/scala/org/apache/spark/sql/delta/DeleteScalaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeleteScalaSuite.scala
@@ -17,8 +17,7 @@
 package org.apache.spark.sql.delta
 
 import io.delta.tables.{DeltaTable, DeltaTableTestUtils}
-
-import org.apache.spark.sql.{functions, Row}
+import org.apache.spark.sql.{Row, functions}
 
 class DeleteScalaSuite extends DeleteSuiteBase {
 

--- a/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
@@ -18,13 +18,12 @@ package org.apache.spark.sql.delta
 
 import java.io.File
 
-import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.hadoop.fs.Path
-import org.scalatest.BeforeAndAfterEach
-
-import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.util.Utils
+import org.scalatest.BeforeAndAfterEach
 
 abstract class DeleteSuiteBase extends QueryTest
   with SharedSparkSession with BeforeAndAfterEach {

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaConfigSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaConfigSuite.scala
@@ -18,9 +18,8 @@ package org.apache.spark.sql.delta
 
 import java.util.concurrent.TimeUnit
 
-import org.apache.spark.sql.delta.DeltaConfigs.{isValidIntervalConfigValue, parseCalendarInterval}
-
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.delta.DeltaConfigs.{isValidIntervalConfigValue, parseCalendarInterval}
 import org.apache.spark.unsafe.types.CalendarInterval
 
 class DeltaConfigSuite extends SparkFunSuite {

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -19,10 +19,9 @@ package org.apache.spark.sql.delta
 import scala.sys.process.Process
 
 import org.apache.hadoop.fs.Path
-import org.scalatest.GivenWhenThen
-
 import org.apache.spark.sql.QueryTest
-import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
+import org.apache.spark.sql.test.{SQLTestUtils, SharedSparkSession}
+import org.scalatest.GivenWhenThen
 
 trait DeltaErrorsSuiteBase
     extends QueryTest

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaGenerateSymlinkManifestSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaGenerateSymlinkManifestSuite.scala
@@ -19,15 +19,14 @@ package org.apache.spark.sql.delta
 import java.io.File
 import java.net.URI
 
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs._
+import org.apache.hadoop.util.Progressable
+import org.apache.spark.sql._
 import org.apache.spark.sql.delta.commands.DeltaGenerateCommand
 import org.apache.spark.sql.delta.hooks.GenerateSymlinkManifest
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.util.DeltaFileOperations
-import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs._
-import org.apache.hadoop.util.Progressable
-
-import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSparkSession
 
@@ -511,8 +510,8 @@ class SymlinkManifestFailureTestAbstractFileSystem(
     false) {
 
   // Implementation copied from RawLocalFs
-  import org.apache.hadoop.fs.local.LocalConfigKeys
   import org.apache.hadoop.fs._
+  import org.apache.hadoop.fs.local.LocalConfigKeys
 
   override def getUriDefaultPort(): Int = -1
   override def getServerDefaults(): FsServerDefaults = LocalConfigKeys.getServerDefaults()

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -18,14 +18,13 @@ package org.apache.spark.sql.delta
 
 import java.io.{File, FileNotFoundException}
 
+import org.apache.hadoop.fs.Path
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql._
 import org.apache.spark.sql.delta.DeltaOperations.Truncate
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
-import org.apache.hadoop.fs.Path
-
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql._
-import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
+import org.apache.spark.sql.test.{SQLTestUtils, SharedSparkSession}
 import org.apache.spark.util.Utils
 
 // scalastyle:off: removeFile

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
@@ -18,10 +18,8 @@ package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.delta.actions.{Action, FileAction}
 import org.apache.spark.sql.delta.util.FileNames
-
-import org.apache.spark.SparkConf
-import org.apache.spark.sql.{AnalysisException, QueryTest}
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.{AnalysisException, QueryTest}
 import org.apache.spark.util.Utils
 
 class DeltaOptionSuite extends QueryTest

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -18,11 +18,10 @@ package org.apache.spark.sql.delta
 
 import java.io.File
 
+import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.util.FileNames.deltaFile
-
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
 

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
@@ -18,12 +18,11 @@ package org.apache.spark.sql.delta
 
 import java.io.File
 
-import org.apache.spark.sql.delta.actions.{Action, AddFile, RemoveFile}
-import org.apache.spark.sql.delta.util.FileNames
 import org.apache.hadoop.fs.Path
-
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.delta.actions.{Action, AddFile, RemoveFile}
+import org.apache.spark.sql.delta.util.FileNames
 import org.apache.spark.sql.test.SQLTestUtils
 import org.apache.spark.util.ManualClock
 

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuiteBase.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuiteBase.scala
@@ -18,12 +18,11 @@ package org.apache.spark.sql.delta
 
 import java.io.File
 
-import org.apache.spark.sql.delta.DeltaOperations.Truncate
-import org.apache.spark.sql.delta.util.FileNames
 import org.apache.hadoop.fs.Path
-
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.delta.DeltaOperations.Truncate
+import org.apache.spark.sql.delta.util.FileNames
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.unsafe.types.CalendarInterval
 

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
@@ -19,17 +19,16 @@ package org.apache.spark.sql.delta
 import java.io.File
 import java.util.Locale
 
-import org.apache.spark.sql.delta.actions.CommitInfo
 import org.apache.commons.io.FileUtils
-import org.scalatest.time.SpanSugar._
-
 import org.apache.spark.sql._
+import org.apache.spark.sql.delta.actions.CommitInfo
 import org.apache.spark.sql.execution.DataSourceScanExec
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.streaming._
 import org.apache.spark.sql.types._
+import org.scalatest.time.SpanSugar._
 
 class DeltaSinkSuite extends StreamTest {
 

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -20,16 +20,15 @@ import java.io.{File, FileInputStream, OutputStream}
 import java.net.URI
 import java.util.UUID
 
-import org.apache.spark.sql.delta.actions.{AddFile, InvalidProtocolVersionException, Protocol}
-import org.apache.spark.sql.delta.sources.{DeltaSourceOffset, DeltaSQLConf}
-import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.fs.{FileStatus, Path, RawLocalFileSystem}
-
 import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.delta.actions.{AddFile, InvalidProtocolVersionException, Protocol}
+import org.apache.spark.sql.delta.sources.{DeltaSQLConf, DeltaSourceOffset}
+import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
 import org.apache.spark.sql.execution.streaming._
-import org.apache.spark.sql.streaming.{OutputMode, StreamingQueryException, Trigger}
 import org.apache.spark.sql.streaming.util.StreamManualClock
+import org.apache.spark.sql.streaming.{OutputMode, StreamingQueryException, Trigger}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.unsafe.types.CalendarInterval
 import org.apache.spark.util.{ManualClock, Utils}

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuiteBase.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuiteBase.scala
@@ -18,9 +18,8 @@ package org.apache.spark.sql.delta
 
 import java.io.File
 
-import org.apache.spark.sql.delta.actions.Format
-
 import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.delta.actions.Format
 import org.apache.spark.sql.streaming.StreamTest
 import org.apache.spark.sql.types.StructType
 

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -19,20 +19,19 @@ package org.apache.spark.sql.delta
 import java.io.{File, FileNotFoundException}
 import java.util.concurrent.atomic.AtomicInteger
 
-import org.apache.spark.sql.delta.files.TahoeLogFileIndex
-import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.hadoop.fs.{FileSystem, Path}
-
 import org.apache.spark.SparkException
 import org.apache.spark.scheduler.{SparkListener, SparkListenerJobStart}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.InSet
 import org.apache.spark.sql.catalyst.plans.logical.Filter
+import org.apache.spark.sql.delta.files.TahoeLogFileIndex
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.OPTIMIZER_METADATA_ONLY
-import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
+import org.apache.spark.sql.test.{SQLTestUtils, SharedSparkSession}
 import org.apache.spark.util.Utils
 
 class DeltaSuite extends QueryTest

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
@@ -24,14 +24,13 @@ import java.util.{Calendar, Date, TimeZone}
 import scala.concurrent.duration._
 import scala.language.implicitConversions
 
+import org.apache.commons.lang3.time.DateUtils
+import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.spark.sql.delta.DeltaHistoryManager.BufferingLogDeletionIterator
 import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.spark.sql.delta.util.FileNames
-import org.apache.commons.lang3.time.DateUtils
-import org.apache.hadoop.fs.{FileStatus, Path}
-
+import org.apache.spark.sql.test.{SQLTestUtils, SharedSparkSession}
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
-import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
 import org.apache.spark.util.ManualClock
 
 class DeltaTimeTravelSuite extends QueryTest

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
@@ -20,20 +20,19 @@ import java.io.File
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
+import org.apache.commons.io.FileUtils
+import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.delta.DeltaOperations.{Delete, Write}
 import org.apache.spark.sql.delta.actions.{AddFile, Metadata, RemoveFile}
 import org.apache.spark.sql.delta.commands.VacuumCommand
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.util.DeltaFileOperations
-import org.apache.commons.io.FileUtils
-import org.apache.hadoop.fs.Path
-import org.scalatest.GivenWhenThen
-
-import org.apache.spark.sql.{AnalysisException, QueryTest, SaveMode}
-import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
+import org.apache.spark.sql.test.{SQLTestUtils, SharedSparkSession}
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.{AnalysisException, QueryTest, SaveMode}
 import org.apache.spark.unsafe.types.CalendarInterval
 import org.apache.spark.util.ManualClock
+import org.scalatest.GivenWhenThen
 
 trait DeltaVacuumSuiteBase extends QueryTest
   with SharedSparkSession

--- a/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
@@ -16,13 +16,11 @@
 
 package org.apache.spark.sql.delta
 
-import java.io.File
-import java.io.FileNotFoundException
+import java.io.{File, FileNotFoundException}
 
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
-
-import org.apache.spark.sql.{DataFrame, QueryTest, Row}
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.{DataFrame, QueryTest, Row}
 import org.apache.spark.util.Utils
 
 trait DescribeDeltaDetailSuiteBase extends QueryTest

--- a/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
@@ -19,13 +19,11 @@ package org.apache.spark.sql.delta
 import org.apache.spark.sql.delta.actions.CommitInfo
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
-import org.scalatest.Tag
-
-import org.apache.spark.sql.{AnalysisException, Column, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.execution.streaming.MemoryStream
-import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql._
 import org.apache.spark.util.Utils
+import org.scalatest.Tag
 
 trait DescribeDeltaHistorySuiteBase
   extends QueryTest

--- a/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
@@ -16,12 +16,12 @@
 
 package org.apache.spark.sql.delta
 
+import org.apache.spark.sql._
 import org.apache.spark.sql.delta.actions.CommitInfo
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql._
 import org.apache.spark.util.Utils
 import org.scalatest.Tag
 

--- a/src/test/scala/org/apache/spark/sql/delta/EvolvabilitySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/EvolvabilitySuite.scala
@@ -16,9 +16,8 @@
 
 package org.apache.spark.sql.delta
 
-import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
 import org.apache.hadoop.fs.Path
-
+import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
 import org.apache.spark.sql.functions.typedLit
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SQLTestUtils

--- a/src/test/scala/org/apache/spark/sql/delta/EvolvabilitySuiteBase.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/EvolvabilitySuiteBase.scala
@@ -18,13 +18,12 @@ package org.apache.spark.sql.delta
 
 import java.io.File
 
-import org.apache.spark.sql.delta.actions.{Action, FileAction, SingleAction}
 import org.apache.hadoop.fs.Path
-
-import org.apache.spark.sql.{QueryTest, SparkSession}
+import org.apache.spark.sql.delta.actions.{Action, FileAction, SingleAction}
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{QueryTest, SparkSession}
 import org.apache.spark.util.Utils
 
 trait EvolvabilitySuiteBase extends QueryTest with SharedSparkSession {
@@ -88,8 +87,9 @@ object EvolvabilitySuiteBase {
 
   /** Validate the generated data contains all [[Action]] types */
   def validateData(spark: SparkSession, path: String): Unit = {
-    import org.apache.spark.sql.delta.util.FileNames._
     import scala.reflect.runtime.{universe => ru}
+
+    import org.apache.spark.sql.delta.util.FileNames._
     import spark.implicits._
 
     val mirror = ru.runtimeMirror(this.getClass.getClassLoader)

--- a/src/test/scala/org/apache/spark/sql/delta/FileNamesSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/FileNamesSuite.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.delta
 
 import org.apache.hadoop.fs.Path
-
 import org.apache.spark.SparkFunSuite
 
 class FileNamesSuite extends SparkFunSuite {

--- a/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
@@ -19,12 +19,11 @@ package org.apache.spark.sql.delta
 import java.io.{File, IOException}
 import java.net.URI
 
+import org.apache.hadoop.fs.{Path, RawLocalFileSystem}
+import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.spark.sql.delta.storage._
-import org.apache.hadoop.fs.{Path, RawLocalFileSystem}
-
-import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.Utils
 
@@ -197,8 +196,8 @@ class FakeAbstractFileSystem(uri: URI, conf: org.apache.hadoop.conf.Configuratio
     false) {
 
   // Implementation copied from RawLocalFs
-  import org.apache.hadoop.fs.local.LocalConfigKeys
   import org.apache.hadoop.fs._
+  import org.apache.hadoop.fs.local.LocalConfigKeys
 
   override def getUriDefaultPort(): Int = -1
   override def getServerDefaults(): FsServerDefaults = LocalConfigKeys.getServerDefaults()

--- a/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.delta
 import java.util.Locale
 
 import io.delta.tables._
-
 import org.apache.spark.sql._
 import org.apache.spark.sql.types.StructType
 

--- a/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
@@ -21,13 +21,12 @@ import java.lang.{Integer => JInt}
 import java.util.Locale
 
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.scalatest.BeforeAndAfterEach
-
-import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
+import org.apache.spark.sql.test.{SQLTestUtils, SharedSparkSession}
 import org.apache.spark.sql.types.{IntegerType, MapType, StringType, StructType}
+import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.util.Utils
+import org.scalatest.BeforeAndAfterEach
 
 abstract class MergeIntoSuiteBase
     extends QueryTest

--- a/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -16,16 +16,13 @@
 
 package org.apache.spark.sql.delta
 
-import java.util.ConcurrentModificationException
-
-import org.apache.spark.sql.delta.DeltaOperations.{Delete, ManualUpdate, Truncate}
-import org.apache.spark.sql.delta.actions.{Action, AddFile, FileAction, Metadata, RemoveFile, SetTransaction}
 import org.apache.hadoop.fs.Path
-
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
+import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
+import org.apache.spark.sql.{QueryTest, Row}
 
 class OptimisticTransactionSuite extends QueryTest with SharedSparkSession {
   private val addA = AddFile("a", Map.empty, 1, 1, dataChange = true)

--- a/src/test/scala/org/apache/spark/sql/delta/UpdateScalaSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/UpdateScalaSuite.scala
@@ -19,8 +19,7 @@ package org.apache.spark.sql.delta
 import java.util.Locale
 
 import io.delta.tables.DeltaTableTestUtils
-
-import org.apache.spark.sql.{functions, Row}
+import org.apache.spark.sql.{Row, functions}
 
 class UpdateScalaSuite extends UpdateSuiteBase {
 

--- a/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
@@ -21,14 +21,13 @@ import java.util.Locale
 
 import scala.language.implicitConversions
 
-import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.hadoop.fs.Path
-import org.scalatest.BeforeAndAfterEach
-
-import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
-import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.test.{SQLTestUtils, SharedSparkSession}
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.util.Utils
+import org.scalatest.BeforeAndAfterEach
 
 abstract class UpdateSuiteBase
   extends QueryTest

--- a/src/test/scala/org/apache/spark/sql/delta/schema/CaseSensitivitySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/schema/CaseSensitivitySuite.scala
@@ -18,15 +18,14 @@ package org.apache.spark.sql.delta.schema
 
 import java.io.File
 
+import org.apache.spark.sql._
 import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.actions.AddFile
-
-import org.apache.spark.sql._
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.{StreamingQuery, StreamingQueryException}
-import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
+import org.apache.spark.sql.test.{SQLTestUtils, SharedSparkSession}
 
 class CaseSensitivitySuite extends QueryTest
   with SharedSparkSession  with SQLTestUtils {

--- a/src/test/scala/org/apache/spark/sql/delta/schema/InvariantEnforcementSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/schema/InvariantEnforcementSuite.scala
@@ -20,15 +20,14 @@ import java.io.File
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.sql.delta.{DeltaLog, DeltaOperations}
-import org.apache.spark.sql.delta.actions.Metadata
-import org.apache.spark.sql.delta.schema.Invariants.{ArbitraryExpression, NotNull, PersistedExpression}
-
 import org.apache.spark.SparkException
 import org.apache.spark.sql._
+import org.apache.spark.sql.delta.actions.Metadata
+import org.apache.spark.sql.delta.schema.Invariants.{ArbitraryExpression, NotNull, PersistedExpression}
+import org.apache.spark.sql.delta.{DeltaLog, DeltaOperations}
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.streaming.StreamingQueryException
-import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
+import org.apache.spark.sql.test.{SQLTestUtils, SharedSparkSession}
 import org.apache.spark.sql.types._
 
 class InvariantEnforcementSuite extends QueryTest

--- a/src/test/scala/org/apache/spark/sql/delta/schema/SchemaEnforcementSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/schema/SchemaEnforcementSuite.scala
@@ -19,18 +19,16 @@ package org.apache.spark.sql.delta.schema
 import java.io.File
 
 // scalastyle:off import.ordering.noEmptyLine
-import org.apache.spark.sql.delta.{DeltaLog, DeltaOptions}
+import org.apache.spark.sql._
 import org.apache.spark.sql.delta.actions.SingleAction
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
-
-import org.apache.spark.SparkConf
-import org.apache.spark.sql._
+import org.apache.spark.sql.delta.{DeltaLog, DeltaOptions}
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.StreamingQueryException
-import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
+import org.apache.spark.sql.test.{SQLTestUtils, SharedSparkSession}
 import org.apache.spark.sql.types._
 
 sealed trait SaveOperation {

--- a/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
@@ -18,11 +18,9 @@ package org.apache.spark.sql.delta.schema
 
 import java.util.Locale
 
-
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
-import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
+import org.apache.spark.sql.test.{SQLTestUtils, SharedSparkSession}
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 
 class SchemaUtilsSuite extends QueryTest
   with SharedSparkSession

--- a/src/test/scala/org/apache/spark/sql/delta/test/DeltaSQLCommandTest.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/test/DeltaSQLCommandTest.scala
@@ -17,10 +17,9 @@
 package org.apache.spark.sql.delta.test
 
 import io.delta.sql.DeltaSparkSessionExtension
-
 import org.apache.spark.SparkConf
+import org.apache.spark.sql.test.{SharedSparkSession, TestSparkSession}
 import org.apache.spark.sql.{SparkSession, SparkSessionExtensions}
-import org.apache.spark.sql.test.{TestSparkSession, SharedSparkSession}
 
 /**
  * Because `TestSparkSession` doesn't pick up the conf `spark.sql.extensions` in Spark 2.4.x, we use


### PR DESCRIPTION
I noticed that the Scala imports seem to be inconsistently formatted across files.

For this PR, I ran IntelliJ's "Optimize Imports" command which has cleaned up the imports and made the formatting consistent.

cc: @suhsteve @imback82 @rapoth