### PR TITLE
Add config to set snapshot cache storage level

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit
 
 import org.apache.spark.internal.config.ConfigBuilder
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.storage.StorageLevel
 
 /**
  * [[SQLConf]] entries for Delta features.
@@ -108,6 +109,13 @@ trait DeltaSQLConfBase {
       .intConf
       .checkValue(n => n >= 0, "must not be negative.")
       .createWithDefault(2)
+
+  val DELTA_SNAPSHOT_CACHE_STORAGE_LEVEL =
+    buildConf("snapshotCache.storageLevel")
+      .internal()
+      .doc("The cache StorageLevel to use for caching the DeltaLog Snapshot")
+      .stringConf
+      .createWithDefault("MEMORY_AND_DISK_SER")
 
   val DELTA_PARTITION_COLUMN_CHECK_ENABLED =
     buildConf("partitionColumnValidity.enabled")

--- a/core/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
@@ -26,6 +26,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkException
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
+import org.apache.spark.storage.StorageLevel
 
 class SnapshotManagementSuite extends QueryTest with SQLTestUtils with SharedSparkSession {
 
@@ -302,6 +303,41 @@ class SnapshotManagementSuite extends QueryTest with SQLTestUtils with SharedSpa
         versions = Array(3, 2, 1),
         expectedStartVersion = None,
         expectedEndVersion = None)
+    }
+  }
+
+  test("configurable snapshot cache storage level") {
+    withTempDir { tempDir =>
+      val path = tempDir.getCanonicalPath
+      spark.range(10).write.format("delta").save(path)
+      DeltaLog.clearCache()
+      assert(sparkContext.getPersistentRDDs.isEmpty)
+
+      withSQLConf(DeltaSQLConf.DELTA_SNAPSHOT_CACHE_STORAGE_LEVEL.key -> "DISK_ONLY") {
+        spark.read.format("delta").load(path)
+        val persistedRDDs = sparkContext.getPersistentRDDs
+        assert(persistedRDDs.size == 1)
+        assert(persistedRDDs.values.head.getStorageLevel == StorageLevel.DISK_ONLY)
+      }
+
+      DeltaLog.clearCache()
+      assert(sparkContext.getPersistentRDDs.isEmpty)
+
+      withSQLConf(DeltaSQLConf.DELTA_SNAPSHOT_CACHE_STORAGE_LEVEL.key -> "NONE") {
+        spark.read.format("delta").load(path)
+        val persistedRDDs = sparkContext.getPersistentRDDs
+        assert(persistedRDDs.size == 1)
+        assert(persistedRDDs.values.head.getStorageLevel == StorageLevel.NONE)
+      }
+
+      DeltaLog.clearCache()
+      assert(sparkContext.getPersistentRDDs.isEmpty)
+
+      withSQLConf(DeltaSQLConf.DELTA_SNAPSHOT_CACHE_STORAGE_LEVEL.key -> "invalid") {
+        intercept[IllegalArgumentException] {
+          spark.read.format("delta").load(path)
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Resolves #999 

Adds a config to set the storage level for snapshot caching. Current behavior remains the same, but offers the ability to choose the storage level for a session. This benefits streaming workloads that don't benefit from the snapshot being cached, and offers to ways to improve dynamic allocation:
- Set the storage level to disk only, and then you can use the serve cache from shuffle service mechanism to still have the data cached but be able to deallocate the executors
- Set the storage level to none to just disable caching of the snapshot

Question: should storage level of NONE be treated differently, or just go through the same persist path?