### PR TITLE
Fix DeltaTable._condition_to_jcolumn and DeltaTable._dict_to_jmap usage

### DIFF
--- a/python/delta/tables.py
+++ b/python/delta/tables.py
@@ -481,8 +481,8 @@ class DeltaTable(object):
                 raise TypeError(e)
         return jmap
 
-    @classmethod
-    def _condition_to_jcolumn(cls, condition, argname="'condition'"):
+    @staticmethod
+    def _condition_to_jcolumn(condition, argname="'condition'"):
         if condition is None:
             jcondition = None
         elif type(condition) is Column:


### PR DESCRIPTION
Correct `DeltaTable._condition_to_jcolumn` and `DeltaTable._dict_to_jmap` usage and convert both from `@classmethod` to `@staticmethod`

Closes #801