### PR TITLE
Refactor some tests in the delta code

### DIFF
--- a/src/test/scala/io/delta/tables/DeltaTableSuite.scala
+++ b/src/test/scala/io/delta/tables/DeltaTableSuite.scala
@@ -17,10 +17,7 @@
 package io.delta.tables
 
 import java.util.Locale
-
-
 import org.apache.spark.sql.{AnalysisException, QueryTest}
-import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.test.SharedSparkSession
 
 class DeltaTableSuite extends QueryTest
@@ -65,7 +62,6 @@ class DeltaTableSuite extends QueryTest
   }
 
   test("isDeltaTable - with non-Delta table path") {
-    val msg = "not a delta table"
     withTempDir { dir =>
       testData.write.format("parquet").mode("overwrite").save(dir.getAbsolutePath)
       assert(!DeltaTable.isDeltaTable(dir.getAbsolutePath))

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
@@ -18,8 +18,6 @@ package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.delta.actions.{Action, FileAction}
 import org.apache.spark.sql.delta.util.FileNames
-
-import org.apache.spark.SparkConf
 import org.apache.spark.sql.{AnalysisException, QueryTest}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.Utils
@@ -115,7 +113,6 @@ class DeltaOptionSuite extends QueryTest
 
       // Overwriting the schema of the existing table while having dataChange as false.
       val e3 = intercept[AnalysisException] {
-        val df = spark.read.format("delta").load(tempDir.getAbsolutePath)
         spark.range(50)
           .withColumn("id3", 'id + 1)
           .write

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -147,7 +147,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase {
       testStream(df)(
         AssertOnQuery { q => q.processAllAvailable(); true },
         CheckAnswer((0 until 5).map(_.toString): _*),
-        AssertOnQuery { q =>
+        AssertOnQuery { _ =>
           withMetadata(deltaLog, StructType.fromDDL("id LONG, value STRING"))
           true
         },
@@ -582,7 +582,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase {
         AssertOnQuery { q => q.processAllAvailable(); true },
         CheckAnswer("keep1", "keep2"),
         StopStream,
-        AssertOnQuery { q =>
+        AssertOnQuery { _ =>
           Utils.deleteRecursively(inputDir)
           val deltaLog = DeltaLog.forTable(spark, new Path(inputDir.toURI))
           // All Delta tables in tests use the same tableId by default. Here we pass a new tableId
@@ -832,7 +832,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase {
 
       // Make sure OffsetSeqLog won't choke on the offset we wrote
       withTempDir { logPath =>
-        val seqLog = new OffsetSeqLog(spark, logPath.toString) {
+        new OffsetSeqLog(spark, logPath.toString) {
           val offsetSeq = this.deserialize(new FileInputStream(offsetFile))
           val out = new OutputStream() { override def write(b: Int): Unit = { } }
           this.serialize(offsetSeq, out)
@@ -981,7 +981,7 @@ class MonotonicallyIncreasingTimestampFS extends RawLocalFileSystem {
   override def getFileStatus(f: Path): FileStatus = {
     val original = super.getFileStatus(f)
     time += 1000L
-    new FileStatus(original.getLen, original.isDir, 0, 0, time, f)
+    new FileStatus(original.getLen, original.isDirectory, 0, 0, time, f)
   }
 }
 

--- a/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -16,12 +16,9 @@
 
 package org.apache.spark.sql.delta
 
-import java.util.ConcurrentModificationException
-
-import org.apache.spark.sql.delta.DeltaOperations.{Delete, ManualUpdate, Truncate}
+import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.actions.{Action, AddFile, FileAction, Metadata, RemoveFile, SetTransaction}
 import org.apache.hadoop.fs.Path
-
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.test.SharedSparkSession
@@ -640,8 +637,8 @@ class OptimisticTransactionSuite extends QueryTest with SharedSparkSession {
       partitionCols: Seq[String] = "part" :: Nil)(
       test: DeltaLog => Unit): Unit = {
 
-    val schema = new StructType(partitionCols.map(p => new StructField(p, StringType)).toArray)
-    var actionWithMetaData =
+    val schema = StructType(partitionCols.map(p => StructField(p, StringType)).toArray)
+    val actionWithMetaData =
       actions :+ Metadata(partitionColumns = partitionCols, schemaString = schema.json)
 
     withTempDir { tempDir =>


### PR DESCRIPTION
The main goal of this Pull Request is to make small changes in the tests by providing very minor changes which in most cases consists of :

- removing unused imports
- removing unused values
- stop using a deprecated method and replace it by the adequate method
- replacing var by val when possible
- not using the new operator when instantiating a scala case class (like StructField or StructType)

These changes were tested by running all the tests.