### PR TITLE
Remove unused class AlterTableReplaceColumnsDeltaCommand

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -506,52 +506,6 @@ case class AlterTableChangeColumnDeltaCommand(
 }
 
 /**
- * A command to replace columns for a Delta table, support changing the comment of a column,
- * reordering columns, and loosening nullabilities.
- *
- * The syntax of using this command in SQL is:
- * {{{
- *   ALTER TABLE table_identifier REPLACE COLUMNS (col_spec[, col_spec ...]);
- * }}}
- */
-case class AlterTableReplaceColumnsDeltaCommand(
-    table: DeltaTableV2,
-    columns: Seq[StructField])
-  extends LeafRunnableCommand with AlterDeltaTableCommand with IgnoreCachedData {
-
-  override def run(sparkSession: SparkSession): Seq[Row] = {
-    val deltaLog = table.deltaLog
-    recordDeltaOperation(deltaLog, "delta.ddl.alter.replaceColumns") {
-      val txn = startTransaction()
-
-      val metadata = txn.metadata
-      val existingSchema = metadata.schema
-
-      val resolver = sparkSession.sessionState.conf.resolver
-      val changingSchema = StructType(columns)
-
-      SchemaUtils.canChangeDataType(existingSchema, changingSchema, resolver,
-        txn.metadata.columnMappingMode).foreach { operation =>
-        throw DeltaErrors.alterTableReplaceColumnsException(
-          existingSchema, changingSchema, operation)
-      }
-
-      val newSchema = SchemaUtils.changeDataType(existingSchema, changingSchema, resolver)
-        .asInstanceOf[StructType]
-
-      SchemaMergingUtils.checkColumnNameDuplication(newSchema, "in replacing columns")
-      SchemaUtils.checkSchemaFieldNames(newSchema, metadata.columnMappingMode)
-
-      val newMetadata = metadata.copy(schemaString = newSchema.json)
-      txn.updateMetadata(newMetadata)
-      txn.commit(Nil, DeltaOperations.ReplaceColumns(columns))
-
-      Seq.empty[Row]
-    }
-  }
-}
-
-/**
  * A command to change the location of a Delta table. Effectively, this only changes the symlink
  * in the Hive MetaStore from one Delta table to another.
  *


### PR DESCRIPTION
## Description

Remove unused class `AlterTableReplaceColumnsDeltaCommand`
 
Resolves #1189