### PR TITLE
[1105] Change Data Feed - PR 1 - Batch Reading

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -394,7 +394,9 @@ trait DeltaConfigsBase extends DeltaLogging {
     "needs to be a boolean.")
 
   /**
-   * Enable change data feed output. Not implemented.
+   * Enable change data feed output.
+   * When enabled, DELETE, UPDATE, and MERGE INTO operations will need to do additional work to
+   * output their change data in an efficiently readable format.
    */
   val CHANGE_DATA_FEED = buildConfig[Boolean](
     "enableChangeDataFeed",

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -275,10 +275,16 @@ object DeltaErrors
   }
 
 
+  /**
+   * Throwable used when CDC options contain no 'start'.
+   */
   def noStartVersionForCDC(): Throwable = {
     new AnalysisException(s"No startingVersion or startingTimestamp provided for CDC read.")
   }
 
+  /**
+   * Throwable used when CDC is not enabled according to table metadata.
+   */
   def changeDataNotRecordedException(version: Long, start: Long, end: Long): Throwable = {
     new DeltaAnalysisException(
       errorClass = "MISSING_CHANGE_DATA",
@@ -286,11 +292,17 @@ object DeltaErrors
         DeltaConfigs.CHANGE_DATA_FEED.key))
   }
 
+  /**
+   * Throwable used for invalid CDC 'start' and 'end' options, where end < start
+   */
   def endBeforeStartVersionInCDC(start: Long, end: Long): Throwable = {
     new IllegalArgumentException(
       s"CDC range from start $start to end $end was invalid. End cannot be before start.")
   }
 
+  /**
+   * Throwable used for invalid CDC 'start' and 'latest' options, where latest < start
+   */
   def startVersionAfterLatestVersion(start: Long, latest: Long): Throwable = {
     new IllegalArgumentException(
       s"Provided Start version($start) for reading change data is invalid. " +

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -275,6 +275,28 @@ object DeltaErrors
   }
 
 
+  def noStartVersionForCDC(): Throwable = {
+    new AnalysisException(s"No startingVersion or startingTimestamp provided for CDC read.")
+  }
+
+  def changeDataNotRecordedException(version: Long, start: Long, end: Long): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "MISSING_CHANGE_DATA",
+      messageParameters = Array(start.toString, end.toString, version.toString,
+        DeltaConfigs.CHANGE_DATA_FEED.key))
+  }
+
+  def endBeforeStartVersionInCDC(start: Long, end: Long): Throwable = {
+    new IllegalArgumentException(
+      s"CDC range from start $start to end $end was invalid. End cannot be before start.")
+  }
+
+  def startVersionAfterLatestVersion(start: Long, latest: Long): Throwable = {
+    new IllegalArgumentException(
+      s"Provided Start version($start) for reading change data is invalid. " +
+        s"Start version cannot be greater than the latest version of the table($latest).")
+  }
+
   def addColumnAtIndexLessThanZeroException(pos: String, col: String): Throwable = {
     new DeltaAnalysisException(
       errorClass = "ADD_COLUMN_AT_INDEX_LESS_THAN_ZERO",

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -158,7 +158,6 @@ object Protocol {
     if (DeltaConfigs.CHANGE_DATA_FEED.fromMetaData(metadata)) {
       minimumRequired = Protocol(0, minWriterVersion = 4)
       featuresUsed.append("Change data feed")
-      throw DeltaErrors.cdcNotAllowedInThisVersion()
     }
 
     if (ColumnWithDefaultExprUtils.hasIdentityColumn(metadata.schema)) {

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
@@ -1,0 +1,442 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands.cdc
+
+import java.sql.Timestamp
+
+import scala.collection.mutable.ListBuffer
+
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaErrors, DeltaHistoryManager, DeltaLog, DeltaOperations, DeltaParquetFileFormat, DeltaTableUtils, DeltaTimeTravelSpec, Snapshot}
+import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, AddFile, CommitInfo, FileAction, Metadata, RemoveFile}
+import org.apache.spark.sql.delta.files.{CdcAddFileIndex, TahoeChangeFileIndex, TahoeFileIndex, TahoeRemoveFileIndex}
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.schema.SchemaUtils
+import org.apache.spark.sql.delta.sources.{DeltaDataSource, DeltaSource}
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession, SQLContext}
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.sources.{BaseRelation, Filter, PrunedFilteredScan}
+import org.apache.spark.sql.types.{LongType, StringType, StructType, TimestampType}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+/**
+ * The API that allows reading Change data between two versions of a table.
+ *
+ * The basic abstraction here is the CDC type column defined by [[CDCReader.CDC_TYPE_COLUMN_NAME]].
+ * When CDC is enabled, our writer will treat this column as a special partition column even though
+ * it's not part of the table. Writers should generate a query that has two types of rows in it:
+ * the main data in partition CDC_TYPE_NOT_CDC and the CDC data with the appropriate CDC type value.
+ *
+ * [[org.apache.spark.sql.delta.files.DelayedCommitProtocol]]
+ * does special handling for this column, dispatching the main data to its normal location while the
+ * CDC data is sent to [[AddCDCFile]] entries.
+ */
+object CDCReader extends DeltaLogging {
+  // Definitions for the CDC type column. Delta writers will write data with a non-null value for
+  // this column into [[AddCDCFile]] actions separate from the main table, and the CDC reader will
+  // read this column to determine what type of change it was.
+  val CDC_TYPE_COLUMN_NAME = "_change_type" // emitted from data
+  val CDC_COMMIT_VERSION = "_commit_version" // inferred by reader
+  val CDC_COMMIT_TIMESTAMP = "_commit_timestamp" // inferred by reader
+  val CDC_TYPE_DELETE = "delete"
+  val CDC_TYPE_INSERT = "insert"
+  val CDC_TYPE_UPDATE_PREIMAGE = "update_preimage"
+  val CDC_TYPE_UPDATE_POSTIMAGE = "update_postimage"
+
+  // A special sentinel value indicating rows which are part of the main table rather than change
+  // data. Delta writers will partition rows with this value away from the CDC data and
+  // write them as normal to the main table.
+  // Note that we specifically avoid using `null` here, because partition values of `null` are in
+  // some scenarios mapped to a special string for Hive compatibility.
+  val CDC_TYPE_NOT_CDC: String = null
+
+  // The virtual column name used for dividing CDC data from main table data. Delta writers should
+  // permit this column through even though it's not part of the main table, and the
+  // [[DelayedCommitProtocol]] will apply some special handling, ensuring there's only a
+  // subfolder with __is_cdc = true and writing data with __is_cdc = false to the base location
+  // as it would with CDC output off.
+  // This is a bit redundant with CDC_TYPE_COL, but partitioning directly on the type would mean
+  // that CDC of each type is partitioned away separately, exacerbating small file problems.
+  val CDC_PARTITION_COL = "__is_cdc" // emitted by data
+
+  // The top-level folder within the Delta table containing change data. This folder may contain
+  // partitions within itself.
+  val CDC_LOCATION = "_change_data"
+
+  // CDC specific columns in data written by operations
+  val CDC_COLUMNS_IN_DATA = Seq(CDC_PARTITION_COL, CDC_TYPE_COLUMN_NAME)
+
+  /**
+   * Given timestamp or version this method returns the corresponding version for that timestamp
+   * or the version itself.
+   */
+  def getVersionForCDC(
+      spark: SparkSession,
+      deltaLog: DeltaLog,
+      conf: SQLConf,
+      options: CaseInsensitiveStringMap,
+      versionKey: String,
+      timestampKey: String): Option[Long] = {
+    if (options.containsKey(versionKey)) {
+      Some(options.get(versionKey).toLong)
+    } else if (options.containsKey(timestampKey)) {
+      val ts = options.get(timestampKey)
+      val spec = DeltaTimeTravelSpec(Some(Literal(ts)), None, Some("cdcReader"))
+      if (timestampKey == DeltaDataSource.CDC_START_TIMESTAMP_KEY) {
+        // For the starting timestamp we need to find a version after the provided timestamp
+        // we can use the same semantics as streaming.
+        val resolvedVersion = DeltaSource.getStartingVersionFromTimestamp(
+          spark,
+          deltaLog,
+          spec.getTimestamp(spark.sessionState.conf)
+        )
+        Some(resolvedVersion)
+      } else {
+        // For ending timestamp the version should be before the provided timestamp.
+        val resolvedVersion = DeltaTableUtils.resolveTimeTravelVersion(
+          conf,
+          deltaLog,
+          spec
+        )
+        Some(resolvedVersion._1)
+      }
+    } else {
+      None
+    }
+  }
+
+  /**
+   * Get a Relation that represents change data between two snapshots of the table.
+   */
+  def getCDCRelation(
+      spark: SparkSession,
+      deltaLog: DeltaLog,
+      snapshotToUse: Snapshot,
+      partitionFilters: Seq[Expression],
+      conf: SQLConf,
+      options: CaseInsensitiveStringMap): BaseRelation = {
+
+    val startingVersion = getVersionForCDC(
+      spark,
+      deltaLog,
+      conf,
+      options,
+      DeltaDataSource.CDC_START_VERSION_KEY,
+      DeltaDataSource.CDC_START_TIMESTAMP_KEY
+    )
+
+    if (startingVersion.isEmpty) {
+      throw DeltaErrors.noStartVersionForCDC()
+    }
+
+    // add a version check here that is cheap instead of after trying to list a large version
+    // that doesn't exist
+    if (startingVersion.get > snapshotToUse.version) {
+      throw DeltaErrors.startVersionAfterLatestVersion(
+        startingVersion.get, snapshotToUse.version)
+    }
+
+    val endingVersion = getVersionForCDC(
+      spark,
+      deltaLog,
+      conf,
+      options,
+      DeltaDataSource.CDC_END_VERSION_KEY,
+      DeltaDataSource.CDC_END_TIMESTAMP_KEY
+    )
+
+    if (endingVersion.exists(_ < startingVersion.get)) {
+      throw DeltaErrors.endBeforeStartVersionInCDC(startingVersion.get, endingVersion.get)
+    }
+
+    logInfo(s"startingVersion: $startingVersion, endingVersion: $endingVersion")
+
+    DeltaCDFRelation(
+      cdcReadSchema(snapshotToUse.metadata.schema),
+      spark.sqlContext,
+      deltaLog,
+      startingVersion,
+      endingVersion
+    )
+  }
+
+  /**
+   * A special BaseRelation wrapper for CDF reads.
+   */
+  case class DeltaCDFRelation(
+      schema: StructType,
+      sqlContext: SQLContext,
+      deltaLog: DeltaLog,
+      startingVersion: Option[Long],
+      endingVersion: Option[Long]) extends BaseRelation with PrunedFilteredScan {
+
+    override def buildScan(requiredColumns: Array[String], filters: Array[Filter]): RDD[Row] = {
+      val df = changesToBatchDF(
+        deltaLog,
+        startingVersion.get,
+        endingVersion.getOrElse {
+          // If no ending version was specified, use the latest version as of scan building time.
+          // Note that this line won't be invoked (and thus we won't incur the update() cost)
+          // when endingVersion is present.
+          deltaLog.update().version
+        },
+        sqlContext.sparkSession)
+
+      df.select(requiredColumns.map(SchemaUtils.fieldNameToColumn): _*).rdd
+    }
+  }
+
+  /**
+   * For a sequence of changes(AddFile, RemoveFile, AddCDCFile) create a DataFrame that represents
+   * that captured change data between start and end inclusive.
+   *
+   * @param deltaLog - DeltaLog for the table for which we are creating a cdc dataFrame
+   * @param start - startingVersion of the changes
+   * @param end - endingVersion of the changes
+   * @param changes - changes is an iterator of all FileActions for a particular commit version.
+   * @param isStreaming - indicates whether the DataFrame returned is a streaming DataFrame
+   * @param spark - SparkSession
+   * @return CDCInfo which contains the DataFrame of the changes as well as the statistics
+   *         related to the changes
+   */
+  def changesToDF(
+      deltaLog: DeltaLog,
+      start: Long,
+      end: Long,
+      changes: Iterator[(Long, Seq[Action])],
+      spark: SparkSession,
+      isStreaming: Boolean = false): CDCVersionDiffInfo = {
+
+    if (end < start) {
+      throw DeltaErrors.endBeforeStartVersionInCDC(start, end)
+    }
+
+    val snapshot = deltaLog.snapshot
+
+    // Correct timestamp values are only available through DeltaHistoryManager.getCommits(). Commit
+    // info timestamps are wrong, and file modification times are wrong because they need to be
+    // monotonized first. This just performs a list (we don't read the contents of the files in
+    // getCommits()) so it's not a big deal.
+    val timestampsByVersion: Map[Long, Timestamp] = {
+      val monotonizationStart =
+        Seq(start - DeltaHistoryManager.POTENTIALLY_UNMONOTONIZED_TIMESTAMPS, 0).max
+      val commits = DeltaHistoryManager.getCommits(
+        deltaLog.store,
+        deltaLog.logPath,
+        monotonizationStart,
+        Some(end + 1),
+        deltaLog.newDeltaHadoopConf())
+
+      // Note that the timestamps come from filesystem modification timestamps, so they're
+      // milliseconds since epoch and we don't need to deal with timezones.
+      commits.map(f => (f.version -> new Timestamp(f.timestamp))).toMap
+    }
+
+    val changeFiles = ListBuffer[CDCDataSpec[AddCDCFile]]()
+    val addFiles = ListBuffer[CDCDataSpec[AddFile]]()
+    val removeFiles = ListBuffer[CDCDataSpec[RemoveFile]]()
+    if (!isCDCEnabledOnTable(deltaLog.getSnapshotAt(start).metadata)) {
+      throw DeltaErrors.changeDataNotRecordedException(start, start, end)
+    }
+
+    var totalBytes = 0L
+    var totalFiles = 0L
+
+    changes.foreach {
+      case (v, actions) =>
+        // Check whether CDC was newly disabled in this version. (We should have already checked
+        // that it's enabled for the starting version, so checking this for each version
+        // incrementally is sufficient to ensure that it's enabled for the entire range.)
+        val cdcDisabled = actions.exists {
+          case m: Metadata => !isCDCEnabledOnTable(m)
+          case _ => false
+        }
+
+        if (cdcDisabled) {
+          throw DeltaErrors.changeDataNotRecordedException(v, start, end)
+        }
+
+        // Set up buffers for all action types to avoid multiple passes.
+        val cdcActions = ListBuffer[AddCDCFile]()
+        val addActions = ListBuffer[AddFile]()
+        val removeActions = ListBuffer[RemoveFile]()
+        val ts = timestampsByVersion.get(v).orNull
+
+        // Note that the CommitInfo is *not* guaranteed to be generated in 100% of cases.
+        // We are using it only for a hotfix-safe mitigation/defense-in-depth - the value
+        // extracted here cannot be relied on for correctness.
+        var commitInfo: Option[CommitInfo] = None
+        actions.foreach {
+          case c: AddCDCFile =>
+            cdcActions.append(c)
+            totalFiles += 1L
+            totalBytes += c.size
+          case a: AddFile =>
+            addActions.append(a)
+            totalFiles += 1L
+            totalBytes += a.size
+          case r: RemoveFile =>
+            removeActions.append(r)
+            totalFiles += 1L
+            totalBytes += r.size.getOrElse(0L)
+          case i: CommitInfo => commitInfo = Some(i)
+          case _ => // do nothing
+        }
+
+        // If there are CDC actions, we read them exclusively.
+        if (cdcActions.nonEmpty) {
+          changeFiles.append(CDCDataSpec(v, ts, cdcActions.toSeq))
+        } else {
+          // MERGE will sometimes rewrite files in a way which *could* have changed data
+          // (so dataChange = true) but did not actually do so (so no CDC will be produced).
+          // In this case the correct CDC output is empty - we shouldn't serve it from
+          // those files.
+          // This should be handled within the command, but as a hotfix-safe fix, we check the
+          // metrics. If the command reported 0 rows inserted, updated, or deleted, then CDC
+          // shouldn't be produced.
+          val isMerge = commitInfo.isDefined &&
+            commitInfo.get.operation == DeltaOperations.Merge(None, Nil, Nil).name
+          val knownToHaveNoChangedRows = {
+            val metrics = commitInfo.flatMap(_.operationMetrics).getOrElse(Map.empty)
+            // Note that if any metrics are missing, this condition will be false and we won't skip.
+            // Unfortunately there are no predefined constants for these metric values.
+            Seq("numTargetRowsInserted", "numTargetRowsUpdated", "numTargetRowsDeleted").forall {
+              metrics.get(_).contains("0")
+            }
+          }
+          if (isMerge && knownToHaveNoChangedRows) {
+            // This was introduced for a hotfix, so we're mirroring the existing logic as closely
+            // as possible - it'd likely be safe to just return an empty dataframe here.
+            addFiles.append(CDCDataSpec(v, ts, Nil))
+            removeFiles.append(CDCDataSpec(v, ts, Nil))
+          } else {
+            // Otherwise, we take the AddFile and RemoveFile actions with dataChange = true and
+            // infer CDC from them.
+            val addActions = actions.collect { case a: AddFile if a.dataChange => a }
+            val removeActions = actions.collect { case r: RemoveFile if r.dataChange => r }
+            addFiles.append(CDCDataSpec(v, ts, addActions))
+            removeFiles.append(CDCDataSpec(v, ts, removeActions))
+          }
+        }
+    }
+
+    val dfs = ListBuffer[DataFrame]()
+    if (changeFiles.nonEmpty) {
+      dfs.append(scanIndex(
+        spark,
+        new TahoeChangeFileIndex(spark, changeFiles.toSeq, deltaLog, deltaLog.dataPath, snapshot),
+        snapshot.metadata,
+        isStreaming))
+    }
+
+    if (addFiles.nonEmpty) {
+      dfs.append(scanIndex(
+        spark,
+        new CdcAddFileIndex(spark, addFiles.toSeq, deltaLog, deltaLog.dataPath, snapshot),
+        snapshot.metadata,
+        isStreaming))
+    }
+
+    if (removeFiles.nonEmpty) {
+      dfs.append(scanIndex(
+        spark,
+        new TahoeRemoveFileIndex(spark, removeFiles.toSeq, deltaLog, deltaLog.dataPath, snapshot),
+        snapshot.metadata,
+        isStreaming))
+    }
+
+    CDCVersionDiffInfo(dfs.reduce((df1, df2) => df1.unionAll(df2)), totalFiles, totalBytes)
+  }
+
+  /**
+   * Get the block of change data from start to end Delta log versions (both sides inclusive).
+   * The returned DataFrame has isStreaming set to false.
+   */
+  def changesToBatchDF(
+      deltaLog: DeltaLog,
+      start: Long,
+      end: Long,
+      spark: SparkSession): DataFrame = {
+
+    val itr = deltaLog.getChanges(start)
+    changesToDF(deltaLog, start, end, itr.takeWhile(_._1 <= end), spark, isStreaming = false)
+      .fileChangeDf
+  }
+
+  /**
+   * Build a dataframe from the specified file index. We can't use a DataFrame scan directly on the
+   * file names because that scan wouldn't include partition columns.
+   */
+  def scanIndex(
+      spark: SparkSession,
+      index: TahoeFileIndex,
+      metadata: Metadata,
+      isStreaming: Boolean = false): DataFrame = {
+    val relation = HadoopFsRelation(
+      index,
+      index.partitionSchema,
+      cdcReadSchema(metadata.schema),
+      bucketSpec = None,
+      new DeltaParquetFileFormat(metadata.columnMappingMode, metadata.schema),
+      options = index.deltaLog.options)(spark)
+    val plan = LogicalRelation(relation, isStreaming = isStreaming)
+    Dataset.ofRows(spark, plan)
+  }
+
+  /**
+   * Append CDC metadata columns to the provided schema.
+   */
+  def cdcReadSchema(deltaSchema: StructType): StructType = {
+    deltaSchema
+      .add(CDC_TYPE_COLUMN_NAME, StringType)
+      .add(CDC_COMMIT_VERSION, LongType)
+      .add(CDC_COMMIT_TIMESTAMP, TimestampType)
+  }
+
+  /**
+   * Based on the read options passed it indicates whether the read was a cdc read or not.
+   */
+  def isCDCRead(options: CaseInsensitiveStringMap): Boolean = {
+    val cdcEnabled = options.containsKey(DeltaDataSource.CDC_ENABLED_KEY) &&
+      options.get(DeltaDataSource.CDC_ENABLED_KEY) == "true"
+
+    val cdcLegacyConfEnabled = options.containsKey(DeltaDataSource.CDC_ENABLED_KEY_LEGACY) &&
+      options.get(DeltaDataSource.CDC_ENABLED_KEY_LEGACY) == "true"
+
+    cdcEnabled || cdcLegacyConfEnabled
+  }
+
+  /**
+   * Determine if the metadata provided has cdc enabled or not.
+   */
+  def isCDCEnabledOnTable(metadata: Metadata): Boolean = {
+    DeltaConfigs.CHANGE_DATA_FEED.fromMetaData(metadata)
+  }
+
+  case class CDCDataSpec[T <: FileAction](version: Long, timestamp: Timestamp, actions: Seq[T])
+
+  /**
+   * Represents the changes between some start and end version of a Delta table
+   * @param fileChangeDf contains all of the file changes (AddFile, RemoveFile, AddCDCFile)
+   * @param numFiles the number of AddFile + RemoveFile + AddCDCFiles that are in the df
+   * @param numBytes the total size of the AddFile + RemoveFile + AddCDCFiles that are in the df
+   */
+  case class CDCVersionDiffInfo(fileChangeDf: DataFrame, numFiles: Long, numBytes: Long)
+}

--- a/core/src/main/scala/org/apache/spark/sql/delta/files/CdcAddFileIndex.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/files/CdcAddFileIndex.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.files
+
+import org.apache.spark.sql.delta.{DeltaLog, Snapshot}
+import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.actions.SingleAction.addFileEncoder
+import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.commands.cdc.CDCReader._
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.types.StructType
+
+/**
+ * A [[TahoeFileIndex]] for scanning a sequence of added files as CDC. Similar to
+ * [[TahoeBatchFileIndex]], with a bit of special handling to attach the log version
+ * and CDC type on a per-file basis.
+ */
+class CdcAddFileIndex(
+    override val spark: SparkSession,
+    filesByVersion: Seq[CDCDataSpec[AddFile]],
+    deltaLog: DeltaLog,
+    path: Path,
+    snapshot: Snapshot)
+  extends TahoeBatchFileIndex(
+    spark, "cdcRead", filesByVersion.flatMap(_.actions), deltaLog, path, snapshot) {
+
+  override def matchingFiles(
+      partitionFilters: Seq[Expression],
+      dataFilters: Seq[Expression]): Seq[AddFile] = {
+    val addFiles = filesByVersion.flatMap {
+      case CDCDataSpec(version, ts, files) =>
+        files.map { f =>
+          // We add the metadata as faked partition columns in order to attach it on a per-file
+          // basis.
+          val newPartitionVals = f.partitionValues +
+            (CDC_COMMIT_VERSION -> version.toString) +
+            (CDC_COMMIT_TIMESTAMP -> Option(ts).map(_.toString).orNull) +
+            (CDC_TYPE_COLUMN_NAME -> CDC_TYPE_INSERT)
+          f.copy(partitionValues = newPartitionVals)
+        }
+    }
+    DeltaLog.filterFileList(
+        partitionSchema,
+        spark.createDataset(addFiles)(addFileEncoder).toDF(),
+        partitionFilters)
+        .as[AddFile](addFileEncoder)
+        .collect()
+  }
+
+  override def inputFiles: Array[String] = {
+    filesByVersion.flatMap(_.actions).map(f => absolutePath(f.path).toString).toArray
+  }
+
+  override val partitionSchema: StructType =
+    CDCReader.cdcReadSchema(snapshot.metadata.partitionSchema)
+}

--- a/core/src/main/scala/org/apache/spark/sql/delta/files/TahoeChangeFileIndex.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/files/TahoeChangeFileIndex.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.files
+
+import org.apache.spark.sql.delta.{DeltaLog, Snapshot}
+import org.apache.spark.sql.delta.actions.{AddCDCFile, AddFile}
+import org.apache.spark.sql.delta.actions.SingleAction.addFileEncoder
+import org.apache.spark.sql.delta.commands.cdc.CDCReader.{CDC_COMMIT_TIMESTAMP, CDC_COMMIT_VERSION, CDCDataSpec}
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.types.{LongType, StructType, TimestampType}
+
+/**
+ * A [[TahoeFileIndex]] for scanning a sequence of CDC files. Similar to [[TahoeBatchFileIndex]],
+ * the equivalent for reading [[AddFile]] actions.
+ */
+class TahoeChangeFileIndex(
+    spark: SparkSession,
+    val filesByVersion: Seq[CDCDataSpec[AddCDCFile]],
+    deltaLog: DeltaLog,
+    path: Path,
+    snapshot: Snapshot) extends TahoeFileIndex(spark, deltaLog, path) {
+
+  override def tableVersion: Long = snapshot.version
+
+  override def matchingFiles(
+      partitionFilters: Seq[Expression],
+      dataFilters: Seq[Expression]): Seq[AddFile] = {
+    // Make some fake AddFiles to satisfy the interface.
+    val addFiles = filesByVersion.flatMap {
+      case CDCDataSpec(version, ts, files) =>
+        files.map { f =>
+          // We add the metadata as faked partition columns in order to attach it on a per-file
+          // basis.
+          val newPartitionVals = f.partitionValues +
+            (CDC_COMMIT_VERSION -> version.toString) +
+            (CDC_COMMIT_TIMESTAMP -> Option(ts).map(_.toString).orNull)
+          AddFile(f.path, newPartitionVals, f.size, 0, dataChange = false, tags = f.tags)
+        }
+    }
+    DeltaLog.filterFileList(
+        partitionSchema,
+        spark.createDataset(addFiles)(addFileEncoder).toDF(),
+        partitionFilters)
+      .as[AddFile](addFileEncoder)
+      .collect()
+  }
+
+  override def inputFiles: Array[String] = {
+    filesByVersion.flatMap(_.actions).map(f => absolutePath(f.path).toString).toArray
+  }
+
+  override val partitionSchema: StructType = snapshot.metadata.partitionSchema
+    .add(CDC_COMMIT_VERSION, LongType)
+    .add(CDC_COMMIT_TIMESTAMP, TimestampType)
+
+  override def refresh(): Unit = {}
+
+  override val sizeInBytes: Long = filesByVersion.flatMap(_.actions).map(_.size).sum
+}

--- a/core/src/main/scala/org/apache/spark/sql/delta/files/TahoeRemoveFileIndex.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/files/TahoeRemoveFileIndex.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.files
+
+import org.apache.spark.sql.delta.{DeltaLog, Snapshot}
+import org.apache.spark.sql.delta.actions.{AddFile, RemoveFile}
+import org.apache.spark.sql.delta.actions.SingleAction.addFileEncoder
+import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.commands.cdc.CDCReader._
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.types.StructType
+
+/**
+ * A [[TahoeFileIndex]] for scanning a sequence of removed files as CDC. Similar to
+ * [[TahoeBatchFileIndex]], the equivalent for reading [[AddFile]] actions.
+ */
+class TahoeRemoveFileIndex(
+    spark: SparkSession,
+    val filesByVersion: Seq[CDCDataSpec[RemoveFile]],
+    deltaLog: DeltaLog,
+    path: Path,
+    snapshot: Snapshot) extends TahoeFileIndex(spark, deltaLog, path) {
+
+  override def tableVersion: Long = snapshot.version
+
+  override def matchingFiles(
+      partitionFilters: Seq[Expression],
+      dataFilters: Seq[Expression]): Seq[AddFile] = {
+    // Make some fake AddFiles to satisfy the interface.
+    // Make some fake AddFiles to satisfy the interface.
+    val addFiles = filesByVersion.flatMap {
+      case CDCDataSpec(version, ts, files) =>
+        files.map { r =>
+          if (!r.extendedFileMetadata.getOrElse(false)) {
+            // This shouldn't happen in user queries - the CDC flag was added at the same time as
+            // extended metadata, so all removes in a table with CDC enabled should have it. (The
+            // only exception is FSCK removes, which we screen out separately because they have
+            // dataChange set to false.)
+            throw new IllegalStateException(
+              s"RemoveFile created without extended metadata is ineligible for CDC:\n$r")
+          }
+          // We add the metadata as faked partition columns in order to attach it on a per-file
+          // basis.
+          val newPartitionVals = r.partitionValues +
+            (CDC_COMMIT_VERSION -> version.toString) +
+            (CDC_COMMIT_TIMESTAMP -> Option(ts).map(_.toString).orNull) +
+            (CDC_TYPE_COLUMN_NAME -> CDC_TYPE_DELETE)
+          AddFile(r.path, newPartitionVals, r.size.getOrElse(0L), 0, r.dataChange, tags = r.tags)
+        }
+    }
+    DeltaLog.filterFileList(
+        partitionSchema,
+        spark.createDataset(addFiles)(addFileEncoder).toDF(),
+        partitionFilters)
+      .as[AddFile](addFileEncoder)
+      .collect()
+  }
+
+  override def inputFiles: Array[String] = {
+    filesByVersion.flatMap(_.actions).map(f => absolutePath(f.path).toString).toArray
+  }
+
+  override def partitionSchema: StructType =
+    CDCReader.cdcReadSchema(snapshot.metadata.partitionSchema)
+
+  override def refresh(): Unit = {}
+
+  override val sizeInBytes: Long = filesByVersion.flatMap(_.actions).map(_.size.getOrElse(0L)).sum
+}

--- a/core/src/main/scala/org/apache/spark/sql/delta/files/TahoeRemoveFileIndex.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/files/TahoeRemoveFileIndex.scala
@@ -44,7 +44,6 @@ class TahoeRemoveFileIndex(
       partitionFilters: Seq[Expression],
       dataFilters: Seq[Expression]): Seq[AddFile] = {
     // Make some fake AddFiles to satisfy the interface.
-    // Make some fake AddFiles to satisfy the interface.
     val addFiles = filesByVersion.flatMap {
       case CDCDataSpec(version, ts, files) =>
         files.map { r =>

--- a/core/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
@@ -223,10 +223,6 @@ trait TransactionalWrite extends DeltaLogging { self: OptimisticTransactionImpl 
       data: Dataset[_],
       writeOptions: Option[DeltaOptions],
       additionalConstraints: Seq[Constraint]): Seq[FileAction] = {
-    if (DeltaConfigs.CHANGE_DATA_FEED.fromMetaData(metadata)) {
-      throw DeltaErrors.cdcWriteNotAllowedInThisVersion()
-    }
-
     hasWritten = true
 
     val spark = data.sparkSession

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
@@ -213,6 +213,17 @@ object DeltaDataSource extends DatabricksLogging {
    */
   final val TIME_TRAVEL_VERSION_KEY = "versionAsOf"
 
+  final val CDC_START_VERSION_KEY = "startingVersion"
+
+  final val CDC_START_TIMESTAMP_KEY = "startingTimestamp"
+
+  final val CDC_END_VERSION_KEY = "endingVersion"
+
+  final val CDC_END_TIMESTAMP_KEY = "endingTimestamp"
+
+  final val CDC_ENABLED_KEY = "readChangeFeed"
+
+  final val CDC_ENABLED_KEY_LEGACY = "readChangeData"
 
   def encodePartitioningColumns(columns: Seq[String]): String = {
     Serialization.write(columns)

--- a/core/src/test/scala/org/apache/spark/sql/delta/CheckCDCAnswer.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/CheckCDCAnswer.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.sql.Timestamp
+
+import org.apache.spark.sql.delta.commands.cdc.CDCReader.{CDC_COMMIT_TIMESTAMP, CDC_COMMIT_VERSION}
+
+import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+
+trait CheckCDCAnswer extends QueryTest {
+  /**
+   * Check the result of a CDC operation. The expected answer should include only CDC type and
+   * log version - the timestamp is nondeterministic, so we'll check just that it matches the
+   * correct value in the Delta log.
+   *
+   * @param log            The Delta log for the table CDC is being extracted from.
+   * @param df             The computed dataframe, which should match the default CDC result schema.
+   *                       Callers doing projections on top should use checkAnswer directly.
+   * @param expectedAnswer The expected results for the CDC query, excluding the CDC_LOG_TIMESTAMP
+   *                       column which we handle inside this method.
+   */
+  def checkCDCAnswer(log: DeltaLog, df: => DataFrame, expectedAnswer: Seq[Row]): Unit = {
+    checkAnswer(df.drop(CDC_COMMIT_TIMESTAMP), expectedAnswer)
+
+    val timestampsByVersion = df.select(CDC_COMMIT_VERSION, CDC_COMMIT_TIMESTAMP).collect()
+      .map { row =>
+        val version = row.getLong(0)
+        val ts = row.getTimestamp(1)
+        (version -> ts)
+      }.toMap
+    val correctTimestampsByVersion = {
+      // Results should match the fully monotonized commits. Note that this map will include
+      // all versions of the table but only the ones in timestampsByVersion are checked for
+      // correctness.
+      val commits = DeltaHistoryManager.getCommits(
+        log.store,
+        log.logPath,
+        start = 0,
+        end = None,
+        log.newDeltaHadoopConf())
+
+      // Note that the timestamps come from filesystem modification timestamps, so they're
+      // milliseconds since epoch and we don't need to deal with timezones.
+      commits.map(f => (f.version -> new Timestamp(f.timestamp))).toMap
+    }
+
+    timestampsByVersion.keySet.foreach { version =>
+      assert(timestampsByVersion(version) === correctTimestampsByVersion(version))
+    }
+  }
+
+  def checkCDCAnswer(log: DeltaLog, df: => DataFrame, expectedAnswer: DataFrame): Unit = {
+    checkCDCAnswer(log, df, expectedAnswer.collect())
+  }
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/cdc/CDCReaderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/cdc/CDCReaderSuite.scala
@@ -1,0 +1,230 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.cdc
+
+// scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.actions.{Action, AddCDCFile}
+import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.commands.cdc.CDCReader._
+import org.apache.spark.sql.delta.files.DelayedCommitProtocol
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.execution.SQLExecution
+import org.apache.spark.sql.execution.datasources.FileFormatWriter
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.test.SharedSparkSession
+
+class CDCReaderSuite
+  extends QueryTest  with CheckCDCAnswer
+  with SharedSparkSession
+  with DeltaSQLCommandTest
+  with DeltaColumnMappingTestUtils {
+
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaConfigs.CHANGE_DATA_FEED.defaultTablePropertyKey, "true")
+
+  /**
+   * Write a commit with just CDC data. Returns the committed version.
+   */
+  private def writeCdcData(
+      log: DeltaLog,
+      data: DataFrame,
+      extraActions: Seq[Action] = Seq.empty): Long = {
+    log.withNewTransaction { txn =>
+      val qe = data.queryExecution
+      val basePath = log.dataPath.toString
+
+      // column mapped mode forces to use random file prefix
+      val randomPrefixes = if (columnMappingEnabled) {
+        Some(DeltaConfigs.RANDOM_PREFIX_LENGTH.fromMetaData(log.snapshot.metadata))
+      } else {
+        None
+      }
+      // we need to convert to physical name in column mapping mode
+      val mappedOutput = if (columnMappingEnabled) {
+        val metadata = log.snapshot.metadata
+        DeltaColumnMapping.createPhysicalAttributes(
+          qe.analyzed.output, metadata.schema, metadata.columnMappingMode
+        )
+      } else {
+        qe.analyzed.output
+      }
+
+      SQLExecution.withNewExecutionId(qe) {
+        var committer = new DelayedCommitProtocol("delta", basePath, randomPrefixes)
+        FileFormatWriter.write(
+          sparkSession = spark,
+          plan = qe.executedPlan,
+          fileFormat = log.fileFormat(),
+          committer = committer,
+          outputSpec = FileFormatWriter.OutputSpec(basePath, Map.empty, mappedOutput),
+          hadoopConf = log.newDeltaHadoopConf(),
+          partitionColumns = Seq.empty,
+          bucketSpec = None,
+          statsTrackers = Seq.empty,
+          options = Map.empty)
+
+        val cdc = committer.addedStatuses.map { a =>
+          AddCDCFile(a.path, Map.empty, a.size)
+        }
+        txn.commit(extraActions ++ cdc, DeltaOperations.ManualUpdate)
+      }
+    }
+  }
+
+  test("simple CDC scan") {
+    withTempDir { dir =>
+      val log = DeltaLog.forTable(spark, dir.getAbsolutePath)
+      val data = spark.range(10)
+      val cdcData = spark.range(20, 25).withColumn(CDC_TYPE_COLUMN_NAME, lit("insert"))
+
+      data.write.format("delta").save(dir.getAbsolutePath)
+      sql(s"DELETE FROM delta.`${dir.getAbsolutePath}`")
+      writeCdcData(log, cdcData)
+
+      // For this basic test, we check each of the versions individually in addition to the full
+      // range to try and catch weird corner cases.
+      checkCDCAnswer(
+        log,
+        CDCReader.changesToBatchDF(log, 0, 0, spark),
+        data.withColumn(CDC_TYPE_COLUMN_NAME, lit("insert"))
+          .withColumn(CDC_COMMIT_VERSION, lit(0))
+      )
+      checkCDCAnswer(
+        log,
+        CDCReader.changesToBatchDF(log, 1, 1, spark),
+        data.withColumn(CDC_TYPE_COLUMN_NAME, lit("delete"))
+          .withColumn(CDC_COMMIT_VERSION, lit(1))
+      )
+      checkCDCAnswer(
+        log,
+        CDCReader.changesToBatchDF(log, 2, 2, spark),
+        cdcData.withColumn(CDC_COMMIT_VERSION, lit(2))
+      )
+      checkCDCAnswer(
+        log,
+        CDCReader.changesToBatchDF(log, 0, 2, spark),
+        data.withColumn(CDC_TYPE_COLUMN_NAME, lit("insert"))
+          .withColumn(CDC_COMMIT_VERSION, lit(0))
+          .unionAll(data
+            .withColumn(CDC_TYPE_COLUMN_NAME, lit("delete"))
+            .withColumn(CDC_COMMIT_VERSION, lit(1)))
+          .unionAll(cdcData.withColumn(CDC_COMMIT_VERSION, lit(2)))
+      )
+    }
+  }
+
+  test("cdc update ops") {
+    withTempDir { dir =>
+      val log = DeltaLog.forTable(spark, dir.getAbsolutePath)
+      val data = spark.range(10)
+
+      data.write.format("delta").save(dir.getAbsolutePath)
+      writeCdcData(
+        log,
+        spark.range(20, 25).toDF().withColumn(CDC_TYPE_COLUMN_NAME, lit("update_pre")))
+      writeCdcData(
+        log,
+        spark.range(30, 35).toDF().withColumn(CDC_TYPE_COLUMN_NAME, lit("update_post")))
+
+      checkCDCAnswer(
+        log,
+        CDCReader.changesToBatchDF(log, 0, 2, spark),
+        data.withColumn(CDC_TYPE_COLUMN_NAME, lit("insert"))
+          .withColumn(CDC_COMMIT_VERSION, lit(0))
+          .unionAll(spark.range(20, 25).withColumn(CDC_TYPE_COLUMN_NAME, lit("update_pre"))
+              .withColumn(CDC_COMMIT_VERSION, lit(1))
+          )
+          .unionAll(spark.range(30, 35).withColumn(CDC_TYPE_COLUMN_NAME, lit("update_post"))
+              .withColumn(CDC_COMMIT_VERSION, lit(2))
+          )
+      )
+    }
+  }
+
+  test("dataChange = false operations ignored") {
+    withTempDir { dir =>
+      val log = DeltaLog.forTable(spark, dir.getAbsolutePath)
+      val data = spark.range(10)
+
+      data.write.format("delta").save(dir.getAbsolutePath)
+      sql(s"OPTIMIZE delta.`${dir.getAbsolutePath}`")
+
+      checkCDCAnswer(
+        log,
+        CDCReader.changesToBatchDF(log, 0, 1, spark),
+        data.withColumn(CDC_TYPE_COLUMN_NAME, lit("insert"))
+          .withColumn(CDC_COMMIT_VERSION, lit(0))
+      )
+    }
+  }
+
+  test("range with start and end equal") {
+    withTempDir { dir =>
+      val log = DeltaLog.forTable(spark, dir.getAbsolutePath)
+      val data = spark.range(10)
+      val cdcData = spark.range(0, 5).withColumn(CDC_TYPE_COLUMN_NAME, lit("delete"))
+          .withColumn(CDC_COMMIT_VERSION, lit(1))
+
+      data.write.format("delta").save(dir.getAbsolutePath)
+      writeCdcData(log, cdcData)
+
+      checkCDCAnswer(
+        log,
+        CDCReader.changesToBatchDF(log, 0, 0, spark),
+        data.withColumn(CDC_TYPE_COLUMN_NAME, lit("insert"))
+          .withColumn(CDC_COMMIT_VERSION, lit(0))
+      )
+
+      checkCDCAnswer(
+        log,
+        CDCReader.changesToBatchDF(log, 1, 1, spark),
+        cdcData)
+    }
+  }
+
+  test("range past the end of the log") {
+    withTempDir { dir =>
+      val log = DeltaLog.forTable(spark, dir.getAbsolutePath)
+      spark.range(10).write.format("delta").save(dir.getAbsolutePath)
+
+      checkCDCAnswer(
+        log,
+        CDCReader.changesToBatchDF(log, 0, 1, spark),
+        spark.range(10).withColumn(CDC_TYPE_COLUMN_NAME, lit("insert"))
+          .withColumn(CDC_COMMIT_VERSION, lit(0))
+      )
+    }
+  }
+
+  test("invalid range - end before start") {
+    withTempDir { dir =>
+      val log = DeltaLog.forTable(spark, dir.getAbsolutePath)
+      spark.range(10).write.format("delta").save(dir.getAbsolutePath)
+      spark.range(20).write.format("delta").mode("append").save(dir.getAbsolutePath)
+
+      intercept[IllegalArgumentException] {
+        CDCReader.changesToBatchDF(log, 1, 0, spark)
+      }
+    }
+  }
+
+}
+

--- a/core/src/test/scala/org/apache/spark/sql/delta/cdc/CDCReaderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/cdc/CDCReaderSuite.scala
@@ -225,6 +225,5 @@ class CDCReaderSuite
       }
     }
   }
-
 }
 


### PR DESCRIPTION
See the project plan at #1105.

This PR introduces a key class used for CDF and CDC in DeltaLake: `CDCReader`. As the class docs say,

```
The basic abstraction here is the CDC type column defined by [[CDCReader.CDC_TYPE_COLUMN_NAME]].
When CDC is enabled, our writer will treat this column as a special partition column even though
it's not part of the table. Writers should generate a query that has two types of rows in it:
the main data in partition CDC_TYPE_NOT_CDC and the CDC data with the appropriate CDC type value.
```

We also add `CDCReaderSuite` which tests very basic functionality of the CDCReader.

We also update `DelayedCommitProtocol` to understand and handle cases when CDC is enabled. For example, it knows to keep track of the added CDC files during a write, and how to properly partition CDC data from main table data.