### PR TITLE
Block SHOW CREATE TABLE for Delta

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaUnsupportedOperationsCheck.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaUnsupportedOperationsCheck.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.ResolvedTable
 import org.apache.spark.sql.catalyst.catalog.CatalogTableType
-import org.apache.spark.sql.catalyst.plans.logical.{AppendData, DropTable, LogicalPlan, OverwriteByExpression, V2WriteCommand}
+import org.apache.spark.sql.catalyst.plans.logical.{AppendData, DropTable, LogicalPlan, OverwriteByExpression, ShowCreateTable, V2WriteCommand}
 import org.apache.spark.sql.execution.command._
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 
@@ -98,6 +98,10 @@ case class DeltaUnsupportedOperationsCheck(spark: SparkSession)
     case i: InsertIntoDataSourceDirCommand =>
       recordDeltaEvent(null, "delta.unsupported.insertDirectory")
       fail(operation = "INSERT OVERWRITE DIRECTORY", i.provider)
+
+    case ShowCreateTable(t: ResolvedTable, _, _) if t.table.isInstanceOf[DeltaTableV2] =>
+      recordDeltaEvent(null, "delta.unsupported.showCreateTable")
+      fail(operation = "SHOW CREATE TABLE", "DELTA")
 
     // Delta table checks
     case append: AppendData =>

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaDDLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaDDLSuite.scala
@@ -433,11 +433,12 @@ abstract class DeltaDDLTestBase extends QueryTest with SQLTestUtils {
 
   /**
    * Although Spark 3.2 adds the support for SHOW CREATE TABLE for v2 tables, it doesn't work
-   * properly for some delta features, such as Delta constraints and generated columns.
+   * properly for Delta. For example, table properties, constraints and generated columns are not
+   * showed properly.
    *
-   * TODO(SC-83986): We should block it for unsupported tables
+   * TODO Implement Delta's own ShowCreateTableCommand to show the Delta table definition correctly
    */
-  ignore("SHOW CREATE TABLE should not include OPTIONS except for path - not supported") {
+  test("SHOW CREATE TABLE is not supported") {
     withTable("delta_test") {
       sql(
         s"""
@@ -448,7 +449,7 @@ abstract class DeltaDDLTestBase extends QueryTest with SQLTestUtils {
       val e = intercept[AnalysisException] {
         sql("SHOW CREATE TABLE delta_test").collect()(0).getString(0)
       }
-      assert(e.message.equals("SHOW CREATE TABLE is not supported for v2 tables."))
+      assert(e.message.contains("`SHOW CREATE TABLE` is not supported for Delta table"))
     }
 
     withTempDir { dir =>
@@ -464,7 +465,7 @@ abstract class DeltaDDLTestBase extends QueryTest with SQLTestUtils {
         val e = intercept[AnalysisException] {
           sql("SHOW CREATE TABLE delta_test").collect()(0).getString(0)
         }
-        assert(e.message.equals("SHOW CREATE TABLE is not supported for v2 tables."))
+        assert(e.message.contains("`SHOW CREATE TABLE` is not supported for Delta table"))
       }
     }
   }


### PR DESCRIPTION
Although Spark 3.2 adds the support for SHOW CREATE TABLE for v2 tables, it doesn't work properly for Delta. For example, table properties, constraints and generated columns are not showed properly.

This PR blocks SHOW CREATE TABLE for Delta to unblock 1.1.0 release. In the future, we should implement Delta's own ShowCreateTableCommand to show the Delta table definition correctly