### PR TITLE
Enable streaming / CDF streaming reads on column mapping enabled tables with fewer limitations

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -68,15 +68,15 @@
     ],
     "sqlState" : "42000"
   },
-  "DELTA_BLOCK_CDF_COLUMN_MAPPING_READS" : {
-    "message" : [
-      "Change Data Feed (CDF) reads are not supported on tables with column mapping schema changes (e.g. rename or drop). Read schema: <newSchema>. Incompatible schema: <oldSchema>. <hint>"
-    ],
-    "sqlState" : "0A000"
-  },
   "DELTA_BLOCK_COLUMN_MAPPING_AND_CDC_OPERATION" : {
     "message" : [
       "Operation \"<opName>\" is not allowed when the table has enabled change data feed (CDF) and has undergone schema changes using DROP COLUMN or RENAME COLUMN."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DELTA_BLOCK_COLUMN_MAPPING_SCHEMA_INCOMPATIBLE_OPERATION" : {
+    "message" : [
+      "<opName> is not supported on tables with column mapping schema changes (e.g. rename or drop). Read schema: <readSchema>. Incompatible schema: <incompatibleSchema>. You may force enable streaming read at your own risk by turning on <config>."
     ],
     "sqlState" : "0A000"
   },
@@ -1294,6 +1294,12 @@
     ],
     "sqlState" : "22000"
   },
+  "DELTA_STREAM_CHECK_COLUMN_MAPPING_NO_SNAPSHOT" : {
+    "message" : [
+      "Failed to obtain Delta log snapshot for the start version when checking column mapping schema changes. Please choose a different start version, or force enable streaming read at your own risk by setting '<config>' to 'true'."
+    ],
+    "sqlState" : "22000"
+  },
   "DELTA_TABLE_ALREADY_CONTAINS_CDC_COLUMNS" : {
     "message" : [
       "Unable to enable Change Data Capture on the table. The table already contains",
@@ -1538,12 +1544,6 @@
       "Schema changes are not allowed during the change of column mapping mode.",
       "",
       ""
-    ],
-    "sqlState" : "0A000"
-  },
-  "DELTA_UNSUPPORTED_COLUMN_MAPPING_STREAMING_READS" : {
-    "message" : [
-      "Streaming reads from a Delta table with column mapping enabled are not supported."
     ],
     "sqlState" : "0A000"
   },

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
@@ -522,15 +522,17 @@ trait DeltaColumnMappingBase extends DeltaLogging {
   def isColumnMappingReadCompatible(newMetadata: Metadata, oldMetadata: Metadata): Boolean = {
     val (oldMode, newMode) = (oldMetadata.columnMappingMode, newMetadata.columnMappingMode)
     if (oldMode != NoMapping && newMode != NoMapping) {
+      require(oldMode == newMode, "changing mode is not supported")
       // Both changes are post column mapping enabled
       !isRenameColumnOperation(newMetadata, oldMetadata) &&
-      !isDropColumnOperation(newMetadata, oldMetadata)
+        !isDropColumnOperation(newMetadata, oldMetadata)
     } else if (oldMode == NoMapping && newMode != NoMapping) {
       // The old metadata does not have column mapping while the new metadata does, in this case
       // we assume an upgrade has happened in between.
       // So we manually construct a post-upgrade schema for the old metadata and compare that with
       // the new metadata, as the upgrade would use the logical name as the physical name, we could
-      // easily capture any difference in the schema using the same is{XXX}ColumnOperation utils.
+      // easily capture any difference in the schema using the same is{Drop,Rename}ColumnOperation
+      // utils.
       var upgradedMetadata = assignColumnIdAndPhysicalName(
         oldMetadata, oldMetadata, isChangingModeOnExistingTable = true
       )

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2659,10 +2659,10 @@ case class ColumnMappingException(msg: String, mode: DeltaColumnMappingMode)
  * operation, user should always be able to use `escapeConfigName` to fall back at own risk.
  */
 class DeltaColumnMappingUnsupportedSchemaIncompatibleException(
-    opName: String,
-    readSchema: StructType,
-    incompatibleSchema: StructType,
-    escapeConfigName: String,
+    val opName: String,
+    val readSchema: StructType,
+    val incompatibleSchema: StructType,
+    val escapeConfigName: String,
     val additionalProperties: Map[String, String] = Map.empty)
   extends DeltaUnsupportedOperationException(
     errorClass = "DELTA_BLOCK_COLUMN_MAPPING_SCHEMA_INCOMPATIBLE_OPERATION",

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -303,16 +303,18 @@ object DeltaOperations {
   }
 
   /** Recorded when columns are dropped. */
+  val OP_DROP_COLUMN = "DROP COLUMNS"
   case class DropColumns(
-    colsToDrop: Seq[Seq[String]]) extends Operation("DROP COLUMNS") {
+    colsToDrop: Seq[Seq[String]]) extends Operation(OP_DROP_COLUMN) {
 
     override val parameters: Map[String, Any] = Map(
       "columns" -> JsonUtils.toJson(colsToDrop.map(UnresolvedAttribute(_).name)))
   }
 
   /** Recorded when column is renamed */
+  val OP_RENAME_COLUMN = "RENAME COLUMN"
   case class RenameColumn(oldColumnPath: Seq[String], newColumnPath: Seq[String])
-    extends Operation("RENAME COLUMN") {
+    extends Operation(OP_RENAME_COLUMN) {
     override val parameters: Map[String, Any] = Map(
       "oldColumnPath" -> UnresolvedAttribute(oldColumnPath).name,
       "newColumnPath" -> UnresolvedAttribute(newColumnPath).name

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -793,6 +793,17 @@ trait DeltaSQLConfBase {
       .createWithDefault(false)
   }
 
+  val DELTA_STREAMING_UNSAFE_READ_ON_INCOMPATIBLE_SCHEMA_CHANGES =
+    buildConf("streaming.unsafeReadOnIncompatibleSchemaChanges.enabled")
+      .doc(
+        "Streaming read on Delta table with column mapping schema operations " +
+          "(e.g. rename or drop column) is currently blocked due to potential data loss and " +
+        "schema confusion. However, existing users may use this flag to force unblock " +
+          "if they'd like to take the risk.")
+      .internal()
+      .booleanConf
+      .createWithDefault(false)
+
   val DELTA_CDF_UNSAFE_BATCH_READ_ON_INCOMPATIBLE_SCHEMA_CHANGES =
     buildConf("changeDataFeed.unsafeBatchReadOnIncompatibleSchemaChanges.enabled")
       .doc(

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSuite.scala
@@ -799,10 +799,10 @@ abstract class DeltaCDCColumnMappingSuiteBase extends DeltaCDCScalaSuite
   with DeltaColumnMappingTestUtils {
 
   private def assertBlocked(f: => Unit): Unit = {
-    val e = intercept[DeltaUnsupportedOperationException] {
+    val e = intercept[DeltaColumnMappingUnsupportedSchemaIncompatibleException] {
       f
     }
-    assert(e.getErrorClass == "DELTA_BLOCK_CDF_COLUMN_MAPPING_READS" &&
+    assert(e.getErrorClass == "DELTA_BLOCK_COLUMN_MAPPING_SCHEMA_INCOMPATIBLE_OPERATION" &&
       e.getMessage.contains(
         DeltaSQLConf.DELTA_CDF_UNSAFE_BATCH_READ_ON_INCOMPATIBLE_SCHEMA_CHANGES.key))
   }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingTestUtils.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingTestUtils.scala
@@ -352,6 +352,21 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
     sql(s"CONVERT TO DELTA $tableOrPath")
   }
 
+  /**
+   * Force enable streaming read (with possible data loss) on column mapping enabled table with
+   * drop / rename schema changes.
+   */
+  protected def withStreamingReadOnColumnMappingTableEnabled(f: => Unit): Unit = {
+    if (columnMappingEnabled) {
+      withSQLConf(
+        DeltaSQLConf.DELTA_STREAMING_UNSAFE_READ_ON_INCOMPATIBLE_SCHEMA_CHANGES.key -> "true") {
+        f
+      }
+    } else {
+      f
+    }
+  }
+
 }
 
 trait DeltaColumnMappingTestUtils extends DeltaColumnMappingTestUtilsBase

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2419,15 +2419,6 @@ trait DeltaErrorsSuiteBase
         "Can only drop nested columns from StructType. Found StructField(invalid1,StringType,true)")
     }
     {
-      val e = intercept[DeltaUnsupportedOperationException] {
-        throw DeltaErrors.blockStreamingReadsOnColumnMappingEnabledTable
-      }
-      assert(e.getErrorClass == "DELTA_UNSUPPORTED_COLUMN_MAPPING_STREAMING_READS")
-      assert(e.getSqlState == "0A000")
-      assert(e.getMessage ==
-        "Streaming reads from a Delta table with column mapping enabled are not supported.")
-    }
-    {
       val columnsThatNeedRename = Set("c0", "c1")
       val schema = StructType(Seq(StructField("schema1", StringType)))
       val e = intercept[DeltaAnalysisException] {
@@ -2449,15 +2440,57 @@ trait DeltaErrorsSuiteBase
       assert(e.getMessage == s"Can't set location multiple times. Found ${locations}")
     }
     {
-      val e = intercept[DeltaUnsupportedOperationException] {
-        throw DeltaErrors.blockCdfAndColumnMappingReads(isStreaming = false)
+      val e = intercept[DeltaColumnMappingUnsupportedSchemaIncompatibleException] {
+        throw DeltaErrors.blockStreamingReadsOnColumnMappingEnabledTable(
+          StructType.fromDDL("id int"),
+          StructType.fromDDL("id2 int"),
+          isCdfRead = true,
+          detectedDuringStreaming = true
+        )
       }
-      assert(e.getErrorClass == "DELTA_BLOCK_CDF_COLUMN_MAPPING_READS")
+      assert(e.getErrorClass == "DELTA_BLOCK_COLUMN_MAPPING_SCHEMA_INCOMPATIBLE_OPERATION")
       assert(e.getSqlState == "0A000")
-      assert(e.getMessage.contains("Change Data Feed (CDF) reads are not supported on tables with" +
-        " column mapping schema changes (e.g. rename or drop)"))
-      assert(e.getMessage.contains(
-        DeltaSQLConf.DELTA_CDF_UNSAFE_BATCH_READ_ON_INCOMPATIBLE_SCHEMA_CHANGES.key))
+      assert(e.getMessage == "Streaming read of Change Data Feed (CDF) is not supported " +
+        "on tables with column mapping schema changes (e.g. rename or drop). " +
+        s"Read schema: ${StructType.fromDDL("id int").json}. " +
+        s"Incompatible schema: ${StructType.fromDDL("id2 int").json}. " +
+        "You may force enable streaming read at your own risk by turning on " +
+        s"${DeltaSQLConf.DELTA_STREAMING_UNSAFE_READ_ON_INCOMPATIBLE_SCHEMA_CHANGES.key}.")
+      assert(e.additionalProperties("detectedDuringStreaming").toBoolean)
+    }
+    {
+      val e = intercept[DeltaColumnMappingUnsupportedSchemaIncompatibleException] {
+        throw DeltaErrors.blockStreamingReadsOnColumnMappingEnabledTable(
+          StructType.fromDDL("id int"),
+          StructType.fromDDL("id2 int"),
+          isCdfRead = false,
+          detectedDuringStreaming = false
+        )
+      }
+      assert(e.getErrorClass == "DELTA_BLOCK_COLUMN_MAPPING_SCHEMA_INCOMPATIBLE_OPERATION")
+      assert(e.getSqlState == "0A000")
+      assert(e.getMessage == "Streaming read is not supported " +
+        "on tables with column mapping schema changes (e.g. rename or drop). " +
+        s"Read schema: ${StructType.fromDDL("id int").json}. " +
+        s"Incompatible schema: ${StructType.fromDDL("id2 int").json}. " +
+        "You may force enable streaming read at your own risk by turning on " +
+        s"${DeltaSQLConf.DELTA_STREAMING_UNSAFE_READ_ON_INCOMPATIBLE_SCHEMA_CHANGES.key}.")
+      assert(!e.additionalProperties("detectedDuringStreaming").toBoolean)
+    }
+    {
+      val e = intercept[DeltaColumnMappingUnsupportedSchemaIncompatibleException] {
+        throw DeltaErrors.blockBatchCdfReadOnColumnMappingEnabledTable(
+          readSchema = StructType.fromDDL("id int"),
+          incompatibleSchema = StructType.fromDDL("id2 int"))
+      }
+      assert(e.getErrorClass == "DELTA_BLOCK_COLUMN_MAPPING_SCHEMA_INCOMPATIBLE_OPERATION")
+      assert(e.getSqlState == "0A000")
+      assert(e.getMessage == "Change Data Feed (CDF) read is not supported on tables with " +
+        "column mapping schema changes (e.g. rename or drop). " +
+        s"Read schema: ${StructType.fromDDL("id int").json}. " +
+        s"Incompatible schema: ${StructType.fromDDL("id2 int").json}. " +
+        "You may force enable streaming read at your own risk by turning on " +
+        s"${DeltaSQLConf.DELTA_CDF_UNSAFE_BATCH_READ_ON_INCOMPATIBLE_SCHEMA_CHANGES.key}.")
     }
     {
       val e = intercept[DeltaUnsupportedOperationException] {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSourceColumnMappingSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSourceColumnMappingSuite.scala
@@ -1,0 +1,509 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.io.File
+import java.util.UUID
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.sources.{DeltaSource, DeltaSQLConf}
+import org.apache.spark.sql.delta.util.JsonUtils
+import org.apache.commons.lang3.exception.ExceptionUtils
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.execution.streaming.StreamingExecutionRelation
+import org.apache.spark.sql.streaming.{DataStreamReader, StreamTest}
+import org.apache.spark.sql.types.StructType
+
+trait ColumnMappingStreamingWorkflowSuiteBase extends StreamTest
+  with DeltaColumnMappingTestUtils {
+
+  import testImplicits._
+
+  // Whether we are requesting CDC streaming changes
+  protected def isCdcTest: Boolean
+
+  // Drop CDC fields because they are not useful for testing the blocking behavior
+  private def dropCDCFields(df: DataFrame): DataFrame =
+    df.drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+      .drop(CDCReader.CDC_TYPE_COLUMN_NAME)
+      .drop(CDCReader.CDC_COMMIT_VERSION)
+
+  // DataStreamReader to use
+  // Set a small max file per trigger to ensure we could catch failures ASAP
+  private def dsr: DataStreamReader = if (isCdcTest) {
+    spark.readStream.format("delta")
+      .option(DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION, "1")
+      .option(DeltaOptions.CDC_READ_OPTION, "true")
+  } else {
+    spark.readStream.format("delta")
+      .option(DeltaOptions.MAX_FILES_PER_TRIGGER_OPTION, "1")
+  }
+
+  private val ProcessAllAvailableIgnoreError = Execute { q =>
+    try {
+      q.processAllAvailable()
+    } catch {
+      case _: Throwable =>
+        // swallow the errors so we could check answer and failure on the query later
+    }
+  }
+
+  private def isColumnMappingSchemaIncompatibleFailure(
+      t: Throwable,
+      detectedDuringStreaming: Boolean): Boolean = t match {
+    case e: DeltaColumnMappingUnsupportedSchemaIncompatibleException =>
+      if (isCdcTest) {
+        e.opName == "Streaming read of Change Data Feed (CDF)"
+      } else {
+        e.opName == "Streaming read"
+      } && e.additionalProperties.get("detectedDuringStreaming")
+        .exists(_.toBoolean == detectedDuringStreaming)
+    case _ => false
+  }
+
+  private val ExpectStreamStartInCompatibleSchemaFailure =
+    ExpectFailure[DeltaColumnMappingUnsupportedSchemaIncompatibleException] { t =>
+      assert(isColumnMappingSchemaIncompatibleFailure(t, detectedDuringStreaming = false))
+    }
+
+  private val ExpectInStreamSchemaChangeFailure =
+    ExpectFailure[DeltaColumnMappingUnsupportedSchemaIncompatibleException] { t =>
+      assert(isColumnMappingSchemaIncompatibleFailure(t, detectedDuringStreaming = true))
+    }
+
+  private val ExpectGenericColumnMappingFailure =
+    ExpectFailure[DeltaColumnMappingUnsupportedSchemaIncompatibleException]()
+
+  // Failure thrown by the current DeltaSource schema change incompatible check
+  private val existingRetryableInStreamSchemaChangeFailure = Execute { q =>
+    // Similar to ExpectFailure but allows more fine-grained checking of exceptions
+    failAfter(streamingTimeout) {
+      try {
+        q.awaitTermination()
+      } catch {
+        case _: Throwable =>
+          // swallow the exception
+      }
+      val cause = ExceptionUtils.getRootCause(q.exception.get)
+      assert(cause.getMessage.contains("Detected schema change"))
+    }
+  }
+
+  private def checkStreamStartBlocked(
+      df: DataFrame,
+      ckpt: File,
+      expectedFailure: StreamAction): Unit = {
+    // Restart the stream from the same checkpoint will pick up the dropped schema and our
+    // column mapping check will kick in and error out.
+    testStream(df)(
+      StartStream(checkpointLocation = ckpt.getCanonicalPath),
+      ProcessAllAvailableIgnoreError,
+      // No batches have been served
+      CheckLastBatch(Nil: _*),
+      expectedFailure
+    )
+  }
+
+  private def writeDeltaData(
+      data: Seq[Int],
+      deltaLog: DeltaLog,
+      userSpecifiedSchema: Option[StructType] = None): Unit = {
+    val schema = userSpecifiedSchema.getOrElse(deltaLog.update().schema)
+    data.foreach { i =>
+      val data = Seq(Row(schema.map(_ => i.toString): _*))
+      spark.createDataFrame(data.asJava, schema)
+        .write.format("delta").mode("append").save(deltaLog.dataPath.toString)
+    }
+  }
+
+  test("deltaLog snapshot should not be updated outside of the stream") {
+    withTempDir { dir =>
+      val tablePath = dir.getCanonicalPath
+      // write initial data
+      Seq(1).toDF("id").write.format("delta").mode("overwrite").save(tablePath)
+      // record initial snapshot version and warm DeltaLog cache
+      val initialDeltaLog = DeltaLog.forTable(spark, tablePath)
+      // start streaming
+      val df = spark.readStream.format("delta").load(tablePath)
+      testStream(df)(
+        StartStream(),
+        ProcessAllAvailable(),
+        AssertOnQuery { q =>
+          // write more data
+          Seq(2).toDF("id").write.format("delta").mode("append").save(tablePath)
+          // update deltaLog externally
+          initialDeltaLog.update()
+          assert(initialDeltaLog.snapshot.version == 1)
+          // query start snapshot should not change
+          val source = q.logicalPlan.collectFirst {
+            case r: StreamingExecutionRelation =>
+              r.source.asInstanceOf[DeltaSource]
+          }.get
+          // same delta log but stream start version not affected
+          source.deltaLog == initialDeltaLog && source.snapshotAtSourceInit.version == 0
+        }
+      )
+    }
+  }
+
+  test("column mapping + streaming - allowed workflows - column addition") {
+    // column addition schema evolution should not be blocked upon restart
+    withTempDir { inputDir =>
+      val deltaLog = DeltaLog.forTable(spark, new Path(inputDir.toURI))
+      writeDeltaData(0 until 5, deltaLog, Some(StructType.fromDDL("id string, value string")))
+
+      val checkpointDir = new File(inputDir, "_checkpoint")
+
+      def df: DataFrame = dropCDCFields(dsr.load(inputDir.getCanonicalPath))
+
+      testStream(df)(
+        StartStream(checkpointLocation = checkpointDir.getCanonicalPath),
+        ProcessAllAvailable(),
+        CheckAnswer((0 until 5).map(i => (i.toString, i.toString)): _*),
+        Execute { _ =>
+          sql(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` ADD COLUMN (value2 string)")
+        },
+        Execute { _ =>
+          writeDeltaData(5 until 10, deltaLog)
+        },
+        existingRetryableInStreamSchemaChangeFailure
+      )
+
+      testStream(df)(
+        StartStream(checkpointLocation = checkpointDir.getCanonicalPath),
+        ProcessAllAvailable(),
+        // Sink is reinitialized, only 5-10 are ingested
+        CheckAnswer(
+          (5 until 10).map(i => (i.toString, i.toString, i.toString)): _*)
+      )
+    }
+
+  }
+
+  test("column mapping + streaming - allowed workflows - upgrade to name mode") {
+    // upgrade should not blocked both during the stream AND during stream restart
+    withTempDir { inputDir =>
+      val deltaLog = DeltaLog.forTable(spark, new Path(inputDir.toURI))
+      withColumnMappingConf("none") {
+        writeDeltaData(0 until 5, deltaLog, Some(StructType.fromDDL("id string, name string")))
+      }
+
+      def df: DataFrame = dropCDCFields(dsr.load(inputDir.getCanonicalPath))
+
+      val checkpointDir = new File(inputDir, "_checkpoint")
+
+      testStream(df)(
+        StartStream(checkpointLocation = checkpointDir.getCanonicalPath),
+        ProcessAllAvailable(),
+        CheckAnswer((0 until 5).map(i => (i.toString, i.toString)): _*),
+        Execute { _ =>
+          sql(
+            s"""
+               |ALTER TABLE delta.`${inputDir.getCanonicalPath}`
+               |SET TBLPROPERTIES (
+               |  ${DeltaConfigs.COLUMN_MAPPING_MODE.key} = "name",
+               |  ${DeltaConfigs.MIN_READER_VERSION.key} = "2",
+               |  ${DeltaConfigs.MIN_WRITER_VERSION.key} = "5")""".stripMargin)
+        },
+        Execute { _ =>
+          writeDeltaData(5 until 10, deltaLog)
+        },
+        ProcessAllAvailable(),
+        CheckAnswer((0 until 10).map(i => (i.toString, i.toString)): _*),
+        // add column schema evolution should fail the stream
+        Execute { _ =>
+          sql(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` ADD COLUMN (value2 string)")
+        },
+        Execute { _ =>
+          writeDeltaData(10 until 15, deltaLog)
+        },
+        existingRetryableInStreamSchemaChangeFailure
+      )
+
+      // but should not block after restarting, now in column mapping mode
+      testStream(df)(
+        StartStream(checkpointLocation = checkpointDir.getCanonicalPath),
+        ProcessAllAvailable(),
+        // Sink is reinitialized, only 10-15 are ingested
+        CheckAnswer(
+          (10 until 15).map(i => (i.toString, i.toString, i.toString)): _*)
+      )
+
+      // use a different checkpoint to simulate a clean stream restart
+      val checkpointDir2 = new File(inputDir, "_checkpoint2")
+
+      testStream(df)(
+        StartStream(checkpointLocation = checkpointDir2.getCanonicalPath),
+        ProcessAllAvailable(),
+        // Since the latest schema contain the additional column, it is null for previous batches.
+        // This is fine as it is consistent with the current semantics.
+        CheckAnswer((0 until 10).map(i => (i.toString, i.toString, null)) ++
+          (10 until 15).map(i => (i.toString, i.toString, i.toString)): _*),
+        StopStream
+      )
+    }
+  }
+
+  /**
+   * Setup the test table for testing blocked workflow, this will create a id or name mode table
+   * based on which tests it is run.
+   */
+  protected def setupTestTable(deltaLog: DeltaLog): Unit = {
+    require(columnMappingModeString != NoMapping.name)
+    val tablePath = deltaLog.dataPath.toString
+
+    // For name mapping, we use upgrade to stir things up a little
+    if (columnMappingModeString == NameMapping.name) {
+      // initialize with no column mapping
+      withColumnMappingConf("none") {
+        writeDeltaData(0 until 5, deltaLog, Some(StructType.fromDDL("id string, value string")))
+      }
+
+      // upgrade to name mode
+      sql(
+        s"""
+           |ALTER TABLE delta.`${tablePath}`
+           |SET TBLPROPERTIES (
+           |  ${DeltaConfigs.COLUMN_MAPPING_MODE.key} = "name",
+           |  ${DeltaConfigs.MIN_READER_VERSION.key} = "2",
+           |  ${DeltaConfigs.MIN_WRITER_VERSION.key} = "5")""".stripMargin)
+
+      // write more data post upgrade
+      writeDeltaData(5 until 10, deltaLog)
+    }
+  }
+
+  test("column mapping + streaming: blocking workflow - drop column") {
+    val schemaAlterQuery = "DROP COLUMN value"
+    val schemaRestoreQuery = "ADD COLUMN (value string)"
+
+    withTempDir { inputDir =>
+      val deltaLog = DeltaLog.forTable(spark, new Path(inputDir.toURI))
+      setupTestTable(deltaLog)
+
+      // change schema
+      sql(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` $schemaAlterQuery")
+
+      // write more data post change schema
+      writeDeltaData(10 until 15, deltaLog)
+
+      // Test the two code paths below
+      // Case 1 - Restart did not specify a start version, this will successfully serve the initial
+      //          entire existing data based on the initial snapshot's schema, which is basically
+      //          the stream schema, all schema changes in between are ignored.
+      //          But once the initial snapshot is served, all subsequent batches will fail if
+      //          encountering a schema change during streaming, and all restart effort should fail.
+      val checkpointDir = new File(inputDir, "_checkpoint")
+      val df = dropCDCFields(dsr.load(inputDir.getCanonicalPath))
+
+      testStream(df)(
+        StartStream(checkpointLocation = checkpointDir.getCanonicalPath),
+        ProcessAllAvailable(),
+        // Initial data (pre + post upgrade + post change schema) all served
+        CheckAnswer((0 until 15).map(i => i.toString): _*),
+        Execute { _ =>
+          // write more data in new schema during streaming
+          writeDeltaData(15 until 20, deltaLog)
+        },
+        ProcessAllAvailable(),
+        // can still work because the schema is still compatible
+        CheckAnswer((0 until 20).map(i => i.toString): _*),
+        // But a new schema change would cause stream to fail
+        // Note here we are restoring back the original schema, see next case for how we test
+        // some extra special cases when schemas are reverted.
+        Execute { _ =>
+          sql(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` $schemaRestoreQuery")
+        },
+        // write more data in updated schema again
+        Execute { _ =>
+          writeDeltaData(20 until 25, deltaLog)
+        },
+        // The last batch should not be processed and stream should fail
+        ProcessAllAvailableIgnoreError,
+        // sink data did not change
+        CheckAnswer((0 until 20).map(i => i.toString): _*),
+        // The schemaRestoreQuery for DROP column is ADD column so it fails a more benign error
+        existingRetryableInStreamSchemaChangeFailure
+      )
+
+      val df2 = dropCDCFields(dsr.load(inputDir.getCanonicalPath))
+      // Since the initial snapshot ignores all schema changes, the most recent schema change
+      // is just ADD COLUMN, which can be retried.
+      testStream(df2)(
+        StartStream(checkpointLocation = checkpointDir.getCanonicalPath),
+        // but an additional drop should fail the stream as we are capturing data changes now
+        Execute { _ =>
+          sql(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` $schemaAlterQuery")
+        },
+        ProcessAllAvailableIgnoreError,
+        ExpectInStreamSchemaChangeFailure
+      )
+      // The latest DROP columns blocks the stream.
+      if (isCdcTest) {
+        checkStreamStartBlocked(df2, checkpointDir, ExpectGenericColumnMappingFailure)
+      } else {
+        checkStreamStartBlocked(df2, checkpointDir, ExpectStreamStartInCompatibleSchemaFailure)
+      }
+
+      // Case 2 - Specifically we use startingVersion=0 to simulate serving the entire table's data
+      //          in a streaming fashion, ignoring the initialSnapshot.
+      //          Here we test the special case when the latest schema is "restored".
+      val checkpointDir2 = new File(inputDir, "_checkpoint2")
+      val dfStartAtZero = dropCDCFields(dsr
+        .option(DeltaOptions.STARTING_VERSION_OPTION, "0")
+        .load(inputDir.getCanonicalPath))
+
+      if (isCdcTest) {
+        checkStreamStartBlocked(dfStartAtZero, checkpointDir2, ExpectGenericColumnMappingFailure)
+      } else {
+        // In the case when we drop and add a column back
+        // the restart should still fail directly because all the historical batches with the same
+        // old logical name now will have a different physical name we would have data loss
+
+        // lets add back the column we just dropped before
+        sql(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` $schemaRestoreQuery")
+        assert(DeltaLog.forTable(spark, inputDir.getCanonicalPath).snapshot.schema.size == 2)
+
+        // restart should block right away
+        checkStreamStartBlocked(
+          dfStartAtZero, checkpointDir, ExpectStreamStartInCompatibleSchemaFailure)
+      }
+    }
+  }
+
+  test("column mapping + streaming: blocking workflow - rename column") {
+    val schemaAlterQuery = "RENAME COLUMN value TO value2"
+    val schemaRestoreQuery = "RENAME COLUMN value2 TO value"
+
+    withTempDir { inputDir =>
+      val deltaLog = DeltaLog.forTable(spark, new Path(inputDir.toURI))
+      setupTestTable(deltaLog)
+
+      // change schema
+      sql(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` $schemaAlterQuery")
+
+      // write more data post change schema
+      writeDeltaData(10 until 15, deltaLog)
+
+      // Test the two code paths below
+      // Case 1 - Restart did not specify a start version, this will successfully serve the initial
+      //          entire existing data based on the initial snapshot's schema, which is basically
+      //          the stream schema, all schema changes in between are ignored.
+      //          But once the initial snapshot is served, all subsequent batches will fail if
+      //          encountering a schema change during streaming, and all restart effort should fail.
+      val checkpointDir = new File(inputDir, "_checkpoint")
+      val df = dropCDCFields(dsr.load(inputDir.getCanonicalPath))
+
+      testStream(df)(
+        StartStream(checkpointLocation = checkpointDir.getCanonicalPath),
+        ProcessAllAvailable(),
+        // Initial data (pre + post upgrade + post change schema) all served
+        CheckAnswer((0 until 15).map(i => (i.toString, i.toString)): _*),
+        Execute { _ =>
+          // write more data in new schema during streaming
+          writeDeltaData(15 until 20, deltaLog)
+        },
+        ProcessAllAvailable(),
+        // can still work because the schema is still compatible
+        CheckAnswer((0 until 20).map(i => (i.toString, i.toString)): _*),
+        // But a new schema change would cause stream to fail
+        // Note here we are restoring back the original schema, see next case for how we test
+        // some extra special cases when schemas are reverted.
+        Execute { _ =>
+          sql(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` $schemaRestoreQuery")
+        },
+        // write more data in updated schema again
+        Execute { _ =>
+          writeDeltaData(20 until 25, deltaLog)
+        },
+        // the last batch should not be processed and stream should fail
+        ProcessAllAvailableIgnoreError,
+        // sink data did not change
+        CheckAnswer((0 until 20).map(i => (i.toString, i.toString)): _*),
+        // detected schema change
+        ExpectInStreamSchemaChangeFailure
+      )
+
+      val df2 = dropCDCFields(dsr.load(inputDir.getCanonicalPath))
+      // Renamed columns could not proceed after restore because its schema change is not read
+      // compatible at all.
+      checkStreamStartBlocked(df2, checkpointDir, ExpectStreamStartInCompatibleSchemaFailure)
+
+      // Case 2 - Specifically we use startingVersion=0 to simulate serving the entire table's data
+      //          in a streaming fashion, ignoring the initialSnapshot.
+      //          Here we test the special case when the latest schema is "restored".
+      if (isCdcTest) {
+        val checkpointDir2 = new File(inputDir, "_checkpoint2")
+        val dfStartAtZero = dropCDCFields(dsr
+          .option(DeltaOptions.STARTING_VERSION_OPTION, "0")
+          .load(inputDir.getCanonicalPath))
+        checkStreamStartBlocked(dfStartAtZero, checkpointDir2, ExpectGenericColumnMappingFailure)
+      } else {
+        // In the trickier case when we rename a column and rename back, we could not
+        // immediately detect the schema incompatibility at stream start, so we will move on.
+        // This is fine because the batches served will be compatible until the in-stream check
+        // finds another schema change action and fail.
+        val checkpointDir2 = new File(inputDir, s"_checkpoint_${UUID.randomUUID.toString}")
+        val dfStartAtZero = dropCDCFields(dsr
+          .option(DeltaOptions.STARTING_VERSION_OPTION, "0")
+          .load(inputDir.getCanonicalPath))
+        testStream(dfStartAtZero)(
+          // The stream could not move past version 10, because batches after which
+          // will be incompatible with the latest schema.
+          StartStream(checkpointLocation = checkpointDir2.getCanonicalPath),
+          ProcessAllAvailableIgnoreError,
+          AssertOnQuery { q =>
+            val latestLoadedVersion = JsonUtils.fromJson[Map[String, Any]](
+              q.committedOffsets.values.head.json()
+            ).apply("reservoirVersion").asInstanceOf[Number].longValue()
+            latestLoadedVersion <= 10
+          },
+          ExpectInStreamSchemaChangeFailure
+        )
+        // restart won't move forward either
+        val df2 = dropCDCFields(dsr.load(inputDir.getCanonicalPath))
+        checkStreamStartBlocked(df2, checkpointDir2, ExpectInStreamSchemaChangeFailure)
+      }
+    }
+  }
+}
+
+
+class DeltaSourceNameColumnMappingSuite extends DeltaSourceSuite
+  with ColumnMappingStreamingWorkflowSuiteBase
+  with DeltaColumnMappingEnableNameMode {
+
+  override protected def isCdcTest: Boolean = false
+
+  override protected def runOnlyTests = Seq(
+    "basic",
+    "maxBytesPerTrigger: metadata checkpoint",
+    "maxFilesPerTrigger: metadata checkpoint",
+    "allow to change schema before starting a streaming query",
+
+    // streaming blocking semantics test
+    "deltaLog snapshot should not be updated outside of the stream",
+    "column mapping + streaming - allowed workflows - column addition",
+    "column mapping + streaming - allowed workflows - upgrade to name mode",
+    "column mapping + streaming: blocking workflow - drop column",
+    "column mapping + streaming: blocking workflow - rename column"
+  )
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -41,7 +41,9 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.{ManualClock, Utils}
 
-class DeltaSourceSuite extends DeltaSourceSuiteBase with DeltaSQLCommandTest {
+class DeltaSourceSuite extends DeltaSourceSuiteBase
+  with DeltaColumnMappingTestUtils
+  with DeltaSQLCommandTest {
 
   import testImplicits._
 
@@ -1182,11 +1184,15 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase with DeltaSQLCommandTest {
       }.getMessage.contains("Cannot time travel Delta table to version 0"))
 
       // Can start from version 1 even if it's not recreatable
-      withTempView("startingVersion_test") {
-        testStartingVersion(1L)
-        checkAnswer(
-          spark.table("startingVersion_test"),
-          (10 until 20).map(_.toLong).toDF())
+      // TODO: currently we would error out if we couldn't construct the snapshot to check column
+      //  mapping enable tables. Unblock this once we roll out the proper semantics.
+      withStreamingReadOnColumnMappingTableEnabled {
+        withTempView("startingVersion_test") {
+          testStartingVersion(1L)
+          checkAnswer(
+            spark.table("startingVersion_test"),
+            (10 until 20).map(_.toLong).toDF())
+        }
       }
     }
   }
@@ -1242,19 +1248,23 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase with DeltaSQLCommandTest {
 
       // Although version 1 has been deleted, restarting the query should still work as we have
       // processed files in version 1. In other words, query restart should ignore "startingVersion"
-      testStartingVersion(1L)
-      checkAnswer(
-        spark.read.format("delta").load(outputDir.getCanonicalPath),
-        ((10 until 30) ++ (40 until 50)).map(_.toLong).toDF()) // the gap caused by "alter table"
+      // TODO: currently we would error out if we couldn't construct the snapshot to check column
+      //  mapping enable tables. Unblock this once we roll out the proper semantics.
+      withStreamingReadOnColumnMappingTableEnabled {
+        testStartingVersion(1L)
+        checkAnswer(
+          spark.read.format("delta").load(outputDir.getCanonicalPath),
+          ((10 until 30) ++ (40 until 50)).map(_.toLong).toDF()) // the gap caused by "alter table"
 
-      // But if we start a new query, it should fail.
-      val newCheckpointDir = Utils.createTempDir()
-      try {
-        assert(intercept[StreamingQueryException] {
-          testStartingVersion(1L, newCheckpointDir.getCanonicalPath)
-        }.getMessage.contains("[2, 4]"))
-      } finally {
-        Utils.deleteRecursively(newCheckpointDir)
+        // But if we start a new query, it should fail.
+        val newCheckpointDir = Utils.createTempDir()
+        try {
+          assert(intercept[StreamingQueryException] {
+            testStartingVersion(1L, newCheckpointDir.getCanonicalPath)
+          }.getMessage.contains("[2, 4]"))
+        } finally {
+          Utils.deleteRecursively(newCheckpointDir)
+        }
       }
     }
   }
@@ -1329,11 +1339,15 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase with DeltaSQLCommandTest {
       new File(FileNames.deltaFile(deltaLog.logPath, 0).toUri).delete()
 
       // Can start from version 1 even if it's not recreatable
-      withTempView("startingTimestamp_test") {
-        testStartingTimestamp("2020-07-14")
-        checkAnswer(
-          spark.table("startingTimestamp_test"),
-          (10 until 20).map(_.toLong).toDF())
+      // TODO: currently we would error out if we couldn't construct the snapshot to check column
+      //  mapping enable tables. Unblock this once we roll out the proper semantics.
+      withStreamingReadOnColumnMappingTableEnabled {
+        withTempView("startingTimestamp_test") {
+          testStartingTimestamp("2020-07-14")
+          checkAnswer(
+            spark.table("startingTimestamp_test"),
+            (10 until 20).map(_.toLong).toDF())
+        }
       }
     }
   }
@@ -1409,80 +1423,6 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase with DeltaSQLCommandTest {
         } finally {
           q.stop()
         }
-      }
-    }
-  }
-
-  test(s"block streaming reads from a column mapping enabled table") {
-    withTempDir { inputDir =>
-      val path = inputDir.getCanonicalPath
-      withTable("t1") {
-        sql(
-          s"""
-             |CREATE TABLE t1 (value STRING) USING DELTA
-             |TBLPROPERTIES(
-             |${DeltaConfigs.COLUMN_MAPPING_MODE.key} = 'name',
-             |${DeltaConfigs.MIN_READER_VERSION.key} = '2',
-             |${DeltaConfigs.MIN_WRITER_VERSION.key} = '5'
-             |) LOCATION '$path'
-             |""".stripMargin)
-
-        Seq("keep1", "keep2", "keep3", "drop1").toDF("value")
-            .write.format("delta").mode("append").saveAsTable("t1")
-
-        Seq(true, false).foreach { isStartVersion0 =>
-          withClue(s"isStartVersion0 = $isStartVersion0") {
-            var dfr = spark.readStream.format("delta")
-            if (isStartVersion0) {
-              // By default the stream starts at the latest version in the table
-              dfr = dfr.option("startingVersion", "0")
-            }
-            val df = dfr.load(path).filter($"value" contains "keep")
-
-            val ex = intercept[Exception] {
-              testStream(df)(ProcessAllAvailable())
-            }
-            assert(ex.getMessage contains
-              "Streaming reads from a Delta table with column mapping enabled are not supported.")
-          }
-        }
-      }
-    }
-  }
-
-  test("block streaming reads after a table is upgraded with column mapping") {
-    withTempDir { inputDir =>
-      val path = inputDir.getCanonicalPath
-      withTable("t1") {
-        sql(s"CREATE TABLE t1 (value STRING) USING DELTA LOCATION '$path'")
-
-        Seq("keep1", "keep2", "keep3", "drop1").toDF("value")
-            .write.format("delta").mode("append").saveAsTable("t1")
-
-        val df = spark.readStream
-            .format("delta")
-            .load(path)
-            .filter($"value" contains "keep")
-
-        val ex = intercept[Exception] {
-          testStream(df)(
-            ProcessAllAvailable(),
-            Execute { _ =>
-              sql(
-                s"""
-                   |ALTER TABLE t1
-                   |SET TBLPROPERTIES (
-                   |  '${DeltaConfigs.MIN_READER_VERSION.key}' = '2',
-                   |  '${DeltaConfigs.MIN_WRITER_VERSION.key}' = '5',
-                   |  '${DeltaConfigs.COLUMN_MAPPING_MODE.key}'='name')
-                   |""".stripMargin)
-            },
-            AddToReservoir(inputDir, Seq("keep7", "drop2").toDF()),
-            ProcessAllAvailable()
-          )
-        }
-        assert(ex.getMessage contains
-          "Streaming reads from a Delta table with column mapping enabled are not supported.")
       }
     }
   }
@@ -1939,132 +1879,6 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase with DeltaSQLCommandTest {
     }
   }
 }
-
-abstract class DeltaSourceColumnMappingSuiteBase extends DeltaSourceSuite {
-  import testImplicits._
-
-  testQuietly("drop column from source disallowed by MicroBatchExecution") {
-    withSQLConf(DeltaSQLConf.DELTA_ALTER_TABLE_DROP_COLUMN_ENABLED.key -> "true") {
-      withTempDir { inputDir =>
-        val deltaLog = DeltaLog.forTable(spark, new Path(inputDir.toURI))
-        (0 until 5).foreach { i =>
-          val v = Seq((i.toString, i.toString)).toDF("id", "value")
-          v.write.mode("append").format("delta").save(deltaLog.dataPath.toString)
-        }
-
-        val checkpointDir = new File(inputDir, "_checkpoint")
-
-        // reinitialize stream after restart
-        def df: DataFrame = spark.readStream
-          .format("delta")
-          .load(inputDir.getCanonicalPath)
-
-        testStream(df)(
-          StartStream(checkpointLocation = checkpointDir.getCanonicalPath),
-          ProcessAllAvailable(),
-          CheckAnswerRows((0 until 5).map(i => Row(i.toString, i.toString)), false, false),
-          Execute { _ =>
-            sql(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` DROP COLUMN value")
-          },
-          Execute { _ =>
-            // write more data
-            (5 until 10).foreach { i =>
-              val v = Seq(i.toString).toDF("id")
-              v.write.mode("append").format("delta").save(deltaLog.dataPath.toString)
-            }
-          },
-          // should have another batch with diff schema and should fail
-          ExpectFailure[SparkException] { t =>
-            assert(t.asInstanceOf[SparkThrowable].getErrorClass === "INTERNAL_ERROR")
-            assert(t.getCause.getMessage.contains("Invalid batch"))
-          }
-        )
-
-        // Restart the stream from the same checkpoint should pick up the new schema
-        // Since `testStream` creates a new sink every time, the rows for the new data will
-        // be refreshed as well.
-        testStream(df)(
-          StartStream(checkpointLocation = checkpointDir.getCanonicalPath),
-          ProcessAllAvailable(),
-          // 5-10 is recovered due to the previous failure, and is the only data in the sink
-          // note they only have one item, which is the new schema
-          CheckAnswerRows((5 until 10).map(i => Row(i.toString)), false, false),
-          Execute { _ =>
-            // write more data
-            (10 until 15)
-              .map(i => i.toString)
-              .toDF("id")
-              .write
-              .format("delta")
-              .mode("append")
-              .save(deltaLog.dataPath.toString)
-          },
-          ProcessAllAvailable(),
-          CheckAnswerRows((5 until 15).map(i => Row(i.toString)), false, false)
-        )
-      }
-    }
-  }
-
-  testQuietly("rename a column disallowed by DeltaSource's schema check") {
-    withTempDir { inputDir =>
-      val deltaLog = DeltaLog.forTable(spark, new Path(inputDir.toURI))
-      (0 until 5).foreach { i =>
-        val v = Seq((i.toString, i.toString)).toDF("id", "value")
-        v.write.mode("append").format("delta").save(deltaLog.dataPath.toString)
-      }
-
-      val checkpointDir = new File(inputDir, "_checkpoint")
-
-      // reinitialize stream after restart
-      def df: DataFrame = spark.readStream
-        .format("delta")
-        .load(inputDir.getCanonicalPath)
-
-      testStream(df)(
-        StartStream(checkpointLocation = checkpointDir.getCanonicalPath),
-        ProcessAllAvailable(),
-        CheckAnswer((0 until 5).map(i => (i.toString, i.toString)): _*),
-        Execute { _ =>
-          sql(s"ALTER TABLE delta.`${inputDir.getCanonicalPath}` " +
-            s"RENAME COLUMN value TO new_value")
-        },
-        Execute { _ =>
-          (5 until 10).foreach { i =>
-            val v = Seq((i.toString, i.toString)).toDF("id", "new_value")
-            v.write.mode("append").format("delta").save(deltaLog.dataPath.toString)
-          }
-        },
-        ExpectFailure[IllegalStateException](t =>
-          assert(t.getMessage.contains("Detected schema change")))
-      )
-
-      // Restart the stream from the same checkpoint should pick up the new schema
-      // Since `testStream` creates a new sink every time, the rows for the new data will
-      // be refreshed as well.
-      testStream(df)(
-        StartStream(checkpointLocation = checkpointDir.getCanonicalPath),
-        ProcessAllAvailable(),
-        // 5-10 is recovered due to the previous failure, and is the only data in the sink
-        CheckAnswerRows((5 until 10).map(i => Row(i.toString, i.toString)), false, false),
-        Execute { _ =>
-          // write more data
-          (10 until 15)
-            .map(i => (i.toString, i.toString))
-            .toDF("id", "new_value")
-            .write
-            .format("delta")
-            .mode("append")
-            .save(deltaLog.dataPath.toString)
-        },
-        ProcessAllAvailable(),
-        CheckAnswerRows((5 until 15).map(i => Row(i.toString, i.toString)), false, false)
-      )
-    }
-  }
-
-}
-
 
 /**
  * A FileSystem implementation that returns monotonically increasing timestamps for file creation.


### PR DESCRIPTION
## Description
Resolves https://github.com/delta-io/delta/issues/1357

As streaming uses the latest schema to read historical data batches and column mapping schema changes (e.g. rename/drop column) can cause latest schema to diverge, we decided to temporarily completely block streaming read on column mapping tables before.

As a close follow up in this PR, we think it is at least possible to enable the following use cases:

Read from a column mapping table without rename or drop column operations.
Upgrade to column mapping tables.
Existing compatible schema change operations such as ADD COLUMN.

## How was this patch tested?
New unit tests.

## Does this PR introduce _any_ user-facing changes?
No

