### PR TITLE
Clarify delta-log entries JSON format in PROTOCOL.md #762

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -102,7 +102,7 @@ For example:
 ```
 ./_delta_log/00000000000000000000.json
 ```
-
+Delta files use new-line delimited JSON format, where every action is stored as a single line JSON document.
 A delta file, `n.json`, contains an atomic set of [_actions_](#Actions) that should be applied to the previous table state, `n-1.json`, in order to the construct `n`th snapshot of the table.
 An action changes one aspect of the table's state, for example, adding or removing a file.
 


### PR DESCRIPTION
Clarify the format for delta-log entries on the documentation to explain that every action is written as a JSON document and separated by a new-line character.

Signed-off-by: Alexandre Lopes <aleaugustoplus@gmail.com>