### PR TITLE
Allow LogStore to select implementation based on URI - #503

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -75,7 +75,7 @@ class DeltaLog private(
   protected def spark = SparkSession.active
 
   /** Used to read and write physical log files and checkpoints. */
-  lazy val store = createLogStore(spark)
+  lazy val store = createLogStore(logPath, spark)
   /** Direct access to the underlying storage system. */
   private[delta] lazy val fs = logPath.getFileSystem(spark.sessionState.newHadoopConf)
 

--- a/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
@@ -236,7 +236,8 @@ trait GenerateSymlinkManifestImpl extends PostCommitHook with DeltaLogging with 
     import spark.implicits._
 
     val tableAbsPathForManifest =
-      LogStore(spark.sparkContext).resolvePathOnPhysicalStorage(deltaLogDataPath).toString
+      LogStore(deltaLogDataPath, spark.sparkContext)
+          .resolvePathOnPhysicalStorage(deltaLogDataPath).toString
 
     /** Write the data file relative paths to manifestDirAbsPath/manifest as absolute paths */
     def writeSingleManifestFile(
@@ -250,7 +251,7 @@ trait GenerateSymlinkManifestImpl extends PostCommitHook with DeltaLogging with 
       val manifestContent = dataFileRelativePaths.map { relativePath =>
         DeltaFileOperations.absolutePath(tableAbsPathForManifest, relativePath).toString
       }
-      val logStore = LogStore(SparkEnv.get.conf, hadoopConf.value)
+      val logStore = LogStore(new Path(manifestDirAbsPath), SparkEnv.get.conf, hadoopConf.value)
       logStore.write(manifestFilePath, manifestContent, overwrite = true)
     }
 


### PR DESCRIPTION
Updating LogStore to have new overload taking in the log Path, and checking its URI to determine the LogStore implementation (only used if existing config property is not set)

Adding test to LogStoreSuiteBase for the FS based selection