### PR TITLE
Delta Storage: Update HadoopFileSystemLogStore #953

### DIFF
--- a/storage/src/main/java/io/delta/storage/HadoopFileSystemLogStore.java
+++ b/storage/src/main/java/io/delta/storage/HadoopFileSystemLogStore.java
@@ -79,7 +79,7 @@ public abstract class HadoopFileSystemLogStore extends LogStore {
     protected void writeWithRename(
             Path path,
             Iterator<String> actions,
-            Boolean overwrite,
+            boolean overwrite,
             Configuration hadoopConf) throws IOException {
         FileSystem fs = path.getFileSystem(hadoopConf);
 
@@ -102,8 +102,8 @@ public abstract class HadoopFileSystemLogStore extends LogStore {
                 throw new FileAlreadyExistsException(path.toString());
             }
             Path tempPath = createTempPath(path);
-            Boolean streamClosed = false; // This flag is to avoid double close
-            Boolean renameDone = false;   // This flag is to save the delete operation in most of cases.
+            boolean streamClosed = false; // This flag is to avoid double close
+            boolean renameDone = false;   // This flag is to save the delete operation in most of cases.
             final FSDataOutputStream stream = fs.create(tempPath);
             try {
                 while (actions.hasNext()) {
@@ -123,7 +123,7 @@ public abstract class HadoopFileSystemLogStore extends LogStore {
                             );
                         }
                     }
-                } catch (org.apache.hadoop.fs.FileAlreadyExistsException e) {
+                } catch (FileAlreadyExistsException e) {
                     throw new FileAlreadyExistsException(path.toString());
                 }
             } finally {

--- a/storage/src/main/java/io/delta/storage/HadoopFileSystemLogStore.java
+++ b/storage/src/main/java/io/delta/storage/HadoopFileSystemLogStore.java
@@ -123,7 +123,7 @@ public abstract class HadoopFileSystemLogStore extends LogStore {
                             );
                         }
                     }
-                } catch (FileAlreadyExistsException e) {
+                } catch (org.apache.hadoop.fs.FileAlreadyExistsException e) {
                     throw new FileAlreadyExistsException(path.toString());
                 }
             } finally {


### PR DESCRIPTION
- Update HadoopFileSystemLogStore.java to include writeWithRename
- Required for child classes  [[AzureLogStore](https://github.com/delta-io/delta/blob/master/core/src/main/scala/org/apache/spark/sql/delta/storage/AzureLogStore.scala)](url)
