### PR TITLE
Fix 'since' for new DeltaTable.forPath APIs

### DIFF
--- a/core/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -661,7 +661,7 @@ object DeltaTable {
    * path is invalid (i.e. either no table exists or an existing table is not a Delta table),
    * it throws a `not a Delta table` error.
    *
-   * @param hadoopConf: Hadoop configuration starting with "fs." or "dfs." will be picked up
+   * @param hadoopConf Hadoop configuration starting with "fs." or "dfs." will be picked up
    *                    by `DeltaTable` to access the file system when executing queries.
    *                    Other configurations will not be allowed.
    *
@@ -703,7 +703,7 @@ object DeltaTable {
   * path, If the given path is invalid (i.e. either no table exists or an existing table is not a
   * Delta table), it throws a `not a Delta table` error.
   *
-  * @param hadoopConf: Hadoop configuration starting with "fs." or "dfs." will be picked up
+  * @param hadoopConf Hadoop configuration starting with "fs." or "dfs." will be picked up
   *                    by `DeltaTable` to access the file system when executing queries.
   *                    Other configurations will be ignored.
   *

--- a/core/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -672,7 +672,7 @@ object DeltaTable {
    *   )
    *   DeltaTable.forPath(spark, "/path/to/table", hadoopConf)
    * }}}
-   * @since 2.1.0
+   * @since 2.2.0
    */
   def forPath(
       sparkSession: SparkSession,
@@ -714,7 +714,7 @@ object DeltaTable {
   *   )
   *   DeltaTable.forPath(spark, "/path/to/table", hadoopConf)
   * }}}
-  * @since 2.1.0
+  * @since 2.2.0
   */
   def forPath(
       sparkSession: SparkSession,


### PR DESCRIPTION
## Description

New `DeltaTable.forPath` APIs missed `2.1.0` release. Changed `since` to `2.2.0`.
