### PR TITLE
Scala and Python API for Describe Detail

### DIFF
--- a/core/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -135,6 +135,14 @@ class DeltaTable private[tables](
   def history(): DataFrame = {
     executeHistory(deltaLog)
   }
+
+  /**
+   * Get the details of a Delta table such as the format, name, and size.
+   *
+   * @since 2.0.0
+   */
+  def details(): DataFrame = {
+    executeDetails(deltaLog.dataPath.toString, table.getTableIdentifierIfExists)
   }
 
   /**

--- a/core/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -98,7 +98,7 @@ class DeltaTable private[tables](
    * @since 0.3.0
    */
   def vacuum(retentionHours: Double): DataFrame = {
-    executeVacuum(deltaLog, Some(retentionHours))
+    executeVacuum(deltaLog, Some(retentionHours), table.getTableIdentifierIfExists)
   }
 
   /**
@@ -111,7 +111,7 @@ class DeltaTable private[tables](
    * @since 0.3.0
    */
   def vacuum(): DataFrame = {
-    executeVacuum(deltaLog, None)
+    executeVacuum(deltaLog, None, table.getTableIdentifierIfExists)
   }
 
   /**
@@ -123,7 +123,7 @@ class DeltaTable private[tables](
    * @since 0.3.0
    */
   def history(limit: Int): DataFrame = {
-    executeHistory(deltaLog, Some(limit))
+    executeHistory(deltaLog, Some(limit), table.getTableIdentifierIfExists)
   }
 
   /**
@@ -133,7 +133,7 @@ class DeltaTable private[tables](
    * @since 0.3.0
    */
   def history(): DataFrame = {
-    executeHistory(deltaLog)
+    executeHistory(deltaLog, tableId = table.getTableIdentifierIfExists)
   }
 
   /**

--- a/core/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -98,7 +98,7 @@ class DeltaTable private[tables](
    * @since 0.3.0
    */
   def vacuum(retentionHours: Double): DataFrame = {
-    executeVacuum(deltaLog, Some(retentionHours), table.getTableIdentifierIfExists)
+    executeVacuum(deltaLog, Some(retentionHours))
   }
 
   /**
@@ -111,7 +111,7 @@ class DeltaTable private[tables](
    * @since 0.3.0
    */
   def vacuum(): DataFrame = {
-    executeVacuum(deltaLog, None, table.getTableIdentifierIfExists)
+    executeVacuum(deltaLog, None)
   }
 
   /**
@@ -123,7 +123,7 @@ class DeltaTable private[tables](
    * @since 0.3.0
    */
   def history(limit: Int): DataFrame = {
-    executeHistory(deltaLog, Some(limit), table.getTableIdentifierIfExists)
+    executeHistory(deltaLog, Some(limit))
   }
 
   /**
@@ -133,7 +133,8 @@ class DeltaTable private[tables](
    * @since 0.3.0
    */
   def history(): DataFrame = {
-    executeHistory(deltaLog, tableId = table.getTableIdentifierIfExists)
+    executeHistory(deltaLog)
+  }
   }
 
   /**

--- a/core/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -139,7 +139,7 @@ class DeltaTable private[tables](
   /**
    * Get the details of a Delta table such as the format, name, and size.
    *
-   * @since 2.0.0
+   * @since 2.1.0
    */
   def details(): DataFrame = {
     executeDetails(deltaLog.dataPath.toString, table.getTableIdentifierIfExists)

--- a/core/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
+++ b/core/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
@@ -21,7 +21,7 @@ import scala.collection.Map
 import org.apache.spark.sql.catalyst.TimeTravel
 import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
-import org.apache.spark.sql.delta.commands.{DeltaGenerateCommand, RestoreTableCommand, VacuumCommand}
+import org.apache.spark.sql.delta.commands.{DeltaGenerateCommand, DescribeDeltaDetailCommand, VacuumCommand}
 import org.apache.spark.sql.delta.util.AnalysisHelper
 import io.delta.tables.DeltaTable
 
@@ -49,6 +49,13 @@ trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
     val history = deltaLog.history
     val spark = self.toDF.sparkSession
     spark.createDataFrame(history.getHistory(limit))
+  }
+
+  protected def executeDetails(
+      path: String,
+      tableIdentifier: Option[TableIdentifier]): DataFrame = {
+    val details = DescribeDeltaDetailCommand(Option(path), tableIdentifier)
+    toDataset(sparkSession, details)
   }
 
   protected def executeGenerate(tblIdentifier: String, mode: String): Unit = {

--- a/core/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
+++ b/core/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
@@ -45,8 +45,7 @@ trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
 
   protected def executeHistory(
       deltaLog: DeltaLog,
-      limit: Option[Int] = None,
-      tableId: Option[TableIdentifier] = None): DataFrame = {
+      limit: Option[Int] = None): DataFrame = {
     val history = deltaLog.history
     val spark = self.toDF.sparkSession
     spark.createDataFrame(history.getHistory(limit))
@@ -73,9 +72,8 @@ trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
 
   protected def executeVacuum(
       deltaLog: DeltaLog,
-      retentionHours: Option[Double],
-      tableId: Option[TableIdentifier] = None): DataFrame = {
-    VacuumCommand.gc(sparkSession, deltaLog, false, retentionHours)
+      retentionHours: Option[Double]): DataFrame = {
+    VacuumCommand.gc(sparkSession, deltaLog, dryRun = false, retentionHours)
     sparkSession.emptyDataFrame
   }
 

--- a/core/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
+++ b/core/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
@@ -45,7 +45,8 @@ trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
 
   protected def executeHistory(
       deltaLog: DeltaLog,
-      limit: Option[Int] = None): DataFrame = {
+      limit: Option[Int] = None,
+      tableId: Option[TableIdentifier] = None): DataFrame = {
     val history = deltaLog.history
     val spark = self.toDF.sparkSession
     spark.createDataFrame(history.getHistory(limit))
@@ -79,8 +80,9 @@ trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
 
   protected def executeVacuum(
       deltaLog: DeltaLog,
-      retentionHours: Option[Double]): DataFrame = {
-    VacuumCommand.gc(sparkSession, deltaLog, dryRun = false, retentionHours)
+      retentionHours: Option[Double],
+      tableId: Option[TableIdentifier] = None): DataFrame = {
+    VacuumCommand.gc(sparkSession, deltaLog, false, retentionHours)
     sparkSession.emptyDataFrame
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
@@ -80,13 +80,16 @@ trait DescribeDeltaDetailSuiteBase extends QueryTest
       )
     }
   }
+
+  test("delta table: SQL details using table path") {
+    describeDeltaDetailTest(f => s"'${f.toString()}'")
   }
 
-  test("delta table: delta table identifier") {
+  test("delta table: SQL details using table identifier") {
     describeDeltaDetailTest(f => s"delta.`${f.toString()}`")
   }
 
-  test("non-delta table: table name") {
+  test("non-delta table: SQL details using table name") {
     withTable("describe_detail") {
       sql(
         """
@@ -107,7 +110,7 @@ trait DescribeDeltaDetailSuiteBase extends QueryTest
     }
   }
 
-  test("non-delta table: path") {
+  test("non-delta table: SQL details using table path") {
     val tempDir = Utils.createTempDir().toString
     Seq(1 -> 1).toDF("column1", "column2")
       .write
@@ -121,7 +124,7 @@ trait DescribeDeltaDetailSuiteBase extends QueryTest
       Seq("location"))
   }
 
-  test("non-delta table: path doesn't exist") {
+  test("non-delta table: SQL details when table path doesn't exist") {
     val tempDir = Utils.createTempDir()
     tempDir.delete()
     val e = intercept[FileNotFoundException] {
@@ -130,7 +133,7 @@ trait DescribeDeltaDetailSuiteBase extends QueryTest
     assert(e.getMessage.contains(tempDir.toString))
   }
 
-  test("delta table: table name") {
+  test("delta table: SQL details using table name") {
     withTable("describe_detail") {
       sql(
         """

--- a/core/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
@@ -58,8 +58,28 @@ trait DescribeDeltaDetailSuiteBase extends QueryTest
       Seq("format", "partitionColumns", "numFiles"))
   }
 
-  test("delta table: path") {
-    describeDeltaDetailTest(f => s"'${f.toString()}'")
+  test("delta table: Scala details using table path") {
+    val tempDir = Utils.createTempDir().toString
+    Seq(1, 2, 3).toDF().write.format("delta").save(tempDir)
+
+    val deltaTable = io.delta.tables.DeltaTable.forPath(spark, tempDir)
+    checkAnswer(
+      deltaTable.details().select("format"),
+      Seq(Row("delta"))
+    )
+  }
+
+  test("delta table: Scala details using table name") {
+    withTable("delta_test") {
+      Seq(1, 2, 3).toDF().write.format("delta").saveAsTable("delta_test")
+
+      val deltaTable = io.delta.tables.DeltaTable.forName(spark, "delta_test")
+      checkAnswer(
+        deltaTable.details().select("format"),
+        Seq(Row("delta"))
+      )
+    }
+  }
   }
 
   test("delta table: delta table identifier") {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
@@ -52,21 +52,19 @@ trait DescribeDeltaDetailSuiteBase extends QueryTest
       .format("delta")
       .partitionBy("column1")
       .save(tempDir.toString())
+
+    // Check SQL details
     checkResult(
       sql(s"DESCRIBE DETAIL ${f(tempDir)}"),
       Seq("delta", Array("column1"), 1),
       Seq("format", "partitionColumns", "numFiles"))
-  }
 
-  test("delta table: Scala details using table path") {
-    val tempDir = Utils.createTempDir().toString
-    Seq(1, 2, 3).toDF().write.format("delta").save(tempDir)
-
-    val deltaTable = io.delta.tables.DeltaTable.forPath(spark, tempDir)
-    checkAnswer(
-      deltaTable.details().select("format"),
-      Seq(Row("delta"))
-    )
+    // Check Scala details
+    val deltaTable = io.delta.tables.DeltaTable.forPath(spark, tempDir.toString)
+    checkResult(
+      deltaTable.details(),
+      Seq("delta", Array("column1"), 1),
+      Seq("format", "partitionColumns", "numFiles"))
   }
 
   test("delta table: Scala details using table name") {
@@ -81,11 +79,11 @@ trait DescribeDeltaDetailSuiteBase extends QueryTest
     }
   }
 
-  test("delta table: SQL details using table path") {
+  test("delta table: path") {
     describeDeltaDetailTest(f => s"'${f.toString()}'")
   }
 
-  test("delta table: SQL details using table identifier") {
+  test("delta table: delta table identifier") {
     describeDeltaDetailTest(f => s"delta.`${f.toString()}`")
   }
 

--- a/examples/python/utilities.py
+++ b/examples/python/utilities.py
@@ -49,6 +49,9 @@ deltaTable.vacuum()
 print("######## Describe history for the table ######")
 deltaTable.history().show()
 
+print("######## Describe details for the table ######")
+deltaTable.details().show()
+
 # Generate manifest
 print("######## Generating manifest ######")
 deltaTable.generate("SYMLINK_FORMAT_MANIFEST")

--- a/examples/scala/src/main/scala/example/Utilities.scala
+++ b/examples/scala/src/main/scala/example/Utilities.scala
@@ -63,6 +63,9 @@ object Utilities {
     println("Describe History for the table")
     deltaTable.history().show()
 
+    println("Describe Details for the table")
+    deltaTable.details().show()
+
     // Generate manifest
     println("Generate Manifest files")
     deltaTable.generate("SYMLINK_FORMAT_MANIFEST")

--- a/python/delta/tables.py
+++ b/python/delta/tables.py
@@ -278,6 +278,23 @@ class DeltaTable(object):
                 getattr(self._spark, "_wrapped", self._spark)  # type: ignore[attr-defined]
             )
 
+    @since(2.0)  # type: ignore[arg-type]
+    def details(self) -> DataFrame:
+        """
+        Get the details of a Delta table such as the format, name, and size.
+
+        Example::
+
+            detailsDF = deltaTable.details() # get the full details of the table
+
+        :return Information of the table (format, name, size, etc.)
+        :rtype: pyspark.sql.DataFrame
+        """
+        return DataFrame(
+            self._jdt.details(),
+            getattr(self._spark, "_wrapped", self._spark)  # type: ignore[attr-defined]
+        )
+
     @classmethod
     @since(0.4)  # type: ignore[arg-type]
     def convertToDelta(

--- a/python/delta/tables.py
+++ b/python/delta/tables.py
@@ -278,7 +278,7 @@ class DeltaTable(object):
                 getattr(self._spark, "_wrapped", self._spark)  # type: ignore[attr-defined]
             )
 
-    @since(2.0)  # type: ignore[arg-type]
+    @since(2.1)  # type: ignore[arg-type]
     def details(self) -> DataFrame:
         """
         Get the details of a Delta table such as the format, name, and size.

--- a/python/delta/tests/test_deltatable.py
+++ b/python/delta/tests/test_deltatable.py
@@ -325,6 +325,16 @@ class DeltaTableTests(DeltaTestCase):
             [Row("Overwrite")],
             StructType([StructField("operationParameters.mode", StringType(), True)]))
 
+    def test_details(self) -> None:
+        self.__writeDeltaTable([('a', 1), ('b', 2), ('c', 3)])
+        dt = DeltaTable.forPath(self.spark, self.tempFile)
+        details = dt.details()
+        self.__checkAnswer(
+            details.select('format'),
+            [Row('delta')],
+            StructType([StructField('format', StringType(), True)])
+        )
+
     def test_vacuum(self) -> None:
         self.__writeDeltaTable([('a', 1), ('b', 2), ('c', 3)])
         dt = DeltaTable.forPath(self.spark, self.tempFile)


### PR DESCRIPTION
## Description
Resolves #1188

### PR changes 
Added a `details()` function to the Python and Scala APIs of `DeltaTable` similar to running `DESCRIBE DETAIL` to get information about a table (name, format, size, etc.) 

### Why we need the changes
Just like we have `DeltaTable.history()`, there should be a `DeltaTable.details()`

## How was this patch tested?
- Scala unit tests were added to [DescribeDeltaDetailSuite.scala](https://github.com/hedibejaoui/delta/blob/70cf2656b44798136edf39a46678fa1de2b67f0b/core/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala#L61) 
- Python unit tests were added to [tables.py](https://github.com/hedibejaoui/delta/blob/70cf2656b44798136edf39a46678fa1de2b67f0b/python/delta/tables.py#L281)
- Extended Scala and Python utilities examples and checked output of `python3 run-integration-tests.py --use-local`:
```bash
[info] Describe Details for the table
[info] +------+--------------------+----+-----------+--------------------+--------------------+--------------------+----------------+--------+-----------+----------+----------------+----------------+
[info] |format|                  id|name|description|            location|           createdAt|        lastModified|partitionColumns|numFiles|sizeInBytes|properties|minReaderVersion|minWriterVersion|
[info] +------+--------------------+----+-----------+--------------------+--------------------+--------------------+----------------+--------+-----------+----------+----------------+----------------+
[info] | delta|13a60c59-2527-4cc...|null|       null|file:/tmp/parquet...|2022-07-02 15:13:...|2022-07-02 15:13:...|              []|       6|       2656|        {}|               1|               2|
[info] +------+--------------------+----+-----------+--------------------+--------------------+--------------------+----------------+--------+-----------+----------+----------------+----------------+
..
######## Describe details for the table ######
+------+--------------------+----+-----------+--------------------+--------------------+--------------------+----------------+--------+-----------+----------+----------------+----------------+
|format|                  id|name|description|            location|           createdAt|        lastModified|partitionColumns|numFiles|sizeInBytes|properties|minReaderVersion|minWriterVersion|
+------+--------------------+----+-----------+--------------------+--------------------+--------------------+----------------+--------+-----------+----------+----------------+----------------+
| delta|46d665c3-b2bd-4de...|null|       null|file:/tmp/delta-t...|2022-07-02 15:27:...|2022-07-02 15:27:...|              []|       6|       2656|        {}|               1|               2|
+------+--------------------+----+-----------+--------------------+--------------------+--------------------+----------------+--------+-----------+----------+----------------+----------------+
``` 

## Does this PR introduce _any_ user-facing changes?
No
