### PR TITLE
Add SupportsPartitionManagement trait for SHOW PARTITIONS support

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaNotSupportedDDLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaNotSupportedDDLSuite.scala
@@ -82,6 +82,14 @@ abstract class DeltaNotSupportedDDLBase extends QueryTest
     assert(allErrMessages.exists(err => e.getMessage.toLowerCase(Locale.ROOT).contains(err)))
   }
 
+  def assertUnsupportedRuntime(query: String, messages: String*): Unit = {
+    val allErrMessages = "operation not allowed" +: messages
+    val e = intercept[RuntimeException] {
+      sql(query)
+    }
+    assert(allErrMessages.exists(err => e.getMessage.toLowerCase(Locale.ROOT).contains(err)))
+  }
+
   private def assertIgnored(query: String): Unit = {
     val outputStream = new java.io.ByteArrayOutputStream()
     Console.withOut(outputStream) {
@@ -125,15 +133,15 @@ abstract class DeltaNotSupportedDDLBase extends QueryTest
   }
 
   test("ALTER TABLE ADD PARTITION") {
-    assertUnsupported(
+    assertUnsupportedRuntime(
       s"ALTER TABLE $partitionedTableName ADD PARTITION (p1=3)",
-      "can not alter partitions")
+      "manually adding partitions")
   }
 
   test("ALTER TABLE DROP PARTITION") {
-    assertUnsupported(
+    assertUnsupportedRuntime(
       s"ALTER TABLE $partitionedTableName DROP PARTITION (p1=2)",
-      "can not alter partitions")
+      "manually dropping partitions")
   }
 
   test("ALTER TABLE RECOVER PARTITIONS") {


### PR DESCRIPTION
Resolves #681 

Adds `SupportsPartitionManagement` trait to the V2 table to support the `SHOW PARTITIONS` SQL command. Most of the methods in the trait simply throw an unsupported exception, as they aren't relevant for Delta. The `listPartitionIdentifiers` is the bulk of the logic. There's a lot of casting between strings and real types, not sure if I implemented everything the best way, so very open to suggestions. Specifically:

- I just added the methods to the end of the DeltaTableV2 class, is there a better/more logical place to put them?
- Is the file I added the test too the correct place to put them or should they be in a different file?
- Is there anything more I should test (that other features like add/drop partitions throw exceptions)?