### PR TITLE
Fix pipenv used in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             pyenv install 3.7.4
             pyenv global system 3.7.4
             pipenv install
-            pipenv --python 3.7 run pip install pip install https://docs.delta.io/spark3artifacts/rc1/distributions/pyspark-3.0.0.tar.gz
+            pipenv --python 3.7 run pip install https://docs.delta.io/spark3artifacts/rc1/distributions/pyspark-3.0.0.tar.gz
             pipenv --python 3.7 run pip install flake8==3.5.0 pypandoc==1.3.3
       - run:
           name: Run Scala/Java and Python tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,6 @@ jobs:
             pipenv run pip install https://docs.delta.io/spark3artifacts/rc1/distributions/pyspark-3.0.0.tar.gz
             pipenv run pip install flake8==3.5.0 pypandoc==1.3.3
       - run:
-            name: Run Scala/Java and Python tests
-            command: |
-              pipenv run python run-tests.py
+          name: Run Scala/Java and Python tests
+          command: |
+            pipenv run python run-tests.py

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,10 @@ jobs:
             eval "$(pyenv virtualenv-init -)"
             pyenv install 3.7.4
             pyenv global system 3.7.4
-            pipenv install
-            pipenv --python 3.7 run pip install https://docs.delta.io/spark3artifacts/rc1/distributions/pyspark-3.0.0.tar.gz
-            pipenv --python 3.7 run pip install flake8==3.5.0 pypandoc==1.3.3
-            pipenv --python 3.7 run python run-tests.py
+            pipenv --python 3.7 install
+            pipenv run pip install https://docs.delta.io/spark3artifacts/rc1/distributions/pyspark-3.0.0.tar.gz
+            pipenv run pip install flake8==3.5.0 pypandoc==1.3.3
+      - run:
+            name: Run Scala/Java and Python tests
+            command: |
+              pipenv run python run-tests.py

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,4 @@ jobs:
             pipenv install
             pipenv --python 3.7 run pip install https://docs.delta.io/spark3artifacts/rc1/distributions/pyspark-3.0.0.tar.gz
             pipenv --python 3.7 run pip install flake8==3.5.0 pypandoc==1.3.3
-      - run:
-          name: Run Scala/Java and Python tests
-          command: |
             pipenv --python 3.7 run python run-tests.py

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,4 +26,4 @@ jobs:
       - run:
           name: Run Scala/Java and Python tests
           command: |
-            pipenv run python run-tests.py
+            pipenv --python 3.7 run python run-tests.py

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,8 @@ jobs:
             pyenv install 3.7.4
             pyenv global system 3.7.4
             pipenv install
-            pipenv run pip install pip install https://docs.delta.io/spark3artifacts/rc1/distributions/pyspark-3.0.0.tar.gz
-            pipenv run pip install flake8==3.5.0 pypandoc==1.3.3
+            pipenv --python 3.7 run pip install pip install https://docs.delta.io/spark3artifacts/rc1/distributions/pyspark-3.0.0.tar.gz
+            pipenv --python 3.7 run pip install flake8==3.5.0 pypandoc==1.3.3
       - run:
           name: Run Scala/Java and Python tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,4 +23,7 @@ jobs:
             pipenv install
             pipenv --python 3.7 run pip install https://docs.delta.io/spark3artifacts/rc1/distributions/pyspark-3.0.0.tar.gz
             pipenv --python 3.7 run pip install flake8==3.5.0 pypandoc==1.3.3
+      - run:
+          name: Run Scala/Java and Python tests
+          command: |
             pipenv --python 3.7 run python run-tests.py

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -37,7 +37,7 @@ def test(root_dir, package):
 
     for test_file in test_files:
         try:
-            cmd = ["spark-submit",
+            cmd = ["pipenv", "--python", "3.7" "run", "spark-submit",
                    "--driver-class-path=%s" % extra_class_path,
                    "--packages", package, test_file]
             print("Running tests in %s\n=============" % test_file)

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -37,7 +37,7 @@ def test(root_dir, package):
 
     for test_file in test_files:
         try:
-            cmd = ["pipenv", "--python", "3.7" "run", "spark-submit",
+            cmd = ["pipenv", "--python", "3.7", "run", "spark-submit",
                    "--driver-class-path=%s" % extra_class_path,
                    "--packages", package, test_file]
             print("Running tests in %s\n=============" % test_file)

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -37,7 +37,7 @@ def test(root_dir, package):
 
     for test_file in test_files:
         try:
-            cmd = ["pipenv", "--python", "3.7", "run", "spark-submit",
+            cmd = ["spark-submit",
                    "--driver-class-path=%s" % extra_class_path,
                    "--packages", package, test_file]
             print("Running tests in %s\n=============" % test_file)


### PR DESCRIPTION
It's trying to install pyspark with python 3.5 instead of the system global 3.7.