### PR TITLE
[Issue #1088] Allow write option "compression" as for parquet write options

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -187,6 +187,7 @@ object DeltaOptions extends DeltaLogging {
   val DATA_CHANGE_OPTION = "dataChange"
   val STARTING_VERSION_OPTION = "startingVersion"
   val STARTING_TIMESTAMP_OPTION = "startingTimestamp"
+  val COMPRESSION = "compression"
 
   val validOptionKeys : Set[String] = Set(
     REPLACE_WHERE_OPTION,
@@ -203,6 +204,7 @@ object DeltaOptions extends DeltaLogging {
     DATA_CHANGE_OPTION,
     STARTING_TIMESTAMP_OPTION,
     STARTING_VERSION_OPTION,
+    COMPRESSION,
     "queryName",
     "checkpointLocation",
     "path",

--- a/core/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
@@ -296,9 +296,10 @@ trait TransactionalWrite extends DeltaLogging { self: OptimisticTransactionImpl 
       val options = writeOptions match {
         case None => Map.empty[String, String]
         case Some(writeOptions) =>
-          writeOptions.options.filterKeys(key =>
-            key.equalsIgnoreCase("maxRecordsPerFile")
-          ).toMap
+          writeOptions.options.filterKeys { key =>
+            key.equalsIgnoreCase("maxRecordsPerFile") ||
+              key.equalsIgnoreCase(DeltaOptions.COMPRESSION)
+          }.toMap
       }
 
       try {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
@@ -20,10 +20,12 @@ import org.apache.spark.sql.delta.actions.{Action, FileAction}
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.util.FileNames
 import org.apache.commons.io.FileUtils
-
+import org.apache.parquet.format.CompressionCodec
 import org.apache.spark.sql.{AnalysisException, QueryTest}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.Utils
+
+import java.util.Locale
 
 class DeltaOptionSuite extends QueryTest
   with SharedSparkSession  with DeltaSQLCommandTest {
@@ -168,12 +170,71 @@ class DeltaOptionSuite extends QueryTest
       val path = tempDir.getCanonicalPath
       withTable("maxRecordsPerFile") {
         spark.range(100)
-          .writeTo(s"maxRecordsPerFile")
+          .writeTo("maxRecordsPerFile")
           .using("delta")
           .option("maxRecordsPerFile", 5)
           .tableProperty("location", path)
           .create()
         assert(FileUtils.listFiles(tempDir, Array("parquet"), false).size === 20)
+      }
+    }
+  }
+
+  test("support no compression write option (defaults to snappy)") {
+    withTempDir { tempDir =>
+      val path = tempDir.getCanonicalPath
+      withTable("compression") {
+        spark.range(100)
+          .writeTo("compression")
+          .using("delta")
+          .tableProperty("location", path)
+          .create()
+        assert(FileUtils.listFiles(tempDir, Array("snappy.parquet"), false).size > 0)
+      }
+    }
+  }
+
+  // LZO and BROTLI left out as additional library dependencies needed
+  val codecsAndSubExtensions = Seq(
+    CompressionCodec.UNCOMPRESSED -> "",
+    CompressionCodec.SNAPPY -> "snappy.",
+    CompressionCodec.GZIP -> "gz.",
+    CompressionCodec.LZ4 -> "lz4.",
+    CompressionCodec.ZSTD -> "zstd."
+  )
+
+  codecsAndSubExtensions.foreach { case (codec, subExt) =>
+    val codecName = codec.name().toLowerCase(Locale.ROOT)
+    test(s"support compression codec '${codecName}' as write option") {
+      withTempDir { tempDir =>
+        val path = tempDir.getCanonicalPath
+        withTable(s"compression_${codecName}") {
+          spark.range(100)
+            .writeTo(s"compression_${codecName}")
+            .using("delta")
+            .option("compression", codecName)
+            .tableProperty("location", path)
+            .create()
+          assert(FileUtils.listFiles(tempDir, Array(s"${subExt}parquet"), false).size > 0)
+        }
+      }
+    }
+  }
+
+  test("invalid compression write option") {
+    withTempDir { tempDir =>
+      val path = tempDir.getCanonicalPath
+      withTable("compression") {
+        val e = intercept[IllegalArgumentException] {
+          spark.range(100)
+            .writeTo("compression")
+            .using("delta")
+            .option("compression", "???")
+            .tableProperty("location", path)
+            .create()
+        }
+        val expectedMessage = "Codec [???] is not available. Available codecs are "
+        assert(e.getMessage.startsWith(expectedMessage))
       }
     }
   }


### PR DESCRIPTION

## Description

This PR allows the use of the "compression" parquet write option in delta.

## How was this patch tested?

Tests were added. Testing cases where "compression" option is absent and defaults to snappy, "compression" specifies a valid value and eventually "compression" provides an invalid value and raises an exception.

## Does this PR introduce _any_ user-facing changes?

Yes, please check issue #1088 for examples.
