### PR TITLE
Added Metastore/SQL integration tests for python/scala

### DIFF
--- a/examples/python/quickstart.py
+++ b/examples/python/quickstart.py
@@ -28,14 +28,13 @@ try:
 except:
     pass
 
-# Enable SQL and for the current spark session. we need to set the following configs
-# to enable SQL Commands
-# config io.delta.sql.DeltaSparkSessionExtension -- to enable custom Delta-specific SQL commands
-
 conf = SparkConf() \
-    .setAppName("utilities") \
+    .setAppName("quickstart") \
     .setMaster("local[*]")
 
+# Enable SQL commands and Update/Delete/Merge for the current spark session. 
+# we need to set the following configs
+# config io.delta.sql.DeltaSparkSessionExtension -- to enable custom Delta-specific SQL commands
 conf.set("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
 sc = SparkContext(conf=conf)
 spark = SparkSession(sc)

--- a/examples/python/quickstart.py
+++ b/examples/python/quickstart.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-from pyspark import SparkContext
+from pyspark import SparkContext, SparkConf
 from pyspark.sql import Column, DataFrame, SparkSession, SQLContext, functions
 from pyspark.sql.functions import *
 from py4j.java_collections import MapConverter
@@ -28,15 +28,17 @@ try:
 except:
     pass
 
-# Create SparkContext
-sc = SparkContext()
-sqlContext = SQLContext(sc)
+# Enable SQL and for the current spark session. we need to set the following configs
+# to enable SQL Commands
+# config io.delta.sql.DeltaSparkSessionExtension -- to enable custom Delta-specific SQL commands
 
-spark = SparkSession \
-    .builder \
-    .appName("quickstart") \
-    .master("local[*]") \
-    .getOrCreate()
+conf = SparkConf() \
+    .setAppName("utilities") \
+    .setMaster("local[*]")
+
+conf.set("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+sc = SparkContext(conf=conf)
+spark = SparkSession(sc)
 
 # Create a table
 print("############# Creating a table ###############")

--- a/examples/python/quickstart_metastore_sql.py
+++ b/examples/python/quickstart_metastore_sql.py
@@ -1,0 +1,79 @@
+from pyspark import SparkContext, SparkConf
+from pyspark.sql import Column, DataFrame, SparkSession, SQLContext, functions
+from pyspark.sql.functions import *
+from py4j.java_collections import MapConverter
+from delta.tables import *
+import shutil
+import threading
+
+tableName = "tbltestpython"
+
+# Enable SQL and Metastore tables for the current spark session. we need to set the following configs 
+# to enable SQL Commands
+# config io.delta.sql.DeltaSparkSessionExtension -- to enable custom Delta-specific SQL commands
+# To enable metastore table 
+
+conf = SparkConf() \
+    .setAppName("metastore-sql") \
+    .setMaster("local[*]") 
+
+conf.set("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+conf.set("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+sc = SparkContext(conf=conf)
+spark = SparkSession(sc)
+
+# Clear any previous runs
+try:
+    spark.sql("DROP TABLE " + tableName)
+except:
+    pass
+
+# Create a table
+print("############# Creating a table ###############")
+spark.range(0, 5).write.format("delta").mode("overwrite").saveAsTable(tableName)
+
+# Read the table
+print("############ Reading the table ###############")
+spark.sql("SELECT * FROM %s" % tableName).show()
+
+# Upsert (merge) new data
+print("########### Upsert new data #############")
+newData = spark.range(0, 20).write.format("delta").mode("overwrite").saveAsTable("newData")
+
+spark.sql('''MERGE INTO {0} USING newData
+        ON {0}.id = newData.id
+        WHEN MATCHED THEN 
+          UPDATE SET {0}.id = newData.id
+        WHEN NOT MATCHED THEN INSERT *
+    '''.format(tableName))
+
+spark.sql("SELECT * FROM %s" % tableName).show()
+
+# Update table data
+print("########## Overwrite the table ###########")
+data = spark.range(5, 10)
+data.write.format("delta").mode("overwrite").saveAsTable(tableName)
+spark.sql("SELECT * FROM %s" % tableName).show()
+
+
+# Update every even value by adding 100 to it
+print("########### Update to the table(add 100 to every even value) ##############")
+spark.sql("UPDATE {0} SET id = (id + 100) WHERE (id % 2 == 0)".format(tableName))
+spark.sql("SELECT * FROM %s" % tableName).show()
+
+# Delete every even value
+print("######### Delete every even value ##############")
+spark.sql("DELETE FROM {0} WHERE (id % 2 == 0)".format(tableName))
+spark.sql("SELECT * FROM %s" % tableName).show()
+
+
+# Read old version of data using time travel
+print("######## Read old data using time travel ############")
+df = spark.read.format("delta").option("versionAsOf", 0).load("/tmp/delta-table")
+df.show()
+
+# cleanup
+try:
+    spark.sql("DROP TABLE " + tableName)
+except:
+    pass

--- a/examples/python/quickstart_metastore_sql.py
+++ b/examples/python/quickstart_metastore_sql.py
@@ -8,14 +8,12 @@ import threading
 
 tableName = "tbltestpython"
 
-# Enable SQL and Metastore tables for the current spark session. we need to set the following configs 
-# to enable SQL Commands
-# config io.delta.sql.DeltaSparkSessionExtension -- to enable custom Delta-specific SQL commands
-# To enable metastore table 
-
 conf = SparkConf() \
-    .setAppName("metastore-sql") \
+    .setAppName("quickstart-metastore-sql") \
     .setMaster("local[*]") 
+
+# Enable SQL/DML commands and Metastore tables for the current spark session.
+# We need to set the following configs 
 
 conf.set("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
 conf.set("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")

--- a/examples/python/quickstart_metastore_sql.py
+++ b/examples/python/quickstart_metastore_sql.py
@@ -67,7 +67,7 @@ spark.sql("SELECT * FROM %s" % tableName).show()
 
 # Read old version of data using time travel
 print("######## Read old data using time travel ############")
-df = spark.read.format("delta").option("versionAsOf", 0).load("/tmp/delta-table")
+df = spark.read.format("delta").option("versionAsOf", 0).table(tableName)
 df.show()
 
 # cleanup

--- a/examples/python/utilities.py
+++ b/examples/python/utilities.py
@@ -22,14 +22,13 @@ from delta.tables import *
 import shutil
 import threading
 
-# Enable SQL and for the current spark session. we need to set the following configs
-# to enable SQL Commands
-# config io.delta.sql.DeltaSparkSessionExtension -- to enable custom Delta-specific SQL commands
-
 conf = SparkConf() \
     .setAppName("utilities") \
     .setMaster("local[*]")
 
+# Enable SQL and for the current spark session. we need to set the following configs
+# to enable SQL Commands
+# config io.delta.sql.DeltaSparkSessionExtension -- to enable custom Delta-specific SQL commands
 conf.set("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
 sc = SparkContext(conf=conf)
 spark = SparkSession(sc)

--- a/examples/scala/build.sbt
+++ b/examples/scala/build.sbt
@@ -17,7 +17,7 @@
 name := "example"
 organization := "com.example"
 organizationName := "example"
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.10"
 version := "0.1.0"
 
 def getDeltaVersion(): String = {
@@ -35,5 +35,6 @@ lazy val root = (project in file("."))
   .settings(
     name := "hello-world",
     libraryDependencies += "io.delta" %% "delta-core" % getDeltaVersion(),
-    libraryDependencies += "org.apache.spark" %% "spark-sql" % "2.4.3",
+    libraryDependencies += "org.apache.spark" %% "spark-sql" % "3.0.0-SNAPSHOT",
+    resolvers += "Temporary Staging of Spark 3.0" at "https://docs.delta.io/spark3artifacts/snapshot-5687b31be3f/maven/",
     resolvers += "Delta" at "https://dl.bintray.com/delta-io/delta/")

--- a/examples/scala/src/main/scala/example/QuickStartMetastoreSQL.scala
+++ b/examples/scala/src/main/scala/example/QuickStartMetastoreSQL.scala
@@ -24,72 +24,68 @@ import org.apache.spark.sql.functions._
 import org.apache.commons.io.FileUtils
 import java.io.File
 
-object Quickstart {
+object QuickStartMetastoreSQL {
   def main(args: Array[String]): Unit = {
     // Create Spark Conf
     val conf = new SparkConf()
         .setAppName("QuickStart")
         .setMaster("local[*]")
 
-    conf.set("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")      
+    // Enable SQL Commands and Metastore tables
+    conf.set("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+    conf.set("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
     val sc = new SparkContext(conf)
     val sqlContext = new SQLContext(sc)
     // Create a Spark Session
     val spark = sqlContext.sparkSession
+    val tableName = "tblname"
+
+    // Clear up old session
+    spark.sql(s"DROP TABLE IF EXISTS $tableName")
 
     // Create a table
     println("Creating a table")
-    val file = new File("/tmp/delta-table")
-    val path = file.getCanonicalPath
     var data = spark.range(0, 5)
-    data.write.format("delta").save(path)
+    data.write.format("delta").saveAsTable(tableName)
 
     // Read table
     println("Reading the table")
-    val df = spark.read.format("delta").load(path)
-    df.show()
+    spark.sql(s"SELECT * FROM $tableName").show()
 
     // Upsert (merge) new data
     println("Upsert new data")
-    val newData = spark.range(0, 20).toDF
-    val deltaTable = DeltaTable.forPath(path)
+    val newData = spark.range(0, 20).write.format("delta").mode("overwrite").saveAsTable("newData")
+    spark.sql(s"""MERGE INTO $tableName USING newData
+        ON ${tableName}.id = newData.id
+        WHEN MATCHED THEN
+          UPDATE SET ${tableName}.id = newData.id
+        WHEN NOT MATCHED THEN INSERT *
+    """)
 
-    deltaTable.as("oldData")
-      .merge(
-        newData.as("newData"),
-        "oldData.id = newData.id")
-      .whenMatched
-      .update(Map("id" -> col("newData.id")))
-      .whenNotMatched
-      .insert(Map("id" -> col("newData.id")))
-      .execute()
-
-    deltaTable.toDF.show()
+    spark.sql(s"SELECT * FROM $tableName").show()
 
     // Update table data
     println("Overwrite the table")
     data = spark.range(5, 10)
-    data.write.format("delta").mode("overwrite").save(path)
-    deltaTable.toDF.show()
+    data.write.format("delta").mode("overwrite").saveAsTable(tableName)
+    spark.sql(s"SELECT * FROM $tableName").show()
 
     // Update every even value by adding 100 to it
     println("Update to the table (add 100 to every even value)")
-    deltaTable.update(
-      condition = expr("id % 2 == 0"),
-      set = Map("id" -> expr("id + 100")))
-    deltaTable.toDF.show()
+    spark.sql(s"UPDATE $tableName SET id = (id + 100) WHERE (id % 2 == 0)")
+    spark.sql(s"SELECT * FROM $tableName").show()
 
     // Delete every even value
-    deltaTable.delete(condition = expr("id % 2 == 0"))
-    deltaTable.toDF.show()
+    spark.sql(s"DELETE FROM $tableName WHERE (id % 2 == 0)")
+    spark.sql(s"SELECT * FROM $tableName").show()
 
     // Read old version of the data using time travel
     print("Read old data using time travel")
-    val df2 = spark.read.format("delta").option("versionAsOf", 0).load(path)
+    val df2 = spark.read.format("delta").option("versionAsOf", 0).table(tableName)
     df2.show()
 
     // Cleanup
-    FileUtils.deleteDirectory(file)
+    spark.sql(s"DROP TABLE IF EXISTS $tableName")
     spark.stop()
   }
 }


### PR DESCRIPTION
- Modified old tests to work with Spark 3.0 by adding the right spark conf
- Added a new test to test Metastore tables and SQL