### PR TITLE
Fix table properties case sensitivity in CreateDeltaTable

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.catalyst.analysis.{Analyzer, CannotReplaceMissingTab
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.execution.command.{LeafRunnableCommand, RunnableCommand}
 import org.apache.spark.sql.types.StructType
@@ -317,7 +318,8 @@ case class CreateDeltaTableCommand(
           path, tableDesc.partitionColumnNames, existingMetadata.partitionColumns)
       }
 
-      if (tableDesc.properties.nonEmpty && tableDesc.properties != existingMetadata.configuration) {
+      if (tableDesc.properties.nonEmpty &&
+        tableDesc.properties != CaseInsensitiveMap(existingMetadata.configuration)) {
         throw DeltaErrors.createTableWithDifferentPropertiesException(
           path, tableDesc.properties, existingMetadata.configuration)
       }


### PR DESCRIPTION
## Description

Resolves #1291

## How was this patch tested?

Tested by locally running the patched Delta library and confirming this fixes the issue at hand

## Does this PR introduce _any_ user-facing changes?

No