### PR TITLE
 Make sure that writeOptions is used when passed to the writeFiles function

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -154,7 +154,7 @@ trait DeltaReadOptions extends DeltaOptionParser {
  */
 class DeltaOptions(
     @transient protected[delta] val options: CaseInsensitiveMap[String],
-    @transient protected val sqlConf: SQLConf)
+    @transient protected[delta] val sqlConf: SQLConf)
   extends DeltaWriteOptions with DeltaReadOptions with Serializable {
 
   DeltaOptions.verifyOptions(options)

--- a/core/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.delta.files
 
 import scala.collection.mutable.ListBuffer
-
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.constraints.{Constraint, Constraints, DeltaInvariantCheckerExec}
@@ -26,13 +25,13 @@ import org.apache.spark.sql.delta.schema._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.hadoop.fs.Path
-
 import org.apache.spark.SparkException
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.datasources.{BasicWriteJobStatsTracker, FileFormatWriter, WriteJobStatsTracker}
-import org.apache.spark.sql.types.{ArrayType, MapType, StructType}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
 
 /**
@@ -148,7 +147,7 @@ trait TransactionalWrite extends DeltaLogging { self: OptimisticTransactionImpl 
     val outputPath = deltaLog.dataPath
 
     val (options, sparkConf) = writeOptions match {
-      case None => (Map.empty[String, String], null)
+      case None => (Map.empty[String, String], null.asInstanceOf[SQLConf])
       case Some(writeOptions) => (writeOptions.options, writeOptions.sqlConf)
     }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
@@ -146,12 +146,10 @@ trait TransactionalWrite extends DeltaLogging { self: OptimisticTransactionImpl 
     val partitionSchema = metadata.partitionSchema
     val outputPath = deltaLog.dataPath
 
-    val (options, sparkConf) = writeOptions match {
+    val (options, _) = writeOptions match {
       case None => (Map.empty[String, String], null.asInstanceOf[SQLConf])
       case Some(writeOptions) => (writeOptions.options, writeOptions.sqlConf)
     }
-
-    sparkConf.settings.forEach((key, value) => spark.conf.set(key, value))
 
     val (queryExecution, output, generatedColumnConstraints) =
       normalizeData(deltaLog, data, metadata.partitionColumns)


### PR DESCRIPTION
I have realized while digging into the code that we have a function called ```writeFiles``` inside the ```TransactionaWriter``` with an unused parameter ```writeOptions```.
This Pull Request changes the code so it's now possible to pass ```DeltaOptions``` to the ```writeFiles``` function and use its values during the write.
Before these changes, the code never used what we pass as write options.
