### PR TITLE
Add feature flag for dynamic partition overwrite

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -116,16 +116,21 @@ trait DeltaWriteOptionsImpl extends DeltaOptionParser {
 
   /** Whether to only overwrite partitions that have data written into it at runtime. */
   def isDynamicPartitionOverwriteMode: Boolean = {
-    val mode = options.get(PARTITION_OVERWRITE_MODE_OPTION)
-      .getOrElse(sqlConf.getConf(SQLConf.PARTITION_OVERWRITE_MODE))
-    if (!DeltaOptions.PARTITION_OVERWRITE_MODE_VALUES.exists(mode.equalsIgnoreCase(_))) {
-      val acceptableStr =
-        DeltaOptions.PARTITION_OVERWRITE_MODE_VALUES.map("'" + _ + "'").mkString(" or ")
-      throw DeltaErrors.illegalDeltaOptionException(
-        PARTITION_OVERWRITE_MODE_OPTION, mode, s"must be ${acceptableStr}"
-      )
+    if (!sqlConf.getConf(DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED)) {
+      // If dynamic partition overwrite mode is disabled, fallback to the default behavior
+      false
+    } else {
+      val mode = options.get(PARTITION_OVERWRITE_MODE_OPTION)
+        .getOrElse(sqlConf.getConf(SQLConf.PARTITION_OVERWRITE_MODE))
+      if (!DeltaOptions.PARTITION_OVERWRITE_MODE_VALUES.exists(mode.equalsIgnoreCase(_))) {
+        val acceptableStr =
+          DeltaOptions.PARTITION_OVERWRITE_MODE_VALUES.map("'" + _ + "'").mkString(" or ")
+        throw DeltaErrors.illegalDeltaOptionException(
+          PARTITION_OVERWRITE_MODE_OPTION, mode, s"must be ${acceptableStr}"
+        )
+      }
+      mode.equalsIgnoreCase("DYNAMIC")
     }
-    mode.equalsIgnoreCase("DYNAMIC")
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -737,6 +737,14 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(false)
   }
+  val DYNAMIC_PARTITION_OVERWRITE_ENABLED =
+    buildConf("partitionOverwriteMode.dynamic.enabled")
+      .doc("Whether to overwrite partitions dynamically when 'partitionOverwriteMode' is set to " +
+        "'dynamic' in either the SQL conf, or a DataFrameWriter option. When this is disabled " +
+        "'partitionOverwriteMode' will be ignored.")
+      .internal()
+      .booleanConf
+      .createWithDefault(true)
 }
 
 object DeltaSQLConf extends DeltaSQLConfBase

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -737,8 +737,9 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(false)
   }
+
   val DYNAMIC_PARTITION_OVERWRITE_ENABLED =
-    buildConf("partitionOverwriteMode.dynamic.enabled")
+    buildConf("dynamicPartitionOverwrite.enabled")
       .doc("Whether to overwrite partitions dynamically when 'partitionOverwriteMode' is set to " +
         "'dynamic' in either the SQL conf, or a DataFrameWriter option. When this is disabled " +
         "'partitionOverwriteMode' will be ignored.")

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
@@ -265,6 +265,7 @@ class DeltaOptionSuite extends QueryTest
       }
     }
   }
+
   test("DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED = false: " +
     "partitionOverwriteMode is set to invalid value in options") {
     // partitionOverwriteMode is ignored and no error is thrown

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
@@ -21,6 +21,7 @@ import java.util.Locale
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.DeltaOptions.PARTITION_OVERWRITE_MODE_OPTION
 import org.apache.spark.sql.delta.actions.{Action, FileAction}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.util.FileNames
 import org.apache.commons.io.FileUtils
@@ -242,10 +243,34 @@ class DeltaOptionSuite extends QueryTest
     }
   }
 
-  test("partitionOverwriteMode is set to invalid value in options") {
-    withTempDir { tempDir =>
-      val invalidMode = "ADAPTIVE"
-      val e = intercept[IllegalArgumentException] {
+  test("DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED = true: " +
+    "partitionOverwriteMode is set to invalid value in options") {
+    withSQLConf(DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key -> "true") {
+      withTempDir { tempDir =>
+        val invalidMode = "ADAPTIVE"
+        val e = intercept[IllegalArgumentException] {
+          Seq(1, 2, 3).toDF
+            .withColumn("part", $"value" % 2)
+            .write
+            .format("delta")
+            .partitionBy("part")
+            .option("partitionOverwriteMode", invalidMode)
+            .save(tempDir.getAbsolutePath)
+        }
+        assert(e.getMessage ===
+          DeltaErrors.illegalDeltaOptionException(
+            PARTITION_OVERWRITE_MODE_OPTION, invalidMode, "must be 'STATIC' or 'DYNAMIC'"
+          ).getMessage
+        )
+      }
+    }
+  }
+  test("DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED = false: " +
+    "partitionOverwriteMode is set to invalid value in options") {
+    // partitionOverwriteMode is ignored and no error is thrown
+    withSQLConf(DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key -> "false") {
+      withTempDir { tempDir =>
+        val invalidMode = "ADAPTIVE"
         Seq(1, 2, 3).toDF
           .withColumn("part", $"value" % 2)
           .write
@@ -254,11 +279,6 @@ class DeltaOptionSuite extends QueryTest
           .option("partitionOverwriteMode", invalidMode)
           .save(tempDir.getAbsolutePath)
       }
-      assert(e.getMessage ===
-        DeltaErrors.illegalDeltaOptionException(
-          PARTITION_OVERWRITE_MODE_OPTION, invalidMode, "must be 'STATIC' or 'DYNAMIC'"
-        ).getMessage
-      )
     }
   }
 }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -669,6 +669,9 @@ class DeltaSuite extends QueryTest
 
   test("DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED = false: defaults to static overwrites") {
     withSQLConf(DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key -> "false") {
+      // This checks that when dynamic partition overwrite mode is disabled, we return to our
+      // previous behavior: setting `partitionOverwriteMode` to `dynamic` is a no-op, and we
+      // statically overwrite data
 
       // DataFrame write, dynamic partition overwrite enabled in DataFrameWriter option
       withTempDir { tempDir =>

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -667,153 +667,194 @@ class DeltaSuite extends QueryTest
     }
   }
 
+  test("DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED = false: defaults to static overwrites") {
+    withSQLConf(DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key -> "false") {
+      withTempDir { tempDir =>
+        def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
+
+        Seq(1, 2, 3).toDF
+          .withColumn("part", $"value" % 2)
+          .write
+          .format("delta")
+          .partitionBy("part")
+          .mode("append")
+          .save(tempDir.getCanonicalPath)
+
+        Seq(1, 5).toDF
+          .withColumn("part", $"value" % 2)
+          .write
+          .format("delta")
+          .partitionBy("part")
+          .mode("overwrite")
+          .option(DeltaOptions.PARTITION_OVERWRITE_MODE_OPTION, "dynamic")
+          .save(tempDir.getCanonicalPath)
+        checkDatasetUnorderly(data.select("value").as[Int], 1, 5)
+      }
+
+      withSQLConf(SQLConf.PARTITION_OVERWRITE_MODE.key -> "dynamic") {
+        withTempDir { tempDir =>
+          def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
+
+          Seq(1, 2, 3).toDF
+            .withColumn("part", $"value" % 2)
+            .write
+            .format("delta")
+            .partitionBy("part")
+            .mode("append")
+            .save(tempDir.getCanonicalPath)
+
+          Seq(1, 5).toDF
+            .withColumn("part", $"value" % 2)
+            .write
+            .format("delta")
+            .partitionBy("part")
+            .mode("overwrite")
+            .save(tempDir.getCanonicalPath)
+          checkDatasetUnorderly(data.select("value").as[Int], 1, 5)
+        }
+      }
+
+      withSQLConf(SQLConf.PARTITION_OVERWRITE_MODE.key ->  "dynamic") {
+        val table_name = "test_table"
+        withTable(table_name) {
+          spark.sql(
+            s"CREATE TABLE $table_name (value int, part int) USING DELTA PARTITIONED BY (part)")
+          spark.sql(s"INSERT INTO $table_name VALUES (1, 1), (2, 0), (3, 1)")
+          spark.sql(s"INSERT OVERWRITE $table_name VALUES (1, 1), (5, 1)")
+          checkDatasetUnorderly(spark.sql(s"SELECT value FROM $table_name").as[Int], 1, 5)
+        }
+      }
+    }
+  }
+
   test("batch write: append, dynamic partition overwrite integer partition column") {
-    withTempDir { tempDir =>
-      def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
+    withSQLConf(DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key -> "true") {
+      withTempDir { tempDir =>
+        def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
 
-      Seq(1, 2, 3).toDF
-        .withColumn("part", $"value" % 2)
-        .write
-        .format("delta")
-        .partitionBy("part")
-        .mode("append")
-        .save(tempDir.getCanonicalPath)
+        Seq(1, 2, 3).toDF
+          .withColumn("part", $"value" % 2)
+          .write
+          .format("delta")
+          .partitionBy("part")
+          .mode("append")
+          .save(tempDir.getCanonicalPath)
 
-      Seq(1, 5).toDF
-        .withColumn("part", $"value" % 2)
-        .write
-        .format("delta")
-        .partitionBy("part")
-        .mode("overwrite")
-        .option(DeltaOptions.PARTITION_OVERWRITE_MODE_OPTION, "dynamic")
-        .save(tempDir.getCanonicalPath)
-      checkDatasetUnorderly(data.select("value").as[Int], 1, 2, 5)
+        Seq(1, 5).toDF
+          .withColumn("part", $"value" % 2)
+          .write
+          .format("delta")
+          .partitionBy("part")
+          .mode("overwrite")
+          .option(DeltaOptions.PARTITION_OVERWRITE_MODE_OPTION, "dynamic")
+          .save(tempDir.getCanonicalPath)
+        checkDatasetUnorderly(data.select("value").as[Int], 1, 2, 5)
+      }
     }
   }
 
   test("batch write: append, dynamic partition overwrite string partition column") {
-    withTempDir { tempDir =>
-      def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
+    withSQLConf(DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key -> "true") {
+      withTempDir { tempDir =>
+        def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
 
-      Seq(("a", "x"), ("b", "y"), ("c", "x")).toDF("value", "part")
-        .write
-        .format("delta")
-        .partitionBy("part")
-        .mode("append")
-        .save(tempDir.getCanonicalPath)
+        Seq(("a", "x"), ("b", "y"), ("c", "x")).toDF("value", "part")
+          .write
+          .format("delta")
+          .partitionBy("part")
+          .mode("append")
+          .save(tempDir.getCanonicalPath)
 
-      Seq(("a", "x"), ("d", "x")).toDF("value", "part")
-        .write
-        .format("delta")
-        .partitionBy("part")
-        .mode("overwrite")
-        .option(DeltaOptions.PARTITION_OVERWRITE_MODE_OPTION, "dynamic")
-        .save(tempDir.getCanonicalPath)
-      checkDatasetUnorderly(data.select("value").as[String], "a", "b", "d")
+        Seq(("a", "x"), ("d", "x")).toDF("value", "part")
+          .write
+          .format("delta")
+          .partitionBy("part")
+          .mode("overwrite")
+          .option(DeltaOptions.PARTITION_OVERWRITE_MODE_OPTION, "dynamic")
+          .save(tempDir.getCanonicalPath)
+        checkDatasetUnorderly(data.select("value").as[String], "a", "b", "d")
+      }
     }
   }
 
   test("batch write: append, dynamic partition overwrite overwrites nothing") {
-    withTempDir { tempDir =>
-      def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
+    withSQLConf(DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key -> "true") {
+      withTempDir { tempDir =>
+        def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
 
-      Seq(("a", "x"), ("b", "y"), ("c", "x")).toDF("value", "part")
-        .write
-        .format("delta")
-        .partitionBy("part")
-        .mode("append")
-        .save(tempDir.getCanonicalPath)
+        Seq(("a", "x"), ("b", "y"), ("c", "x")).toDF("value", "part")
+          .write
+          .format("delta")
+          .partitionBy("part")
+          .mode("append")
+          .save(tempDir.getCanonicalPath)
 
-      Seq(("d", "z")).toDF("value", "part")
-        .write
-        .format("delta")
-        .partitionBy("part")
-        .mode("overwrite")
-        .option(DeltaOptions.PARTITION_OVERWRITE_MODE_OPTION, "dynamic")
-        .save(tempDir.getCanonicalPath)
-      checkDatasetUnorderly(data.select("value", "part").as[(String, String)],
-        ("a", "x"), ("b", "y"), ("c", "x"), ("d", "z"))
+        Seq(("d", "z")).toDF("value", "part")
+          .write
+          .format("delta")
+          .partitionBy("part")
+          .mode("overwrite")
+          .option(DeltaOptions.PARTITION_OVERWRITE_MODE_OPTION, "dynamic")
+          .save(tempDir.getCanonicalPath)
+        checkDatasetUnorderly(data.select("value", "part").as[(String, String)],
+          ("a", "x"), ("b", "y"), ("c", "x"), ("d", "z"))
+      }
     }
   }
 
   test("batch write: append, dynamic partition overwrite multiple partition columns") {
-    withTempDir { tempDir =>
-      def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
+    withSQLConf(DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key -> "true") {
+      withTempDir { tempDir =>
+        def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
 
-      Seq(("a", "x", 1), ("b", "y", 2), ("c", "x", 3)).toDF("part1", "part2", "value")
-        .write
-        .format("delta")
-        .partitionBy("part1", "part2")
-        .mode("append")
-        .save(tempDir.getCanonicalPath)
+        Seq(("a", "x", 1), ("b", "y", 2), ("c", "x", 3)).toDF("part1", "part2", "value")
+          .write
+          .format("delta")
+          .partitionBy("part1", "part2")
+          .mode("append")
+          .save(tempDir.getCanonicalPath)
 
-      Seq(("a", "x", 4), ("d", "x", 5)).toDF("part1", "part2", "value")
-        .write
-        .format("delta")
-        .partitionBy("part1", "part2")
-        .mode("overwrite")
-        .option(DeltaOptions.PARTITION_OVERWRITE_MODE_OPTION, "dynamic")
-        .save(tempDir.getCanonicalPath)
-      checkDatasetUnorderly(data.select("part1", "part2", "value").as[(String, String, Int)],
-        ("a", "x", 4), ("b", "y", 2), ("c", "x", 3), ("d", "x", 5))
+        Seq(("a", "x", 4), ("d", "x", 5)).toDF("part1", "part2", "value")
+          .write
+          .format("delta")
+          .partitionBy("part1", "part2")
+          .mode("overwrite")
+          .option(DeltaOptions.PARTITION_OVERWRITE_MODE_OPTION, "dynamic")
+          .save(tempDir.getCanonicalPath)
+        checkDatasetUnorderly(data.select("part1", "part2", "value").as[(String, String, Int)],
+          ("a", "x", 4), ("b", "y", 2), ("c", "x", 3), ("d", "x", 5))
+      }
     }
   }
 
   test("batch write: append, dynamic partition overwrite without partitionBy") {
-    withTempDir { tempDir =>
-      def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
+    withSQLConf(DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key -> "true") {
+      withTempDir { tempDir =>
+        def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
 
-      Seq(1, 2, 3).toDF
-        .withColumn("part", $"value" % 2)
-        .write
-        .format("delta")
-        .partitionBy("part")
-        .mode("append")
-        .save(tempDir.getCanonicalPath)
+        Seq(1, 2, 3).toDF
+          .withColumn("part", $"value" % 2)
+          .write
+          .format("delta")
+          .partitionBy("part")
+          .mode("append")
+          .save(tempDir.getCanonicalPath)
 
-      Seq(1, 5).toDF
-        .withColumn("part", $"value" % 2)
-        .write
-        .format("delta")
-        .mode("overwrite")
-        .option(DeltaOptions.PARTITION_OVERWRITE_MODE_OPTION, "dynamic")
-        .save(tempDir.getCanonicalPath)
-      checkDatasetUnorderly(data.select("value").as[Int], 1, 2, 5)
+        Seq(1, 5).toDF
+          .withColumn("part", $"value" % 2)
+          .write
+          .format("delta")
+          .mode("overwrite")
+          .option(DeltaOptions.PARTITION_OVERWRITE_MODE_OPTION, "dynamic")
+          .save(tempDir.getCanonicalPath)
+        checkDatasetUnorderly(data.select("value").as[Int], 1, 2, 5)
+      }
     }
   }
 
   test(
     "batch write: append, dynamic partition overwrite option not supported with replaceWhere") {
-    withTempDir { tempDir =>
-      def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
-
-      Seq((1, "x"), (2, "y"), (3, "z")).toDF("value", "part2")
-        .withColumn("part1", $"value" % 2)
-        .write
-        .format("delta")
-        .partitionBy("part1", "part2")
-        .mode("append")
-        .save(tempDir.getCanonicalPath)
-
-      val e = intercept[AnalysisException] {
-        Seq((3, "x"), (5, "x")).toDF("value", "part2")
-          .withColumn("part1", $"value" % 2)
-          .write
-          .format("delta")
-          .partitionBy("part1", "part2")
-          .mode("overwrite")
-          .option(DeltaOptions.REPLACE_WHERE_OPTION, "part1 = 1")
-          .option(DeltaOptions.PARTITION_OVERWRITE_MODE_OPTION, "dynamic")
-          .save(tempDir.getCanonicalPath)
-      }
-      assert(e.getMessage ===
-        "'replaceWhere' cannot be used when 'partitionOverwriteMode' is set to 'DYNAMIC'")
-    }
-  }
-
-  test(
-    "batch write: append, dynamic partition overwrite conf not supported with replaceWhere") {
-    withSQLConf(SQLConf.PARTITION_OVERWRITE_MODE.key -> "dynamic") {
+    withSQLConf(DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key -> "true") {
       withTempDir { tempDir =>
         def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
 
@@ -833,6 +874,7 @@ class DeltaSuite extends QueryTest
             .partitionBy("part1", "part2")
             .mode("overwrite")
             .option(DeltaOptions.REPLACE_WHERE_OPTION, "part1 = 1")
+            .option(DeltaOptions.PARTITION_OVERWRITE_MODE_OPTION, "dynamic")
             .save(tempDir.getCanonicalPath)
         }
         assert(e.getMessage ===
@@ -841,34 +883,97 @@ class DeltaSuite extends QueryTest
     }
   }
 
+  test(
+    "batch write: append, dynamic partition overwrite conf not supported with replaceWhere") {
+    withSQLConf(DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key -> "true") {
+      withSQLConf(SQLConf.PARTITION_OVERWRITE_MODE.key -> "dynamic") {
+        withTempDir { tempDir =>
+          def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
+
+          Seq((1, "x"), (2, "y"), (3, "z")).toDF("value", "part2")
+            .withColumn("part1", $"value" % 2)
+            .write
+            .format("delta")
+            .partitionBy("part1", "part2")
+            .mode("append")
+            .save(tempDir.getCanonicalPath)
+
+          val e = intercept[AnalysisException] {
+            Seq((3, "x"), (5, "x")).toDF("value", "part2")
+              .withColumn("part1", $"value" % 2)
+              .write
+              .format("delta")
+              .partitionBy("part1", "part2")
+              .mode("overwrite")
+              .option(DeltaOptions.REPLACE_WHERE_OPTION, "part1 = 1")
+              .save(tempDir.getCanonicalPath)
+          }
+          assert(e.getMessage ===
+            "'replaceWhere' cannot be used when 'partitionOverwriteMode' is set to 'DYNAMIC'")
+        }
+      }
+    }
+  }
+
   test("batch write: append, dynamic partition overwrite set via conf") {
-    withSQLConf(SQLConf.PARTITION_OVERWRITE_MODE.key -> "dynamic") {
-      withTempDir { tempDir =>
-        def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
+    withSQLConf(DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key -> "true") {
+      withSQLConf(SQLConf.PARTITION_OVERWRITE_MODE.key -> "dynamic") {
+        withTempDir { tempDir =>
+          def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
 
-        Seq(1, 2, 3).toDF
-          .withColumn("part", $"value" % 2)
-          .write
-          .format("delta")
-          .partitionBy("part")
-          .mode("append")
-          .save(tempDir.getCanonicalPath)
+          Seq(1, 2, 3).toDF
+            .withColumn("part", $"value" % 2)
+            .write
+            .format("delta")
+            .partitionBy("part")
+            .mode("append")
+            .save(tempDir.getCanonicalPath)
 
-        Seq(1, 5).toDF
-          .withColumn("part", $"value" % 2)
-          .write
-          .format("delta")
-          .partitionBy("part")
-          .mode("overwrite")
-          .save(tempDir.getCanonicalPath)
-        checkDatasetUnorderly(data.select("value").as[Int], 1, 2, 5)
+          Seq(1, 5).toDF
+            .withColumn("part", $"value" % 2)
+            .write
+            .format("delta")
+            .partitionBy("part")
+            .mode("overwrite")
+            .save(tempDir.getCanonicalPath)
+          checkDatasetUnorderly(data.select("value").as[Int], 1, 2, 5)
+        }
       }
     }
   }
 
   test(
     "batch write: append, dynamic partition overwrite set via conf and overridden via option") {
-    withSQLConf(SQLConf.PARTITION_OVERWRITE_MODE.key -> "dynamic") {
+    withSQLConf(DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key -> "true") {
+      withSQLConf(SQLConf.PARTITION_OVERWRITE_MODE.key -> "dynamic") {
+        withTempDir { tempDir =>
+          def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
+
+          Seq(1, 2, 3).toDF
+            .withColumn("part", $"value" % 2)
+            .write
+            .format("delta")
+            .partitionBy("part")
+            .mode("append")
+            .save(tempDir.getCanonicalPath)
+
+          Seq(1, 5).toDF
+            .withColumn("part", $"value" % 2)
+            .write
+            .format("delta")
+            .partitionBy("part")
+            .option(DeltaOptions.PARTITION_OVERWRITE_MODE_OPTION, "static")
+            .mode("overwrite")
+            .save(tempDir.getCanonicalPath)
+          checkDatasetUnorderly(data.select("value").as[Int], 1, 5)
+        }
+      }
+    }
+  }
+
+  test(
+    "batch write: append, overwrite without partitions should ignore partition overwrite mode") {
+    withSQLConf(DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key -> "true") {
       withTempDir { tempDir =>
         def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
 
@@ -876,7 +981,6 @@ class DeltaSuite extends QueryTest
           .withColumn("part", $"value" % 2)
           .write
           .format("delta")
-          .partitionBy("part")
           .mode("append")
           .save(tempDir.getCanonicalPath)
 
@@ -884,35 +988,11 @@ class DeltaSuite extends QueryTest
           .withColumn("part", $"value" % 2)
           .write
           .format("delta")
-          .partitionBy("part")
-          .option(DeltaOptions.PARTITION_OVERWRITE_MODE_OPTION, "static")
           .mode("overwrite")
+          .option(DeltaOptions.PARTITION_OVERWRITE_MODE_OPTION, "dynamic")
           .save(tempDir.getCanonicalPath)
         checkDatasetUnorderly(data.select("value").as[Int], 1, 5)
       }
-    }
-  }
-
-  test(
-    "batch write: append, overwrite without partitions should ignore partition overwrite mode") {
-    withTempDir { tempDir =>
-      def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
-
-      Seq(1, 2, 3).toDF
-        .withColumn("part", $"value" % 2)
-        .write
-        .format("delta")
-        .mode("append")
-        .save(tempDir.getCanonicalPath)
-
-      Seq(1, 5).toDF
-        .withColumn("part", $"value" % 2)
-        .write
-        .format("delta")
-        .mode("overwrite")
-        .option(DeltaOptions.PARTITION_OVERWRITE_MODE_OPTION, "dynamic")
-        .save(tempDir.getCanonicalPath)
-      checkDatasetUnorderly(data.select("value").as[Int], 1, 5)
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -669,6 +669,8 @@ class DeltaSuite extends QueryTest
 
   test("DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED = false: defaults to static overwrites") {
     withSQLConf(DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key -> "false") {
+
+      // DataFrame write, dynamic partition overwrite enabled in DataFrameWriter option
       withTempDir { tempDir =>
         def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
 
@@ -691,6 +693,7 @@ class DeltaSuite extends QueryTest
         checkDatasetUnorderly(data.select("value").as[Int], 1, 5)
       }
 
+      // DataFrame write, dynamic partition overwrite enabled in sparkConf
       withSQLConf(SQLConf.PARTITION_OVERWRITE_MODE.key -> "dynamic") {
         withTempDir { tempDir =>
           def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
@@ -714,6 +717,7 @@ class DeltaSuite extends QueryTest
         }
       }
 
+      // SQL write
       withSQLConf(SQLConf.PARTITION_OVERWRITE_MODE.key ->  "dynamic") {
         val table_name = "test_table"
         withTable(table_name) {


### PR DESCRIPTION
### Changes

This pull request adds a feature flag `DYNAMIC_PARTITION_OVERWRITE_ENABLED` for dynamic partition overwrite mode.

### Testing
Adds tests to `DeltaSuite` and `DeltaOptionsSuite` to check when it's disabled.

