### PR TITLE
Optimize merge command when there is no whenNotMatched clause #342

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
@@ -103,6 +103,7 @@ case class MergeIntoCommand(
 
   /** Whether this merge statement only inserts new data. */
   private def isInsertOnly: Boolean = matchedClauses.isEmpty && notMatchedClause.isDefined
+  private def isMatchedOnly: Boolean = notMatchedClause.isEmpty
 
   lazy val updateClause: Option[DeltaMergeIntoUpdateClause] =
     matchedClauses.collectFirst { case u: DeltaMergeIntoUpdateClause => u }
@@ -288,7 +289,7 @@ case class MergeIntoCommand(
 
   /**
    * Write new files by reading the touched files and updating/inserting data using the source
-   * query/table. This is implemented using a full-outer-join using the merge condition.
+   * query/table. This is implemented using a full|right-outer-join using the merge condition.
    */
   private def writeAllChanges(
     spark: SparkSession,
@@ -299,8 +300,14 @@ case class MergeIntoCommand(
     // Generate a new logical plan that has same output attributes exprIds as the target plan.
     // This allows us to apply the existing resolved update/insert expressions.
     val newTarget = buildTargetPlanWithFiles(deltaTxn, filesToRewrite)
+    val joinType = if (isMatchedOnly &&
+      spark.conf.get(DeltaSQLConf.MERGE_MATCHED_ONLY_ENABLED)) {
+      "rightOuter"
+    } else {
+      "fullOuter"
+    }
 
-    logDebug(s"""writeAllChanges using full outer join:
+    logDebug(s"""writeAllChanges using $joinType join:
                 |  source.output: ${source.outputSet}
                 |  target.output: ${target.outputSet}
                 |  condition: $condition
@@ -314,16 +321,16 @@ case class MergeIntoCommand(
     val incrNoopCountExpr = makeMetricUpdateUDF("numTargetRowsCopied")
     val incrDeletedCountExpr = makeMetricUpdateUDF("numTargetRowsDeleted")
 
-    // Apply full outer join to find both, matches and non-matches. We are adding two boolean fields
+    // Apply an outer join to find both, matches and non-matches. We are adding two boolean fields
     // with value `true`, one to each side of the join. Whether this field is null or not after
-    // the full outer join, will allow us to identify whether the resultanet joined row was a
+    // the outer join, will allow us to identify whether the resultant joined row was a
     // matched inner result or an unmatched result with null on one side.
     val joinedDF = {
       val sourceDF = Dataset.ofRows(spark, source)
         .withColumn(SOURCE_ROW_PRESENT_COL, new Column(incrSourceRowCountExpr))
       val targetDF = Dataset.ofRows(spark, newTarget)
         .withColumn(TARGET_ROW_PRESENT_COL, lit(true))
-      sourceDF.join(targetDF, new Column(condition), "fullOuter")
+      sourceDF.join(targetDF, new Column(condition), joinType)
     }
 
     val joinedPlan = joinedDF.queryExecution.analyzed

--- a/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -226,4 +226,13 @@ object DeltaSQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val MERGE_MATCHED_ONLY_ENABLED =
+    buildConf("merge.optimizeMatchedOnlyMerge.enabled")
+      .internal()
+      .doc(
+        """If enabled, merge without 'when not matched' clause will be optimized to use a
+          |right outer join instead of a full outer join.
+      """.stripMargin)
+      .booleanConf
+      .createWithDefault(true)
 }


### PR DESCRIPTION
When Merge command doesn't have a whenNotMatched clause, the Full Outer Join in MergeIntoCommand.writeAllChanges can be changed to Right Outer Join. Since left/source side is usually small, this can enable Broadcast join - closes #342 