### PR TITLE
[1199] Add better error message when delta-storage dependency can't be found

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2148,6 +2148,22 @@ trait DeltaErrorsBase
       messageParameters = Array(dataFilters)
     )
   }
+
+  def missingDeltaStorageJar(e: NoClassDefFoundError): Throwable = {
+    // scalastyle:off line.size.limit
+    new NoClassDefFoundError(
+      s"""${e.getMessage}
+         |Please ensure that the delta-storage dependency is included.
+         |
+         |If using Python, please ensure you call `configure_spark_with_delta_pip` or use
+         |`--packages io.delta:delta-core_<version>`.
+         |See https://docs.delta.io/latest/quick-start.html#python.
+         |
+         |More information about this dependency and how to include it can be found here:
+         |https://docs.delta.io/latest/porting.html#delta-lake-1-1-or-below-to-delta-lake-1-2-or-above.
+         |""".stripMargin)
+    // scalastyle:on line.size.limit
+  }
 }
 
 object DeltaErrors extends DeltaErrorsBase

--- a/core/src/main/scala/org/apache/spark/sql/delta/storage/DelegatingLogStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/storage/DelegatingLogStore.scala
@@ -25,6 +25,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 
 import org.apache.spark.SparkEnv
+import org.apache.spark.sql.delta.DeltaErrors
 
 
 /**
@@ -152,6 +153,14 @@ class DelegatingLogStore(hadoopConf: Configuration)
 }
 
 object DelegatingLogStore {
+
+  try {
+    // load any arbitrary delta-storage class to ensure the dependency has been included
+    classOf[io.delta.storage.S3SingleDriverLogStore]
+  } catch {
+    case e: NoClassDefFoundError =>
+      throw DeltaErrors.missingDeltaStorageJar(e)
+  }
 
   /**
    * Java LogStore (io.delta.storage) implementations are now the default.

--- a/examples/python/missing_delta_storage_jar.py
+++ b/examples/python/missing_delta_storage_jar.py
@@ -23,8 +23,6 @@ try:
     # Clear any previous runs
     shutil.rmtree(path, ignore_errors=True)
 
-    # Enable SQL commands and Update/Delete/Merge for the current spark session.
-    # we need to set the following configs
     spark = SparkSession.builder \
         .appName("missing logstore jar") \
         .master("local[*]") \

--- a/examples/python/missing_delta_storage_jar.py
+++ b/examples/python/missing_delta_storage_jar.py
@@ -1,0 +1,46 @@
+#
+# Copyright (2021) The Delta Lake Project Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyspark.sql import SparkSession
+import shutil
+
+path = "/tmp/delta-table/missing_logstore_jar"
+
+try:
+    # Clear any previous runs
+    shutil.rmtree(path, ignore_errors=True)
+
+    # Enable SQL commands and Update/Delete/Merge for the current spark session.
+    # we need to set the following configs
+    spark = SparkSession.builder \
+        .appName("missing logstore jar") \
+        .master("local[*]") \
+        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
+        .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog") \
+        .getOrCreate()
+
+    spark.range(0, 5).write.format("delta").save(path)
+
+except Exception as e:
+    assert "Please ensure that the delta-storage dependency is included." in str(e)
+    print("SUCCESS - error was thrown, as expected")
+
+else:
+    assert False, "The write to the delta table should have thrown without the delta-storage JAR."
+
+finally:
+    # cleanup
+    shutil.rmtree(path, ignore_errors=True)

--- a/run-integration-tests.py
+++ b/run-integration-tests.py
@@ -135,7 +135,6 @@ def test_missing_delta_storage_jar(root_dir, version, use_local):
         raise
 
 
-
 def run_dynamodb_logstore_integration_tests(root_dir, version, test_name, extra_maven_repo,
                                             extra_packages, conf, use_local):
     print(

--- a/run-integration-tests.py
+++ b/run-integration-tests.py
@@ -68,7 +68,7 @@ def run_python_integration_tests(root_dir, version, test_name, extra_maven_repo,
         run_cmd(["build/sbt", "publishM2"])
 
     test_dir = path.join(root_dir, path.join("examples", "python"))
-    files_to_skip = {"using_with_pip.py"}
+    files_to_skip = {"using_with_pip.py", "missing_delta_storage_jar.py"}
 
     test_files = [path.join(test_dir, f) for f in os.listdir(test_dir)
                   if path.isfile(path.join(test_dir, f)) and

--- a/run-integration-tests.py
+++ b/run-integration-tests.py
@@ -98,6 +98,44 @@ def run_python_integration_tests(root_dir, version, test_name, extra_maven_repo,
             raise
 
 
+def test_missing_delta_storage_jar(root_dir, version, use_local):
+    if not use_local:
+        print("Skipping 'missing_delta_storage_jar' - test should only run in local mode")
+        return
+
+    print("\n\n##### Running 'missing_delta_storage_jar' on version %s #####" % str(version))
+
+    clear_artifact_cache()
+
+    run_cmd(["build/sbt", "publishM2"])
+
+    print("Clearing delta-storage artifact")
+    delete_if_exists(os.path.expanduser("~/.m2/repository/io/delta/delta-storage"))
+    delete_if_exists(os.path.expanduser("~/.ivy2/cache/io.delta/delta-storage"))
+    delete_if_exists(os.path.expanduser("~/.ivy2/local/io.delta/delta-storage"))
+
+    python_root_dir = path.join(root_dir, "python")
+    extra_class_path = path.join(python_root_dir, path.join("delta", "testing"))
+    test_file = path.join(root_dir, path.join("examples", "python", "missing_delta_storage_jar.py"))
+    jar = path.join(
+        os.path.expanduser("~/.m2/repository/io/delta/"),
+        "delta-core_2.12",
+        version,
+        "delta-core_2.12-%s.jar" % str(version))
+
+    try:
+        cmd = ["spark-submit",
+               "--driver-class-path=%s" % extra_class_path,  # for less verbose logging
+               "--jars", jar, test_file]
+        print("\nRunning Python tests in %s\n=============" % test_file)
+        print("Command: %s" % " ".join(cmd))
+        run_cmd(cmd, stream_output=True)
+    except:
+        print("Failed Python tests in %s" % (test_file))
+        raise
+
+
+
 def run_dynamodb_logstore_integration_tests(root_dir, version, test_name, extra_maven_repo,
                                             extra_packages, conf, use_local):
     print(
@@ -337,6 +375,8 @@ if __name__ == "__main__":
     if run_python:
         run_python_integration_tests(root_dir, args.version, args.test, args.maven_repo,
                                      args.use_local)
+
+        test_missing_delta_storage_jar(root_dir, args.version, args.use_local)
 
     if run_pip:
         run_pip_installation_tests(root_dir, args.version, args.use_testpypi, args.maven_repo)


### PR DESCRIPTION
## Description

Resolves #1199 
 
This PR checks that classes within the delta-storage dependency can be properly found. If not, we throw an error message with more information and link on how to solve this problem.

## How was this patch tested?
Wrote an integration test. In this test, we run a python file using `spark-submit` by passing in the `delta-core` JAR instead of the package. This is not the suggested way to do this. But by doing it this way, we know that the `delta-storage` JAR will be missing, and that we can expect our nice error message to be thrown.

You can execute this test using: `python3 run-integration-tests.py --python-only --use-local`