### PR TITLE
Integrate scala examples with the integration tests

### DIFF
--- a/examples/scala/build.sbt
+++ b/examples/scala/build.sbt
@@ -20,9 +20,20 @@ organizationName := "example"
 scalaVersion := "2.11.12"
 version := "0.1.0"
 
+def getDeltaVersion(): String = {
+  val envVars = System.getenv
+  if (envVars.containsKey("DELTA_VERSION")) {
+    val version = envVars.get("DELTA_VERSION")
+    println("Using Delta version " + version)
+    version
+  } else {
+    "0.5.0"
+  }
+}
+
 lazy val root = (project in file("."))
   .settings(
     name := "hello-world",
-    libraryDependencies += "io.delta" %% "delta-core" % "0.5.0",
+    libraryDependencies += "io.delta" %% "delta-core" % getDeltaVersion(),
     libraryDependencies += "org.apache.spark" %% "spark-sql" % "2.4.3",
     resolvers += "Delta" at "https://dl.bintray.com/delta-io/delta/")

--- a/run-integration-tests.py
+++ b/run-integration-tests.py
@@ -134,4 +134,4 @@ if __name__ == "__main__":
             version = fd.readline().split('"')[1]
 
     run_scala_integration_tests(root_dir, version)
-    # run_python_integration_tests(root_dir, version)
+    run_python_integration_tests(root_dir, version)

--- a/run-integration-tests.py
+++ b/run-integration-tests.py
@@ -26,20 +26,35 @@ import string
 import tempfile
 
 
-# TODO Scala integration tests
-def run_scala_integration_tests(root_dir, package):
-    pass
+def run_scala_integration_tests(root_dir, version):
+    print("##### Running Scala tests on version %s #####" % str(version))
+    clear_artifact_cache()
+    test_dir = path.join(root_dir, "examples", "scala")
+    test_src_dir = path.join(test_dir, "src", "main", "scala", "example")
+    test_classes = [f.replace(".scala", "") for f in os.listdir(test_src_dir)
+                  if f.endswith(".scala") and not f.startswith("_")]
+    with WorkingDirectory(test_dir):
+        for test_class in test_classes:
+            try:
+                cmd = ["build/sbt", "runMain example.%s" % test_class]
+                print("Running Scala tests in %s\n=====================" % test_class)
+                print("Command: %s" % str(cmd))
+                run_cmd(cmd, stream_output=True, env={"DELTA_VERSION": str(version)})
+            except:
+                print("Failed Scala tests in %s" % (test_class))
+                raise
 
 
-def run_python_integration_tests(root_dir, package):
-    print("##### Running Python tests #####")
+def run_python_integration_tests(root_dir, version):
+    print("##### Running Python tests on version %s #####" % str(version))
+    clear_artifact_cache()
     test_dir = path.join(root_dir, path.join("examples", "python"))
     test_files = [path.join(test_dir, f) for f in os.listdir(test_dir)
                   if path.isfile(path.join(test_dir, f)) and
                   f.endswith(".py") and not f.startswith("_")]
     python_root_dir = path.join(root_dir, "python")
     extra_class_path = path.join(python_root_dir, path.join("delta", "testing"))
-    # bintray repo url
+    package = "io.delta:delta-core_2.11:" + version
     repo = 'https://dl.bintray.com/delta-io/delta'
     for test_file in test_files:
         try:
@@ -47,12 +62,18 @@ def run_python_integration_tests(root_dir, package):
                    "--driver-class-path=%s" % extra_class_path,  # for less verbose logging
                    "--packages", package,
                    "--repositories", repo, test_file]
-            print("Running tests in %s\n=============" % test_file)
+            print("Running Python tests in %s\n=============" % test_file)
             print("Command: %s" % str(cmd))
             run_cmd(cmd, stream_output=True)
         except:
-            print("Failed tests in %s" % (test_file))
+            print("Failed Python tests in %s" % (test_file))
             raise
+
+
+def clear_artifact_cache(): 
+    print("Clearing Delta artifacts from ivy2 and mvn cache") 
+    run_cmd([ "rm", "-rf", "~/.ivy2/cache/io.delta/"], stream_output=True)
+    run_cmd([ "rm", "-rf", "~/.m2/repository/io/delta/"], stream_output=True)
 
 
 def run_cmd(cmd, throw_on_error=True, env=None, stream_output=False, **kwargs):
@@ -81,6 +102,18 @@ def run_cmd(cmd, throw_on_error=True, env=None, stream_output=False, **kwargs):
                 (exit_code, stdout, stderr))
         return (exit_code, stdout, stderr)
 
+# pylint: disable=too-few-public-methods
+class WorkingDirectory(object):
+    def __init__(self, working_directory):
+        self.working_directory = working_directory
+        self.old_workdir = os.getcwd()
+
+    def __enter__(self):
+        os.chdir(self.working_directory)
+
+    def __exit__(self, tpe, value, traceback):
+        os.chdir(self.old_workdir)
+
 
 if __name__ == "__main__":
     """
@@ -90,7 +123,6 @@ if __name__ == "__main__":
         "
     """
     root_dir = path.dirname(path.dirname(__file__))
-    repo = None
     # check if version is provided as an argument
     version = '0.0.0'
     if len(sys.argv) >= 2:
@@ -100,7 +132,6 @@ if __name__ == "__main__":
     if version == '0.0.0':
         with open(path.join(root_dir, "version.sbt")) as fd:
             version = fd.readline().split('"')[1]
-    package = "io.delta:delta-core_2.11:" + version
 
-    run_scala_integration_tests(root_dir, package)
-    run_python_integration_tests(root_dir, package)
+    run_scala_integration_tests(root_dir, version)
+    # run_python_integration_tests(root_dir, version)


### PR DESCRIPTION
Update `run-integration-tests.py` to run the scala tests
- Update scala example build file to take the version from the env variable DELTA_VERSION
- Update run-integration-tests.py to call all scala examples with the given version injected via env variable