### PR TITLE
[MINOR] Make end boundary of history optional (undefined)

### DIFF
--- a/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -155,7 +155,7 @@ class DeltaTable private[tables](
    */
   @Evolving
   def history(): DataFrame = {
-    executeHistory(deltaLog, None, table.getTableIdentifierIfExists)
+    executeHistory(deltaLog, tableId = table.getTableIdentifierIfExists)
   }
 
   /**

--- a/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
+++ b/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
@@ -41,9 +41,9 @@ trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
 
   protected def executeHistory(
       deltaLog: DeltaLog,
-      limit: Option[Int],
+      limit: Option[Int] = None,
       tableId: Option[TableIdentifier] = None): DataFrame = {
-    val history = new DeltaHistoryManager(deltaLog)
+    val history = deltaLog.history
     val spark = self.toDF.sparkSession
     spark.createDataFrame(history.getHistory(limit))
   }

--- a/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
@@ -63,14 +63,14 @@ class DeltaHistoryManager(
     val listStart = limitOpt.map { limit =>
       math.max(deltaLog.update().version - limit + 1, 0)
     }.getOrElse(getEarliestDeltaFile)
-    getHistory(listStart, None)
+    getHistory(listStart)
   }
 
   /**
    * Get the commit information of the Delta table from commit `[start, end)`. If `end` is `None`,
    * we return all commits from start to now.
    */
-  def getHistory(start: Long, end: Option[Long]): Seq[CommitInfo] = {
+  def getHistory(start: Long, end: Option[Long] = None): Seq[CommitInfo] = {
     val _spark = spark
     import _spark.implicits._
     val conf = getSerializableHadoopConf


### PR DESCRIPTION
Since `None` is used for the end boundary of a delta table history it could also easily be "transferred" up the call chain and be the default input value. That's the purpose of the PR.

Signed-off-by: Jacek Laskowski <jacek@japila.pl>