### PR TITLE
Create PyPI release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ jobs:
             pipenv --python 3.7 install
             pipenv run pip install pyspark==3.1.1
             pipenv run pip install flake8==3.5.0 pypandoc==1.3.3
+            pipenv run pip install importlib_metadata==3.10.0
       - run:
           name: Run Scala/Java and Python tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,6 @@
-version: 2.1
-
-workflows:
-  test_and_deploy:
-    jobs:
-      - test
-      - deploy:
-          requires:
-            - test
-          filters:
-            tags:
-              only: /^v.*/ # runs only for tags starting with 'v'
-            branches:
-              ignore: /.*/ # doesn't run for branches
-
+version: 2
 jobs:
-  test:
+  build:
     docker:
       - image: circleci/openjdk:8u181-jdk # java 8
     steps:
@@ -37,37 +23,7 @@ jobs:
             pipenv --python 3.7 install
             pipenv run pip install pyspark==3.1.1
             pipenv run pip install flake8==3.5.0 pypandoc==1.3.3
-            pipenv run pip install importlib_metadata==3.10.0
       - run:
           name: Run Scala/Java and Python tests
           command: |
             pipenv run python run-tests.py
-
-  deploy:
-    docker:
-      - image: circleci/python:3.6
-    steps:
-      - checkout
-      - run:
-          name: verify git tag vs. version
-          command: |
-            python3 -m venv venv
-            . venv/bin/activate
-            python setup.py verify
-      - run:
-          name: init .pypirc
-          command: |
-            echo -e "[pypi]" >> ~/.pypirc
-            echo -e "username = <username>" >> ~/.pypirc
-            echo -e "password = $PYPI_PASSWORD" >> ~/.pypirc
-      - run:
-          name: create packages
-          command: |
-            python setup.py sdist
-            python setup.py bdist_wheel
-      - run:
-          name: upload to pypi
-          command: |
-            . venv/bin/activate
-            pip install twine
-            twine upload dist/*

--- a/examples/python/quickstart_maven_install.py
+++ b/examples/python/quickstart_maven_install.py
@@ -1,0 +1,54 @@
+#
+# Copyright (2020) The Delta Lake Project Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyspark.sql import Column, DataFrame, SparkSession, functions
+from delta import *
+import shutil
+
+spark = SparkSession.builder \
+    .appName("get_maven_coord") \
+    .master("local[*]") \
+    .config("spark.jars.packages", get_delta_maven_coordinate()) \
+    .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
+    .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog") \
+    .config("spark.sql.sources.parallelPartitionDiscovery.parallelism", "4") \
+    .getOrCreate()
+
+# Clear previous run's delta-tables
+try:
+    shutil.rmtree("/tmp/delta-table")
+except:
+    pass
+
+# Create a table
+print("########### Create a Parquet table ##############")
+data = spark.range(0, 5)
+data.write.format("parquet").save("/tmp/delta-table")
+
+# Convert to delta
+print("########### Convert to Delta ###########")
+DeltaTable.convertToDelta(spark, "parquet.`/tmp/delta-table`")
+
+# Read the table
+df = spark.read.format("delta").load("/tmp/delta-table")
+df.show()
+
+deltaTable = DeltaTable.forPath(spark, "/tmp/delta-table")
+print("######## Vacuum the table ########")
+deltaTable.vacuum()
+
+# cleanup
+shutil.rmtree("/tmp/delta-table")

--- a/pypi_release.sh
+++ b/pypi_release.sh
@@ -1,0 +1,4 @@
+python3 -m pip install --user --upgrade twine
+
+python setup.py bdist_wheel && python setup.py sdist
+twine upload dist/*

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,14 @@
+#Delta Lake
+Delta Lake is an open source storage layer that brings reliability to data lakes. Delta Lake provides ACID transactions, scalable metadata handling, and unifies streaming and batch data processing. Delta Lake runs on top of your existing data lake and is fully compatible with Apache Spark APIs.
+
+<https://delta.io>
+
+## Online Documentation
+
+You can find the latest Delta Lake documentation on the [project web page](https://docs.delta.io/latest/delta-intro.html)
+
+## Python Packaging
+
+This README file only contains basic information related to pip installed Delta Lake.
+This packaging is currently experimental and may change in future versions (although we will do our best to keep compatibility).
+

--- a/python/README.md
+++ b/python/README.md
@@ -11,9 +11,3 @@ You can find the latest Delta Lake documentation on the [project web page](https
 
 This README file only contains basic information related to pip installed Delta Lake.
 This packaging is currently experimental and may change in future versions (although we will do our best to keep compatibility).
-
-## Python Requirements
-
-Pyspark >= 3.0.0
-
-importlib_metadata >= 3.10.0

--- a/python/README.md
+++ b/python/README.md
@@ -12,3 +12,8 @@ You can find the latest Delta Lake documentation on the [project web page](https
 This README file only contains basic information related to pip installed Delta Lake.
 This packaging is currently experimental and may change in future versions (although we will do our best to keep compatibility).
 
+## Python Requirements
+
+Pyspark >= 3.0.0
+
+importlib_metadata >= 3.10.0

--- a/python/delta/utils.py
+++ b/python/delta/utils.py
@@ -13,8 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import importlib_metadata
 
-from delta.tables import DeltaTable
-from delta.utils import get_delta_maven_coordinate
-
-__all__ = ['DeltaTable', 'get_delta_maven_coordinate']
+def get_delta_maven_coordinate():
+    delta_version = importlib_metadata.version("delta-io")
+    scala_version = "2.12"
+    return f"io.delta:delta-core_{scala_version}:{delta_version}"

--- a/python/delta/utils.py
+++ b/python/delta/utils.py
@@ -15,6 +15,7 @@
 #
 import importlib_metadata
 
+
 def get_delta_maven_coordinate():
     delta_version = importlib_metadata.version("delta-io")
     scala_version = "2.12"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,12 @@ from setuptools import setup
 from setuptools.command.install import install
 
 # delta.io version
-VERSION = "0.5.0"
+def get_version_from_sbt():
+    with open("version.sbt") as fp:
+        version = fp.read().strip()
+    return version.split('"')[1].split("-")[0]
+
+VERSION = get_version_from_sbt()
 
 class VerifyVersionCommand(install):
     """Custom command to verify that the git tag matches our version"""
@@ -22,13 +27,23 @@ class VerifyVersionCommand(install):
             )
             sys.exit(info)
 
+with open("python/README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
 setup(
-    name="delta.io",
+    name="delta-io",
     version=VERSION,
-    description="Python wrapper for Delta Lake",
-    url="https://github.com/delta-io/delta",
-    author="TODO",
-    author_email="TODO",
+    description="Delta Lake Python API",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/delta-io/delta/tree/master",
+    project_urls={
+        'Source': 'https://github.com/delta-io/delta',
+        'Documentation': 'https://docs.delta.io/latest/index.html',
+        'Issues': 'https://github.com/delta-io/delta/issues'
+    },
+    author="Delta Lake Users and Developers",
+    author_email="delta-users@googlegroups.com",
     license="Apache-2.0",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -42,7 +57,7 @@ setup(
     package_dir = {'': 'python'},
     packages=['delta'],
     install_requires=[
-        'pyspark>=2.4.2',
+        'pyspark>=3.0.0',
     ],
     python_requires='>=3',
     cmdclass={

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ with open("python/README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(
-    name="delta-io",
+    name="delta.io",
     version=VERSION,
     description="Delta Lake Python API",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     package_dir = {'': 'python'},
     packages=['delta'],
     install_requires=[
-        'pyspark>=3.0.0',
+        'pyspark>=3.1.0',
         'importlib_metadata>=3.10.0',
     ],
     python_requires='>=3',

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
     packages=['delta'],
     install_requires=[
         'pyspark>=3.0.0',
+        'importlib_metadata>=3.10.0',
     ],
     python_requires='>=3',
     cmdclass={


### PR DESCRIPTION
Related to #282, contains code from #353.

This PR contains two changes:

- Creates a PyPI release
- A Python-only function, `delta.get_delta_maven_coordinate()` that gets the currently installed version, to be used in an IDE when initializing a spark session, like: `.config("spark.jars.packages",  delta.get_delta_maven_coordinate())`. The idea here is to allow the package to be self-referential, avoiding version mismatch problems which can be tough to debug. 

A few items need to be addressed:

- Get a username and password for PyPI. The username will be added in config.yml (<username>), whereas the password will be stored in $PYPI_PASSWORD env variable in circleci.

Other notes:
- This change only targets IDE workflows. Command-line programs like `pyspark` and `spark-submit` will still need to specify the delta.io package on launch, see [quickstart docs](https://docs.delta.io/latest/quick-start.html#pyspark).