### PR TITLE
Update integration tests to run with all published Scala versions

### DIFF
--- a/examples/scala/build.sbt
+++ b/examples/scala/build.sbt
@@ -21,7 +21,19 @@ organizationName := "example"
 val scala212 = "2.12.14"
 val scala213 = "2.13.5"
 
-scalaVersion := scala212
+def getScalaVersion(): String = {
+  val envVars = System.getenv
+  if (envVars.containsKey("SCALA_VERSION")) {
+    val version = envVars.get("SCALA_VERSION")
+    println("Using Scala version " + version)
+    if (version == "2.13") {
+      return scala213
+    }
+  }
+  scala212
+}
+
+scalaVersion := getScalaVersion
 version := "0.1.0"
 
 def getDeltaVersion(): String = {

--- a/run-integration-tests.py
+++ b/run-integration-tests.py
@@ -30,14 +30,14 @@ def delete_if_exists(path):
         print("Deleted %s " % path)
 
 
-def run_scala_integration_tests(root_dir, version, test_name, extra_maven_repo):
-    print("\n\n##### Running Scala tests on version %s #####" % str(version))
+def run_scala_integration_tests(root_dir, version, test_name, extra_maven_repo, scala_version):
+    print("\n\n##### Running Scala tests on delta version %s and scala version %s #####" % (str(version), scala_version))
     clear_artifact_cache()
     test_dir = path.join(root_dir, "examples", "scala")
     test_src_dir = path.join(test_dir, "src", "main", "scala", "example")
     test_classes = [f.replace(".scala", "") for f in os.listdir(test_src_dir)
                     if f.endswith(".scala") and not f.startswith("_")]
-    env = {"DELTA_VERSION": str(version)}
+    env = {"DELTA_VERSION": str(version), "SCALA_VERSION": scala_version}
     if extra_maven_repo:
         env["EXTRA_MAVEN_REPO"] = extra_maven_repo
     with WorkingDirectory(test_dir):
@@ -204,6 +204,11 @@ if __name__ == "__main__":
         action="store_true",
         help="Run only Scala tests")
     parser.add_argument(
+        "--scala-version",
+        required=False,
+        default="2.12",
+        help="Specify scala version for scala tests only, valid values are '2.12' and '2.13'")
+    parser.add_argument(
         "--pip-only",
         required=False,
         default=False,
@@ -234,6 +239,9 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
+    if args.scala_version not in ["2.12", "2.13"]:
+        raise Exception("Scala version can only be specified as --scala-version 2.12 or --scala-version 2.13")
+
     if args.pip_only and args.no_pip:
         raise Exception("Cannot specify both --pip-only and --no-pip")
 
@@ -242,7 +250,7 @@ if __name__ == "__main__":
     run_pip = not args.python_only and not args.scala_only and not args.no_pip
 
     if run_scala:
-        run_scala_integration_tests(root_dir, args.version, args.test, args.maven_repo)
+        run_scala_integration_tests(root_dir, args.version, args.test, args.maven_repo, args.scala_version)
 
     if run_python:
         run_python_integration_tests(root_dir, args.version, args.test, args.maven_repo)


### PR DESCRIPTION
This PR adds a new flag --scala-version to `run-integration-tests.py`.

You can run the following commands:

```
$ python run-integration-tests.py --version 1.1.0 --scala-version 2.13 --scala-only
$ python run-integration-tests.py --version 1.1.0 --scala-version 2.12 --scala-only
$ python run-integration-tests.py --version 1.1.0 --scala-only
```

It defaults to 2.12 when a version is not provided and fails if any version other than 2.12 and 2.13 are provided.

The build.sbt is also updated in the build.sbt in examples/scala/build.sbt to fetch scala version from ENV var `SCALA_VERSION`. 

This is meant to resolve issue #846.