### PR TITLE
Upgrade SBT to 1.5.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/openjdk:8u181-jdk # java 8
+      - image: cimg/openjdk:8.0.282
     steps:
       - checkout
       - run:

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.swp
 *~
 .DS_Store
+.bsp/
 .cache
 .classpath
 .ensime

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 *.swp
 *~
 .DS_Store
-.bsp/
 .cache
 .classpath
 .ensime

--- a/build.sbt
+++ b/build.sbt
@@ -51,28 +51,22 @@ lazy val core = (project in file("core"))
       "org.apache.spark" %% "spark-hive" % sparkVersion % "test" classifier "tests",
 
       // Compiler plugins
-      // -- Bump up the genjavadoc version explicitly to 0.16 to work with Scala 2.12
-      // compilerPlugin("com.typesafe.genjavadoc" %% "genjavadoc-plugin" % "0.16" cross CrossVersion.full)
+      // -- Bump up the genjavadoc version explicitly to 0.18 to work with Scala 2.12
+      compilerPlugin("com.typesafe.genjavadoc" %% "genjavadoc-plugin" % "0.18" cross CrossVersion.full)
     ),
-    (mappings in (Compile, packageBin)) := (mappings in (Compile, packageBin)).value ++
+    Compile / packageBin / mappings := (Compile / packageBin / mappings).value ++
         listPythonFiles(baseDirectory.value.getParentFile / "python"),
 
-    // antlr4Settings,
-    antlr4Version in Antlr4 := "4.8",
-    antlr4PackageName in Antlr4 := Some("io.delta.sql.parser"),
-    antlr4GenListener in Antlr4 := true,
-    antlr4GenVisitor in Antlr4 := true,
+    Antlr4 / antlr4Version:= "4.8",
+    Antlr4 / antlr4PackageName := Some("io.delta.sql.parser"),
+    Antlr4 / antlr4GenListener := true,
+    Antlr4 / antlr4GenVisitor := true,
 
-    // Antlr4 / antlr4Version:= "4.8",
-    // Antlr4 / antlr4PackageName := Some("io.delta.sql.parser"),
-    // Antlr4 / antlr4GenListener := true,
-    // Antlr4 / antlr4GenVisitor := true,
-
-    testOptions in Test += Tests.Argument("-oDF"),
-    testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
+    Test / testOptions += Tests.Argument("-oDF"),
+    Test / testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
 
     // Don't execute in parallel since we can't have multiple Sparks in the same JVM
-    parallelExecution in Test := false,
+    Test / parallelExecution := false,
 
     scalacOptions ++= Seq(
       "-target:jvm-1.8",
@@ -82,7 +76,7 @@ lazy val core = (project in file("core"))
     javaOptions += "-Xmx1024m",
 
     // Configurations to speed up tests and reduce memory footprint
-    javaOptions in Test ++= Seq(
+    Test / javaOptions ++= Seq(
       "-Dspark.ui.enabled=false",
       "-Dspark.ui.showConsoleProgress=false",
       "-Dspark.databricks.delta.snapshotPartitions=2",
@@ -97,7 +91,7 @@ lazy val core = (project in file("core"))
       val dir = baseDirectory.value.getParentFile / "target" / "scala-2.12" / "classes"
       Files.createDirectories(dir.toPath)
     },
-    (compile in Compile) := ((compile in Compile) dependsOn createTargetClassesDir).value
+    Compile / compile := ((Compile / compile) dependsOn createTargetClassesDir).value
   )
 
 lazy val contribs = (project in file("contribs"))
@@ -107,14 +101,14 @@ lazy val contribs = (project in file("contribs"))
     commonSettings,
     scalaStyleSettings,
     releaseSettings,
-    (mappings in (Compile, packageBin)) := (mappings in (Compile, packageBin)).value ++
+    Compile / packageBin / mappings := (Compile / packageBin / mappings).value ++
       listPythonFiles(baseDirectory.value.getParentFile / "python"),
 
-    testOptions in Test += Tests.Argument("-oDF"),
-    testOptions in Test += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
+    Test / testOptions += Tests.Argument("-oDF"),
+    Test / testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
 
     // Don't execute in parallel since we can't have multiple Sparks in the same JVM
-    parallelExecution in Test := false,
+    Test / parallelExecution := false,
 
     scalacOptions ++= Seq(
       "-target:jvm-1.8"
@@ -123,7 +117,7 @@ lazy val contribs = (project in file("contribs"))
     javaOptions += "-Xmx1024m",
 
     // Configurations to speed up tests and reduce memory footprint
-    javaOptions in Test ++= Seq(
+    Test / javaOptions ++= Seq(
       "-Dspark.ui.enabled=false",
       "-Dspark.ui.showConsoleProgress=false",
       "-Dspark.databricks.delta.snapshotPartitions=2",
@@ -138,7 +132,7 @@ lazy val contribs = (project in file("contribs"))
       val dir = baseDirectory.value.getParentFile / "target" / "scala-2.12" / "classes"
       Files.createDirectories(dir.toPath)
     },
-    (compile in Compile) := ((compile in Compile) dependsOn createTargetClassesDir).value
+    Compile / compile := ((Compile / compile) dependsOn createTargetClassesDir).value
   )
 
 /**
@@ -157,7 +151,7 @@ def listPythonFiles(pythonBase: File): Seq[(File, String)] = {
   pythonFiles pair Path.relativeTo(pythonBase)
 }
 
-parallelExecution in ThisBuild := false
+ThisBuild / parallelExecution := false
 
 val createTargetClassesDir = taskKey[Unit]("create target classes dir")
 
@@ -166,19 +160,19 @@ val createTargetClassesDir = taskKey[Unit]("create target classes dir")
  * ScalaStyle settings *
  ***********************
  */
-scalastyleConfig in ThisBuild := baseDirectory.value / "scalastyle-config.xml"
+ThisBuild / scalastyleConfig := baseDirectory.value / "scalastyle-config.xml"
 
 lazy val compileScalastyle = taskKey[Unit]("compileScalastyle")
 lazy val testScalastyle = taskKey[Unit]("testScalastyle")
 
 lazy val scalaStyleSettings = Seq(
-  compileScalastyle := scalastyle.in(Compile).toTask("").value,
+  compileScalastyle := (Compile / scalastyle).toTask("").value,
 
-  (compile in Compile) := ((compile in Compile) dependsOn compileScalastyle).value,
+  Compile / compile := ((Compile / compile) dependsOn compileScalastyle).value,
 
-  testScalastyle := scalastyle.in(Test).toTask("").value,
+  testScalastyle := (Test / scalastyle).toTask("").value,
 
-  (test in Test) := ((test in Test) dependsOn testScalastyle).value
+  Test / test := ((Test / test) dependsOn testScalastyle).value
 )
 
 /*
@@ -217,7 +211,7 @@ def getPrevVersion(currentVersion: String): String = {
 }
 
 lazy val mimaSettings = Seq(
-  (test in Test) := ((test in Test) dependsOn mimaReportBinaryIssues).value,
+  Test / test := ((Test / test) dependsOn mimaReportBinaryIssues).value,
   mimaPreviousArtifacts := Set("io.delta" %% "delta-core" %  getPrevVersion(version.value)),
   mimaBinaryIssueFilters ++= MimaExcludes.ignoredABIProblems
 )
@@ -238,7 +232,6 @@ def ignoreUndocumentedPackages(packages: Seq[Seq[java.io.File]]): Seq[Seq[java.i
 }
 
 lazy val unidocSettings = Seq(
-  unidocGenjavadocVersion := "0.18",
   
   // Configure Scala unidoc
   ScalaUnidoc / unidoc / scalacOptions ++= Seq(
@@ -262,7 +255,7 @@ lazy val unidocSettings = Seq(
   },
 
   // Ensure unidoc is run with tests
-  (test in Test) := ((test in Test) dependsOn unidoc.in(Compile)).value
+  Test / test := ((Test / test) dependsOn (Compile / unidoc)).value
 )
 
 /*

--- a/build/sbt-launch-lib.bash
+++ b/build/sbt-launch-lib.bash
@@ -38,12 +38,11 @@ dlog () {
 
 acquire_sbt_jar () {
   SBT_VERSION=`awk -F "=" '/sbt\.version/ {print $2}' ./project/build.properties`
-  # Download sbt from mirror URL if the environment variable is provided
-  if [[ "${SBT_VERSION}" == "0.13.18" ]] && [[ -n "${SBT_MIRROR_JAR_URL}" ]]; then
-    URL1="${SBT_MIRROR_JAR_URL}"
-  else
-    URL1="https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch.jar"
-  fi
+  # DEFAULT_ARTIFACT_REPOSITORY env variable can be used to only fetch
+  # artifacts from internal repos only.
+  # Ex:
+  #   DEFAULT_ARTIFACT_REPOSITORY=https://artifacts.internal.com/libs-release/
+  URL1=${DEFAULT_ARTIFACT_REPOSITORY:-https://repo1.maven.org/maven2/}org/scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch-${SBT_VERSION}.jar
   JAR=build/sbt-launch-${SBT_VERSION}.jar
 
   sbt_jar=$JAR
@@ -61,13 +60,13 @@ acquire_sbt_jar () {
       wget --quiet ${URL1} -O "${JAR_DL}" &&\
         mv "${JAR_DL}" "${JAR}"
     else
-      printf "You do not have curl or wget installed, please install sbt manually from http://www.scala-sbt.org/\n"
+      printf "You do not have curl or wget installed, please install sbt manually from https://www.scala-sbt.org/\n"
       exit -1
     fi
     fi
     if [ ! -f "${JAR}" ]; then
     # We failed to download
-    printf "Our attempt to download sbt locally to ${JAR} failed. Please install sbt manually from http://www.scala-sbt.org/\n"
+    printf "Our attempt to download sbt locally to ${JAR} failed. Please install sbt manually from https://www.scala-sbt.org/\n"
     exit -1
     fi
     printf "Launching sbt from ${JAR}\n"

--- a/examples/scala/build/sbt-launch-lib.bash
+++ b/examples/scala/build/sbt-launch-lib.bash
@@ -38,7 +38,7 @@ dlog () {
 
 acquire_sbt_jar () {
   SBT_VERSION=`awk -F "=" '/sbt\.version/ {print $2}' ./project/build.properties`
-  URL1=https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch.jar
+  URL1=${DEFAULT_ARTIFACT_REPOSITORY:-https://repo1.maven.org/maven2/}org/scala-sbt/sbt-launch/${SBT_VERSION}/sbt-launch-${SBT_VERSION}.jar
   JAR=build/sbt-launch-${SBT_VERSION}.jar
 
   sbt_jar=$JAR

--- a/examples/scala/project/build.properties
+++ b/examples/scala/project/build.properties
@@ -33,4 +33,4 @@
 #  limitations under the License.
 #
 
-sbt.version=0.13.18
+sbt.version=1.5.5

--- a/project/build.properties
+++ b/project/build.properties
@@ -33,4 +33,4 @@
 #  limitations under the License.
 #
 
-sbt.version=0.13.18
+sbt.version=1.5.5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,28 +14,11 @@
  * limitations under the License.
  */
 
-
-// resolvers += Resolver.url("artifactory", url("https://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
-
-// resolvers += "bintray-spark-packages" at "https://dl.bintray.com/spark-packages/maven/"
-
-// resolvers += "Typesafe Repository" at "https://repo.typesafe.com/typesafe/releases/"
-
-// resolvers += DefaultMavenRepository
-
-// resolvers += Resolver.url("bintray-sbt-plugins", url("https://dl.bintray.com/sbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
-
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
-// addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
-
-// addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 
-// addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.0.0")
-
-// addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
@@ -44,6 +27,3 @@ addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.9.2")
 
 addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.3")
-
-// resolvers += Resolver.url("typesafe sbt-plugins",
-//   url("https://dl.bintray.com/typesafe/sbt-plugins"))(Resolver.ivyStylePatterns)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,8 +18,6 @@ addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.0.0")
-
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
@@ -27,3 +25,5 @@ addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.9.2")
 
 addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.3")
+
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,29 +15,35 @@
  */
 
 
-resolvers += Resolver.url("artifactory", url("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
+// resolvers += Resolver.url("artifactory", url("https://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 
-resolvers += "bintray-spark-packages" at "https://dl.bintray.com/spark-packages/maven/"
+// resolvers += "bintray-spark-packages" at "https://dl.bintray.com/spark-packages/maven/"
 
-resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
+// resolvers += "Typesafe Repository" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.github.sbt" % "sbt-release" % "1.0.15")
+// resolvers += DefaultMavenRepository
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
+// resolvers += Resolver.url("bintray-sbt-plugins", url("https://dl.bintray.com/sbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
+// addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
+// addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
+
+// addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.0.0")
+
+// addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.9.2")
 
-addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.7.13")
+addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.8.3")
 
-resolvers += Resolver.url("typesafe sbt-plugins",
-  url("https://dl.bintray.com/typesafe/sbt-plugins"))(Resolver.ivyStylePatterns)
+// resolvers += Resolver.url("typesafe sbt-plugins",
+//   url("https://dl.bintray.com/typesafe/sbt-plugins"))(Resolver.ivyStylePatterns)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.0-SNAPSHOT"
+ThisBuild / version := "1.1.0-SNAPSHOT"


### PR DESCRIPTION
This PR takes over the SBT upgrade work from #642 . Thanks Jacek Laskowski for the initial investigation and great work!

All pass:
- `build/sbt compile`
- `build/sbt package`
- `build/sbt test`
- `build/sbt unidoc`

And (in `examples/scala`
- `build/sbt package`
- `build/sbt compile`