### PR TITLE
Use exists instead of combining map with .getOrElse(false) in the DeltaOptions

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -76,7 +76,7 @@ trait DeltaWriteOptionsImpl extends DeltaOptionParser {
    * MODIFY permissions, when schema changes require OWN permissions.
    */
   def canOverwriteSchema: Boolean = {
-    options.get(OVERWRITE_SCHEMA_OPTION).map(toBoolean(_, OVERWRITE_SCHEMA_OPTION)).getOrElse(false)
+    options.get(OVERWRITE_SCHEMA_OPTION).exists(toBoolean(_, OVERWRITE_SCHEMA_OPTION))
   }
 
   /**
@@ -86,7 +86,7 @@ trait DeltaWriteOptionsImpl extends DeltaOptionParser {
    * This makes sure streaming queries reading from this table will not see any new changes
    */
   def rearrangeOnly: Boolean = {
-    options.get(DATA_CHANGE_OPTION).map(!toBoolean(_, DATA_CHANGE_OPTION)).getOrElse(false)
+    options.get(DATA_CHANGE_OPTION).exists(!toBoolean(_, DATA_CHANGE_OPTION))
   }
 
 }
@@ -109,13 +109,11 @@ trait DeltaReadOptions extends DeltaOptionParser {
   }
 
   val ignoreFileDeletion = options.get(IGNORE_FILE_DELETION_OPTION)
-    .map(toBoolean(_, IGNORE_FILE_DELETION_OPTION)).getOrElse(false)
+    .exists(toBoolean(_, IGNORE_FILE_DELETION_OPTION))
 
-  val ignoreChanges = options.get(IGNORE_CHANGES_OPTION)
-    .map(toBoolean(_, IGNORE_CHANGES_OPTION)).getOrElse(false)
+  val ignoreChanges = options.get(IGNORE_CHANGES_OPTION).exists(toBoolean(_, IGNORE_CHANGES_OPTION))
 
-  val ignoreDeletes = options.get(IGNORE_DELETES_OPTION)
-    .map(toBoolean(_, IGNORE_DELETES_OPTION)).getOrElse(false)
+  val ignoreDeletes = options.get(IGNORE_DELETES_OPTION).exists(toBoolean(_, IGNORE_DELETES_OPTION))
 
   val excludeRegex: Option[Regex] = try options.get(EXCLUDE_REGEX_OPTION).map(_.r) catch {
     case e: PatternSyntaxException =>


### PR DESCRIPTION
The main goal of this Pull Request is to enhance the scala code of the Delta Options by using the ```exists``` method on Scala Options instead of combining ```.map``` with ```.getOrElse(false)```.
