### PR TITLE
Make DeltaTable Java Serializable

### DIFF
--- a/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -39,8 +39,27 @@ import org.apache.spark.sql.types.StructType
  * @since 0.3.0
  */
 @Evolving
-class DeltaTable private[tables](df: Dataset[Row], deltaLog: DeltaLog)
+class DeltaTable private[tables](
+  @transient private val _df: Dataset[Row], @transient private val _deltaLog: DeltaLog)
   extends DeltaTableOperations with Serializable {
+
+  def deltaLog: DeltaLog = {
+    /** Assert the codes run in the driver. */
+    if (_deltaLog == null) {
+      throw new IllegalStateException("DeltaTable cannot be used in executors")
+    }
+
+    _deltaLog
+  }
+
+  def df: Dataset[Row] = {
+    /** Assert the codes run in the driver. */
+    if (_df == null) {
+      throw new IllegalStateException("DeltaTable cannot be used in executors")
+    }
+
+    _df
+  }
 
   /**
    * :: Evolving ::

--- a/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -40,7 +40,7 @@ import org.apache.spark.sql.types.StructType
  */
 @Evolving
 class DeltaTable private[tables](df: Dataset[Row], deltaLog: DeltaLog)
-  extends DeltaTableOperations {
+  extends DeltaTableOperations with Serializable {
 
   /**
    * :: Evolving ::

--- a/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -43,7 +43,7 @@ class DeltaTable private[tables](
   @transient private val _df: Dataset[Row], @transient private val _deltaLog: DeltaLog)
   extends DeltaTableOperations with Serializable {
 
-  def deltaLog: DeltaLog = {
+  protected def deltaLog: DeltaLog = {
     /** Assert the codes run in the driver. */
     if (_deltaLog == null) {
       throw new IllegalStateException("DeltaTable cannot be used in executors")
@@ -52,7 +52,7 @@ class DeltaTable private[tables](
     _deltaLog
   }
 
-  def df: Dataset[Row] = {
+  protected def df: Dataset[Row] = {
     /** Assert the codes run in the driver. */
     if (_df == null) {
       throw new IllegalStateException("DeltaTable cannot be used in executors")

--- a/src/test/scala/io/delta/tables/DeltaTableSuite.scala
+++ b/src/test/scala/io/delta/tables/DeltaTableSuite.scala
@@ -125,4 +125,19 @@ class DeltaTableSuite extends QueryTest
     val e = intercept[AnalysisException] { thunk }
     assert(e.getMessage.toLowerCase(Locale.ROOT).contains(expectedMsg.toLowerCase(Locale.ROOT)))
   }
+
+  test("java serializable") {
+    import testImplicits._
+
+    withTempDir { dir =>
+      spark.range(5).write.format("delta").mode("append").save(dir.getAbsolutePath)
+      val dt = DeltaTable.forPath(dir.getAbsolutePath)
+      val x = 3
+      spark.range(5).as[Long].map{ row: Long =>
+        dt
+        row + x
+      }.show()
+
+    }
+  }
 }

--- a/src/test/scala/io/delta/tables/DeltaTableSuite.scala
+++ b/src/test/scala/io/delta/tables/DeltaTableSuite.scala
@@ -21,6 +21,7 @@ import java.util.Locale
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.{AnalysisException, QueryTest}
 import org.apache.spark.sql.test.SharedSparkSession
 
@@ -126,15 +127,15 @@ class DeltaTableSuite extends QueryTest
     assert(e.getMessage.toLowerCase(Locale.ROOT).contains(expectedMsg.toLowerCase(Locale.ROOT)))
   }
 
-  test("java serializable") {
+  test("DeltaTable is Java Serializable but cannot be used in executors") {
     import testImplicits._
 
-    val e = intercept[IllegalStateException] {
+    val e = intercept[SparkException] {
       withTempDir { dir =>
         testData.write.format("delta").mode("append").save(dir.getAbsolutePath)
         val dt: DeltaTable = DeltaTable.forPath(dir.getAbsolutePath)
         spark.range(5).as[Long].map{ row: Long =>
-          dt.delete()
+          dt.toDF
           row + 3
         }.show()
 


### PR DESCRIPTION
fixes #485 

Make `DeltaTable` Serializable so that it can be sent to executors without throwing `NotSerializableException`. However, methods of `DeltaTable` should not be allowed to run on the executors so should throw a clear exception explaining this.

credit-where-credit-is-due: @zsxwing 