### PR TITLE
[954] Update DelegatingLogStore to use Java LogStore implementations by default

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/storage/DelegatingLogStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/storage/DelegatingLogStore.scala
@@ -147,9 +147,12 @@ class DelegatingLogStore(hadoopConf: Configuration)
 
 object DelegatingLogStore {
 
-  val defaultS3LogStoreClassName = classOf[S3SingleDriverLogStore].getName
-  val defaultAzureLogStoreClassName = classOf[AzureLogStore].getName
-  val defaultHDFSLogStoreClassName = classOf[HDFSLogStore].getName
+  /**
+   * Java LogStore (io.delta.storage) implementations are now the default.
+   */
+  val defaultS3LogStoreClassName = classOf[io.delta.storage.HDFSLogStore].getName
+  val defaultAzureLogStoreClassName = classOf[io.delta.storage.AzureLogStore].getName
+  val defaultHDFSLogStoreClassName = classOf[io.delta.storage.HDFSLogStore].getName
 
   // Supported schemes with default.
   val s3Schemes = Set("s3", "s3a", "s3n")

--- a/core/src/test/scala/org/apache/spark/sql/delta/DelegatingLogStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DelegatingLogStoreSuite.scala
@@ -16,9 +16,9 @@
 
 package org.apache.spark.sql.delta
 
+import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.delta.storage.{DelegatingLogStore, LogStore, LogStoreAdaptor}
-import org.apache.hadoop.fs.Path
-
+import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.LocalSparkSession._
@@ -27,8 +27,7 @@ import org.apache.spark.sql.SparkSession
 class DelegatingLogStoreSuite
   extends SparkFunSuite {
 
-
-  private val customLogStoreClassName = classOf[io.delta.storage.HDFSLogStore].getName
+  private val customLogStoreClassName = classOf[CustomPublicLogStore].getName
 
   private def fakeSchemeWithNoDefault = "fake"
 
@@ -44,14 +43,19 @@ class DelegatingLogStoreSuite
     val sparkConf = new SparkConf().setMaster("local")
     val classConfKey = LogStore.logStoreClassConfKey
     val schemeConfKey = LogStore.logStoreSchemeConfKey(scheme)
+
+    // this will set/unset spark.delta.logStore.class -> $classConf
     classConf match {
       case Some(conf) => sparkConf.set(classConfKey, conf)
       case _ => sparkConf.remove(classConfKey)
     }
+
+    // this will set/unset spark.delta.logStore.${scheme}.impl -> $schemeConf
     schemeConf match {
       case Some(conf) => sparkConf.set(schemeConfKey, conf)
       case _ => sparkConf.remove(schemeConfKey)
     }
+
     sparkConf
   }
 
@@ -64,7 +68,7 @@ class DelegatingLogStoreSuite
    * @param expClassName Expected LogStore class name resolved by DelegatingLogStore.
    * @param expAdaptor True if DelegatingLogStore is expected to resolve to LogStore adaptor, for
    *                   which the actual implementation inside will be checked. This happens when
-   *                   LogStore is set to subclass of the new LogStore API.
+   *                   LogStore is set to subclass of the new [[io.delta.storage.LogStore]] API.
    */
   private def testDelegatingLogStore(
       scheme: String,
@@ -101,13 +105,24 @@ class DelegatingLogStoreSuite
 
   test("DelegatingLogStore resolution using default scheme confs") {
     for (scheme <- DelegatingLogStore.s3Schemes) {
-      testDelegatingLogStore(scheme, None, DelegatingLogStore.defaultS3LogStoreClassName, false)
+      testDelegatingLogStore(
+        scheme,
+        schemeConf = None,
+        expClassName = DelegatingLogStore.defaultS3LogStoreClassName,
+        expAdaptor = true)
     }
     for (scheme <- DelegatingLogStore.azureSchemes) {
-      testDelegatingLogStore(scheme, None, DelegatingLogStore.defaultAzureLogStoreClassName, false)
+      testDelegatingLogStore(
+        scheme,
+        schemeConf = None,
+        expClassName = DelegatingLogStore.defaultAzureLogStoreClassName,
+        expAdaptor = true)
     }
-    testDelegatingLogStore(fakeSchemeWithNoDefault, None,
-      DelegatingLogStore.defaultHDFSLogStoreClassName, false)
+    testDelegatingLogStore(
+      scheme = fakeSchemeWithNoDefault,
+      schemeConf = None,
+      expClassName = DelegatingLogStore.defaultHDFSLogStoreClassName,
+      expAdaptor = true)
   }
 
   test("DelegatingLogStore resolution using customized scheme confs") {
@@ -115,11 +130,22 @@ class DelegatingLogStoreSuite
       fakeSchemeWithNoDefault
     for (scheme <- allTestSchemes) {
       for (store <- Seq(
+        // default (java) classes (in io.delta.storage)
         DelegatingLogStore.defaultS3LogStoreClassName,
         DelegatingLogStore.defaultAzureLogStoreClassName,
         DelegatingLogStore.defaultHDFSLogStoreClassName,
+        // deprecated (scala) classes
+        classOf[org.apache.spark.sql.delta.storage.S3SingleDriverLogStore].getName,
+        classOf[org.apache.spark.sql.delta.storage.AzureLogStore].getName,
+        classOf[org.apache.spark.sql.delta.storage.HDFSLogStore].getName,
         customLogStoreClassName)) {
-        testDelegatingLogStore(scheme, Some(store), store, store == customLogStoreClassName)
+
+        // we set spark.delta.logStore.${scheme}.impl -> $store
+        testDelegatingLogStore(
+          scheme,
+          schemeConf = Some(store),
+          expClassName = store,
+          expAdaptor = store.contains("io.delta.storage") || store == customLogStoreClassName)
       }
     }
   }
@@ -156,5 +182,45 @@ class DelegatingLogStoreSuite
     assert(e.getMessage.contains(
       "(`spark.delta.logStore.class`) and (`spark.delta.logStore.s3a.impl`) " +
         "cannot be set at the same time"))
+  }
+}
+
+//////////////////
+// Helper Class //
+//////////////////
+
+class CustomPublicLogStore(initHadoopConf: Configuration)
+  extends io.delta.storage.LogStore(initHadoopConf) {
+
+  private val logStoreInternal = new io.delta.storage.HDFSLogStore(initHadoopConf)
+
+  override def read(
+      path: Path,
+      hadoopConf: Configuration): io.delta.storage.CloseableIterator[String] = {
+    logStoreInternal.read(path, hadoopConf)
+  }
+
+  override def write(
+      path: Path,
+      actions: java.util.Iterator[String],
+      overwrite: java.lang.Boolean,
+      hadoopConf: Configuration): Unit = {
+    logStoreInternal.write(path, actions, overwrite, hadoopConf)
+  }
+
+  override def listFrom(
+      path: Path,
+      hadoopConf: Configuration): java.util.Iterator[FileStatus] = {
+    logStoreInternal.listFrom(path, hadoopConf)
+  }
+
+  override def resolvePathOnPhysicalStorage(
+      path: Path,
+      hadoopConf: Configuration): Path = {
+    logStoreInternal.resolvePathOnPhysicalStorage(path, hadoopConf)
+  }
+
+  override def isPartialWriteVisible(path: Path, hadoopConf: Configuration): java.lang.Boolean = {
+    logStoreInternal.isPartialWriteVisible(path, hadoopConf)
   }
 }


### PR DESCRIPTION
Resolves [#954](https://github.com/delta-io/delta/issues/954)

## Description
- `DelegatingLogStore.scala` now, by default, uses the `io.delta.storage` Java `LogStore` implementations. At runtime, each of these implementations is then wrapped inside of a `LogStoreAdapter` to be used as a `LogStore.scala` throughout the delta code base.

## How was this patch tested?

Updated existing unit tests. We test setting the scheme for both the default (java) LogStores, as well as the previous scala LogStores.

Thus, if a user specifies a Scala LogStore for a given scheme, that will continue to work.