### PR TITLE
UPDATE SET clause should support correlated scalar subquery

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
@@ -25,7 +25,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.sql.{Column, Dataset, Row, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.{Alias, Expression, If, Literal}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, SupportsSubquery}
 import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
@@ -47,7 +47,7 @@ case class UpdateCommand(
     target: LogicalPlan,
     updateExpressions: Seq[Expression],
     condition: Option[Expression])
-  extends RunnableCommand with DeltaCommand {
+  extends RunnableCommand with DeltaCommand with SupportsSubquery {
 
   override def innerChildren: Seq[QueryPlan[_]] = Seq(target)
 


### PR DESCRIPTION
Current Delta support non-correlated scalar subquery in the UPDATE SET clause.
```sql
UPDATE target as t
SET t.value = (SELECT max(s.value) FROM source s)
```
This PR makes it to support correlated scalar subquery:
```sql
UPDATE target as t
SET t.value =
 (
   SELECT sum(s.value)
   FROM source s WHERE s.key1 = t.key2
 )
```
Without the PR, it will throw
```
Correlated scalar sub-queries can only be used in a Filter/Aggregate/Project and a few commands
```