### PR TITLE
Fix attribute resolution failure when insert overwrite some constants

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -64,8 +64,8 @@ class DeltaAnalysis(session: SparkSession, conf: SQLConf)
       if query.resolved && needsSchemaAdjustment(d.name(), query, d.schema()) =>
       val projection = normalizeQueryColumns(query, d)
       if (projection != query) {
-        val aliases = AttributeMap(query.output.zip(projection.output).filter {
-          case (l: AttributeReference, r: AttributeReference) => !l.sameRef(r)
+        val aliases = AttributeMap(query.output.zip(projection.output).collect {
+          case (l: AttributeReference, r: AttributeReference) if !l.sameRef(r) => (l, r)
         })
         val newDeleteExpr = deleteExpr.transformUp {
           case a: AttributeReference => aliases.getOrElse(a, a)

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTableSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTableSuite.scala
@@ -45,6 +45,27 @@ class DeltaInsertIntoSQLSuite extends DeltaInsertIntoTests(false, true)
       sql(s"INSERT $overwrite TABLE $tableName SELECT * FROM $tmpView")
     }
   }
+
+  test("normalize query columns should consider duplicated constant") {
+    withTable("t1", "t2") {
+      sql("CREATE TABLE t1 (a int, b int, c int) USING delta PARTITIONED BY (b, c)")
+      sql("INSERT OVERWRITE TABLE t1 PARTITION (c=2) SELECT 3, 2")
+      checkAnswer(
+        sql("SELECT * FROM t1"),
+        Row(3, 2, 2) :: Nil
+      )
+      sql("INSERT OVERWRITE TABLE t1 PARTITION (b=2, c=2) SELECT 3")
+      checkAnswer(
+        sql("SELECT * FROM t1"),
+        Row(3, 2, 2) :: Nil
+      )
+      sql("INSERT OVERWRITE TABLE t1 PARTITION (b=2, c) SELECT 3, 2")
+      checkAnswer(
+        sql("SELECT * FROM t1"),
+        Row(3, 2, 2) :: Nil
+      )
+    }
+  }
 }
 
 class DeltaInsertIntoSQLByPathSuite extends DeltaInsertIntoTests(false, true)

--- a/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTableSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTableSuite.scala
@@ -46,23 +46,23 @@ class DeltaInsertIntoSQLSuite extends DeltaInsertIntoTests(false, true)
     }
   }
 
-  test("normalize query columns should consider duplicated constant") {
-    withTable("t1", "t2") {
+  test("insert overwrite should work with selecting constants") {
+    withTable("t1") {
       sql("CREATE TABLE t1 (a int, b int, c int) USING delta PARTITIONED BY (b, c)")
-      sql("INSERT OVERWRITE TABLE t1 PARTITION (c=2) SELECT 3, 2")
+      sql("INSERT OVERWRITE TABLE t1 PARTITION (c=3) SELECT 1, 2")
       checkAnswer(
         sql("SELECT * FROM t1"),
-        Row(3, 2, 2) :: Nil
+        Row(1, 2, 3) :: Nil
       )
-      sql("INSERT OVERWRITE TABLE t1 PARTITION (b=2, c=2) SELECT 3")
+      sql("INSERT OVERWRITE TABLE t1 PARTITION (b=2, c=3) SELECT 1")
       checkAnswer(
         sql("SELECT * FROM t1"),
-        Row(3, 2, 2) :: Nil
+        Row(1, 2, 3) :: Nil
       )
-      sql("INSERT OVERWRITE TABLE t1 PARTITION (b=2, c) SELECT 3, 2")
+      sql("INSERT OVERWRITE TABLE t1 PARTITION (b=2, c) SELECT 1, 3")
       checkAnswer(
         sql("SELECT * FROM t1"),
-        Row(3, 2, 2) :: Nil
+        Row(1, 2, 3) :: Nil
       )
     }
   }


### PR DESCRIPTION
This PR will fix the resolution failure when insert overwrite some constants

How to reproduce:
```sql
-- create a partitioned delta table
CREATE TABLE t1 (a int, b int, c int) USING delta PARTITIONED BY (b, c);
```
Below three queries all failed with attributes resolution phase.
```sql
-- make sure there are two columns with same values: b=2, c=2
INSERT OVERWRITE TABLE t1 PARTITION (c=2) SELECT 3, 2;
INSERT OVERWRITE TABLE t1 PARTITION (b=2, c=2) SELECT 3;
INSERT OVERWRITE TABLE t1 PARTITION (b=2, c) SELECT 3, 2;
```

These three queries all throw exception
> Resolved attribute(s) c#792 missing from a#793,b#794,c#795 in operator !OverwriteByExpression RelationV2[a#789, b#790, c#791] default.t1, (c#792 = cast(2 as int)), false. Attribute(s) with the same name appear in the operation: c. Please check if the right attribute(s) are used.;;
!OverwriteByExpression RelationV2[a#789, b#790, c#791] default.t1, (c#792 = cast(2 as int)), false
+- Project [2#787 AS a#793, 2#788 AS b#794, c#792 AS c#795]
   +- Project [2#787, 2#788, cast(2 as int) AS c#792]
      +- Project [2 AS 2#787, 2 AS 2#788]
         +- OneRowRelation
