### PR TITLE
Add isolationLevel delta config but only allow Serializable for now

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -496,6 +496,19 @@ trait DeltaConfigsBase extends DeltaLogging {
     opt => opt.forall(isValidIntervalConfigValue),
     "needs to be provided as a calendar interval such as '2 weeks'. Months " +
       "and years are not accepted. You may specify '365 days' for a year instead.")
+
+  /**
+   * The isolation level of a table defines the degree to which a transaction must be isolated from
+   * modifications made by concurrent transactions. Delta supports two isolation levels:
+   * Serializable and WriteSerializable. The default is Serializable.
+   */
+  val ISOLATION_LEVEL = buildConfig[IsolationLevel](
+    "isolationLevel",
+    Serializable.toString,
+    IsolationLevel.fromString(_),
+    _ == Serializable,
+    "currently only Serializable isolation level is allowed"
+  )
 }
 
 object DeltaConfigs extends DeltaConfigsBase

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -499,15 +499,15 @@ trait DeltaConfigsBase extends DeltaLogging {
 
   /**
    * The isolation level of a table defines the degree to which a transaction must be isolated from
-   * modifications made by concurrent transactions. Delta supports two isolation levels:
-   * Serializable and WriteSerializable. The default is Serializable.
+   * modifications made by concurrent transactions. Delta currently supports one isolation level:
+   * Serializable.
    */
   val ISOLATION_LEVEL = buildConfig[IsolationLevel](
     "isolationLevel",
     Serializable.toString,
     IsolationLevel.fromString(_),
     _ == Serializable,
-    "currently only Serializable isolation level is allowed"
+    "must be Serializable"
   )
 }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -192,13 +192,6 @@ class DeltaLog private(
     }
   }
 
-  /**
-   * [[IsolationLevel]] as set in table delta config and to be passed into the transaction.
-   */
-  private[delta] def isolationLevel: IsolationLevel = {
-    DeltaConfigs.ISOLATION_LEVEL.fromMetaData(metadata)
-  }
-
   /* ------------------ *
    |  Delta Management  |
    * ------------------ */

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -192,6 +192,13 @@ class DeltaLog private(
     }
   }
 
+  /**
+   * [[IsolationLevel]] as set in table delta config and to be passed into the transaction.
+   */
+  private[delta] def isolationLevel: IsolationLevel = {
+    DeltaConfigs.ISOLATION_LEVEL.fromMetaData(metadata)
+  }
+
   /* ------------------ *
    |  Delta Management  |
    * ------------------ */

--- a/core/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1021,7 +1021,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
   }
 
   protected def getDefaultIsolationLevel(): IsolationLevel = {
-    Serializable
+    deltaLog.isolationLevel
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1020,8 +1020,11 @@ trait OptimisticTransactionImpl extends TransactionalWrite
     allowFallbackToSnapshotIsolation
   }
 
+  /**
+  * Default [[IsolationLevel]] as set in table metadata.
+  */
   protected def getDefaultIsolationLevel(): IsolationLevel = {
-    deltaLog.isolationLevel
+    DeltaConfigs.ISOLATION_LEVEL.fromMetaData(metadata)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1023,7 +1023,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
   /**
   * Default [[IsolationLevel]] as set in table metadata.
   */
-  protected def getDefaultIsolationLevel(): IsolationLevel = {
+  private[delta] def getDefaultIsolationLevel(): IsolationLevel = {
     DeltaConfigs.ISOLATION_LEVEL.fromMetaData(metadata)
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaConfigSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaConfigSuite.scala
@@ -159,8 +159,8 @@ class DeltaConfigSuite extends SparkFunSuite
     }
   }
 
-  test("Allow setting Serializable Isolation Level") {
-    // (1) we can set valid and supported isolation level
+  test("allow setting valid and supported isolation level") {
+    // currently only Serializable isolation level is supported
     withTempDir { dir =>
       sql(
         s"""CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta
@@ -172,8 +172,9 @@ class DeltaConfigSuite extends SparkFunSuite
 
       assert(isolationLevel == Serializable)
     }
+  }
 
-    // (2) we can not set valid but unsupported isolation level
+  test("do not allow setting valid but unsupported isolation level") {
     withTempDir { dir =>
       val e = intercept[IllegalArgumentException] {
         sql(
@@ -184,8 +185,9 @@ class DeltaConfigSuite extends SparkFunSuite
       val msg = "requirement failed: delta.isolationLevel must be Serializable"
       assert(e.getMessage == msg)
     }
-
-    // (3) we can not set invalid isolation level
+  }
+  
+  test("do not allow setting invalid isolation level") {
     withTempDir { dir =>
       val e = intercept[IllegalArgumentException] {
         sql(

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaConfigSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaConfigSuite.scala
@@ -168,7 +168,7 @@ class DeltaConfigSuite extends SparkFunSuite
            |""".stripMargin)
 
       val isolationLevel =
-        DeltaLog.forTable(spark, dir.getCanonicalPath).isolationLevel
+        DeltaLog.forTable(spark, dir.getCanonicalPath).startTransaction().getDefaultIsolationLevel()
 
       assert(isolationLevel == Serializable)
     }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaConfigSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaConfigSuite.scala
@@ -186,7 +186,7 @@ class DeltaConfigSuite extends SparkFunSuite
       assert(e.getMessage == msg)
     }
   }
-  
+
   test("do not allow setting invalid isolation level") {
     withTempDir { dir =>
       val e = intercept[IllegalArgumentException] {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaConfigSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaConfigSuite.scala
@@ -175,13 +175,13 @@ class DeltaConfigSuite extends SparkFunSuite
 
     // (1) we can not set writable serializable isolation level
     withTempDir { dir =>
-      val e = intercept[DeltaIllegalArgumentException] {
+      val e = intercept[IllegalArgumentException] {
         sql(
           s"""CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta
-             |TBLPROPERTIES ('delta.isolationLevel' = 'WritableSerializable')
+             |TBLPROPERTIES ('delta.isolationLevel' = 'WriteSerializable')
              |""".stripMargin)
       }
-      var msg = "invalid isolation level 'WritableSerializable'"
+      val msg = "requirement failed: delta.isolationLevel must be Serializable"
       assert(e.getMessage == msg)
     }
   }


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

Resolves #1265 

## How was this patch tested?

Added test to DeltaConfigSuite for setting isolation level

## Does this PR introduce _any_ user-facing changes?

Yes, user can now set `delta.isolationLevel = Serializable` on table