### PR TITLE
Add support for Restore SQL Command in Delta OSS

### DIFF
--- a/core/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
+++ b/core/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
@@ -80,6 +80,8 @@ statement
         (LIMIT limit=INTEGER_VALUE)?                                    #describeDeltaHistory
     | CONVERT TO DELTA table=qualifiedName
         (PARTITIONED BY '(' colTypeList ')')?                           #convert
+    | RESTORE TABLE? table=qualifiedName TO?
+            clause=temporalClause                                       #restore
     | ALTER TABLE table=qualifiedName ADD CONSTRAINT name=identifier
       constraint                                                        #addTableConstraint
     | ALTER TABLE table=qualifiedName
@@ -87,6 +89,11 @@ statement
     | OPTIMIZE (path=STRING | table=qualifiedName)
         (WHERE partitionPredicate = exprToken)?                    #optimizeTable
     | .*?                                                               #passThrough
+    ;
+
+temporalClause
+    : FOR? (SYSTEM_VERSION | VERSION) AS OF version=(INTEGER_VALUE | STRING)
+    | FOR? (SYSTEM_TIME | TIMESTAMP) AS OF timestamp=STRING
     ;
 
 qualifiedName
@@ -142,11 +149,13 @@ nonReserved
     | CONVERT | TO | DELTA | PARTITIONED | BY
     | DESC | DESCRIBE | LIMIT | DETAIL
     | GENERATE | FOR | TABLE | CHECK | EXISTS | OPTIMIZE
+    | RESTORE | AS | OF
     ;
 
 // Define how the keywords above should appear in a user's SQL statement.
 ADD: 'ADD';
 ALTER: 'ALTER';
+AS: 'AS';
 BY: 'BY';
 CHECK: 'CHECK';
 COMMENT: 'COMMENT';
@@ -167,15 +176,21 @@ LIMIT: 'LIMIT';
 MINUS: '-';
 NOT: 'NOT' | '!';
 NULL: 'NULL';
+OF: 'OF';
 OPTIMIZE: 'OPTIMIZE';
 FOR: 'FOR';
 TABLE: 'TABLE';
 PARTITIONED: 'PARTITIONED';
+RESTORE: 'RESTORE';
 RETAIN: 'RETAIN';
 RUN: 'RUN';
+SYSTEM_TIME: 'SYSTEM_TIME';
+SYSTEM_VERSION: 'SYSTEM_VERSION';
 TO: 'TO';
+TIMESTAMP: 'TIMESTAMP';
 VACUUM: 'VACUUM';
 WHERE: 'WHERE';
+VERSION: 'VERSION';
 
 // Multi-character operator tokens need to be defined even though we don't explicitly reference
 // them so that they can be recognized as single tokens when parsing. If we split them up and

--- a/core/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
+++ b/core/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.delta.stats.PrepareDeltaScan
 import io.delta.sql.parser.DeltaSqlParser
 
 import org.apache.spark.sql.SparkSessionExtensions
+import org.apache.spark.sql.delta.PreprocessTableRestore
 import org.apache.spark.sql.internal.SQLConf
 
 /**
@@ -75,6 +76,9 @@ class DeltaSparkSessionExtension extends (SparkSessionExtensions => Unit) {
   override def apply(extensions: SparkSessionExtensions): Unit = {
     extensions.injectParser { (session, parser) =>
       new DeltaSqlParser(parser)
+    }
+    extensions.injectResolutionRule { session =>
+      new PreprocessTableRestore(session)
     }
     extensions.injectResolutionRule { session =>
       new DeltaAnalysis(session)

--- a/core/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -470,8 +470,7 @@ class DeltaTable private[tables](
    * @since 1.2.0
    */
   def restoreToVersion(version: Long): DataFrame = {
-
-    executeRestore(deltaLog, Some(version), None)
+    executeRestore(table, Some(version), None)
   }
 
   /**
@@ -485,8 +484,7 @@ class DeltaTable private[tables](
    * @since 1.2.0
    */
   def restoreToTimestamp(timestamp: String): DataFrame = {
-
-    executeRestore(deltaLog, None, Some(timestamp))
+    executeRestore(table, None, Some(timestamp))
   }
 
 

--- a/core/src/main/scala/org/apache/spark/sql/catalyst/TimeTravel.scala
+++ b/core/src/main/scala/org/apache/spark/sql/catalyst/TimeTravel.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst
+
+// scalastyle:off import.ordering.noEmptyLine
+import java.sql.Timestamp
+
+import com.databricks.spark.util.DatabricksLogging
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, Expression, RuntimeReplaceable, Unevaluable}
+import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan}
+
+/**
+ * A logical node used to time travel the child relation to the given `timestamp` or `version`.
+ * The `child` must support time travel, e.g. Delta, and cannot be a view, subquery or stream.
+ * The timestamp expression cannot be a subquery. It must be a timestamp expression.
+ * @param creationSource The API used to perform time travel, e.g. `atSyntax`, `dfReader` or SQL
+ */
+case class TimeTravel(
+    relation: LogicalPlan,
+    timestamp: Option[Expression],
+    version: Option[Long],
+    creationSource: Option[String]) extends LeafNode with DatabricksLogging {
+
+  assert(version.isEmpty ^ timestamp.isEmpty,
+    "Either the version or timestamp should be provided for time travel")
+
+  override def output: Seq[Attribute] = Nil
+
+  override lazy val resolved: Boolean = false
+}

--- a/core/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/RestoreTableStatement.scala
+++ b/core/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/RestoreTableStatement.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.TimeTravel
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+/**
+ * RESTORE TABLE statement as parsed from SQL
+ *
+ * @param table - logical node of the table that will be restored, internally contains either
+ *              version or timestamp.
+ */
+case class RestoreTableStatement(table: TimeTravel) extends UnaryNode {
+
+  override def child: LogicalPlan = table
+
+  override def output: Seq[Attribute] = Nil
+
+  override protected def withNewChildInternal(newChild: LogicalPlan): RestoreTableStatement =
+    copy(table = newChild.asInstanceOf[TimeTravel])
+}

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -920,6 +920,23 @@ object DeltaErrors
     )
   }
 
+  def restoreTimestampGreaterThanLatestException(
+      userTimestamp: String,
+      latestTimestamp: String): Throwable = {
+    new AnalysisException(
+      s"Cannot restore table to timestamp ($userTimestamp) as it is after the latest version " +
+        s"available. Please use a timestamp before ($latestTimestamp)"
+    )
+  }
+
+  def restoreTimestampBeforeEarliestException(
+      userTimestamp: String,
+      earliestTimestamp: String): Throwable = {
+    new AnalysisException(
+      s"Cannot restore table to timestamp ($userTimestamp) as it is before the earliest version " +
+        s"available. Please use a timestamp after ($earliestTimestamp)"
+    )
+  }
 
   def timeTravelNotSupportedException: Throwable = {
     new AnalysisException("Cannot time travel views, subqueries or streams.")

--- a/core/src/main/scala/org/apache/spark/sql/delta/PreprocessTableRestore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/PreprocessTableRestore.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.catalyst.TimeTravel
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.{AnalysisException, SparkSession}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
+import org.apache.spark.sql.catalyst.catalog.CatalogTableType
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.util.quoteIfNeeded
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Preprocesses the [[RestoreTableStatement]] logical plan before converting it to
+ * [[RestoreTableCommand]].
+ * - Resolves the [[UnresolvedRelation]] in [[RestoreTableStatement]]'s child [[TimeTravel]].
+ *   Currently Delta depends on Spark 3.2 which does not resolve the [[UnresolvedRelation]]
+ *   in [[TimeTravel]]. Once Delta upgrades to Spark 3.3, this code can be removed.
+ */
+case class PreprocessTableRestore(sparkSession: SparkSession) extends Rule[LogicalPlan] {
+
+  override def conf: SQLConf = sparkSession.sessionState.conf
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperators {
+    case _ @ RestoreTableStatement(tt @ TimeTravel(ur @ UnresolvedRelation(_, _, _), _, _, _)) =>
+      val tableId = ur.multipartIdentifier match {
+        case Seq(tbl) => TableIdentifier(tbl)
+        case Seq(db, tbl) => TableIdentifier(tbl, Some(db))
+        case _ => throw new AnalysisException(s"Illegal table name ${ur.multipartIdentifier}")
+      }
+
+      val catalog = sparkSession.sessionState.catalog
+      val deltaTableV2 = if (DeltaTableUtils.isDeltaTable(sparkSession, tableId)) {
+        val tbl = catalog.getTableMetadata(tableId)
+        DeltaTableV2(sparkSession, new Path(tbl.location), Some(tbl))
+      } else if (DeltaTableUtils.isValidPath(tableId)) {
+        DeltaTableV2(sparkSession, new Path(tableId.table))
+      } else {
+        if (
+          (catalog.tableExists(tableId) &&
+            catalog.getTableMetadata(tableId).tableType == CatalogTableType.VIEW) ||
+          catalog.isTempView(ur.multipartIdentifier)) {
+          // If table exists and not found to be a view, throw not supported error
+          throw DeltaErrors.notADeltaTableException("RESTORE")
+        } else {
+          ur.failAnalysis(s"Table not found: " +
+            s"${ur.multipartIdentifier.map(quoteIfNeeded).mkString(".")}")
+        }
+      }
+
+      val identifier = deltaTableV2.getTableIdentifierIfExists.map(
+        id => Identifier.of(id.database.toArray, id.table))
+      val sourceRelation = DataSourceV2Relation.create(deltaTableV2, None, identifier)
+      return RestoreTableStatement(
+        TimeTravel(
+          sourceRelation,
+          tt.timestamp,
+          tt.version,
+          tt.creationSource))
+  }
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/RestoreTableSQLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/RestoreTableSQLSuite.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.{AnalysisException, DataFrame}
+
+/** Restore tests using the SQL. */
+class RestoreTableSQLSuite extends RestoreTableSuiteBase {
+
+  override def restoreTableToVersion(
+      tblId: String,
+      version: Int,
+      isTable: Boolean,
+      expectNoOp: Boolean = false): DataFrame = {
+    val identifier = if (isTable) {
+      tblId
+    } else {
+      s"delta.`$tblId`"
+    }
+    spark.sql(s"RESTORE TABLE $identifier VERSION AS OF ${version}")
+  }
+
+  override def restoreTableToTimestamp(
+      tblId: String,
+      timestamp: String,
+      isTable: Boolean,
+      expectNoOp: Boolean = false): DataFrame = {
+    val identifier = if (isTable) {
+      tblId
+    } else {
+      s"delta.`$tblId`"
+    }
+    spark.sql(s"RESTORE $identifier TO TIMESTAMP AS OF '${timestamp}'")
+  }
+
+  test("restoring a table that doesn't exist") {
+    val ex = intercept[AnalysisException] {
+      sql(s"RESTORE TABLE not_exists VERSION AS OF 0")
+    }
+    assert(ex.getMessage.contains("Table not found"))
+  }
+
+  test("restoring a view") {
+    withTempView("tmp") {
+      sql("CREATE OR REPLACE TEMP VIEW tmp AS SELECT * FROM range(10)")
+      val ex = intercept[AnalysisException] {
+        sql(s"RESTORE tmp TO VERSION AS OF 0")
+      }
+      assert(ex.getMessage.contains("only supported for Delta tables"))
+    }
+  }
+
+  test("restoring a view over a Delta table") {
+    withTable("delta_table") {
+      withView("tmp") {
+        sql("CREATE TABLE delta_table USING delta AS SELECT * FROM range(10)")
+        sql("CREATE VIEW tmp AS SELECT * FROM delta_table")
+        val ex = intercept[AnalysisException] {
+          sql(s"RESTORE TABLE tmp VERSION AS OF 0")
+        }
+        assert(ex.getMessage.contains("only supported for Delta tables"))
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds RESTORE SQL syntax and handling the parsed SQL command to execute the RESTORE using the existing `RestoreTableCommand`.

```
RESTORE [TABLE] <tableIdentifier> TO VERSION AS OF <versionId>
ex: RESTORE TABLE delta.`s3://bucket/table/deltatabl1` TO VERSION AS OF 20

RESTORE [TABLE] <tableIdentifier> TO TIMESTAMP AS OF <timestamp string>
RESTORE TABLE delta.`s3://bucket/table/deltatabl1` TO TIMESTAMP AS OF '2021-11-18'
```

This PR also refactors the `RestoreTableCommand` to take `DeltaTableV2` with time travel info and both SQL and Scala API to use the same method i.e construct `DeltaTableV2` and pass it to `RestoreTableCommand`.

Also adds a test suite.

This closes https://github.com/delta-io/delta/issues/891

GitOrigin-RevId: 85d85a3f964efe3c2c06de00c7c52d27b349f559