### PR TITLE
[SC-29179] Add Table ID in schema mismatch errors

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -811,9 +811,9 @@ class MetadataMismatchErrorBuilder {
 
   private var mentionedOption = false
 
-  def addSchemaMismatch(original: StructType, data: StructType): Unit = {
+  def addSchemaMismatch(original: StructType, data: StructType, id: String): Unit = {
     bits ++=
-      s"""A schema mismatch detected when writing to the Delta table.
+      s"""A schema mismatch detected when writing to the Delta table (Table ID: $id).
          |To enable schema migration, please set:
          |'.option("${DeltaOptions.MERGE_SCHEMA_OPTION}", "true")'.
          |

--- a/src/main/scala/org/apache/spark/sql/delta/schema/ImplicitMetadataOperation.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/schema/ImplicitMetadataOperation.scala
@@ -111,7 +111,7 @@ trait ImplicitMetadataOperation extends DeltaLogging {
       recordDeltaEvent(txn.deltaLog, "delta.schemaValidation.failure")
       val errorBuilder = new MetadataMismatchErrorBuilder
       if (isNewSchema) {
-        errorBuilder.addSchemaMismatch(txn.metadata.schema, dataSchema)
+        errorBuilder.addSchemaMismatch(txn.metadata.schema, dataSchema, txn.metadata.id)
       }
       if (isNewPartitioning) {
         errorBuilder.addPartitioningMismatch(txn.metadata.partitionColumns, normalizedPartitionCols)

--- a/src/test/scala/org/apache/spark/sql/delta/schema/SchemaEnforcementSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/schema/SchemaEnforcementSuite.scala
@@ -253,6 +253,19 @@ trait AppendSaveModeTests extends BatchWriterTest {
       }
     }
   }
+
+  equivalenceTest("ensure schema mismatch error message contains table ID") {
+    disableAutoMigration {
+      withTempDir { dir =>
+        spark.range(10).write.append(dir)
+        val e = intercept[AnalysisException] {
+          spark.range(10).withColumn("part", 'id + 1).write.append(dir)
+        }
+        assert(e.getMessage.contains("schema mismatch detected"))
+        assert(e.getMessage.contains(s"Table ID: ${DeltaLog.forTable(spark, dir).tableId}"))
+      }
+    }
+  }
 }
 
 trait AppendOutputModeTests extends SchemaEnforcementSuiteBase with SharedSparkSession


### PR DESCRIPTION
This commit adds the ID of the table being written to in schema mismatch error messages.