### PR TITLE
Fix python test failures

### DIFF
--- a/python/delta/exceptions.py
+++ b/python/delta/exceptions.py
@@ -18,8 +18,13 @@ from typing import TYPE_CHECKING, Optional
 
 from pyspark import SparkContext
 from pyspark.sql import utils
-from pyspark.sql.utils import CapturedException
-
+from pyspark.sql.utils import (
+    AnalysisException,
+    CapturedException,
+    IllegalArgumentException,
+    ParseException
+)
+from py4j.java_gateway import is_instance_of  # type: ignore[import]
 
 if TYPE_CHECKING:
     from py4j.java_gateway import JavaObject, JVMView  # type: ignore[import]
@@ -119,7 +124,19 @@ def _convert_delta_exception(e: "JavaObject") -> Optional[CapturedException]:
     c: "JavaObject" = e.getCause()
 
     jvm: "JVMView" = SparkContext._jvm  # type: ignore[attr-defined]
+    gw = SparkContext._gateway  # type: ignore[attr-defined]
     stacktrace = jvm.org.apache.spark.util.Utils.exceptionString(e)
+
+    # Temporary workaround until Delta Lake is upgraded to Spark 3.3
+    # Below three exception handling cases are copied from
+    # https://github.com/apache/spark/blob/master/python/pyspark/sql/utils.py#L156
+    if is_instance_of(gw, e, "org.apache.spark.sql.catalyst.parser.ParseException"):
+        return ParseException(s.split(': ', 1)[1], stacktrace, c)
+    # Order matters. ParseException inherits AnalysisException.
+    if is_instance_of(gw, e, "org.apache.spark.sql.AnalysisException"):
+        return AnalysisException(s.split(': ', 1)[1], stacktrace, c)
+    if is_instance_of(gw, e, "java.lang.IllegalArgumentException"):
+        return IllegalArgumentException(s.split(': ', 1)[1], stacktrace, c)
 
     if s.startswith('io.delta.exceptions.DeltaConcurrentModificationException: '):
         return DeltaConcurrentModificationException(s.split(': ', 1)[1], stacktrace, c)


### PR DESCRIPTION
## Description
Currently two python tests are failing on master branch (986ab1cfa46c93f848ab682880b18dbd5b193059) due to incorrect exception handling. These tests are added as part of 462418c77b0165fbdb1b28d772087a91b559591f. These tests rely [Apache Spark 3.3 python exception handling](https://github.com/apache/spark/blob/master/python/pyspark/sql/utils.py#L156). Currently Delta relies on Apache Spark 3.2.1. Until Delta lake upgrades to 3.3, copy the exception handling cases from Apache Spark 3.3 to Delta Lake python exception handling.

## How was this patch tested?
Ran the tests in CI and verified all Python tests pass.
