### PR TITLE
DeltaLog checks for required Spark configs and throws an error if not found

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -283,6 +283,9 @@
       "    .config(\"<catalogKey>\", \"<catalogClassName>\")",
       "    ...",
       "    .getOrCreate()",
+      "",
+      "If you are using spark-shell/pyspark/spark-submit, you can add the required configurations to the command as show below:",
+      "--conf spark.sql.extensions=<sparkSessionExtensionName> --conf <catalogKey>=<catalogClassName>",
       ""
     ],
     "sqlState" : "42000"

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1544,6 +1544,16 @@ trait DeltaErrorsBase
     )
   }
 
+  def configureSparkSessionWithExtensionAndCatalog(
+      originalException: Option[Throwable]): Throwable = {
+    val catalogImplConfig = SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key
+    new DeltaIllegalStateException(
+      errorClass = "DELTA_CONFIGURE_SPARK_SESSION_WITH_EXTENSION_AND_CATALOG",
+      messageParameters = Array(classOf[DeltaSparkSessionExtension].getName,
+        catalogImplConfig, classOf[DeltaCatalog].getName),
+      cause = originalException.getOrElse(null))
+  }
+
   def duplicateColumnsOnUpdateTable(originalException: Throwable): Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_DUPLICATE_COLUMNS_ON_UPDATE_TABLE",

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1540,6 +1540,8 @@ trait DeltaErrorsBase
     new DeltaAnalysisException(
       errorClass = "DELTA_CONFIGURE_SPARK_SESSION_WITH_EXTENSION_AND_CATALOG",
       messageParameters = Array(classOf[DeltaSparkSessionExtension].getName,
+        catalogImplConfig, classOf[DeltaCatalog].getName,
+        classOf[DeltaSparkSessionExtension].getName,
         catalogImplConfig, classOf[DeltaCatalog].getName),
       cause = originalException)
   }

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1534,24 +1534,14 @@ trait DeltaErrorsBase
          """.stripMargin
   }
 
-  def configureSparkSessionWithExtensionAndCatalog(originalException: Throwable): Throwable = {
+  def configureSparkSessionWithExtensionAndCatalog(
+      originalException: Option[Throwable]): Throwable = {
     val catalogImplConfig = SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key
     new DeltaAnalysisException(
       errorClass = "DELTA_CONFIGURE_SPARK_SESSION_WITH_EXTENSION_AND_CATALOG",
       messageParameters = Array(classOf[DeltaSparkSessionExtension].getName,
         catalogImplConfig, classOf[DeltaCatalog].getName),
-      cause = Some(originalException)
-    )
-  }
-
-  def configureSparkSessionWithExtensionAndCatalog(
-      originalException: Option[Throwable]): Throwable = {
-    val catalogImplConfig = SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key
-    new DeltaIllegalStateException(
-      errorClass = "DELTA_CONFIGURE_SPARK_SESSION_WITH_EXTENSION_AND_CATALOG",
-      messageParameters = Array(classOf[DeltaSparkSessionExtension].getName,
-        catalogImplConfig, classOf[DeltaCatalog].getName),
-      cause = originalException.getOrElse(null))
+      cause = originalException)
   }
 
   def duplicateColumnsOnUpdateTable(originalException: Throwable): Throwable = {

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -82,19 +82,7 @@ class DeltaLog private(
 
   protected def spark = SparkSession.active
 
-  /**
-   * Verify the required Spark conf for delta
-   * Throw `DeltaErrors.configureSparkSessionWithExtensionAndCatalog` exception if
-   * `spark.sql.catalog.spark_catalog` config is missing. We do not check for
-   * `spark.sql.extensions` because DeltaSparkSessionExtension can alternatively
-   * be activated using the `.withExtension()` API. This check can be disabled
-   * by setting DELTA_CHECK_REQUIRED_SPARK_CONF to false.
-   */
-  if(spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF)) {
-    if (spark.sparkContext.conf.getOption(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key).isEmpty) {
-      throw DeltaErrors.configureSparkSessionWithExtensionAndCatalog(None)
-    }
-  }
+  checkRequiredConfigurations()
 
   /**
    * Keep a reference to `SparkContext` used to create `DeltaLog`. `DeltaLog` cannot be used when
@@ -468,6 +456,22 @@ class DeltaLog private(
     }
   }
 
+  /**
+   * Verify the required Spark conf for delta
+   * Throw `DeltaErrors.configureSparkSessionWithExtensionAndCatalog` exception if
+   * `spark.sql.catalog.spark_catalog` config is missing. We do not check for
+   * `spark.sql.extensions` because DeltaSparkSessionExtension can alternatively
+   * be activated using the `.withExtension()` API. This check can be disabled
+   * by setting DELTA_CHECK_REQUIRED_SPARK_CONF to false.
+   */
+  protected def checkRequiredConfigurations() {
+    if (spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK)) {
+      if (spark.conf.getOption(
+        SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key).isEmpty) {
+        throw DeltaErrors.configureSparkSessionWithExtensionAndCatalog(None)
+      }
+    }
+  }
 }
 
 object DeltaLog extends DeltaLogging {

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -811,11 +811,9 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(false)
 
-  val DELTA_CHECK_REQUIRED_SPARK_CONF =
-    buildConf("checkRequiredSparkConf.enabled")
-      .doc(
-      """Whether we check if SparkSession is initialized with spark.sql.extensions
-          | and spark.sql.catalog.spark_catalog conf""".stripMargin)
+  val DELTA_REQUIRED_SPARK_CONFS_CHECK =
+    buildConf("requiredSparkConfsCheck.enabled")
+      .doc("Whether to verify SparkSession is initialized with required configurations.")
       .internal()
       .booleanConf
       .createWithDefault(true)

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -810,6 +810,15 @@ trait DeltaSQLConfBase {
           |""".stripMargin)
       .booleanConf
       .createWithDefault(false)
+
+  val DELTA_CHECK_REQUIRED_SPARK_CONF =
+    buildConf("checkRequiredSparkConf.enabled")
+      .doc(
+      """Whether we check if SparkSession is initialized with spark.sql.extensions
+          | and spark.sql.catalog.spark_catalog conf""".stripMargin)
+      .internal()
+      .booleanConf
+      .createWithDefault(true)
 }
 
 object DeltaSQLConf extends DeltaSQLConfBase

--- a/core/src/main/scala/org/apache/spark/sql/delta/util/AnalysisHelper.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/util/AnalysisHelper.scala
@@ -104,7 +104,7 @@ trait AnalysisHelper {
 
     try { f } catch {
       case e: Exception if isExtensionOrCatalogError(e) =>
-        throw DeltaErrors.configureSparkSessionWithExtensionAndCatalog(e)
+        throw DeltaErrors.configureSparkSessionWithExtensionAndCatalog(Some(e))
     }
   }
 

--- a/core/src/test/java/io/delta/sql/JavaDeltaSparkSessionExtensionSuite.java
+++ b/core/src/test/java/io/delta/sql/JavaDeltaSparkSessionExtensionSuite.java
@@ -30,6 +30,8 @@ public class JavaDeltaSparkSessionExtensionSuite {
                 .appName("JavaDeltaSparkSessionExtensionSuiteUsingSQLConf")
                 .master("local[2]")
                 .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+                .config("spark.sql.catalog.spark_catalog",
+                        "org.apache.spark.sql.delta.catalog.DeltaCatalog")
                 .getOrCreate();
         try {
             String input = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "input")

--- a/core/src/test/java/org/apache/spark/sql/delta/MergeIntoJavaSuite.java
+++ b/core/src/test/java/org/apache/spark/sql/delta/MergeIntoJavaSuite.java
@@ -34,14 +34,16 @@ import org.junit.Test;
 
 import org.apache.spark.sql.test.TestSparkSession;
 
-public class MergeIntoJavaSuite implements Serializable, DeltaSQLCommandJavaTest {
-    private transient SparkSession spark;
+public class MergeIntoJavaSuite implements Serializable {
+    private transient TestSparkSession spark;
     private transient String tempPath;
 
     @Before
     public void setUp() {
-        spark = buildSparkSession();
+        spark = new TestSparkSession();
         tempPath = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark").toString();
+        // disable the spark conf check
+        spark.sqlContext().conf().setConfString("spark.databricks.delta.checkRequiredSparkConf.enabled", "false");
     }
 
     @After

--- a/core/src/test/java/org/apache/spark/sql/delta/MergeIntoJavaSuite.java
+++ b/core/src/test/java/org/apache/spark/sql/delta/MergeIntoJavaSuite.java
@@ -43,7 +43,7 @@ public class MergeIntoJavaSuite implements Serializable {
         spark = new TestSparkSession();
         tempPath = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark").toString();
         // disable the spark conf check
-        spark.sqlContext().conf().setConfString("spark.databricks.delta.checkRequiredSparkConf.enabled", "false");
+        spark.sqlContext().conf().setConfString("spark.databricks.delta.requiredSparkConfsCheck.enabled", "false");
     }
 
     @After

--- a/core/src/test/java/org/apache/spark/sql/delta/MergeIntoJavaSuite.java
+++ b/core/src/test/java/org/apache/spark/sql/delta/MergeIntoJavaSuite.java
@@ -33,6 +33,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.spark.sql.test.TestSparkSession;
+import org.apache.spark.sql.delta.catalog.DeltaCatalog;
+import org.apache.spark.sql.internal.SQLConf;
 
 public class MergeIntoJavaSuite implements Serializable {
     private transient TestSparkSession spark;
@@ -42,8 +44,7 @@ public class MergeIntoJavaSuite implements Serializable {
     public void setUp() {
         spark = new TestSparkSession();
         tempPath = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark").toString();
-        // disable the spark conf check
-        spark.sqlContext().conf().setConfString("spark.databricks.delta.requiredSparkConfsCheck.enabled", "false");
+        spark.sqlContext().conf().setConfString(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION().key(), DeltaCatalog.class.getCanonicalName());
     }
 
     @After

--- a/core/src/test/java/org/apache/spark/sql/delta/MergeIntoJavaSuite.java
+++ b/core/src/test/java/org/apache/spark/sql/delta/MergeIntoJavaSuite.java
@@ -34,13 +34,13 @@ import org.junit.Test;
 
 import org.apache.spark.sql.test.TestSparkSession;
 
-public class MergeIntoJavaSuite implements Serializable {
-    private transient TestSparkSession spark;
+public class MergeIntoJavaSuite implements Serializable, DeltaSQLCommandJavaTest {
+    private transient SparkSession spark;
     private transient String tempPath;
 
     @Before
     public void setUp() {
-        spark = new TestSparkSession();
+        spark = buildSparkSession();
         tempPath = Utils.createTempDir(System.getProperty("java.io.tmpdir"), "spark").toString();
     }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -27,14 +27,11 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 // scalastyle:off: removeFile
-class ActionSerializerSuite extends QueryTest with SharedSparkSession {
-
-  protected override def sparkConf = {
-    // disable the spark conf check
-    super.sparkConf.set(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
-  }
+class ActionSerializerSuite extends QueryTest
+  with SharedSparkSession with DeltaSQLCommandTest {
 
   roundTripCompare("Add",
     AddFile("test", Map.empty, 1, 1, dataChange = true))

--- a/core/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -27,9 +27,11 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 // scalastyle:off: removeFile
-class ActionSerializerSuite extends QueryTest with SharedSparkSession {
+class ActionSerializerSuite extends QueryTest with SharedSparkSession
+with DeltaSQLCommandTest {
 
   roundTripCompare("Add",
     AddFile("test", Map.empty, 1, 1, dataChange = true))

--- a/core/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -27,11 +27,14 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 // scalastyle:off: removeFile
-class ActionSerializerSuite extends QueryTest with SharedSparkSession
-with DeltaSQLCommandTest {
+class ActionSerializerSuite extends QueryTest with SharedSparkSession {
+
+  protected override def sparkConf = {
+    // disable the spark conf check
+    super.sparkConf.set(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
+  }
 
   roundTripCompare("Add",
     AddFile("test", Map.empty, 1, 1, dataChange = true))

--- a/core/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -33,7 +33,7 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession {
 
   protected override def sparkConf = {
     // disable the spark conf check
-    super.sparkConf.set(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
+    super.sparkConf.set(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
   }
 
   roundTripCompare("Add",

--- a/core/src/test/scala/org/apache/spark/sql/delta/CheckpointMetadataSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/CheckpointMetadataSuite.scala
@@ -27,13 +27,11 @@ import org.apache.commons.io.IOUtils
 
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StructType}
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
-class CheckpointMetadataSuite extends SharedSparkSession {
+class CheckpointMetadataSuite extends SharedSparkSession
+  with DeltaSQLCommandTest {
 
-  protected override def sparkConf = {
-    // disable the spark conf check
-    super.sparkConf.set(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
-  }
   // same checkpoint schema for tests
   private val checkpointSchema = Some(new StructType().add("c1", IntegerType, nullable = false))
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/CheckpointMetadataSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/CheckpointMetadataSuite.scala
@@ -27,10 +27,13 @@ import org.apache.commons.io.IOUtils
 
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StructType}
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
-class CheckpointMetadataSuite extends SharedSparkSession with DeltaSQLCommandTest {
+class CheckpointMetadataSuite extends SharedSparkSession {
 
+  protected override def sparkConf = {
+    // disable the spark conf check
+    super.sparkConf.set(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
+  }
   // same checkpoint schema for tests
   private val checkpointSchema = Some(new StructType().add("c1", IntegerType, nullable = false))
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/CheckpointMetadataSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/CheckpointMetadataSuite.scala
@@ -27,8 +27,9 @@ import org.apache.commons.io.IOUtils
 
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StructType}
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
-class CheckpointMetadataSuite extends SharedSparkSession {
+class CheckpointMetadataSuite extends SharedSparkSession with DeltaSQLCommandTest {
 
   // same checkpoint schema for tests
   private val checkpointSchema = Some(new StructType().add("c1", IntegerType, nullable = false))

--- a/core/src/test/scala/org/apache/spark/sql/delta/CheckpointMetadataSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/CheckpointMetadataSuite.scala
@@ -32,7 +32,7 @@ class CheckpointMetadataSuite extends SharedSparkSession {
 
   protected override def sparkConf = {
     // disable the spark conf check
-    super.sparkConf.set(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
+    super.sparkConf.set(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
   }
   // same checkpoint schema for tests
   private val checkpointSchema = Some(new StructType().add("c1", IntegerType, nullable = false))

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaCommitLockSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaCommitLockSuite.scala
@@ -25,6 +25,8 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.{LocalSparkSession, SparkSession}
 import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.util.Utils
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.delta.catalog.DeltaCatalog
 
 class DeltaCommitLockSuite extends SparkFunSuite with LocalSparkSession with SQLHelper {
 
@@ -38,7 +40,7 @@ class DeltaCommitLockSuite extends SparkFunSuite with LocalSparkSession with SQL
     spark = SparkSession.builder()
       .config("spark.delta.logStore.class", classOf[AzureLogStore].getName)
       .master("local[2]")
-      .config(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
+      .config(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key, classOf[DeltaCatalog].getName)
       .getOrCreate()
     val path = Utils.createTempDir()
     try {
@@ -59,7 +61,7 @@ class DeltaCommitLockSuite extends SparkFunSuite with LocalSparkSession with SQL
     spark = SparkSession.builder()
       .config("spark.delta.logStore.class", classOf[S3SingleDriverLogStore].getName)
       .master("local[2]")
-      .config(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
+      .config(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key, classOf[DeltaCatalog].getName)
       .getOrCreate()
     val path = Utils.createTempDir()
     try {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaCommitLockSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaCommitLockSuite.scala
@@ -25,6 +25,9 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.{LocalSparkSession, SparkSession}
 import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.util.Utils
+import org.apache.spark.sql.delta.catalog.DeltaCatalog
+import io.delta.sql.DeltaSparkSessionExtension
+import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 
 class DeltaCommitLockSuite extends SparkFunSuite with LocalSparkSession with SQLHelper {
 
@@ -38,6 +41,9 @@ class DeltaCommitLockSuite extends SparkFunSuite with LocalSparkSession with SQL
     spark = SparkSession.builder()
       .config("spark.delta.logStore.class", classOf[AzureLogStore].getName)
       .master("local[2]")
+      .config(StaticSQLConf.SPARK_SESSION_EXTENSIONS.key,
+        classOf[DeltaSparkSessionExtension].getName)
+      .config(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key, classOf[DeltaCatalog].getName)
       .getOrCreate()
     val path = Utils.createTempDir()
     try {
@@ -58,6 +64,9 @@ class DeltaCommitLockSuite extends SparkFunSuite with LocalSparkSession with SQL
     spark = SparkSession.builder()
       .config("spark.delta.logStore.class", classOf[S3SingleDriverLogStore].getName)
       .master("local[2]")
+      .config(StaticSQLConf.SPARK_SESSION_EXTENSIONS.key,
+        classOf[DeltaSparkSessionExtension].getName)
+      .config(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key, classOf[DeltaCatalog].getName)
       .getOrCreate()
     val path = Utils.createTempDir()
     try {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaCommitLockSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaCommitLockSuite.scala
@@ -25,9 +25,6 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.{LocalSparkSession, SparkSession}
 import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.util.Utils
-import org.apache.spark.sql.delta.catalog.DeltaCatalog
-import io.delta.sql.DeltaSparkSessionExtension
-import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 
 class DeltaCommitLockSuite extends SparkFunSuite with LocalSparkSession with SQLHelper {
 
@@ -41,9 +38,7 @@ class DeltaCommitLockSuite extends SparkFunSuite with LocalSparkSession with SQL
     spark = SparkSession.builder()
       .config("spark.delta.logStore.class", classOf[AzureLogStore].getName)
       .master("local[2]")
-      .config(StaticSQLConf.SPARK_SESSION_EXTENSIONS.key,
-        classOf[DeltaSparkSessionExtension].getName)
-      .config(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key, classOf[DeltaCatalog].getName)
+      .config(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
       .getOrCreate()
     val path = Utils.createTempDir()
     try {
@@ -64,9 +59,7 @@ class DeltaCommitLockSuite extends SparkFunSuite with LocalSparkSession with SQL
     spark = SparkSession.builder()
       .config("spark.delta.logStore.class", classOf[S3SingleDriverLogStore].getName)
       .master("local[2]")
-      .config(StaticSQLConf.SPARK_SESSION_EXTENSIONS.key,
-        classOf[DeltaSparkSessionExtension].getName)
-      .config(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key, classOf[DeltaCatalog].getName)
+      .config(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
       .getOrCreate()
     val path = Utils.createTempDir()
     try {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaCommitLockSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaCommitLockSuite.scala
@@ -38,7 +38,7 @@ class DeltaCommitLockSuite extends SparkFunSuite with LocalSparkSession with SQL
     spark = SparkSession.builder()
       .config("spark.delta.logStore.class", classOf[AzureLogStore].getName)
       .master("local[2]")
-      .config(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
+      .config(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
       .getOrCreate()
     val path = Utils.createTempDir()
     try {
@@ -59,7 +59,7 @@ class DeltaCommitLockSuite extends SparkFunSuite with LocalSparkSession with SQL
     spark = SparkSession.builder()
       .config("spark.delta.logStore.class", classOf[S3SingleDriverLogStore].getName)
       .master("local[2]")
-      .config(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
+      .config(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
       .getOrCreate()
     val path = Utils.createTempDir()
     try {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameHadoopOptionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameHadoopOptionsSuite.scala
@@ -24,8 +24,10 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
-class DeltaDataFrameHadoopOptionsSuite extends QueryTest with SQLTestUtils with SharedSparkSession {
+class DeltaDataFrameHadoopOptionsSuite extends QueryTest with SQLTestUtils
+  with SharedSparkSession with DeltaSQLCommandTest {
 
   protected override def sparkConf =
     super.sparkConf.set("spark.delta.logStore.fake.impl", classOf[LocalLogStore].getName)

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameHadoopOptionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameHadoopOptionsSuite.scala
@@ -24,14 +24,13 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
-class DeltaDataFrameHadoopOptionsSuite extends QueryTest with SQLTestUtils with SharedSparkSession {
+class DeltaDataFrameHadoopOptionsSuite extends QueryTest with SQLTestUtils
+  with SharedSparkSession with DeltaSQLCommandTest {
 
   protected override def sparkConf =
     super.sparkConf.set("spark.delta.logStore.fake.impl", classOf[LocalLogStore].getName)
-      // disable the spark conf check
-      .set(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
-
   /**
    * Create Hadoop file system options for `FakeFileSystem`. If Delta doesn't pick up them,
    * it won't be able to read/write any files using `fake://`.

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameHadoopOptionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameHadoopOptionsSuite.scala
@@ -24,13 +24,13 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
-class DeltaDataFrameHadoopOptionsSuite extends QueryTest with SQLTestUtils
-  with SharedSparkSession with DeltaSQLCommandTest {
+class DeltaDataFrameHadoopOptionsSuite extends QueryTest with SQLTestUtils with SharedSparkSession {
 
   protected override def sparkConf =
     super.sparkConf.set("spark.delta.logStore.fake.impl", classOf[LocalLogStore].getName)
+      // disable the spark conf check
+      .set(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
 
   /**
    * Create Hadoop file system options for `FakeFileSystem`. If Delta doesn't pick up them,

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1788,7 +1788,7 @@ trait DeltaErrorsSuiteBase
     }
     {
       val e = intercept[DeltaAnalysisException] {
-        throw DeltaErrors.configureSparkSessionWithExtensionAndCatalog(new Throwable())
+        throw DeltaErrors.configureSparkSessionWithExtensionAndCatalog(Some(new Throwable()))
       }
       assert(e.getErrorClass == "DELTA_CONFIGURE_SPARK_SESSION_WITH_EXTENSION_AND_CATALOG")
       assert(e.getSqlState == "42000")

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1962,10 +1962,11 @@ trait DeltaErrorsSuiteBase
            |    .config("$catalogImplConfig", "${classOf[DeltaCatalog].getName}")
            |    ...
            |    .getOrCreate()
-           |
-           |If you are using spark-shell/pyspark/spark-submit, you can add the required configurations to the command as show below:
-           |--conf spark.sql.extensions=${classOf[DeltaSparkSessionExtension].getName} --conf ${catalogImplConfig}=${classOf[DeltaCatalog].getName}
-           |""".stripMargin
+           |""".stripMargin +
+          "\nIf you are using spark-shell/pyspark/spark-submit, you can add the required " +
+           "configurations to the command as show below:\n"  +
+          s"--conf spark.sql.extensions=${classOf[DeltaSparkSessionExtension].getName} " +
+          s"--conf ${catalogImplConfig}=${classOf[DeltaCatalog].getName}\n"
       assert(e.getMessage == msg)
     }
     {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1804,6 +1804,9 @@ trait DeltaErrorsSuiteBase
            |    .config("$catalogImplConfig", "${classOf[DeltaCatalog].getName}")
            |    ...
            |    .getOrCreate()
+           |
+           |If you are using spark-shell/pyspark/spark-submit, you can add the required configurations to the command as show below:
+           |--conf spark.sql.extensions=${classOf[DeltaSparkSessionExtension].getName} --conf ${catalogImplConfig}=${classOf[DeltaCatalog].getName}
            |""".stripMargin
       assert(e.getMessage == msg)
     }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -47,7 +47,7 @@ import org.apache.spark.sql.catalyst.expressions.{AttributeReference, ExprId, Le
 import org.apache.spark.sql.catalyst.expressions.Uuid
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 import org.apache.spark.sql.connector.catalog.Identifier
-import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
 import org.apache.spark.sql.types.{CalendarIntervalType, DataTypes, DateType, IntegerType, StringType, StructField, StructType, TimestampNTZType}
 
@@ -1143,7 +1143,7 @@ trait DeltaErrorsSuiteBase
       }
       assert(e.getErrorClass == "DELTA_CONSTRAINT_ALREADY_EXISTS")
       assert(e.getSqlState == "42000")
-      assert(e.getMessage == "Constraint 'name' already exists as a CHECK constraint. Please " +
+      assert(e.getMessage == "Constraint 'name' already exists. Please " +
         "delete the old constraint first.\nOld constraint:\noldExpr")
     }
     {
@@ -1794,14 +1794,13 @@ trait DeltaErrorsSuiteBase
       assert(e.getSqlState == "42000")
 
       val catalogImplConfig = SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key
-      val deltaSparkExtConf = StaticSQLConf.SPARK_SESSION_EXTENSIONS.key
       val msg =
         s"""This Delta operation requires the SparkSession to be configured with the
            |DeltaSparkSessionExtension and the DeltaCatalog. Please set the necessary
            |configurations when creating the SparkSession as shown below.
            |
            |  SparkSession.builder()
-           |    .config("$deltaSparkExtConf", "${classOf[DeltaSparkSessionExtension].getName}")
+           |    .config("spark.sql.extensions", "${classOf[DeltaSparkSessionExtension].getName}")
            |    .config("$catalogImplConfig", "${classOf[DeltaCatalog].getName}")
            |    ...
            |    .getOrCreate()
@@ -1991,6 +1990,22 @@ trait DeltaErrorsSuiteBase
       assert(e.getSqlState == "22000")
       assert(e.getMessage ==
         "Using column c0 of type IntegerType as a partition column is not supported.")
+    }
+    {
+      val catalogPartitionSchema = StructType(Seq(StructField("a", IntegerType)))
+      val userPartitionSchema = StructType(Seq(StructField("b", StringType)))
+      val e = intercept[DeltaAnalysisException] {
+        throw DeltaErrors.unexpectedPartitionSchemaFromUserException(catalogPartitionSchema,
+          userPartitionSchema)
+      }
+      assert(e.getErrorClass == "DELTA_UNEXPECTED_PARTITION_SCHEMA_FROM_USER")
+      assert(e.getSqlState == "42000")
+      assert(e.getMessage ==
+        "CONVERT TO DELTA was called with a partition schema different from the partition " +
+          "schema inferred from the catalog, please avoid providing the schema so that the " +
+          "partition schema can be chosen from the catalog.\n" +
+          s"\ncatalog partition schema:\n${catalogPartitionSchema.treeString}" +
+          s"\nprovided partition schema:\n${userPartitionSchema.treeString}")
     }
     {
       val e = intercept[DeltaIllegalArgumentException] {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
@@ -34,16 +34,21 @@ import org.scalatest.GivenWhenThen
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{AnalysisException, QueryTest}
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.Utils
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 /** A set of tests which we can open source after Spark 3.0 is released. */
 trait DeltaTimeTravelTests extends QueryTest
-    with SharedSparkSession    with DeltaSQLCommandTest with GivenWhenThen {
+    with SharedSparkSession    with GivenWhenThen {
   protected implicit def durationToLong(duration: FiniteDuration): Long = {
     duration.toMillis
+  }
+
+  protected override def sparkConf = {
+    // disable the spark conf check
+    super.sparkConf.set(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
   }
 
   protected implicit def longToTimestamp(ts: Long): Timestamp = new Timestamp(ts)

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
@@ -37,10 +37,11 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.Utils
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 /** A set of tests which we can open source after Spark 3.0 is released. */
 trait DeltaTimeTravelTests extends QueryTest
-    with SharedSparkSession    with GivenWhenThen {
+    with SharedSparkSession    with DeltaSQLCommandTest with GivenWhenThen {
   protected implicit def durationToLong(duration: FiniteDuration): Long = {
     duration.toMillis
   }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
@@ -35,7 +35,6 @@ import org.scalatest.GivenWhenThen
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.Utils
@@ -46,11 +45,6 @@ trait DeltaTimeTravelTests extends QueryTest
     with DeltaSQLCommandTest {
   protected implicit def durationToLong(duration: FiniteDuration): Long = {
     duration.toMillis
-  }
-
-  protected override def sparkConf = {
-    // disable the spark conf check
-    super.sparkConf.set(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
   }
 
   protected implicit def longToTimestamp(ts: Long): Timestamp = new Timestamp(ts)

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
@@ -48,7 +48,7 @@ trait DeltaTimeTravelTests extends QueryTest
 
   protected override def sparkConf = {
     // disable the spark conf check
-    super.sparkConf.set(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
+    super.sparkConf.set(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
   }
 
   protected implicit def longToTimestamp(ts: Long): Timestamp = new Timestamp(ts)

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -38,7 +38,7 @@ class DeltaLogSuite extends QueryTest
 
   protected override def sparkConf = {
     // disable the spark conf check
-    super.sparkConf.set(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
+    super.sparkConf.set(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
   }
   protected val testOp = Truncate()
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -31,15 +31,12 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
 import org.apache.spark.util.Utils
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 // scalastyle:off: removeFile
 class DeltaLogSuite extends QueryTest
-  with SharedSparkSession  with SQLTestUtils {
+  with SharedSparkSession  with SQLTestUtils with DeltaSQLCommandTest {
 
-  protected override def sparkConf = {
-    // disable the spark conf check
-    super.sparkConf.set(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
-  }
   protected val testOp = Truncate()
 
   testQuietly("checkpoint") {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -30,15 +30,16 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.util.Utils
-import org.apache.spark.sql.delta.catalog.DeltaCatalog
-import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
-import io.delta.sql.DeltaSparkSessionExtension
+
 // scalastyle:off: removeFile
 class DeltaLogSuite extends QueryTest
-  with SharedSparkSession  with SQLTestUtils with DeltaSQLCommandTest {
+  with SharedSparkSession  with SQLTestUtils {
 
+  protected override def sparkConf = {
+    // disable the spark conf check
+    super.sparkConf.set(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
+  }
   protected val testOp = Truncate()
 
   testQuietly("checkpoint") {
@@ -159,7 +160,7 @@ class DeltaLogSuite extends QueryTest
 
     val deltas = log2.snapshot.logSegment.deltas
     assert(deltas.length === 4, "Expected 4 files starting at version 11 to 14")
-    val versions = deltas.map(f => FileNames.deltaVersion(f.getPath)).sorted
+    val versions = deltas.map(FileNames.deltaVersion).sorted
     assert(versions === Seq[Long](11, 12, 13, 14), "Received the wrong files for update")
   }
 
@@ -506,56 +507,6 @@ class DeltaLogSuite extends QueryTest
         spark.read.format("delta").load(path),
         spark.range(30).toDF()
       )
-    }
-  }
-
-  test("DeltaLog should throw exception if spark.sql.extensions and " +
-    "spark.sql.catalog.spark_catalog configs are not found") {
-    withTempDir { dir =>
-      SparkSession.cleanupAnyExistingSession()
-      val testSpark = SparkSession.builder()
-        .appName("DeltaLogSparkExtensionTest")
-        .master("local[2]")
-        .getOrCreate()
-
-      val path = new Path(dir.getCanonicalPath)
-      val e = intercept[DeltaRuntimeException] {
-        DeltaLog.forTable(testSpark, path)
-      }
-      assert(e.getErrorClass == "DELTA_CONFIGURE_SPARK_SESSION_WITH_EXTENSION_AND_CATALOG")
-    }
-  }
-
-  test("DeltaLog should not throw exception if SparkSession in initialized with " +
-    "spark.sql.extensions and spark.sql.catalog.spark_catalog conf") {
-    withTempDir { dir =>
-      SparkSession.cleanupAnyExistingSession()
-      val testSpark = SparkSession.builder()
-        .appName("DeltaLogSparkExtensionTest")
-        .master("local[2]")
-        .config(StaticSQLConf.SPARK_SESSION_EXTENSIONS.key,
-          classOf[DeltaSparkSessionExtension].getName)
-        .config(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key, classOf[DeltaCatalog].getName)
-        .getOrCreate()
-
-      val path = new Path(dir.getCanonicalPath)
-      assert(DeltaLog.forTable(testSpark, path).tableExists == false)
-    }
-  }
-
-  test("DeltaLog should not throw exception if SparkSession in initialized with " +
-    ".withExtension api and spark.sql.catalog.spark_catalog conf is set") {
-    withTempDir { dir =>
-      SparkSession.cleanupAnyExistingSession()
-      val testSpark = SparkSession.builder()
-        .appName("DeltaLogSparkExtensionTest")
-        .master("local[2]")
-        .withExtensions(new io.delta.sql.DeltaSparkSessionExtension)
-        .config(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key, classOf[DeltaCatalog].getName)
-        .getOrCreate()
-
-      val path = new Path(dir.getCanonicalPath)
-      assert(DeltaLog.forTable(testSpark, path).tableExists == false)
     }
   }
 }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaRestartSessionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaRestartSessionSuite.scala
@@ -18,14 +18,15 @@ package org.apache.spark.sql.delta
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.catalog.DeltaCatalog
+import org.apache.spark.sql.internal.SQLConf
 
 class DeltaRestartSessionSuite extends SparkFunSuite {
 
   test("restart Spark session should work") {
     withTempDir { dir =>
       var spark = SparkSession.builder().master("local[2]")
-        .config(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
+        .config(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key, classOf[DeltaCatalog].getName)
         .getOrCreate()
       try {
         val path = dir.getCanonicalPath
@@ -34,7 +35,7 @@ class DeltaRestartSessionSuite extends SparkFunSuite {
 
         spark.stop()
         spark = SparkSession.builder().master("local[2]")
-          .config(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
+          .config(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key, classOf[DeltaCatalog].getName)
           .getOrCreate()
         spark.range(10).write.format("delta").mode("overwrite").save(path)
         spark.read.format("delta").load(path).count()

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaRestartSessionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaRestartSessionSuite.scala
@@ -25,7 +25,7 @@ class DeltaRestartSessionSuite extends SparkFunSuite {
   test("restart Spark session should work") {
     withTempDir { dir =>
       var spark = SparkSession.builder().master("local[2]")
-        .config(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
+        .config(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
         .getOrCreate()
       try {
         val path = dir.getCanonicalPath
@@ -34,7 +34,7 @@ class DeltaRestartSessionSuite extends SparkFunSuite {
 
         spark.stop()
         spark = SparkSession.builder().master("local[2]")
-          .config(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
+          .config(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
           .getOrCreate()
         spark.range(10).write.format("delta").mode("overwrite").save(path)
         spark.read.format("delta").load(path).count()

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaRestartSessionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaRestartSessionSuite.scala
@@ -18,19 +18,14 @@ package org.apache.spark.sql.delta
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.SparkSession
-import io.delta.sql.DeltaSparkSessionExtension
-import org.apache.spark.sql.delta.catalog.DeltaCatalog
-import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 class DeltaRestartSessionSuite extends SparkFunSuite {
 
   test("restart Spark session should work") {
     withTempDir { dir =>
       var spark = SparkSession.builder().master("local[2]")
-        .config(StaticSQLConf.SPARK_SESSION_EXTENSIONS.key,
-          classOf[DeltaSparkSessionExtension].getName)
-        .config(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key,
-          classOf[DeltaCatalog].getName)
+        .config(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
         .getOrCreate()
       try {
         val path = dir.getCanonicalPath
@@ -39,10 +34,7 @@ class DeltaRestartSessionSuite extends SparkFunSuite {
 
         spark.stop()
         spark = SparkSession.builder().master("local[2]")
-          .config(StaticSQLConf.SPARK_SESSION_EXTENSIONS.key,
-            classOf[DeltaSparkSessionExtension].getName)
-          .config(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key,
-            classOf[DeltaCatalog].getName)
+          .config(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
           .getOrCreate()
         spark.range(10).write.format("delta").mode("overwrite").save(path)
         spark.read.format("delta").load(path).count()

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaRestartSessionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaRestartSessionSuite.scala
@@ -18,19 +18,32 @@ package org.apache.spark.sql.delta
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.SparkSession
+import io.delta.sql.DeltaSparkSessionExtension
+import org.apache.spark.sql.delta.catalog.DeltaCatalog
+import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 
 class DeltaRestartSessionSuite extends SparkFunSuite {
 
   test("restart Spark session should work") {
     withTempDir { dir =>
-      var spark = SparkSession.builder().master("local[2]").getOrCreate()
+      var spark = SparkSession.builder().master("local[2]")
+        .config(StaticSQLConf.SPARK_SESSION_EXTENSIONS.key,
+          classOf[DeltaSparkSessionExtension].getName)
+        .config(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key,
+          classOf[DeltaCatalog].getName)
+        .getOrCreate()
       try {
         val path = dir.getCanonicalPath
         spark.range(10).write.format("delta").mode("overwrite").save(path)
         spark.read.format("delta").load(path).count()
 
         spark.stop()
-        spark = SparkSession.builder().master("local[2]").getOrCreate()
+        spark = SparkSession.builder().master("local[2]")
+          .config(StaticSQLConf.SPARK_SESSION_EXTENSIONS.key,
+            classOf[DeltaSparkSessionExtension].getName)
+          .config(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key,
+            classOf[DeltaCatalog].getName)
+          .getOrCreate()
         spark.range(10).write.format("delta").mode("overwrite").save(path)
         spark.read.format("delta").load(path).count()
       }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
@@ -34,8 +34,10 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.streaming._
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
-class DeltaSinkSuite extends StreamTest with DeltaColumnMappingTestUtils {
+class DeltaSinkSuite extends StreamTest with DeltaColumnMappingTestUtils
+  with DeltaSQLCommandTest {
 
   override val streamingTimeout = 60.seconds
   import testImplicits._

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
@@ -42,7 +42,7 @@ class DeltaSinkSuite extends StreamTest with DeltaColumnMappingTestUtils {
 
   protected override def sparkConf = {
     // disable the spark conf check
-    super.sparkConf.set(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
+    super.sparkConf.set(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
   }
 
   // Before we start running the tests in this suite, we should let Spark perform all necessary set

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
@@ -34,16 +34,13 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.streaming._
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
-class DeltaSinkSuite extends StreamTest with DeltaColumnMappingTestUtils {
+class DeltaSinkSuite extends StreamTest with DeltaColumnMappingTestUtils
+  with DeltaSQLCommandTest {
 
   override val streamingTimeout = 60.seconds
   import testImplicits._
-
-  protected override def sparkConf = {
-    // disable the spark conf check
-    super.sparkConf.set(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
-  }
 
   // Before we start running the tests in this suite, we should let Spark perform all necessary set
   // up that needs to be done for streaming. Without this, the first test in the suite may be flaky

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
@@ -34,13 +34,16 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.streaming._
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
-class DeltaSinkSuite extends StreamTest with DeltaColumnMappingTestUtils
-  with DeltaSQLCommandTest {
+class DeltaSinkSuite extends StreamTest with DeltaColumnMappingTestUtils {
 
   override val streamingTimeout = 60.seconds
   import testImplicits._
+
+  protected override def sparkConf = {
+    // disable the spark conf check
+    super.sparkConf.set(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
+  }
 
   // Before we start running the tests in this suite, we should let Spark perform all necessary set
   // up that needs to be done for streaming. Without this, the first test in the suite may be flaky

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
@@ -33,10 +33,12 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 
 import org.apache.spark.sql.{functions, AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.util.ManualClock
 
 class DeltaTimeTravelSuite extends QueryTest
-  with SharedSparkSession  with SQLTestUtils {
+  with SharedSparkSession  with SQLTestUtils
+  with DeltaSQLCommandTest {
 
   import testImplicits._
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
@@ -49,7 +49,7 @@ class DeltaTimeTravelSuite extends QueryTest
 
   protected override def sparkConf = {
     // disable the spark conf check
-    super.sparkConf.set(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
+    super.sparkConf.set(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
   }
 
   private implicit def longToTimestamp(ts: Long): Timestamp = new Timestamp(ts)

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
@@ -33,12 +33,11 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 
 import org.apache.spark.sql.{functions, AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.util.ManualClock
 
 class DeltaTimeTravelSuite extends QueryTest
-  with SharedSparkSession  with SQLTestUtils
-  with DeltaSQLCommandTest {
+  with SharedSparkSession  with SQLTestUtils {
 
   import testImplicits._
 
@@ -46,6 +45,11 @@ class DeltaTimeTravelSuite extends QueryTest
 
   private implicit def durationToLong(duration: FiniteDuration): Long = {
     duration.toMillis
+  }
+
+  protected override def sparkConf = {
+    // disable the spark conf check
+    super.sparkConf.set(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
   }
 
   private implicit def longToTimestamp(ts: Long): Timestamp = new Timestamp(ts)

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
@@ -33,8 +33,6 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 
 import org.apache.spark.sql.{functions, AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
-import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.util.ManualClock
 
 class DeltaTimeTravelSuite extends QueryTest
   with SharedSparkSession  with SQLTestUtils
@@ -46,11 +44,6 @@ class DeltaTimeTravelSuite extends QueryTest
 
   private implicit def durationToLong(duration: FiniteDuration): Long = {
     duration.toMillis
-  }
-
-  protected override def sparkConf = {
-    // disable the spark conf check
-    super.sparkConf.set(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
   }
 
   private implicit def longToTimestamp(ts: Long): Timestamp = new Timestamp(ts)

--- a/core/src/test/scala/org/apache/spark/sql/delta/DuplicatingListLogStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DuplicatingListLogStoreSuite.scala
@@ -28,7 +28,6 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 class DuplicatingListLogStore(sparkConf: SparkConf, defaultHadoopConf: Configuration)
   extends HDFSLogStore(sparkConf, defaultHadoopConf) {
@@ -44,11 +43,13 @@ class DuplicatingListLogStore(sparkConf: SparkConf, defaultHadoopConf: Configura
   }
 }
 
-class DuplicatingListLogStoreSuite extends SharedSparkSession with DeltaSQLCommandTest {
+class DuplicatingListLogStoreSuite extends SharedSparkSession {
 
   override def sparkConf: SparkConf = {
     super.sparkConf.set("spark.databricks.tahoe.logStore.class",
       classOf[DuplicatingListLogStore].getName)
+    // disable the spark conf check
+    .set(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
   }
 
   def pathExists(deltaLog: DeltaLog, filePath: String): Boolean = {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DuplicatingListLogStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DuplicatingListLogStoreSuite.scala
@@ -28,6 +28,7 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 class DuplicatingListLogStore(sparkConf: SparkConf, defaultHadoopConf: Configuration)
   extends HDFSLogStore(sparkConf, defaultHadoopConf) {
@@ -43,7 +44,7 @@ class DuplicatingListLogStore(sparkConf: SparkConf, defaultHadoopConf: Configura
   }
 }
 
-class DuplicatingListLogStoreSuite extends SharedSparkSession {
+class DuplicatingListLogStoreSuite extends SharedSparkSession with DeltaSQLCommandTest {
 
   override def sparkConf: SparkConf = {
     super.sparkConf.set("spark.databricks.tahoe.logStore.class",

--- a/core/src/test/scala/org/apache/spark/sql/delta/DuplicatingListLogStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DuplicatingListLogStoreSuite.scala
@@ -49,7 +49,7 @@ class DuplicatingListLogStoreSuite extends SharedSparkSession {
     super.sparkConf.set("spark.databricks.tahoe.logStore.class",
       classOf[DuplicatingListLogStore].getName)
     // disable the spark conf check
-    .set(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
+    .set(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
   }
 
   def pathExists(deltaLog: DeltaLog, filePath: String): Boolean = {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DuplicatingListLogStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DuplicatingListLogStoreSuite.scala
@@ -28,6 +28,7 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 class DuplicatingListLogStore(sparkConf: SparkConf, defaultHadoopConf: Configuration)
   extends HDFSLogStore(sparkConf, defaultHadoopConf) {
@@ -43,13 +44,12 @@ class DuplicatingListLogStore(sparkConf: SparkConf, defaultHadoopConf: Configura
   }
 }
 
-class DuplicatingListLogStoreSuite extends SharedSparkSession {
+class DuplicatingListLogStoreSuite extends SharedSparkSession
+  with DeltaSQLCommandTest {
 
   override def sparkConf: SparkConf = {
     super.sparkConf.set("spark.databricks.tahoe.logStore.class",
       classOf[DuplicatingListLogStore].getName)
-    // disable the spark conf check
-    .set(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
   }
 
   def pathExists(deltaLog: DeltaLog, filePath: String): Boolean = {

--- a/core/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
@@ -41,7 +41,7 @@ import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 abstract class LogStoreSuiteBase extends QueryTest
   with LogStoreProvider
-  with SharedSparkSession with DeltaSQLCommandTest{
+  with SharedSparkSession with DeltaSQLCommandTest {
 
   def logStoreClassName: String
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
@@ -48,7 +48,7 @@ abstract class LogStoreSuiteBase extends QueryTest
   protected override def sparkConf = {
     super.sparkConf.set(logStoreClassConfKey, logStoreClassName)
       // disable the spark conf check
-      .set(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
+      .set(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
   }
 
   // scalastyle:off deltahadoopconfiguration

--- a/core/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
@@ -32,8 +32,8 @@ import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.sql.{LocalSparkSession, QueryTest, SparkSession}
 import org.apache.spark.sql.LocalSparkSession.withSparkSession
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.util.Utils
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 /////////////////////
 // Base Test Suite //
@@ -41,12 +41,14 @@ import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 abstract class LogStoreSuiteBase extends QueryTest
   with LogStoreProvider
-  with SharedSparkSession with DeltaSQLCommandTest {
+  with SharedSparkSession {
 
   def logStoreClassName: String
 
   protected override def sparkConf = {
     super.sparkConf.set(logStoreClassConfKey, logStoreClassName)
+      // disable the spark conf check
+      .set(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
   }
 
   // scalastyle:off deltahadoopconfiguration

--- a/core/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.{LocalSparkSession, QueryTest, SparkSession}
 import org.apache.spark.sql.LocalSparkSession.withSparkSession
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.Utils
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 /////////////////////
 // Base Test Suite //
@@ -40,7 +41,7 @@ import org.apache.spark.util.Utils
 
 abstract class LogStoreSuiteBase extends QueryTest
   with LogStoreProvider
-  with SharedSparkSession {
+  with SharedSparkSession with DeltaSQLCommandTest{
 
   def logStoreClassName: String
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
@@ -34,8 +34,8 @@ import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.sql.{LocalSparkSession, QueryTest, SparkSession}
 import org.apache.spark.sql.LocalSparkSession.withSparkSession
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.util.Utils
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 /////////////////////
 // Base Test Suite //
@@ -43,14 +43,13 @@ import org.apache.spark.util.Utils
 
 abstract class LogStoreSuiteBase extends QueryTest
   with LogStoreProvider
-  with SharedSparkSession {
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
 
   def logStoreClassName: String
 
   protected override def sparkConf = {
     super.sparkConf.set(logStoreClassConfKey, logStoreClassName)
-      // disable the spark conf check
-      .set(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
   }
 
   // scalastyle:off deltahadoopconfiguration

--- a/core/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionLegacyTests.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionLegacyTests.scala
@@ -24,13 +24,14 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
-
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 // These tests are potentially a subset of the tests already in OptimisticTransactionSuite.
 // These tests can potentially be removed but only after confirming that these tests are
 // truly a subset of the tests in OptimisticTransactionSuite.
 trait OptimisticTransactionLegacyTests
   extends QueryTest
-  with SharedSparkSession {
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
 
   private val addA = AddFile("a", Map.empty, 1, 1, dataChange = true)
   private val addB = AddFile("b", Map.empty, 1, 1, dataChange = true)

--- a/core/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionLegacyTests.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionLegacyTests.scala
@@ -24,20 +24,25 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
 // These tests are potentially a subset of the tests already in OptimisticTransactionSuite.
 // These tests can potentially be removed but only after confirming that these tests are
 // truly a subset of the tests in OptimisticTransactionSuite.
 trait OptimisticTransactionLegacyTests
   extends QueryTest
-  with SharedSparkSession
-  with DeltaSQLCommandTest {
+  with SharedSparkSession {
 
   private val addA = AddFile("a", Map.empty, 1, 1, dataChange = true)
   private val addB = AddFile("b", Map.empty, 1, 1, dataChange = true)
   private val addC = AddFile("c", Map.empty, 1, 1, dataChange = true)
 
   import testImplicits._
+
+  protected override def sparkConf = {
+    // disable the spark conf check
+    super.sparkConf.set(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
+  }
 
   test("block append against metadata change") {
     withTempDir { tempDir =>

--- a/core/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionLegacyTests.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionLegacyTests.scala
@@ -41,7 +41,7 @@ trait OptimisticTransactionLegacyTests
 
   protected override def sparkConf = {
     // disable the spark conf check
-    super.sparkConf.set(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
+    super.sparkConf.set(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
   }
 
   test("block append against metadata change") {

--- a/core/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionLegacyTests.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionLegacyTests.scala
@@ -24,25 +24,20 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
-import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 // These tests are potentially a subset of the tests already in OptimisticTransactionSuite.
 // These tests can potentially be removed but only after confirming that these tests are
 // truly a subset of the tests in OptimisticTransactionSuite.
 trait OptimisticTransactionLegacyTests
   extends QueryTest
-  with SharedSparkSession {
+  with SharedSparkSession with DeltaSQLCommandTest {
 
   private val addA = AddFile("a", Map.empty, 1, 1, dataChange = true)
   private val addB = AddFile("b", Map.empty, 1, 1, dataChange = true)
   private val addC = AddFile("c", Map.empty, 1, 1, dataChange = true)
 
   import testImplicits._
-
-  protected override def sparkConf = {
-    // disable the spark conf check
-    super.sparkConf.set(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
-  }
 
   test("block append against metadata change") {
     withTempDir { tempDir =>

--- a/core/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
@@ -27,11 +27,13 @@ import org.apache.spark.SparkException
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
 import org.apache.spark.storage.StorageLevel
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
-class SnapshotManagementSuite extends QueryTest with SQLTestUtils
-  with SharedSparkSession with DeltaSQLCommandTest {
+class SnapshotManagementSuite extends QueryTest with SQLTestUtils with SharedSparkSession {
 
+  protected override def sparkConf = {
+    // disable the spark conf check
+    super.sparkConf.set(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
+  }
 
   /**
    * Truncate an existing checkpoint file to create a corrupt file.

--- a/core/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
@@ -27,8 +27,10 @@ import org.apache.spark.SparkException
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
 import org.apache.spark.storage.StorageLevel
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
-class SnapshotManagementSuite extends QueryTest with SQLTestUtils with SharedSparkSession {
+class SnapshotManagementSuite extends QueryTest with SQLTestUtils
+  with SharedSparkSession with DeltaSQLCommandTest {
 
 
   /**

--- a/core/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
@@ -27,13 +27,11 @@ import org.apache.spark.SparkException
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
 import org.apache.spark.storage.StorageLevel
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
-class SnapshotManagementSuite extends QueryTest with SQLTestUtils with SharedSparkSession {
+class SnapshotManagementSuite extends QueryTest with SQLTestUtils
+  with SharedSparkSession with DeltaSQLCommandTest {
 
-  protected override def sparkConf = {
-    // disable the spark conf check
-    super.sparkConf.set(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
-  }
 
   /**
    * Truncate an existing checkpoint file to create a corrupt file.

--- a/core/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
@@ -32,7 +32,7 @@ class SnapshotManagementSuite extends QueryTest with SQLTestUtils with SharedSpa
 
   protected override def sparkConf = {
     // disable the spark conf check
-    super.sparkConf.set(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
+    super.sparkConf.set(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/sql/delta/schema/SchemaEnforcementSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/schema/SchemaEnforcementSuite.scala
@@ -897,6 +897,7 @@ class SchemaEnforcementWithTableSuite
 
 class SchemaEnforcementStreamingSuite
   extends AppendOutputModeTests
-  with CompleteOutputModeTests {
+  with CompleteOutputModeTests
+  with DeltaSQLCommandTest {
 }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/schema/SchemaEnforcementSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/schema/SchemaEnforcementSuite.scala
@@ -897,7 +897,11 @@ class SchemaEnforcementWithTableSuite
 
 class SchemaEnforcementStreamingSuite
   extends AppendOutputModeTests
-  with CompleteOutputModeTests
-  with DeltaSQLCommandTest {
+  with CompleteOutputModeTests {
+
+  protected override def sparkConf = {
+    // disable the spark conf check
+    super.sparkConf.set(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
+  }
 }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/schema/SchemaEnforcementSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/schema/SchemaEnforcementSuite.scala
@@ -897,11 +897,7 @@ class SchemaEnforcementWithTableSuite
 
 class SchemaEnforcementStreamingSuite
   extends AppendOutputModeTests
-  with CompleteOutputModeTests {
-
-  protected override def sparkConf = {
-    // disable the spark conf check
-    super.sparkConf.set(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
-  }
+  with CompleteOutputModeTests
+  with DeltaSQLCommandTest {
 }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/schema/SchemaEnforcementSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/schema/SchemaEnforcementSuite.scala
@@ -901,7 +901,7 @@ class SchemaEnforcementStreamingSuite
 
   protected override def sparkConf = {
     // disable the spark conf check
-    super.sparkConf.set(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
+    super.sparkConf.set(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.delta.stats
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.test.{TestsStatistics, DeltaSQLCommandTest}
+import org.apache.spark.sql.delta.test.TestsStatistics
 import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.hadoop.fs.Path
 import org.scalatest.exceptions.TestFailedException
@@ -33,9 +33,14 @@ import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 class StatsCollectionSuite
   extends QueryTest
   with SharedSparkSession  with DeltaColumnMappingTestUtils
-  with TestsStatistics with DeltaSQLCommandTest {
+  with TestsStatistics {
 
   import testImplicits._
+
+  protected override def sparkConf = {
+    // disable the spark conf check
+    super.sparkConf.set(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
+  }
 
 
   test("on write") {

--- a/core/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.delta.stats
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.test.TestsStatistics
+import org.apache.spark.sql.delta.test.{TestsStatistics, DeltaSQLCommandTest}
 import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.hadoop.fs.Path
 import org.scalatest.exceptions.TestFailedException
@@ -33,7 +33,7 @@ import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 class StatsCollectionSuite
   extends QueryTest
   with SharedSparkSession  with DeltaColumnMappingTestUtils
-  with TestsStatistics {
+  with TestsStatistics with DeltaSQLCommandTest {
 
   import testImplicits._
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
@@ -29,18 +29,14 @@ import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 class StatsCollectionSuite
   extends QueryTest
   with SharedSparkSession  with DeltaColumnMappingTestUtils
-  with TestsStatistics {
+  with TestsStatistics with DeltaSQLCommandTest {
 
   import testImplicits._
-
-  protected override def sparkConf = {
-    // disable the spark conf check
-    super.sparkConf.set(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
-  }
 
 
   test("on write") {

--- a/core/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
@@ -39,7 +39,7 @@ class StatsCollectionSuite
 
   protected override def sparkConf = {
     // disable the spark conf check
-    super.sparkConf.set(DeltaSQLConf.DELTA_CHECK_REQUIRED_SPARK_CONF.key, "false")
+    super.sparkConf.set(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK.key, "false")
   }
 
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
Resolves https://github.com/delta-io/delta/issues/1144


## How was this patch tested?

- Added a new test in `DeltaLogSuite`: 
``` scala
test("DeltaLog should not throw exception if SparkSession in initialized with " +
    ".withExtension api and spark.sql.catalog.spark_catalog conf is set")

test("DeltaLog should not throw exception if SparkSession in initialized with " +
    ".withExtension api and spark.sql.catalog.spark_catalog conf is set")
```
- Refactored other unit tests

## Does this PR introduce _any_ user-facing changes?

Yes. If  `spark.sql.catalog.spark_catalog` configuration is not found in the `SparkSession`, it now throws the following user friendly error.

```
This Delta operation requires the SparkSession to be configured with the
DeltaSparkSessionExtension and the DeltaCatalog. Please set the necessary
configurations when creating the SparkSession as shown below.

  SparkSession.builder()
    .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
    .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
    ...
    .getOrCreate()

If you are using spark-shell/pyspark/spark-submit, you can add the required configurations to the command as show below: --conf spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension --conf spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog
```


Signed-off-by: Ganesh Chand<<ganeshchand@gmail.com>>
