### PR TITLE
Adding a test parallelization strategy (#1128)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,7 @@
  */
 
 import java.nio.file.Files
+import TestParallelization._
 
 val sparkVersion = "3.2.0"
 val scala212 = "2.12.14"
@@ -48,6 +49,7 @@ lazy val core = (project in file("core"))
     mimaSettings,
     unidocSettings,
     releaseSettings,
+    TestParallelization.testGroupingInDifferentJVMSettings ++ TestParallelization.simpleGroupingStrategySettings,
     libraryDependencies ++= Seq(
       // Adding test classifier seems to break transitive resolution of the core dependencies
       "org.apache.spark" %% "spark-hive" % sparkVersion % "provided",

--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,6 @@ lazy val core = (project in file("core"))
     mimaSettings,
     unidocSettings,
     releaseSettings,
-    TestParallelization.testGroupingInDifferentJVMSettings ++ TestParallelization.simpleGroupingStrategySettings,
     libraryDependencies ++= Seq(
       // Adding test classifier seems to break transitive resolution of the core dependencies
       "org.apache.spark" %% "spark-hive" % sparkVersion % "provided",
@@ -123,7 +122,8 @@ lazy val core = (project in file("core"))
            |}
            |""".stripMargin)
       Seq(file)
-    }
+    },
+    TestParallelization.testGroupingInDifferentJVMSettings ++ TestParallelization.simpleGroupingStrategySettings,
   )
 
 lazy val contribs = (project in file("contribs"))

--- a/build.sbt
+++ b/build.sbt
@@ -123,7 +123,7 @@ lazy val core = (project in file("core"))
            |""".stripMargin)
       Seq(file)
     },
-    TestParallelization.testGroupingInDifferentJVMSettings ++ TestParallelization.simpleGroupingStrategySettings,
+    TestParallelization.settings,
   )
 
 lazy val contribs = (project in file("contribs"))

--- a/project/TestParallelization.scala
+++ b/project/TestParallelization.scala
@@ -10,7 +10,14 @@ object TestParallelization {
       val grouping = tests.foldLeft(groupingStrategy) {
         case (strategy, testDefinition) => strategy.add(testDefinition)
       }
-      grouping.testGroups
+      val logger = streams.value.log
+      logger.info(s"Tests will be grouped in ${grouping.testGroups.size} groups")
+      val groups = grouping.testGroups
+      groups.foreach{
+          group =>
+            logger.info(s"${group.name} contains ${group.tests.size} tests")
+      }
+      groups
     }
   )
 
@@ -77,7 +84,7 @@ object TestParallelization {
 
     def apply(groupCount: Int,
               baseDir: File, forkOptionsTemplate: ForkOptions): GroupingStrategy = {
-      val testGroups = (0 to groupCount).map {
+      val testGroups = (0 until groupCount).map {
         groupIdx =>
           val forkOptions = forkOptionsTemplate.withRunJVMOptions(
             runJVMOptions = forkOptionsTemplate.runJVMOptions ++

--- a/project/TestParallelization.scala
+++ b/project/TestParallelization.scala
@@ -1,0 +1,94 @@
+import sbt.Keys._
+import sbt._
+
+object TestParallelization {
+
+  lazy val testGroupingInDifferentJVMSettings = Seq(
+    Test / testGrouping := {
+      val tests = (Test / definedTests).value
+      val groupingStrategy = (Test / testGroupingStrategy).value
+      val grouping = tests.foldLeft(groupingStrategy) {
+        case (strategy, testDefinition) => strategy.add(testDefinition)
+      }
+      grouping.testGroups
+    }
+  )
+
+  lazy val simpleGroupingStrategySettings = Seq(
+    Test / forkTestJVMCount := {
+      sys.env.get("DELTA_TEST_JVM_COUNT").map(_.toInt).getOrElse(4)
+    },
+    Test / testGroupingStrategy := {
+      val groupsCount = (Test / forkTestJVMCount).value
+      val baseJvmDir = baseDirectory.value
+      SimpleHashStrategy(groupsCount, baseJvmDir, defaultForkOptions.value)
+    }
+
+  )
+  val forkTestJVMCount = SettingKey[Int]("fork test jvm count",
+    "The number of separate JVM to use for tests"
+  )
+
+  val testGroupingStrategy = TaskKey[GroupingStrategy]("test grouping strategy",
+    "The strategy to allocate different groups to different jvms"
+  )
+  private val defaultForkOptions = Def.task {
+    ForkOptions(
+      javaHome = javaHome.value,
+      outputStrategy = outputStrategy.value,
+      bootJars = Vector.empty,
+      workingDirectory = Some(baseDirectory.value),
+      runJVMOptions = (Test / javaOptions).value.toVector,
+      connectInput = connectInput.value,
+      envVars = (Test / envVars).value
+    )
+  }
+
+  sealed trait GroupingStrategy {
+
+    def add(testDefinition: TestDefinition): GroupingStrategy
+
+    def testGroups: List[Tests.Group]
+
+  }
+
+  class SimpleHashStrategy(groups: Map[Int, Tests.Group]) extends GroupingStrategy {
+
+    lazy val testGroups = groups.values.toList
+    val groupCount = groups.size
+
+    override def add(testDefinition: TestDefinition): GroupingStrategy = {
+      val groupIdx = testDefinition.name.hashCode % groupCount
+      val currentGroup = groups(groupIdx)
+      val updatedGroup = currentGroup.withTests(
+        currentGroup.tests :+ testDefinition
+      )
+      new SimpleHashStrategy(groups + (groupIdx -> updatedGroup))
+    }
+
+  }
+
+  object SimpleHashStrategy {
+
+    def apply(groupCount: Int,
+              baseDir: File, forkOptionsTemplate: ForkOptions): GroupingStrategy = {
+      val testGroups = (0 to groupCount).map {
+        groupIdx =>
+          val forkOptions = forkOptionsTemplate.withRunJVMOptions(
+            runJVMOptions = forkOptionsTemplate.runJVMOptions ++
+              Seq(s"-Djava.io.tmpdir=${baseDir}/target/tmp/$groupIdx")
+          )
+          val group = Tests.Group(
+            name = s"Test group ${groupIdx}",
+            tests = Nil,
+            runPolicy = Tests.SubProcess(forkOptions)
+          )
+          groupIdx -> group
+      }
+      new SimpleHashStrategy(testGroups.toMap)
+    }
+  }
+
+
+
+}

--- a/project/TestParallelization.scala
+++ b/project/TestParallelization.scala
@@ -58,7 +58,7 @@ object TestParallelization {
     val groupCount = groups.size
 
     override def add(testDefinition: TestDefinition): GroupingStrategy = {
-      val groupIdx = testDefinition.name.hashCode % groupCount
+      val groupIdx = math.abs(testDefinition.name.hashCode % groupCount)
       val currentGroup = groups(groupIdx)
       val updatedGroup = currentGroup.withTests(
         currentGroup.tests :+ testDefinition

--- a/project/TestParallelization.scala
+++ b/project/TestParallelization.scala
@@ -3,27 +3,51 @@ import sbt._
 
 object TestParallelization {
 
-  lazy val testGroupingInDifferentJVMSettings = Seq(
-    Test / testGrouping := {
-      val tests = (Test / definedTests).value
-      val groupingStrategy = (Test / testGroupingStrategy).value
-      val grouping = tests.foldLeft(groupingStrategy) {
-        case (strategy, testDefinition) => strategy.add(testDefinition)
-      }
-      val logger = streams.value.log
-      logger.info(s"Tests will be grouped in ${grouping.testGroups.size} groups")
-      val groups = grouping.testGroups
-      groups.foreach{
+  lazy val settings = {
+    if (sys.env.isDefinedAt("TEST_RUN_IN_PARALLEL")) {
+      customTestGroupingSettings ++ simpleGroupingStrategySettings
+    }
+    else {
+      Seq.empty[Setting[_]]
+    }
+  }
+
+  /**
+    Replace the default value for Test / testGrouping settingKey
+    and set it to a new value calculated by using the custom Task
+   [[testGroupingStrategy]]. Adding these settings to the build
+    will require to separately provide a value for the TaskKey
+    [[testGroupingStrategy]]
+   */
+  lazy val customTestGroupingSettings = {
+    Seq(
+      Test / testGrouping := {
+        val tests = (Test / definedTests).value
+        val groupingStrategy = (Test / testGroupingStrategy).value
+        val grouping = tests.foldLeft(groupingStrategy) {
+          case (strategy, testDefinition) => strategy.add(testDefinition)
+        }
+        val logger = streams.value.log
+        logger.info(s"Tests will be grouped in ${grouping.testGroups.size} groups")
+        val groups = grouping.testGroups
+        groups.foreach{
           group =>
             logger.info(s"${group.name} contains ${group.tests.size} tests")
+        }
+        groups
       }
-      groups
-    }
-  )
+    )
+  }
 
+
+
+  /**
+      Sets the Test / testGroupingStrategy Task to an instance of the
+      SimpleHashStrategy
+   */
   lazy val simpleGroupingStrategySettings = Seq(
     Test / forkTestJVMCount := {
-      sys.env.get("DELTA_TEST_JVM_COUNT").map(_.toInt).getOrElse(4)
+      sys.env.get("TEST_PARALLELISM_COUNT").map(_.toInt).getOrElse(4)
     },
     Test / testGroupingStrategy := {
       val groupsCount = (Test / forkTestJVMCount).value
@@ -42,7 +66,8 @@ object TestParallelization {
   )
 
   val testGroupingStrategy = TaskKey[GroupingStrategy]("test grouping strategy",
-    "The strategy to allocate different groups to different jvms"
+    "The strategy to allocate different tests into groups," +
+      "potentially using multiple JVMS for their execution"
   )
   private val defaultForkOptions = Def.task {
     ForkOptions(
@@ -55,16 +80,33 @@ object TestParallelization {
       envVars = (Test / envVars).value
     )
   }
-
+  /**
+   * Base trait to group tests.
+   *
+   * By default SBT will run all tests as if they belong to a single group,
+   * but allows tests to be grouped. Setting [[sbt.Keys.testGrouping]] to
+   * a list of groups replace the default single-group definition.
+   *
+   * When creating an instance of [[sbt.Tests.Group]] it is possible to specify
+   * an [[sbt.Tests.TestRunPolicy]]: this parameter can be used to use multiple
+   * subprocesses for test execution
+   *
+   */
   sealed trait GroupingStrategy {
 
+    /**
+     * Adds an [[sbt.TestDefinition]] to this GroupingStrategy and
+     * returns an updated Grouping Strategy
+     */
     def add(testDefinition: TestDefinition): GroupingStrategy
 
+    /**
+     * Returns the test groups built from this GroupingStrategy
+     */
     def testGroups: List[Tests.Group]
-
   }
 
-  class SimpleHashStrategy(groups: Map[Int, Tests.Group]) extends GroupingStrategy {
+  class SimpleHashStrategy private(groups: Map[Int, Tests.Group]) extends GroupingStrategy {
 
     lazy val testGroups = groups.values.toList
     val groupCount = groups.size
@@ -77,7 +119,6 @@ object TestParallelization {
       )
       new SimpleHashStrategy(groups + (groupIdx -> updatedGroup))
     }
-
   }
 
   object SimpleHashStrategy {
@@ -100,7 +141,5 @@ object TestParallelization {
       new SimpleHashStrategy(testGroups.toMap)
     }
   }
-
-
 
 }

--- a/project/TestParallelization.scala
+++ b/project/TestParallelization.scala
@@ -4,7 +4,8 @@ import sbt._
 object TestParallelization {
 
   lazy val settings = {
-    if (sys.env.isDefinedAt("TEST_RUN_IN_PARALLEL")) {
+    val parallelismCount = sys.env.get("TEST_PARALLELISM_COUNT")
+    if (parallelismCount.exists( _.toInt > 1)) {
       customTestGroupingSettings ++ simpleGroupingStrategySettings
     }
     else {

--- a/project/TestParallelization.scala
+++ b/project/TestParallelization.scala
@@ -22,9 +22,14 @@ object TestParallelization {
       val groupsCount = (Test / forkTestJVMCount).value
       val baseJvmDir = baseDirectory.value
       SimpleHashStrategy(groupsCount, baseJvmDir, defaultForkOptions.value)
+    },
+    Test / parallelExecution := true,
+    Global / concurrentRestrictions := {
+      Seq(Tags.limit(Tags.ForkedTestGroup, (Test / forkTestJVMCount).value))
     }
-
   )
+
+
   val forkTestJVMCount = SettingKey[Int]("fork test jvm count",
     "The number of separate JVM to use for tests"
   )


### PR DESCRIPTION
## Description

Adds a test parallelization option to run Delta tests on different JVM addressing #1128:
- Implements a generic abstraction called `GroupingStrategy` and a default implementation `SimpleHashStrategy` that uses a fixed number of `Test.Groups` each forked in its own JVM.
- Provides two collection of settings, one that can be added to enable test parallelization, one to use the default strategy which will use 4 JVM unless separately specified by an environment variable called `DELTA_TEST_JVM_COUNT`
- Adds those two settings to the core package 

Resolves #1128 on local developer machine, but not on the CI Pipeline. 

## How was this patch tested?

Logging has been introduced using SBT logger so to get some statistics around the distribution of tests
```
sbt:delta-core> Test/testGrouping
[info] scalastyle using config /Users/edmondoporcu/Development/personal/delta/scalastyle-config.xml
[info] scalastyle Processed 151 file(s)
[info] scalastyle Found 0 errors
[info] scalastyle Found 0 warnings
[info] scalastyle Found 0 infos
[info] scalastyle Finished in 25 ms
[success] created output: /Users/edmondoporcu/Development/personal/delta/core/target
[info] Tests will be grouped in 4 groups
[info] Test group 0 contains 34 tests
[info] Test group 1 contains 31 tests
[info] Test group 2 contains 34 tests
[info] Test group 3 contains 30 tests
[success] Total time: 6 s, completed Jul 3, 2022 3:39:29 PM
```

Additionally running tops on my Macbook shows 4 JVM running as expected, all with the same Parent PID
<img width="1212" alt="Screen Shot 2022-07-03 at 3 40 53 PM" src="https://user-images.githubusercontent.com/812841/177059600-3aebbb39-0620-41e8-90f7-4ec023c3ffd4.png">


Still need to be tested, needs to trigger build on CI/CD

## Does this PR introduce _any_ user-facing changes?

No