### PR TITLE
Fix misc issues with Delta 1.1 release process

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ crossScalaVersions := Nil
 
 lazy val commonSettings = Seq(
   organization := "io.delta",
-  scalaVersion := "2.12.14",
+  scalaVersion := scala212,
   crossScalaVersions := Seq(scala212, scala213),
   fork := true
 )
@@ -302,9 +302,6 @@ lazy val releaseSettings = Seq(
   Test / publishArtifact := false,
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   releaseCrossBuild := true,
-  // Following two lines need to get around https://github.com/sbt/sbt/issues/4275
-  publishConfiguration := publishConfiguration.value.withOverwrite(true),
-  publishLocalConfiguration := publishLocalConfiguration.value.withOverwrite(true),
   publishTo := {
     val nexus = "https://oss.sonatype.org/"
     if (isSnapshot.value) {
@@ -363,8 +360,7 @@ lazy val releaseSettings = Seq(
 publishArtifact := false  // Don't release the root project
 publish / skip := true
 publishTo := Some("snapshots" at "https://oss.sonatype.org/content/repositories/snapshots")
-// don't use sbt-release's cross facility
-releaseCrossBuild := false
+releaseCrossBuild := false  // Don't use sbt-release's cross facility
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
@@ -374,5 +370,6 @@ releaseProcess := Seq[ReleaseStep](
   tagRelease,
   releaseStepCommandAndRemaining("+publishSigned"),
   setNextVersion,
-  commitNextVersion
+  commitNextVersion,
+  pushChanges
 )

--- a/build.sbt
+++ b/build.sbt
@@ -370,6 +370,5 @@ releaseProcess := Seq[ReleaseStep](
   tagRelease,
   releaseStepCommandAndRemaining("+publishSigned"),
   setNextVersion,
-  commitNextVersion,
-  pushChanges
+  commitNextVersion
 )

--- a/run-integration-tests.py
+++ b/run-integration-tests.py
@@ -128,6 +128,7 @@ def run_pip_installation_tests(root_dir, version, use_testpypi, extra_maven_repo
 def clear_artifact_cache():
     print("Clearing Delta artifacts from ivy2 and mvn cache")
     delete_if_exists(os.path.expanduser("~/.ivy2/cache/io.delta"))
+    delete_if_exists(os.path.expanduser("~/.ivy2/local/io.delta"))
     delete_if_exists(os.path.expanduser("~/.m2/repository/io/delta/"))
 
 


### PR DESCRIPTION
In order to have our release process properly cross-publish our different Scala versions, we had to re-arrange some codes in `build.sbt`.

I followed this tutorial [here](https://www.acervera.com/blog/2020/04/sbt-crossversion-release-bintray/#sbt-release-configuration) which basically just has us move the `releaseProcess` to the root project instead of in each sub-project. This step is also documented on the official sbt docs [here](https://www.scala-sbt.org/1.x/docs/Cross-Build.html#Note+about+sbt-release).

I also noticed, when running our integration tests, that they were at first using the **old** JAR, and not the newly-staged JAR. Clearing the ivy2 local directory resolved this.