### PR TITLE
Fixed two subtle bugs in merge resolution

### DIFF
--- a/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/merge.scala
+++ b/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/merge.scala
@@ -277,7 +277,7 @@ object MergeInto {
             val unresolvedAttrib = UnresolvedAttribute(colNameParts)
             val resolutionErrorMsg =
               s"Cannot resolve ${unresolvedAttrib.sql} in target columns in $typ " +
-                s"clause given columns ${target.output.map(_.sql).mkString(", ")}"
+                s"clause given columns ${planToResolveAction.output.map(_.sql).mkString(", ")}"
 
             // Resolve the target column name without database/table/view qualifiers
             // If clause allows nested field to be target, then this will return the all the

--- a/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
@@ -1136,7 +1136,7 @@ abstract class MergeIntoSuiteBase
         source = Seq.empty,
         target = Seq.empty,
         sourceKeyValueNames = ("key", "newValue"),
-        targetKeyValueNames = ("key", "oldValue"),
+        targetKeyValueNames = ("key", "oldValue")
       ) { case (sourceName, targetName) =>
         val errMsg = intercept[AnalysisException] {
           executeMerge(s"$targetName t", s"$sourceName s", mergeOn, mergeClauses: _*)


### PR DESCRIPTION
Here are the two bugs fixed.

1. Insert condition should be resolved only with source and not with source+target. This was because clause conditions were being resolved with the full `merge` plan (i.e., with both source and target output attribs) independent of the clause type. This PR fixes it by using the `planToResolveAction` to resolve the references of the condition, which is customized for each clause type.

2. Fix for bug #252 where incorrect columns were being printed as valid columns names. In the code, `plan.references` were being printed as valid column names. This is wrong because `references` includes invalid column names as well. This PR fixes it by using the output attributes of `plan.children` which are the only valid column names that can be referred to.

Updated unit tests to verify the presence/absence of valid/invalid column names.

Closes #252 