### PR TITLE
Skip SortExec for partitioning columns in OPTIMIZE

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/constraints/DeltaInvariantCheckerExec.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/constraints/DeltaInvariantCheckerExec.scala
@@ -53,7 +53,7 @@ case class DeltaInvariantChecker(
 object DeltaInvariantCheckerStrategy extends SparkStrategy {
   override def apply(plan: LogicalPlan): Seq[SparkPlan] = plan match {
     case DeltaInvariantChecker(child, constraints) =>
-      DeltaInvariantCheckerExec(planLater(child), constraints) :: Nil
+      DeltaInvariantCheckerExec(planLater(child), constraints, None) :: Nil
     case _ => Nil
   }
 }
@@ -64,7 +64,8 @@ object DeltaInvariantCheckerStrategy extends SparkStrategy {
  */
 case class DeltaInvariantCheckerExec(
     child: SparkPlan,
-    constraints: Seq[Constraint]) extends UnaryExecNode {
+    constraints: Seq[Constraint],
+    childOrdering: Option[Seq[SortOrder]]) extends UnaryExecNode {
 
   override def output: Seq[Attribute] = child.output
 
@@ -83,7 +84,7 @@ case class DeltaInvariantCheckerExec(
     }
   }
 
-  override def outputOrdering: Seq[SortOrder] = child.outputOrdering
+  override def outputOrdering: Seq[SortOrder] = childOrdering.getOrElse(child.outputOrdering)
 
   override def outputPartitioning: Partitioning = child.outputPartitioning
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

In OPTIMIZE, as it just reads from one directory to compact data, we don't need `SortExec` for partitioned data.
We can skip it by passing the plan with SortOrder of partitioned columns.

Fixes #948 

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Test data: 860MB parquet in total, 100 files

Non partitioned data
```
spark.range(200000000).map { _ =>
    (scala.util.Random.nextInt(10).toLong, scala.util.Random.nextInt(1000000000), scala.util.Random.nextInt(1))
}.toDF("colA", "colB", "colC").repartition(100).write.mode("overwrite").format("delta").save(dataPath)
```

Partitioned data, but all values are same (colC = 0)
```
spark.range(200000000).map { _ =>
    (scala.util.Random.nextInt(10).toLong, scala.util.Random.nextInt(1000000000), scala.util.Random.nextInt(1))
}.toDF("colA", "colB", "colC").repartition(100).write.partitionBy("colC").mode("overwrite").format("delta").save(dataPath + "1")
```

E2E duration of OPTIMIZE with master + the PR
- non-partitioned: 2 min 28 sec
- partitioned: 2 min 24 sec

E2E duration of OPTIMIZE with master
- non-partitioned: 2 min 30 sec
- partitioned: 3 min 4 sec


## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No