### PR TITLE
Add Java 17 build test to GitHub action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,15 +6,16 @@ jobs:
     strategy:
       matrix:
         scala: [2.12.15, 2.13.5]
+        java: [ '8', '17' ]
     env:
       SCALA_VERSION: ${{ matrix.scala }}
     steps:
       - uses: actions/checkout@v2
-      - name: install java
+      - name: install java ${{ matrix.java }}
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: '8'
+          java-version: ${{ matrix.java }}
       - name: Cache Scala, SBT
         uses: actions/cache@v2
         with:

--- a/build.sbt
+++ b/build.sbt
@@ -35,6 +35,22 @@ lazy val commonSettings = Seq(
   fork := true,
   scalacOptions ++= Seq("-target:jvm-1.8", "-Ywarn-unused:imports"),
   javacOptions ++= Seq("-source", "1.8"),
+  javaOptions ++= Seq(
+    "-XX:+IgnoreUnrecognizedVMOptions",
+    "--add-opens=java.base/java.lang=ALL-UNNAMED",
+    "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
+    "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED",
+    "--add-opens=java.base/java.io=ALL-UNNAMED",
+    "--add-opens=java.base/java.net=ALL-UNNAMED",
+    "--add-opens=java.base/java.nio=ALL-UNNAMED",
+    "--add-opens=java.base/java.util=ALL-UNNAMED",
+    "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED",
+    "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED",
+    "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+    "--add-opens=java.base/sun.nio.cs=ALL-UNNAMED",
+    "--add-opens=java.base/sun.security.action=ALL-UNNAMED",
+    "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED"
+  ),
   // -target cannot be passed as a parameter to javadoc. See https://github.com/sbt/sbt/issues/355
   Compile / compile / javacOptions ++= Seq("-target", "1.8")
 )

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -143,7 +143,8 @@ trait DeltaErrorsSuiteBase
     testUrls()
   }
 
-  test("test DeltaErrors methods") {
+  // Split to multiple tests to avoid JDK issue if running on JDK 17.
+  test("test DeltaErrors methods part 1") {
     {
       val e = intercept[DeltaIllegalStateException] {
         throw DeltaErrors.tableAlreadyContainsCDCColumns(Seq("col1", "col2"))
@@ -1693,6 +1694,9 @@ trait DeltaErrorsSuiteBase
       assert(e.getMessage ==
         "Multi-column In predicates are not supported in the dummyOp condition.")
     }
+  }
+
+  test("test DeltaErrors methods part 2") {
     {
       val e = intercept[DeltaAnalysisException] {
         throw DeltaErrors.newNotNullViolated(10L, "table1", UnresolvedAttribute("col1"))


### PR DESCRIPTION
## Description

We plan to run Spark on JDK 17 due to the performance issue:
https://issues.apache.org/jira/browse/SPARK-40303
https://bugs.openjdk.org/browse/JDK-8159720

Spark's dependencies could run on JDK 17 as well.

This PR add Java 17 build test to GitHub action.

## How was this patch tested?

It is test only patch.

## Does this PR introduce _any_ user-facing changes?

No.
