### PR TITLE
Delta README updates

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -129,10 +129,10 @@ Checkpoints for a given version must only be created after the associated delta 
 ### Last Checkpoint File
 The Delta transaction log will often contain many (e.g. 10,000+) files.
 Listing such a large directory can be prohibitively expensive.
-The last checkpoint file can help reduce the cost of constructing the lastest snapshot of the table by providing a pointer to near the end of the log.
+The last checkpoint file can help reduce the cost of constructing the latest snapshot of the table by providing a pointer to near the end of the log.
 
 Rather than list the entire directory, readers can locate a recent checkpoint by looking at the `_delta_log/_last_checkpoint` file.
-Due to the zero-padded encoding of the files in the log, the version id of this recent checkpoint can be used on storage systems that support lexigraphically-sorted, paginated directory listing to enumerate any delta files or newer checkpoints that comprise more recent versions of the table.
+Due to the zero-padded encoding of the files in the log, the version id of this recent checkpoint can be used on storage systems that support lexicographically-sorted, paginated directory listing to enumerate any delta files or newer checkpoints that comprise more recent versions of the table.
 
 This last checkpoint file is encoded as JSON and contains the following information:
 
@@ -367,7 +367,7 @@ This section documents additional requirements that writers must follow in order
  - Columns present in the schema of the table MAY be missing from data files. Readers SHOULD fill these missing columns in with `null`.
 
 ## Delta Log Entries
-- A single log entry MUST NOT include more than one action that reconcile with each other.
+- A single log entry MUST NOT include more than one action that reconciles with each other.
   - Add / Remove actions with the same `path`
   - More than one Metadata action
   - More than one protocol action
@@ -445,7 +445,7 @@ Name | Description
 -|-
 numRecords | The number of records in this file.
 
-Per-column statistics record information for each column in the file and they are encoded mirroring the schema of the actual data.
+Per-column statistics record information for each column in the file and they are encoded, mirroring the schema of the actual data.
 For example, given the following data schema:
 ```
 |-- a: struct
@@ -527,7 +527,7 @@ Field Name | Description
 name| Name of this (possibly nested) column
 type| String containing the name of a primitive type, a struct definition, an array definition or a map definition
 nullable| Boolean denoting whether this field can be null
-metadata| A JSON map containing information about this column. Keys prefixed with `Delta` are reserved for the implementation. See [TODO](#) for more information on column level metadata that must clients must handle when writing to a table.
+metadata| A JSON map containing information about this column. Keys prefixed with `Delta` are reserved for the implementation. See [TODO](#) for more information on column level metadata that clients must handle when writing to a table.
 
 ### Array Type
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Starting from 0.7.0, Delta Lake is only available with Scala version 2.12.
 <dependency>
   <groupId>io.delta</groupId>
   <artifactId>delta-core_2.12</artifactId>
-  <version>0.7.0</version>
+  <version>0.8.0</version>
 </dependency>
 ```
 
@@ -27,7 +27,7 @@ Starting from 0.7.0, Delta Lake is only available with Scala version 2.12.
 You include Delta Lake in your SBT project by adding the following line to your build.sbt file:
 
 ```scala
-libraryDependencies += "io.delta" %% "delta-core" % "0.7.0"
+libraryDependencies += "io.delta" %% "delta-core" % "0.8.0"
 ```
 
 ## API Documentation
@@ -50,7 +50,7 @@ All other interfaces in this library are considered internal, and they are subje
 
 ### Data Storage Compatibility
 
-Delta Lake guarantees backward compatibility for all Delta Lake tables (i.e., newer versions of Delta Lake will always be able to read tables written by older versions of Delta Lake). However, we reserve the right to break forwards compatibility as new features are introduced to the transaction protocol (i.e., an older version of Delta Lake may not be able to read a table produced by a newer version).
+Delta Lake guarantees backward compatibility for all Delta Lake tables (i.e., newer versions of Delta Lake will always be able to read tables written by older versions of Delta Lake). However, we reserve the right to break forward compatibility as new features are introduced to the transaction protocol (i.e., an older version of Delta Lake may not be able to read a table produced by a newer version).
 
 Breaking changes in the protocol are indicated by incrementing the minimum reader/writer version in the `Protocol` [action](https://github.com/delta-io/delta/blob/master/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala).
 


### PR DESCRIPTION
- fix grammar
- use 0.8.0 as the latest version in README