### PR TITLE
ensure that format specification in Metadata is respected

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
@@ -159,7 +159,7 @@ trait TransactionalWrite extends DeltaLogging { self: OptimisticTransactionImpl 
         partitionColumns = partitioningColumns,
         bucketSpec = None,
         statsTrackers = statsTrackers,
-        options = Map.empty)
+        options = snapshot.metadata.format.options)
     }
 
     committer.addedStatuses


### PR DESCRIPTION
ensure that `Metadata.format.options` is respected - closes #362