### PR TITLE
WIP: Hidden partitioning using generated columns

### DIFF
--- a/core/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
+++ b/core/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
@@ -93,5 +93,8 @@ class DeltaSparkSessionExtension extends (SparkSessionExtensions => Unit) {
     extensions.injectOptimizerRule { session =>
       new ActiveOptimisticTransactionRule(session)
     }
+    extensions.injectOptimizerRule { session =>
+      new HiddenPartitioningRule(session)
+    }
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/delta/HiddenPartitioningRule.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/HiddenPartitioningRule.scala
@@ -1,0 +1,158 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.planning.PhysicalOperation
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, V2WriteCommand}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.delta.files.{PinnedTahoeFileIndex, TahoeLogFileIndex}
+
+
+/**
+ * This rule tries to find if we attempt to read the same table when there is an active transaction.
+ * If so, reading the same table should use the same snapshot of the transaction, and the
+ * transaction should also record the filters that are used to read the table.
+ *
+ */
+class HiddenPartitioningRule(spark: SparkSession) extends Rule[LogicalPlan] {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+
+    // We need to first prepare the scans in the subqueries of a node. Otherwise, because of the
+    // short-circuiting nature of the pattern matching in the transform method, if a
+    // PhysicalOperation node is matched, its subqueries that may contain other PhysicalOperation
+    // nodes will be skipped.
+    def transformSubqueries(plan: LogicalPlan): LogicalPlan =
+      plan transformAllExpressions {
+        case subquery: SubqueryExpression =>
+          subquery.withNewPlan(transform(subquery.plan))
+      }
+
+    def transform(plan: LogicalPlan): LogicalPlan =
+      transformSubqueries(plan) transform {
+        case p @ PhysicalOperation(_, filters, DeltaTable(fileIndex: TahoeLogFileIndex))
+            if fileIndex.deltaLog.snapshot.hiddenPartitioningColumns.nonEmpty &&
+            filters.nonEmpty =>
+
+          val hiddenPartitioningColumns = fileIndex.deltaLog.snapshot.hiddenPartitioningColumns
+          val generatedColumnSources = hiddenPartitioningColumns.flatMap { field =>
+            GeneratedColumn.getGenerationExpression(field).collect {
+              case UnresolvedAttribute(nameParts) =>
+                nameParts -> HiddenPartition(field.name, false, value => value)
+              case e @ Cast(UnresolvedAttribute(nameParts), _, _, _) =>
+                nameParts -> HiddenPartition(field.name, true, value => e.copy(child = value))
+            }
+          }.toMap
+
+          val resolver = spark.sessionState.conf.resolver
+
+          val hiddenPartitioningFilters = filters.flatMap(_ match {
+            case EqualTo(left, right) =>
+              extractNameAndValue(left, right).flatMap { case (name, value) =>
+                generatedColumnSources.get(name).flatMap { hiddenPartition =>
+                  p.resolve(Seq(hiddenPartition.fieldName), resolver).map { attr =>
+                    EqualTo(attr, hiddenPartition.generator(value))
+                  }
+                }
+              }
+            case LessThanOrEqual(left, right) =>
+              extractNameAndValue(left, right).flatMap { case (name, value) =>
+                generatedColumnSources.get(name).flatMap { hiddenPartition =>
+                  p.resolve(Seq(hiddenPartition.fieldName), resolver).map { attr =>
+                    LessThanOrEqual(attr, hiddenPartition.generator(value))
+                  }
+                }
+              }
+            case LessThan(left, right) =>
+              extractNameAndValue(left, right).flatMap { case (name, value) =>
+                generatedColumnSources.get(name).flatMap { hiddenPartition =>
+                  p.resolve(Seq(hiddenPartition.fieldName), resolver).map { attr =>
+                    if (hiddenPartition.lostPrecision) {
+                      LessThanOrEqual(attr, hiddenPartition.generator(value))
+                    } else {
+                      LessThan(attr, hiddenPartition.generator(value))
+                    }
+                  }
+                }
+              }
+            case GreaterThanOrEqual(left, right) =>
+              extractNameAndValue(left, right).flatMap { case (name, value) =>
+                generatedColumnSources.get(name).flatMap { hiddenPartition =>
+                  p.resolve(Seq(hiddenPartition.fieldName), resolver).map { attr =>
+                    GreaterThanOrEqual(attr, hiddenPartition.generator(value))
+                  }
+                }
+              }
+            case GreaterThan(left, right) =>
+              extractNameAndValue(left, right).flatMap { case (name, value) =>
+                generatedColumnSources.get(name).flatMap { hiddenPartition =>
+                  p.resolve(Seq(hiddenPartition.fieldName), resolver).map { attr =>
+                    if (hiddenPartition.lostPrecision) {
+                      GreaterThanOrEqual(attr, hiddenPartition.generator(value))
+                    } else {
+                      GreaterThan(attr, hiddenPartition.generator(value))
+                    }
+                  }
+                }
+              }
+            case _ => None
+          })
+
+          var newFilters = hiddenPartitioningFilters.filter(!filters.contains(_))
+          if (newFilters.nonEmpty) {
+            p.transformUp {
+              case d @ DeltaTable(_: TahoeLogFileIndex) =>
+                Filter(newFilters.reduce(And), d)
+            }
+          } else {
+            p
+          }
+      }
+
+    transform(plan)
+  }
+
+  private def getNestedFieldName(expr: Expression): Seq[String] = {
+    expr match {
+      case g: GetStructField =>
+        getNestedFieldName(g.child).toSeq ++ Seq(g.extractFieldName)
+      case a: AttributeReference =>
+        Seq(a.name)
+      case _ =>
+        throw new Exception("Bad path")
+    }
+  }
+
+  private def extractNameAndValue(left: Expression, right: Expression
+      ): Option[(Seq[String], Expression)] = {
+    (left, right) match {
+      case (attr: AttributeReference, value: Literal) => Some((Seq(attr.name), value))
+      case (attr: GetStructField, value: Literal) =>
+        Some((getNestedFieldName(attr), value))
+      case (value: Literal, attr: AttributeReference) => Some((Seq(attr.name), value))
+      case (value: Literal, attr: GetStructField) =>
+        Some((getNestedFieldName(attr), value))
+      case _ => None
+    }
+  }
+}
+
+case class HiddenPartition(fieldName: String, lostPrecision: Boolean,
+    generator: Expression => Expression)

--- a/core/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{StructField, StructType}
 import org.apache.spark.util.{SerializableConfiguration, Utils}
 
 /**
@@ -232,6 +232,10 @@ class Snapshot(
 
   /** Returns the data schema of the table, the schema of the columns written out to file. */
   def dataSchema: StructType = metadata.dataSchema
+
+  def hiddenPartitioningColumns: Seq[StructField] = {
+    metadata.partitionSchema.fields.filter(GeneratedColumn.isGeneratedColumn(protocol, _))
+  }
 
   /** Number of columns to collect stats on for data skipping */
   lazy val numIndexedCols: Int = DeltaConfigs.DATA_SKIPPING_NUM_INDEXED_COLS.fromMetaData(metadata)

--- a/core/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
@@ -1612,11 +1612,11 @@ trait GeneratedColumnSuiteBase extends GeneratedColumnTest {
           .format("delta")
           .mode("append")
           .save(path)
-        
+
         // Read only one partition
         var query = spark.read.format("delta").load(path).where("id = 1")
         checkPartitioningAnswer(query, 1, Seq(Row(1, 1)))
-        
+
         query = spark.read.format("delta").load(path).where("id <= 1")
         checkPartitioningAnswer(query, 2, Seq(Row(0, 0), Row(1, 1)))
 
@@ -1630,18 +1630,19 @@ trait GeneratedColumnSuiteBase extends GeneratedColumnTest {
     withTempDir { tempDir =>
       val path = tempDir.getCanonicalPath
       withTableName("hidden_partitioning") { table =>
-        createTable(table, Some(path), "part bigint, nested struct<id: bigint>", Map("part" -> "nested.id"), Seq("part"))
+        createTable(table, Some(path), "part bigint, nested struct<id: bigint>",
+          Map("part" -> "nested.id"), Seq("part"))
         spark.range(3)
           .select(struct(col("id")).alias("nested"))
           .write
           .format("delta")
           .mode("append")
           .save(path)
-        
+
         // Read only one partition
         var query = spark.read.format("delta").load(path).where("nested.id = 1")
         checkPartitioningAnswer(query, 1, Seq(Row(1, Row(1))))
-        
+
         query = spark.read.format("delta").load(path).where("nested.id <= 1")
         checkPartitioningAnswer(query, 2, Seq(Row(0, Row(0)), Row(1, Row(1))))
 
@@ -1655,17 +1656,18 @@ trait GeneratedColumnSuiteBase extends GeneratedColumnTest {
     withTempDir { tempDir =>
       val path = tempDir.getCanonicalPath
       withTableName("hidden_partitioning") { table =>
-        createTable(table, Some(path), "part int, id bigint", Map("part" -> "cast(id as int)"), Seq("part"))
+        createTable(table, Some(path), "part int, id bigint",
+          Map("part" -> "cast(id as int)"), Seq("part"))
         spark.range(3)
           .write
           .format("delta")
           .mode("append")
           .save(path)
-        
+
         // Read only one partition
         var query = spark.read.format("delta").load(path).where("id = 1")
         checkPartitioningAnswer(query, 1, Seq(Row(1, 1)))
-        
+
         query = spark.read.format("delta").load(path).where("id <= 1")
         checkPartitioningAnswer(query, 2, Seq(Row(0, 0), Row(1, 1)))
 
@@ -1679,18 +1681,19 @@ trait GeneratedColumnSuiteBase extends GeneratedColumnTest {
     withTempDir { tempDir =>
       val path = tempDir.getCanonicalPath
       withTableName("hidden_partitioning") { table =>
-        createTable(table, Some(path), "part int, nested struct<id: bigint>", Map("part" -> "cast(nested.id as int)"), Seq("part"))
+        createTable(table, Some(path), "part int, nested struct<id: bigint>",
+          Map("part" -> "cast(nested.id as int)"), Seq("part"))
         spark.range(3)
           .select(struct(col("id")).alias("nested"))
           .write
           .format("delta")
           .mode("append")
           .save(path)
-        
+
         // Read only one partition
         var query = spark.read.format("delta").load(path).where("nested.id = 1")
         checkPartitioningAnswer(query, 1, Seq(Row(1, Row(1))))
-        
+
         query = spark.read.format("delta").load(path).where("nested.id <= 1")
         checkPartitioningAnswer(query, 2, Seq(Row(0, Row(0)), Row(1, Row(1))))
 


### PR DESCRIPTION
Attempt at #490 

I started playing around this and got something working so I wanted to see what others thought of it. It implements very basic hidden partitioning functionality using an optimizer rule on top of generated columns. Just a rough initial implementation, but basically it looks for partition columns that are also generated columns, and if the generation expression matches certain expressions (right now just direct copy and cast), and there are literal filters on the source of the generated expression, a new filter will be added with the generated expression applied to the literal filter and then applied to the generated column, which then gets pushed as a partition filter.

It's very happy path right now, but wanted to see if this even makes sense as an option or if there's something fundamentally that won't work before going any further.