### PR TITLE
Fix a typing mistake in the WriteIntoDelta's javadoc

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.execution.command.RunnableCommand
  *
  * Existing Table Semantics
  *  - The save mode will control how existing data is handled (i.e. overwrite, append, etc)
- *  - The schema will of the DataFrame will be checked and if there are new columns present
+ *  - The schema of the DataFrame will be checked and if there are new columns present
  *    they will be added to the tables schema. Conflicting columns (i.e. a INT, and a STRING)
  *    will result in an exception
  *  - The partition columns, if present are validated against the existing metadata. If not


### PR DESCRIPTION
While digging into delta's code, I found a typing mistake in the javadoc of ```WriteIntoDelta``` which I fixed in this Pull Request.