### PR TITLE
Python API for restoring delta table

### DIFF
--- a/python/delta/tables.py
+++ b/python/delta/tables.py
@@ -537,6 +537,46 @@ class DeltaTable(object):
                              type(writerVersion))
         jdt.upgradeTableProtocol(readerVersion, writerVersion)
 
+    @since(1.2)  # type: ignore[arg-type]
+    def restoreToVersion(self, version: int) -> DataFrame:
+        """
+        Restore the DeltaTable to an older version of the table specified by version number.
+
+        Example::
+
+            deltaTable.restoreToVersion(1)
+
+        :param version: target version of restored table
+        :return: Dataframe with metrics of restore operation.
+        :rtype: pyspark.sql.DataFrame
+        """
+
+        return DataFrame(
+            self._jdt.restoreToVersion(version),
+            self._spark._wrapped  # type: ignore[attr-defined]
+        )
+
+    @since(1.2)  # type: ignore[arg-type]
+    def restoreToTimestamp(self, timestamp: str) -> DataFrame:
+        """
+        Restore the DeltaTable to an older version of the table specified by a timestamp.
+        Timestamp can be of the format yyyy-MM-dd or yyyy-MM-dd HH:mm:ss
+
+        Example::
+
+            deltaTable.restoreToTimestamp('2021-01-01')
+            deltaTable.restoreToTimestamp('2021-01-01 01:01:01')
+
+        :param timestamp: target timestamp of restored table
+        :return: Dataframe with metrics of restore operation.
+        :rtype: pyspark.sql.DataFrame
+        """
+
+        return DataFrame(
+            self._jdt.restoreToTimestamp(timestamp),
+            self._spark._wrapped  # type: ignore[attr-defined]
+        )
+
     @staticmethod
     def _dict_to_jmap(
         sparkSession: SparkSession,

--- a/python/delta/tests/test_deltatable.py
+++ b/python/delta/tests/test_deltatable.py
@@ -798,7 +798,8 @@ class DeltaTableTests(DeltaTestCase):
                                    overwriteSchema='true')
 
         overwritten = DeltaTable.forPath(self.spark, self.tempFile).toDF()
-        self.__checkAnswer(overwritten, [Row(key_new='a', value_new=3), Row(key_new='b', value_new=2)])
+        self.__checkAnswer(overwritten,
+                           [Row(key_new='a', value_new=3), Row(key_new='b', value_new=2)])
 
         DeltaTable.forPath(self.spark, self.tempFile).restoreToVersion(0)
         restored = DeltaTable.forPath(self.spark, self.tempFile).toDF()
@@ -818,7 +819,8 @@ class DeltaTableTests(DeltaTestCase):
                                    overwriteSchema='true')
 
         overwritten = DeltaTable.forPath(self.spark, self.tempFile).toDF()
-        self.__checkAnswer(overwritten, [Row(key_new='a', value_new=3), Row(key_new='b', value_new=2)])
+        self.__checkAnswer(overwritten,
+                           [Row(key_new='a', value_new=3), Row(key_new='b', value_new=2)])
 
         DeltaTable.forPath(self.spark, self.tempFile).restoreToTimestamp(timestampToRestore)
 


### PR DESCRIPTION
 * Add possibility to restore delta table using version or timestamp from pyspark
   Examples:
   ```
   DeltaTable.forPath(spark, path).restoreToVersion(0)
   DeltaTable.forPath(spark, path).restoreToTimestamp('2021-01-01 01:01-01')
   ```

Tested by unit tests.

Fixes https://github.com/delta-io/delta/issues/890

Signed-off-by: Maksym Dovhal <maksym.dovhal@gmail.com>