### PR TITLE
Implements fetching file sets for delta streaming using datasets

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -97,6 +97,9 @@ trait DeltaWriteOptionsImpl extends DeltaOptionParser {
 trait DeltaReadOptions extends DeltaOptionParser {
   import DeltaOptions._
 
+  val datasetForDeltaStreaming = options.get(DATASET_FOR_DELTA_STREAMING_OPTION)
+    .exists(toBoolean(_, DATASET_FOR_DELTA_STREAMING_OPTION))
+
   val maxFilesPerTrigger = options.get(MAX_FILES_PER_TRIGGER_OPTION).map { str =>
     Try(str.toInt).toOption.filter(_ > 0).getOrElse {
       throw DeltaErrors.illegalDeltaOptionException(
@@ -175,6 +178,7 @@ object DeltaOptions extends DeltaLogging {
   /** An option to specify user-defined metadata in commitInfo */
   val USER_METADATA_OPTION = "userMetadata"
 
+  val DATASET_FOR_DELTA_STREAMING_OPTION = "datasetForDeltaStreaming"
   val MAX_FILES_PER_TRIGGER_OPTION = "maxFilesPerTrigger"
   val MAX_FILES_PER_TRIGGER_OPTION_DEFAULT = 1000
   val MAX_BYTES_PER_TRIGGER_OPTION = "maxBytesPerTrigger"

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -16,4 +16,4 @@
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
 
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M14")


### PR DESCRIPTION
This should make streaming against tables with very busy/large logs
much more performant.  The current implementation of streaming works
very well if the stream is close to current.  However if it falls
very far behind, many json files will need to be downloaded to the
driver and processed to build the files in the next micro batch

This also pushes partition filtering ahead of the checks against
maxFilesPerTrigger and maxBytesPerTrigger.  This will make these
parameters much more useful when streaming against a table with a
where clause which only selects a very small subset of a large table

I was not able to layer in two checks which are present in the
existing implementation, breaking delta protocol changes and breaking
schema changes.  Those checks are currently implemented as side
effects in a filtering step.

They could probably be re-implemented with a bit more work

This feature is moved behind the option: datasetForDeltaStreaming