### PR TITLE
Scala API for restoring delta table

### DIFF
--- a/core/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -16,6 +16,7 @@
 
 package io.delta.tables
 
+import java.sql.Timestamp
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.delta._
@@ -471,6 +472,24 @@ class DeltaTable private[tables](
    */
   def upgradeTableProtocol(readerVersion: Int, writerVersion: Int): Unit = {
     deltaLog.upgradeProtocol(Protocol(readerVersion, writerVersion))
+  }
+
+  /**
+   * Restores delta table to specific version.
+   * @param version version to be restored
+   * @since 1.2.0
+   */
+  def restore(version: Long): Unit = {
+    executeRestore(deltaLog, version = Some(version))
+  }
+
+  /**
+   * Restores delta table to the latest commit that happened at or before `timestamp`.
+   * @param timestamp timestamp to be restored
+   * @since 1.2.0
+   */
+  def restore(timestamp: Timestamp): Unit = {
+    executeRestore(deltaLog, timestamp = Option(timestamp))
   }
 }
 

--- a/core/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -479,16 +479,19 @@ class DeltaTable private[tables](
    * @param version version to be restored
    * @since 1.2.0
    */
-  def restore(version: Long): Unit = {
+  def restoreToVersion(version: Long): Unit = {
     executeRestore(deltaLog, version = Some(version))
   }
 
   /**
    * Restores delta table to the latest commit that happened at or before `timestamp`.
-   * @param timestamp timestamp to be restored
+   * `timestamp` string must be in a format that can be cast to a timestamp, such as
+   * `yyyy-MM-dd` or `yyyy-MM-dd HH:mm:ss.SSSS`.(for possible formats see description
+   * of method org.apache.spark.sql.catalyst.util.DateTimeUtils.parseTimestampString
+   * @param timestamp string presentation of timestamp to be restored
    * @since 1.2.0
    */
-  def restore(timestamp: Timestamp): Unit = {
+  def restoreToTimestamp(timestamp: String): Unit = {
     executeRestore(deltaLog, timestamp = Option(timestamp))
   }
 }

--- a/core/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
+++ b/core/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
@@ -79,7 +79,7 @@ trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
   protected def executeRestore(
       deltaLog: DeltaLog,
       version: Option[Long] = None,
-      timestamp: Option[Timestamp] = None): DataFrame = {
+      timestamp: Option[String] = None): DataFrame = {
     RestoreTableCommand(deltaLog, version, timestamp).run(sparkSession)
     sparkSession.emptyDataFrame
   }

--- a/core/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
+++ b/core/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
@@ -16,17 +16,18 @@
 
 package io.delta.tables.execution
 
+import java.sql.Timestamp
 import scala.collection.Map
 
-import org.apache.spark.sql.delta.{DeltaErrors, DeltaHistoryManager, DeltaLog, PreprocessTableUpdate}
-import org.apache.spark.sql.delta.commands.{DeleteCommand, DeltaGenerateCommand, VacuumCommand}
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.commands.{DeltaGenerateCommand, RestoreTableCommand, VacuumCommand}
 import org.apache.spark.sql.delta.util.AnalysisHelper
 import io.delta.tables.DeltaTable
 
-import org.apache.spark.sql.{functions, Column, DataFrame, Dataset}
+import org.apache.spark.sql.{functions, Column, DataFrame}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
-import org.apache.spark.sql.catalyst.expressions.{Expression, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical._
 
 /**
@@ -72,6 +73,14 @@ trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
       retentionHours: Option[Double],
       tableId: Option[TableIdentifier] = None): DataFrame = {
     VacuumCommand.gc(sparkSession, deltaLog, false, retentionHours)
+    sparkSession.emptyDataFrame
+  }
+
+  protected def executeRestore(
+      deltaLog: DeltaLog,
+      version: Option[Long] = None,
+      timestamp: Option[Timestamp] = None): DataFrame = {
+    RestoreTableCommand(deltaLog, version, timestamp).run(sparkSession)
     sparkSession.emptyDataFrame
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -35,7 +35,6 @@ import org.apache.spark.{SparkConf, SparkEnv}
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
-import org.apache.spark.sql.catalyst.catalog.BucketSpec
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.internal.SQLConf
@@ -1402,6 +1401,15 @@ object DeltaErrors
       conflictingCommit)
     new io.delta.exceptions.ConcurrentTransactionException(message)
   }
+
+  def restoreMissedDataFilesError(missedFiles: Array[String], version: Long): Throwable =
+    new IllegalArgumentException(
+      s"""Not all files from version $version are available in file system.
+         | Missed files (top 100 files): ${missedFiles.mkString(",")}.
+         | Please use more recent version or timestamp for restoring.
+         | To disable check update option ${SQLConf.IGNORE_MISSING_FILES.key}"""
+        .stripMargin
+   )
 
 }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -343,6 +343,17 @@ object DeltaOperations {
   case class TestOperation(operationName: String = "TEST") extends Operation(operationName) {
     override val parameters: Map[String, Any] = Map.empty
   }
+
+  /** Recorded when restoring the table. */
+  case class Restore(
+      version: Option[Long] = None,
+      timestamp: Option[Long] = None) extends Operation("RESTORE") {
+    override val parameters: Map[String, Any] = Map(
+      "version" -> version,
+      "timestamp" -> timestamp
+    )
+    override def changesData: Boolean = true
+  }
 }
 
 private[delta] object DeltaOperationMetrics {

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -347,7 +347,7 @@ object DeltaOperations {
   /** Recorded when restoring the table. */
   case class Restore(
       version: Option[Long] = None,
-      timestamp: Option[Long] = None) extends Operation("RESTORE") {
+      timestamp: Option[String] = None) extends Operation("RESTORE") {
     override val parameters: Map[String, Any] = Map(
       "version" -> version,
       "timestamp" -> timestamp

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
@@ -1,0 +1,184 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands
+
+import java.sql.Timestamp
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.actions.{AddFile, RemoveFile}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf._
+import org.apache.spark.sql.delta.util.DeltaFileOperations.absolutePath
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.{Dataset, Row, SparkSession}
+import org.apache.spark.sql.internal.SQLConf.IGNORE_MISSING_FILES
+import org.apache.spark.util.SerializableConfiguration
+
+/**
+ * Perform restore of delta table to a specified version or timestamp
+ *
+ * Algorithm:
+ *  1) Read the latest snapshot of the table.
+ *  2) Read snapshot for version or timestamp to restore
+ *  3) Compute files available in snapshot for restoring (files were removed by some commit)
+ *  but missed in the latest. Add these files into commit as AddFile action.
+ *  4) Compute files available in the latest snapshot (files were added after version to restore)
+ *  but missed in the snapshot to restore. Add these files into commit as RemoveFile action.
+ *  5) If SQLConf.IGNORE_MISSING_FILES option is false (default value) check availability of AddFile
+ *  in file system.
+ *  6) Commit metadata, Protocol, all RemoveFile and AddFile actions
+ *  into delta log using `commitLarge`.
+ *  7) If table was modified in parallel then ignore restore and raise exception.
+ */
+case class RestoreTableCommand(
+  deltaLog: DeltaLog,
+  version: Option[Long],
+  timestamp: Option[Timestamp]
+) extends LeafRunnableCommand with DeltaCommand {
+
+  override def run(spark: SparkSession): Seq[Row] = {
+    recordDeltaOperation(deltaLog, "delta.restore") {
+
+      require(version.isEmpty ^ timestamp.isEmpty,
+        "Either the version or timestamp should be provided for restore")
+      val parallelism = restoreParallelism(spark)
+      val latestSnapshot = deltaLog.update()
+      val versionToRestore = version.getOrElse(
+        deltaLog
+          .history
+          .getActiveCommitAtTime(timestamp.get, canReturnLastCommit = true)
+          .version
+      )
+
+      require(versionToRestore < latestSnapshot.version,
+        s"Version to restore ($versionToRestore) should be less then " +
+        s"last available version (${latestSnapshot.version})")
+
+      val snapshotToRestore = deltaLog.getSnapshotAt(versionToRestore)
+      val latestSnapshotFiles = latestSnapshot.allFiles
+      val snapshotToRestoreFiles = snapshotToRestore.allFiles
+
+      import spark.implicits._
+      import collection.JavaConverters._
+
+      val filesToAdd = snapshotToRestoreFiles
+        .join(
+          latestSnapshotFiles,
+          snapshotToRestoreFiles("path") ===  latestSnapshotFiles("path"),
+          "left_anti")
+        .as[AddFile]
+        .map(_.copy(dataChange = true))
+        .repartition(parallelism)
+        .cache() // To avoid Dataset recompute for each partition of toLocalIterator()
+
+      checkSnapshotFilesAvailability(deltaLog, filesToAdd, versionToRestore)
+
+      val filesToRemove = latestSnapshotFiles
+        .join(
+          snapshotToRestoreFiles,
+          latestSnapshotFiles("path") ===  snapshotToRestoreFiles("path"),
+          "left_anti")
+        .as[AddFile]
+        .map(_.removeWithTimestamp())
+        .repartition(parallelism)
+        .cache() // To avoid Dataset recompute for each partition of toLocalIterator()
+
+      // Commit files, metrics, protocol and metadata to delta log
+      deltaLog.withNewTransaction { txn =>
+
+        val metrics = computeMetrics(filesToAdd, filesToRemove, snapshotToRestore)
+        val addActions = filesToAdd.toLocalIterator().asScala
+        val removeActions = filesToRemove.toLocalIterator().asScala
+
+        txn.updateMetadata(snapshotToRestore.metadata)
+
+        commitLarge(
+          spark,
+          txn,
+          addActions ++ removeActions,
+          DeltaOperations.Restore(version, timestamp.map(_.getTime)),
+          Map.empty,
+          metrics)
+      }
+      filesToAdd.unpersist()
+      filesToRemove.unpersist()
+
+      Seq.empty[Row]
+    }
+  }
+
+  private def restoreParallelism(spark: SparkSession): Int = spark
+    .sessionState
+    .conf
+    .getConf(DELTA_RESTORE_PARALLELISM)
+
+  private def computeMetrics(
+    toAdd: Dataset[AddFile],
+    toRemove: Dataset[RemoveFile],
+    snapshot: Snapshot
+  ): Map[String, String] = {
+    import toAdd.sparkSession.implicits._
+
+    val (numRestoredFiles, restoredFilesSize) = toAdd
+      .agg("size" -> "count", "size" -> "sum").as[(Long, Option[Long])].head()
+
+    val (numRemovedFiles, removedFilesSize) = toRemove
+      .agg("size" -> "count", "size" -> "sum").as[(Long, Option[Long])].head()
+
+    Map(
+      "numRestoredFiles" -> numRestoredFiles,
+      "restoredFilesSize" -> restoredFilesSize.getOrElse(0),
+      "numRemovedFiles" -> numRemovedFiles,
+      "removedFilesSize" -> removedFilesSize.getOrElse(0),
+      "numOfFilesAfterRestore" -> snapshot.numOfFiles,
+      "tableSizeAfterRestore" -> snapshot.sizeInBytes
+    ).mapValues(_.toString).toMap
+  }
+
+  /* Prevent users from running restore to table version with missed
+   * data files (manually deleted or vacuumed). Restoring to this version partially
+   * is still possible if spark.sql.files.ignoreMissingFiles is set to true
+   */
+  private def checkSnapshotFilesAvailability(
+      deltaLog: DeltaLog, files: Dataset[AddFile], version: Long): Unit = {
+
+    implicit val spark: SparkSession = files.sparkSession
+    val ignore = spark
+      .sessionState
+      .conf
+      .getConf(IGNORE_MISSING_FILES)
+
+    if (!ignore) {
+      val path = deltaLog.dataPath
+      val hadoopConf = spark.sparkContext.broadcast(
+        new SerializableConfiguration(deltaLog.newDeltaHadoopConf()))
+
+      import spark.implicits._
+      val missedFiles = files
+        .repartition(restoreParallelism(spark))
+        .mapPartitions { files =>
+          val fs = path.getFileSystem(hadoopConf.value.value)
+          val pathStr = path.toUri.getPath
+          files.filterNot(f => fs.exists(absolutePath(pathStr, f.path)))
+        }
+        .map(_.path)
+        .head(100)
+
+      if (missedFiles.nonEmpty) {
+        throw DeltaErrors.restoreMissedDataFilesError(missedFiles, version)
+      }
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
@@ -88,7 +88,9 @@ case class RestoreTableCommand(
             "left_anti")
           .as[AddFile]
           .map(_.copy(dataChange = true))
-          .cache() // To avoid Dataset recompute for each partition of toLocalIterator()
+          // To avoid recompute of Dataset with wide transformation by toLocalIterator and
+          // checkSnapshotFilesAvailability method with spark.sql.files.ignoreMissingFiles=false
+          .cache()
 
         val filesToRemove = latestSnapshotFiles
           .join(
@@ -97,7 +99,8 @@ case class RestoreTableCommand(
             "left_anti")
           .as[AddFile]
           .map(_.removeWithTimestamp())
-          .cache() // To avoid Dataset recompute for each partition of toLocalIterator()
+          // To avoid recompute of Dataset with wide transformation by toLocalIterator
+          .cache()
 
         try {
           checkSnapshotFilesAvailability(deltaLog, filesToAdd, versionToRestore)

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
@@ -135,7 +135,6 @@ case class RestoreTableCommand(
       }
     } match {
       case Success(Some(tsMicroseconds)) => new Timestamp(tsMicroseconds / 1000)
-      case Success(None) => throw timestampInvalid(Literal("null"))
       case _ => throw timestampInvalid(Literal(timestamp.get))
     }
   }

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -502,6 +502,13 @@ trait DeltaSQLConfBase {
           |""".stripMargin)
       .booleanConf
       .createWithDefault(true)
+
+  val DELTA_RESTORE_PARALLELISM =
+    buildConf("restore.parallelism")
+      .doc("Number of parallel spark tasks used for data restoring." +
+        " Small value may causes OOM while restoring huge table.")
+      .intConf
+      .createWithDefault(1)
 }
 
 object DeltaSQLConf extends DeltaSQLConfBase

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -502,13 +502,6 @@ trait DeltaSQLConfBase {
           |""".stripMargin)
       .booleanConf
       .createWithDefault(true)
-
-  val DELTA_RESTORE_PARALLELISM =
-    buildConf("restore.parallelism")
-      .doc("Number of parallel spark tasks used for data restoring." +
-        " Small value may causes OOM while restoring huge table.")
-      .intConf
-      .createWithDefault(1)
 }
 
 object DeltaSQLConf extends DeltaSQLConfBase

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaRestoreTableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaRestoreTableSuite.scala
@@ -1,0 +1,148 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.io.File
+import java.sql.Timestamp
+import scala.language.implicitConversions
+
+import io.delta.implicits.DeltaDataFrameWriter
+import io.delta.tables.DeltaTable.{forPath => DeltaTableForPath}
+import org.apache.commons.io.FileUtils
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.{SQLTestUtils, SharedSparkSession}
+import org.apache.spark.sql.{DataFrame, QueryTest, SaveMode}
+
+trait DeltaRestoreTableSuiteBase extends QueryTest
+  with SharedSparkSession
+  with SQLTestUtils
+  with DeltaTestUtilsForTempViews {
+
+  private lazy val versionZeroData = spark.range(2).withSequenceColumn("seq").toDF()
+  private lazy val versionOneData = spark.range(2, 4)
+    .withSequenceColumn("seq")
+    .withColumnRenamed("id", "new_id")
+  private lazy val allDatasets = Seq(versionZeroData, versionOneData)
+
+  test("basic case - Scala restore table using version - Non-partitioned") {
+    withMultiVersionedDeltaTable(allDatasets) { deltaPath =>
+
+      DeltaTableForPath(deltaPath).restore(0)
+
+      testRestoredTable(deltaPath)
+    }
+  }
+
+  test("basic case - Scala restore table using version - Partitioned") {
+    withMultiVersionedDeltaTable(allDatasets, Some("seq")) { deltaPath =>
+
+      DeltaTableForPath(deltaPath).restore(0)
+
+      testRestoredTable(deltaPath)
+    }
+  }
+
+  test("basic case - Scala restore table using timestamp - Non-partitioned") {
+    withMultiVersionedDeltaTable(allDatasets) { deltaPath =>
+      val zeroVersionTs = new Timestamp(
+        DeltaLog.forTable(spark, deltaPath).getSnapshotAt(0).timestamp)
+
+      DeltaTableForPath(deltaPath).restore(zeroVersionTs)
+
+      testRestoredTable(deltaPath)
+    }
+  }
+
+  test("basic case - Scala restore table using timestamp - Partitioned") {
+    withMultiVersionedDeltaTable(allDatasets, Some("seq")) { deltaPath =>
+      val zeroVersionTs = new Timestamp(
+        DeltaLog.forTable(spark, deltaPath).getSnapshotAt(0).timestamp)
+
+      DeltaTableForPath(deltaPath).restore(zeroVersionTs)
+
+      testRestoredTable(deltaPath)
+    }
+  }
+
+  test("basic case - Scala restore failed if any data file is missed" +
+      " and spark.sql.files.ignoreMissingFiles=false") {
+    withMultiVersionedDeltaTable(allDatasets) { deltaPath =>
+      import testImplicits._
+      // Remove one data files from table
+      val file = DeltaLog.forTable(spark, deltaPath).getSnapshotAt(0).allFiles.map(_.path).head()
+      FileUtils.deleteQuietly(new File(new Path(deltaPath, file).toUri.toString))
+
+      val ex = intercept[IllegalArgumentException](DeltaTableForPath(deltaPath).restore(0))
+      assert(ex.getMessage.contains(file), s"Error message doesn't contain missed file $file."
+        + s"Error message:\n ${ex.getMessage}")
+    }
+  }
+
+  test("basic case - Scala restore failed if any data file is missed" +
+      " and spark.sql.files.ignoreMissingFiles=true") {
+    withSQLConf(SQLConf.IGNORE_MISSING_FILES.key -> "true") {
+      withMultiVersionedDeltaTable(allDatasets) { deltaPath =>
+        import testImplicits._
+        // Remove one data files from table
+        val file = DeltaLog.forTable(spark, deltaPath).getSnapshotAt(0).allFiles.map(_.path).head()
+        FileUtils.deleteQuietly(new File(new Path(deltaPath, file).toUri.toString))
+
+        DeltaTableForPath(deltaPath).restore(0)
+
+        testRestoredTable(deltaPath, validateData = false)
+      }
+    }
+  }
+
+  test("basic case - Scala restore failed to restore incorrect version") {
+    withMultiVersionedDeltaTable(allDatasets) { deltaPath =>
+
+      intercept[IllegalArgumentException](DeltaTableForPath(deltaPath).restore(Long.MaxValue))
+    }
+  }
+
+  def withMultiVersionedDeltaTable(
+    datasets: Seq[DataFrame],
+    partitionBy: Option[String] = None)(f: String => Unit): Unit = {
+    withTempDir { tempDir =>
+      val deltaPath = tempDir.getAbsolutePath
+
+      datasets.foreach { ds =>
+        val writer = ds.write.option("mergeSchema", "true").mode(SaveMode.Overwrite)
+        partitionBy.foreach(writer.partitionBy(_))
+        writer.delta(deltaPath)
+      }
+
+      f(deltaPath)
+    }
+  }
+
+  def testRestoredTable(deltaPath: String, validateData: Boolean = true): Unit = {
+    val expected = DeltaLog.forTable(spark, deltaPath).getSnapshotAt(0)
+    val restored = DeltaLog.forTable(spark, deltaPath).update()
+
+    assert(expected.metadata == restored.metadata, "Incorrect metadata was restored")
+    checkAnswer(expected.allFiles.toDF(), restored.allFiles.toDF())
+    if (validateData) checkAnswer(DeltaTableForPath(deltaPath).toDF, versionZeroData)
+  }
+}
+
+class DeltaRestoreTableSuite
+  extends DeltaRestoreTableSuiteBase with DeltaSQLCommandTest


### PR DESCRIPTION
Add possibility to restore delta table using version or timestamp.
Examples:
```scala
io.delta.tables.DeltaTable.forPath("/some_delta_path").restoreToVersion(1)
io.delta.tables.DeltaTable.forPath("/some_delta_path").restoreToTimestamp("2021-01-01 00:00:00.000")
io.delta.tables.DeltaTable.forPath("/some_delta_path").restoreToTimestamp("2021-01-01")
```
Fixes https://github.com/delta-io/delta/issues/632

Signed-off-by: Maksym Dovhal <maksym.dovhal@gmail.com>

Tested locally using spark-shell
```bash
sbt package
spark-shell --jars ./core/target/scala-2.12/delta-core_2.12-1.1.0-SNAPSHOT.jar --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"
```

```scala
spark.range(2).write.format("delta").mode("overwrite").save("/tmp/delta_restore_test")
spark.range(2,3).withColumnRenamed("id", "id_new").write.option("mergeSchema", "true").format("delta").mode("overwrite").save("/tmp/delta_restore_test")
io.delta.tables.DeltaTable.forPath("/tmp/delta_restore_test").restoreToVersion(0)
io.delta.tables.DeltaTable.forPath("/tmp/delta_restore_test").restoreToTimestamp("2021-12-18 16:40:14.54")
// At next day
io.delta.tables.DeltaTable.forPath("/tmp/delta_restore_test").restoreToVersion(0)
io.delta.tables.DeltaTable.forPath("/tmp/delta_restore_test").restoreToTimestamp("2021-12-19")
io.delta.tables.DeltaTable.forPath("/tmp/delta_restore_test").history().show(false)
```
Output:
```
+-------+-----------------------+------+--------+---------+------------------------------------------------------+----+--------+---------+-----------+--------------+-------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------+------------+--------------------------------------------+
|version|timestamp              |userId|userName|operation|operationParameters                                   |job |notebook|clusterId|readVersion|isolationLevel|isBlindAppend|operationMetrics                                                                                                                                             |userMetadata|engineInfo                                  |
+-------+-----------------------+------+--------+---------+------------------------------------------------------+----+--------+---------+-----------+--------------+-------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------+------------+--------------------------------------------+
|5      |2021-12-19 09:43:41.604|null  |null    |RESTORE  |{version -> null, timestamp -> 2021-12-19}            |null|null    |null     |4          |Serializable  |false        |{numRestoredFiles -> 2, removedFilesSize -> 1252, numRemovedFiles -> 3, restoredFilesSize -> 794, numOfFilesAfterRestore -> 2, tableSizeAfterRestore -> 794} |null        |Apache-Spark/3.2.0 Delta-Lake/1.1.0-SNAPSHOT|
|4      |2021-12-19 09:43:17.415|null  |null    |RESTORE  |{version -> 0, timestamp -> null}                     |null|null    |null     |3          |Serializable  |false        |{numRestoredFiles -> 3, removedFilesSize -> 794, numRemovedFiles -> 2, restoredFilesSize -> 1252, numOfFilesAfterRestore -> 3, tableSizeAfterRestore -> 1252}|null        |Apache-Spark/3.2.0 Delta-Lake/1.1.0-SNAPSHOT|
|3      |2021-12-18 16:42:14.083|null  |null    |RESTORE  |{version -> null, timestamp -> 2021-12-18 16:40:14.54}|null|null    |null     |2          |Serializable  |false        |{numRestoredFiles -> 2, removedFilesSize -> 1252, numRemovedFiles -> 3, restoredFilesSize -> 794, numOfFilesAfterRestore -> 2, tableSizeAfterRestore -> 794} |null        |Apache-Spark/3.2.0 Delta-Lake/1.1.0-SNAPSHOT|
|2      |2021-12-18 16:40:53.861|null  |null    |RESTORE  |{version -> 0, timestamp -> null}                     |null|null    |null     |1          |Serializable  |false        |{numRestoredFiles -> 3, removedFilesSize -> 794, numRemovedFiles -> 2, restoredFilesSize -> 1252, numOfFilesAfterRestore -> 3, tableSizeAfterRestore -> 1252}|null        |Apache-Spark/3.2.0 Delta-Lake/1.1.0-SNAPSHOT|
|1      |2021-12-18 16:40:14.54 |null  |null    |WRITE    |{mode -> Overwrite, partitionBy -> []}                |null|null    |null     |0          |Serializable  |false        |{numFiles -> 2, numOutputRows -> 1, numOutputBytes -> 794}                                                                                                   |null        |Apache-Spark/3.2.0 Delta-Lake/1.1.0-SNAPSHOT|
|0      |2021-12-18 16:40:08.045|null  |null    |WRITE    |{mode -> Overwrite, partitionBy -> []}                |null|null    |null     |null       |Serializable  |false        |{numFiles -> 3, numOutputRows -> 2, numOutputBytes -> 1252}                                                                                                  |null        |Apache-Spark/3.2.0 Delta-Lake/1.1.0-SNAPSHOT|
+-------+-----------------------+------+--------+---------+------------------------------------------------------+----+--------+---------+-----------+--------------+-------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------+------------+--------------------------------------------+
```
Examples of transactions:
/tmp/delta_restore_test/_delta_log/00000000000000000000.json
```json
{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}
{"metaData":{"id":"b090f082-f927-4372-9537-9623ae280ad8","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"long\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{},"createdTime":1639838404635}}
{"add":{"path":"part-00000-cb74dd35-ae80-4b3a-b97c-ea492e11ddc3-c000.snappy.parquet","partitionValues":{},"size":296,"modificationTime":1639838406641,"dataChange":true}}
{"add":{"path":"part-00005-beac50f7-dbe7-40b7-9ce2-5e0e6a1607ad-c000.snappy.parquet","partitionValues":{},"size":478,"modificationTime":1639838406642,"dataChange":true}}
{"add":{"path":"part-00011-7e35258f-a724-43f3-8622-c7efa51f01a6-c000.snappy.parquet","partitionValues":{},"size":478,"modificationTime":1639838406642,"dataChange":true}}
{"commitInfo":{"timestamp":1639838407868,"operation":"WRITE","operationParameters":{"mode":"Overwrite","partitionBy":"[]"},"isolationLevel":"Serializable","isBlindAppend":false,"operationMetrics":{"numFiles":"3","numOutputRows":"2","numOutputBytes":"1252"},"engineInfo":"Apache-Spark/3.2.0 Delta-Lake/1.1.0-SNAPSHOT"}}
```
/tmp/delta_restore_test/_delta_log/00000000000000000001.json
```json
{"metaData":{"id":"b090f082-f927-4372-9537-9623ae280ad8","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"long\",\"nullable\":true,\"metadata\":{}},{\"name\":\"id_new\",\"type\":\"long\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{},"createdTime":1639838404635}}
{"add":{"path":"part-00000-b71c3566-429b-4038-8127-6e480656038c-c000.snappy.parquet","partitionValues":{},"size":304,"modificationTime":1639838414041,"dataChange":true}}
{"add":{"path":"part-00011-7a5341e6-4876-467a-b33d-56d8dc0bf243-c000.snappy.parquet","partitionValues":{},"size":490,"modificationTime":1639838414041,"dataChange":true}}
{"remove":{"path":"part-00000-cb74dd35-ae80-4b3a-b97c-ea492e11ddc3-c000.snappy.parquet","deletionTimestamp":1639838414511,"dataChange":true,"extendedFileMetadata":true,"partitionValues":{},"size":296}}
{"remove":{"path":"part-00011-7e35258f-a724-43f3-8622-c7efa51f01a6-c000.snappy.parquet","deletionTimestamp":1639838414511,"dataChange":true,"extendedFileMetadata":true,"partitionValues":{},"size":478}}
{"remove":{"path":"part-00005-beac50f7-dbe7-40b7-9ce2-5e0e6a1607ad-c000.snappy.parquet","deletionTimestamp":1639838414511,"dataChange":true,"extendedFileMetadata":true,"partitionValues":{},"size":478}}
{"commitInfo":{"timestamp":1639838414511,"operation":"WRITE","operationParameters":{"mode":"Overwrite","partitionBy":"[]"},"readVersion":0,"isolationLevel":"Serializable","isBlindAppend":false,"operationMetrics":{"numFiles":"2","numOutputRows":"1","numOutputBytes":"794"},"engineInfo":"Apache-Spark/3.2.0 Delta-Lake/1.1.0-SNAPSHOT"}}
```
/tmp/delta_restore_test/_delta_log/00000000000000000002.json
```json
{"commitInfo":{"timestamp":1639838436332,"operation":"RESTORE","operationParameters":{"version":0,"timestamp":null},"readVersion":1,"isolationLevel":"Serializable","isBlindAppend":false,"operationMetrics":{"numRestoredFiles":"3","removedFilesSize":"794","numRemovedFiles":"2","restoredFilesSize":"1252","numOfFilesAfterRestore":"3","tableSizeAfterRestore":"1252"},"engineInfo":"Apache-Spark/3.2.0 Delta-Lake/1.1.0-SNAPSHOT"}}
{"metaData":{"id":"b090f082-f927-4372-9537-9623ae280ad8","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"long\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{},"createdTime":1639838404635}}
{"add":{"path":"part-00005-beac50f7-dbe7-40b7-9ce2-5e0e6a1607ad-c000.snappy.parquet","partitionValues":{},"size":478,"modificationTime":1639838406642,"dataChange":true}}
{"add":{"path":"part-00011-7e35258f-a724-43f3-8622-c7efa51f01a6-c000.snappy.parquet","partitionValues":{},"size":478,"modificationTime":1639838406642,"dataChange":true}}
{"add":{"path":"part-00000-cb74dd35-ae80-4b3a-b97c-ea492e11ddc3-c000.snappy.parquet","partitionValues":{},"size":296,"modificationTime":1639838406641,"dataChange":true}}
{"remove":{"path":"part-00011-7a5341e6-4876-467a-b33d-56d8dc0bf243-c000.snappy.parquet","deletionTimestamp":1639838435578,"dataChange":true,"extendedFileMetadata":true,"partitionValues":{},"size":490}}
{"remove":{"path":"part-00000-b71c3566-429b-4038-8127-6e480656038c-c000.snappy.parquet","deletionTimestamp":1639838435586,"dataChange":true,"extendedFileMetadata":true,"partitionValues":{},"size":304}}
```
/tmp/delta_restore_test/_delta_log/00000000000000000003.json
```json
{"commitInfo":{"timestamp":1639838517073,"operation":"RESTORE","operationParameters":{"version":null,"timestamp":"2021-12-18 16:40:14.54"},"readVersion":2,"isolationLevel":"Serializable","isBlindAppend":false,"operationMetrics":{"numRestoredFiles":"2","removedFilesSize":"1252","numRemovedFiles":"3","restoredFilesSize":"794","numOfFilesAfterRestore":"2","tableSizeAfterRestore":"794"},"engineInfo":"Apache-Spark/3.2.0 Delta-Lake/1.1.0-SNAPSHOT"}}
{"metaData":{"id":"b090f082-f927-4372-9537-9623ae280ad8","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"long\",\"nullable\":true,\"metadata\":{}},{\"name\":\"id_new\",\"type\":\"long\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{},"createdTime":1639838404635}}
{"add":{"path":"part-00011-7a5341e6-4876-467a-b33d-56d8dc0bf243-c000.snappy.parquet","partitionValues":{},"size":490,"modificationTime":1639838414041,"dataChange":true}}
{"add":{"path":"part-00000-b71c3566-429b-4038-8127-6e480656038c-c000.snappy.parquet","partitionValues":{},"size":304,"modificationTime":1639838414041,"dataChange":true}}
{"remove":{"path":"part-00005-beac50f7-dbe7-40b7-9ce2-5e0e6a1607ad-c000.snappy.parquet","deletionTimestamp":1639838516199,"dataChange":true,"extendedFileMetadata":true,"partitionValues":{},"size":478}}
{"remove":{"path":"part-00011-7e35258f-a724-43f3-8622-c7efa51f01a6-c000.snappy.parquet","deletionTimestamp":1639838516199,"dataChange":true,"extendedFileMetadata":true,"partitionValues":{},"size":478}}
{"remove":{"path":"part-00000-cb74dd35-ae80-4b3a-b97c-ea492e11ddc3-c000.snappy.parquet","deletionTimestamp":1639838516202,"dataChange":true,"extendedFileMetadata":true,"partitionValues":{},"size":296}}
```
/tmp/delta_restore_test/_delta_log/00000000000000000004.json
```json
{"commitInfo":{"timestamp":1639899780668,"operation":"RESTORE","operationParameters":{"version":0,"timestamp":null},"readVersion":3,"isolationLevel":"Serializable","isBlindAppend":false,"operationMetrics":{"numRestoredFiles":"3","removedFilesSize":"794","numRemovedFiles":"2","restoredFilesSize":"1252","numOfFilesAfterRestore":"3","tableSizeAfterRestore":"1252"},"engineInfo":"Apache-Spark/3.2.0 Delta-Lake/1.1.0-SNAPSHOT"}}
{"metaData":{"id":"b090f082-f927-4372-9537-9623ae280ad8","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"long\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{},"createdTime":1639838404635}}
{"add":{"path":"part-00005-beac50f7-dbe7-40b7-9ce2-5e0e6a1607ad-c000.snappy.parquet","partitionValues":{},"size":478,"modificationTime":1639838406642,"dataChange":true}}
{"add":{"path":"part-00011-7e35258f-a724-43f3-8622-c7efa51f01a6-c000.snappy.parquet","partitionValues":{},"size":478,"modificationTime":1639838406642,"dataChange":true}}
{"add":{"path":"part-00000-cb74dd35-ae80-4b3a-b97c-ea492e11ddc3-c000.snappy.parquet","partitionValues":{},"size":296,"modificationTime":1639838406641,"dataChange":true}}
{"remove":{"path":"part-00011-7a5341e6-4876-467a-b33d-56d8dc0bf243-c000.snappy.parquet","deletionTimestamp":1639899779981,"dataChange":true,"extendedFileMetadata":true,"partitionValues":{},"size":490}}
{"remove":{"path":"part-00000-b71c3566-429b-4038-8127-6e480656038c-c000.snappy.parquet","deletionTimestamp":1639899779981,"dataChange":true,"extendedFileMetadata":true,"partitionValues":{},"size":304}}
```
/tmp/delta_restore_test/_delta_log/00000000000000000005.json
```json
{"commitInfo":{"timestamp":1639899805962,"operation":"RESTORE","operationParameters":{"version":null,"timestamp":"2021-12-19"},"readVersion":4,"isolationLevel":"Serializable","isBlindAppend":false,"operationMetrics":{"numRestoredFiles":"2","removedFilesSize":"1252","numRemovedFiles":"3","restoredFilesSize":"794","numOfFilesAfterRestore":"2","tableSizeAfterRestore":"794"},"engineInfo":"Apache-Spark/3.2.0 Delta-Lake/1.1.0-SNAPSHOT"}}
{"metaData":{"id":"b090f082-f927-4372-9537-9623ae280ad8","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"id\",\"type\":\"long\",\"nullable\":true,\"metadata\":{}},{\"name\":\"id_new\",\"type\":\"long\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{},"createdTime":1639838404635}}
{"add":{"path":"part-00011-7a5341e6-4876-467a-b33d-56d8dc0bf243-c000.snappy.parquet","partitionValues":{},"size":490,"modificationTime":1639838414041,"dataChange":true}}
{"add":{"path":"part-00000-b71c3566-429b-4038-8127-6e480656038c-c000.snappy.parquet","partitionValues":{},"size":304,"modificationTime":1639838414041,"dataChange":true}}
{"remove":{"path":"part-00005-beac50f7-dbe7-40b7-9ce2-5e0e6a1607ad-c000.snappy.parquet","deletionTimestamp":1639899805448,"dataChange":true,"extendedFileMetadata":true,"partitionValues":{},"size":478}}
{"remove":{"path":"part-00011-7e35258f-a724-43f3-8622-c7efa51f01a6-c000.snappy.parquet","deletionTimestamp":1639899805445,"dataChange":true,"extendedFileMetadata":true,"partitionValues":{},"size":478}}
{"remove":{"path":"part-00000-cb74dd35-ae80-4b3a-b97c-ea492e11ddc3-c000.snappy.parquet","deletionTimestamp":1639899805444,"dataChange":true,"extendedFileMetadata":true,"partitionValues":{},"size":296}}
```
