### PR TITLE
Fix python integration tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -169,7 +169,7 @@ lazy val storage = (project in file("storage"))
   .settings (
     name := "delta-storage",
     commonSettings,
-    releaseSettings,
+    releaseSettings, // TODO: proper artifact name
     libraryDependencies ++= Seq(
       // User can provide any 2.x or 3.x version. We don't use any new fancy APIs. Watch out for
       // versions with known vulnerabilities.
@@ -187,10 +187,9 @@ lazy val storageDynamodb = (project in file("storage-dynamodb"))
   .settings (
     name := "delta-storage-dynamodb",
     commonSettings,
-    skipReleaseSettings, // comment when running integration tests
-    // releaseSettings, // uncomment when running integration tests
+    releaseSettings, // TODO: proper artifact name
     libraryDependencies ++= Seq(
-      "com.amazonaws" % "aws-java-sdk" % "1.7.4"
+      "com.amazonaws" % "aws-java-sdk" % "1.7.4" // TODO: mark as provided?
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -187,8 +187,8 @@ lazy val storageDynamodb = (project in file("storage-dynamodb"))
   .settings (
     name := "delta-storage-dynamodb",
     commonSettings,
-    skipReleaseSettings,
-    // releaseSettings,
+    skipReleaseSettings, // comment when running integration tests
+    // releaseSettings, // uncomment when running integration tests
     libraryDependencies ++= Seq(
       "com.amazonaws" % "aws-java-sdk" % "1.7.4"
     )

--- a/examples/python/dynamodb_logstore.py
+++ b/examples/python/dynamodb_logstore.py
@@ -53,7 +53,7 @@ TODO: update this comment with proper delta-storage artifact ID (i.e. no _2.12 s
   --python-only \
   --conf spark.jars.ivySettings=/workspace/ivy.settings \
          spark.driver.extraJavaOptions=-Dlog4j.configuration=file:debug/log4j.properties \
-  --packages io.delta:delta-storage_2.12:${VERSION},org.apache.hadoop:hadoop-aws:3.3.1,com.amazonaws:aws-java-sdk-bundle:1.12.142
+  --packages io.delta:delta-storage-dynamodb_2.12:${VERSION},org.apache.hadoop:hadoop-aws:3.3.1,com.amazonaws:aws-java-sdk-bundle:1.12.142
 """
 
 # conf

--- a/examples/python/dynamodb_logstore.py
+++ b/examples/python/dynamodb_logstore.py
@@ -43,14 +43,17 @@ export DELTA_CONCURRENT_WRITERS=2
 export DELTA_CONCURRENT_READERS=2
 export DELTA_TABLE_PATH=s3a://test-bucket/delta-test/
 export DELTA_DYNAMO_TABLE=delta_log_test
-export DELTA_STORAGE=io.delta.storage.DynamoDBLogStore
+export DELTA_STORAGE=io.delta.storage.DynamoDBLogStoreScala # TODO: remove `Scala` when Java version finished
 export DELTA_NUM_ROWS=16
+
+TODO: update this comment with proper delta-storage artifact ID (i.e. no _2.12 scala version)
+
 ./run-integration-tests.py \
   --test dynamodb_logstore.py \
   --python-only \
   --conf spark.jars.ivySettings=/workspace/ivy.settings \
          spark.driver.extraJavaOptions=-Dlog4j.configuration=file:debug/log4j.properties \
-  --packages io.delta:delta-contribs_2.12:${VERSION},org.apache.hadoop:hadoop-aws:3.3.1,com.amazonaws:aws-java-sdk-bundle:1.12.142
+  --packages io.delta:delta-storage_2.12:${VERSION},org.apache.hadoop:hadoop-aws:3.3.1,com.amazonaws:aws-java-sdk-bundle:1.12.142
 """
 
 # conf
@@ -59,7 +62,8 @@ concurrent_writers = int(os.environ.get("DELTA_CONCURRENT_WRITERS", 2))
 concurrent_readers = int(os.environ.get("DELTA_CONCURRENT_READERS", 2))
 num_rows = int(os.environ.get("DELTA_NUM_ROWS", 32))
 
-delta_storage = os.environ.get("DELTA_STORAGE", "io.delta.storage.DynamoDBLogStore")
+# TODO change back to default io.delta.storage.DynamoDBLogStore
+delta_storage = os.environ.get("DELTA_STORAGE", "io.delta.storage.DynamoDBLogStoreScala")
 dynamo_table_name = os.environ.get("DELTA_DYNAMO_TABLE", "delta_log_test")
 dynamo_region = os.environ.get("DELTA_DYNAMO_REGION", "us-west-2")
 dynamo_error_rates = os.environ.get("DELTA_DYNAMO_ERROR_RATES", "")
@@ -81,15 +85,17 @@ dynamo table name: {dynamo_table_name}
 """
 print(test_log)
 
+# TODO: update to spark.delta.DynamoDBLogStore.tableName (no `Scala`) when Java version finished
+
 spark = SparkSession \
     .builder \
     .appName("utilities") \
     .master("local[*]") \
     .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
     .config("spark.delta.logStore.class", delta_storage) \
-    .config("spark.delta.DynamoDBLogStore.tableName", dynamo_table_name) \
-    .config("spark.delta.DynamoDBLogStore.region", dynamo_region) \
-    .config("spark.delta.DynamoDBLogStore.errorRates", dynamo_error_rates) \
+    .config("spark.delta.DynamoDBLogStoreScala.tableName", dynamo_table_name) \
+    .config("spark.delta.DynamoDBLogStoreScala.region", dynamo_region) \
+    .config("spark.delta.DynamoDBLogStoreScala.errorRates", dynamo_error_rates) \
     .getOrCreate()
 
 data = spark.createDataFrame([], "id: int, a: int")

--- a/run-integration-tests.py
+++ b/run-integration-tests.py
@@ -60,6 +60,7 @@ def run_scala_integration_tests(root_dir, version, test_name, extra_maven_repo, 
 def run_python_integration_tests(root_dir, version, test_name, extra_maven_repo, extra_packages, jars, conf):
     print("\n\n##### Running Python tests on version %s #####" % str(version))
     clear_artifact_cache()
+    run_cmd(["build/sbt", "publishM2"])
     test_dir = path.join(root_dir, path.join("examples", "python"))
     files_to_skip = {"using_with_pip.py"}
 
@@ -90,10 +91,12 @@ def run_python_integration_tests(root_dir, version, test_name, extra_maven_repo,
             cmd = ["spark-submit",
                    "--driver-class-path=%s" % extra_class_path,  # for less verbose logging
                    "--packages", package,
-                   *jars,
-                   "--repositories", repo] + conf_args + [test_file]
+                   *jars] + conf_args + [test_file]
+            if repo:
+                cmd = cmd + ["--repositories", repo]
+
             print("\nRunning Python tests in %s\n=============" % test_file)
-            print("Command: %s" % str(cmd))
+            print("Command: %s" % " ".join(cmd))
             run_cmd(cmd, stream_output=True)
         except:
             print("Failed Python tests in %s" % (test_file))

--- a/run-integration-tests.py
+++ b/run-integration-tests.py
@@ -76,8 +76,8 @@ def run_python_integration_tests(root_dir, version, test_name, extra_maven_repo,
         package += "," + extra_packages
 
     jars = jars and ["--jars", jars] or []
+    repos = extra_maven_repo and ["--repositories", extra_maven_repo] or []
 
-    repo = extra_maven_repo if extra_maven_repo else ""
     conf_args = []
     if conf:
         for i in conf:
@@ -91,9 +91,7 @@ def run_python_integration_tests(root_dir, version, test_name, extra_maven_repo,
             cmd = ["spark-submit",
                    "--driver-class-path=%s" % extra_class_path,  # for less verbose logging
                    "--packages", package,
-                   *jars] + conf_args + [test_file]
-            if repo:
-                cmd = cmd + ["--repositories", repo]
+                   *jars] + repos + conf_args + [test_file]
 
             print("\nRunning Python tests in %s\n=============" % test_file)
             print("Command: %s" % " ".join(cmd))


### PR DESCRIPTION
In the last few commits of the core scala DynamoDBLogStore work, we a) refactored from contribs to storage-dynamodb artifact, and also renamed `DynamoDBLogStore.scala` to `DynamoDBLogStoreScala.scala`

This PR updates the integration tests to work with those latest changes.