### PR TITLE
Add support for optimize (file compaction) on Delta tables

### DIFF
--- a/core/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
+++ b/core/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
@@ -84,6 +84,8 @@ statement
       constraint                                                        #addTableConstraint
     | ALTER TABLE table=qualifiedName
         DROP CONSTRAINT (IF EXISTS)? name=identifier                    #dropTableConstraint
+    | OPTIMIZE (path=STRING | table=qualifiedName)
+        (WHERE partitionPredicate = exprToken)?                    #optimizeTable
     | .*?                                                               #passThrough
     ;
 
@@ -124,12 +126,12 @@ number
     ;
 
 constraint
-    : CHECK '(' checkExprToken+ ')'                                 #checkConstraint
+    : CHECK '(' exprToken+ ')'                                 #checkConstraint
     ;
 
 // We don't have an expression rule in our grammar here, so we just grab the tokens and defer
 // parsing them to later.
-checkExprToken
+exprToken
     :  .+?
     ;
 
@@ -139,7 +141,7 @@ nonReserved
     : VACUUM | RETAIN | HOURS | DRY | RUN
     | CONVERT | TO | DELTA | PARTITIONED | BY
     | DESC | DESCRIBE | LIMIT | DETAIL
-    | GENERATE | FOR | TABLE | CHECK | EXISTS
+    | GENERATE | FOR | TABLE | CHECK | EXISTS | OPTIMIZE
     ;
 
 // Define how the keywords above should appear in a user's SQL statement.
@@ -165,6 +167,7 @@ LIMIT: 'LIMIT';
 MINUS: '-';
 NOT: 'NOT' | '!';
 NULL: 'NULL';
+OPTIMIZE: 'OPTIMIZE';
 FOR: 'FOR';
 TABLE: 'TABLE';
 PARTITIONED: 'PARTITIONED';
@@ -172,6 +175,7 @@ RETAIN: 'RETAIN';
 RUN: 'RUN';
 TO: 'TO';
 VACUUM: 'VACUUM';
+WHERE: 'WHERE';
 
 // Multi-character operator tokens need to be defined even though we don't explicitly reference
 // them so that they can be recognized as single tokens when parsing. If we split them up and

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -975,6 +975,10 @@ object DeltaErrors
     new AnalysisException("Cannot describe the history of a view.")
   }
 
+  def viewNotSupported(operationName: String): Throwable = {
+    new AnalysisException(s"Operation $operationName can not be performed on a view")
+  }
+
   def copyIntoValidationRequireDeltaTableExists: Throwable = {
     new AnalysisException("COPY INTO validation failed. Target table does not exist.")
   }

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -330,6 +330,17 @@ object DeltaOperations {
     override def changesData: Boolean = true
   }
 
+  val OPTIMIZE_OPERATION_NAME = "OPTIMIZE"
+
+  /** Recorded when optimizing the table. */
+  case class Optimize(
+      predicate: Seq[String]
+  ) extends Operation(OPTIMIZE_OPERATION_NAME) {
+    override val parameters: Map[String, Any] = Map(
+      "predicate" -> JsonUtils.toJson(predicate)
+      )
+  }
+
 
   private def structFieldToMap(colPath: Seq[String], field: StructField): Map[String, Any] = {
     Map(

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
@@ -35,6 +35,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{Analyzer, EliminateSubqueryAliases, NoSuchTableException, UnresolvedAttribute, UnresolvedRelation}
+import org.apache.spark.sql.catalyst.catalog.CatalogTableType
 import org.apache.spark.sql.catalyst.expressions.{Expression, SubqueryExpression}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -392,16 +393,28 @@ trait DeltaCommand extends DeltaLogging {
       path: Option[String],
       tableIdentifier: Option[TableIdentifier],
       operationName: String): DeltaLog = {
-    val tablePath = tableIdentifier.map { ti =>
-      DeltaTableIdentifier(spark, ti) match {
-        case Some(id) if id.path.nonEmpty =>
-          new Path(id.path.get)
-        case _ =>
-          new Path(spark.sessionState.catalog.getTableMetadata(ti).location)
+    val tablePath =
+      if (path.nonEmpty) {
+        new Path(path.get)
+      } else if (tableIdentifier.nonEmpty) {
+        val sessionCatalog = spark.sessionState.catalog
+        lazy val metadata = sessionCatalog.getTableMetadata(tableIdentifier.get)
+
+        DeltaTableIdentifier(spark, tableIdentifier.get) match {
+          case Some(id) if id.path.nonEmpty =>
+            new Path(id.path.get)
+          case Some(id) if id.table.nonEmpty =>
+            new Path(metadata.location)
+          case _ =>
+            if (metadata.tableType == CatalogTableType.VIEW) {
+              throw DeltaErrors.viewNotSupported(operationName)
+            }
+            throw DeltaErrors.notADeltaTableException(operationName)
+        }
+      } else {
+        throw DeltaErrors.missingTableIdentifierException(operationName)
       }
-    }.orElse(path.map(new Path(_))).getOrElse {
-      throw DeltaErrors.missingTableIdentifierException(operationName)
-    }
+
     val deltaLog = DeltaLog.forTable(spark, tablePath)
     if (deltaLog.snapshot.version < 0) {
       throw DeltaErrors.notADeltaTableException(

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
@@ -393,7 +393,12 @@ trait DeltaCommand extends DeltaLogging {
       tableIdentifier: Option[TableIdentifier],
       operationName: String): DeltaLog = {
     val tablePath = tableIdentifier.map { ti =>
-      new Path(spark.sessionState.catalog.getTableMetadata(ti).location)
+      DeltaTableIdentifier(spark, ti) match {
+        case Some(id) if id.path.nonEmpty =>
+          new Path(id.path.get)
+        case _ =>
+          new Path(spark.sessionState.catalog.getTableMetadata(ti).location)
+      }
     }.orElse(path.map(new Path(_))).getOrElse {
       throw DeltaErrors.missingTableIdentifierException(operationName)
     }

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -1,0 +1,271 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands
+
+import java.util.ConcurrentModificationException
+
+import scala.collection.mutable.ArrayBuffer
+import scala.collection.parallel.ForkJoinTaskSupport
+import scala.collection.parallel.immutable.ParVector
+
+import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaOperations, OptimisticTransaction}
+import org.apache.spark.sql.delta.DeltaOperations.Operation
+import org.apache.spark.sql.delta.actions.{Action, AddFile, FileAction, RemoveFile}
+import org.apache.spark.sql.delta.commands.optimize.{FileSizeStats, OptimizeMetrics, OptimizeStats, ZOrderStats}
+import org.apache.spark.sql.delta.files.SQLMetricsReporting
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.SparkContext.SPARK_JOB_GROUP_ID
+import org.apache.spark.sql.{Encoders, Row, SparkSession}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression, Literal}
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.types.StringType
+import org.apache.spark.util.{SystemClock, ThreadUtils}
+
+/** Base class defining abstract optimize command */
+abstract class OptimizeTableCommandBase extends LeafRunnableCommand with DeltaCommand {
+
+  override val output: Seq[Attribute] = Seq(
+    AttributeReference("path", StringType)(),
+    AttributeReference("metrics", Encoders.product[OptimizeMetrics].schema)())
+}
+
+/**
+ * The `optimize` command implementation for Spark SQL. Example SQL:
+ * {{{
+ *    OPTIMIZE ('/path/to/dir' | delta.table) [WHERE part = 25];
+ * }}}
+ */
+case class OptimizeTableCommand(
+    path: Option[String],
+    tableId: Option[TableIdentifier],
+    partitionPredicate: Option[String])
+  extends OptimizeTableCommandBase {
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val deltaLog = getDeltaLog(sparkSession, path, tableId, "OPTIMIZE")
+
+    // Parse the predicate expression into Catalyst expression and verify only simple filters
+    // on partition columns are present
+    val partitionPredicates = partitionPredicate.map(predicate => {
+      val predicates = parsePredicates(sparkSession, predicate)
+      verifyPartitionPredicates(
+        sparkSession,
+        deltaLog.snapshot.metadata.partitionColumns,
+        predicates)
+      predicates
+    }).getOrElse(Seq(Literal.TrueLiteral))
+
+    new OptimizeExecutor(sparkSession, deltaLog, partitionPredicates)
+        .optimize()
+  }
+}
+
+/**
+ * Optimize job which compacts small files into larger files to reduce
+ * the number of files and potentially allow more efficient reads.
+ *
+ * @param sparkSession Spark environment reference.
+ * @param deltaLog Delta table that is being optimized.
+ * @param partitionPredicate List of partition predicates to select subset of files to optimize.
+ */
+class OptimizeExecutor(
+    sparkSession: SparkSession,
+    deltaLog: DeltaLog,
+    partitionPredicate: Seq[Expression])
+  extends DeltaCommand with SQLMetricsReporting with Serializable {
+
+  /** Timestamp to use in [[FileAction]] */
+  private val operationTimestamp = new SystemClock().getTimeMillis()
+
+  def optimize(): Seq[Row] = {
+    recordDeltaOperation(deltaLog, "delta.optimize") {
+      val minFileSize = sparkSession.sessionState.conf.getConf(
+        DeltaSQLConf.DELTA_OPTIMIZE_MIN_FILE_SIZE)
+      val maxFileSize = sparkSession.sessionState.conf.getConf(
+        DeltaSQLConf.DELTA_OPTIMIZE_MAX_FILE_SIZE)
+      require(minFileSize > 0, "minFileSize must be > 0")
+      require(maxFileSize > 0, "maxFileSize must be > 0")
+
+      val txn = deltaLog.startTransaction()
+      if (txn.readVersion == -1) {
+        throw DeltaErrors.notADeltaTableException(deltaLog.dataPath.toString)
+      }
+
+      val candidateFiles = txn.filterFiles(partitionPredicate)
+      val partitionSchema = txn.metadata.partitionSchema
+
+      val filesToCompact = candidateFiles.filter(_.size < minFileSize)
+      val partitionsToCompact = filesToCompact.groupBy(_.partitionValues).toSeq
+
+      val jobs = groupFilesIntoBins(partitionsToCompact, maxFileSize)
+
+      val parallelJobCollection = new ParVector(jobs.toVector)
+
+      // Create a task pool to parallelize the submission of optimization jobs to Spark.
+      val forkJoinPoolTaskSupport = new ForkJoinTaskSupport(ThreadUtils.newForkJoinPool(
+        "OptimizeJob",
+        sparkSession.sessionState.conf.getConf(DeltaSQLConf.DELTA_OPTIMIZE_MAX_THREADS)))
+
+      parallelJobCollection.tasksupport = forkJoinPoolTaskSupport
+
+      val updates = jobs.flatMap(
+        partitionBinGroup => runCompactBinJob(txn, partitionBinGroup._1, partitionBinGroup._2)).seq
+
+      val addedFiles = updates.collect { case a: AddFile => a }
+      val removedFiles = updates.collect { case r: RemoveFile => r }
+      if (addedFiles.size > 0) {
+        val operation = DeltaOperations.Optimize(partitionPredicate.map(_.sql))
+        commitAndRetry(txn, operation, updates) { newTxn =>
+          val newPartitionSchema = newTxn.metadata.partitionSchema
+          val candidateSetOld = candidateFiles.map(_.path).toSet
+          val candidateSetNew = newTxn.filterFiles(partitionPredicate).map(_.path).toSet
+
+          // As long as all of the files that we compacted are still part of the table,
+          // and the partitioning has not changed it is valid to continue to try
+          // and commit this checkpoint.
+          if (candidateSetOld.subsetOf(candidateSetNew) && partitionSchema == newPartitionSchema) {
+            true
+          } else {
+            val deleted = candidateSetOld -- candidateSetNew
+            logWarning(s"The following compacted files were delete " +
+              s"during checkpoint ${deleted.mkString(",")}. Aborting the compaction.")
+            false
+          }
+        }
+      }
+
+      val optimizeStats = OptimizeStats()
+      optimizeStats.addedFilesSizeStats.merge(addedFiles)
+      optimizeStats.removedFilesSizeStats.merge(removedFiles)
+      optimizeStats.numPartitionsOptimized = jobs.map(j => j._1).distinct.size
+      optimizeStats.numBatches = jobs.size
+      optimizeStats.totalConsideredFiles = candidateFiles.size
+      optimizeStats.totalFilesSkipped = optimizeStats.totalConsideredFiles - removedFiles.size
+
+      return Seq(Row(deltaLog.dataPath.toString, optimizeStats.toOptimizeMetrics))
+    }
+  }
+
+  /**
+   * Utility methods to group files into bins for compaction.
+   *
+   * @param partitionsToCompact List of files to compact group by partition.
+   *                            Partition is defined by the partition values (partCol -> partValue)
+   * @param maxTargetFileSize Max size (in bytes) of the compaction output file.
+   * @return Sequence of bins. Each bin contains one or more files from the same
+   *         partition and targeted for one output file.
+   */
+  private def groupFilesIntoBins(
+      partitionsToCompact: Seq[(Map[String, String], Seq[AddFile])],
+      maxTargetFileSize: Long): Seq[(Map[String, String], Seq[AddFile])] = {
+    partitionsToCompact.flatMap {
+      case (partition, files) =>
+        val bins = new ArrayBuffer[Seq[AddFile]]()
+
+        val currentBin = new ArrayBuffer[AddFile]()
+        var currentBinSize = 0L
+
+        files.sortBy(_.size).foreach { file =>
+          // Generally, a bin is a group of existing files, whose total size does not exceed the
+          // desired maxFileSize. They will be coalesced into a single output file.
+          if (file.size + currentBinSize > maxTargetFileSize) {
+            bins += currentBin.toVector
+            currentBin.clear()
+            currentBin += file
+            currentBinSize = file.size
+          } else {
+            currentBin += file
+            currentBinSize += file.size
+          }
+        }
+
+        if (currentBin.nonEmpty) {
+          bins += currentBin.toVector
+        }
+
+        bins.map(b => (partition, b))
+          .filter(_._2.size > 1) // select bins that have at least two files
+    }
+  }
+
+  /**
+   * Utility method to run a Spark job to compact the files in given bin
+   *
+   * @param txn [[OptimisticTransaction]] instance in use to commit the changes to DeltaLog.
+   * @param partition Partition values of the partition that files in [[bin]] belongs to.
+   * @param bin List of files to compact into one large file.
+   */
+  private def runCompactBinJob(
+      txn: OptimisticTransaction,
+      partition: Map[String, String],
+      bin: Seq[AddFile]): Seq[FileAction] = {
+    val baseTablePath = deltaLog.dataPath
+
+    val input = txn.deltaLog.createDataFrame(txn.snapshot, bin, actionTypeOpt = Some("Optimize"))
+    val repartitionDF = input.coalesce(numPartitions = 1)
+
+    val partitionDesc = partition.toSeq.map(entry => entry._1 + "=" + entry._2).mkString(",")
+
+    val partitionName = if (partition.isEmpty) "" else s" in partition ($partitionDesc)"
+    val description = s"$baseTablePath<br/>Optimizing ${bin.size} files" + partitionName
+    sparkSession.sparkContext.setJobGroup(
+      sparkSession.sparkContext.getLocalProperty(SPARK_JOB_GROUP_ID),
+      description)
+
+    val addFiles = txn.writeFiles(repartitionDF).collect {
+      case a: AddFile =>
+        a.copy(dataChange = false)
+      case other =>
+        throw new IllegalStateException(
+          s"Unexpected action $other with type ${other.getClass}. File compaction job output" +
+              s"should only have AddFiles")
+    }
+    val removeFiles = bin.map(f => f.removeWithTimestamp(operationTimestamp, dataChange = false))
+    val updates = addFiles ++ removeFiles
+    updates
+  }
+
+  /**
+   * Attempts to commit the given actions to the log. In the case of a concurrent update,
+   * the given function will be invoked with a new transaction to allow custom conflict
+   * detection logic to indicate it is safe to try again, by returning `true`.
+   *
+   * This function will continue to try to commit to the log as long as `f` returns `true`,
+   * otherwise throws a subclass of [[ConcurrentModificationException]].
+   */
+  private def commitAndRetry(
+      txn: OptimisticTransaction,
+      optimizeOperation: Operation,
+      actions: Seq[Action])(
+      f: OptimisticTransaction => Boolean): Unit = {
+    try {
+      txn.commit(actions, optimizeOperation)
+    } catch {
+      case e: ConcurrentModificationException =>
+        val newTxn = txn.deltaLog.startTransaction()
+        if (f(newTxn)) {
+          logInfo("Retrying commit after checking for semantic conflicts with concurrent updates.")
+          commitAndRetry(newTxn, optimizeOperation, actions)(f)
+        } else {
+          logWarning("Semantic conflicts detected. Aborting operation.")
+          throw e
+        }
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -124,7 +124,7 @@ class OptimizeExecutor(
 
       parallelJobCollection.tasksupport = forkJoinPoolTaskSupport
 
-      val updates = jobs.flatMap(
+      val updates = parallelJobCollection.flatMap(
         partitionBinGroup => runCompactBinJob(txn, partitionBinGroup._1, partitionBinGroup._2)).seq
 
       val addedFiles = updates.collect { case a: AddFile => a }

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/optimize/OptimizeStats.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/optimize/OptimizeStats.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands.optimize
+
+import org.apache.spark.sql.delta.actions.{AddFile, FileAction, RemoveFile}
+
+// scalastyle:off import.ordering.noEmptyLine
+
+/**
+ * Stats for an OPTIMIZE operation accumulated across all batches.
+ */
+case class OptimizeStats(
+    var addedFilesSizeStats: FileSizeStats = FileSizeStats(),
+    var removedFilesSizeStats: FileSizeStats = FileSizeStats(),
+    var numPartitionsOptimized: Long = 0,
+    var zOrderStats: Option[ZOrderStats] = None,
+    var numBatches: Long = 0,
+    var totalConsideredFiles: Long = 0,
+    var totalFilesSkipped: Long = 0,
+    var preserveInsertionOrder: Boolean = false) {
+
+  def toOptimizeMetrics: OptimizeMetrics = {
+    OptimizeMetrics(
+      numFilesAdded = addedFilesSizeStats.totalFiles,
+      numFilesRemoved = removedFilesSizeStats.totalFiles,
+      filesAdded = addedFilesSizeStats.toFileSizeMetrics,
+      filesRemoved = removedFilesSizeStats.toFileSizeMetrics,
+      partitionsOptimized = numPartitionsOptimized,
+      zOrderStats = zOrderStats,
+      numBatches = numBatches,
+      totalConsideredFiles = totalConsideredFiles,
+      totalFilesSkipped = totalFilesSkipped,
+      preserveInsertionOrder = preserveInsertionOrder
+    )
+  }
+}
+
+case class FileSizeStats(
+    var minFileSize: Long = 0,
+    var maxFileSize: Long = 0,
+    var totalFiles: Long = 0,
+    var totalSize: Long = 0) {
+
+  def avgFileSize: Double = if (totalFiles > 0) {
+      totalSize * 1.0 / totalFiles
+    } else {
+      0.0
+    }
+
+  def merge(candidateFiles: Seq[FileAction]): Unit = {
+    if (totalFiles == 0 && candidateFiles.nonEmpty) {
+      minFileSize = Long.MaxValue
+      maxFileSize = Long.MinValue
+    }
+    candidateFiles.foreach { file =>
+      val fileSize = file match {
+        case addFile: AddFile => addFile.size
+        case removeFile: RemoveFile => removeFile.size.getOrElse(0L)
+        case default =>
+          throw new IllegalArgumentException(s"Unknown FileAction type: ${default.getClass}")
+      }
+      minFileSize = math.min(fileSize, minFileSize)
+      maxFileSize = math.max(fileSize, maxFileSize)
+      totalSize += fileSize
+    }
+    totalFiles += candidateFiles.length
+  }
+
+
+  def toFileSizeMetrics: FileSizeMetrics = {
+    if (totalFiles == 0) {
+      return FileSizeMetrics(min = None, max = None, avg = 0, totalFiles = 0, totalSize = 0)
+    }
+    FileSizeMetrics(
+      min = Some(minFileSize),
+      max = Some(maxFileSize),
+      avg = avgFileSize,
+      totalFiles = totalFiles,
+      totalSize = totalSize)
+  }
+}
+/**
+ * Metrics returned by the optimize command.
+ *
+ * @param numFilesAdded number of files added by optimize
+ * @param numFilesRemoved number of files removed by optimize
+ * @param filesAdded Stats for the files added
+ * @param filesRemoved Stats for the files removed
+ * @param partitionsOptimized Number of partitions optimized
+ * @param zOrderStats Z-Order stats
+ * @param numBatches Number of batches
+ * @param totalConsideredFiles Number of files considered for the Optimize operation.
+ * @param totalFilesSkipped Number of files that are skipped from being Optimized.
+ * @param preserveInsertionOrder If optimize was run with insertion preservation enabled.
+ */
+case class OptimizeMetrics(
+    numFilesAdded: Long,
+    numFilesRemoved: Long,
+    filesAdded: FileSizeMetrics =
+      FileSizeMetrics(min = None, max = None, avg = 0, totalFiles = 0, totalSize = 0),
+    filesRemoved: FileSizeMetrics =
+      FileSizeMetrics(min = None, max = None, avg = 0, totalFiles = 0, totalSize = 0),
+    partitionsOptimized: Long = 0,
+    zOrderStats: Option[ZOrderStats] = None,
+    numBatches: Long,
+    totalConsideredFiles: Long,
+    totalFilesSkipped: Long = 0,
+    preserveInsertionOrder: Boolean = false)
+
+/**
+ * Basic Stats on file sizes.
+ *
+ * @param min Minimum file size
+ * @param max Maximum file size
+ * @param avg Average of the file size
+ * @param totalFiles Total number of files
+ * @param totalSize Total size of the files
+ */
+case class FileSizeMetrics(
+    min: Option[Long],
+    max: Option[Long],
+    avg: Double,
+    totalFiles: Long,
+    totalSize: Long)

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/optimize/ZOrderMetrics.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/optimize/ZOrderMetrics.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands.optimize
+
+// scalastyle:off import.ordering.noEmptyLine
+
+/**
+ * Aggregated file stats for a category of ZCube files.
+ * @param num Total number of files.
+ * @param size Total size of files in bytes.
+ */
+case class ZOrderFileStats(num: Long, size: Long)
+
+object ZOrderFileStats {
+  def apply(v: Iterable[(Int, Long)]): ZOrderFileStats = {
+    v.foldLeft(ZOrderFileStats(0, 0)) { (a, b) =>
+      ZOrderFileStats(a.num + b._1, a.size + b._2)
+    }
+  }
+}
+
+/**
+ * Aggregated stats for OPTIMIZE ZORDERBY command.
+ * This is a public facing API, consider any change carefully.
+ *
+ * @param strategyName ZCubeMergeStrategy used.
+ * @param inputCubeFiles Files in the ZCube matching the current OPTIMIZE operation.
+ * @param inputOtherFiles Files not in any ZCube or in other ZCube orderings.
+ * @param inputNumCubes Number of different cubes among input files.
+ * @param mergedFiles Subset of input files merged by the current operation
+ * @param numOutputCubes Number of output ZCubes written out
+ * @param mergedNumCubes Number of different cubes among merged files.
+ */
+case class ZOrderStats(
+  strategyName: String,
+  inputCubeFiles: ZOrderFileStats,
+  inputOtherFiles: ZOrderFileStats,
+  inputNumCubes: Long,
+  mergedFiles: ZOrderFileStats,
+  numOutputCubes: Long,
+  mergedNumCubes: Option[Long] = None
+)
+
+/**
+ * Aggregated usage logs stats for OPTIMIZE ZORDERBY command.
+ *
+ * Some of the fields (strategyName/inputCubeFiles/inputOtherFiles/inputNumCubes/mergedFiles/
+ * numOutputCubes/mergedNumCubes) are redundant in [[ZOrderStatsForUsageLogs]] as well as
+ * [[ZOrderStatsForUsageLogs.optimizeStats.zOrderStats]]. The fields are kept in
+ * [[ZOrderStatsForUsageLogs]] for backward compatibility.
+ */
+case class ZOrderStatsForUsageLogs(
+    strategyName: String,
+    inputCubeFiles: ZOrderFileStats,
+    inputOtherFiles: ZOrderFileStats,
+    inputNumCubes: Long,
+    mergedFiles: ZOrderFileStats,
+    numOutputCubes: Long,
+    mergedNumCubes: Option[Long] = None,
+    optimizeStats: OptimizeStats,
+    executeTimeTakenMs: Long,
+    curve: String)
+
+object ZOrderStatsForUsageLogs {
+  def apply(
+      optimizeStats: OptimizeStats,
+      executeTimeTakenMs: Long,
+      curve: String): ZOrderStatsForUsageLogs = {
+    require(optimizeStats.zOrderStats.nonEmpty)
+    val zOrderStats = optimizeStats.zOrderStats.get
+    ZOrderStatsForUsageLogs(zOrderStats.strategyName, zOrderStats.inputCubeFiles,
+      zOrderStats.inputOtherFiles, zOrderStats.inputNumCubes, zOrderStats.mergedFiles,
+      zOrderStats.numOutputCubes, zOrderStats.mergedNumCubes, optimizeStats,
+      executeTimeTakenMs, curve)
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -531,6 +531,38 @@ trait DeltaSQLConfBase {
           |""".stripMargin)
       .booleanConf
       .createWithDefault(true)
+
+  val DELTA_OPTIMIZE_MIN_FILE_SIZE =
+    buildConf("optimize.minFileSize")
+        .internal()
+        .doc(
+          """Files which are smaller than this threshold (in bytes) will be grouped together
+             | and rewritten as larger files by the OPTIMIZE command.
+             |""".stripMargin)
+        .longConf
+        .checkValue(_ >= 0, "minFileSize has to be positive")
+        .createWithDefault(1024 * 1024 * 1024)
+
+  val DELTA_OPTIMIZE_MAX_FILE_SIZE =
+    buildConf("optimize.maxFileSize")
+        .internal()
+        .doc("Target file size produced by the OPTIMIZE command.")
+        .longConf
+        .checkValue(_ >= 0, "maxFileSize has to be positive")
+        .createWithDefault(1024 * 1024 * 1024)
+
+  val DELTA_OPTIMIZE_MAX_THREADS =
+    buildConf("optimize.maxThreads")
+        .internal()
+        .doc(
+          """
+            |Maximum number of parallel jobs allowed in OPTIMIZE command. Increasing the maximum
+            | parallel jobs allows the OPTIMIZE command to run faster, but increases the job
+            | management on the Spark driver side.
+            |""".stripMargin)
+        .intConf
+        .checkValue(_ > 0, "'optimize.maxThreads' must be positive.")
+        .createWithDefault(15)
 }
 
 object DeltaSQLConf extends DeltaSQLConfBase

--- a/core/src/test/scala/org/apache/spark/sql/delta/BlockWritesLocalFileSystem.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/BlockWritesLocalFileSystem.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.net.URI
+import java.util.concurrent.CountDownLatch
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{DelegateToFileSystem, FSDataOutputStream, Path, RawLocalFileSystem}
+import org.apache.hadoop.util.Progressable
+
+/**
+ * This custom fs implementation is used for testing the execution multiple batches of Optimize.
+ */
+class BlockWritesLocalFileSystem extends RawLocalFileSystem {
+  private var uri: URI = _
+
+  override def getScheme: String = "block"
+
+  override def initialize(name: URI, conf: Configuration): Unit = {
+    uri = URI.create(name.getScheme + ":///")
+    super.initialize(name, conf)
+  }
+
+  override def getUri(): URI = if (uri == null) {
+    // RawLocalFileSystem's constructor will call this one before `initialize` is called.
+    // Just return the super's URI to avoid NPE.
+    super.getUri
+  } else {
+    uri
+  }
+
+  override def create(
+      f: Path,
+      overwrite: Boolean,
+      bufferSize: Int,
+      replication: Short,
+      blockSize: Long,
+      progress: Progressable): FSDataOutputStream = {
+    // called when data files and log files are written
+    BlockWritesLocalFileSystem.blockLatch.countDown()
+    BlockWritesLocalFileSystem.blockLatch.await()
+    super.create(f, overwrite, bufferSize, replication, blockSize, progress)
+  }
+}
+
+/**
+ * An AbstractFileSystem implementation wrapper around [[BlockWritesLocalFileSystem]].
+ */
+class BlockWritesAbstractFileSystem(uri: URI, conf: Configuration)
+    extends DelegateToFileSystem(
+      uri,
+      new BlockWritesLocalFileSystem,
+      conf,
+      BlockWritesLocalFileSystem.scheme,
+      false) {
+}
+
+/**
+ * Singleton for BlockWritesLocalFileSystem used to initialize the file system countdown latch.
+ */
+object BlockWritesLocalFileSystem {
+  val scheme = "block"
+
+  /** latch that blocks writes */
+  private var blockLatch: CountDownLatch = _
+
+  /**
+   * @param numWrites - writing is blocked until there are `numWrites` concurrent writes to
+   *                  the file system.
+   */
+  def blockUntilConcurrentWrites(numWrites: Integer): Unit = {
+    blockLatch = new CountDownLatch(numWrites)
+  }
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeCompactionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeCompactionSuite.scala
@@ -1,0 +1,317 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.optimize
+
+import java.io.File
+
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils
+import org.apache.spark.sql.catalyst.parser.ParseException
+import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * Base class containing tests for Delta table Optimize (file compaction)
+ */
+trait OptimizeCompactionSuiteBase extends QueryTest
+  with SharedSparkSession {
+
+  import testImplicits._
+
+  test("optimize command: with database and table name") {
+    withTempDir { tempDir =>
+      val dbName = "delta_db"
+      val tableName = s"$dbName.delta_optimize"
+      withDatabase(dbName) {
+        spark.sql(s"create database $dbName")
+        withTable(tableName) {
+          appendToDeltaTable(Seq(1, 2, 3).toDF(), tempDir.toString, partitionColumns = None)
+          appendToDeltaTable(Seq(4, 5, 6).toDF(), tempDir.toString, partitionColumns = None)
+
+          spark.sql(s"create table $tableName using delta location '$tempDir'")
+
+          val deltaLog = DeltaLog.forTable(spark, tempDir)
+          val versionBeforeOptimize = deltaLog.snapshot.version
+          spark.sql(s"OPTIMIZE $tableName")
+          deltaLog.update()
+          assert(deltaLog.snapshot.version === versionBeforeOptimize + 1)
+          checkDatasetUnorderly(spark.table(tableName).as[Int], 1, 2, 3, 4, 5, 6)
+        }
+      }
+    }
+  }
+
+  test("optimize command") {
+    withTempDir { tempDir =>
+      appendToDeltaTable(Seq(1, 2, 3).toDF(), tempDir.toString, partitionColumns = None)
+      appendToDeltaTable(Seq(4, 5, 6).toDF(), tempDir.toString, partitionColumns = None)
+
+      def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
+
+      val deltaLog = DeltaLog.forTable(spark, tempDir)
+      val versionBeforeOptimize = deltaLog.snapshot.version
+      spark.sql(s"OPTIMIZE '${tempDir.getCanonicalPath}'")
+      deltaLog.update()
+      assert(deltaLog.snapshot.version === versionBeforeOptimize + 1)
+      checkDatasetUnorderly(data.toDF().as[Int], 1, 2, 3, 4, 5, 6)
+    }
+  }
+
+  test("optimize command: predicate on non-partition column") {
+    withTempDir { tempDir =>
+      val path = new File(tempDir, "testTable").getCanonicalPath
+      val partitionColumns = Some(Seq("id"))
+      appendToDeltaTable(
+        Seq(1, 2, 3).toDF("value").withColumn("id", 'value % 2),
+        path,
+        partitionColumns)
+
+      val e = intercept[AnalysisException] {
+        // Should fail when predicate is on a non-partition column
+        spark.sql(s"OPTIMIZE '$path' WHERE value < 4")
+      }
+      assert(e.getMessage.contains("Predicate references non-partition column 'value'. " +
+                                       "Only the partition columns may be referenced: [id]"))
+    }
+  }
+
+  test("optimize command: on partitioned table - all partitions") {
+    withTempDir { tempDir =>
+      val path = new File(tempDir, "testTable").getCanonicalPath
+      val partitionColumns = Some(Seq("id"))
+      appendToDeltaTable(
+        Seq(1, 2, 3).toDF("value").withColumn("id", 'value % 2),
+        path,
+        partitionColumns)
+
+      appendToDeltaTable(
+        Seq(4, 5, 6).toDF("value").withColumn("id", 'value % 2),
+        path,
+        partitionColumns)
+
+      val deltaLogBefore = DeltaLog.forTable(spark, path)
+      val txnBefore = deltaLogBefore.startTransaction();
+      val fileListBefore = txnBefore.filterFiles();
+      val versionBefore = deltaLogBefore.snapshot.version
+
+      // Expect each partition have more than one file
+      (0 to 1).foreach(partId =>
+        assert(fileListBefore.count(_.partitionValues === Map("id" -> partId.toString)) > 1))
+
+      spark.sql(s"OPTIMIZE '$path'")
+
+      val deltaLogAfter = DeltaLog.forTable(spark, path)
+      val txnAfter = deltaLogAfter.startTransaction();
+      val fileListAfter = txnAfter.filterFiles();
+
+      (0 to 1).foreach(partId =>
+        assert(fileListAfter.count(_.partitionValues === Map("id" -> partId.toString)) === 1))
+
+      // version is incremented
+      assert(deltaLogAfter.snapshot.version === versionBefore + 1)
+
+      // data should remain the same after the OPTIMIZE
+      checkDatasetUnorderly(
+        spark.read.format("delta").load(path).select("value").as[Long],
+        (1L to 6L): _*)
+    }
+  }
+
+  test("optimize command: on partitioned table - selected partitions") {
+    withTempDir { tempDir =>
+      val path = new File(tempDir, "testTable").getCanonicalPath
+      val partitionColumns = Some(Seq("id"))
+      appendToDeltaTable(
+        Seq(1, 2, 3).toDF("value").withColumn("id", 'value % 2),
+        path,
+        partitionColumns)
+
+      appendToDeltaTable(
+        Seq(4, 5, 6).toDF("value").withColumn("id", 'value % 2),
+        path,
+        partitionColumns)
+
+      val deltaLogBefore = DeltaLog.forTable(spark, path)
+      val txnBefore = deltaLogBefore.startTransaction();
+      val fileListBefore = txnBefore.filterFiles()
+
+      assert(fileListBefore.length >= 3)
+      assert(fileListBefore.count(_.partitionValues === Map("id" -> "0")) > 1)
+
+      val versionBefore = deltaLogBefore.snapshot.version
+      spark.sql(s"OPTIMIZE '$path' WHERE id = 0")
+
+      val deltaLogAfter = DeltaLog.forTable(spark, path)
+      val txnAfter = deltaLogBefore.startTransaction();
+      val fileListAfter = txnAfter.filterFiles()
+
+      assert(fileListBefore.length > fileListAfter.length)
+      // Optimized partition should contain only one file
+      assert(fileListAfter.count(_.partitionValues === Map("id" -> "0")) === 1)
+
+      // File counts in partitions that are not part of the OPTIMIZE should remain the same
+      assert(fileListAfter.count(_.partitionValues === Map("id" -> "1")) ===
+                 fileListAfter.count(_.partitionValues === Map("id" -> "1")))
+
+      // version is incremented
+      assert(deltaLogAfter.snapshot.version === versionBefore + 1)
+
+      // data should remain the same after the OPTIMIZE
+      checkDatasetUnorderly(
+        spark.read.format("delta").load(path).select("value").as[Long],
+        (1L to 6L): _*)
+    }
+  }
+
+  test("optimize command: on null partition columns") {
+    withTempDir { tempDir =>
+      val path = new File(tempDir, "testTable").getCanonicalPath
+      val partitionColumn = "part"
+
+      (1 to 5).foreach { _ =>
+        appendToDeltaTable(
+          Seq(("a", 1), ("b", 2), (null.asInstanceOf[String], 3), ("", 4))
+              .toDF(partitionColumn, "value"),
+          path,
+          Some(Seq(partitionColumn)))
+      }
+
+      val deltaLogBefore = DeltaLog.forTable(spark, path)
+      val txnBefore = deltaLogBefore.startTransaction();
+      val fileListBefore = txnBefore.filterFiles()
+      val versionBefore = deltaLogBefore.snapshot.version
+
+      val filesInEachPartitionBefore =
+        fileListBefore.groupBy(file => new Path(file.path).getParent.getName)
+
+      // There exist at least one file in each partition
+      assert(filesInEachPartitionBefore.forall(_._2.length > 1))
+
+      // And there is a partition for null values
+      assert(filesInEachPartitionBefore.keys.exists(
+        _ === s"part=${ExternalCatalogUtils.DEFAULT_PARTITION_NAME}"))
+
+      spark.sql(s"OPTIMIZE '$path'")
+
+      val deltaLogAfter = DeltaLog.forTable(spark, path)
+      val txnAfter = deltaLogBefore.startTransaction();
+      val fileListAfter = txnAfter.filterFiles()
+
+      // Number of files is less than before optimize
+      assert(fileListBefore.length > fileListAfter.length)
+
+      // Optimized partition should contain only one file in null partition
+      assert(fileListAfter.count(
+        _.partitionValues === Map[String, String](partitionColumn -> null)) === 1)
+
+      // version is incremented
+      assert(deltaLogAfter.snapshot.version === versionBefore + 1)
+
+      // data should remain the same after the OPTIMIZE
+      checkAnswer(
+        spark.read.format("delta").load(path).groupBy(partitionColumn).count(),
+        Seq(Row("a", 5), Row("b", 5), Row(null, 10)))
+    }
+  }
+
+  test("optimize command: on table with multiple partition columns") {
+    withTempDir { tempDir =>
+      val path = new File(tempDir, "testTable").getCanonicalPath
+      val partitionColumns = Seq("date", "part")
+
+      Seq(10, 100).foreach { count =>
+        appendToDeltaTable(
+          spark.range(count)
+              .select('id, lit("2017-10-10").cast("date") as 'date, 'id % 5 as 'part),
+          path,
+          Some(partitionColumns))
+      }
+
+      val deltaLogBefore = DeltaLog.forTable(spark, path)
+      val txnBefore = deltaLogBefore.startTransaction();
+      val fileListBefore = txnBefore.filterFiles()
+      val versionBefore = deltaLogBefore.snapshot.version
+      val fileCountInTestPartitionBefore = fileListBefore
+          .count(_.partitionValues === Map[String, String]("date" -> "2017-10-10", "part" -> "3"))
+
+      spark.sql(s"OPTIMIZE '$path' WHERE date = '2017-10-10' and part = 3")
+
+      val deltaLogAfter = DeltaLog.forTable(spark, path)
+      val txnAfter = deltaLogBefore.startTransaction();
+      val fileListAfter = txnAfter.filterFiles()
+
+      // Number of files is less than before optimize
+      assert(fileListBefore.length > fileListAfter.length)
+
+      // Optimized partition should contain only one file in null partition and less number
+      // of files than before optimize
+      val fileCountInTestPartitionAfter = fileListAfter
+          .count(_.partitionValues === Map[String, String]("date" -> "2017-10-10", "part" -> "3"))
+      assert(fileCountInTestPartitionAfter === 1L)
+      assert(fileCountInTestPartitionBefore > fileCountInTestPartitionAfter,
+             "Expected the partition to count less number of files after optimzie.")
+
+      // version is incremented
+      assert(deltaLogAfter.snapshot.version === versionBefore + 1)
+    }
+  }
+
+  test("optimize command: missing path") {
+    val e = intercept[ParseException] {
+      spark.sql(s"OPTIMIZE")
+    }
+    assert(e.getMessage.contains("OPTIMIZE"))
+  }
+
+  test("optimize command: missing predicate on path") {
+    val e = intercept[ParseException] {
+      spark.sql(s"OPTIMIZE /doesnt/exist WHERE")
+    }
+    assert(e.getMessage.contains("OPTIMIZE"))
+  }
+
+  test("optimize command: non boolean expression") {
+    val e = intercept[ParseException] {
+      spark.sql(s"OPTIMIZE /doesnt/exist WHERE 1+1")
+    }
+    assert(e.getMessage.contains("OPTIMIZE"))
+  }
+
+  /**
+   * Utility method to append the given data to the Delta table located at the given path.
+   * Optionally partitions the data.
+   */
+  protected def appendToDeltaTable[T](
+      data: Dataset[T], tablePath: String, partitionColumns: Option[Seq[String]] = None): Unit = {
+    var df = data.repartition(1).write;
+    partitionColumns.map(columns => {
+      df = df.partitionBy(columns: _*)
+    })
+    df.format("delta").mode("append").save(tablePath)
+  }
+}
+
+/**
+ * Runs optimize compaction tests.
+ */
+class OptimizeCompactionSuite extends OptimizeCompactionSuiteBase
+  with DeltaSQLCommandTest
+

--- a/core/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeMetricsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeMetricsSuite.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.optimize
+
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.commands.optimize.{FileSizeStats, OptimizeMetrics}
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.functions.floor
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types._
+
+/** Tests that run optimize and verify the returned output (metrics) is expected. */
+trait OptimizeMetricsSuiteBase extends QueryTest
+    with SharedSparkSession  {
+
+  import testImplicits._
+
+  test("optimize metrics") {
+    withTempDir { tempDir =>
+      val skewedRightSeq =
+        0.to(79).seq ++ 40.to(79).seq ++ 60.to(79).seq ++ 70.to(79).seq ++ 75.to(79).seq
+      skewedRightSeq.toDF().withColumn("p", floor('value / 10)).repartition(4)
+        .write.partitionBy("p").format("delta").save(tempDir.toString)
+      val deltaLog = DeltaLog.forTable(spark, tempDir)
+      val startCount = deltaLog.snapshot.numOfFiles
+      val startSizes = deltaLog.snapshot.allFiles.select('size).as[Long].collect()
+      val res = spark.sql(s"OPTIMIZE delta.`${tempDir.toString}`")
+      val metrics: OptimizeMetrics = res.select($"metrics.*").as[OptimizeMetrics].head()
+      val finalSizes = deltaLog.snapshot.allFiles.select('size).collect().map(_.getLong(0))
+      val finalNumFiles = deltaLog.snapshot.numOfFiles
+      assert(metrics.numFilesAdded == finalNumFiles)
+      assert(metrics.numFilesRemoved == startCount)
+      assert(metrics.filesAdded.min.get == finalSizes.min)
+      assert(metrics.filesAdded.max.get == finalSizes.max)
+      assert(metrics.filesRemoved.max.get == startSizes.max)
+      assert(metrics.filesRemoved.min.get == startSizes.min)
+      assert(metrics.totalConsideredFiles == startCount)
+      assert(metrics.totalFilesSkipped == 0)
+    }
+  }
+
+  /**
+   * Ensure public API for metrics persists
+   */
+  test("optimize command output schema") {
+
+    val zOrderFileStatsSchema = StructType(Seq(
+      StructField("num", LongType, nullable = false),
+      StructField("size", LongType, nullable = false)
+    ))
+
+    val zOrderStatsSchema = StructType(Seq(
+      StructField("strategyName", StringType, nullable = true),
+      StructField("inputCubeFiles", zOrderFileStatsSchema, nullable = true),
+      StructField("inputOtherFiles", zOrderFileStatsSchema, nullable = true),
+      StructField("inputNumCubes", LongType, nullable = false),
+      StructField("mergedFiles", zOrderFileStatsSchema, nullable = true),
+      StructField("numOutputCubes", LongType, nullable = false),
+      StructField("mergedNumCubes", LongType, nullable = true)
+    ))
+    val fileSizeMetricsSchema = StructType(Seq(
+      StructField("min", LongType, nullable = true),
+      StructField("max", LongType, nullable = true),
+      StructField("avg", DoubleType, nullable = false),
+      StructField("totalFiles", LongType, nullable = false),
+      StructField("totalSize", LongType, nullable = false)
+    ))
+
+    val optimizeMetricsSchema = StructType(Seq(
+      StructField("numFilesAdded", LongType, nullable = false),
+      StructField("numFilesRemoved", LongType, nullable = false),
+      StructField("filesAdded", fileSizeMetricsSchema, nullable = true),
+      StructField("filesRemoved", fileSizeMetricsSchema, nullable = true),
+      StructField("partitionsOptimized", LongType, nullable = false),
+      StructField("zOrderStats", zOrderStatsSchema, nullable = true),
+      StructField("numBatches", LongType, nullable = false),
+      StructField("totalConsideredFiles", LongType, nullable = false),
+      StructField("totalFilesSkipped", LongType, nullable = false),
+      StructField("preserveInsertionOrder", BooleanType, nullable = false)
+    ))
+    val optimizeSchema = StructType(Seq(
+      StructField("path", StringType, nullable = true),
+      StructField("metrics", optimizeMetricsSchema, nullable = true)
+    ))
+    withTempDir { tempDir =>
+      spark.range(0, 10).write.format("delta").save(tempDir.toString)
+      val res = sql(s"OPTIMIZE delta.`${tempDir.toString}`")
+      assert(res.schema == optimizeSchema)
+    }
+  }
+
+  test("optimize metrics on idempotent operations") {
+    val tblName = "tblName"
+    withTable(tblName) {
+      // Create Delta table
+      spark.range(10).write.format("delta").saveAsTable(tblName)
+
+      // First Optimize
+      spark.sql(s"OPTIMIZE $tblName")
+
+      // Second Optimize
+      val res = spark.sql(s"OPTIMIZE $tblName")
+      val actMetrics: OptimizeMetrics = res.select($"metrics.*").as[OptimizeMetrics].head()
+      val expMetrics = OptimizeMetrics(
+        numFilesAdded = 0,
+        numFilesRemoved = 0,
+        filesAdded = FileSizeStats().toFileSizeMetrics,
+        filesRemoved = FileSizeStats().toFileSizeMetrics,
+        partitionsOptimized = 0,
+        zOrderStats = None,
+        numBatches = 0,
+        totalConsideredFiles = 1,
+        totalFilesSkipped = 1,
+        preserveInsertionOrder = false)
+
+      assert(actMetrics === expMetrics)
+    }
+  }
+}
+
+class OptimizeMetricsSuite extends OptimizeMetricsSuiteBase
+  with DeltaSQLCommandTest

--- a/core/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeMetricsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeMetricsSuite.scala
@@ -117,6 +117,8 @@ trait OptimizeMetricsSuiteBase extends QueryTest
       // Second Optimize
       val res = spark.sql(s"OPTIMIZE $tblName")
       val actMetrics: OptimizeMetrics = res.select($"metrics.*").as[OptimizeMetrics].head()
+      var preserveInsertionOrder = false
+
       val expMetrics = OptimizeMetrics(
         numFilesAdded = 0,
         numFilesRemoved = 0,
@@ -127,7 +129,7 @@ trait OptimizeMetricsSuiteBase extends QueryTest
         numBatches = 0,
         totalConsideredFiles = 1,
         totalFilesSkipped = 1,
-        preserveInsertionOrder = false)
+        preserveInsertionOrder = preserveInsertionOrder)
 
       assert(actMetrics === expMetrics)
     }


### PR DESCRIPTION
## Overview
This work adds the “OPTIMIZE (file compaction)” as outlined in issue #927

## Implementation Details

- Add OPTIMIZE SQL command to grammar file DeltaSqlBase.g4
- Handle the Optimize table SQL command in DeltaSqlParser.scala by creating a DeltaCommand implementation of OPTIMIZE (file compaction).
- Implement DeltaCommand for OPTIMIZE (file compaction) (OptimizeTableCommand). Algorithm is as follows:
- List all the files in latest snapshot that satisfy the given partition predicate
   - Go through the files and filter out all files that are greater than the minimum size (DeltaSQLConf.DELTA_OPTIMIZE_MIN_FILE_SIZE)
   - Group files by each partition
   - For each partition divide the files into bins where the sum of the size of the files in a bin is <= DeltaSQLConf.DELTA_OPTIMIZE_MAX_FILE_SIZE
   - Run a Spark job for each bin that reads the files in the bin and writes the output in a single file. The command can run DeltaSQLConfig.DELTA_OPTIMIZE_MAX_THREADS number of parallel jobs, each working on one bin.
   - At the end, create a DeltaLog transaction that adds the output files generated and removes the compacted files.
   - At each step, collect metrics to output in the Optimize SQL command.
- Tests

This resolves #927.
