### PR TITLE
 Limit SetTxn action retention in the Delta Log

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -475,6 +475,20 @@ trait DeltaConfigsBase extends DeltaLogging {
     "",
     minimumProtocolVersion = Some(DeltaColumnMapping.MIN_PROTOCOL_VERSION),
     userConfigurable = false)
+
+
+  /**
+   * The shortest duration within which new [[Snapshot]]s will retain transaction identifiers (i.e.
+   * [[SetTransaction]]s). When a new [[Snapshot]] sees a transaction identifier older than or equal
+   * to the specified TRANSACTION_ID_RETENTION_DURATION, it considers it expired and ignores it.
+   */
+  val TRANSACTION_ID_RETENTION_DURATION = buildConfig[Option[CalendarInterval]](
+    "setTransactionRetentionDuration",
+    null,
+    v => if (v == null) None else Some(parseCalendarInterval(v)),
+    opt => opt.forall(isValidIntervalConfigValue),
+    "needs to be provided as a calendar interval such as '2 weeks'. Months " +
+      "and years are not accepted. You may specify '365 days' for a year instead.")
 }
 
 object DeltaConfigs extends DeltaConfigsBase

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -143,6 +143,20 @@ class DeltaLog private(
   }
 
   /**
+   * [[SetTransaction]]s before this timestamp will be considered expired and dropped from the
+   * state, but no files will be deleted.
+   */
+  def minSetTransactionRetentionTimestamp: Option[Long] = {
+    val intervalOpt = DeltaConfigs.TRANSACTION_ID_RETENTION_DURATION.fromMetaData(metadata)
+
+    if (intervalOpt.isDefined) {
+      Some(clock.getTimeMillis() - DeltaConfigs.getMilliSeconds(intervalOpt.get))
+    } else {
+      None
+    }
+  }
+
+  /**
    * Checks whether this table only accepts appends. If so it will throw an error in operations that
    * can remove data such as DELETE/UPDATE/MERGE.
    */

--- a/core/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -294,7 +294,7 @@ trait SnapshotManagement { self: DeltaLog =>
         deltaLog = this,
         timestamp = segment.lastCommitTimestamp,
         checksumOpt = checksumOpt,
-        minSetTransactionRetentionTimestamp = None,
+        minSetTransactionRetentionTimestamp = minSetTransactionRetentionTimestamp,
         checkpointMetadataOpt = getCheckpointMetadataForSegment(segment, checkpointMetadataOptHint))
     }
   }

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/InMemoryLogReplay.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/InMemoryLogReplay.scala
@@ -72,7 +72,13 @@ class InMemoryLogReplay(
   }
 
   private def getTransactions: Iterable[SetTransaction] = {
-    transactions.values
+    if (minSetTransactionRetentionTimestamp.isEmpty) {
+      transactions.values
+    } else {
+      transactions.values.filter { txn =>
+        txn.lastUpdated.exists(_ > minSetTransactionRetentionTimestamp.get)
+      }
+    }
   }
 
   /** Returns the current state of the Table as an iterator of actions. */

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaConfigSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaConfigSuite.scala
@@ -18,12 +18,17 @@ package org.apache.spark.sql.delta
 
 import java.util.concurrent.TimeUnit
 
-import org.apache.spark.sql.delta.DeltaConfigs.{isValidIntervalConfigValue, parseCalendarInterval}
+import org.apache.spark.sql.delta.DeltaConfigs.{getMilliSeconds, isValidIntervalConfigValue, parseCalendarInterval}
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.unsafe.types.CalendarInterval
+import org.apache.spark.util.ManualClock
 
-class DeltaConfigSuite extends SparkFunSuite {
+class DeltaConfigSuite extends SparkFunSuite
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
 
   test("parseCalendarInterval") {
     for (input <- Seq("5 MINUTES", "5 minutes", "5 Minutes", "inTERval 5 minutes")) {
@@ -66,6 +71,49 @@ class DeltaConfigSuite extends SparkFunSuite {
         "1 month",
         "1 year")) {
       assert(!isValidIntervalConfigValue(parseCalendarInterval(input)), s"$input")
+    }
+  }
+
+  test("Optional Calendar Interval config") {
+    val clock = new ManualClock(System.currentTimeMillis())
+
+    // case 1: duration not specified
+    withTempDir { dir =>
+      sql(s"CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta")
+
+      val retentionTimestampOpt =
+        DeltaLog.forTable(spark, dir.getCanonicalPath, clock).minSetTransactionRetentionTimestamp
+
+      assert(retentionTimestampOpt.isEmpty)
+    }
+
+    // case 2: valid duration specified
+    withTempDir { dir =>
+      sql(
+        s"""CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta
+           |TBLPROPERTIES ('delta.setTransactionRetentionDuration' = 'interval 1 days')
+           |""".stripMargin)
+
+      DeltaLog.clearCache() // we want to ensure we can use the ManualClock we pass in
+
+      val log = DeltaLog.forTable(spark, dir.getCanonicalPath, clock)
+      val retentionTimestampOpt = log.minSetTransactionRetentionTimestamp
+      assert(log.clock.getTimeMillis() == clock.getTimeMillis())
+      val expectedRetentionTimestamp =
+        clock.getTimeMillis() - getMilliSeconds(parseCalendarInterval("interval 1 days"))
+
+      assert(retentionTimestampOpt.contains(expectedRetentionTimestamp))
+    }
+
+    // case 3: invalid duration specified
+    withTempDir { dir =>
+      val e = intercept[IllegalArgumentException] {
+        sql(
+          s"""CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta
+             |TBLPROPERTIES ('delta.setTransactionRetentionDuration' = 'interval 1 foo')
+             |""".stripMargin)
+      }
+      assert(e.getMessage.contains("Invalid interval"))
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds a new optional table property `delta.setTransactionRetentionDuration` that lets users set a duration so that newly created snapshots ignore all `SetTransaction`s older than that duration. Since we have allowed options to specify arbitration txnAppId and txnVersion for idempotent writes, there is a chance that unlimited number of SetTxn actions will forever clutter the Delta log. This is an opt-in mechanism to clear those actions.

## How was this patch tested?
New unit tests
