### PR TITLE
Pin pipenv version to fix the broken Python setup

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,8 @@ jobs:
           echo "=====> 2"
           pipenv --python 3.7 install
           echo "=====> 3"
-          pipenv run pip install urllib3==1.24.3 pyspark==3.1.0 flake8==3.5.0 pypandoc==1.3.3 importlib_metadata==3.10.0
+          pipenv run pip install requests --upgrade
+          pipenv run pip install urllib3==1.24.3 pyspark==3.2.0 flake8==3.5.0 pypandoc==1.3.3 importlib_metadata==3.10.0
       - name: Run Scala/Java and Python tests
         run: |
           pipenv run python run-tests.py

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
           echo "=====> 2"
           pipenv --python 3.7 install
           echo "=====> 3"
-          pipenv run pip install urllib3==1.24.3 pyspark==3.2.0 flake8==3.5.0 pypandoc==1.3.3 importlib_metadata==3.10.0
+          pipenv run pip install urllib3==1.24.3 pyspark==3.1.0 flake8==3.5.0 pypandoc==1.3.3 importlib_metadata==3.10.0
       - name: Run Scala/Java and Python tests
         run: |
           pipenv run python run-tests.py

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,7 @@ jobs:
           pyenv install 3.7.4
           pyenv global system 3.7.4
           pipenv --python 3.7 install
+          pipenv run pip install urllib3==1.24.3
           pipenv run pip install pyspark==3.2.0
           pipenv run pip install flake8==3.5.0 pypandoc==1.3.3
           pipenv run pip install importlib_metadata==3.10.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,9 @@ jobs:
           pyenv install 3.7.4
           pyenv global system 3.7.4
           pipenv --python 3.7 install
-          pipenv run pip install urllib3==1.24.3 pyspark==3.2.0 flake8==3.5.0 pypandoc==1.3.3 importlib_metadata==3.10.0
+          pipenv run pip install pyspark==3.2.0
+          pipenv run pip install flake8==3.5.0 pypandoc==1.3.3
+          pipenv run pip install importlib_metadata==3.10.0
       - name: Run Scala/Java and Python tests
         run: |
           pipenv run python run-tests.py

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,12 +35,12 @@ jobs:
           eval "$(pyenv init -)"
           eval "$(pyenv virtualenv-init -)"
           pyenv install 3.7.4
+          echo "=====> 1"
           pyenv global system 3.7.4
+          echo "=====> 2"
           pipenv --python 3.7 install
-          pipenv run pip install urllib3==1.24.3
-          pipenv run pip install pyspark==3.2.0
-          pipenv run pip install flake8==3.5.0 pypandoc==1.3.3
-          pipenv run pip install importlib_metadata==3.10.0
+          echo "=====> 3"
+          pipenv run pip install urllib3==1.24.3 pyspark==3.2.0 flake8==3.5.0 pypandoc==1.3.3 importlib_metadata==3.10.0
       - name: Run Scala/Java and Python tests
         run: |
           pipenv run python run-tests.py

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,18 +29,14 @@ jobs:
           sudo apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
           sudo apt install libedit-dev
           sudo apt install python3-pip --fix-missing
-          sudo pip3 install pipenv
+          sudo pip3 install pipenv==2021.5.29
           curl https://pyenv.run | bash
           export PATH="~/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
           eval "$(pyenv virtualenv-init -)"
           pyenv install 3.7.4
-          echo "=====> 1"
           pyenv global system 3.7.4
-          echo "=====> 2"
           pipenv --python 3.7 install
-          echo "=====> 3"
-          pipenv run pip install requests --upgrade
           pipenv run pip install urllib3==1.24.3 pyspark==3.2.0 flake8==3.5.0 pypandoc==1.3.3 importlib_metadata==3.10.0
       - name: Run Scala/Java and Python tests
         run: |

--- a/run-tests.py
+++ b/run-tests.py
@@ -72,5 +72,5 @@ if __name__ == "__main__":
         run_cmd(cmd, stream_output=True)
     else:
         root_dir = os.path.dirname(os.path.dirname(__file__))
-        # run_sbt_tests(root_dir)
+        run_sbt_tests(root_dir)
         run_python_tests(root_dir)

--- a/run-tests.py
+++ b/run-tests.py
@@ -72,5 +72,5 @@ if __name__ == "__main__":
         run_cmd(cmd, stream_output=True)
     else:
         root_dir = os.path.dirname(os.path.dirname(__file__))
-        run_sbt_tests(root_dir)
+        # run_sbt_tests(root_dir)
         run_python_tests(root_dir)


### PR DESCRIPTION
Our Python setup is broken with the following error:

```
Traceback (most recent call last):
  File "/usr/local/bin/pipenv", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.8/dist-packages/pipenv/vendor/click/core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/pipenv/vendor/click/core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.8/dist-packages/pipenv/vendor/click/core.py", line 1668, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.8/dist-packages/pipenv/vendor/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.8/dist-packages/pipenv/vendor/click/core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/pipenv/vendor/click/decorators.py", line 84, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/pipenv/vendor/click/core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/pipenv/cli/command.py", line 440, in run
    do_run(
  File "/usr/local/lib/python3.8/dist-packages/pipenv/core.py", line 2456, in do_run
    ensure_project(
  File "/usr/local/lib/python3.8/dist-packages/pipenv/core.py", line 560, in ensure_project
    ensure_pipfile(
  File "/usr/local/lib/python3.8/dist-packages/pipenv/core.py", line 269, in ensure_pipfile
    project.create_pipfile(python=python)
  File "/usr/local/lib/python3.8/dist-packages/pipenv/project.py", line 710, in create_pipfile
    from .vendor.pip_shims.shims import InstallCommand
ImportError: cannot import name 'InstallCommand' from 'pipenv.vendor.pip_shims.shims' (/usr/local/lib/python3.8/dist-packages/pipenv/vendor/pip_shims/shims.py)
```

By comparing the build logs, I found it's because pipenv's new release `2021.11.5.post0` broke it.

Green build log
```
Collecting pipenv
  Downloading pipenv-2021.5.29-py2.py3-none-any.whl (3.9 MB)
``` 

Red build log
```
Collecting pipenv
  Downloading pipenv-2021.11.5.post0-py2.py3-none-any.whl (3.9 MB)
```

This PR pins pipenv to 2021.5.29 (The previous one we use) to fix the build.