### PR TITLE
[988] Add 'IntelliJ Setup' section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Breaking changes in the protocol are indicated by incrementing the minimum reade
 * For the high-level Delta Lake roadmap, see [Delta Lake 2022H1 roadmap](http://delta.io/roadmap).  
 * For the detailed timeline, see the [project roadmap](https://github.com/delta-io/delta/milestones). 
 
-# Building
+## Building
 
 Delta Lake is compiled using [SBT](https://www.scala-sbt.org/1.x/docs/Command-Line-Reference.html).
 
@@ -99,7 +99,7 @@ To execute tests, run
 
 Refer to [SBT docs](https://www.scala-sbt.org/1.x/docs/Command-Line-Reference.html) for more commands.
 
-# Transaction Protocol
+## Transaction Protocol
 
 [Delta Transaction Log Protocol](PROTOCOL.md) document provides a specification of the transaction protocol.
 
@@ -117,19 +117,19 @@ See the [online documentation on Storage Configuration](https://docs.delta.io/la
 
 Delta Lake ensures _serializability_ for concurrent reads and writes. Please see [Delta Lake Concurrency Control](https://docs.delta.io/latest/delta-concurrency.html) for more details.
 
-# Reporting issues
+## Reporting issues
 
 We use [GitHub Issues](https://github.com/delta-io/delta/issues) to track community reported issues. You can also [contact](#community) the community for getting answers.
 
-# Contributing 
+## Contributing 
 We welcome contributions to Delta Lake. See our [CONTRIBUTING.md](https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md) for more details.
 
 We also adhere to the [Delta Lake Code of Conduct](https://github.com/delta-io/delta/blob/master/CODE_OF_CONDUCT.md).
 
-# License
+## License
 Apache License 2.0, see [LICENSE](https://github.com/delta-io/delta/blob/master/LICENSE.txt).
 
-# Community
+## Community
 
 There are two mediums of communication within the Delta Lake community.
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,39 @@ We welcome contributions to Delta Lake. See our [CONTRIBUTING.md](https://github
 
 We also adhere to the [Delta Lake Code of Conduct](https://github.com/delta-io/delta/blob/master/CODE_OF_CONDUCT.md).
 
+## IntelliJ Setup
+
+IntelliJ is the recommended IDE to use when developing Delta Lake. To import Delta Lake as a new project:
+1. Clone Delta Lake into, for example, `~/delta`.
+2. In IntelliJ, select `File` > `New Project` > `Project from Existing Sources...` and select `~/delta`.
+3. Under `Import project from external model` select `sbt`. Click `Next`.
+4. Under `Project JDK` specify a valid Java `1.8` JDK and opt to use SBT shell for `project reload` and `builds`.
+5. Click `Finish`.
+
+### Setup Verification
+
+After waiting for IntelliJ to index, verify your setup by running a test suite in IntelliJ.
+1. Search for and open `DeltaLogSuite`
+2. Next to the class declaration, right click on the two green arrows and select `Run 'DeltaLogSuite'`
+
+### Troubleshooting
+
+If you see errors of the form
+
+```
+Error:(46, 28) object DeltaSqlBaseParser is not a member of package io.delta.sql.parser
+import io.delta.sql.parser.DeltaSqlBaseParser._
+...
+Error:(91, 22) not found: type DeltaSqlBaseParser
+    val parser = new DeltaSqlBaseParser(tokenStream)
+```
+
+then follow these steps:
+1. Compile using the SBT CLI: `build/sbt compile`.
+2. Go to `File` > `Project Structure...` > `Modules` > `delta-core`.
+3. In the right panel under `Source Folders` remove any `target` folders, e.g. `target/scala-2.12/src_managed/main [generated]`
+4. Click `Apply` and then re-run your test.
+
 ## License
 Apache License 2.0, see [LICENSE](https://github.com/delta-io/delta/blob/master/LICENSE.txt).
 

--- a/README.md
+++ b/README.md
@@ -81,24 +81,6 @@ Breaking changes in the protocol are indicated by incrementing the minimum reade
 * For the high-level Delta Lake roadmap, see [Delta Lake 2022H1 roadmap](http://delta.io/roadmap).  
 * For the detailed timeline, see the [project roadmap](https://github.com/delta-io/delta/milestones). 
 
-## Building
-
-Delta Lake is compiled using [SBT](https://www.scala-sbt.org/1.x/docs/Command-Line-Reference.html).
-
-To compile, run
-
-    build/sbt compile
-
-To generate artifacts, run
-
-    build/sbt package
-
-To execute tests, run
-
-    build/sbt test
-
-Refer to [SBT docs](https://www.scala-sbt.org/1.x/docs/Command-Line-Reference.html) for more commands.
-
 ## Transaction Protocol
 
 [Delta Transaction Log Protocol](PROTOCOL.md) document provides a specification of the transaction protocol.
@@ -125,6 +107,24 @@ We use [GitHub Issues](https://github.com/delta-io/delta/issues) to track commun
 We welcome contributions to Delta Lake. See our [CONTRIBUTING.md](https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md) for more details.
 
 We also adhere to the [Delta Lake Code of Conduct](https://github.com/delta-io/delta/blob/master/CODE_OF_CONDUCT.md).
+
+## Building
+
+Delta Lake is compiled using [SBT](https://www.scala-sbt.org/1.x/docs/Command-Line-Reference.html).
+
+To compile, run
+
+    build/sbt compile
+
+To generate artifacts, run
+
+    build/sbt package
+
+To execute tests, run
+
+    build/sbt test
+
+Refer to [SBT docs](https://www.scala-sbt.org/1.x/docs/Command-Line-Reference.html) for more commands.
 
 ## IntelliJ Setup
 


### PR DESCRIPTION
## Description
- Resolves #988
- Adds an IntelliJ Setup section to README.md which describes how to setup delta-lake in IntelliJ and how to fix a common build error

## How was this patch tested?
Re-cloned Delta Lake and followed the steps myself.