### PR TITLE
Create `predicateToken` to workaround an ANTLR issue to fix Optimize command parsing

### DIFF
--- a/core/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
+++ b/core/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
@@ -87,7 +87,7 @@ statement
     | ALTER TABLE table=qualifiedName
         DROP CONSTRAINT (IF EXISTS)? name=identifier                    #dropTableConstraint
     | OPTIMIZE (path=STRING | table=qualifiedName)
-        (WHERE partitionPredicate = exprToken)?
+        (WHERE partitionPredicate = predicateToken)?
         (zorderSpec)?                                                   #optimizeTable
     | .*?                                                               #passThrough
     ;
@@ -140,6 +140,13 @@ number
 
 constraint
     : CHECK '(' exprToken+ ')'                                 #checkConstraint
+    ;
+
+// We don't have an expression rule in our grammar here, so we just grab the tokens and defer
+// parsing them to later. Although this is the same as `exprToken`, we have to re-define it to
+// workaround an ANTLR issue (https://github.com/delta-io/delta/issues/1205)
+predicateToken
+    :  .+?
     ;
 
 // We don't have an expression rule in our grammar here, so we just grab the tokens and defer

--- a/core/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
+++ b/core/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
@@ -285,7 +285,7 @@ class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
     tokens.map(_.getText).mkString(" ")
   }
 
-  private def extractRawText(exprContext: ExprTokenContext): String = {
+  private def extractRawText(exprContext: ParserRuleContext): String = {
     // Extract the raw expression which will be parsed later
     exprContext.getStart.getInputStream.getText(new Interval(
       exprContext.getStart.getStartIndex,

--- a/core/src/test/scala/io/delta/sql/parser/DeltaSqlParserSuite.scala
+++ b/core/src/test/scala/io/delta/sql/parser/DeltaSqlParserSuite.scala
@@ -66,6 +66,10 @@ class DeltaSqlParserSuite extends SparkFunSuite {
     assert(parser.parsePlan("OPTIMIZE tbl WHERE part = 1 ZORDER BY col1, col2.subcol") ===
       OptimizeTableCommand(None, Some(tblId("tbl")), Some("part = 1"))(
         Seq(unresolvedAttr("col1"), unresolvedAttr("col2", "subcol"))))
+
+    assert(parser.parsePlan("OPTIMIZE tbl WHERE part = 1 ZORDER BY (col1, col2.subcol)") ===
+      OptimizeTableCommand(None, Some(tblId("tbl")), Some("part = 1"))(
+        Seq(unresolvedAttr("col1"), unresolvedAttr("col2", "subcol"))))
   }
 
   test("OPTIMIZE command new tokens are non-reserved keywords") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Fixes https://github.com/delta-io/delta/issues/1205 

It's unclear which ANTLR issue we are hitting. But creating a new `predicateToken` fix it.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

The new added test

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
