### PR TITLE
[1094] Fix config for S3 multi-cluster mode

### DIFF
--- a/storage-s3-dynamodb/integration_tests/dynamodb_logstore.py
+++ b/storage-s3-dynamodb/integration_tests/dynamodb_logstore.py
@@ -45,7 +45,7 @@ export DELTA_STORAGE=io.delta.storage.S3DynamoDBLogStore
 export DELTA_NUM_ROWS=16
 
 ./run-integration-tests.py --run-storage-s3-dynamodb-integration-tests \
-    --dbb-packages org.apache.hadoop:hadoop-aws:3.3.1,com.amazonaws:aws-java-sdk-bundle:1.12.142 \
+    --dbb-packages org.apache.hadoop:hadoop-aws:3.3.1 \
     --dbb-conf spark.jars.ivySettings=/workspace/ivy.settings \
         spark.driver.extraJavaOptions=-Dlog4j.configuration=file:debug/log4j.properties
 """
@@ -89,21 +89,23 @@ spark = SparkSession \
     .config("spark.delta.logStore.s3.impl", delta_storage) \
     .config("spark.delta.logStore.s3a.impl", delta_storage) \
     .config("spark.delta.logStore.s3n.impl", delta_storage) \
-    .config("io.delta.storage.S3DynamoDBLogStore.ddb.tableName", dynamo_table_name) \
-    .config("io.delta.storage.S3DynamoDBLogStore.ddb.region", dynamo_region) \
-    .config("io.delta.storage.S3DynamoDBLogStore.errorRates", dynamo_error_rates) \
-    .config("io.delta.storage.S3DynamoDBLogStore.provisionedThroughput.rcu", 12) \
-    .config("io.delta.storage.S3DynamoDBLogStore.provisionedThroughput.wcu", 13) \
+    .config("spark.io.delta.storage.S3DynamoDBLogStore.ddb.tableName", dynamo_table_name) \
+    .config("spark.io.delta.storage.S3DynamoDBLogStore.ddb.region", dynamo_region) \
+    .config("spark.io.delta.storage.S3DynamoDBLogStore.errorRates", dynamo_error_rates) \
+    .config("spark.io.delta.storage.S3DynamoDBLogStore.provisionedThroughput.rcu", 12) \
+    .config("spark.io.delta.storage.S3DynamoDBLogStore.provisionedThroughput.wcu", 13) \
     .getOrCreate()
 
 spark.sparkContext.setLogLevel("INFO")
 
 data = spark.createDataFrame([], "id: int, a: int")
+print("writing:", data.collect())
 data.write.format("delta").mode("overwrite").partitionBy("id").save(delta_table_path)
 
 
 def write_tx(n):
     data = spark.createDataFrame([[n, n]], "id: int, a: int")
+    print("writing:", data.collect())
     data.write.format("delta").mode("append").partitionBy("id").save(delta_table_path)
 
 

--- a/storage-s3-dynamodb/integration_tests/dynamodb_logstore.py
+++ b/storage-s3-dynamodb/integration_tests/dynamodb_logstore.py
@@ -60,6 +60,7 @@ num_rows = int(os.environ.get("DELTA_NUM_ROWS", 16))
 delta_storage = os.environ.get("DELTA_STORAGE", "io.delta.storage.S3DynamoDBLogStore")
 dynamo_table_name = os.environ.get("DELTA_DYNAMO_TABLE", "delta_log_test")
 dynamo_region = os.environ.get("DELTA_DYNAMO_REGION", "us-west-2")
+# used only by FailingS3DynamoDBLogStore
 dynamo_error_rates = os.environ.get("DELTA_DYNAMO_ERROR_RATES", "")
 
 if delta_table_path is None:
@@ -86,6 +87,8 @@ spark = SparkSession \
     .master("local[*]") \
     .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
     .config("spark.delta.logStore.s3.impl", delta_storage) \
+    .config("spark.delta.logStore.s3a.impl", delta_storage) \
+    .config("spark.delta.logStore.s3n.impl", delta_storage) \
     .config("io.delta.storage.S3DynamoDBLogStore.ddb.tableName", dynamo_table_name) \
     .config("io.delta.storage.S3DynamoDBLogStore.ddb.region", dynamo_region) \
     .config("io.delta.storage.S3DynamoDBLogStore.errorRates", dynamo_error_rates) \
@@ -93,7 +96,7 @@ spark = SparkSession \
     .config("io.delta.storage.S3DynamoDBLogStore.provisionedThroughput.wcu", 13) \
     .getOrCreate()
 
-# spark.sparkContext.setLogLevel("INFO")
+spark.sparkContext.setLogLevel("INFO")
 
 data = spark.createDataFrame([], "id: int, a: int")
 data.write.format("delta").mode("overwrite").partitionBy("id").save(delta_table_path)

--- a/storage-s3-dynamodb/integration_tests/dynamodb_logstore.py
+++ b/storage-s3-dynamodb/integration_tests/dynamodb_logstore.py
@@ -85,10 +85,12 @@ spark = SparkSession \
     .appName("utilities") \
     .master("local[*]") \
     .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
-    .config("spark.delta.logStore.class", delta_storage) \
-    .config("io.delta.storage.ddb.tableName", dynamo_table_name) \
-    .config("io.delta.storage.ddb.region", dynamo_region) \
-    .config("io.delta.storage.errorRates", dynamo_error_rates) \
+    .config("spark.delta.logStore.s3.impl", delta_storage) \
+    .config("io.delta.storage.S3DynamoDBLogStore.ddb.tableName", dynamo_table_name) \
+    .config("io.delta.storage.S3DynamoDBLogStore.ddb.region", dynamo_region) \
+    .config("io.delta.storage.S3DynamoDBLogStore.errorRates", dynamo_error_rates) \
+    .config("io.delta.storage.S3DynamoDBLogStore.provisionedThroughput.rcu", 12) \
+    .config("io.delta.storage.S3DynamoDBLogStore.provisionedThroughput.wcu", 13) \
     .getOrCreate()
 
 # spark.sparkContext.setLogLevel("INFO")

--- a/storage-s3-dynamodb/src/main/java/io/delta/storage/S3DynamoDBLogStore.java
+++ b/storage-s3-dynamodb/src/main/java/io/delta/storage/S3DynamoDBLogStore.java
@@ -232,8 +232,8 @@ public class S3DynamoDBLogStore extends BaseExternalLogStore {
                 final long wcu = Long.parseLong(getParam(hadoopConf, DDB_CREATE_TABLE_WCU, "5"));
 
                 LOG.info(
-                    "DynamoDB table `{}` in region `{}` does not exist."
-                    + "Creating it now with provisioned throughput of {} RCUs and {} WCUs.",
+                    "DynamoDB table `{}` in region `{}` does not exist. " +
+                    "Creating it now with provisioned throughput of {} RCUs and {} WCUs.",
                     tableName, regionName, rcu, wcu);
                 try {
                     client.createTable(

--- a/storage-s3-dynamodb/src/main/java/io/delta/storage/S3DynamoDBLogStore.java
+++ b/storage-s3-dynamodb/src/main/java/io/delta/storage/S3DynamoDBLogStore.java
@@ -71,12 +71,15 @@ public class S3DynamoDBLogStore extends BaseExternalLogStore {
     private static final Logger LOG = LoggerFactory.getLogger(S3DynamoDBLogStore.class);
 
     /**
-     * Configuration keys for the DynamoDB client
+     * Configuration keys for the DynamoDB client. Keys are of the form $CONF_PREFIX.$CONF,
+     * e.g. io.delta.storage.S3DynamoDBLogStore.ddb.tableName
      */
-    private static final String CONF_PREFIX = "io.delta.storage.";
+    private static final String CONF_PREFIX = "io.delta.storage.S3DynamoDBLogStore";
     private static final String DBB_CLIENT_TABLE = "ddb.tableName";
     private static final String DBB_CLIENT_REGION = "ddb.region";
     private static final String DBB_CLIENT_CREDENTIALS_PROVIDER = "credentials.provider";
+    private static final String DDB_CREATE_TABLE_RCU = "provisionedThroughput.rcu";
+    private static final String DDB_CREATE_TABLE_WCU = "provisionedThroughput.wcu";
 
     /**
      * DynamoDB table attribute keys
@@ -221,8 +224,8 @@ public class S3DynamoDBLogStore extends BaseExternalLogStore {
                 TableDescription descr = result.getTable();
                 status = descr.getTableStatus();
             } catch (ResourceNotFoundException e) {
-                final long rcu = Long.parseLong(getParam(hadoopConf, "provisionedThroughput.rcu", "5"));
-                final long wcu = Long.parseLong(getParam(hadoopConf, "provisionedThroughput.wcu", "5"));
+                final long rcu = Long.parseLong(getParam(hadoopConf, DDB_CREATE_TABLE_RCU, "5"));
+                final long wcu = Long.parseLong(getParam(hadoopConf, DDB_CREATE_TABLE_WCU, "5"));
 
                 LOG.info(
                     "DynamoDB table `{}` in region `{}` does not exist."
@@ -291,7 +294,7 @@ public class S3DynamoDBLogStore extends BaseExternalLogStore {
 
     protected String getParam(Configuration config, String name, String defaultValue) {
         return config.get(
-            String.format("%s%s", CONF_PREFIX, name),
+            String.format("%s.%s", CONF_PREFIX, name),
             defaultValue
         );
     }

--- a/storage-s3-dynamodb/src/test/scala/io/delta/storage/ExternalLogStoreSuite.scala
+++ b/storage-s3-dynamodb/src/test/scala/io/delta/storage/ExternalLogStoreSuite.scala
@@ -21,9 +21,10 @@ import java.net.URI
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
+import org.scalatest.funsuite.AnyFunSuite
+
 import org.apache.spark.sql.delta.FakeFileSystem
 import org.apache.spark.sql.delta.util.FileNames
-import org.scalatest.funsuite.AnyFunSuite
 
 /////////////////////
 // Base Test Suite //


### PR DESCRIPTION
## Problem Description
- problem 1: there was a mismatch between the config params in the documentation (`io.delta.storage.S3DynamoDBLogStore.ddb.tableName`) and the config params actually used in the code + in the integration test (`io.delta.storage.ddb.tableName`).
- solution 1: include the `S3DynamoDBLogStore` string in the config in the code.
- problem 2: the `io.delta.storage` prefix didn't work when specified using `--conf`. they DID work using `spark.conf.set()` or `SparkSession.builder.config()` but not with `--conf`.
- solution 2: we now allow 2 prefixes.
  - `spark.io.delta.storage.S3DynamoDBLogStore.$key.....` this will work all contexts (`--conf`, `spark.conf.set()`, etc).
  - `io.delta.storage.S3DynamoDBLogStore.$key`. this is the original prefix. this will be able to be used by delta-standalone and flink and hive. they just use hadoopConfs and don't need to have prefix starting with `spark`

## PR Description
- resolves https://github.com/delta-io/delta/issues/1094
- update config for S3 multi-cluster mode (i.e. S3DynamoDBLogStore) to match the public documentation. the configs were missing the string literal `S3DynamoDBLogStore` from the conf prefix
- now supports 2 confs. `spark.io.delta.storage.S3DynamoDBLogStore.$key` and `io.delta.storage.S3DynamoDBLogStore.$key`.

## How was this patch tested?

- added unit test for the 2 new confs
- ran integration test using existing + new s3 table, and using existing + new ddb table
- ran manual tests using locally published jars on pyspark + spark-shell + spark-submit (spark-submit via integration test)
- tested using `--conf` as well as `spark.conf.set` as well as `SparkSession.builder.config()`

## Does this PR introduce _any_ user-facing changes?

Not really, just fixes a just-released, experimental LogStore config key
