### PR TITLE
Add option to overwrite on first batch of stream

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -85,6 +85,13 @@ trait DeltaWriteOptionsImpl extends DeltaOptionParser {
   }
 
   /**
+   * Whether we should overwrite the Delta table on the first batch of a stream.
+   */
+  def overwriteOnFirstBatch: Boolean = {
+    options.get(STREAMING_OVERWRITE).exists(toBoolean(_, STREAMING_OVERWRITE))
+  }
+
+  /**
    * Whether to write new data to the table or just rearrange data that is already
    * part of the table. This option declares that the data being written by this job
    * does not change any data in the table and merely rearranges existing data.
@@ -219,6 +226,8 @@ object DeltaOptions extends DeltaLogging {
   val MERGE_SCHEMA_OPTION = "mergeSchema"
   /** An option to allow overwriting schema and partitioning during an overwrite write operation. */
   val OVERWRITE_SCHEMA_OPTION = "overwriteSchema"
+  /** An option to make a stream overwrite any existing data on the frist batch. */
+  val STREAMING_OVERWRITE = "streamingOverwrite"
   /** An option to specify user-defined metadata in commitInfo */
   val USER_METADATA_OPTION = "userMetadata"
 
@@ -256,6 +265,7 @@ object DeltaOptions extends DeltaLogging {
     MERGE_SCHEMA_OPTION,
     EXCLUDE_REGEX_OPTION,
     OVERWRITE_SCHEMA_OPTION,
+    STREAMING_OVERWRITE,
     USER_METADATA_OPTION,
     PARTITION_OVERWRITE_MODE_OPTION,
     MAX_FILES_PER_TRIGGER_OPTION,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Resolves https://github.com/delta-io/delta/issues/1346

Adds the option to overwrite a table on the first batch of a new stream. See the issue for the use case. I wasn't sure what to name the config so definitely open to other options if this is an acceptable addition.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
New UTs

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Adds a new option for streaming writes.
