### PR TITLE
DELETE should return the number of deleted rows

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -93,9 +93,7 @@ case class DeleteCommand(
       // Re-cache all cached plans(including this relation itself, if it's cached) that refer to
       // this data source relation.
       sparkSession.sharedState.cacheManager.recacheByPlan(sparkSession, target)
-      Seq(
-        Row(this.metrics.getOrElse("numDeletedRows", 0))
-      )
+      Seq(Row(this.metrics.get("numDeletedRows").map(_.value).getOrElse(0L)))
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -84,18 +84,22 @@ case class DeleteCommand(
   final override def run(sparkSession: SparkSession): Seq[Row] = {
     recordDeltaOperation(deltaLog, "delta.dml.delete") {
       deltaLog.assertRemovable()
-      deltaLog.withNewTransaction { txn =>
+      val rowCount = deltaLog.withNewTransaction { txn =>
         val deleteActions = performDelete(sparkSession, deltaLog, txn)
         if (deleteActions.nonEmpty) {
           txn.commit(deleteActions, DeltaOperations.Delete(condition.map(_.sql).toSeq))
+        }
+        else {
+          0L
         }
       }
       // Re-cache all cached plans(including this relation itself, if it's cached) that refer to
       // this data source relation.
       sparkSession.sharedState.cacheManager.recacheByPlan(sparkSession, target)
+      Seq(
+        Row("numDeletedRows", rowCount)
+      )
     }
-
-    Seq.empty[Row]
   }
 
   def performDelete(

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -84,20 +84,17 @@ case class DeleteCommand(
   final override def run(sparkSession: SparkSession): Seq[Row] = {
     recordDeltaOperation(deltaLog, "delta.dml.delete") {
       deltaLog.assertRemovable()
-      val rowCount = deltaLog.withNewTransaction { txn =>
+      deltaLog.withNewTransaction { txn =>
         val deleteActions = performDelete(sparkSession, deltaLog, txn)
         if (deleteActions.nonEmpty) {
           txn.commit(deleteActions, DeltaOperations.Delete(condition.map(_.sql).toSeq))
-        }
-        else {
-          0L
         }
       }
       // Re-cache all cached plans(including this relation itself, if it's cached) that refer to
       // this data source relation.
       sparkSession.sharedState.cacheManager.recacheByPlan(sparkSession, target)
       Seq(
-        Row("numDeletedRows", rowCount)
+        Row(this.metrics.getOrElse("numDeletedRows", 0))
       )
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
@@ -45,7 +45,7 @@ class DeleteSQLSuite extends DeleteSuiteBase  with DeltaSQLCommandTest {
       withTempView("v") {
         Seq((1, 1), (0, 3), (1, 5)).toDF("key", "value").write.format("delta").saveAsTable("tab")
         spark.table("tab").as("name").createTempView("v")
-        checkAnswer(sql("DELETE FROM v WHERE key = 1"), Row("2"))
+        checkAnswer(sql("DELETE FROM v WHERE key = 1"), Row(2))
         checkAnswer(spark.table("tab"), Row(0, 3))
       }
     }
@@ -56,7 +56,7 @@ class DeleteSQLSuite extends DeleteSuiteBase  with DeltaSQLCommandTest {
       withTempView("v") {
         Seq((1, 1), (0, 3), (1, 5)).toDF("key", "value").write.format("delta").saveAsTable("tab")
         sql("CREATE TEMP VIEW v AS SELECT * FROM tab")
-        checkAnswer(sql("DELETE FROM v WHERE key = 1 AND VALUE = 5"), Row("1"))
+        checkAnswer(sql("DELETE FROM v WHERE key = 1 AND VALUE = 5"), Row(1))
         checkAnswer(spark.table("tab"), Seq(Row(1, 1), Row(0, 3)))
       }
     }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
@@ -56,7 +56,7 @@ class DeleteSQLSuite extends DeleteSuiteBase  with DeltaSQLCommandTest {
       withTempView("v") {
         Seq((1, 1), (0, 3), (1, 5)).toDF("key", "value").write.format("delta").saveAsTable("tab")
         sql("CREATE TEMP VIEW v AS SELECT * FROM tab")
-        checkAnswer(sql("DELETE FROM v WHERE key = 1 AND VALUE = 5"), Row(1))
+        checkAnswer(sql("DELETE FROM v WHERE key = 1 AND value = 5"), Row(1))
         checkAnswer(spark.table("tab"), Seq(Row(1, 1), Row(0, 3)))
       }
     }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
@@ -45,7 +45,7 @@ class DeleteSQLSuite extends DeleteSuiteBase  with DeltaSQLCommandTest {
       withTempView("v") {
         Seq((1, 1), (0, 3), (1, 5)).toDF("key", "value").write.format("delta").saveAsTable("tab")
         spark.table("tab").as("name").createTempView("v")
-        sql("DELETE FROM v WHERE key = 1")
+        checkAnswer(sql("DELETE FROM v WHERE key = 1"), Row("2"))
         checkAnswer(spark.table("tab"), Row(0, 3))
       }
     }
@@ -56,7 +56,7 @@ class DeleteSQLSuite extends DeleteSuiteBase  with DeltaSQLCommandTest {
       withTempView("v") {
         Seq((1, 1), (0, 3), (1, 5)).toDF("key", "value").write.format("delta").saveAsTable("tab")
         sql("CREATE TEMP VIEW v AS SELECT * FROM tab")
-        sql("DELETE FROM v WHERE key = 1 AND VALUE = 5")
+        checkAnswer(sql("DELETE FROM v WHERE key = 1 AND VALUE = 5"), Row("1"))
         checkAnswer(spark.table("tab"), Seq(Row(1, 1), Row(0, 3)))
       }
     }


### PR DESCRIPTION


## Description

Resolves #1222

## How was this patch tested?

The SQL test suite was extended

## Does this PR introduce _any_ user-facing changes?

The returned DataFrame from a delete should not be empty, but it will contain a single row