### PR TITLE
Create PyPI release for python

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 workflows:
   test_and_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,20 @@
 version: 2
+
+workflows:
+  test_and_deploy:
+    jobs:
+      - test
+      - deploy:
+          requires:
+            - test
+          filters:
+            tags:
+              only: /^v.*/ # runs only for tags starting with 'v'
+            branches:
+              ignore: /.*/ # doesn't run for branches
+
 jobs:
-  build:
+  test:
     docker:
       - image: circleci/openjdk:8u181-jdk # java 8
     steps:
@@ -26,3 +40,32 @@ jobs:
           name: Run Scala/Java and Python tests
           command: |
             pipenv run python run-tests.py
+
+  deploy:
+    docker:
+      - image: circleci/python:3.6
+    steps:
+      - checkout
+      - run:
+          name: verify git tag vs. version
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            python setup.py verify
+      - run:
+          name: init .pypirc
+          command: |
+            echo -e "[pypi]" >> ~/.pypirc
+            echo -e "username = <username>" >> ~/.pypirc
+            echo -e "password = $PYPI_PASSWORD" >> ~/.pypirc
+      - run:
+          name: create packages
+          command: |
+            python setup.py sdist
+            python setup.py bdist_wheel
+      - run:
+          name: upload to pypi
+          command: |
+            . venv/bin/activate
+            pip install twine
+            twine upload dist/*

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+import sys
+
+from setuptools import setup
+from setuptools.command.install import install
+
+# delta.io version
+VERSION = "0.5.0"
+
+class VerifyVersionCommand(install):
+    """Custom command to verify that the git tag matches our version"""
+    description = 'verify that the git tag matches our version'
+
+    def run(self):
+        tag = os.getenv('CIRCLE_TAG')
+
+        if tag != VERSION:
+            info = "Git tag: {0} does not match the version of this app: {1}".format(
+                tag, VERSION
+            )
+            sys.exit(info)
+
+setup(
+    name="delta.io",
+    version=VERSION,
+    description="Python wrapper for Delta Lake",
+    url="https://github.com/delta-io/delta",
+    author="TODO",
+    author_email="TODO",
+    license="Apache-2.0",
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Programming Language :: Python :: 3",
+    ],
+    keywords='delta.io',
+    package_dir = {'': 'python'},
+    packages=['delta'],
+    install_requires=[
+        'pyspark>=2.4.2',
+    ],
+    python_requires='>=3',
+    cmdclass={
+        'verify': VerifyVersionCommand,
+    }
+)


### PR DESCRIPTION
Hello,

This is related to issue #282.

With this PR:
- A setup.py file is added. 
- Circleci workflow is updated to release the package on PyPI when a tag starting with `v` is created.

Need to address the following:
- Get a username and password for PyPI. The username will be added in config.yml (`<username>`), whereas the password will be stored in `$PYPI_PASSWORD` env variable in circleci. 
- Review the metadata in setup.py and decide what the `author` and `author_email` values should be. I also used `delta.io` as the package name since `delta` was used already. 
- Added `pyspark` as an install dependency (i.e. will get installed when you do `pip install delta.io`) but whether it needs to stay there is open for discussion.