### PR TITLE
Don't mock `pyspark` import for python API doc generation

### DIFF
--- a/docs/python/conf.py
+++ b/docs/python/conf.py
@@ -79,6 +79,3 @@ master_doc = 'index'
 
 # Display the classes in the generated in the same order as the classes appear in the source files.`
 autodoc_member_order = 'bysource'
-
-# Ignore 'import pyspark' if pyspark is not installed.
-autodoc_mock_imports = ["pyspark"]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Currently our python api docs has `sphinx.ext.autodoc.importer._MockObject object at 0x105f04580>` for all `pyspark` objects. This is because our sphinx configuration "mocks" all the imports under `pyspark`. This removes `pyspark` from `autodoc_moc_imports`.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Build the docs locally in a `pipenv` with `pyspark==3.2.1` installed. @vkorukanti also verified this fix.

## Does this PR introduce _any_ user-facing changes?

No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
