### PR TITLE
Recreate DeltaLog objects when the original SparkContext is stopped

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.delta
 
 // scalastyle:off import.ordering.noEmptyLine
 import java.io.{File, IOException}
+import java.lang.ref.WeakReference
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
 
@@ -39,6 +40,7 @@ import com.google.common.cache.{CacheBuilder, RemovalNotification}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 
+import org.apache.spark.SparkContext
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{Resolver, UnresolvedAttribute}
@@ -77,6 +79,13 @@ class DeltaLog private(
   private lazy implicit val _clock = clock
 
   protected def spark = SparkSession.active
+
+  /**
+   * Keep a reference to `SparkContext` used to create `DeltaLog`. `DeltaLog` cannot be used when
+   * `SparkContext` is stopped. We keep the reference so that we can check whether the cache is
+   * still valid and drop invalid `DeltaLog`` objects.
+   */
+  private val sparkContext = new WeakReference(spark.sparkContext)
 
   /**
    * Returns the Hadoop [[Configuration]] object which can be used to access the file system. All
@@ -553,16 +562,29 @@ object DeltaLog extends DeltaLogging {
           new DeltaLog(path, path.getParent, fileSystemOptions, clock)
         }
     }
-    // The following cases will still create a new ActionLog even if there is a cached
-    // ActionLog using a different format path:
-    // - Different `scheme`
-    // - Different `authority` (e.g., different user tokens in the path)
-    // - Different mount point.
-    try {
-      deltaLogCache.get(path -> fileSystemOptions, () => createDeltaLog())
-    } catch {
-      case e: com.google.common.util.concurrent.UncheckedExecutionException =>
-        throw e.getCause
+
+    def getDeltaLogFromCache(): DeltaLog = {
+      // The following cases will still create a new ActionLog even if there is a cached
+      // ActionLog using a different format path:
+      // - Different `scheme`
+      // - Different `authority` (e.g., different user tokens in the path)
+      // - Different mount point.
+      try {
+        deltaLogCache.get(path -> fileSystemOptions, () => createDeltaLog())
+      } catch {
+        case e: com.google.common.util.concurrent.UncheckedExecutionException =>
+          throw e.getCause
+      }
+    }
+
+    val deltaLog = getDeltaLogFromCache()
+    if (Option(deltaLog.sparkContext.get).map(_.isStopped).getOrElse(true)) {
+      // Invalid the cached `DeltaLog` and create a new one because the `SparkContext` of the cached
+      // `DeltaLog` has been stopped.
+      deltaLogCache.invalidate(path -> fileSystemOptions)
+      getDeltaLogFromCache()
+    } else {
+      deltaLog
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaRestartSessionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaRestartSessionSuite.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.SparkSession
+
+class DeltaRestartSessionSuite extends SparkFunSuite {
+
+  test("restart Spark session should work") {
+    withTempDir { dir =>
+      var spark = SparkSession.builder().master("local[2]").getOrCreate()
+      try {
+        val path = dir.getCanonicalPath
+        spark.range(10).write.format("delta").mode("overwrite").save(path)
+        spark.read.format("delta").load(path).count()
+
+        spark.stop()
+        spark = SparkSession.builder().master("local[2]").getOrCreate()
+        spark.range(10).write.format("delta").mode("overwrite").save(path)
+        spark.read.format("delta").load(path).count()
+      }
+      finally {
+        spark.stop()
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR keeps a reference to `SparkContext` in `DeltaLog` and uses it to detect whether the `SparkContext` used to create `DeltaLog` is stopped. If it's stopped, we should remove the invalid cached `DeltaLog` and create a new one.

Closes #629