### PR TITLE
Use File System for log reads instead of FileContext of Default HDFSLogStore

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.delta
 
 // scalastyle:off import.ordering.noEmptyLine
-import java.io.FileNotFoundException
+import java.io.{FileNotFoundException, IOException}
 import java.util.ConcurrentModificationException
 
 import org.apache.spark.sql.delta.actions.{CommitInfo, Metadata}
@@ -87,7 +87,8 @@ trait DocsPath {
     "multipleSourceRowMatchingTargetRowInMergeException",
     "faqRelativePath",
     "ignoreStreamingUpdatesAndDeletesWarning",
-    "concurrentModificationExceptionMsg"
+    "concurrentModificationExceptionMsg",
+    "incorrectLogStoreImplementationException"
   )
 }
 
@@ -148,6 +149,17 @@ object DeltaErrors
     new InvariantViolationException(s"Column ${UnresolvedAttribute(invariant.column).name}" +
       s", which is defined as ${invariant.rule.name}, is missing from the data being " +
       s"written into the table.")
+  }
+
+  def incorrectLogStoreImplementationException(
+      sparkConf: SparkConf,
+      cause: Throwable): Throwable = {
+    new IOException(s"""The error typically occurs when the default LogStore implementation, that
+      | is, HDFSLogStore, is used to write into a Delta table on a non-HDFS storage system.
+      | In order to get the transactional ACID guarantees on table updates, you have to use the
+      | correct implementation of LogStore that is appropriate for your storage system.
+      | See ${generateDocsLink(sparkConf, "/delta-storage.html")} " for details.
+      """.stripMargin, cause)
   }
 
   def staticPartitionsNotSupportedException: Throwable = {

--- a/src/main/scala/org/apache/spark/sql/delta/storage/HDFSLogStore.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/storage/HDFSLogStore.scala
@@ -16,22 +16,21 @@
 
 package org.apache.spark.sql.delta.storage
 
-import java.io._
+import java.io.{IOException, _}
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.FileAlreadyExistsException
 import java.util.{EnumSet, UUID}
 
-import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 
-import org.apache.commons.io.IOUtils
+import org.apache.spark.sql.delta.DeltaErrors
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
 import org.apache.hadoop.fs.CreateFlag.CREATE
 import org.apache.hadoop.fs.Options.{ChecksumOpt, CreateOpts}
 
-import org.apache.spark.{SparkConf, SparkContext}
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.SparkConf
+import org.apache.spark.internal.Logging
 
 /**
  * The [[LogStore]] implementation for HDFS, which uses Hadoop [[FileContext]] API's to
@@ -41,30 +40,17 @@ import org.apache.spark.sql.SparkSession
  *
  * 2. Consistent file listing: HDFS file listing is consistent.
  */
-class HDFSLogStore(sparkConf: SparkConf, defaultHadoopConf: Configuration) extends LogStore {
-
-  def this(sc: SparkContext) = this(sc.getConf, sc.hadoopConfiguration)
-
-  protected def getActiveHadoopConf: Configuration = {
-    SparkSession.getActiveSession.map(_.sessionState.newHadoopConf()).getOrElse(defaultHadoopConf)
-  }
+class HDFSLogStore(sparkConf: SparkConf, defaultHadoopConf: Configuration)
+  extends HadoopFileSystemLogStore(sparkConf, defaultHadoopConf) with Logging{
 
   protected def getFileContext(path: Path): FileContext = {
-    FileContext.getFileContext(path.toUri, getActiveHadoopConf)
+    FileContext.getFileContext(path.toUri, getHadoopConfiguration)
   }
 
-  override def read(path: Path): Seq[String] = {
-    val stream = getFileContext(path).open(path)
-    try {
-      val reader = new BufferedReader(new InputStreamReader(stream, UTF_8))
-      IOUtils.readLines(reader).asScala.map(_.trim)
-    } finally {
-      stream.close()
-    }
-  }
+  val noAbstractFileSystemExceptionMessage = "No AbstractFileSystem"
 
   def write(path: Path, actions: Iterator[String], overwrite: Boolean = false): Unit = {
-    val isLocalFs = path.getFileSystem(getActiveHadoopConf).isInstanceOf[RawLocalFileSystem]
+    val isLocalFs = path.getFileSystem(getHadoopConfiguration).isInstanceOf[RawLocalFileSystem]
     if (isLocalFs) {
       // We need to add `synchronized` for RawLocalFileSystem as its rename will not throw an
       // exception when the target file exists. Hence we must make sure `exists + rename` in
@@ -80,8 +66,14 @@ class HDFSLogStore(sparkConf: SparkConf, defaultHadoopConf: Configuration) exten
   }
 
   private def writeInternal(path: Path, actions: Iterator[String], overwrite: Boolean): Unit = {
-    val fc = getFileContext(path)
-
+    val fc: FileContext = try {
+      getFileContext(path)
+    } catch {
+      case e: IOException if e.getMessage.contains(noAbstractFileSystemExceptionMessage) =>
+        val newException = DeltaErrors.incorrectLogStoreImplementationException(sparkConf, e)
+        logError(newException.getMessage, newException.getCause)
+        throw newException
+    }
     if (!overwrite && fc.util.exists(path)) {
       // This is needed for the tests to throw error with local file system
       throw new FileAlreadyExistsException(path.toString)
@@ -117,10 +109,6 @@ class HDFSLogStore(sparkConf: SparkConf, defaultHadoopConf: Configuration) exten
     }
   }
 
-  private def createTempPath(path: Path): Path = {
-    new Path(path.getParent, s".${path.getName}.${UUID.randomUUID}.tmp")
-  }
-
   private def tryRemoveCrcFile(fc: FileContext, path: Path): Unit = {
     try {
       val checksumFile = new Path(path.getParent, s".${path.getName}.crc")
@@ -131,21 +119,6 @@ class HDFSLogStore(sparkConf: SparkConf, defaultHadoopConf: Configuration) exten
     } catch {
       case NonFatal(_) => // ignore, we are removing crc file as "best-effort"
     }
-  }
-
-  override def listFrom(path: Path): Iterator[FileStatus] = {
-    val fc = getFileContext(path)
-    if (!fc.util.exists(path.getParent)) {
-      throw new FileNotFoundException(s"No such file or directory: ${path.getParent}")
-    }
-    val files = fc.util.listStatus(path.getParent)
-    files.filter(_.getPath.getName >= path.getName).sortBy(_.getPath.getName).iterator
-  }
-
-  override def invalidateCache(): Unit = {}
-
-  override def resolvePathOnPhysicalStorage(path: Path): Path = {
-    getFileContext(path).makeQualified(path)
   }
 
   override def isPartialWriteVisible(path: Path): Boolean = true

--- a/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
@@ -21,7 +21,6 @@ import java.net.URI
 
 import scala.collection.mutable.ArrayBuffer
 
-import com.databricks.service.SparkServiceTestUtils
 import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.spark.sql.delta.storage._


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use file system APIs for log reads.
Throw a better error message for writes

### How was this patch tested?
Added a couple of tests in the HDFSLogStoreSuite


closes https://github.com/delta-io/delta/issues/347

GitOrigin-RevId: 0e532a46e1195392be7a60563d38f47c84c8147f