### PR TITLE
[DO_NOT_MERGE][Delta 2.1 Release] Backport commits to branch-2.1

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -64,7 +64,7 @@
   },
   "DELTA_BLOCK_CDF_COLUMN_MAPPING_READS" : {
     "message" : [
-      "Change data feed (CDF) reads are currently not supported on tables with column mapping enabled."
+      "Change Data Feed (CDF) reads are not supported on tables with column mapping schema changes (e.g. rename or drop). Read schema: <newSchema>. Incompatible schema: <oldSchema>. <hint>"
     ],
     "sqlState" : "0A000"
   },

--- a/core/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -135,11 +135,14 @@ class DeltaTable private[tables](
   }
 
   /**
+   * :: Evolving ::
+   *
    * Get the details of a Delta table such as the format, name, and size.
    *
    * @since 2.1.0
    */
-  def details(): DataFrame = {
+  @Evolving
+  def detail(): DataFrame = {
     executeDetails(deltaLog.dataPath.toString, table.getTableIdentifierIfExists)
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2265,9 +2265,22 @@ trait DeltaErrorsBase
     // scalastyle:on line.size.limit
   }
 
-  def blockCdfAndColumnMappingReads(): Throwable = {
+
+  val columnMappingCDFBatchBlockHint: String =
+    s"You may force enable batch CDF read at your own risk by turning on " +
+      s"${DeltaSQLConf.DELTA_CDF_UNSAFE_BATCH_READ_ON_INCOMPATIBLE_SCHEMA_CHANGES.key}."
+
+  def blockCdfAndColumnMappingReads(
+      isStreaming: Boolean,
+      readSchema: Option[StructType] = None,
+      incompatibleSchema: Option[StructType] = None): Throwable = {
     new DeltaUnsupportedOperationException(
-      errorClass = "DELTA_BLOCK_CDF_COLUMN_MAPPING_READS"
+      errorClass = "DELTA_BLOCK_CDF_COLUMN_MAPPING_READS",
+      messageParameters = Array(
+        readSchema.map(_.json).getOrElse(""),
+        incompatibleSchema.map(_.json).getOrElse(""),
+        if (isStreaming) "" else columnMappingCDFBatchBlockHint
+      )
     )
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
@@ -20,7 +20,7 @@ import java.sql.Timestamp
 
 import scala.collection.mutable.ListBuffer
 
-import org.apache.spark.sql.delta.{DeltaConfigs, DeltaErrors, DeltaHistoryManager, DeltaLog, DeltaOperations, DeltaParquetFileFormat, DeltaTableUtils, DeltaTimeTravelSpec, NoMapping, Snapshot}
+import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, AddFile, CommitInfo, FileAction, Metadata, RemoveFile}
 import org.apache.spark.sql.delta.files.{CdcAddFileIndex, TahoeChangeFileIndex, TahoeFileIndex, TahoeRemoveFileIndex}
 import org.apache.spark.sql.delta.metering.DeltaLogging
@@ -264,8 +264,10 @@ object CDCReader extends DeltaLogging {
 
     // If the table has column mapping enabled, throw an error. With column mapping, certain schema
     // changes are possible (rename a column or drop a column) which don't work well with CDF.
-    if (snapshot.metadata.columnMappingMode != NoMapping) {
-      throw DeltaErrors.blockCdfAndColumnMappingReads()
+    // TODO: remove this after the proper blocking semantics is rolled out
+    // This is only blocking streaming CDF, batch CDF will be blocked differently below.
+    if (isStreaming && snapshot.metadata.columnMappingMode != NoMapping) {
+      throw DeltaErrors.blockCdfAndColumnMappingReads(isStreaming)
     }
 
     // A map from change version to associated commit timestamp.
@@ -275,8 +277,33 @@ object CDCReader extends DeltaLogging {
     val changeFiles = ListBuffer[CDCDataSpec[AddCDCFile]]()
     val addFiles = ListBuffer[CDCDataSpec[AddFile]]()
     val removeFiles = ListBuffer[CDCDataSpec[RemoveFile]]()
+
+    val startVersionSnapshot = deltaLog.getSnapshotAt(start)
     if (!isCDCEnabledOnTable(deltaLog.getSnapshotAt(start).metadata)) {
       throw DeltaErrors.changeDataNotRecordedException(start, start, end)
+    }
+
+    /**
+     * TODO: Unblock this when we figure out the correct semantics.
+     *  Currently batch CDC read on column mapping tables with Rename/Drop is blocked due to
+     *  unclear semantics.
+     *  Streaming CDF read is blocked on a separate code path in DeltaSource.
+     */
+    val shouldCheckToBlockBatchReadOnColumnMappingTable =
+      !isStreaming &&
+      snapshot.metadata.columnMappingMode != NoMapping &&
+      !spark.sessionState.conf.getConf(
+        DeltaSQLConf.DELTA_CDF_UNSAFE_BATCH_READ_ON_INCOMPATIBLE_SCHEMA_CHANGES)
+
+    // Compare with start snapshot's metadata schema to fail fast
+    if (shouldCheckToBlockBatchReadOnColumnMappingTable &&
+        !DeltaColumnMapping.isColumnMappingReadCompatible(
+          snapshot.metadata, startVersionSnapshot.metadata)) {
+      throw DeltaErrors.blockCdfAndColumnMappingReads(
+        isStreaming,
+        Some(snapshot.metadata.schema),
+        Some(startVersionSnapshot.metadata.schema)
+      )
     }
 
     var totalBytes = 0L
@@ -294,6 +321,19 @@ object CDCReader extends DeltaLogging {
 
         if (cdcDisabled) {
           throw DeltaErrors.changeDataNotRecordedException(v, start, end)
+        }
+
+        // Check all intermediary metadata schema changes as well
+        if (shouldCheckToBlockBatchReadOnColumnMappingTable) {
+           actions.collect { case a: Metadata => a }.foreach { metadata =>
+             if (!DeltaColumnMapping.isColumnMappingReadCompatible(snapshot.metadata, metadata)) {
+               throw DeltaErrors.blockCdfAndColumnMappingReads(
+                 isStreaming,
+                 Some(snapshot.metadata.schema),
+                 Some(metadata.schema)
+               )
+             }
+           }
         }
 
         // Set up buffers for all action types to avoid multiple passes.

--- a/core/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -1028,8 +1028,14 @@ object SchemaUtils extends DeltaLogging {
     case BooleanType =>
     case ByteType =>
     case ShortType =>
-    case IntegerType | _: YearMonthIntervalType =>
-    case LongType | _: DayTimeIntervalType =>
+    case IntegerType =>
+    case dt: YearMonthIntervalType =>
+      assert(columnPath.nonEmpty, "'columnPath' must not be empty")
+      unsupportedDataTypes += UnsupportedDataTypeInfo(prettyFieldName(columnPath), dt)
+    case LongType =>
+    case dt: DayTimeIntervalType =>
+      assert(columnPath.nonEmpty, "'columnPath' must not be empty")
+      unsupportedDataTypes += UnsupportedDataTypeInfo(prettyFieldName(columnPath), dt)
     case FloatType =>
     case DoubleType =>
     case StringType =>

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -793,6 +793,17 @@ trait DeltaSQLConfBase {
       .createWithDefault(false)
   }
 
+  val DELTA_CDF_UNSAFE_BATCH_READ_ON_INCOMPATIBLE_SCHEMA_CHANGES =
+    buildConf("changeDataFeed.unsafeBatchReadOnIncompatibleSchemaChanges.enabled")
+      .doc(
+        "Reading change data in batch (e.g. using `table_changes()`) on Delta table with " +
+          "column mapping schema operations is currently blocked due to potential data loss and " +
+          "schema confusion. However, existing users may use this flag to force unblock " +
+          "if they'd like to take the risk.")
+      .internal()
+      .booleanConf
+      .createWithDefault(false)
+
   val DYNAMIC_PARTITION_OVERWRITE_ENABLED =
     buildConf("dynamicPartitionOverwrite.enabled")
       .doc("Whether to overwrite partitions dynamically when 'partitionOverwriteMode' is set to " +

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
 import org.apache.spark.sql.connector.read.streaming
-import org.apache.spark.sql.connector.read.streaming.{ReadAllAvailable, ReadLimit, ReadMaxFiles, SupportsAdmissionControl}
+import org.apache.spark.sql.connector.read.streaming.{ReadAllAvailable, ReadLimit, ReadMaxFiles, SupportsAdmissionControl, SupportsTriggerAvailableNow}
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.types.StructType
 
@@ -93,6 +93,7 @@ private[delta] case class IndexedFile(
  */
 trait DeltaSourceBase extends Source
     with SupportsAdmissionControl
+    with SupportsTriggerAvailableNow
     with DeltaLogging { self: DeltaSource =>
 
   override val schema: StructType = {
@@ -106,6 +107,13 @@ trait DeltaSourceBase extends Source
   }
 
   protected var lastOffsetForTriggerAvailableNow: DeltaSourceOffset = _
+
+  override def prepareForTriggerAvailableNow(): Unit = {
+    val offset = latestOffset(null, ReadLimit.allAvailable())
+    if (offset != null) {
+      lastOffsetForTriggerAvailableNow = DeltaSourceOffset(tableId, offset)
+    }
+  }
 
   protected def getFileChangesWithRateLimit(
       fromVersion: Long,

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceOffset.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceOffset.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.delta.util.JsonUtils
 import org.json4s._
 import org.json4s.jackson.JsonMethods.parse
 
+import org.apache.spark.sql.connector.read.streaming.{Offset => OffsetV2}
 import org.apache.spark.sql.execution.streaming.{Offset, SerializedOffset}
 
 /**
@@ -87,10 +88,10 @@ object DeltaSourceOffset {
     )
   }
 
-  def apply(reservoirId: String, offset: Offset): DeltaSourceOffset = {
+  def apply(reservoirId: String, offset: OffsetV2): DeltaSourceOffset = {
     offset match {
       case o: DeltaSourceOffset => o
-      case s: SerializedOffset =>
+      case s =>
         validateSourceVersion(s.json)
         val o = JsonUtils.mapper.readValue[DeltaSourceOffset](s.json)
         if (o.reservoirId != reservoirId) {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaCDCStreamSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaCDCStreamSuite.scala
@@ -826,8 +826,8 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
       val e = intercept[StreamingQueryException] {
         f
       }.getCause.getMessage
-      assert(e == "Change data feed (CDF) reads are currently not supported on tables " +
-        "with column mapping enabled.")
+      assert(e.contains("Change Data Feed (CDF) reads are not supported on tables with " +
+        "column mapping schema changes (e.g. rename or drop)"))
     }
 
     Seq(0, 1).foreach { startingVersion =>

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaCDCStreamSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaCDCStreamSuite.scala
@@ -32,7 +32,7 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.streaming.{StreamingQuery, StreamingQueryException, StreamTest}
+import org.apache.spark.sql.streaming.{StreamingQuery, StreamingQueryException, StreamTest, Trigger}
 import org.apache.spark.sql.types.StructType
 
 trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
@@ -620,6 +620,49 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
 
       testStream(df)(
         ProcessAllAvailable(),
+        CheckProgress(rowsPerBatch)
+      )
+    }
+  }
+
+  test("maxFilesPerTrigger with Trigger.AvailableNow respects read limits") {
+    withTempDir { inputDir =>
+      // version 0 - 2 AddFiles
+      spark.range(2)
+        .withColumn("part", 'id % 2)
+        .withColumn("col3", lit(0))
+        .repartition(1)
+        .write
+        .format("delta")
+        .partitionBy("part")
+        .save(inputDir.getAbsolutePath)
+
+      val deltaTable = io.delta.tables.DeltaTable.forPath(inputDir.getAbsolutePath)
+      // version 1 - 2 AddCDCFiles
+      deltaTable.update(expr("col3 < 2"), Map("col3" -> lit("0")))
+
+      // version 2 - 2 AddCDCFiles
+      deltaTable.update(expr("col3 < 2"), Map("col3" -> lit("1")))
+
+      val df = spark.readStream
+        .format("delta")
+        .option(DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION, "3")
+        .option(DeltaOptions.CDC_READ_OPTION, "true")
+        .option("startingVersion", "0")
+        .load(inputDir.getCanonicalPath)
+
+      // test whether the AddCDCFile commits do not get split up.
+      val rowsPerBatch = Seq(
+        2, // 2 rows from the 2 AddFile
+        4, // 4 rows(pre and post image) from the 2 AddCDCFiles
+        4 // 4 rows(pre and post image) from 2 AddCDCFiles
+      )
+
+      testStream(df)(
+        StartStream(Trigger.AvailableNow),
+        Execute { query =>
+          assert(query.awaitTermination(10000))
+        },
         CheckProgress(rowsPerBatch)
       )
     }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
@@ -495,6 +495,106 @@ class DeltaColumnMappingSuite extends QueryTest
     assert(DeltaColumnMapping.findMaxColumnId(new StructType()) == 0)
   }
 
+  // TODO: repurpose this once we roll out the proper semantics for CM + streaming
+  testColumnMapping("isColumnMappingReadCompatible") { mode =>
+    // Set up table based on mode and return the initial metadata actions for comparison
+    def setupInitialTable(deltaLog: DeltaLog): (MetadataAction, MetadataAction) = {
+      val tablePath = deltaLog.dataPath.toString
+      if (mode == NameMapping.name) {
+        Seq((1, "a"), (2, "b")).toDF("id", "name")
+          .write.mode("append").format("delta").save(tablePath)
+        // schema: <id, name>
+        val m0 = deltaLog.update().metadata
+
+        // add a column
+        sql(s"ALTER TABLE delta.`$tablePath` ADD COLUMN (score long)")
+        // schema: <id, name, score>
+        val m1 = deltaLog.update().metadata
+
+        // column mapping not enabled -> not blocked at all
+        assert(DeltaColumnMapping.isColumnMappingReadCompatible(m1, m0))
+
+        // upgrade to name mode
+        alterTableWithProps(s"delta.`$tablePath`", Map(
+          DeltaConfigs.COLUMN_MAPPING_MODE.key -> "name",
+          DeltaConfigs.MIN_READER_VERSION.key -> "2",
+          DeltaConfigs.MIN_WRITER_VERSION.key -> "5"))
+
+        (m0, m1)
+      } else {
+        // for id mode, just create the table
+        withSQLConf(DeltaConfigs.COLUMN_MAPPING_MODE.defaultTablePropertyKey -> "id") {
+          Seq((1, "a"), (2, "b")).toDF("id", "name")
+            .write.mode("append").format("delta").save(tablePath)
+        }
+        // schema: <id, name>
+        val m0 = deltaLog.update().metadata
+
+        // add a column
+        sql(s"ALTER TABLE delta.`$tablePath` ADD COLUMN (score long)")
+        // schema: <id, name, score>
+        val m1 = deltaLog.update().metadata
+
+        // add column shouldn't block
+        assert(DeltaColumnMapping.isColumnMappingReadCompatible(m1, m0))
+
+        (m0, m1)
+      }
+    }
+
+    withTempDir { dir =>
+      val tablePath = dir.getCanonicalPath
+      val deltaLog = DeltaLog.forTable(spark, tablePath)
+
+      val (m0, m1) = setupInitialTable(deltaLog)
+
+      // schema: <id, name, score>
+      val m2 = deltaLog.update().metadata
+
+      assert(DeltaColumnMapping.isColumnMappingReadCompatible(m2, m1))
+      assert(DeltaColumnMapping.isColumnMappingReadCompatible(m2, m0))
+
+      // rename column
+      sql(s"ALTER TABLE delta.`$tablePath` RENAME COLUMN score TO age")
+      // schema: <id, name, age>
+      val m3 = deltaLog.update().metadata
+
+      assert(!DeltaColumnMapping.isColumnMappingReadCompatible(m3, m2))
+      assert(!DeltaColumnMapping.isColumnMappingReadCompatible(m3, m1))
+      // But IS read compatible with the initial schema, because the added column should not
+      // be blocked by this column mapping check.
+      assert(DeltaColumnMapping.isColumnMappingReadCompatible(m3, m0))
+
+      // drop a column
+      sql(s"ALTER TABLE delta.`$tablePath` DROP COLUMN age")
+      // schema: <id, name>
+      val m4 = deltaLog.update().metadata
+
+      assert(!DeltaColumnMapping.isColumnMappingReadCompatible(m4, m3))
+      assert(!DeltaColumnMapping.isColumnMappingReadCompatible(m4, m2))
+      assert(!DeltaColumnMapping.isColumnMappingReadCompatible(m4, m1))
+      // but IS read compatible with the initial schema, because the added column is dropped
+      assert(DeltaColumnMapping.isColumnMappingReadCompatible(m4, m0))
+
+      // add back the same column
+      sql(s"ALTER TABLE delta.`$tablePath` ADD COLUMN (score long)")
+      // schema: <id, name, score>
+      val m5 = deltaLog.update().metadata
+
+      // It IS read compatible with the previous schema, because the added column should not
+      // blocked by this column mapping check.
+      assert(DeltaColumnMapping.isColumnMappingReadCompatible(m5, m4))
+      assert(!DeltaColumnMapping.isColumnMappingReadCompatible(m5, m3))
+      assert(!DeltaColumnMapping.isColumnMappingReadCompatible(m5, m2))
+      // But Since the new added column has a different physical name as all previous columns,
+      // even it has the same logical name as say, m1.schema, we will still block
+      assert(!DeltaColumnMapping.isColumnMappingReadCompatible(m5, m1))
+      // But it IS read compatible with the initial schema, because the added column should not
+      // be blocked by this column mapping check.
+      assert(DeltaColumnMapping.isColumnMappingReadCompatible(m5, m0))
+    }
+  }
+
   test("create table under id mode should be blocked") {
     withTable("t1") {
       val mode = "id"

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2250,12 +2250,14 @@ trait DeltaErrorsSuiteBase
     }
     {
       val e = intercept[DeltaUnsupportedOperationException] {
-        throw DeltaErrors.blockCdfAndColumnMappingReads()
+        throw DeltaErrors.blockCdfAndColumnMappingReads(isStreaming = false)
       }
       assert(e.getErrorClass == "DELTA_BLOCK_CDF_COLUMN_MAPPING_READS")
       assert(e.getSqlState == "0A000")
-      assert(e.getMessage == "Change data feed (CDF) reads are currently not supported on tables " +
-        "with column mapping enabled.")
+      assert(e.getMessage.contains("Change Data Feed (CDF) reads are not supported on tables with" +
+        " column mapping schema changes (e.g. rename or drop)"))
+      assert(e.getMessage.contains(
+        DeltaSQLConf.DELTA_CDF_UNSAFE_BATCH_READ_ON_INCOMPATIBLE_SCHEMA_CHANGES.key))
     }
     {
       val e = intercept[DeltaUnsupportedOperationException] {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
@@ -62,7 +62,7 @@ trait DescribeDeltaDetailSuiteBase extends QueryTest
     // Check Scala details
     val deltaTable = io.delta.tables.DeltaTable.forPath(spark, tempDir.toString)
     checkResult(
-      deltaTable.details(),
+      deltaTable.detail(),
       Seq("delta", Array("column1"), 1),
       Seq("format", "partitionColumns", "numFiles"))
   }
@@ -73,7 +73,7 @@ trait DescribeDeltaDetailSuiteBase extends QueryTest
 
       val deltaTable = io.delta.tables.DeltaTable.forName(spark, "delta_test")
       checkAnswer(
-        deltaTable.details().select("format"),
+        deltaTable.detail().select("format"),
         Seq(Row("delta"))
       )
     }

--- a/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.delta
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest}
 
-import org.apache.spark.sql.{AnalysisException, Row}
+import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.catalyst.analysis.{Analyzer, ResolveSessionCatalog}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical.{DeltaMergeInto, LogicalPlan}
@@ -82,7 +82,7 @@ class MergeIntoSQLSuite extends MergeIntoSuiteBase  with DeltaSQLCommandTest
         update = "key2 = 20 + src.key3, value = 20 + src.value",
         insert = "(key2, value) VALUES (src.key3 - 10, src.value + 10)")
 
-      sql(cte + merge)
+      QueryTest.checkAnswer(sql(cte + merge), Seq(Row(2, 1, 0, 1)))
       checkAnswer(readDeltaTable(tempPath),
         Row(1, 4) :: // No change
         Row(22, 23) :: // Update

--- a/core/src/test/scala/org/apache/spark/sql/delta/UpdateSQLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/UpdateSQLSuite.scala
@@ -16,9 +16,10 @@
 
 package org.apache.spark.sql.delta
 
+// scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{QueryTest, Row}
 
 class UpdateSQLSuite extends UpdateSuiteBase  with DeltaSQLCommandTest {
 
@@ -68,7 +69,7 @@ class UpdateSQLSuite extends UpdateSuiteBase  with DeltaSQLCommandTest {
       withTempView("v") {
         Seq((0, 3)).toDF("key", "value").write.format("delta").saveAsTable("tab")
         sql("CREATE TEMP VIEW v AS SELECT * FROM tab")
-        sql("UPDATE v SET key = 1 WHERE key = 0 AND value = 3")
+        QueryTest.checkAnswer(sql("UPDATE v SET key = 1 WHERE key = 0 AND value = 3"), Seq(Row(1)))
         checkAnswer(spark.table("tab"), Row(1, 3))
       }
     }

--- a/core/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
@@ -1544,9 +1544,13 @@ class SchemaUtilsSuite extends QueryTest
     assertUnsupportedDataType(ByteType, Nil)
     assertUnsupportedDataType(ShortType, Nil)
     assertUnsupportedDataType(IntegerType, Nil)
-    assertUnsupportedDataType(YearMonthIntervalType.DEFAULT, Nil)
     assertUnsupportedDataType(LongType, Nil)
-    assertUnsupportedDataType(DayTimeIntervalType.DEFAULT, Nil)
+    assertUnsupportedDataType(
+      YearMonthIntervalType.DEFAULT,
+      Seq(UnsupportedDataTypeInfo("col", YearMonthIntervalType.DEFAULT)))
+    assertUnsupportedDataType(
+      DayTimeIntervalType.DEFAULT,
+      Seq(UnsupportedDataTypeInfo("col", DayTimeIntervalType.DEFAULT)))
     assertUnsupportedDataType(FloatType, Nil)
     assertUnsupportedDataType(DoubleType, Nil)
     assertUnsupportedDataType(StringType, Nil)

--- a/examples/python/utilities.py
+++ b/examples/python/utilities.py
@@ -50,7 +50,7 @@ print("######## Describe history for the table ######")
 deltaTable.history().show()
 
 print("######## Describe details for the table ######")
-deltaTable.details().show()
+deltaTable.detail().show()
 
 # Generate manifest
 print("######## Generating manifest ######")

--- a/examples/scala/src/main/scala/example/Utilities.scala
+++ b/examples/scala/src/main/scala/example/Utilities.scala
@@ -64,7 +64,7 @@ object Utilities {
     deltaTable.history().show()
 
     println("Describe Details for the table")
-    deltaTable.details().show()
+    deltaTable.detail().show()
 
     // Generate manifest
     println("Generate Manifest files")

--- a/python/delta/tables.py
+++ b/python/delta/tables.py
@@ -279,19 +279,21 @@ class DeltaTable(object):
             )
 
     @since(2.1)  # type: ignore[arg-type]
-    def details(self) -> DataFrame:
+    def detail(self) -> DataFrame:
         """
         Get the details of a Delta table such as the format, name, and size.
 
         Example::
 
-            detailsDF = deltaTable.details() # get the full details of the table
+            detailDF = deltaTable.detail() # get the full details of the table
 
         :return Information of the table (format, name, size, etc.)
         :rtype: pyspark.sql.DataFrame
+
+        .. note:: Evolving
         """
         return DataFrame(
-            self._jdt.details(),
+            self._jdt.detail(),
             getattr(self._spark, "_wrapped", self._spark)  # type: ignore[attr-defined]
         )
 

--- a/python/delta/tests/test_deltatable.py
+++ b/python/delta/tests/test_deltatable.py
@@ -327,10 +327,10 @@ class DeltaTableTests(DeltaTestCase):
             [Row("Overwrite")],
             StructType([StructField("operationParameters.mode", StringType(), True)]))
 
-    def test_details(self) -> None:
+    def test_detail(self) -> None:
         self.__writeDeltaTable([('a', 1), ('b', 2), ('c', 3)])
         dt = DeltaTable.forPath(self.spark, self.tempFile)
-        details = dt.details()
+        details = dt.detail()
         self.__checkAnswer(
             details.select('format'),
             [Row('delta')],


### PR DESCRIPTION
Cherry-pick the following:

05c39329d902e0f4a49f9edb7312c18a2b20cb29 Enable batch CDF queries on column mapping enabled tables with fewer limitations
4ff810943d2f00143fba5a3795b753d0a76a90b5 Block interval types in Delta
f7cc05f50f3bc8feb262340f096410500077d82f  Change DeltaTable.details() to DeltaTable.detail() to be consistent with SQL
3ff10fa9bcf8f54a6cb2448fabc92a70d0e98972  Trigger available now
3ce34c9371fa5c75107c83043b3b20a16f8963b5  Fix merge command `numTargetFilesAdded` metric
8df1844d4cdd89ab9567b2f70aa0453bc004ff37 Make update command return the number of updated rows.
0058673322aea1f375f297405872be1176888041 Make MERGE operation return useful metrics

**Do not merge this PR, this is just for the purpose of review.**