### PR TITLE
Fix Delta Standalone link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ See the [online documentation](https://docs.delta.io/latest/) for the latest rel
 * [Python API docs](https://docs.delta.io/latest/api/python/index.html)
 
 ## Compatibility
-[Delta Standalone](https://www.youtube.com/c/deltalake) library is a single-node Java library that can be used to read from and write to Delta tables. Specifically, this library provides APIs to interact with a table’s metadata in the transaction log, implementing the Delta Transaction Log Protocol to achieve the transactional guarantees of the Delta Lake format.
+[Delta Standalone](https://docs.delta.io/latest/delta-standalone.html) library is a single-node Java library that can be used to read from and write to Delta tables. Specifically, this library provides APIs to interact with a table’s metadata in the transaction log, implementing the Delta Transaction Log Protocol to achieve the transactional guarantees of the Delta Lake format.
 
 
 ### API Compatibility


### PR DESCRIPTION
## Description

`Delta Standalone` link was pointing to the YouTube channel. Changing it to the docs links.

## How was this patch tested?

N/A

## Does this PR introduce _any_ user-facing changes?

N/A
