### PR TITLE
1105 block cdc column mapping reads

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -62,6 +62,12 @@
     ],
     "sqlState" : "42000"
   },
+  "DELTA_BLOCK_CDF_COLUMN_MAPPING_READS" : {
+    "message" : [
+      "Change data feed (CDF) reads are currently not supported on tables with column mapping enabled."
+    ],
+    "sqlState" : "0A000"
+  },
   "DELTA_BLOOM_FILTER_DROP_ON_NON_EXISTING_COLUMNS" : {
     "message" : [
       "Cannot drop bloom filter indices for the following non-existent column(s): <unknownColumns>"

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2223,6 +2223,12 @@ trait DeltaErrorsBase
          |""".stripMargin)
     // scalastyle:on line.size.limit
   }
+
+  def blockCdfAndColumnMappingReads(): Throwable = {
+    new DeltaUnsupportedOperationException(
+      errorClass = "DELTA_BLOCK_CDF_COLUMN_MAPPING_READS"
+    )
+  }
 }
 
 object DeltaErrors extends DeltaErrorsBase

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
@@ -20,15 +20,14 @@ import java.sql.Timestamp
 
 import scala.collection.mutable.ListBuffer
 
-import org.apache.spark.sql.delta.{DeltaConfigs, DeltaErrors, DeltaHistoryManager, DeltaLog, DeltaOperations, DeltaParquetFileFormat, DeltaTableUtils, DeltaTimeTravelSpec, Snapshot}
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaErrors, DeltaHistoryManager, DeltaLog, DeltaOperations, DeltaParquetFileFormat, DeltaTableUtils, DeltaTimeTravelSpec, NoMapping, Snapshot}
 import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, AddFile, CommitInfo, FileAction, Metadata, RemoveFile}
 import org.apache.spark.sql.delta.files.{CdcAddFileIndex, TahoeChangeFileIndex, TahoeFileIndex, TahoeRemoveFileIndex}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.SchemaUtils
-import org.apache.spark.sql.delta.sources.{DeltaDataSource, DeltaSource, DeltaSQLConf}
-
+import org.apache.spark.sql.delta.sources.{DeltaDataSource, DeltaSQLConf, DeltaSource}
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession, SQLContext}
+import org.apache.spark.sql.{DataFrame, Dataset, Row, SQLContext, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.internal.SQLConf
@@ -261,6 +260,12 @@ object CDCReader extends DeltaLogging {
     }
 
     val snapshot = deltaLog.snapshot
+
+    // If the table has column mapping enabled, throw an error. With column mapping, certain schema
+    // changes are possible (rename a column or drop a column) which don't work well with CDF.
+    if (snapshot.metadata.columnMappingMode != NoMapping) {
+      throw DeltaErrors.blockCdfAndColumnMappingReads()
+    }
 
     // A map from change version to associated commit timestamp.
     val timestampsByVersion: Map[Long, Timestamp] =

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSuite.scala
@@ -688,6 +688,32 @@ abstract class DeltaCDCSuiteBase
       }
     }
   }
+
+  test("should block CDC reads when Column Mapping enabled - batch") {
+    withTable("t1") {
+      sql(
+        s"""
+           |CREATE TABLE t1 (id LONG) USING DELTA
+           |TBLPROPERTIES(
+           |  '${DeltaConfigs.COLUMN_MAPPING_MODE.key}'='name',
+           |  '${DeltaConfigs.CHANGE_DATA_FEED.key}'='true',
+           |  '${DeltaConfigs.MIN_READER_VERSION.key}'='2',
+           |  '${DeltaConfigs.MIN_WRITER_VERSION.key}'='5'
+           |)
+           |""".stripMargin)
+      spark.range(10).write.format("delta").mode("append").saveAsTable("t1")
+
+      // case 1: batch read
+      spark.read.format("delta").table("t1").show()
+
+      // case 2: batch CDC read
+      val e = intercept[DeltaUnsupportedOperationException] {
+        cdcRead(new TableName("t1"), StartingVersion("0"), EndingVersion("1")).show()
+      }.getMessage
+      assert(e == "Change data feed (CDF) reads are currently not supported on tables with " +
+        "column mapping enabled.")
+    }
+  }
 }
 
 class DeltaCDCScalaSuite extends DeltaCDCSuiteBase {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2176,6 +2176,15 @@ trait DeltaErrorsSuiteBase
       assert(e.getSqlState == "42000")
       assert(e.getMessage == s"Can't set location multiple times. Found ${locations}")
     }
+    {
+      val e = intercept[DeltaUnsupportedOperationException] {
+        throw DeltaErrors.blockCdfAndColumnMappingReads()
+      }
+      assert(e.getErrorClass == "DELTA_BLOCK_CDF_COLUMN_MAPPING_READS")
+      assert(e.getSqlState == "0A000")
+      assert(e.getMessage == "Change data feed (CDF) reads are currently not supported on tables " +
+        "with column mapping enabled.")
+    }
   }
 }
 


### PR DESCRIPTION
## Description

This PR blocks CDF read queries (batch, streaming) in Delta Lake whenever column mapping (CM) is enabled. We do this because CDF + CM semantics are currently undefined.

## How was this patch tested?

Adds a new unit test and covers cases of
- batch read with CM, CDF disabled -> okay
- stream read with CM, CDF disabled -> okay
- batch read with CM, CDF enabled -> blocked
- stream read with CM, CDF enabled -> blocked

## Does this PR introduce _any_ user-facing changes?

No. Not 'new' as CDF is not yet released in Delta Lake.
