### PR TITLE
Idempotent writes using Dataframe write options 

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -253,6 +253,10 @@
     "message" : [ "A generated column cannot use a non-existent column or another generated column" ],
     "sqlState" : "42000"
   },
+  "DELTA_INVALID_IDEMPOTENT_WRITES_OPTIONS" : {
+    "message" : [ "Invalid options for idempotent Dataframe writes: <reason>" ],
+    "sqlState" : "42000"
+  },
   "DELTA_INVALID_ISOLATION_LEVEL" : {
     "message" : [ "invalid isolation level '<isolationLevel>'" ],
     "sqlState" : "25000"

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -704,6 +704,11 @@ object DeltaErrors
       s"Invalid value '$input' for option '$name', $explain")
   }
 
+  def invalidIdempotentWritesOptionsException(explain: String): Throwable = {
+    new DeltaIllegalArgumentException(
+      errorClass = "DELTA_INVALID_IDEMPOTENT_WRITES_OPTIONS",
+      messageParameters = Array(explain))
+  }
 
   def startingVersionAndTimestampBothSetException(
       versionOptKey: String,

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -437,7 +437,6 @@ private[delta] object DeltaOperationMetrics {
     "rewriteTimeMs" // time taken to rewrite the matched files
   )
 
-
   val UPDATE = Set(
     "numAddedFiles", // number of files added
     "numRemovedFiles", // number of files removed

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1340,6 +1340,14 @@ trait DeltaErrorsSuiteBase
       assert(e.getSqlState == "42000")
       assert(e.getMessage == "Not nullable column not found in struct: struct1")
     }
+    {
+      val e = intercept[DeltaIllegalArgumentException] {
+        throw DeltaErrors.invalidIdempotentWritesOptionsException("reason")
+      }
+      assert(e.getErrorClass == "DELTA_INVALID_IDEMPOTENT_WRITES_OPTIONS")
+      assert(e.getSqlState == "42000")
+      assert(e.getMessage == "Invalid options for idempotent Dataframe writes: reason")
+    }
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -38,6 +38,7 @@ import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRela
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.functions.struct
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.streaming.StreamingQuery
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.Utils
@@ -1642,6 +1643,127 @@ class DeltaSuite extends QueryTest
     // rename dir2 to dir1 then read
     dir2.renameTo(dir1)
     checkAnswer(spark.read.format("delta").load(dir1.getCanonicalPath), spark.range(10).toDF)
+  }
+
+  test("idempotent Dataframe writes") {
+    withTempDir{ dir =>
+      val appId1 = "myAppId1"
+      val appId2 = "myAppId2"
+      def runQuery(appId: String, seq: Seq[Int], version: Long, expectedCount: Long): Unit = {
+        seq.toDF().write.format("delta")
+          .option(DeltaOptions.TXN_VERSION, version)
+          .option(DeltaOptions.TXN_APP_ID, appId)
+          .mode("append")
+          .save(dir.getCanonicalPath)
+        val i = spark.read.format("delta").load(dir.getCanonicalPath).count()
+        assert(i == expectedCount)
+      }
+      var s = Seq(1, 2, 3)
+      // The first 2 runs must succeed increasing the expected count.
+      runQuery(appId1, s, 1, 3)
+      runQuery(appId1, s, 2, 6)
+
+      // Even if the version is not consecutive, higher versions should commit successfully.
+      runQuery(appId1, s, 5, 9)
+
+      // This run should be ignored because it uses an older version.
+      runQuery(appId1, s, 5, 9)
+
+      // Use a different app ID, but same version. This should succeed.
+      runQuery(appId2, s, 5, 12)
+
+      // Verify that specifying only one of the options -- either appId or version -- fails.
+      val e1 = intercept[Exception] {
+        Seq(1, 2, 3).toDF().write.format("delta").option(DeltaOptions.TXN_APP_ID, 1)
+          .mode("append").save(dir.getCanonicalPath)
+      }
+      assert(e1.getMessage.contains("Invalid options for idempotent Dataframe writes"))
+      val e2 = intercept[Exception] {
+        Seq(1, 2, 3).toDF().write.format("delta").option(DeltaOptions.TXN_VERSION, 1)
+          .mode("append").save(dir.getCanonicalPath)
+      }
+      assert(e2.getMessage.contains("Invalid options for idempotent Dataframe writes"))
+    }
+  }
+
+  test("idempotent writes in streaming foreachBatch") {
+    // Function to get a checkpoint location and 2 table locations.
+    def withTempDirs(f: (File, File, File) => Unit): Unit = {
+      withTempDir { file1 =>
+        withTempDir { file2 =>
+          withTempDir { file3 =>
+            f(file1, file2, file3)
+          }
+        }
+      }
+    }
+
+    // In this test, we are going to run a streaming query in a deterministic way.
+    // This streaming query uses foreachBatch to append data to two tables, and
+    // depending on a boolean flag, the query can fail between the two table writes.
+    // By setting this flag, we will test whether both tables are consistenly updated
+    // when query resumes after failure - no duplicates, no data missing.
+
+    withTempDirs { (checkpointDir, table1Dir, table2Dir) =>
+      @volatile var shouldFail = false
+
+      /* Function to write a batch's data to 2 tables */
+      def runBatch(batch: DataFrame, appId: String, batchId: Long): Unit = {
+        // Append to table 1
+        batch.write.format("delta")
+          .option(DeltaOptions.TXN_VERSION, batchId)
+          .option(DeltaOptions.TXN_APP_ID, appId)
+          .mode("append").save(table1Dir.getCanonicalPath)
+        if (shouldFail) {
+          throw new Exception("Terminating execution")
+        } else {
+          // Append to table 2
+          batch.write.format("delta")
+            .option(DeltaOptions.TXN_VERSION, batchId)
+            .option(DeltaOptions.TXN_APP_ID, appId)
+            .mode("append").save(table2Dir.getCanonicalPath)
+        }
+      }
+
+      @volatile var query: StreamingQuery = null
+
+      // Prepare a streaming query
+      val inputData = MemoryStream[Int]
+      val df = inputData.toDF()
+      val streamWriter = df.writeStream
+        .option("checkpointLocation", checkpointDir.getCanonicalPath)
+        .foreachBatch { (batch: DataFrame, id: Long) => {
+          runBatch(batch, query.id.toString, id) }
+        }
+
+      /* Add data and run streaming query, then verify # rows in 2 tables */
+      def runQuery(dataToAdd: Int, expectedTable1Count: Int, expectedTable2Count: Int): Unit = {
+        inputData.addData(dataToAdd)
+        query = streamWriter.start()
+        try {
+          query.processAllAvailable()
+        } catch {
+          case e: Exception =>
+            assert(e.getMessage.contains("Terminating execution"))
+        } finally {
+          query.stop()
+        }
+        val t1Count = spark.read.format("delta").load(table1Dir.getCanonicalPath).count()
+        assert(t1Count == expectedTable1Count)
+        val t2Count = spark.read.format("delta").load(table2Dir.getCanonicalPath).count()
+        assert(t2Count == expectedTable2Count)
+      }
+
+      // Run the query 3 times. First time without failure, both the output tables are updated.
+      shouldFail = false
+      runQuery(dataToAdd = 0, expectedTable1Count = 1, expectedTable2Count = 1)
+      // Second time with failure. Only one of the tables should be updated.
+      shouldFail = true
+      runQuery(dataToAdd = 1, expectedTable1Count = 2, expectedTable2Count = 1)
+      // Third time without failure. Both the tables should be consistently updated.
+      shouldFail = false
+      runQuery(dataToAdd = 2, expectedTable1Count = 3, expectedTable2Count = 3)
+    }
   }
 }
 


### PR DESCRIPTION
## Description

This PR makes changes to support idempotent delta writes within foreachBatch() command. Prior to this change, streaming delta writes within foreachBatch command were not idempotent -- that is, rerunning a failed batch could result in duplicate data writes.

With this change, we expose two options to the users:
- `txnAppId`: A unique string that customers can pass on each dataframe write. For example, customers can use the StreamingQuery's id as appId.
- `txnVersion`: A monotonically increasing number that acts as transaction version. The streaming batch id can be used as the txnVersion.

Combination of txnAppId and txnVersion are used to identify duplicate writes and ignore duplicate writes by the runtime. Specifically, WriteIntoDelta class is modified to persist the transaction state (which includes the txnAppId and txnVersion) and consult on new writes to the same location.

Example:
```
df.write.format("delta").option("txnAppId", "myapp").option("txnVersion", 1).save(tablePath)
df.write.format("delta").option("txnAppId", "myapp").option("txnVersion", 1).save(tablePath) // this will be ignored
```
## How was this patch tested?

New unit tests

## Does this PR introduce _any_ user-facing changes?

Yes, new options, as described above.

