### PR TITLE
[1105] Delta Lake Change Data Feed support - streaming reads

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -122,6 +122,8 @@ trait DeltaReadOptions extends DeltaOptionParser {
   val failOnDataLoss = options.get(FAIL_ON_DATA_LOSS_OPTION)
     .forall(toBoolean(_, FAIL_ON_DATA_LOSS_OPTION)) // thanks to forall: by default true
 
+  val readChangeFeed = options.get(CDC_READ_OPTION).exists(toBoolean(_, CDC_READ_OPTION)) ||
+    options.get(CDC_READ_OPTION_LEGACY).exists(toBoolean(_, CDC_READ_OPTION_LEGACY))
 
   val excludeRegex: Option[Regex] = try options.get(EXCLUDE_REGEX_OPTION).map(_.r) catch {
     case e: PatternSyntaxException =>

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceCDCSupport.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceCDCSupport.scala
@@ -1,0 +1,280 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.sources
+
+import org.apache.spark.sql.delta.DeltaErrors
+import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, AddFile, CommitInfo, FileAction, Metadata, Protocol, RemoveFile, SetTransaction}
+import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.schema.SchemaUtils
+
+import org.apache.spark.sql.DataFrame
+
+/**
+ * Helper functions for CDC-specific handling for DeltaSource.
+ */
+trait DeltaSourceCDCSupport { self: DeltaSource =>
+
+  /////////////////////////
+  // Nested helper class //
+  /////////////////////////
+
+  /**
+   * This class represents an iterator of Change metadata(AddFile, RemoveFile, AddCDCFile)
+   * for a particular version.
+   * @param fileActionsItr - Iterator of IndexedFiles for a particular commit.
+   * @param isInitialSnapshot - Indicates whether the commit version is the initial snapshot or not.
+   */
+  class IndexedChangeFileSeq(
+      fileActionsItr: Iterator[IndexedFile],
+      isInitialSnapshot: Boolean) {
+
+    private def moreThanFrom(
+        indexedFile: IndexedFile, fromVersion: Long, fromIndex: Long): Boolean = {
+      // we need to filter out files so that we get only files after the startingOffset
+      indexedFile.version > fromVersion ||
+        (indexedFile.index == -1 || indexedFile.index > fromIndex)
+    }
+
+    private def lessThanEnd(
+        indexedFile: IndexedFile,
+        endOffset: Option[DeltaSourceOffset]): Boolean = {
+      // we need to filter out files so that they are within the end offsets.
+      if (endOffset.isEmpty) {
+        true
+      } else {
+        indexedFile.version < endOffset.get.reservoirVersion ||
+          (indexedFile.version <= endOffset.get.reservoirVersion &&
+            indexedFile.index <= endOffset.get.index)
+      }
+    }
+
+    private def noMatchesRegex(indexedFile: IndexedFile): Boolean = {
+      excludeRegex.forall(_.findFirstIn(indexedFile.getFileAction.path).isEmpty)
+    }
+
+    private def hasFileAction(indexedFile: IndexedFile): Boolean = {
+      indexedFile.getFileAction != null
+    }
+
+    private def hasAddsOrRemoves(indexedFile: IndexedFile): Boolean = {
+      indexedFile.add != null || indexedFile.remove != null
+    }
+
+    private def isValidIndexedFile(
+        indexedFile: IndexedFile,
+        fromVersion: Long,
+        fromIndex: Long,
+        endOffset: Option[DeltaSourceOffset]): Boolean = {
+      hasFileAction(indexedFile) && moreThanFrom(indexedFile, fromVersion, fromIndex) &&
+        lessThanEnd(indexedFile, endOffset) && noMatchesRegex(indexedFile) &&
+        lessThanEnd(indexedFile, Option(lastOffsetForTriggerAvailableNow))
+    }
+
+    /**
+     * Returns the IndexedFiles for particular commit version after rate-limiting and filtering
+     * out based on version boundaries.
+     */
+    def filterFiles(
+        fromVersion: Long,
+        fromIndex: Long,
+        limits: Option[AdmissionLimits],
+        endOffset: Option[DeltaSourceOffset] = None): Iterator[IndexedFile] = {
+
+      if (limits.isEmpty) {
+        return fileActionsItr.filter(isValidIndexedFile(_, fromVersion, fromIndex, endOffset))
+      }
+      val admissionControl = limits.get
+      if (isInitialSnapshot) {
+        // In this case we only have AddFiles as we are returning the snapshot of the table.
+        // NOTE: the initial snapshot can be huge hence we do not do a toSeq here.
+        fileActionsItr.filter(isValidIndexedFile(_, fromVersion, fromIndex, endOffset))
+          .takeWhile { indexedFile =>
+            admissionControl.admit(Some(indexedFile.add))
+          }
+      } else {
+        // Change data for a commit can be either recorded by a Seq[AddCDCFiles] or
+        // a Seq[AddFile]/ Seq[RemoveFile]
+        val fileActions = fileActionsItr.toSeq
+        val cdcFiles = fileActions.filter(_.cdc != null) // get only cdc commits.
+        if (cdcFiles.nonEmpty) {
+          // CDC of commit is represented by AddCDCFile
+          val filteredFiles = cdcFiles
+            .filter(isValidIndexedFile(_, fromVersion, fromIndex, endOffset))
+          // For CDC commits we either admit the entire commit or nothing at all.
+          // This is to avoid returning `update_preimage` and `update_postimage` in separate
+          // batches.
+          if (admissionControl.admit(filteredFiles.map(_.cdc))) {
+            filteredFiles.toIterator
+          } else {
+            Iterator()
+          }
+        } else {
+          // CDC is recorded as AddFile or RemoveFile
+          fileActions.filter(hasAddsOrRemoves(_))
+            .filter(
+              isValidIndexedFile(_, fromVersion, fromIndex, endOffset)
+            ).takeWhile { indexedFile =>
+            admissionControl.admit(Some(indexedFile.getFileAction))
+          }.toIterator
+        }
+      }
+    }
+  }
+
+  ///////////////////////////////
+  // Util methods for children //
+  ///////////////////////////////
+
+  /**
+   * Get the changes from startVersion, startIndex to the end for CDC case. We need to call
+   * CDCReader to get the CDC DataFrame.
+   *
+   * @param startVersion - calculated starting version
+   * @param startIndex - calculated starting index
+   * @param isStartingVersion - whether the stream has to return the initial snapshot or not
+   * @param endOffset - Offset that signifies the end of the stream.
+   * @return the DataFrame containing the file changes (AddFile, RemoveFile, AddCDCFile)
+   */
+  protected def getCDCFileChangesAndCreateDataFrame(
+      startVersion: Long,
+      startIndex: Long,
+      isStartingVersion: Boolean,
+      endOffset: DeltaSourceOffset): DataFrame = {
+    val changes: Iterator[(Long, Iterator[IndexedFile])] =
+      getFileChangesForCDC(startVersion, startIndex, isStartingVersion, None, Some(endOffset))
+
+    val groupedFileActions: Iterator[(Long, Seq[FileAction])] =
+      changes.map { case (v, indexFiles) =>
+        (v, indexFiles.map { _.getFileAction }.toSeq)
+      }
+
+    val cdcInfo = CDCReader.changesToDF(
+      deltaLog,
+      startVersion,
+      endOffset.reservoirVersion,
+      groupedFileActions,
+      spark,
+      isStreaming = true
+    )
+
+    cdcInfo.fileChangeDf
+  }
+
+  /**
+   * Get the changes starting from (fromVersion, fromIndex). fromVersion is included.
+   * It returns an  iterator of (log_version, fileActions)
+   */
+  protected def getFileChangesForCDC(
+      fromVersion: Long,
+      fromIndex: Long,
+      isStartingVersion: Boolean,
+      limits: Option[AdmissionLimits],
+      endOffset: Option[DeltaSourceOffset]): Iterator[(Long, Iterator[IndexedFile])] = {
+
+    /** Returns matching files that were added on or after startVersion among delta logs. */
+    def filterAndIndexDeltaLogs(startVersion: Long): Iterator[(Long, IndexedChangeFileSeq)] = {
+      deltaLog.getChanges(startVersion, options.failOnDataLoss).map { case (version, actions) =>
+        val fileActions = filterCDCActions(actions, version)
+        val itr = Iterator(IndexedFile(version, -1, null)) ++ fileActions
+          .zipWithIndex.map {
+          case (action: AddFile, index) =>
+            IndexedFile(version, index.toLong, action, isLast = index + 1 == fileActions.size)
+          case (cdcFile: AddCDCFile, index) =>
+            IndexedFile(
+              version,
+              index.toLong,
+              add = null,
+              cdc = cdcFile,
+              isLast = index + 1 == fileActions.size)
+          case (remove: RemoveFile, index) =>
+            IndexedFile(
+              version,
+              index.toLong,
+              add = null,
+              remove = remove,
+              isLast = index + 1 == fileActions.size)
+        }
+        (version,
+          new IndexedChangeFileSeq(itr, isInitialSnapshot = false))
+      }
+    }
+
+    val iter: Iterator[(Long, IndexedChangeFileSeq)] = if (isStartingVersion) {
+      // If we are reading change data from the start of the table we need to
+      // get the latest snapshot of the table as well.
+      val snapshot: Iterator[IndexedFile] = getSnapshotAt(fromVersion).map { m =>
+        // When we get the snapshot the dataChange is false for the AddFile actions
+        // We need to set it to true for it to be considered by the CDCReader.
+        if (m.add != null) {
+          m.copy(add = m.add.copy(dataChange = true))
+        } else {
+          m
+        }
+      }
+      val snapshotItr: Iterator[(Long, IndexedChangeFileSeq)] = Iterator((
+        fromVersion,
+        new IndexedChangeFileSeq(snapshot, isInitialSnapshot = true)
+      ))
+
+      snapshotItr ++ filterAndIndexDeltaLogs(fromVersion + 1)
+    } else {
+      filterAndIndexDeltaLogs(fromVersion)
+    }
+
+    iter.map { case (version, indexItr) =>
+      (version, indexItr.filterFiles(fromVersion, fromIndex, limits, endOffset))
+    }
+  }
+
+  /////////////////////
+  // Private methods //
+  /////////////////////
+
+  /**
+   * Filter out non CDC actions and only return CDC ones. This will either be AddCDCFiles
+   * or AddFile and RemoveFiles
+   */
+  private def filterCDCActions(
+      actions: Seq[Action],
+      version: Long): Seq[FileAction] = {
+    if (actions.exists(_.isInstanceOf[AddCDCFile])) {
+      actions.filter(_.isInstanceOf[AddCDCFile]).asInstanceOf[Seq[FileAction]]
+    } else {
+      actions.filter {
+        case a: AddFile =>
+          a.dataChange
+        case r: RemoveFile =>
+          r.dataChange
+        case cdc: AddCDCFile =>
+          false
+        case m: Metadata =>
+          val cdcSchema = CDCReader.cdcReadSchema(m.schema)
+          if (!SchemaUtils.isReadCompatible(cdcSchema, schema)) {
+            throw DeltaErrors.schemaChangedException(schema, cdcSchema, false)
+          }
+          false
+        case protocol: Protocol =>
+          deltaLog.protocolRead(protocol)
+          false
+        case _: SetTransaction | _: CommitInfo =>
+          false
+        case null => // Some crazy future feature. Ignore
+          false
+      }.asInstanceOf[Seq[FileAction]]
+    }
+  }
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaCDCStreamSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaCDCStreamSuite.scala
@@ -1,0 +1,677 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.io.File
+import java.sql.Timestamp
+import java.text.SimpleDateFormat
+import java.util.Date
+
+import scala.language.implicitConversions
+
+import org.apache.spark.sql.delta.actions.AddCDCFile
+import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.util.FileNames
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.streaming.{StreamingQueryException, StreamTest}
+import org.apache.spark.sql.types.StructType
+
+trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
+  with DeltaSourceSuiteBase with DeltaColumnMappingTestUtils {
+
+  import testImplicits._
+  import io.delta.implicits._
+
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaConfigs.CHANGE_DATA_FEED.defaultTablePropertyKey, "true")
+
+  /** Modify timestamp for a delta commit, used to test timestamp querying */
+  def modifyDeltaTimestamp(deltaLog: DeltaLog, version: Long, time: Long): Unit = {
+    val file = new File(FileNames.deltaFile(deltaLog.logPath, version).toUri)
+    file.setLastModified(time)
+    val crc = new File(FileNames.checksumFile(deltaLog.logPath, version).toUri)
+    if (crc.exists()) {
+      crc.setLastModified(time)
+    }
+  }
+
+  /**
+   * Create two tests for maxFilesPerTrigger and maxBytesPerTrigger
+   */
+  protected def testRateLimit(
+      name: String,
+      maxFilesPerTrigger: String,
+      maxBytesPerTrigger: String)(f: (String, String) => Unit): Unit = {
+    Seq(("maxFilesPerTrigger", maxFilesPerTrigger), ("maxBytesPerTrigger", maxBytesPerTrigger))
+      .foreach { case (key: String, value: String) =>
+        test(s"rateLimit - $key - $name") {
+          f(key, value)
+        }
+      }
+  }
+
+  testQuietly("no startingVersion should result fetch the entire snapshot") {
+    withTempDir { inputDir =>
+      withSQLConf(DeltaConfigs.CHANGE_DATA_FEED.defaultTablePropertyKey -> "false") {
+        // version 0
+        Seq(1, 9).toDF("value").write.format("delta").save(inputDir.getAbsolutePath)
+
+        val deltaTable = io.delta.tables.DeltaTable.forPath(inputDir.getAbsolutePath)
+        // version 1
+        deltaTable.delete("value = 9")
+
+        // version 2
+        Seq(2).toDF("value").write.format("delta")
+          .mode("append")
+          .save(inputDir.getAbsolutePath)
+      }
+      // enable cdc - version 3
+      sql(s"ALTER TABLE delta.`${inputDir.getAbsolutePath}` SET TBLPROPERTIES " +
+        s"(${DeltaConfigs.CHANGE_DATA_FEED.key}=true)")
+
+      val df = spark.readStream
+        .option(DeltaOptions.CDC_READ_OPTION, "true")
+        .format("delta")
+        .load(inputDir.getCanonicalPath)
+        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+
+      val deltaTable = io.delta.tables.DeltaTable.forPath(inputDir.getAbsolutePath)
+      testStream(df) (
+        ProcessAllAvailable(),
+        CheckAnswer((1, "insert", 3), (2, "insert", 3)),
+        Execute { _ =>
+          deltaTable.delete("value = 1") // version 4
+        },
+        ProcessAllAvailable(),
+        CheckAnswer((1, "insert", 3), (2, "insert", 3), (1, "delete", 4))
+      )
+    }
+  }
+
+  test("startingVersion = latest") {
+    withTempDir { inputDir =>
+      Seq(1, 2).toDF("value").write.format("delta").save(inputDir.getAbsolutePath)
+
+      val df = spark.readStream
+        .option(DeltaOptions.CDC_READ_OPTION, "true")
+        .option("startingVersion", "latest")
+        .format("delta")
+        .load(inputDir.getCanonicalPath)
+        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+
+      testStream(df) (
+        ProcessAllAvailable(),
+        CheckAnswer(),
+        AddToReservoir(inputDir, Seq(3).toDF("value")),
+        ProcessAllAvailable(),
+        CheckAnswer((3, "insert", 1))
+      )
+    }
+  }
+
+  test("user provided startingVersion") {
+    withTempDir { inputDir =>
+      // version 0
+      Seq(1, 2, 3).toDF("id").write.delta(inputDir.toString)
+
+      // version 1
+      Seq(4, 5).toDF("id").write.mode("append").delta(inputDir.toString)
+
+      // version 2
+      val deltaTable = io.delta.tables.DeltaTable.forPath(inputDir.getAbsolutePath)
+
+      val df = spark.readStream
+        .option(DeltaOptions.CDC_READ_OPTION, "true")
+        .option("startingVersion", "1")
+        .format("delta")
+        .load(inputDir.toString)
+        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+
+      testStream(df) (
+        ProcessAllAvailable(),
+        CheckAnswer((4, "insert", 1), (5, "insert", 1)),
+        Execute { _ =>
+          deltaTable.delete("id = 3") // version 2
+        },
+        ProcessAllAvailable(),
+        CheckAnswer((4, "insert", 1), (5, "insert", 1), (3, "delete", 2))
+      )
+    }
+  }
+
+  test("user provided startingTimestamp") {
+    withTempDir { inputDir =>
+      // version 0
+      Seq(1, 2, 3).toDF("id").write.delta(inputDir.toString)
+      val deltaLog = DeltaLog.forTable(spark, inputDir.getAbsolutePath)
+      modifyDeltaTimestamp(deltaLog, 0, 1000)
+
+      // version 1
+      Seq(-1).toDF("id").write.mode("append").delta(inputDir.toString)
+      modifyDeltaTimestamp(deltaLog, 1, 2000)
+
+      val deltaTable = io.delta.tables.DeltaTable.forPath(inputDir.getAbsolutePath)
+      val startTs = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+        .format(new Date(2000))
+      val df = spark.readStream
+        .option(DeltaOptions.CDC_READ_OPTION, "true")
+        .option("startingTimestamp", startTs)
+        .format("delta")
+        .load(inputDir.toString)
+        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+
+      testStream(df) (
+        ProcessAllAvailable(),
+        CheckAnswer((-1, "insert", 1)),
+        Execute { _ =>
+          deltaTable.update(expr("id == -1"), Map("id" -> lit("4")))
+        },
+        ProcessAllAvailable(),
+        CheckAnswer((-1, "insert", 1), (-1, "update_preimage", 2), (4, "update_postimage", 2))
+      )
+    }
+  }
+
+  testQuietly("starting[Version/Timestamp] > latest version") {
+    withTempDirs { (inputDir, outputDir, checkpointDir) =>
+      // version 0
+      Seq(1, 2, 3, 4, 5, 6).toDF("id").write.delta(inputDir.toString)
+      val deltaLog = DeltaLog.forTable(spark, inputDir.getAbsolutePath)
+      modifyDeltaTimestamp(deltaLog, 0, 1000)
+
+      val df1 = spark.readStream
+        .option(DeltaOptions.CDC_READ_OPTION, "true")
+        .option("startingVersion", 1)
+        .format("delta")
+        .load(inputDir.toString)
+        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+
+      val startTs = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+        .format(new Date(3000))
+      val commitTs = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+      .format(new Date(1000))
+      val df2 = spark.readStream
+        .option(DeltaOptions.CDC_READ_OPTION, "true")
+        .option("startingTimestamp", startTs)
+        .format("delta")
+        .load(inputDir.toString)
+
+      val e1 = VersionNotFoundException(1, 0, 0).getMessage
+      val e2 = DeltaErrors.timestampGreaterThanLatestCommit(
+        new Timestamp(3000), new Timestamp(1000), commitTs).getMessage
+
+      Seq((df1, e1), (df2, e2)).foreach { pair =>
+        val df = pair._1
+        val stream = df.select("id").writeStream
+          .option("checkpointLocation", checkpointDir.toString)
+          .outputMode("append")
+          .format("delta")
+          .start(outputDir.getAbsolutePath)
+        val e = intercept[StreamingQueryException] {
+          stream.processAllAvailable()
+        }
+        stream.stop()
+        assert(e.cause.getMessage === pair._2)
+      }
+    }
+  }
+
+  testQuietly("startingVersion and startingTimestamp are both set") {
+    withTempDir { tableDir =>
+      val tablePath = tableDir.getCanonicalPath
+      spark.range(10).write.format("delta").save(tableDir.getAbsolutePath)
+      val q = spark.readStream
+        .format("delta")
+        .option(DeltaOptions.CDC_READ_OPTION, "true")
+        .option("startingVersion", 0L)
+        .option("startingTimestamp", "2020-07-15")
+        .load(tablePath)
+        .writeStream
+        .format("console")
+        .start()
+      assert(intercept[StreamingQueryException] {
+        q.processAllAvailable()
+      }.getMessage.contains("Please either provide 'startingVersion' or 'startingTimestamp'"))
+      q.stop()
+    }
+  }
+
+  test("cdc streams should respect checkpoint") {
+    withTempDirs { (inputDir, outputDir, checkpointDir) =>
+      // write 3 versions
+      Seq(1, 2, 3).toDF("id").write.format("delta").save(inputDir.getAbsolutePath)
+      Seq(4, 5, 6).toDF("id").write.format("delta")
+        .mode("append")
+        .save(inputDir.getAbsolutePath)
+
+      val deltaTable = io.delta.tables.DeltaTable.forPath(inputDir.getAbsolutePath)
+      deltaTable.delete("id = 5")
+
+      val checkpointDir1 = new Path(checkpointDir.getAbsolutePath, "ck1")
+      val checkpointDir2 = new Path(checkpointDir.getAbsolutePath, "ck2")
+
+      def streamChanges(
+          startingVersion: Long,
+          checkpointLocation: String): Unit = {
+        val q = spark.readStream
+          .format("delta")
+          .option(DeltaOptions.CDC_READ_OPTION, "true")
+          .option("startingVersion", startingVersion)
+          .load(inputDir.getCanonicalPath)
+          .select("id")
+          .writeStream
+          .format("delta")
+          .option("checkpointLocation", checkpointLocation)
+          .start(outputDir.getCanonicalPath)
+        try {
+          q.processAllAvailable()
+        } finally {
+          q.stop()
+        }
+      }
+
+      streamChanges(1, checkpointDir1.toString)
+      checkAnswer(
+        spark.read.format("delta").load(outputDir.getCanonicalPath),
+        Seq(4, 5, 5, 6).map(_.toLong).toDF("id"))
+
+      // Second time streaming should not write the rows again
+      streamChanges(1, checkpointDir1.toString)
+      checkAnswer(
+        spark.read.format("delta").load(outputDir.getCanonicalPath),
+        Seq(4, 5, 5, 6).map(_.toLong).toDF("id"))
+
+      // new checkpoint location
+      streamChanges(1, checkpointDir2.toString)
+      checkAnswer(
+        spark.read.format("delta").load(outputDir.getCanonicalPath),
+        Seq(4, 4, 5, 5, 5, 5, 6, 6).map(_.toLong).toDF("id"))
+    }
+  }
+
+  test("cdc streams should be able to get offset when there only RemoveFiles") {
+    withTempDir { inputDir =>
+      // version 0
+      spark.range(2).withColumn("part", 'id % 2)
+          .write
+          .format("delta")
+          .partitionBy("part")
+          .save(inputDir.getAbsolutePath)
+
+      val deltaTable = io.delta.tables.DeltaTable.forPath(inputDir.getAbsolutePath)
+
+      val df = spark.readStream
+        .option(DeltaOptions.CDC_READ_OPTION, "true")
+        .option("startingVersion", 0)
+        .format("delta")
+        .load(inputDir.toString)
+        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+
+      testStream(df) (
+        ProcessAllAvailable(),
+        CheckAnswer((0, 0, "insert", 0), (1, 1, "insert", 0)),
+        Execute { _ =>
+          deltaTable.delete("part = 0") // version 2
+        },
+        ProcessAllAvailable(),
+        CheckAnswer((0, 0, "insert", 0), (1, 1, "insert", 0), (0, 0, "delete", 1))
+      )
+    }
+  }
+
+  test("cdc streams should work starting from RemoveFile") {
+    withTempDir { inputDir =>
+      // version 0
+      spark.range(2).withColumn("part", 'id % 2)
+        .write
+        .format("delta")
+        .partitionBy("part")
+        .save(inputDir.getAbsolutePath)
+
+      val deltaTable = io.delta.tables.DeltaTable.forPath(inputDir.getAbsolutePath)
+
+      deltaTable.delete("part = 0")
+
+      val df = spark.readStream
+        .option(DeltaOptions.CDC_READ_OPTION, "true")
+        .option("startingVersion", 1)
+        .format("delta")
+        .load(inputDir.toString)
+        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+
+      testStream(df) (
+        ProcessAllAvailable(),
+        CheckAnswer((0, 0, "delete", 1))
+      )
+    }
+  }
+
+  test("cdc streams should work starting from AddCDCFile") {
+    withTempDir { inputDir =>
+      // version 0
+      spark.range(2).withColumn("col2", 'id % 2)
+        .repartition(1)
+        .write
+        .format("delta")
+        .save(inputDir.getAbsolutePath)
+
+      val deltaTable = io.delta.tables.DeltaTable.forPath(inputDir.getAbsolutePath)
+
+      deltaTable.delete("col2 = 0")
+
+      val df = spark.readStream
+        .option(DeltaOptions.CDC_READ_OPTION, "true")
+        .option("startingVersion", 1)
+        .format("delta")
+        .load(inputDir.toString)
+        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+
+      testStream(df) (
+        ProcessAllAvailable(),
+        CheckAnswer((0, 0, "delete", 1)),
+        AddToReservoir(inputDir, spark.range(2, 3).withColumn("col2", 'id % 2)),
+        ProcessAllAvailable(),
+        CheckAnswer((0, 0, "delete", 1), (2, 0, "insert", 2))
+      )
+    }
+  }
+
+  testRateLimit(s"overall", "1", "1b") { (key, value) =>
+    withTempDir { inputDir =>
+      val deltaLog = DeltaLog.forTable(spark, new Path(inputDir.toURI))
+
+      // write - version 0 - 2 AddFiles - Adds 4 rows
+      spark.range(0, 4, 1, 1).toDF("id")
+        .withColumn("part", col("id") % 2) // 2 partitions
+        .write
+        .format("delta")
+        .partitionBy("part")
+        .save(inputDir.getAbsolutePath)
+
+      assert(deltaLog.snapshot.version == 0)
+      assert(deltaLog.snapshot.numOfFiles == 2)
+
+      // write - version 1 - 1 AddFile - Adds 1 row
+      Seq(4L).toDF("id").withColumn("part", lit(-1L))
+        .write
+        .format("delta")
+        .mode("append")
+        .partitionBy("part")
+        .save(deltaLog.dataPath.toString)
+      assert(deltaLog.snapshot.version == 1)
+      assert(deltaLog.snapshot.numOfFiles == 3)
+
+      // delete - version 2 - 1 RemoveFile - Removes 1 row
+      val deltaTable = io.delta.tables.DeltaTable.forPath(inputDir.getAbsolutePath)
+      deltaTable.delete("part = -1")
+      assert(deltaLog.snapshot.version == 2)
+      assert(deltaLog.snapshot.numOfFiles == 2)
+
+      // update the table - version 3 - 2 cdc files - Updates 2 rows
+      deltaTable.update(expr("id < 2"), Map("id" -> lit(0L)))
+
+      // update the table - version 4 - 2 cdc files - Updates 2 rows
+      deltaTable.update(expr("id > 1"), Map("id" -> lit(0L)))
+
+      val rowsPerBatch = Seq(
+        2, // 2 rows from 1 AddFile
+        2, // 2 rows from the 2nd AddFile
+        1, // 1 row from the 3rd AddFile
+        1, // 1 row from the RemoveFile
+        4, // 4 rows(pre_image and post_image) from the 2 AddCDCFile
+        4 // 4 rows(pre_image and post_image) from the 2 AddCDCFile
+      )
+      val q = spark.readStream
+        .format("delta")
+        .option(key, value)
+        .option(DeltaOptions.CDC_READ_OPTION, "true")
+        .option("startingVersion", "0")
+        .load(inputDir.getCanonicalPath)
+        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+
+      testStream(q) (
+        ProcessAllAvailable(),
+        CheckProgress(rowsPerBatch)
+      )
+    }
+  }
+
+  testRateLimit(s"starting from initial snapshot", "1", "1b") { (key, value) =>
+    withTempDir { inputDir =>
+      // 3 commits - 3 AddFiles each
+      (0 until 3).foreach { i =>
+        spark.range(i, i + 1, 1, 1)
+          .write
+          .mode("append")
+          .format("delta")
+          .save(inputDir.getAbsolutePath)
+      }
+      val deltaLog = DeltaLog.forTable(spark, new Path(inputDir.toURI))
+      assert(deltaLog.snapshot.numOfFiles === 3)
+
+      // 1 commit - 2 AddFiles
+      spark.range(3, 5, 1, 2)
+        .write
+        .mode("append")
+        .format("delta")
+        .save(inputDir.getAbsolutePath)
+
+      assert(deltaLog.snapshot.numOfFiles === 5)
+
+      val q = spark.readStream
+        .format("delta")
+        .option(key, value)
+        .option(DeltaOptions.CDC_READ_OPTION, "true")
+        .load(inputDir.getCanonicalPath)
+        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+
+      // 5 batches for the 5 commits split across commits and index number.
+      val rowsPerBatch = Seq(1, 1, 1, 1, 1)
+
+      testStream(q)(
+        ProcessAllAvailable(),
+        CheckProgress(rowsPerBatch),
+        CheckAnswer(
+          (0, "insert", 3),
+          (1, "insert", 3),
+          (2, "insert", 3),
+          (3, "insert", 3),
+          (4, "insert", 3)
+        )
+      )
+    }
+  }
+
+  testRateLimit(s"should not deadlock", "1", "1b") { (key, value) =>
+    withTempDir { inputDir =>
+      // version 0 - 2 AddFiles
+      spark.range(2)
+        .withColumn("part", 'id % 2)
+        .withColumn("col3", lit(0))
+        .repartition(1)
+        .write
+        .format("delta")
+        .partitionBy("part")
+        .save(inputDir.getAbsolutePath)
+
+      val deltaTable = io.delta.tables.DeltaTable.forPath(inputDir.getAbsolutePath)
+      // version 1 - 2 AddCDCFiles
+      deltaTable.update(expr("col3 < 2"), Map("col3" -> lit("0")))
+
+      // version 2 - 2 AddCDCFiles
+      deltaTable.update(expr("col3 < 2"), Map("col3" -> lit("1")))
+
+      val df = spark.readStream
+        .format("delta")
+        .option(key, value)
+        .option(DeltaOptions.CDC_READ_OPTION, "true")
+        .option("startingVersion", "1")
+        .load(inputDir.getCanonicalPath)
+        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+
+      testStream(df)(
+        ProcessAllAvailable(),
+        CheckProgress(Seq(4, 4)) // 4 rows(pre and post image) from the 2 AddCDCFiles
+      )
+    }
+  }
+
+  test("maxFilesPerTrigger - 2 successive AddCDCFile commits") {
+    withTempDir { inputDir =>
+      // version 0 - 2 AddFiles
+      spark.range(2)
+        .withColumn("part", 'id % 2)
+        .withColumn("col3", lit(0))
+        .repartition(1)
+        .write
+        .format("delta")
+        .partitionBy("part")
+        .save(inputDir.getAbsolutePath)
+
+      val deltaTable = io.delta.tables.DeltaTable.forPath(inputDir.getAbsolutePath)
+      // version 1 - 2 AddCDCFiles
+      deltaTable.update(expr("col3 < 2"), Map("col3" -> lit("0")))
+
+      // version 2 - 2 AddCDCFiles
+      deltaTable.update(expr("col3 < 2"), Map("col3" -> lit("1")))
+
+      val df = spark.readStream
+        .format("delta")
+        .option(DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION, "3")
+        .option(DeltaOptions.CDC_READ_OPTION, "true")
+        .option("startingVersion", "0")
+        .load(inputDir.getCanonicalPath)
+
+      // test whether the AddCDCFile commits do not get split up.
+      val rowsPerBatch = Seq(
+        2, // 2 rows from the 2 AddFile
+        4, // 4 rows(pre and post image) from the 2 AddCDCFiles
+        4 // 4 rows(pre and post image) from 2 AddCDCFiles
+      )
+
+      testStream(df)(
+        ProcessAllAvailable(),
+        CheckProgress(rowsPerBatch)
+      )
+    }
+  }
+
+  test("excludeRegex works with cdc") {
+    withTempDir { inputDir =>
+      spark.range(2)
+        .withColumn("part", 'id % 2)
+        .repartition(1)
+        .write
+        .format("delta")
+        .partitionBy("part")
+        .save(inputDir.getAbsolutePath)
+
+      val df = spark.readStream
+        .option(DeltaOptions.CDC_READ_OPTION, "true")
+        .option("startingVersion", "0")
+        .option(DeltaOptions.EXCLUDE_REGEX_OPTION, "part=0")
+        .format("delta")
+        .load(inputDir.getCanonicalPath)
+        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+
+      testStream(df)(
+        ProcessAllAvailable(),
+        CheckAnswer((1, 1, "insert", 0)) // first file should get excluded
+      )
+    }
+  }
+
+  test("excludeRegex on cdcPath should not return Add/RemoveFiles") {
+    withTempDir { inputDir =>
+      // version 0 - 1 AddFile
+      Seq(0).toDF("id")
+        .withColumn("col2", lit("0"))
+        .repartition(1)
+        .write
+        .format("delta")
+        .save(inputDir.getAbsolutePath)
+
+      val deltaTable = io.delta.tables.DeltaTable.forPath(inputDir.getAbsolutePath)
+      // version 1 - 1 ChangeFile
+      deltaTable.update(expr("col2 < 2"), Map("col2" -> lit("1")))
+
+      val deltaLog = DeltaLog.forTable(spark, inputDir.getAbsolutePath)
+      val excludePath = deltaLog.getChanges(1).next()._2
+        .filter(_.isInstanceOf[AddCDCFile])
+        .head
+        .asInstanceOf[AddCDCFile]
+        .path
+
+      val df = spark.readStream
+        .option(DeltaOptions.CDC_READ_OPTION, "true")
+        .option("startingVersion", "0")
+        .option(DeltaOptions.EXCLUDE_REGEX_OPTION, excludePath)
+        .format("delta")
+        .load(inputDir.getCanonicalPath)
+        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+
+      testStream(df)(
+        ProcessAllAvailable(),
+        CheckAnswer((0, "0", "insert", 0)) // first file should get excluded
+      )
+    }
+  }
+
+  test("schema check for cdc stream") {
+    withTempDir { inputDir =>
+      val deltaLog = DeltaLog.forTable(spark, new Path(inputDir.toURI))
+      (0 until 5).foreach { i =>
+        Seq(i).toDF.write.mode("append").format("delta").save(deltaLog.dataPath.toString)
+      }
+
+      val df = spark.readStream
+        .format("delta")
+        .option(DeltaOptions.CDC_READ_OPTION, "true")
+        .option("startingVersion", 0)
+        .load(inputDir.getCanonicalPath)
+        .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+
+      testStream(df)(
+        AssertOnQuery { q => q.processAllAvailable(); true },
+        CheckAnswer(
+          (0, "insert", 0),
+          (1, "insert", 1),
+          (2, "insert", 2),
+          (3, "insert", 3),
+          (4, "insert", 4)
+        ),
+        // no schema changed exception should be thrown.
+        AssertOnQuery { _ =>
+          withMetadata(deltaLog, StructType.fromDDL("value int"))
+          true
+        },
+        AssertOnQuery { _ =>
+          withMetadata(deltaLog, StructType.fromDDL("id int, value string"))
+          true
+        },
+        ExpectFailure[IllegalStateException](t =>
+          assert(t.getMessage.contains("Detected schema change")))
+      )
+    }
+  }
+}
+
+class DeltaCDCStreamSuite extends DeltaCDCStreamSuiteBase


### PR DESCRIPTION
## Description

This PR adds CDF + Streaming functionality, as part of the ongoing CDF project #1105.

The bulk of this PR is
a) adding `DeltaSourceCDCSuppor`t. This PR adds on the necessary CDF functionality to DeltaSource.
b) updating `DeltaSource` to use the various `DeltaSourceCDCSupport` APIs when CDF is enabled
c) adding a new test suite

## How was this patch tested?

New UTs.

## Does this PR introduce _any_ user-facing changes?
No.
