### PR TITLE
Add checksum in _last_checkpoint

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -9,6 +9,7 @@
     - [Delta Log Entries](#delta-log-entries)
     - [Checkpoints](#checkpoints)
     - [Last Checkpoint File](#last-checkpoint-file)
+      - [JSON checksum](#json-checksum)
   - [Actions](#actions)
     - [Change Metadata](#change-metadata)
       - [Format Specification](#format-specification)
@@ -156,6 +157,53 @@ size | The number of actions that are stored in the checkpoint.
 parts | The number of fragments if the last checkpoint was written in multiple parts. This field is optional.
 sizeInBytes | The number of bytes of the checkpoint. This field is optional.
 numOfAddFiles | The number of AddFile actions in the checkpoint. This field is optional.
+checksum | The checksum of the last checkpoint JSON. This field is optional.
+
+The checksum field is an optional field which contains the MD5 checksum for fields of the last checkpoint json file.
+Last checkpoint file readers are encouraged to validate the checksum, if present, and writers are encouraged to write the checksum
+while overwriting the file. Refer to [this section](#json-checksum) for rules around calculating the checksum field
+for the last checkpoint JSON.
+
+#### JSON checksum
+To generate the checksum for the last checkpoint JSON, firstly, the checksum JSON is canonicalized and converted to a string. Then
+the 32 character MD5 digest is calculated on the resultant string to get the checksum. Rules for [JSON](https://datatracker.ietf.org/doc/html/rfc8259) canonicalization are:
+
+1. Literal values (`true`, `false`, and `null`) are their own canonical form
+2. Numeric values (e.g. `42` or `3.14`) are their own canonical form
+3. String values (e.g. `"hello world"`) are canonicalized by preserving the surrounding quotes and [URL-encoding](#how-to-url-encode-keys-and-string-values)
+their content, e.g. `"hello%20world"`
+4. Object values (e.g. `{"a": 10, "b": {"y": null, "x": "https://delta.io"} }` are canonicalized by:
+   * Canonicalize each scalar (leaf) value following the rule for its type (literal, numeric, string)
+   * Canonicalize each (string) name along the path to that value
+   * Connect path segments by `+`, e.g. `"b"+"y"`
+   * Connect path and value pairs by `=`, e.g. `"b"+"y"=null`
+   * Sort canonicalized path/value pairs using a byte-order sort on paths. The byte-order sort can be done by converting paths to byte array using UTF-8 charset\
+    and then comparing them, e.g. `"a" < "b"."x" < "b"."y"`
+   * Separate ordered pairs by `,`, e.g. `"a"=10,"b"+"x"="https%3A%2F%2Fdelta.io","b"+"y"=null`
+
+5. Array values (e.g. `[null, "hi ho", 2.71]`) are canonicalized as if they were objects, except the "name" has numeric type instead of string type, and gives the (0-based) 
+position of the corresponding array element, e.g. `0=null,1="hi%20ho",2=2.71`
+
+6. Top level `checksum` key is ignored in the canonicalization process. e.g. 
+`{"k1": "v1", "checksum": "<anything>", "k3": 23}` is canonicalized to `"k1"="v1","k3"=23`
+
+7. Duplicate keys are not allowed in the last checkpoint JSON and such JSON is considered invalid.
+
+Given the following test sample JSON, a correct implementation of JSON canonicalization should produce the corresponding canonicalized form and checksum value:
+e.g.
+Json: `{"k0":"'v 0'", "checksum": "adsaskfljadfkjadfkj", "k1":{"k2": 2, "k3": ["v3", [1, 2], {"k4": "v4", "k5": ["v5", "v6", "v7"]}]}}`\
+Canonicalized form: `"k0"="%27v%200%27","k1"+"k2"=2,"k1"+"k3"+0="v3","k1"+"k3"+1+0=1,"k1"+"k3"+1+1=2,"k1"+"k3"+2+"k4"="v4","k1"+"k3"+2+"k5"+0="v5","k1"+"k3"+2+"k5"+1="v6","k1"+"k3"+2+"k5"+2="v7"`\
+Checksum is `6a92d155a59bf2eecbd4b4ec7fd1f875`
+
+##### How to URL encode keys and string values
+The [URL Encoding](https://datatracker.ietf.org/doc/html/rfc3986) spec is a bit flexible to give a reliable encoding. e.g. the spec allows both
+uppercase and lowercase as part of percent-encoding. Thus, we require a stricter set of rules for encoding:
+
+1. The string to be encoded must be represented as octets according to the UTF-8 character encoding
+2. All octets except a-z / A-Z / 0-9 / "-" / "." / "_" / "~" are reserved
+3. Always [percent-encode](https://datatracker.ietf.org/doc/html/rfc3986#section-2) reserved octets
+4. Never percent-encode non-reserved octets
+5. A percent-encoded octet consists of three characters: `%` followed by its 2-digit hexadecimal value in uppercase letters, e.g. `>` encodes to `%3E`
 
 ## Actions
 Actions modify the state of the table and they are stored both in delta files and in checkpoints.

--- a/core/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -20,6 +20,7 @@ import java.io.FileNotFoundException
 import java.util.UUID
 
 import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 import scala.math.Ordering.Implicits._
 import scala.util.control.NonFatal
 
@@ -31,12 +32,17 @@ import org.apache.spark.sql.delta.storage.LogStore
 import org.apache.spark.sql.delta.util.DeltaFileOperations
 import org.apache.spark.sql.delta.util.FileNames._
 import org.apache.spark.sql.delta.util.JsonUtils
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.node.ObjectNode
+import org.apache.commons.codec.digest.DigestUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapred.{JobConf, TaskAttemptContextImpl, TaskAttemptID}
 import org.apache.hadoop.mapreduce.{Job, TaskType}
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.{Column, DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.expressions.{Cast, ElementAt, Literal}
@@ -50,12 +56,20 @@ import org.apache.spark.util.Utils
 /**
  * Records information about a checkpoint.
  *
+ * This class provides the checksum validation logic, needed to ensure that content of
+ * LAST_CHECKPOINT file points to a valid json. The readers might read some part from old file and
+ * some part from the new file (if the file is read across multiple requests). In some rare
+ * scenarios, the split read might produce a valid json and readers will be able to parse it and
+ * convert it into a [[CheckpointMetaData]] object that contains invalid data. In order to prevent
+ * using it, we do a checksum match on the read json to validate that it is consistent.
+ *
  * @param version the version of this checkpoint
  * @param size the number of actions in the checkpoint
  * @param parts the number of parts when the checkpoint has multiple parts. None if this is a
  *              singular checkpoint
  * @param sizeInBytes the number of bytes of the checkpoint
  * @param numOfAddFiles the number of AddFile actions in the checkpoint
+ * @param checksum the checksum of the [[CheckpointMetaData]].
  */
 case class CheckpointMetaData(
     version: Long,
@@ -64,7 +78,126 @@ case class CheckpointMetaData(
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
     sizeInBytes: Option[Long],
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
-    numOfAddFiles: Option[Long])
+    numOfAddFiles: Option[Long],
+    checksum: Option[String] = None)
+
+object CheckpointMetaData {
+
+  val STORED_CHECKSUM_KEY = "checksum"
+
+  /**
+   * Returns the json representation of this [[CheckpointMetaData]] object.
+   * Also adds the checksum to the returned json if `addChecksum` is set. The checksum can be
+   * used by readers to validate consistency of the [[CheckpointMetadata]].
+   * It is calculated using rules mentioned in "JSON checksum" section in PROTOCOL.md.
+   */
+  def serializeToJson(chkMetadata: CheckpointMetaData, addChecksum: Boolean): String = {
+    val jsonStr: String = JsonUtils.toJson(chkMetadata.copy(checksum = None))
+    if (!addChecksum) return jsonStr
+    val rootNode = JsonUtils.mapper.readValue(jsonStr, classOf[ObjectNode])
+    val checksum = treeNodeToChecksum(rootNode)
+    rootNode.put(STORED_CHECKSUM_KEY, checksum).toString
+  }
+
+  /**
+   * Converts the given `jsonStr` into a [[CheckpointMetaData]] object.
+   * if `validate` is set, then it also validates the consistency of the json:
+   *  - calculating the checksum and comparing it with the `storedChecksum`.
+   *  - json should not have any duplicates.
+   */
+  def deserializeFromJson(jsonStr: String, validate: Boolean): CheckpointMetaData = {
+    if (validate) {
+      val (storedChecksumOpt, actualChecksum) = CheckpointMetaData.getChecksums(jsonStr)
+      storedChecksumOpt.filter(_ != actualChecksum).foreach { storedChecksum =>
+        throw new IllegalStateException(s"Checksum validation failed for json: $jsonStr,\n" +
+          s"storedChecksum:$storedChecksum, actualChecksum:$actualChecksum")
+      }
+    }
+
+    // This means:
+    // 1) EITHER: Checksum validation is config-disabled
+    // 2) OR: The json lacked a checksum (e.g. written by old client). Nothing to validate.
+    // 3) OR: The Stored checksum matches the calculated one. Validation succeeded.
+    JsonUtils.fromJson[CheckpointMetaData](jsonStr)
+  }
+
+  /**
+   * Analyzes the json representation of [[CheckpointMetaData]] and returns checksum tuple where
+   * - first element refers to the stored checksum in the json representation of
+   *   [[CheckpointMetaData]], None if the checksum is not present.
+   * - second element refers to the checksum computed from the canonicalized json representation of
+   *   the [[CheckpointMetaData]].
+   */
+  def getChecksums(jsonStr: String): (Option[String], String) = {
+    val reader =
+      JsonUtils.mapper.reader().withFeatures(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY)
+    val rootNode = reader.readTree(jsonStr)
+    val storedChecksum = if (rootNode.has(STORED_CHECKSUM_KEY)) {
+        Some(rootNode.get(STORED_CHECKSUM_KEY).asText())
+      } else {
+        None
+      }
+    val actualChecksum = treeNodeToChecksum(rootNode)
+    storedChecksum -> actualChecksum
+  }
+
+  /**
+   * Canonicalizes the given `treeNode` json and returns its md5 checksum.
+   * Refer to "JSON checksum" section in PROTOCOL.md for canonicalization steps.
+   */
+  def treeNodeToChecksum(treeNode: JsonNode): String = {
+    val jsonEntriesBuffer = ArrayBuffer.empty[(String, String)]
+
+    import scala.collection.JavaConverters._
+    def traverseJsonNode(currentNode: JsonNode, prefix: ArrayBuffer[String]): Unit = {
+      if (currentNode.isObject) {
+        currentNode.fields().asScala.foreach { entry =>
+          prefix.append(encodeString(entry.getKey))
+          traverseJsonNode(entry.getValue, prefix)
+          prefix.trimEnd(1)
+        }
+      } else if (currentNode.isArray) {
+        currentNode.asScala.zipWithIndex.foreach { case (jsonNode, index) =>
+          prefix.append(index.toString)
+          traverseJsonNode(jsonNode, prefix)
+          prefix.trimEnd(1)
+        }
+      } else {
+        var nodeValue = currentNode.asText()
+        if (currentNode.isTextual) nodeValue = encodeString(nodeValue)
+        jsonEntriesBuffer.append(prefix.mkString("+") -> nodeValue)
+      }
+    }
+    traverseJsonNode(treeNode, prefix = ArrayBuffer.empty)
+    import Ordering.Implicits._
+    val normalizedJsonKeyValues = jsonEntriesBuffer
+      .filter { case (k, _) => k != s""""$STORED_CHECKSUM_KEY"""" }
+      .map { case (k, v) => s"$k=$v" }
+      .sortBy(_.toSeq: Seq[Char])
+      .mkString(",")
+    DigestUtils.md5Hex(normalizedJsonKeyValues)
+  }
+
+  private val isUnreservedOctet =
+    (Set.empty ++ ('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9') ++ "-._~").map(_.toByte)
+
+  /**
+   * URL encodes a String based on the following rules:
+   * 1. Use uppercase hexadecimals for all percent encodings
+   * 2. percent-encode everything other than unreserved characters
+   * 3. unreserved characters are = a-z / A-Z / 0-9 / "-" / "." / "_" / "~"
+   */
+  private def encodeString(str: String): String = {
+    val result = str.getBytes(java.nio.charset.StandardCharsets.UTF_8).map {
+      case b if isUnreservedOctet(b) => b.toChar.toString
+      case b =>
+        // convert to char equivalent of unsigned byte
+        val c = (b & 0xff)
+        f"%%$c%02X"
+    }.mkString
+    s""""$result""""
+  }
+}
 
 /**
  * A class to help with comparing checkpoints with each other, where we may have had concurrent
@@ -154,15 +287,7 @@ trait Checkpoints extends DeltaLogging {
         if (snapshotToCheckpoint.version < 0) {
           throw DeltaErrors.checkpointNonExistTable(dataPath)
         }
-        val checkpointMetaData = writeCheckpointFiles(snapshotToCheckpoint)
-        val json = JsonUtils.toJson(checkpointMetaData)
-        store.write(
-          LAST_CHECKPOINT,
-          Iterator(json),
-          overwrite = true,
-          newDeltaHadoopConf())
-
-        doLogCleanup()
+        checkpointAndCleanUpDeltaLog(snapshotToCheckpoint)
       } catch {
         // Catch all non-fatal exceptions, since the checkpoint is written after the commit
         // has completed. From the perspective of the user, the commit completed successfully.
@@ -188,6 +313,17 @@ trait Checkpoints extends DeltaLogging {
     }
   }
 
+  protected def checkpointAndCleanUpDeltaLog(
+      snapshotToCheckpoint: Snapshot): Unit = {
+    val lastCheckpointChecksumEnabled = spark.sessionState.conf.getConf(
+      DeltaSQLConf.LAST_CHECKPOINT_CHECKSUM_ENABLED)
+
+    val checkpointMetaData = writeCheckpointFiles(snapshotToCheckpoint)
+    val json = CheckpointMetaData.serializeToJson(checkpointMetaData, lastCheckpointChecksumEnabled)
+    store.write(LAST_CHECKPOINT, Iterator(json), overwrite = true, newDeltaHadoopConf())
+    doLogCleanup()
+  }
+
   protected def writeCheckpointFiles(snapshotToCheckpoint: Snapshot): CheckpointMetaData = {
     Checkpoints.writeCheckpoint(spark, this, snapshotToCheckpoint)
   }
@@ -202,9 +338,9 @@ trait Checkpoints extends DeltaLogging {
     recordFrameProfile("Delta", "Checkpoints.loadMetadataFromFile") {
       try {
         val checkpointMetadataJson = store.read(LAST_CHECKPOINT, newDeltaHadoopConf())
-        val checkpointMetadata =
-          JsonUtils.mapper.readValue[CheckpointMetaData](checkpointMetadataJson.head)
-        Some(checkpointMetadata)
+        val validate = spark.sessionState.conf.getConf(
+          DeltaSQLConf.LAST_CHECKPOINT_CHECKSUM_ENABLED)
+        Some(CheckpointMetaData.deserializeFromJson(checkpointMetadataJson.head, validate))
       } catch {
         case _: FileNotFoundException =>
           None
@@ -214,6 +350,12 @@ trait Checkpoints extends DeltaLogging {
           Thread.sleep(1000)
           loadMetadataFromFile(tries + 1)
         case NonFatal(e) =>
+          recordDeltaEvent(
+            self,
+            "delta.lastCheckpoint.read.corruptedJson",
+            data = Map("exception" -> Utils.exceptionString(e))
+          )
+
           logWarning(s"$LAST_CHECKPOINT is corrupted. Will search the checkpoint files directly", e)
           // Hit a partial file. This could happen on Azure as overwriting _last_checkpoint file is
           // not atomic. We will try to list all files to find the latest checkpoint and restore

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -424,6 +424,14 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
+  val LAST_CHECKPOINT_CHECKSUM_ENABLED =
+    buildConf("lastCheckpoint.checksum.enabled")
+      .internal()
+      .doc("Controls whether to write the checksum while writing the LAST_CHECKPOINT file and" +
+        " whether to validate it while reading the LAST_CHECKPOINT file")
+      .booleanConf
+      .createWithDefault(true)
+
   val DELTA_WRITE_CHECKSUM_ENABLED =
     buildConf("writeChecksumFile.enabled")
       .doc("Whether the checksum file can be written.")

--- a/core/src/test/scala/org/apache/spark/sql/delta/CheckpointMetadataSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/CheckpointMetadataSuite.scala
@@ -1,0 +1,259 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+// scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.util.JsonUtils
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.exc.MismatchedInputException
+import com.google.common.io.{ByteStreams, Closeables}
+import org.apache.commons.codec.digest.DigestUtils
+import org.apache.commons.io.IOUtils
+
+import org.apache.spark.sql.test.SharedSparkSession
+
+class CheckpointMetadataSuite extends SharedSparkSession {
+
+  private def jsonStringToChecksum(jsonStr: String): String = {
+    val rootNode = JsonUtils.mapper.readValue(jsonStr, classOf[JsonNode])
+    CheckpointMetaData.treeNodeToChecksum(rootNode)
+  }
+
+  test("test json to checksum conversion with maps") {
+    // test with different ordering and spaces, with different value data types
+    val s1 = """{"k1":"v1","k4":"v4","k3":23.45,"k2":123}"""
+    val s2 = """{"k1":"v1","k3":23.45,"k2":123,      "k4":"v4"}"""
+    assert(jsonStringToChecksum(s1) === jsonStringToChecksum(s2))
+
+    // test json with nested maps
+    val s3 =
+      """{"k1":"v1","k4":{"k41":"v41","k40":{"k401":401,"k402":"402"}},"k3":23.45,"k2":123}"""
+    val s4 =
+      """{"k1":"v1","k4":{"k40":{"k401":401,"k402":"402"},   "k41":"v41"},"k3":23.45,"k2":123}"""
+    assert(jsonStringToChecksum(s3) === jsonStringToChecksum(s4))
+
+    // test empty json
+    val s5 = """{    }"""
+    val s6 = """{}"""
+    assert(jsonStringToChecksum(s5) === jsonStringToChecksum(s6))
+
+    // negative test: value for a specific key k4 is not same.
+    val s7 = """{"k1":"v1","k4":"v4","k3":23.45,"k2":123}"""
+    val s8 = """{"k1":"v1","k4":"v1","k3":23.45,"k2":123}"""
+    assert(jsonStringToChecksum(s7) != jsonStringToChecksum(s8))
+  }
+
+  test("test json to checksum conversion with array") {
+    // has top level array and array values are json objects
+    val s1 = """[{"id":"j1","stuff":"things"},{"stuff":"t2","id":"j2"}]"""
+    val s2 = """[{"id" : "j1", "stuff" : "things"}, {"id" : "j2", "stuff" : "t2"}]"""
+    assert(jsonStringToChecksum(s1) === jsonStringToChecksum(s2))
+
+    // array as part of value for a json key and array value has single json object
+    val s3 = """{"id":"j1","stuff":[{"hello": "world", "hello1": "world1"}]}"""
+    val s4 = """{"id":   "j1","stuff":[{"hello1": "world1", "hello": "world"}]}"""
+    assert(jsonStringToChecksum(s3) === jsonStringToChecksum(s4))
+
+    // array as part of value for a json key and array values are multiple json objects
+    val s5 = """{"id":"j1","stuff":[{"hello": "world"}, {"hello1": "world1"}]}"""
+    val s6 = """{"id":   "j1","stuff":[{"hello":"world"},{"hello1":"world1"}]}"""
+    assert(jsonStringToChecksum(s5) === jsonStringToChecksum(s6))
+
+    // Negative case: array as part of value for a json key and array values are multiple json
+    // objects with different order.
+    val s7 = """{"id":"j1","stuff":[{"hello1": "world1"}, {"hello": "world"}]}"""
+    val s8 = """{"id":   "j1","stuff":[{"hello":"world"},{"hello1":"world1"}]}"""
+    assert(jsonStringToChecksum(s7) != jsonStringToChecksum(s8))
+
+    // array has scalar string values
+    val s9 = """{"id":"j1","stuff":["a", "b"]}"""
+    val s10 = """{"stuff":["a","b"], "id":   "j1"}"""
+    assert(jsonStringToChecksum(s9) === jsonStringToChecksum(s10))
+
+    // array has scalar int values
+    val s11 = """{"id":"j1","stuff":[1, 2]}"""
+    val s12 = """{"stuff":[1,2], "id":   "j1"}"""
+    assert(jsonStringToChecksum(s11) === jsonStringToChecksum(s12))
+
+    // Negative case: array has scalar values in different order
+    val s13 = """{"id":"j1","stuff":["a", "b", "c"]}"""
+    val s14 = """{"id":"j1","stuff":["c", "a", "b"]}"""
+    assert(jsonStringToChecksum(s13) != jsonStringToChecksum(s14))
+  }
+
+  // scalastyle:off line.size.limit
+  test("test json normalization") {
+    // test with different data types
+    val s1 = """{"k1":"v1","k4":"v4","k3":23.45,"k2":123,"k6":null,"k5":true}"""
+    val normalizedS1 = """"k1"="v1","k2"=123,"k3"=23.45,"k4"="v4","k5"=true,"k6"=null"""
+    assert(jsonStringToChecksum(s1) === DigestUtils.md5Hex(normalizedS1))
+
+    // test json with nested maps
+    val s2 =
+      """{"k1":"v1","k4":{"k41":"v41","k40":{"k401":401,"k402":"402"}},"k3":23.45,"k2":123}"""
+    val normalizedS2 = """"k1"="v1","k2"=123,"k3"=23.45,"k4"+"k40"+"k401"=401,"k4"+"k40"+"k402"="402","k4"+"k41"="v41""""
+    assert(jsonStringToChecksum(s2) === DigestUtils.md5Hex(normalizedS2))
+
+    // test with arrays
+    val s3 = """{"stuff":[{"hx": "wx","h1":"w1"}, {"h2": "w2"}],"id":1}"""
+    val normalizedS3 = """"id"=1,"stuff"+0+"h1"="w1","stuff"+0+"hx"="wx","stuff"+1+"h2"="w2""""
+    assert(jsonStringToChecksum(s3) === DigestUtils.md5Hex(normalizedS3))
+
+    // test top level `checksum` key is ignored in canonicalization
+    val s4 = """{"k1":"v1","checksum":"daswefdssfd","k3":23.45,"k2":123}"""
+    val normalizedS4 = """"k1"="v1","k2"=123,"k3"=23.45"""
+    assert(jsonStringToChecksum(s4) === DigestUtils.md5Hex(normalizedS4))
+
+    // test empty json
+    val s5 = """{    }"""
+    val normalizedS5 = """"""
+    assert(jsonStringToChecksum(s5) === DigestUtils.md5Hex(normalizedS5))
+
+    // test with complex strings
+    val s6 = """{"k0":"normal","k1":"'v1'","k4":"'v4","k3":":hello","k2":"\"double quote str\""}"""
+    val normalizedS6 = """"k0"="normal","k1"="%27v1%27","k2"="%22double%20quote%20str%22","k3"="%3Ahello","k4"="%27v4""""
+    assert(jsonStringToChecksum(s6) === DigestUtils.md5Hex(normalizedS6))
+
+    // test covering different ASCII characters
+    val s7 = """{"k0":"normal","k1":"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789%'`~!@#$%^&*()_+-={[}]|\\;:'\"\/?.>,<"}"""
+    val normalizedS7 = """"k0"="normal","k1"="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789%25%27%60~%21%40%23%24%25%5E%26%2A%28%29_%2B-%3D%7B%5B%7D%5D%7C%5C%3B%3A%27%22%2F%3F.%3E%2C%3C""""
+    assert(jsonStringToChecksum(s7) === DigestUtils.md5Hex(normalizedS7))
+
+    // test with nested maps and arrays
+    // This example is also part of Delta's PROTOCOL.md. We should keep these two in sync.
+    val s8 = """{"k0":"'v 0'", "checksum": "adsaskfljadfkjadfkj", "k1":{"k2": 2, "k3": ["v3", [1, 2], {"k4": "v4", "k5": ["v5", "v6", "v7"]}]}}"""
+    val normalizedS8 = """"k0"="%27v%200%27","k1"+"k2"=2,"k1"+"k3"+0="v3","k1"+"k3"+1+0=1,"k1"+"k3"+1+1=2,"k1"+"k3"+2+"k4"="v4","k1"+"k3"+2+"k5"+0="v5","k1"+"k3"+2+"k5"+1="v6","k1"+"k3"+2+"k5"+2="v7""""
+    assert(jsonStringToChecksum(s8) === DigestUtils.md5Hex(normalizedS8))
+    assert(jsonStringToChecksum(s8) === "6a92d155a59bf2eecbd4b4ec7fd1f875")
+
+    // test non-ASCII character
+    // scalastyle:off nonascii
+    val s9 = s"""{"k0":"normal","k1":"a€+"}"""
+    val normalizedS9 = """"k0"="normal","k1"="a%E2%82%AC%2B""""
+    assert(jsonStringToChecksum(s9) === DigestUtils.md5Hex(normalizedS9))
+    // scalastyle:on nonascii
+  }
+  // scalastyle:on line.size.limit
+
+  test("test CheckpointMetadata checksum") {
+    val cm1 = CheckpointMetaData(version = 1, size = 2, parts = Some(3),
+      sizeInBytes = Some(20L), numOfAddFiles = Some(2L))
+    val (stored1, actual1) =
+      CheckpointMetaData.getChecksums(CheckpointMetaData.serializeToJson(cm1, addChecksum = true))
+    assert(stored1 === Some(actual1))
+
+    // checksum mismatch when version changes.
+    val cm2 = CheckpointMetaData(version = 2, size = 2, parts = Some(3),
+      sizeInBytes = Some(20L), numOfAddFiles = Some(2L))
+    val (stored2, actual2) =
+      CheckpointMetaData.getChecksums(CheckpointMetaData.serializeToJson(cm2, addChecksum = true))
+    assert(stored2 === Some(actual2))
+    assert(stored2 != stored1)
+
+    // `checksum` doesn't participate in `actualChecksum` calculation.
+    val cm3 = CheckpointMetaData(version = 1, size = 2, parts = Some(3),
+      checksum = Some("XYZ"), sizeInBytes = Some(20L), numOfAddFiles = Some(2L))
+    val (stored3, actual3) =
+      CheckpointMetaData.getChecksums(CheckpointMetaData.serializeToJson(cm3, addChecksum = true))
+    assert(stored3 === Some(actual3))
+    assert(stored3 === stored1)
+
+    // checksum doesn't depend on spaces and order of field
+    val json1 = """{"version":1,"size":2,"parts":3}"""
+    val json2 = """{"version":1 ,"parts":3,"size":2}"""
+    assert(jsonStringToChecksum(json1) === jsonStringToChecksum(json2))
+    // `checksum` is ignored while calculating json
+    val json3 = """{"version":1 ,"parts":3,"size":2,"checksum":"xyz"}"""
+    assert(jsonStringToChecksum(json1) === jsonStringToChecksum(json3))
+    // Change in any value changes the checksum
+    val json4 = """{"version":4,"size":2,"parts":3}"""
+    assert(jsonStringToChecksum(json1) != jsonStringToChecksum(json4))
+
+  }
+
+  test("test backward compatibility - json without checksum is deserialized properly") {
+    val jsonStr = """{"version":1,"size":2,"parts":3,"sizeInBytes":20,"numOfAddFiles":2}"""
+    val expectedCheckpointMetaData = CheckpointMetaData(
+      version = 1, size = 2, parts = Some(3), sizeInBytes = Some(20), numOfAddFiles = Some(2))
+    assert(CheckpointMetaData.deserializeFromJson(jsonStr, validate = true) ===
+      expectedCheckpointMetaData)
+  }
+
+  test("CheckpointMetadata - serialize/deserialize") {
+    val cm1 = CheckpointMetaData(version = 1, size = 2, parts = Some(3),
+      checksum = Some("XYZ"), sizeInBytes = Some(20L), numOfAddFiles = Some(2L))
+    val cm2 = CheckpointMetaData(version = 1, size = 2, parts = Some(3), checksum = None,
+      sizeInBytes = Some(20L), numOfAddFiles = Some(2L))
+
+    val actualChecksum = CheckpointMetaData.getChecksums(
+      CheckpointMetaData.serializeToJson(cm1, addChecksum = true))._2
+    val cmWithCorrectChecksum = cm1.copy(checksum = Some(actualChecksum))
+
+    for(cm <- Seq(cm1, cm2)) {
+      val json = CheckpointMetaData.serializeToJson(cm, addChecksum = true)
+      assert(CheckpointMetaData.deserializeFromJson(json, validate = true)
+        === cmWithCorrectChecksum)
+      assert(CheckpointMetaData.serializeToJson(cm, addChecksum = true) ===
+        """{"version":1,"size":2,"parts":3,"sizeInBytes":20,"numOfAddFiles":2,""" +
+        """"checksum":"d284dd651155acfdd7ad605de36a599a"}""")
+    }
+
+    assert(CheckpointMetaData.serializeToJson(cm1, addChecksum = true)
+      === CheckpointMetaData.serializeToJson(cm2, addChecksum = true))
+  }
+
+  test("CheckpointMetadata - json with duplicate keys should fail") {
+    val jsonString =
+      """{"version":1,"size":3,"parts":3,"checksum":"d84a0aa11c93304d57feca6acaceb7fb","size":2}"""
+    intercept[MismatchedInputException] {
+      CheckpointMetaData.deserializeFromJson(jsonString, validate = true)
+    }
+    // Deserialization shouldn't fail when validate is false and the last `size` overrides the
+    // previous size.
+    assert(CheckpointMetaData.deserializeFromJson(jsonString, validate = false).size === 2)
+  }
+
+  test("CheckpointMetadata - test checksum is written only when config is enabled") {
+    withTempDir { dir =>
+      spark.range(10).write.format("delta").save(dir.getAbsolutePath)
+      val log = DeltaLog.forTable(spark, dir)
+
+      def readLastCheckpointFile(): String = {
+        val fs = log.LAST_CHECKPOINT.getFileSystem(log.newDeltaHadoopConf())
+        val is = fs.open(log.LAST_CHECKPOINT)
+        try {
+          IOUtils.toString(is, "UTF-8")
+        } finally {
+          is.close()
+        }
+      }
+
+      withSQLConf(DeltaSQLConf.LAST_CHECKPOINT_CHECKSUM_ENABLED.key -> "true") {
+        DeltaLog.forTable(spark, dir).checkpoint()
+        assert(readLastCheckpointFile().contains("checksum"))
+      }
+
+      spark.range(10).write.mode("append").format("delta").save(dir.getAbsolutePath)
+      withSQLConf(DeltaSQLConf.LAST_CHECKPOINT_CHECKSUM_ENABLED.key -> "false") {
+        DeltaLog.forTable(spark, dir).checkpoint()
+        assert(!readLastCheckpointFile().contains("checksum"))
+      }
+    }
+  }
+
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnRenameSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnRenameSuite.scala
@@ -245,6 +245,7 @@ class DeltaColumnRenameSuite extends QueryTest
         spark.sql("alter table t1 rename column arr to arr1")
       }
 
+
       // cannot rename b because its child is referenced
       assertException("Cannot rename column b") {
         spark.sql("alter table t1 rename column b to b1")
@@ -280,7 +281,7 @@ class DeltaColumnRenameSuite extends QueryTest
     }
   }
 
-  test("rename with constraints - map element") {
+  test("rename with constraints - map element - oss only") {
     withTable("t1") {
       val schemaWithNotNull =
         simpleNestedData.schema.toDDL.replace("c: STRING", "c: STRING NOT NULL")

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaDropColumnSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaDropColumnSuite.scala
@@ -195,7 +195,7 @@ class DeltaDropColumnSuite extends QueryTest
     }
   }
 
-  test("drop column with constraints - map element") {
+  test("drop column with constraints - map element - oss only") {
     def drop(table: String, columns: Seq[String]): Unit =
       sql(s"alter table $table drop column (${columns.mkString(",")})")
 


### PR DESCRIPTION
## Description

This PR adds Checksum field to LAST_CHECKPOINT file. The checksum is written when LAST_CHECKPOINT file is written and it is validated when LAST_CHECKPOINT is read during snapshot creating.

This is needed to prevent scenarios like SplitReads which might occur when concurrent readers and writers are involved.  

This resolved #1114.

## How was this patch tested?

Added UTs

## Does this PR introduce _any_ user-facing changes?

No