### PR TITLE
Change DeltaTable.details() to DeltaTable.detail() to be consistent with SQL

### DIFF
--- a/core/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -135,11 +135,14 @@ class DeltaTable private[tables](
   }
 
   /**
+   * :: Evolving ::
+   *
    * Get the details of a Delta table such as the format, name, and size.
    *
    * @since 2.1.0
    */
-  def details(): DataFrame = {
+  @Evolving
+  def detail(): DataFrame = {
     executeDetails(deltaLog.dataPath.toString, table.getTableIdentifierIfExists)
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
@@ -62,7 +62,7 @@ trait DescribeDeltaDetailSuiteBase extends QueryTest
     // Check Scala details
     val deltaTable = io.delta.tables.DeltaTable.forPath(spark, tempDir.toString)
     checkResult(
-      deltaTable.details(),
+      deltaTable.detail(),
       Seq("delta", Array("column1"), 1),
       Seq("format", "partitionColumns", "numFiles"))
   }
@@ -73,7 +73,7 @@ trait DescribeDeltaDetailSuiteBase extends QueryTest
 
       val deltaTable = io.delta.tables.DeltaTable.forName(spark, "delta_test")
       checkAnswer(
-        deltaTable.details().select("format"),
+        deltaTable.detail().select("format"),
         Seq(Row("delta"))
       )
     }

--- a/examples/python/utilities.py
+++ b/examples/python/utilities.py
@@ -50,7 +50,7 @@ print("######## Describe history for the table ######")
 deltaTable.history().show()
 
 print("######## Describe details for the table ######")
-deltaTable.details().show()
+deltaTable.detail().show()
 
 # Generate manifest
 print("######## Generating manifest ######")

--- a/examples/scala/src/main/scala/example/Utilities.scala
+++ b/examples/scala/src/main/scala/example/Utilities.scala
@@ -64,7 +64,7 @@ object Utilities {
     deltaTable.history().show()
 
     println("Describe Details for the table")
-    deltaTable.details().show()
+    deltaTable.detail().show()
 
     // Generate manifest
     println("Generate Manifest files")

--- a/python/delta/tables.py
+++ b/python/delta/tables.py
@@ -279,19 +279,21 @@ class DeltaTable(object):
             )
 
     @since(2.1)  # type: ignore[arg-type]
-    def details(self) -> DataFrame:
+    def detail(self) -> DataFrame:
         """
         Get the details of a Delta table such as the format, name, and size.
 
         Example::
 
-            detailsDF = deltaTable.details() # get the full details of the table
+            detailDF = deltaTable.detail() # get the full details of the table
 
         :return Information of the table (format, name, size, etc.)
         :rtype: pyspark.sql.DataFrame
+
+        .. note:: Evolving
         """
         return DataFrame(
-            self._jdt.details(),
+            self._jdt.detail(),
             getattr(self._spark, "_wrapped", self._spark)  # type: ignore[attr-defined]
         )
 

--- a/python/delta/tests/test_deltatable.py
+++ b/python/delta/tests/test_deltatable.py
@@ -327,10 +327,10 @@ class DeltaTableTests(DeltaTestCase):
             [Row("Overwrite")],
             StructType([StructField("operationParameters.mode", StringType(), True)]))
 
-    def test_details(self) -> None:
+    def test_detail(self) -> None:
         self.__writeDeltaTable([('a', 1), ('b', 2), ('c', 3)])
         dt = DeltaTable.forPath(self.spark, self.tempFile)
-        details = dt.details()
+        details = dt.detail()
         self.__checkAnswer(
             details.select('format'),
             [Row('delta')],


### PR DESCRIPTION

## Description

Change DeltaTable.details() to DeltaTable.detail() to be consistent with SQL command `DESCRIBE DETAIL`

Also adds the @evolving tag.

## How was this patch tested?

Updates corresponding tests.