### PR TITLE
Fix broken link in PROTOCOL.md file

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -333,7 +333,7 @@ Transaction identifiers allow this information to be recorded atomically in the 
 Transaction identifiers are stored in the form of `appId` `version` pairs, where `appId` is a unique identifier for the process that is modifying the table and `version` is an indication of how much progress has been made by that application.
 The atomic recording of this information along with modifications to the table enables these external system to make their writes into a Delta table _idempotent_.
 
-For example, the [Delta Sink for Apache Spark's Structured Streaming](https://github.com/delta-io/delta/blob/master/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala) ensures exactly-once semantics when writing a stream into a table using the following process:
+For example, the [Delta Sink for Apache Spark's Structured Streaming](https://github.com/delta-io/delta/blob/master/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala) ensures exactly-once semantics when writing a stream into a table using the following process:
  1. Record in a write-ahead-log the data that will be written, along with a monotonically increasing identifier for this batch.
  2. Check the current version of the transaction with `appId = streamId` in the target table. If this value is greater than or equal to the batch being written, then this data has already been added to the table and processing can skip to the next batch.
  3. Write the data optimistically into the table.


### PR DESCRIPTION
## Description

There was a broken link in `PROTOCOL.md` file. It is the link titled `Delta Sink for Apache Spark's Structured Streaming` inside **Transaction Identifiers** section. 

The fix is a simple change in the URL to point to the right source file.

## How was this patch tested?

It is a markdown update hence no tests included.

## Does this PR introduce _any_ user-facing changes?

No.