### PR TITLE
Option to ignore concurrent changes to files read

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -107,7 +107,8 @@ private[delta] class ConflictChecker(
     spark: SparkSession,
     initialCurrentTransactionInfo: CurrentTransactionInfo,
     winningCommitVersion: Long,
-    isolationLevel: IsolationLevel) extends DeltaLogging {
+    isolationLevel: IsolationLevel,
+    ignoreReadChanges: Boolean) extends DeltaLogging {
 
   protected val startTimeMs = System.currentTimeMillis()
   protected val timingStats = mutable.HashMap[String, Long]()
@@ -124,8 +125,10 @@ private[delta] class ConflictChecker(
   def checkConflicts(): CurrentTransactionInfo = {
     checkProtocolCompatibility()
     checkNoMetadataUpdates()
-    checkForAddedFilesThatShouldHaveBeenReadByCurrentTxn()
-    checkForDeletedFilesAgainstCurrentTxnReadFiles()
+    if (!ignoreReadChanges) {
+      checkForAddedFilesThatShouldHaveBeenReadByCurrentTxn()
+      checkForDeletedFilesAgainstCurrentTxnReadFiles()
+    }
     checkForDeletedFilesAgainstCurrentTxnDeletedFiles()
     checkForUpdatedApplicationTransactionIdsThatCurrentTxnDependsOn()
     logMetrics()

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -22,7 +22,7 @@ import java.util.regex.PatternSyntaxException
 import scala.util.Try
 import scala.util.matching.Regex
 
-import org.apache.spark.sql.delta.DeltaOptions.{DATA_CHANGE_OPTION, MERGE_SCHEMA_OPTION, OVERWRITE_SCHEMA_OPTION, PARTITION_OVERWRITE_MODE_OPTION}
+import org.apache.spark.sql.delta.DeltaOptions.{DATA_CHANGE_OPTION, MERGE_SCHEMA_OPTION, IGNORE_READ_CHANGES_OPTION, OVERWRITE_SCHEMA_OPTION, PARTITION_OVERWRITE_MODE_OPTION}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
@@ -136,6 +136,17 @@ trait DeltaWriteOptionsImpl extends DeltaOptionParser {
       mode.equalsIgnoreCase(PARTITION_OVERWRITE_MODE_DYNAMIC)
     }
   }
+
+  /**
+   * Whether to ignore any changes (added files, deletes) to files read.
+   * If changes to files read don't matter to you and you set this option
+   * you will not get a ConcurrentAppendException if these files were changed by
+   * other transactions, and your transactions might become blind appends if the
+   * files read prevented it from becoming this.
+   */
+  def ignoreReadChanges: Boolean = {
+    options.get(IGNORE_READ_CHANGES_OPTION).exists(toBoolean(_, IGNORE_READ_CHANGES_OPTION))
+  }
 }
 
 trait DeltaReadOptions extends DeltaOptionParser {
@@ -234,6 +245,7 @@ object DeltaOptions extends DeltaLogging {
   val IGNORE_FILE_DELETION_OPTION = "ignoreFileDeletion"
   val IGNORE_CHANGES_OPTION = "ignoreChanges"
   val IGNORE_DELETES_OPTION = "ignoreDeletes"
+  val IGNORE_READ_CHANGES_OPTION = "ignoreReadChanges"
   val FAIL_ON_DATA_LOSS_OPTION = "failOnDataLoss"
   val OPTIMIZE_WRITE_OPTION = "optimizeWrite"
   val DATA_CHANGE_OPTION = "dataChange"
@@ -261,6 +273,7 @@ object DeltaOptions extends DeltaLogging {
     IGNORE_FILE_DELETION_OPTION,
     IGNORE_CHANGES_OPTION,
     IGNORE_DELETES_OPTION,
+    IGNORE_READ_CHANGES_OPTION,
     FAIL_ON_DATA_LOSS_OPTION,
     OPTIMIZE_WRITE_OPTION,
     DATA_CHANGE_OPTION,

--- a/core/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -195,6 +195,12 @@ trait OptimisticTransactionImpl extends TransactionalWrite
   /** Whether the whole table was read during the transaction. */
   protected var readTheWholeTable = false
 
+  /**
+   * Whether to ignore any changes to files read
+   * which is relevant for conflict checking or blind appends.
+   */
+  protected var ignoreFilesReadChanges = false
+
   /** Tracks if this transaction has already committed. */
   protected var committed = false
 
@@ -521,6 +527,11 @@ trait OptimisticTransactionImpl extends TransactionalWrite
     readTheWholeTable = true
   }
 
+  /** Ignore any changes to files read during conflict checking for transaction. */
+  def ignoreReadChanges(): Unit = {
+    ignoreFilesReadChanges = true
+  }
+
   /** Mark the given files as read within this transaction. */
   def withFilesRead(files: Seq[AddFile]): Unit = {
     readFiles ++= files
@@ -647,7 +658,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
           val dependsOnFiles = readPredicates.nonEmpty || readFiles.nonEmpty
           val onlyAddFiles =
             preparedActions.collect { case f: FileAction => f }.forall(_.isInstanceOf[AddFile])
-          onlyAddFiles && !dependsOnFiles
+          onlyAddFiles && (!dependsOnFiles || ignoreFilesReadChanges)
         }
 
         commitInfo = CommitInfo(
@@ -1272,7 +1283,8 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       spark,
       currentTransactionInfo,
       otherCommitVersion,
-      commitIsolationLevel)
+      commitIsolationLevel,
+      ignoreFilesReadChanges)
     conflictChecker.checkConflicts()
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -97,7 +97,6 @@ case class WriteIntoDelta(
       val actions = write(txn, sparkSession)
       val operation = DeltaOperations.Write(mode, Option(partitionColumns),
         options.replaceWhere, options.userMetadata)
-      // Allow user to override if this is a blind append
       if (options.ignoreReadChanges) {
         txn.ignoreReadChanges()
       }

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -97,6 +97,10 @@ case class WriteIntoDelta(
       val actions = write(txn, sparkSession)
       val operation = DeltaOperations.Write(mode, Option(partitionColumns),
         options.replaceWhere, options.userMetadata)
+      // Allow user to override if this is a blind append
+      if (options.ignoreReadChanges) {
+        txn.ignoreReadChanges()
+      }
       txn.commit(actions, operation)
     }
     Seq.empty

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
@@ -77,12 +77,9 @@ class DeltaSink(
     if (selfScan) {
       txn.readWholeTable()
     }
-
-    // Allow user to override if this is a blind append
     if (options.ignoreReadChanges) {
       txn.ignoreReadChanges()
     }
-
     // Streaming sinks can't blindly overwrite schema. See Schema Management design doc for details
     updateMetadata(data.sparkSession, txn, data.schema, partitionColumns, Map.empty,
       outputMode == OutputMode.Complete(), rearrangeOnly = false)

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
@@ -78,6 +78,11 @@ class DeltaSink(
       txn.readWholeTable()
     }
 
+    // Allow user to override if this is a blind append
+    if (options.ignoreReadChanges) {
+      txn.ignoreReadChanges()
+    }
+
     // Streaming sinks can't blindly overwrite schema. See Schema Management design doc for details
     updateMetadata(data.sparkSession, txn, data.schema, partitionColumns, Map.empty,
       outputMode == OutputMode.Complete(), rearrangeOnly = false)

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
@@ -456,12 +456,14 @@ class DeltaSinkSuite extends StreamTest with DeltaColumnMappingTestUtils {
 
       def tableData: DataFrame = spark.read.format("delta").load(outputDir.toString)
 
-      def appendToTable(df: DataFrame): Unit = failAfter(streamingTimeout) {
+      def appendToTable(df: DataFrame, options: Map[String, String] = Map.empty
+      ): Unit = failAfter(streamingTimeout) {
         var q: StreamingQuery = null
         try {
           input.addData(0)
           q = df.writeStream
             .format("delta")
+            .options(options)
             .option("checkpointLocation", checkpointDir.toString)
             .start(outputDir.toString)
           q.processAllAvailable()
@@ -491,6 +493,12 @@ class DeltaSinkSuite extends StreamTest with DeltaColumnMappingTestUtils {
       assert(
         !isLastCommitBlindAppend,
         "joining with target table in the query should have isBlindAppend = false")
+
+      // Join with the table should have isBlindAppend = false if ignoreReadChanges option is set
+      appendToTable(inputDataStream.join(tableData, "value"), Map("ignoreReadChanges" -> "true"))
+      assert(
+        isLastCommitBlindAppend,
+        "joining with target table in the query should respect isBlindAppend = true option")
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
@@ -494,11 +494,12 @@ class DeltaSinkSuite extends StreamTest with DeltaColumnMappingTestUtils {
         !isLastCommitBlindAppend,
         "joining with target table in the query should have isBlindAppend = false")
 
-      // Join with the table should have isBlindAppend = false if ignoreReadChanges option is set
+      // Join with the table should have isBlindAppend = true if ignoreReadChanges = true
       appendToTable(inputDataStream.join(tableData, "value"), Map("ignoreReadChanges" -> "true"))
       assert(
         isLastCommitBlindAppend,
-        "joining with target table in the query should respect isBlindAppend = true option")
+        "joining with target table in the query should have isBlindAppend = true" +
+          " if ignoreReadChanges = true")
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -1939,6 +1939,16 @@ class DeltaSuite extends QueryTest
         checkAnswer(spark.table("blind_append"), Row(1) :: Row(1) :: Row(1) :: Row(1) :: Nil)
         assert(sql("desc history blind_append")
           .select("version", "isBlindAppend").head == Row(3, false))
+        sql("INSERT INTO blind_append VALUES(2)") // version = 4
+        spark.read.format("delta").load(path)
+          .where("value = 2")
+          .write.mode("append").format("delta")
+          .option(DeltaOptions.IGNORE_READ_CHANGES_OPTION, true)
+          .save(path) // version = 5
+        checkAnswer(spark.table("blind_append"), Row(1) :: Row(1) :: Row(1) :: Row(1) :: Row(2)
+          :: Row(2) :: Nil)
+        assert(sql("desc history blind_append")
+          .select("version", "isBlindAppend").head == Row(5, true))
       }
     }
   }
@@ -1955,6 +1965,14 @@ class DeltaSuite extends QueryTest
         checkAnswer(spark.table("blind_append"), Row(1) :: Row(1) :: Nil)
         assert(sql("desc history blind_append")
           .select("version", "isBlindAppend").head == Row(2, false))
+        spark.read.format("delta").load(path)
+          .where("value = 1")
+          .writeTo("blind_append")
+          .option(DeltaOptions.IGNORE_READ_CHANGES_OPTION, "true")
+          .append() // version = 3
+        checkAnswer(spark.table("blind_append"), Row(1) :: Row(1) :: Row(1) :: Row(1) :: Nil)
+        assert(sql("desc history blind_append")
+          .select("version", "isBlindAppend").head == Row(3, true))
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -124,7 +124,7 @@ class OptimisticTransactionSuite
     errorMessageHint = Some("[x=1]" :: "TRUNCATE" :: Nil))
 
   check(
-    "add / read + write with ignoreReadChanges",
+    "add / read + write with ignoreReadChanges = true",
     conflicts = false,
     setup = Seq(
       Metadata(
@@ -137,10 +137,7 @@ class OptimisticTransactionSuite
     ),
     concurrentWrites = Seq(
       AddFile("a", Map("x" -> "1"), 1, 1, dataChange = true)),
-    actions = Seq(AddFile("b", Map("x" -> "1"), 1, 1, dataChange = true)),
-    // commit info should show operation as truncate, because that's the operation used by the
-    // harness
-    errorMessageHint = Some("[x=1]" :: "TRUNCATE" :: Nil))
+    actions = Seq(AddFile("b", Map("x" -> "1"), 1, 1, dataChange = true)))
 
   check(
     "add / read + no write",  // no write = no real conflicting change even though data was added


### PR DESCRIPTION
## Description

Resolves https://github.com/delta-io/delta/issues/1304

## How was this patch tested?

Added tests to DeltaSinkSuite, DeltaSuite and OptimisticTransactionSuite

## Does this PR introduce _any_ user-facing changes?

Yes, user can now set `.option("ignoreReadChanges", "true")` on writes
