### PR TITLE
Optimization: Don't make new parquet file if write DF is empty

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -102,7 +102,13 @@ case class WriteIntoDelta(
       deltaLog.fs.mkdirs(deltaLog.logPath)
     }
 
-    val newFiles = txn.writeFiles(data, Some(options))
+    // If data has no rows, we don't need to write any new files.
+    val newFiles = if (data.take(1).isEmpty) {
+      Seq.empty
+    } else {
+      txn.writeFiles(data, Some(options))
+    }
+
     val deletedFiles = (mode, partitionFilters) match {
       case (SaveMode.Overwrite, None) =>
         txn.filterFiles().map(_.remove)


### PR DESCRIPTION
Right now, if you try to append or overwrite a Delta table with an empty `DataFrame`, Delta will write a 0-row Parquet file to disk and include it as an "add" on the transaction log.  This 0-row file isn't helpful and just bloats the directory and transaction log.

This PR changes `WriteIntoDelta.scala` to not write any new files if `data` has no rows.

cc: @rapoth @suhsteve @imback82 