### PR TITLE
Block unsupported data type when updating a Delta table schema

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -302,6 +302,10 @@
     "message" : [ "Creating a bloom filter index on a column with type %s is unsupported: %s" ],
     "sqlState" : "0A000"
   },
+  "DELTA_UNSUPPORTED_DATA_TYPES" : {
+    "message" : [ "Found columns using unsupported data types: %s. You can set '%s' to 'false' to disable the type check. Disabling this type check may allow users to create unsupported Delta tables and should only be used when trying to read/write legacy tables." ],
+    "sqlState" : "0A000"
+  },
   "DELTA_UNSUPPORTED_EXPRESSION_GENERATED_COLUMN" : {
     "message" : [ "%s cannot be used in a generated column" ],
     "sqlState" : "0A000"

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.delta.catalog.DeltaCatalog
 import org.apache.spark.sql.delta.constraints.Constraints
 import org.apache.spark.sql.delta.hooks.PostCommitHook
 import org.apache.spark.sql.delta.metering.DeltaLogging
-import org.apache.spark.sql.delta.schema.{InvariantViolationException, SchemaUtils}
+import org.apache.spark.sql.delta.schema.{InvariantViolationException, SchemaUtils, UnsupportedDataTypeInfo}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.JsonUtils
 import io.delta.sql.DeltaSparkSessionExtension
@@ -1379,6 +1379,18 @@ object DeltaErrors
     new DeltaAnalysisException(
       errorClass = "DELTA_CANNOT_CHANGE_DATA_TYPE",
       messageParameters = Array(msg)
+    )
+  }
+
+  def unsupportedDataTypes(
+      unsupportedDataType: UnsupportedDataTypeInfo,
+      moreUnsupportedDataTypes: UnsupportedDataTypeInfo*): Throwable = {
+    val prettyMessage = (unsupportedDataType +: moreUnsupportedDataTypes)
+      .map(dt => s"${dt.column}: ${dt.dataType}")
+      .mkString("[", ", ", "]")
+    new DeltaAnalysisException(
+      errorClass = "DELTA_UNSUPPORTED_DATA_TYPES",
+      messageParameters = Array(prettyMessage, DeltaSQLConf.DELTA_SCHEMA_TYPE_CHECK.key)
     )
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -292,6 +292,16 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(false)
 
+  val DELTA_SCHEMA_TYPE_CHECK =
+    buildConf("schema.typeCheck.enabled")
+      .doc(
+        """Enable the data type check when updating the table schema. Disabling this flag may
+          | allow users to create unsupported Delta tables and should only be used when trying to
+          | read/write legacy tables.""".stripMargin)
+      .internal()
+      .booleanConf
+      .createWithDefault(true)
+
   val DELTA_ASSUMES_DROP_CONSTRAINT_IF_EXISTS =
     buildConf("constraints.assumesDropIfExists.enabled")
       .doc("""If true, DROP CONSTRAINT quietly drops nonexistent constraints even without

--- a/core/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
@@ -22,9 +22,13 @@ import java.util.regex.Pattern
 
 import org.apache.spark.sql.delta.schema.SchemaMergingUtils._
 import org.apache.spark.sql.delta.sources.DeltaSourceUtils.GENERATION_EXPRESSION_METADATA_KEY
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import io.delta.tables.DeltaTable
 import org.scalatest.GivenWhenThen
 
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
@@ -33,7 +37,8 @@ import org.apache.spark.sql.types._
 class SchemaUtilsSuite extends QueryTest
   with SharedSparkSession
   with GivenWhenThen
-  with SQLTestUtils {
+  with SQLTestUtils
+  with DeltaSQLCommandTest {
   import SchemaUtils._
   import testImplicits._
 
@@ -1515,4 +1520,136 @@ class SchemaUtilsSuite extends QueryTest
     }
 
   }
+
+  test("findUnsupportedDataTypes") {
+    def assertUnsupportedDataType(
+        dataType: DataType,
+        expected: Seq[UnsupportedDataTypeInfo]): Unit = {
+      val schema = StructType(Seq(StructField("col", dataType)))
+      assert(findUnsupportedDataTypes(schema) == expected)
+    }
+
+    assertUnsupportedDataType(NullType, Nil)
+    assertUnsupportedDataType(BooleanType, Nil)
+    assertUnsupportedDataType(ByteType, Nil)
+    assertUnsupportedDataType(ShortType, Nil)
+    assertUnsupportedDataType(IntegerType, Nil)
+    assertUnsupportedDataType(YearMonthIntervalType.DEFAULT, Nil)
+    assertUnsupportedDataType(LongType, Nil)
+    assertUnsupportedDataType(DayTimeIntervalType.DEFAULT, Nil)
+    assertUnsupportedDataType(FloatType, Nil)
+    assertUnsupportedDataType(DoubleType, Nil)
+    assertUnsupportedDataType(StringType, Nil)
+    assertUnsupportedDataType(DateType, Nil)
+    assertUnsupportedDataType(TimestampType, Nil)
+    assertUnsupportedDataType(
+      TimestampNTZType,
+      Seq(UnsupportedDataTypeInfo("col", TimestampNTZType)))
+    assertUnsupportedDataType(
+      CalendarIntervalType,
+      Seq(UnsupportedDataTypeInfo("col", CalendarIntervalType)))
+    assertUnsupportedDataType(BinaryType, Nil)
+    assertUnsupportedDataType(DataTypes.createDecimalType(), Nil)
+    assertUnsupportedDataType(
+      UnsupportedDataType,
+      Seq(UnsupportedDataTypeInfo("col", UnsupportedDataType)))
+
+    // array
+    assertUnsupportedDataType(ArrayType(IntegerType, true), Nil)
+    assertUnsupportedDataType(
+      ArrayType(UnsupportedDataType, true),
+      Seq(UnsupportedDataTypeInfo("col[]", UnsupportedDataType)))
+
+    // map
+    assertUnsupportedDataType(MapType(IntegerType, IntegerType, true), Nil)
+    assertUnsupportedDataType(
+      MapType(UnsupportedDataType, IntegerType, true),
+      Seq(UnsupportedDataTypeInfo("col[key]", UnsupportedDataType)))
+    assertUnsupportedDataType(
+      MapType(IntegerType, UnsupportedDataType, true),
+      Seq(UnsupportedDataTypeInfo("col[value]", UnsupportedDataType)))
+    assertUnsupportedDataType(
+      MapType(UnsupportedDataType, UnsupportedDataType, true),
+      Seq(
+        UnsupportedDataTypeInfo("col[key]", UnsupportedDataType),
+        UnsupportedDataTypeInfo("col[value]", UnsupportedDataType)))
+
+    // struct
+    assertUnsupportedDataType(StructType(StructField("f", LongType) :: Nil), Nil)
+    assertUnsupportedDataType(
+      StructType(StructField("a", LongType) :: StructField("dot.name", UnsupportedDataType) :: Nil),
+      Seq(UnsupportedDataTypeInfo("col.`dot.name`", UnsupportedDataType)))
+    val nestedStructType = StructType(Seq(
+      StructField("a", LongType),
+      StructField("b", StructType(Seq(
+        StructField("c", LongType),
+        StructField("d", UnsupportedDataType)
+      ))),
+      StructField("e", StructType(Seq(
+        StructField("f", LongType),
+        StructField("g", UnsupportedDataType)
+      )))
+    ))
+    assertUnsupportedDataType(
+      nestedStructType,
+      Seq(
+        UnsupportedDataTypeInfo("col.b.d", UnsupportedDataType),
+        UnsupportedDataTypeInfo("col.e.g", UnsupportedDataType)))
+
+    // udt
+    assertUnsupportedDataType(new PointUDT, Nil)
+    assertUnsupportedDataType(
+      new UnsupportedUDT,
+      Seq(UnsupportedDataTypeInfo("col", UnsupportedDataType)))
+  }
+
+  test("unsupported data type check") {
+    withTempDir { tempDir =>
+      val path = tempDir.getCanonicalPath
+
+      def createTableUsingTimestampNTZType(): Unit = {
+        DeltaTable.create().addColumn("t", TimestampNTZType, true).location(path).execute()
+      }
+
+      val e = intercept[AnalysisException] {
+        createTableUsingTimestampNTZType()
+      }
+      assert(
+        e.getMessage.contains("Found columns using unsupported data types: [t: TimestampNTZType]"))
+      assert(e.getMessage.contains(DeltaSQLConf.DELTA_SCHEMA_TYPE_CHECK.key))
+
+      withSQLConf(DeltaSQLConf.DELTA_SCHEMA_TYPE_CHECK.key -> "false") {
+        createTableUsingTimestampNTZType()
+      }
+    }
+  }
+}
+
+object UnsupportedDataType extends DataType {
+  override def defaultSize: Int = throw new UnsupportedOperationException("defaultSize")
+  override def asNullable: DataType = throw new UnsupportedOperationException("asNullable")
+  override def toString: String = "UnsupportedDataType"
+}
+
+@SQLUserDefinedType(udt = classOf[PointUDT])
+case class Point(x: Int, y: Int)
+
+class PointUDT extends UserDefinedType[Point] {
+  override def sqlType: DataType = StructType(Array(
+    StructField("x", IntegerType, nullable = false),
+    StructField("y", IntegerType, nullable = false)))
+
+  override def serialize(obj: Point): Any = InternalRow(obj.x, obj.y)
+
+  override def deserialize(datum: Any): Point = datum match {
+    case row: InternalRow => Point(row.getInt(0), row.getInt(1))
+  }
+
+  override def userClass: Class[Point] = classOf[Point]
+
+  override def toString: String = "PointUDT"
+}
+
+class UnsupportedUDT extends PointUDT {
+  override def sqlType: DataType = UnsupportedDataType
 }


### PR DESCRIPTION
## Description

Currently Delta doesn't do a data type check hence any data type added by Spark will be supported by Delta automatically. This causes Delta support the following types unintentionally:
  - YearMonthIntervalType
  - DayTimeIntervalType
  - UserDefinedType 


In order to prevent such issue from happening, this PR will:
- Add a data type check to only allow the following data types in a Delta table.
The data types defined in the [Protocol](https://github.com/delta-io/delta/blob/6905ce757f67935960a9a13ecb6854d53c117d31/PROTOCOL.md#schema-serialization-format).
  - YearMonthIntervalType
  - DayTimeIntervalType
  - UserDefinedType

- Add an internal flag `spark.databricks.delta.schema.typeCheck.enabled` to allow users to disable the check in case it’s needed.
- Any new data type added in future will be blocked by default.
- `TimestampNTZType` will be rejected given that a user cannot read/write a Delta table using `TimestampNTZType` today.

## How was this patch tested?

New added tests.

## Does this PR introduce _any_ user-facing changes?

No. This is not a user facing change because we don't expect this would break any existing workflows.
