### PR TITLE
Fix ConflictChecker for READ-APPEND after OPTIMIZE

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -96,7 +96,7 @@ private[delta] class WinningCommitSummary(val actions: Seq[Action], val commitVe
   val changedDataAddedFiles: Seq[AddFile] = if (isBlindAppendOption.getOrElse(false)) {
     Seq()
   } else {
-    addedFiles
+    addedFiles.filter(_.dataChange)
   }
   val onlyAddFiles: Boolean = actions.collect { case f: FileAction => f }
     .forall(_.isInstanceOf[AddFile])

--- a/core/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -247,7 +247,9 @@ private[delta] class ConflictChecker(
           winningCommitSummary.commitInfo, s"$filePath")
       }
 
+      // scalastyle:off sparkimplicits
       import spark.implicits._
+      // scalastyle:on sparkimplicits
       val predicatesMatchingRemovedFiles = ExpressionSet(
         currentTransactionInfo.readPredicates).iterator.flatMap { p =>
         // ES-366661: use readSnapshot's partitionSchema as that is what we read in the

--- a/core/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -70,6 +70,24 @@ class OptimisticTransactionSuite
     actions = Seq(
       AddFile("b", Map("x" -> "2"), 1, 1, dataChange = true)))
 
+  check("append / delete / optimize",
+    conflicts = true,
+    setup = Seq(
+      Metadata(
+        schemaString = new StructType().add("x", IntegerType).json,
+        partitionColumns = Seq("x")),
+      RemoveFile("a", None, partitionValues = Map("x" -> "2"), dataChange = false),
+      RemoveFile("d", None, partitionValues = Map("x" -> "2"), dataChange = false),
+      AddFile("ad", Map("x" -> "2"), 1, 1, dataChange = false)
+    ),
+    reads = Seq(
+      t => t.filterFiles(EqualTo('x, Literal(2)) :: Nil)
+    ),
+    concurrentWrites = Seq(
+      RemoveFile("ad", None, partitionValues = Map("x" -> "2"), dataChange = true)
+    ),
+    actions = Seq(AddFile("b", Map("x" -> "2"), 1, 1, dataChange = true)))
+
   check("optimize / append",
     conflicts = false,
     setup = Seq(

--- a/core/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -56,7 +56,9 @@ class OptimisticTransactionSuite
     setup = Seq(
       Metadata(
         schemaString = new StructType().add("x", IntegerType).json,
-        partitionColumns = Seq("x"))
+        partitionColumns = Seq("x")),
+      AddFile("a", partitionValues = Map("x" -> "2"), 1, 1, dataChange = true),
+      AddFile("d", partitionValues = Map("x" -> "2"), 1, 1, dataChange = true)
     ),
     reads = Seq(
       t => t.filterFiles(EqualTo('x, Literal(2)) :: Nil)
@@ -73,7 +75,9 @@ class OptimisticTransactionSuite
     setup = Seq(
       Metadata(
         schemaString = new StructType().add("x", IntegerType).json,
-        partitionColumns = Seq("x"))
+        partitionColumns = Seq("x")),
+      AddFile("a", partitionValues = Map("x" -> "2"), 1, 1, dataChange = true),
+      AddFile("d", partitionValues = Map("x" -> "2"), 1, 1, dataChange = true)
     ),
     reads = Seq(
       t => t.filterFiles(EqualTo('x, Literal(2)) :: Nil)
@@ -144,7 +148,9 @@ class OptimisticTransactionSuite
     setup = Seq(
       Metadata(
         schemaString = new StructType().add("x", IntegerType).json,
-        partitionColumns = Seq("x"))
+        partitionColumns = Seq("x")),
+      AddFile("a", partitionValues = Map("x" -> "2"), 1, 1, dataChange = true),
+      AddFile("d", partitionValues = Map("x" -> "2"), 1, 1, dataChange = true)
     ),
     reads = Seq(
       t => t.filterFiles(EqualTo('x, Literal(2)) :: Nil)
@@ -161,7 +167,9 @@ class OptimisticTransactionSuite
     setup = Seq(
       Metadata(
         schemaString = new StructType().add("x", IntegerType).json,
-        partitionColumns = Seq("x"))
+        partitionColumns = Seq("x")),
+      AddFile("a", partitionValues = Map("x" -> "2"), 1, 1, dataChange = true),
+      AddFile("d", partitionValues = Map("x" -> "2"), 1, 1, dataChange = true)
     ),
     reads = Seq(
       t => t.filterFiles(EqualTo('x, Literal(2)) :: Nil)

--- a/core/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -51,6 +51,40 @@ class OptimisticTransactionSuite
     actions = Seq(
       addB))
 
+  check("append / optimize",
+    conflicts = false,
+    setup = Seq(
+      Metadata(
+        schemaString = new StructType().add("x", IntegerType).json,
+        partitionColumns = Seq("x"))
+    ),
+    reads = Seq(
+      t => t.filterFiles(EqualTo('x, Literal(2)) :: Nil)
+    ),
+    concurrentWrites = Seq(
+      RemoveFile("a", None, partitionValues = Map("x" -> "2"), dataChange = false),
+      RemoveFile("d", None, partitionValues = Map("x" -> "2"), dataChange = false),
+      AddFile("c", Map("x" -> "2"), 1, 1, dataChange = false)),
+    actions = Seq(
+      AddFile("b", Map("x" -> "2"), 1, 1, dataChange = true)))
+
+  check("optimize / append",
+    conflicts = false,
+    setup = Seq(
+      Metadata(
+        schemaString = new StructType().add("x", IntegerType).json,
+        partitionColumns = Seq("x"))
+    ),
+    reads = Seq(
+      t => t.filterFiles(EqualTo('x, Literal(2)) :: Nil)
+    ),
+    concurrentWrites = Seq(
+      AddFile("b", Map("x" -> "2"), 1, 1, dataChange = true)),
+    actions = Seq(
+      RemoveFile("a", None, partitionValues = Map("x" -> "2"), dataChange = false),
+      RemoveFile("d", None, partitionValues = Map("x" -> "2"), dataChange = false),
+      AddFile("c", Map("x" -> "2"), 1, 1, dataChange = false)))
+
   check(
     "disjoint txns",
     conflicts = false,
@@ -104,6 +138,40 @@ class OptimisticTransactionSuite
       RemoveFile("a", Some(4))),
     actions = Seq(
       RemoveFile("a", Some(5))))
+
+  check("optimize / delete",
+    conflicts = true,
+    setup = Seq(
+      Metadata(
+        schemaString = new StructType().add("x", IntegerType).json,
+        partitionColumns = Seq("x"))
+    ),
+    reads = Seq(
+      t => t.filterFiles(EqualTo('x, Literal(2)) :: Nil)
+    ),
+    concurrentWrites = Seq(
+      RemoveFile("a", None, partitionValues = Map("x" -> "2"), dataChange = true)),
+    actions = Seq(
+      RemoveFile("a", None, partitionValues = Map("x" -> "2"), dataChange = false),
+      RemoveFile("d", None, partitionValues = Map("x" -> "2"), dataChange = false),
+      AddFile("c", Map("x" -> "2"), 1, 1, dataChange = false)))
+
+  check("delete / optimize",
+    conflicts = true,
+    setup = Seq(
+      Metadata(
+        schemaString = new StructType().add("x", IntegerType).json,
+        partitionColumns = Seq("x"))
+    ),
+    reads = Seq(
+      t => t.filterFiles(EqualTo('x, Literal(2)) :: Nil)
+    ),
+    actions = Seq(
+      RemoveFile("a", None, partitionValues = Map("x" -> "2"), dataChange = false),
+      RemoveFile("d", None, partitionValues = Map("x" -> "2"), dataChange = false),
+      AddFile("c", Map("x" -> "2"), 1, 1, dataChange = false)),
+    concurrentWrites = Seq(
+      RemoveFile("a", None, partitionValues = Map("x" -> "2"), dataChange = true)))
 
   check(
     "add / read + write",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Allow read with newly added files with dataChange=false and removed files with dataChange=false by concurrent transactions.
dataChange=false files are created by OPTIMIZE operation, so the content should be same.

The following functions are to check both cases.
- checkForAddedFilesThatShouldHaveBeenReadByCurrentTxn
- checkForDeletedFilesAgainstCurrentTxnReadFiles

We can address the issue by
- fix `changedDataAddedFiles` to check dataChange flag of AddFile
- add `changedDataRemovedFiles` for RemoveFile

## How was this patch tested?
Unit tests

## Does this PR introduce _any_ user-facing changes?
No, a bug fix when Optimize transaction is committed while concurrent Reads.