### PR TITLE
[1105] Block commits when CDF enabled + DROP/RENAME operation + FileActions

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -39,6 +39,10 @@
     "message" : [ "CREATE TABLE contains two different locations: <identifier> and <location>.", "You can remove the LOCATION clause from the CREATE TABLE statement, or set", "<config> to true to skip this check.", "" ],
     "sqlState" : "42000"
   },
+  "DELTA_BLOCK_COLUMN_MAPPING_AND_CDC_OPERATION" : {
+    "message" : [ "Operation <opName> is not allowed when your table has enabled change data feed (CDF) and has undergone schema changes using DROP COLUMN or RENAME COLUMN." ],
+    "sqlState" : "0A000"
+  },
   "DELTA_BLOOM_FILTER_DROP_ON_NON_EXISTING_COLUMNS" : {
     "message" : [ "Cannot drop bloom filter indices for the following non-existent column(s): <unknownColumns>" ],
     "sqlState" : "42000"

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2201,6 +2201,13 @@ trait DeltaErrorsBase
       messageParameters = Array(dataFilters)
     )
   }
+
+  def blockColumnMappingAndCdcOperation(op: DeltaOperations.Operation): Throwable = {
+    new DeltaUnsupportedOperationException(
+      errorClass = "DELTA_BLOCK_COLUMN_MAPPING_AND_CDC_OPERATION",
+      messageParameters = Array(op.name)
+    )
+  }
 }
 
 object DeltaErrors extends DeltaErrorsBase

--- a/core/src/main/scala/org/apache/spark/sql/delta/schema/SchemaMergingUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/schema/SchemaMergingUtils.scala
@@ -38,6 +38,51 @@ object SchemaMergingUtils {
 
   val DELTA_COL_RESOLVER: (String, String) => Boolean =
     org.apache.spark.sql.catalyst.analysis.caseInsensitiveResolution
+
+  /**
+   * Returns pairs of (full column name path, field) in this schema as a list. For example, a schema
+   * like:
+   *   <field a>          | - a
+   *   <field 1>          | | - 1
+   *   <field 2>          | | - 2
+   *   <field b>          | - b
+   *   <field c>          | - c
+   *   <field `foo.bar`>  | | - `foo.bar`
+   *   <field 3>          |   | - 3
+   *   will get return [
+   *     ([a], <field a>), ([a, 1], <field 1>), ([a, 2], <field 2>), ([b], <field b>),
+   *     ([c], <field c>), ([c, foo.bar], <field foo.bar>), ([c, foo.bar, 3], <field 3>)
+   *   ]
+   */
+  def explode(schema: StructType): Seq[(Seq[String], StructField)] = {
+    def recurseIntoComplexTypes(complexType: DataType): Seq[(Seq[String], StructField)] = {
+      complexType match {
+        case s: StructType => explode(s)
+        case a: ArrayType => recurseIntoComplexTypes(a.elementType)
+          .map { case (path, field) => (Seq("element") ++ path, field) }
+        case m: MapType =>
+          recurseIntoComplexTypes(m.keyType)
+            .map { case (path, field) => (Seq("key") ++ path, field) } ++
+          recurseIntoComplexTypes(m.valueType)
+            .map { case (path, field) => (Seq("value") ++ path, field) }
+        case _ => Nil
+      }
+    }
+
+    schema.flatMap {
+      case f @ StructField(name, s: StructType, _, _) =>
+        Seq((Seq(name), f)) ++
+          explode(s).map { case (path, field) => (Seq(name) ++ path, field) }
+      case f @ StructField(name, a: ArrayType, _, _) =>
+        Seq((Seq(name), f)) ++
+          recurseIntoComplexTypes(a).map { case (path, field) => (Seq(name) ++ path, field) }
+      case f @ StructField(name, m: MapType, _, _) =>
+        Seq((Seq(name), f)) ++
+          recurseIntoComplexTypes(m).map { case (path, field) => (Seq(name) ++ path, field) }
+      case f => (Seq(f.name), f) :: Nil
+    }
+  }
+
   /**
    * Returns all column names in this schema as a flat list. For example, a schema like:
    *   | - a
@@ -50,30 +95,7 @@ object SchemaMergingUtils {
    *   will get flattened to: "a", "a.1", "a.2", "b", "c", "c.nest", "c.nest.3"
    */
   def explodeNestedFieldNames(schema: StructType): Seq[String] = {
-    def explode(schema: StructType): Seq[Seq[String]] = {
-      def recurseIntoComplexTypes(complexType: DataType): Seq[Seq[String]] = {
-        complexType match {
-          case s: StructType => explode(s)
-          case a: ArrayType => recurseIntoComplexTypes(a.elementType).map(Seq("element") ++ _)
-          case m: MapType =>
-            recurseIntoComplexTypes(m.keyType).map(Seq("key") ++ _) ++
-              recurseIntoComplexTypes(m.valueType).map(Seq("value") ++ _)
-          case _ => Nil
-        }
-      }
-
-      schema.flatMap {
-        case StructField(name, s: StructType, _, _) =>
-          Seq(Seq(name)) ++ explode(s).map(nested => Seq(name) ++ nested)
-        case StructField(name, a: ArrayType, _, _) =>
-          Seq(Seq(name)) ++ recurseIntoComplexTypes(a).map(nested => Seq(name) ++ nested)
-        case StructField(name, m: MapType, _, _) =>
-          Seq(Seq(name)) ++ recurseIntoComplexTypes(m).map(nested => Seq(name) ++ nested)
-        case f => Seq(f.name) :: Nil
-      }
-    }
-
-    explode(schema).map(UnresolvedAttribute.apply(_).name)
+    explode(schema).map { case (path, _) => path }.map(UnresolvedAttribute.apply(_).name)
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
@@ -23,6 +23,7 @@ import java.nio.file.Files
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
+import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, AddFile, Metadata => MetadataAction, SetTransaction}
 import org.apache.spark.sql.delta.schema.SchemaMergingUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
@@ -230,6 +231,34 @@ class DeltaColumnMappingSuite extends QueryTest
       true,
       withId(2)
     )
+
+  protected val schemaWithPhysicalNamesNested = new StructType()
+    .add("a", StringType, true, withPhysicalName("aaa"))
+    .add("b",
+      // let's call this nested struct 'X'.
+      new StructType()
+        .add("c", StringType, true, withPhysicalName("ccc"))
+        .add("d", IntegerType, true, withPhysicalName("ddd"))
+        .add("foo.bar",
+          new StructType().add("f", LongType, true, withPhysicalName("fff")),
+          true,
+          withPhysicalName("foo.foo.foo.bar.bar.bar")),
+      true,
+      withPhysicalName("bbb")
+    )
+    .add("g",
+      // nested struct 'X' (see above) is repeated here.
+      new StructType()
+        .add("c", StringType, true, withPhysicalName("ccc"))
+        .add("d", IntegerType, true, withPhysicalName("ddd"))
+        .add("foo.bar",
+          new StructType().add("f", LongType, true, withPhysicalName("fff")),
+          true,
+          withPhysicalName("foo.foo.foo.bar.bar.bar")),
+      true,
+      withPhysicalName("ggg")
+    )
+    .add("h", IntegerType, true, withPhysicalName("hhh"))
 
   protected val schemaWithIdNestedRandom = new StructType()
     .add("a", StringType, true, withId(111))
@@ -1199,4 +1228,236 @@ class DeltaColumnMappingSuite extends QueryTest
         DeltaConfigs.MIN_WRITER_VERSION.key -> "5"))
     }
   }
+
+  test("getPhysicalNameFieldMap") {
+    // To keep things simple, we use schema `schemaWithPhysicalNamesNested` such that the
+    // physical name is just the logical name repeated three times.
+
+    val actual = DeltaColumnMapping
+      .getPhysicalNameFieldMap(schemaWithPhysicalNamesNested)
+      .map { case (physicalPath, field) => (physicalPath, field.name) }
+
+    val expected = Map[Seq[String], String](
+      Seq("aaa") -> "a",
+      Seq("bbb") -> "b",
+      Seq("bbb", "ccc") -> "c",
+      Seq("bbb", "ddd") -> "d",
+      Seq("bbb", "foo.foo.foo.bar.bar.bar") -> "foo.bar",
+      Seq("bbb", "foo.foo.foo.bar.bar.bar", "fff") -> "f",
+      Seq("ggg") -> "g",
+      Seq("ggg", "ccc") -> "c",
+      Seq("ggg", "ddd") -> "d",
+      Seq("ggg", "foo.foo.foo.bar.bar.bar") -> "foo.bar",
+      Seq("ggg", "foo.foo.foo.bar.bar.bar", "fff") -> "f",
+      Seq("hhh") -> "h"
+    )
+
+    assert(expected === actual,
+      s"""
+         |The actual physicalName -> logicalName map
+         |${actual.mkString("\n")}
+         |did not equal the expected map
+         |${expected.mkString("\n")}
+         |""".stripMargin)
+  }
+
+  testColumnMapping("is drop/rename column operation") { mode =>
+    import DeltaColumnMapping.{isDropColumnOperation, isRenameColumnOperation}
+    val m = DeltaColumnMappingMode(mode)
+
+    withTable("t1") {
+      def getMetadata(): MetadataAction = {
+        DeltaLog.forTable(spark, TableIdentifier("t1")).update().metadata
+      }
+
+      createStrictSchemaTableWithDeltaTableApi(
+        "t1",
+        schemaWithPhysicalNamesNested,
+        Map(DeltaConfigs.COLUMN_MAPPING_MODE.key -> mode)
+      )
+
+      // case 1: currentSchema compared with itself
+      var currentMetadata = getMetadata()
+      var newMetadata = getMetadata()
+      assert(
+        !isDropColumnOperation(newMetadata, currentMetadata) &&
+          !isRenameColumnOperation(newMetadata, currentMetadata)
+      )
+
+      // case 2: add a top-level column
+      sql("ALTER TABLE t1 ADD COLUMNS (ping INT)")
+      currentMetadata = newMetadata
+      newMetadata = getMetadata()
+      assert(
+        !isDropColumnOperation(newMetadata, currentMetadata) &&
+          !isRenameColumnOperation(newMetadata, currentMetadata)
+      )
+
+      // case 3: add a nested column
+      sql("ALTER TABLE t1 ADD COLUMNS (b.`foo.bar`.`my.new;col()` LONG)")
+      currentMetadata = newMetadata
+      newMetadata = getMetadata()
+      assert(
+        !isDropColumnOperation(newMetadata, currentMetadata) &&
+          !isRenameColumnOperation(newMetadata, currentMetadata)
+      )
+
+      // case 4: drop a top-level column
+      sql("ALTER TABLE t1 DROP COLUMN (ping)")
+      currentMetadata = newMetadata
+      newMetadata = getMetadata()
+      assert(
+        isDropColumnOperation(newMetadata, currentMetadata) &&
+          !isRenameColumnOperation(newMetadata, currentMetadata)
+      )
+
+      // case 5: drop a nested column
+      sql("ALTER TABLE t1 DROP COLUMN (g.`foo.bar`)")
+      currentMetadata = newMetadata
+      newMetadata = getMetadata()
+      assert(
+        isDropColumnOperation(newMetadata, currentMetadata) &&
+          !isRenameColumnOperation(newMetadata, currentMetadata)
+      )
+
+      // case 6: rename a top-level column
+      sql("ALTER TABLE t1 RENAME COLUMN a TO pong")
+      currentMetadata = newMetadata
+      newMetadata = getMetadata()
+      assert(
+        !isDropColumnOperation(newMetadata, currentMetadata) &&
+          isRenameColumnOperation(newMetadata, currentMetadata)
+      )
+
+      // case 7: rename a nested column
+      sql("ALTER TABLE t1 RENAME COLUMN b.c TO c2")
+      currentMetadata = newMetadata
+      newMetadata = getMetadata()
+      assert(
+        !isDropColumnOperation(newMetadata, currentMetadata) &&
+          isRenameColumnOperation(newMetadata, currentMetadata)
+      )
+    }
+  }
+
+  Seq(true, false).foreach { cdfEnabled =>
+    val shouldBlock = cdfEnabled
+    val shouldBlockStr = if (shouldBlock) "should block" else "should not block"
+
+    def checkHelper(
+        log: DeltaLog,
+        newSchema: StructType,
+        action: Action,
+        shouldFail: Boolean = shouldBlock): Unit = {
+      val txn = log.startTransaction()
+      txn.updateMetadata(txn.metadata.copy(schemaString = newSchema.json))
+
+      if (shouldFail) {
+        val e = intercept[DeltaUnsupportedOperationException] {
+          txn.commit(action :: Nil, DeltaOperations.ManualUpdate)
+        }.getMessage
+        assert(e == "Operation Manual Update is not allowed when your table has enabled change " +
+          "data feed (CDF) and has undergone schema changes using DROP COLUMN or RENAME COLUMN.")
+      } else {
+        txn.commit(action :: Nil, DeltaOperations.ManualUpdate)
+      }
+    }
+
+    val fileActions = Seq(
+      AddFile("foo", Map.empty, 1L, 1L, dataChange = true),
+      AddFile("foo", Map.empty, 1L, 1L, dataChange = true).remove) ++
+      (if (cdfEnabled) AddCDCFile("foo", Map.empty, 1L) :: Nil else Nil)
+
+    testColumnMapping(
+      s"CDF and Column Mapping: $shouldBlockStr when CDF=$cdfEnabled",
+      enableSQLConf = true) { mode =>
+
+      def createTable(): Unit = {
+        createStrictSchemaTableWithDeltaTableApi(
+          "t1",
+          schemaWithPhysicalNamesNested,
+          Map(
+            DeltaConfigs.COLUMN_MAPPING_MODE.key -> mode,
+            DeltaConfigs.CHANGE_DATA_FEED.key -> cdfEnabled.toString
+          )
+        )
+      }
+
+      Seq("h", "b.`foo.bar`.f").foreach { colName =>
+
+        // case 1: drop column with non-FileAction action should always pass
+        withTable("t1") {
+          createTable()
+          val log = DeltaLog.forTable(spark, TableIdentifier("t1"))
+          val droppedColumnSchema = sql("SELECT * FROM t1").drop(colName).schema
+          checkHelper(log, droppedColumnSchema, SetTransaction("id", 1, None), shouldFail = false)
+        }
+
+        // case 2: rename column with FileAction should fail if $shouldBlock == true
+        fileActions.foreach { fileAction =>
+          withTable("t1") {
+            createTable()
+            val log = DeltaLog.forTable(spark, TableIdentifier("t1"))
+            withSQLConf(DeltaConfigs.COLUMN_MAPPING_MODE.defaultTablePropertyKey -> mode) {
+              withTable("t2") {
+                sql("DROP TABLE IF EXISTS t2")
+                sql("CREATE TABLE t2 USING DELTA AS SELECT * FROM t1")
+                sql(s"ALTER TABLE t2 RENAME COLUMN $colName TO ii")
+                val renamedColumnSchema = sql("SELECT * FROM t2").schema
+                checkHelper(log, renamedColumnSchema, fileAction)
+              }
+            }
+          }
+        }
+
+        // case 3: drop column with FileAction should fail if $shouldBlock == true
+        fileActions.foreach { fileAction =>
+          withTable("t1") {
+            createTable()
+            val log = DeltaLog.forTable(spark, TableIdentifier("t1"))
+            val droppedColumnSchema = sql("SELECT * FROM t1").drop(colName).schema
+            checkHelper(log, droppedColumnSchema, fileAction)
+          }
+        }
+      }
+    }
+  }
+
+  test("should block CM upgrade when commit has FileActions and CDF enabled") {
+    Seq(true, false).foreach { cdfEnabled =>
+      withTable("t1") {
+        createTableWithSQLAPI(
+          "t1",
+          props = Map(DeltaConfigs.CHANGE_DATA_FEED.key -> cdfEnabled.toString))
+
+        val log = DeltaLog.forTable(spark, TableIdentifier("t1"))
+        val currMetadata = log.snapshot.metadata
+        val upgradeMetadata = currMetadata.copy(
+          configuration = currMetadata.configuration ++ Map(
+            DeltaConfigs.MIN_READER_VERSION.key -> "2",
+            DeltaConfigs.MIN_WRITER_VERSION.key -> "5",
+            DeltaConfigs.COLUMN_MAPPING_MODE.key -> NameMapping.name
+          )
+        )
+
+        val txn = log.startTransaction()
+        txn.updateMetadata(upgradeMetadata)
+
+        if (cdfEnabled) {
+          val e = intercept[DeltaUnsupportedOperationException] {
+            txn.commit(
+              AddFile("foo", Map.empty, 1L, 1L, dataChange = true) :: Nil,
+              DeltaOperations.ManualUpdate)
+          }.getMessage
+          assert(e == "Operation Manual Update is not allowed when your table has enabled change " +
+            "data feed (CDF) and has undergone schema changes using DROP COLUMN or RENAME COLUMN.")
+        } else {
+          txn.commit(
+            AddFile("foo", Map.empty, 1L, 1L, dataChange = true) :: Nil,
+            DeltaOperations.ManualUpdate)
+        }
+      }
+    }
+  }
+
 }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2167,6 +2167,16 @@ trait DeltaErrorsSuiteBase
       assert(e.getSqlState == "42000")
       assert(e.getMessage == s"Can't set location multiple times. Found ${locations}")
     }
+    {
+      val e = intercept[DeltaUnsupportedOperationException] {
+        throw DeltaErrors.blockColumnMappingAndCdcOperation(DeltaOperations.ManualUpdate)
+      }
+      assert(e.getErrorClass == "DELTA_BLOCK_COLUMN_MAPPING_AND_CDC_OPERATION")
+      assert(e.getSqlState == "0A000")
+      assert(e.getMessage == "Operation Manual Update is not allowed when your table has " +
+        "enabled change data feed (CDF) and has undergone schema changes using DROP COLUMN or " +
+        "RENAME COLUMN.")
+    }
   }
 }
 


### PR DESCRIPTION
## Description

This PR block commits if
1. table has CDC enabled and there are `FileActions` to write
2. table has column mapping enabled and there is a column mapping related metadata action (e.g. DROP, RENAME, upgrade)

We do this because the current semantics is undefined. So, we block it for now, and can un-block it in the future once we define the expected output.

Please note: under current public APIs, this scenario is not possible. e.g. during a DROP or RENAME operation, only metadata is changes, so no `FileAction`s are committed. Nonetheless, we want to future proof this.

This block occurs during `OptimisticTransactionImpl::prepareCommit`

At a high level, this PR solves the given problem by solving 3 smaller problems

- what is the mapping of physical -> logical names for a given schema? For this we add `DeltaColumnMapping::getPhysicalNameFieldMap`
- given a new schema and an existing schema, detect a drop/rename column operation using the map from 1). For this we add `DeltaColumnMapping::isDropColumnOperation` and `DeltaColumnMapping::isRenameColumnOperation`
- Using the helper method from 2, implement the desired blocking algorithm. For this we add `OptimisticTransaction::performCdcColumnMappingCheck`.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

For each of the 3 sub-problems described above, we add a unit test to `DeltaColumnMappingSuite`.