### PR TITLE
Made the python api doc generation more robust

### DIFF
--- a/docs/python/Makefile
+++ b/docs/python/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -W
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/docs/python/conf.py
+++ b/docs/python/conf.py
@@ -71,7 +71,7 @@ html_theme = 'nature'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = [] # default value was ['_static']
 
 
 # Fix for doc generation to work on older version of sphinx as well.
@@ -79,3 +79,6 @@ master_doc = 'index'
 
 # Display the classes in the generated in the same order as the classes appear in the source files.`
 autodoc_member_order = 'bysource'
+
+# Ignore 'import pyspark' if pyspark is not installed.
+autodoc_mock_imports = ["pyspark"]

--- a/python/delta/tables.py
+++ b/python/delta/tables.py
@@ -67,8 +67,10 @@ class DeltaTable(object):
 
         :param mode: mode for the type of manifest file to be generated
                      The valid modes are as follows (not case sensitive):
-                      - "symlink_format_manifest" : This will generate manifests in symlink format
-                                                    for Presto and Athena read support.
+
+                     - "symlink_format_manifest": This will generate manifests in symlink format
+                                                  for Presto and Athena read support.
+
                      See the online documentation for more information.
 
         .. note:: Evolving


### PR DESCRIPTION
- Made sphinx throw all warnings as errors. Sphinx tends to mark a build successful even if there are major issues (e.g., import not found) that cause the contents of built docs to be invalid. These issues shows up as warning, and converting them to errors allows them to be caught in the CI/CD loop early on.
- Fixed indentation issues in docs.
- Ignore pyspark not being present during python doc generation.
