### PR TITLE
Multiple rows matching is only checked when there is an UPDATE clause

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
@@ -244,7 +244,9 @@ case class MergeIntoCommand(
 
     // Calculate frequency of matches per source row
     val matchedRowCounts = collectTouchedFiles.groupBy(ROW_ID_COL).agg(sum("one").as("count"))
-    if (matchedRowCounts.filter("count > 1").count() != 0) {
+    // Even there is no update clause, we still need this inner join job to fill touchedFilesAccum,
+    // but the exception is thrown only with update clause.
+    if (matchedRowCounts.filter("count > 1").count() != 0 && updateClause.isDefined) {
       throw DeltaErrors.multipleSourceRowMatchingTargetRowInMergeException(spark)
     }
 

--- a/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
@@ -246,7 +246,8 @@ case class MergeIntoCommand(
     val matchedRowCounts = collectTouchedFiles.groupBy(ROW_ID_COL).agg(sum("one").as("count"))
     // Even there is no update clause, we still need this inner join job to fill touchedFilesAccum,
     // but the exception is thrown only with update clause.
-    if (matchedRowCounts.filter("count > 1").count() != 0 && updateClause.isDefined) {
+    if (matchedRowCounts.filter("count > 1").count() != 0 &&
+        (updateClause.isDefined || !isMatchedOnly)) {
       throw DeltaErrors.multipleSourceRowMatchingTargetRowInMergeException(spark)
     }
 

--- a/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
@@ -1301,7 +1301,7 @@ abstract class MergeIntoSuiteBase
       (2, 2)    // (1, 1) deleted
     ))          // (3, 30) not inserted as not insert clause
 
-  testExtendedMerge(s"extended syntax - only delete with multiple matches")(
+  testExtendedMerge(s"extended syntax - only unconditional delete with multiple matches")(
     source = (0, 0) :: (1, 10) :: (1, 100) :: (3, 30) :: Nil,
     target = (1, 1) :: (2, 2) :: Nil,
     mergeOn = "s.key = t.key",

--- a/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
@@ -531,6 +531,22 @@ abstract class MergeIntoSuiteBase
     }
   }
 
+  testQuietly("No update clause - more than one source rows match the same target row") {
+    withTable("source") {
+      Seq((1, 1), (0, 3), (1, 5)).toDF("key1", "value").createOrReplaceTempView("source")
+      append(Seq((2, 2), (1, 4)).toDF("key2", "value"))
+
+      executeMerge(
+        tgt = s"delta.`$tempPath` as target",
+        src = "source src",
+        cond = "src.key1 = target.key2",
+        delete())
+
+      checkAnswer(readDeltaTable(tempPath),
+        Row(2, 2) :: Nil)
+    }
+  }
+
   test("More than one target rows match the same source row") {
     withTable("source") {
       Seq((1, 5), (2, 9)).toDF("key1", "value").createOrReplaceTempView("source")


### PR DESCRIPTION
```scala
  def multipleSourceRowMatchingTargetRowInMergeException(spark: SparkSession): Throwable = {
    new UnsupportedOperationException(
      s"""Cannot perform MERGE as multiple source rows matched and attempted to update the same
         |target row in the Delta table. By SQL semantics of merge, when multiple source rows match
         |on the same target row, the update operation is ambiguous as it is unclear which source
         |should be used to update the matching target row.
         |You can preprocess the source table to eliminate the possibility of multiple matches.
         |Please refer to
         |${generateDocsLink(spark.sparkContext.getConf,
        "/delta-update.html#upsert-into-a-table-using-merge")}""".stripMargin
    )
  }
```

Checking multiple rows matching is to avoid updating the same target row in the Delta table. So for delete only clause (without update clause), we should not throw this exception.