### PR TITLE
Enable replaceWhere when DPO (dynamic partition overwrite) is enabled in the Spark configuration

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -1119,7 +1119,9 @@
     "sqlState" : "22000"
   },
   "DELTA_REPLACE_WHERE_WITH_DYNAMIC_PARTITION_OVERWRITE" : {
-    "message" : [ "A 'replaceWhere' expression and 'partitionOverwriteMode'='dynamic' cannot both be set in the DataFrameWriter options." ],
+    "message" : [
+      "A 'replaceWhere' expression and 'partitionOverwriteMode'='dynamic' cannot both be set in the DataFrameWriter options."
+    ],
     "sqlState" : "42000"
   },
   "DELTA_REPLACE_WHERE_WITH_FILTER_DATA_CHANGE_UNSET" : {

--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -1118,6 +1118,10 @@
     ],
     "sqlState" : "22000"
   },
+  "DELTA_REPLACE_WHERE_WITH_DYNAMIC_PARTITION_OVERWRITE" : {
+    "message" : [ "A 'replaceWhere' expression and 'partitionOverwriteMode'='dynamic' cannot both be set in the DataFrameWriter options." ],
+    "sqlState" : "42000"
+  },
   "DELTA_REPLACE_WHERE_WITH_FILTER_DATA_CHANGE_UNSET" : {
     "message" : [
       "'replaceWhere' cannot be used with data filters when 'dataChange' is set to false. Filters: <dataFilters>"

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2133,6 +2133,12 @@ trait DeltaErrorsBase
     )
   }
 
+  def replaceWhereUsedWithDynamicPartitionOverwrite(): Throwable = {
+    new DeltaIllegalArgumentException(
+      errorClass = "DELTA_REPLACE_WHERE_WITH_DYNAMIC_PARTITION_OVERWRITE"
+    )
+  }
+
   def replaceWhereUsedInOverwrite(): Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_REPLACE_WHERE_IN_OVERWRITE", messageParameters = Array.empty

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -114,6 +114,10 @@ trait DeltaWriteOptionsImpl extends DeltaOptionParser {
 
   validateIdempotentWriteOptions()
 
+  /** Whether partitionOverwriteMode is provided as a DataFrameWriter option. */
+  val partitionOverwriteModeInOptions: Boolean =
+    options.contains(PARTITION_OVERWRITE_MODE_OPTION)
+
   /** Whether to only overwrite partitions that have data written into it at runtime. */
   def isDynamicPartitionOverwriteMode: Boolean = {
     if (!sqlConf.getConf(DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED)) {

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -133,7 +133,7 @@ trait DeltaWriteOptionsImpl extends DeltaOptionParser {
           PARTITION_OVERWRITE_MODE_OPTION, mode, s"must be ${acceptableStr}"
         )
       }
-      mode.equalsIgnoreCase("DYNAMIC")
+      mode.equalsIgnoreCase(PARTITION_OVERWRITE_MODE_DYNAMIC)
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -56,8 +56,13 @@ import org.apache.spark.sql.types.{StringType, StructType}
  *
  * In combination with `Overwrite` dynamic partition overwrite mode (option `partitionOverwriteMode`
  * set to `dynamic`, or in spark conf `spark.sql.sources.partitionOverwriteMode` set to `dynamic`)
- * is also supported. However a `replaceWhere` option can not be used while dynamic partition mode
- * is enabled.
+ * is also supported.
+ *
+ * Dynamic partition overwrite mode conflicts with `replaceWhere`:
+ *   - If a `replaceWhere` option is provided, and dynamic partition overwrite mode is enabled in
+ *   the DataFrameWriter options, an error will be thrown.
+ *   - If a `replaceWhere` option is provided, and dynamic partition overwrite mode is enabled in
+ *   the spark conf, data will be overwritten according to the `replaceWhere` expression
  *
  * @param schemaInCatalog The schema created in Catalog. We will use this schema to update metadata
  *                        when it is set (in CTAS code path), and otherwise use schema from `data`.
@@ -137,19 +142,23 @@ case class WriteIntoDelta(
       sparkSession.conf.get(DeltaSQLConf.REPLACEWHERE_DATACOLUMNS_ENABLED)
 
     val useDynamicPartitionOverwriteMode = {
-      val useDynamic = txn.metadata.partitionColumns.nonEmpty &&
-        options.isDynamicPartitionOverwriteMode
-      options.replaceWhere.foreach { _ =>
-        if (useDynamic && options.partitionOverwriteModeInOptions) {
-          // We throw an error when:
-          // 1. replaceWhere is provided
+      if (txn.metadata.partitionColumns.isEmpty) {
+        // We ignore dynamic partition overwrite mode for non-partitioned tables
+        false
+      } else if (options.replaceWhere.nonEmpty) {
+        if (options.partitionOverwriteModeInOptions && options.isDynamicPartitionOverwriteMode) {
+          // replaceWhere and dynamic partition overwrite conflict because they both specify which
+          // data to overwrite. We throw an error when:
+          // 1. replaceWhere is provided in a DataFrameWriter option
           // 2. partitionOverwriteMode is set to "dynamic" in a DataFrameWriter option
-          // 3. the table is partitioned
           throw DeltaErrors.replaceWhereUsedWithDynamicPartitionOverwrite()
+        } else {
+          // If replaceWhere is provided, we do not use dynamic partition overwrite, even if it's
+          // enabled in the spark session configuration, since generally query-specific configs take
+          // precedence over session configs
+          false
         }
-      }
-      // If replaceWhere is provided, we do not use dynamic partition overwrite
-      useDynamic && options.replaceWhere.isEmpty
+      } else options.isDynamicPartitionOverwriteMode
     }
 
     // Validate partition predicates

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1601,6 +1601,14 @@ trait DeltaErrorsSuiteBase
       assert(e.getMessage == "No file found in the directory: dir.")
     }
     {
+      val e = intercept[DeltaIllegalArgumentException] {
+        throw DeltaErrors.replaceWhereUsedWithDynamicPartitionOverwrite()
+      }
+      assert(e.getErrorClass == "DELTA_REPLACE_WHERE_WITH_DYNAMIC_PARTITION_OVERWRITE")
+      assert(e.getMessage == "A 'replaceWhere' expression and 'partitionOverwriteMode'='dynamic' " +
+        "cannot both be set in the DataFrameWriter options.")
+    }
+    {
       val e = intercept[DeltaAnalysisException] {
         throw DeltaErrors.replaceWhereUsedInOverwrite()
       }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -859,8 +859,39 @@ class DeltaSuite extends QueryTest
     }
   }
 
-  test(
-    "batch write: append, dynamic partition overwrite option not supported with replaceWhere") {
+  test("batch write: append, dynamic partition overwrite conf, replaceWhere takes precedence") {
+    // when dynamic partition overwrite mode is enabled in the spark configuration, and a
+    // replaceWhere expression is provided, we delete data according to the replaceWhere expression
+    withSQLConf(
+      DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key -> "true",
+      SQLConf.PARTITION_OVERWRITE_MODE.key -> "dynamic") {
+      withTempDir { tempDir =>
+        def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
+
+        Seq((1, "x"), (2, "y"), (3, "z")).toDF("value", "part2")
+          .withColumn("part1", $"value" % 2)
+          .write
+          .format("delta")
+          .partitionBy("part1", "part2")
+          .mode("append")
+          .save(tempDir.getCanonicalPath)
+
+        Seq((5, "x")).toDF("value", "part2")
+          .withColumn("part1", $"value" % 2)
+          .write
+          .format("delta")
+          .partitionBy("part1", "part2")
+          .mode("overwrite")
+          .option(DeltaOptions.REPLACE_WHERE_OPTION, "part1 = 1")
+          .save(tempDir.getCanonicalPath)
+        checkDatasetUnorderly(data.select($"value").as[Int], 2, 5)
+      }
+    }
+  }
+
+  test("batch write: append, replaceWhere + dynamic partition overwrite enabled in options") {
+    // when dynamic partition overwrite mode is enabled in the DataFrameWriter options, and
+    // a replaceWhere expression is provided, we throw an error
     withSQLConf(DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key -> "true") {
       withTempDir { tempDir =>
         def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
@@ -873,113 +904,79 @@ class DeltaSuite extends QueryTest
           .mode("append")
           .save(tempDir.getCanonicalPath)
 
-        val e = intercept[AnalysisException] {
+        val e = intercept[IllegalArgumentException] {
           Seq((3, "x"), (5, "x")).toDF("value", "part2")
             .withColumn("part1", $"value" % 2)
             .write
             .format("delta")
             .partitionBy("part1", "part2")
             .mode("overwrite")
-            .option(DeltaOptions.REPLACE_WHERE_OPTION, "part1 = 1")
             .option(DeltaOptions.PARTITION_OVERWRITE_MODE_OPTION, "dynamic")
+            .option(DeltaOptions.REPLACE_WHERE_OPTION, "part1 = 1")
             .save(tempDir.getCanonicalPath)
         }
-        assert(e.getMessage ===
-          "'replaceWhere' cannot be used when 'partitionOverwriteMode' is set to 'DYNAMIC'")
-      }
-    }
-  }
-
-  test(
-    "batch write: append, dynamic partition overwrite conf not supported with replaceWhere") {
-    withSQLConf(DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key -> "true") {
-      withSQLConf(SQLConf.PARTITION_OVERWRITE_MODE.key -> "dynamic") {
-        withTempDir { tempDir =>
-          def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
-
-          Seq((1, "x"), (2, "y"), (3, "z")).toDF("value", "part2")
-            .withColumn("part1", $"value" % 2)
-            .write
-            .format("delta")
-            .partitionBy("part1", "part2")
-            .mode("append")
-            .save(tempDir.getCanonicalPath)
-
-          val e = intercept[AnalysisException] {
-            Seq((3, "x"), (5, "x")).toDF("value", "part2")
-              .withColumn("part1", $"value" % 2)
-              .write
-              .format("delta")
-              .partitionBy("part1", "part2")
-              .mode("overwrite")
-              .option(DeltaOptions.REPLACE_WHERE_OPTION, "part1 = 1")
-              .save(tempDir.getCanonicalPath)
-          }
-          assert(e.getMessage ===
-            "'replaceWhere' cannot be used when 'partitionOverwriteMode' is set to 'DYNAMIC'")
-        }
+        assert(e.getMessage === "A 'replaceWhere' expression and " +
+          "'partitionOverwriteMode'='dynamic' cannot both be set in the DataFrameWriter options.")
       }
     }
   }
 
   test("batch write: append, dynamic partition overwrite set via conf") {
-    withSQLConf(DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key -> "true") {
-      withSQLConf(SQLConf.PARTITION_OVERWRITE_MODE.key -> "dynamic") {
-        withTempDir { tempDir =>
-          def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
+    withSQLConf(
+      DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key -> "true",
+      SQLConf.PARTITION_OVERWRITE_MODE.key -> "dynamic") {
+      withTempDir { tempDir =>
+        def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
 
-          Seq(1, 2, 3).toDF
-            .withColumn("part", $"value" % 2)
-            .write
-            .format("delta")
-            .partitionBy("part")
-            .mode("append")
-            .save(tempDir.getCanonicalPath)
+        Seq(1, 2, 3).toDF
+          .withColumn("part", $"value" % 2)
+          .write
+          .format("delta")
+          .partitionBy("part")
+          .mode("append")
+          .save(tempDir.getCanonicalPath)
 
-          Seq(1, 5).toDF
-            .withColumn("part", $"value" % 2)
-            .write
-            .format("delta")
-            .partitionBy("part")
-            .mode("overwrite")
-            .save(tempDir.getCanonicalPath)
-          checkDatasetUnorderly(data.select("value").as[Int], 1, 2, 5)
-        }
+        Seq(1, 5).toDF
+          .withColumn("part", $"value" % 2)
+          .write
+          .format("delta")
+          .partitionBy("part")
+          .mode("overwrite")
+          .save(tempDir.getCanonicalPath)
+        checkDatasetUnorderly(data.select("value").as[Int], 1, 2, 5)
       }
     }
   }
 
-  test(
-    "batch write: append, dynamic partition overwrite set via conf and overridden via option") {
-    withSQLConf(DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key -> "true") {
-      withSQLConf(SQLConf.PARTITION_OVERWRITE_MODE.key -> "dynamic") {
-        withTempDir { tempDir =>
-          def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
+  test("batch write: append, dynamic partition overwrite set via conf and overridden via option") {
+    withSQLConf(
+      DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key -> "true",
+      SQLConf.PARTITION_OVERWRITE_MODE.key -> "dynamic") {
+      withTempDir { tempDir =>
+        def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
 
-          Seq(1, 2, 3).toDF
-            .withColumn("part", $"value" % 2)
-            .write
-            .format("delta")
-            .partitionBy("part")
-            .mode("append")
-            .save(tempDir.getCanonicalPath)
+        Seq(1, 2, 3).toDF
+          .withColumn("part", $"value" % 2)
+          .write
+          .format("delta")
+          .partitionBy("part")
+          .mode("append")
+          .save(tempDir.getCanonicalPath)
 
-          Seq(1, 5).toDF
-            .withColumn("part", $"value" % 2)
-            .write
-            .format("delta")
-            .partitionBy("part")
-            .option(DeltaOptions.PARTITION_OVERWRITE_MODE_OPTION, "static")
-            .mode("overwrite")
-            .save(tempDir.getCanonicalPath)
-          checkDatasetUnorderly(data.select("value").as[Int], 1, 5)
-        }
+        Seq(1, 5).toDF
+          .withColumn("part", $"value" % 2)
+          .write
+          .format("delta")
+          .partitionBy("part")
+          .option(DeltaOptions.PARTITION_OVERWRITE_MODE_OPTION, "static")
+          .mode("overwrite")
+          .save(tempDir.getCanonicalPath)
+        checkDatasetUnorderly(data.select("value").as[Int], 1, 5)
       }
     }
   }
 
-  test(
-    "batch write: append, overwrite without partitions should ignore partition overwrite mode") {
+  test("batch write: append, overwrite without partitions should ignore partition overwrite mode") {
     withSQLConf(DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key -> "true") {
       withTempDir { tempDir =>
         def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
@@ -999,6 +996,34 @@ class DeltaSuite extends QueryTest
           .option(DeltaOptions.PARTITION_OVERWRITE_MODE_OPTION, "dynamic")
           .save(tempDir.getCanonicalPath)
         checkDatasetUnorderly(data.select("value").as[Int], 1, 5)
+      }
+    }
+  }
+
+  test("batch write: append, overwrite non-partitioned table with replaceWhere ignores partition " +
+    "overwrite mode option") {
+    // we check here that setting both replaceWhere and dynamic partition overwrite in the
+    // DataFrameWriter options is allowed for a non-partitioned table
+    withSQLConf(DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key -> "true") {
+      withTempDir { tempDir =>
+        def data: DataFrame = spark.read.format("delta").load(tempDir.toString)
+
+        Seq(1, 2, 3).toDF
+          .withColumn("part", $"value" % 2)
+          .write
+          .format("delta")
+          .mode("append")
+          .save(tempDir.getCanonicalPath)
+
+        Seq(1, 5).toDF
+          .withColumn("part", $"value" % 2)
+          .write
+          .format("delta")
+          .mode("overwrite")
+          .option(DeltaOptions.REPLACE_WHERE_OPTION, "part = 1")
+          .option(DeltaOptions.PARTITION_OVERWRITE_MODE_OPTION, "dynamic")
+          .save(tempDir.getCanonicalPath)
+        checkDatasetUnorderly(data.select("value").as[Int], 1, 2, 5)
       }
     }
   }


### PR DESCRIPTION
### Description

This PR changes how `replaceWhere` and DPO interact with each other.

Current behavior:
- DPO + replaceWhere always throws an error

Behavior in this PR:
- DPO in spark session configuration + replaceWhere = data overwritten according to replaceWhere
- DPO as DataFrameWriter option + replaceWhere = throw error

### Testing

Updates and adds a test to `DeltaSuite`.
