### PR TITLE
TestSparkSession in JavaDeltaTableSuite cannot be accessed

### DIFF
--- a/src/test/java/org/apache/spark/sql/delta/JavaDeltaTableSuite.java
+++ b/src/test/java/org/apache/spark/sql/delta/JavaDeltaTableSuite.java
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package io.delta.tables;
+package org.apache.spark.sql.delta;
 
 import java.util.Arrays;
 import java.util.List;
 
+import io.delta.tables.DeltaTable;
 import org.apache.spark.sql.test.*;
 import org.apache.spark.sql.*;
 


### PR DESCRIPTION
When we package the test-jar (for example, adding `publishArtifact in Test := true` to `build.sbt`), we get the error
```
[error] /Users/lajin/git/my/delta/src/test/java/io/delta/tables/JavaDeltaTableSuite.java:33: class TestSparkSession in package test cannot be accessed
[error]   private transient TestSparkSession spark;
[error]
```

So thie PR is to move `JavaDeltaTableSuite.java` to the right folder.