### PR TITLE
[ZOrderBy] Add `interleave_bits` expression

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/expressions/InterleaveBits.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/expressions/InterleaveBits.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.expressions
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression}
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.types.{BinaryType, DataType, IntegerType}
+
+
+/**
+ * Interleaves the bits of its input data in a round-robin fashion.
+ *
+ * If the input data is seen as a series of multidimensional points, this function computes the
+ * corresponding Z-values, in a way that's preserving data locality: input points that are close
+ * in the multidimensional space will be mapped to points that are close on the Z-order curve.
+ *
+ * The returned value is a byte array where the size of the array is 4 * num of input columns.
+ *
+ * @see https://en.wikipedia.org/wiki/Z-order_curve
+ *
+ * @note Only supports input expressions of type Int for now.
+ */
+case class InterleaveBits(children: Seq[Expression])
+  extends Expression with ExpectsInputTypes
+    with CodegenFallback /* TODO: implement doGenCode() */ {
+
+  private val n: Int = children.size
+
+  override def inputTypes: Seq[DataType] = Seq.fill(n)(IntegerType)
+
+  override def dataType: DataType = BinaryType
+
+  override def nullable: Boolean = false
+
+  /** Nulls in the input will be treated like this value */
+  val nullValue: Int = 0
+
+  private val childrenArray: Array[Expression] = children.toArray
+
+  private val ints = new Array[Int](n)
+
+  override def eval(input: InternalRow): Any = {
+    var i = 0
+    while (i < n) {
+      val int = childrenArray(i).eval(input) match {
+        case null => nullValue
+        case int: Int => int
+        case any => throw new IllegalArgumentException(
+          s"${this.getClass.getSimpleName} expects only inputs of type Int, but got: " +
+            s"$any of type${any.getClass.getSimpleName}")
+      }
+      ints.update(i, int)
+      i += 1
+    }
+
+    val ret = new Array[Byte](n * 4)
+    var ret_idx: Int = 0
+    var ret_bit: Int = 7
+    var ret_byte: Byte = 0
+
+    var bit = 31 /* going from most to least significant bit */
+    while (bit >= 0) {
+      var idx = 0
+      while (idx < n) {
+        ret_byte = (ret_byte | (((ints(idx) >> bit) & 1) << ret_bit)).toByte
+        ret_bit -= 1
+        if (ret_bit == -1) {
+          // finished processing a byte
+          ret.update(ret_idx, ret_byte)
+          ret_byte = 0
+          ret_idx += 1
+          ret_bit = 7
+        }
+        idx += 1
+      }
+      bit -= 1
+    }
+    assert(ret_idx == n * 4)
+    assert(ret_bit == 7)
+    ret
+  }
+
+  override protected def withNewChildrenInternal(
+    newChildren: IndexedSeq[Expression]): InterleaveBits = copy(children = newChildren)
+}

--- a/core/src/main/scala/org/apache/spark/sql/delta/skipping/MultiDimClusteringFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/skipping/MultiDimClusteringFunctions.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.delta.skipping
 
 // scalastyle:off import.ordering.noEmptyLine
-import org.apache.spark.sql.delta.expressions.RangePartitionId
+import org.apache.spark.sql.delta.expressions.{InterleaveBits, RangePartitionId}
 
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.catalyst.expressions.Expression
@@ -36,5 +36,22 @@ object MultiDimClusteringFunctions {
    */
   def range_partition_id(col: Column, numPartitions: Int): Column = withExpr {
     RangePartitionId(col.expr, numPartitions)
+  }
+
+  /**
+   * Interleaves the bits of its input data in a round-robin fashion.
+   *
+   * If the input data is seen as a series of multidimensional points, this function computes the
+   * corresponding Z-values, in a way that's preserving data locality: input points that are close
+   * in the multidimensional space will be mapped to points that are close on the Z-order curve.
+   *
+   * The returned value is a byte array where the size of the array is 4 * num of input columns.
+   *
+   * @see https://en.wikipedia.org/wiki/Z-order_curve
+   *
+   * @note Only supports input expressions of type Int for now.
+   */
+  def interleave_bits(cols: Column*): Column = withExpr {
+    InterleaveBits(cols.map(_.expr))
   }
 }

--- a/core/src/test/scala/org/apache/spark/sql/delta/expressions/InterleaveBitsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/expressions/InterleaveBitsSuite.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.expressions
+
+import java.nio.ByteBuffer
+
+import scala.util.Random
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.TypeCheckSuccess
+import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionEvalHelper, Literal}
+import org.apache.spark.sql.types.IntegerType
+
+
+class InterleaveBitsSuite extends SparkFunSuite with ExpressionEvalHelper {
+
+  def intToBinary(x: Int): Array[Byte] = {
+    ByteBuffer.allocate(4).putInt(x).array()
+  }
+
+  def checkInterleaving(input: Seq[Expression], expectedOutput: Any): Unit = {
+    checkEvaluation(InterleaveBits(input), expectedOutput)
+  }
+
+  test("0 inputs") {
+    checkInterleaving(Seq.empty[Expression], Array.empty[Byte])
+  }
+
+  test("1 input") {
+    for { i <- 1.to(10) } {
+      val r = Random.nextInt()
+      checkInterleaving(Seq(Literal(r)), intToBinary(r))
+    }
+  }
+
+  test("2 inputs") {
+    checkInterleaving(
+      input = Seq(
+        0x000ff0ff,
+        0xfff00f00
+      ).map(Literal(_)),
+      expectedOutput =
+        Array(0x55, 0x55, 0x55, 0xaa, 0xaa, 0x55, 0xaa, 0xaa)
+          .map(_.toByte))
+  }
+
+  test("3 inputs") {
+    checkInterleaving(
+      input = Seq(
+        0xff00,
+        0x00ff,
+        0x0000
+      ).map(Literal(_)),
+      expectedOutput =
+        Array(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x92, 0x49, 0x24, 0x49, 0x24, 0x92)
+          .map(_.toByte))
+  }
+
+  test("nulls") {
+    val ones = 0xffffffff
+    checkInterleaving(
+      Seq(Literal(ones), Literal.create(null, IntegerType)), Array.fill(8)(0xaa.toByte))
+    checkInterleaving(
+      Seq(Literal.create(null, IntegerType), Literal(ones)), Array.fill(8)(0x55.toByte))
+
+    for { i <- 0.to(6) } {
+      checkInterleaving(
+        Seq.fill(i)(Literal.create(null, IntegerType)), Array.fill(i * 4)(0x00.toByte))
+    }
+  }
+
+  test("consistency") {
+    for { num_inputs <- 1 to 10 } {
+      checkConsistencyBetweenInterpretedAndCodegen(InterleaveBits(_), IntegerType, num_inputs)
+    }
+  }
+
+  test("supported types") {
+    // only int for now
+    InterleaveBits(Seq(Literal(0))).checkInputDataTypes() == TypeCheckSuccess
+    // nothing else
+    InterleaveBits(Seq(Literal(false))).checkInputDataTypes() != TypeCheckSuccess
+    InterleaveBits(Seq(Literal(0.toLong))).checkInputDataTypes() != TypeCheckSuccess
+    InterleaveBits(Seq(Literal(0.toDouble))).checkInputDataTypes() != TypeCheckSuccess
+    InterleaveBits(Seq(Literal(0.toString))).checkInputDataTypes() != TypeCheckSuccess
+  }
+}


### PR DESCRIPTION
This PR is part of https://github.com/delta-io/delta/issues/1134.

It implements `interleave_bits(col1:int, col2:int, …. col_n:int) -> byte array (Z-order value)`. This expression is used to combine multiple Z-order by columns into a [Z-order value](https://en.wikipedia.org/wiki/Z-order_curve). This Z-order value is used to layout the data such that the records with Z-Order By column having close values remain close when stored in files.

Detailed design details are [here](https://docs.google.com/document/d/1TYFxAUvhtYqQ6IHAZXjliVuitA5D1u793PMnzsH_3vs/edit?usp=sharing),
specifically [this](https://docs.google.com/document/d/1TYFxAUvhtYqQ6IHAZXjliVuitA5D1u793PMnzsH_3vs/edit#bookmark=id.pngsryg3gbl2) section.

GitOrigin-RevId: ffc1bbf8562c37d316d1d798789db618f03a540c