### PR TITLE
Fix thread pool leak in optimize

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeCompactionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeCompactionSuite.scala
@@ -18,6 +18,8 @@ package org.apache.spark.sql.delta.optimize
 
 import java.io.File
 
+import scala.collection.JavaConverters._
+
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
@@ -76,6 +78,10 @@ trait OptimizeCompactionSuiteBase extends QueryTest
       deltaLog.update()
       assert(deltaLog.snapshot.version === versionBeforeOptimize + 1)
       checkDatasetUnorderly(data.toDF().as[Int], 1, 2, 3, 4, 5, 6)
+
+      // Make sure thread pool is shut down
+      assert(Thread.getAllStackTraces.keySet.asScala
+        .filter(_.getName.startsWith("OptimizeJob")).isEmpty)
     }
   }
 


### PR DESCRIPTION
Adds shutting down the thread pool after we're done with it in an optimize job. This is particularly important right now before incremental optimization is implemented, since manual batching will create and leave around a new thread pool per batch.