### PR TITLE
Add test to LogStoreSuite for HDFSLogStore rename() error edge case

### DIFF
--- a/storage/src/main/java/io/delta/storage/HDFSLogStore.java
+++ b/storage/src/main/java/io/delta/storage/HDFSLogStore.java
@@ -127,7 +127,7 @@ public class HDFSLogStore extends HadoopFileSystemLogStore {
                 // resolved
                 tryRemoveCrcFile(fc, tempPath);
             } catch (org.apache.hadoop.fs.FileAlreadyExistsException e) {
-                throw new FileNotFoundException(path.toString());
+                throw new FileAlreadyExistsException(path.toString());
             }
         } finally {
             if (!streamClosed) {


### PR DESCRIPTION
- follow up to https://github.com/delta-io/delta/pull/980
- rename `class HDFSLogStoreSuite` to `trait `HDFSLogStoreSuiteBase` so that internal (scala) and public (java) HDFSLogStore suites can both use that trait
- we add a specific test to `HDFSLogStoreSuiteBase` to test the `HDFSLogStore.writeInternal ... rename` edge case brought up by the above PR #980 