### PR TITLE
[WIP] Run Tests Concurrently + Upgrade to SBT 1.3.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,10 +77,12 @@ concurrentRestrictions := {
   val testParallelismOpt = sys.env.get("DELTA_TEST_PARALLELISM").map(_.toInt)
   val parallelism = testParallelismOpt.getOrElse(defaultParallelism)
 
+  val logger = sLog.value
+
   if (testParallelismOpt.isDefined) {
-    println(s"Tests will run with user specified ${parallelism}x Parallelism")
+    logger.info(s"Tests will run with user specified ${parallelism}x Parallelism")
   } else {
-    println(s"Tests will run with default ${parallelism}x Parallelism")
+    logger.info(s"Tests will run with default ${parallelism}x Parallelism")
   }
 
   Seq(Tags.limit(Tags.ForkedTestGroup, parallelism))

--- a/build.sbt
+++ b/build.sbt
@@ -20,22 +20,22 @@ organization := "io.delta"
 
 scalaVersion := "2.12.10"
 
-sparkVersion := "3.0.0"
+val sparkVersion = "3.0.0"
 
 libraryDependencies ++= Seq(
   // Adding test classifier seems to break transitive resolution of the core dependencies
-  "org.apache.spark" %% "spark-hive" % sparkVersion.value % "provided",
-  "org.apache.spark" %% "spark-sql" % sparkVersion.value % "provided",
-  "org.apache.spark" %% "spark-core" % sparkVersion.value % "provided",
-  "org.apache.spark" %% "spark-catalyst" % sparkVersion.value % "provided",
+  "org.apache.spark" %% "spark-hive" % sparkVersion % "provided",
+  "org.apache.spark" %% "spark-sql" % sparkVersion % "provided",
+  "org.apache.spark" %% "spark-core" % sparkVersion % "provided",
+  "org.apache.spark" %% "spark-catalyst" % sparkVersion % "provided",
 
   // Test deps
   "org.scalatest" %% "scalatest" % "3.0.5" % "test",
   "junit" % "junit" % "4.12" % "test",
   "com.novocode" % "junit-interface" % "0.11" % "test",
-  "org.apache.spark" %% "spark-catalyst" % sparkVersion.value % "test" classifier "tests",
-  "org.apache.spark" %% "spark-core" % sparkVersion.value % "test" classifier "tests",
-  "org.apache.spark" %% "spark-sql" % sparkVersion.value % "test" classifier "tests",
+  "org.apache.spark" %% "spark-catalyst" % sparkVersion % "test" classifier "tests",
+  "org.apache.spark" %% "spark-core" % sparkVersion % "test" classifier "tests",
+  "org.apache.spark" %% "spark-sql" % sparkVersion % "test" classifier "tests",
 
   // Compiler plugins
   // -- Bump up the genjavadoc version explicitly to 0.16 to work with Scala 2.12
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
 
 resolvers += "Temporary Staging of Spark 3.0" at "https://docs.delta.io/spark3artifacts/rc1/maven/"
 
-antlr4Settings
+enablePlugins(Antlr4Plugin)
 
 antlr4Version in Antlr4 := "4.7"
 
@@ -160,6 +160,7 @@ unidocAllSources in(JavaUnidoc, unidoc) := {
  * Spark Packages settings *
  ***************************/
 
+/* TODO: Re-enable once we get Spark Package working on SBT 1.x
 spName := "databricks/delta-core"
 
 spAppendScalaVersion := true
@@ -171,6 +172,7 @@ spIgnoreProvided := true
 packageBin in Compile := spPackage.value
 
 sparkComponents := Seq("sql")
+*/
 
 /********************
  * Release settings *

--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,7 @@ Test / testGrouping := (Test / testGrouping).value.flatMap { group =>
 concurrentRestrictions := {
   val testParallelismOpt = sys.env.get("DELTA_TEST_PARALLELISM").map(_.toInt)
   // Default to number of processors / 2
-  val defaultParallelism = java.lang.Runtime.getRuntime().availableProcessors() / 2
+  val defaultParallelism = java.lang.Runtime.getRuntime().availableProcessors() / 3
   val parallelism = testParallelismOpt.getOrElse(defaultParallelism)
 
   if (testParallelismOpt.isDefined) {

--- a/build.sbt
+++ b/build.sbt
@@ -68,10 +68,13 @@ Test / testGrouping := (Test / testGrouping).value.flatMap { group =>
   group.tests.map(test => sbt.Tests.Group(test.name, Seq(test), sbt.Tests.SubProcess(ForkOptions())))
 }
 
+// We need to set concurrent restrictions to execute tests in parallel. By default SBT sets this to
+// 1x parallelism for forked JVMs.
 concurrentRestrictions := {
-  val testParallelismOpt = sys.env.get("DELTA_TEST_PARALLELISM").map(_.toInt)
-  // Default to number of processors / 2
+  // Default to number of processors / 3
   val defaultParallelism = java.lang.Runtime.getRuntime().availableProcessors() / 3
+  // Allow users to specify parallelism with env var
+  val testParallelismOpt = sys.env.get("DELTA_TEST_PARALLELISM").map(_.toInt)
   val parallelism = testParallelismOpt.getOrElse(defaultParallelism)
 
   if (testParallelismOpt.isDefined) {

--- a/build/sbt
+++ b/build/sbt
@@ -1,183 +1,606 @@
 #!/usr/bin/env bash
-
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+# A more capable sbt runner, coincidentally also called sbt.
+# Author: Paul Phillips <paulp@improving.org>
+# https://github.com/paulp/sbt-extras
 
-#
-# This file contains code from the Apache Spark project (original license above).
-# It contains modifications, which are licensed as follows:
-#
+set -o pipefail
 
-#
-#  Copyright (2020) The Delta Lake Project Authors.
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#  http://www.apache.org/licenses/LICENSE-2.0
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-#
+declare -r sbt_release_version="1.3.10"
+declare -r sbt_unreleased_version="1.3.10"
 
+declare -r latest_213="2.13.2"
+declare -r latest_212="2.12.11"
+declare -r latest_211="2.11.12"
+declare -r latest_210="2.10.7"
+declare -r latest_29="2.9.3"
+declare -r latest_28="2.8.2"
 
-# When creating new tests for Spark SQL Hive, the HADOOP_CLASSPATH must contain the hive jars so
-# that we can run Hive to generate the golden answer.  This is not required for normal development
-# or testing.
-if [ -n "$HIVE_HOME" ]; then
-    for i in "$HIVE_HOME"/lib/*
-    do HADOOP_CLASSPATH="$HADOOP_CLASSPATH:$i"
-    done
-    export HADOOP_CLASSPATH
-fi
+declare -r buildProps="project/build.properties"
 
-realpath () {
-(
-  TARGET_FILE="$1"
+declare -r sbt_launch_ivy_release_repo="https://repo.typesafe.com/typesafe/ivy-releases"
+declare -r sbt_launch_ivy_snapshot_repo="https://repo.scala-sbt.org/scalasbt/ivy-snapshots"
+declare -r sbt_launch_mvn_release_repo="https://repo.scala-sbt.org/scalasbt/maven-releases"
+declare -r sbt_launch_mvn_snapshot_repo="https://repo.scala-sbt.org/scalasbt/maven-snapshots"
 
-  cd "$(dirname "$TARGET_FILE")"
-  TARGET_FILE="$(basename "$TARGET_FILE")"
+declare -r default_jvm_opts_common="-Xms512m -Xss2m -XX:MaxInlineLevel=18"
+declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy -Dsbt.coursier.home=project/.coursier"
 
-  COUNT=0
-  while [ -L "$TARGET_FILE" -a $COUNT -lt 100 ]
-  do
-      TARGET_FILE="$(readlink "$TARGET_FILE")"
-      cd $(dirname "$TARGET_FILE")
-      TARGET_FILE="$(basename $TARGET_FILE)"
-      COUNT=$(($COUNT + 1))
-  done
+declare sbt_jar sbt_dir sbt_create sbt_version sbt_script sbt_new
+declare sbt_explicit_version
+declare verbose noshare batch trace_level
 
-  echo "$(pwd -P)/"$TARGET_FILE""
-)
+declare java_cmd="java"
+declare sbt_launch_dir="$HOME/.sbt/launchers"
+declare sbt_launch_repo
+
+# pull -J and -D options to give to java.
+declare -a java_args scalac_args sbt_commands residual_args
+
+# args to jvm/sbt via files or environment variables
+declare -a extra_jvm_opts extra_sbt_opts
+
+echoerr() { echo >&2 "$@"; }
+vlog()    { [[ -n "$verbose" ]] && echoerr "$@"; }
+die()     {
+  echo "Aborting: $*"
+  exit 1
 }
 
-if [[ "$JENKINS_URL" != "" ]]; then
-  # Make Jenkins use Google Mirror first as Maven Central may ban us
-  SBT_REPOSITORIES_CONFIG="$(dirname "$(realpath "$0")")/sbt-config/repositories"
-  export SBT_OPTS="-Dsbt.override.build.repos=true -Dsbt.repository.config=$SBT_REPOSITORIES_CONFIG"
-fi
+setTrapExit() {
+  # save stty and trap exit, to ensure echo is re-enabled if we are interrupted.
+  SBT_STTY="$(stty -g 2>/dev/null)"
+  export SBT_STTY
 
-. "$(dirname "$(realpath "$0")")"/sbt-launch-lib.bash
+  # restore stty settings (echo in particular)
+  onSbtRunnerExit() {
+    [ -t 0 ] || return
+    vlog ""
+    vlog "restoring stty: $SBT_STTY"
+    stty "$SBT_STTY"
+  }
 
+  vlog "saving stty: $SBT_STTY"
+  trap onSbtRunnerExit EXIT
+}
 
-declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy"
-declare -r sbt_opts_file=".sbtopts"
-declare -r etc_sbt_opts_file="/etc/sbt/sbtopts"
+# this seems to cover the bases on OSX, and someone will
+# have to tell me about the others.
+get_script_path() {
+  local path="$1"
+  [[ -L "$path" ]] || {
+    echo "$path"
+    return
+  }
+
+  local -r target="$(readlink "$path")"
+  if [[ "${target:0:1}" == "/" ]]; then
+    echo "$target"
+  else
+    echo "${path%/*}/$target"
+  fi
+}
+
+script_path="$(get_script_path "${BASH_SOURCE[0]}")"
+declare -r script_path
+script_name="${script_path##*/}"
+declare -r script_name
+
+init_default_option_file() {
+  local overriding_var="${!1}"
+  local default_file="$2"
+  if [[ ! -r "$default_file" && "$overriding_var" =~ ^@(.*)$ ]]; then
+    local envvar_file="${BASH_REMATCH[1]}"
+    if [[ -r "$envvar_file" ]]; then
+      default_file="$envvar_file"
+    fi
+  fi
+  echo "$default_file"
+}
+
+sbt_opts_file="$(init_default_option_file SBT_OPTS .sbtopts)"
+jvm_opts_file="$(init_default_option_file JVM_OPTS .jvmopts)"
+
+build_props_sbt() {
+  [[ -r "$buildProps" ]] &&
+    grep '^sbt\.version' "$buildProps" | tr '=\r' ' ' | awk '{ print $2; }'
+}
+
+set_sbt_version() {
+  sbt_version="${sbt_explicit_version:-$(build_props_sbt)}"
+  [[ -n "$sbt_version" ]] || sbt_version=$sbt_release_version
+  export sbt_version
+}
+
+url_base() {
+  local version="$1"
+
+  case "$version" in
+    0.7.*)     echo "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/simple-build-tool" ;;
+    0.10.*)    echo "$sbt_launch_ivy_release_repo" ;;
+    0.11.[12]) echo "$sbt_launch_ivy_release_repo" ;;
+    0.*-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9]) # ie "*-yyyymmdd-hhMMss"
+      echo          "$sbt_launch_ivy_snapshot_repo" ;;
+    0.*)       echo "$sbt_launch_ivy_release_repo" ;;
+    *-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]T[0-9][0-9][0-9][0-9][0-9][0-9]) # ie "*-yyyymmddThhMMss"
+      echo          "$sbt_launch_mvn_snapshot_repo" ;;
+    *)         echo "$sbt_launch_mvn_release_repo" ;;
+  esac
+}
+
+make_url() {
+  local version="$1"
+
+  local base="${sbt_launch_repo:-$(url_base "$version")}"
+
+  case "$version" in
+    0.7.*)     echo "$base/sbt-launch-0.7.7.jar" ;;
+    0.10.*)    echo "$base/org.scala-tools.sbt/sbt-launch/$version/sbt-launch.jar" ;;
+    0.11.[12]) echo "$base/org.scala-tools.sbt/sbt-launch/$version/sbt-launch.jar" ;;
+    0.*)       echo "$base/org.scala-sbt/sbt-launch/$version/sbt-launch.jar" ;;
+    *)         echo "$base/org/scala-sbt/sbt-launch/$version/sbt-launch-${version}.jar" ;;
+  esac
+}
+
+addJava()      {
+  vlog "[addJava] arg = '$1'"
+  java_args+=("$1")
+}
+addSbt()       {
+  vlog "[addSbt] arg = '$1'"
+  sbt_commands+=("$1")
+}
+addScalac()    {
+  vlog "[addScalac] arg = '$1'"
+  scalac_args+=("$1")
+}
+addResidual()  {
+  vlog "[residual] arg = '$1'"
+  residual_args+=("$1")
+}
+
+addResolver() { addSbt "set resolvers += $1"; }
+
+addDebugger() { addJava "-Xdebug" && addJava "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=$1"; }
+
+setThisBuild() {
+  vlog "[addBuild] args = '$*'"
+  local key="$1" && shift
+  addSbt "set $key in ThisBuild := $*"
+}
+setScalaVersion() {
+  [[ "$1" == *"-SNAPSHOT" ]] && addResolver 'Resolver.sonatypeRepo("snapshots")'
+  addSbt "++ $1"
+}
+setJavaHome() {
+  java_cmd="$1/bin/java"
+  setThisBuild javaHome "_root_.scala.Some(file(\"$1\"))"
+  export JAVA_HOME="$1"
+  export JDK_HOME="$1"
+  export PATH="$JAVA_HOME/bin:$PATH"
+}
+
+getJavaVersion() {
+  local -r str=$("$1" -version 2>&1 | grep -E -e '(java|openjdk) version' | awk '{ print $3 }' | tr -d '"')
+
+  # java -version on java8 says 1.8.x
+  # but on 9 and 10 it's 9.x.y and 10.x.y.
+  if [[ "$str" =~ ^1\.([0-9]+)(\..*)?$ ]]; then
+    echo "${BASH_REMATCH[1]}"
+  elif [[ "$str" =~ ^([0-9]+)(\..*)?$ ]]; then
+    echo "${BASH_REMATCH[1]}"
+  elif [[ -n "$str" ]]; then
+    echoerr "Can't parse java version from: $str"
+  fi
+}
+
+checkJava() {
+  # Warn if there is a Java version mismatch between PATH and JAVA_HOME/JDK_HOME
+
+  [[ -n "$JAVA_HOME" && -e "$JAVA_HOME/bin/java"    ]] && java="$JAVA_HOME/bin/java"
+  [[ -n "$JDK_HOME" && -e "$JDK_HOME/lib/tools.jar" ]] && java="$JDK_HOME/bin/java"
+
+  if [[ -n "$java" ]]; then
+    pathJavaVersion=$(getJavaVersion java)
+    homeJavaVersion=$(getJavaVersion "$java")
+    if [[ "$pathJavaVersion" != "$homeJavaVersion" ]]; then
+      echoerr "Warning: Java version mismatch between PATH and JAVA_HOME/JDK_HOME, sbt will use the one in PATH"
+      echoerr "  Either: fix your PATH, remove JAVA_HOME/JDK_HOME or use -java-home"
+      echoerr "  java version from PATH:               $pathJavaVersion"
+      echoerr "  java version from JAVA_HOME/JDK_HOME: $homeJavaVersion"
+    fi
+  fi
+}
+
+java_version() {
+  local -r version=$(getJavaVersion "$java_cmd")
+  vlog "Detected Java version: $version"
+  echo "$version"
+}
+
+# MaxPermSize critical on pre-8 JVMs but incurs noisy warning on 8+
+default_jvm_opts() {
+  local -r v="$(java_version)"
+  if [[ $v -ge 10 ]]; then
+    echo "$default_jvm_opts_common -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
+  elif [[ $v -ge 8 ]]; then
+    echo "$default_jvm_opts_common"
+  else
+    echo "-XX:MaxPermSize=384m $default_jvm_opts_common"
+  fi
+}
+
+execRunner() {
+  # print the arguments one to a line, quoting any containing spaces
+  vlog "# Executing command line:" && {
+    for arg; do
+      if [[ -n "$arg" ]]; then
+        if printf "%s\n" "$arg" | grep -q ' '; then
+          printf >&2 "\"%s\"\n" "$arg"
+        else
+          printf >&2 "%s\n" "$arg"
+        fi
+      fi
+    done
+    vlog ""
+  }
+
+  setTrapExit
+
+  if [[ -n "$batch" ]]; then
+    "$@" </dev/null
+  else
+    "$@"
+  fi
+}
+
+jar_url() { make_url "$1"; }
+
+is_cygwin() { [[ "$(uname -a)" == "CYGWIN"* ]]; }
+
+jar_file() {
+  is_cygwin &&
+    cygpath -w "$sbt_launch_dir/$1/sbt-launch.jar" ||
+    echo "$sbt_launch_dir/$1/sbt-launch.jar"
+}
+
+download_url() {
+  local url="$1"
+  local jar="$2"
+
+  mkdir -p "${jar%/*}" && {
+    if command -v curl >/dev/null 2>&1; then
+      curl --fail --silent --location "$url" --output "$jar"
+    elif command -v wget >/dev/null 2>&1; then
+      wget -q -O "$jar" "$url"
+    fi
+  } && [[ -r "$jar" ]]
+}
+
+acquire_sbt_jar() {
+  {
+    sbt_jar="$(jar_file "$sbt_version")"
+    [[ -r "$sbt_jar" ]]
+  } || {
+    sbt_jar="$HOME/.ivy2/local/org.scala-sbt/sbt-launch/$sbt_version/jars/sbt-launch.jar"
+    [[ -r "$sbt_jar" ]]
+  } || {
+    sbt_jar="$(jar_file "$sbt_version")"
+    jar_url="$(make_url "$sbt_version")"
+
+    echoerr "Downloading sbt launcher for ${sbt_version}:"
+    echoerr "  From  ${jar_url}"
+    echoerr "    To  ${sbt_jar}"
+
+    download_url "${jar_url}" "${sbt_jar}"
+
+    case "${sbt_version}" in
+      0.*)
+        vlog "SBT versions < 1.0 do not have published MD5 checksums, skipping check"
+        echo ""
+        ;;
+      *)   verify_sbt_jar "${sbt_jar}" ;;
+    esac
+  }
+}
+
+verify_sbt_jar() {
+  local jar="${1}"
+  local md5="${jar}.md5"
+  md5url="$(make_url "${sbt_version}").md5"
+
+  echoerr "Downloading sbt launcher ${sbt_version} md5 hash:"
+  echoerr "  From  ${md5url}"
+  echoerr "    To  ${md5}"
+
+  download_url "${md5url}" "${md5}" >/dev/null 2>&1
+
+  if command -v md5sum >/dev/null 2>&1; then
+    if echo "$(cat "${md5}")  ${jar}" | md5sum -c -; then
+      rm -rf "${md5}"
+      return 0
+    else
+      echoerr "Checksum does not match"
+      return 1
+    fi
+  elif command -v md5 >/dev/null 2>&1; then
+    if [ "$(md5 -q "${jar}")" == "$(cat "${md5}")" ]; then
+      rm -rf "${md5}"
+      return 0
+    else
+      echoerr "Checksum does not match"
+      return 1
+    fi
+  elif command -v openssl >/dev/null 2>&1; then
+    if [ "$(openssl md5 -r "${jar}" | awk '{print $1}')" == "$(cat "${md5}")" ]; then
+      rm -rf "${md5}"
+      return 0
+    else
+      echoerr "Checksum does not match"
+      return 1
+    fi
+  else
+    echoerr "Could not find an MD5 command"
+    return 1
+  fi
+}
 
 usage() {
- cat <<EOM
+  set_sbt_version
+  cat <<EOM
 Usage: $script_name [options]
 
+Note that options which are passed along to sbt begin with -- whereas
+options to this runner use a single dash. Any sbt command can be scheduled
+to run first by prefixing the command with --, so --warn, --error and so on
+are not special.
+
   -h | -help         print this message
-  -v | -verbose      this runner is chattier
-  -d | -debug        set sbt log level to debug
+  -v                 verbose operation (this runner is chattier)
+  -d, -w, -q         aliases for --debug, --warn, --error (q means quiet)
+  -x                 debug this script
+  -trace <level>     display stack traces with a max of <level> frames (default: -1, traces suppressed)
+  -debug-inc         enable debugging log for the incremental compiler
   -no-colors         disable ANSI color codes
   -sbt-create        start sbt even if current directory contains no sbt project
-  -sbt-dir   <path>  path to global settings/plugins directory (default: ~/.sbt)
-  -sbt-boot  <path>  path to shared boot directory (default: ~/.sbt/boot in 0.11 series)
+  -sbt-dir   <path>  path to global settings/plugins directory (default: ~/.sbt/<version>)
+  -sbt-boot  <path>  path to shared boot directory (default: ~/.sbt/boot in 0.11+)
   -ivy       <path>  path to local Ivy repository (default: ~/.ivy2)
-  -mem    <integer>  set memory options (default: $sbt_mem, which is $(get_mem_opts $sbt_mem))
   -no-share          use all local caches; no sharing
-  -no-global         uses global caches, but does not use global ~/.sbt directory.
+  -offline           put sbt in offline mode
   -jvm-debug <port>  Turn on JVM debugging, open at the given port.
   -batch             Disable interactive mode
+  -prompt <expr>     Set the sbt prompt; in expr, 's' is the State and 'e' is Extracted
+  -script <file>     Run the specified file as a scala script
 
-  # sbt version (default: from project/build.properties if present, else latest release)
-  -sbt-version  <version>   use the specified version of sbt
-  -sbt-jar      <path>      use the specified jar as the sbt launcher
-  -sbt-rc                   use an RC version of sbt
-  -sbt-snapshot             use a snapshot version of sbt
+  # sbt version (default: sbt.version from $buildProps if present, otherwise $sbt_release_version)
+  -sbt-version <version>  use the specified version of sbt (default: $sbt_release_version)
+  -sbt-force-latest       force the use of the latest release of sbt: $sbt_release_version
+  -sbt-dev                use the latest pre-release version of sbt: $sbt_unreleased_version
+  -sbt-jar      <path>    use the specified jar as the sbt launcher
+  -sbt-launch-dir <path>  directory to hold sbt launchers (default: $sbt_launch_dir)
+  -sbt-launch-repo <url>  repo url for downloading sbt launcher jar (default: $(url_base "$sbt_version"))
+
+  # scala version (default: as chosen by sbt)
+  -28                        use $latest_28
+  -29                        use $latest_29
+  -210                       use $latest_210
+  -211                       use $latest_211
+  -212                       use $latest_212
+  -213                       use $latest_213
+  -scala-home <path>         use the scala build at the specified directory
+  -scala-version <version>   use the specified version of scala
+  -binary-version <version>  use the specified scala version when searching for dependencies
 
   # java version (default: java from PATH, currently $(java -version 2>&1 | grep version))
-  -java-home <path>         alternate JAVA_HOME
+  -java-home <path>          alternate JAVA_HOME
 
-  # jvm options and output control
-  JAVA_OPTS          environment variable, if unset uses "$java_opts"
-  SBT_OPTS           environment variable, if unset uses "$default_sbt_opts"
-  .sbtopts           if this file exists in the current directory, it is
-                     prepended to the runner args
-  /etc/sbt/sbtopts   if this file exists, it is prepended to the runner args
-  -Dkey=val          pass -Dkey=val directly to the java runtime
-  -J-X               pass option -X directly to the java runtime
-                     (-J is stripped)
-  -S-X               add -X to sbt's scalacOptions (-S is stripped)
-  -PmavenProfiles    Enable a maven profile for the build.
+  # passing options to the jvm - note it does NOT use JAVA_OPTS due to pollution
+  # The default set is used if JVM_OPTS is unset and no -jvm-opts file is found
+  <default>         $(default_jvm_opts)
+  JVM_OPTS          environment variable holding either the jvm args directly, or
+                    the reference to a file containing jvm args if given path is prepended by '@' (e.g. '@/etc/jvmopts')
+                    Note: "@"-file is overridden by local '.jvmopts' or '-jvm-opts' argument.
+  -jvm-opts <path>  file containing jvm args (if not given, .jvmopts in project root is used if present)
+  -Dkey=val         pass -Dkey=val directly to the jvm
+  -J-X              pass option -X directly to the jvm (-J is stripped)
 
-In the case of duplicated or conflicting options, the order above
-shows precedence: JAVA_OPTS lowest, command line options highest.
+  # passing options to sbt, OR to this runner
+  SBT_OPTS          environment variable holding either the sbt args directly, or
+                    the reference to a file containing sbt args if given path is prepended by '@' (e.g. '@/etc/sbtopts')
+                    Note: "@"-file is overridden by local '.sbtopts' or '-sbt-opts' argument.
+  -sbt-opts <path>  file containing sbt args (if not given, .sbtopts in project root is used if present)
+  -S-X              add -X to sbt's scalacOptions (-S is stripped)
 EOM
+  exit 0
 }
 
-process_my_args () {
+process_args() {
+  require_arg() {
+    local type="$1"
+    local opt="$2"
+    local arg="$3"
+
+    if [[ -z "$arg" ]] || [[ "${arg:0:1}" == "-" ]]; then
+      die "$opt requires <$type> argument"
+    fi
+  }
   while [[ $# -gt 0 ]]; do
     case "$1" in
-     -no-colors) addJava "-Dsbt.log.noformat=true" && shift ;;
-      -no-share) addJava "$noshare_opts" && shift ;;
-     -no-global) addJava "-Dsbt.global.base=$(pwd)/project/.sbtboot" && shift ;;
-      -sbt-boot) require_arg path "$1" "$2" && addJava "-Dsbt.boot.directory=$2" && shift 2 ;;
-       -sbt-dir) require_arg path "$1" "$2" && addJava "-Dsbt.global.base=$2" && shift 2 ;;
-     -debug-inc) addJava "-Dxsbt.inc.debug=true" && shift ;;
-         -batch) exec </dev/null && shift ;;
+      -h |   -help) usage ;;
+      -v)           verbose=true && shift ;;
+      -d)           addSbt "--debug" && shift ;;
+      -w)           addSbt "--warn"  && shift ;;
+      -q)           addSbt "--error" && shift ;;
+      -x)           shift ;; # currently unused
+      -trace)       require_arg integer "$1" "$2" && trace_level="$2" && shift 2 ;;
+      -debug-inc)   addJava "-Dxsbt.inc.debug=true" && shift ;;
 
-    -sbt-create) sbt_create=true && shift ;;
+      -no-colors)   addJava "-Dsbt.log.noformat=true" && shift ;;
+      -sbt-create)  sbt_create=true && shift ;;
+      -sbt-dir)     require_arg path "$1" "$2" && sbt_dir="$2" && shift 2 ;;
+      -sbt-boot)    require_arg path "$1" "$2" && addJava "-Dsbt.boot.directory=$2" && shift 2 ;;
+      -ivy)         require_arg path "$1" "$2" && addJava "-Dsbt.ivy.home=$2" && shift 2 ;;
+      -no-share)    noshare=true && shift ;;
+      -offline)     addSbt "set offline in Global := true" && shift ;;
+      -jvm-debug)   require_arg port "$1" "$2" && addDebugger "$2" && shift 2 ;;
+      -batch)       batch=true && shift ;;
+      -prompt)      require_arg "expr" "$1" "$2" && setThisBuild shellPrompt "(s => { val e = Project.extract(s) ; $2 })" && shift 2 ;;
+      -script)      require_arg file "$1" "$2" && sbt_script="$2" && addJava "-Dsbt.main.class=sbt.ScriptMain" && shift 2 ;;
 
-              *) addResidual "$1" && shift ;;
+      -sbt-version) require_arg version "$1" "$2" && sbt_explicit_version="$2" && shift 2 ;;
+      -sbt-force-latest) sbt_explicit_version="$sbt_release_version" && shift ;;
+      -sbt-dev)     sbt_explicit_version="$sbt_unreleased_version" && shift ;;
+      -sbt-jar)     require_arg path "$1" "$2" && sbt_jar="$2" && shift 2 ;;
+      -sbt-launch-dir) require_arg path "$1" "$2" && sbt_launch_dir="$2" && shift 2 ;;
+      -sbt-launch-repo) require_arg path "$1" "$2" && sbt_launch_repo="$2" && shift 2 ;;
+
+      -28)          setScalaVersion "$latest_28"  && shift ;;
+      -29)          setScalaVersion "$latest_29"  && shift ;;
+      -210)         setScalaVersion "$latest_210" && shift ;;
+      -211)         setScalaVersion "$latest_211" && shift ;;
+      -212)         setScalaVersion "$latest_212" && shift ;;
+      -213)         setScalaVersion "$latest_213" && shift ;;
+
+      -scala-version) require_arg version "$1" "$2" && setScalaVersion "$2" && shift 2 ;;
+      -binary-version) require_arg version "$1" "$2" && setThisBuild scalaBinaryVersion "\"$2\"" && shift 2 ;;
+      -scala-home)  require_arg path "$1" "$2" && setThisBuild scalaHome "_root_.scala.Some(file(\"$2\"))" && shift 2 ;;
+      -java-home)   require_arg path "$1" "$2" && setJavaHome "$2" && shift 2 ;;
+      -sbt-opts)    require_arg path "$1" "$2" && sbt_opts_file="$2" && shift 2 ;;
+      -jvm-opts)    require_arg path "$1" "$2" && jvm_opts_file="$2" && shift 2 ;;
+
+      -D*)          addJava "$1" && shift ;;
+      -J*)          addJava "${1:2}" && shift ;;
+      -S*)          addScalac "${1:2}" && shift ;;
+
+      new)          sbt_new=true && : ${sbt_explicit_version:=$sbt_release_version} && addResidual "$1" && shift ;;
+
+      *)            addResidual "$1" && shift ;;
     esac
   done
-
-  # Now, ensure sbt version is used.
-  [[ "${sbt_version}XXX" != "XXX" ]] && addJava "-Dsbt.version=$sbt_version"
 }
 
-loadConfigFile() {
-  cat "$1" | sed '/^\#/d'
+# process the direct command line arguments
+process_args "$@"
+
+# skip #-styled comments and blank lines
+readConfigFile() {
+  local end=false
+  until $end; do
+    read -r || end=true
+    [[ $REPLY =~ ^# ]] || [[ -z $REPLY ]] || echo "$REPLY"
+  done <"$1"
 }
 
-# if sbtopts files exist, prepend their contents to $@ so it can be processed by this runner
-[[ -f "$etc_sbt_opts_file" ]] && set -- $(loadConfigFile "$etc_sbt_opts_file") "$@"
-[[ -f "$sbt_opts_file" ]] && set -- $(loadConfigFile "$sbt_opts_file") "$@"
+# if there are file/environment sbt_opts, process again so we
+# can supply args to this runner
+if [[ -r "$sbt_opts_file" ]]; then
+  vlog "Using sbt options defined in file $sbt_opts_file"
+  while read -r opt; do extra_sbt_opts+=("$opt"); done < <(readConfigFile "$sbt_opts_file")
+elif [[ -n "$SBT_OPTS" && ! ("$SBT_OPTS" =~ ^@.*) ]]; then
+  vlog "Using sbt options defined in variable \$SBT_OPTS"
+  IFS=" " read -r -a extra_sbt_opts <<<"$SBT_OPTS"
+else
+  vlog "No extra sbt options have been defined"
+fi
 
-exit_status=127
-saved_stty=""
+[[ -n "${extra_sbt_opts[*]}" ]] && process_args "${extra_sbt_opts[@]}"
 
-restoreSttySettings() {
-  stty $saved_stty
-  saved_stty=""
+# reset "$@" to the residual args
+set -- "${residual_args[@]}"
+argumentCount=$#
+
+# set sbt version
+set_sbt_version
+
+checkJava
+
+# only exists in 0.12+
+setTraceLevel() {
+  case "$sbt_version" in
+    "0.7."* | "0.10."* | "0.11."*) echoerr "Cannot set trace level in sbt version $sbt_version" ;;
+    *)                             setThisBuild traceLevel "$trace_level" ;;
+  esac
 }
 
-onExit() {
-  if [[ "$saved_stty" != "" ]]; then
-    restoreSttySettings
+# set scalacOptions if we were given any -S opts
+[[ ${#scalac_args[@]} -eq 0 ]] || addSbt "set scalacOptions in ThisBuild += \"${scalac_args[*]}\""
+
+[[ -n "$sbt_explicit_version" && -z "$sbt_new" ]] && addJava "-Dsbt.version=$sbt_explicit_version"
+vlog "Detected sbt version $sbt_version"
+
+if [[ -n "$sbt_script" ]]; then
+  residual_args=("$sbt_script" "${residual_args[@]}")
+else
+  # no args - alert them there's stuff in here
+  ((argumentCount > 0)) || {
+    vlog "Starting $script_name: invoke with -help for other options"
+    residual_args=(shell)
+  }
+fi
+
+# verify this is an sbt dir, -create was given or user attempts to run a scala script
+[[ -r ./build.sbt || -d ./project || -n "$sbt_create" || -n "$sbt_script" || -n "$sbt_new" ]] || {
+  cat <<EOM
+$(pwd) doesn't appear to be an sbt project.
+If you want to start sbt anyway, run:
+  $0 -sbt-create
+
+EOM
+  exit 1
+}
+
+# pick up completion if present; todo
+# shellcheck disable=SC1091
+[[ -r .sbt_completion.sh ]] && source .sbt_completion.sh
+
+# directory to store sbt launchers
+[[ -d "$sbt_launch_dir" ]] || mkdir -p "$sbt_launch_dir"
+[[ -w "$sbt_launch_dir" ]] || sbt_launch_dir="$(mktemp -d -t sbt_extras_launchers.XXXXXX)"
+
+# no jar? download it.
+[[ -r "$sbt_jar" ]] || acquire_sbt_jar || {
+  # still no jar? uh-oh.
+  echo "Could not download and verify the launcher. Obtain the jar manually and place it at $sbt_jar"
+  exit 1
+}
+
+if [[ -n "$noshare" ]]; then
+  for opt in ${noshare_opts}; do
+    addJava "$opt"
+  done
+else
+  case "$sbt_version" in
+    "0.7."* | "0.10."* | "0.11."* | "0.12."*)
+      [[ -n "$sbt_dir" ]] || {
+        sbt_dir="$HOME/.sbt/$sbt_version"
+        vlog "Using $sbt_dir as sbt dir, -sbt-dir to override."
+      }
+      ;;
+  esac
+
+  if [[ -n "$sbt_dir" ]]; then
+    addJava "-Dsbt.global.base=$sbt_dir"
   fi
-  exit $exit_status
-}
+fi
 
-saveSttySettings() {
-  saved_stty=$(stty -g 2>/dev/null)
-  if [[ ! $? ]]; then
-    saved_stty=""
-  fi
-}
+if [[ -r "$jvm_opts_file" ]]; then
+  vlog "Using jvm options defined in file $jvm_opts_file"
+  while read -r opt; do extra_jvm_opts+=("$opt"); done < <(readConfigFile "$jvm_opts_file")
+elif [[ -n "$JVM_OPTS" && ! ("$JVM_OPTS" =~ ^@.*) ]]; then
+  vlog "Using jvm options defined in \$JVM_OPTS variable"
+  IFS=" " read -r -a extra_jvm_opts <<<"$JVM_OPTS"
+else
+  vlog "Using default jvm options"
+  IFS=" " read -r -a extra_jvm_opts <<<"$( default_jvm_opts)"
+fi
 
-saveSttySettings
-trap onExit INT
+# traceLevel is 0.12+
+[[ -n "$trace_level" ]] && setTraceLevel
 
-run "$@"
-
-exit_status=$?
-onExit
+execRunner "$java_cmd" \
+  "${extra_jvm_opts[@]}" \
+  "${java_args[@]}" \
+  -jar "$sbt_jar" \
+  "${sbt_commands[@]}" \
+  "${residual_args[@]}"

--- a/project/build.properties
+++ b/project/build.properties
@@ -33,4 +33,4 @@
 #  limitations under the License.
 #
 
-sbt.version=0.13.18
+sbt.version=1.3.10

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,11 +21,12 @@ resolvers += "bintray-spark-packages" at "https://dl.bintray.com/spark-packages/
 
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.6")
+// sbt-spark-package is not published for SBT 1.x
+// addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.6")
 
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
 
@@ -37,7 +38,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")
 
-addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.7.13")
+addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.2")
 
 resolvers += Resolver.url("typesafe sbt-plugins",
   url("https://dl.bintray.com/typesafe/sbt-plugins"))(Resolver.ivyStylePatterns)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -36,7 +36,7 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
 
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.7.0")
 
 addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.2")
 


### PR DESCRIPTION
This is a work in progress PR that upgrades SBT to 1.3.10. This brings a number of enhancements:
- Coursier based dependency resolution - Coursier resolves much faster than Ivy. This is true both in CI (when first downloading dependencies) and during local/iterative development (re-resolution on startup and between commands is faster as well)
- Better Console - The SBT console now shows inprogress compile/test/tasks (similar to Bazel)
- Parallel Test Execution - This was also available in SBT 0.13.x, but it's now easier to configure and enable across all test projects while still being able to control parallelism

This PR is still WIP as a number of workflows need to be tested and changes need to be verified
- Releasing a new version of Delta - I had to bump the sbt-release plugin.
- Ensuring Coursier and Ivy produce the same dependency resolution - it's possible that Delta pulls in artifacts with different versions as a result of the switch to Coursier. If this is the case, we may need to manually pin artifacts & versions.
- A few test cases fail when run in parallel - we'll need to either fix them tag them to run serially.

The biggest TODO is re-building sbt-spark-package for SBT 1.x - This is the one SBT plugin that doesn't have an SBT 1.x compatible version.