### PR TITLE
[ZOrderBy] Add zOrderBy column names to DeltaOperation

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -343,10 +343,12 @@ object DeltaOperations {
 
   /** Recorded when optimizing the table. */
   case class Optimize(
-      predicate: Seq[String]
+      predicate: Seq[String],
+      zOrderBy: Seq[String] = Seq.empty
   ) extends OptimizeOrReorg(OPTIMIZE_OPERATION_NAME) {
     override val parameters: Map[String, Any] = Map(
-      "predicate" -> JsonUtils.toJson(predicate)
+      "predicate" -> JsonUtils.toJson(predicate),
+      "zOrderBy" -> JsonUtils.toJson(zOrderBy)
     )
 
     override val operationMetrics: Set[String] = DeltaOperationMetrics.OPTIMIZE

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -232,7 +232,7 @@ class OptimizeExecutor(
         val inputFileStats =
           ZOrderFileStats(removedFiles.size, removedFiles.map(_.size.getOrElse(0L)).sum)
         optimizeStats.zOrderStats = Some(ZOrderStats(
-          strategyName = "zorder",
+          strategyName = "all", // process all files in the partition
           inputCubeFiles = ZOrderFileStats(0, 0),
           inputOtherFiles = inputFileStats,
           inputNumCubes = 0,

--- a/core/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeMetricsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeMetricsSuite.scala
@@ -263,15 +263,25 @@ trait OptimizeMetricsSuiteBase extends QueryTest
         assert(metrics.totalFilesSkipped === 0)
         assert(metrics.totalConsideredFiles === metrics.numFilesRemoved)
 
-        val expZOrderMetrics = Some(ZOrderStats(
-          strategyName = "all",
-          inputCubeFiles = ZOrderFileStats(0, 0),
-          inputOtherFiles = ZOrderFileStats(startCount, startSizes.sum),
-          inputNumCubes = 0,
-          mergedFiles = ZOrderFileStats(startCount, startSizes.sum),
-          numOutputCubes = 10 // one for each partition
-          ))
-        assert(metrics.zOrderStats === expZOrderMetrics)
+        val expZOrderMetrics = s"""{
+          |  "strategyName" : "all",
+          |  "inputCubeFiles" : {
+          |    "num" : 0,
+          |    "size" : 0
+          |  },
+          |  "inputOtherFiles" : {
+          |    "num" : $startCount,
+          |    "size" : ${startSizes.sum}
+          |  },
+          |  "inputNumCubes" : 0,
+          |  "mergedFiles" : {
+          |    "num" : $startCount,
+          |    "size" : ${startSizes.sum}
+          |  },
+          |  "numOutputCubes" : 10
+          |}""".stripMargin
+
+        assert(metrics.zOrderStats === Some(JsonUtils.fromJson[ZOrderStats](expZOrderMetrics)))
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add zOrderBy columns to DeltaOperation `Optimize`. This will help log the zOrderBy columns in Delta table history

## How was this patch tested?
Added test for checking the Delta history once the zOrderBy command is complete
Added test to verify the zOrderBy command output. As part of this test a bug was found where we are assigning the number of zCubes constructed as 1. It should be equal to the number of partitions.