### PR TITLE
Revert usages of Delta*Exception extending DeltaThrowable

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/deltaMerge.scala
+++ b/core/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/deltaMerge.scala
@@ -18,7 +18,6 @@ package org.apache.spark.sql.catalyst.plans.logical
 
 import java.util.Locale
 
-import org.apache.spark.sql.delta.DeltaAnalysisException
 import org.apache.spark.sql.delta.schema.SchemaMergingUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
@@ -151,9 +150,7 @@ object DeltaMergeIntoClause {
         case Assignment(key: UnresolvedAttribute, expr) => DeltaMergeAction(key.nameParts, expr)
         case Assignment(key: Attribute, expr) => DeltaMergeAction(Seq(key.name), expr)
         case other =>
-          throw new DeltaAnalysisException(
-            errorClass = "DELTA_MERGE_UNEXPECTED_ASSIGNMENT_KEY",
-            messageParameters = Array(s"${other.getClass}", s"$other"))
+          throw new AnalysisException(s"Unexpected assignment key: ${other.getClass} - $other")
       }
     }
   }

--- a/core/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -377,7 +377,7 @@ object Checkpoints extends DeltaLogging {
         } else {
           // There should be only one writer writing the checkpoint file, so there must be
           // something wrong here.
-          throw DeltaErrors.failOnCheckpoint(src, dest)
+          throw new IllegalStateException(s"Cannot rename $src to $dest")
         }
       } finally {
         if (!renameDone) {

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -277,16 +277,13 @@ object DeltaErrors
   }
 
   def notADeltaTableException(deltaTableIdentifier: DeltaTableIdentifier): Throwable = {
-    new DeltaAnalysisException(
-      errorClass = "MISSING_DELTA_TABLE",
-      messageParameters = Array(s"$deltaTableIdentifier"))
+    new AnalysisException(s"$deltaTableIdentifier is not a Delta table.")
   }
 
   def notADeltaTableException(
       operation: String, deltaTableIdentifier: DeltaTableIdentifier): Throwable = {
-    new DeltaAnalysisException(
-      errorClass = "DELTA_TABLE_ONLY_OPERATION",
-      messageParameters = Array(s"$deltaTableIdentifier", s"$operation"))
+    new AnalysisException(s"$deltaTableIdentifier is not a Delta table. " +
+      s"$operation is only supported for Delta tables.")
   }
 
   def notADeltaTableException(operation: String): Throwable = {
@@ -318,9 +315,10 @@ object DeltaErrors
   }
 
   def invalidColumnName(name: String): Throwable = {
-    new DeltaAnalysisException(
-      errorClass = "INVALID_CHARACTERS_IN_COLUMN_NAME",
-      messageParameters = Array(name))
+    new AnalysisException(
+      s"""Attribute name "$name" contains invalid character(s) among " ,;{}()\\n\\t=".
+         |Please use alias to rename it.
+      """.stripMargin.split("\n").mkString(" ").trim)
   }
 
   def invalidPartitionColumn(e: AnalysisException): Throwable = {
@@ -639,15 +637,13 @@ object DeltaErrors
   }
 
   def updateSetColumnNotFoundException(col: String, colList: Seq[String]): Throwable = {
-    new DeltaAnalysisException(
-      errorClass = "MISSING_SET_COLUMN",
-      messageParameters = Array(formatColumn(col), formatColumnList(colList)))
+    new AnalysisException(
+      s"SET column ${formatColumn(col)} not found given columns: ${formatColumnList(colList)}.")
   }
 
   def updateSetConflictException(cols: Seq[String]): Throwable = {
-    new DeltaAnalysisException(
-      errorClass = "CONFLICT_SET_COLUMN",
-      messageParameters = Array(formatColumnList(cols)))
+    new AnalysisException(
+      s"There is a conflict from these SET columns: ${formatColumnList(cols)}.")
   }
 
   def updateNonStructTypeFieldNotSupportedException(col: String, s: DataType): Throwable = {
@@ -668,9 +664,8 @@ object DeltaErrors
   }
 
   def bloomFilterOnNestedColumnNotSupportedException(name: String): Throwable = {
-    new DeltaAnalysisException(
-      errorClass = "UNSUPPORTED_NESTED_COLUMN_IN_BLOOM_FILTER",
-      messageParameters = Array(name))
+    new AnalysisException(
+      s"Creating a bloom filer index on a nested column is currently unsupported: $name")
   }
 
   def bloomFilterOnColumnTypeNotSupportedException(name: String, dataType: DataType): Throwable = {
@@ -1190,8 +1185,9 @@ object DeltaErrors
   }
 
   def generatedColumnsReferToWrongColumns(e: AnalysisException): Throwable = {
-    new DeltaAnalysisException(
-      errorClass = "INVALID_GENERATED_COLUMN_REFERENCES", Array.empty, cause = Some(e))
+    new AnalysisException(
+      "A generated column cannot use a non-existent column or another generated column",
+      cause = Some(e))
   }
 
   def generatedColumnsUpdateColumnType(current: StructField, update: StructField): Throwable = {
@@ -1278,9 +1274,8 @@ object DeltaErrors
   }
 
   def changeColumnMappingModeNotSupported(oldMode: String, newMode: String): Throwable = {
-    new DeltaColumnMappingUnsupportedException(
-      errorClass = "UNSUPPORTED_COLUMN_MAPPING_MODE_CHANGE",
-      messageParameters = Array(oldMode, newMode))
+    new ColumnMappingUnsupportedException("Changing column mapping mode from" +
+      s" '$oldMode' to '$newMode' is not supported.")
   }
 
   def writesWithColumnMappingNotSupported: Throwable = {

--- a/core/src/main/scala/org/apache/spark/sql/delta/constraints/DeltaInvariantCheckerExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/constraints/DeltaInvariantCheckerExec.scala
@@ -174,11 +174,9 @@ object DeltaInvariantCheckerExec {
           optimizedLogicalPlan match {
             case ExpressionLogicalPlanWrapper(e) => e
             // This should never happen.
-            case plan => throw new DeltaIllegalStateException(
-              errorClass = "INTERNAL_ERROR",
-              messageParameters = Array(
-                "Applying type casting resulted in a bad plan rather than a simple expression.\n" +
-               s"Plan:${plan.prettyJson}\n"))
+            case plan => throw new IllegalStateException(
+              "Applying type casting resulted in a bad plan rather than a simple expression.\n" +
+              s"Plan:${plan.prettyJson}\n")
           }
       }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/schema/SchemaMergingUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/schema/SchemaMergingUtils.scala
@@ -20,8 +20,6 @@ import java.util.Locale
 
 import scala.util.control.NonFatal
 
-import org.apache.spark.sql.delta.DeltaAnalysisException
-
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.{Resolver, TypeCoercion, UnresolvedAttribute}
 import org.apache.spark.sql.catalyst.expressions.Literal
@@ -204,18 +202,14 @@ object SchemaMergingUtils {
           if ((leftPrecision == rightPrecision) && (leftScale == rightScale)) {
             current
           } else if ((leftPrecision != rightPrecision) && (leftScale != rightScale)) {
-            throw new DeltaAnalysisException(
-              errorClass = "MERGE_INCOMPATIBLE_DECIMAL_TYPE",
-              messageParameters = Array(
-                s"precision $leftPrecision and $rightPrecision & scale $leftScale and $rightScale"))
+            throw new AnalysisException("Failed to merge decimal types with incompatible " +
+              s"precision $leftPrecision and $rightPrecision & scale $leftScale and $rightScale")
           } else if (leftPrecision != rightPrecision) {
-            throw new DeltaAnalysisException(
-              errorClass = "MERGE_INCOMPATIBLE_DECIMAL_TYPE",
-              messageParameters = Array(s"precision $leftPrecision and $rightPrecision"))
+            throw new AnalysisException("Failed to merge decimal types with incompatible " +
+              s"precision $leftPrecision and $rightPrecision")
           } else {
-            throw new DeltaAnalysisException(
-              errorClass = "MERGE_INCOMPATIBLE_DECIMAL_TYPE",
-              messageParameters = Array(s"scale $leftScale and $rightScale"))
+            throw new AnalysisException("Failed to merge decimal types with incompatible " +
+              s"scale $leftScale and $rightScale")
           }
         case _ if current == update =>
           current

--- a/core/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -23,7 +23,7 @@ import scala.collection.Set._
 import scala.collection.mutable
 import scala.util.control.NonFatal
 
-import org.apache.spark.sql.delta.{DeltaAnalysisException, DeltaColumnMappingMode, DeltaConfigs, DeltaErrors, GeneratedColumn, NoMapping}
+import org.apache.spark.sql.delta.{DeltaColumnMappingMode, DeltaConfigs, DeltaErrors, GeneratedColumn, NoMapping}
 import org.apache.spark.sql.delta.actions
 import org.apache.spark.sql.delta.schema.SchemaMergingUtils._
 import org.apache.spark.sql.delta.sources.DeltaSourceUtils.GENERATION_EXPRESSION_METADATA_KEY
@@ -123,14 +123,14 @@ object SchemaUtils {
         struct(nested: _*).alias(sf.name)
       case a: ArrayType if typeExistsRecursively(a)(_.isInstanceOf[NullType]) =>
         val colName = UnresolvedAttribute.apply(nameStack :+ sf.name).name
-        throw new DeltaAnalysisException(
-          errorClass = "COMPLEX_TYPE_COLUMN_CANNOT_CONTAIN_NULL_TYPE",
-          messageParameters = Array(colName, "ArrayType"))
+        throw new AnalysisException(
+          s"Found nested NullType in column $colName which is of ArrayType. Delta doesn't " +
+            "support writing NullType in complex types.")
       case m: MapType if typeExistsRecursively(m)(_.isInstanceOf[NullType]) =>
         val colName = UnresolvedAttribute.apply(nameStack :+ sf.name).name
-        throw new DeltaAnalysisException(
-          errorClass = "COMPLEX_TYPE_COLUMN_CANNOT_CONTAIN_NULL_TYPE",
-          messageParameters = Array(colName, "NullType"))
+        throw new AnalysisException(
+          s"Found nested NullType in column $colName which is of MapType. Delta doesn't " +
+            "support writing NullType in complex types.")
       case _ =>
         val colName = UnresolvedAttribute.apply(nameStack :+ sf.name).name
         col(colName).alias(sf.name)

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -108,8 +108,8 @@ trait DeltaErrorsSuiteBase
     testUrls()
   }
 
-
-  test("test DeltaErrors OSS methods") {
+  // Disabled due to delta-io/delta/issue/1070
+  ignore("test DeltaErrors OSS methods") {
     {
       val e = intercept[DeltaIllegalStateException] {
         throw DeltaErrors.failOnCheckpoint(new Path("path-1"), new Path("path-2"))

--- a/core/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
@@ -503,7 +503,7 @@ trait GeneratedColumnSuiteBase extends GeneratedColumnTest {
     val f1 = StructField("c1", IntegerType)
     val f2 = withGenerationExpression(StructField("c2", IntegerType), "c10 + 10")
     val schema = StructType(f1 :: f2 :: Nil)
-    val e = intercept[DeltaAnalysisException](validateGeneratedColumns(spark, schema))
+    val e = intercept[AnalysisException](validateGeneratedColumns(spark, schema))
     errorContains(e.getMessage,
       "A generated column cannot use a non-existent column or another generated column")
   }
@@ -527,7 +527,7 @@ trait GeneratedColumnSuiteBase extends GeneratedColumnTest {
     val f2 = withGenerationExpression(StructField("c2", IntegerType), "c1 + 10")
     val f3 = withGenerationExpression(StructField("c3", IntegerType), "c2 + 10")
     val schema = StructType(f1 :: f2 :: f3 :: Nil)
-    val e = intercept[DeltaAnalysisException](validateGeneratedColumns(spark, schema))
+    val e = intercept[AnalysisException](validateGeneratedColumns(spark, schema))
     errorContains(e.getMessage,
       "A generated column cannot use a non-existent column or another generated column")
   }

--- a/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
@@ -293,7 +293,7 @@ class MergeIntoSQLSuite extends MergeIntoSuiteBase  with DeltaSQLCommandTest
       createTempViewFromTable(targetName, isSQLTempView)
       val fieldNames = spark.table(targetName).schema.fieldNames
       val fieldNamesStr = fieldNames.mkString("`", "`, `", "`")
-      val e = intercept[DeltaAnalysisException] {
+      val e = intercept[AnalysisException] {
         executeMerge(
           target = "v t",
           source = s"$sourceName s",

--- a/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
@@ -780,7 +780,7 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase  with DeltaSQLCommandTest
 
   test("delta merge into clause with invalid data type.") {
     import org.apache.spark.sql.catalyst.dsl.expressions._
-    intercept[DeltaAnalysisException] {
+    intercept[AnalysisException] {
       DeltaMergeIntoClause.toActions(Seq(Assignment("1".expr, "1".expr)))
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
Commit 59d5ea2 replaced the usage of `AnalysisException` with `DeltaAnalysisException`. This caused the Python API exception conversion to not work. Earlier the exception `AnalysisException` used to be convertd to PySpark's `AnalysisException` (code is [here](https://github.com/databricks/runtime/blob/master/python/pyspark/sql/utils.py#L156)). With 59d5ea2, exception `DeltaAnalysisException` is thrown directly as a Py4JError.

Revert the usage of `DeltaAnalysisException` to not break the Python API compatibility.

Summary of reverts.
* `DeltaAnalysisException` - Reverted in all production code. Only place this remains is in a disabled test in `DeltaErrorsSuite`
* `DeltaIllegalArgumentException` - This is used only in two helper methods (`copyIntoEncryptionSseCRequired` and `copyIntoEncryptionMasterKeyRequired`) in `DeltaErrors` which are not used anywhere in the production code.
* `DeltaIllegalStateException` - Used only in couple of places (`Checkpoints.scala`, `DeltaInvariantCheckerExec.scala`) which are reverted in this PR. Remaining uses are in utility method `DeltaErrors.failOnCheckpoint` which is not used anywhere in the production code.
* `DeltaColumnMappingUnsupportedException` - This is used in few places like when column rename not supported, generating manifest file, convert to delta and few schema change operations. These changes are not reverted. Let me know if this needs revert as well.

Resolves #1086
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Locally.

```
(base) $ spark-3.2.1-bin-hadoop3.2 % pyspark --packages io.delta:delta-core_2.12:1.2.1-SNAPSHOT --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"


downloading file:~/.m2/repository/io/delta/delta-core_2.12/1.2.1-SNAPSHOT/delta-core_2.12-1.2.1-SNAPSHOT.jar ...

>>> df = spark.read.format("delta").load("/tmp/delta-table2234234")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/anaconda3/lib/python3.9/site-packages/pyspark/sql/readwriter.py", line 158, in load
    return self._df(self._jreader.load(path))
  File "/opt/anaconda3/lib/python3.9/site-packages/pyspark/python/lib/py4j-0.10.9.3-src.zip/py4j/java_gateway.py", line 1321, in __call__
  File "/opt/anaconda3/lib/python3.9/site-packages/pyspark/sql/utils.py", line 117, in deco
    raise converted from None
pyspark.sql.utils.AnalysisException: `/tmp/delta-table2234234` is not a Delta table.
```

