### PR TITLE
[MINOR] Code Cleanup / Refactoring

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2442,7 +2442,7 @@ class MetadataMismatchErrorBuilder {
       s"""To overwrite your schema or change partitioning, please set:
          |'.option("${DeltaOptions.OVERWRITE_SCHEMA_OPTION}", "true")'.
          |
-           |Note that the schema can't be overwritten when using
+         |Note that the schema can't be overwritten when using
          |'${DeltaOptions.REPLACE_WHERE_OPTION}'.
          """.stripMargin :: Nil
   }

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -75,9 +75,7 @@ trait DeltaWriteOptionsImpl extends DeltaOptionParser {
   }
 
   /**
-   * Whether to allow overwriting the schema of a Delta table in an overwrite mode operation. If
-   * ACLs are enabled, we can't change the schema of an operation through a write, which requires
-   * MODIFY permissions, when schema changes require OWN permissions.
+   * Whether to allow overwriting the schema of a Delta table in an overwrite mode operation.
    */
   def canOverwriteSchema: Boolean = {
     options.get(OVERWRITE_SCHEMA_OPTION).exists(toBoolean(_, OVERWRITE_SCHEMA_OPTION))

--- a/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
@@ -96,9 +96,9 @@ class DeltaCatalog extends DelegatingCatalogExtension
       case _ => true
     }.toMap
     val (partitionColumns, maybeBucketSpec) = convertTransforms(partitions)
-    var newSchema = schema
-    var newPartitionColumns = partitionColumns
-    var newBucketSpec = maybeBucketSpec
+    val newSchema = schema
+    val newPartitionColumns = partitionColumns
+    val newBucketSpec = maybeBucketSpec
     val conf = spark.sessionState.conf
 
     val isByPath = isPathIdentifier(ident)
@@ -119,7 +119,7 @@ class DeltaCatalog extends DelegatingCatalogExtension
     val id = {
       TableIdentifier(ident.name(), ident.namespace().lastOption)
     }
-    var locUriOpt = location.map(CatalogUtils.stringToURI)
+    val locUriOpt = location.map(CatalogUtils.stringToURI)
     val existingTableOpt = getExistingTableIfExists(id)
     val loc = locUriOpt
       .orElse(existingTableOpt.flatMap(_.storage.locationUri))
@@ -194,7 +194,7 @@ class DeltaCatalog extends DelegatingCatalogExtension
 
   private def getProvider(properties: util.Map[String, String]): String = {
     Option(properties.get("provider"))
-      .getOrElse(spark.sessionState.conf.getConf(SQLConf.DEFAULT_DATA_SOURCE_NAME))
+      .getOrElse(spark.sessionState.conf.defaultDataSourceName)
   }
 
   override def createTable(

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -429,7 +429,8 @@ case class CreateDeltaTableCommand(
         operation == TableCreationModes.Replace)
     // If a user explicitly specifies not to overwrite the schema, during a replace, we should
     // tell them that it's not supported
-    val dontOverwriteSchema = !options.canOverwriteSchema
+    val dontOverwriteSchema = options.options.contains(DeltaOptions.OVERWRITE_SCHEMA_OPTION) &&
+      !options.canOverwriteSchema
     if (isReplace && dontOverwriteSchema) {
       throw DeltaErrors.illegalUsageException(DeltaOptions.OVERWRITE_SCHEMA_OPTION, "replacing")
     }

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
@@ -17,18 +17,15 @@
 package org.apache.spark.sql.delta.commands.cdc
 
 import java.sql.Timestamp
-
 import scala.collection.mutable.ListBuffer
-
-import org.apache.spark.sql.delta.{DeltaConfigs, DeltaErrors, DeltaHistoryManager, DeltaLog, DeltaOperations, DeltaParquetFileFormat, DeltaTableUtils, DeltaTimeTravelSpec, NoMapping, Snapshot}
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaErrors, DeltaHistoryManager, DeltaLog, DeltaOperations, DeltaOptions, DeltaParquetFileFormat, DeltaTableUtils, DeltaTimeTravelSpec, NoMapping, Snapshot}
 import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, AddFile, CommitInfo, FileAction, Metadata, RemoveFile}
 import org.apache.spark.sql.delta.files.{CdcAddFileIndex, TahoeChangeFileIndex, TahoeFileIndex, TahoeRemoveFileIndex}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.SchemaUtils
-import org.apache.spark.sql.delta.sources.{DeltaDataSource, DeltaSource, DeltaSQLConf}
-
+import org.apache.spark.sql.delta.sources.{DeltaDataSource, DeltaSQLConf, DeltaSource}
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession, SQLContext}
+import org.apache.spark.sql.{DataFrame, Dataset, Row, SQLContext, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.internal.SQLConf

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.delta.commands.cdc
 
 import java.sql.Timestamp
+
 import scala.collection.mutable.ListBuffer
 import org.apache.spark.sql.delta.{DeltaConfigs, DeltaErrors, DeltaHistoryManager, DeltaLog, DeltaOperations, DeltaOptions, DeltaParquetFileFormat, DeltaTableUtils, DeltaTimeTravelSpec, NoMapping, Snapshot}
 import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, AddFile, CommitInfo, FileAction, Metadata, RemoveFile}

--- a/core/src/main/scala/org/apache/spark/sql/delta/files/DelayedCommitProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/files/DelayedCommitProtocol.scala
@@ -203,14 +203,12 @@ class DelayedCommitProtocol(
       taskContext: TaskAttemptContext): FileAction = {
     // The partitioning in the Delta log action will be read back as part of the data, so our
     // virtual CDC_PARTITION_COL needs to be stripped out.
-    val partitioning = f._1.filter { case (k, v) => k != CDC_PARTITION_COL }
+    val partitioning = f._1.filter { case (k, _) => k != CDC_PARTITION_COL }
     f._1.get(CDC_PARTITION_COL) match {
       case Some("true") =>
-        val partitioning = f._1.filter { case (k, v) => k != CDC_PARTITION_COL }
         AddCDCFile(f._2, partitioning, stat.getLen)
       case _ =>
-        val addFile = AddFile(f._2, partitioning, stat.getLen, stat.getModificationTime, true)
-        addFile
+        AddFile(f._2, partitioning, stat.getLen, stat.getModificationTime, dataChange = true)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -194,9 +194,7 @@ object SchemaUtils extends DeltaLogging {
     } else {
       // Allow the same shortcut logic (as the above `if` stmt) if the only extra fields are CDC
       // metadata fields.
-      val nonCdcFields = dataFields.filterNot { f =>
-        f == CDCReader.CDC_PARTITION_COL || f == CDCReader.CDC_TYPE_COLUMN_NAME
-      }
+      val nonCdcFields = dataFields.filterNot(CDCReader.CDC_COLUMNS_IN_DATA.contains)
       if (nonCdcFields.subsetOf(tableFields)) {
         return data.toDF()
       }

--- a/core/src/test/scala/org/apache/spark/sql/delta/cdc/CDCReaderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/cdc/CDCReaderSuite.scala
@@ -72,7 +72,7 @@ class CDCReaderSuite
       }
 
       SQLExecution.withNewExecutionId(qe) {
-        var committer = new DelayedCommitProtocol("delta", basePath, randomPrefixes)
+        val committer = new DelayedCommitProtocol("delta", basePath, randomPrefixes)
         FileFormatWriter.write(
           sparkSession = spark,
           plan = qe.executedPlan,


### PR DESCRIPTION
Code Cleanup / Refactoring:

- Use vals (not vars)
- Fix scaladocs
- Use constants
- Check table availability with txn.deltaLog.tableExists (not txn.readVersion > -1)
- Import reorg
- Remove unused values

## How was this patch tested?

1. `./build/sbt clean package test:compile`
2. `./build/sbt clean '++ 2.13.5 ; package ; test:compile'`

Waiting for the repo build to execute the entire testsuite.

## Does this PR introduce _any_ user-facing changes?

No