### PR TITLE
Natively handle errors when calling `shutil.rmtree` in Python examples 

### DIFF
--- a/examples/python/quickstart.py
+++ b/examples/python/quickstart.py
@@ -20,10 +20,7 @@ from delta.tables import DeltaTable
 import shutil
 
 # Clear any previous runs
-try:
-    shutil.rmtree("/tmp/delta-table")
-except:
-    pass
+shutil.rmtree("/tmp/delta-table", ignore_errors=True)
 
 # Enable SQL commands and Update/Delete/Merge for the current spark session.
 # we need to set the following configs

--- a/examples/python/quickstart_sql_on_paths.py
+++ b/examples/python/quickstart_sql_on_paths.py
@@ -4,10 +4,7 @@ import shutil
 
 table_dir = "/tmp/delta-table"
 # Clear any previous runs
-try:
-    shutil.rmtree(table_dir)
-except:
-    pass
+shutil.rmtree(table_dir, ignore_errors=True)
 
 # Enable SQL/DML commands and Metastore tables for the current spark session.
 # We need to set the following configs

--- a/examples/python/streaming.py
+++ b/examples/python/streaming.py
@@ -30,10 +30,7 @@ spark = SparkSession.builder \
     .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog") \
     .getOrCreate()
 
-try:
-    shutil.rmtree("/tmp/delta-streaming/")
-except:
-    pass
+shutil.rmtree("/tmp/delta-streaming/", ignore_errors=Trues)
 
 # Create a table(key, value) of some data
 data = spark.range(8)
@@ -118,8 +115,6 @@ stream4.awaitTermination(10)
 stream4.stop()
 print("######### After streaming write #########")
 spark.read.format("delta").load(tbl1).show()
+
 # cleanup
-try:
-    shutil.rmtree("/tmp/delta-streaming/")
-except:
-    pass
+shutil.rmtree("/tmp/delta-streaming/", ignore_errors=True)

--- a/examples/python/streaming.py
+++ b/examples/python/streaming.py
@@ -30,7 +30,7 @@ spark = SparkSession.builder \
     .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog") \
     .getOrCreate()
 
-shutil.rmtree("/tmp/delta-streaming/", ignore_errors=Trues)
+shutil.rmtree("/tmp/delta-streaming/", ignore_errors=True)
 
 # Create a table(key, value) of some data
 data = spark.range(8)

--- a/examples/python/using_with_pip.py
+++ b/examples/python/using_with_pip.py
@@ -39,10 +39,7 @@ spark = configure_spark_with_delta_pip(builder).getOrCreate()
 
 
 # Clear previous run's delta-tables
-try:
-    shutil.rmtree("/tmp/delta-table")
-except:
-    pass
+shutil.rmtree("/tmp/delta-table", ignore_errors=True)
 
 print("########### Create a Parquet table ##############")
 data = spark.range(0, 5)

--- a/examples/python/utilities.py
+++ b/examples/python/utilities.py
@@ -27,10 +27,7 @@ spark = SparkSession.builder \
     .getOrCreate()
 
 # Clear previous run's delta-tables
-try:
-    shutil.rmtree("/tmp/delta-table")
-except:
-    pass
+shutil.rmtree("/tmp/delta-table", ignore_errors=True)
 
 # Create a table
 print("########### Create a Parquet table ##############")


### PR DESCRIPTION
In Python examples', remove the try-except block in favor of `shutil`'s native error handling, avoiding possible inconsistencies that could come from the high extent of the pure `except` statement.