### PR TITLE
Add OPTIMIZE operation commit metrics in DeltaLog

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -337,6 +337,7 @@ object DeltaOperations {
     override val parameters: Map[String, Any] = Map(
       "predicate" -> JsonUtils.toJson(predicate)
       )
+    override val operationMetrics: Set[String] = DeltaOperationMetrics.OPTIMIZE
   }
 
 
@@ -430,6 +431,18 @@ private[delta] object DeltaOperationMetrics {
     "executionTimeMs",  // time taken to execute the entire operation
     "scanTimeMs", // time taken to scan the files for matches
     "rewriteTimeMs" // time taken to rewrite the matched files
+  )
+
+  val OPTIMIZE = Set(
+    "numAddedFiles", // number of files added
+    "numRemovedFiles", // number of files removed
+    "numAddedBytes", // number of bytes added by optimize
+    "numRemovedBytes", // number of bytes removed by optimize
+    "minFileSize", // the size of the smallest file
+    "p25FileSize", // the size of the 25th percentile file
+    "p50FileSize", // the median file size
+    "p75FileSize", // the 75th percentile of the file sizes
+    "maxFileSize" // the size of the largest file
   )
 
 }

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -444,5 +444,4 @@ private[delta] object DeltaOperationMetrics {
     "p75FileSize", // the 75th percentile of the file sizes
     "maxFileSize" // the size of the largest file
   )
-
 }

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -25,15 +25,18 @@ import scala.collection.parallel.immutable.ParVector
 import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaOperations, OptimisticTransaction}
 import org.apache.spark.sql.delta.DeltaOperations.Operation
 import org.apache.spark.sql.delta.actions.{Action, AddFile, FileAction, RemoveFile}
-import org.apache.spark.sql.delta.commands.optimize.{FileSizeStats, OptimizeMetrics, OptimizeStats, ZOrderStats}
+import org.apache.spark.sql.delta.commands.optimize.{FileSizeStatsWithHistogram, OptimizeMetrics, OptimizeStats}
 import org.apache.spark.sql.delta.files.SQLMetricsReporting
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
+import org.apache.spark.SparkContext
 import org.apache.spark.SparkContext.SPARK_JOB_GROUP_ID
 import org.apache.spark.sql.{Encoders, Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression, Literal}
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.execution.metric.SQLMetrics.createMetric
 import org.apache.spark.sql.types.StringType
 import org.apache.spark.util.{SystemClock, ThreadUtils}
 
@@ -131,7 +134,8 @@ class OptimizeExecutor(
       val removedFiles = updates.collect { case r: RemoveFile => r }
       if (addedFiles.size > 0) {
         val operation = DeltaOperations.Optimize(partitionPredicate.map(_.sql))
-        commitAndRetry(txn, operation, updates) { newTxn =>
+        val metrics = createMetrics(sparkSession.sparkContext, addedFiles, removedFiles)
+        commitAndRetry(txn, operation, updates, metrics) { newTxn =>
           val newPartitionSchema = newTxn.metadata.partitionSchema
           val candidateSetOld = candidateFiles.map(_.path).toSet
           val candidateSetNew = newTxn.filterFiles(partitionPredicate).map(_.path).toSet
@@ -252,20 +256,61 @@ class OptimizeExecutor(
   private def commitAndRetry(
       txn: OptimisticTransaction,
       optimizeOperation: Operation,
-      actions: Seq[Action])(
-      f: OptimisticTransaction => Boolean): Unit = {
+      actions: Seq[Action],
+      metrics: Map[String, SQLMetric])(f: OptimisticTransaction => Boolean): Unit = {
     try {
+      txn.registerSQLMetrics(sparkSession, metrics)
       txn.commit(actions, optimizeOperation)
     } catch {
       case e: ConcurrentModificationException =>
         val newTxn = txn.deltaLog.startTransaction()
         if (f(newTxn)) {
           logInfo("Retrying commit after checking for semantic conflicts with concurrent updates.")
-          commitAndRetry(newTxn, optimizeOperation, actions)(f)
+          commitAndRetry(newTxn, optimizeOperation, actions, metrics)(f)
         } else {
           logWarning("Semantic conflicts detected. Aborting operation.")
           throw e
         }
     }
+  }
+
+  /** Create a map of SQL metrics for adding to the commit history. */
+  private def createMetrics(
+      sparkContext: SparkContext,
+      addedFiles: Seq[AddFile],
+      removedFiles: Seq[RemoveFile]): Map[String, SQLMetric] = {
+
+    def setAndReturnMetric(description: String, value: Long) = {
+      val metric = createMetric(sparkContext, description)
+      metric.set(value)
+      metric
+    }
+
+    def totalSize(actions: Seq[FileAction]): Long = {
+      var totalSize = 0L
+      actions.foreach { file =>
+        val fileSize = file match {
+          case addFile: AddFile => addFile.size
+          case removeFile: RemoveFile => removeFile.size.getOrElse(0L)
+          case default =>
+            throw new IllegalArgumentException(s"Unknown FileAction type: ${default.getClass}")
+        }
+        totalSize += fileSize
+      }
+      totalSize
+    }
+
+    val sizeStats = FileSizeStatsWithHistogram.create(addedFiles.map(_.size).sorted)
+    Map[String, SQLMetric](
+      "minFileSize" -> setAndReturnMetric("minimum file size", sizeStats.get.min),
+      "p25FileSize" -> setAndReturnMetric("25th percentile file size", sizeStats.get.p25),
+      "p50FileSize" -> setAndReturnMetric("50th percentile file size", sizeStats.get.p50),
+      "p75FileSize" -> setAndReturnMetric("75th percentile file size", sizeStats.get.p75),
+      "maxFileSize" -> setAndReturnMetric("maximum file size", sizeStats.get.max),
+      "numAddedFiles" -> setAndReturnMetric("total number of files added.", addedFiles.size),
+      "numRemovedFiles" -> setAndReturnMetric("total number of files removed.", removedFiles.size),
+      "numAddedBytes" -> setAndReturnMetric("total number of bytes added", totalSize(addedFiles)),
+      "numRemovedBytes" ->
+        setAndReturnMetric("total number of bytes removed", totalSize(removedFiles)))
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/optimize/OptimizeStats.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/optimize/OptimizeStats.scala
@@ -94,6 +94,42 @@ case class FileSizeStats(
   }
 }
 /**
+ * Percentiles on the file sizes in this batch.
+ * @param min Size of the smallest file
+ * @param p25 Size of the 25th percentile file
+ * @param p50 Size of the 50th percentile file
+ * @param p75 Size of the 75th percentile file
+ * @param max Size of the largest file
+ */
+case class FileSizeStatsWithHistogram(
+     min: Long,
+     p25: Long,
+     p50: Long,
+     p75: Long,
+     max: Long)
+
+object FileSizeStatsWithHistogram {
+
+  /**
+   * Creates a [[FileSizeStatsWithHistogram]] based on the passed sorted file sizes
+   * @return Some(fileSizeStatsWithHistogram) if sizes are non-empty, else returns None
+   */
+  def create(sizes: Seq[Long]): Option[FileSizeStatsWithHistogram] = {
+    if (sizes.isEmpty) {
+      return None
+    }
+    val count = sizes.length
+    Some(FileSizeStatsWithHistogram(
+      min = sizes.head,
+      // we do not need to ceil the computed index as arrays start at 0
+      p25 = sizes(count / 4),
+      p50 = sizes(count / 2),
+      p75 = sizes(count * 3 / 4),
+      max = sizes.last))
+  }
+}
+
+/**
  * Metrics returned by the optimize command.
  *
  * @param numFilesAdded number of files added by optimize


### PR DESCRIPTION
Commit metrics in DeltaLog are helpful when looking at the history of the Delta Table. Following metrics are added:

```
    "numAddedFiles", // number of files added
    "numRemovedFiles", // number of files removed
    "numAddedBytes", // number of bytes added by optimize
    "numRemovedBytes", // number of bytes removed by optimize
    "minFileSize", // the size of the smallest file
    "p25FileSize", // the size of the 25th percentile file
    "p50FileSize", // the median file size
    "p75FileSize", // the 75th percentile of the file sizes
    "maxFileSize" // the size of the largest file
```

GitOrigin-RevId: fde186d11e38381b9ad469535d91aa31ccd6ff62