### PR TITLE
API to create empty DeltaTable

### DIFF
--- a/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -691,7 +691,7 @@ object DeltaTable {
     val emptyDataFrame =
       sparkSession.createDataFrame(sparkSession.sparkContext.emptyRDD[Row], schema)
     emptyDataFrame.write.format("delta").save(path)
-    DeltaTable.forPath(path)
+    DeltaTable.forPath(sparkSession, path)
   }
 
   /**
@@ -699,7 +699,7 @@ object DeltaTable {
    *
    * Create an empty DeltaTable with the provided `schema` at the provided file `path`.
    *
-   * Note: This uses the active SparkSession in the current thread to search for the table. Hence,
+   * Note: This uses the active SparkSession in the current thread to create the table. Hence,
    * this throws error if active SparkSession has not been set, that is,
    * `SparkSession.getActiveSession()` is empty.
    *

--- a/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -710,7 +710,6 @@ object DeltaTable {
     val sparkSession = SparkSession.getActiveSession.getOrElse {
       throw new IllegalArgumentException("Could not find active SparkSession")
     }
-
     createEmpty(sparkSession, schema, path)
   }
 }

--- a/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -691,7 +691,7 @@ object DeltaTable {
     val emptyDataFrame =
       sparkSession.createDataFrame(sparkSession.sparkContext.emptyRDD[Row], schema)
     emptyDataFrame.write.format("delta").save(path)
-    DeltaTable.forPath(sparkSession, path)
+    new DeltaTable(emptyDataFrame, DeltaLog.forTable(sparkSession, path))
   }
 
   /**


### PR DESCRIPTION
This PR adds an API that creates an empty DeltaTable with a provided schema at a provided file path. 

This API is useful in notebook scenarios where you want to create an empty DeltaTable and then add data to it later. 

(The other code formatting changes in this PR were auto-applied by IntelliJ.  If folks don't like them, I can revert them.)