### PR TITLE
Add null check to avoid NPE when Exception message is null while merging.

### DIFF
--- a/src/main/scala/org/apache/spark/sql/delta/util/AnalysisHelper.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/util/AnalysisHelper.scala
@@ -79,7 +79,9 @@ trait AnalysisHelper {
     ).map(_.toLowerCase())
 
     def isExtensionOrCatalogError(error: Exception): Boolean = {
-      possibleErrorMsgs.exists(m => error.getMessage().toLowerCase().contains(m))
+      possibleErrorMsgs.exists(m => {
+        error.getMessage != null && error.getMessage.toLowerCase().contains(m)
+      })
     }
 
     try { f } catch {

--- a/src/main/scala/org/apache/spark/sql/delta/util/AnalysisHelper.scala
+++ b/src/main/scala/org/apache/spark/sql/delta/util/AnalysisHelper.scala
@@ -79,9 +79,9 @@ trait AnalysisHelper {
     ).map(_.toLowerCase())
 
     def isExtensionOrCatalogError(error: Exception): Boolean = {
-      possibleErrorMsgs.exists(m => {
+      possibleErrorMsgs.exists { m =>
         error.getMessage != null && error.getMessage.toLowerCase().contains(m)
-      })
+      }
     }
 
     try { f } catch {

--- a/src/test/scala/org/apache/spark/sql/delta/util/AnalysisHelperSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/util/AnalysisHelperSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta.util
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.test.SharedSparkSession
 
-class AnalysisHelperTest extends QueryTest with SharedSparkSession {
+class AnalysisHelperSuite extends QueryTest with SharedSparkSession {
 
   test("should not throw NullPointerException when Exception has null description") {
 

--- a/src/test/scala/org/apache/spark/sql/delta/util/AnalysisHelperSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/util/AnalysisHelperSuite.scala
@@ -22,7 +22,6 @@ import org.apache.spark.sql.test.SharedSparkSession
 class AnalysisHelperSuite extends QueryTest with SharedSparkSession {
 
   test("should not throw NullPointerException when Exception has null description") {
-
     class FakeAnalysisHelper extends AnalysisHelper {
       def throwInterruptedException(): Unit = super.improveUnsupportedOpError {
         throw new InterruptedException()

--- a/src/test/scala/org/apache/spark/sql/delta/util/AnalysisHelperTest.scala
+++ b/src/test/scala/org/apache/spark/sql/delta/util/AnalysisHelperTest.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (2020) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.util
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+class AnalysisHelperTest extends QueryTest with SharedSparkSession {
+
+  test("should not throw NullPointerException when Exception has null description") {
+
+    class FakeAnalysisHelper extends AnalysisHelper {
+      def throwInterruptedException(): Unit = super.improveUnsupportedOpError {
+        throw new InterruptedException()
+      }
+    }
+
+    // Should throw original exception
+    assertThrows[InterruptedException] {
+      new FakeAnalysisHelper {}.throwInterruptedException()
+    }
+  }
+}


### PR DESCRIPTION
Hi,

When we interrupt a stream that updates a Delta table using _merge_ mode, the JVM runtime throws a plain `InterruptedException` with no description and the `AnalysisHelper` expects that all exceptions have a message and this causes a `NullPointerException` on such cases. This PR adds a null check to avoid that. Also added a unit test for this scenario.

Thank you,
Bruno