### PR TITLE
Delta un supported column mapping error message change 

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -1382,16 +1382,7 @@
     "message" : [
       "",
       "Your current table protocol version does not support changing column mapping modes",
-      "using <config>.",
-      "",
-      "Required Delta protocol version for column mapping:",
-      "<requiredVersion>",
-      "Your table's current Delta protocol version:",
-      "<currentVersion>",
-      "",
-      "Please upgrade your table's protocol version using ALTER TABLE SET TBLPROPERTIES and try again.",
-      "",
-      ""
+      "using <config>.<advice>"
     ],
     "sqlState" : "0A000"
   },

--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -1382,7 +1382,13 @@
     "message" : [
       "",
       "Your current table protocol version does not support changing column mapping modes",
-      "using <config>.<advice>"
+      "using <config>.",
+      "",
+      "Required Delta protocol version for column mapping:",
+      "<requiredVersion>",
+      "Your table's current Delta protocol version:",
+      "<currentVersion>",
+      "<advice>"
     ],
     "sqlState" : "0A000"
   },

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1779,8 +1779,7 @@ trait DeltaErrorsBase
       errorClass = "DELTA_UNSUPPORTED_COLUMN_MAPPING_PROTOCOL",
       messageParameters = Array(
         s"${DeltaConfigs.COLUMN_MAPPING_MODE.key}",
-        s"${DeltaColumnMapping.MIN_PROTOCOL_VERSION.toString}",
-        s"$oldProtocol"))
+        columnMappingAdviceMessage))
   }
 
   private def columnMappingAdviceMessage: String = {

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1779,6 +1779,8 @@ trait DeltaErrorsBase
       errorClass = "DELTA_UNSUPPORTED_COLUMN_MAPPING_PROTOCOL",
       messageParameters = Array(
         s"${DeltaConfigs.COLUMN_MAPPING_MODE.key}",
+        s"${DeltaColumnMapping.MIN_PROTOCOL_VERSION.toString}",
+        s"$oldProtocol",
         columnMappingAdviceMessage))
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1793,8 +1793,7 @@ trait DeltaErrorsBase
        |   'delta.columnMapping.mode' = 'name',
        |   'delta.minReaderVersion' = '2',
        |   'delta.minWriterVersion' = '5')
-       |
-    """.stripMargin
+       |""".stripMargin
   }
 
   def columnRenameNotSupported: Throwable = {

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1785,9 +1785,9 @@ trait DeltaErrorsBase
   private def columnMappingAdviceMessage: String = {
     s"""
        |Please upgrade your Delta table to reader version 2 and writer version 5
-       | and change the column mapping mode to 'name' mapping. You can use the following command:
+       |and change the column mapping mode to 'name' mapping. You can use the following command:
        |
-       | ALTER TABLE <table_name> SET TBLPROPERTIES (
+       |ALTER TABLE <table_name> SET TBLPROPERTIES (
        |   'delta.columnMapping.mode' = 'name',
        |   'delta.minReaderVersion' = '2',
        |   'delta.minWriterVersion' = '5')

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -417,9 +417,9 @@ trait DeltaErrorsSuiteBase
            |Your current table protocol version does not support changing column mapping modes
            |using delta.columnMapping.mode.
            |Please upgrade your Delta table to reader version 2 and writer version 5
-           | and change the column mapping mode to 'name' mapping. You can use the following command:
+           |and change the column mapping mode to 'name' mapping. You can use the following command:
            |
-           | ALTER TABLE <table_name> SET TBLPROPERTIES (
+           |ALTER TABLE <table_name> SET TBLPROPERTIES (
            |   'delta.columnMapping.mode' = 'name',
            |   'delta.minReaderVersion' = '2',
            |   'delta.minWriterVersion' = '5')

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -429,8 +429,7 @@ trait DeltaErrorsSuiteBase
            |   'delta.columnMapping.mode' = 'name',
            |   'delta.minReaderVersion' = '2',
            |   'delta.minWriterVersion' = '5')
-           |
-    """.stripMargin)
+           |""".stripMargin)
     }
     {
       val e = intercept[DeltaColumnMappingUnsupportedException] {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -416,6 +416,12 @@ trait DeltaErrorsSuiteBase
         s"""
            |Your current table protocol version does not support changing column mapping modes
            |using delta.columnMapping.mode.
+           |
+           |Required Delta protocol version for column mapping:
+           |Protocol(2,5)
+           |Your table's current Delta protocol version:
+           |Protocol(2,6)
+           |
            |Please upgrade your Delta table to reader version 2 and writer version 5
            |and change the column mapping mode to 'name' mapping. You can use the following command:
            |

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -412,20 +412,19 @@ trait DeltaErrorsSuiteBase
       val e = intercept[DeltaColumnMappingUnsupportedException] {
         throw DeltaErrors.changeColumnMappingModeOnOldProtocol(Protocol())
       }
-      val cmd = "ALTER TABLE SET TBLPROPERTIES"
       assert(e.getMessage ==
         s"""
            |Your current table protocol version does not support changing column mapping modes
            |using delta.columnMapping.mode.
+           |Please upgrade your Delta table to reader version 2 and writer version 5
+           | and change the column mapping mode to 'name' mapping. You can use the following command:
            |
-           |Required Delta protocol version for column mapping:
-           |Protocol(2,5)
-           |Your table's current Delta protocol version:
-           |Protocol(2,6)
+           | ALTER TABLE <table_name> SET TBLPROPERTIES (
+           |   'delta.columnMapping.mode' = 'name',
+           |   'delta.minReaderVersion' = '2',
+           |   'delta.minWriterVersion' = '5')
            |
-           |Please upgrade your table's protocol version using $cmd and try again.
-           |
-           |""".stripMargin)
+    """.stripMargin)
     }
     {
       val e = intercept[DeltaColumnMappingUnsupportedException] {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
Resolves #1186

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

From SqlTest Suite

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

Yes

### Console Output before Change :

```
Exception in thread "main" org.apache.spark.sql.delta.DeltaColumnMappingUnsupportedException: 
Your current table protocol version does not support changing column mapping modes
using delta.columnMapping.mode.

Required Delta protocol version for column mapping:
Protocol(2,5)
Your table's current Delta protocol version:
Protocol(1,2)

Please upgrade your table's protocol version using ALTER TABLE SET TBLPROPERTIES and try again.

```



### Console Output after Change :

```
Exception in thread "main" org.apache.spark.sql.delta.DeltaColumnMappingUnsupportedException: 
Your current table protocol version does not support changing column mapping modes
using delta.columnMapping.mode.

Required Delta protocol version for column mapping:
Protocol(2,5)
Your table's current Delta protocol version:
Protocol(1,2)

Please upgrade your Delta table to reader version 2 and writer version 5
and change the column mapping mode to 'name' mapping. You can use the following command:

ALTER TABLE <table_name> SET TBLPROPERTIES (
   'delta.columnMapping.mode' = 'name',
   'delta.minReaderVersion' = '2',
   'delta.minWriterVersion' = '5')


```

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
