### PR TITLE
Fix ClassLoader issue when loading error mapping resource file in `--packages` mode

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaThrowableSuite.scala
@@ -16,9 +16,7 @@
 
 package org.apache.spark.sql.delta
 
-import java.net.URL
-
-import org.apache.spark.sql.delta.DeltaThrowableHelper.{deltaErrorClassSource, deltaErrorClassToInfoMap}
+import org.apache.spark.sql.delta.DeltaThrowableHelper.{deltaErrorClassSource, deltaErrorClassToInfoMap, sparkErrorClassesMap}
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.core.JsonParser.Feature.STRICT_DUPLICATE_DETECTION
 import com.fasterxml.jackson.core.`type`.TypeReference
@@ -28,7 +26,6 @@ import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.apache.commons.io.IOUtils
 
 import org.apache.spark.{ErrorInfo, SparkFunSuite}
-import org.apache.spark.util.Utils
 
 /** Test suite for Delta Throwables. */
 class DeltaThrowableSuite extends SparkFunSuite {
@@ -53,12 +50,7 @@ class DeltaThrowableSuite extends SparkFunSuite {
   }
 
   test("No error classes are shared by Delta and Spark") {
-    val mapper = JsonMapper.builder().addModule(DefaultScalaModule).build()
-    val sparkErrorClassSource: URL =
-      Utils.getSparkClassLoader.getResource("error/error-classes.json")
-    val sparkErrorClasses = mapper.readValue(
-      sparkErrorClassSource, new TypeReference[Map[String, ErrorInfo]]() {})
-    assert(deltaErrorClassToInfoMap.keySet.intersect(sparkErrorClasses.keySet).isEmpty)
+    assert(deltaErrorClassToInfoMap.keySet.intersect(sparkErrorClassesMap.keySet).isEmpty)
   }
 
   test("Delta error classes are correctly formatted") {


### PR DESCRIPTION

This PR fixes the resource loading error when Delta jars are loaded using `--packages` mode (eg. pyspark etc). The issue is caused by placement of Delta jars in separate place than Spark jars in pyspark.

Fix is to use `Utils.getContextOrSparkClassLoader` instead of `Utils.getSparkClassLoader` as the former searches for resources in Delta jars (current context) first before searching in Spark jars.

Proper integration test is pending. For now manually tested.

This fixes https://github.com/delta-io/delta/issues/1070

GitOrigin-RevId: 1b93cebb936e324d55cf2f3f18f5576f714807cc

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
