### PR TITLE
add execution/scan/rewrite time

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -308,30 +308,35 @@ object DeltaOperations {
 }
 
 private[delta] object DeltaOperationMetrics {
+
+  val EXECUTION_TIME_MS = "executionTimeMs" // milliseconds of the execution time
+  val SCAN_TIME_MS = "scanTimeMs" // milliseconds spent on finding the target data
+  val REWRITE_TIME_MS = "rewriteTimeMs" // milliseconds spent on rewriting the target data
+
   val WRITE = Set(
     "numFiles", // number of files written
     "numOutputBytes", // size in bytes of the written contents
     "numOutputRows" // number of rows written
-  )
+  ) + EXECUTION_TIME_MS
 
   val STREAMING_UPDATE = Set(
     "numAddedFiles", // number of files added
     "numRemovedFiles", // number of files removed
     "numOutputRows", // number of rows written
     "numOutputBytes" // number of output writes
-  )
+  ) + EXECUTION_TIME_MS
 
   val DELETE = Set(
     "numAddedFiles", // number of files added
     "numRemovedFiles", // number of files removed
     "numDeletedRows", // number of rows removed
     "numCopiedRows" // number of rows copied in the process of deleting files
-  )
+  ) + EXECUTION_TIME_MS + SCAN_TIME_MS + REWRITE_TIME_MS
 
   /** Deleting the entire table or partition would prevent row level metrics from being recorded */
   val DELETE_PARTITIONS = Set(
     "numRemovedFiles" // number of files removed
-  )
+  ) + EXECUTION_TIME_MS + SCAN_TIME_MS + REWRITE_TIME_MS
 
   val TRUNCATE = Set(
     "numRemovedFiles" // number of files removed
@@ -366,12 +371,12 @@ private[delta] object DeltaOperationMetrics {
     "numOutputRows", // total number of rows written out
     "numTargetFilesAdded", // num files added to the sink(target)
     "numTargetFilesRemoved" // number of files removed from the sink(target)
-  )
+  ) + EXECUTION_TIME_MS
 
   val UPDATE = Set(
     "numAddedFiles", // number of files added
     "numRemovedFiles", // number of files removed
     "numUpdatedRows", // number of rows updated
     "numCopiedRows" // number of rows just copied over in the process of updating files.
-  )
+  ) + EXECUTION_TIME_MS + SCAN_TIME_MS + REWRITE_TIME_MS
 }

--- a/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
@@ -334,6 +334,7 @@ trait DescribeDeltaHistorySuiteBase
         // Check if operation metrics from history are accurate
         checkOperationMetrics(expectedMetrics, operationMetrics, DeltaOperationMetrics.WRITE)
         assert(operationMetrics("numOutputBytes").toLong > 0)
+        assert(operationMetrics("executionTimeMs").toLong > 0)
       }
     }
   }
@@ -364,6 +365,7 @@ trait DescribeDeltaHistorySuiteBase
           "numSourceRows" -> "100"
         )
         checkOperationMetrics(expectedMetrics, operationMetrics, DeltaOperationMetrics.MERGE)
+        assert(operationMetrics("executionTimeMs").toLong > 0)
       }
     }
   }
@@ -395,6 +397,7 @@ trait DescribeDeltaHistorySuiteBase
         )
         checkOperationMetrics(
           expectedMetrics, operationMetrics, DeltaOperationMetrics.STREAMING_UPDATE)
+        assert(operationMetrics("executionTimeMs").toLong > 0)
 
         // check if second batch also returns correct metrics.
         memoryStream.addData(1, 2, 3)
@@ -408,6 +411,7 @@ trait DescribeDeltaHistorySuiteBase
         checkOperationMetrics(
           expectedMetrics2, operationMetrics, DeltaOperationMetrics.STREAMING_UPDATE)
         assert(operationMetrics("numOutputBytes").toLong > 0)
+
         q.stop()
       }
     }
@@ -446,6 +450,7 @@ trait DescribeDeltaHistorySuiteBase
         )
         checkOperationMetrics(
           expectedMetrics, operationMetrics, DeltaOperationMetrics.STREAMING_UPDATE)
+        assert(operationMetrics("executionTimeMs").toLong > 0)
       }
     }
   }
@@ -477,6 +482,9 @@ trait DescribeDeltaHistorySuiteBase
           "numCopiedRows" -> expectedRowCount.toString
         )
         checkOperationMetrics(expectedMetrics, operationMetrics, DeltaOperationMetrics.UPDATE)
+        assert(operationMetrics("executionTimeMs").toLong > 0)
+        assert(operationMetrics("scanTimeMs").toLong > 0)
+        assert(operationMetrics("rewriteTimeMs").toLong > 0)
       }
     }
   }
@@ -511,6 +519,9 @@ trait DescribeDeltaHistorySuiteBase
           "numRemovedFiles" -> (numFilesBeforeUpdate / numPartitions).toString
         )
         checkOperationMetrics(expectedMetrics, operationMetrics, DeltaOperationMetrics.UPDATE)
+        assert(operationMetrics("executionTimeMs").toLong > 0)
+        assert(operationMetrics("scanTimeMs").toLong > 0)
+        assert(operationMetrics("rewriteTimeMs").toLong > 0)
       }
     }
   }
@@ -544,6 +555,9 @@ trait DescribeDeltaHistorySuiteBase
           "numCopiedRows" -> (numRows - rowsToDelete).toString
         )
         checkOperationMetrics(expectedMetrics, operationMetrics, DeltaOperationMetrics.DELETE)
+        assert(operationMetrics("executionTimeMs").toLong > 0)
+        assert(operationMetrics("scanTimeMs").toLong > 0)
+        assert(operationMetrics("rewriteTimeMs").toLong > 0)
       }
     }
   }
@@ -571,6 +585,9 @@ trait DescribeDeltaHistorySuiteBase
         // row level metrics are not collected for deletes with parition columns
         checkOperationMetrics(
           expectedMetrics, operationMetrics, DeltaOperationMetrics.DELETE_PARTITIONS)
+        assert(operationMetrics("executionTimeMs").toLong > 0)
+        assert(operationMetrics("scanTimeMs").toLong > 0)
+        assert(operationMetrics("rewriteTimeMs").toLong == 0)
       }
     }
   }
@@ -598,6 +615,8 @@ trait DescribeDeltaHistorySuiteBase
         )
         checkOperationMetrics(
           expectedMetrics, operationMetrics, DeltaOperationMetrics.DELETE_PARTITIONS)
+        assert(operationMetrics("scanTimeMs").toLong > 0)
+        assert(operationMetrics("rewriteTimeMs").toLong == 0)
       }
     }
   }


### PR DESCRIPTION
I think it's useful to record some time cost in the history display.

add execution time in operation_metrics
add scan & rewrite time in operation_metrics for Update&Delete