### PR TITLE
Add Checkpoint Schema in Checkpoint Metadata

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -157,6 +157,7 @@ size | The number of actions that are stored in the checkpoint.
 parts | The number of fragments if the last checkpoint was written in multiple parts. This field is optional.
 sizeInBytes | The number of bytes of the checkpoint. This field is optional.
 numOfAddFiles | The number of AddFile actions in the checkpoint. This field is optional.
+checkpointSchema | The schema of the checkpoint file. This field is optional.
 checksum | The checksum of the last checkpoint JSON. This field is optional.
 
 The checksum field is an optional field which contains the MD5 checksum for fields of the last checkpoint json file.

--- a/core/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -63,7 +63,8 @@ class Snapshot(
     val deltaLog: DeltaLog,
     val timestamp: Long,
     val checksumOpt: Option[VersionChecksum],
-    val minSetTransactionRetentionTimestamp: Option[Long] = None)
+    val minSetTransactionRetentionTimestamp: Option[Long] = None,
+    checkpointMetadataOpt: Option[CheckpointMetaData] = None)
   extends StateCache
   with StatisticsCollection
   with DataSkippingReader
@@ -326,6 +327,8 @@ class Snapshot(
     assertLogFilesBelongToTable(path, logSegment.checkpoint)
     DeltaLogFileIndex(DeltaLogFileIndex.CHECKPOINT_FILE_FORMAT, logSegment.checkpoint)
   }
+
+  def getCheckpointMetadataOpt: Option[CheckpointMetaData] = checkpointMetadataOpt
 
   def deltaFileSizeInBytes(): Long = deltaFileIndexOpt.map(_.sizeInBytes).getOrElse(0L)
   def checkpointSizeInBytes(): Long = checkpointFileIndexOpt.map(_.sizeInBytes).getOrElse(0L)

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -434,6 +434,14 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
+  val CHECKPOINT_SCHEMA_WRITE_THRESHOLD_LENGTH =
+    buildConf("checkpointSchema.writeThresholdLength")
+      .internal()
+      .doc("Checkpoint schema larger than this threshold won't be written to the last checkpoint" +
+        " file")
+      .intConf
+      .createWithDefault(20000)
+
   val LAST_CHECKPOINT_CHECKSUM_ENABLED =
     buildConf("lastCheckpoint.checksum.enabled")
       .internal()

--- a/core/src/test/scala/org/apache/spark/sql/delta/EvolvabilitySuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/EvolvabilitySuite.scala
@@ -70,13 +70,13 @@ class EvolvabilitySuite extends EvolvabilitySuiteBase with DeltaSQLCommandTest {
 
   testQuietly("parse old version CheckpointMetaData") {
     assert(JsonUtils.mapper.readValue[CheckpointMetaData]("""{"version":1,"size":1}""")
-      === CheckpointMetaData(1, 1, None, None, None))
+      === CheckpointMetaData(1, 1, None, None, None, None))
   }
 
   test("parse partial version CheckpointMetaData") {
     assert(JsonUtils.mapper.readValue[CheckpointMetaData](
       """{"version":1,"size":1,"parts":100}""") ===
-      CheckpointMetaData(1, 1, Some(100), None, None))
+      CheckpointMetaData(1, 1, Some(100), None, None, None))
   }
 
   // Following tests verify that operations on Delta table won't fail when there is an

--- a/core/src/test/scala/org/apache/spark/sql/delta/EvolvabilitySuiteBase.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/EvolvabilitySuiteBase.scala
@@ -48,6 +48,7 @@ abstract class EvolvabilitySuiteBase extends QueryTest with SharedSparkSession
     // Check we can load CheckpointMetaData
     assert(deltaLog.lastCheckpoint.get.version === 3)
     assert(deltaLog.lastCheckpoint.get.size === 6L)
+    assert(deltaLog.lastCheckpoint.get.checkpointSchema.isEmpty)
 
     // Check we can parse all `Action`s in delta files. It doesn't check correctness.
     deltaLog.getChanges(0L).toList.map(_._2.toList)


### PR DESCRIPTION
## Description

This PR added the checkpoint file schema to `CheckpointMetadata` (stored in `_last_checkpoint`) and expose the checkpoint file schema in `Snapshot` for future improvements.

## How was this patch tested?
UTs

## Does this PR introduce _any_ user-facing changes?

No