### PR TITLE
Update DelegatingLogStore log statement to include LogStoreAdapter.logStoreImpl class

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/storage/DelegatingLogStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/storage/DelegatingLogStore.scala
@@ -65,7 +65,13 @@ class DelegatingLogStore(hadoopConf: Configuration)
               .orElse(DelegatingLogStore.getDefaultLogStoreClassName(scheme))
             val logStore = logStoreClassNameOpt.map(createLogStore(_)).getOrElse(defaultLogStore)
             schemeToLogStoreMap += scheme -> logStore
-            logInfo(s"LogStore ${logStore.getClass.getName} is used for scheme ${scheme}")
+
+            val actualLogStoreClassName = logStore match {
+              case lsa: LogStoreAdaptor => s"LogStoreAdapter(${lsa.logStoreImpl.getClass.getName})"
+              case _ => logStore.getClass.getName
+            }
+            logInfo(s"LogStore `$actualLogStoreClassName` is used for scheme `$scheme`")
+
             logStore
           }
         }


### PR DESCRIPTION
## Description

Update the logInfo statement in DelegatingLogStore to include the actual implementation class of the LogStoreAdapter

## How was this patch tested?

published jars locally and tested with pyspark
