### PR TITLE
Make MERGE operation return useful metrics

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
@@ -17,8 +17,10 @@
 package org.apache.spark.sql.delta.commands
 
 import java.util.concurrent.TimeUnit
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.{AddCDCFile, AddFile, FileAction}
 import org.apache.spark.sql.delta.files._

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
@@ -219,10 +219,10 @@ case class MergeIntoCommand(
   override val canOverwriteSchema: Boolean = false
 
   override val output: Seq[Attribute] = Seq(
-    AttributeReference("number of affected rows", LongType)(),
-    AttributeReference("number of updated rows", LongType)(),
-    AttributeReference("number of deleted rows", LongType)(),
-    AttributeReference("number of inserted rows", LongType)())
+    AttributeReference("num_affected_rows", LongType)(),
+    AttributeReference("num_updated_rows", LongType)(),
+    AttributeReference("num_deleted_rows", LongType)(),
+    AttributeReference("num_inserted_rows", LongType)())
 
   @transient private lazy val sc: SparkContext = SparkContext.getOrCreate()
   @transient private lazy val targetDeltaLog: DeltaLog = targetFileIndex.deltaLog

--- a/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
@@ -82,7 +82,8 @@ class MergeIntoSQLSuite extends MergeIntoSuiteBase  with DeltaSQLCommandTest
         update = "key2 = 20 + src.key3, value = 20 + src.value",
         insert = "(key2, value) VALUES (src.key3 - 10, src.value + 10)")
 
-      sql(cte + merge)
+//      print(sql(cte + merge).explain(true))
+      checkAnswer(sql(cte + merge), Row(2, 1, 0, 1))
       checkAnswer(readDeltaTable(tempPath),
         Row(1, 4) :: // No change
         Row(22, 23) :: // Update

--- a/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.delta
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest}
 
-import org.apache.spark.sql.{AnalysisException, Row}
+import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.catalyst.analysis.{Analyzer, ResolveSessionCatalog}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical.{DeltaMergeInto, LogicalPlan}
@@ -82,8 +82,7 @@ class MergeIntoSQLSuite extends MergeIntoSuiteBase  with DeltaSQLCommandTest
         update = "key2 = 20 + src.key3, value = 20 + src.value",
         insert = "(key2, value) VALUES (src.key3 - 10, src.value + 10)")
 
-//      print(sql(cte + merge).explain(true))
-      checkAnswer(sql(cte + merge), Row(2, 1, 0, 1))
+      QueryTest.checkAnswer(sql(cte + merge), Seq(Row(2, 1, 0, 1)))
       checkAnswer(readDeltaTable(tempPath),
         Row(1, 4) :: // No change
         Row(22, 23) :: // Update


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

Resolves #1322 
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
sql test Suit

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes

Console Output after Change :

```
+-----------------+----------------+----------------+-----------------+
|num_affected_rows|num_updated_rows|num_deleted_rows|num_inserted_rows|
+-----------------+----------------+----------------+-----------------+
|                2|               1|               0|                1|
+-----------------+----------------+----------------+-----------------+
```
<img width="818" alt="image" src="https://user-images.githubusercontent.com/46790654/184258611-eb817bae-487a-491b-bddb-738a39949d8b.png">


