### PR TITLE
[ZOrder] Fast approach of interleaving bits

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/expressions/InterleaveBits.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/expressions/InterleaveBits.scala
@@ -52,9 +52,8 @@ case class InterleaveBits(children: Seq[Expression])
 
   private val childrenArray: Array[Expression] = children.toArray
 
-  private val ints = new Array[Int](n)
-
   override def eval(input: InternalRow): Any = {
+    val ints = new Array[Int](n)
     var i = 0
     while (i < n) {
       val int = childrenArray(i).eval(input) match {
@@ -70,7 +69,7 @@ case class InterleaveBits(children: Seq[Expression])
     interleaveBits(ints)
   }
 
-  def defaultInterleaveBits(): Array[Byte] = {
+  def defaultInterleaveBits(inputs: Array[Int]): Array[Byte] = {
     val ret = new Array[Byte](n * 4)
     var ret_idx: Int = 0
     var ret_bit: Int = 7
@@ -80,7 +79,7 @@ case class InterleaveBits(children: Seq[Expression])
     while (bit >= 0) {
       var idx = 0
       while (idx < n) {
-        ret_byte = (ret_byte | (((ints(idx) >> bit) & 1) << ret_bit)).toByte
+        ret_byte = (ret_byte | (((inputs(idx) >> bit) & 1) << ret_bit)).toByte
         ret_bit -= 1
         if (ret_bit == -1) {
           // finished processing a byte
@@ -100,7 +99,7 @@ case class InterleaveBits(children: Seq[Expression])
 
   def interleaveBits(inputs: Array[Int]): Array[Byte] = {
     inputs.length match {
-      // it's a more fast approach
+      // it's a more fast approach, use O(4 * 8)
       // can see http://graphics.stanford.edu/~seander/bithacks.html#InterleaveTableObvious
       case 0 => Array.empty
       case 1 => intToByte(inputs(0))
@@ -113,7 +112,7 @@ case class InterleaveBits(children: Seq[Expression])
         inputs(0))
       case 8 => interleave8Ints(inputs(7), inputs(6), inputs(5), inputs(4), inputs(3), inputs(2),
         inputs(1), inputs(0))
-      case _ => defaultInterleaveBits()
+      case _ => defaultInterleaveBits(inputs)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/expressions/InterleaveBits.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/expressions/InterleaveBits.scala
@@ -67,7 +67,10 @@ case class InterleaveBits(children: Seq[Expression])
       ints.update(i, int)
       i += 1
     }
+    interleaveBits(ints)
+  }
 
+  def defaultInterleaveBits(): Array[Byte] = {
     val ret = new Array[Byte](n * 4)
     var ret_idx: Int = 0
     var ret_bit: Int = 7
@@ -93,6 +96,287 @@ case class InterleaveBits(children: Seq[Expression])
     assert(ret_idx == n * 4)
     assert(ret_bit == 7)
     ret
+  }
+
+  def interleaveBits(inputs: Array[Int]): Array[Byte] = {
+    inputs.length match {
+      // it's a more fast approach
+      // can see http://graphics.stanford.edu/~seander/bithacks.html#InterleaveTableObvious
+      case 0 => Array.empty
+      case 1 => intToByte(inputs(0))
+      case 2 => interleave2Ints(inputs(1), inputs(0))
+      case 3 => interleave3Ints(inputs(2), inputs(1), inputs(0))
+      case 4 => interleave4Ints(inputs(3), inputs(2), inputs(1), inputs(0))
+      case 5 => interleave5Ints(inputs(4), inputs(3), inputs(2), inputs(1), inputs(0))
+      case 6 => interleave6Ints(inputs(5), inputs(4), inputs(3), inputs(2), inputs(1), inputs(0))
+      case 7 => interleave7Ints(inputs(6), inputs(5), inputs(4), inputs(3), inputs(2), inputs(1),
+        inputs(0))
+      case 8 => interleave8Ints(inputs(7), inputs(6), inputs(5), inputs(4), inputs(3), inputs(2),
+        inputs(1), inputs(0))
+      case _ => defaultInterleaveBits()
+    }
+  }
+
+  private def interleave2Ints(i1: Int, i2: Int): Array[Byte] = {
+    val result = new Array[Byte](8)
+    var i = 0
+    while (i < 4) {
+      val tmp1 = ((i1 >> (i * 8)) & 0xFF).toByte
+      val tmp2 = ((i2 >> (i * 8)) & 0xFF).toByte
+
+      var z = 0
+      var j = 0
+      while (j < 8) {
+        val x_masked = tmp1 & (1 << j)
+        val y_masked = tmp2 & (1 << j)
+        z |= (x_masked << j)
+        z |= (y_masked << (j + 1))
+        j = j + 1
+      }
+      result((3 - i) * 2 + 1) = (z & 0xFF).toByte
+      result((3 - i) * 2) = ((z >> 8) & 0xFF).toByte
+      i = i + 1
+    }
+    result
+  }
+
+  def intToByte(input: Int): Array[Byte] = {
+    val result = new Array[Byte](4)
+    var i = 0
+    while (i <= 3) {
+      val offset = i * 8
+      result(3 - i) = ((input >> offset) & 0xFF).toByte
+      i += 1
+    }
+    result
+  }
+
+  private def interleave3Ints(i1: Int, i2: Int, i3: Int): Array[Byte] = {
+    val result = new Array[Byte](12)
+    var i = 0
+    while (i < 4) {
+      val tmp1 = ((i1 >> (i * 8)) & 0xFF).toByte
+      val tmp2 = ((i2 >> (i * 8)) & 0xFF).toByte
+      val tmp3 = ((i3 >> (i * 8)) & 0xFF).toByte
+
+      var z = 0
+      var j = 0
+      while (j < 8) {
+        val r1_mask = tmp1 & (1 << j)
+        val r2_mask = tmp2 & (1 << j)
+        val r3_mask = tmp3 & (1 << j)
+        z |= (r1_mask << (2 * j)) | (r2_mask << (2 * j + 1)) | (r3_mask << (2 * j + 2))
+        j = j + 1
+      }
+      result((3 - i) * 3 + 2) = (z & 0xFF).toByte
+      result((3 - i) * 3 + 1) = ((z >> 8) & 0xFF).toByte
+      result((3 - i) * 3) = ((z >> 16) & 0xFF).toByte
+      i = i + 1
+    }
+    result
+  }
+
+  private def interleave4Ints(i1: Int, i2: Int, i3: Int, i4: Int): Array[Byte] = {
+    val result = new Array[Byte](16)
+    var i = 0
+    while (i < 4) {
+      val tmp1 = ((i1 >> (i * 8)) & 0xFF).toByte
+      val tmp2 = ((i2 >> (i * 8)) & 0xFF).toByte
+      val tmp3 = ((i3 >> (i * 8)) & 0xFF).toByte
+      val tmp4 = ((i4 >> (i * 8)) & 0xFF).toByte
+
+      var z = 0
+      var j = 0
+      while (j < 8) {
+        val r1_mask = tmp1 & (1 << j)
+        val r2_mask = tmp2 & (1 << j)
+        val r3_mask = tmp3 & (1 << j)
+        val r4_mask = tmp4 & (1 << j)
+        z |= (r1_mask << (3 * j)) | (r2_mask << (3 * j + 1)) | (r3_mask << (3 * j + 2)) |
+          (r4_mask << (3 * j + 3))
+        j = j + 1
+      }
+      result((3 - i) * 4 + 3) = (z & 0xFF).toByte
+      result((3 - i) * 4 + 2) = ((z >> 8) & 0xFF).toByte
+      result((3 - i) * 4 + 1) = ((z >> 16) & 0xFF).toByte
+      result((3 - i) * 4) = ((z >> 24) & 0xFF).toByte
+      i = i + 1
+    }
+    result
+  }
+
+  private def interleave5Ints(
+      i1: Int,
+      i2: Int,
+      i3: Int,
+      i4: Int,
+      i5: Int): Array[Byte] = {
+    val result = new Array[Byte](20)
+    var i = 0
+    while (i < 4) {
+      val tmp1 = ((i1 >> (i * 8)) & 0xFF).toByte
+      val tmp2 = ((i2 >> (i * 8)) & 0xFF).toByte
+      val tmp3 = ((i3 >> (i * 8)) & 0xFF).toByte
+      val tmp4 = ((i4 >> (i * 8)) & 0xFF).toByte
+      val tmp5 = ((i5 >> (i * 8)) & 0xFF).toByte
+
+      var z = 0L
+      var j = 0
+      while (j < 8) {
+        val r1_mask = tmp1 & (1 << j)
+        val r2_mask = tmp2 & (1 << j)
+        val r3_mask = tmp3 & (1 << j)
+        val r4_mask = tmp4 & (1 << j)
+        val r5_mask = tmp5 & (1 << j)
+        z |= (r1_mask << (4 * j)) | (r2_mask << (4 * j + 1)) | (r3_mask << (4 * j + 2)) |
+          (r4_mask << (4 * j + 3)) | (r5_mask << (4 * j + 4))
+        j = j + 1
+      }
+      result((3 - i) * 5 + 4) = (z & 0xFF).toByte
+      result((3 - i) * 5 + 3) = ((z >> 8) & 0xFF).toByte
+      result((3 - i) * 5 + 2) = ((z >> 16) & 0xFF).toByte
+      result((3 - i) * 5 + 1) = ((z >> 24) & 0xFF).toByte
+      result((3 - i) * 5) = ((z >> 32) & 0xFF).toByte
+      i = i + 1
+    }
+    result
+  }
+
+  private def interleave6Ints(
+      i1: Int,
+      i2: Int,
+      i3: Int,
+      i4: Int,
+      i5: Int,
+      i6: Int): Array[Byte] = {
+    val result = new Array[Byte](24)
+    var i = 0
+    while (i < 4) {
+      val tmp1 = ((i1 >> (i * 8)) & 0xFF).toByte
+      val tmp2 = ((i2 >> (i * 8)) & 0xFF).toByte
+      val tmp3 = ((i3 >> (i * 8)) & 0xFF).toByte
+      val tmp4 = ((i4 >> (i * 8)) & 0xFF).toByte
+      val tmp5 = ((i5 >> (i * 8)) & 0xFF).toByte
+      val tmp6 = ((i6 >> (i * 8)) & 0xFF).toByte
+
+      var z = 0L
+      var j = 0
+      while (j < 8) {
+        val r1_mask = tmp1 & (1 << j)
+        val r2_mask = tmp2 & (1 << j)
+        val r3_mask = tmp3 & (1 << j)
+        val r4_mask = tmp4 & (1 << j)
+        val r5_mask = tmp5 & (1 << j)
+        val r6_mask = tmp6 & (1 << j)
+        z |= (r1_mask << (5 * j)) | (r2_mask << (5 * j + 1)) | (r3_mask << (5 * j + 2)) |
+          (r4_mask << (5 * j + 3)) | (r5_mask << (5 * j + 4)) | (r6_mask << (5 * j + 5))
+        j = j + 1
+      }
+      result((3 - i) * 6 + 5) = (z & 0xFF).toByte
+      result((3 - i) * 6 + 4) = ((z >> 8) & 0xFF).toByte
+      result((3 - i) * 6 + 3) = ((z >> 16) & 0xFF).toByte
+      result((3 - i) * 6 + 2) = ((z >> 24) & 0xFF).toByte
+      result((3 - i) * 6 + 1) = ((z >> 32) & 0xFF).toByte
+      result((3 - i) * 6) = ((z >> 40) & 0xFF).toByte
+      i = i + 1
+    }
+    result
+  }
+
+  private def interleave7Ints(
+      i1: Int,
+      i2: Int,
+      i3: Int,
+      i4: Int,
+      i5: Int,
+      i6: Int,
+      i7: Int): Array[Byte] = {
+    val result = new Array[Byte](28)
+    var i = 0
+    while (i < 4) {
+      val tmp1 = ((i1 >> (i * 8)) & 0xFF).toByte
+      val tmp2 = ((i2 >> (i * 8)) & 0xFF).toByte
+      val tmp3 = ((i3 >> (i * 8)) & 0xFF).toByte
+      val tmp4 = ((i4 >> (i * 8)) & 0xFF).toByte
+      val tmp5 = ((i5 >> (i * 8)) & 0xFF).toByte
+      val tmp6 = ((i6 >> (i * 8)) & 0xFF).toByte
+      val tmp7 = ((i7 >> (i * 8)) & 0xFF).toByte
+
+      var z = 0L
+      var j = 0
+      while (j < 8) {
+        val r1_mask = tmp1 & (1 << j)
+        val r2_mask = tmp2 & (1 << j)
+        val r3_mask = tmp3 & (1 << j)
+        val r4_mask = tmp4 & (1 << j)
+        val r5_mask = tmp5 & (1 << j)
+        val r6_mask = tmp6 & (1 << j)
+        val r7_mask = tmp7 & (1 << j)
+        z |= (r1_mask << (6 * j)) | (r2_mask << (6 * j + 1)) | (r3_mask << (6 * j + 2)) |
+          (r4_mask << (6 * j + 3)) | (r5_mask << (6 * j + 4)) | (r6_mask << (6 * j + 5)) |
+          (r7_mask << (6 * j + 6))
+        j = j + 1
+      }
+      result((3 - i) * 7 + 6) = (z & 0xFF).toByte
+      result((3 - i) * 7 + 5) = ((z >> 8) & 0xFF).toByte
+      result((3 - i) * 7 + 4) = ((z >> 16) & 0xFF).toByte
+      result((3 - i) * 7 + 3) = ((z >> 24) & 0xFF).toByte
+      result((3 - i) * 7 + 2) = ((z >> 32) & 0xFF).toByte
+      result((3 - i) * 7 + 1) = ((z >> 40) & 0xFF).toByte
+      result((3 - i) * 7) = ((z >> 48) & 0xFF).toByte
+      i = i + 1
+    }
+    result
+  }
+
+  private def interleave8Ints(
+      i1: Int,
+      i2: Int,
+      i3: Int,
+      i4: Int,
+      i5: Int,
+      i6: Int,
+      i7: Int,
+      i8: Int): Array[Byte] = {
+    val result = new Array[Byte](32)
+    var i = 0
+    while (i < 4) {
+      val tmp1 = ((i1 >> (i * 8)) & 0xFF).toByte
+      val tmp2 = ((i2 >> (i * 8)) & 0xFF).toByte
+      val tmp3 = ((i3 >> (i * 8)) & 0xFF).toByte
+      val tmp4 = ((i4 >> (i * 8)) & 0xFF).toByte
+      val tmp5 = ((i5 >> (i * 8)) & 0xFF).toByte
+      val tmp6 = ((i6 >> (i * 8)) & 0xFF).toByte
+      val tmp7 = ((i7 >> (i * 8)) & 0xFF).toByte
+      val tmp8 = ((i8 >> (i * 8)) & 0xFF).toByte
+
+      var z = 0L
+      var j = 0
+      while (j < 8) {
+        val r1_mask = tmp1 & (1 << j)
+        val r2_mask = tmp2 & (1 << j)
+        val r3_mask = tmp3 & (1 << j)
+        val r4_mask = tmp4 & (1 << j)
+        val r5_mask = tmp5 & (1 << j)
+        val r6_mask = tmp6 & (1 << j)
+        val r7_mask = tmp7 & (1 << j)
+        val r8_mask = tmp8 & (1 << j)
+        z |= (r1_mask << (7 * j)) | (r2_mask << (7 * j + 1)) | (r3_mask << (7 * j + 2)) |
+          (r4_mask << (7 * j + 3)) | (r5_mask << (7 * j + 4)) | (r6_mask << (7 * j + 5)) |
+          (r7_mask << (7 * j + 6)) | (r8_mask << (7 * j + 7))
+        j = j + 1
+      }
+      result((3 - i) * 8 + 7) = (z & 0xFF).toByte
+      result((3 - i) * 8 + 6) = ((z >> 8) & 0xFF).toByte
+      result((3 - i) * 8 + 5) = ((z >> 16) & 0xFF).toByte
+      result((3 - i) * 8 + 4) = ((z >> 24) & 0xFF).toByte
+      result((3 - i) * 8 + 3) = ((z >> 32) & 0xFF).toByte
+      result((3 - i) * 8 + 2) = ((z >> 40) & 0xFF).toByte
+      result((3 - i) * 8 + 1) = ((z >> 48) & 0xFF).toByte
+      result((3 - i) * 8) = ((z >> 56) & 0xFF).toByte
+      i = i + 1
+    }
+    result
   }
 
   override protected def withNewChildrenInternal(

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -651,6 +651,16 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
+  val FAST_INTERLEAVE_BITS_ENABLED =
+    buildConf("optimize.zorder.fastInterleaveBits.enabled")
+      .internal()
+      .doc(
+        """
+          |When true using the O(4 * 8) algorithm for interleave bit, otherwise the O(32 * n)
+          |algorithm, n is the number of input columns""".stripMargin)
+      .booleanConf
+      .createWithDefault(false)
+
   val INTERNAL_UDF_OPTIMIZATION_ENABLED =
     buildConf("internalUdfOptimization.enabled")
       .internal()
@@ -746,16 +756,6 @@ trait DeltaSQLConfBase {
       .internal()
       .booleanConf
       .createWithDefault(true)
-
-  val FAST_INTERLEAVE_BITS_ENABLED =
-    buildConf("fast.interleaveBits.enabled")
-      .internal()
-      .doc(
-        """
-          |When true using the O(4 * 8) algorithm for interleave bit, otherwise the O(32 * n)
-          |algorithm, n is the number of input columns""".stripMargin)
-      .booleanConf
-      .createWithDefault(false)
 }
 
 object DeltaSQLConf extends DeltaSQLConfBase

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -727,6 +727,7 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
+<<<<<<< HEAD
   val DELTA_CDF_ALLOW_OUT_OF_RANGE_TIMESTAMP = {
     buildConf("changeDataFeed.timestampOutOfRange.enabled")
       .doc(
@@ -746,6 +747,16 @@ trait DeltaSQLConfBase {
       .internal()
       .booleanConf
       .createWithDefault(true)
+
+  val FAST_INTERLEAVE_BITS_ENABLED =
+    buildConf("fast.interleaveBits.enabled")
+      .internal()
+      .doc(
+        """
+          |When true using the O(4 * 8) algorithm for interleave bit, otherwise the O(32 * n)
+          |algorithm, n is the number of input columns""".stripMargin)
+      .booleanConf
+      .createWithDefault(false)
 }
 
 object DeltaSQLConf extends DeltaSQLConfBase

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -727,7 +727,6 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
-<<<<<<< HEAD
   val DELTA_CDF_ALLOW_OUT_OF_RANGE_TIMESTAMP = {
     buildConf("changeDataFeed.timestampOutOfRange.enabled")
       .doc(

--- a/core/src/test/scala/org/apache/spark/sql/delta/expressions/InterleaveBitsBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/expressions/InterleaveBitsBenchmark.scala
@@ -1,0 +1,71 @@
+package org.apache.spark.sql.delta.expressions
+
+import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
+import org.apache.spark.sql.catalyst.expressions.{BoundReference, Expression, ExpressionEvalHelper, Literal}
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
+
+/**
+ * @time 2022/5/25 4:12 PM
+ * @author fchen <cloud.chenfu@gmail.com>
+ */
+object InterleaveBitsBenchmark extends BenchmarkBase {
+
+  private val numRows = 1 * 1000 * 1000
+
+  private def randomInt(numColumns: Int): Seq[Array[Int]] = {
+    (1 to numRows).map { l =>
+      val arr = new Array[Int](numColumns)
+      (0 until numColumns).foreach(col => arr(col) = l)
+      arr
+    }
+  }
+
+  def createExpression(numColumns: Int): Expression = {
+
+    val inputs = (0 until numColumns).map { i =>
+      $"c_$i".int.at(i)
+    }
+    InterleaveBits(inputs)
+  }
+
+  protected def create_row(values: Any*): InternalRow = {
+    InternalRow.fromSeq(values.map(CatalystTypeConverters.convertToCatalyst))
+  }
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    val benchmark =
+      new Benchmark(s"$numRows rows interleave bits benchmark", numRows, output = output)
+    benchmark.addCase("1 int columns benchmark", 3) { _ =>
+      val interleaveBits = createExpression(1)
+      randomInt(1).foreach { input =>
+        interleaveBits.eval(create_row(input: _*))
+      }
+    }
+
+    benchmark.addCase("2 int columns benchmark", 3) { _ =>
+      val interleaveBits = createExpression(2)
+      randomInt(2).foreach { input =>
+        interleaveBits.eval(create_row(input: _*))
+      }
+    }
+
+    benchmark.addCase("3 int columns benchmark", 3) { _ =>
+      val interleaveBits = createExpression(3)
+      randomInt(3).foreach { input =>
+        interleaveBits.eval(create_row(input: _*))
+      }
+    }
+
+    benchmark.addCase("4 int columns benchmark", 3) { _ =>
+      val interleaveBits = createExpression(4)
+      randomInt(4).foreach { input =>
+        interleaveBits.eval(create_row(input: _*))
+      }
+    }
+    benchmark.run()
+  }
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/expressions/InterleaveBitsBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/expressions/InterleaveBitsBenchmark.scala
@@ -32,10 +32,18 @@ object InterleaveBitsBenchmark extends BenchmarkBase {
 
   private val numRows = 1 * 1000 * 1000
 
-  private def randomInt(numColumns: Int): Seq[Array[Int]] = {
+  private def seqInt(numColumns: Int): Seq[Array[Int]] = {
     (1 to numRows).map { l =>
       val arr = new Array[Int](numColumns)
       (0 until numColumns).foreach(col => arr(col) = l)
+      arr
+    }
+  }
+
+  private def randomInt(numColumns: Int): Seq[Array[Int]] = {
+    (1 to numRows).map { l =>
+      val arr = new Array[Int](numColumns)
+      (0 until numColumns).foreach(col => arr(col) = scala.util.Random.nextInt())
       arr
     }
   }
@@ -54,28 +62,56 @@ object InterleaveBitsBenchmark extends BenchmarkBase {
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
     val benchmark =
       new Benchmark(s"$numRows rows interleave bits benchmark", numRows, output = output)
-    benchmark.addCase("1 int columns benchmark", 3) { _ =>
+    benchmark.addCase("sequence - 1 int columns benchmark", 3) { _ =>
+      val interleaveBits = createExpression(1)
+      seqInt(1).foreach { input =>
+        interleaveBits.eval(create_row(input: _*))
+      }
+    }
+
+    benchmark.addCase("sequence - 2 int columns benchmark", 3) { _ =>
+      val interleaveBits = createExpression(2)
+      seqInt(2).foreach { input =>
+        interleaveBits.eval(create_row(input: _*))
+      }
+    }
+
+    benchmark.addCase("sequence - 3 int columns benchmark", 3) { _ =>
+      val interleaveBits = createExpression(3)
+      seqInt(3).foreach { input =>
+        interleaveBits.eval(create_row(input: _*))
+      }
+    }
+
+    benchmark.addCase("sequence - 4 int columns benchmark", 3) { _ =>
+      val interleaveBits = createExpression(4)
+      seqInt(4).foreach { input =>
+        interleaveBits.eval(create_row(input: _*))
+      }
+    }
+
+    benchmark.addCase("random - 1 int columns benchmark", 3) { _ =>
       val interleaveBits = createExpression(1)
       randomInt(1).foreach { input =>
         interleaveBits.eval(create_row(input: _*))
       }
     }
 
-    benchmark.addCase("2 int columns benchmark", 3) { _ =>
+    benchmark.addCase("random - 2 int columns benchmark", 3) { _ =>
       val interleaveBits = createExpression(2)
       randomInt(2).foreach { input =>
         interleaveBits.eval(create_row(input: _*))
       }
     }
 
-    benchmark.addCase("3 int columns benchmark", 3) { _ =>
+    benchmark.addCase("random - 3 int columns benchmark", 3) { _ =>
       val interleaveBits = createExpression(3)
       randomInt(3).foreach { input =>
         interleaveBits.eval(create_row(input: _*))
       }
     }
 
-    benchmark.addCase("4 int columns benchmark", 3) { _ =>
+    benchmark.addCase(" random - 4 int columns benchmark", 3) { _ =>
       val interleaveBits = createExpression(4)
       randomInt(4).foreach { input =>
         interleaveBits.eval(create_row(input: _*))

--- a/core/src/test/scala/org/apache/spark/sql/delta/expressions/InterleaveBitsBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/expressions/InterleaveBitsBenchmark.scala
@@ -1,16 +1,16 @@
 package org.apache.spark.sql.delta.expressions
 
 import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
-import org.apache.spark.sql.catalyst.expressions.{BoundReference, Expression, ExpressionEvalHelper, Literal}
-import org.apache.spark.sql.functions._
-import org.apache.spark.sql.Column
-import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
 
 /**
- * @time 2022/5/25 4:12 PM
- * @author fchen <cloud.chenfu@gmail.com>
+ * Benchmark to measure performance for interleave bits.
+ * To run this benchmark:
+ * {{{
+ *   build/sbt "core/test:runMain org.apache.spark.sql.delta.expressions.InterleaveBitsBenchmark"
+ * }}}
  */
 object InterleaveBitsBenchmark extends BenchmarkBase {
 
@@ -24,8 +24,7 @@ object InterleaveBitsBenchmark extends BenchmarkBase {
     }
   }
 
-  def createExpression(numColumns: Int): Expression = {
-
+  private def createExpression(numColumns: Int): Expression = {
     val inputs = (0 until numColumns).map { i =>
       $"c_$i".int.at(i)
     }

--- a/core/src/test/scala/org/apache/spark/sql/delta/expressions/InterleaveBitsBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/expressions/InterleaveBitsBenchmark.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.sql.delta.expressions
 
 import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}

--- a/core/src/test/scala/org/apache/spark/sql/delta/expressions/InterleaveBitsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/expressions/InterleaveBitsSuite.scala
@@ -75,6 +75,61 @@ class InterleaveBitsSuite extends SparkFunSuite with ExpressionEvalHelper {
           .map(_.toByte))
   }
 
+  test("9 inputs") {
+    val result = Array(
+      0x00000000,
+      0x00000000,
+      0x00000000,
+      0x00000000,
+      0x00000000,
+      0x00000000,
+      0x00000000,
+      0x00000000,
+      0x00000000,
+      0x00000000,
+      0x00000000,
+      0x00000000,
+      0x00000000,
+      0x00000000,
+      0x00000000,
+      0x00000000,
+      0x00000000,
+      0x00000000,
+      0xffffff92,
+      0x00000049,
+      0x00000024,
+      0xffffff92,
+      0x00000049,
+      0x00000024,
+      0xffffff92,
+      0x00000049,
+      0x00000024,
+      0x00000049,
+      0x00000024,
+      0xffffff92,
+      0x00000049,
+      0x00000024,
+      0xffffff92,
+      0x00000049,
+      0x00000024,
+      0xffffff92
+    )
+    checkInterleaving(
+      input = Seq(
+        0xff00,
+        0x00ff,
+        0x0000,
+        0xff00,
+        0x00ff,
+        0x0000,
+        0xff00,
+        0x00ff,
+        0x0000
+      ).map(Literal(_)),
+      expectedOutput = result.map(_.toByte)
+    )
+  }
+
   test("nulls") {
     val ones = 0xffffffff
     checkInterleaving(

--- a/core/src/test/scala/org/apache/spark/sql/delta/expressions/InterleaveBitsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/expressions/InterleaveBitsSuite.scala
@@ -163,7 +163,7 @@ class InterleaveBitsSuite extends SparkFunSuite with ExpressionEvalHelper {
     val numIters = sys.env
       .get("NUMBER_OF_ITERATIONS_TO_INTERLEAVE_BITS")
       .map(_.toInt)
-      .getOrElse(100000000)
+      .getOrElse(1000000)
     var i = 0
     while (i < numIters) {
       // generate n columns where 1 <= n <= 8


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
to resolve https://github.com/delta-io/delta/pull/1149#discussion_r881782878

Improve interleave bits perf, the basic idea is from http://graphics.stanford.edu/~seander/bithacks.html#InterleaveTableObvious


## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Existing UTs.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

# Benchmark

Before this PR `spark.databricks.delta.optimize.zorder.fastInterleaveBits.enabled = false`:

```
[info] Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.15.5
[info] Intel(R) Core(TM) i7-6820HQ CPU @ 2.70GHz
[info] 1000000 rows interleave bits benchmark:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
[info] ------------------------------------------------------------------------------------------------------------------------
[info] sequence - 1 int columns benchmark                  428            440          16          2.3         427.6       1.0X
[info] sequence - 2 int columns benchmark                  572            605          39          1.7         571.6       0.7X
[info] sequence - 3 int columns benchmark                  749            768          32          1.3         748.6       0.6X
[info] sequence - 4 int columns benchmark                  893            934          64          1.1         892.9       0.5X
[info] random - 1 int columns benchmark                    384            391          11          2.6         383.9       1.1X
[info] random - 2 int columns benchmark                    551            557           7          1.8         550.9       0.8X
[info] random - 3 int columns benchmark                    716            722           6          1.4         716.3       0.6X
[info]  random - 4 int columns benchmark                   922            932          11          1.1         922.4       0.5X
```

After this PR `spark.databricks.delta.optimize.zorder.fastInterleaveBits.enabled  = true`:
```
[info] Java HotSpot(TM) 64-Bit Server VM 1.8.0_202-b08 on Mac OS X 10.15.5
[info] Intel(R) Core(TM) i7-6820HQ CPU @ 2.70GHz
[info] 1000000 rows interleave bits benchmark:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
[info] ------------------------------------------------------------------------------------------------------------------------
[info] sequence - 1 int columns benchmark                  299            340          36          3.3         298.5       1.0X
[info] sequence - 2 int columns benchmark                  423            459          50          2.4         423.5       0.7X
[info] sequence - 3 int columns benchmark                  560            579          24          1.8         560.4       0.5X
[info] sequence - 4 int columns benchmark                  694            719          37          1.4         694.0       0.4X
[info] random - 1 int columns benchmark                    270            274           4          3.7         269.8       1.1X
[info] random - 2 int columns benchmark                    418            428          13          2.4         418.4       0.7X
[info] random - 3 int columns benchmark                    548            568          32          1.8         547.6       0.5X
[info]  random - 4 int columns benchmark                   680            686           6          1.5         679.6       0.4X
```

cc and thank the Apache Kyuubi interleave bits author @ulysses-you