### PR TITLE
DataSkippingReader - `EqualNullSafe` support

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
@@ -29,11 +29,11 @@ import org.apache.spark.sql.{DataFrame, _}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.Literal.{FalseLiteral, TrueLiteral}
-import org.apache.spark.sql.catalyst.util.{GenericArrayData, TypeUtils}
+import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.execution.InSubqueryExec
 import org.apache.spark.sql.expressions.SparkUserDefinedFunction
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types.{AtomicType, BooleanType, ByteType, CalendarIntervalType, DataType, DateType, DoubleType, FloatType, IntegerType, LongType, NumericType, ShortType, StringType, StructType, TimestampType}
+import org.apache.spark.sql.types.{AtomicType, BooleanType, CalendarIntervalType, DataType, DateType, NumericType, StringType, StructType, TimestampType}
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 
 /**
@@ -416,7 +416,8 @@ trait DataSkippingReaderBase
       constructDataFilters(IsNull(e))
 
     // Match any file whose min/max range contains the requested point.
-    case EqualTo(SkippingEligibleColumn(a), SkippingEligibleLiteral(v)) =>
+    case Equality(SkippingEligibleColumn(a), lit @ SkippingEligibleLiteral(v)) =>
+      assert(lit.value != null)
       val minCol = StatsColumn(MIN, a)
       val maxCol = StatsColumn(MAX, a)
       getStatsColumnOpt(minCol).flatMap { min =>
@@ -426,9 +427,11 @@ trait DataSkippingReaderBase
       }
     case EqualTo(v: Literal, a) =>
       constructDataFilters(EqualTo(a, v))
+    case EqualNullSafe(v: Literal, a) =>
+      constructDataFilters(EqualNullSafe(a, v))
 
     // Match any file whose min/max range contains anything other than the rejected point.
-    case Not(EqualTo(SkippingEligibleColumn(a), SkippingEligibleLiteral(v))) =>
+    case Not(Equality(SkippingEligibleColumn(a), SkippingEligibleLiteral(v))) =>
       val minCol = StatsColumn(MIN, a)
       val maxCol = StatsColumn(MAX, a)
       getStatsColumnOpt(minCol).flatMap { min =>
@@ -438,6 +441,8 @@ trait DataSkippingReaderBase
       }
     case Not(EqualTo(v: Literal, a)) =>
       constructDataFilters(Not(EqualTo(a, v)))
+    case Not(EqualNullSafe(v: Literal, a)) =>
+      constructDataFilters(Not(EqualNullSafe(a, v)))
 
     // Match any file whose min is less than the requested upper bound.
     case LessThan(SkippingEligibleColumn(a), SkippingEligibleLiteral(v)) =>


### PR DESCRIPTION
Resolves  https://github.com/delta-io/delta/pull/974#discussion_r825686186

Add `EqualNullSafe` support

|Expression| Behavior|
| --- | --- |
|`EqualNullSafe(Literal(null, _), a)` | this will be optimized to `IsNull(a)` by rule `NullPropagation` |
|`EqualNullSafe(NonNullLiteral(v, _), _)`| this has the same behavior as `EqualsTo(NonNullLiteral(v, _), _)` |
|`Not(EqualNullSafe(NonNullLiteral(v, _), _))`|this has the same behavior as `Not(EqualsTo(NonNullLiteral(v, _), _))`|
|`Not(EqualNullSafe(Literal(null, _), a))` | this will be optimized to `Not(IsNull(a))` by rule `NullPropagation` and then optimized to `IsNotNull(a)` by rule `BooleanSimplification`|

