### PR TITLE
configure_spark_with_delta_pip fix to stop overwriting spark.jars.packages

### DIFF
--- a/python/delta/pip_utils.py
+++ b/python/delta/pip_utils.py
@@ -13,11 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from typing import List
+
 from pyspark.sql import SparkSession
 
 
 def configure_spark_with_delta_pip(
-    spark_session_builder: SparkSession.Builder
+    spark_session_builder: SparkSession.Builder,
+    extra_packages: List[str] = None
 ) -> SparkSession.Builder:
     """
     Utility function to configure a SparkSession builder such that the generated SparkSession
@@ -37,6 +40,7 @@ def configure_spark_with_delta_pip(
 
     :param spark_session_builder: SparkSession.Builder object being used to configure and
                                   create a SparkSession.
+    :param extra_packages: Allow for spark session to include other packages other than delta.
     :return: Updated SparkSession.Builder object
 
     .. versionadded:: 1.0
@@ -65,4 +69,8 @@ See the online documentation for the correct usage of this function.
     scala_version = "2.12"
     maven_artifact = f"io.delta:delta-core_{scala_version}:{delta_version}"
 
-    return spark_session_builder.config("spark.jars.packages", maven_artifact)
+    extra_packages = extra_packages or []
+    all_artifacts = extra_packages + [maven_artifact]
+    packages_str = ",".join(all_artifacts)
+
+    return spark_session_builder.config("spark.jars.packages", packages_str)

--- a/python/delta/pip_utils.py
+++ b/python/delta/pip_utils.py
@@ -13,14 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import List
+from typing import List, Optional
 
 from pyspark.sql import SparkSession
 
 
 def configure_spark_with_delta_pip(
     spark_session_builder: SparkSession.Builder,
-    extra_packages: List[str] = None
+    extra_packages: Optional[List[str]] = None
 ) -> SparkSession.Builder:
     """
     Utility function to configure a SparkSession builder such that the generated SparkSession
@@ -69,7 +69,7 @@ See the online documentation for the correct usage of this function.
     scala_version = "2.12"
     maven_artifact = f"io.delta:delta-core_{scala_version}:{delta_version}"
 
-    extra_packages = extra_packages or []
+    extra_packages = extra_packages if extra_packages is not None else []
     all_artifacts = extra_packages + [maven_artifact]
     packages_str = ",".join(all_artifacts)
 

--- a/python/delta/pip_utils.py
+++ b/python/delta/pip_utils.py
@@ -38,9 +38,17 @@ def configure_spark_with_delta_pip(
 
         spark = configure_spark_with_delta_pip(builder).getOrCreate()
 
+    3. If you would like to add more packages, use the `extra_packages` parameter.
+
+        builder = SparkSession.builder \
+            .master("local[*]") \
+            .appName("test")
+        my_packages = ["org.apache.spark:spark-sql-kafka-0-10_2.12:x.y.z"]
+        spark = configure_spark_with_delta_pip(builder, extra_packages=my_packages).getOrCreate()
+
     :param spark_session_builder: SparkSession.Builder object being used to configure and
                                   create a SparkSession.
-    :param extra_packages: Allow for spark session to include other packages other than delta.
+    :param extra_packages: Set other packages to add to Spark session besides Delta Lake.
     :return: Updated SparkSession.Builder object
 
     .. versionadded:: 1.0
@@ -70,7 +78,7 @@ See the online documentation for the correct usage of this function.
     maven_artifact = f"io.delta:delta-core_{scala_version}:{delta_version}"
 
     extra_packages = extra_packages if extra_packages is not None else []
-    all_artifacts = extra_packages + [maven_artifact]
+    all_artifacts = [maven_artifact] + extra_packages
     packages_str = ",".join(all_artifacts)
 
     return spark_session_builder.config("spark.jars.packages", packages_str)

--- a/python/delta/tests/test_pip_utils.py
+++ b/python/delta/tests/test_pip_utils.py
@@ -31,9 +31,8 @@ class PipUtilsTests(unittest.TestCase):
             .appName("pip-test") \
             .master("local[*]") \
             .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
-            .config(
-            "spark.sql.catalog.spark_catalog",
-            "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+            .config("spark.sql.catalog.spark_catalog",
+                    "org.apache.spark.sql.delta.catalog.DeltaCatalog")
 
         self.spark = delta.configure_spark_with_delta_pip(builder).getOrCreate()
         self.tempPath = tempfile.mkdtemp()
@@ -56,9 +55,8 @@ class PipUtilsCustomJarsTests(unittest.TestCase):
             .appName("pip-test") \
             .master("local[*]") \
             .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
-            .config(
-            "spark.sql.catalog.spark_catalog",
-            "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+            .config("spark.sql.catalog.spark_catalog",
+                    "org.apache.spark.sql.delta.catalog.DeltaCatalog")
 
         import importlib_metadata
         scala_version = "2.12"

--- a/python/delta/tests/test_pip_utils.py
+++ b/python/delta/tests/test_pip_utils.py
@@ -76,7 +76,6 @@ class PipUtilsCustomJarsTests(unittest.TestCase):
 if __name__ == "__main__":
     try:
         import xmlrunner
-
         testRunner = xmlrunner.XMLTestRunner(output='target/test-reports', verbosity=4)
     except ImportError:
         testRunner = None

--- a/python/delta/tests/test_pip_utils.py
+++ b/python/delta/tests/test_pip_utils.py
@@ -73,7 +73,6 @@ class PipUtilsCustomJarsTests(unittest.TestCase):
         shutil.rmtree(self.tempPath)
 
     def test_maven_jar_loaded(self) -> None:
-        # Read and write Delta table to check that the maven jars are loaded and Delta works.
         packages: List[str] = self.spark.conf.get("spark.jars.packages").split(",")
 
         # Check `spark.jars.packages` contains `extra_packages`


### PR DESCRIPTION
This pull request enhances `configure_spark_with_delta_pip` function to add an optional parameter extra_packages to allow for users to add their custom jars as required.

A test was added class was added `PipUtilsCustomJarsTests` to unit test by adding a duplicate of the delta jar and see if spark conf contained both jars in the assertion.

A new test class was added due to having to modify the spark session rather than using the existing test class. 

This resolves issue #889.