### PR TITLE
Allow schema evolution in nested fields unrelated to generated columns

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -1014,7 +1014,7 @@ case class Metadata(
    * we should never change its type.
    */
   @JsonIgnore
-  lazy val fixedTypeColumns: Set[String] =
+  lazy val fixedTypeColumns: Set[Seq[String]] =
     GeneratedColumn.getGeneratedColumnsAndColumnsUsedByGeneratedColumns(schema)
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/ImplicitMetadataOperation.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/ImplicitMetadataOperation.scala
@@ -154,7 +154,7 @@ object ImplicitMetadataOperation {
         if (GeneratedColumn.satisfyGeneratedColumnProtocol(txn.protocol)) {
           txn.metadata.fixedTypeColumns
         } else {
-          Set.empty[String]
+          Set.empty[Seq[String]]
         }
       SchemaMergingUtils.mergeSchemas(
         txn.metadata.schema,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaMergingUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaMergingUtils.scala
@@ -170,9 +170,6 @@ object SchemaMergingUtils {
       fixedTypeColumns: Set[Seq[String]] = Set.empty,
       caseSensitive: Boolean = false): StructType = {
     checkColumnNameDuplication(dataSchema, "in the data to save", caseSensitive)
-    // scalastyle:off println
-    println(fixedTypeColumns)
-    // scalastyle:on println
     def merge(
         current: DataType,
         update: DataType,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1402,7 +1402,7 @@ trait DeltaErrorsSuiteBase
       val e = intercept[DeltaAnalysisException] {
         val s1 = StructType(Seq(StructField("c0", IntegerType, true)))
         val s2 = StructType(Seq(StructField("c0", StringType, false)))
-        SchemaMergingUtils.mergeSchemas(s1, s2, false, false, Set("c0"))
+        SchemaMergingUtils.mergeSchemas(s1, s2, false, false, Set(Seq("c0")))
       }
       checkErrorMessage(e, Some("DELTA_GENERATED_COLUMNS_DATA_TYPE_MISMATCH"), Some("42K09"),
         Some("Column c0 is a generated column or a column used by a generated " +

--- a/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
@@ -795,7 +795,7 @@ trait GeneratedColumnSuiteBase extends GeneratedColumnTest {
     val map2 = withGenerationExpression(StructField("m2", IntegerType), "m1.x + 10")
     testSchema(Seq(map1, map2), Set(Seq("m1"), Seq("m2")))
 
-    // Map with struct types doesn't track passed the map
+    // Map with struct type doesn't track passed the map
     val map3 = StructField("m3", MapType(StringType, StructType(Seq(
       StructField("y", IntegerType)))))
     val map4 = withGenerationExpression(StructField("m4", IntegerType), "m3.x.y + 10")
@@ -805,7 +805,7 @@ trait GeneratedColumnSuiteBase extends GeneratedColumnTest {
     val array2 = withGenerationExpression(StructField("a2", IntegerType), "a1[0] + 10")
     testSchema(Seq(array1, array2), Set(Seq("a1"), Seq("a2")))
 
-    // Array with struct types doesn't track passed the array
+    // Array with struct type doesn't track passed the array
     val array3 = StructField("a3", ArrayType(StructType(Seq(StructField("y", IntegerType)))))
     val array4 = withGenerationExpression(StructField("a4", IntegerType), "a3[0].y + 10")
     testSchema(Seq(array3, array4), Set(Seq("a3"), Seq("a4")))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
@@ -783,6 +783,9 @@ trait GeneratedColumnSuiteBase extends GeneratedColumnTest {
     val f6x = StructField("c6.x", IntegerType)
     val f7x = withGenerationExpression(StructField("c7.x", IntegerType), "`c6.x` + 10")
     val f8 = withGenerationExpression(StructField("c8", IntegerType), "c6.x + 10")
+    val f9 = StructField("c9", StructType(StructField("x", StructType(StructField("y", IntegerType)
+      :: Nil)) :: Nil))
+    val f10 = withGenerationExpression(StructField("c10", IntegerType), "c9.x.y + 10")
     testSchema(Seq(f1, f2), Set(Seq("c1"), Seq("c2")))
     testSchema(Seq(f1, f2, f3), Set(Seq("c1"), Seq("c2")))
     testSchema(Seq(f1, f2, f3, f4), Set(Seq("c1"), Seq("c2"), Seq("c3"), Seq("c4")))
@@ -790,6 +793,7 @@ trait GeneratedColumnSuiteBase extends GeneratedColumnTest {
     testSchema(Seq(f6x, f7x), Set(Seq("c6.x"), Seq("c7.x")))
     testSchema(Seq(f6, f6x, f7x), Set(Seq("c6.x"), Seq("c7.x")))
     testSchema(Seq(f6, f6x, f8), Set(Seq("c6", "x"), Seq("c8")))
+    testSchema(Seq(f9, f10), Set(Seq("c9", "x", "y"), Seq("c10")))
 
     val map1 = StructField("m1", MapType(StringType, IntegerType))
     val map2 = withGenerationExpression(StructField("m2", IntegerType), "m1.x + 10")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
Resolves https://github.com/delta-io/delta/issues/1281

Updating the schema of a field involved in generated columns is not allowed, because it could change the semantics of the generated field. However, the fields used by generated fields is only tracked at the top level of the schema. This updates the checks to track the full nested path to the field used by generated columns, so that other fields in those nested structs can be updated, as they are unrelated to the generated column.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
New and updated UTs.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
Adds new capability to update nested field types.

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
