### PR TITLE
Enable to run TPCDS performance benchmarks on GCP

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -111,6 +111,20 @@ gcloud dataproc clusters create delta-performance-benchmarks-cluster \
     --image-version 2.0-debian10
 ```
 
+#### Input data
+The benchmark is run using the raw TPC-DS data which has been provided as Apache Parquet files. There are two
+predefined datasets of different size, 1GB and 3TB, located in `s3://devrel-delta-datasets/tpcds-2.13/tpcds_sf1_parquet/`
+and `s3://devrel-delta-datasets/tpcds-2.13/tpcds_sf3000_parquet/`, respectively. Please keep in mind that
+`devrel-delta-datasets` bucket is configured as [Requester Pays](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ObjectsinRequesterPaysBuckets.html) bucket,
+so [access requests have to be configured properly](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ObjectsinRequesterPaysBuckets.html).
+
+Unfortunately, Hadoop in versions available in Dataproc does not support *Requester Pays* feature. It will be available
+as of Hadoop 3.3.4 ([HADOOP-14661](https://issues.apache.org/jira/browse/HADOOP-14661)).
+
+In consequence, one need to copy the datasets to Google Storage manually before running benchmarks. The simplest
+solution is to copy the data in two steps: first to a S3 bucket with *Requester Pays* disabled, then copy the data
+using [Cloud Storage Transfer Service](https://cloud.google.com/storage-transfer/docs/how-to).
+
 _________________
 
 ### Test the cluster setup

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -134,6 +134,8 @@ Navigate to your local copy of this repository and this benchmark directory. The
 Verify that you have the following information
   - <HOST_NAME>: Cluster master node host name
   - <PEM_FILE>: Local path to your PEM file for SSH into the master node.
+  - <SSH_USER>: The username that will be used to SSH into the master node. The username is tied to the SSH key you
+    have imported into the cloud. It defaults to `hadoop`.
   - <BENCHMARK_PATH>: Path where tables will be created. Make sure your credentials have read/write permission to that path.
   - <CLOUD_PROVIDER>: Currently either `gcp` or `aws`. For each storage type, different Delta properties might be added.
     
@@ -143,6 +145,7 @@ Then run a simple table write-read test: Run the following in your shell.
 ./run-benchmark.py \
     --cluster-hostname <HOSTNAME> \
     -i <PEM_FILE> \
+    --ssh-user <SSH_USER> \
     --benchmark-path <BENCHMARK_PATH> \
     --cloud-provider <CLOUD_PROVIDER> \
     --benchmark test
@@ -215,6 +218,7 @@ Now that you are familiar with how the framework runs the workload, you can try 
     ./run-benchmark.py \
         --cluster-hostname <HOSTNAME> \
         -i <PEM_FILE> \
+        --ssh-user <SSH_USER> \
         --benchmark-path <BENCHMARK_PATH> \
         --cloud-provider <CLOUD_PROVIDER> \
         --benchmark tpcds-1gb-delta-load
@@ -224,6 +228,7 @@ Now that you are familiar with how the framework runs the workload, you can try 
     ./run-benchmark.py \
         --cluster-hostname <HOSTNAME> \
         -i <PEM_FILE> \
+        --ssh-user <SSH_USER> \
         --benchmark-path <BENCHMARK_PATH> \
         --source-path <SOURCE_PATH> \
         --cloud-provider gcp \
@@ -235,6 +240,7 @@ Now that you are familiar with how the framework runs the workload, you can try 
     ./run-benchmark.py \
         --cluster-hostname <HOSTNAME> \
         -i <PEM_FILE> \
+        --ssh-user <SSH_USER> \
         --benchmark-path <BENCHMARK_PATH> \
         --cloud-provider <CLOUD_PROVIDER> \
         --benchmark tpcds-1gb-delta
@@ -248,6 +254,7 @@ Finally, you are all set up to run the full scale benchmark. Similar to the 1GB 
     ./run-benchmark.py \
         --cluster-hostname <HOSTNAME> \
         -i <PEM_FILE> \
+        --ssh-user <SSH_USER> \
         --benchmark-path <BENCHMARK_PATH> \
         --cloud-provider <CLOUD_PROVIDER> \
         --benchmark tpcds-3tb-delta-load
@@ -257,6 +264,7 @@ Finally, you are all set up to run the full scale benchmark. Similar to the 1GB 
     ./run-benchmark.py \
         --cluster-hostname <HOSTNAME> \
         -i <PEM_FILE> \
+        --ssh-user <SSH_USER> \
         --benchmark-path <BENCHMARK_PATH> \
         --source-path <SOURCE_PATH> \
         --cloud-provider gcp \
@@ -268,6 +276,7 @@ Finally, you are all set up to run the full scale benchmark. Similar to the 1GB 
     ./run-benchmark.py \
         --cluster-hostname <HOSTNAME> \
         -i <PEM_FILE> \
+        --ssh-user <SSH_USER> \
         --benchmark-path <BENCHMARK_PATH> \
         --cloud-provider <CLOUD_PROVIDER> \
         --benchmark tpcds-3tb-delta

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -132,14 +132,20 @@ Navigate to your local copy of this repository and this benchmark directory. The
 
 #### Run simple test workload
 Verify that you have the following information
-  - <HOST_NAME>: EMR cluster master node host name
+  - <HOST_NAME>: Cluster master node host name
   - <PEM_FILE>: Local path to your PEM file for SSH into the master node.
-  - <BENCHMARK_PATH>: S3 path where tables will be created. Make sure your AWS credentials have read/write permission to that path.
+  - <BENCHMARK_PATH>: Path where tables will be created. Make sure your credentials have read/write permission to that path.
+  - <CLOUD_PROVIDER>: Currently either `gcp` or `aws`. For each storage type, different Delta properties might be added.
     
 Then run a simple table write-read test: Run the following in your shell.
  
 ```sh
-./run-benchmark.py --cluster-hostname <HOSTNAME> -i <PEM_FILE> --benchmark-path <BENCHMARK_PATH> --benchmark test 
+./run-benchmark.py \
+    --cluster-hostname <HOSTNAME> \
+    -i <PEM_FILE> \
+    --benchmark-path <BENCHMARK_PATH> \
+    --cloud-provider <CLOUD_PROVIDER> \
+    --benchmark test
 ```
 
 If this works correctly, then you should see an output that look like this.
@@ -204,16 +210,68 @@ The above metrics are also written to a json file and uploaded to the given path
 Now that you are familiar with how the framework runs the workload, you can try running the small scale TPC-DS benchmark.
 
 
-1. Load data as Delta tables: `./run-benchmark.py --cluster-hostname <HOSTNAME> -i <PEM_FILE> --benchmark-path <BENCHMARK_PATH> --benchmark tpcds-1gb-delta-load`
+1. Load data as Delta tables:
+    ```bash
+    ./run-benchmark.py \
+        --cluster-hostname <HOSTNAME> \
+        -i <PEM_FILE> \
+        --benchmark-path <BENCHMARK_PATH> \
+        --cloud-provider <CLOUD_PROVIDER> \
+        --benchmark tpcds-1gb-delta-load
+    ```
+   If you run the benchmark in GCP you should provide `--source-path <SOURCE_PATH>` parameter, where `<SOURCE_PATH>` is the location of the raw parquet input data files (see *Input data* section).
+    ```bash
+    ./run-benchmark.py \
+        --cluster-hostname <HOSTNAME> \
+        -i <PEM_FILE> \
+        --benchmark-path <BENCHMARK_PATH> \
+        --source-path <SOURCE_PATH> \
+        --cloud-provider gcp \
+        --benchmark tpcds-1gb-delta-load
+    ```
 
-2. Run queries on Delta tables: `./run-benchmark.py --cluster-hostname <HOSTNAME> -i <PEM_FILE> --benchmark-path <BENCHMARK_PATH> --benchmark tpcds-1gb-delta`
+3. Run queries on Delta tables:
+    ```bash
+    ./run-benchmark.py \
+        --cluster-hostname <HOSTNAME> \
+        -i <PEM_FILE> \
+        --benchmark-path <BENCHMARK_PATH> \
+        --cloud-provider <CLOUD_PROVIDER> \
+        --benchmark tpcds-1gb-delta
+    ```
 
 ### Run 3TB TPC-DS
 Finally, you are all set up to run the full scale benchmark. Similar to the 1GB benchmark, run the following
 
-1. Load data as Delta tables: `./run-benchmark.py --cluster-hostname <HOSTNAME> -i <PEM_FILE> --benchmark-path <BENCHMARK_PATH> --benchmark tpcds-3tb-delta-load`
+1. Load data as Delta tables:
+    ```bash
+    ./run-benchmark.py \
+        --cluster-hostname <HOSTNAME> \
+        -i <PEM_FILE> \
+        --benchmark-path <BENCHMARK_PATH> \
+        --cloud-provider <CLOUD_PROVIDER> \
+        --benchmark tpcds-3tb-delta-load
+    ```
+   If you run the benchmark in GCP you should provide `--source-path <SOURCE_PATH>` parameter, where `<SOURCE_PATH>` is the location of the raw parquet input data files (see *Input data* section).
+    ```bash
+    ./run-benchmark.py \
+        --cluster-hostname <HOSTNAME> \
+        -i <PEM_FILE> \
+        --benchmark-path <BENCHMARK_PATH> \
+        --source-path <SOURCE_PATH> \
+        --cloud-provider gcp \
+        --benchmark tpcds-3tb-delta-load
+    ```
 
-2. Run queries on Delta tables: `./run-benchmark.py --cluster-hostname <HOSTNAME> -i <PEM_FILE> --benchmark-path <BENCHMARK_PATH> --benchmark tpcds-3tb-delta`
+2. Run queries on Delta tables:
+    ```bash
+    ./run-benchmark.py \
+        --cluster-hostname <HOSTNAME> \
+        -i <PEM_FILE> \
+        --benchmark-path <BENCHMARK_PATH> \
+        --cloud-provider <CLOUD_PROVIDER> \
+        --benchmark tpcds-3tb-delta
+    ```
 
 Compare the results using the generated JSON files.
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -124,65 +124,65 @@ Verify that you have the following information
     
 Then run a simple table write-read test: Run the following in your shell.
  
-    ```sh
-    ./run-benchmark.py --cluster-hostname <HOSTNAME> -i <PEM_FILE> --benchmark-path <BENCHMARK_PATH> --benchmark test 
-    ```
+```sh
+./run-benchmark.py --cluster-hostname <HOSTNAME> -i <PEM_FILE> --benchmark-path <BENCHMARK_PATH> --benchmark test 
+```
 
 If this works correctly, then you should see an output that look like this.
      
-    ```text
-    >>> Benchmark script generated and uploaded
+```text
+>>> Benchmark script generated and uploaded
+
+...
+There is a screen on:
+12001..ip-172-31-21-247	(Detached)
+
+Files for this benchmark:
+20220126-191336-test-benchmarks.jar
+20220126-191336-test-cmd.sh
+20220126-191336-test-out.txt
+>>> Benchmark script started in a screen. Stdout piped into 20220126-191336-test-out.txt.Final report will be generated on completion in 20220126-191336-test-report.json.
+```
+
+The test workload launched in a `screen` is going to run the following: 
+- Spark jobs to run a simple SQL query
+- Create a Delta table in the given location 
+- Read it back
     
-    ...
-    There is a screen on:
-    12001..ip-172-31-21-247	(Detached)
-    
-    Files for this benchmark:
-    20220126-191336-test-benchmarks.jar
-    20220126-191336-test-cmd.sh
-    20220126-191336-test-out.txt
-    >>> Benchmark script started in a screen. Stdout piped into 20220126-191336-test-out.txt.Final report will be generated on completion in 20220126-191336-test-report.json.
-    ```
-   
-    The test workload launched in a `screen` is going to run the following: 
-    - Spark jobs to run a simple SQL query
-    - Create a Delta table in the given location 
-    - Read it back
-    
-    To see whether they worked correctly, SSH into the node and check the output of 20220126-191336-test-out.txt. Once the workload terminates, the last few lines should be something like the following:
-    ```text
-    RESULT:
-    {
-      "benchmarkSpecs" : {
-        "benchmarkPath" : ...,
-        "benchmarkId" : "20220126-191336-test"
-      },
-      "queryResults" : [ {
-        "name" : "sql-test",
-        "durationMs" : 11075
-      }, {
-        "name" : "db-list-test",
-        "durationMs" : 208
-      }, {
-        "name" : "db-create-test",
-        "durationMs" : 4070
-      }, {
-        "name" : "db-use-test",
-        "durationMs" : 41
-      }, {
-        "name" : "table-drop-test",
-        "durationMs" : 74
-      }, {
-        "name" : "table-create-test",
-        "durationMs" : 33812
-      }, {
-        "name" : "table-query-test",
-        "durationMs" : 4795
-      } ]
-    }
-    FILE UPLOAD: Uploaded /home/hadoop/20220126-191336-test-report.json to s3:// ...
-    SUCCESS
-    ```
+To see whether they worked correctly, SSH into the node and check the output of 20220126-191336-test-out.txt. Once the workload terminates, the last few lines should be something like the following:
+```text
+RESULT:
+{
+  "benchmarkSpecs" : {
+    "benchmarkPath" : ...,
+    "benchmarkId" : "20220126-191336-test"
+  },
+  "queryResults" : [ {
+    "name" : "sql-test",
+    "durationMs" : 11075
+  }, {
+    "name" : "db-list-test",
+    "durationMs" : 208
+  }, {
+    "name" : "db-create-test",
+    "durationMs" : 4070
+  }, {
+    "name" : "db-use-test",
+    "durationMs" : 41
+  }, {
+    "name" : "table-drop-test",
+    "durationMs" : 74
+  }, {
+    "name" : "table-create-test",
+    "durationMs" : 33812
+  }, {
+    "name" : "table-query-test",
+    "durationMs" : 4795
+  } ]
+}
+FILE UPLOAD: Uploaded /home/hadoop/20220126-191336-test-report.json to s3:// ...
+SUCCESS
+```
     
 The above metrics are also written to a json file and uploaded to the given path. Please verify that both the table and report are generated in that path. 
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -11,7 +11,7 @@ This TPC-DS benchmark is constructed such that you have to run the following two
 
 The next section will provide the detailed steps of how to setup the necessary Hive Metastore and a cluster, how to test the setup with small-scale data, and then finally run the full scale benchmark.
 
-### Amazon Web Services
+### Configure cluster with Amazon Web Services
 
 #### Prerequisites
 - An AWS account with necessary permissions to do the following:
@@ -51,7 +51,7 @@ Create a new S3 bucket (or use an existing one) which is in the same region as y
 
 _________________
 
-### Google Cloud Platform
+### Configure cluster with Google Cloud Platform
 
 #### Prerequisites
 - A GCP account with necessary permissions to do the following:

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,25 +1,27 @@
 # Benchmarks 
 
 ## Overview
-This is a basic framework for writing benchmarks to measure Delta's performance. It is currently designed to run benchmark on Spark running in an EMR cluster. However, it can be easily extended for other Spark-based benchmarks. To get started, first download/clone this repository in your local machine. Then you have to set up an EMR cluster and run the benchmark scripts in this directory. See the next section for more details.
+This is a basic framework for writing benchmarks to measure Delta's performance. It is currently designed to run benchmark on Spark running in an EMR or a Dataproc cluster. However, it can be easily extended for other Spark-based benchmarks. To get started, first download/clone this repository in your local machine. Then you have to set up a cluster and run the benchmark scripts in this directory. See the next section for more details.
 
 ## Running TPC-DS benchmark
 
 This TPC-DS benchmark is constructed such that you have to run the following two steps. 
-1. *Load data*: You have to create the TPC-DS database with all the Delta tables. To do that, the raw TPC-DS data has been provided as Apache Parquet files. In this step you will have to use your EMR cluster to read the parquet files and rewrite them as Delta tables.
+1. *Load data*: You have to create the TPC-DS database with all the Delta tables. To do that, the raw TPC-DS data has been provided as Apache Parquet files. In this step you will have to use your EMR or a Dataproc cluster to read the parquet files and rewrite them as Delta tables.
 2. *Query data*: Then, using the tables definitions in the Hive Metatore, you can run the 99 benchmark queries.   
 
-The next section will provide the detailed steps of how to setup the necessary Hive Metastore and EMR cluster, how to test the setup with small-scale data, and then finally run the full scale benchmark.  
+The next section will provide the detailed steps of how to setup the necessary Hive Metastore and a cluster, how to test the setup with small-scale data, and then finally run the full scale benchmark.
 
-### Prerequisites
+### Amazon Web Services
+
+#### Prerequisites
 - An AWS account with necessary permissions to do the following:
   - Manage RDS instances for creating an external Hive Metastore
   - Manage EMR clusters for running the benchmark
   - Read and write to an S3 bucket from the EMR cluster
 - A S3 bucket which will be used to generate the TPC-DS data.
-- A machine which has access to the AWS setup and where this repository has been downloaded or cloned. 
+- A machine which has access to the AWS setup and where this repository has been downloaded or cloned.
 
-### Create external Hive Metastore using Amazon RDS
+#### Create external Hive Metastore using Amazon RDS
 Create an external Hive Metastore in a MySQL database using Amazon RDS with the following specifications:
 - MySQL 8.x on a `db.m5.large`.
 - General purpose SSDs, and no Autoscaling storage.
@@ -29,7 +31,7 @@ Create an external Hive Metastore in a MySQL database using Amazon RDS with the 
 
 After the database is ready, note the JDBC connection details, the username and password. We will need them for the next step. Note that this step needs to be done just once. All EMR clusters can connect and reused this Hive Metastsore. 
   
-### Create EMR cluster
+#### Create EMR cluster
 Create an EMR cluster that connects to the external Hive Metastore.  Here are the specifications of the EMR cluster required for running benchmarks.
 - EMR version 6.5.0 having Apache Spark 3.1
 - Master - i3.2xlarge
@@ -44,8 +46,72 @@ Once the EMR cluster is ready, note the following:
 - PEM file for SSH into the master node.
 These will be needed to run the workloads in this framework. 
 
-### Prepare S3 bucket
-Create a new S3 bucket (or use an existing one) which is in the same region your EMR cluster.
+#### Prepare S3 bucket
+Create a new S3 bucket (or use an existing one) which is in the same region as your EMR cluster.
+
+_________________
+
+### Google Cloud Platform
+
+#### Prerequisites
+- A GCP account with necessary permissions to do the following:
+  - Manage Dataproc clusters for running the benchmark
+  - Manage Dataproc Metastore instances
+  - Read and write to a GCS bucket from the Dataproc cluster
+- A GCS bucket which will be used to generate the TPC-DS data.
+- A machine which has access to the GCP setup and where this repository has been downloaded or cloned.
+- SSH keys for a user which will be used to access the master node. The user's SSH key can be either [a project-wide key](https://cloud.google.com/compute/docs/connect/add-ssh-keys#add_ssh_keys_to_project_metadata) 
+  or assigned to the [master node](https://cloud.google.com/compute/docs/connect/add-ssh-keys#after-vm-creation) only.
+- Ideally, all GCP components used in benchmark should be in the same location (Storage bucket, Dataproc Metastore service and Dataproc cluster).
+
+#### Prepare GCS bucket
+Create a new GCS bucket (or use an existing one) which is in the same region as your Dataproc cluster.
+
+#### Create Dataproc Metastore
+You can create [Dataproc metastore](https://cloud.google.com/dataproc-metastore/docs/create-service)
+either via Web Console or gcloud command.
+
+Sample create command:
+```bash
+gcloud metastore services create dataproc-metastore-for-benchmarks \
+    --location=<region> \
+    --tier=enterprise
+```
+
+#### Create Dataproc cluster
+Here are the specifications of the Dataproc cluster required for running benchmarks.
+- Image version >= 2.0 having Apache Spark 3.1
+- Master - n2-highmem-8 (8 vCPU, 64 GB memory)
+- Workers - 16 x n2-highmem-8 (or just 2 workers if you are just testing by running the 1GB benchmark).
+- The cluster connects to the Dataproc Metastore.
+- Same region and subnet as those of the Dataproc Metastore and GCS bucket.
+- No autoscaling.
+
+Sample create command:
+```bash
+gcloud dataproc clusters create delta-performance-benchmarks-cluster \
+    --project <project-name> \
+    --enable-component-gateway \
+    --region <region> \
+    --zone <zone> \
+    --subnet default \
+    --master-machine-type n2-highmem-8 \
+    --master-boot-disk-type pd-ssd \
+    --master-boot-disk-size 100 \
+    --num-master-local-ssds 4 \
+    --master-local-ssd-interface NVME \
+    --num-workers 16 \
+    --worker-machine-type n2-highmem-8 \
+    --worker-boot-disk-type pd-ssd \
+    --worker-boot-disk-size 100 \
+    --num-worker-local-ssds 4 \
+    --worker-local-ssd-interface NVME \
+    --dataproc-metastore projects/<project-name>/locations/<region>/services/dataproc-metastore-for-benchmarks \
+    --enable-component-gateway \
+    --image-version 2.0-debian10
+```
+
+_________________
 
 ### Test the cluster setup
 Navigate to your local copy of this repository and this benchmark directory. Then run the following steps.
@@ -136,6 +202,8 @@ Finally, you are all set up to run the full scale benchmark. Similar to the 1GB 
 2. Run queries on Delta tables: `./run-benchmark.py --cluster-hostname <HOSTNAME> -i <PEM_FILE> --benchmark-path <BENCHMARK_PATH> --benchmark tpcds-3tb-delta`
 
 Compare the results using the generated JSON files.
+
+_________________
 
 ## Internals of the framework
 

--- a/benchmarks/build.sbt
+++ b/benchmarks/build.sbt
@@ -20,7 +20,7 @@ scalaVersion := "2.12.14"
 lazy val root = (project in file("."))
   .settings(
     name := "benchmarks",
-    libraryDependencies += "org.apache.spark" %% "spark-sql" % "3.2.0" % "provided",
+    libraryDependencies += "org.apache.spark" %% "spark-sql" % "3.1.2" % "provided",
     libraryDependencies += "com.github.scopt" %% "scopt" % "4.0.1",
     libraryDependencies += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.1",
 

--- a/benchmarks/run-benchmark.py
+++ b/benchmarks/run-benchmark.py
@@ -41,6 +41,10 @@ benchmarks = {
 
 }
 
+delta_log_store_classes = {
+    "aws": "spark.delta.logStore.class=org.apache.spark.sql.delta.storage.S3SingleDriverLogStore",
+    "gcp": "spark.delta.logStore.gs.impl=io.delta.storage.GCSLogStore",
+}
 
 if __name__ == "__main__":
     """
@@ -62,7 +66,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--cluster-hostname",
         required=True,
-        help="Hostname or public IP of the EMR driver")
+        help="Hostname or public IP of the cluster driver")
     parser.add_argument(
         "--ssh-id-file", "-i",
         required=True,
@@ -79,6 +83,10 @@ if __name__ == "__main__":
         help="Local path to delta repository which will be used for running the benchmark " +
              "instead of the version specified in the specification. Make sure that new delta" +
              " version is compatible with version in the spec.")
+    parser.add_argument(
+        "--cloud-provider",
+        choices=delta_log_store_classes.keys(),
+        help="Cloud where the benchmark will be executed.")
 
     args, passthru_args = parser.parse_known_args()
 
@@ -95,6 +103,7 @@ if __name__ == "__main__":
                         "\n".join(benchmarks.keys()) +
                         "\nSee this python file for more details.")
     benchmark_spec.append_spark_confs(args.spark_conf)
+    benchmark_spec.append_spark_conf(delta_log_store_classes.get(args.cloud_provider))
     benchmark_spec.append_main_class_args(passthru_args)
     print("------")
     print("Benchmark spec to run:\n" + str(vars(benchmark_spec)))

--- a/benchmarks/run-benchmark.py
+++ b/benchmarks/run-benchmark.py
@@ -34,10 +34,14 @@ benchmarks = {
     # TPC-DS data load
     "tpcds-1gb-delta-load": DeltaTPCDSDataLoadSpec(delta_version=delta_version, scale_in_gb=1),
     "tpcds-3tb-delta-load": DeltaTPCDSDataLoadSpec(delta_version=delta_version, scale_in_gb=3000),
+    "tpcds-1gb-parquet-load": ParquetTPCDSDataLoadSpec(scale_in_gb=1),
+    "tpcds-3tb-parquet-load": ParquetTPCDSDataLoadSpec(scale_in_gb=3000),
 
     # TPC-DS benchmark
     "tpcds-1gb-delta": DeltaTPCDSBenchmarkSpec(delta_version=delta_version, scale_in_gb=1),
     "tpcds-3tb-delta": DeltaTPCDSBenchmarkSpec(delta_version=delta_version, scale_in_gb=3000),
+    "tpcds-1gb-parquet": ParquetTPCDSBenchmarkSpec(scale_in_gb=1),
+    "tpcds-3tb-parquet": ParquetTPCDSBenchmarkSpec(scale_in_gb=3000),
 
 }
 

--- a/benchmarks/run-benchmark.py
+++ b/benchmarks/run-benchmark.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
 
     Example usage:
 
-    ./run-benchmark.py --cluster-hostname <hostname> -i <pem file>  --cloud-provider <cloud provider> --benchmark test
+    ./run-benchmark.py --cluster-hostname <hostname> -i <pem file> --ssh-user <ssh user> --cloud-provider <cloud provider> --benchmark test
 
     """
 

--- a/benchmarks/run-benchmark.py
+++ b/benchmarks/run-benchmark.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
 
     Example usage:
 
-    ./run-benchmark.py -h <hostname> i <pem file> --benchmark test 
+    ./run-benchmark.py --cluster-hostname <hostname> -i <pem file>  --cloud-provider <cloud provider> --benchmark test
 
     """
 

--- a/benchmarks/run-benchmark.py
+++ b/benchmarks/run-benchmark.py
@@ -87,12 +87,16 @@ if __name__ == "__main__":
         "--cloud-provider",
         choices=delta_log_store_classes.keys(),
         help="Cloud where the benchmark will be executed.")
+    parser.add_argument(
+        "--ssh-user",
+        default="hadoop",
+        help="The user which is used to communicate with the master via SSH.")
 
     args, passthru_args = parser.parse_known_args()
 
     if args.resume_benchmark is not None:
         Benchmark.wait_for_completion(
-            args.cluster_hostname, args.ssh_id_file, args.resume_benchmark)
+            args.cluster_hostname, args.ssh_id_file, args.resume_benchmark, args.ssh_user)
         exit(0)
 
     # Create and run the benchmark
@@ -113,4 +117,4 @@ if __name__ == "__main__":
                           use_spark_shell=True, local_delta_dir=args.use_local_delta_dir)
     benchmark_dir = os.path.dirname(os.path.abspath(__file__))
     with WorkingDirectory(benchmark_dir):
-        benchmark.run(args.cluster_hostname, args.ssh_id_file)
+        benchmark.run(args.cluster_hostname, args.ssh_id_file, args.ssh_user)

--- a/benchmarks/scripts/benchmarks.py
+++ b/benchmarks/scripts/benchmarks.py
@@ -63,7 +63,8 @@ class BenchmarkSpec:
         main_class_args = ' '.join(self.benchmark_main_class_args)
         spark_shell_args_str = ' '.join(self.extra_spark_shell_args)
         spark_submit_cmd = (
-            f"spark-submit {spark_shell_args_str} --packages {self.maven_artifacts} " +
+            f"spark-submit {spark_shell_args_str} " +
+            (f"--packages {self.maven_artifacts} " if self.maven_artifacts else "") +
             f"{spark_conf_str} --class {self.benchmark_main_class} " +
             f"{benchmark_jar_path} {main_class_args}"
         )
@@ -77,7 +78,8 @@ class BenchmarkSpec:
             spark_conf_str += f"""--conf "{conf}" """
         spark_shell_args_str = ' '.join(self.extra_spark_shell_args)
         spark_shell_cmd = (
-                f"spark-shell {spark_shell_args_str} --packages {self.maven_artifacts} " +
+                f"spark-shell {spark_shell_args_str} " +
+                (f"--packages {self.maven_artifacts} " if self.maven_artifacts else "") +
                 f"{spark_conf_str} --jars {benchmark_jar_path} -I {benchmark_init_file_path}"
         )
         print(spark_shell_cmd)
@@ -154,6 +156,34 @@ class DeltaTPCDSDataLoadSpec(TPCDSDataLoadSpec, DeltaBenchmarkSpec):
 class DeltaTPCDSBenchmarkSpec(TPCDSBenchmarkSpec, DeltaBenchmarkSpec):
     def __init__(self, delta_version, scale_in_gb=1):
         super().__init__(delta_version=delta_version, scale_in_gb=scale_in_gb)
+
+
+# ============== Parquet benchmark specifications ==============
+
+
+class ParquetBenchmarkSpec(BenchmarkSpec):
+    """
+    Specification of a benchmark using the Parquet format
+    """
+    def __init__(self, benchmark_main_class, main_class_args=None, **kwargs):
+        super().__init__(
+            format_name="parquet",
+            maven_artifacts=None,
+            spark_confs=[],
+            benchmark_main_class=benchmark_main_class,
+            main_class_args=main_class_args,
+            **kwargs
+        )
+
+
+class ParquetTPCDSDataLoadSpec(TPCDSDataLoadSpec, ParquetBenchmarkSpec):
+    def __init__(self, scale_in_gb=1):
+        super().__init__(scale_in_gb=scale_in_gb)
+
+
+class ParquetTPCDSBenchmarkSpec(TPCDSBenchmarkSpec, ParquetBenchmarkSpec):
+    def __init__(self, scale_in_gb=1):
+        super().__init__(scale_in_gb=scale_in_gb)
 
 
 # ============== General benchmark execution ==============

--- a/benchmarks/scripts/benchmarks.py
+++ b/benchmarks/scripts/benchmarks.py
@@ -269,10 +269,24 @@ touch {self.completed_file}
         script_file_name = f"{self.benchmark_id}-install-deps.sh"
         script_file_text = """
 #!/bin/bash
-packagesNeeded='screen'
-if [ -x "$(command -v yum)" ]; then sudo yum install $packagesNeeded
-elif [ -x "$(command -v apt)" ]; then sudo apt install $packagesNeeded
-else echo "Failed to install packages: Package manager not found. You must manually install: $packagesNeeded">&2; exit 1; fi
+package='screen'
+if [ -x "$(command -v yum)" ]; then
+    if rpm -q $package; then
+        echo "$package has already been installed"
+    else	    
+        sudo yum -y install $package
+    fi
+elif [ -x "$(command -v apt)" ]; then 
+    if dpkg -s $package; then
+        echo "$package has already been installed"
+    else
+        sudo apt install $package
+    fi
+else
+    echo "Failed to install packages: Package manager not found. You must manually install: $package">&2; exit 1;
+fi
+
+
         """.strip()
         self.copy_script_via_ssh(cluster_hostname, ssh_id_file, ssh_user, script_file_name, script_file_text)
         print(">>> Install dependencies script generated and uploaded\n")

--- a/benchmarks/scripts/benchmarks.py
+++ b/benchmarks/scripts/benchmarks.py
@@ -145,7 +145,7 @@ class DeltaBenchmarkSpec(BenchmarkSpec):
 
     @staticmethod
     def delta_maven_artifacts(delta_version, scala_version):
-        return f"io.delta:delta-core_{scala_version}:{delta_version},io.delta:delta-hive_{scala_version}:0.2.0"
+        return f"io.delta:delta-core_{scala_version}:{delta_version},io.delta:delta-contribs_{scala_version}:{delta_version},io.delta:delta-hive_{scala_version}:0.2.0"
 
 
 class DeltaTPCDSDataLoadSpec(TPCDSDataLoadSpec, DeltaBenchmarkSpec):

--- a/benchmarks/scripts/benchmarks.py
+++ b/benchmarks/scripts/benchmarks.py
@@ -27,7 +27,7 @@ class BenchmarkSpec:
     :param maven_artifacts: Maven artifact name in x:y:z format
     :param spark_confs: list of spark conf strings in key=value format
     :param benchmark_main_class: Name of main Scala class from the JAR to run
-    :param main_class_args command line args for the main class
+    :param main_class_args: command line args for the main class
     """
     def __init__(
             self, format_name, maven_artifacts, spark_confs,
@@ -42,6 +42,10 @@ class BenchmarkSpec:
         self.benchmark_main_class = benchmark_main_class
         self.benchmark_main_class_args = main_class_args
         self.extra_spark_shell_args = extra_spark_shell_args
+
+    def append_spark_conf(self, new_conf):
+        if isinstance(new_conf, str):
+            self.spark_confs.append(new_conf)
 
     def append_spark_confs(self, new_confs):
         if new_confs is not None and isinstance(new_confs, list):
@@ -120,8 +124,7 @@ class DeltaBenchmarkSpec(BenchmarkSpec):
     def __init__(self, delta_version, benchmark_main_class, main_class_args=None, scala_version="2.12", **kwargs):
         delta_spark_confs = [
             "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension",
-            "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog",
-            "spark.delta.logStore.class=org.apache.spark.sql.delta.storage.S3SingleDriverLogStore"
+            "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"
         ]
         self.scala_version = scala_version
 

--- a/benchmarks/scripts/benchmarks.py
+++ b/benchmarks/scripts/benchmarks.py
@@ -324,7 +324,8 @@ else echo "Failed to install packages: Package manager not found. You must manua
             )
             print(scp_cmd)
             run_cmd(scp_cmd, stream_output=True)
-            run_cmd(f"ssh -i {ssh_id_file} {ssh_user}@{cluster_hostname} chmod +x {script_file_name}")
+            run_cmd_over_ssh(f"chmod +x {script_file_name}", cluster_hostname, ssh_id_file, ssh_user,
+                             throw_on_error=False)
         finally:
             if os.path.exists(script_file_name):
                 os.remove(script_file_name)

--- a/benchmarks/scripts/utils.py
+++ b/benchmarks/scripts/utils.py
@@ -48,7 +48,7 @@ def run_cmd(cmd, throw_on_error=True, env=None, stream_output=False, **kwargs):
         return exit_code, stdout, stderr
 
 
-def run_cmd_over_ssh(cmd, host, ssh_id_file, user="hadoop", **kwargs):
+def run_cmd_over_ssh(cmd, host, ssh_id_file, user, **kwargs):
     full_cmd = f"""ssh -i {ssh_id_file} {user}@{host} "{cmd}" """
     return run_cmd(full_cmd, **kwargs)
 

--- a/benchmarks/src/main/scala/benchmark/Benchmark.scala
+++ b/benchmarks/src/main/scala/benchmark/Benchmark.scala
@@ -17,6 +17,7 @@
 package benchmark
 
 import scala.collection.mutable
+import java.net.URI
 import java.nio.file.{Files, Paths}
 import java.nio.charset.StandardCharsets
 
@@ -202,7 +203,10 @@ abstract class Benchmark(private val conf: BenchmarkConf) {
 
   private def uploadFile(localPath: String, targetPath: String): Unit = {
     try {
-      s"aws s3 cp $localPath $targetPath/" !
+      val scheme = new URI(targetPath).getScheme
+      if (scheme.equals("s3")) s"aws s3 cp $localPath $targetPath/" !
+      else if (scheme.equals("gs")) s"gsutil cp $localPath $targetPath/" !
+      else throw new IllegalArgumentException(String.format("Unsupported scheme %s.", scheme))
 
       println(s"FILE UPLOAD: Uploaded $localPath to $targetPath")
     } catch {

--- a/benchmarks/src/main/scala/benchmark/TPCDSDataLoad.scala
+++ b/benchmarks/src/main/scala/benchmark/TPCDSDataLoad.scala
@@ -52,9 +52,9 @@ object TPCDSDataLoadConf {
         .text("Name of the target database to create with TPC-DS tables in necessary format"),
       opt[String]("source-path")
         .optional()
-        .valueName("<path in s3 to load the TPC-DS raw data from>")
+        .valueName("<path to the TPC-DS raw input data>")
         .action((x, c) => c.copy(sourcePath = Some(x)))
-        .text("Name of the database to create"),
+        .text("The location of the TPC-DS raw input data"),
       opt[String]("exclude-nulls")
         .optional()
         .valueName("true/false")


### PR DESCRIPTION
## Description

This PR enables to run TCPDS performance benchmarks not only on AWS but also on Google Cloud Platform.This is an extension of the framework introduced by: https://github.com/delta-io/delta/pull/973 .

In order to run the benchmark, you need to manually create a Dataproc cluster first. All prerequisites and sample gcloud commands are in README file. After that you can run *Load data* and *Query data* steps provided by the framework.

Please see the README updates for more details.

## How was this patch tested?

I manually ran the benchmarks on GCP.

## Does this PR introduce _any_ user-facing changes?

No.
