### PR TITLE
Add Option to the deletionTimestamp from the Remove Action in the PROTOCOL

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -252,7 +252,7 @@ The schema of the `remove` action is as follows:
 Field Name | Data Type | Description
 -|-|-
 path| String | A relative path to a file from the root of the table or an absolute path to a file that should be removed from the table. The path is a URI as specified by [RFC 2396 URI Generic Syntax](https://www.ietf.org/rfc/rfc2396.txt), which needs to be decoded to get the file path.
-deletionTimestamp | Long | The time the deletion occurred, represented as milliseconds since the epoch
+deletionTimestamp | Option[Long] | The time the deletion occurred, represented as milliseconds since the epoch
 dataChange | Boolean | When `false` the records in the removed file must be contained in one or more `add` file actions in the same version
 extendedFileMetadata | Boolean | When `true` the fields `partitionValues`, `size`, and `tags` are present
 partitionValues| Map[String, String] | A map from partition column to value for this file. See also [Partition Value Serialization](#Partition-Value-Serialization)


### PR DESCRIPTION
The deletionTimestamp in the Remove action is an Option: https://github.com/delta-io/delta/blob/master/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala#L319