### PR TITLE
Add hive delta catalog

### DIFF
--- a/src/main/scala/io/delta/hive/DeltaInputFormat.scala
+++ b/src/main/scala/io/delta/hive/DeltaInputFormat.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (2020) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.hive
+
+import org.apache.hadoop.io.{ArrayWritable, NullWritable}
+import org.apache.hadoop.mapred.{FileInputFormat, InputSplit, JobConf, RecordReader, Reporter}
+import org.apache.parquet.hadoop.ParquetInputFormat
+
+class DeltaInputFormat(realInput: ParquetInputFormat[ArrayWritable])
+  extends FileInputFormat[NullWritable, ArrayWritable] {
+
+  override def getRecordReader(split: InputSplit, job: JobConf, reporter: Reporter):
+  RecordReader[NullWritable, ArrayWritable] = throw new UnsupportedOperationException(
+    "This are the mock class in order to be able spark to run")
+}

--- a/src/main/scala/io/delta/hive/DeltaOutputFormat.scala
+++ b/src/main/scala/io/delta/hive/DeltaOutputFormat.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (2020) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.hive
+
+import org.apache.hadoop.fs.FileSystem
+import org.apache.hadoop.io.{ArrayWritable, NullWritable}
+import org.apache.hadoop.mapred.{JobConf, OutputFormat, RecordWriter}
+import org.apache.hadoop.util.Progressable
+
+class DeltaOutputFormat extends OutputFormat[NullWritable, ArrayWritable] {
+
+  private def writingNotSupported[T](): T = {
+    throw new UnsupportedOperationException(
+      "This are the mock class in order to be able spark to run")
+  }
+
+  override def getRecordWriter(ignored: FileSystem, job: JobConf, name: String,
+                               progress: Progressable):
+    RecordWriter[NullWritable, ArrayWritable] = writingNotSupported()
+
+  override def checkOutputSpecs(ignored: FileSystem, job: JobConf): Unit = writingNotSupported()
+}

--- a/src/main/scala/io/delta/hive/DeltaStorageHandler.scala
+++ b/src/main/scala/io/delta/hive/DeltaStorageHandler.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright (2020) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.hive
+
+import org.apache.hadoop.hive.ql.metadata.DefaultStorageHandler
+
+class DeltaStorageHandler extends DefaultStorageHandler

--- a/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
+++ b/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
@@ -234,7 +234,8 @@ class DeltaMergeBuilder private(
       throw DeltaErrors.analysisException("Failed to resolve\n", plan = Some(resolvedMergeInto))
     }
     // Preprocess the actions and verify
-    val mergeIntoCommand = PreprocessTableMerge(sparkSession.sessionState.conf)(resolvedMergeInto)
+    val mergeIntoCommand = PreprocessTableMerge(sparkSession.sessionState.conf,
+      targetTable.catalogTable)(resolvedMergeInto)
     sparkSession.sessionState.analyzer.checkAnalysis(mergeIntoCommand)
     mergeIntoCommand.run(sparkSession)
   }

--- a/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -17,16 +17,15 @@
 package io.delta.tables
 
 import scala.collection.JavaConverters._
-
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.Protocol
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import io.delta.tables.execution._
 import org.apache.hadoop.fs.Path
-
 import org.apache.spark.annotation._
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.types.StructType
 
 /**
@@ -95,6 +94,16 @@ class DeltaTable private[tables](
    */
   @Evolving
   def toDF: Dataset[Row] = df
+
+  /**
+   * :: Evolving ::
+   *
+   * Get if exists the catalog of the table
+   *
+   * @since 0.8.0
+   */
+  @Evolving
+  def catalogTable: Option[CatalogTable] = table.catalogTable
 
   /**
    * :: Evolving ::

--- a/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/deltaMerge.scala
+++ b/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/deltaMerge.scala
@@ -19,13 +19,13 @@ package org.apache.spark.sql.catalyst.plans.logical
 import java.util.Locale
 
 import scala.collection.mutable
-
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis._
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, Expression, Literal, UnaryExpression}
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, Expression, Literal, UnaryExpression, Unevaluable}
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{ByteType, DataType, IntegerType, ShortType, StructField, StructType}
@@ -212,7 +212,8 @@ case class DeltaMergeInto(
     condition: Expression,
     matchedClauses: Seq[DeltaMergeIntoMatchedClause],
     notMatchedClauses: Seq[DeltaMergeIntoInsertClause],
-    migratedSchema: Option[StructType] = None) extends Command {
+    migratedSchema: Option[StructType] = None,
+    catalogTable: Option[CatalogTable] = None) extends Command {
 
   (matchedClauses ++ notMatchedClauses).foreach(_.verifyActions())
 
@@ -261,7 +262,7 @@ object DeltaMergeInto {
       resolveExpr: (Expression, LogicalPlan) => Expression): DeltaMergeInto = {
 
     val DeltaMergeInto(
-        target, source, condition, matchedClauses, notMatchedClause, migratedSchema) =
+        target, source, condition, matchedClauses, notMatchedClause, migratedSchema, catalogTable) =
       merge
 
     // We must do manual resolution as the expressions in different clauses of the MERGE have

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -77,7 +77,7 @@ object DeltaTableUtils extends PredicateHelper
   with DeltaLogging {
 
   /** Check whether this table is a Delta table based on information from the Catalog. */
-  def isDeltaTable(table: CatalogTable): Boolean = DeltaSourceUtils.isDeltaTable(table.provider)
+  def isDeltaTable(table: CatalogTable): Boolean = DeltaSourceUtils.isDeltaTable(table)
 
   /**
    * Check whether the provided table name is a Delta table based on information from the Catalog.

--- a/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -119,7 +119,7 @@ case class DeltaTableV2(
   ).asJava
 
   override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {
-    new WriteIntoDeltaBuilder(deltaLog, info.options)
+    new WriteIntoDeltaBuilder(this, deltaLog, info.options)
   }
 
   /**
@@ -155,6 +155,7 @@ case class DeltaTableV2(
 }
 
 private class WriteIntoDeltaBuilder(
+    table : DeltaTableV2,
     log: DeltaLog,
     writeOptions: CaseInsensitiveStringMap)
   extends WriteBuilder with V1WriteBuilder with SupportsOverwrite with SupportsTruncate {
@@ -190,7 +191,8 @@ private class WriteIntoDeltaBuilder(
           new DeltaOptions(options.toMap, session.sessionState.conf),
           Nil,
           log.snapshot.metadata.configuration,
-          data).run(session)
+          data,
+          catalogTable = table.catalogTable).run(session)
 
         // TODO: Push this to Apache Spark
         // Re-cache all cached plans(including this relation itself, if it's cached) that refer

--- a/src/main/scala/org/apache/spark/sql/delta/catalog/HiveDeltaCatalog.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/catalog/HiveDeltaCatalog.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (2020) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.catalog
+
+import java.net.URI
+
+import io.delta.hive.{DeltaInputFormat, DeltaOutputFormat, DeltaStorageHandler}
+import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe
+import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogUtils}
+import org.apache.spark.sql.execution.datasources.DataSource
+
+class HiveDeltaCatalog extends DeltaCatalog {
+
+  override protected def getProvider : String = "hive"
+
+  override protected def getStorage(tableProperties : Map[String, String],
+                                    locationUri : Option[URI]) : CatalogStorageFormat = {
+    val properties : Map[String, String] = if (locationUri.isDefined) {
+      Map("path" -> CatalogUtils.URIToString(locationUri.get))
+    } else {
+      Map()
+    }
+    DataSource.buildStorageFormatFromOptions(tableProperties)
+      .copy(locationUri = locationUri,
+        serde = Some(classOf[ParquetHiveSerDe].getCanonicalName),
+        inputFormat = Some(classOf[DeltaInputFormat].getCanonicalName),
+        outputFormat = Some(classOf[DeltaOutputFormat].getCanonicalName),
+        properties = properties)
+  }
+
+
+  override protected def getTableProperties(
+                      tableProperties : Map[String, String]) : Map[String, String] =
+    tableProperties +
+      ("storage_handler" -> classOf[DeltaStorageHandler].getCanonicalName)
+}

--- a/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -20,8 +20,9 @@ package org.apache.spark.sql.delta.commands
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.{Action, AddFile}
 import org.apache.spark.sql.delta.schema.ImplicitMetadataOperation
-
 import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.execution.command.RunnableCommand
 
 /**
@@ -43,12 +44,13 @@ import org.apache.spark.sql.execution.command.RunnableCommand
  * replace data that matches a predicate.
  */
 case class WriteIntoDelta(
-    deltaLog: DeltaLog,
-    mode: SaveMode,
-    options: DeltaOptions,
-    partitionColumns: Seq[String],
-    configuration: Map[String, String],
-    data: DataFrame)
+     deltaLog: DeltaLog,
+     mode: SaveMode,
+     options: DeltaOptions,
+     partitionColumns: Seq[String],
+     configuration: Map[String, String],
+     data: DataFrame,
+     catalogTable: Option[CatalogTable] = None)
   extends RunnableCommand
   with ImplicitMetadataOperation
   with DeltaCommand {
@@ -83,7 +85,8 @@ case class WriteIntoDelta(
       }
     }
     val rearrangeOnly = options.rearrangeOnly
-    updateMetadata(txn, data, partitionColumns, configuration, isOverwriteOperation, rearrangeOnly)
+    updateMetadata(txn, data, partitionColumns, configuration, catalogTable,
+      isOverwriteOperation, rearrangeOnly)
 
     // Validate partition predicates
     val replaceWhere = options.replaceWhere

--- a/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
@@ -82,7 +82,9 @@ class DeltaSink(
       data,
       partitionColumns,
       configuration = Map.empty,
-      outputMode == OutputMode.Complete())
+      None,
+      outputMode == OutputMode.Complete()
+    )
 
     val currentVersion = txn.txnVersion(queryId)
     if (currentVersion >= batchId) {

--- a/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceUtils.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceUtils.scala
@@ -18,7 +18,9 @@ package org.apache.spark.sql.delta.sources
 
 import java.util.Locale
 
+import io.delta.hive.DeltaStorageHandler
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.sources
@@ -40,6 +42,15 @@ object DeltaSourceUtils {
   def isDeltaTable(provider: Option[String]): Boolean = {
     provider.exists(isDeltaDataSourceName)
   }
+
+  def isDeltaTable(table: CatalogTable): Boolean = {
+    table.provider.exists(isDeltaDataSourceName) ||
+      (table.provider.exists(name => name.toLowerCase(Locale.ROOT) == "hive") &&
+        table.properties.get("storage_handler")
+          .exists(p => classOf[DeltaStorageHandler].getCanonicalName.equals(p))
+        )
+  }
+
 
   /** Creates Spark literals from a value exposed by the public Spark API. */
   private def createLiteral(value: Any): expressions.Literal = value match {

--- a/src/test/scala/org/apache/spark/sql/delta/HiveDeltaCatalogDDLSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/HiveDeltaCatalogDDLSuite.scala
@@ -1,0 +1,393 @@
+/*
+ * Copyright (2020) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
+import org.apache.spark.sql.delta.DeltaConfigs.CHECKPOINT_INTERVAL
+import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+import org.apache.spark.sql.delta.test.HiveDeltaSQLCommandTest
+import org.apache.spark.sql.test.{SQLTestUtils, SharedSparkSession}
+import org.apache.spark.sql.types.{ArrayType, DoubleType, IntegerType, LongType, MapType, StringType, StructField, StructType}
+
+class HiveDeltaCatalogDDLSuite  extends QueryTest with SharedSparkSession
+            with SQLTestUtils with HiveDeltaSQLCommandTest with DeltaAlterTableTestBase {
+
+    override protected def createTable(schema: String,
+                                       tblProperties: Map[String, String]): String = {
+        val props = tblProperties.map { case (key, value) =>
+            s"'$key' = '$value'"
+        }.mkString(", ")
+        val propsString = if (tblProperties.isEmpty) "" else s" TBLPROPERTIES ($props)"
+        sql(s"CREATE TABLE delta_test ($schema) USING delta$propsString")
+        "delta_test"
+    }
+
+    override protected def createTable(df: DataFrame, partitionedBy: Seq[String]): String = {
+        df.write.partitionBy(partitionedBy: _*).format("delta").saveAsTable("delta_test")
+        "delta_test"
+    }
+
+    override protected def dropTable(identifier: String): Unit = {
+        sql(s"DROP TABLE IF EXISTS $identifier")
+    }
+
+    override protected def getDeltaLog(identifier: String): DeltaLog = {
+        DeltaLog.forTable(spark, TableIdentifier(identifier))
+    }
+
+    import testImplicits._
+
+    private def getDeltaLog(table: CatalogTable): DeltaLog = {
+        getDeltaLog(new Path(table.storage.locationUri.get))
+    }
+
+    protected def getDeltaLog(path: Path): DeltaLog = {
+        DeltaLog.forTable(spark, path)
+    }
+
+    test("Create hive delta table") {
+        withTempDir { tempDir =>
+            withTable("delta_test") {
+                val catalog = spark.sessionState.catalog
+                sql("CREATE TABLE delta_test(a LONG, b String) USING delta " +
+                  s"OPTIONS (path='${tempDir.getCanonicalPath}')")
+                val table = catalog.getTableMetadata(TableIdentifier("delta_test"))
+                assert(table.tableType == CatalogTableType.EXTERNAL)
+                assert(table.provider.contains("hive"))
+                assert(table.properties("storage_handler") === "io.delta.hive.DeltaStorageHandler")
+
+                // Query the data and the metadata directly via the DeltaLog
+                val deltaLog = getDeltaLog(table)
+
+                assert(deltaLog.snapshot.schema == new StructType()
+                  .add("a", "long")
+                  .add("b", "string")
+                )
+                assert(deltaLog.snapshot.metadata.partitionColumns.isEmpty)
+
+                val externalTable = catalog.externalCatalog.getTable("default", "delta_test")
+                assert(externalTable.schema == deltaLog.snapshot.schema)
+                assert(externalTable.partitionColumnNames.isEmpty)
+
+                sql("INSERT INTO delta_test SELECT 1, 'a'")
+                checkAnswer(
+                    sql("SELECT * FROM delta_test"),
+                    Seq(Row(1L, "a")))
+            }
+        }
+    }
+
+    test("Create hive delta table with partionning") {
+        withTempDir { tempDir =>
+            withTable("delta_test") {
+                sql("CREATE TABLE delta_test(a LONG, b String) USING delta PARTITIONED BY (a)" +
+                  s"OPTIONS (path='${tempDir.getCanonicalPath}')")
+                val catalog = spark.sessionState.catalog
+                val table = catalog.getTableMetadata(TableIdentifier("delta_test"))
+                assert(table.tableType == CatalogTableType.EXTERNAL)
+                assert(table.provider.contains("hive"))
+                assert(table.properties("storage_handler") === "io.delta.hive.DeltaStorageHandler")
+
+                // Query the data and the metadata directly via the DeltaLog
+                val deltaLog = getDeltaLog(table)
+
+                assert(deltaLog.snapshot.schema == new StructType()
+                  .add("a", "long")
+                  .add("b", "string")
+                )
+                assert(deltaLog.snapshot.metadata.partitionSchema ==
+                  new StructType().add("a", "long"))
+
+                val externalTable = catalog.externalCatalog.getTable("default", "delta_test")
+                assert(externalTable.schema == deltaLog.snapshot.schema)
+                assert(externalTable.partitionColumnNames.isEmpty)
+
+                sql("INSERT INTO delta_test SELECT 1, 'a'")
+                checkAnswer(
+                    sql("SELECT * FROM delta_test"),
+                    Seq(Row(1L, "a")))
+            }
+        }
+    }
+
+    test("Create hive delta table with using location") {
+        withTempDir { dir =>
+            withTable("delta_test") {
+                val path = dir.getCanonicalPath()
+
+                val df = Seq(
+                    (1, "IT", "Alice"),
+                    (2, "CS", "Bob"),
+                    (3, "IT", "Carol")).toDF("id", "dept", "name")
+                df.write.format("delta").partitionBy("name", "dept").save(path)
+
+                sql(s"CREATE TABLE delta_test USING delta LOCATION '$path'")
+                val catalog = spark.sessionState.catalog
+                val table = catalog.getTableMetadata(TableIdentifier("delta_test"))
+                assert(table.tableType == CatalogTableType.EXTERNAL)
+                assert(table.provider.contains("hive"))
+                assert(table.properties("storage_handler") === "io.delta.hive.DeltaStorageHandler")
+
+                val deltaLog = getDeltaLog(table)
+
+                assert(deltaLog.snapshot.schema == new StructType()
+                  .add("id", "int")
+                  .add("dept", "string")
+                  .add("name", "string")
+                )
+                assert(deltaLog.snapshot.metadata.partitionSchema == new StructType()
+                  .add("name", "string")
+                  .add("dept", "string")
+                )
+
+                val externalTable = catalog.externalCatalog.getTable("default", "delta_test")
+                assert(externalTable.schema == deltaLog.snapshot.schema)
+                assert(externalTable.partitionColumnNames.isEmpty)
+            }
+        }
+    }
+
+    test("Create hive delta table with usins save as table") {
+        withTempDir { dir =>
+            withTable("delta_test") {
+                val df = Seq(
+                    (1, "IT", "Alice"),
+                    (2, "CS", "Bob"),
+                    (3, "IT", "Carol")).toDF("id", "dept", "name")
+                df.write.format("delta").partitionBy("name", "dept").saveAsTable("delta_test")
+                val catalog = spark.sessionState.catalog
+                val table = catalog.getTableMetadata(TableIdentifier("delta_test"))
+                assert(table.tableType == CatalogTableType.MANAGED)
+                assert(table.provider.contains("hive"))
+                assert(table.properties("storage_handler") === "io.delta.hive.DeltaStorageHandler")
+
+                val deltaLog = getDeltaLog(table)
+
+                assert(deltaLog.snapshot.schema == new StructType()
+                  .add("id", "int")
+                  .add("dept", "string")
+                  .add("name", "string")
+                )
+                assert(deltaLog.snapshot.metadata.partitionSchema == new StructType()
+                  .add("name", "string")
+                  .add("dept", "string")
+                )
+
+                val externalTable = catalog.externalCatalog.getTable("default", "delta_test")
+                assert(externalTable.schema == deltaLog.snapshot.schema)
+                assert(externalTable.partitionColumnNames.isEmpty)
+            }
+        }
+    }
+
+    ddlTest("Alter table add column") {
+        withDeltaTable(Seq((1, "a"), (2, "b")).toDF("v1", "v2")) { tableName =>
+
+            sql("ALTER TABLE delta_test add column (v3 long)")
+
+            val deltaLog = getDeltaLog(tableName)
+            assert(deltaLog.snapshot.schema == new StructType()
+              .add("v1", "integer").add("v2", "string").add("v3", "long"))
+
+            val catalog = spark.sessionState.catalog
+            val externalAlterTable = catalog.externalCatalog.getTable("default", tableName)
+            assert(externalAlterTable.schema == deltaLog.snapshot.schema)
+        }
+    }
+
+    ddlTest("CHANGE COLUMN - add a comment") {
+        withDeltaTable(Seq((1, "a"), (2, "b")).toDF("v1", "v2")) { tableName =>
+
+            sql(s"ALTER TABLE $tableName CHANGE COLUMN v1 v1 integer COMMENT 'a comment'")
+
+            val deltaLog = getDeltaLog(tableName)
+            assert(deltaLog.snapshot.schema == new StructType()
+              .add("v1", "integer", true, "a comment").add("v2", "string"))
+
+            val catalog = spark.sessionState.catalog
+            val externalAlterTable = catalog.externalCatalog.getTable("default", tableName)
+            assert(externalAlterTable.schema == deltaLog.snapshot.schema)
+        }
+    }
+
+    test("CHANGE COLUMN - move to first") {
+        val df = Seq((1, "a", true), (2, "b", false)).toDF("v1", "v2", "v3")
+        withDeltaTable(df, Seq("v2", "v3")) { tableName =>
+
+            sql(s"ALTER TABLE $tableName CHANGE COLUMN v3 v3 boolean FIRST")
+
+            val deltaLog = getDeltaLog(tableName)
+            assert(deltaLog.snapshot.schema == new StructType()
+              .add("v3", "boolean").add("v1", "integer").add("v2", "string"))
+
+            checkDatasetUnorderly(
+                spark.table(tableName).as[(Boolean, Int, String)],
+                (true, 1, "a"), (false, 2, "b"))
+
+            val catalog = spark.sessionState.catalog
+            val externalAlterTable = catalog.externalCatalog.getTable("default", tableName)
+            assert(externalAlterTable.schema == deltaLog.snapshot.schema)
+        }
+    }
+
+    ddlTest("Merge schema by dataframe") {
+        withDeltaTable(Seq((1, "a"), (2, "b")).toDF("v1", "v2")) { tableName =>
+            val catalog = spark.sessionState.catalog
+            val data = List(
+                Row(1, "aa", Seq(11.0, 12.0), Map("k1" -> 11, "k12" -> 12), Row(13, "v11"))
+            )
+            val schema: StructType = StructType(
+                  StructField(name = "v1", IntegerType, nullable = true) ::
+                  StructField(name = "v2", StringType, nullable = true) ::
+                  StructField(name = "array", ArrayType(DoubleType, containsNull = true),
+                      nullable = true) ::
+                  StructField(name = "map", MapType(StringType, IntegerType,
+                      valueContainsNull = true), nullable = true) ::
+                  StructField(name = "struct", StructType(
+                        StructField(name = "int", IntegerType, nullable = true) ::
+                        StructField(name = "string", StringType, nullable = true) :: Nil
+                  ), nullable = true
+                  ) :: Nil
+            )
+
+            spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+              .write.format("delta").option("mergeSchema", "true").mode("append")
+              .saveAsTable(tableName)
+
+            assert(getDeltaLog(tableName).snapshot.schema == schema)
+
+            assert(catalog.externalCatalog.getTable("default", tableName).schema == schema)
+
+            val schema2: StructType = StructType(
+                  StructField(name = "v1", IntegerType, nullable = true) ::
+                  StructField(name = "v2", StringType, nullable = true) ::
+                  StructField(name = "array", ArrayType(DoubleType, containsNull = true),
+                      nullable = true) ::
+                  StructField(name = "map", MapType(StringType, IntegerType,
+                      valueContainsNull = true), nullable = true) ::
+                  StructField(name = "struct", StructType(
+                        StructField(name = "int", IntegerType, nullable = true) ::
+                        StructField(name = "string", StringType, nullable = true) ::
+                        StructField(name = "long", LongType, nullable = true) :: Nil
+                  ), nullable = true
+                  ) :: Nil
+            )
+            val data2 = List(
+                Row(1, "aa", Seq(11.0, 12.0), Map("k1" -> 11, "k12" -> 12), Row(13, "v11", 2L))
+            )
+
+            spark.createDataFrame(spark.sparkContext.parallelize(data2), schema2)
+              .write.format("delta").option("mergeSchema", "true").mode("append")
+              .saveAsTable(tableName)
+            assert(getDeltaLog(tableName).snapshot.schema == schema2)
+
+            assert(catalog.externalCatalog.getTable("default", tableName).schema == schema2)
+        }
+    }
+
+    ddlTest("Merge schema with merge by sql") {
+        withDeltaTable(Seq((1, "a"), (2, "b")).toDF("v1", "v2")) { tableName =>
+            sql("SET spark.databricks.delta.schema.autoMerge.enabled = true")
+            Seq((3, "a", 1.0)).toDF("v1", "v2", "v3").createOrReplaceTempView("updateTable")
+            sql(
+                s"""MERGE INTO $tableName as s USING updateTable as u on s.v1 = u.v1
+                   | WHEN NOT MATCHED THEN INSERT *
+                   |""".stripMargin
+            )
+
+
+            val deltaLog = getDeltaLog(tableName)
+            assert(deltaLog.snapshot.schema == new StructType()
+              .add("v1", "integer")
+              .add("v2", "string")
+              .add("v3", "double")
+            )
+
+            val catalog = spark.sessionState.catalog
+            val externalAlterTable = catalog.externalCatalog.getTable("default", tableName)
+            assert(externalAlterTable.schema == deltaLog.snapshot.schema)
+        }
+    }
+
+    ddlTest("Merge schema with merge by dataframe") {
+        withDeltaTable(Seq((1, "a"), (2, "b")).toDF("v1", "v2")) { tableName =>
+            sql("SET spark.databricks.delta.schema.autoMerge.enabled = true")
+            io.delta.tables.DeltaTable.forName(tableName).as("s").merge(
+                Seq((3, "a", 1.0)).toDF("v1", "v2", "v3").as("u"),
+                "s.v1 = u.v1"
+            ).whenNotMatched().insertAll().execute()
+
+
+            val deltaLog = getDeltaLog(tableName)
+            assert(deltaLog.snapshot.schema == new StructType()
+              .add("v1", "integer")
+              .add("v2", "string")
+              .add("v3", "double")
+            )
+
+            val catalog = spark.sessionState.catalog
+            val externalAlterTable = catalog.externalCatalog.getTable("default", tableName)
+            assert(externalAlterTable.schema == deltaLog.snapshot.schema)
+        }
+    }
+
+    ddlTest("SET/UNSET TBLPROPERTIES - simple") {
+        withDeltaTable("v1 int, v2 string") { tableName =>
+
+            sql(s"""
+                   |ALTER TABLE $tableName
+                   |SET TBLPROPERTIES (
+                   |  'delta.logRetentionDuration' = '2 weeks',
+                   |  'delta.checkpointInterval' = '20',
+                   |  'key' = 'value'
+                   |)""".stripMargin)
+
+            val deltaLog = getDeltaLog(tableName)
+            val snapshot1 = deltaLog.update()
+            assert(snapshot1.metadata.configuration == Map(
+                "storage_handler" -> "io.delta.hive.DeltaStorageHandler",
+                "delta.logRetentionDuration" -> "2 weeks",
+                "delta.checkpointInterval" -> "20",
+                "key" -> "value"))
+            assert(deltaLog.deltaRetentionMillis == 2 * 7 * 24 * 60 * 60 * 1000)
+            assert(deltaLog.checkpointInterval == 20)
+
+            val catalog = spark.sessionState.catalog
+            val table = catalog.getTableMetadata(TableIdentifier("delta_test"))
+            assert(table.tableType == CatalogTableType.MANAGED)
+            assert(table.provider.contains("hive"))
+            assert(table.properties === snapshot1.metadata.configuration)
+
+            sql(s"ALTER TABLE $tableName UNSET TBLPROPERTIES ('delta.checkpointInterval', 'key')")
+
+            val snapshot2 = deltaLog.update()
+            assert(snapshot2.metadata.configuration == Map(
+                "storage_handler" -> "io.delta.hive.DeltaStorageHandler",
+                "delta.logRetentionDuration" -> "2 weeks"))
+            assert(deltaLog.deltaRetentionMillis == 2 * 7 * 24 * 60 * 60 * 1000)
+            assert(deltaLog.checkpointInterval ==
+              CHECKPOINT_INTERVAL.fromString(CHECKPOINT_INTERVAL.defaultValue))
+            val tableUnset = catalog.getTableMetadata(TableIdentifier("delta_test"))
+            assert(tableUnset.tableType == CatalogTableType.MANAGED)
+            assert(tableUnset.provider.contains("hive"))
+            assert(tableUnset.properties === snapshot2.metadata.configuration)
+        }
+    }
+
+}

--- a/src/test/scala/org/apache/spark/sql/delta/test/DeltaCatalogHiveTest.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/test/DeltaCatalogHiveTest.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (2020) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.test
+
+import org.apache.spark.sql.delta.catalog.DeltaCatalog
+import io.delta.sql.DeltaSparkSessionExtension
+import org.scalatest.BeforeAndAfterAll
+
+import org.apache.spark.{SparkContext, SparkFunSuite}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.hive.test.{TestHive, TestHiveContext}
+import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
+import org.apache.spark.sql.test.SQLTestUtils
+
+/**
+ * Test utility for initializing a SparkSession with a Hive Client and a Hive Catalog for testing
+ * DDL operations. Typical tests leverage an in-memory catalog with a mock catalog client. Here we
+ * use real Hive classes.
+ */
+trait DeltaCatalogHiveTest extends SparkFunSuite with BeforeAndAfterAll { self: SQLTestUtils =>
+
+  private var _session: SparkSession = _
+  private var _hiveContext: TestHiveContext = _
+  private var _sc: SparkContext = _
+
+  override def beforeAll(): Unit = {
+    val conf = TestHive.sparkSession.sparkContext.getConf.clone()
+    TestHive.sparkSession.stop()
+    conf.set(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key, classOf[DeltaCatalog].getName)
+    conf.set(StaticSQLConf.SPARK_SESSION_EXTENSIONS.key,
+      classOf[DeltaSparkSessionExtension].getName)
+    _sc = new SparkContext("local", this.getClass.getName, conf)
+    _hiveContext = new TestHiveContext(_sc)
+    _session = _hiveContext.sparkSession
+    SparkSession.setActiveSession(_session)
+    super.beforeAll()
+  }
+
+  override protected def spark: SparkSession = _session
+
+  override def afterAll(): Unit = {
+    try {
+      _hiveContext.reset()
+    } finally {
+      _sc.stop()
+    }
+  }
+}

--- a/src/test/scala/org/apache/spark/sql/delta/test/HiveDeltaCatalogHiveTest.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/test/HiveDeltaCatalogHiveTest.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright (2020) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.test
+
+import io.delta.sql.DeltaSparkSessionExtension
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.delta.catalog.HiveDeltaCatalog
+import org.apache.spark.sql.hive.test.{TestHive, TestHiveContext}
+import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
+import org.apache.spark.sql.test.SQLTestUtils
+import org.apache.spark.{SparkContext, SparkFunSuite}
+import org.scalatest.BeforeAndAfterAll
+
+/**
+ * Test utility for initializing a SparkSession with a Hive Client and a Hive Catalog for testing
+ * DDL operations. Typical tests leverage an in-memory catalog with a mock catalog client. Here we
+ * use real Hive classes.
+ */
+trait HiveDeltaCatalogHiveTest extends SparkFunSuite with BeforeAndAfterAll { self: SQLTestUtils =>
+
+  private var _session: SparkSession = _
+  private var _hiveContext: TestHiveContext = _
+  private var _sc: SparkContext = _
+
+  override def beforeAll(): Unit = {
+    val conf = TestHive.sparkSession.sparkContext.getConf.clone()
+    TestHive.sparkSession.stop()
+    conf.set(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key, classOf[HiveDeltaCatalog].getName)
+    conf.set(StaticSQLConf.SPARK_SESSION_EXTENSIONS.key,
+      classOf[DeltaSparkSessionExtension].getName)
+    _sc = new SparkContext("local", this.getClass.getName, conf)
+    _hiveContext = new TestHiveContext(_sc)
+    _session = _hiveContext.sparkSession
+    SparkSession.setActiveSession(_session)
+    super.beforeAll()
+  }
+
+  override protected def spark: SparkSession = _session
+
+  override def afterAll(): Unit = {
+    try {
+      _hiveContext.reset()
+    } finally {
+      _sc.stop()
+    }
+  }
+}

--- a/src/test/scala/org/apache/spark/sql/delta/test/HiveDeltaSQLCommandTest.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/test/HiveDeltaSQLCommandTest.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright (2020) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.test
+
+import org.apache.spark.sql.delta.catalog.HiveDeltaCatalog
+import io.delta.sql.DeltaSparkSessionExtension
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.{SparkSession, SparkSessionExtensions}
+import org.apache.spark.sql.test.{SharedSparkSession, TestSparkSession}
+
+/**
+ * Because `TestSparkSession` doesn't pick up the conf `spark.sql.extensions` in Spark 2.4.x, we use
+ * this class to inject Delta's extension in our tests.
+ *
+ * @see https://issues.apache.org/jira/browse/SPARK-25003
+ */
+class HiveDeltaTestSparkSession(sparkConf: SparkConf) extends TestSparkSession(sparkConf) {
+  override val extensions: SparkSessionExtensions = {
+    val extensions = new SparkSessionExtensions
+    new DeltaSparkSessionExtension().apply(extensions)
+    extensions
+  }
+}
+
+/**
+ * A trait for tests that are testing a fully set up SparkSession with all of Delta's requirements,
+ * such as the configuration of the DeltaCatalog and the addition of all Delta extensions.
+ */
+trait HiveDeltaSQLCommandTest { self: SharedSparkSession =>
+
+  override protected def createSparkSession: TestSparkSession = {
+    SparkSession.cleanupAnyExistingSession()
+    val session = new HiveDeltaTestSparkSession(sparkConf)
+    session.conf.set(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key,
+      classOf[HiveDeltaCatalog].getName)
+    session
+  }
+}


### PR DESCRIPTION
Currently Delta catalog create a table in HiveMetastore but delta-io connectors cannot use it because it's not hive compatible.
 
The hive delta catalog create a delta table compatible with Spark SQL and Hive Tez