### PR TITLE
Delta 1.1 `org.codehaus.jackson` dependency fix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,8 @@ lazy val core = (project in file("core"))
       "org.apache.spark" %% "spark-core" % sparkVersion % "provided",
       "org.apache.spark" %% "spark-catalyst" % sparkVersion % "provided",
 
-      // Spark 3.2 no longer includes org.codehaus.jackson as a runtime dependency
+      // spark-sql 3.2.0's parquet-hadoop 1.12.1 dependency no longer includes org.codehaus.jackson
+      // as a dependency, so we include it here instead.
       "org.codehaus.jackson" % "jackson-core-asl" % "1.9.13",
 
       // Test deps

--- a/build.sbt
+++ b/build.sbt
@@ -48,6 +48,9 @@ lazy val core = (project in file("core"))
       "org.apache.spark" %% "spark-core" % sparkVersion % "provided",
       "org.apache.spark" %% "spark-catalyst" % sparkVersion % "provided",
 
+      // Spark 3.2 no longer includes org.codehaus.jackson as a runtime dependency
+      "org.codehaus.jackson" % "jackson-core-asl" % "1.9.13",
+
       // Test deps
       "org.scalatest" %% "scalatest" % "3.2.9" % "test",
       "junit" % "junit" % "4.12" % "test",


### PR DESCRIPTION
Delta 1.1.0 staged JAR is failing integration tests with error `java.lang.AssertionError: unsafe symbol JsonRawValue (child of package annotate) in runtime reflection universe`.

Further investigation has led to realizing that Delta 1.0.0 does have `org.codehaus.jackson` as a runtime dependency, but our staged Delta 1.1.0 does not.