### PR TITLE
Pypi packaging automated test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ build/*.jar
 build/apache-maven*
 build/scala*
 build/zinc*
-build/lib
 cache
 checkpoint
 conf/*.cmd
@@ -68,7 +67,6 @@ docs/python/_build/
 python/test_coverage/coverage_data
 python/test_coverage/htmlcov
 python/pyspark/python
-python/delta_spark.egg-info
 reports/
 scalastyle-on-compile.generated.xml
 scalastyle-output.xml

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ build/*.jar
 build/apache-maven*
 build/scala*
 build/zinc*
+build/lib
 cache
 checkpoint
 conf/*.cmd
@@ -67,6 +68,7 @@ docs/python/_build/
 python/test_coverage/coverage_data
 python/test_coverage/htmlcov
 python/pyspark/python
+python/delta_spark.egg-info
 reports/
 scalastyle-on-compile.generated.xml
 scalastyle-output.xml

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -40,7 +40,7 @@ def test(root_dir, package):
                    "--packages", package, test_file]
             print("Running tests in %s\n=============" % test_file)
             print("Command: %s" % str(cmd))
-            run_cmd(cmd, stream_output=True, print_cmd=False)
+            run_cmd(cmd, stream_output=True)
         except:
             print("Failed tests in %s" % (test_file))
             raise
@@ -105,10 +105,10 @@ def run_python_style_checks(root_dir):
 def run_pypi_packaging_tests(root_dir):
     """
     We want to test that the PyPi artifact for this delta version can be generated,
-    locally installed, and used in pyton tests.
+    locally installed, and used in python tests.
 
-    We will uninstall any existing local delta artifact.
-    We will generate a new local delta artifact.
+    We will uninstall any existing local delta PyPi artifact.
+    We will generate a new local delta PyPi artifact.
     We will install it into the local PyPi repository.
     And then we will run relevant python tests to ensure everything works as exepcted.
     """
@@ -120,9 +120,6 @@ def run_pypi_packaging_tests(root_dir):
 
     # uninstall packages if they exist
     run_cmd(["pip3", "uninstall", "--yes", "delta-spark", "pyspark"], stream_output=True)
-
-    # No need to rm -rf local .ivy and .m2 io/delta caches.
-    # They were deleted in `prepare`, and then new artifacts were locally published to them
 
     # install helper pip packages
     run_cmd(["pip3", "install", "wheel", "twine", "setuptools", "--upgrade"], stream_output=True)

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -130,7 +130,10 @@ def run_pypi_packaging_tests(root_dir):
     delete_if_exists(wheel_dist_dir)
 
     # generate artifacts
-    run_cmd(["python3", "setup.py", "bdist_wheel"], stream_output=True, stderr=open('/dev/null', 'w'))
+    run_cmd( \
+        ["python3", "setup.py", "bdist_wheel"], \
+        stream_output=True, \
+        stderr=open('/dev/null', 'w'))
 
     run_cmd(["python3", "setup.py", "sdist"], stream_output=True)
 

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -130,9 +130,9 @@ def run_pypi_packaging_tests(root_dir):
     delete_if_exists(wheel_dist_dir)
 
     # generate artifacts
-    run_cmd( \
-        ["python3", "setup.py", "bdist_wheel"], \
-        stream_output=True, \
+    run_cmd(
+        ["python3", "setup.py", "bdist_wheel"],
+        stream_output=True,
         stderr=open('/dev/null', 'w'))
 
     run_cmd(["python3", "setup.py", "sdist"], stream_output=True)

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -152,34 +152,6 @@ if __name__ == "__main__":
     root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     package = prepare(root_dir)
 
-    # This line causes this error
-    #
-    # starting python compilation test...
-    # Python compilation failed with the following errors:
-    # Compiling /Users/scott.sandre/delta/python/delta/tests/test_sql.py ...
-    # File "/Users/scott.sandre/delta/python/delta/tests/test_sql.py", line 97
-    #     return self.spark.sql(f"SELECT * FROM {table}")
-    #                                                 ^
-    # SyntaxError: invalid syntax
-
-    # Compiling /Users/scott.sandre/delta/python/delta/pip_utils.py ...
-    # File "/Users/scott.sandre/delta/python/delta/pip_utils.py", line 51
-    #     msg = f'''
-    # This function must be called with a SparkSession builder as the argument.
-    # The argument found is of type {str(type(spark_session_builder))}.
-    # See the online documentation for the correct usage of this function.
-    #         '''
-                
-                                                                            
-                                                                    
-                                                                        
-    #         ^
-    # SyntaxError: invalid syntax
-    # 1
-    #
-    # run_python_style_checks(root_dir) <---------------------
-
-    # This line also causes errors for me...
-    # test(root_dir, package)
-    
+    run_python_style_checks(root_dir)
+    test(root_dir, package)
     run_pypi_packaging_tests(root_dir)

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -98,6 +98,7 @@ def run_cmd(cmd, throw_on_error=True, env=None, stream_output=False, **kwargs):
 def run_python_style_checks(root_dir):
     run_cmd([os.path.join(root_dir, "dev", "lint-python")], stream_output=True)
 
+
 def run_pypi_packaging_tests(root_dir):
     print("##### Running PyPi Packaging tests #####")
 
@@ -111,7 +112,7 @@ def run_pypi_packaging_tests(root_dir):
     print("### Clearing Delta artifacts from ivy2 and mvn cache")
     run_cmd(["rm", "-rf", "~/.ivy2/cache/io.delta/"], stream_output=True)
     run_cmd(["rm", "-rf", "~/.m2/repository/io/delta/"], stream_output=True)
-    
+
     install_cmd = ["pip3", "install", "wheel", "twine", "setuptools", "--upgrade"]
     print("### Executing:" + " ".join(install_cmd))
     run_cmd(install_cmd, stream_output=True)
@@ -130,7 +131,7 @@ def run_pypi_packaging_tests(root_dir):
     run_cmd(gen_artifacts_cmd_2, stream_output=True)
 
     # we need, for example, 1.1.0_SNAPSHOT not 1.1.0-SNAPSHOT
-    version_formatted = version.replace("-","_")
+    version_formatted = version.replace("-", "_")
     delta_whl_name = "delta_spark-" + version_formatted + "-py3-none-any.whl"
 
     install_whl_cmd = ["pip3", "install", path.join(dist_dir, delta_whl_name)]

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -88,7 +88,7 @@ def run_cmd(cmd, throw_on_error=True, env=None, stream_output=False, **kwargs):
             **kwargs)
         (stdout, stderr) = child.communicate()
         exit_code = child.wait()
-        if throw_on_error and exit_code is not 0:
+        if throw_on_error and exit_code != 0:
             raise Exception(
                 "Non-zero exitcode: %s\n\nSTDOUT:\n%s\n\nSTDERR:%s" %
                 (exit_code, stdout, stderr))
@@ -100,6 +100,7 @@ def run_python_style_checks(root_dir):
 
 def run_pypi_packaging_tests(root_dir):
     print("##### Running PyPi Packaging tests #####")
+
     version = '0.0.0'
     with open(os.path.join(root_dir, "version.sbt")) as fd:
         version = fd.readline().split('"')[1]
@@ -128,7 +129,7 @@ def run_pypi_packaging_tests(root_dir):
     print("### Executing: " + " ".join(gen_artifacts_cmd_2))
     run_cmd(gen_artifacts_cmd_2, stream_output=True)
 
-        # we need, for example, 1.1.0_SNAPSHOT not 1.1.0-SNAPSHOT
+    # we need, for example, 1.1.0_SNAPSHOT not 1.1.0-SNAPSHOT
     version_formatted = version.replace("-","_")
     delta_whl_name = "delta_spark-" + version_formatted + "-py3-none-any.whl"
 
@@ -150,6 +151,35 @@ def run_pypi_packaging_tests(root_dir):
 if __name__ == "__main__":
     root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     package = prepare(root_dir)
-    # run_python_style_checks(root_dir)
+
+    # This line causes this error
+    #
+    # starting python compilation test...
+    # Python compilation failed with the following errors:
+    # Compiling /Users/scott.sandre/delta/python/delta/tests/test_sql.py ...
+    # File "/Users/scott.sandre/delta/python/delta/tests/test_sql.py", line 97
+    #     return self.spark.sql(f"SELECT * FROM {table}")
+    #                                                 ^
+    # SyntaxError: invalid syntax
+
+    # Compiling /Users/scott.sandre/delta/python/delta/pip_utils.py ...
+    # File "/Users/scott.sandre/delta/python/delta/pip_utils.py", line 51
+    #     msg = f'''
+    # This function must be called with a SparkSession builder as the argument.
+    # The argument found is of type {str(type(spark_session_builder))}.
+    # See the online documentation for the correct usage of this function.
+    #         '''
+                
+                                                                            
+                                                                    
+                                                                        
+    #         ^
+    # SyntaxError: invalid syntax
+    # 1
+    #
+    # run_python_style_checks(root_dir) <---------------------
+
+    # This line also causes errors for me...
     # test(root_dir, package)
+    
     run_pypi_packaging_tests(root_dir)

--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -121,9 +121,8 @@ def run_pypi_packaging_tests(root_dir):
     # uninstall packages if they exist
     run_cmd(["pip3", "uninstall", "--yes", "delta-spark", "pyspark"], stream_output=True)
 
-    print("### Clearing Delta artifacts from ivy2 and mvn cache")
-    run_cmd(["rm", "-rf", "~/.ivy2/cache/io.delta/"], stream_output=True)
-    run_cmd(["rm", "-rf", "~/.m2/repository/io/delta/"], stream_output=True)
+    # No need to rm -rf local .ivy and .m2 io/delta caches.
+    # They were deleted in `prepare`, and then new artifacts were locally published to them
 
     # install helper pip packages
     run_cmd(["pip3", "install", "wheel", "twine", "setuptools", "--upgrade"], stream_output=True)

--- a/run-integration-tests.py
+++ b/run-integration-tests.py
@@ -19,7 +19,15 @@
 import os
 import subprocess
 from os import path
+import shutil
 import argparse
+
+
+def delete_if_exists(path):
+    # if path exists, delete it.
+    if os.path.exists(path):
+        shutil.rmtree(path)
+        print("Deleted %s " % path)
 
 
 def run_scala_integration_tests(root_dir, version, test_name, extra_maven_repo):
@@ -119,8 +127,8 @@ def run_pip_installation_tests(root_dir, version, use_testpypi, extra_maven_repo
 
 def clear_artifact_cache():
     print("Clearing Delta artifacts from ivy2 and mvn cache")
-    run_cmd(["rm", "-rf", "~/.ivy2/cache/io.delta/"], stream_output=True)
-    run_cmd(["rm", "-rf", "~/.m2/repository/io/delta/"], stream_output=True)
+    delete_if_exists(os.path.expanduser("~/.ivy2/cache/io.delta"))
+    delete_if_exists(os.path.expanduser("~/.m2/repository/io/delta/"))
 
 
 def run_cmd(cmd, throw_on_error=True, env=None, stream_output=False, **kwargs):


### PR DESCRIPTION

## What does this change?
Create an automated test so that the pypi delta package is installed and used in python tests every commit.

## Test / Confirmation 1
I changed the `version.sbt` version to be `version in ThisBuild := "1.1.0-SNAPSHOT-TEST"` (and did not commit those changes)

That version (with the `-TEST` appended to it) was then used when executing `using_with_pip.py`

```
### Executing: pip3 install /Users/scott.sandre/delta/dist/delta_spark-1.1.0_SNAPSHOT_TEST-py3-none-any.whl
Processing ./dist/delta_spark-1.1.0_SNAPSHOT_TEST-py3-none-any.whl
Collecting pyspark<3.2.0,>=3.1.0
  Using cached pyspark-3.1.2-py2.py3-none-any.whl
Requirement already satisfied: importlib-metadata>=3.10.0 in /usr/local/lib/python3.9/site-packages (from delta-spark==1.1.0-SNAPSHOT-TEST) (4.6.1)
Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.9/site-packages (from importlib-metadata>=3.10.0->delta-spark==1.1.0-SNAPSHOT-TEST) (3.5.0)
Requirement already satisfied: py4j==0.10.9 in /usr/local/lib/python3.9/site-packages (from pyspark<3.2.0,>=3.1.0->delta-spark==1.1.0-SNAPSHOT-TEST) (0.10.9)
Installing collected packages: pyspark, delta-spark
Successfully installed delta-spark-1.1.0-SNAPSHOT-TEST pyspark-3.1.2
Test command: ['python3', '/Users/scott.sandre/delta/examples/python/using_with_pip.py']
:: loading settings :: url = jar:file:/usr/local/lib/python3.9/site-packages/pyspark/jars/ivy-2.4.0.jar!/org/apache/ivy/core/settings/ivysettings.xml
Ivy Default Cache set to: /Users/scott.sandre/.ivy2/cache
The jars for the packages stored in: /Users/scott.sandre/.ivy2/jars
io.delta#delta-core_2.12 added as a dependency
:: resolving dependencies :: org.apache.spark#spark-submit-parent-0b707f56-f34e-4a63-9008-b9090b7f024c;1.0
	confs: [default]
	found io.delta#delta-core_2.12;1.1.0-SNAPSHOT-TEST in local-m2-cache
	found org.antlr#antlr4;4.8 in local-m2-cache
	found org.antlr#antlr4-runtime;4.8 in local-m2-cache
	found org.antlr#antlr-runtime;3.5.2 in local-m2-cache
	found org.antlr#ST4;4.3 in local-m2-cache
	found org.abego.treelayout#org.abego.treelayout.core;1.0.3 in local-m2-cache
	found org.glassfish#javax.json;1.0.4 in local-m2-cache
	found com.ibm.icu#icu4j;61.1 in local-m2-cache
downloading file:/Users/scott.sandre/.m2/repository/io/delta/delta-core_2.12/1.1.0-SNAPSHOT-TEST/delta-core_2.12-1.1.0-SNAPSHOT-TEST.jar ...
	[SUCCESSFUL ] io.delta#delta-core_2.12;1.1.0-SNAPSHOT-TEST!delta-core_2.12.jar (4ms)
:: resolution report :: resolve 611ms :: artifacts dl 10ms
	:: modules in use:
	com.ibm.icu#icu4j;61.1 from local-m2-cache in [default]
	io.delta#delta-core_2.12;1.1.0-SNAPSHOT-TEST from local-m2-cache in [default]
	org.abego.treelayout#org.abego.treelayout.core;1.0.3 from local-m2-cache in [default]
	org.antlr#ST4;4.3 from local-m2-cache in [default]
	org.antlr#antlr-runtime;3.5.2 from local-m2-cache in [default]
	org.antlr#antlr4;4.8 from local-m2-cache in [default]
	org.antlr#antlr4-runtime;4.8 from local-m2-cache in [default]
	org.glassfish#javax.json;1.0.4 from local-m2-cache in [default]
	---------------------------------------------------------------------
	|                  |            modules            ||   artifacts   |
	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
	---------------------------------------------------------------------
	|      default     |   8   |   2   |   2   |   0   ||   8   |   1   |
	---------------------------------------------------------------------
```

## Test / Confirmation 2
I added
```
// scalastyle:off println
println("pypi TEST")
// scalastyle:on println
```
to the top (constructor) of `DeltaLog.scala` (and did not commit those changes).

While running the `using_with_pip.py` tests, you can see that the `println` is executed:
```
########### Create a Parquet table ##############
########### Convert to Delta ###########
pypi TEST
########### Read table with DataFrames ###########
+---+
| id|
+---+
|  1|
|  4|
|  0|
|  2|
|  3|
+---+

########### Read table with DeltaTable ###########
+---+
| id|
+---+
|  1|
|  4|
|  0|
|  2|
|  3|
+---+

Therefore, this specific package version was used.
```