### PR TITLE
Use isSameLogAs instead of comparing directly composite ids of two deltaLogs

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/files/TahoeFileIndex.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/files/TahoeFileIndex.scala
@@ -175,7 +175,7 @@ case class TahoeLogFileIndex(
 
   override def equals(that: Any): Boolean = that match {
     case t: TahoeLogFileIndex =>
-      t.path == path && t.deltaLog.compositeId == deltaLog.compositeId &&
+      t.path == path && t.deltaLog.isSameLogAs(deltaLog) &&
         t.versionToUse == versionToUse && t.partitionFilters == partitionFilters
     case _ => false
   }
@@ -255,7 +255,7 @@ case class PinnedTahoeFileIndex(
 
   override def equals(that: Any): Boolean = that match {
     case t: PinnedTahoeFileIndex =>
-      t.path == path && t.deltaLog.compositeId == deltaLog.compositeId &&
+      t.path == path && t.deltaLog.isSameLogAs(deltaLog) &&
         t.snapshot.version == snapshot.version
     case _ => false
   }


### PR DESCRIPTION
The main goal of this Pull Request is to use the ```isSameLogAs```function when possible.