### PR TITLE
Add test for broken SET NOT NULL; Fix ALTER TABLE semi-colon error

### DIFF
--- a/core/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
+++ b/core/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
@@ -67,7 +67,7 @@ tokens {
 }
 
 singleStatement
-    : statement EOF
+    : statement ';'* EOF
     ;
 
 // If you add keywords here that should not be reserved, add them to 'nonReserved' list.

--- a/core/src/test/scala/org/apache/spark/sql/delta/schema/CheckConstraintsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/schema/CheckConstraintsSuite.scala
@@ -367,17 +367,15 @@ class CheckConstraintsSuite extends QueryTest
     }
   }
 
-  // TODO fix this
+  // TODO: https://github.com/delta-io/delta/issues/831
   testQuietly("SET NOT NULL constraint fails") {
-    withSQLConf((DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_WRITER_VERSION.key, "3")) {
-      withTable("my_table") {
-        sql("CREATE TABLE my_table (id INT) USING DELTA;")
-        sql("INSERT INTO my_table VALUES (1);")
-        val e = intercept[AnalysisException] {
-          sql("ALTER TABLE my_table CHANGE COLUMN id SET NOT NULL;")
-        }.getMessage()
-        assert(e.contains("Cannot change nullable column to non-nullable"))
-      }
+    withTable("my_table") {
+      sql("CREATE TABLE my_table (id INT) USING DELTA;")
+      sql("INSERT INTO my_table VALUES (1);")
+      val e = intercept[AnalysisException] {
+        sql("ALTER TABLE my_table CHANGE COLUMN id SET NOT NULL;")
+      }.getMessage()
+      assert(e.contains("Cannot change nullable column to non-nullable"))
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/schema/CheckConstraintsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/schema/CheckConstraintsSuite.scala
@@ -378,36 +378,20 @@ class CheckConstraintsSuite extends QueryTest
         }.getMessage()
         assert(e.contains("Cannot change nullable column to non-nullable"))
       }
-
     }
   }
 
-  // TODO fix this
-  testQuietly("ending semi-colons make ADD, DROP constraint commands fail") {
+  testQuietly("ending semi-colons no longer makes ADD, DROP constraint commands fail") {
     withTable("my_table") {
       sql("CREATE TABLE my_table (birthday DATE) USING DELTA;")
       sql("INSERT INTO my_table VALUES ('2021-11-11');")
 
-      // ADD - no semi-colon will PASS
       sql("ALTER TABLE my_table ADD CONSTRAINT aaa CHECK (birthday > '1900-01-01')")
       sql("ALTER TABLE my_table ADD CONSTRAINT bbb CHECK (birthday > '1900-02-02')")
+      sql("ALTER TABLE my_table ADD CONSTRAINT ccc CHECK (birthday > '1900-03-03');") // semi-colon
 
-      // ADD - with a semi-colon will FAIL
-      val e = intercept[ParseException] {
-        sql("ALTER TABLE my_table ADD CONSTRAINT ccc CHECK (birthday > '1900-03-03');")
-      }.getMessage()
-      assert(e.contains("no viable alternative at input 'ALTER TABLE my_table ADD CONSTRAINT'" +
-        "(line 1, pos 25)"))
-
-      // DROP - no semi-colon will PASS
       sql("ALTER TABLE my_table DROP CONSTRAINT aaa")
-
-      // DROP - with a semi-colon will FAIL
-      val e2 = intercept[ParseException] {
-        sql("ALTER TABLE my_table DROP CONSTRAINT bbb;")
-      }.getMessage()
-      assert(e2.contains("no viable alternative at input 'ALTER TABLE my_table DROP CONSTRAINT'" +
-        "(line 1, pos 26)"))
+      sql("ALTER TABLE my_table DROP CONSTRAINT bbb;") // semi-colon
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/schema/CheckConstraintsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/schema/CheckConstraintsSuite.scala
@@ -370,40 +370,45 @@ class CheckConstraintsSuite extends QueryTest
   // TODO fix this
   testQuietly("SET NOT NULL constraint fails") {
     withSQLConf((DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_WRITER_VERSION.key, "3")) {
-      sql("CREATE TABLE my_table (id INT) USING DELTA;")
-      sql("INSERT INTO my_table VALUES (1);")
-      val e = intercept[AnalysisException] {
-        sql("ALTER TABLE my_table CHANGE COLUMN id SET NOT NULL;")
-      }.getMessage()
-      assert(e.contains("Cannot change nullable column to non-nullable"))
+      withTable("my_table") {
+        sql("CREATE TABLE my_table (id INT) USING DELTA;")
+        sql("INSERT INTO my_table VALUES (1);")
+        val e = intercept[AnalysisException] {
+          sql("ALTER TABLE my_table CHANGE COLUMN id SET NOT NULL;")
+        }.getMessage()
+        assert(e.contains("Cannot change nullable column to non-nullable"))
+      }
+
     }
   }
 
   // TODO fix this
   testQuietly("ending semi-colons make ADD, DROP constraint commands fail") {
-    sql("CREATE TABLE my_table (birthday DATE) USING DELTA;")
-    sql("INSERT INTO my_table VALUES ('2021-11-11');")
+    withTable("my_table") {
+      sql("CREATE TABLE my_table (birthday DATE) USING DELTA;")
+      sql("INSERT INTO my_table VALUES ('2021-11-11');")
 
-    // ADD - no semi-colon will PASS
-    sql("ALTER TABLE my_table ADD CONSTRAINT aaa CHECK (birthday > '1900-01-01')")
-    sql("ALTER TABLE my_table ADD CONSTRAINT bbb CHECK (birthday > '1900-02-02')")
+      // ADD - no semi-colon will PASS
+      sql("ALTER TABLE my_table ADD CONSTRAINT aaa CHECK (birthday > '1900-01-01')")
+      sql("ALTER TABLE my_table ADD CONSTRAINT bbb CHECK (birthday > '1900-02-02')")
 
-    // ADD - with a semi-colon will FAIL
-    val e = intercept[ParseException] {
-      sql("ALTER TABLE my_table ADD CONSTRAINT ccc CHECK (birthday > '1900-03-03');")
-    }.getMessage()
-    assert(e.contains("no viable alternative at input 'ALTER TABLE my_table ADD CONSTRAINT'" +
-      "(line 1, pos 25)"))
+      // ADD - with a semi-colon will FAIL
+      val e = intercept[ParseException] {
+        sql("ALTER TABLE my_table ADD CONSTRAINT ccc CHECK (birthday > '1900-03-03');")
+      }.getMessage()
+      assert(e.contains("no viable alternative at input 'ALTER TABLE my_table ADD CONSTRAINT'" +
+        "(line 1, pos 25)"))
 
-    // DROP - no semi-colon will PASS
-    sql("ALTER TABLE my_table DROP CONSTRAINT aaa")
+      // DROP - no semi-colon will PASS
+      sql("ALTER TABLE my_table DROP CONSTRAINT aaa")
 
-    // DROP - with a semi-colon will FAIL
-    val e2 = intercept[ParseException] {
-      sql("ALTER TABLE my_table DROP CONSTRAINT bbb;")
-    }.getMessage()
-    assert(e2.contains("no viable alternative at input 'ALTER TABLE my_table DROP CONSTRAINT'" +
-      "(line 1, pos 26)"))
+      // DROP - with a semi-colon will FAIL
+      val e2 = intercept[ParseException] {
+        sql("ALTER TABLE my_table DROP CONSTRAINT bbb;")
+      }.getMessage()
+      assert(e2.contains("no viable alternative at input 'ALTER TABLE my_table DROP CONSTRAINT'" +
+        "(line 1, pos 26)"))
+    }
   }
 
 }


### PR DESCRIPTION
Add test for failing statement `ALTER TABLE my_table CHANGE COLUMN id SET NOT NULL;` (Cannot change nullable column to non-nullable)

Fix issue where `ALTER TABLE ... ADD CONSTRAINT ... CHECK ...` commands could not end with a semi-colon.