### PR TITLE
Proposed changes for #1188

### DIFF
--- a/core/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -137,6 +137,15 @@ class DeltaTable private[tables](
   }
 
   /**
+   * Gets the metadata related to the table and present as a dataframe.
+   *
+   * @since 2.0.0
+   */
+  def details(): DataFrame = {
+    executeDetail(Option(deltaLog.dataPath.toString), tableId = table.getTableIdentifierIfExists)
+  }
+
+  /**
    * Generate a manifest for the given Delta Table
    *
    * @param mode Specifies the mode for the generation of the manifest.

--- a/core/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
+++ b/core/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
@@ -17,15 +17,13 @@
 package io.delta.tables.execution
 
 import scala.collection.Map
-
 import org.apache.spark.sql.catalyst.TimeTravel
 import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
-import org.apache.spark.sql.delta.commands.{DeltaGenerateCommand, RestoreTableCommand, VacuumCommand}
+import org.apache.spark.sql.delta.commands.{DeltaGenerateCommand, DescribeDeltaDetailCommand, RestoreTableCommand, VacuumCommand}
 import org.apache.spark.sql.delta.util.AnalysisHelper
 import io.delta.tables.DeltaTable
-
-import org.apache.spark.sql.{functions, Column, DataFrame}
+import org.apache.spark.sql.{Column, DataFrame, functions}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
@@ -50,6 +48,12 @@ trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
     val history = deltaLog.history
     val spark = self.toDF.sparkSession
     spark.createDataFrame(history.getHistory(limit))
+  }
+
+  protected def executeDetail(path: Option[String],
+                                tableId: Option[TableIdentifier] = None): DataFrame = {
+    val detail = DescribeDeltaDetailCommand(path, tableId)
+    toDataset(sparkSession, detail)
   }
 
   protected def executeGenerate(tblIdentifier: String, mode: String): Unit = {

--- a/python/delta/tables.py
+++ b/python/delta/tables.py
@@ -278,6 +278,24 @@ class DeltaTable(object):
                 getattr(self._spark, "_wrapped", self._spark)  # type: ignore[attr-defined]
             )
 
+    @since(2.0)
+    def details(self) -> DataFrame:
+        """
+        Get the details of the table as a spark dataframe. Analogous to running DESCRIBE DETAIL
+
+        Example::
+
+            detailDF = deltaTable.details()    # get the full detail of the table
+
+        :return: Table's details datframe
+        :rtype: pyspark.sql.DataFrame
+        """
+        jdt = self._jdt
+        return DataFrame(
+            jdt.details(),
+            getattr(self._spark, "_wrapped", self._spark)  # type: ignore[attr-defined]
+        )
+
     @classmethod
     @since(0.4)  # type: ignore[arg-type]
     def convertToDelta(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
This resolves issue #1188  

`DESCRIBE DETAIL` is supported in SQL. But similar to `DESCRIBE HISTORY` which has Scala and Python APIs as `DeltaTable.history()`, there should be `DeltaTable.details()`.



## How was this patch tested?
This patch was tested using the spark-shell against open source spark version 3.3.0 via manual verification. There were no existing tests for similar methods. If tests are deemed required, I can resubmit as necessary.

## Does this PR introduce _any_ user-facing changes?
Yes, this PR provides new output for commands on DeltaTable.details() using Scala/Pyspark. Output is similar as below:
```
scala> df.details().show()
+------+--------------------+----+-----------+--------------------+--------------------+--------------------+----------------+--------+-----------+----------+----------------+----------------+
|format|                  id|name|description|            location|           createdAt|        lastModified|partitionColumns|numFiles|sizeInBytes|properties|minReaderVersion|minWriterVersion|
+------+--------------------+----+-----------+--------------------+--------------------+--------------------+----------------+--------+-----------+----------+----------------+----------------+
| delta|c2eaf64d-aaf9-464...|null|       null|file:/tmp/delta-t...|2022-07-01 04:16:...|2022-07-01 04:16:...|              []|       6|       2686|        {}|               1|               2|
+------+--------------------+----+-----------+--------------------+--------------------+--------------------+----------------+--------+-----------+----------+----------------+----------------+
```