### PR TITLE
Allow for schema pruning during update check for files to touch

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
@@ -128,8 +128,8 @@ case class UpdateCommand(
       val pathsToRewrite =
         withStatusCode("DELTA", UpdateCommand.FINDING_TOUCHED_FILES_MSG) {
           data.filter(new Column(updateCondition))
-            .filter(updatedRowUdf())
             .select(input_file_name())
+            .filter(updatedRowUdf())
             .distinct()
             .as[String]
             .collect()

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -28,7 +28,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.scheduler.{SparkListener, SparkListenerJobStart}
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.execution.QueryExecution
+import org.apache.spark.sql.execution.{QueryExecution, SparkPlan}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.util.QueryExecutionListener
 
@@ -57,6 +57,16 @@ trait DeltaTestUtilsBase {
       funcName: String, qe: QueryExecution, error: Exception): Unit = {}
   }
 
+  class PhysicalPlanCapturingListener() extends QueryExecutionListener {
+    val plans = new ArrayBuffer[SparkPlan]
+    override def onSuccess(funcName: String, qe: QueryExecution, durationNs: Long): Unit = {
+      plans.append(qe.sparkPlan)
+    }
+
+    override def onFailure(
+      funcName: String, qe: QueryExecution, error: Exception): Unit = {}
+  }
+
   /**
    * Run a thunk with physical plans for all queries captured and passed into a provided buffer.
    */
@@ -65,6 +75,25 @@ trait DeltaTestUtilsBase {
       optimizedPlan: Boolean)(
       thunk: => Unit): ArrayBuffer[LogicalPlan] = {
     val planCapturingListener = new LogicalPlanCapturingListener(optimizedPlan)
+
+    spark.sparkContext.listenerBus.waitUntilEmpty(15000)
+    spark.listenerManager.register(planCapturingListener)
+    try {
+      thunk
+      spark.sparkContext.listenerBus.waitUntilEmpty(15000)
+      planCapturingListener.plans
+    } finally {
+      spark.listenerManager.unregister(planCapturingListener)
+    }
+  }
+
+  /**
+   * Run a thunk with physical plans for all queries captured and passed into a provided buffer.
+   */
+  def withPhysicalPlansCaptured[T](
+      spark: SparkSession)(
+      thunk: => Unit): ArrayBuffer[SparkPlan] = {
+    val planCapturingListener = new PhysicalPlanCapturingListener()
 
     spark.sparkContext.listenerBus.waitUntilEmpty(15000)
     spark.listenerManager.register(planCapturingListener)

--- a/core/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
@@ -26,6 +26,7 @@ import org.apache.hadoop.fs.Path
 import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
+import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
 import org.apache.spark.sql.types._
@@ -651,6 +652,21 @@ abstract class UpdateSuiteBase
       arrayStructData,
       set = "a.b = array(-1)" :: Nil,
       errMsgs = "Updating nested fields is only supported for StructType" :: Nil)
+  }
+
+  test("schema pruning on finding files to update") {
+    append(Seq((2, 2), (1, 4), (1, 1), (0, 3)).toDF("key", "value"))
+    // spark.conf.set("spark.sql.adaptive.enabled", "false")
+    val executedPlans = DeltaTestUtils.withPhysicalPlansCaptured(spark) {
+      checkUpdate(condition = Some("key = 2"), setClauses = "key = 1, value = 3",
+        expectedResults = Row(1, 3) :: Row(1, 4) :: Row(1, 1) :: Row(0, 3) :: Nil)
+    }
+    val scans = executedPlans.flatMap(_.collect {
+      case f: FileSourceScanExec => f
+    })
+    // The first scan is for finding files to update. We only are matching against the key
+    // so that should be the only field in the schema
+    assert(scans.head.schema == StructType(Seq(StructField("key", IntegerType))))
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Resolves #1201

Allows for schema pruning in the first part of an update to check for files to touch. 

Code snippet I ran:
```python
>>> import pyspark.sql.functions as F
>>> from delta.tables import DeltaTable
>>> table = DeltaTable.forPath(spark, "test")
>>> table.toDF().printSchema()
root
 |-- key: string (nullable = true)
 |-- value: long (nullable = true)

>>> table.update("key = 'c'", set={'value': F.lit(6)})
```

The execution plan for the find files to update:
before:
```
(1) Scan parquet 
Output [2]: [key#526, value#527L]
Batched: true
Location: TahoeBatchFileIndex [file:.../projects/delta/test]
PushedFilters: [IsNotNull(key), EqualTo(key,c)]
ReadSchema: struct<key:string,value:bigint>
```

after:
```
(1) Scan parquet 
Output [1]: [key#686]
Batched: true
Location: TahoeBatchFileIndex [file:.../projects/delta/test]
PushedFilters: [IsNotNull(key), EqualTo(key,c)]
ReadSchema: struct<key:string>
```

Only key is read, not value as well. The line swap should result in the same behavior, but doing the select before the nonDeterminstic UDF allows schema pruning to happen.

## How was this patch tested?
Existing UTs plus screenshot of execution plan.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Performance improvement for update with data predicate.
