### PR TITLE
Support dropping columns as a metadata-only operation

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -134,10 +134,6 @@
     "message" : [ "Dropping partition columns (%s) is not allowed." ],
     "sqlState" : "0A000"
   },
-  "UNSUPPORTED_RENAME_COLUMN" : {
-    "message" : [ "Column rename is not supported for your Delta table. %s" ],
-    "sqlState" : "0A000"
-  },
   "UNSUPPORTED_INVALID_CHARACTERS_IN_COLUMN_NAME" : {
     "message" : [ "Found invalid character(s) among ' ,;{}()\\n\\t=' in the column names of your schema. %s" ],
     "sqlState" : "0A000"
@@ -148,6 +144,10 @@
   },
   "UNSUPPORTED_NESTED_COLUMN_IN_BLOOM_FILTER" : {
     "message" : [ "Creating a bloom filer index on a nested column is currently unsupported: %s" ],
+    "sqlState" : "0A000"
+  },
+  "UNSUPPORTED_RENAME_COLUMN" : {
+    "message" : [ "Column rename is not supported for your Delta table. %s" ],
     "sqlState" : "0A000"
   }
 }

--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -131,7 +131,11 @@
     "sqlState" : "0A000"
   },
   "UNSUPPORTED_DROP_PARTITION_COLUMN" : {
-    "message" : [ "Dropping partition columns is not allowed." ],
+    "message" : [ "Dropping partition columns (%s) is not allowed." ],
+    "sqlState" : "0A000"
+  },
+  "UNSUPPORTED_RENAME_COLUMN" : {
+    "message" : [ "Column rename is not supported for your Delta table. %s" ],
     "sqlState" : "0A000"
   },
   "UNSUPPORTED_INVALID_CHARACTERS_IN_COLUMN_NAME" : {

--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -126,6 +126,18 @@
     "message" : [ "Writing data with column mapping mode is not supported." ],
     "sqlState" : "0A000"
   },
+  "UNSUPPORTED_DROP_COLUMN" : {
+    "message" : [ "DROP COLUMN is not supported for your Delta table. %s" ],
+    "sqlState" : "0A000"
+  },
+  "UNSUPPORTED_DROP_PARTITION_COLUMN" : {
+    "message" : [ "Dropping partition columns is not allowed." ],
+    "sqlState" : "0A000"
+  },
+  "UNSUPPORTED_INVALID_CHARACTERS_IN_COLUMN_NAME" : {
+    "message" : [ "Found invalid character(s) among ' ,;{}()\\n\\t=' in the column names of your schema. %s" ],
+    "sqlState" : "0A000"
+  },
   "UNSUPPORTED_MANIFEST_GENERATION_WITH_COLUMN_MAPPING" : {
     "message" : [ "Manifest generation is not supported for tables that leverage column mapping, as external readers cannot read these Delta tables. See Databricks documentation for more details." ],
     "sqlState" : "0A000"

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1325,32 +1325,34 @@ object DeltaErrors
         s"$oldProtocol"))
   }
 
-  def columnRenameNotSupported(spark: SparkSession, protocol: Protocol): Throwable = {
-    // scalastyle:off line.size.limit
-    val adviceMsg = if (!DeltaColumnMapping.satisfyColumnMappingProtocol(protocol)) {
-      s"""
-         |Please upgrade your Delta table to reader version 2 and writer version 5 (Refer to table versioning at ${generateDocsLink(spark.sparkContext.getConf, "/versioning.html")})
-         | and change the column mapping mode to name mapping. You can use the following command:
-         |
-         | ALTER TABLE <table_name> SET TBLPROPERTIES (
-         |   'delta.columnMapping.mode' = 'name',
-         |   'delta.minReaderVersion' = '2',
-         |   'delta.minWriterVersion' = '5')
-         |
-      """.stripMargin
-    } else {
-      s"""
-         |Please change the column mapping mode to name mapping mode. You can use the following command:
-         |
-         | ALTER TABLE <table_name> SET TBLPROPERTIES ('delta.columnMapping.mode' = 'name')
-      """.stripMargin
-    }
+  private def columnMappingAdviceMessage: String = {
+    s"""
+       |Please upgrade your Delta table to reader version 2 and writer version 5
+       | and change the column mapping mode to name mapping. You can use the following command:
+       |
+       | ALTER TABLE <table_name> SET TBLPROPERTIES (
+       |   'delta.columnMapping.mode' = 'name',
+       |   'delta.minReaderVersion' = '2',
+       |   'delta.minWriterVersion' = '5')
+       |
+    """.stripMargin
+  }
 
+  def columnRenameNotSupported: Throwable = {
+    val adviceMsg = columnMappingAdviceMessage
     new AnalysisException(
       s"""
          |Column rename is not supported for your Delta table. $adviceMsg
          |""".stripMargin)
-    // scalastyle:on line.size.limit
+  }
+
+  def dropColumnNotSupported: Throwable = {
+    val adviceMsg = columnMappingAdviceMessage
+    new DeltaAnalysisException("UNSUPPORTED_DROP_COLUMN", Array(adviceMsg))
+  }
+
+  def dropPartitionColumnNotSupported: Throwable = {
+    new DeltaAnalysisException("UNSUPPORTED_DROP_PARTITION_COLUMN", Array())
   }
 
   def schemaChangeDuringMappingModeChangeNotSupported(
@@ -1362,17 +1364,11 @@ object DeltaErrors
         formatSchema(oldSchema),
         formatSchema(newSchema)))
 
-  def foundInvalidCharsInColumnNames(cause: Throwable): Throwable = {
-    // scalastyle:off line.size.limit
-    var adviceMsg = "Please use alias to rename it."
-
-    new AnalysisException(
-      s"""
-        |Found invalid character(s) among " ,;{}()\\n\\t=" in the column names of your
-        |schema. $adviceMsg
-        |""".stripMargin, cause = Some(cause))
-    // scalastyle:on line.size.limit
-  }
+  def foundInvalidCharsInColumnNames(cause: Throwable): Throwable =
+    new DeltaAnalysisException(
+      errorClass = "UNSUPPORTED_INVALID_CHARACTERS_IN_COLUMN_NAME",
+      messageParameters = Array(columnMappingAdviceMessage),
+      cause = Some(cause))
 
   def foundViolatingConstraintsForColumnChange(
       operation: String,

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1328,7 +1328,7 @@ object DeltaErrors
   private def columnMappingAdviceMessage: String = {
     s"""
        |Please upgrade your Delta table to reader version 2 and writer version 5
-       | and change the column mapping mode to name mapping. You can use the following command:
+       | and change the column mapping mode to 'name' mapping. You can use the following command:
        |
        | ALTER TABLE <table_name> SET TBLPROPERTIES (
        |   'delta.columnMapping.mode' = 'name',
@@ -1340,19 +1340,17 @@ object DeltaErrors
 
   def columnRenameNotSupported: Throwable = {
     val adviceMsg = columnMappingAdviceMessage
-    new AnalysisException(
-      s"""
-         |Column rename is not supported for your Delta table. $adviceMsg
-         |""".stripMargin)
+    new DeltaAnalysisException("UNSUPPORTED_RENAME_COLUMN", Array(adviceMsg))
   }
 
-  def dropColumnNotSupported: Throwable = {
-    val adviceMsg = columnMappingAdviceMessage
+  def dropColumnNotSupported(suggestUpgrade: Boolean): Throwable = {
+    val adviceMsg = if (suggestUpgrade) columnMappingAdviceMessage else ""
     new DeltaAnalysisException("UNSUPPORTED_DROP_COLUMN", Array(adviceMsg))
   }
 
-  def dropPartitionColumnNotSupported: Throwable = {
-    new DeltaAnalysisException("UNSUPPORTED_DROP_PARTITION_COLUMN", Array())
+  def dropPartitionColumnNotSupported(droppingPartCols: Seq[String]): Throwable = {
+    new DeltaAnalysisException("UNSUPPORTED_DROP_PARTITION_COLUMN",
+      Array(droppingPartCols.mkString(",")))
   }
 
   def schemaChangeDuringMappingModeChangeNotSupported(

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -248,6 +248,15 @@ object DeltaOperations {
           ) ++ colPosition.map("position" -> _.toString)
       }))
   }
+
+  /** Recorded when columns are dropped. */
+  case class DropColumns(
+    colsToDrop: Seq[Seq[String]]) extends Operation("DROP COLUMNS") {
+
+    override val parameters: Map[String, Any] = Map(
+      "columns" -> JsonUtils.toJson(colsToDrop.map(UnresolvedAttribute(_).name)))
+  }
+
   /** Recorded when columns are changed. */
   case class ChangeColumn(
       columnPath: Seq[String],

--- a/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
@@ -27,8 +27,7 @@ import scala.collection.mutable
 import org.apache.spark.sql.delta.{DeltaConfigs, DeltaErrors, DeltaTableUtils}
 import org.apache.spark.sql.delta.{DeltaLog, DeltaOptions}
 import org.apache.spark.sql.delta.DeltaTableIdentifier.gluePermissionError
-import org.apache.spark.sql.delta.commands.{AlterTableAddColumnsDeltaCommand, AlterTableChangeColumnDeltaCommand, AlterTableSetLocationDeltaCommand, AlterTableSetPropertiesDeltaCommand, AlterTableUnsetPropertiesDeltaCommand, CreateDeltaTableCommand, TableCreationModes}
-import org.apache.spark.sql.delta.commands.{AlterTableAddConstraintDeltaCommand, AlterTableDropConstraintDeltaCommand, WriteIntoDelta}
+import org.apache.spark.sql.delta.commands._
 import org.apache.spark.sql.delta.constraints.{AddConstraint, DropConstraint}
 import org.apache.spark.sql.delta.sources.{DeltaSourceUtils, DeltaSQLConf}
 import org.apache.hadoop.fs.Path
@@ -458,6 +457,10 @@ class DeltaCatalog extends DelegatingCatalogExtension
               Option(col.comment()),
               Option(col.position()).map(UnresolvedFieldPosition))
           }).run(spark)
+
+      case (t, deleteColumns) if t == classOf[DeleteColumn] =>
+        AlterTableDropColumnsDeltaCommand(
+          table, deleteColumns.asInstanceOf[Seq[DeleteColumn]].map(_.fieldNames().toSeq)).run(spark)
 
       case (t, newProperties) if t == classOf[SetProperty] =>
         AlterTableSetPropertiesDeltaCommand(

--- a/core/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -17,23 +17,19 @@
 package org.apache.spark.sql.delta.schema
 
 // scalastyle:off import.ordering.noEmptyLine
-import java.util.Locale
-
 import scala.collection.Set._
 import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
 
-import org.apache.spark.sql.delta.{DeltaAnalysisException, DeltaColumnMappingMode, DeltaConfigs, DeltaErrors, GeneratedColumn, NoMapping}
-import org.apache.spark.sql.delta.actions
+import org.apache.spark.sql.delta.{DeltaAnalysisException, DeltaColumnMappingMode, DeltaErrors, GeneratedColumn, NoMapping}
+import org.apache.spark.sql.delta.actions.Protocol
 import org.apache.spark.sql.delta.schema.SchemaMergingUtils._
 import org.apache.spark.sql.delta.sources.DeltaSourceUtils.GENERATION_EXPRESSION_METADATA_KEY
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.sql._
-import org.apache.spark.sql.catalyst.analysis.{Resolver, TypeCoercion, UnresolvedAttribute}
-import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
-import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
-import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.catalyst.analysis.{Resolver, UnresolvedAttribute}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.functions.{col, struct}
 import org.apache.spark.sql.internal.SQLConf
@@ -709,6 +705,10 @@ object SchemaUtils {
       }
       (StructType(pre ++ Seq(mid) ++ schema.slice(slicePosition + 1, length)), original)
     } else {
+      if (length == 1) {
+        throw new AnalysisException(
+          "Cannot drop column from a struct type with a single field: " + schema)
+      }
       (StructType(pre ++ schema.slice(slicePosition + 1, length)), schema(slicePosition))
     }
   }
@@ -722,6 +722,7 @@ object SchemaUtils {
       from: DataType,
       to: DataType,
       resolver: Resolver,
+      columnMappingMode: DeltaColumnMappingMode,
       columnPath: Seq[String] = Seq.empty): Option[String] = {
     def verify(cond: Boolean, err: => String): Unit = {
       if (!cond) {
@@ -761,9 +762,11 @@ object SchemaUtils {
                   UnresolvedAttribute(columnPath :+ toField.name).name)
             }
           }
-          verify(remainingFields.isEmpty,
-            s"dropping column(s) [${remainingFields.map(_.name).mkString(", ")}]" +
-            (if (columnPath.nonEmpty) s" from ${UnresolvedAttribute(columnPath).name}" else ""))
+          if (columnMappingMode == NoMapping) {
+            verify(remainingFields.isEmpty,
+              s"dropping column(s) [${remainingFields.map(_.name).mkString(", ")}]" +
+                (if (columnPath.nonEmpty) s" from ${UnresolvedAttribute(columnPath).name}" else ""))
+          }
 
         case (fromDataType, toDataType) =>
           verify(fromDataType == toDataType,
@@ -890,7 +893,6 @@ object SchemaUtils {
 
   /**
    * Check if the schema contains invalid char in the column names depending on the mode.
-   * TODO: We can suggest the mapping mode flag when this feature is in public preview.
    */
   def checkSchemaFieldNames(schema: StructType, columnMappingMode: DeltaColumnMappingMode): Unit = {
     if (columnMappingMode != NoMapping) return
@@ -999,5 +1001,31 @@ object SchemaUtils {
       case _ =>
     }
     false
+  }
+
+  /**
+   * Find all the generated columns that depend on the given target column.
+   */
+  def findDependentGeneratedColumns(
+      sparkSession: SparkSession,
+      targetColumn: Seq[String],
+      protocol: Protocol,
+      schema: StructType): Seq[StructField] = {
+    if (GeneratedColumn.satisfyGeneratedColumnProtocol(protocol) &&
+        GeneratedColumn.hasGeneratedColumns(schema)) {
+
+      val dependentGenCols = ArrayBuffer[StructField]()
+      SchemaMergingUtils.transformColumns(schema) { (_, field, _) =>
+        GeneratedColumn.getGenerationExpressionStr(field.metadata).foreach { exprStr =>
+          val needsToChangeExpr = SchemaUtils.containsDependentExpression(
+            sparkSession, targetColumn, exprStr, sparkSession.sessionState.conf.resolver)
+          if (needsToChangeExpr) dependentGenCols += field
+        }
+        field
+      }
+      dependentGenCols.toList
+    } else {
+      Seq.empty
+    }
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -628,6 +628,15 @@ trait DeltaSQLConfBase {
           |""".stripMargin)
       .booleanConf
       .createWithDefault(true)
+
+  val DELTA_ALTER_TABLE_DROP_COLUMN_ENABLED =
+    buildConf("alterTable.dropColumn.enabled")
+      .internal()
+      .doc(
+        "Whether to enable the drop column feature. This feature is behind this flag with default" +
+          " off until the physical deletion of dropped columns is supported")
+      .booleanConf
+      .createWithDefault(false)
 }
 
 object DeltaSQLConf extends DeltaSQLConfBase

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaArbitraryColumnNameSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaArbitraryColumnNameSuite.scala
@@ -174,6 +174,11 @@ trait DeltaArbitraryColumnNameSuiteBase extends DeltaColumnMappingSuiteBase {
     writer.create()
   }
 
+  protected def assertException(message: String)(block: => Unit): Unit = {
+    val e = intercept[Exception](block)
+
+    assert(e.getMessage.contains(message))
+  }
 }
 
 class DeltaArbitraryColumnNameSuite extends QueryTest

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnRenameSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnRenameSuite.scala
@@ -219,6 +219,7 @@ class DeltaColumnRenameSuite extends QueryTest
     withTable("t1") {
       val schemaWithNotNull =
         simpleNestedData.schema.toDDL.replace("c: STRING", "c: STRING NOT NULL")
+          .replace("`c`: STRING", "`c`: STRING NOT NULL")
 
       withTable("source") {
         spark.sql(
@@ -271,6 +272,10 @@ class DeltaColumnRenameSuite extends QueryTest
           "values ('str3', struct('str1.3', -1), map('k3', 'v3'), array(3, 33))")
       }
 
+      assertException("NOT NULL constraint violated for column: b.c1") {
+        spark.sql("insert into t1 " +
+          "values ('str3', struct(null, 3), map('k3', 'v3'), array(3, 33))")
+      }
 
       // this is a safety flag - it won't error when you turn it off
       withSQLConf(DeltaSQLConf.DELTA_ALTER_TABLE_CHANGE_COLUMN_CHECK_EXPRESSIONS.key -> "false") {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnRenameSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnRenameSuite.scala
@@ -29,12 +29,6 @@ class DeltaColumnRenameSuite extends QueryTest
   with DeltaArbitraryColumnNameSuiteBase
   with GivenWhenThen {
 
-  private def assertException(message: String)(block: => Unit): Unit = {
-    val e = intercept[Exception](block)
-
-    assert(e.getMessage.contains(message))
-  }
-
   testColumnMapping("rename in column mapping mode") { mode =>
     withTable("t1") {
       createTableWithSQLAPI("t1",
@@ -261,7 +255,7 @@ class DeltaColumnRenameSuite extends QueryTest
         spark.sql("alter table t1 rename column b to b1")
       }
 
-      // can still rename map because it's referenced by a null constraint
+      // can still rename b.c because it's referenced by a null constraint
       spark.sql("alter table t1 rename column b.c to c1")
 
       spark.sql("insert into t1 " +

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaDropColumnSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaDropColumnSuite.scala
@@ -1,0 +1,256 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.types.{ArrayType, IntegerType, MapType, StringType, StructType}
+
+class DeltaDropColumnSuite extends QueryTest with DeltaArbitraryColumnNameSuiteBase {
+
+  override protected val sparkConf: SparkConf =
+    super.sparkConf.set(DeltaSQLConf.DELTA_ALTER_TABLE_DROP_COLUMN_ENABLED.key, "true")
+
+  test("drop column") {
+    withTable("t1") {
+      createTableWithSQLAPI("t1",
+        simpleNestedData,
+        Map(DeltaConfigs.COLUMN_MAPPING_MODE.key -> "name"))
+
+      val schemaAfterDelete = StructType(simpleNestedSchema.fields.filter(_.name != "arr"))
+
+      // alter table replace columns
+      spark.sql(s"alter table t1 replace columns (${schemaAfterDelete.toDDL})")
+      checkAnswer(spark.table("t1"), simpleNestedData.drop("arr"))
+
+      // alter table drop column
+      spark.sql("alter table t1 drop columns (a, b.c)")
+      checkAnswer(spark.table("t1"),
+        Seq(
+          Row(Row(1), Map("k1" -> "v1")),
+          Row(Row(2), Map("k2" -> "v2"))))
+
+      // column cannot be queried anymore - even metadata-only queries
+      assert(intercept[AnalysisException] {
+        spark.table("t1").where("a = 'str1'").collect()
+      }.getMessage.contains("does not exist"))
+
+      assert(intercept[AnalysisException] {
+        spark.table("t1").select("min(a)").collect()
+      }.getMessage.contains("does not exist"))
+
+      checkAnswer(
+        spark.sql("describe history t1")
+          .select("operation", "operationParameters")
+          .where("version = 3"),
+        Seq(
+          Row("DROP COLUMNS", Map("columns" -> """["a","b.c"]"""))))
+
+      // dropping non-existent field would fail
+      assertException("Missing field a") {
+        spark.sql("alter table t1 drop column (a)")
+      }
+      // cannot drop the last nested field
+      val e = intercept[AnalysisException] {
+        spark.sql("alter table t1 drop columns (b.d)")
+      }
+      assert(e.getMessage.contains("Cannot drop column from a struct type with a single field"))
+
+      // can drop the parent column
+      spark.sql("alter table t1 drop columns b")
+
+      // cannot drop the last top-level field
+      val e2 = intercept[AnalysisException] {
+        spark.sql("alter table t1 drop columns map")
+      }
+      assert(e2.getMessage.contains("Cannot drop column from a struct type with a single field"))
+
+      spark.sql("alter table t1 add column (e struct<e1 string, e2 string>)")
+
+      // rename column to contain arbitrary chars
+      spark.sql(s"alter table t1 rename column map to `${colName("map")}`")
+
+      // try drop map after rename to arbitrary chars now
+      spark.sql(s"alter table t1 drop columns `${colName("map")}`")
+
+      // corner-case test - can drop a nested column when the top-level column is the only column
+      spark.sql("alter table t1 drop column e.e1")
+    }
+  }
+
+  test("drop column with constraints") {
+    withTable("t1") {
+      val schemaWithNotNull =
+        simpleNestedData.schema.toDDL.replace("c: STRING", "c: STRING NOT NULL")
+
+      withTable("source") {
+        spark.sql(
+          s"""
+             |CREATE TABLE t1 ($schemaWithNotNull)
+             |USING DELTA
+             |${propString(Map(DeltaConfigs.COLUMN_MAPPING_MODE.key -> "name"))}
+             |""".stripMargin)
+        simpleNestedData.write.format("delta").mode("append").saveAsTable("t1")
+      }
+
+      spark.sql("alter table t1 add constraint rangeABC check (concat(a, a) > 'str')")
+      spark.sql("alter table t1 add constraint rangeBD check (`b`.`d` > 0)")
+      spark.sql("alter table t1" +
+        " add constraint mapValue check (map['k1'] = 'v1' or map['k1'] is null)")
+
+      spark.sql("alter table t1 add constraint arrValue check (arr[0] > 0)")
+
+      assertException("Cannot drop column a") {
+        spark.sql("alter table t1 drop column a")
+      }
+
+      assertException("Cannot drop column arr") {
+        spark.sql("alter table t1 drop column arr")
+      }
+
+      assertException("Cannot drop column map") {
+        spark.sql("alter table t1 drop column map")
+      }
+
+      // cannot drop b because its child is referenced
+      assertException("Cannot drop column b") {
+        spark.sql("alter table t1 drop column b")
+      }
+
+      // can still drop b.c because it's referenced by a null constraint
+      spark.sql("alter table t1 drop column b.c")
+
+      // this is a safety flag - it won't error when you turn it off
+      withSQLConf(DeltaSQLConf.DELTA_ALTER_TABLE_CHANGE_COLUMN_CHECK_EXPRESSIONS.key -> "false") {
+        spark.sql("alter table t1 drop columns (b, arr)")
+      }
+    }
+  }
+
+  test("drop with generated column") {
+    withTable("t1") {
+      withSQLConf(DeltaSQLConf.DELTA_ALTER_TABLE_DROP_COLUMN_ENABLED.key -> "true") {
+        val tableBuilder = io.delta.tables.DeltaTable.create(spark).tableName("t1")
+        tableBuilder.property("delta.columnMapping.mode", "name")
+
+        // add existing columns
+        simpleNestedSchema.map(field => (field.name, field.dataType)).foreach(col => {
+          val (colName, dataType) = col
+          val columnBuilder = io.delta.tables.DeltaTable.columnBuilder(spark, colName)
+          columnBuilder.dataType(dataType.sql)
+          tableBuilder.addColumn(columnBuilder.build())
+        })
+
+        // add generated columns
+        val genCol1 = io.delta.tables.DeltaTable.columnBuilder(spark, "genCol1")
+          .dataType("int")
+          .generatedAlwaysAs("length(a)")
+          .build()
+
+        val genCol2 = io.delta.tables.DeltaTable.columnBuilder(spark, "genCol2")
+          .dataType("int")
+          .generatedAlwaysAs("b.d * 100 + arr[0]")
+          .build()
+
+        tableBuilder
+          .addColumn(genCol1)
+          .addColumn(genCol2)
+          .execute()
+
+        simpleNestedData.write.format("delta").mode("append").saveAsTable("t1")
+
+        assertException("Cannot drop column a") {
+          spark.sql("alter table t1 drop column a")
+        }
+
+        assertException("Cannot drop column b") {
+          spark.sql("alter table t1 drop column b")
+        }
+
+        assertException("Cannot drop column b.d") {
+          spark.sql("alter table t1 drop column b.d")
+        }
+
+        assertException("Cannot drop column arr") {
+          spark.sql("alter table t1 drop column arr")
+        }
+
+        // you can still drop b.c as it has no dependent gen col
+        spark.sql("alter table t1 drop column b.c")
+
+        // you can also drop a generated column itself
+        spark.sql("alter table t1 drop column genCol1")
+
+        // add new data after dropping
+        spark.createDataFrame(
+          Seq(Row("str3", Row(3), Map("k3" -> "v3"), Array(3, 33))).asJava,
+          new StructType()
+            .add("a", StringType, true)
+            .add("b",
+              new StructType()
+                .add("d", IntegerType, true))
+            .add("map", MapType(StringType, StringType), true)
+            .add("arr", ArrayType(IntegerType), true))
+          .write.format("delta").mode("append").saveAsTable("t1")
+
+        checkAnswer(spark.table("t1"),
+          Seq(
+            Row("str1", Row(1), Map("k1" -> "v1"), Array(1, 11), 101),
+            Row("str2", Row(2), Map("k2" -> "v2"), Array(2, 22), 202),
+            Row("str3", Row(3), Map("k3" -> "v3"), Array(3, 33), 303)))
+
+        // this is a safety flag - if you turn it off, it will still error but msg is not as helpful
+        withSQLConf(DeltaSQLConf.DELTA_ALTER_TABLE_CHANGE_COLUMN_CHECK_EXPRESSIONS.key -> "false") {
+          assertException("A generated column cannot use a non-existent column") {
+            spark.sql("alter table t1 drop column arr")
+          }
+        }
+      }
+    }
+  }
+
+  test("dropping all columns is not allowed") {
+    withTable("t1") {
+      createTableWithSQLAPI("t1",
+        simpleNestedData,
+        Map(DeltaConfigs.COLUMN_MAPPING_MODE.key -> "name")
+      )
+      val e = intercept[AnalysisException] {
+        sql("alter table t1 drop columns (a, b, map, arr)")
+      }
+      assert(e.getMessage.contains("Cannot drop column"))
+    }
+  }
+
+  test("dropping partition columns is not allowed") {
+    withTable("t1") {
+      createTableWithSQLAPI("t1",
+        simpleNestedData,
+        Map(DeltaConfigs.COLUMN_MAPPING_MODE.key -> "name"),
+        partCols = Seq("a")
+      )
+      val e = intercept[AnalysisException] {
+        sql("alter table t1 drop columns (a)")
+      }
+      assert(e.getMessage.contains("Dropping partition columns is not allowed"))
+    }
+  }
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaDropColumnSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaDropColumnSuite.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.types.{ArrayType, IntegerType, MapType, StringType, StructType}
 
 class DeltaDropColumnSuite extends QueryTest with DeltaArbitraryColumnNameSuiteBase {
-
   override protected val sparkConf: SparkConf =
     super.sparkConf.set(DeltaSQLConf.DELTA_ALTER_TABLE_DROP_COLUMN_ENABLED.key, "true")
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
@@ -926,14 +926,15 @@ class SchemaUtilsSuite extends QueryTest
   test("dropColumn - nested struct") {
     val a = StructField("a", IntegerType)
     val b = StructField("b", StringType)
+    val c = StructField("c", StringType)
     val s = StructField("s", new StructType().add(a).add(b))
-    val schema = new StructType().add(s)
+    val schema = new StructType().add(s).add(c)
 
-    assert(SchemaUtils.dropColumn(schema, Seq(0)) === ((new StructType(), s)))
+    assert(SchemaUtils.dropColumn(schema, Seq(0)) === ((new StructType().add(c), s)))
     assert(SchemaUtils.dropColumn(schema, Seq(0, 0)) ===
-      ((new StructType().add("s", new StructType().add(b)), a)))
+      ((new StructType().add("s", new StructType().add(b)).add(c), a)))
     assert(SchemaUtils.dropColumn(schema, Seq(0, 1)) ===
-      ((new StructType().add("s", new StructType().add(a)), b)))
+      ((new StructType().add("s", new StructType().add(a)).add(c), b)))
 
     expectFailure("Index -1", "lower than 0") {
       SchemaUtils.dropColumn(schema, Seq(0, -1))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

This PR proposes to support ALTER TABLE DROP COLUMN as a metadata-only operation in Delta. No changes needed for the underlying Parquet files. This is only supported for Delta tables that enable column mapping. With column mapping, if a new column with the same name is added later, it won't be confused with the dropped column because the new column will have a different *physical* name than the one being dropped.

Note that there is no way to physically delete the dropped column from Parquet right now. This will be addressed as future work.

This PR partially addresses issue  #1064.

## How was this patch tested?
unit tests

## Does this PR introduce _any_ user-facing changes?

Add a new SQL command 
- ALTER TABLE table_name DROP COLUMN col_name
- ALTER TABLE table_name DROP COLUMNS (col_name1, col2_name2, ...)
