### PR TITLE
Allow log store more latitude in how it stores logs

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -20,22 +20,21 @@ package org.apache.spark.sql.delta
 import java.io.{File, IOException}
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
-
 import scala.concurrent.Future
 import scala.util.Try
 import scala.util.control.NonFatal
-
 import com.databricks.spark.util.TagDefinitions._
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.commands.WriteIntoDelta
 import org.apache.spark.sql.delta.files.{TahoeBatchFileIndex, TahoeLogFileIndex}
+import org.apache.spark.sql.delta.storage.LogFileMeta.isDeltaFile
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.{SchemaMergingUtils, SchemaUtils}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.storage.LogStoreProvider
-import com.google.common.cache.{CacheBuilder, RemovalNotification}
+import org.apache.spark.sql.delta.storage.{LogFileMetaProvider, LogStoreProvider}
+import org.apache.spark.sql.delta.util.FileNames.deltaFile
+import com.google.common.cache.{CacheBuilder, RemovalListener, RemovalNotification}
 import org.apache.hadoop.fs.Path
-
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{Resolver, UnresolvedAttribute}
@@ -64,9 +63,8 @@ class DeltaLog private(
   with MetadataCleanup
   with LogStoreProvider
   with SnapshotManagement
-  with ReadChecksum {
-
-  import org.apache.spark.sql.delta.util.FileNames._
+  with ReadChecksum
+  with LogFileMetaProvider {
 
 
   private lazy implicit val _clock = clock
@@ -75,6 +73,9 @@ class DeltaLog private(
 
   /** Used to read and write physical log files and checkpoints. */
   lazy val store = createLogStore(spark)
+
+  lazy val logFileHandler = createLogFileMetaParser(spark, store)
+
   /** Direct access to the underlying storage system. */
   private[delta] lazy val fs = logPath.getFileSystem(spark.sessionState.newHadoopConf)
 
@@ -218,15 +219,14 @@ class DeltaLog private(
    * return an empty Iterator.
    */
   def getChanges(
-      startVersion: Long,
-      failOnDataLoss: Boolean = false): Iterator[(Long, Seq[Action])] = {
-    val deltas = store.listFrom(deltaFile(logPath, startVersion))
-      .filter(f => isDeltaFile(f.getPath))
+                  startVersion: Long,
+                  failOnDataLoss: Boolean = false): Iterator[(Long, Seq[Action])] = {
+    val deltas = logFileHandler.listFilesFrom(deltaFile(logPath, startVersion)).filter(isDeltaFile)
     // Subtract 1 to ensure that we have the same check for the inclusive startVersion
     var lastSeenVersion = startVersion - 1
     deltas.map { status =>
-      val p = status.getPath
-      val version = deltaVersion(p)
+      val p = status.fileStatus.getPath
+      val version = status.version
       if (failOnDataLoss && version > lastSeenVersion + 1) {
         throw DeltaErrors.failOnDataLossException(lastSeenVersion + 1, version)
       }

--- a/core/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
@@ -19,7 +19,9 @@ package org.apache.spark.sql.delta
 import java.util.{Calendar, TimeZone}
 
 import org.apache.spark.sql.delta.DeltaHistoryManager.BufferingLogDeletionIterator
+import org.apache.spark.sql.delta.storage.LogFileMeta.{isCheckpointFile, isDeltaFile}
 import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.util.FileNames.checkpointPrefix
 import org.apache.commons.lang3.time.DateUtils
 import org.apache.hadoop.fs.{FileStatus, Path}
 
@@ -69,22 +71,19 @@ trait MetadataCleanup extends DeltaLogging {
    *  - be older than `fileCutOffTime`
    */
   private def listExpiredDeltaLogs(fileCutOffTime: Long): Iterator[FileStatus] = {
-    import org.apache.spark.sql.delta.util.FileNames._
 
     val latestCheckpoint = lastCheckpoint
     if (latestCheckpoint.isEmpty) return Iterator.empty
     val threshold = latestCheckpoint.get.version - 1L
-    val files = store.listFrom(checkpointPrefix(logPath, 0))
-      .filter(f => isCheckpointFile(f.getPath) || isDeltaFile(f.getPath))
-    def getVersion(filePath: Path): Long = {
-      if (isCheckpointFile(filePath)) {
-        checkpointVersion(filePath)
-      } else {
-        deltaVersion(filePath)
-      }
-    }
+    val files = logFileHandler.listFilesFrom(checkpointPrefix(logPath, 0))
+      .filter(f => isCheckpointFile(f) || isDeltaFile(f))
+    val versionTuples = files.map(f => (f.fileStatus, f.version)).toArray
+    val versionMap = versionTuples.map(vt => (vt._1.getPath, vt._2)).toMap
 
-    new BufferingLogDeletionIterator(files, fileCutOffTime, threshold, getVersion)
+    new BufferingLogDeletionIterator(versionTuples.map(_._1).iterator,
+      fileCutOffTime,
+      threshold,
+      versionMap)
   }
 
   /** Truncates a timestamp down to the previous midnight and returns the time and a log string */

--- a/core/src/main/scala/org/apache/spark/sql/delta/storage/LogFileMetaParser.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/storage/LogFileMetaParser.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.storage
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileStatus, Path}
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.delta.CheckpointInstance
+import org.apache.spark.sql.delta.util.FileNames._
+import org.apache.spark.util.Utils
+import org.apache.spark.{SparkConf, SparkContext}
+
+import scala.util.Try
+
+sealed case class DeltaFileType(value: String)
+
+object DeltaFileType {
+  object DELTA extends DeltaFileType("DELTA")
+  object CHECKPOINT extends DeltaFileType("CHECKPOINT")
+  object CHECKSUM extends DeltaFileType("CHECKSUM")
+  object UNKNOWN extends DeltaFileType("UNKNOWN")
+
+  val values = Seq(DELTA, CHECKPOINT, CHECKSUM, UNKNOWN)
+
+  def getFileType(path: Path): DeltaFileType = {
+    path match {
+      case f if isCheckpointFile(f) => DeltaFileType.CHECKPOINT
+      case f if isDeltaFile(f) => DeltaFileType.DELTA
+      case f if isChecksumFile(f) => DeltaFileType.CHECKSUM
+      case _ => DeltaFileType.UNKNOWN
+    }
+  }
+}
+
+case class LogFileMeta(fileStatus: FileStatus,
+                      version: Long,
+                      fileType: DeltaFileType,
+                      numParts: Option[Int]) {
+
+  def asCheckpointInstance(): CheckpointInstance = {
+    CheckpointInstance(version, numParts)
+  }
+}
+
+object LogFileMeta {
+  def isCheckpointFile(logFileMeta: LogFileMeta): Boolean = {
+    logFileMeta.fileType == DeltaFileType.CHECKPOINT
+  }
+
+  def isDeltaFile(logFileMeta: LogFileMeta): Boolean = {
+    logFileMeta.fileType == DeltaFileType.DELTA
+  }
+}
+
+
+class LogFileMetaParser(logStore: LogStore) {
+
+  def listFilesFrom(logPath: Path): Iterator[LogFileMeta] = {
+
+    logStore.listFrom(logPath).map(fs => {
+      LogFileMeta(fs,
+        Try(deltaVersion(fs.getPath)).getOrElse(Try(checkpointVersion(fs.getPath)).getOrElse(-1L)),
+        DeltaFileType.getFileType(fs.getPath),
+        numCheckpointParts(fs.getPath))
+    })
+  }
+
+}
+
+object LogFileMetaParser extends LogFileMetaProvider
+  with Logging {
+
+  def apply(sc: SparkContext, logStore: LogStore): LogFileMetaParser = {
+    apply(sc.getConf, sc.hadoopConfiguration, logStore)
+  }
+
+  def apply(sparkConf: SparkConf,
+            hadoopConf: Configuration,
+            logStore: LogStore): LogFileMetaParser = {
+    createLogFileMetaParser(sparkConf, hadoopConf, logStore)
+  }
+}
+
+trait LogFileMetaProvider {
+
+  def createLogFileMetaParser(spark: SparkSession, logStore: LogStore): LogFileMetaParser = {
+    val sc = spark.sparkContext
+    createLogFileMetaParser(sc.getConf, sc.hadoopConfiguration, logStore)
+  }
+
+  def createLogFileMetaParser(sparkConf: SparkConf,
+                              hadoopConf: Configuration,
+                              logStore: LogStore): LogFileMetaParser = {
+    val logStoreClassName = sparkConf.get("spark.delta.logFileHandler.class",
+      classOf[LogFileMetaParser].getName)
+    val logStoreClass = Utils.classForName(logStoreClassName)
+    logStoreClass.getConstructor(classOf[LogStore])
+      .newInstance(logStore).asInstanceOf[LogFileMetaParser]
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/delta/storage/LogStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/storage/LogStore.scala
@@ -125,6 +125,18 @@ trait LogStore {
   }
 
   /**
+   * Let LogStore decide where checkpoints should be stored.
+   *
+   * Typically the checkpoint storage path would be the same as for Delta storage.
+   * This woudl be inside the _delta_log directory. The LogStore impl may wish to control this path
+   * and should inform the Checkpoints methods accordingly. This is only required for checkpoints
+   * as they are the only metadata file not directly written by LogStore.
+   */
+  def resolveCheckpointPath(path: Path): Path = {
+    path
+  }
+
+  /**
    * Whether a partial write is visible when writing to `path`.
    *
    * As this depends on the underlying file system implementations, we require the input of `path`

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
@@ -123,7 +123,7 @@ class DeltaTimeTravelSuite extends QueryTest
       start - 2.seconds, // adjusts to start + 4 ms
       start + 10.seconds)
 
-    val commits = DeltaHistoryManager.getCommits(deltaLog.store, deltaLog.logPath, 0, None)
+    val commits = DeltaHistoryManager.getCommits(deltaLog.logFileHandler, deltaLog.logPath, 0, None)
     assert(commits.map(_.timestamp) === Seq(start,
       start + 1.millis, start + 2.millis, start + 3.millis, start + 4.millis, start + 10.seconds))
   }


### PR DESCRIPTION
This PR extends the LogStore trait to allow implementers more flexibility in how the LogStore stores data. Specifically, it decouples the precise filename of a delta log file from the relevant information: version, file type etc.



Changes in this PR:

* A case class which holds the relevant file properties

* a parser which creates file properties classes from filenames

* scaffolding to change the parser impl in the same manner that the LogStore impl is changed

* a new method on the LogStore to similarly control the checkpoint file as this currently does not pass through the LogStore interface

Signed-off-by: Ryan Murray <rymurr@gmail.com>