### PR TITLE
avoid repetitively folding ZOrderFileStats

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/optimize/ZOrderMetrics.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/optimize/ZOrderMetrics.scala
@@ -27,10 +27,11 @@ case class ZOrderFileStats(num: Long, size: Long)
 
 object ZOrderFileStats {
   def apply(v: Iterable[(Int, Long)]): ZOrderFileStats = {
-    v.foldLeft(ZOrderFileStats(0, 0)) { (a, b) =>
-      ZOrderFileStats(a.num + b._1, a.size + b._2)
+      val (is, ls) = v.foldLeft((0L, 0L)) {
+        case ((i0, l0), (i1, l1)) => (i0 + i1, l0 + l1)
+      }
+      ZOrderFileStats(is, ls)
     }
-  }
 }
 
 /**


### PR DESCRIPTION
## Description
As we want to sum `Iterable[(Int,Long)]` into `(sum of the first element of
tuple, sum of the second element of tuple)` at `ZOrderFileStats.apply(arg: Iterable[(Int,Long)])`, we do not need to wrap them in `ZOrderFileStats`s while processing.




## How was this patch tested?
Existing tests.

## Does this PR introduce _any_ user-facing changes?
No

