### PR TITLE
Fix:Tune DeltaTable.vacuum operation

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
@@ -278,7 +278,7 @@ trait VacuumCommandImpl extends DeltaCommand {
       val counts = fileResultSet.map(p => new Path(new URI(p)))
         .count(f => tryDeleteNonRecursive(fs, f))
       Iterator.single(counts)
-    }(Encoders.scalaInt).collect().sum
+    }(Encoders.scalaInt).reduce(_ + _)
   }
 
   protected def stringToPath(path: String): Path = new Path(new URI(path))


### PR DESCRIPTION
- Tune DeltaTable.vacuum operation to delete files in parallel depending on the number of partitions instead of deleting one by one
- Passed unit testing(org.apache.spark.sql.delta.DeltaVacuumSuite)
- Used it to delete around 300K files on gcs using cluster with 8 workers (n1-standard-4(4CPUs,15GB)) in 10 minutes
  and setting --conf spark.sql.sources.parallelPartitionDiscovery.parallelism=1000