### PR TITLE
Fix an issue in Merge/Update/Delete when the table path contains special chars

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
@@ -166,7 +166,7 @@ trait DeltaCommand extends DeltaLogging {
       basePath: Path,
       filePath: String,
       nameToAddFileMap: Map[String, AddFile]): AddFile = {
-    val absolutePath = DeltaFileOperations.absolutePath(basePath.toUri.toString, filePath).toString
+    val absolutePath = DeltaFileOperations.absolutePath(basePath.toString, filePath).toString
     nameToAddFileMap.getOrElse(absolutePath, {
       throw new IllegalStateException(s"File ($absolutePath) to be rewritten not found " +
         s"among candidate files:\n${nameToAddFileMap.keys.mkString("\n")}")

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -935,11 +935,11 @@ class DeltaSuite extends QueryTest
       spark.sql(s"UPDATE delta.`${directory.getCanonicalPath}` SET value = value + 10")
       spark.sql(s"DELETE FROM delta.`${directory.getCanonicalPath}` WHERE key = 4")
       val inbound = Seq((3, 30)).toDF("key", "value").createOrReplaceTempView("inbound")
-      val mergeInto = s"MERGE INTO delta.`${directory.getCanonicalPath}` AS base"
-      val inboundDF = "USING inbound"
-      val mergeOn = "ON base.key = inbound.key"
+      var mergeInto = s"MERGE INTO delta.`${directory.getCanonicalPath}` AS base "
+      val inboundDF = "USING inbound "
+      val mergeOn = "ON base.key = inbound.key "
       val whenMatched = "WHEN MATCHED THEN UPDATE SET base.value = base.value+inbound.value"
-      spark.sql(mergeInto + inboundDF + mergeOn + whenMatched)
+      spark.sql(mergeInto + inboundDF  + mergeOn  + whenMatched)
       checkAnswer(
         spark.read.format("delta").load(directory.getCanonicalPath),
         Seq((1, 20), (2, 30), (3, 70)).toDF("key", "value")


### PR DESCRIPTION
getTouchedFiles incorrectly calls toUri which will escape the table path when it contains special chars. This causes Merge/Update/Delete not able to find matches files in this case.

This PR removes toUri to fix the issue and adds a test to confirm the fix.

Fix #724
