### PR TITLE
Issue #1436: Fix restore delta table NotSerializableException

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
@@ -18,6 +18,8 @@ package org.apache.spark.sql.delta.commands
 
 import java.sql.Timestamp
 
+import org.apache.hadoop.fs.Path
+
 import scala.collection.JavaConverters._
 import scala.util.{Success, Try}
 
@@ -244,7 +246,7 @@ case class RestoreTableCommand(
 
     val spark: SparkSession = files.sparkSession
 
-    val path = deltaLog.dataPath
+    val pathString = deltaLog.dataPath.toString
     val hadoopConf = spark.sparkContext.broadcast(
       new SerializableConfiguration(deltaLog.newDeltaHadoopConf()))
 
@@ -252,6 +254,7 @@ case class RestoreTableCommand(
 
     val missedFiles = files
       .mapPartitions { files =>
+        val path = new Path(pathString)
         val fs = path.getFileSystem(hadoopConf.value.value)
         val pathStr = path.toUri.getPath
         files.filterNot(f => fs.exists(absolutePath(pathStr, f.path)))


### PR DESCRIPTION
When execute `restore` command on delta table by spark sql with Hadoop 2,  it reported `java.io.NotSerializableException: org.apache.hadoop.fs.Path`

## Description

Resolves #1436 

## How was this patch tested?

Package new version of delta-core jar and put it under $SPARK_HOME/jars directory. Launch spark-sql and execute `restore table xxx TO VERSION AS OF xx` command on existed delta table, it executed successfully. Then execute `DESCRIBE HISTORY xxx` command on the delta table, it show `RESTORE` operation at the last commit.

spark-sql (default)> restore table default.people10m TO VERSION AS OF 4;
table_size_after_restore  num_of_files_after_restore  num_removed_files num_restored_files  removed_files_size  restored_files_size
1808  4 5 4 2260  1808
Time taken: 22.38 seconds, Fetched 1 row(s)

spark-sql (default)> DESCRIBE HISTORY default.people10m;
version timestamp userId  userName  operation operationParameters job notebook  clusterIreadVersion isolationLevel  isBlindAppend operationMetrics  userMetadata  engineInfo
7 2022-10-18 10:23:33.325 NULL  NULL  RESTORE {"timestamp":null,"version":"4"}  NULL  NULL  NULL  Serializable  false {"numOfFilesAfterRestore":"4","numRemovedFiles":"5","numRestoredFiles":"4","removedFilesSize":"2260","restoredFilesSize":"1808","tableSizeAfterRestore":"1808"} NULL  Apache-Spark/3.3.0 Delta-Lake/2.1.0-SNAPSHOT

## Does this PR introduce _any_ user-facing changes?

No
