### PR TITLE
Remove merge.maxInsertCount as not used

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -329,13 +329,6 @@ trait DeltaSQLConfBase {
       .stringConf
       .createWithDefault(".s3-optimization-")
 
-  val MERGE_MAX_INSERT_COUNT =
-    buildConf("merge.maxInsertCount")
-      .internal()
-      .doc("Max row count of inserts in each MERGE execution.")
-      .longConf
-      .createWithDefault(10000L)
-
   val MERGE_INSERT_ONLY_ENABLED =
     buildConf("merge.optimizeInsertOnlyMerge.enabled")
       .internal()


### PR DESCRIPTION
## Description

It was brought up in delta-oss slack channel 
https://delta-users.slack.com/archives/CJ70UCSHM/p1626443655490700 

Remove merge.maxInsertCount as it's not used

ps. SC-81424 