### PR TITLE
Misc integration test updates

### DIFF
--- a/examples/python/table_exists.py
+++ b/examples/python/table_exists.py
@@ -23,7 +23,7 @@ def exists(spark, filepath):
     try:
         spark.read.load(path=filepath, format="delta")
     except AnalysisException as exception:
-        if "is not a Delta table" in exception.desc:
+        if "is not a Delta table" in exception.desc or "Path does not exist" in exception.desc:
             return False
         raise exception
     return True

--- a/examples/scala/src/main/scala/example/QuickstartSQL.scala
+++ b/examples/scala/src/main/scala/example/QuickstartSQL.scala
@@ -80,8 +80,7 @@ object QuickstartSQL {
 
       // Read old version of the data using time travel
       print("Read old data using time travel")
-      val df2 = spark.read.format("delta").option("versionAsOf", 0).table(tableName)
-      df2.show()
+      spark.sql(s"SELECT * FROM $tableName VERSION AS OF 0").show()
     } finally {
       // Cleanup
       spark.sql(s"DROP TABLE IF EXISTS $tableName")


### PR DESCRIPTION
## Description

- Uses SQL for time travel in QuickstartSQL example since support has been added for Delta 2.1
- Updates table_exists.py integration test in response to 11fb2eadf3ead06fa1bcb049e7dcc925e21166e1. That change was included in 2.0 and failing for me with 2.0


## How was this patch tested?

n/a
