### PR TITLE
Fix an issue in Merge/Update/Delete when the table path contains special chars

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
@@ -166,7 +166,7 @@ trait DeltaCommand extends DeltaLogging {
       basePath: Path,
       filePath: String,
       nameToAddFileMap: Map[String, AddFile]): AddFile = {
-    val absolutePath = DeltaFileOperations.absolutePath(basePath.toUri.toString, filePath).toString
+    val absolutePath = DeltaFileOperations.absolutePath(basePath.toString, filePath).toString
     nameToAddFileMap.getOrElse(absolutePath, {
       throw new IllegalStateException(s"File ($absolutePath) to be rewritten not found " +
         s"among candidate files:\n${nameToAddFileMap.keys.mkString("\n")}")

--- a/core/src/test/java/org/apache/spark/sql/delta/UpdateJavaSuite.java
+++ b/core/src/test/java/org/apache/spark/sql/delta/UpdateJavaSuite.java
@@ -115,27 +115,7 @@ public class UpdateJavaSuite implements DeltaSQLCommandJavaTest {
             tuple2(100, 10), tuple2(100, 20), tuple2(3, 30), tuple2(4, 40))).collectAsList();
         QueryTest$.MODULE$.checkAnswer(target.toDF(), expectedAnswer);
     }
-
-    @Test
-    public void testUpdateTableWhenSpaceInPath() {
-        Dataset<Row> targetTable = createKVDataSet(
-                Arrays.asList(tuple2(1, 10), tuple2(2, 20), tuple2(3, 30), tuple2(4, 40)),
-                "key", "value");
-        String javaIoTmpdir = System.getProperty("java.io.tmpdir");
-        String dirWithNonAscii = "/test with space/";
-        String tmpDirFullPath= javaIoTmpdir.concat(dirWithNonAscii);
-        String dir = Utils.createTempDir(tmpDirFullPath, "spark").toString();
-        targetTable.write().format("delta").save(dir);
-        spark.sql("CREATE TABLE test USING DELTA LOCATION '" +dir+ "'");
-        spark.sql("UPDATE test SET key = key + 10");
-        spark.sql("UPDATE test SET key = key + 10 WHERE true");
-        spark.sql("UPDATE test SET key = key + 10 WHERE 1 = 1");
-        spark.sql("UPDATE test SET key = key + 10 WHERE key = key");
-        DeltaTable target = DeltaTable.forPath(spark, dir);
-        List<Row> expectedAnswer = createKVDataSet(
-                Arrays.asList(tuple2(41,10),tuple2(42, 20), tuple2(43, 30), tuple2(44, 40))).collectAsList();
-        QueryTest$.MODULE$.checkAnswer(target.toDF(), expectedAnswer);
-    }
+    
 
     private Dataset<Row> createKVDataSet(
         List<Tuple2<Integer, Integer>> data, String keyName, String valueName) {

--- a/core/src/test/java/org/apache/spark/sql/delta/UpdateJavaSuite.java
+++ b/core/src/test/java/org/apache/spark/sql/delta/UpdateJavaSuite.java
@@ -115,7 +115,6 @@ public class UpdateJavaSuite implements DeltaSQLCommandJavaTest {
             tuple2(100, 10), tuple2(100, 20), tuple2(3, 30), tuple2(4, 40))).collectAsList();
         QueryTest$.MODULE$.checkAnswer(target.toDF(), expectedAnswer);
     }
-    
 
     private Dataset<Row> createKVDataSet(
         List<Tuple2<Integer, Integer>> data, String keyName, String valueName) {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -927,6 +927,25 @@ class DeltaSuite extends QueryTest
     }
   }
 
+  test("get touched files for update, delete and merge") {
+    withTempDir { dir =>
+      val directory = new File(dir, "test with space")
+      val df = Seq((1, 10), (2, 20), (3, 30), (4, 40)).toDF("key", "value")
+      val writer = df.write.format("delta").mode("append")
+      writer.save(directory.getCanonicalPath)
+      spark.sql(s"UPDATE delta.`${directory.getCanonicalPath}` SET value = value + 10")
+      spark.sql(s"DELETE FROM delta.`${directory.getCanonicalPath}` WHERE key = 4")
+      val inbound = Seq((3, 30)).toDF("key", "value").createOrReplaceTempView("inbound")
+      spark.sql(s"MERGE INTO delta.`${directory.getCanonicalPath}` AS base USING inbound" +
+        s" ON base.key = inbound.key WHEN MATCHED THEN UPDATE" +
+        s" SET base.value = base.value+inbound.value")
+      checkAnswer(
+        spark.read.format("delta").load(directory.getCanonicalPath),
+        Seq((1, 20), (2, 30), (3, 70)).toDF("key", "value")
+      )
+    }
+  }
+
   test("can't create zero-column table with a write") {
     withTempDir { dir =>
       intercept[AnalysisException] {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -936,9 +936,11 @@ class DeltaSuite extends QueryTest
       spark.sql(s"UPDATE delta.`${directory.getCanonicalPath}` SET value = value + 10")
       spark.sql(s"DELETE FROM delta.`${directory.getCanonicalPath}` WHERE key = 4")
       val inbound = Seq((3, 30)).toDF("key", "value").createOrReplaceTempView("inbound")
-      spark.sql(s"MERGE INTO delta.`${directory.getCanonicalPath}` AS base USING inbound" +
-        s" ON base.key = inbound.key WHEN MATCHED THEN UPDATE" +
-        s" SET base.value = base.value+inbound.value")
+      val mergeInto = s"MERGE INTO delta.`${directory.getCanonicalPath}` AS base"
+      val inboundDF = "USING inbound"
+      val mergeOn = "ON base.key = inbound.key"
+      val whenMatched = "WHEN MATCHED THEN UPDATE SET base.value = base.value+inbound.value"
+      spark.sql(mergeInto + inboundDF + mergeOn + whenMatched)
       checkAnswer(
         spark.read.format("delta").load(directory.getCanonicalPath),
         Seq((1, 20), (2, 30), (3, 70)).toDF("key", "value")

--- a/core/src/test/scala/org/apache/spark/sql/delta/UpdateScalaSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/UpdateScalaSuite.scala
@@ -17,10 +17,10 @@
 package org.apache.spark.sql.delta
 
 import java.util.Locale
+
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import io.delta.tables.DeltaTableTestUtils
-import org.apache.spark.sql.{Row, functions}
-import org.apache.spark.util.Utils
+import org.apache.spark.sql.{functions, Row}
 
 class UpdateScalaSuite extends UpdateSuiteBase  with DeltaSQLCommandTest {
 
@@ -58,6 +58,7 @@ class UpdateScalaSuite extends UpdateSuiteBase  with DeltaSQLCommandTest {
     checkAnswer(readDeltaTable(tempPath),
       Row(100, 101) :: Row(100, 101) :: Row(3, 30) :: Row(4, 40) :: Nil)
   }
+  
   override protected def executeUpdate(
       target: String,
       set: String,

--- a/core/src/test/scala/org/apache/spark/sql/delta/UpdateScalaSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/UpdateScalaSuite.scala
@@ -58,7 +58,6 @@ class UpdateScalaSuite extends UpdateSuiteBase  with DeltaSQLCommandTest {
     checkAnswer(readDeltaTable(tempPath),
       Row(100, 101) :: Row(100, 101) :: Row(3, 30) :: Row(4, 40) :: Nil)
   }
-  
   override protected def executeUpdate(
       target: String,
       set: String,

--- a/core/src/test/scala/org/apache/spark/sql/delta/UpdateScalaSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/UpdateScalaSuite.scala
@@ -58,24 +58,7 @@ class UpdateScalaSuite extends UpdateSuiteBase  with DeltaSQLCommandTest {
     checkAnswer(readDeltaTable(tempPath),
       Row(100, 101) :: Row(100, 101) :: Row(3, 30) :: Row(4, 40) :: Nil)
   }
-
-  test("update usage test - with space in path") {
-    val tmpDirForTest = System.getProperty("java.io.tmpdir").concat("/test with space/")
-    val dirFile = Utils.createTempDir(tmpDirForTest, "spark")
-    val dir = dirFile.toString
-    val df = Seq((1, 10), (2, 20), (3, 30), (4, 40)).toDF("key", "value")
-    val writer = df.write.format("delta").mode("append")
-    writer.save(dir)
-    spark.sql("CREATE TABLE test USING DELTA LOCATION '" + dir + "'")
-    spark.sql("UPDATE test SET key = key + 10")
-    spark.sql("UPDATE test SET key = key + 10 WHERE true")
-    spark.sql("UPDATE test SET key = key + 10 WHERE 1 = 1")
-    spark.sql("UPDATE test SET key = key + 10 WHERE key = key")
-    checkAnswer(readDeltaTable(dir),
-      Row(41, 10) :: Row(42, 20) :: Row(43, 30) :: Row(44, 40) :: Nil)
-    Utils.deleteRecursively(dirFile)
-  }
-
+  
   override protected def executeUpdate(
       target: String,
       set: String,

--- a/core/src/test/scala/org/apache/spark/sql/delta/UpdateScalaSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/UpdateScalaSuite.scala
@@ -60,7 +60,7 @@ class UpdateScalaSuite extends UpdateSuiteBase  with DeltaSQLCommandTest {
   }
 
   test("update usage test - with space in path") {
-    val tmpDirForTest = System.getProperty("java.io.tmpdir").concat("test with space/")
+    val tmpDirForTest = System.getProperty("java.io.tmpdir").concat("/test with space/")
     val dirFile = Utils.createTempDir(tmpDirForTest, "spark")
     val dir = dirFile.toString
     val df = Seq((1, 10), (2, 20), (3, 30), (4, 40)).toDF("key", "value")

--- a/core/src/test/scala/org/apache/spark/sql/delta/UpdateScalaSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/UpdateScalaSuite.scala
@@ -17,11 +17,10 @@
 package org.apache.spark.sql.delta
 
 import java.util.Locale
-
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import io.delta.tables.DeltaTableTestUtils
-
-import org.apache.spark.sql.{functions, Row}
+import org.apache.spark.sql.{Row, functions}
+import org.apache.spark.util.Utils
 
 class UpdateScalaSuite extends UpdateSuiteBase  with DeltaSQLCommandTest {
 
@@ -58,6 +57,23 @@ class UpdateScalaSuite extends UpdateSuiteBase  with DeltaSQLCommandTest {
       Map("key" -> functions.expr("100"), "value" -> functions.expr("101")))
     checkAnswer(readDeltaTable(tempPath),
       Row(100, 101) :: Row(100, 101) :: Row(3, 30) :: Row(4, 40) :: Nil)
+  }
+
+  test("update usage test - with space in path") {
+    val tmpDirForTest = System.getProperty("java.io.tmpdir").concat("test with space/")
+    val dirFile = Utils.createTempDir(tmpDirForTest, "spark")
+    val dir = dirFile.toString
+    val df = Seq((1, 10), (2, 20), (3, 30), (4, 40)).toDF("key", "value")
+    val writer = df.write.format("delta").mode("append")
+    writer.save(dir)
+    spark.sql("CREATE TABLE test USING DELTA LOCATION '" + dir + "'")
+    spark.sql("UPDATE test SET key = key + 10")
+    spark.sql("UPDATE test SET key = key + 10 WHERE true")
+    spark.sql("UPDATE test SET key = key + 10 WHERE 1 = 1")
+    spark.sql("UPDATE test SET key = key + 10 WHERE key = key")
+    checkAnswer(readDeltaTable(dir),
+      Row(41, 10) :: Row(42, 20) :: Row(43, 30) :: Row(44, 40) :: Nil)
+    Utils.deleteRecursively(dirFile)
   }
 
   override protected def executeUpdate(


### PR DESCRIPTION
`getTouchedFiles` incorrectly calls `toUri` which will escape the table path when it contains special chars. This causes Merge/Update/Delete not able to find matches files in this case.

This PR removes `toUri` to fix the issue and adds a test to confirm the fix.

Fix #724