### PR TITLE
Mention deletion of delta log entries in PROTOCOL

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -95,10 +95,9 @@ This directory format is only used to follow existing conventions and is not req
 Actual partition values for a file must be read from the transaction log.
 
 ### Delta Log Entries
-Delta files are stored as JSON in a directory at the root of the table named `_delta_log`, and together make up the log of all changes that have occurred to a table.
-Delta files are the unit of atomicity for a table, and are named using the next available version number, zero-padded to 20 digits.
+Delta files are stored as JSON in a directory at the root of the table named `_delta_log`, and together with checkpoints make up the log of all changes that have occurred to a table.
 
-For example:
+Delta files are the unit of atomicity for a table, and are named using the next available version number, zero-padded to 20 digits. For example:
 
 ```
 ./_delta_log/00000000000000000000.json
@@ -113,6 +112,7 @@ Checkpoints are also stored in the `_delta_log` directory, and can be created fo
 A checkpoint contains the complete replay of all actions up until this version, with invalid actions removed.
 Invalid actions are those that have been canceled out by a subsequent ones (for example removing a file that has been added), using the [rules for reconciliation](#Action-Reconciliation)
 Checkpoints allow readers to short-cut the cost of reading the log up-to a given point in order to reconstruct a snapshot.
+Once a checkpoint has been written, writers may delete the JSON Delta log entries up until the checkpoint version.
 
 By default, the reference implementation creates a checkpoint every 10 commits.
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -97,7 +97,9 @@ Actual partition values for a file must be read from the transaction log.
 ### Delta Log Entries
 Delta files are stored as JSON in a directory at the root of the table named `_delta_log`, and together with checkpoints make up the log of all changes that have occurred to a table.
 
-Delta files are the unit of atomicity for a table, and are named using the next available version number, zero-padded to 20 digits. For example:
+Delta files are the unit of atomicity for a table, and are named using the next available version number, zero-padded to 20 digits.
+
+For example:
 
 ```
 ./_delta_log/00000000000000000000.json
@@ -111,8 +113,8 @@ Checkpoints are also stored in the `_delta_log` directory, and can be created fo
 
 A checkpoint contains the complete replay of all actions up until this version, with invalid actions removed.
 Invalid actions are those that have been canceled out by a subsequent ones (for example removing a file that has been added), using the [rules for reconciliation](#Action-Reconciliation)
-Checkpoints allow readers to short-cut the cost of reading the log up-to a given point in order to reconstruct a snapshot.
-Once a checkpoint has been written, writers may delete the JSON Delta log entries up until the checkpoint version.
+Checkpoints allow readers to short-cut the cost of reading the log up-to a given point in order to reconstruct a snapshot, and allow older JSON Delta log entries to be deleted after a period of time.
+
 
 By default, the reference implementation creates a checkpoint every 10 commits.
 


### PR DESCRIPTION
Existing writers may delete old JSON log entries if there are newer checkpoints.

Fixes #888.