### PR TITLE
Add a "startingVersion" = "earliest" option for streaming queries

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
@@ -177,7 +177,7 @@ class DeltaHistoryManager(
   def getEarliestVersion(
       mustBeRecreatable: Boolean = true): Long = {
     if (mustBeRecreatable) {
-      getEarliestReproducibleCommit
+      getEarliestReproducibleCommit()
     } else {
       getEarliestDeltaFile(deltaLog)
     }

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
@@ -177,7 +177,7 @@ class DeltaHistoryManager(
   def getEarliestVersion(
       mustBeRecreatable: Boolean = true): Long = {
     if (mustBeRecreatable) {
-      getEarliestReproducibleCommit()
+      getEarliestReproducibleCommit
     } else {
       getEarliestDeltaFile(deltaLog)
     }

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
@@ -163,14 +163,23 @@ class DeltaHistoryManager(
       version: Long,
       mustBeRecreatable: Boolean = true,
       allowOutOfRange: Boolean = false): Unit = {
-    val earliest = if (mustBeRecreatable) {
-      getEarliestReproducibleCommit
-    } else {
-      getEarliestDeltaFile(deltaLog)
-    }
+    val earliest = getEarliestVersion(mustBeRecreatable = mustBeRecreatable)
     val latest = deltaLog.update().version
     if (version < earliest || ((version > latest) && !allowOutOfRange)) {
       throw VersionNotFoundException(version, earliest, latest)
+    }
+  }
+
+  /**
+   * Get the earliest delta version.
+   * @param mustBeRecreatable whether the snapshot of this version needs to be recreated.
+   */
+  def getEarliestVersion(
+      mustBeRecreatable: Boolean = true): Long = {
+    if (mustBeRecreatable) {
+      getEarliestReproducibleCommit
+    } else {
+      getEarliestDeltaFile(deltaLog)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -176,6 +176,7 @@ trait DeltaReadOptions extends DeltaOptionParser {
 
   val startingVersion: Option[DeltaStartingVersion] = options.get(STARTING_VERSION_OPTION).map {
     case "latest" => StartingVersionLatest
+    case "earliest" => StartingVersionEarliest
     case str =>
       Try(str.toLong).toOption.filter(_ >= 0).map(StartingVersion).getOrElse{
         throw DeltaErrors.illegalDeltaOptionException(
@@ -302,4 +303,5 @@ object DeltaOptions extends DeltaLogging {
  */
 sealed trait DeltaStartingVersion
 case object StartingVersionLatest extends DeltaStartingVersion
+case object StartingVersionEarliest extends DeltaStartingVersion
 case class StartingVersion(version: Long) extends DeltaStartingVersion

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -1392,7 +1392,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase with DeltaSQLCommandTest {
     withTempDir { dir =>
       withTempView("startingVersionEarliest") {
         val path = dir.getAbsolutePath
-        spark.range(0, 10).write.format("delta").save(path)
+        spark.range(10).write.format("delta").save(path)
 
         def startTestStreamingQuery(): StreamingQuery = {
           spark.readStream


### PR DESCRIPTION
## Description

This PR adds an option to start a streaming query on Delta source from earliest version.  
This is different than the default behavior of reading the entire table as it allows to only read incremental changes from that version onward.

For example, assuming a Delta table located in `path` with its earliest version being `n`, a user can now replace this query:
```scala
val n = spark.sql(s"describe history delta.`${path}`").orderBy("version").select("version").first().get(0)
spark.readStream.format("delta").option("startingVersion", n).load(path)
```
with the following query:
```scala
spark.readStream.format("delta").option("startingVersion", "earliest").load(path)
```

## How was this patch tested?

Added unit tests in `DeltaSourceSuite.scala`

## Does this PR introduce _any_ user-facing changes?

Allowed the option `startingVersion` in `DeltaOptions.scala` to accept the value `earliest`
