### PR TITLE
Avoid using mutable values in the withRelativePartitionDir method

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
@@ -298,14 +298,14 @@ trait GenerateSymlinkManifestImpl extends PostCommitHook with DeltaLogging with 
 
     require(datasetWithPartitionValues.schema.fieldNames.contains("partitionValues"))
     val colNamePrefix = "_col_"
-    var df: Dataset[_] = datasetWithPartitionValues
 
     // Flatten out nested partition value columns while renaming them, so that the new columns do
     // not conflict with existing columns in DF `pathsWithPartitionValues.
-    val colToRenamedCols = partitionCols.map { column =>
-      val renamedColumn = s"$colNamePrefix$column"
-      df = df.withColumn(renamedColumn, col(s"partitionValues.`$column`"))
-      column -> renamedColumn
+    val colToRenamedCols = partitionCols.map { column => column -> s"$colNamePrefix$column" }
+
+    val df = colToRenamedCols.foldLeft(datasetWithPartitionValues) {
+      case(currentDf, (column, renamedColumn)) =>
+      currentDf.withColumn(renamedColumn, col(s"partitionValues.`$column`"))
     }
 
     // Mapping between original column names to use for generating partition path and

--- a/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
@@ -303,9 +303,9 @@ trait GenerateSymlinkManifestImpl extends PostCommitHook with DeltaLogging with 
     // not conflict with existing columns in DF `pathsWithPartitionValues.
     val colToRenamedCols = partitionCols.map { column => column -> s"$colNamePrefix$column" }
 
-    val df = colToRenamedCols.foldLeft(datasetWithPartitionValues) {
-      case(currentDf, (column, renamedColumn)) =>
-      currentDf.withColumn(renamedColumn, col(s"partitionValues.`$column`"))
+    val df = colToRenamedCols.foldLeft(datasetWithPartitionValues.toDF()) {
+      case(currentDs, (column, renamedColumn)) =>
+        currentDs.withColumn(renamedColumn, col(s"partitionValues.`$column`"))
     }
 
     // Mapping between original column names to use for generating partition path and


### PR DESCRIPTION
The main goal of this simple Pull Request is to provide a simple enhancement of the existing code by avoiding to use a mutable dataframe variable in the ```withRelativePartitionDir``` method.