### PR TITLE
Fix Delta source initialization issue when using AvailableNow

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -620,6 +620,24 @@ trait DeltaSQLConfBase {
       .longConf
       .createWithDefault(128L * 1024 * 1024) // 128MB
 
+  val STREAMING_OFFSET_VALIDATION =
+    buildConf("streaming.offsetValidation.enabled")
+      .internal()
+      .doc("Whether to validate whether delta streaming source generates a smaller offset and " +
+        "moves backward.")
+      .booleanConf
+      .createWithDefault(true)
+
+  val STREAMING_AVAILABLE_NOW_OFFSET_INITIALIZATION_FIX =
+    buildConf("streaming.availableNow.offsetInitializationFix.enabled")
+      .internal()
+      .doc(
+        """Whether to enable the offset initializaion fix for AvailableNow.
+          |This is just a flag to provide the mitigation option if the fix introduces
+          |any bugs.""".stripMargin)
+      .booleanConf
+      .createWithDefault(true)
+
   val LOAD_FILE_SYSTEM_CONFIGS_FROM_DATAFRAME_OPTIONS =
     buildConf("loadFileSystemConfigsFromDataFrameOptions")
       .internal()

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.delta
 import java.io.{File, FileInputStream, OutputStream}
 import java.net.URI
 import java.util.UUID
+import java.util.concurrent.TimeoutException
 
 import scala.concurrent.duration._
 import scala.language.implicitConversions
@@ -1936,6 +1937,135 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase with DeltaSQLCommandTest {
       } finally {
         q.stop()
       }
+    }
+  }
+
+  test("DeltaSourceOffset.validateOffsets") {
+    DeltaSourceOffset.validateOffsets(
+      previousOffset = DeltaSourceOffset(
+        sourceVersion = 1,
+        reservoirId = "foo",
+        reservoirVersion = 4,
+        index = 10,
+        isStartingVersion = false),
+      currentOffset = DeltaSourceOffset(
+        sourceVersion = 1,
+        reservoirId = "foo",
+        reservoirVersion = 4,
+        index = 10,
+        isStartingVersion = false)
+    )
+    DeltaSourceOffset.validateOffsets(
+      previousOffset = DeltaSourceOffset(
+        sourceVersion = 1,
+        reservoirId = "foo",
+        reservoirVersion = 4,
+        index = 10,
+        isStartingVersion = false),
+      currentOffset = DeltaSourceOffset(
+        sourceVersion = 1,
+        reservoirId = "foo",
+        reservoirVersion = 5,
+        index = 1,
+        isStartingVersion = false)
+    )
+
+    assert(intercept[IllegalStateException] {
+      DeltaSourceOffset.validateOffsets(
+        previousOffset = DeltaSourceOffset(
+          sourceVersion = 1,
+          reservoirId = "foo",
+          reservoirVersion = 4,
+          index = 10,
+          isStartingVersion = false),
+        currentOffset = DeltaSourceOffset(
+          sourceVersion = 1,
+          reservoirId = "foo",
+          reservoirVersion = 4,
+          index = 10,
+          isStartingVersion = true)
+      )
+    }.getMessage.contains("Found invalid offsets: 'isStartingVersion' fliped incorrectly."))
+    assert(intercept[IllegalStateException] {
+      DeltaSourceOffset.validateOffsets(
+        previousOffset = DeltaSourceOffset(
+          sourceVersion = 1,
+          reservoirId = "foo",
+          reservoirVersion = 4,
+          index = 10,
+          isStartingVersion = false),
+        currentOffset = DeltaSourceOffset(
+          sourceVersion = 1,
+          reservoirId = "foo",
+          reservoirVersion = 1,
+          index = 10,
+          isStartingVersion = false)
+      )
+    }.getMessage.contains("Found invalid offsets: 'reservoirVersion' moved back."))
+    assert(intercept[IllegalStateException] {
+      DeltaSourceOffset.validateOffsets(
+        previousOffset = DeltaSourceOffset(
+          sourceVersion = 1,
+          reservoirId = "foo",
+          reservoirVersion = 4,
+          index = 10,
+          isStartingVersion = false),
+        currentOffset = DeltaSourceOffset(
+          sourceVersion = 1,
+          reservoirId = "foo",
+          reservoirVersion = 4,
+          index = 9,
+          isStartingVersion = false)
+      )
+    }.getMessage.contains("Found invalid offsets. 'index' moved back."))
+  }
+
+  test("ES-445863: delta source should not hang or reprocess data when using AvailableNow") {
+    withTempDirs { (inputDir, outputDir, checkpointDir) =>
+      def runQuery(): Unit = {
+        val q = spark.readStream
+          .format("delta")
+          .load(inputDir.getCanonicalPath)
+          // Require a partition filter. The max index of files matching the partition filter must
+          // be less than the number of files in the second commit.
+          .where("part = 0")
+          .writeStream
+          .format("delta")
+          .trigger(Trigger.AvailableNow)
+          .option("checkpointLocation", checkpointDir.getCanonicalPath)
+          .start(outputDir.getCanonicalPath)
+        try {
+          if (!q.awaitTermination(60000)) {
+            throw new TimeoutException("the query didn't stop in 60 seconds")
+          }
+        } finally {
+          q.stop()
+        }
+      }
+
+      spark.range(0, 1)
+        .selectExpr("id", "id as part")
+        .repartition(10)
+        .write
+        .partitionBy("part")
+        .format("delta")
+        .mode("append")
+        .save(inputDir.getCanonicalPath)
+      runQuery()
+
+      spark.range(1, 10)
+        .selectExpr("id", "id as part")
+        .repartition(9)
+        .write
+        .partitionBy("part")
+        .format("delta")
+        .mode("append")
+        .save(inputDir.getCanonicalPath)
+      runQuery()
+
+      checkAnswer(
+        spark.read.format("delta").load(outputDir.getCanonicalPath),
+        Row(0, 0) :: Nil)
     }
   }
 }


### PR DESCRIPTION
(Cherry-pick of 29d3a092 for 2.1.1 release)

When using AvailableNow, here are the flows for Delta source:

- New query: prepareForTriggerAvailableNow, (latestOffset -> getBatch)*.
- Restarted query: prepareForTriggerAvailableNow, getBatch, (latestOffset -> getBatch)*.

When restarting a query, getBatch is required to be called first. Otherwise, previousOffset will not be set and latestOffset will assume it's a new query and return an incorrect offset.

Today, we call latestOffset inside prepareForTriggerAvailableNow, which causes the incorrect initialization for lastOffsetForTriggerAvailableNow because previousOffset is not set yet at this moment when restarting a query.

In this PR, we add isTriggerAvailableNow and set it to true in prepareForTriggerAvailableNow without initializing lastOffsetForTriggerAvailableNow, and make lastOffsetForTriggerAvailableNow initialization happen inside latestOffset (for new query) or getBatch (for restarted query) so that it can be initialized correctly. We add an internal flag spark.databricks.delta.streaming.availableNow.offsetInitializationFix.enabled to allow users switching back to the old behavior.

In addition, we also add a validation for previousOffset and currentOffset to make sure they never move backward. This would ensure we will not cause data duplication even if we have any bug in offset generation. `spark.databricks.delta.streaming.offsetValidation.enabled` is added to allow users turning off the check.

