### PR TITLE
Add option to repartition by partition column in merge to reduce the number of files

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
@@ -279,7 +279,8 @@ case class MergeIntoCommand(
     val insertDf = sourceDF.join(targetDF, new Column(condition), "leftanti")
       .select(outputCols: _*)
 
-    val newFiles = deltaTxn.writeFiles(insertDf)
+    val newFiles = deltaTxn
+      .writeFiles(repartitionIfNeeded(spark, insertDf, deltaTxn.metadata.partitionColumns))
     metrics("numTargetFilesBeforeSkipping") += deltaTxn.snapshot.numOfFiles
     metrics("numTargetFilesAfterSkipping") += dataSkippedFiles.size
     metrics("numTargetFilesRemoved") += 0
@@ -386,7 +387,8 @@ case class MergeIntoCommand(
     logDebug("writeAllChanges: join output plan:\n" + outputDF.queryExecution)
 
     // Write to Delta
-    val newFiles = deltaTxn.writeFiles(outputDF)
+    val newFiles = deltaTxn
+      .writeFiles(repartitionIfNeeded(spark, outputDF, deltaTxn.metadata.partitionColumns))
     metrics("numTargetFilesAdded") += newFiles.size
     newFiles
   }
@@ -423,6 +425,18 @@ case class MergeIntoCommand(
   }
 
   private def seqToString(exprs: Seq[Expression]): String = exprs.map(_.sql).mkString("\n\t")
+
+  /** Repartitions the output DataFrame by the partition columns */
+  protected def repartitionIfNeeded(
+      spark: SparkSession,
+      df: DataFrame,
+      partitionColumns: Seq[String]): DataFrame = {
+    if (partitionColumns.nonEmpty && spark.conf.get(DeltaSQLConf.MERGE_REPARTITION_BEFORE_WRITE)) {
+      df.repartition(partitionColumns.map(col): _*)
+    } else {
+      df
+    }
+  }
 }
 
 object MergeIntoCommand {

--- a/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -234,6 +234,17 @@ object DeltaSQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val MERGE_REPARTITION_BEFORE_WRITE =
+    buildConf("merge.repartitionBeforeWrite.enabled")
+      .internal()
+      .doc(
+        """
+          |When enabled, merge will repartition the output by the table's partition columns before
+          |writing the files.
+        """.stripMargin)
+      .booleanConf
+      .createWithDefault(false)
+
   val MERGE_MATCHED_ONLY_ENABLED =
     buildConf("merge.optimizeMatchedOnlyMerge.enabled")
       .internal()


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added a DeltaSQLConf to allow repartition the merge output dataframe by partition columns to reduce the number of files generated by the merge.

## How was this patch tested?
Added unit tests in MergeIntoCommandSuiteBase

Closes #349 

GitOrigin-RevId: 2c152964fd7416382bbe58eab16e5ae5e5bdba37