### PR TITLE
Add "@since" to DeltaMergeMatchedActionBuilder.delete()

### DIFF
--- a/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
+++ b/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
@@ -359,7 +359,6 @@ class DeltaMergeMatchedActionBuilder private(
 
   /**
    * Delete a matched row from the table.
-   *
    * @since 0.3.0
    */
   def delete(): DeltaMergeBuilder = {

--- a/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
+++ b/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
@@ -357,7 +357,11 @@ class DeltaMergeMatchedActionBuilder private(
     mergeBuilder.withClause(updateClause)
   }
 
-  /** Delete a matched row from the table */
+  /**
+   * Delete a matched row from the table.
+   *
+   * @since 0.3.0
+   */
   def delete(): DeltaMergeBuilder = {
     val deleteClause = DeltaMergeIntoDeleteClause(matchCondition.map(_.expr))
     mergeBuilder.withClause(deleteClause)

--- a/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
+++ b/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
@@ -358,9 +358,13 @@ class DeltaMergeMatchedActionBuilder private(
   }
 
   /**
+   * :: Evolving ::
+   *
    * Delete a matched row from the table.
+   *
    * @since 0.3.0
    */
+  @Evolving
   def delete(): DeltaMergeBuilder = {
     val deleteClause = DeltaMergeIntoDeleteClause(matchCondition.map(_.expr))
     mergeBuilder.withClause(deleteClause)

--- a/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
+++ b/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
@@ -361,7 +361,6 @@ class DeltaMergeMatchedActionBuilder private(
    * :: Evolving ::
    *
    * Delete a matched row from the table.
-   *
    * @since 0.3.0
    */
   @Evolving


### PR DESCRIPTION
This small PR adds a `@since 0.3.0` annotation to `DeltaMergeMatchedActionBuilder.delete()`, which seems to be the only public API function missing this.

I also noticed that this function is missing a `@Evolving` tag. Is this intentional?

CC: @rapoth @suhsteve @imback82 