### PR TITLE
Docker Image for playing with DeltaLake

### DIFF
--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,0 +1,40 @@
+FROM jupyter/minimal-notebook
+
+ARG PYTHON_VERSION=3.9
+ARG SCALA_VERSION=2.12
+ARG DELTA_LAKE_VERSION=1.1.0
+ARG SPARK_VERSION=3.2.1
+ARG DELTA_PACKAGE=io.delta:delta-core_${SCALA_VERSION}:${DELTA_LAKE_VERSION}
+
+USER root
+
+RUN apt-get update && \
+    apt-get -y install openjdk-8-jdk r-base \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+USER $NB_UID
+
+ENV JUPYTER_TOKEN="docker"
+ENV JUPYTER_ENABLE_LAB="yes"
+
+RUN pip install delta-spark==${DELTA_LAKE_VERSION}
+
+RUN pip install jupytext
+
+COPY --chown=$NB_UID:$NB_UID python python/
+COPY --chown=$NB_UID:$NB_UID tutorials tutorials/
+
+RUN mkdir -p notebooks
+
+RUN find python/ -name "*.py" -exec basename {} .py ';' | \
+    xargs -I {} jupytext --to .ipynb -o "notebooks/{}.ipynb" "python/{}.py"
+
+ENV SPARK_HOME=/opt/conda/lib/python${PYTHON_VERSION}/site-packages/pyspark
+ENV PATH=${PATH}:/opt/conda/lib/python${PYTHON_VERSION}/site-packages/pyspark/bin
+
+RUN mkdir $SPARK_HOME/conf
+
+RUN echo "spark.jars.packages ${DELTA_PACKAGE}" > $SPARK_HOME/conf/spark-defaults.conf
+RUN echo "spark.sql.extensions  io.delta.sql.DeltaSparkSessionExtension" >> $SPARK_HOME/conf/spark-defaults.conf
+RUN echo "spark.sql.catalog.spark_catalog org.apache.spark.sql.delta.catalog.DeltaCatalog" >> $SPARK_HOME/conf/spark-defaults.conf

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,3 +7,23 @@ In this folder there are examples taken from the delta.io quickstart guide and d
 ### Instructions
 * To run an example in Python run `spark-submit --packages io.delta:delta-core_2.12:{Delta Lake version} PATH/TO/EXAMPLE`
 * To run the Scala examples, `cd examples/scala` and run `./build/sbt "runMain example.{Example class name}"` e.g. `./build/sbt "runMain example.Quickstart"`
+
+### Docker Instructions
+
+#### Building the image
+
+* To build the image run: `docker build -t delta-lake-playground:latest .`
+
+#### Running the image
+
+* After the image is built run jupyterlab using: `docker run -it -p 8888:8888 delta-lake-playground`
+* Open Jupyter in your browser `http://localhost:8888/lab?token=docker`
+
+#### Sample Notebooks
+* There are sample python notebooks which are ported in the notebooks folder.
+
+#### Running Shells
+* In JupyterLab click file and start a terminal
+* In the terminal you can run `spark-shell`, `sparkR` or `pyspark` shell.
+* Delta configurations are already set as a spark default conf
+

--- a/examples/python/quickstart_sql.py
+++ b/examples/python/quickstart_sql.py
@@ -60,7 +60,6 @@ try:
     print("######## Read old data using time travel ############")
     df = spark.read.format("delta").option("versionAsOf", 0).table(tableName)
     df.show()
-
 finally:
     # cleanup
     spark.sql("DROP TABLE " + tableName)

--- a/examples/python/quickstart_sql_on_paths.py
+++ b/examples/python/quickstart_sql_on_paths.py
@@ -57,7 +57,6 @@ try:
     print("######### Delete every even value ##############")
     spark.sql("DELETE FROM delta.`{0}` WHERE (id % 2 == 0)".format(table_dir))
     spark.sql("SELECT * FROM delta.`%s`" % table_dir).show()
-
 finally:
     # cleanup
     spark.sql("DROP TABLE IF EXISTS newData")


### PR DESCRIPTION
This pull request is an attempt to resolve issue #919.

This PR adds instructions in the example directory for a dockerfile.

Instructions on what the image is trying to do:
The base is derived from `jupyter/minimal-notebook` and it installs openjdk-8 and r-lang.

It also installs deltalake 1.1.0, and uses jupytext to convert all the sample python notebooks into example ipynb files.

spark-defaults.conf is also set to introduce delta jars and delta configurations.

The intent is after running the container you have a playground to start using delta, with some starter notebooks.

Go to examples:
```
cd examples
```
To build:
```bash
docker build -t delta-lake-playground:latest .
```
To run:
```bash
docker run -it -p 8888:8888 delta-lake-playground
```

Notes: This image uses python 3.9.x. Those are the only images provided by jupyter that are supporting both intel + arm based builds.

Access the jupyterlab instance via `http://localhost:8888/lab?token=docker`

Signed-off-by: Sri Tikkireddy <sri.tikkireddy@databricks.com>