### PR TITLE
add dryRun in log cleanup

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -114,8 +114,8 @@ trait Checkpoints extends DeltaLogging {
   protected def store: LogStore
   protected def metadata: Metadata
 
-  /** Used to clean up stale log files. */
-  protected def doLogCleanup(): Unit
+  /** Used to clean up stale log files. Files are listed and not removed if dryRun is true */
+  protected def doLogCleanup(dryRun: Boolean = false): DataFrame
 
   /** The path to the file that holds metadata about the most recent checkpoint. */
   val LAST_CHECKPOINT = new Path(logPath, "_last_checkpoint")


### PR DESCRIPTION
# Problem Statement
We can run vacuum() command in a dryRun mode on data in delta tables. We cannot do the same with logs. It can be useful to know which logs are gonna be deleted. For example, you can ask for logs to be deleted and can move them to another storage/cloud to bring them back if needed.

# Proposed Solution
Add dryRun mode on logs

### Technical Notes
I just changed the `Checkpoints.doLogCleanp(): Unit` method signature into `Checkpoints.doLogCleanp(dryRun: Boolean): DataFrame` exactly [how the vacuum command does](https://github.com/delta-io/delta/blob/4277443703c5ab59a567c1e80189bbcdb7495817/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala#L93).

The default value for dryRun is false to be compatible with all the existing implementations.

### Related Issues:
Closes: #504 

Signed-off-by: Giuseppe Lorusso giuseppelorusso92@gmail.com