### PR TITLE
Fix merge command `numTargetFilesAdded` metric

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
@@ -532,6 +532,14 @@ case class MergeIntoCommand(
 
     val newFiles = deltaTxn
       .writeFiles(repartitionIfNeeded(spark, insertDf, deltaTxn.metadata.partitionColumns))
+      .filter {
+        // In some cases (e.g. insert-only when all rows are matched, insert-only with an empty
+        // source, insert-only with an unsatisfied condition) we can write out an empty insertDf.
+        // This is hard to catch before the write without collecting the DF ahead of time. Instead,
+        // we can just accept only the AddFiles that actually add rows.
+        case a: AddFile => a.getNumLogicalRecords > 0
+        case _ => true
+      }
 
     // Update metrics
     metrics("numTargetFilesBeforeSkipping") += deltaTxn.snapshot.numOfFiles
@@ -812,6 +820,14 @@ case class MergeIntoCommand(
     // Write to Delta
     val newFiles = deltaTxn
       .writeFiles(repartitionIfNeeded(spark, outputDF, deltaTxn.metadata.partitionColumns))
+      .filter {
+        // In some cases (e.g. delete with empty source, or empty target, or on disjoint tables)
+        // we can write out an empty outputDF. This is hard to catch before the write without
+        // collecting the DF ahead of time. Instead, we can just accept only the AddFiles that
+        // actually add rows.
+        case a: AddFile => a.getNumLogicalRecords > 0
+        case _ => true
+      }
 
     // Update metrics
     val (addedBytes, addedPartitions) = totalBytesAndDistinctPartitionValues(newFiles)


### PR DESCRIPTION
## Description

This PR fixes a bug in `MergeIntoCommand` where the metric `numTargetFilesAdded` sometimes gave an unexpected value. This PR ensures that `MergeIntoCommand` only writes out new files to the target table that are non-empty (i.e. at least 1 row).

Note: the value was never wrong, for example it would say that we wrote out 1 file, and we did in fact write out 1 empty file. However, there was no logical reason for us to write out an empty file with no rows.

This PR also updates existing tests (which knew about this bug and so were ignored) inside of `MergeIntoMetricsBase`.

## How was this patch tested?

```
build/sbt 'core/testOnly *DescribeDeltaHistorySuite -- -z "merge-metrics"'
```