### PR TITLE
Make JsonUtils.mapper lazy to show a better error

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/util/JsonUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/util/JsonUtils.scala
@@ -23,10 +23,13 @@ import com.fasterxml.jackson.module.scala.{DefaultScalaModule, ScalaObjectMapper
 /** Useful json functions used around the Delta codebase. */
 object JsonUtils {
   /** Used to convert between classes and JSON. */
-  val mapper = new ObjectMapper with ScalaObjectMapper
-  mapper.setSerializationInclusion(Include.NON_ABSENT)
-  mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-  mapper.registerModule(DefaultScalaModule)
+  lazy val mapper = {
+    val _mapper = new ObjectMapper with ScalaObjectMapper
+    _mapper.setSerializationInclusion(Include.NON_ABSENT)
+    _mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    _mapper.registerModule(DefaultScalaModule)
+    _mapper
+  }
 
   def toJson[T: Manifest](obj: T): String = {
     mapper.writeValueAsString(obj)


### PR DESCRIPTION
Currently if failing to initialize `JsonUtils.mapper` (likely `jackson-module-scala` incompatibility issue), class `JsonUtils$` will not be loaded. Because this is a class loading error, the root cause of initialization failure will be shown only once by JVM, and the following calls that touch `JsonUtils` will fail without a cause. This makes users hard to find out the root cause in their logs.

This PR makes JsonUtils.mapper lazy so that the initialization failure will be shown every time `JsonUtils` is touched.