### PR TITLE
Add option to start stream from a specific version

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -121,6 +121,25 @@ trait DeltaReadOptions extends DeltaOptionParser {
       throw new IllegalArgumentException(
         s"Please recheck your syntax for '$EXCLUDE_REGEX_OPTION'", e)
   }
+
+  val startingVersion = options.get(STARTING_VERSION_OPTION).map{ str =>
+    Try(str.toLong).toOption.filter(_ >= 0).getOrElse{
+      throw DeltaErrors.illegalDeltaOptionException(
+        STARTING_VERSION_OPTION, str, "must be greater than or equal to zero")
+    }
+  }
+
+  val startingTimestamp = options.get(STARTING_TIMESTAMP_OPTION)
+
+  private def provideOneStartingOption(): Unit = {
+    if (startingTimestamp.isDefined && startingVersion.isDefined) {
+      throw new IllegalArgumentException(
+        s"Please either provide '$STARTING_TIMESTAMP_OPTION' or '$STARTING_VERSION_OPTION'."
+      )
+    }
+  }
+
+  provideOneStartingOption()
 }
 
 
@@ -157,6 +176,8 @@ object DeltaOptions extends DeltaLogging {
   val IGNORE_DELETES_OPTION = "ignoreDeletes"
   val OPTIMIZE_WRITE_OPTION = "optimizeWrite"
   val DATA_CHANGE_OPTION = "dataChange"
+  val STARTING_VERSION_OPTION = "startingVersion"
+  val STARTING_TIMESTAMP_OPTION = "startingTimestamp"
 
   val validOptionKeys : Set[String] = Set(
     REPLACE_WHERE_OPTION,
@@ -170,6 +191,8 @@ object DeltaOptions extends DeltaLogging {
     IGNORE_DELETES_OPTION,
     OPTIMIZE_WRITE_OPTION,
     DATA_CHANGE_OPTION,
+    STARTING_TIMESTAMP_OPTION,
+    STARTING_VERSION_OPTION,
     "queryName",
     "checkpointLocation",
     "path",

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -26,9 +26,8 @@ import org.apache.spark.sql.delta.DeltaOptions.{DATA_CHANGE_OPTION, MERGE_SCHEMA
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
-import org.apache.commons.lang3.time.FastDateFormat
 import org.apache.spark.network.util.{ByteUnit, JavaUtils}
-import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateTimeUtils}
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.internal.SQLConf
 
 

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -19,16 +19,15 @@ package org.apache.spark.sql.delta
 import java.util.Locale
 import java.util.regex.PatternSyntaxException
 
-import org.apache.commons.lang3.time.FastDateFormat
-
 import scala.util.Try
 import scala.util.matching.Regex
+
 import org.apache.spark.sql.delta.DeltaOptions.{DATA_CHANGE_OPTION, MERGE_SCHEMA_OPTION, OVERWRITE_SCHEMA_OPTION}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.commons.lang3.time.FastDateFormat
 import org.apache.spark.network.util.{ByteUnit, JavaUtils}
-import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.expressions.PreciseTimestampConversion
 import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateTimeUtils}
 import org.apache.spark.sql.internal.SQLConf
 

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -130,19 +130,7 @@ trait DeltaReadOptions extends DeltaOptionParser {
     }
   }
 
-  val startingTimestamp = options.get(STARTING_TIMESTAMP_OPTION).map { str =>
-    val pattern = "yyyy-MM-dd HH:mm:ss"
-    try {
-      val format = FastDateFormat.getInstance(
-        pattern, DateTimeUtils.getTimeZone(sqlConf.sessionLocalTimeZone))
-      new java.sql.Timestamp(format.parse(str).getTime)
-      str
-    } catch {
-      case e: java.text.ParseException =>
-        throw DeltaErrors.illegalDeltaOptionException(
-          STARTING_TIMESTAMP_OPTION, str, s"doesn't match the expected syntax $pattern.")
-    }
-  }
+  val startingTimestamp = options.get(STARTING_TIMESTAMP_OPTION)
 
   private def provideOneStartingOption(): Unit = {
     if (startingTimestamp.isDefined && startingVersion.isDefined) {

--- a/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -179,7 +179,7 @@ case class DeltaSource(
       limits: Option[AdmissionLimits] = Some(new AdmissionLimits())): Option[Offset] = {
 
     val (version, isStartingVersion) = getStartingVersion match {
-      case Some(v) => (v - 1, false)
+      case Some(v) => (v, false)
       case None => (deltaLog.snapshot.version, true)
     }
     if (version < 0) {

--- a/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -386,7 +386,7 @@ case class DeltaSource(
     if (tsOpt.isDefined || versionOpt.isDefined) {
       Some(DeltaTableUtils.resolveTimeTravelVersion(
         spark.sessionState.conf, deltaLog,
-        DeltaTimeTravelSpec(tsOpt.map(Literal(_)), versionOpt, Some("streamSource"))))
+        DeltaTimeTravelSpec(tsOpt.map(Literal(_)), versionOpt, Some("deltaSource"))))
     } else {
       None
     }

--- a/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -382,16 +382,11 @@ case class DeltaSource(
     val tsOpt = options.startingTimestamp
     val versionOpt = options.startingVersion
 
-    if (tsOpt.isDefined) {
+    /** DeltaOption validates input and ensures that only one is provided. */
+    if (tsOpt.isDefined || versionOpt.isDefined) {
       Some(DeltaTableUtils.resolveTimeTravelVersion(
         spark.sessionState.conf, deltaLog,
-        DeltaTimeTravelSpec(Some(Literal(tsOpt.get)), None, Some("dfReader"))))
-    }
-
-    if (versionOpt.isDefined) {
-      Some(DeltaTableUtils.resolveTimeTravelVersion(
-        spark.sessionState.conf, deltaLog,
-        DeltaTimeTravelSpec(None, Some(versionOpt.get), Some("dfReader"))))
+        DeltaTimeTravelSpec(tsOpt.map(Literal(_)), versionOpt, Some("streamSource"))))
     } else {
       None
     }

--- a/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -382,19 +382,17 @@ case class DeltaSource(
   }
 
   /** Extracts whether users provided the option to time travel a relation. */
-  private def getStartingVersion: Option[Long] = {
+  private lazy val getStartingVersion: Option[Long] = {
     val tsOpt = options.startingTimestamp
     val versionOpt = options.startingVersion
 
     /** DeltaOption validates input and ensures that only one is provided. */
-    lazy val result = if (tsOpt.isDefined || versionOpt.isDefined) {
+    if (tsOpt.isDefined || versionOpt.isDefined) {
       Some(DeltaTableUtils.resolveTimeTravelVersion(
         spark.sessionState.conf, deltaLog,
         DeltaTimeTravelSpec(tsOpt.map(Literal(_)), versionOpt, Some("deltaSource")))._1)
     } else {
       None
     }
-
-    result
   }
 }

--- a/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -19,12 +19,15 @@ package org.apache.spark.sql.delta.sources
 // scalastyle:off import.ordering.noEmptyLine
 import java.io.FileNotFoundException
 
+import scala.util.{Failure, Success, Try}
 import scala.util.matching.Regex
+
 import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaOptions, DeltaTableUtils, DeltaTimeTravelSpec}
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.files.DeltaSourceSnapshot
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.SchemaUtils
+
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
@@ -32,8 +35,6 @@ import org.apache.spark.sql.connector.read.streaming
 import org.apache.spark.sql.connector.read.streaming.{ReadAllAvailable, ReadLimit, ReadMaxFiles, SupportsAdmissionControl}
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.types.StructType
-
-import scala.util.{Failure, Success, Try}
 
 /**
  * A case class to help with `Dataset` operations regarding Offset indexing, representing AddFile

--- a/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -20,19 +20,20 @@ package org.apache.spark.sql.delta.sources
 import java.io.FileNotFoundException
 
 import scala.util.matching.Regex
-
-import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaOptions}
+import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaOptions, DeltaTableUtils, DeltaTimeTravelSpec}
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.files.DeltaSourceSnapshot
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.SchemaUtils
-
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.connector.read.streaming
 import org.apache.spark.sql.connector.read.streaming.{ReadAllAvailable, ReadLimit, ReadMaxFiles, SupportsAdmissionControl}
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.types.StructType
+
+import scala.util.{Failure, Success, Try}
 
 /**
  * A case class to help with `Dataset` operations regarding Offset indexing, representing AddFile
@@ -101,6 +102,9 @@ case class DeltaSource(
   // A metadata snapshot when starting the query.
   private var initialState: DeltaSourceSnapshot = null
   private var initialStateVersion: Long = -1L
+
+  final val STARTING_VERSION_KEY = "startingVersion"
+  final val STARTING_TIMESTAMP_KEY = "startingTimestamp"
 
   /**
    * Get the changes starting from (startVersion, startIndex). The start point should not be
@@ -177,12 +181,17 @@ case class DeltaSource(
 
   private def getStartingOffset(
       limits: Option[AdmissionLimits] = Some(new AdmissionLimits())): Option[Offset] = {
-    val version = deltaLog.snapshot.version
+
+    val (version, isStartingVersion) = getTimeTravelVersion(options.options) match {
+      case Some(v) => (v._1, false)
+      case None => (deltaLog.snapshot.version, true)
+    }
     if (version < 0) {
       return None
     }
     val last = iteratorLast(
-      getChangesWithRateLimit(version, -1L, isStartingVersion = true, limits))
+      getChangesWithRateLimit(version, -1L, isStartingVersion = isStartingVersion, limits))
+
     if (last.isEmpty) {
       return None
     }
@@ -369,6 +378,32 @@ case class DeltaSource(
       case composite: CompositeLimit =>
         Some(new AdmissionLimits(Some(composite.files.maxFiles()), composite.bytes.maxBytes))
       case other => throw new UnsupportedOperationException(s"Unknown ReadLimit: $other")
+    }
+  }
+
+  /** Extracts whether users provided the option to time travel a relation. */
+  private def getTimeTravelVersion(
+    parameters: CaseInsensitiveMap[String]): Option[(Long, String)] = {
+    val tsOpt = parameters.get(STARTING_TIMESTAMP_KEY)
+    val versionOpt = parameters.get(STARTING_VERSION_KEY)
+
+    if (tsOpt.isDefined && versionOpt.isDefined) {
+      throw DeltaErrors.provideOneOfInTimeTravel // TODO: change error
+    } else if (tsOpt.isDefined) {
+      Some(DeltaTableUtils.resolveTimeTravelVersion(
+        spark.sessionState.conf, deltaLog,
+        DeltaTimeTravelSpec(Some(Literal(tsOpt.get)), None, Some("dfReader"))))
+    } else if (versionOpt.isDefined) {
+      val version = Try(versionOpt.get.toLong) match {
+        case Success(v) => v
+        case Failure(t) => throw new IllegalArgumentException(
+          s"${DeltaDataSource.TIME_TRAVEL_VERSION_KEY} needs to be a valid bigint value.", t)
+      }
+      Some(DeltaTableUtils.resolveTimeTravelVersion(
+        spark.sessionState.conf, deltaLog,
+        DeltaTimeTravelSpec(None, Some(version), Some("dfReader"))))
+    } else {
+      None
     }
   }
 }

--- a/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -179,14 +179,11 @@ case class DeltaSource(
       limits: Option[AdmissionLimits] = Some(new AdmissionLimits())): Option[Offset] = {
 
     val (version, isStartingVersion) = getStartingVersion match {
-      case Some(v) => (v._1, false)
+      case Some(v) => (v - 1, false)
       case None => (deltaLog.snapshot.version, true)
     }
     if (version < 0) {
       return None
-    }
-    if (options.startingVersion.isDefined || options.startingTimestamp.isDefined) {
-      return Some(DeltaSourceOffset(tableId, version, -1, isStartingVersion = false))
     }
     val last = iteratorLast(
       getChangesWithRateLimit(version, -1L, isStartingVersion = isStartingVersion, limits))
@@ -290,15 +287,18 @@ case class DeltaSource(
     val endOffset = DeltaSourceOffset(tableId, end)
     previousOffset = endOffset // For recovery
     val changes = if (start.isEmpty) {
-      if (endOffset.isStartingVersion) {
-        getChanges(endOffset.reservoirVersion, -1L, isStartingVersion = true)
-      } else if (options.startingVersion.isDefined || options.startingTimestamp.isDefined) {
-        getChanges(endOffset.reservoirVersion, -1L, isStartingVersion = false)
-      } else {
-        assert(endOffset.reservoirVersion > 0, s"invalid reservoirVersion in endOffset: $endOffset")
-        // Load from snapshot `endOffset.reservoirVersion - 1L` so that `index` in `endOffset`
-        // is still valid.
-        getChanges(endOffset.reservoirVersion - 1L, -1L, isStartingVersion = true)
+      getStartingVersion match {
+        case Some(v) => getChanges(v, -1L, isStartingVersion = false)
+        case _ =>
+          if (endOffset.isStartingVersion) {
+            getChanges(endOffset.reservoirVersion, -1L, isStartingVersion = true)
+          } else {
+            assert(
+              endOffset.reservoirVersion > 0, s"invalid reservoirVersion in endOffset: $endOffset")
+            // Load from snapshot `endOffset.reservoirVersion - 1L` so that `index` in `endOffset`
+            // is still valid.
+            getChanges(endOffset.reservoirVersion - 1L, -1L, isStartingVersion = true)
+          }
       }
     } else {
       val startOffset = DeltaSourceOffset(tableId, start.get)
@@ -382,17 +382,19 @@ case class DeltaSource(
   }
 
   /** Extracts whether users provided the option to time travel a relation. */
-  private def getStartingVersion: Option[(Long, String)] = {
+  private def getStartingVersion: Option[Long] = {
     val tsOpt = options.startingTimestamp
     val versionOpt = options.startingVersion
 
     /** DeltaOption validates input and ensures that only one is provided. */
-    if (tsOpt.isDefined || versionOpt.isDefined) {
+    lazy val result = if (tsOpt.isDefined || versionOpt.isDefined) {
       Some(DeltaTableUtils.resolveTimeTravelVersion(
         spark.sessionState.conf, deltaLog,
-        DeltaTimeTravelSpec(tsOpt.map(Literal(_)), versionOpt, Some("deltaSource"))))
+        DeltaTimeTravelSpec(tsOpt.map(Literal(_)), versionOpt, Some("deltaSource")))._1)
     } else {
       None
     }
+
+    result
   }
 }

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -23,8 +23,10 @@ import java.util.UUID
 import org.apache.spark.sql.delta.actions.{AddFile, InvalidProtocolVersionException, Protocol}
 import org.apache.spark.sql.delta.sources.{DeltaSQLConf, DeltaSourceOffset}
 import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
+
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.fs.{FileStatus, Path, RawLocalFileSystem}
+
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.util.IntervalUtils
 import org.apache.spark.sql.execution.streaming._

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -1133,22 +1133,6 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase {
       assert(e2.getCause.isInstanceOf[AnalysisException])
       assert(e2.getCause.getMessage.contains("The provided timestamp: 2020-07-10 17:20:40.0" +
         " is after the latest commit timestamp"))
-
-      val e3 = intercept[StreamingQueryException] {
-        spark.readStream
-          .format("delta")
-          .option("startingTimestamp", "2020-07-10")
-          .load(inputDir.getCanonicalPath)
-          .writeStream
-          .format("delta")
-          .option("checkpointLocation", checkpointDir.getCanonicalPath)
-          .start(outputDir.getCanonicalPath)
-          .processAllAvailable()
-      }
-
-      assert(e3.getCause.isInstanceOf[IllegalArgumentException])
-      assert(e3.getCause.getMessage.contains(
-        "Invalid value '2020-07-10' for option 'startingTimestamp'"))
     }
   }
 }

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -1074,8 +1074,8 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase {
           .processAllAvailable()
       }
 
-      assert(e.getCause.isInstanceOf[AnalysisException])
-      assert(e.getCause.getMessage.contains("Cannot time travel Delta table to version -1"))
+      assert(e.getCause.isInstanceOf[IllegalArgumentException])
+      assert(e.getCause.getMessage.contains("Invalid value '-1' for option 'startingVersion'"))
 
       val e2 = intercept[StreamingQueryException] {
         spark.readStream

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -1020,7 +1020,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase {
 
       val q = spark.readStream
         .format("delta")
-        .option("startingVersion", "0")
+        .option("startingVersion", "1")
         .load(inputDir.getCanonicalPath)
         .writeStream
         .format("delta")
@@ -1131,6 +1131,22 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase {
       assert(e2.getCause.isInstanceOf[AnalysisException])
       assert(e2.getCause.getMessage.contains("The provided timestamp: 2020-07-10 17:20:40.0" +
         " is after the latest commit timestamp"))
+
+      val e3 = intercept[StreamingQueryException] {
+        spark.readStream
+          .format("delta")
+          .option("startingTimestamp", "2020-07-10")
+          .load(inputDir.getCanonicalPath)
+          .writeStream
+          .format("delta")
+          .option("checkpointLocation", checkpointDir.getCanonicalPath)
+          .start(outputDir.getCanonicalPath)
+          .processAllAvailable()
+      }
+
+      assert(e3.getCause.isInstanceOf[IllegalArgumentException])
+      assert(e3.getCause.getMessage.contains(
+        "Invalid value '2020-07-10' for option 'startingTimestamp'"))
     }
   }
 }


### PR DESCRIPTION
**Goal:** Add the ability to start structured streaming from a user provided version as outlined in #474 

**Desc:** This change will introduce `startingVersion` and `startingTimestamp` to the Delta Stream Reader so that users can define a starting point of their stream source without processing the entire table.

**What's the behavior if both startingVersion and startingTimestamp are set?** Both options cannot be provided together. An error will be thrown telling you to choose only one.

**When a query restarts, how does the new options work?** If a query restarts and a checkpoint location is provided, the stream will start from the checkpoints offset as opposed to the provided option.

**If the user uses an old Delta Lake version to read the checkpoint, what will happen?** If we use a newer version of Delta with this option, we will store an offset that looks like: Process up to this version and this index. If the stream fails and someone reverts to an older version of Delta, we would try to process ALL the data in the snapshot up to the end offset which we came up with.

Credit to @brkyvz for a large percentage of the work.