### PR TITLE
Make hadoop provided for storage module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -169,7 +169,7 @@ lazy val storage = (project in file("storage"))
     libraryDependencies ++= Seq(
       // User can provide any 2.x or 3.x version. We don't use any new fancy APIs. Watch out for
       // versions with known vulnerabilities.
-      "org.apache.hadoop" % "hadoop-common" % "3.3.1"
+      "org.apache.hadoop" % "hadoop-common" % "3.3.1" % "provided"
     )
   )
 


### PR DESCRIPTION
Resolves #967 

Make Hadoop dependency provided for storage module. Usages must provide their own Hadoop libraries and versions.