### PR TITLE
Refactor DynamoDB Logstore integration tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -187,10 +187,11 @@ lazy val storageDynamodb = (project in file("storage-dynamodb"))
   .settings (
     name := "delta-storage-dynamodb",
     commonSettings,
-    skipReleaseSettings,
-    // releaseSettings,
+//    skipReleaseSettings,
+     releaseSettings,
     libraryDependencies ++= Seq(
-      "com.amazonaws" % "aws-java-sdk" % "1.7.4"
+      "com.amazonaws" % "aws-java-sdk" % "1.7.4",
+      "org.apache.hadoop" % "hadoop-common" % "3.3.1" % "provided"
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -189,7 +189,7 @@ lazy val storageDynamodb = (project in file("storage-dynamodb"))
     commonSettings,
     releaseSettings, // TODO: proper artifact name
     libraryDependencies ++= Seq(
-      "com.amazonaws" % "aws-java-sdk" % "1.7.4" // TODO: mark as provided?
+      "com.amazonaws" % "aws-java-sdk" % "1.7.4" % "provided"
     )
   )
 

--- a/run-integration-tests.py
+++ b/run-integration-tests.py
@@ -128,7 +128,7 @@ def run_dynamodb_logstore_integration_tests(root_dir, version, test_name, extra_
             print("Command: %s" % " ".join(cmd))
             run_cmd(cmd, stream_output=True)
         except:
-            print("Failed  DynamoDB logstore integration tests tests in %s" % (test_file))
+            print("Failed DynamoDB logstore integration tests tests in %s" % (test_file))
             raise
 
 

--- a/run-integration-tests.py
+++ b/run-integration-tests.py
@@ -105,6 +105,7 @@ def run_dynamodb_logstore_integration_tests(root_dir, version, test_name, extra_
     python_root_dir = path.join(root_dir, "python")
     extra_class_path = path.join(python_root_dir, path.join("delta", "testing"))
     packages = "io.delta:delta-core_2.12:" + version
+    # TODO: update this with proper delta-storage artifact ID (i.e. no _2.12 scala version)
     packages += "," + "io.delta:delta-storage-dynamodb_2.12:" + version
     if extra_packages:
         packages += "," + extra_packages
@@ -282,12 +283,12 @@ if __name__ == "__main__":
         action="store_true",
         help="Run the DynamoDB integration tests (and only them)")
     parser.add_argument(
-        "--packages",
+        "--dbb-packages",
         required=False,
         default=None,
         help="Additional packages required for Dynamodb logstore integration tests")
     parser.add_argument(
-        "--conf",
+        "--dbb-conf",
         required=False,
         default=None,
         nargs="+",
@@ -308,7 +309,7 @@ if __name__ == "__main__":
 
     if args.run_storage_dynamodb_integration_tests:
         run_dynamodb_logstore_integration_tests(
-            root_dir, args.version, args.test, args.maven_repo, args.packages, args.conf
+            root_dir, args.version, args.test, args.maven_repo, args.dbb_packages, args.dbb_conf
         )
         quit()
 

--- a/storage-dynamodb/integration_tests/dynamodb_logstore.py
+++ b/storage-dynamodb/integration_tests/dynamodb_logstore.py
@@ -44,6 +44,7 @@ export DELTA_CONCURRENT_READERS=2
 export DELTA_TABLE_PATH=s3a://test-bucket/delta-test/
 export DELTA_DYNAMO_TABLE=delta_log_test
 export DELTA_DYNAMO_REGION=us-west-2
+export DELTA_STORAGE=io.delta.storage.DynamoDBLogStoreScala # TODO: remove `Scala` when Java version finished
 export DELTA_NUM_ROWS=16
 
 TODO: update this comment with proper delta-storage artifact ID (i.e. no _2.12 scala version)
@@ -62,6 +63,8 @@ concurrent_writers = int(os.environ.get("DELTA_CONCURRENT_WRITERS", 2))
 concurrent_readers = int(os.environ.get("DELTA_CONCURRENT_READERS", 2))
 num_rows = int(os.environ.get("DELTA_NUM_ROWS", 16))
 
+# TODO change back to default io.delta.storage.DynamoDBLogStore
+delta_storage = os.environ.get("DELTA_STORAGE", "io.delta.storage.DynamoDBLogStoreScala")
 dynamo_table_name = os.environ.get("DELTA_DYNAMO_TABLE", "delta_log_test")
 dynamo_region = os.environ.get("DELTA_DYNAMO_REGION", "us-west-2")
 dynamo_error_rates = os.environ.get("DELTA_DYNAMO_ERROR_RATES", "")
@@ -77,6 +80,7 @@ delta table path: {delta_table_path}
 concurrent writers: {concurrent_writers}
 concurrent readers: {concurrent_readers}
 number of rows: {num_rows}
+delta storage: {delta_storage}
 dynamo table name: {dynamo_table_name}
 =====================
 """
@@ -89,7 +93,7 @@ spark = SparkSession \
     .appName("utilities") \
     .master("local[*]") \
     .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
-    .config("spark.delta.logStore.class", "io.delta.storage.DynamoDBLogStoreScala") \
+    .config("spark.delta.logStore.class", delta_storage) \
     .config("spark.delta.DynamoDBLogStoreScala.tableName", dynamo_table_name) \
     .config("spark.delta.DynamoDBLogStoreScala.region", dynamo_region) \
     .config("spark.delta.DynamoDBLogStoreScala.errorRates", dynamo_error_rates) \

--- a/storage-dynamodb/integration_tests/dynamodb_logstore.py
+++ b/storage-dynamodb/integration_tests/dynamodb_logstore.py
@@ -53,12 +53,16 @@ export DELTA_NUM_ROWS=16
   --packages io.delta:delta-contribs_2.12:${VERSION},org.apache.hadoop:hadoop-aws:3.3.1,com.amazonaws:aws-java-sdk-bundle:1.12.142
 """
 
+# TODO: why does the above directions skip DELTA_DYNAMO_REGION
+# what is the error rates?
+
 # conf
 delta_table_path = os.environ.get("DELTA_TABLE_PATH")
 concurrent_writers = int(os.environ.get("DELTA_CONCURRENT_WRITERS", 2))
 concurrent_readers = int(os.environ.get("DELTA_CONCURRENT_READERS", 2))
 num_rows = int(os.environ.get("DELTA_NUM_ROWS", 32))
 
+# TODO: why is this a variable?
 delta_storage = os.environ.get("DELTA_STORAGE", "io.delta.storage.DynamoDBLogStore")
 dynamo_table_name = os.environ.get("DELTA_DYNAMO_TABLE", "delta_log_test")
 dynamo_region = os.environ.get("DELTA_DYNAMO_REGION", "us-west-2")

--- a/storage-dynamodb/integration_tests/dynamodb_logstore.py
+++ b/storage-dynamodb/integration_tests/dynamodb_logstore.py
@@ -60,10 +60,8 @@ export DELTA_NUM_ROWS=16
 delta_table_path = os.environ.get("DELTA_TABLE_PATH")
 concurrent_writers = int(os.environ.get("DELTA_CONCURRENT_WRITERS", 2))
 concurrent_readers = int(os.environ.get("DELTA_CONCURRENT_READERS", 2))
-num_rows = int(os.environ.get("DELTA_NUM_ROWS", 32))
+num_rows = int(os.environ.get("DELTA_NUM_ROWS", 16))
 
-# TODO: why is this a variable?
-delta_storage = os.environ.get("DELTA_STORAGE", "io.delta.storage.DynamoDBLogStore")
 dynamo_table_name = os.environ.get("DELTA_DYNAMO_TABLE", "delta_log_test")
 dynamo_region = os.environ.get("DELTA_DYNAMO_REGION", "us-west-2")
 dynamo_error_rates = os.environ.get("DELTA_DYNAMO_ERROR_RATES", "")
@@ -79,7 +77,6 @@ delta table path: {delta_table_path}
 concurrent writers: {concurrent_writers}
 concurrent readers: {concurrent_readers}
 number of rows: {num_rows}
-delta storage: {delta_storage}
 dynamo table name: {dynamo_table_name}
 =====================
 """
@@ -90,7 +87,7 @@ spark = SparkSession \
     .appName("utilities") \
     .master("local[*]") \
     .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
-    .config("spark.delta.logStore.class", delta_storage) \
+    .config("spark.delta.logStore.class", "io.delta.storage.DynamoDBLogStore") \
     .config("spark.delta.DynamoDBLogStore.tableName", dynamo_table_name) \
     .config("spark.delta.DynamoDBLogStore.region", dynamo_region) \
     .config("spark.delta.DynamoDBLogStore.errorRates", dynamo_error_rates) \

--- a/storage-dynamodb/integration_tests/dynamodb_logstore.py
+++ b/storage-dynamodb/integration_tests/dynamodb_logstore.py
@@ -47,14 +47,10 @@ export DELTA_DYNAMO_REGION=us-west-2
 export DELTA_STORAGE=io.delta.storage.DynamoDBLogStoreScala # TODO: remove `Scala` when Java version finished
 export DELTA_NUM_ROWS=16
 
-TODO: update this comment with proper delta-storage artifact ID (i.e. no _2.12 scala version)
-
-./run-integration-tests.py \
-  --test dynamodb_logstore.py \
-  --python-only \
-  --conf spark.jars.ivySettings=/workspace/ivy.settings \
-         spark.driver.extraJavaOptions=-Dlog4j.configuration=file:debug/log4j.properties \
-  --packages io.delta:delta-storage-dynamodb_2.12:${VERSION},org.apache.hadoop:hadoop-aws:3.3.1,com.amazonaws:aws-java-sdk-bundle:1.12.142
+./run-integration-tests.py --run-storage-dynamodb-integration-tests \
+    --dbb-packages org.apache.hadoop:hadoop-aws:3.3.1,com.amazonaws:aws-java-sdk-bundle:1.12.142 \
+    --dbb-conf spark.jars.ivySettings=/workspace/ivy.settings \
+        spark.driver.extraJavaOptions=-Dlog4j.configuration=file:debug/log4j.properties
 """
 
 # conf

--- a/storage-dynamodb/integration_tests/dynamodb_logstore.py
+++ b/storage-dynamodb/integration_tests/dynamodb_logstore.py
@@ -43,7 +43,7 @@ export DELTA_CONCURRENT_WRITERS=2
 export DELTA_CONCURRENT_READERS=2
 export DELTA_TABLE_PATH=s3a://test-bucket/delta-test/
 export DELTA_DYNAMO_TABLE=delta_log_test
-export DELTA_STORAGE=io.delta.storage.DynamoDBLogStoreScala # TODO: remove `Scala` when Java version finished
+export DELTA_DYNAMO_REGION=us-west-2
 export DELTA_NUM_ROWS=16
 
 TODO: update this comment with proper delta-storage artifact ID (i.e. no _2.12 scala version)
@@ -55,9 +55,6 @@ TODO: update this comment with proper delta-storage artifact ID (i.e. no _2.12 s
          spark.driver.extraJavaOptions=-Dlog4j.configuration=file:debug/log4j.properties \
   --packages io.delta:delta-storage-dynamodb_2.12:${VERSION},org.apache.hadoop:hadoop-aws:3.3.1,com.amazonaws:aws-java-sdk-bundle:1.12.142
 """
-
-# TODO: why does the above directions skip DELTA_DYNAMO_REGION
-# what is the error rates?
 
 # conf
 delta_table_path = os.environ.get("DELTA_TABLE_PATH")


### PR DESCRIPTION
- Refactor `examples/python/dynamodb_logstore.py` into `storage-dynamodb/integration_tests` 
- Move it to a separate test within `run-integration-tests.py`
   - To run the test provide command line argument `--run-storage-dynamodb-integration-tests` (this runs only the DynamoDB logstore test and none of the other integration tests)

- TODO: need to merge #990 into this and adjust code