### PR TITLE
'ANALYZE TABLE' command should fall back to v1 command

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -40,6 +40,7 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+import org.apache.spark.sql.connector.catalog.V1Table
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
@@ -170,6 +171,9 @@ class DeltaAnalysis(session: SparkSession)
       } else deltaMerge
       d.copy(target = stripTempViewForMergeWrapper(d.target))
 
+    // We can remove this when Spark supports ANALYZE TABLE for v2 tables.
+    case a @ AnalyzeTable(t @ ResolvedTable(_, _, dt: DeltaTableV2, _), _, _) =>
+      a.copy(child = t.copy(table = V1Table(dt.v1Table)))
   }
 
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaDDLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaDDLSuite.scala
@@ -516,4 +516,15 @@ abstract class DeltaDDLTestBase extends QueryTest with SQLTestUtils {
     }
   }
 
+  test("Analyze Table should fall back to v1 command") {
+    val tblName = "delta_test"
+    withTable(tblName) {
+      sql(s"CREATE TABLE $tblName USING delta AS SELECT 'foo' as a")
+      val tblIdent = TableIdentifier(tblName)
+      assert(spark.sessionState.catalog.getTableMetadata(tblIdent).stats.isEmpty)
+      sql(s"ANALYZE TABLE $tblName COMPUTE STATISTICS")
+      assert(spark.sessionState.catalog.getTableMetadata(tblIdent).stats.nonEmpty)
+    }
+  }
+
 }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaDDLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaDDLSuite.scala
@@ -520,9 +520,8 @@ abstract class DeltaDDLTestBase extends QueryTest with SQLTestUtils {
     val tblName = "delta_test"
     withTable(tblName) {
       sql(s"CREATE TABLE $tblName USING delta AS SELECT 'foo' as a")
-      val tblIdent = TableIdentifier(tblName)
-      assert(spark.sessionState.catalog.getTableMetadata(tblIdent).stats.isEmpty)
       sql(s"ANALYZE TABLE $tblName COMPUTE STATISTICS")
+      val tblIdent = TableIdentifier(tblName)
       assert(spark.sessionState.catalog.getTableMetadata(tblIdent).stats.nonEmpty)
     }
   }


### PR DESCRIPTION
There are few DDL commands in Spark that are not supported for v2 tables. One of the commands still not supported in Spark 3.2 is `ANALYZE TABLE`. (And I don't see any active development happening for this command for Spark 3.3 yet). Thus, this PR proposes to make v2 delta table fall back to v1 table if the command is `ANALYZE TABLE`.

Without this change, you will see an error message like:
```
ANALYZE TABLE is not supported for v2 tables.
org.apache.spark.sql.AnalysisException: ANALYZE TABLE is not supported for v2 tables.
	at org.apache.spark.sql.errors.QueryCompilationErrors$.notSupportedForV2TablesError(QueryCompilationErrors.scala:928)
	at org.apache.spark.sql.errors.QueryCompilationErrors$.analyzeTableNotSupportedForV2TablesError(QueryCompilationErrors.scala:932)
	at org.apache.spark.sql.execution.datasources.v2.DataSourceV2Strategy.apply(DataSourceV2Strategy.scala:339)
	at org.apache.spark.sql.catalyst.planning.QueryPlanner.$anonfun$plan$1(QueryPlanner.scala:63)
```