### PR TITLE
Made some enhancements on the Scala Options' code

### DIFF
--- a/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
+++ b/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
@@ -96,11 +96,9 @@ trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
   }
 
   private def subqueryNotSupportedCheck(condition: Option[Expression], op: String): Unit = {
-    condition match {
-      case Some(cond) if SubqueryExpression.hasSubquery(cond) =>
+    condition.foreach(cond => if (SubqueryExpression.hasSubquery(cond)) {
         throw DeltaErrors.subqueryNotSupportedException(op, cond)
-      case _ =>
-    }
+    })
   }
 
   protected def executeVacuum(

--- a/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
+++ b/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
@@ -96,9 +96,11 @@ trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
   }
 
   private def subqueryNotSupportedCheck(condition: Option[Expression], op: String): Unit = {
-    condition.foreach(cond => if (SubqueryExpression.hasSubquery(cond)) {
+    condition.foreach { cond =>
+      if (SubqueryExpression.hasSubquery(cond)) {
         throw DeltaErrors.subqueryNotSupportedException(op, cond)
-    })
+      }
+    }
   }
 
   protected def executeVacuum(

--- a/src/main/scala/io/delta/tables/execution/DescribeDeltaHistoryCommand.scala
+++ b/src/main/scala/io/delta/tables/execution/DescribeDeltaHistoryCommand.scala
@@ -36,8 +36,8 @@ case class DescribeDeltaHistoryCommand(
     val basePath =
       new Path(if (table.nonEmpty) {
         DeltaTableIdentifier(sparkSession, table.get) match {
-          case Some(id) => id.path.getOrElse(
-            throw DeltaErrors.tableNotSupportedException("DESCRIBE HISTORY"))
+          case Some(id) => id.path.getOrElse{
+            throw DeltaErrors.tableNotSupportedException("DESCRIBE HISTORY")}
           case None => throw DeltaErrors.notADeltaTableException("DESCRIBE HISTORY")
         }
       } else {

--- a/src/main/scala/io/delta/tables/execution/DescribeDeltaHistoryCommand.scala
+++ b/src/main/scala/io/delta/tables/execution/DescribeDeltaHistoryCommand.scala
@@ -36,8 +36,8 @@ case class DescribeDeltaHistoryCommand(
     val basePath =
       new Path(if (table.nonEmpty) {
         DeltaTableIdentifier(sparkSession, table.get) match {
-          case Some(id) if id.path.isDefined => id.path.get
-          case Some(id) => throw DeltaErrors.tableNotSupportedException("DESCRIBE HISTORY")
+          case Some(id) => id.path.getOrElse(
+            throw DeltaErrors.tableNotSupportedException("DESCRIBE HISTORY"))
           case None => throw DeltaErrors.notADeltaTableException("DESCRIBE HISTORY")
         }
       } else {

--- a/src/main/scala/io/delta/tables/execution/DescribeDeltaHistoryCommand.scala
+++ b/src/main/scala/io/delta/tables/execution/DescribeDeltaHistoryCommand.scala
@@ -36,8 +36,9 @@ case class DescribeDeltaHistoryCommand(
     val basePath =
       new Path(if (table.nonEmpty) {
         DeltaTableIdentifier(sparkSession, table.get) match {
-          case Some(id) => id.path.getOrElse{
-            throw DeltaErrors.tableNotSupportedException("DESCRIBE HISTORY")}
+          case Some(id) => id.path.getOrElse {
+            throw DeltaErrors.tableNotSupportedException("DESCRIBE HISTORY")
+          }
           case None => throw DeltaErrors.notADeltaTableException("DESCRIBE HISTORY")
         }
       } else {

--- a/src/main/scala/io/delta/tables/execution/VacuumTableCommand.scala
+++ b/src/main/scala/io/delta/tables/execution/VacuumTableCommand.scala
@@ -44,7 +44,7 @@ case class VacuumTableCommand(
     val pathToVacuum =
       new Path(if (table.nonEmpty) {
         DeltaTableIdentifier(sparkSession, table.get) match {
-          case Some(id) => id.path.getOrElse(throw DeltaErrors.tableNotSupportedException("VACUUM"))
+          case Some(id) => id.path.getOrElse{throw DeltaErrors.tableNotSupportedException("VACUUM")}
           case None => throw DeltaErrors.notADeltaTableException("VACUUM")
         }
       } else {

--- a/src/main/scala/io/delta/tables/execution/VacuumTableCommand.scala
+++ b/src/main/scala/io/delta/tables/execution/VacuumTableCommand.scala
@@ -44,7 +44,9 @@ case class VacuumTableCommand(
     val pathToVacuum =
       new Path(if (table.nonEmpty) {
         DeltaTableIdentifier(sparkSession, table.get) match {
-          case Some(id) => id.path.getOrElse{throw DeltaErrors.tableNotSupportedException("VACUUM")}
+          case Some(id) => id.path.getOrElse {
+            throw DeltaErrors.tableNotSupportedException("VACUUM")
+          }
           case None => throw DeltaErrors.notADeltaTableException("VACUUM")
         }
       } else {

--- a/src/main/scala/io/delta/tables/execution/VacuumTableCommand.scala
+++ b/src/main/scala/io/delta/tables/execution/VacuumTableCommand.scala
@@ -44,8 +44,7 @@ case class VacuumTableCommand(
     val pathToVacuum =
       new Path(if (table.nonEmpty) {
         DeltaTableIdentifier(sparkSession, table.get) match {
-          case Some(id) if id.path.isDefined => id.path.get
-          case Some(id) => throw DeltaErrors.tableNotSupportedException("VACUUM")
+          case Some(id) => id.path.getOrElse(throw DeltaErrors.tableNotSupportedException("VACUUM"))
           case None => throw DeltaErrors.notADeltaTableException("VACUUM")
         }
       } else {

--- a/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -265,20 +265,16 @@ object SchemaUtils {
         // Dropped a column that was present in the DataFrame schema
         return false
       }
-
       readSchema.forall { newField =>
-        existing.get(newField.name) match {
-          case Some(existingField) =>
-            // we know the name matches modulo case - now verify exact match
-            (existingField.name == newField.name
-              // if existing value is non-nullable, so should be the new value
-              && (existingField.nullable || !newField.nullable)
-              // and the type of the field must be compatible, too
-              && isDatatypeReadCompatible(existingField.dataType, newField.dataType))
-          case None =>
-            // new fields are fine, they just won't be returned
-            true
-        }
+        // new fields are fine, they just won't be returned
+        existing.get(newField.name).forall(existingField => {
+          // we know the name matches modulo case - now verify exact match
+          (existingField.name == newField.name
+            // if existing value is non-nullable, so should be the new value
+            && (existingField.nullable || !newField.nullable)
+            // and the type of the field must be compatible, too
+            && isDatatypeReadCompatible(existingField.dataType, newField.dataType))
+        })
       }
     }
 

--- a/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -267,14 +267,14 @@ object SchemaUtils {
       }
       readSchema.forall { newField =>
         // new fields are fine, they just won't be returned
-        existing.get(newField.name).forall(existingField => {
+        existing.get(newField.name).forall { existingField =>
           // we know the name matches modulo case - now verify exact match
           (existingField.name == newField.name
             // if existing value is non-nullable, so should be the new value
             && (existingField.nullable || !newField.nullable)
             // and the type of the field must be compatible, too
             && isDatatypeReadCompatible(existingField.dataType, newField.dataType))
-        })
+        }
       }
     }
 

--- a/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceUtils.scala
@@ -32,9 +32,6 @@ object DeltaSourceUtils {
 
   /** Check whether this table is a Delta table based on information from the Catalog. */
   def isDeltaTable(provider: Option[String]): Boolean = {
-    provider match {
-      case Some(p) => isDeltaDataSourceName(p)
-      case None => false
-    }
+    provider.exists(isDeltaDataSourceName)
   }
 }


### PR DESCRIPTION
The main goal of this Pull Request is to make some code enhancements on the different Options used in this project.
Some pattern matching snippets were unnecessary since we could have treated options as collections.
for example : 

- **foreach** can replace the following code: 
```
option match {
  case None => {}
  case Some(x) => foo(x)
}
```
- **forall** can replace the following code: 
```
option match {
  case None => true
  case Some(x) => foo(x)
}
```
- **exists** can replace the following code:
```
option match {
  case None => false
  case Some(x) => foo(x)
}
```

I also removed some unnecessary pattern matching conditions which could have been anticipated using a ```getOrElse``` on the Scala Option.

These modifications were tested by running the existant tests.