### PR TITLE
Add a SQL conf to allow arbitrary table properties (disable checks)

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -1320,7 +1320,8 @@
   },
   "DELTA_UNKNOWN_CONFIGURATION" : {
     "message" : [
-      "Unknown configuration was specified: <config>"
+      "Unknown configuration was specified: <config>",
+      "To disable this check, set allowArbitraryProperties.enabled=true in the Spark session configuration."
     ],
     "sqlState" : "0A000"
   },

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -746,6 +746,22 @@ trait DeltaSQLConfBase {
       .internal()
       .booleanConf
       .createWithDefault(true)
+
+  val ALLOW_ARBITRARY_TABLE_PROPERTIES =
+    buildConf("allowArbitraryProperties.enabled")
+      .doc(
+      """Whether we allow arbitrary Delta table properties. When this is enabled, table properties
+          |with the prefix 'delta.' are not checked for validity. Table property validity is based
+          |on the current Delta version being used and feature support in that version. Arbitrary
+          |properties without the 'delta.' prefix are always allowed regardless of this config.
+          |
+          |Please use with caution. When enabled, there will be no warning when unsupported table
+          |properties for the Delta version being used are set, or when properties are set
+          |incorrectly (for example, misspelled).""".stripMargin
+      )
+      .internal()
+      .booleanConf
+      .createWithDefault(false)
 }
 
 object DeltaSQLConf extends DeltaSQLConfBase

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -778,8 +778,10 @@ trait DeltaErrorsSuiteBase
       val e = intercept[DeltaAnalysisException] {
         throw DeltaErrors.unknownConfigurationKeyException("confKey")
       }
+      var msg = "Unknown configuration was specified: confKey\nTo disable this check, set " +
+        "allowArbitraryProperties.enabled=true in the Spark session configuration."
       assert(e.getErrorClass == "DELTA_UNKNOWN_CONFIGURATION")
-      assert(e.getMessage == "Unknown configuration was specified: confKey")
+      assert(e.getMessage == msg)
     }
     {
       val e = intercept[DeltaAnalysisException] {


### PR DESCRIPTION
Adds SQL conf `ALLOW_ARBITRARY_TABLE_PROPERTIES` that disables our enforcement of valid table properties. This added as a solution to https://github.com/delta-io/delta/issues/1129.
    
Adds tests to `DeltaConfigSuite`