### PR TITLE
Fix ActionSerializerSuite

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -215,7 +215,7 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession {
 
   {
     // We want this metadata to be lazy so it is instantiated after `SparkFunSuite::beforeAll`.
-    // This will ensure that `Utils.isTesting` returns true and that its id is to 'testId'.
+    // This will ensure that `Utils.isTesting` returns true and that its id is set to 'testId'.
     lazy val metadata = Metadata(createdTime = Some(2222))
     testActionSerDe(
       "Metadata (with all defaults) - json serialization/deserialization",
@@ -226,6 +226,8 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession {
 
   {
     val schemaStr = new StructType().add("a", "long").json
+    // We want this metadata to be lazy so it is instantiated after `SparkFunSuite::beforeAll`.
+    // This will ensure that `Utils.isTesting` returns true and that its id is set to 'testId'.
     lazy val metadata = Metadata(
       name = "t1",
       description = "desc",

--- a/core/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -213,15 +213,20 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession {
     expectedJson = """{"cdc":{"path":"part=p1/f1","partitionValues":{"x":null},""" +
       """"size":10,"dataChange":false}}""".stripMargin)
 
-  testActionSerDe(
-    "Metadata (with all defaults) - json serialization/deserialization",
-    Metadata(createdTime = Some(2222)),
-    expectedJson = """{"metaData":{"id":"testId","format":{"provider":"parquet",""" +
-    """"options":{}},"partitionColumns":[],"configuration":{},"createdTime":2222}}""")
+  {
+    // We want this metadata to be lazy so it is instantiated after `SparkFunSuite::beforeAll`.
+    // This will ensure that `Utils.isTesting` returns true and that its id is to 'testId'.
+    lazy val metadata = Metadata(createdTime = Some(2222))
+    testActionSerDe(
+      "Metadata (with all defaults) - json serialization/deserialization",
+      metadata,
+      expectedJson = """{"metaData":{"id":"testId","format":{"provider":"parquet",""" +
+        """"options":{}},"partitionColumns":[],"configuration":{},"createdTime":2222}}""")
+  }
 
   {
     val schemaStr = new StructType().add("a", "long").json
-    val metadata = Metadata(
+    lazy val metadata = Metadata(
       name = "t1",
       description = "desc",
       format = Format(provider = "parquet", options = Map("o1" -> "v1")),
@@ -315,7 +320,7 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession {
   /** Test serialization/deserialization of [[Action]] by doing an actual commit */
   private def testActionSerDe(
       name: String,
-      action: Action,
+      action: => Action,
       expectedJson: String,
     extraSettings: Seq[(String, String)] = Seq.empty): Unit = {
     test(name) {


### PR DESCRIPTION
## Description

This test changes when/how actions are instantiated inside of ActionSerializerSuite when passed into testActionSerDe. We change the action type from `Action` to `=> Action`. We also make the failing metadata lazy. This ensures that the metadata are instantiated after `SparkFunSuite::beforeAll` has run. This ensures that `Utils.isTesting` is true, meaning that the metadata will be instantiated with id testId.

## How was this patch tested?

Existing UTs.

## Does this PR introduce _any_ user-facing changes?

No

Resolves delta-io/delta#1283
