### PR TITLE
remove extra snapshot null value check in DeltaLog

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -111,7 +111,7 @@ class DeltaLog private(
 
   // TODO: There is a race here where files could get dropped when increasing the
   // retention interval...
-  protected def metadata = if (snapshot == null) Metadata() else snapshot.metadata
+  protected def metadata = snapshot.metadata
 
   /**
    * Tombstones before this timestamp will be dropped from the state and the files can be


### PR DESCRIPTION
Remove extra snapshot null value check in DeltaLog. It seems the `snapshot` never be null. Let me know if I missed anything, thx.