### PR TITLE
Add selected column mapping tests

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
@@ -63,3 +63,17 @@ class DeleteSQLSuite extends DeleteSuiteBase  with DeltaSQLCommandTest {
   }
 }
 
+
+class DeleteSQLNameColumnMappingSuite extends DeleteSQLSuite
+  with DeltaColumnMappingEnableNameMode {
+
+
+  protected override def runOnlyTests: Seq[String] = Seq(true, false).map { isPartitioned =>
+    s"basic case - delete from a Delta table by name - Partition=$isPartitioned"
+  } ++ Seq(true, false).flatMap { isPartitioned =>
+    Seq(
+      s"where key columns - Partition=$isPartitioned",
+      s"where data columns - Partition=$isPartitioned")
+  }
+
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
@@ -22,7 +22,7 @@ import java.io.File
 import org.apache.spark.sql.delta.DeltaConfigs.CHECKPOINT_INTERVAL
 import org.apache.spark.sql.delta.actions.Metadata
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest}
 
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -1630,3 +1630,18 @@ class DeltaAlterTableByNameSuite
 
 class DeltaAlterTableByPathSuite extends DeltaAlterTableByPathTests with DeltaSQLCommandTest
 
+
+trait DeltaAlterTableColumnMappingSelectedTests extends DeltaColumnMappingSelectedTestMixin {
+  override protected def runOnlyTests = Seq(
+    "ADD COLUMNS into complex types - Array",
+    "CHANGE COLUMN - move to first (nested)",
+    "CHANGE COLUMN - case insensitive")
+}
+
+class DeltaAlterTableByNameNameColumnMappingSuite extends DeltaAlterTableByNameSuite
+  with DeltaColumnMappingEnableNameMode
+  with DeltaAlterTableColumnMappingSelectedTests
+
+class DeltaAlterTableByPathNameColumnMappingSuite extends DeltaAlterTableByPathSuite
+  with DeltaColumnMappingEnableNameMode
+  with DeltaAlterTableColumnMappingSelectedTests

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaCheckpointV2Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaCheckpointV2Suite.scala
@@ -324,3 +324,12 @@ class DeltaCheckpointV2Suite
   }
 }
 
+
+class DeltaCheckpointV2NameColumnMappingSuite extends DeltaCheckpointV2Suite
+  with DeltaColumnMappingEnableNameMode {
+
+  override protected def runOnlyTests = Seq(
+    "unpartitioned table",
+    "partitioned table"
+  )
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingTestUtils.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingTestUtils.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.delta
 import java.io.File
 
 import org.apache.spark.sql.delta.schema.SchemaUtils
+import org.apache.spark.sql.delta.test.DeltaColumnMappingSelectedTestMixin
 import io.delta.tables.{DeltaTable => OSSDeltaTable}
 import org.apache.hadoop.fs.Path
 
@@ -375,10 +376,13 @@ trait DeltaColumnMappingEnableIdMode extends SharedSparkSession
  * Include this trait to enable Name column mapping mode for a suite
  */
 trait DeltaColumnMappingEnableNameMode extends SharedSparkSession
-  with DeltaColumnMappingTestUtils {
+  with DeltaColumnMappingTestUtils
+  with DeltaColumnMappingSelectedTestMixin {
+
+  protected override def columnMappingMode: String = NameMapping.name
 
   protected override def sparkConf: SparkConf =
-    super.sparkConf.set(DeltaConfigs.COLUMN_MAPPING_MODE.defaultTablePropertyKey, "name")
+    super.sparkConf.set(DeltaConfigs.COLUMN_MAPPING_MODE.defaultTablePropertyKey, columnMappingMode)
 
   /**
    * CONVERT TO DELTA can be possible under name mode in tests

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaDDLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaDDLSuite.scala
@@ -81,6 +81,15 @@ class DeltaDDLSuite extends DeltaDDLTestBase with SharedSparkSession  with Delta
 }
 
 
+class DeltaDDLNameColumnMappingSuite extends DeltaDDLSuite
+  with DeltaColumnMappingEnableNameMode {
+
+  override protected def runOnlyTests = Seq(
+    "create table with NOT NULL - check violation through file writing",
+    "ALTER TABLE CHANGE COLUMN with nullability change in struct type - relaxed"
+  )
+}
+
 
 abstract class DeltaDDLTestBase extends QueryTest with SQLTestUtils {
   import testImplicits._

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaDDLUsingPathSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaDDLUsingPathSuite.scala
@@ -148,3 +148,12 @@ class DeltaDDLUsingPathSuite extends DeltaDDLUsingPathTests with DeltaSQLCommand
 }
 
 
+class DeltaDDLUsingPathNameColumnMappingSuite extends DeltaDDLUsingPathSuite
+  with DeltaColumnMappingEnableNameMode {
+
+  override protected def runOnlyTests = Seq(
+    "create table with NOT NULL - check violation through file writing",
+    "ALTER TABLE CHANGE COLUMN with nullability change in struct type - relaxed"
+  )
+}
+

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameWriterV2Suite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameWriterV2Suite.scala
@@ -684,3 +684,20 @@ class DeltaDataFrameWriterV2Suite
   }
 }
 
+
+class DeltaDataFrameWriterV2NameColumnMappingSuite extends DeltaDataFrameWriterV2Suite
+  with DeltaColumnMappingEnableNameMode {
+
+  override protected def getProperties(table: Table): Map[String, String] = {
+    // ignore column mapping configurations
+    dropColumnMappingConfigurations(super.getProperties(table))
+  }
+
+  override protected def runOnlyTests = Seq(
+    "Append: basic append",
+    "Create: with using",
+    "Overwrite: overwrite by expression: true",
+    "Replace: partitioned table"
+  )
+
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTableSuite.scala
@@ -23,7 +23,7 @@ import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest}
 import org.scalatest.BeforeAndAfter
 
 import org.apache.spark.{SparkConf, SparkException}
@@ -166,6 +166,33 @@ class DeltaInsertIntoDataFrameByPathSuite
   }
 }
 
+
+trait DeltaInsertIntoColumnMappingSelectedTests extends DeltaColumnMappingSelectedTestMixin {
+  override protected def runOnlyTests = Seq(
+    "InsertInto: overwrite - mixed clause reordered - static mode",
+    "InsertInto: overwrite - multiple static partitions - dynamic mode"
+  )
+}
+
+class DeltaInsertIntoSQLNameColumnMappingSuite extends DeltaInsertIntoSQLSuite
+  with DeltaColumnMappingEnableNameMode
+  with DeltaInsertIntoColumnMappingSelectedTests {
+  override protected def runOnlyTests: Seq[String] = super.runOnlyTests :+
+    "insert overwrite should work with selecting constants"
+}
+
+class DeltaInsertIntoSQLByPathNameColumnMappingSuite extends DeltaInsertIntoSQLByPathSuite
+  with DeltaColumnMappingEnableNameMode
+  with DeltaInsertIntoColumnMappingSelectedTests
+
+class DeltaInsertIntoDataFrameNameColumnMappingSuite extends DeltaInsertIntoDataFrameSuite
+  with DeltaColumnMappingEnableNameMode
+  with DeltaInsertIntoColumnMappingSelectedTests
+
+class DeltaInsertIntoDataFrameByPathNameColumnMappingSuite
+  extends DeltaInsertIntoDataFrameByPathSuite
+    with DeltaColumnMappingEnableNameMode
+    with DeltaInsertIntoColumnMappingSelectedTests
 
 abstract class DeltaInsertIntoTestsWithTempViews(
     supportsDynamicOverwrite: Boolean,

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
@@ -21,6 +21,7 @@ import java.util.Locale
 
 import org.apache.spark.sql.delta.actions.CommitInfo
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.commons.io.FileUtils
 import org.scalatest.time.SpanSugar._
 
@@ -548,5 +549,18 @@ class DeltaSinkSuite extends StreamTest with DeltaColumnMappingTestUtils {
       }
     }
   }
+}
+
+
+class DeltaSinkNameColumnMappingSuite extends DeltaSinkSuite
+  with DeltaColumnMappingEnableNameMode {
+
+  override protected def runOnlyTests = Seq(
+    "append mode",
+    "complete mode",
+    "partitioned writing and batch reading",
+    "work with aggregation + watermark"
+  )
+
 }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -108,7 +108,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase with DeltaSQLCommandTest {
     }
   }
 
-  test("allow to change schema before staring a streaming query") {
+  test("allow to change schema before starting a streaming query") {
     withTempDir { inputDir =>
       val deltaLog = DeltaLog.forTable(spark, new Path(inputDir.toURI))
       (0 until 5).foreach { i =>
@@ -1718,6 +1718,18 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase with DeltaSQLCommandTest {
 
 }
 
+
+class DeltaSourceNameColumnMappingSuite extends DeltaSourceSuite
+  with DeltaColumnMappingEnableNameMode {
+
+  override protected def runOnlyTests = Seq(
+    "basic",
+    "maxBytesPerTrigger: metadata checkpoint",
+    "maxFilesPerTrigger: metadata checkpoint",
+    "allow to change schema before starting a streaming query"
+  )
+
+}
 
 /**
  * A FileSystem implementation that returns monotonically increasing timestamps for file creation.

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -1679,3 +1679,17 @@ class DeltaSuite extends QueryTest
   }
 }
 
+
+class DeltaNameColumnMappingSuite extends DeltaSuite
+  with DeltaColumnMappingEnableNameMode {
+
+  override protected def runOnlyTests = Seq(
+    "handle partition filters and data filters",
+    "query with predicates should skip partitions",
+    "valid replaceWhere",
+    "batch write: append, overwrite where",
+    "get touched files for update, delete and merge",
+    "isBlindAppend with save and saveAsTable"
+  )
+
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
@@ -1989,3 +1989,29 @@ class DeltaTableCreationSuite
   }
 }
 
+
+class DeltaTableCreationNameColumnMappingSuite extends DeltaTableCreationSuite
+  with DeltaColumnMappingEnableNameMode {
+
+  override protected def getTableProperties(tableName: String): Map[String, String] = {
+    // ignore comparing column mapping properties
+    dropColumnMappingConfigurations(super.getTableProperties(tableName))
+  }
+
+  override protected def runOnlyTests: Seq[String] = Seq(
+    "create table with schema and path",
+    "create external table without schema",
+    "REPLACE TABLE",
+    "CREATE OR REPLACE TABLE on non-empty directory"
+  ) ++ Seq("partitioned" -> Seq("v2"), "non-partitioned" -> Nil)
+    .flatMap { case (isPartitioned, cols) =>
+      SaveMode.values().flatMap { saveMode =>
+        Seq(
+          s"saveAsTable to a new table (managed) - $isPartitioned, saveMode: $saveMode",
+          s"saveAsTable to a new table (external) - $isPartitioned, saveMode: $saveMode")
+      }
+    } ++ Seq("a b", "a:b", "a%b").map { specialChars =>
+      s"location uri contains $specialChars for datasource table"
+    }
+
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta
 
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest}
 
 import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.analysis.{Analyzer, ResolveSessionCatalog}
@@ -329,5 +329,11 @@ class MergeIntoSQLSuite extends MergeIntoSuiteBase  with DeltaSQLCommandTest
 
 
 class MergeIntoSQLNameColumnMappingSuite extends MergeIntoSQLSuite
-  with DeltaColumnMappingEnableNameMode
-  with DeltaColumnMappingTestUtils
+  with DeltaColumnMappingEnableNameMode {
+
+  override protected def columnMappingMode: String = NameMapping.name
+
+  override protected def runOnlyTests: Seq[String] =
+    Seq("schema evolution - new nested column with update non-* and insert * - " +
+      "array of struct - longer target")
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeCompactionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeCompactionSuite.scala
@@ -35,7 +35,8 @@ import org.apache.spark.sql.test.SharedSparkSession
  * Base class containing tests for Delta table Optimize (file compaction)
  */
 trait OptimizeCompactionSuiteBase extends QueryTest
-  with SharedSparkSession {
+  with SharedSparkSession
+  with DeltaColumnMappingTestUtils {
 
   import testImplicits._
 
@@ -115,9 +116,11 @@ trait OptimizeCompactionSuiteBase extends QueryTest
       val fileListBefore = txnBefore.filterFiles();
       val versionBefore = deltaLogBefore.snapshot.version
 
+      val id = "id".phy(deltaLogBefore)
+
       // Expect each partition have more than one file
       (0 to 1).foreach(partId =>
-        assert(fileListBefore.count(_.partitionValues === Map("id" -> partId.toString)) > 1))
+        assert(fileListBefore.count(_.partitionValues === Map(id -> partId.toString)) > 1))
 
       spark.sql(s"OPTIMIZE '$path'")
 
@@ -126,7 +129,7 @@ trait OptimizeCompactionSuiteBase extends QueryTest
       val fileListAfter = txnAfter.filterFiles();
 
       (0 to 1).foreach(partId =>
-        assert(fileListAfter.count(_.partitionValues === Map("id" -> partId.toString)) === 1))
+        assert(fileListAfter.count(_.partitionValues === Map(id -> partId.toString)) === 1))
 
       // version is incremented
       assert(deltaLogAfter.snapshot.version === versionBefore + 1)
@@ -156,8 +159,10 @@ trait OptimizeCompactionSuiteBase extends QueryTest
       val txnBefore = deltaLogBefore.startTransaction();
       val fileListBefore = txnBefore.filterFiles()
 
+      val id = "id".phy(deltaLogBefore)
+
       assert(fileListBefore.length >= 3)
-      assert(fileListBefore.count(_.partitionValues === Map("id" -> "0")) > 1)
+      assert(fileListBefore.count(_.partitionValues === Map(id -> "0")) > 1)
 
       val versionBefore = deltaLogBefore.snapshot.version
       spark.sql(s"OPTIMIZE '$path' WHERE id = 0")
@@ -167,12 +172,13 @@ trait OptimizeCompactionSuiteBase extends QueryTest
       val fileListAfter = txnAfter.filterFiles()
 
       assert(fileListBefore.length > fileListAfter.length)
+
       // Optimized partition should contain only one file
-      assert(fileListAfter.count(_.partitionValues === Map("id" -> "0")) === 1)
+      assert(fileListAfter.count(_.partitionValues === Map(id -> "0")) === 1)
 
       // File counts in partitions that are not part of the OPTIMIZE should remain the same
-      assert(fileListAfter.count(_.partitionValues === Map("id" -> "1")) ===
-                 fileListAfter.count(_.partitionValues === Map("id" -> "1")))
+      assert(fileListAfter.count(_.partitionValues === Map(id -> "1")) ===
+                 fileListAfter.count(_.partitionValues === Map(id -> "1")))
 
       // version is incremented
       assert(deltaLogAfter.snapshot.version === versionBefore + 1)
@@ -202,15 +208,18 @@ trait OptimizeCompactionSuiteBase extends QueryTest
       val fileListBefore = txnBefore.filterFiles()
       val versionBefore = deltaLogBefore.snapshot.version
 
-      val filesInEachPartitionBefore =
-        fileListBefore.groupBy(file => new Path(file.path).getParent.getName)
+      val partitionColumnPhysicalName = partitionColumn.phy(deltaLogBefore)
+
+      // we have only 1 partition here
+      val filesInEachPartitionBefore = groupInputFilesByPartition(
+        fileListBefore.map(_.path).toArray, deltaLogBefore)
 
       // There exist at least one file in each partition
       assert(filesInEachPartitionBefore.forall(_._2.length > 1))
 
       // And there is a partition for null values
       assert(filesInEachPartitionBefore.keys.exists(
-        _ === s"part=${ExternalCatalogUtils.DEFAULT_PARTITION_NAME}"))
+        _ === (partitionColumnPhysicalName, nullPartitionValue)))
 
       spark.sql(s"OPTIMIZE '$path'")
 
@@ -223,7 +232,7 @@ trait OptimizeCompactionSuiteBase extends QueryTest
 
       // Optimized partition should contain only one file in null partition
       assert(fileListAfter.count(
-        _.partitionValues === Map[String, String](partitionColumn -> null)) === 1)
+        _.partitionValues === Map[String, String](partitionColumnPhysicalName -> null)) === 1)
 
       // version is incremented
       assert(deltaLogAfter.snapshot.version === versionBefore + 1)
@@ -252,8 +261,12 @@ trait OptimizeCompactionSuiteBase extends QueryTest
       val txnBefore = deltaLogBefore.startTransaction();
       val fileListBefore = txnBefore.filterFiles()
       val versionBefore = deltaLogBefore.snapshot.version
+
+      val date = "date".phy(deltaLogBefore)
+      val part = "part".phy(deltaLogBefore)
+
       val fileCountInTestPartitionBefore = fileListBefore
-          .count(_.partitionValues === Map[String, String]("date" -> "2017-10-10", "part" -> "3"))
+          .count(_.partitionValues === Map[String, String](date -> "2017-10-10", part -> "3"))
 
       spark.sql(s"OPTIMIZE '$path' WHERE date = '2017-10-10' and part = 3")
 
@@ -267,7 +280,7 @@ trait OptimizeCompactionSuiteBase extends QueryTest
       // Optimized partition should contain only one file in null partition and less number
       // of files than before optimize
       val fileCountInTestPartitionAfter = fileListAfter
-          .count(_.partitionValues === Map[String, String]("date" -> "2017-10-10", "part" -> "3"))
+          .count(_.partitionValues === Map[String, String](date -> "2017-10-10", part -> "3"))
       assert(fileCountInTestPartitionAfter === 1L)
       assert(fileCountInTestPartitionBefore > fileCountInTestPartitionAfter,
              "Expected the partition to count less number of files after optimzie.")
@@ -352,3 +365,11 @@ trait OptimizeCompactionSuiteBase extends QueryTest
 class OptimizeCompactionSuite extends OptimizeCompactionSuiteBase
   with DeltaSQLCommandTest
 
+
+class OptimizeCompactionNameColumnMappingSuite extends OptimizeCompactionSuite
+  with DeltaColumnMappingEnableNameMode {
+  override protected def runOnlyTests = Seq(
+    "optimize command: on table with multiple partition columns",
+    "optimize command: on null partition columns"
+  )
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
@@ -334,3 +334,13 @@ class StatsCollectionSuite
   }
 }
 
+
+class StatsCollectionNameColumnMappingSuite extends StatsCollectionSuite
+  with DeltaColumnMappingEnableNameMode {
+
+  override protected def runOnlyTests = Seq(
+    "on write",
+    "recompute stats with partition predicates"
+  )
+}
+

--- a/core/src/test/scala/org/apache/spark/sql/delta/test/DeltaColumnMappingSelectedTestMixin.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/test/DeltaColumnMappingSelectedTestMixin.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.test
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.delta.{DeltaConfigs, NoMapping}
+import org.scalactic.source.Position
+import org.scalatest.Tag
+import org.scalatest.exceptions.TestFailedException
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.test.SQLTestUtils
+
+/**
+ * A trait for selective enabling certain tests to run for column mapping modes
+ */
+trait DeltaColumnMappingSelectedTestMixin extends SparkFunSuite with SQLTestUtils {
+
+  protected def runOnlyTests: Seq[String] = Seq()
+
+  protected def columnMappingMode: String = NoMapping.name
+
+  private val testsRun: mutable.Set[String] = mutable.Set.empty
+
+  override protected def test(
+      testName: String,
+      testTags: Tag*)(testFun: => Any)(implicit pos: Position): Unit = {
+    if (runOnlyTests.contains(testName)) {
+      super.test(s"$testName - column mapping $columnMappingMode mode", testTags: _*) {
+        testsRun.add(testName)
+        withSQLConf(
+          DeltaConfigs.COLUMN_MAPPING_MODE.defaultTablePropertyKey -> columnMappingMode) {
+          testFun
+        }
+      }
+    } else {
+      super.ignore(s"$testName - ignored by DeltaColumnMappingSelectedTestMixin")(testFun)
+    }
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    val missingTests = runOnlyTests.toSet diff testsRun
+    if (missingTests.nonEmpty) {
+      throw new TestFailedException(
+        Some("Not all selected column mapping tests were run. Missing: " +
+          missingTests.mkString(", ")), None, 0)
+    }
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add selected name mode column mapping tests within critical suites to ensure test coverage.

Covers:
- DDLs: Merge, Insert, DELETE
- Schema evolution
- Checkpointing
- Restore
- Delta as stream source & sink
- Table creation & altering

## How was this patch tested?

Tests are automatically run under column mapping modes.

GitOrigin-RevId: 09771dbad41da4107a36b9d301dc7b318fd5f43a