### PR TITLE
Eliminate ScalaReflection calls from Delta after warming up

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -485,8 +485,6 @@ object Checkpoints extends DeltaLogging {
       spark: SparkSession,
       deltaLog: DeltaLog,
       snapshot: Snapshot): CheckpointMetaData = withDmqTag {
-    import SingleAction._
-
     val hadoopConf = deltaLog.newDeltaHadoopConf()
 
     // The writing of checkpoints doesn't go through log store, so we need to check with the

--- a/core/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -190,14 +190,14 @@ private[delta] class ConflictChecker(
           Seq.empty
       }
 
-      import spark.implicits._
+      import org.apache.spark.sql.delta.implicits._
       val predicatesMatchingAddedFiles = ExpressionSet(
           currentTransactionInfo.readPredicates).iterator.flatMap { p =>
         // ES-366661: use readSnapshot's partitionSchema as that is what we read in the
         // beginning.
         val conflictingFile = DeltaLog.filterFileList(
           partitionSchema = currentTransactionInfo.partitionSchemaAtReadTime,
-          addedFilesToCheckForConflicts.toDF(), p :: Nil).as[AddFile].take(1)
+          addedFilesToCheckForConflicts.toDF(spark), p :: Nil).as[AddFile].take(1)
 
         conflictingFile.headOption.map(f => getPrettyPartitionMessage(f.partitionValues))
       }.take(1).toArray

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
@@ -74,8 +74,7 @@ class DeltaHistoryManager(
   def getHistory(
       start: Long,
       end: Option[Long] = None): Seq[DeltaHistory] = {
-    val _spark = spark
-    import _spark.implicits._
+    import org.apache.spark.sql.delta.implicits._
     val conf = getSerializableHadoopConf
     val logPath = deltaLog.logPath.toString
     // We assume that commits are contiguous, therefore we try to load all of them in order
@@ -386,7 +385,7 @@ object DeltaHistoryManager extends DeltaLogging {
       start: Long,
       end: Long,
       step: Long): Commit = {
-    import spark.implicits._
+    import org.apache.spark.sql.delta.implicits._
     val possibleCommits = spark.range(start, end, step).mapPartitions { startVersions =>
       val logStore = LogStore(SparkEnv.get.conf, conf.value)
       val basePath = new Path(logPath)

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -36,8 +36,10 @@ import com.fasterxml.jackson.databind.annotation.{JsonDeserialize, JsonSerialize
 import org.codehaus.jackson.annotate.JsonRawValue
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.{Encoder, SparkSession}
+import org.apache.spark.sql.{Column, DataFrame, Dataset, Encoder, SparkSession}
+import org.apache.spark.sql.catalyst.ScalaReflection
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DataType, StructField, StructType}
 import org.apache.spark.util.Utils
@@ -713,30 +715,17 @@ case class SingleAction(
 }
 
 object SingleAction extends Logging {
-  private lazy val _encoder: ExpressionEncoder[SingleAction] = try {
-    ExpressionEncoder[SingleAction]()
-  } catch {
-    case e: Throwable =>
-      logError(e.getMessage, e)
-      throw e
-  }
+  implicit def encoder: Encoder[SingleAction] =
+    org.apache.spark.sql.delta.implicits.singleActionEncoder
 
-  private lazy val _addFileEncoder: ExpressionEncoder[AddFile] = try {
-    ExpressionEncoder[AddFile]()
-  } catch {
-    case e: Throwable =>
-      logError(e.getMessage, e)
-      throw e
-  }
+  implicit def addFileEncoder: Encoder[AddFile] =
+    org.apache.spark.sql.delta.implicits.addFileEncoder
 
+  lazy val nullLitForRemoveFile: Column =
+    new Column(Literal(null, ScalaReflection.schemaFor[RemoveFile].dataType))
 
-  implicit def encoder: Encoder[SingleAction] = {
-    _encoder.copy()
-  }
-
-  implicit def addFileEncoder: Encoder[AddFile] = {
-    _addFileEncoder.copy()
-  }
+  lazy val nullLitForAddCDCFile: Column =
+    new Column(Literal(null, ScalaReflection.schemaFor[AddCDCFile].dataType))
 }
 
 /** Serializes Maps containing JSON strings without extra escaping. */

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
@@ -690,7 +690,7 @@ class CatalogFileManifest(
   }
 
   override def doList(): Dataset[SerializableFileStatus] = {
-    import spark.implicits._
+    import org.apache.spark.sql.delta.implicits._
     // Avoid the serialization of this CatalogFileManifest during distributed execution.
     val conf = spark.sparkContext.broadcast(serializableConf)
     val parallelism = spark.sessionState.conf.parallelPartitionDiscoveryParallelism

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/DescribeDeltaHistoryCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/DescribeDeltaHistoryCommand.scala
@@ -89,8 +89,9 @@ case class DescribeDeltaHistoryCommand(
         throw DeltaErrors.notADeltaTableException("DESCRIBE HISTORY")
       }
 
-      import sparkSession.implicits._
-      deltaLog.history.getHistory(limit).toDF().collect().toSeq
+      import org.apache.spark.sql.delta.implicits._
+      val commits = deltaLog.history.getHistory(limit)
+      sparkSession.implicits.localSeqToDatasetHolder(commits).toDF().collect().toSeq
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.delta.commands
 
 // scalastyle:off import.ordering.noEmptyLine
-import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog, DeltaOperations, DeltaTableUtils, OptimisticTransaction}
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog, DeltaOperations, DeltaTableUtils, DeltaUDF, OptimisticTransaction}
 import org.apache.spark.sql.delta.actions.{AddCDCFile, AddFile, FileAction}
 import org.apache.spark.sql.delta.commands.cdc.CDCReader.{CDC_TYPE_COLUMN_NAME, CDC_TYPE_NOT_CDC, CDC_TYPE_UPDATE_POSTIMAGE, CDC_TYPE_UPDATE_PREIMAGE}
 import org.apache.spark.sql.delta.files.{TahoeBatchFileIndex, TahoeFileIndex}
@@ -33,7 +33,7 @@ import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.execution.metric.SQLMetrics.{createMetric, createTimingMetric}
-import org.apache.spark.sql.functions.{array, col, explode, input_file_name, lit, struct, typedLit, udf}
+import org.apache.spark.sql.functions.{array, col, explode, input_file_name, lit, struct}
 
 /**
  * Performs an Update using `updateExpression` on the rows that match `condition`
@@ -87,7 +87,7 @@ case class UpdateCommand(
 
   private def performUpdate(
       sparkSession: SparkSession, deltaLog: DeltaLog, txn: OptimisticTransaction): Unit = {
-    import sparkSession.implicits._
+    import org.apache.spark.sql.delta.implicits._
 
     var numTouchedFiles: Long = 0
     var numRewrittenFiles: Long = 0
@@ -125,7 +125,7 @@ case class UpdateCommand(
       val newTarget = DeltaTableUtils.replaceFileIndex(target, fileIndex)
       val data = Dataset.ofRows(sparkSession, newTarget)
       val updatedRowCount = metrics("numUpdatedRows")
-      val updatedRowUdf = udf { () =>
+      val updatedRowUdf = DeltaUDF.boolean { () =>
         updatedRowCount += 1
         true
       }.asNondeterministic()
@@ -249,7 +249,7 @@ case class UpdateCommand(
     // Number of total rows that we have seen, i.e. are either copying or updating (sum of both).
     // This will be used later, along with numUpdatedRows, to determine numCopiedRows.
     val numTouchedRows = metrics("numTouchedRows")
-    val numTouchedRowsUdf = udf { () =>
+    val numTouchedRowsUdf = DeltaUDF.boolean { () =>
       numTouchedRows += 1
       true
     }.asNondeterministic()
@@ -317,10 +317,9 @@ object UpdateCommand {
         lit(CDC_TYPE_UPDATE_PREIMAGE).as(CDC_TYPE_COLUMN_NAME)
       val postimageCols = namedUpdateCols :+
         lit(CDC_TYPE_UPDATE_POSTIMAGE).as(CDC_TYPE_COLUMN_NAME)
-      val updatedDataCols = namedUpdateCols :+
-        typedLit[String](CDC_TYPE_NOT_CDC).as(CDC_TYPE_COLUMN_NAME)
-      val noopRewriteCols = target.output.map(new Column(_)) :+
-        typedLit[String](CDC_TYPE_NOT_CDC).as(CDC_TYPE_COLUMN_NAME)
+      val notCdcCol = new Column(CDC_TYPE_NOT_CDC).as(CDC_TYPE_COLUMN_NAME)
+      val updatedDataCols = namedUpdateCols :+ notCdcCol
+      val noopRewriteCols = target.output.map(new Column(_)) :+ notCdcCol
       val packedUpdates = array(
         struct(preimageCols: _*),
         struct(postimageCols: _*),

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
@@ -55,7 +55,8 @@ object CDCReader extends DeltaLogging {
   val CDC_TYPE_COLUMN_NAME = "_change_type" // emitted from data
   val CDC_COMMIT_VERSION = "_commit_version" // inferred by reader
   val CDC_COMMIT_TIMESTAMP = "_commit_timestamp" // inferred by reader
-  val CDC_TYPE_DELETE = "delete"
+  val CDC_TYPE_DELETE_STRING = "delete"
+  val CDC_TYPE_DELETE = Literal(CDC_TYPE_DELETE_STRING)
   val CDC_TYPE_INSERT = "insert"
   val CDC_TYPE_UPDATE_PREIMAGE = "update_preimage"
   val CDC_TYPE_UPDATE_POSTIMAGE = "update_postimage"
@@ -65,7 +66,7 @@ object CDCReader extends DeltaLogging {
   // write them as normal to the main table.
   // Note that we specifically avoid using `null` here, because partition values of `null` are in
   // some scenarios mapped to a special string for Hive compatibility.
-  val CDC_TYPE_NOT_CDC: String = null
+  val CDC_TYPE_NOT_CDC: Literal = Literal(null, StringType)
 
   // The virtual column name used for dividing CDC data from main table data. Delta writers should
   // permit this column through even though it's not part of the main table, and the

--- a/core/src/main/scala/org/apache/spark/sql/delta/files/CdcAddFileIndex.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/files/CdcAddFileIndex.scala
@@ -18,9 +18,9 @@ package org.apache.spark.sql.delta.files
 
 import org.apache.spark.sql.delta.{DeltaLog, Snapshot}
 import org.apache.spark.sql.delta.actions.AddFile
-import org.apache.spark.sql.delta.actions.SingleAction.addFileEncoder
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.commands.cdc.CDCReader._
+import org.apache.spark.sql.delta.implicits._
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.SparkSession
@@ -56,12 +56,9 @@ class CdcAddFileIndex(
           f.copy(partitionValues = newPartitionVals)
         }
     }
-    DeltaLog.filterFileList(
-        partitionSchema,
-        spark.createDataset(addFiles)(addFileEncoder).toDF(),
-        partitionFilters)
-        .as[AddFile](addFileEncoder)
-        .collect()
+    DeltaLog.filterFileList(partitionSchema, addFiles.toDF(spark), partitionFilters)
+      .as[AddFile]
+      .collect()
   }
 
   override def inputFiles: Array[String] = {

--- a/core/src/main/scala/org/apache/spark/sql/delta/files/DeltaSourceSnapshot.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/files/DeltaSourceSnapshot.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.delta.files
 
 import org.apache.spark.sql.delta.{DeltaLog, DeltaTableUtils, Snapshot}
-import org.apache.spark.sql.delta.actions.{AddCDCFile, RemoveFile}
+import org.apache.spark.sql.delta.actions.SingleAction
 import org.apache.spark.sql.delta.sources.IndexedFile
 import org.apache.spark.sql.delta.util.StateCache
 
@@ -51,14 +51,15 @@ class DeltaSourceSnapshot(
   }
 
   protected def initialFiles: Dataset[IndexedFile] = {
-    import spark.implicits._
+    import spark.implicits.rddToDatasetHolder
+    import org.apache.spark.sql.delta.implicits._
 
     cacheDS(
       snapshot.allFiles.sort("modificationTime", "path")
         .rdd.zipWithIndex()
         .toDF("add", "index")
-        .withColumn("remove", typedLit(Option.empty[RemoveFile]))
-        .withColumn("cdc", typedLit(Option.empty[AddCDCFile]))
+        .withColumn("remove", SingleAction.nullLitForRemoveFile)
+        .withColumn("cdc", SingleAction.nullLitForAddCDCFile)
         .withColumn("version", lit(version))
         .withColumn("isLast", lit(false))
         .as[IndexedFile],
@@ -80,7 +81,7 @@ trait SnapshotIterator {
   private var result: Iterable[IndexedFile] = _
 
   def iterator(): Iterator[IndexedFile] = {
-    import spark.implicits._
+    import org.apache.spark.sql.delta.implicits._
     if (result == null) {
       result = DeltaLog.filterFileList(
         snapshot.metadata.partitionSchema,

--- a/core/src/main/scala/org/apache/spark/sql/delta/files/TahoeChangeFileIndex.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/files/TahoeChangeFileIndex.scala
@@ -18,8 +18,8 @@ package org.apache.spark.sql.delta.files
 
 import org.apache.spark.sql.delta.{DeltaLog, Snapshot}
 import org.apache.spark.sql.delta.actions.{AddCDCFile, AddFile}
-import org.apache.spark.sql.delta.actions.SingleAction.addFileEncoder
 import org.apache.spark.sql.delta.commands.cdc.CDCReader.{CDC_COMMIT_TIMESTAMP, CDC_COMMIT_VERSION, CDCDataSpec}
+import org.apache.spark.sql.delta.implicits._
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.SparkSession
@@ -54,11 +54,8 @@ class TahoeChangeFileIndex(
           AddFile(f.path, newPartitionVals, f.size, 0, dataChange = false, tags = f.tags)
         }
     }
-    DeltaLog.filterFileList(
-        partitionSchema,
-        spark.createDataset(addFiles)(addFileEncoder).toDF(),
-        partitionFilters)
-      .as[AddFile](addFileEncoder)
+    DeltaLog.filterFileList(partitionSchema, addFiles.toDF(spark), partitionFilters)
+      .as[AddFile]
       .collect()
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/files/TahoeFileIndex.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/files/TahoeFileIndex.scala
@@ -22,7 +22,7 @@ import java.util.Objects
 
 import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaErrors, DeltaLog, NoMapping, Snapshot}
 import org.apache.spark.sql.delta.actions.AddFile
-import org.apache.spark.sql.delta.actions.SingleAction.addFileEncoder
+import org.apache.spark.sql.delta.implicits._
 import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.hadoop.fs.FileStatus
@@ -237,9 +237,8 @@ class TahoeBatchFileIndex(
       partitionFilters: Seq[Expression],
       dataFilters: Seq[Expression]): Seq[AddFile] = {
     DeltaLog.filterFileList(
-      snapshot.metadata.partitionSchema,
-      spark.createDataset(addFiles)(addFileEncoder).toDF(), partitionFilters)
-      .as[AddFile](addFileEncoder)
+      snapshot.metadata.partitionSchema, addFiles.toDF(spark), partitionFilters)
+      .as[AddFile]
       .collect()
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
@@ -94,7 +94,7 @@ trait GenerateSymlinkManifestImpl extends PostCommitHook with DeltaLogging with 
       currentSnapshot: Snapshot,
       actions: Seq[Action]): Unit = recordManifestGeneration(deltaLog, full = false) {
 
-    import spark.implicits._
+    import org.apache.spark.sql.delta.implicits._
 
     checkColumnMappingMode(currentSnapshot.metadata)
 
@@ -249,7 +249,7 @@ trait GenerateSymlinkManifestImpl extends PostCommitHook with DeltaLogging with 
       hadoopConf: SerializableConfiguration): Set[String] = {
 
     val spark = fileNamesForManifest.sparkSession
-    import spark.implicits._
+    import org.apache.spark.sql.delta.implicits._
 
     val tableAbsPathForManifest = LogStore(spark)
       .resolvePathOnPhysicalStorage(deltaLogDataPath, hadoopConf.value).toString

--- a/core/src/main/scala/org/apache/spark/sql/delta/implicits/RichSparkClasses.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/implicits/RichSparkClasses.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.implicits
+
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.plans.QueryPlan
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.{RuleId, UnknownRuleId}
+import org.apache.spark.sql.catalyst.trees.{AlwaysProcess, TreePatternBits}
+import org.apache.spark.sql.delta.util.DeltaEncoders
+import org.apache.spark.sql.types.{ArrayType, MapType, StructField, StructType}
+
+trait RichSparkClasses {
+
+  /**
+   * This implicit class is used to provide helpful methods used throughout the code that are not
+   * provided by Spark-Catalyst's StructType.
+   */
+  implicit class RichStructType(structType: StructType) {
+
+    /**
+     * Returns a field in this struct and its child structs, case insensitively.
+     *
+     * If includeCollections is true, this will return fields that are nested in maps and arrays.
+     *
+     * @param fieldNames The path to the field, in order from the root. For example, the column
+     *                   nested.a.b.c would be Seq("nested", "a", "b", "c").
+     */
+    def findNestedFieldIgnoreCase(
+        fieldNames: Seq[String],
+        includeCollections: Boolean = false): Option[StructField] = {
+      val fieldOption = fieldNames.headOption.flatMap {
+        fieldName => structType.find(_.name.equalsIgnoreCase(fieldName))
+      }
+      fieldOption match {
+        case Some(field) =>
+          (fieldNames.tail, field.dataType, includeCollections) match {
+            case (Seq(), _, _) =>
+              Some(field)
+
+            case (names, struct: StructType, _) =>
+              struct.findNestedFieldIgnoreCase(names, includeCollections)
+
+            case (_, _, false) =>
+              None // types nested in maps and arrays are not used
+
+            case (Seq("key"), MapType(keyType, _, _), true) =>
+              // return the key type as a struct field to include nullability
+              Some(StructField("key", keyType, nullable = false))
+
+            case (Seq("key", names @ _*), MapType(struct: StructType, _, _), true) =>
+              struct.findNestedFieldIgnoreCase(names, includeCollections)
+
+            case (Seq("value"), MapType(_, valueType, isNullable), true) =>
+              // return the value type as a struct field to include nullability
+              Some(StructField("value", valueType, nullable = isNullable))
+
+            case (Seq("value", names @ _*), MapType(_, struct: StructType, _), true) =>
+              struct.findNestedFieldIgnoreCase(names, includeCollections)
+
+            case (Seq("element"), ArrayType(elementType, isNullable), true) =>
+              // return the element type as a struct field to include nullability
+              Some(StructField("element", elementType, nullable = isNullable))
+
+            case (Seq("element", names @ _*), ArrayType(struct: StructType, _), true) =>
+              struct.findNestedFieldIgnoreCase(names, includeCollections)
+
+            case _ =>
+              None
+          }
+        case _ =>
+          None
+      }
+    }
+  }
+
+  /**
+   * This implicit class is used to provide helpful methods used throughout the code that are not
+   * provided by Spark-Catalyst's LogicalPlan.
+   */
+  implicit class RichLogicalPlan(plan: LogicalPlan) {
+    /**
+     * Returns the result of running QueryPlan.transformExpressionsUpWithPruning on this node
+     * and all its children.
+     */
+    def transformAllExpressionsUpWithPruning(
+        cond: TreePatternBits => Boolean,
+        ruleId: RuleId = UnknownRuleId)(
+        rule: PartialFunction[Expression, Expression]
+      ): LogicalPlan = {
+      plan.transformUpWithPruning(cond, ruleId) {
+        case q: QueryPlan[_] =>
+          q.transformExpressionsUpWithPruning(cond, ruleId)(rule)
+      }
+    }
+
+    /**
+     * Returns the result of running QueryPlan.transformExpressionsUp on this node
+     * and all its children.
+     */
+    def transformAllExpressionsUp(
+        rule: PartialFunction[Expression, Expression]): LogicalPlan = {
+      transformAllExpressionsUpWithPruning(AlwaysProcess.fn, UnknownRuleId)(rule)
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingStatsTracker.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingStatsTracker.scala
@@ -56,7 +56,7 @@ class DeltaTaskStatisticsTracker(
 
   // For example, when strings are involved, statsColExpr might look like
   // struct(
-  //   count("*") as "numRecords"
+  //   count(new Column("*")) as "numRecords"
   //   struct(
   //     substring(min(col), 0, stringPrefix))
   //   ) as "minValues",

--- a/core/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
@@ -127,7 +127,7 @@ trait StatisticsCollection extends UsesMetadataFields with DeltaLogging {
         // Truncate and pad string max values as necessary
         case (c, SkippingEligibleDataType(StringType)) =>
           val udfTruncateMax =
-            DeltaUDF.stringStringUdf(StatisticsCollection.truncateMaxStringAgg(stringPrefix)_)
+            DeltaUDF.stringFromString(StatisticsCollection.truncateMaxStringAgg(stringPrefix)_)
           udfTruncateMax(max(c))
 
         // Collect all numeric max values

--- a/core/src/main/scala/org/apache/spark/sql/delta/util/DeltaEncoders.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/util/DeltaEncoders.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.util
+
+import scala.reflect.runtime.universe.TypeTag
+
+import org.apache.spark.sql.delta.{DeltaHistory, DeltaHistoryManager, SerializableFileStatus, Snapshot}
+import org.apache.spark.sql.delta.actions.{AddFile, RemoveFile, SingleAction}
+import org.apache.spark.sql.delta.sources.IndexedFile
+
+import org.apache.spark.sql.Encoder
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+
+private[delta] class DeltaEncoder[T: TypeTag] {
+  private lazy val _encoder = ExpressionEncoder[T]()
+
+  def get: Encoder[T] = {
+    _encoder.copy()
+  }
+}
+
+/**
+ * Define a few `Encoder`s to reuse in Delta in order to avoid touching Scala reflection after
+ * warming up. This will be mixed into `org.apache.spark.sql.delta.implicits`. Use
+ * `import org.apache.spark.sql.delta.implicits._` to use these `Encoder`s.
+ */
+private[delta] trait DeltaEncoders {
+  private lazy val _IntEncoder = new DeltaEncoder[Int]
+  implicit def intEncoder: Encoder[Int] = _IntEncoder.get
+
+  private lazy val _longEncoder = new DeltaEncoder[Long]
+  implicit def longEncoder: Encoder[Long] = _longEncoder.get
+
+  private lazy val _stringEncoder = new DeltaEncoder[String]
+  implicit def stringEncoder: Encoder[String] = _stringEncoder.get
+
+  private lazy val _longLongEncoder = new DeltaEncoder[(Long, Long)]
+  implicit def longLongEncoder: Encoder[(Long, Long)] = _longLongEncoder.get
+
+  private lazy val _stringLongEncoder = new DeltaEncoder[(String, Long)]
+  implicit def stringLongEncoder: Encoder[(String, Long)] = _stringLongEncoder.get
+
+  private lazy val _stringStringEncoder = new DeltaEncoder[(String, String)]
+  implicit def stringStringEncoder: Encoder[(String, String)] = _stringStringEncoder.get
+
+  private lazy val _javaLongEncoder = new DeltaEncoder[java.lang.Long]
+  implicit def javaLongEncoder: Encoder[java.lang.Long] = _javaLongEncoder.get
+
+  private lazy val _singleActionEncoder = new DeltaEncoder[SingleAction]
+  implicit def singleActionEncoder: Encoder[SingleAction] = _singleActionEncoder.get
+
+  private lazy val _addFileEncoder = new DeltaEncoder[AddFile]
+  implicit def addFileEncoder: Encoder[AddFile] = _addFileEncoder.get
+
+  private lazy val _removeFileEncoder = new DeltaEncoder[RemoveFile]
+  implicit def removeFileEncoder: Encoder[RemoveFile] = _removeFileEncoder.get
+
+  private lazy val _serializableFileStatusEncoder = new DeltaEncoder[SerializableFileStatus]
+  implicit def serializableFileStatusEncoder: Encoder[SerializableFileStatus] =
+    _serializableFileStatusEncoder.get
+
+  private lazy val _indexedFileEncoder = new DeltaEncoder[IndexedFile]
+  implicit def indexedFileEncoder: Encoder[IndexedFile] = _indexedFileEncoder.get
+
+  private lazy val _addFileWithIndexEncoder = new DeltaEncoder[(AddFile, Long)]
+  implicit def addFileWithIndexEncoder: Encoder[(AddFile, Long)] = _addFileWithIndexEncoder.get
+
+  private lazy val _deltaHistoryEncoder = new DeltaEncoder[DeltaHistory]
+  implicit def deltaHistoryEncoder: Encoder[DeltaHistory] = _deltaHistoryEncoder.get
+
+  private lazy val _historyCommitEncoder = new DeltaEncoder[DeltaHistoryManager.Commit]
+  implicit def historyCommitEncoder: Encoder[DeltaHistoryManager.Commit] = _historyCommitEncoder.get
+
+  private lazy val _snapshotStateEncoder = new DeltaEncoder[Snapshot.State]
+  implicit def snapshotStateEncoder: Encoder[Snapshot.State] = _snapshotStateEncoder.get
+}

--- a/core/src/main/scala/org/apache/spark/sql/delta/util/DeltaFileOperations.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/util/DeltaFileOperations.scala
@@ -215,7 +215,7 @@ object DeltaFileOperations extends DeltaLogging {
       hiddenFileNameFilter: String => Boolean = defaultHiddenFileFilter,
       fileListingParallelism: Option[Int] = None,
       listAsDirectories: Boolean = true): Dataset[SerializableFileStatus] = {
-    import spark.implicits._
+    import org.apache.spark.sql.delta.implicits._
     if (subDirs.isEmpty) return spark.emptyDataset[SerializableFileStatus]
     val listParallelism = fileListingParallelism.getOrElse(spark.sparkContext.defaultParallelism)
     val dirsAndFiles = spark.sparkContext.parallelize(subDirs).mapPartitions { dirs =>

--- a/core/src/test/scala/io/delta/sql/DeltaExtensionAndCatalogSuite.scala
+++ b/core/src/test/scala/io/delta/sql/DeltaExtensionAndCatalogSuite.scala
@@ -113,7 +113,9 @@ class DeltaExtensionAndCatalogSuite extends SparkFunSuite {
     withSparkSession(
       SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key -> classOf[DeltaCatalog].getName
     ) { spark =>
+      // scalastyle:off sparkimplicits
       import spark.implicits._
+      // scalastyle:on sparkimplicits
 
       val tablePath = createTempDir()
       spark.range(1, 10).toDF("key")
@@ -146,7 +148,9 @@ class DeltaExtensionAndCatalogSuite extends SparkFunSuite {
     withSparkSession(
       SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key -> classOf[DeltaCatalog].getName
     ) { spark =>
+      // scalastyle:off sparkimplicits
       import spark.implicits._
+      // scalastyle:on sparkimplicits
 
       spark.range(1, 10).toDF("key")
         .withColumn("value", col("key")).write.format("delta").saveAsTable("tbl")
@@ -177,7 +181,9 @@ class DeltaExtensionAndCatalogSuite extends SparkFunSuite {
     withSparkSession(
       "spark.sql.extensions" -> classOf[DeltaSparkSessionExtension].getName
     ) { spark =>
+      // scalastyle:off sparkimplicits
       import spark.implicits._
+      // scalastyle:on sparkimplicits
       val tablePath = createTempDir()
 
       spark.range(1, 10).toDF("key").withColumn("value", col("key"))

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaImplicitsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaImplicitsSuite.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+// scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.sql.delta.actions.AddFile
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.test.SharedSparkSession
+
+class DeltaImplicitsSuite extends SparkFunSuite with SharedSparkSession {
+
+  private def testImplict(name: String, func: => Unit): Unit = {
+    test(name) {
+      func
+    }
+  }
+
+  import org.apache.spark.sql.delta.implicits._
+
+  testImplict("int", intEncoder)
+  testImplict("long", longEncoder)
+  testImplict("string", stringEncoder)
+  testImplict("longLong", longLongEncoder)
+  testImplict("stringLong", stringLongEncoder)
+  testImplict("stringString", stringStringEncoder)
+  testImplict("javaLong", javaLongEncoder)
+  testImplict("singleAction", singleActionEncoder)
+  testImplict("addFile", addFileEncoder)
+  testImplict("removeFile", removeFileEncoder)
+  testImplict("serializableFileStatus", serializableFileStatusEncoder)
+  testImplict("indexedFile", indexedFileEncoder)
+  testImplict("addFileWithIndex", addFileWithIndexEncoder)
+  testImplict("deltaHistoryEncoder", deltaHistoryEncoder)
+  testImplict("historyCommitEncoder", historyCommitEncoder)
+  testImplict("snapshotStateEncoder", snapshotStateEncoder)
+
+  testImplict("RichAddFileSeq: toDF", Seq(AddFile("foo", Map.empty, 0, 0, true)).toDF(spark))
+  testImplict("RichAddFileSeq: toDS", Seq(AddFile("foo", Map.empty, 0, 0, true)).toDS(spark))
+  testImplict("RichStringSeq: toDF", Seq("foo").toDF(spark))
+  testImplict("RichStringSeq: toDF(col)", Seq("foo").toDF(spark, "str"))
+  testImplict("RichIntSeq: toDF", Seq(1).toDF(spark))
+  testImplict("RichIntSeq: toDF(col)", Seq(1).toDF(spark, "int"))
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaUDFSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaUDFSuite.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+// scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.sql.{Encoder, QueryTest, Row}
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.test.SharedSparkSession
+
+class DeltaUDFSuite extends QueryTest with SharedSparkSession {
+
+  import testImplicits._
+
+  private def testUDF(
+      name: String,
+      testResultFunc: => Unit): Unit = {
+    test(name) {
+      // Verify the returned UDF function is working correctly
+      testResultFunc
+    }
+  }
+
+  private def testUDF(
+      name: String,
+      func: => UserDefinedFunction,
+      expected: Any): Unit = {
+    testUDF(
+      name,
+      checkAnswer(Seq("foo").toDF.select(func()), Row(expected))
+    )
+  }
+
+  private def testUDF[T: Encoder](
+      name: String,
+      func: => UserDefinedFunction,
+      input: T,
+      expected: Any): Unit = {
+    testUDF(
+      name,
+      checkAnswer(Seq(input).toDF.select(func(col("value"))), Row(expected))
+    )
+  }
+
+  private def testUDF[T1: Encoder, T2: Encoder](
+      name: String,
+      func: => UserDefinedFunction,
+      input1: T1,
+      input2: T2,
+      expected: Any): Unit = {
+    testUDF(
+      name,
+      {
+        val df = Seq(input1)
+          .toDF("value1")
+          .withColumn("value2", lit(input2).as[T2])
+          .select(func(col("value1"), col("value2")))
+        checkAnswer(df, Row(expected))
+      }
+    )
+  }
+
+  testUDF(
+    name = "stringFromString",
+    func = DeltaUDF.stringFromString(x => x),
+    input = "foo",
+    expected = "foo")
+  testUDF(
+    name = "intFromString",
+    func = DeltaUDF.intFromString(x => x.toInt),
+    input = "100",
+    expected = 100)
+  testUDF(
+    name = "intFromStringBoolean",
+    func = DeltaUDF.intFromStringBoolean((x, y) => 1),
+    input1 = "foo",
+    input2 = true,
+    expected = 1)
+  testUDF(name = "boolean", func = DeltaUDF.boolean(() => true), expected = true)
+  testUDF(
+    name = "stringFromMap",
+    func = DeltaUDF.stringFromMap(x => x.toString),
+    input = Map("foo" -> "bar"),
+    expected = "Map(foo -> bar)")
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/EvolvabilitySuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/EvolvabilitySuite.scala
@@ -21,10 +21,12 @@ import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
 import org.apache.hadoop.fs.Path
 
 // scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.execution.streaming.MemoryStream
-import org.apache.spark.sql.functions.typedLit
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.Trigger
+import org.apache.spark.sql.types.StringType
 import org.apache.spark.util.Utils
 
 class EvolvabilitySuite extends EvolvabilitySuiteBase with DeltaSQLCommandTest {
@@ -43,8 +45,8 @@ class EvolvabilitySuite extends EvolvabilitySuiteBase with DeltaSQLCommandTest {
 
   test("serialized partition values must contain null values") {
     val tempDir = Utils.createTempDir().toString
-    val df1 = spark.range(5).withColumn("part", typedLit[String](null))
-    val df2 = spark.range(5).withColumn("part", typedLit("1"))
+    val df1 = spark.range(5).withColumn("part", new Column(Literal(null, StringType)))
+    val df2 = spark.range(5).withColumn("part", new Column(Literal("1")))
     df1.union(df2).coalesce(1).write.partitionBy("part").format("delta").save(tempDir)
 
     // Clear the cache

--- a/core/src/test/scala/org/apache/spark/sql/delta/EvolvabilitySuiteBase.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/EvolvabilitySuiteBase.scala
@@ -146,17 +146,17 @@ object EvolvabilitySuiteBase {
       spark: SparkSession,
       path: String,
       tblProps: Map[DeltaConfig[_], String] = Map.empty): Unit = {
-    import spark.implicits._
+    import org.apache.spark.sql.delta.implicits._
     implicit val s = spark.sqlContext
 
-    Seq(1, 2, 3).toDF().write.format("delta").save(path)
+    Seq(1, 2, 3).toDF(spark).write.format("delta").save(path)
     if (tblProps.nonEmpty) {
       val tblPropsStr = tblProps.map { case (k, v) => s"'${k.key}' = '$v'" }.mkString(", ")
       spark.sql(s"CREATE TABLE test USING DELTA LOCATION '$path'")
       spark.sql(s"ALTER TABLE test SET TBLPROPERTIES($tblPropsStr)")
     }
-    Seq(1, 2, 3).toDF().write.format("delta").mode("append").save(path)
-    Seq(1, 2, 3).toDF().write.format("delta").mode("overwrite").save(path)
+    Seq(1, 2, 3).toDF(spark).write.format("delta").mode("append").save(path)
+    Seq(1, 2, 3).toDF(spark).write.format("delta").mode("overwrite").save(path)
 
     val checkpoint = Utils.createTempDir().toString
     val data = MemoryStream[Int]
@@ -176,7 +176,7 @@ object EvolvabilitySuiteBase {
   def validateData(spark: SparkSession, path: String): Unit = {
     import org.apache.spark.sql.delta.util.FileNames._
     import scala.reflect.runtime.{universe => ru}
-    import spark.implicits._
+    import org.apache.spark.sql.delta.implicits._
 
     val mirror = ru.runtimeMirror(this.getClass.getClassLoader)
 
@@ -216,7 +216,9 @@ object EvolvabilitySuiteBase {
 
   /** Generate the transaction log with extra column in checkpoint and json. */
   def generateTransactionLogWithExtraColumn(spark: SparkSession, path: String): Unit = {
+    // scalastyle:off sparkimplicits
     import spark.implicits._
+    // scalastyle:on sparkimplicits
     implicit val s = spark.sqlContext
 
     val absPath = new File(path).getAbsolutePath

--- a/core/src/test/scala/org/apache/spark/sql/delta/skipping/MultiDimClusteringSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/skipping/MultiDimClusteringSuite.scala
@@ -32,7 +32,9 @@ class MultiDimClusteringSuite extends QueryTest
     with SharedSparkSession with DeltaSQLCommandTest {
 
   private lazy val sparkSession = spark
+  // scalastyle:off sparkimplicits
   import sparkSession.implicits._
+  // scalastyle:on sparkimplicits
 
   test("Negative case - ZOrder clustering expression with zero columns") {
     val ex = intercept[AssertionError] {

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -295,6 +295,32 @@ This file is divided into 3 sections:
     ]]></customMessage>
   </check>
 
+  <check customId="typedlit" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">typed[lL]it</parameter></parameters>
+    <customMessage><![CDATA[
+      'typedlit' or `typedLit` uses ScalaReflection to resolve the data type which is inefficient in concurrent
+      queries. In most cases, you can use `lit` or `new Column(Literal(...))` instead.
+      If you must use it, wrap the code block with
+      // scalastyle:off typedlit
+      typedLit("foo")
+      // scalastyle:on typedlit
+    ]]></customMessage>
+  </check>
+
+  <check customId="sparkimplicits" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">spark(Session)?.implicits._</parameter></parameters>
+    <customMessage><![CDATA[
+      When importing `spark.implicits._`, it's easy to create an `Encoder` unintentionally which can hurt
+      the performance a lot in concurrent queries. You can use `import com.databricks.sql.transaction.tahoe.implicits._`
+      instead to use `Encoder`s we cache for reusing. If this doesn't work, you can define new `Encoder`s
+      in `DeltaEncoders` to cache and reuse them.
+      If you must use it, wrap the code block with
+      // scalastyle:off sparkimplicits
+      import spark.implicits._
+      // scalastyle:on sparkimplicits
+    ]]></customMessage>
+  </check>
+
   <check customId="throwerror" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">throw new \w+Error\(</parameter></parameters>
     <customMessage><![CDATA[
@@ -303,6 +329,18 @@ This file is divided into 3 sections:
       // scalastyle:off throwerror
       throw new XXXError(...)
       // scalastyle:on throwerror
+    ]]></customMessage>
+  </check>
+
+  <check customId="countstring" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">count\("</parameter></parameters>
+    <customMessage><![CDATA[
+      'count(String)' returns 'TypedColumn' and touches ScalaReflection which is inefficient in concurrent queries.
+      In most cases, you don't need a 'TypedColumn' and you should use 'count(new Column("..."))' instead.
+      If you must use it, wrap the code block with
+      // scalastyle:off countstring
+      count("foo")
+      // scalastyle:on countstring
     ]]></customMessage>
   </check>
 


### PR DESCRIPTION
## Description

Spark's `ScalaReflection` is a performance killer when the concurrency is high. This PR makes the following changes to eliminate unnecessary ScalaReflection calls from Delta after warming up:

- `typedlit` calls [Liternal.create](https://github.com/apache/spark/blob/144d4c546f7023b20e07619134feca1a46017a5f/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala#L167) which will touch `ScalaReflection`. This PR replaces `typedlit` with `lit` or `new Column(Liternal.apply(v, <data type>))`. Most of changes in this PR are caused by changing `val CDC_TYPE_NOT_CDC: String = null` to `val CDC_TYPE_NOT_CDC: Literal = Literal(null, StringType)`.
  - A new style check is added to block `typedlit`.
- Add more templates to `DeltaUDF` and use these templates to create `udf`s in Delta to avoid touching `ScalaReflection`.
- `count(*)` will touch `as(ExpressionEncoder[Long]())` in order to return a `TypedColumn`. Replace it with `count(new Column("*"))` in Delta so that we can avoid touching Scala reflection code.
  - A new style check is added to block `count(string)`.
- Add a new `DeltaEncoder` class to simplify the code pattern that uses `ExpressionEncoder`. We introduce `DeltaEncoders` to cache all reusable `Encoder`s and mix it into `com.databricks.sql.transaction.tahoe.implicits._`. With this change, we can replace `import spark.implicits._` (always create new `Encoder`s) with `com.databricks.sql.transaction.tahoe.implicits._` (reuse the shared `Encoder`s) to minimize the code touching `ScalaReflection` after warming up.
  - A scala style check is added to block `spark.implicits._`.

## How was this patch tested?

New tests + existing tests.

## Does this PR introduce _any_ user-facing changes?

No.
