### PR TITLE
Update run-integration-tests.py to be able to use local source code

### DIFF
--- a/run-integration-tests.py
+++ b/run-integration-tests.py
@@ -36,7 +36,7 @@ def run_scala_integration_tests(root_dir, version, test_name, extra_maven_repo, 
           % (str(version), scala_version))
     clear_artifact_cache()
     if use_local:
-        run_cmd(["build/sbt", "publishLocal"])
+        run_cmd(["build/sbt", "publishM2"])
 
     test_dir = path.join(root_dir, "examples", "scala")
     test_src_dir = path.join(test_dir, "src", "main", "scala", "example")
@@ -65,7 +65,7 @@ def run_python_integration_tests(root_dir, version, test_name, extra_maven_repo,
     print("\n\n##### Running Python tests on version %s #####" % str(version))
     clear_artifact_cache()
     if use_local:
-        run_cmd(["build/sbt", "publishLocal"])
+        run_cmd(["build/sbt", "publishM2"])
 
     test_dir = path.join(root_dir, path.join("examples", "python"))
     files_to_skip = {"using_with_pip.py"}

--- a/run-integration-tests.py
+++ b/run-integration-tests.py
@@ -30,10 +30,14 @@ def delete_if_exists(path):
         print("Deleted %s " % path)
 
 
-def run_scala_integration_tests(root_dir, version, test_name, extra_maven_repo, scala_version):
+def run_scala_integration_tests(root_dir, version, test_name, extra_maven_repo, scala_version,
+                                use_local):
     print("\n\n##### Running Scala tests on delta version %s and scala version %s #####"
           % (str(version), scala_version))
     clear_artifact_cache()
+    if use_local:
+        run_cmd(["build/sbt", "publishLocal"])
+
     test_dir = path.join(root_dir, "examples", "scala")
     test_src_dir = path.join(test_dir, "src", "main", "scala", "example")
     test_classes = [f.replace(".scala", "") for f in os.listdir(test_src_dir)
@@ -57,9 +61,12 @@ def run_scala_integration_tests(root_dir, version, test_name, extra_maven_repo, 
                 raise
 
 
-def run_python_integration_tests(root_dir, version, test_name, extra_maven_repo):
+def run_python_integration_tests(root_dir, version, test_name, extra_maven_repo, use_local):
     print("\n\n##### Running Python tests on version %s #####" % str(version))
     clear_artifact_cache()
+    if use_local:
+        run_cmd(["build/sbt", "publishLocal"])
+
     test_dir = path.join(root_dir, path.join("examples", "python"))
     files_to_skip = {"using_with_pip.py"}
 
@@ -237,6 +244,13 @@ if __name__ == "__main__":
         default=False,
         action="store_true",
         help="Use testpypi for testing pip installation")
+    parser.add_argument(
+        "--use-local",
+        required=False,
+        default=False,
+        action="store_true",
+        help="Generate JARs from local source code and use to run tests"
+    )
 
     args = parser.parse_args()
 
@@ -247,16 +261,20 @@ if __name__ == "__main__":
     if args.pip_only and args.no_pip:
         raise Exception("Cannot specify both --pip-only and --no-pip")
 
+    if args.use_local and (args.version != default_version):
+        raise Exception("Cannot specify --use-local with a --version different than in version.sbt")
+
     run_python = not args.scala_only and not args.pip_only
     run_scala = not args.python_only and not args.pip_only
     run_pip = not args.python_only and not args.scala_only and not args.no_pip
 
     if run_scala:
         run_scala_integration_tests(root_dir, args.version, args.test, args.maven_repo,
-                                    args.scala_version)
+                                    args.scala_version, args.use_local)
 
     if run_python:
-        run_python_integration_tests(root_dir, args.version, args.test, args.maven_repo)
+        run_python_integration_tests(root_dir, args.version, args.test, args.maven_repo,
+                                    args.use_local)
 
     if run_pip:
         run_pip_installation_tests(root_dir, args.version, args.use_testpypi, args.maven_repo)


### PR DESCRIPTION
Right now `run-integration-tests.py` can only be run with a released, or staged version. This PR adds a flag `--use-local` that allows us to run the integration tests for any local version.

`--use-local` uses `build/sbt publishLocal` to package the local source code before running the tests.

