### PR TITLE
Fix describeDeltaDetailsCommand that return a stale metadata

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/DescribeDeltaDetailsCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/DescribeDeltaDetailsCommand.scala
@@ -77,7 +77,7 @@ case class DescribeDeltaDetailCommand(
 
     val deltaLog = DeltaLog.forTable(sparkSession, basePath)
     recordDeltaOperation(deltaLog, "delta.ddl.describeDetails") {
-      val snapshot = deltaLog.snapshot
+      val snapshot = deltaLog.update()
       if (snapshot.version == -1) {
         if (path.nonEmpty) {
           val fs = new Path(path.get).getFileSystem(deltaLog.newDeltaHadoopConf())


### PR DESCRIPTION
DescribeDeltaDetailsCommand doesn't call DeltaLog.update

See https://github.com/delta-io/delta/issues/921