### PR TITLE
Remove obsolete dependency on org.codehaus.jackson

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,10 +56,6 @@ lazy val core = (project in file("core"))
       "org.apache.spark" %% "spark-core" % sparkVersion % "provided",
       "org.apache.spark" %% "spark-catalyst" % sparkVersion % "provided",
 
-      // spark-sql 3.2.0's parquet-hadoop 1.12.1 dependency no longer includes org.codehaus.jackson
-      // as a dependency, so we include it here instead.
-      "org.codehaus.jackson" % "jackson-core-asl" % "1.9.13",
-
       // Test deps
       "org.scalatest" %% "scalatest" % "3.2.9" % "test",
       "org.scalatestplus" %% "scalacheck-1-15" % "3.2.9.0" % "test",

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -33,7 +33,6 @@ import com.fasterxml.jackson.annotation._
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind._
 import com.fasterxml.jackson.databind.annotation.{JsonDeserialize, JsonSerialize}
-import org.codehaus.jackson.annotate.JsonRawValue
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Column, DataFrame, Dataset, Encoder, SparkSession}


### PR DESCRIPTION
`org.codehaus.jackson.annotate.JsonRawValue` is a no-op today. Remove it and dependency on `org.codehaus.jackson:jackson-core-asl` can be simply dropped as well.

Signed-off-by: Patrick Marx <patrick.marx@1und1.de>