### PR TITLE
[ZOrderBy] Add `range_partition_id` expression

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,6 +57,7 @@ lazy val core = (project in file("core"))
 
       // Test deps
       "org.scalatest" %% "scalatest" % "3.2.9" % "test",
+      "org.scalatestplus" %% "scalacheck-1-15" % "3.2.9.0" % "test",
       "junit" % "junit" % "4.12" % "test",
       "com.novocode" % "junit-interface" % "0.11" % "test",
       "org.apache.spark" %% "spark-catalyst" % sparkVersion % "test" classifier "tests",

--- a/core/src/main/scala/org/apache/spark/sql/delta/expressions/RangePartitionId.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/expressions/RangePartitionId.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.expressions
+
+import org.apache.spark.Partitioner
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
+import org.apache.spark.sql.catalyst.expressions.{Expression, GenericInternalRow, RowOrdering, UnaryExpression, Unevaluable}
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
+import org.apache.spark.sql.types._
+
+
+/**
+ * Unevaluable placeholder expression to be rewritten by the optimizer into [[PartitionerExpr]]
+ *
+ * This is just a convenient way to introduce the former, without the need to manually construct the
+ * [[RangePartitioner]] beforehand, which requires an RDD to be sampled in order to determine range
+ * partition boundaries. The optimizer rule will take care of all that.
+ *
+ * @see [[org.apache.spark.sql.delta.optimizer.RangeRepartitionIdRewrite]]
+ */
+case class RangePartitionId(child: Expression, numPartitions: Int)
+  extends UnaryExpression with Unevaluable {
+
+  require(numPartitions > 0)
+
+  override def checkInputDataTypes(): TypeCheckResult = {
+    if (RowOrdering.isOrderable(child.dataType)) {
+      TypeCheckResult.TypeCheckSuccess
+    } else {
+      TypeCheckResult.TypeCheckFailure(s"cannot sort data type ${child.dataType.simpleString}")
+    }
+  }
+
+  override def dataType: DataType = IntegerType
+
+  override def nullable: Boolean = false
+
+  override protected def withNewChildInternal(newChild: Expression): RangePartitionId =
+    copy(child = newChild)
+}
+
+/**
+ * Thin wrapper around [[Partitioner]] instances that are used in Shuffle operations.
+ * TODO: If needed elsewhere, consider moving it into its own file.
+ */
+case class PartitionerExpr(child: Expression, partitioner: Partitioner)
+  extends UnaryExpression {
+
+  override def dataType: DataType = IntegerType
+
+  override def nullable: Boolean = false
+
+  private lazy val row = new GenericInternalRow(Array[Any](null))
+
+  override def eval(input: InternalRow): Any = {
+    val value: Any = child.eval(input)
+    row.update(0, value)
+    partitioner.getPartition(row)
+  }
+
+  override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
+    val partitionerReference = ctx.addReferenceObj("partitioner", partitioner)
+    val rowReference = ctx.addReferenceObj("row", row)
+
+    nullSafeCodeGen(ctx, ev, input =>
+      s"""$rowReference.update(0, $input);
+         |${ev.value} = $partitionerReference.getPartition($rowReference);
+       """.stripMargin)
+  }
+
+  override protected def withNewChildInternal(newChild: Expression): PartitionerExpr =
+    copy(child = newChild)
+}
+
+

--- a/core/src/main/scala/org/apache/spark/sql/delta/expressions/RangePartitionId.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/expressions/RangePartitionId.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.types._
 case class RangePartitionId(child: Expression, numPartitions: Int)
   extends UnaryExpression with Unevaluable {
 
-  require(numPartitions > 0)
+  require(numPartitions > 0, "expected the number partitions to be greater than zero")
 
   override def checkInputDataTypes(): TypeCheckResult = {
     if (RowOrdering.isOrderable(child.dataType)) {

--- a/core/src/main/scala/org/apache/spark/sql/delta/optimizer/RangePartitionIdRewrite.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/optimizer/RangePartitionIdRewrite.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.optimizer
+
+import org.apache.spark.sql.delta.expressions.{PartitionerExpr, RangePartitionId}
+
+import org.apache.spark.{RangePartitioner, SparkContext}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Alias, Ascending, IsNotNull, SortOrder}
+import org.apache.spark.sql.catalyst.expressions.codegen.LazilyGeneratedOrdering
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project, UnaryNode}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.{QueryExecution, SQLExecution}
+import org.apache.spark.util.MutablePair
+
+
+/**
+ * Rewrites all [[RangePartitionId]] into [[PartitionerExpr]] by running sampling jobs
+ * on the child RDD in order to determine the range boundaries.
+ */
+case class RangePartitionIdRewrite(session: SparkSession)
+  extends Rule[LogicalPlan] {
+  import RangePartitionIdRewrite._
+
+  private def sampleSizeHint: Int = conf.rangeExchangeSampleSizePerPartition
+
+  def apply(plan: LogicalPlan): LogicalPlan = plan transformUp {
+    case node: UnaryNode => node.transformExpressionsUp {
+      case RangePartitionId(expr, n) =>
+        val aliasedExpr = Alias(expr, "__RPI_child_col__")()
+        val exprAttr = aliasedExpr.toAttribute
+
+        val planForSampling = Filter(IsNotNull(exprAttr), Project(Seq(aliasedExpr), node.child))
+        val qeForSampling = new QueryExecution(session, planForSampling)
+
+        val desc = s"RangePartitionId($expr, $n) sampling"
+        val jobGroupId = session.sparkContext.getLocalProperty(SparkContext.SPARK_JOB_GROUP_ID)
+        withCallSite(session.sparkContext, desc) {
+          SQLExecution.withNewExecutionId(qeForSampling) {
+            withJobGroup(session.sparkContext, jobGroupId, desc) {
+              // The code below is inspired from ShuffleExchangeExec.prepareShuffleDependency()
+
+              // Internally, RangePartitioner runs a job on the RDD that samples keys to compute
+              // partition bounds. To get accurate samples, we need to copy the mutable keys.
+              val rddForSampling = qeForSampling.toRdd.mapPartitionsInternal { iter =>
+                val mutablePair = new MutablePair[InternalRow, Null]()
+                iter.map(row => mutablePair.update(row.copy(), null))
+              }
+
+              val sortOrder = SortOrder(exprAttr, Ascending)
+              implicit val ordering = new LazilyGeneratedOrdering(Seq(sortOrder), Seq(exprAttr))
+              val partitioner = new RangePartitioner(n, rddForSampling, true, sampleSizeHint)
+
+              PartitionerExpr(expr, partitioner)
+            }
+          }
+        }
+    }
+  }
+}
+
+object RangePartitionIdRewrite {
+  /**
+   * Executes the equivalent [[SparkContext.setJobGroup()]] call, runs the given `body`,
+   * then restores the original jobGroup.
+   */
+  private def withJobGroup[T](
+      sparkContext: SparkContext,
+      groupId: String,
+      description: String)
+      (body: => T): T = {
+    val oldJobDesc = sparkContext.getLocalProperty("spark.job.description")
+    val oldGroupId = sparkContext.getLocalProperty("spark.jobGroup.id")
+    val oldJobInterrupt = sparkContext.getLocalProperty("spark.job.interruptOnCancel")
+    sparkContext.setJobGroup(groupId, description, interruptOnCancel = true)
+    try body finally {
+      sparkContext.setJobGroup(
+        oldGroupId, oldJobDesc, Option(oldJobInterrupt).map(_.toBoolean).getOrElse(false))
+    }
+  }
+
+  /**
+   * Executes the equivalent setCallSite() call, runs the given `body`,
+   * then restores the original call site.
+   */
+  private def withCallSite[T](sparkContext: SparkContext, shortCallSite: String)(body: => T): T = {
+    val oldCallSiteShortForm = sparkContext.getLocalProperty("callSite.short")
+    val oldCallSiteLongForm = sparkContext.getLocalProperty("callSite.long")
+    sparkContext.setCallSite(shortCallSite)
+    try body finally {
+      sparkContext.setLocalProperty("callSite.short", oldCallSiteShortForm)
+      sparkContext.setLocalProperty("callSite.long", oldCallSiteLongForm)
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/delta/skipping/MultiDimClusteringFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/skipping/MultiDimClusteringFunctions.scala
@@ -30,6 +30,9 @@ object MultiDimClusteringFunctions {
    * Conceptually range-partitions the domain of values of the given column into `numPartitions`
    * partitions and computes the partition number that every value of that column corresponds to.
    * One can think of this as an approximate rank() function.
+   *
+   * Ex. For a column with values (0, 1, 3, 15, 36, 99) and numPartitions = 3 returns
+   * partition range ids as (0, 0, 1, 1, 2, 2).
    */
   def range_partition_id(col: Column, numPartitions: Int): Column = withExpr {
     RangePartitionId(col.expr, numPartitions)

--- a/core/src/main/scala/org/apache/spark/sql/delta/skipping/MultiDimClusteringFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/skipping/MultiDimClusteringFunctions.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.skipping
+
+// scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.sql.delta.expressions.RangePartitionId
+
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.catalyst.expressions.Expression
+
+/** Functions for multi-dimensional clustering of the data */
+object MultiDimClusteringFunctions {
+  private def withExpr(expr: Expression): Column = new Column(expr)
+
+  /**
+   * Conceptually range-partitions the domain of values of the given column into `numPartitions`
+   * partitions and computes the partition number that every value of that column corresponds to.
+   * One can think of this as an approximate rank() function.
+   */
+  def range_partition_id(col: Column, numPartitions: Int): Column = withExpr {
+    RangePartitionId(col.expr, numPartitions)
+  }
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/expressions/RangePartitionIdSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/expressions/RangePartitionIdSuite.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.expressions
+
+import scala.reflect.ClassTag
+
+import org.apache.spark.{Partitioner, RangePartitioner, SparkFunSuite}
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.test.SharedSparkSession
+
+
+class RangePartitionIdSuite
+  extends SparkFunSuite with ExpressionEvalHelper with SharedSparkSession {
+
+  def getPartitioner[T : Ordering : ClassTag](data: Seq[T], partitions: Int): Partitioner = {
+    implicit val ordering = new Ordering[GenericInternalRow] {
+      override def compare(x: GenericInternalRow, y: GenericInternalRow): Int = {
+        def getValue0AsT(row: GenericInternalRow): T = row.values.head.asInstanceOf[T]
+        val orderingT = implicitly[Ordering[T]]
+        orderingT.compare(getValue0AsT(x), getValue0AsT(y))
+      }
+    }
+
+    val rdd =
+      spark.sparkContext.parallelize(data).filter(_ != null)
+        .map(key => (new GenericInternalRow(Array[Any](key)), null))
+
+    new RangePartitioner(partitions, rdd)
+  }
+
+  def testRangePartitionerExpr[T : Ordering : ClassTag](
+    data: Seq[T], partitions: Int, childExpr: Expression, expected: Any): Unit = {
+    val rangePartitioner = getPartitioner(data, partitions)
+    checkEvaluation(PartitionerExpr(childExpr, rangePartitioner), expected)
+  }
+
+  test("RangePartitionerExpr: test basic") {
+    val data = 0.until(12)
+    for { numPartitions <- Seq(2, 3, 4, 6) } {
+      val rangePartitioner = getPartitioner(data, numPartitions)
+      data.foreach { i =>
+        val expected = i / (data.size / numPartitions)
+        checkEvaluation(PartitionerExpr(Literal(i), rangePartitioner), expected)
+      }
+    }
+  }
+
+  test("RangePartitionerExpr: null values") {
+    testRangePartitionerExpr(
+      data = 0.until(10),
+      partitions = 2,
+      childExpr = Literal(null),
+      expected = 0)
+  }
+
+  test("RangePartitionerExpr: null data") {
+    testRangePartitionerExpr(
+      data = 0.until(10).map(_ => null),
+      partitions = 2,
+      childExpr = Literal("asd"),
+      expected = 0)
+  }
+
+  test("RangePartitionId: unevaluable") {
+    intercept[UnsupportedOperationException] {
+      evaluateWithoutCodegen(RangePartitionId(Literal(2), 10))
+    }
+  }
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/skipping/MultiDimClusteringFunctionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/skipping/MultiDimClusteringFunctionsSuite.scala
@@ -84,7 +84,7 @@ class MultiDimClusteringFunctionsSuite extends QueryTest
         Row("b", 20)))
   }
 
-  test("range_partition_id(): corner cases") {
+  testQuietly("range_partition_id(): corner cases") {
     // invalid number of partitions.
     val ex1 = intercept[IllegalArgumentException] {
       spark.range(10).select(range_partition_id($"id", 0)).show

--- a/core/src/test/scala/org/apache/spark/sql/delta/skipping/MultiDimClusteringFunctionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/skipping/MultiDimClusteringFunctionsSuite.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.skipping
+
+import java.nio.ByteBuffer
+
+import scala.util.Random
+
+import org.apache.spark.sql.delta.skipping.MultiDimClusteringFunctions._
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+/** Tests for [[MultiDimClusterFunctions]] */
+class MultiDimClusteringFunctionsSuite extends QueryTest
+    with SharedSparkSession with DeltaSQLCommandTest {
+  import testImplicits._
+
+  test("range_partition_id(): simple") {
+    val numTuples = 20
+    val data = 0.to(numTuples - 1)
+
+    for { div <- Seq(1, 2, 4, 5, 10, 20) } {
+      checkAnswer(
+        Random.shuffle(data).toDF("col")
+          .withColumn("rpi", range_partition_id($"col", data.size / div)),
+        data.map(i => Row(i, i / div))
+      )
+    }
+  }
+
+  test("range_partition_id(): two columns") {
+    val data = Seq("a" -> 10, "b" -> 20, "c" -> 30, "d" -> 40)
+
+    checkAnswer(
+      Random.shuffle(data).toDF("c1", "c2")
+        .withColumn("r1", range_partition_id($"c1", 2))
+        .withColumn("r2", range_partition_id($"c2", 4)),
+      Seq(
+        Row("a", 10, 0, 0),
+        Row("b", 20, 0, 1),
+        Row("c", 30, 1, 2),
+        Row("d", 40, 1, 3)))
+
+    checkAnswer(
+      Random.shuffle(data).toDF("c1", "c2")
+        .withColumn("r1", range_partition_id($"c1", 2))
+        .distinct
+        .withColumn("r2", range_partition_id($"c2", 4)),
+      Seq(
+        Row("a", 10, 0, 0),
+        Row("b", 20, 0, 1),
+        Row("c", 30, 1, 2),
+        Row("d", 40, 1, 3)))
+
+    checkAnswer(
+      Random.shuffle(data).toDF("c1", "c2")
+        .where(range_partition_id($"c1", 2) === 0)
+        .sort(range_partition_id($"c2", 4)),
+      Seq(
+        Row("a", 10),
+        Row("b", 20)))
+  }
+
+  testQuietly("range_partition_id(): corner cases") {
+    intercept[IllegalArgumentException] {
+      spark.range(10).select(range_partition_id($"id", 0)).show
+    }
+
+    intercept[IllegalArgumentException] {
+      withSQLConf(SQLConf.RANGE_EXCHANGE_SAMPLE_SIZE_PER_PARTITION.key -> "0") {
+        spark.range(10).withColumn("rpi", range_partition_id($"id", 10)).show
+      }
+    }
+
+    checkAnswer(
+      spark.range(1).withColumn("rpi", range_partition_id($"id", 1000)),
+      Row(0, 0))
+
+    checkAnswer(
+      spark.range(0).withColumn("rpi", range_partition_id($"id", 1000)),
+      Seq.empty[Row])
+
+    checkAnswer(
+      Seq("a", null, "b", null).toDF("id").withColumn("rpi", range_partition_id($"id", 10)),
+      Seq(
+        Row("a", 0),
+        Row("b", 1),
+        Row(null, 0),
+        Row(null, 0)))
+
+    checkAnswer(
+      spark.range(1).withColumn("id", lit(null)).withColumn("rpi", range_partition_id($"id", 10)),
+      Row(null, 0))
+
+    checkAnswer(
+      spark.range(1).withColumn("id", lit(Array(1, 2)))
+        .withColumn("rpi", range_partition_id($"id", 10)),
+      Row(Array(1, 2), 0))
+  }
+
+  def intToBinary(x: Int): Array[Byte] = {
+    ByteBuffer.allocate(4).putInt(x).array()
+  }
+}


### PR DESCRIPTION
## Description

This PR is part of https://github.com/delta-io/delta/issues/1134.

It implementis `range_partition_id(col, N) -> int` expression. This expression is used to
convert each Z-order column values to a range id. The range ids are selected by sampling the input column.
For sampling and choosing the ranges make use of the existing `RangePartitioner` in Spark.

Detailed design details are [here](https://docs.google.com/document/d/1TYFxAUvhtYqQ6IHAZXjliVuitA5D1u793PMnzsH_3vs/edit?usp=sharing),
specifically [this](https://docs.google.com/document/d/1TYFxAUvhtYqQ6IHAZXjliVuitA5D1u793PMnzsH_3vs/edit#bookmark=id.5aav37q4qho2) section.

GitOrigin-RevId: ca01bf03a398abd72dc96279dd864294bb00df9b

## How was this patch tested?
UTs

## Does this PR introduce _any_ user-facing changes?
No
