### PR TITLE
Add test infra for running selected column mapping tests

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta
 
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest}
 
 import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.analysis.{Analyzer, ResolveSessionCatalog}
@@ -331,3 +331,11 @@ class MergeIntoSQLSuite extends MergeIntoSuiteBase  with DeltaSQLCommandTest
 class MergeIntoSQLNameColumnMappingSuite extends MergeIntoSQLSuite
   with DeltaColumnMappingEnableNameMode
   with DeltaColumnMappingTestUtils
+  with DeltaColumnMappingSelectedTestMixin {
+
+  override protected def columnMappingMode: String = NameMapping.name
+
+  override protected def runOnlyTests: Seq[String] =
+    Seq("schema evolution - new nested column with update non-* and insert * - " +
+      "array of struct - longer target")
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/test/DeltaColumnMappingSelectedTestMixin.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/test/DeltaColumnMappingSelectedTestMixin.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.test
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.delta.{DeltaConfigs, NoMapping}
+import org.scalactic.source.Position
+import org.scalatest.Tag
+import org.scalatest.exceptions.TestFailedException
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.test.SQLTestUtils
+
+/**
+ * A trait for selective enabling certain tests to run for column mapping modes
+ */
+trait DeltaColumnMappingSelectedTestMixin extends SparkFunSuite with SQLTestUtils {
+
+  protected def runOnlyTests: Seq[String] = Seq()
+
+  protected def columnMappingMode: String = NoMapping.name
+
+  private val testsRun: mutable.Set[String] = mutable.Set.empty
+
+  override protected def test(
+      testName: String,
+      testTags: Tag*)(testFun: => Any)(implicit pos: Position): Unit = {
+    if (runOnlyTests.contains(testName)) {
+      super.test(s"$testName - column mapping $columnMappingMode mode", testTags: _*) {
+        testsRun.add(testName)
+        withSQLConf(
+          DeltaConfigs.COLUMN_MAPPING_MODE.defaultTablePropertyKey -> columnMappingMode) {
+          testFun
+        }
+      }
+    } else {
+      super.ignore(s"$testName - ignored by DeltaColumnMappingSelectedTestMixin")(testFun)
+    }
+  }
+
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+    val missingTests = runOnlyTests.toSet diff testsRun
+    if (missingTests.nonEmpty) {
+      throw new TestFailedException(
+        Some("Not all selected column mapping tests were run. Missing: " +
+          missingTests.mkString(", ")), None, 0)
+    }
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implementing the test infra for selecting column mapping tests so we won't overwhelm the test runners.

Enabled one `MergeIntoSQLSuite` test to demonstrate the effect.

## How was this patch tested?

The tests are automatically run.

GitOrigin-RevId: 81427d90936f03647170cd4703f102d1ec49728b