### PR TITLE
Support Auto Compaction

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -472,6 +472,16 @@ trait DeltaConfigsBase extends DeltaLogging {
     "needs to be a boolean.")
 
   /**
+   * Enable auto compaction.
+   */
+  val AUTO_COMPACT = buildConfig[Boolean](
+    "autoOptimize.autoCompact",
+    "false",
+    _.toBoolean,
+    _ => true,
+    "needs to be a boolean.")
+
+  /**
    * The number of columns to collect stats on for data skipping. A value of -1 means collecting
    * stats for all columns. Updating this conf does not trigger stats re-collection, but redefines
    * the stats schema of table, i.e., it will change the behavior of future stats collection

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -441,14 +441,18 @@ object DeltaOperations {
   val OPTIMIZE_OPERATION_NAME = "OPTIMIZE"
   /** parameter key to indicate which columns to z-order by */
   val ZORDER_PARAMETER_KEY = "zOrderBy"
+  /** operation name for Auto Compaction */
+  val AUTOCOMPACTION_OPERATION_NAME = "auto"
 
   /** Recorded when optimizing the table. */
   case class Optimize(
       predicate: Seq[Expression],
-      zOrderBy: Seq[String] = Seq.empty
+      zOrderBy: Seq[String] = Seq.empty,
+      auto: Boolean
   ) extends OptimizeOrReorg(OPTIMIZE_OPERATION_NAME, predicate) {
     override val parameters: Map[String, Any] = super.parameters ++ Map(
-      ZORDER_PARAMETER_KEY -> JsonUtils.toJson(zOrderBy)
+      ZORDER_PARAMETER_KEY -> JsonUtils.toJson(zOrderBy),
+      AUTOCOMPACTION_OPERATION_NAME -> auto
     )
 
     override val operationMetrics: Set[String] = DeltaOperationMetrics.OPTIMIZE

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/DoAutoCompaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/DoAutoCompaction.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.hooks
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.delta.{DeltaErrors, OptimisticTransactionImpl, Snapshot}
+import org.apache.spark.sql.delta.actions.{Action, AddFile}
+import org.apache.spark.sql.delta.commands.{DeltaOptimizeContext, OptimizeExecutor}
+import org.apache.spark.sql.delta.metering.DeltaLogging
+
+/**
+ * Post commit hook to trigger compaction.
+ */
+object DoAutoCompaction extends PostCommitHook
+  with DeltaLogging
+  with Serializable {
+
+  override val name: String = "Triggers compaction if necessary"
+
+  override def run(
+      spark: SparkSession,
+      txn: OptimisticTransactionImpl,
+      committedVersion: Long,
+      postCommitSnapshot: Snapshot,
+      committedActions: Seq[Action]): Unit = {
+
+    val newTxn = txn.deltaLog.startTransaction()
+    val addedFiles = committedActions.collect { case a: AddFile => a }
+    if (addedFiles.nonEmpty) {
+      new OptimizeExecutor(spark, newTxn, Seq.empty, Seq.empty, DeltaOptimizeContext(isAuto = true))
+        .autoCompact(addedFiles)
+    }
+  }
+
+  override def handleError(error: Throwable, version: Long): Unit = {
+    throw DeltaErrors.postCommitHookFailedException(this, version, name, error)
+  }
+}
+

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -859,6 +859,52 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(false)
 
+  val AUTO_COMPACT_ENABLED =
+    buildConf("autoCompact.enabled")
+      .internal()
+      .doc("Enables auto compaction after table update.")
+      .booleanConf
+      .createOptional
+
+  val AUTO_COMPACT_MAX_FILE_SIZE =
+    buildConf("autoCompact.maxFileSize")
+      .internal()
+      .doc("Maximum file size for auto compaction.")
+      .longConf
+      .createWithDefault(128 * 1024 * 1024)
+
+  val AUTO_COMPACT_MIN_NUM_FILES =
+    buildConf("autoCompact.minNumFiles")
+      .internal()
+      .doc("Minimum number of files in a directory to trigger auto compaction.")
+      .longConf
+      .createWithDefault(50)
+
+  val AUTO_COMPACT_MAX_COMPACT_BYTES =
+    buildConf("autoCompact.maxCompactBytes")
+      .internal()
+      .doc("Maximum amount of data for auto compaction.")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefaultString("20GB")
+
+  val AUTO_COMPACT_TARGET =
+    buildConf("autoCompact.target")
+      .internal()
+      .doc(
+        """
+          |Target files for auto compaction.
+          | "table", "commit", "partition" options are available. (default: partition)
+          | If "table", all files in table are eligible for auto compaction.
+          | If "commit", added/updated files by the commit are eligible.
+          | If "partition", all files in partitions containing any added/updated files
+          |  by the commit are eligible.
+          |""".stripMargin
+      )
+      .stringConf
+      .transform(_.toLowerCase(Locale.ROOT))
+      .checkValues(Set("table", "commit", "partition"))
+      .createWithDefault("partition")
+
   val DELTA_ALTER_TABLE_CHANGE_COLUMN_CHECK_EXPRESSIONS =
     buildConf("alterTable.changeColumn.checkExpressions")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAutoOptimizeSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAutoOptimizeSuite.scala
@@ -1,0 +1,369 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.functions._
+
+class DeltaAutoOptimizeSuite extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest
+  with DeletionVectorsTestUtils {
+
+  def writeDataToCheckAutoCompact(
+      numFiles: Int,
+      dataPath: String,
+      partitioned: Boolean = false,
+      mode: String = "overwrite"): Unit = {
+    val df = spark
+      .range(50000)
+      .withColumn("colA", rand() * 10000000 cast "long")
+      .withColumn("colB", rand() * 1000000000 cast "int")
+      .withColumn("colC", rand() * 2 cast "int")
+      .drop("id")
+      .repartition(numFiles)
+    if (partitioned) {
+      df.write
+        .partitionBy("colC")
+        .mode(mode)
+        .format("delta")
+        .save(dataPath)
+    } else {
+      df.write
+        .mode(mode)
+        .format("delta")
+        .save(dataPath)
+    }
+  }
+
+  def checkTableVersionAndNumFiles(
+      path: String,
+      expectedVer: Long,
+      expectedNumFiles: Long): Unit = {
+    val dt = DeltaLog.forTable(spark, path)
+    assert(dt.unsafeVolatileSnapshot.allFiles.count() == expectedNumFiles)
+    assert(dt.unsafeVolatileSnapshot.version == expectedVer)
+  }
+
+  test("test enabling autoCompact") {
+    val tableName = "autoCompactTestTable"
+    val tableName2 = s"${tableName}2"
+    withTable(tableName, tableName2) {
+      withTempDir { dir =>
+        val rootPath = dir.getCanonicalPath
+        val path = new Path(rootPath, "table1").toString
+        var expectedTableVersion = -1
+        spark.conf.unset(DeltaSQLConf.AUTO_COMPACT_ENABLED.key)
+        writeDataToCheckAutoCompact(100, path)
+        // No autoCompact triggered - version should be 0.
+        expectedTableVersion += 1
+        checkTableVersionAndNumFiles(path, expectedTableVersion, 100)
+
+        // Create table
+        spark.sql(s"CREATE TABLE $tableName USING DELTA LOCATION '$path'")
+        spark.sql(
+          s"ALTER TABLE $tableName SET TBLPROPERTIES (delta.autoOptimize.autoCompact = true)")
+        expectedTableVersion += 1 // version increased due to ALTER TABLE
+
+        writeDataToCheckAutoCompact(100, path)
+        expectedTableVersion += 2 // autoCompact should be triggered
+        checkTableVersionAndNumFiles(path, expectedTableVersion, 1)
+
+        withSQLConf(DeltaSQLConf.AUTO_COMPACT_ENABLED.key -> "false") {
+          // Session config should be prior to table properties
+          writeDataToCheckAutoCompact(100, path)
+          expectedTableVersion += 1 // autoCompact should not be triggered
+          checkTableVersionAndNumFiles(path, expectedTableVersion, 100)
+        }
+
+        spark.sql(
+          s"ALTER TABLE $tableName SET TBLPROPERTIES (delta.autoOptimize.autoCompact = false)")
+        expectedTableVersion += 1 // version increased due to SET TBLPROPERTIES
+
+        withSQLConf(DeltaSQLConf.AUTO_COMPACT_ENABLED.key -> "true") {
+          // Session config should be prior to table properties
+          writeDataToCheckAutoCompact(100, path)
+          expectedTableVersion += 2 // autoCompact should be triggered
+          checkTableVersionAndNumFiles(path, expectedTableVersion, 1)
+        }
+
+        spark.conf.unset(DeltaSQLConf.AUTO_COMPACT_ENABLED.key)
+
+        withSQLConf(
+          "spark.databricks.delta.properties.defaults.autoOptimize.autoCompact" -> "true") {
+          val path3 = new Path(rootPath, "table3").toString
+          writeDataToCheckAutoCompact(100, path3)
+          // autoCompact should be triggered for path2.
+          checkTableVersionAndNumFiles(path3, 1, 1)
+        }
+      }
+    }
+  }
+
+  test("test autoCompact configs") {
+    val tableName = "autoCompactTestTable"
+    withTable(tableName) {
+      withTempDir { dir =>
+        val rootPath = dir.getCanonicalPath
+        val path = new Path(rootPath, "table1").toString
+        var expectedTableVersion = -1
+        withSQLConf(DeltaSQLConf.AUTO_COMPACT_ENABLED.key -> "true") {
+          writeDataToCheckAutoCompact(100, path, partitioned = true)
+          expectedTableVersion += 2 // autoCompact should be triggered
+          checkTableVersionAndNumFiles(path, expectedTableVersion, 2)
+
+          withSQLConf(DeltaSQLConf.AUTO_COMPACT_MIN_NUM_FILES.key -> "200") {
+            writeDataToCheckAutoCompact(100, path, partitioned = true)
+            expectedTableVersion += 1 // autoCompact should not be triggered
+            checkTableVersionAndNumFiles(path, expectedTableVersion, 200)
+          }
+
+          withSQLConf(DeltaSQLConf.AUTO_COMPACT_MAX_FILE_SIZE.key -> "1") {
+            writeDataToCheckAutoCompact(100, path, partitioned = true)
+            expectedTableVersion += 1 // autoCompact should not be triggered
+            checkTableVersionAndNumFiles(path, expectedTableVersion, 200)
+          }
+
+          withSQLConf(DeltaSQLConf.DELTA_OPTIMIZE_MAX_FILE_SIZE.key -> "101024",
+            DeltaSQLConf.AUTO_COMPACT_MIN_NUM_FILES.key -> "2") {
+            val dt = io.delta.tables.DeltaTable.forPath(path)
+            dt.optimize().executeCompaction()
+            expectedTableVersion += 1 // autoCompact should not be triggered
+            checkTableVersionAndNumFiles(path, expectedTableVersion, 8)
+          }
+
+          withSQLConf(DeltaSQLConf.AUTO_COMPACT_MIN_NUM_FILES.key -> "100") {
+            writeDataToCheckAutoCompact(100, path, partitioned = true)
+            expectedTableVersion += 2 // autoCompact should be triggered
+            checkTableVersionAndNumFiles(path, expectedTableVersion, 2)
+          }
+        }
+      }
+    }
+  }
+
+  test("test max compact data size config") {
+    withTempDir { dir =>
+      val rootPath = dir.getCanonicalPath
+      val path = new Path(rootPath, "table1").toString
+      var expectedTableVersion = -1
+      writeDataToCheckAutoCompact(100, path, partitioned = true)
+      expectedTableVersion += 1
+      checkTableVersionAndNumFiles(path, expectedTableVersion, 200)
+      val dt = io.delta.tables.DeltaTable.forPath(path)
+      val dl = DeltaLog.forTable(spark, path)
+      val sizeLimit =
+        dl.unsafeVolatileSnapshot.allFiles
+          .filter(col("path").contains("colC=1"))
+          .agg(sum(col("size")))
+          .head
+          .getLong(0) * 2
+
+      withSQLConf(DeltaSQLConf.AUTO_COMPACT_ENABLED.key -> "true",
+        DeltaSQLConf.AUTO_COMPACT_MAX_COMPACT_BYTES.key -> sizeLimit.toString) {
+        dt.toDF
+          .filter("colC == 1")
+          .repartition(50)
+          .write
+          .format("delta")
+          .mode("append")
+          .save(path)
+        val dl = DeltaLog.forTable(spark, path)
+        // version 0: write, 1: append, 2: autoCompact
+        assert(dl.unsafeVolatileSnapshot.version == 2)
+
+        {
+          val afterAutoCompact =
+            dl.unsafeVolatileSnapshot.allFiles.filter(col("path").contains("colC=1")).count
+          val beforeAutoCompact = dl
+            .getSnapshotAt(dl.unsafeVolatileSnapshot.version - 1)
+            .allFiles
+            .filter(col("path").contains("colC=1"))
+            .count
+          assert(beforeAutoCompact == 150)
+          assert(afterAutoCompact == 1)
+        }
+
+        {
+          val afterAutoCompact =
+            dl.unsafeVolatileSnapshot.allFiles.filter(col("path").contains("colC=0")).count
+          val beforeAutoCompact = dl
+            .getSnapshotAt(dl.unsafeVolatileSnapshot.version - 1)
+            .allFiles
+            .filter(col("path").contains("colC=0"))
+            .count
+          assert(beforeAutoCompact == 100)
+          assert(afterAutoCompact == 100)
+        }
+      }
+    }
+  }
+
+  test("test autoCompact.target config") {
+    withTempDir { dir =>
+      val rootPath = dir.getCanonicalPath
+      val path1 = new Path(rootPath, "table1").toString
+      val path2 = new Path(rootPath, "table2").toString
+      val path3 = new Path(rootPath, "table3").toString
+      val path4 = new Path(rootPath, "table4").toString
+      val path5 = new Path(rootPath, "table5").toString
+
+      def testAutoCompactTarget(
+          path: String,
+          target: String,
+          expectedColC1Cnt: Long,
+          expectedColC2Cnt: Long): Unit = {
+        writeDataToCheckAutoCompact(100, path, partitioned = true)
+        val dt = io.delta.tables.DeltaTable.forPath(path)
+
+        withSQLConf(
+          DeltaSQLConf.AUTO_COMPACT_ENABLED.key -> "true",
+          DeltaSQLConf.AUTO_COMPACT_TARGET.key -> target) {
+          dt.toDF
+            .filter("colC == 1")
+            .repartition(50)
+            .write
+            .format("delta")
+            .mode("append")
+            .save(path)
+
+          val dl = DeltaLog.forTable(spark, path)
+          // version 0: write, 1: append, 2: autoCompact
+          assert(dl.unsafeVolatileSnapshot.version == 2, target)
+
+          {
+            val afterAutoCompact =
+              dl.unsafeVolatileSnapshot.allFiles.filter(col("path").contains("colC=1")).count
+            val beforeAutoCompact = dl
+              .getSnapshotAt(dl.unsafeVolatileSnapshot.version - 1)
+              .allFiles
+              .filter(col("path").contains("colC=1"))
+              .count
+
+            assert(beforeAutoCompact == 150)
+            assert(afterAutoCompact == expectedColC1Cnt)
+          }
+
+          {
+            val afterAutoCompact =
+              dl.unsafeVolatileSnapshot.allFiles.filter(col("path").contains("colC=0")).count
+            val beforeAutoCompact = dl
+              .getSnapshotAt(dl.unsafeVolatileSnapshot.version - 1)
+              .allFiles
+              .filter(col("path").contains("colC=0"))
+              .count
+
+            assert(beforeAutoCompact == 100)
+            assert(afterAutoCompact == expectedColC2Cnt)
+          }
+        }
+      }
+      // Existing files are not optimized; newly added 50 files should be optimized.
+      // 100 of colC=0, 101 of colC=1
+      testAutoCompactTarget(path1, "commit", 101, 100)
+      // Modified partition should be optimized.
+      // 100 of colC=0, 1 of colC=1
+      testAutoCompactTarget(path2, "partition", 1, 100)
+
+      // table option should compact all partitions
+      testAutoCompactTarget(path4, "table", 1, 1)
+
+      withSQLConf(
+        DeltaSQLConf.AUTO_COMPACT_ENABLED.key -> "true",
+        DeltaSQLConf.AUTO_COMPACT_TARGET.key -> "partition") {
+        writeDataToCheckAutoCompact(100, path3)
+        // non-partitioned data should work with "partition" option.
+        checkTableVersionAndNumFiles(path3, 1, 1)
+      }
+
+      withSQLConf(
+        "spark.databricks.delta.autoCompact.enabled" -> "true",
+        "spark.databricks.delta.autoCompact.target" -> "partition") {
+        writeDataToCheckAutoCompact(100, path5)
+        // non-partitioned data should work with "partition" option.
+        checkTableVersionAndNumFiles(path5, 1, 1)
+      }
+
+      val e = intercept[IllegalArgumentException](
+        withSQLConf(DeltaSQLConf.AUTO_COMPACT_TARGET.key -> "tabel") {
+          writeDataToCheckAutoCompact(10, path3, partitioned = true)
+        })
+      assert(e.getMessage.contains("should be one of table, commit, partition, but was tabel"))
+    }
+  }
+
+  test("test autoCompact with DVs") {
+    withTempDir { tempDir =>
+      val path = tempDir.getAbsolutePath
+      withSQLConf(
+        DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.defaultTablePropertyKey -> "true") {
+        // Create 47 files each with 1000 records
+        spark.range(start = 0, end = 10000, step = 1, numPartitions = 47)
+          .toDF("id")
+          .withColumn(colName = "extra", lit("just a random text to fill up the space....."))
+          .write.format("delta").mode("append").save(path) // v0
+
+        val deltaLog = DeltaLog.forTable(spark, path)
+        val filesV0 = deltaLog.unsafeVolatileSnapshot.allFiles.collect()
+        assert(filesV0.size == 47)
+
+        // Default `optimize.maxDeletedRowsRatio` is 0.05.
+        // Delete slightly more than threshold ration in two files, less in one of the file
+        val file0 = filesV0(1)
+        val file1 = filesV0(4)
+        val file2 = filesV0(8)
+        deleteRows(deltaLog, file0, approxPhyRows = 1000, ratioOfRowsToDelete = 0.06d) // v1
+        deleteRows(deltaLog, file1, approxPhyRows = 1000, ratioOfRowsToDelete = 0.06d) // v2
+        deleteRows(deltaLog, file2, approxPhyRows = 1000, ratioOfRowsToDelete = 0.01d) // v3
+
+        // Save the data before optimize for comparing it later with optimize
+        val data = spark.read.format("delta").load(path)
+
+        withSQLConf(DeltaSQLConf.AUTO_COMPACT_ENABLED.key -> "true",
+          DeltaSQLConf.AUTO_COMPACT_TARGET.key -> "table") {
+          data.write.format("delta").mode("append").save(path) // v4 and v5
+        }
+        val appendChanges = deltaLog.getChanges(startVersion = 4).next()._2
+        val autoOptimizeChanges = deltaLog.getChanges(startVersion = 5).next()._2
+
+        // We expect the initial files and the ones from the last append to be compacted.
+        val expectedRemoveFiles = (filesV0 ++ addedFiles(appendChanges)).map(_.path).toSet
+
+        assert(removedFiles(autoOptimizeChanges).map(_.path).toSet === expectedRemoveFiles)
+
+        assert(addedFiles(autoOptimizeChanges).size == 1) // Expect one new file added
+
+        // Verify the final data after optimization hasn't changed.
+        checkAnswer(spark.read.format("delta").load(path), data)
+      }
+    }
+  }
+
+  private def removedFiles(actions: Seq[Action]): Seq[RemoveFile] = {
+    actions.filter(_.isInstanceOf[RemoveFile]).map(_.asInstanceOf[RemoveFile])
+  }
+
+  private def addedFiles(actions: Seq[Action]): Seq[AddFile] = {
+    actions.filter(_.isInstanceOf[AddFile]).map(_.asInstanceOf[AddFile])
+  }
+}
+

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuiteBase.scala
@@ -176,7 +176,7 @@ trait OptimisticTransactionSuiteBase
       actions: Seq[FileAction],
       deltaLog: DeltaLog)(
       checkErrorFun: DeltaRuntimeException => Unit): Unit = {
-    val operation = DeltaOperations.Optimize(Seq.empty, zOrderBy = Seq.empty)
+    val operation = DeltaOperations.Optimize(Seq.empty, zOrderBy = Seq.empty, auto = false)
     val txn = deltaLog.startTransaction()
     val e = intercept[DeltaRuntimeException] {
       withSQLConf(DeltaSQLConf.DELTA_DUPLICATE_ACTION_CHECK_ENABLED.key -> "true") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Support Auto Compaction described in:
https://docs.databricks.com/delta/optimizations/auto-optimize.html#how-auto-compaction-works

We can support Auto compaction via a new post commit hook and OptimizeCommand with less size threshold.

`spark.databricks.delta.autoCompact.enabled` (default: false)
`spark.databricks.delta.autoCompact.maxFileSize` (default: 128MB)
`spark.databricks.delta.autoCompact.minNumFiles` (default: 50)

The configs above are same as Databricks Auto compaction.

#### New config1 - autoCompact.maxCompactBytes
As it will be triggered after every table update, I introduced another config to control the total amount of data to be optimized for an auto compaction operation:
`spark.databricks.delta.autoCompact.maxCompactBytes` (default: 20GB)

In Databricks, it's adjusted based on available cluster resources. The config is a quick and easy workaround for it.

#### New config2 - autoCompact.target
The PR adds another new config - `autoCompact.target` to change target files for auto compaction.
`spark.databricks.delta.autoCompact.target` (default: "partition")
- `table`: target all files in the table
- `commit`: target only added/updated files of the commit which is triggering auto compaction.
- `partition`: target only the partitions containing any of added/updated files of the commit which is triggering auto compaction.

Users are usually writing/updating data only for few partitions, and don't expect changes in other partitions.
In case the table is not optimized, the default behavior `table` might cause some conflicts between other partitions unexpectedly and added/updated files in the triggering commit might not be optimized if there are many small files in other partitions.

Fixes #815

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Unit tests

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Support Auto compaction feature

