### PR TITLE
fix add column after an array<map> column

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -505,7 +505,7 @@ object SchemaUtils {
         case (Seq(), ArrayType(s: StructType, _)) =>
           find(colTail, s, stack :+ thisCol)
         case (Seq(), ArrayType(_, _)) =>
-          (Seq(0), 0)
+          (Nil, 0)
         case (_, ArrayType(_, _)) =>
           throw new AnalysisException(
             s"""An ArrayType was found. In order to access elements of an ArrayType, specify

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
@@ -754,6 +754,24 @@ trait DeltaAlterTableTests extends DeltaAlterTableTestBase {
     }
   }
 
+  test("ADD COLUMNS - adding after an ArrayType<MapType> column") {
+    val df = Seq((1, "a"), (2, "b")).toDF("v1", "v2")
+      .withColumn("v3", array(map(col("v1"), col("v2"))))
+    withDeltaTable(df) { tableName =>
+
+      sql(s"ALTER TABLE $tableName ADD COLUMNS (v4 string AFTER V3)")
+
+      val deltaLog = getDeltaLog(tableName)
+      assertEqual(deltaLog.snapshot.schema, new StructType()
+        .add("v1", IntegerType)
+        .add("v2", StringType)
+        .add("v3", ArrayType(
+          MapType(IntegerType, StringType)))
+        .add("v4", StringType))
+
+    }
+  }
+
   ///////////////////////////////
   // CHANGE COLUMN
   ///////////////////////////////

--- a/core/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
@@ -796,6 +796,8 @@ class SchemaUtilsSuite extends QueryTest
         new StructType()
           .add("k", new StructType()
           .add("l", IntegerType))))
+      .add("m", ArrayType(
+        MapType(StringType, StringType)))
     assert(SchemaUtils.findColumnPosition(Seq("a"), schema) === ((Seq(0), 2)))
     assert(SchemaUtils.findColumnPosition(Seq("A"), schema) === ((Seq(0), 2)))
     expectFailure("Couldn't find", schema.treeString) {
@@ -818,6 +820,7 @@ class SchemaUtilsSuite extends QueryTest
     assert(SchemaUtils.findColumnPosition(Seq("i", "value", "k"), schema) === ((Seq(4, 1, 0), 1)))
     assert(SchemaUtils.findColumnPosition(Seq("i", "key"), schema) === ((Seq(4, 0), 0)))
     assert(SchemaUtils.findColumnPosition(Seq("i", "value"), schema) === ((Seq(4, 1), 1)))
+    assert(SchemaUtils.findColumnPosition(Seq("m"), schema) === ((Seq(5), 0)))
 
     val resolver = org.apache.spark.sql.catalyst.analysis.caseSensitiveResolution
     Seq(Seq("A", "b"), Seq("a", "B"), Seq("d", "element", "B"), Seq("f", "key", "H"))


### PR DESCRIPTION
When execute to add column after a column whose dataType is `ArrayType` and the `ArrayType`'s dataType is not `StructType`, an exception will be raised as follow:

`Cannot add col3 because its parent is not a StructType. Found ArrayType(MapType(StringType,StringType,true),true)`.

The codes can reproduce this case are shown:

```
create table s1 (id int) using delta;

alter table s1 add columns (array_map_col array<map<string,string>>);

alter table s1 add columns (col3 string after array_map_col);
```
with tracking the source code, i think adding the `col3` column above after `array_map_col` is considered to be inserted inside `array_map_col`. So open this pr.