### PR TITLE
Delta Storage: initial project setup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -167,7 +167,8 @@ lazy val storage = (project in file("storage"))
     commonSettings,
     releaseSettings,
     libraryDependencies ++= Seq(
-      "org.apache.hadoop" % "hadoop-client-api" % "3.3.1" % "provided"
+      // User can provide any version >= 3.1.0 (released in 2018). We don't use any new fancy APIs.
+      "org.apache.hadoop" % "hadoop-client-api" % "3.1.0" % "provided"
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -167,7 +167,7 @@ lazy val storage = (project in file("storage"))
     commonSettings,
     releaseSettings,
     libraryDependencies ++= Seq(
-      // User can provide any version >= 3.1.0 (released in 2018). We don't use any new fancy APIs.
+      // User can provide any 2.x or 3.x version. We don't use any new fancy APIs.
       "org.apache.hadoop" % "hadoop-client-api" % "3.1.0" % "provided"
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -165,7 +165,6 @@ lazy val storage = (project in file("storage"))
   .settings (
     name := "delta-storage",
     commonSettings,
-    mimaSettings,
     releaseSettings,
     libraryDependencies ++= Seq(
       "org.apache.hadoop" % "hadoop-client-api" % "3.3.1" % "provided"

--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,7 @@ lazy val commonSettings = Seq(
 )
 
 lazy val core = (project in file("core"))
+  .dependsOn(storage)
   .enablePlugins(GenJavadocPlugin, JavaUnidocPlugin, ScalaUnidocPlugin, Antlr4Plugin)
   .settings (
     name := "delta-core",
@@ -156,6 +157,19 @@ lazy val contribs = (project in file("contribs"))
       Files.createDirectories(dir.toPath)
     },
     Compile / compile := ((Compile / compile) dependsOn createTargetClassesDir).value
+  )
+
+// TODO javastyle tests
+// TODO unidoc
+lazy val storage = (project in file("storage"))
+  .settings (
+    name := "delta-storage",
+    commonSettings,
+    mimaSettings,
+    releaseSettings,
+    libraryDependencies ++= Seq(
+      "org.apache.hadoop" % "hadoop-client-api" % "3.3.1" % "provided"
+    )
   )
 
 /**

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -22,6 +22,7 @@ import com.typesafe.tools.mima.core.ProblemFilters._
  */
 object MimaExcludes {
   val ignoredABIProblems = Seq(
+      // scalastyle:off line.size.limit
       ProblemFilters.exclude[Problem]("org.*"),
       ProblemFilters.exclude[Problem]("io.delta.sql.parser.*"),
       ProblemFilters.exclude[Problem]("io.delta.tables.execution.*"),
@@ -77,7 +78,13 @@ object MimaExcludes {
       ProblemFilters.exclude[DirectMissingMethodProblem]("io.delta.tables.DeltaMergeBuilder.initializeLogIfNecessary$default$2"),
 
       // Changes in 0.7.0
-      ProblemFilters.exclude[DirectMissingMethodProblem]("io.delta.tables.DeltaTable.makeUpdateTable")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("io.delta.tables.DeltaTable.makeUpdateTable"),
+
+      // Changes in 1.2.0
+      ProblemFilters.exclude[MissingClassProblem]("io.delta.storage.LogStore"),
+      ProblemFilters.exclude[MissingClassProblem]("io.delta.storage.CloseableIterator")
+
+      // scalastyle:on line.size.limit
   )
 }
 

--- a/storage/src/main/java/io/delta/storage/CloseableIterator.java
+++ b/storage/src/main/java/io/delta/storage/CloseableIterator.java
@@ -16,8 +16,6 @@
 
 package io.delta.storage;
 
-import org.apache.spark.annotation.DeveloperApi;
-
 import java.io.Closeable;
 import java.util.Iterator;
 
@@ -29,5 +27,4 @@ import java.util.Iterator;
  *
  * @since 1.0.0
  */
-@DeveloperApi
 public interface CloseableIterator<T> extends Iterator<T>, Closeable {}

--- a/storage/src/main/java/io/delta/storage/LogStore.java
+++ b/storage/src/main/java/io/delta/storage/LogStore.java
@@ -19,7 +19,6 @@ package io.delta.storage;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
-import org.apache.spark.annotation.DeveloperApi;
 
 import java.io.FileNotFoundException;
 import java.nio.file.FileAlreadyExistsException;
@@ -50,7 +49,6 @@ import java.util.Iterator;
  *
  * @since 1.0.0
  */
-@DeveloperApi
 public abstract class LogStore {
 
   private Configuration initHadoopConf;


### PR DESCRIPTION
Move over the `LogStore` and `CloseableIterator` interfaces from `delta-core`'s `io.delta.storage` package