### PR TITLE
Make HDFSLogStore consistent with an Observer NameNode

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/storage/HDFSLogStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/storage/HDFSLogStore.scala
@@ -126,18 +126,24 @@ class HDFSLogStore(sparkConf: SparkConf, defaultHadoopConf: Configuration)
       }
     }
 
-    // Normally when using HDFS with an Observer NameNode setup, there would be read after write
-    // consistency within a single process, so the write would be guaranteed to be visible on the
-    // next read. However, since we are using the FileContext API for writing (for atomic rename),
-    // and the FileSystem API for reading (for more compatibility with various file systems), we
-    // are essentially using two separate clients that are not guaranteed to be kept in sync.
-    // Therefore we "msync" the FileSystem instance, which is cached across all uses of the same
-    // protocol/host combination, to make sure the next read through the HDFSLogStore can see this
-    // write.
-    // Any underlying FileSystem that is not the DistributedFileSystem will simply throw an
-    // UnsupportedOperationException, which can be ignored. Additionally, if an older version of
-    // Hadoop is being used that does not include msync, a NoSuchMethodError will be thrown while
-    // looking up the method, which can also be safely ignored.
+    msyncIfSupported(path, hadoopConf)
+  }
+
+  /**
+   * Normally when using HDFS with an Observer NameNode setup, there would be read after write
+   * consistency within a single process, so the write would be guaranteed to be visible on the
+   * next read. However, since we are using the FileContext API for writing (for atomic rename),
+   * and the FileSystem API for reading (for more compatibility with various file systems), we
+   * are essentially using two separate clients that are not guaranteed to be kept in sync.
+   * Therefore we "msync" the FileSystem instance, which is cached across all uses of the same
+   * protocol/host combination, to make sure the next read through the HDFSLogStore can see this
+   * write.
+   * Any underlying FileSystem that is not the DistributedFileSystem will simply throw an
+   * UnsupportedOperationException, which can be ignored. Additionally, if an older version of
+   * Hadoop is being used that does not include msync, a NoSuchMethodError will be thrown while
+   * looking up the method, which can also be safely ignored.
+   */
+  private def msyncIfSupported(path: Path, hadoopConf: Configuration): Unit = {
     try {
       val fs = path.getFileSystem(hadoopConf)
       val msync = fs.getClass.getMethod("msync")
@@ -145,9 +151,10 @@ class HDFSLogStore(sparkConf: SparkConf, defaultHadoopConf: Configuration)
     } catch {
       case parent: InvocationTargetException =>
         parent.getCause match {
-          case _: UnsupportedOperationException | _: NoSuchMethodError =>
+          case _: UnsupportedOperationException =>
           case e => throw e
         }
+      case _: NoSuchMethodException =>
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/storage/HDFSLogStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/storage/HDFSLogStore.scala
@@ -149,12 +149,7 @@ class HDFSLogStore(sparkConf: SparkConf, defaultHadoopConf: Configuration)
       val msync = fs.getClass.getMethod("msync")
       msync.invoke(fs)
     } catch {
-      case parent: InvocationTargetException =>
-        parent.getCause match {
-          case _: UnsupportedOperationException =>
-          case e => throw e
-        }
-      case _: NoSuchMethodException =>
+      case NonFatal(_) => // ignore, calling msync is best effort
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
@@ -315,15 +315,10 @@ trait HDFSLogStoreSuiteBase extends LogStoreSuiteBase {
         // Initialize the TimestampLocalFileSystem object which will be reused later due to the
         // FileSystem cache
         assert(store.listFrom(path, sessionHadoopConf).length == 0)
-        // The LocalFileSystem only tracks modified time at second granularity, so we need to
-        // wait a second to make sure the behavior works, otherwise the below `listFrom` would
-        // succeed even without the `msync` call, as the file timestamp is rounded down to the
-        // nearest second.
-        Thread.sleep(1000)
 
         store.write(path, Iterator("zero", "none"), overwrite = false, sessionHadoopConf)
         // Verify `msync` is called by checking whether `listFrom` returns the latest result.
-        // Without the `msync` call, the TimestampLocalFileSystem would not see this file
+        // Without the `msync` call, the TimestampLocalFileSystem would not see this file.
         assert(store.listFrom(path, sessionHadoopConf).length == 1)
       }
     }

--- a/core/src/test/scala/org/apache/spark/sql/delta/TimestampLocalFileSystem.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/TimestampLocalFileSystem.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.net.URI
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{DelegateToFileSystem, Path, RawLocalFileSystem}
+import org.apache.hadoop.fs.FileStatus
+
+/**
+ * This custom fs implementation is used for testing the msync calling in HDFSLogStore writes
+ */
+class TimestampLocalFileSystem extends RawLocalFileSystem {
+
+  private var uri: URI = _
+  private var latestTimestamp: Long = 0
+
+  override def getScheme: String = TimestampLocalFileSystem.scheme
+
+  override def initialize(name: URI, conf: Configuration): Unit = {
+    uri = URI.create(name.getScheme + ":///")
+    latestTimestamp = System.currentTimeMillis()
+    super.initialize(name, conf)
+  }
+
+  override def getUri(): URI = if (uri == null) {
+    // RawLocalFileSystem's constructor will call this one before `initialize` is called.
+    // Just return the super's URI to avoid NPE.
+    super.getUri
+  } else {
+    uri
+  }
+
+  override def listStatus(path: Path): Array[FileStatus] = {
+    super.listStatus(path).filter(_.getModificationTime <= latestTimestamp)
+  }
+
+  override def msync(): Unit = {
+    latestTimestamp = System.currentTimeMillis()
+  }
+}
+
+class TimestampAbstractFileSystem(uri: URI, conf: Configuration)
+    extends DelegateToFileSystem(
+      uri,
+      new TimestampLocalFileSystem,
+      conf,
+      TimestampLocalFileSystem.scheme,
+      false)
+
+/**
+ * Singleton for BlockWritesLocalFileSystem used to initialize the file system countdown latch.
+ */
+object TimestampLocalFileSystem {
+  val scheme = "ts"
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/TimestampLocalFileSystem.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/TimestampLocalFileSystem.scala
@@ -35,7 +35,6 @@ class TimestampLocalFileSystem extends RawLocalFileSystem {
 
   override def initialize(name: URI, conf: Configuration): Unit = {
     uri = URI.create(name.getScheme + ":///")
-    latestTimestamp = System.currentTimeMillis()
     super.initialize(name, conf)
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/TimestampLocalFileSystem.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/TimestampLocalFileSystem.scala
@@ -23,7 +23,8 @@ import org.apache.hadoop.fs.{DelegateToFileSystem, Path, RawLocalFileSystem}
 import org.apache.hadoop.fs.FileStatus
 
 /**
- * This custom fs implementation is used for testing the msync calling in HDFSLogStore writes
+ * This custom fs implementation is used for testing the msync calling in HDFSLogStore writes.
+ * If `msync` is not called, `listStatus` will return stale results.
  */
 class TimestampLocalFileSystem extends RawLocalFileSystem {
 

--- a/storage/src/main/java/io/delta/storage/HDFSLogStore.java
+++ b/storage/src/main/java/io/delta/storage/HDFSLogStore.java
@@ -19,7 +19,6 @@ package io.delta.storage;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InterruptedIOException;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;


### PR DESCRIPTION
Resolves #767

Adds an `msync` call after a successful write in the HDFSLogStore. This is needed because after a write using the FileContext API, the FileSystem API, which is used for reading, is not guaranteed to be able to read the write, even from the same process. This causes issues when a transaction is committed and then the new version is immediately read. This msync on the FileSystem API forces the cached FileSystem object to update it's internal state version so that the next read is guaranteed to see the write.