### PR TITLE
Enable batch CDF queries on column mapping enabled tables with fewer limitations

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -70,7 +70,7 @@
   },
   "DELTA_BLOCK_CDF_COLUMN_MAPPING_READS" : {
     "message" : [
-      "Change data feed (CDF) reads are currently not supported on tables with column mapping enabled."
+      "Change Data Feed (CDF) reads are not supported on tables with column mapping schema changes (e.g. rename or drop). Read schema: <newSchema>. Incompatible schema: <oldSchema>. <hint>"
     ],
     "sqlState" : "0A000"
   },

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2356,9 +2356,22 @@ trait DeltaErrorsBase
     // scalastyle:on line.size.limit
   }
 
-  def blockCdfAndColumnMappingReads(): Throwable = {
+
+  val columnMappingCDFBatchBlockHint: String =
+    s"You may force enable batch CDF read at your own risk by turning on " +
+      s"${DeltaSQLConf.DELTA_CDF_UNSAFE_BATCH_READ_ON_INCOMPATIBLE_SCHEMA_CHANGES.key}."
+
+  def blockCdfAndColumnMappingReads(
+      isStreaming: Boolean,
+      readSchema: Option[StructType] = None,
+      incompatibleSchema: Option[StructType] = None): Throwable = {
     new DeltaUnsupportedOperationException(
-      errorClass = "DELTA_BLOCK_CDF_COLUMN_MAPPING_READS"
+      errorClass = "DELTA_BLOCK_CDF_COLUMN_MAPPING_READS",
+      messageParameters = Array(
+        readSchema.map(_.json).getOrElse(""),
+        incompatibleSchema.map(_.json).getOrElse(""),
+        if (isStreaming) "" else columnMappingCDFBatchBlockHint
+      )
     )
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
@@ -20,7 +20,7 @@ import java.sql.Timestamp
 
 import scala.collection.mutable.ListBuffer
 
-import org.apache.spark.sql.delta.{DeltaConfigs, DeltaErrors, DeltaHistoryManager, DeltaLog, DeltaOperations, DeltaParquetFileFormat, DeltaTableUtils, DeltaTimeTravelSpec, NoMapping, Snapshot}
+import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, AddFile, CommitInfo, FileAction, Metadata, RemoveFile}
 import org.apache.spark.sql.delta.files.{CdcAddFileIndex, TahoeChangeFileIndex, TahoeFileIndex, TahoeRemoveFileIndex}
 import org.apache.spark.sql.delta.metering.DeltaLogging
@@ -265,8 +265,10 @@ object CDCReader extends DeltaLogging {
 
     // If the table has column mapping enabled, throw an error. With column mapping, certain schema
     // changes are possible (rename a column or drop a column) which don't work well with CDF.
-    if (snapshot.metadata.columnMappingMode != NoMapping) {
-      throw DeltaErrors.blockCdfAndColumnMappingReads()
+    // TODO: remove this after the proper blocking semantics is rolled out
+    // This is only blocking streaming CDF, batch CDF will be blocked differently below.
+    if (isStreaming && snapshot.metadata.columnMappingMode != NoMapping) {
+      throw DeltaErrors.blockCdfAndColumnMappingReads(isStreaming)
     }
 
     // A map from change version to associated commit timestamp.
@@ -276,8 +278,33 @@ object CDCReader extends DeltaLogging {
     val changeFiles = ListBuffer[CDCDataSpec[AddCDCFile]]()
     val addFiles = ListBuffer[CDCDataSpec[AddFile]]()
     val removeFiles = ListBuffer[CDCDataSpec[RemoveFile]]()
+
+    val startVersionSnapshot = deltaLog.getSnapshotAt(start)
     if (!isCDCEnabledOnTable(deltaLog.getSnapshotAt(start).metadata)) {
       throw DeltaErrors.changeDataNotRecordedException(start, start, end)
+    }
+
+    /**
+     * TODO: Unblock this when we figure out the correct semantics.
+     *  Currently batch CDC read on column mapping tables with Rename/Drop is blocked due to
+     *  unclear semantics.
+     *  Streaming CDF read is blocked on a separate code path in DeltaSource.
+     */
+    val shouldCheckToBlockBatchReadOnColumnMappingTable =
+      !isStreaming &&
+      snapshot.metadata.columnMappingMode != NoMapping &&
+      !spark.sessionState.conf.getConf(
+        DeltaSQLConf.DELTA_CDF_UNSAFE_BATCH_READ_ON_INCOMPATIBLE_SCHEMA_CHANGES)
+
+    // Compare with start snapshot's metadata schema to fail fast
+    if (shouldCheckToBlockBatchReadOnColumnMappingTable &&
+        !DeltaColumnMapping.isColumnMappingReadCompatible(
+          snapshot.metadata, startVersionSnapshot.metadata)) {
+      throw DeltaErrors.blockCdfAndColumnMappingReads(
+        isStreaming,
+        Some(snapshot.metadata.schema),
+        Some(startVersionSnapshot.metadata.schema)
+      )
     }
 
     var totalBytes = 0L
@@ -295,6 +322,19 @@ object CDCReader extends DeltaLogging {
 
         if (cdcDisabled) {
           throw DeltaErrors.changeDataNotRecordedException(v, start, end)
+        }
+
+        // Check all intermediary metadata schema changes as well
+        if (shouldCheckToBlockBatchReadOnColumnMappingTable) {
+           actions.collect { case a: Metadata => a }.foreach { metadata =>
+             if (!DeltaColumnMapping.isColumnMappingReadCompatible(snapshot.metadata, metadata)) {
+               throw DeltaErrors.blockCdfAndColumnMappingReads(
+                 isStreaming,
+                 Some(snapshot.metadata.schema),
+                 Some(metadata.schema)
+               )
+             }
+           }
         }
 
         // Set up buffers for all action types to avoid multiple passes.

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -793,6 +793,17 @@ trait DeltaSQLConfBase {
       .createWithDefault(false)
   }
 
+  val DELTA_CDF_UNSAFE_BATCH_READ_ON_INCOMPATIBLE_SCHEMA_CHANGES =
+    buildConf("changeDataFeed.unsafeBatchReadOnIncompatibleSchemaChanges.enabled")
+      .doc(
+        "Reading change data in batch (e.g. using `table_changes()`) on Delta table with " +
+          "column mapping schema operations is currently blocked due to potential data loss and " +
+          "schema confusion. However, existing users may use this flag to force unblock " +
+          "if they'd like to take the risk.")
+      .internal()
+      .booleanConf
+      .createWithDefault(false)
+
   val DYNAMIC_PARTITION_OVERWRITE_ENABLED =
     buildConf("dynamicPartitionOverwrite.enabled")
       .doc("Whether to overwrite partitions dynamically when 'partitionOverwriteMode' is set to " +

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaCDCStreamSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaCDCStreamSuite.scala
@@ -783,8 +783,8 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
       val e = intercept[StreamingQueryException] {
         f
       }.getCause.getMessage
-      assert(e == "Change data feed (CDF) reads are currently not supported on tables " +
-        "with column mapping enabled.")
+      assert(e.contains("Change Data Feed (CDF) reads are not supported on tables with " +
+        "column mapping schema changes (e.g. rename or drop)"))
     }
 
     Seq(0, 1).foreach { startingVersion =>

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
@@ -495,6 +495,106 @@ class DeltaColumnMappingSuite extends QueryTest
     assert(DeltaColumnMapping.findMaxColumnId(new StructType()) == 0)
   }
 
+  // TODO: repurpose this once we roll out the proper semantics for CM + streaming
+  testColumnMapping("isColumnMappingReadCompatible") { mode =>
+    // Set up table based on mode and return the initial metadata actions for comparison
+    def setupInitialTable(deltaLog: DeltaLog): (MetadataAction, MetadataAction) = {
+      val tablePath = deltaLog.dataPath.toString
+      if (mode == NameMapping.name) {
+        Seq((1, "a"), (2, "b")).toDF("id", "name")
+          .write.mode("append").format("delta").save(tablePath)
+        // schema: <id, name>
+        val m0 = deltaLog.update().metadata
+
+        // add a column
+        sql(s"ALTER TABLE delta.`$tablePath` ADD COLUMN (score long)")
+        // schema: <id, name, score>
+        val m1 = deltaLog.update().metadata
+
+        // column mapping not enabled -> not blocked at all
+        assert(DeltaColumnMapping.isColumnMappingReadCompatible(m1, m0))
+
+        // upgrade to name mode
+        alterTableWithProps(s"delta.`$tablePath`", Map(
+          DeltaConfigs.COLUMN_MAPPING_MODE.key -> "name",
+          DeltaConfigs.MIN_READER_VERSION.key -> "2",
+          DeltaConfigs.MIN_WRITER_VERSION.key -> "5"))
+
+        (m0, m1)
+      } else {
+        // for id mode, just create the table
+        withSQLConf(DeltaConfigs.COLUMN_MAPPING_MODE.defaultTablePropertyKey -> "id") {
+          Seq((1, "a"), (2, "b")).toDF("id", "name")
+            .write.mode("append").format("delta").save(tablePath)
+        }
+        // schema: <id, name>
+        val m0 = deltaLog.update().metadata
+
+        // add a column
+        sql(s"ALTER TABLE delta.`$tablePath` ADD COLUMN (score long)")
+        // schema: <id, name, score>
+        val m1 = deltaLog.update().metadata
+
+        // add column shouldn't block
+        assert(DeltaColumnMapping.isColumnMappingReadCompatible(m1, m0))
+
+        (m0, m1)
+      }
+    }
+
+    withTempDir { dir =>
+      val tablePath = dir.getCanonicalPath
+      val deltaLog = DeltaLog.forTable(spark, tablePath)
+
+      val (m0, m1) = setupInitialTable(deltaLog)
+
+      // schema: <id, name, score>
+      val m2 = deltaLog.update().metadata
+
+      assert(DeltaColumnMapping.isColumnMappingReadCompatible(m2, m1))
+      assert(DeltaColumnMapping.isColumnMappingReadCompatible(m2, m0))
+
+      // rename column
+      sql(s"ALTER TABLE delta.`$tablePath` RENAME COLUMN score TO age")
+      // schema: <id, name, age>
+      val m3 = deltaLog.update().metadata
+
+      assert(!DeltaColumnMapping.isColumnMappingReadCompatible(m3, m2))
+      assert(!DeltaColumnMapping.isColumnMappingReadCompatible(m3, m1))
+      // But IS read compatible with the initial schema, because the added column should not
+      // be blocked by this column mapping check.
+      assert(DeltaColumnMapping.isColumnMappingReadCompatible(m3, m0))
+
+      // drop a column
+      sql(s"ALTER TABLE delta.`$tablePath` DROP COLUMN age")
+      // schema: <id, name>
+      val m4 = deltaLog.update().metadata
+
+      assert(!DeltaColumnMapping.isColumnMappingReadCompatible(m4, m3))
+      assert(!DeltaColumnMapping.isColumnMappingReadCompatible(m4, m2))
+      assert(!DeltaColumnMapping.isColumnMappingReadCompatible(m4, m1))
+      // but IS read compatible with the initial schema, because the added column is dropped
+      assert(DeltaColumnMapping.isColumnMappingReadCompatible(m4, m0))
+
+      // add back the same column
+      sql(s"ALTER TABLE delta.`$tablePath` ADD COLUMN (score long)")
+      // schema: <id, name, score>
+      val m5 = deltaLog.update().metadata
+
+      // It IS read compatible with the previous schema, because the added column should not
+      // blocked by this column mapping check.
+      assert(DeltaColumnMapping.isColumnMappingReadCompatible(m5, m4))
+      assert(!DeltaColumnMapping.isColumnMappingReadCompatible(m5, m3))
+      assert(!DeltaColumnMapping.isColumnMappingReadCompatible(m5, m2))
+      // But Since the new added column has a different physical name as all previous columns,
+      // even it has the same logical name as say, m1.schema, we will still block
+      assert(!DeltaColumnMapping.isColumnMappingReadCompatible(m5, m1))
+      // But it IS read compatible with the initial schema, because the added column should not
+      // be blocked by this column mapping check.
+      assert(DeltaColumnMapping.isColumnMappingReadCompatible(m5, m0))
+    }
+  }
+
   test("create table under id mode should be blocked") {
     withTable("t1") {
       val mode = "id"

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2450,12 +2450,14 @@ trait DeltaErrorsSuiteBase
     }
     {
       val e = intercept[DeltaUnsupportedOperationException] {
-        throw DeltaErrors.blockCdfAndColumnMappingReads()
+        throw DeltaErrors.blockCdfAndColumnMappingReads(isStreaming = false)
       }
       assert(e.getErrorClass == "DELTA_BLOCK_CDF_COLUMN_MAPPING_READS")
       assert(e.getSqlState == "0A000")
-      assert(e.getMessage == "Change data feed (CDF) reads are currently not supported on tables " +
-        "with column mapping enabled.")
+      assert(e.getMessage.contains("Change Data Feed (CDF) reads are not supported on tables with" +
+        " column mapping schema changes (e.g. rename or drop)"))
+      assert(e.getMessage.contains(
+        DeltaSQLConf.DELTA_CDF_UNSAFE_BATCH_READ_ON_INCOMPATIBLE_SCHEMA_CHANGES.key))
     }
     {
       val e = intercept[DeltaUnsupportedOperationException] {


### PR DESCRIPTION
Resolves #1349

Due to the unclear behavior of streaming/CDC read on column mapping tables, we decide to temporarily block batch CDC read when user has performed rename or drop column operations after enabling column mapping.
Note that the following is not blocked:
1. CDC Read from a column mapping table without rename or drop column operations.
2. Upgrade to column mapping tables.
3. Existing compatible schema change operations such as ADD COLUMN.

New unit tests.