### PR TITLE
Python: fix convertToDelta to return a delta.tables.DeltaTable. Close #726.

### DIFF
--- a/python/delta/tables.py
+++ b/python/delta/tables.py
@@ -271,7 +271,7 @@ class DeltaTable(object):
             jdt = sparkSession._sc._jvm.io.delta.tables.DeltaTable.convertToDelta(
                 sparkSession._jsparkSession, identifier,
                 partitionSchema)
-        return jdt
+        return DeltaTable(sparkSession, jdt)
 
     @classmethod
     @since(0.4)


### PR DESCRIPTION
Wrap the return value of convertToDelta in a DeltaTable.

Author: Tom Lynch <lync0143@gmail.com>