### PR TITLE
Expose option canReturnLastCommit to delta reader

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -157,6 +157,8 @@ object DeltaOptions extends DeltaLogging {
   val OPTIMIZE_WRITE_OPTION = "optimizeWrite"
   val DATA_CHANGE_OPTION = "dataChange"
 
+  val TIME_TRAVEL_TS_CRLC_KEY = "canReturnLastCommit"
+
   val validOptionKeys : Set[String] = Set(
     REPLACE_WHERE_OPTION,
     MERGE_SCHEMA_OPTION,
@@ -172,6 +174,7 @@ object DeltaOptions extends DeltaLogging {
     "checkpointLocation",
     "path",
     "timestampAsOf",
+    "canReturnLastCommit",
     "versionAsOf"
   )
 

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -289,7 +289,10 @@ object DeltaTableUtils extends PredicateHelper
       userVersion -> "version"
     } else {
       val timestamp = tt.getTimestamp(conf.sessionLocalTimeZone)
-      deltaLog.history.getActiveCommitAtTime(timestamp, false).version -> "timestamp"
+      deltaLog.history.getActiveCommitAtTime(
+        timestamp,
+        tt.canReturnLastCommit.getOrElse(false)
+      ).version -> "timestamp"
     }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaTimeTravelSpec.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaTimeTravelSpec.scala
@@ -31,11 +31,14 @@ import org.apache.spark.sql.types.{LongType, TimestampType}
  * The specification to time travel a Delta Table to the given `timestamp` or `version`.
  * @param timestamp An expression that can be evaluated into a timestamp. The expression cannot
  *                  be a subquery.
+ * @param canReturnLastCommit Whether we can return the latest version of the table if the
+ *                            provided timestamp is after the latest commit.
  * @param version The version of the table to time travel to. Must be >= 0.
  * @param creationSource The API used to perform time travel, e.g. `atSyntax`, `dfReader` or SQL
  */
 case class DeltaTimeTravelSpec(
     timestamp: Option[Expression],
+    canReturnLastCommit: Option[Boolean],
     version: Option[Long],
     creationSource: Option[String]) {
 
@@ -86,11 +89,12 @@ object DeltaTimeTravelSpec {
         // Drop the 18 characters in the right, which is the timestamp format and the @ character.
         val realIdentifier = identifier.dropRight(TIMESTAMP_FORMAT_LENGTH + 1)
 
-        DeltaTimeTravelSpec(Some(timestamp), None, Some("atSyntax.path")) -> realIdentifier
+        DeltaTimeTravelSpec(Some(timestamp), Some(false), None, Some("atSyntax.path")) ->
+          realIdentifier
       case VERSION_URI_FOR_TIME_TRAVEL(v) =>
         // Drop the version, and `@v` characters from the identifier
         val realIdentifier = identifier.dropRight(v.length + 2)
-        DeltaTimeTravelSpec(None, Some(v.toLong), Some("atSyntax.path")) -> realIdentifier
+        DeltaTimeTravelSpec(None, None, Some(v.toLong), Some("atSyntax.path")) -> realIdentifier
     }
   }
 


### PR DESCRIPTION
As per https://github.com/delta-io/delta/issues/195

This change exposes canReturnLastCommit so that if using the `timestampAsOf` functionality the user can choose to allow timestamps greater than the last commit to be treated as 'as-at the last commit'.

```scala
        spark.read.format("delta").option("timestampAsOf", "2018-10-24 15:16:18")
          .option("canReturnLastCommit", "false")
          .load(tblLoc)
```