### PR TITLE
CDF Scala + Python integration tests

### DIFF
--- a/examples/python/change_data_feed.py
+++ b/examples/python/change_data_feed.py
@@ -1,0 +1,109 @@
+#
+# Copyright (2021) The Delta Lake Project Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import col, expr
+from delta.tables import DeltaTable
+import shutil
+
+
+path = "/tmp/delta-change-data-feed"
+
+# Clear any previous runs
+shutil.rmtree(path, ignore_errors=True)
+
+# Enable SQL commands and Update/Delete/Merge for the current spark session.
+# we need to set the following configs
+spark = SparkSession.builder \
+    .appName("Change Data Feed") \
+    .master("local[*]") \
+    .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
+    .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog") \
+    .getOrCreate()
+
+
+def read_cdc_by_path(starting_version):
+    return spark.read.format("delta") \
+        .option("readChangeFeed", "true") \
+        .option("startingVersion", str(starting_version)) \
+        .load(path) \
+        .orderBy("_change_type", "id")
+
+
+def read_cdc_by_table_name(starting_version):
+    return spark.read.format("delta") \
+        .option("readChangeFeed", "true") \
+        .option("startingVersion", str(starting_version)) \
+        .table("table") \
+        .orderBy("_change_type", "id")
+
+
+def stream_cdc_by_path(starting_version):
+    return spark.readStream.format("delta") \
+        .option("readChangeFeed", "true") \
+        .option("startingVersion", str(starting_version)) \
+        .load(path) \
+        .writeStream \
+        .format("console") \
+        .start()
+
+
+def stream_cdc_by_table_name(starting_version):
+    return spark.readStream.format("delta") \
+        .option("readChangeFeed", "true") \
+        .option("startingVersion", str(starting_version)) \
+        .table("table") \
+        .writeStream \
+        .format("console") \
+        .start()
+
+spark.sql('''CREATE TABLE table (id LONG)
+             USING DELTA
+             TBLPROPERTIES (delta.enableChangeDataFeed = true)
+             LOCATION '{0}'
+         '''.format(path))
+
+spark.range(0, 10).write.format("delta").mode("append").save(path)  # v1
+
+read_cdc_by_path(1).show()
+
+spark.read.format("delta").load(path).orderBy("id").show()
+
+table = DeltaTable.forPath(spark, path)
+
+table.update(set={"id": expr("id + 1")})  # v2
+
+read_cdc_by_path(2).show()
+
+table.delete(condition=expr("id >= 5"))  # v3
+
+read_cdc_by_table_name(3).show()
+
+# TODO merge
+
+print("Starting CDF stream 1")
+cdfStream1 = stream_cdc_by_path(0)
+cdfStream1.awaitTermination(10)
+cdfStream1.stop()
+
+print("Starting CDF stream 2")
+cdfStream2 = stream_cdc_by_table_name(0)
+cdfStream2.awaitTermination(10)
+cdfStream2.stop()
+
+# cleanup
+shutil.rmtree(path, ignore_errors=True)
+

--- a/examples/scala/build.sbt
+++ b/examples/scala/build.sbt
@@ -23,15 +23,16 @@ val scala213 = "2.13.8"
 val deltaVersion = "1.2.0"
 
 val lookupSparkVersion: PartialFunction[String, String] = {
-  case v12x if v12x.startsWith("1.2") => "3.2.1"
-  case v11x if v11x.startsWith("1.1") => "3.2.1"
-  case v10x if v10x.startsWith("1.0") => "3.1.1"
+  case v10x_and_above if Try {
+        v10x_and_above.split('.')(0).toInt
+      }.toOption.exists(_ >= 1) =>
+    "3.2.1"
   case v07x_v08x
       if v07x_v08x.startsWith("0.7") || v07x_v08x.startsWith("0.8") =>
     "3.0.2"
   case belowv07 if Try {
-        belowv07.split(".")(1).toInt
-      }.toOption.map(_ < 7).getOrElse(false) =>
+        belowv07.split('.')(1).toInt
+      }.toOption.exists(_ < 7) =>
     "2.4.4"
   case v =>
     throw new RuntimeException(
@@ -91,6 +92,7 @@ lazy val root = (project in file("."))
       )
     ),
     extraMavenRepo,
+    resolvers += Resolver.mavenLocal,
     scalacOptions ++= Seq(
       "-deprecation",
       "-feature"

--- a/examples/scala/src/main/scala/example/ChangeDataFeed.scala
+++ b/examples/scala/src/main/scala/example/ChangeDataFeed.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package example
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.{DataFrame, SQLContext, SparkSession}
+import org.apache.spark.sql.streaming.{StreamingQuery}
+import io.delta.tables._
+
+import org.apache.spark.sql.functions._
+import org.apache.commons.io.FileUtils
+import java.io.File
+
+object ChangeDataFeed {
+  def main(args: Array[String]): Unit = {
+    val spark = SparkSession
+      .builder()
+      .appName("ChangeDataFeed")
+      .master("local[*]")
+      .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+      .config(
+        "spark.sql.catalog.spark_catalog",
+        "org.apache.spark.sql.delta.catalog.DeltaCatalog"
+      )
+      .getOrCreate()
+
+    val path = "/tmp/delta-change-data-feed"
+    val file = new File(path)
+    if (file.exists()) FileUtils.deleteDirectory(file)
+
+    def readCDCByPath(startingVersion: Int): DataFrame = {
+      spark.read.format("delta")
+        .option("readChangeFeed", "true")
+        .option("startingVersion", startingVersion.toString)
+        .load(path)
+        .orderBy("_change_type", "id")
+    }
+
+    def readCDCByTableName(startingVersion: Int): DataFrame = {
+      spark.read.format("delta")
+        .option("readChangeFeed", "true")
+        .option("startingVersion", startingVersion.toString)
+        .table("table")
+        .orderBy("_change_type", "id")
+    }
+
+    def streamCDCByPath(startingVersion: Int): StreamingQuery = {
+      spark.readStream.format("delta")
+        .option("readChangeFeed", "true")
+        .option("startingVersion", startingVersion.toString)
+        .load(path)
+        .writeStream
+        .format("console")
+        .start()
+    }
+
+    def streamCDCByTableName(startingVersion: Int): StreamingQuery = {
+      spark.readStream.format("delta")
+        .option("readChangeFeed", "true")
+        .option("startingVersion", startingVersion.toString)
+        .table("table")
+        .writeStream
+        .format("console")
+        .start()
+    }
+
+    spark.sql(
+      s"""
+         |CREATE TABLE table (id LONG)
+         |USING DELTA
+         |TBLPROPERTIES (delta.enableChangeDataFeed = true)
+         |LOCATION '$path'""".stripMargin) // v0
+
+    spark.range(0, 10).write.format("delta").mode("append").save(path)  // v1
+
+    readCDCByPath(1).show()
+
+    val table = io.delta.tables.DeltaTable.forPath(path)
+
+    spark.read.format("delta").load(path).orderBy("id").show()
+
+    table.update(Map("id" -> expr("id + 1"))) // v2
+
+    readCDCByPath(2).show()
+
+    table.delete(expr("id >= 5")) // v3
+
+    readCDCByTableName(3).show()
+
+    // TODO merge
+
+    val cdfStream1 = streamCDCByPath(0)
+    cdfStream1.awaitTermination(5000)
+    cdfStream1.stop()
+
+    val cdfStream2 = streamCDCByTableName(0)
+    cdfStream2.awaitTermination(5000)
+    cdfStream2.stop()
+  }
+}

--- a/examples/scala/src/main/scala/example/ChangeDataFeed.scala
+++ b/examples/scala/src/main/scala/example/ChangeDataFeed.scala
@@ -89,9 +89,9 @@ object ChangeDataFeed {
 
     readCDCByPath(1).show()
 
-    val table = io.delta.tables.DeltaTable.forPath(path)
-
     spark.read.format("delta").load(path).orderBy("id").show()
+
+    val table = io.delta.tables.DeltaTable.forPath(path)
 
     table.update(Map("id" -> expr("id + 1"))) // v2
 


### PR DESCRIPTION
This PR adds two integration tests / examples for CDF, one in python and one in scala. These integration tests run insert, update, delete, and merge commands on a table with CDF enabled, and then read those CDC changes. They perform both batch and streaming reads.

You can run them using
```
python3 run-integration-tests.py --use-local --scala-only --test ChangeDataFeed
```
and
```
python3 run-integration-tests.py --use-local --python-only --test change_data_feed
```