### PR TITLE
 Raise error when dataType was not provided

### DIFF
--- a/core/src/main/scala/io/delta/tables/DeltaColumnBuilder.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaColumnBuilder.scala
@@ -20,6 +20,7 @@ import org.apache.spark.sql.delta.sources.DeltaSourceUtils.GENERATION_EXPRESSION
 
 import org.apache.spark.annotation._
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.delta.DeltaErrors
 import org.apache.spark.sql.types.{DataType, MetadataBuilder, StructField}
 
 /**
@@ -126,6 +127,10 @@ class DeltaColumnBuilder private[tables](
       metadataBuilder.putString("comment", comment.get)
     }
     val fieldMetadata = metadataBuilder.build()
+    if (dataType == null) {
+      throw DeltaErrors.analysisException("dataType should not be null for a column," +
+        " Please Provide dataType of the column ")
+    }
     StructField(
       colName,
       dataType,

--- a/core/src/main/scala/io/delta/tables/DeltaColumnBuilder.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaColumnBuilder.scala
@@ -128,7 +128,7 @@ class DeltaColumnBuilder private[tables](
     }
     val fieldMetadata = metadataBuilder.build()
     if (dataType == null) {
-      throw DeltaErrors.analysisException(s"The data type of column $colName is not provided")
+      throw DeltaErrors.analysisException(s"The data type of the column $colName is not provided")
     }
     StructField(
       colName,

--- a/core/src/main/scala/io/delta/tables/DeltaColumnBuilder.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaColumnBuilder.scala
@@ -128,8 +128,7 @@ class DeltaColumnBuilder private[tables](
     }
     val fieldMetadata = metadataBuilder.build()
     if (dataType == null) {
-      throw DeltaErrors.analysisException("dataType should not be null for a column," +
-        " Please Provide dataType of the column ")
+      throw DeltaErrors.analysisException(s"The data type of column $colName is not provided")
     }
     StructField(
       colName,

--- a/core/src/test/scala/io/delta/tables/DeltaTableBuilderSuite.scala
+++ b/core/src/test/scala/io/delta/tables/DeltaTableBuilderSuite.scala
@@ -228,6 +228,18 @@ class DeltaTableBuilderSuite extends QueryTest with SharedSparkSession with Delt
     }
   }
 
+  test("test addColumn using columnBuilder, without dataType") {
+    val e = intercept[AnalysisException] {
+      io.delta.tables.DeltaTable.create().addColumn(
+        DeltaTable.columnBuilder("value")
+          .generatedAlwaysAs("true")
+          .nullable(true)
+          .build).execute()
+    }
+    assert(e.getMessage.equals("dataType should not be null for a column," +
+      " Please Provide dataType of the column "))
+  }
+
   testCreateTable("create_table") { table =>
     defaultCreateTableBuilder(ifNotExists = false, Some(table)).execute()
   }

--- a/core/src/test/scala/io/delta/tables/DeltaTableBuilderSuite.scala
+++ b/core/src/test/scala/io/delta/tables/DeltaTableBuilderSuite.scala
@@ -232,10 +232,10 @@ class DeltaTableBuilderSuite extends QueryTest with SharedSparkSession with Delt
     val e = intercept[AnalysisException] {
       DeltaTable.columnBuilder("value")
         .generatedAlwaysAs("true")
-        . nullable(true)
+        .nullable(true)
         .build()
     }
-    assert(e.getMessage.equals(s"The data type of column value is not provided"))
+    assert(e.getMessage == "The data type of the column value is not provided")
   }
 
   testCreateTable("create_table") { table =>

--- a/core/src/test/scala/io/delta/tables/DeltaTableBuilderSuite.scala
+++ b/core/src/test/scala/io/delta/tables/DeltaTableBuilderSuite.scala
@@ -230,14 +230,19 @@ class DeltaTableBuilderSuite extends QueryTest with SharedSparkSession with Delt
 
   test("test addColumn using columnBuilder, without dataType") {
     val e = intercept[AnalysisException] {
-      io.delta.tables.DeltaTable.create().addColumn(
-        DeltaTable.columnBuilder("value")
-          .generatedAlwaysAs("true")
-          .nullable(true)
-          .build).execute()
+
+      DeltaTable.columnBuilder("value")
+        .generatedAlwaysAs("true")
+        . nullable(true)
+        .build()
+
+//      io.delta.tables.DeltaTable.create().addColumn(
+//        DeltaTable.columnBuilder("value")
+//          .generatedAlwaysAs("true")
+//          .nullable(true)
+//          .build).execute()
     }
-    assert(e.getMessage.equals("dataType should not be null for a column," +
-      " Please Provide dataType of the column "))
+    assert(e.getMessage.equals(s"The data type of column value is not provided"))
   }
 
   testCreateTable("create_table") { table =>

--- a/core/src/test/scala/io/delta/tables/DeltaTableBuilderSuite.scala
+++ b/core/src/test/scala/io/delta/tables/DeltaTableBuilderSuite.scala
@@ -230,17 +230,10 @@ class DeltaTableBuilderSuite extends QueryTest with SharedSparkSession with Delt
 
   test("test addColumn using columnBuilder, without dataType") {
     val e = intercept[AnalysisException] {
-
       DeltaTable.columnBuilder("value")
         .generatedAlwaysAs("true")
         . nullable(true)
         .build()
-
-//      io.delta.tables.DeltaTable.create().addColumn(
-//        DeltaTable.columnBuilder("value")
-//          .generatedAlwaysAs("true")
-//          .nullable(true)
-//          .build).execute()
     }
     assert(e.getMessage.equals(s"The data type of column value is not provided"))
   }


### PR DESCRIPTION
throw Error explicitly,  if dataType was not provided for DeltaColumnBuilder :

issue Raised and Discussed here: https://github.com/delta-io/delta/issues/698
