### PR TITLE
Remove sbt-coursier from plugings

### DIFF
--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -15,5 +15,3 @@
  */
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
-
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")


### PR DESCRIPTION
Resolves #800 

Remove `sbt-coursier` from build.

sbt 1.3.x includes `sbt-coursier` so it's no longer needed after version upgrade, version shipped with sbt 1.5.5 resolves this issue.

Verified by running `build/sbt package`