### PR TITLE
Block streaming reads when column mapping is enabled

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -39,6 +39,12 @@
     "message" : [ "CREATE TABLE contains two different locations: <identifier> and <location>.", "You can remove the LOCATION clause from the CREATE TABLE statement, or set", "<config> to true to skip this check.", "" ],
     "sqlState" : "42000"
   },
+  "DELTA_BLOCK_STREAMING_COLUMN_MAPPING_READS" : {
+    "message" : [
+      "Streaming reads from a Delta table with column mapping enabled are not supported."
+    ],
+    "sqlState" : "0A000"
+  },
   "DELTA_BLOOM_FILTER_DROP_ON_NON_EXISTING_COLUMNS" : {
     "message" : [ "Cannot drop bloom filter indices for the following non-existent column(s): <unknownColumns>" ],
     "sqlState" : "42000"

--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -40,9 +40,7 @@
     "sqlState" : "42000"
   },
   "DELTA_BLOCK_STREAMING_COLUMN_MAPPING_READS" : {
-    "message" : [
-      "Streaming reads from a Delta table with column mapping enabled are not supported."
-    ],
+    "message" : [ "Streaming reads from a Delta table with column mapping enabled are not supported." ],
     "sqlState" : "0A000"
   },
   "DELTA_BLOOM_FILTER_DROP_ON_NON_EXISTING_COLUMNS" : {

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -930,6 +930,11 @@ trait DeltaErrorsBase
     )
   }
 
+  def blockStreamingReadsOnColumnMappingEnabledTable: Throwable = {
+    new DeltaUnsupportedOperationException(
+      errorClass = "DELTA_BLOCK_STREAMING_COLUMN_MAPPING_READS")
+  }
+
   def bloomFilterOnPartitionColumnNotSupportedException(name: String): Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_UNSUPPORTED_PARTITION_COLUMN_IN_BLOOM_FILTER",

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -22,7 +22,7 @@ import java.sql.Timestamp
 
 import scala.util.matching.Regex
 
-import org.apache.spark.sql.delta.{ColumnWithDefaultExprUtils, DeltaErrors, DeltaLog, DeltaOptions, DeltaTimeTravelSpec, GeneratedColumn, Snapshot, StartingVersion, StartingVersionLatest}
+import org.apache.spark.sql.delta.{ColumnWithDefaultExprUtils, DeltaErrors, DeltaLog, DeltaOptions, DeltaTimeTravelSpec, GeneratedColumn, NoMapping, Snapshot, StartingVersion, StartingVersionLatest}
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.files.DeltaSourceSnapshot
@@ -384,6 +384,12 @@ case class DeltaSource(
             }
           }
       }
+    }
+
+    // If the table has column mapping enabled, throw an error. With column mapping, certain schema
+    // changes are possible (rename a column or drop a column) which don't work well with streaming.
+    if (deltaLog.snapshot.metadata.columnMappingMode != NoMapping) {
+      throw DeltaErrors.blockStreamingReadsOnColumnMappingEnabledTable
     }
 
     var iter = if (isStartingVersion) {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2147,6 +2147,15 @@ trait DeltaErrorsSuiteBase
         "Can only drop nested columns from StructType. Found StructField(invalid1,StringType,true)")
     }
     {
+      val e = intercept[DeltaUnsupportedOperationException] {
+        throw DeltaErrors.blockStreamingReadsOnColumnMappingEnabledTable
+      }
+      assert(e.getErrorClass == "DELTA_BLOCK_STREAMING_COLUMN_MAPPING_READS")
+      assert(e.getSqlState == "0A000")
+      assert(e.getMessage ==
+        "Streaming reads from a Delta table with column mapping enabled are not supported.")
+    }
+    {
       val columnsThatNeedRename = Set("c0", "c1")
       val schema = StructType(Seq(StructField("schema1", StringType)))
       val e = intercept[DeltaAnalysisException] {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -1314,6 +1314,80 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase with DeltaSQLCommandTest {
     }
   }
 
+  test(s"block streaming reads from a column mapping enabled table") {
+    withTempDir { inputDir =>
+      val path = inputDir.getCanonicalPath
+      withTable("t1") {
+        sql(
+          s"""
+             |CREATE TABLE t1 (value STRING) USING DELTA
+             |TBLPROPERTIES(
+             |${DeltaConfigs.COLUMN_MAPPING_MODE.key} = 'name',
+             |${DeltaConfigs.MIN_READER_VERSION.key} = '2',
+             |${DeltaConfigs.MIN_WRITER_VERSION.key} = '5'
+             |) LOCATION '$path'
+             |""".stripMargin)
+
+        Seq("keep1", "keep2", "keep3", "drop1").toDF("value")
+            .write.format("delta").mode("append").saveAsTable("t1")
+
+        Seq(true, false).foreach { isStartVersion0 =>
+          withClue(s"isStartVersion0 = $isStartVersion0") {
+            var dfr = spark.readStream.format("delta")
+            if (isStartVersion0) {
+              // By default the stream starts at the latest version in the table
+              dfr = dfr.option("startingVersion", "0")
+            }
+            val df = dfr.load(path).filter($"value" contains "keep")
+
+            val ex = intercept[Exception] {
+              testStream(df)(ProcessAllAvailable())
+            }
+            assert(ex.getMessage contains
+              "Streaming reads from a Delta table with column mapping enabled are not supported.")
+          }
+        }
+      }
+    }
+  }
+
+  test("block streaming reads after a table is upgraded with column mapping") {
+    withTempDir { inputDir =>
+      val path = inputDir.getCanonicalPath
+      withTable("t1") {
+        sql(s"CREATE TABLE t1 (value STRING) USING DELTA LOCATION '$path'")
+
+        Seq("keep1", "keep2", "keep3", "drop1").toDF("value")
+            .write.format("delta").mode("append").saveAsTable("t1")
+
+        val df = spark.readStream
+            .format("delta")
+            .load(path)
+            .filter($"value" contains "keep")
+
+        val ex = intercept[Exception] {
+          testStream(df)(
+            ProcessAllAvailable(),
+            Execute { _ =>
+              sql(
+                s"""
+                   |ALTER TABLE t1
+                   |SET TBLPROPERTIES (
+                   |  '${DeltaConfigs.MIN_READER_VERSION.key}' = '2',
+                   |  '${DeltaConfigs.MIN_WRITER_VERSION.key}' = '5',
+                   |  '${DeltaConfigs.COLUMN_MAPPING_MODE.key}'='name')
+                   |""".stripMargin)
+            },
+            AddToReservoir(inputDir, Seq("keep7", "drop2").toDF()),
+            ProcessAllAvailable()
+          )
+        }
+        assert(ex.getMessage contains
+          "Streaming reads from a Delta table with column mapping enabled are not supported.")
+      }
+    }
+  }
+
   test("startingVersion latest") {
     withTempDir { dir =>
       withTempView("startingVersionTest") {
@@ -1892,18 +1966,6 @@ abstract class DeltaSourceColumnMappingSuiteBase extends DeltaSourceSuite {
 
 }
 
-
-class DeltaSourceNameColumnMappingSuite extends DeltaSourceColumnMappingSuiteBase
-  with DeltaColumnMappingEnableNameMode {
-
-  override protected def runOnlyTests = Seq(
-    "basic",
-    "maxBytesPerTrigger: metadata checkpoint",
-    "maxFilesPerTrigger: metadata checkpoint",
-    "allow to change schema before starting a streaming query"
-  )
-
-}
 
 /**
  * A FileSystem implementation that returns monotonically increasing timestamps for file creation.


### PR DESCRIPTION
GitOrigin-RevId: 1311a5b0d431f7d190c3b7edd540460af915bcdd

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
Column mapping enables schema changes such as rename a column and drop a column. These schema change operations have undefined behavior in streaming. As a proactive step we are blocking streaming reads from a Delta table that has column mapping enabled.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Added UTs

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
