### PR TITLE
Add RESTORE operation metrics

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -326,6 +326,8 @@ object DeltaOperations {
       "version" -> version,
       "timestamp" -> timestamp)
     override def changesData: Boolean = true
+
+    override val operationMetrics: Set[String] = DeltaOperationMetrics.RESTORE
   }
 
   val OPTIMIZE_OPERATION_NAME = "OPTIMIZE"
@@ -430,6 +432,15 @@ private[delta] object DeltaOperationMetrics {
     "executionTimeMs",  // time taken to execute the entire operation
     "scanTimeMs", // time taken to scan the files for matches
     "rewriteTimeMs" // time taken to rewrite the matched files
+  )
+
+  val RESTORE = Set(
+    "tableSizeAfterRestore", // table size in bytes after restore
+    "numOfFilesAfterRestore", // number of files in the table after restore
+    "numRemovedFiles", // number of files removed by the restore operation
+    "numRestoredFiles", // number of files that were added as a result of the restore
+    "removedFilesSize", // size in bytes of files removed by the restore
+    "restoredFilesSize" // size in bytes of files added by the restore
   )
 
 }

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -442,5 +442,4 @@ private[delta] object DeltaOperationMetrics {
     "removedFilesSize", // size in bytes of files removed by the restore
     "restoredFilesSize" // size in bytes of files added by the restore
   )
-
 }

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
@@ -162,16 +162,16 @@ case class RestoreTableCommand(
           addActions ++ removeActions,
           DeltaOperations.Restore(version, timestamp),
           Map.empty,
-          metrics)
-      }
+          metrics.mapValues(_.toString).toMap)
 
-      Seq(Row(
-        metrics.get(TABLE_SIZE_AFTER_RESTORE),
-        metrics.get(NUM_OF_FILES_AFTER_RESTORE),
-        metrics.get(NUM_REMOVED_FILES),
-        metrics.get(NUM_RESTORED_FILES),
-        metrics.get(REMOVED_FILES_SIZE),
-        metrics.get(RESTORED_FILES_SIZE)))
+        Seq(Row(
+          metrics.get(TABLE_SIZE_AFTER_RESTORE),
+          metrics.get(NUM_OF_FILES_AFTER_RESTORE),
+          metrics.get(NUM_REMOVED_FILES),
+          metrics.get(NUM_RESTORED_FILES),
+          metrics.get(REMOVED_FILES_SIZE),
+          metrics.get(RESTORED_FILES_SIZE)))
+      }
     }
   }
 
@@ -198,7 +198,7 @@ case class RestoreTableCommand(
     toAdd: Dataset[AddFile],
     toRemove: Dataset[RemoveFile],
     snapshot: Snapshot
-  ): Map[String, String] = {
+  ): Map[String, Long] = {
     import toAdd.sparkSession.implicits._
 
     val (numRestoredFiles, restoredFilesSize) = toAdd
@@ -214,7 +214,7 @@ case class RestoreTableCommand(
       REMOVED_FILES_SIZE -> removedFilesSize.getOrElse(0),
       NUM_OF_FILES_AFTER_RESTORE -> snapshot.numOfFiles,
       TABLE_SIZE_AFTER_RESTORE -> snapshot.sizeInBytes
-    ).mapValues(_.toString).toMap
+    )
   }
 
   /* Prevent users from running restore to table version with missed

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
@@ -28,13 +28,43 @@ import org.apache.spark.sql.delta.util.DeltaFileOperations.absolutePath
 
 import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Literal}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.IGNORE_MISSING_FILES
+import org.apache.spark.sql.types.LongType
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.SerializableConfiguration
+
+/** Base trait class for RESTORE. Defines command output schema and metrics. */
+trait RestoreTableCommandBase {
+
+  // RESTORE operation metrics
+  val TABLE_SIZE_AFTER_RESTORE = "tableSizeAfterRestore"
+  val NUM_OF_FILES_AFTER_RESTORE = "numOfFilesAfterRestore"
+  val NUM_REMOVED_FILES = "numRemovedFiles"
+  val NUM_RESTORED_FILES = "numRestoredFiles"
+  val REMOVED_FILES_SIZE = "removedFilesSize"
+  val RESTORED_FILES_SIZE = "restoredFilesSize"
+
+  // SQL way column names for RESTORE command output
+  private val COLUMN_TABLE_SIZE_AFTER_RESTORE = "table_size_after_restore"
+  private val COLUMN_NUM_OF_FILES_AFTER_RESTORE = "num_of_files_after_restore"
+  private val COLUMN_NUM_REMOVED_FILES = "num_removed_files"
+  private val COLUMN_NUM_RESTORED_FILES = "num_restored_files"
+  private val COLUMN_REMOVED_FILES_SIZE = "removed_files_size"
+  private val COLUMN_RESTORED_FILES_SIZE = "restored_files_size"
+
+  val outputSchema: Seq[Attribute] = Seq(
+    AttributeReference(COLUMN_TABLE_SIZE_AFTER_RESTORE, LongType)(),
+    AttributeReference(COLUMN_NUM_OF_FILES_AFTER_RESTORE, LongType)(),
+    AttributeReference(COLUMN_NUM_REMOVED_FILES, LongType)(),
+    AttributeReference(COLUMN_NUM_RESTORED_FILES, LongType)(),
+    AttributeReference(COLUMN_REMOVED_FILES_SIZE, LongType)(),
+    AttributeReference(COLUMN_RESTORED_FILES_SIZE, LongType)()
+  )
+}
 
 /**
  * Perform restore of delta table to a specified version or timestamp
@@ -55,7 +85,10 @@ import org.apache.spark.util.SerializableConfiguration
  */
 case class RestoreTableCommand(
     sourceTable: DeltaTableV2,
-    targetIdent: TableIdentifier) extends LeafRunnableCommand with DeltaCommand {
+    targetIdent: TableIdentifier)
+  extends LeafRunnableCommand with DeltaCommand with RestoreTableCommandBase {
+
+  override val output: Seq[Attribute] = outputSchema
 
   override def run(spark: SparkSession): Seq[Row] = {
     val deltaLog = sourceTable.deltaLog
@@ -132,7 +165,13 @@ case class RestoreTableCommand(
           metrics)
       }
 
-      Seq.empty[Row]
+      Seq(Row(
+        metrics.get(TABLE_SIZE_AFTER_RESTORE),
+        metrics.get(NUM_OF_FILES_AFTER_RESTORE),
+        metrics.get(NUM_REMOVED_FILES),
+        metrics.get(NUM_RESTORED_FILES),
+        metrics.get(REMOVED_FILES_SIZE),
+        metrics.get(RESTORED_FILES_SIZE)))
     }
   }
 
@@ -169,12 +208,12 @@ case class RestoreTableCommand(
       .agg("size" -> "count", "size" -> "sum").as[(Long, Option[Long])].head()
 
     Map(
-      "numRestoredFiles" -> numRestoredFiles,
-      "restoredFilesSize" -> restoredFilesSize.getOrElse(0),
-      "numRemovedFiles" -> numRemovedFiles,
-      "removedFilesSize" -> removedFilesSize.getOrElse(0),
-      "numOfFilesAfterRestore" -> snapshot.numOfFiles,
-      "tableSizeAfterRestore" -> snapshot.sizeInBytes
+      NUM_RESTORED_FILES -> numRestoredFiles,
+      RESTORED_FILES_SIZE -> restoredFilesSize.getOrElse(0),
+      NUM_REMOVED_FILES -> numRemovedFiles,
+      REMOVED_FILES_SIZE -> removedFilesSize.getOrElse(0),
+      NUM_OF_FILES_AFTER_RESTORE -> snapshot.numOfFiles,
+      TABLE_SIZE_AFTER_RESTORE -> snapshot.sizeInBytes
     ).mapValues(_.toString).toMap
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/RestoreTableSuiteBase.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/RestoreTableSuiteBase.scala
@@ -238,11 +238,13 @@ trait RestoreTableSuiteBase extends QueryTest with SharedSparkSession  with Delt
         assert(actualOutputMetrics.schema == expectedRestoreOutputSchema)
 
         val outputRow = actualOutputMetrics.take(1).head
-        assert(outputRow.getLong(0) == 1177L) // table_size_after_restore
+        // File sizes are flaky due to differences in order of data (=> encoding size differences)
+        assert(outputRow.getLong(0) > 0L) // table_size_after_restore
         assert(outputRow.getLong(1) == 2L) // num_of_files_after_restore
         assert(outputRow.getLong(2) == 2L) // num_removed_files
         assert(outputRow.getLong(3) == 0L) // num_restored_files
-        assert(outputRow.getLong(4) == 1177L) // removed_files_size
+        // File sizes are flaky due to differences in order of data (=> encoding size differences)
+        assert(outputRow.getLong(4) > 0L) // removed_files_size
         assert(outputRow.getLong(5) == 0L) // restored_files_size
       }
     }

--- a/core/src/test/scala/org/apache/spark/sql/delta/RestoreTableSuiteBase.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/RestoreTableSuiteBase.scala
@@ -17,16 +17,15 @@
 package org.apache.spark.sql.delta
 
 import java.io.File
-import java.text.SimpleDateFormat
 
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.util.FileNames
 
-import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
+import org.apache.spark.sql.{DataFrame, QueryTest}
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types._
 
 /** Base suite containing the restore tests. */
 trait RestoreTableSuiteBase extends QueryTest with SharedSparkSession  with DeltaSQLCommandTest {
@@ -178,6 +177,74 @@ trait RestoreTableSuiteBase extends QueryTest with SharedSparkSession  with Delt
       restoreTableToVersion(tempDir.getAbsolutePath, 2, false)
       checkAnswer(spark.read.format("delta").load(tempDir.getAbsolutePath), df1)
       assert(deltaLog.update().version == 4)
+    }
+  }
+
+  test("restore operation metrics in Delta table history") {
+    withSQLConf(DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "true") {
+      withTempDir { tempDir =>
+        val df1 = Seq(1, 2, 3).toDF("id")
+        val df2 = Seq(4, 5, 6).toDF("id")
+        df1.write.format("delta").save(tempDir.getAbsolutePath)
+        val deltaLog = DeltaLog.forTable(spark, tempDir.getAbsolutePath)
+        df2.write.format("delta").mode("append").save(tempDir.getAbsolutePath)
+        assert(deltaLog.update().version == 1)
+
+        // we have two versions now, let's restore to version 0 first
+        restoreTableToVersion(tempDir.getAbsolutePath, 0, false)
+
+        val deltaTable = io.delta.tables.DeltaTable.forPath(spark, tempDir.getAbsolutePath)
+
+        val actualOperationMetrics = deltaTable.history(1).select("operationMetrics")
+            .take(1)
+            .head
+            .getMap(0)
+            .asInstanceOf[Map[String, String]]
+
+        // File sizes are flaky due to differences in order of data (=> encoding size differences)
+        assert(actualOperationMetrics.get("tableSizeAfterRestore").isDefined)
+        assert(actualOperationMetrics.get("numOfFilesAfterRestore").get == "2")
+        assert(actualOperationMetrics.get("numRemovedFiles").get == "2")
+        assert(actualOperationMetrics.get("numRestoredFiles").get == "0")
+        // File sizes are flaky due to differences in order of data (=> encoding size differences)
+        assert(actualOperationMetrics.get("removedFilesSize").isDefined)
+        assert(actualOperationMetrics.get("restoredFilesSize").get == "0")
+      }
+    }
+  }
+
+  test("restore command output metrics") {
+    withSQLConf(DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "true") {
+      withTempDir { tempDir =>
+        val df1 = Seq(1, 2, 3).toDF("id")
+        val df2 = Seq(4, 5, 6).toDF("id")
+        df1.write.format("delta").save(tempDir.getAbsolutePath)
+        val deltaLog = DeltaLog.forTable(spark, tempDir.getAbsolutePath)
+        df2.write.format("delta").mode("append").save(tempDir.getAbsolutePath)
+        assert(deltaLog.update().version == 1)
+
+        // we have two versions now, let's restore to version 0 first
+        val actualOutputMetrics = restoreTableToVersion(tempDir.getAbsolutePath, 0, false)
+
+        // verify the schema
+        val expectedRestoreOutputSchema = StructType(Seq(
+          StructField("table_size_after_restore", LongType),
+          StructField("num_of_files_after_restore", LongType),
+          StructField("num_removed_files", LongType),
+          StructField("num_restored_files", LongType),
+          StructField("removed_files_size", LongType),
+          StructField("restored_files_size", LongType)
+        ))
+        assert(actualOutputMetrics.schema == expectedRestoreOutputSchema)
+
+        val outputRow = actualOutputMetrics.take(1).head
+        assert(outputRow.getLong(0) == 1177L) // table_size_after_restore
+        assert(outputRow.getLong(1) == 2L) // num_of_files_after_restore
+        assert(outputRow.getLong(2) == 2L) // num_removed_files
+        assert(outputRow.getLong(3) == 0L) // num_restored_files
+        assert(outputRow.getLong(4) == 1177L) // removed_files_size
+        assert(outputRow.getLong(5) == 0L) // restored_files_size
+      }
     }
   }
 }


### PR DESCRIPTION
This change adds the following metrics to Delta commit log as part of committing RESTORE changes.

```
    "tableSizeAfterRestore", // table size in bytes after restore
    "numOfFilesAfterRestore", // number of files in the table after restore
    "numRemovedFiles", // number of files removed by the restore operation
    "numRestoredFiles", // number of files that were added as a result of the restore
    "removedFilesSize", // size in bytes of files removed by the restore
    "restoredFilesSize" // size in bytes of files added by the restore
```

Same metrics are output as command output.
```
   "table_size_after_restore"
    "num_of_files_after_restore"
    "num_removed_files"
    "num_restored_files"
    "removed_files_size"
    "restored_files_size"
```

GitOrigin-RevId: 5cb482912aeab412eba1ec2fe371c8cf586f8fba