### PR TITLE
Add support for delta atomic commit read

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -112,6 +112,9 @@ trait DeltaReadOptions extends DeltaOptionParser {
     }
   }
 
+  val readAtomicCommits = options.get(READ_ATOMIC_COMMITS_OPTION)
+    .exists(toBoolean(_, READ_ATOMIC_COMMITS_OPTION))
+
   val ignoreFileDeletion = options.get(IGNORE_FILE_DELETION_OPTION)
     .exists(toBoolean(_, IGNORE_FILE_DELETION_OPTION))
 
@@ -188,6 +191,7 @@ object DeltaOptions extends DeltaLogging {
   val DATA_CHANGE_OPTION = "dataChange"
   val STARTING_VERSION_OPTION = "startingVersion"
   val STARTING_TIMESTAMP_OPTION = "startingTimestamp"
+  val READ_ATOMIC_COMMITS_OPTION = "readAtomicCommits"
 
   val validOptionKeys : Set[String] = Set(
     REPLACE_WHERE_OPTION,
@@ -204,6 +208,7 @@ object DeltaOptions extends DeltaLogging {
     DATA_CHANGE_OPTION,
     STARTING_TIMESTAMP_OPTION,
     STARTING_VERSION_OPTION,
+    READ_ATOMIC_COMMITS_OPTION,
     "queryName",
     "checkpointLocation",
     "path",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
This PR adds support for atomic commits read when reading data from a delta table.

[PIP](https://docs.google.com/document/d/1DCNNscqvZohHk0uwLVg245duAnZ_PESDH5NF431ZXgs/edit?usp=sharing)

Resolves #1026 

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Unit tests

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
Add a new config when reading delta as a streaming source
```
val q = spark.readStream
  .format("delta")
  .option("readAtomicCommits", "true")
  .load(path)
```

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
