### PR TITLE
Support Ceph Storage.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -124,6 +124,10 @@ lazy val contribs = (project in file("contribs"))
     commonSettings,
     scalaStyleSettings,
     releaseSettings,
+    libraryDependencies ++= Seq(
+      // Adding object storage dependencies
+      "org.javaswift" % "joss" % "0.10.2"
+    ),
     Compile / packageBin / mappings := (Compile / packageBin / mappings).value ++
       listPythonFiles(baseDirectory.value.getParentFile / "python"),
 

--- a/contribs/src/main/scala/io/delta/storage/cephobjectstore/CephStoreInputStream.scala
+++ b/contribs/src/main/scala/io/delta/storage/cephobjectstore/CephStoreInputStream.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.cephobjectstore
+
+import org.apache.hadoop.fs.{PositionedReadable, Seekable}
+import java.io.{ByteArrayInputStream, IOException}
+
+/**
+ * The input stream for Ceph RGW.
+ * The class uses downloading to read data from the object content
+ * stream.
+ */
+class CephStoreInputStream(buf: Array[Byte])
+  extends ByteArrayInputStream(buf) with Seekable with PositionedReadable {
+  @throws[IOException]
+  override def read(position: Long, buffer: Array[Byte], offset: Int, length: Int): Int = {
+    System.arraycopy(buf, position.toInt, buffer, offset, length)
+    length
+  }
+
+  override def readFully(position: Long, buffer: Array[Byte], offset: Int, length: Int): Unit = {
+    read(position, buffer, offset, length)
+  }
+
+  @throws[IOException]
+  override def readFully(position: Long, buffer: Array[Byte]): Unit = {
+    read(position, buffer, 0, buffer.length)
+  }
+
+  @throws[IOException]
+  override def seek(pos: Long): Unit = {
+    reset()
+    skip(pos)
+  }
+
+  @throws[IOException]
+  override def getPos: Long = pos
+
+  @throws[IOException]
+  override def seekToNewSource(targetPos: Long): Boolean = {
+    false
+  }
+  }

--- a/contribs/src/main/scala/io/delta/storage/cephobjectstore/CephStoreOutputStream.scala
+++ b/contribs/src/main/scala/io/delta/storage/cephobjectstore/CephStoreOutputStream.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.cephobjectstore
+
+import com.google.common.util.concurrent.{ListeningExecutorService, MoreExecutors}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{LocalDirAllocator, Path}
+import org.apache.log4j.Logger
+import org.javaswift.joss.model.Account
+import java.io._
+import java.util
+
+/**
+ * Asynchronous multi-part based uploading mechanism to support huge file
+ *  Data will be buffered on local disk, then uploaded
+ */
+class CephStoreOutputStream extends OutputStream {
+  private val LOG = Logger.getLogger(this.getClass)
+  private var account: Account = null
+  private var conf: Configuration = null
+  private var closed = false
+  private var key: String = null
+  private var blockFile: File = null
+  private val blockFiles = new util.HashMap[Integer, File]
+  private var blockSize = 0L
+  private var blockId = 0
+  private var blockWritten = 0L
+  private var blockStream: OutputStream = null
+  private val singleByte = new Array[Byte](1)
+  private var directoryAllocator: LocalDirAllocator = null
+  private val boundedThreadPool: ListeningExecutorService = null
+  private val blockOutputActiveBlocks: Integer = null
+  private var bucketName: String = null
+
+  def this(conf: Configuration, store: Account, key: String, blockSize: Long, bucketName: String) {
+    this()
+    this.bucketName = bucketName
+    this.account = store
+    this.conf = conf
+    this.key = key
+    this.blockSize = blockSize
+    this.blockFile = newBlockFile
+    this.blockStream = new BufferedOutputStream(new FileOutputStream(blockFile))
+  }
+
+
+  private def newBlockFile: File = {
+    if (conf.get("fs.ceph.tmp.dir") == null) conf.set(
+      "fs.ceph.tmp.dir", conf.get("hadoop.tmp.dir") + "/oss")
+    if (directoryAllocator == null) directoryAllocator = new LocalDirAllocator("fs.ceph.tmp.dir")
+    directoryAllocator.createTmpFileForWrite(
+      String.format("ceph-block-%04d-", Int.box(blockId)), blockSize, conf)
+  }
+
+
+  override def flush(): Unit = {
+    blockStream.flush()
+  }
+
+  override def close(): Unit = {
+    if (closed) return
+    blockStream.flush()
+    blockStream.close()
+    if (!blockFiles.values.contains(blockFile)) {
+      blockId += 1
+      blockFiles.put(blockId, blockFile)
+    }
+    try if (blockFiles.size == 1) {
+      val storeObject = blockFile.getAbsoluteFile
+      val fis = new FileInputStream(storeObject)
+      val hdfsPath = new Path(key)
+      val objectPath = hdfsPath.toUri.getPath
+      account.getContainer(bucketName).getObject(objectPath.substring(1)).uploadObject(fis)
+    }
+    removeTemporaryFiles()
+    closed = true
+
+  }
+
+  @throws[IOException]
+  override def write(b: Int): Unit = {
+    singleByte(0) = b.toByte
+    write(singleByte, 0, 1)
+  }
+
+  @throws[IOException]
+  override def write(b: Array[Byte], off: Int, len: Int): Unit = {
+    if (closed) throw new IOException("Stream closed.")
+    blockStream.write(b, off, len)
+    blockWritten += len
+    if (blockWritten >= blockSize) {
+      blockWritten = 0L
+    }
+  }
+
+  private def removeTemporaryFiles(): Unit = {
+    blockFiles.values().forEach(file => {
+      if (file != null && file.exists && !file.delete) LOG.warn("Failed to delete temporary file")
+    })
+  }
+
+}

--- a/contribs/src/main/scala/io/delta/storage/cephobjectstore/CephStoreStatus.scala
+++ b/contribs/src/main/scala/io/delta/storage/cephobjectstore/CephStoreStatus.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.cephobjectstore
+
+import org.apache.hadoop.fs.permission.FsPermission
+import org.apache.hadoop.fs.{FileStatus, Path}
+
+/**
+ * This class is used by listStatus for Ceph RGW files.
+ */
+class CephStoreStatus(length: Long, isdir: Boolean, block_replication: Int,
+                      blocksize: Long, modification_time: Long, access_time: Long,
+                      permission: FsPermission, owner: String, group: String, symlink: Path,
+                      path: Path)
+  extends FileStatus(length: Long, isdir: Boolean, block_replication: Int,
+    blocksize: Long, modification_time: Long, access_time: Long,
+    permission: FsPermission, owner: String, group: String, symlink: Path,
+    path: Path) {
+
+
+  def this(modification_time: Long, path: Path, owner: String) {
+    this(0, true, 1, 0, modification_time,
+      0, null, owner, null, null, path)
+    setOwner(owner)
+    setGroup(owner)
+  }
+
+  def this(length: Long, modification_time: Long, path: Path,
+           blockSize: Long, owner: String) {
+    this(length, false, 1, blockSize, modification_time,
+      0, null, owner, null, null, path)
+    setOwner(owner)
+    setGroup(owner)
+  }
+}

--- a/contribs/src/main/scala/io/delta/storage/cephobjectstore/CephStoreSystem.scala
+++ b/contribs/src/main/scala/io/delta/storage/cephobjectstore/CephStoreSystem.scala
@@ -1,0 +1,255 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.cephobjectstore
+
+import io.delta.storage.cephobjectstore.CephStoreUtil._
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs
+import org.apache.hadoop.fs._
+import org.apache.hadoop.fs.permission.FsPermission
+import org.apache.hadoop.security.UserGroupInformation
+import org.apache.hadoop.util.Progressable
+import org.apache.log4j.Logger
+import org.javaswift.joss.client.factory.{AccountFactory, AuthenticationMethod}
+import org.javaswift.joss.model.Account
+
+import java.io.{FileNotFoundException, IOException}
+import java.net.URI
+import java.util
+import scala.util.control.Breaks
+
+
+/**
+ * Implementation of FileSystem for Ceph RGW ,
+ * used to access Ceph RGW system in a filesystem style.
+ */
+class CephStoreSystem extends FileSystem {
+  val LOG = Logger.getLogger(this.getClass)
+  private val FS_CEPH_USERNAME = "spark.hadoop.fs.ceph.username"
+  private val FS_CEPH_PASSWORD = "spark.hadoop.fs.ceph.password"
+  private val FS_CEPH_URI = "spark.hadoop.fs.ceph.uri"
+  private var account: Account = null
+  private var bucketName: String = null
+  private var uri: URI = null
+  private val workingDir: Path = null
+  private var username: String = null
+
+
+  override def getScheme(): String = {
+    val scheme = "ceph"
+    scheme
+  }
+
+  /**
+   * Initialize new FileSystem.
+   * the uri of the file system, including host, port, etc.
+   *
+   * @param conf configuration of the file system
+   * @throws IOException IO problems
+   */
+  override def initialize(uri: URI, conf: Configuration): Unit = {
+    this.setConf(conf)
+    checkRootPath(uri)
+    this.bucketName = uri.getHost
+    this.username = UserGroupInformation.getCurrentUser.getShortUserName
+    this.uri = uri
+    this.account = getAccount
+    super.initialize(uri, conf)
+  }
+
+  private def getAccount = {
+    val conf = getConf
+    try {
+      new AccountFactory().setUsername(
+        conf.get(FS_CEPH_USERNAME)).setPassword(
+        conf.get(FS_CEPH_PASSWORD)).setAuthenticationMethod(
+        AuthenticationMethod.BASIC).setAuthUrl(conf.get(FS_CEPH_URI)).createAccount
+    } catch {
+      case e: IOException =>
+        e.printStackTrace()
+        throw new IOException("Failed to create account! Please check your user information")
+
+    }
+  }
+
+  override def getUri: URI = uri
+
+  /**
+   * Does the path represent to a directory ?
+   *
+   * @Returns: true if this is a directory.
+   */
+  def isDir(path: Path): Boolean = {
+    val containerName = path.toUri.getHost
+    val objectName = getObjectPath(path)
+    val objects = account.getContainer(containerName).list(getSuffixes(objectName), "", 2)
+    if (objects.size() > 0) return true
+    false
+  }
+
+  override def open(path: Path, i: Int): FSDataInputStream = {
+    val fileStatus = getFileStatus(path)
+    if (fileStatus.isDirectory) {
+      throw new FileNotFoundException("Can't open " + path + " because it is a directory")
+    }
+    val container = account.getContainer(bucketName)
+    val storedObject = container.getObject(getObjectPath(path))
+    val byte = storedObject.downloadObject()
+    new FSDataInputStream(new CephStoreInputStream(byte))
+  }
+
+  @throws[IOException]
+  override def create(path: Path, fsPermission: FsPermission,
+                      overwrite: Boolean, bufferSize: Int, replication: Short, blockSize: Long,
+                      progress: Progressable): FSDataOutputStream = {
+    val out = this.createCephObjectOutputStream(path)
+    new FSDataOutputStream(out, this.statistics)
+  }
+
+  @throws[IOException]
+  protected def createCephObjectOutputStream(path: Path) = {
+    val partSizeKB = 1024
+    new CephStoreOutputStream(this.getConf, account, path.toUri.toString, partSizeKB, bucketName)
+  }
+
+  @throws[IOException]
+  override def append(f: Path, bufferSize: Int, progress: Progressable): Nothing = {
+    throw new IOException("Append is not supported!")
+  }
+
+  override def rename(srcPath: Path, dstPath: Path): Boolean = {
+    throw new IOException("Rename is not supported!")
+  }
+
+  override def delete(path: Path, recursive: Boolean): Boolean = {
+    try {
+      val container = account.getContainer(bucketName)
+      val objectName = getObjectPath(path)
+      val storeObject = container.getObject(objectName)
+      if (storeObject.exists) storeObject.delete()
+      return true
+    } catch {
+      case ex: Exception =>
+        ex.printStackTrace()
+        LOG.error("Failed to delete :" + path)
+
+    }
+    false
+
+  }
+
+  def pathToKey(path: Path): String = {
+    var pathFinal = path
+    if (!path.isAbsolute) pathFinal = new Path(workingDir.toUri.toString, path.toString)
+    if (path.toUri.getScheme != null && path.toUri.getPath.isEmpty) return ""
+    getObjectPath(pathFinal)
+  }
+
+  def qualify(path: Path): Path = path.makeQualified(uri, workingDir)
+
+  override def listStatus(objectPath: Path): Array[FileStatus] = {
+    val path = qualify(objectPath)
+    var key = pathToKey(path)
+    val fileStatus = getFileStatus(path)
+    if (fileStatus.isDirectory) if (!key.isEmpty) key = getSuffixes(key)
+    val containerSize = account.getContainer(objectPath.toUri.getHost).list().size()
+    val objectsList = account.getContainer(bucketName)
+      .list(getObjectPath(objectPath), "", containerSize)
+    val cephObjectStatuses = new util.ArrayList[FileStatus]
+    objectsList.forEach(storedObject => {
+      if (storedObject.getName.equals(getSuffixes(key))) {
+        LOG.debug("Ignoring: " + storedObject.getName)
+      } else {
+        val completePath = getCompletePath(objectPath, storedObject)
+        val hdfsPath = new Path(completePath)
+        val objectStatus = getFileStatus(hdfsPath)
+        cephObjectStatuses.add(objectStatus)
+      }
+    })
+    cephObjectStatuses.toArray(new Array[FileStatus](0))
+  }
+
+
+  override def setWorkingDirectory(new_dir: fs.Path): Unit = {
+    throw new IOException("Set working directory is not supported!")
+  }
+
+  override def getWorkingDirectory(): Path = {
+    new Path(uri.toString)
+  }
+
+  override def mkdirs(path: Path, fsPermission: FsPermission): Boolean = {
+    var fileStatus: FileStatus = null
+    var temPath: Path = null
+    val qualifyPath = qualify(path)
+    try {
+      fileStatus = getFileStatus(path)
+      if (fileStatus.isDirectory) return true
+      else throw new FileAlreadyExistsException("Path is a file: " + path)
+    } catch {
+      case e: FileNotFoundException =>
+        temPath = path.getParent
+        val loop = new Breaks
+        loop.breakable {
+          while (temPath != null) {
+            try {
+              fileStatus = getFileStatus(temPath)
+              if (fileStatus.isDirectory) {
+                loop.break
+              }
+              if (fileStatus.isFile) {
+                throw new FileAlreadyExistsException(
+                  String.format("Can't make directory for path '%s' since it is a file.", temPath))
+              }
+            }
+            catch {
+              case e: FileNotFoundException =>
+                temPath = temPath.getParent
+
+            }
+          }
+        }
+
+    }
+    val objectName = getSuffixes(path.toUri.getHost) + pathToKey(qualifyPath)
+    val postfix = objectName.endsWith("/")
+    if (!postfix) account.getContainer(getSuffixes(objectName)).create()
+    else account.getContainer(objectName)
+    true
+  }
+
+  override def getFileStatus(path: Path): FileStatus = {
+    val qualifyPath = qualify(path)
+    var LastModifiedAsTime: Long = 0
+    val objectPath = getObjectPath(path)
+    if (objectPath.length == 0) {
+      return new CephStoreStatus(LastModifiedAsTime, qualifyPath, username)
+    }
+    val objectsList = account.getContainer(bucketName).list(objectPath, "", 2)
+    if (objectsList.size() < 1) {
+      throw new FileNotFoundException("No such file or directory: " + qualifyPath)
+    }
+    if (isDir(path)) {
+      return new CephStoreStatus(0, qualifyPath, username)
+    }
+    LastModifiedAsTime = account.getContainer(bucketName)
+      .getObject(objectPath).getLastModifiedAsDate.getTime
+    val contentLength = account.getContainer(bucketName).getObject(objectPath).getContentLength
+    new CephStoreStatus(contentLength, LastModifiedAsTime,
+      qualifyPath, getDefaultBlockSize(qualifyPath), username)
+  }
+}

--- a/contribs/src/main/scala/io/delta/storage/cephobjectstore/CephStoreUtil.scala
+++ b/contribs/src/main/scala/io/delta/storage/cephobjectstore/CephStoreUtil.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.cephobjectstore
+
+import org.apache.hadoop.fs.Path
+import org.javaswift.joss.model.StoredObject
+
+import java.io.IOException
+import java.net.URI
+
+/**
+ * Utility methods for Ceph RGW code.
+ */
+object CephStoreUtil {
+
+  /**
+   * Check the completeness of the path
+   *
+   * @throws IOException IO problems
+   */
+  def checkRootPath(uri: URI): Unit = {
+    val objectUri = uri
+    if (objectUri == null) {
+      throw new IOException("Path cannot be null, ceph://<your-container-name>/<your-object-path>")
+    }
+    if (!objectUri.getScheme.equals("ceph")) {
+      throw new IOException("Scheme is wrong, ceph://<your-container-name>/<your-object-path>")
+    }
+    if (objectUri.getHost == null) throw new IOException("Container name cannot be null")
+    val objectPath = new Path(objectUri)
+    if (objectPath.toString().endsWith("_delta_log")) {
+      val parentPath = objectPath.getParent
+      if (getObjectPath(parentPath).equals("")) {
+        throw new IOException("Object name cannot be null")
+      }
+    }
+    else if (getObjectPath(objectPath).equals("")) {
+      throw new IOException("Object name cannot be null")
+    }
+  }
+
+  def getObjectPath(path: Path): String = {
+    val objectUri = path.toUri
+    val objectPath = objectUri.getPath.substring(1)
+    objectPath
+  }
+
+  def getCompletePath(path: Path, storeObject: StoredObject): String = {
+    val host = path.toUri.getHost
+    val completePath = "ceph://" + host + "/" + storeObject.getName
+    completePath
+  }
+
+  def getSuffixes(string: String): String = {
+    val str = string + "/"
+    str
+  }
+
+
+}

--- a/contribs/src/test/scala/io/delta/storage/CephStoreTest.scala
+++ b/contribs/src/test/scala/io/delta/storage/CephStoreTest.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.storage
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.{LocalSparkSession, SparkSession}
+import org.apache.spark.sql.catalyst.plans.SQLHelper
+import org.apache.spark.sql.delta.storage.S3SingleDriverLogStore
+
+
+class CephStoreTest extends SparkFunSuite with LocalSparkSession with SQLHelper {
+
+  test("commit lock flag on Ceph RGW") {
+    spark = SparkSession.builder()
+      .appName("Quickstart")
+      .master("local[*]")
+      .config("spark.delta.logStore.class", classOf[S3SingleDriverLogStore].getName)
+      .config("spark.hadoop.fs.s3a.connection.ssl.enabled", "false")
+      .config("fs.ceph.impl", "io.delta.storage.cephobjectstore.CephStoreSystem")
+      .config("spark.hadoop.fs.ceph.username", "<your-ceph-rgw-username>")
+      .config("spark.hadoop.fs.ceph.password", "<your-ceph-rgw-secret-key>")
+      .config("spark.hadoop.fs.ceph.uri", "<your-ceph-rgw-uri>")
+      .config("fs.oss.buffer.dir", "<your-tmp-file-path>")
+      .getOrCreate()
+
+    // Try out some basic Delta table operations on Ceph RGW  (in Scala):
+    //
+    // spark.range(5).write.format("delta")
+    // .save("ceph://<your-ceph-rgw-container>/<path-to-delta-table>")
+    // spark.read.format("delta")
+    // .load("ceph://<your-ceph-rgw-container>/<path-to-delta-table>").show()
+
+    // Update table data
+    //
+    // spark.range(5, 10).write.format("delta").mode("overwrite")
+    // .save("ceph://<your-ceph-rgw-container>/<path-to-delta-table>")
+    //  df.show()
+
+    // Read older versions of data using time travel
+    //
+    // df = spark.read.format("delta").option("versionAsOf", 0)
+    // .load("ceph://<your-ceph-rgw-container>/<path-to-delta-table>")
+    // df.show()
+
+
+  }
+}


### PR DESCRIPTION
We supported the storage of Ceph. Data connection between Delta Lake and Object store system Ceph RGW is established by Openstack Swift API. Path’s scheme is "ceph". Full path is "ceph://{your-cephrgw-container}/{path-to-delta-table}". Please refer to testing file for more detailed configurations. Logstore can use class S3SingleDriverLogStore.