### PR TITLE
Upgrade Scala to 2.12.15

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        scala: [2.12.14, 2.13.5]
+        scala: [2.12.15, 2.13.5]
     env:
       SCALA_VERSION: ${{ matrix.scala }}
     steps:

--- a/benchmarks/build.sbt
+++ b/benchmarks/build.sbt
@@ -15,7 +15,7 @@
  */
 
 name := "benchmarks"
-scalaVersion := "2.12.14"
+scalaVersion := "2.12.15"
 
 lazy val root = (project in file("."))
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ import java.nio.file.Files
 import TestParallelization._
 
 val sparkVersion = "3.3.0"
-val scala212 = "2.12.14"
+val scala212 = "2.12.15"
 val scala213 = "2.13.5"
 val default_scala_version = scala212
 val all_scala_versions = Seq(scala212, scala213)


### PR DESCRIPTION
## Description

Upgrade Scala to 2.12.15 to fix `java.lang.IllegalArgumentException: too many arguments` if running on JDK 17:
```
[info] Caused by: java.lang.reflect.InvocationTargetException
[info] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[info] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
[info] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[info] 	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
[info] 	at java.base/java.lang.invoke.SerializedLambda.readResolve(SerializedLambda.java:278)
[info] 	... 71 more
[info] Caused by: java.lang.IllegalArgumentException: too many arguments
[info] 	at java.base/java.lang.invoke.LambdaMetafactory.altMetafactory(LambdaMetafactory.java:511)
[info] 	at scala.runtime.LambdaDeserializer$.makeCallSite$1(LambdaDeserializer.scala:105)
[info] 	at scala.runtime.LambdaDeserializer$.deserializeLambda(LambdaDeserializer.scala:114)
[info] 	at scala.runtime.LambdaDeserialize.deserializeLambda(LambdaDeserialize.java:38)
[info] 	at org.apache.spark.sql.execution.LocalTableScanExec.$deserializeLambda$(LocalTableScanExec.scala)
[info] 	... 76 more
```

## How was this patch tested?

Existing test.

## Does this PR introduce _any_ user-facing changes?

No.
