### PR TITLE
Cache snapshot state rdd immediately

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/util/StateCache.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/util/StateCache.scala
@@ -59,6 +59,10 @@ trait StateCache extends DeltaLogging {
         }
         rdd.setName(name)
         rdd.persist(storageLevel)
+        if (!storageLevel.equals(StorageLevel.NONE)) {
+          // Cache rdd now to avoid OOM of snapshot aggregation query.
+          rdd.count()
+        }
         cached += rdd
         val dsCache = new DatasetRefCache(() => {
           Dataset.ofRows(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Cache Snapshot stateDS immediately to avoid OOM while calculating computedState.

When creating a new snapshot, there is aggregate function for computedState that stateDS is accessed for the first time.
https://github.com/delta-io/delta/blob/a109bab61407e7c02fa551291f81cf12a58f1f6a/core/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala#L212

Since it's not cached in memory yet, the query is executed inefficiently:

![image](https://user-images.githubusercontent.com/51077614/194205324-53d8232e-25eb-4f12-bc54-5f8d8e6b0abd.png)
<img width="355" alt="image" src="https://user-images.githubusercontent.com/51077614/194205459-8825ac2b-c0f7-4b80-8342-59855da3c7e3.png">

That aggregate stage emits all rows not just partial results. All the rows are consumed by single partition:

<img width="355" alt="image" src="https://user-images.githubusercontent.com/51077614/194206258-3c1c0878-fe55-4637-a21c-aa02988110ec.png">

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, fixes a bug