### PR TITLE
[1022] LogStore: Replace spark.sparkContext.hadoopConfiguration by spark.sessionState.newHadoopConf(

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
@@ -244,7 +244,7 @@ trait GenerateSymlinkManifestImpl extends PostCommitHook with DeltaLogging with 
     val spark = fileNamesForManifest.sparkSession
     import spark.implicits._
 
-    val tableAbsPathForManifest = LogStore(spark.sparkContext)
+    val tableAbsPathForManifest = LogStore(spark)
       .resolvePathOnPhysicalStorage(deltaLogDataPath, hadoopConf.value).toString
 
     /** Write the data file relative paths to manifestDirAbsPath/manifest as absolute paths */

--- a/core/src/test/scala/org/apache/spark/sql/delta/DelegatingLogStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DelegatingLogStoreSuite.scala
@@ -93,8 +93,8 @@ class DelegatingLogStoreSuite
   private def testLogStoreClassConfNoSchemeConf(scheme: String) {
     val sparkConf = constructSparkConf(scheme, Some(customLogStoreClassName), None)
     withSparkSession(SparkSession.builder.config(sparkConf).getOrCreate()) { spark =>
-      assert(LogStore(spark.sparkContext).isInstanceOf[LogStoreAdaptor])
-      assert(LogStore(spark.sparkContext).asInstanceOf[LogStoreAdaptor]
+      assert(LogStore(spark).isInstanceOf[LogStoreAdaptor])
+      assert(LogStore(spark).asInstanceOf[LogStoreAdaptor]
         .logStoreImpl.getClass.getName == customLogStoreClassName)
     }
   }
@@ -133,7 +133,7 @@ class DelegatingLogStoreSuite
       Some(DelegatingLogStore.defaultAzureLogStoreClassName))
     val e = intercept[AnalysisException](
       withSparkSession(SparkSession.builder.config(sparkConf).getOrCreate()) { spark =>
-        LogStore(spark.sparkContext)
+        LogStore(spark)
       }
     )
     assert(e.getMessage.contains(
@@ -150,7 +150,7 @@ class DelegatingLogStoreSuite
       Some(DelegatingLogStore.defaultAzureLogStoreClassName))
     val e = intercept[AnalysisException](
       withSparkSession(SparkSession.builder.config(sparkConf).getOrCreate()) { spark =>
-        LogStore(spark.sparkContext)
+        LogStore(spark)
       }
     )
     assert(e.getMessage.contains(

--- a/core/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
@@ -48,7 +48,7 @@ abstract class LogStoreSuiteBase extends QueryTest
   protected def testInitFromSparkConf(): Unit = {
     test("instantiation through SparkConf") {
       assert(spark.sparkContext.getConf.get(logStoreClassConfKey) == logStoreClassName)
-      assert(LogStore(spark.sparkContext).getClass.getName == logStoreClassName)
+      assert(LogStore(spark).getClass.getName == logStoreClassName)
     }
   }
 
@@ -400,8 +400,8 @@ abstract class PublicLogStoreSuite extends LogStoreSuiteBase {
   protected override def testInitFromSparkConf(): Unit = {
     test("instantiation through SparkConf") {
       assert(spark.sparkContext.getConf.get(logStoreClassConfKey) == publicLogStoreClassName)
-      assert(LogStore(spark.sparkContext).getClass.getName == logStoreClassName)
-      assert(LogStore(spark.sparkContext).asInstanceOf[LogStoreAdaptor]
+      assert(LogStore(spark).getClass.getName == logStoreClassName)
+      assert(LogStore(spark).asInstanceOf[LogStoreAdaptor]
         .logStoreImpl.getClass.getName == publicLogStoreClassName)
 
     }

--- a/core/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
@@ -26,9 +26,9 @@ import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.spark.sql.delta.storage._
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path, RawLocalFileSystem}
-import org.apache.spark.SparkConf
+import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.sql.LocalSparkSession.withSparkSession
-import org.apache.spark.sql.{QueryTest, SparkSession}
+import org.apache.spark.sql.{LocalSparkSession, QueryTest, SparkSession}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.Utils
 
@@ -397,7 +397,7 @@ class FakePublicLogStore(initHadoopConf: Configuration)
  * We want to ensure that, to set configuration values for the Java LogStore implementations,
  * users can simply use `--conf $key=$value`, instead of `--conf spark.hadoop.$key=$value`
  */
-class CorrectHadoopConfSuite extends QueryTest with SharedSparkSession {
+class CorrectHadoopConfSuite extends SparkFunSuite with LocalSparkSession with LogStoreProvider {
   test("java LogStore is instantiated with hadoopConf with SQLConf values") {
     val sparkConf = new SparkConf()
       .setMaster("local")
@@ -408,7 +408,7 @@ class CorrectHadoopConfSuite extends QueryTest with SharedSparkSession {
     withSparkSession(SparkSession.builder.config(sparkConf).getOrCreate()) { spark =>
       // this will instantiate the FakePublicLogStore above. If its assertion fails,
       // then this test will fail
-      LogStore(spark)
+      createLogStore(spark)
     }
   }
 }


### PR DESCRIPTION
- resolves https://github.com/delta-io/delta/issues/1022

Instantiates a LogStore using `spark.sessionState.newHadoopConf` instead of using `spark.sparkContext.hadoopConfiguration`. This ensures that the SQLConf values get passed to the hadoopConfig, and that users can pass in hadoopConfig values using `$key=$value` instead of having to use `spark.hadoop.$key=$value`.