### PR TITLE
external PostCommitHook implementation

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -394,6 +394,16 @@ trait DeltaConfigsBase extends DeltaLogging {
     _ => true,
     "needs to be a boolean.")
 
+  val EXTERNAL_POST_COMMIT_HOOK_CLASS = buildConfig[Option[String]](
+    "postCommitHookClass",
+    null,
+    v => Option(v),
+    a => a.nonEmpty,
+    "This class must be a subclass of PostCommitHook, " +
+      "and must have a zero-arg constructor. " +
+      "Note: This configuration will not changed for next transactions, " +
+      "once it is added to delta table, need to run alter command to remove or chance this.")
+
   /**
    * When enabled, we will write file statistics in the checkpoint in JSON format as the "stats"
    * column.

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -1003,6 +1003,21 @@ class DeltaSuite extends QueryTest
     }
   }
 
+  test("postCommitHookClass conf from table metadata") {
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      withSQLConf(
+        "spark.databricks.delta.properties.defaults.postCommitHookClass" ->
+          classOf[ExternalPostCommitHook].getName) {
+        spark.range(5).write.format("delta").save(path)
+
+        val tableConfigs = DeltaLog.forTable(spark, path).update().metadata.configuration
+        assert(tableConfigs.get("delta.postCommitHookClass") ==
+          Some(classOf[ExternalPostCommitHook].getName))
+      }
+    }
+  }
+
   test("SC-24982 - initial snapshot has zero partitions") {
     withTempDir { tempDir =>
       val deltaLog = DeltaLog.forTable(spark, tempDir)

--- a/core/src/test/scala/org/apache/spark/sql/delta/ExternalPostCommitHookSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/ExternalPostCommitHookSuite.scala
@@ -1,0 +1,41 @@
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.delta.actions.Action
+import org.apache.spark.sql.delta.hooks.PostCommitHook
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+class ExternalPostCommitHookSuite extends DeltaGenerateSymlinkManifestSuiteBase
+  with DeltaSQLCommandTest {
+
+  import testImplicits._
+
+  test("generate manifest with postCommitHookClass") {
+    withTempDir { tablePath =>
+      tablePath.delete()
+      withSQLConf(
+        "spark.databricks.delta.properties.defaults.postCommitHookClass" ->
+          classOf[ExternalPostCommitHook].getName) {
+        spark.createDataset(spark.sparkContext.parallelize(1 to 100, 7))
+          .write.format("delta").mode("overwrite").save(tablePath.toString)
+
+        assertManifest(tablePath, expectSameFiles = true, expectedNumFiles = 7)
+      }
+    }
+  }
+}
+
+class ExternalPostCommitHook extends PostCommitHook {
+  /** A user friendly name for the hook for error reporting purposes. */
+  override val name: String = "ExternalPostCommitHook"
+
+  /** Executes the hook. */
+  override def run(
+    spark: SparkSession,
+    txn: OptimisticTransactionImpl,
+    committedActions: Seq[Action]): Unit = {
+
+    // Create a Delta table and call the scala api for generating manifest files
+    spark.sql(s"GENERATE symlink_ForMat_Manifest FOR TABLE delta.`${txn.deltaLog.dataPath}`")
+  }
+}


### PR DESCRIPTION
### Intro
This PR introduces a new optional configuration _**spark.databricks.delta.properties.defaults.postCommitHookClass**_ that specifies the class name of a custom PostCommitHook. 
This class must extend _**org.apache.spark.sql.delta.hooks.PostCommitHook**_. This feature allows users to execute their own logic after each transaction commit.

For example, 
There is no direct way, if a user wants to register delta table partitions to glue catalog, so it can be further used in Athena or Presto. 
Using this hook implementation, he/she can extract partitions from committedActions and via _alter table add partition_ statement it can be registered to catalog.

### Usage
The user creates their custom hooks by extending PostCommitHook:

```
package org.apache.spark.sql.delta

import org.apache.spark.sql.SparkSession
import org.apache.spark.sql.delta.actions.Action
import org.apache.spark.sql.delta.hooks.PostCommitHook

class ExternalPostCommitHook extends PostCommitHook {
  /** A user friendly name for the hook for error reporting purposes. */
  override val name: String = "ExternalPostCommitHook"

  /** Executes the hook. */
  override def run(
    spark: SparkSession,
    txn: OptimisticTransactionImpl,
    committedActions: Seq[Action]): Unit = {

    // Create a Delta table and call the scala api for generating manifest files
    spark.sql(s"GENERATE symlink_ForMat_Manifest FOR TABLE delta.`${txn.deltaLog.dataPath}`")
  }
}
```

They can then use their **_ExternalPostCommitHook_** in their application by setting the config:

`spark.conf.set("spark.databricks.delta.properties.defaults.postCommitHookClass", "org.apache.spark.sql.delta.ExternalPostCommitHook")`

### Testing
This PR includes a unit test that generates the manifest file using the hook.