### PR TITLE
Fix bug on merge command when DELTA_COLLECT_STATS is disabled

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -255,8 +255,6 @@ sealed trait FileAction extends Action {
   @JsonIgnore
   def numLogicalRecords: Option[Long]
   @JsonIgnore
-  def getNumLogicalRecords: Long = numLogicalRecords.getOrElse(0L)
-  @JsonIgnore
   val partitionValues: Map[String, String]
   @JsonIgnore
   def getFileSize: Long

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
@@ -546,7 +546,7 @@ case class MergeIntoCommand(
         // This is hard to catch before the write without collecting the DF ahead of time. Instead,
         // we can just accept only the AddFiles that actually add rows or
         // when we don't know the number of records
-        case a: AddFile => a.numLogicalRecords.getOrElse(1L) > 0
+        case a: AddFile => a.numLogicalRecords.forall(_ > 0)
         case _ => true
       }
 
@@ -832,7 +832,7 @@ case class MergeIntoCommand(
         // we can write out an empty outputDF. This is hard to catch before the write without
         // collecting the DF ahead of time. Instead, we can just accept only the AddFiles that
         // actually add rows or when we don't know the number of records
-        case a: AddFile => a.numLogicalRecords.getOrElse(1L) > 0
+        case a: AddFile => a.numLogicalRecords.forall(_ > 0)
         case _ => true
       }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
@@ -544,8 +544,9 @@ case class MergeIntoCommand(
         // In some cases (e.g. insert-only when all rows are matched, insert-only with an empty
         // source, insert-only with an unsatisfied condition) we can write out an empty insertDf.
         // This is hard to catch before the write without collecting the DF ahead of time. Instead,
-        // we can just accept only the AddFiles that actually add rows.
-        case a: AddFile => a.getNumLogicalRecords > 0
+        // we can just accept only the AddFiles that actually add rows or
+        // when we don't know the number of records
+        case a: AddFile => a.numLogicalRecords.getOrElse(1L) > 0
         case _ => true
       }
 
@@ -830,8 +831,8 @@ case class MergeIntoCommand(
         // In some cases (e.g. delete with empty source, or empty target, or on disjoint tables)
         // we can write out an empty outputDF. This is hard to catch before the write without
         // collecting the DF ahead of time. Instead, we can just accept only the AddFiles that
-        // actually add rows.
-        case a: AddFile => a.getNumLogicalRecords > 0
+        // actually add rows or when we don't know the number of records
+        case a: AddFile => a.numLogicalRecords.getOrElse(1L) > 0
         case _ => true
       }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
@@ -35,28 +35,46 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase  with DeltaSQLCommandTest
   import testImplicits._
 
   test("basic scala API") {
-    Seq("true", "false").foreach { flag =>
-      withSQLConf((DeltaSQLConf.DELTA_COLLECT_STATS.key, flag)) {
-        withTable("source") {
-          append(Seq((1, 10), (2, 20)).toDF("key1", "value1"), Nil) // target
-          val source = Seq((1, 100), (3, 30)).toDF("key2", "value2") // source
-          val targetTable = io.delta.tables.DeltaTable.forPath(spark, tempPath)
+    withTable("source") {
+      append(Seq((1, 10), (2, 20)).toDF("key1", "value1"), Nil)  // target
+      val source = Seq((1, 100), (3, 30)).toDF("key2", "value2")  // source
 
-          targetTable
-            .merge(source, "key1 = key2")
-            .whenMatched().updateExpr(Map("key1" -> "key2", "value1" -> "value2"))
-            .whenNotMatched().insertExpr(Map("key1" -> "key2", "value1" -> "value2"))
-            .execute()
+      io.delta.tables.DeltaTable.forPath(spark, tempPath)
+        .merge(source, "key1 = key2")
+        .whenMatched().updateExpr(Map("key1" -> "key2", "value1" -> "value2"))
+        .whenNotMatched().insertExpr(Map("key1" -> "key2", "value1" -> "value2"))
+        .execute()
 
-          checkAnswer(
-            readDeltaTable(tempPath),
-            Row(1, 100) :: // Update
-              Row(2, 20) :: // No change
-              Row(3, 30) :: // Insert
-              Nil)
+      checkAnswer(
+        readDeltaTable(tempPath),
+        Row(1, 100) ::    // Update
+          Row(2, 20) ::     // No change
+          Row(3, 30) ::     // Insert
+          Nil)
+    }
+  }
 
-          targetTable.delete()
-        }
+
+  // test created to validate a fix for a bug where merge command was
+  // resulting in a empty target table when statistics collection is disabled
+  test("basic scala API - without stats") {
+    withSQLConf((DeltaSQLConf.DELTA_COLLECT_STATS.key, "false")) {
+      withTable("source") {
+        append(Seq((1, 10), (2, 20)).toDF("key1", "value1"), Nil) // target
+        val source = Seq((1, 100), (3, 30)).toDF("key2", "value2") // source
+
+        io.delta.tables.DeltaTable.forPath(spark, tempPath)
+          .merge(source, "key1 = key2")
+          .whenMatched().updateExpr(Map("key1" -> "key2", "value1" -> "value2"))
+          .whenNotMatched().insertExpr(Map("key1" -> "key2", "value1" -> "value2"))
+          .execute()
+
+        checkAnswer(
+          readDeltaTable(tempPath),
+          Row(1, 100) :: // Update
+            Row(2, 20) :: // No change
+            Row(3, 30) :: // Insert
+            Nil)
       }
     }
   }


### PR DESCRIPTION
## Description
When Delta stats is disabled the merge command removes all delta files and don't add any, resulting in an empty table.

## How was this patch tested?

Add a new test to run without statistics.

## Does this PR introduce _any_ user-facing changes?
No
