### PR TITLE
Parse the partition structure using the delta_log as the base path

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
@@ -397,7 +397,7 @@ abstract class ConvertToDeltaCommandBase(
     val (partitionOpt, _) = PartitionUtils.parsePartition(
       dir,
       typeInference = false,
-      basePaths = Set.empty,
+      basePaths = Set(basePath),
       userSpecifiedDataTypes = Map.empty,
       validatePartitionColumns = false,
       java.util.TimeZone.getDefault,

--- a/src/test/scala/org/apache/spark/sql/delta/ConvertToDeltaSuiteBase.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/ConvertToDeltaSuiteBase.scala
@@ -1036,4 +1036,19 @@ trait ConvertToDeltaHiveTableTests extends ConvertToDeltaTestUtils with SQLTestU
       }
     }
   }
+
+  test("can convert a partition-like table path") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      writeFiles(path, simpleDF, partCols = Seq("key1", "key2"))
+
+      val basePath = s"$path/key1=1/"
+      convertToDelta(s"parquet.`$basePath`", Some("key2 string"))
+
+      checkAnswer(
+        sql(s"select id from delta.`$basePath` where key2 = '1'"),
+        simpleDF.filter("id % 2 == 1").filter("id % 3 == 1").select("id"))
+    }
+  }
+
 }


### PR DESCRIPTION
This allows converting a location that is under a path that looks like a partition value. For example, running the convert to delta command over a path like `s3://massive-events/year=2020/` would fail because the command will try to compare the partitions above the delta log base path.

Signed-off-by: Mike Dias <mike.rodrigues.dias@gmail.com>