### PR TITLE
Support Negative Index Version Numbers

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
@@ -148,11 +148,16 @@ class DeltaHistoryManager(
    * Check whether the given version exists.
    * @param mustBeRecreatable whether the snapshot of this version needs to be recreated.
    */
-  def checkVersionExists(version: Long, mustBeRecreatable: Boolean = true): Unit = {
+  def checkVersionExists(version: Long, mustBeRecreatable: Boolean = true): Long = {
     val earliest = if (mustBeRecreatable) getEarliestReproducibleCommit else getEarliestDeltaFile
     val latest = deltaLog.update().version
-    if (version < earliest || version > latest) {
+
+    // Resolve negative indexes from the latest version.
+    val resolvedVersion = if (version < 0) latest + version else version
+    if (resolvedVersion < earliest || resolvedVersion > latest) {
       throw VersionNotFoundException(version, earliest, latest)
+    } else {
+      resolvedVersion
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -128,11 +128,7 @@ trait DeltaReadOptions extends DeltaOptionParser {
 
   val startingVersion: Option[DeltaStartingVersion] = options.get(STARTING_VERSION_OPTION).map {
     case "latest" => StartingVersionLatest
-    case str =>
-      Try(str.toLong).toOption.filter(_ >= 0).map(StartingVersion).getOrElse{
-        throw DeltaErrors.illegalDeltaOptionException(
-          STARTING_VERSION_OPTION, str, "must be greater than or equal to zero")
-      }
+    case str => Try(str.toLong).toOption.map(StartingVersion).get
   }
 
   val startingTimestamp = options.get(STARTING_TIMESTAMP_OPTION)

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -344,9 +344,8 @@ object DeltaTableUtils extends PredicateHelper
       deltaLog: DeltaLog,
       tt: DeltaTimeTravelSpec): (Long, String) = {
     if (tt.version.isDefined) {
-      val userVersion = tt.version.get
-      deltaLog.history.checkVersionExists(userVersion)
-      userVersion -> "version"
+      val resolvedVersion = deltaLog.history.checkVersionExists(tt.version.get)
+      resolvedVersion -> "version"
     } else {
       val timestamp = tt.getTimestamp(conf)
       deltaLog.history.getActiveCommitAtTime(timestamp, false).version -> "timestamp"

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -477,7 +477,6 @@ case class DeltaSource(
           // when starting from a given version, we don't need the snapshot of this version. So
           // `mustBeRecreatable` is set to `false`.
           deltaLog.history.checkVersionExists(version, mustBeRecreatable = false)
-          version
       }
       Some(v)
     } else if (options.startingTimestamp.isDefined) {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
@@ -730,9 +730,6 @@ class DeltaTimeTravelSuite extends QueryTest
       val start = 1540415658000L
       generateCommits(tblLoc, start, start + 20.minutes, start + 40.minutes)
 
-      val df = spark.read.format("delta").load(identifierWithVersion(tblLoc, 0))
-      checkAnswer(df.groupBy().count(), Row(10L))
-
       checkAnswer(
         spark.read.format("delta").option("versionAsOf", -1).load(tblLoc).groupBy().count(),
         Row(20)


### PR DESCRIPTION
The feature ask is 
> to have the ability to define negative version numbers like VERSION AS OF -1 to get the previous version, VERSION AS OF -2 to get the version two commits ago etc... similar to what you can do in Python with arrays to select the trailing elements.

resolves #636 

### Feature Behavior
Similar to `latest` semantics, reading a negative indexed version won't always return the same version. 

For example, if the sequence of events is 
1. you query `versionAsOf(-1)`
2. a process writes to the table thus creating a new version
3. you query `versionAsOf(-1)` again after the write

your retrieved versions will be different. 

If you query for a negative indexed version that has an absolute value higher than the latest version available, you will get a `VersionNotFoundException` saying something similar to "Cannot time travel Delta table to version -N".


### Technical Solution Description

I've done this by resolving negative index version numbers to their positive counterparts in the `DeltaHistoryManager` and allowing negative versions in `DeltaOptions` for streaming scenarios. 