### PR TITLE
[ZOrderBy] Add transformation for multi-dimensional clustering of the data

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/skipping/MultiDimClustering.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/skipping/MultiDimClustering.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.skipping
+
+import java.util.UUID
+
+import org.apache.spark.sql.delta.skipping.MultiDimClusteringFunctions._
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql._
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types._
+
+/** Trait for changing the data layout using a multi-dimensional clustering algorithm */
+trait MultiDimClustering extends Logging {
+  /** Repartition the given `df` into `approxNumPartitions` based on the provided `colNames`. */
+  def cluster(
+      df: DataFrame,
+      colNames: Seq[String],
+      approxNumPartitions: Int): DataFrame
+}
+
+object MultiDimClustering {
+  /** Repartition the given dataframe `df` into `approxNumPartitions` on the given `colNames`. */
+  def cluster(
+      df: DataFrame,
+      approxNumPartitions: Int,
+      colNames: Seq[String]): DataFrame = {
+    assert(colNames.nonEmpty, "Cannot cluster by zero columns!")
+    ZOrderClustering.cluster(df, colNames, approxNumPartitions)
+  }
+}
+
+/** Base class for space filling curve based clustering e.g. ZOrder */
+trait SpaceFillingCurveClustering extends MultiDimClustering {
+
+  protected def getClusteringExpression(cols: Seq[Column], numRanges: Int): Column
+
+  override def cluster(
+      df: DataFrame,
+      colNames: Seq[String],
+      approxNumPartitions: Int): DataFrame = {
+    val conf = df.sparkSession.sessionState.conf
+    val numRanges = conf.getConf(DeltaSQLConf.MDC_NUM_RANGE_IDS)
+    val addNoise = conf.getConf(DeltaSQLConf.MDC_ADD_NOISE)
+
+    val cols = colNames.map(df(_))
+    val mdcCol = getClusteringExpression(cols, numRanges)
+    val repartitionKeyColName = s"${UUID.randomUUID().toString}-rpKey1"
+
+    var repartitionedDf = if (addNoise) {
+      val randByteColName = s"${UUID.randomUUID().toString}-rpKey2"
+      val randByteCol = (rand() * 255 - 128).cast(ByteType)
+      df.withColumn(repartitionKeyColName, mdcCol).withColumn(randByteColName, randByteCol)
+        .repartitionByRange(approxNumPartitions, col(repartitionKeyColName), col(randByteColName))
+        .drop(randByteColName)
+    } else {
+      df.withColumn(repartitionKeyColName, mdcCol)
+        .repartitionByRange(approxNumPartitions, col(repartitionKeyColName))
+    }
+
+    repartitionedDf.drop(repartitionKeyColName)
+  }
+}
+
+/** Implement Z-Order clustering */
+object ZOrderClustering extends SpaceFillingCurveClustering {
+  override protected[skipping] def getClusteringExpression(
+      cols: Seq[Column], numRanges: Int): Column = {
+    assert(cols.size >= 1, "Cannot do Z-Order clustering by zero columns!")
+    val rangeIdCols = cols.map(range_partition_id(_, numRanges))
+    interleave_bits(rangeIdCols: _*).cast(StringType)
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -603,10 +603,10 @@ trait DeltaSQLConfBase {
       .createWithDefault(true)
 
   /**
-   * This conf has a special prefix `spark.databricks.io` because this is the conf value already
-   * used by Databricks' data skipping implementation. There's no benefit to making OSS users,
-   * some of whom are Databricks customers, have to keep track of two different conf values for the
-   * same data skipping parameter.
+   * The below confs have a special prefix `spark.databricks.io` because this is the conf value
+   * already used by Databricks' data skipping implementation. There's no benefit to making OSS
+   * users, some of whom are Databricks customers, have to keep track of two different conf
+   * values for the same data skipping parameter.
    */
   val DATA_SKIPPING_STRING_PREFIX_LENGTH =
     SQLConf.buildConf("spark.databricks.io.skipping.stringPrefixLength")
@@ -614,6 +614,24 @@ trait DeltaSQLConfBase {
       .doc("For string columns, how long prefix to store in the data skipping index.")
       .intConf
       .createWithDefault(32)
+
+  val MDC_NUM_RANGE_IDS =
+    SQLConf.buildConf("spark.databricks.io.skipping.mdc.rangeId.max")
+      .internal()
+      .doc("This controls the domain of rangeId values to be interleaved. The bigger, the better " +
+         "granularity, but at the expense of performance (more data gets sampled).")
+      .intConf
+      .checkValue(_ > 1, "'spark.databricks.io.skipping.mdc.rangeId.max' must be greater than 1")
+      .createWithDefault(1000)
+
+  val MDC_ADD_NOISE =
+    SQLConf.buildConf("spark.databricks.io.skipping.mdc.addNoise")
+      .internal()
+      .doc("Whether or not a random byte should be added as a suffix to the interleaved bits " +
+         "when computing the Z-order values for MDC. This can help deal with skew, but may " +
+         "have a negative impact on overall min/max skipping effectiveness.")
+      .booleanConf
+      .createWithDefault(true)
 
   val INTERNAL_UDF_OPTIMIZATION_ENABLED =
     buildConf("internalUdfOptimization.enabled")

--- a/core/src/test/scala/org/apache/spark/sql/delta/skipping/MultiDimClusteringSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/skipping/MultiDimClusteringSuite.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.skipping
+
+import java.io.File
+
+import scala.util.Random
+
+// scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.sql.delta.sources.DeltaSQLConf._
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.functions.expr
+import org.apache.spark.sql.test.SharedSparkSession
+
+class MultiDimClusteringSuite extends QueryTest
+    with SharedSparkSession with DeltaSQLCommandTest {
+
+  private lazy val sparkSession = spark
+  import sparkSession.implicits._
+
+  test("Negative case - ZOrder clustering expression with zero columns") {
+    val ex = intercept[AssertionError] {
+      ZOrderClustering.getClusteringExpression(Seq.empty, 20)
+    }
+    assert(ex.getMessage contains "Cannot do Z-Order clustering by zero columns!")
+  }
+
+  test("ZOrder clustering expression with one column") {
+    val cluster = ZOrderClustering.getClusteringExpression(Seq(expr("col1")), 20)
+    assert(cluster.expr.toString ===
+      "cast(interleavebits(rangepartitionid('col1, 20)) as string)")
+  }
+
+  test("ZOrder clustering expression with two column") {
+    val cluster = ZOrderClustering.getClusteringExpression(Seq(expr("col1"), expr("col2")), 20)
+    assert(cluster.expr.toString ===
+      "cast(interleavebits(rangepartitionid('col1, 20), rangepartitionid('col2, 20)) as string)")
+  }
+
+  test("ensure records with close Z-order values are close in the output") {
+    withTempDir { tempDir =>
+      withSQLConf(
+        MDC_NUM_RANGE_IDS.key -> "4",
+        MDC_ADD_NOISE.key -> "false") {
+        val data = Seq(
+          "a" -> 20, "a" -> 20, // Same Z-order value // Z-Order 0
+          "b" -> 20,                                  // Z-Order 1
+          "c" -> 30,                                  // Z-Order 2
+          "d" -> 70,                                  // Z-Order 3
+          "e" -> 90, "e" -> 90, "e" -> 90, // Same Z-order value // Z-Order 5
+          "f" -> 200,                                 // Z-Order 8
+          "g" -> 10,                                  // Z-Order 6
+          "h" -> 20)                                  // Z-Order 7
+
+        // Randomize the data. Use seed for deterministic input.
+        val inputDf = new Random(seed = 101).shuffle(data)
+            .toDF("c1", "c2")
+
+        // Cluster the data and range partition into four partitions
+        val outputDf = MultiDimClustering.cluster(
+          inputDf,
+          approxNumPartitions = 4,
+          colNames = Seq("c1", "c2"))
+        outputDf.write.parquet(new File(tempDir, "source").getCanonicalPath)
+
+        // Load the partition 0 and verify that it contains (a, 20), (a, 20), (b, 20)
+        checkAnswer(
+          Seq("a" -> 20, "a" -> 20, "b" -> 20).toDF("c1", "c2"),
+          sparkSession.read.parquet(new File(tempDir, "source/part-00000*").getCanonicalPath))
+
+        // partition 1
+        checkAnswer(
+          Seq("c" -> 30, "d" -> 70, "e" -> 90, "e" -> 90, "e" -> 90).toDF("c1", "c2"),
+          sparkSession.read.parquet(new File(tempDir, "source/part-00001*").getCanonicalPath))
+
+        // partition 2
+        checkAnswer(
+          Seq("h" -> 20, "g" -> 10).toDF("c1", "c2"),
+          sparkSession.read.parquet(new File(tempDir, "source/part-00002*").getCanonicalPath))
+
+        // partition 3
+        checkAnswer(
+          Seq("f" -> 200).toDF("c1", "c2"),
+          sparkSession.read.parquet(new File(tempDir, "source/part-00003*").getCanonicalPath))
+      }
+    }
+  }
+
+  test(s"try clustering with different ranges and noise flag on/off") {
+    Seq("true", "false").foreach { addNoise =>
+      Seq("20", "100", "200", "1000").foreach { numRanges =>
+        withSQLConf(
+          MDC_NUM_RANGE_IDS.key -> numRanges,
+          MDC_ADD_NOISE.key -> addNoise) {
+          val data = Seq.range(0, 100)
+          val inputDf = Random.shuffle(data).map(x => (x, x * 113 % 101)).toDF("col1", "col2")
+          val outputDf = MultiDimClustering.cluster(
+            inputDf,
+            approxNumPartitions = 10,
+            colNames = Seq("col1", "col2"))
+          // Underlying data shouldn't change
+          checkAnswer(outputDf, inputDf)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is part of https://github.com/delta-io/delta/issues/1134.

This PR adds `MultiDimClustering` which makes use of the [`range_partition_id`](https://github.com/delta-io/delta/pull/1137) and [`interleave_bits`](https://github.com/delta-io/delta/pull/1149) to transform the layout of the data in Z-order clustering. Detailed design details are [here](https://docs.google.com/document/d/1TYFxAUvhtYqQ6IHAZXjliVuitA5D1u793PMnzsH_3vs/edit?usp=sharing).

Following are the two new options to control the clustering

- DeltaSQLConf.OPTIMIZE_ZORDERBY_NUM_RANGE_IDS - This controls the domain of rangeId values to be interleaved. The bigger, the better granularity, but at the expense of performance (more data gets sampled).

- DeltaSQLConf.OPTIMIZE_ZORDERBY_ADD_NOISE - Whether or not a random byte should be added as a suffix to the interleaved bits when computing the Z-order values for multi dimensional clustering. This can help deal with skew, but may have a negative impact on overall min/max skipping effectiveness.

Unit tests are added.