### PR TITLE
Make Delta a bit more inclusive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@ conf/*.properties
 conf/*.sh
 conf/*.xml
 conf/java-opts
-conf/slaves
 dependency-reduced-pom.xml
 derby.log
 dev/create-release/*final

--- a/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/DeltaDelete.scala
+++ b/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/DeltaDelete.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.catalyst.plans.logical
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 
 // This only used by Delta which needs to be compatible with DBR 6 and can't use the new class
-// added in the master branch: `DeleteFromTable`.
+// added in Spark 3.0: `DeleteFromTable`.
 case class DeltaDelete(
     child: LogicalPlan,
     condition: Option[Expression])

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -64,7 +64,7 @@ trait DocsPath {
    *
    * @param relativePath the relative path after the base url to access.
    * @param skipValidation whether to validate that the function generating the link is
-   *                       in the whitelist
+   *                       in the allowlist.
    * @return The entire URL of the documentation link
    */
   def generateDocsLink(

--- a/src/main/scala/org/apache/spark/sql/delta/util/FileNames.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/util/FileNames.scala
@@ -87,9 +87,10 @@ object FileNames {
   def checkpointVersion(path: Path): Long = path.getName.split("\\.")(0).toLong
 
   /**
-   * Get the version of the checkpoint, checksum or delta file. Throws an error if the log file
-   * path is unexpected. Must be used after whitelisting the list of files during a transaction
-   * log listing for forwards compatibility.
+   * Get the version of the checkpoint, checksum or delta file. Throws an error if an unexpected
+   * file type is seen. These unexpected files should be filtered out to ensure forward
+   * compatibility in cases where new file types are added, but without an explicit protocol
+   * upgrade.
    */
   def getFileVersion(path: Path): Long = {
     if (isCheckpointFile(path)) {
@@ -101,7 +102,7 @@ object FileNames {
     } else {
       // scalastyle:off throwerror
       throw new AssertionError(
-        "The file listing needs to be whitelisted to know files before this method can be called.")
+        s"Unexpected file type found in transaction log: $path")
       // scalastyle:on throwerror
     }
   }


### PR DESCRIPTION
Removes some archaic terminology from the codebase in the interest of making Delta more inclusive. There is more work to be done as in some cases no alternative APIs exist in Spark, but this is a small step forward.