### PR TITLE
[#837] Multipart checkpoints

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -314,14 +314,17 @@ object Checkpoints extends DeltaLogging {
     val checkpointRowCount = res.getLong(0)
     val numOfFiles = res.getLong(1)
 
-    val checkpointPaths = maxActionsPerFile.map { maxActions =>
-      val numCheckpointFiles = (checkpointRowCount - 1) / maxActions + 1
+    val numCheckpointFiles = maxActionsPerFile.map { maxActions =>
+      (checkpointRowCount - 1) / maxActions + 1
+    }.getOrElse(1L)
+
+    val checkpointPaths = if (numCheckpointFiles > 1) {
       checkpointFileWithParts(snapshot.path, snapshot.version, numCheckpointFiles.toInt)
-    }.getOrElse {
+    } else {
       checkpointFileSingular(snapshot.path, snapshot.version) :: Nil
     }
 
-    val numPartsOption = if (maxActionsPerFile.isDefined) {
+    val numPartsOption = if (numCheckpointFiles > 1) {
       Some(checkpointPaths.length)
     } else {
       None

--- a/core/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -413,11 +413,11 @@ object Checkpoints extends DeltaLogging {
 
     if (useRename) {
       var renameDone = false
+      val fs = snapshot.path.getFileSystem(hadoopConf)
       try {
         writtenPaths.zipWithIndex.foreach { case (writtenPath, index) =>
           val src = new Path(writtenPath)
           val dest = new Path(paths(index))
-          val fs = dest.getFileSystem(hadoopConf)
           if (!fs.rename(src, dest)) {
             throw DeltaErrors.failOnCheckpoint(src, dest)
           }
@@ -428,7 +428,6 @@ object Checkpoints extends DeltaLogging {
           writtenPaths.foreach { writtenPath =>
             scala.util.Try {
               val src = new Path(writtenPath)
-              val fs = src.getFileSystem(hadoopConf)
               fs.delete(src, false)
             }
           }

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -430,6 +430,7 @@ trait DeltaSQLConfBase {
       .doc("Maximum number of actions to add to a checkpoint file before splitting it up. " +
         "This can speed up writing and reading checkpoints by adding parallelization.")
       .intConf
+      .checkValue(_ > 0, "maxActionsPerFile has to be positive")
       .createOptional
 
   val DELTA_WRITE_CHECKSUM_ENABLED =

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -429,7 +429,7 @@ trait DeltaSQLConfBase {
       .internal()
       .doc("The limit at which we will start parallelizing the checkpoint. We will attempt to " +
           "write a maximum of this many actions per checkpoint file.")
-      .intConf
+      .longConf
       .checkValue(_ > 0, "partSize has to be positive")
       .createOptional
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -424,13 +424,13 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
-  val DELTA_CHECKPOINT_MAX_ACTIONS_PER_FILE =
-    buildConf("checkpoint.maxActionsPerFile")
+  val DELTA_CHECKPOINT_PART_SIZE =
+    buildConf("checkpoint.partSize")
       .internal()
-      .doc("Maximum number of actions to add to a checkpoint file before splitting it up. " +
-        "This can speed up writing and reading checkpoints by adding parallelization.")
+      .doc("The limit at which we will start parallelizing the checkpoint. We will attempt to " +
+          "write a maximum of this many actions per checkpoint file.")
       .intConf
-      .checkValue(_ > 0, "maxActionsPerFile has to be positive")
+      .checkValue(_ > 0, "partSize has to be positive")
       .createOptional
 
   val DELTA_WRITE_CHECKSUM_ENABLED =

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -424,6 +424,14 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
+  val DELTA_CHECKPOINT_MAX_ACTIONS_PER_FILE =
+    buildConf("checkpoint.maxActionsPerFile")
+      .internal()
+      .doc("Maximum number of actions to add to a checkpoint file before splitting it up. " +
+        "This can speed up writing and reading checkpoints by adding parallelization.")
+      .intConf
+      .createOptional
+
   val DELTA_WRITE_CHECKSUM_ENABLED =
     buildConf("writeChecksumFile.enabled")
       .doc("Whether the checksum file can be written.")

--- a/core/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
@@ -69,7 +69,7 @@ class SnapshotManagementSuite extends QueryTest with SQLTestUtils with SharedSpa
 
   private def testWithAndWithoutMultipartCheckpoint(name: String)(f: (Option[Int]) => Unit) = {
     testQuietly(name) {
-      withSQLConf(DeltaSQLConf.DELTA_CHECKPOINT_MAX_ACTIONS_PER_FILE.key -> "1") {
+      withSQLConf(DeltaSQLConf.DELTA_CHECKPOINT_PART_SIZE.key -> "1") {
         f(Some(1))
         f(Some(2))
       }

--- a/core/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
@@ -41,12 +41,24 @@ class SnapshotManagementSuite extends QueryTest with SQLTestUtils with SharedSpa
   private def makeCorruptCheckpointFile(
       path: String,
       checkpointVersion: Long,
-      shouldBeEmpty: Boolean): Unit = {
-    val checkpointFile =
-      FileNames.checkpointFileSingular(new Path(path, "_delta_log"), checkpointVersion).toString
-    val cp = new RandomAccessFile(checkpointFile, "rw")
-    cp.setLength(if (shouldBeEmpty) 0 else 10)
-    cp.close()
+      shouldBeEmpty: Boolean,
+      multipart: Option[(Int, Int)] = None): Unit = {
+    if (multipart.isDefined) {
+      val (part, totalParts) = multipart.get
+      val checkpointFile = FileNames.checkpointFileWithParts(new Path(path, "_delta_log"),
+        checkpointVersion, totalParts)(part - 1).toString
+      assert(new File(checkpointFile).exists)
+      val cp = new RandomAccessFile(checkpointFile, "rw")
+      cp.setLength(if (shouldBeEmpty) 0 else 10)
+      cp.close()
+    } else {
+      val checkpointFile =
+        FileNames.checkpointFileSingular(new Path(path, "_delta_log"), checkpointVersion).toString
+      assert(new File(checkpointFile).exists)
+      val cp = new RandomAccessFile(checkpointFile, "rw")
+      cp.setLength(if (shouldBeEmpty) 0 else 10)
+      cp.close()
+    }
   }
 
   private def deleteLogVersion(path: String, version: Long): Unit = {
@@ -56,121 +68,208 @@ class SnapshotManagementSuite extends QueryTest with SQLTestUtils with SharedSpa
   }
 
   testQuietly("recover from a corrupt checkpoint: previous checkpoint doesn't exist") {
-    withTempDir { tempDir =>
-      val path = tempDir.getCanonicalPath
-      spark.range(10).write.format("delta").save(path)
-      val deltaLog = DeltaLog.forTable(spark, path)
-      deltaLog.checkpoint()
+    for (useMultipart <- Seq(true, false)) {
+      // Test the first part and not the first part
+      val partsToCorrupt = if (useMultipart) {
+        Some(1) :: Some(2) :: Nil
+      } else {
+        None :: Nil
+      }
+      val maxActions = if (useMultipart) 1 else 10000
+      withSQLConf(DeltaSQLConf.DELTA_CHECKPOINT_MAX_ACTIONS_PER_FILE.key -> maxActions.toString) {
+        partsToCorrupt.foreach { partToCorrupt =>
+          withTempDir { tempDir =>
+            val path = tempDir.getCanonicalPath
+            spark.range(10).write.format("delta").save(path)
+            var deltaLog = DeltaLog.forTable(spark, path)
+            deltaLog.checkpoint()
 
-      // We have different code paths for empty and non-empty checkpoints
-      for (testEmptyCheckpoint <- Seq(true, false)) {
-        makeCorruptCheckpointFile(path, checkpointVersion = 0, shouldBeEmpty = testEmptyCheckpoint)
-        DeltaLog.clearCache()
-        // Checkpoint 0 is corrupted. Verify that we can still create the snapshot using
-        // existing json files.
-        DeltaLog.forTable(spark, path).snapshot
+            DeltaLog.clearCache()
+            deltaLog = DeltaLog.forTable(spark, path)
+            val checkpointParts = deltaLog.snapshot.logSegment.checkpoint.length
+            val multipart = partToCorrupt.map((_, checkpointParts))
+
+            // We have different code paths for empty and non-empty checkpoints
+            for (testEmptyCheckpoint <- Seq(true, false)) {
+              makeCorruptCheckpointFile(path, checkpointVersion = 0,
+                shouldBeEmpty = testEmptyCheckpoint, multipart = multipart)
+              DeltaLog.clearCache()
+              // Checkpoint 0 is corrupted. Verify that we can still create the snapshot using
+              // existing json files.
+              DeltaLog.forTable(spark, path).snapshot
+            }
+          }
+        }
       }
     }
   }
 
   testQuietly("recover from a corrupt checkpoint: previous checkpoint exists") {
-    withTempDir { tempDir =>
-      // Create checkpoint 0 and 1
-      val path = tempDir.getCanonicalPath
-      spark.range(10).write.format("delta").save(path)
-      val deltaLog = DeltaLog.forTable(spark, path)
-      deltaLog.checkpoint()
-      spark.range(10).write.format("delta").mode("append").save(path)
-      deltaLog.update()
-      deltaLog.checkpoint()
+    for (useMultipart <- Seq(true, false)) {
+      // Test the first part and not the first part
+      val partsToCorrupt = if (useMultipart) {
+        Some(1) :: Some(2) :: Nil
+      } else {
+        None :: Nil
+      }
+      val maxActions = if (useMultipart) 1 else 10000
+      withSQLConf(DeltaSQLConf.DELTA_CHECKPOINT_MAX_ACTIONS_PER_FILE.key -> maxActions.toString) {
+        partsToCorrupt.foreach { partToCorrupt =>
+          withTempDir { tempDir =>
+            // Create checkpoint 0 and 1
+            val path = tempDir.getCanonicalPath
+            spark.range(10).write.format("delta").save(path)
+            var deltaLog = DeltaLog.forTable(spark, path)
+            deltaLog.checkpoint()
+            spark.range(10).write.format("delta").mode("append").save(path)
+            deltaLog.update()
+            deltaLog.checkpoint()
 
-      // We have different code paths for empty and non-empty checkpoints
-      for (testEmptyCheckpoint <- Seq(true, false)) {
-        makeCorruptCheckpointFile(path, checkpointVersion = 1, shouldBeEmpty = testEmptyCheckpoint)
-        // Checkpoint 1 is corrupted. Verify that we can still create the snapshot using
-        // checkpoint 0.
-        DeltaLog.clearCache()
-        DeltaLog.forTable(spark, path).snapshot
+            DeltaLog.clearCache()
+            deltaLog = DeltaLog.forTable(spark, path)
+            val checkpointParts = deltaLog.snapshot.logSegment.checkpoint.length
+            val multipart = partToCorrupt.map((_, checkpointParts))
+
+            // We have different code paths for empty and non-empty checkpoints
+            for (testEmptyCheckpoint <- Seq(true, false)) {
+              makeCorruptCheckpointFile(path, checkpointVersion = 1,
+                shouldBeEmpty = testEmptyCheckpoint, multipart = multipart)
+              // Checkpoint 1 is corrupted. Verify that we can still create the snapshot using
+              // checkpoint 0.
+              DeltaLog.clearCache()
+              DeltaLog.forTable(spark, path).snapshot
+            }
+          }
+        }
       }
     }
   }
 
   testQuietly("should not recover when the current checkpoint is broken but we don't have the " +
     "entire history") {
-    withTempDir { tempDir =>
-      val path = tempDir.getCanonicalPath
-      spark.range(10).write.format("delta").save(path)
-      spark.range(10).write.format("delta").mode("append").save(path)
-      DeltaLog.forTable(spark, path).checkpoint()
-      deleteLogVersion(path, version = 0)
-      DeltaLog.clearCache()
+    for (useMultipart <- Seq(true, false)) {
+      // Test the first part and not the first part
+      val partsToCorrupt = if (useMultipart) {
+        Some(1) :: Some(2) :: Nil
+      } else {
+        None :: Nil
+      }
+      val maxActions = if (useMultipart) 1 else 10000
+      withSQLConf(DeltaSQLConf.DELTA_CHECKPOINT_MAX_ACTIONS_PER_FILE.key -> maxActions.toString) {
+        partsToCorrupt.foreach { partToCorrupt =>
+          withTempDir { tempDir =>
+            val path = tempDir.getCanonicalPath
+            spark.range(10).write.format("delta").save(path)
+            spark.range(10).write.format("delta").mode("append").save(path)
+            DeltaLog.forTable(spark, path).checkpoint()
+            deleteLogVersion(path, version = 0)
+            DeltaLog.clearCache()
 
-      // We have different code paths for empty and non-empty checkpoints, and also different code
-      // paths when listing with or without a checkpoint hint.
-      for (testEmptyCheckpoint <- Seq(true, false)) {
-        makeCorruptCheckpointFile(path, checkpointVersion = 1, shouldBeEmpty = testEmptyCheckpoint)
+            val deltaLog = DeltaLog.forTable(spark, path)
+            val checkpointParts = deltaLog.snapshot.logSegment.checkpoint.length
+            val multipart = partToCorrupt.map((_, checkpointParts))
 
-        // When finding a Delta log for the first time, we rely on _last_checkpoint hint
-        val e = intercept[Exception] { DeltaLog.forTable(spark, path).snapshot }
-        if (testEmptyCheckpoint) {
-          // - checkpoint 1 is NOT in the list result
-          // - try to get an alternative LogSegment in `getLogSegmentForVersion`
-          // - fail to get an alternative LogSegment
-          // - throw the below exception
-          assert(e.isInstanceOf[IllegalStateException] &&
-            e.getMessage.contains("Couldn't find all part files of the checkpoint version: 1"))
-        } else {
-          // - checkpoint 1 is in the list result
-          // - Snapshot creation triggers state reconstruction
-          // - fail to read protocol+metadata from checkpoint 1
-          // - throw FileReadException
-          // - fail to get an alternative LogSegment
-          // - cannot find log file 0 so throw the above checkpoint 1 read failure
-          // Guava cache wraps the root cause
-          assert(e.isInstanceOf[ExecutionException] && e.getCause.isInstanceOf[SparkException] &&
-            e.getMessage.contains("0001.checkpoint.parquet is not a Parquet file"))
+            DeltaLog.clearCache()
+
+            // We have different code paths for empty and non-empty checkpoints, and also different
+            // code paths when listing with or without a checkpoint hint.
+            for (testEmptyCheckpoint <- Seq(true, false)) {
+              makeCorruptCheckpointFile(path, checkpointVersion = 1,
+                shouldBeEmpty = testEmptyCheckpoint, multipart = multipart)
+              // When finding a Delta log for the first time, we rely on _last_checkpoint hint
+              val e = intercept[Exception] { DeltaLog.forTable(spark, path).snapshot }
+              // DeltaLog.forTable(spark, path).snapshot
+              if (testEmptyCheckpoint) {
+                // - checkpoint 1 is NOT in the list result
+                // - try to get an alternative LogSegment in `getLogSegmentForVersion`
+                // - fail to get an alternative LogSegment
+                // - throw the below exception
+                assert(e.isInstanceOf[IllegalStateException] && e.getMessage.contains(
+                  "Couldn't find all part files of the checkpoint version: 1"))
+              } else {
+                // - checkpoint 1 is in the list result
+                // - Snapshot creation triggers state reconstruction
+                // - fail to read protocol+metadata from checkpoint 1
+                // - throw FileReadException
+                // - fail to get an alternative LogSegment
+                // - cannot find log file 0 so throw the above checkpoint 1 read failure
+                // Guava cache wraps the root cause
+                assert(e.isInstanceOf[ExecutionException] &&
+                  e.getCause.isInstanceOf[SparkException] &&
+                  e.getMessage.contains("0001.checkpoint") &&
+                  e.getMessage.contains(".parquet is not a Parquet file"))
+              }
+            }
+          }
         }
       }
     }
   }
 
   testQuietly("should not recover when both the current and previous checkpoints are broken") {
-    withTempDir { tempDir =>
-      val path = tempDir.getCanonicalPath
-      val staleLog = DeltaLog.forTable(spark, path)
-      DeltaLog.clearCache()
+    for (useMultipart <- Seq(true, false)) {
+      // Test the first part and not the first part
+      val partsToCorrupt = if (useMultipart) {
+        Some(1) :: Some(2) :: Nil
+      } else {
+        None :: Nil
+      }
+      val maxActions = if (useMultipart) 1 else 10000
+      withSQLConf(DeltaSQLConf.DELTA_CHECKPOINT_MAX_ACTIONS_PER_FILE.key -> maxActions.toString) {
+        partsToCorrupt.foreach { partToCorrupt =>
+          withTempDir { tempDir =>
+            val path = tempDir.getCanonicalPath
+            val staleLog = DeltaLog.forTable(spark, path)
+            DeltaLog.clearCache()
 
-      spark.range(10).write.format("delta").save(path)
-      val deltaLog = DeltaLog.forTable(spark, path)
-      deltaLog.checkpoint()
-      spark.range(10).write.format("delta").mode("append").save(path)
-      deltaLog.update()
-      deltaLog.checkpoint()
-      deleteLogVersion(path, version = 0)
-      makeCorruptCheckpointFile(path, checkpointVersion = 0, shouldBeEmpty = false)
+            spark.range(10).write.format("delta").save(path)
+            val deltaLog = DeltaLog.forTable(spark, path)
+            deltaLog.checkpoint()
+            DeltaLog.clearCache()
+            val checkpointParts0 =
+              DeltaLog.forTable(spark, path).snapshot.logSegment.checkpoint.length
 
-      // We have different code paths for empty and non-empty checkpoints
-      for (testEmptyCheckpoint <- Seq(true, false)) {
-        makeCorruptCheckpointFile(path, checkpointVersion = 1, shouldBeEmpty = testEmptyCheckpoint)
+            spark.range(10).write.format("delta").mode("append").save(path)
+            deltaLog.update()
+            deltaLog.checkpoint()
+            deleteLogVersion(path, version = 0)
 
-        // The code paths are different, but the error and message end up being the same:
-        //
-        // testEmptyCheckpoint = true:
-        // - checkpoint 1 is NOT in the list result.
-        // - fallback to load version 0 using checkpoint 0
-        // - fail to read checkpoint 0
-        // - cannot find log file 0 so throw the above checkpoint 0 read failure
-        //
-        // testEmptyCheckpoint = false:
-        // - checkpoint 1 is in the list result.
-        // - Snapshot creation triggers state reconstruction
-        // - fail to read protocol+metadata from checkpoint 1
-        // - fallback to load version 0 using checkpoint 0
-        // - fail to read checkpoint 0
-        // - cannot find log file 0 so throw the original checkpoint 1 read failure
-        val e = intercept[SparkException] { staleLog.update() }
-        val version = if (testEmptyCheckpoint) 0 else 1
-        assert(e.getMessage.contains(f"$version%020d.checkpoint.parquet is not a Parquet file"))
+            DeltaLog.clearCache()
+            val checkpointParts1 =
+              DeltaLog.forTable(spark, path).snapshot.logSegment.checkpoint.length
+
+            makeCorruptCheckpointFile(path, checkpointVersion = 0, shouldBeEmpty = false,
+              multipart = partToCorrupt.map((_, checkpointParts0)))
+
+            val multipart = partToCorrupt.map((_, checkpointParts1))
+
+            // We have different code paths for empty and non-empty checkpoints
+            for (testEmptyCheckpoint <- Seq(true, false)) {
+              makeCorruptCheckpointFile(path, checkpointVersion = 1,
+                shouldBeEmpty = testEmptyCheckpoint, multipart = multipart)
+
+              // The code paths are different, but the error and message end up being the same:
+              //
+              // testEmptyCheckpoint = true:
+              // - checkpoint 1 is NOT in the list result.
+              // - fallback to load version 0 using checkpoint 0
+              // - fail to read checkpoint 0
+              // - cannot find log file 0 so throw the above checkpoint 0 read failure
+              //
+              // testEmptyCheckpoint = false:
+              // - checkpoint 1 is in the list result.
+              // - Snapshot creation triggers state reconstruction
+              // - fail to read protocol+metadata from checkpoint 1
+              // - fallback to load version 0 using checkpoint 0
+              // - fail to read checkpoint 0
+              // - cannot find log file 0 so throw the original checkpoint 1 read failure
+              val e = intercept[SparkException] { staleLog.update() }
+              val version = if (testEmptyCheckpoint) 0 else 1
+              assert(e.getMessage.contains(f"$version%020d.checkpoint") &&
+                e.getMessage.contains(".parquet is not a Parquet file"))
+            }
+          }
+        }
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
@@ -410,6 +410,8 @@ class SnapshotManagementSuite extends QueryTest with SQLTestUtils with SharedSpa
       val path = tempDir.getCanonicalPath
       spark.range(10).write.format("delta").save(path)
       DeltaLog.clearCache()
+      // Corrupted snapshot tests leave a cached snapshot not tracked by the DeltaLog cache
+      sparkContext.getPersistentRDDs.foreach(_._2.unpersist())
       assert(sparkContext.getPersistentRDDs.isEmpty)
 
       withSQLConf(DeltaSQLConf.DELTA_SNAPSHOT_CACHE_STORAGE_LEVEL.key -> "DISK_ONLY") {


### PR DESCRIPTION
Resolves #837 

Adds a config that sets the maximum number of actions to include in a single file of a multipart checkpoint. If the total actions of a snapshot is larger than this, the checkpoint will be split up into multiple parts.

It is disabled by default so the behavior is purely opt-in, as most users probably don't know about actions or how to set this value. In the future it could be set to some sane default value if there's some consensus on what it should be.