### PR TITLE
[WIP] V2 reader support

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -153,12 +153,13 @@ class DeltaAnalysis(session: SparkSession)
       }
 
     case dsv2 @ DataSourceV2Relation(d: DeltaTableV2, _, _, _, options) =>
-      if (!d.capabilities().contains(BATCH_READ)) {
+      val tableWithOptions = d.withOptions(options.asScala.toMap)
+      if (!tableWithOptions.capabilities().contains(BATCH_READ)) {
         // Table doesn't support V2 reads, fall back to V1 relation
         DeltaRelation.fromV2Relation(d, dsv2, options)
       } else {
         // Apply options from the V2Relation and return the updated table
-        dsv2.copy(table = d.withOptions(options.asScala.toMap))
+        dsv2.copy(table = tableWithOptions)
       }
 
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -162,13 +162,6 @@ class DeltaAnalysis(session: SparkSession)
         dsv2.copy(table = tableWithOptions)
       }
 
-
-    // Normalize differences between DataFrameReader and SQL reads. Options have already been
-    // pushed to DeltaTableV2 so are no longer needed.
-    // case dsv2 @ DataSourceV2Relation(d: DeltaTableV2, output, _, _, _)
-    //     if d.capabilities().contains(BATCH_READ) =>
-    //   dsv2.copy(catalog = None, identifier = None, options = CaseInsensitiveStringMap.empty())
-
     // DML - TODO: Remove these Delta-specific DML logical plans and use Spark's plans directly
 
     case d @ DeleteFromTable(table, condition) if d.childrenResolved =>

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -33,8 +33,8 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project}
 import org.apache.spark.sql.connector.expressions.{FieldReference, IdentityTransform}
 import org.apache.spark.sql.execution.datasources.{FileFormat, HadoopFsRelation, LogicalRelation}
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, DataSourceV2ScanRelation}
+import org.apache.spark.sql.internal.SQLConf
 
 /**
  * Extractor Object for pulling out the table scan of a Delta table. It could be a full scan

--- a/core/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -505,7 +505,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
     }
   }
 
-  /** Returns a[[DeltaScan]] based on the given filters. */
+  /** Returns a [[DeltaScan]] based on the given filters. */
   override def filesForScan(
     filters: Seq[Expression],
     keepNumRecords: Boolean = false
@@ -537,6 +537,11 @@ trait OptimisticTransactionImpl extends TransactionalWrite
     }
     readPredicates += partitionFilters.reduceLeftOption(And).getOrElse(Literal.TrueLiteral)
     readFiles ++= scan.files
+    // scalastyle:off println
+    // println("filterFiles")
+    // println(scan.files.length)
+    // println()
+    // scalastyle:on println
     scan.files
   }
 
@@ -569,10 +574,19 @@ trait OptimisticTransactionImpl extends TransactionalWrite
   def readWholeTable(): Unit = {
     readPredicates += Literal.TrueLiteral
     readTheWholeTable = true
+    // scalastyle:off println
+    // println("readWholeTable")
+    // println()
+    // scalastyle:on println
   }
 
   /** Mark the given files as read within this transaction. */
   def withFilesRead(files: Seq[AddFile]): Unit = {
+    // scalastyle:off println
+    // println("withFilesRead")
+    // println(files.length)
+    // println()
+    // scalastyle:on println
     readFiles ++= files
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -558,11 +558,6 @@ trait OptimisticTransactionImpl extends TransactionalWrite
     }
     readPredicates += partitionFilters.reduceLeftOption(And).getOrElse(Literal.TrueLiteral)
     readFiles ++= scan.files
-    // scalastyle:off println
-    // println("filterFiles")
-    // println(scan.files.length)
-    // println()
-    // scalastyle:on println
     scan.files
   }
 
@@ -595,19 +590,10 @@ trait OptimisticTransactionImpl extends TransactionalWrite
   def readWholeTable(): Unit = {
     readPredicates += Literal.TrueLiteral
     readTheWholeTable = true
-    // scalastyle:off println
-    // println("readWholeTable")
-    // println()
-    // scalastyle:on println
   }
 
   /** Mark the given files as read within this transaction. */
   def withFilesRead(files: Seq[AddFile]): Unit = {
-    // scalastyle:off println
-    // println("withFilesRead")
-    // println(files.length)
-    // println()
-    // scalastyle:on println
     readFiles ++= files
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/PreprocessTableMerge.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/PreprocessTableMerge.scala
@@ -36,6 +36,7 @@ import org.apache.spark.sql.catalyst.trees.TreePattern.CURRENT_LIKE
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.{instantToMicros, localDateTimeToMicros}
 import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DateType, StringType, StructField, StructType, TimestampNTZType, TimestampType}
 
@@ -87,7 +88,9 @@ case class PreprocessTableMerge(override val conf: SQLConf)
     }
     val generatedColumns = GeneratedColumn.getGeneratedColumns(
       tahoeFileIndex.snapshotAtAnalysis)
-    if (generatedColumns.nonEmpty && !deltaLogicalPlan.isInstanceOf[LogicalRelation]) {
+    val isTempView = !deltaLogicalPlan.isInstanceOf[LogicalRelation] &&
+      !deltaLogicalPlan.isInstanceOf[DataSourceV2Relation]
+    if (generatedColumns.nonEmpty && isTempView) {
       throw DeltaErrors.operationOnTempViewWithGenerateColsNotSupported("MERGE INTO")
     }
     // Additional columns with default expressions.

--- a/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
@@ -24,9 +24,8 @@ import java.util.Locale
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
-import scala.util.{Failure, Success, Try}
 
-import org.apache.spark.sql.delta.{DeltaConfigs, DeltaErrors, DeltaTableUtils, DeltaTimeTravelSpec}
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaErrors, DeltaTableUtils}
 import org.apache.spark.sql.delta.{DeltaLog, DeltaOptions}
 import org.apache.spark.sql.delta.DeltaTableIdentifier.gluePermissionError
 import org.apache.spark.sql.delta.commands._
@@ -35,12 +34,10 @@ import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.{DeltaDataSource, DeltaSourceUtils, DeltaSQLConf}
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{AnalysisException, DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{NoSuchDatabaseException, NoSuchNamespaceException, NoSuchTableException, UnresolvedAttribute, UnresolvedFieldName, UnresolvedFieldPosition}
 import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogTable, CatalogTableType, CatalogUtils, SessionCatalog}
-import org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, QualifiedColType}
 import org.apache.spark.sql.connector.catalog.{DelegatingCatalogExtension, Identifier, StagedTable, StagingTableCatalog, SupportsWrite, Table, TableCapability, TableCatalog, TableChange, V1Table}
 import org.apache.spark.sql.connector.catalog.TableCapability._

--- a/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
@@ -24,8 +24,9 @@ import java.util.Locale
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+import scala.util.{Failure, Success, Try}
 
-import org.apache.spark.sql.delta.{DeltaConfigs, DeltaErrors, DeltaTableUtils}
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaErrors, DeltaTableUtils, DeltaTimeTravelSpec}
 import org.apache.spark.sql.delta.{DeltaLog, DeltaOptions}
 import org.apache.spark.sql.delta.DeltaTableIdentifier.gluePermissionError
 import org.apache.spark.sql.delta.commands._
@@ -39,6 +40,7 @@ import org.apache.spark.sql.{AnalysisException, DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{NoSuchDatabaseException, NoSuchNamespaceException, NoSuchTableException, UnresolvedAttribute, UnresolvedFieldName, UnresolvedFieldPosition}
 import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogTable, CatalogTableType, CatalogUtils, SessionCatalog}
+import org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, QualifiedColType}
 import org.apache.spark.sql.connector.catalog.{DelegatingCatalogExtension, Identifier, StagedTable, StagingTableCatalog, SupportsWrite, Table, TableCapability, TableCatalog, TableChange, V1Table}
 import org.apache.spark.sql.connector.catalog.TableCapability._

--- a/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaScanBuilder.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaScanBuilder.scala
@@ -31,6 +31,17 @@ import org.apache.spark.sql.execution.datasources.v2.parquet.{ParquetScan, Parqu
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
+
+/**
+ * The scan builder for V2 Delta table reads. Mostly serves the same purpose as the
+ * PrepareDeltaScan optimization rule. The scan building happens after the PreCBO rules.
+ *
+ * @param deltaFileIndex The file index for the read
+ * @param metadata Metadata for the table to check the column mapping mode
+ * @param tableSchema The schema of the table with all Delta metadata
+ * @param readSchema The schema of the table with Delta metadata removed
+ * @param options File system options for the scan
+ */
 class DeltaScanBuilder(
     sparkSession: SparkSession,
     deltaFileIndex: TahoeFileIndex,

--- a/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaScanBuilder.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaScanBuilder.scala
@@ -18,7 +18,6 @@ package org.apache.spark.sql.delta.catalog
 
 import org.apache.spark.sql.delta.actions.Metadata
 import org.apache.spark.sql.delta.stats.PrepareDeltaScanBase
-import org.apache.spark.sql.delta.OptimisticTransaction
 import org.apache.spark.sql.delta.stats.DeltaScanGenerator
 import org.apache.spark.sql.delta.stats.DeltaScan
 import org.apache.spark.sql.delta.GeneratedColumn
@@ -49,11 +48,7 @@ class DeltaScanBuilder(
   protected def getDeltaScanGenerator(index: TahoeLogFileIndex): DeltaScanGenerator = {
     // The first case means that we've fixed the table snapshot for time travel
     if (index.isTimeTravelQuery) return index.getSnapshot
-    val scanGenerator = OptimisticTransaction.getActive().map(_.getDeltaScanGenerator(index))
-      .getOrElse {
-        val snapshot = index.getSnapshot
-        snapshot
-      }
+    val scanGenerator = index.getSnapshot
     // Test compatibility with PrepareDeltaScan
     import PrepareDeltaScanBase._
     if (onGetDeltaScanGeneratorCallback != null) onGetDeltaScanGeneratorCallback(scanGenerator)

--- a/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaScanBuilder.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaScanBuilder.scala
@@ -137,7 +137,9 @@ class DeltaScanBuilder(
           Seq.empty
         }
 
-      val preparedScan = scanGenerator.filesForScan(filters ++ generatedPartitionFilters)
+      val preparedScan = withStatusCode("DELTA", "Filtering files for query") {
+        scanGenerator.filesForScan(filters ++ generatedPartitionFilters)
+      }
       preparedIndex = getPreparedIndex(preparedScan, logFileIndex)
     }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaScanBuilder.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaScanBuilder.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.catalog
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.delta.{ColumnWithDefaultExprUtils, DeltaColumnMapping, DeltaErrors, DeltaLog, DeltaTableUtils, DeltaTimeTravelSpec, Snapshot}
+import org.apache.spark.sql.delta.files.{TahoeFileIndex, TahoeLogFileIndex}
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.sources.DeltaDataSource
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.connector.read.{Scan, ScanBuilder}
+import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
+import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScanBuilder
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.sql.delta.stats.PrepareDeltaScanBase
+import org.apache.spark.sql.delta.OptimisticTransaction
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.stats.DeltaScanGenerator
+import org.apache.spark.sql.delta.stats.DeltaScan
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.delta.GeneratedColumn
+import org.apache.spark.sql.delta.stats.PreparedDeltaFileIndex
+import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
+
+class DeltaScanBuilder(
+    sparkSession: SparkSession,
+    deltaFileIndex: TahoeFileIndex,
+    tableSchema: StructType,
+    options: CaseInsensitiveStringMap)
+  extends ParquetScanBuilder(sparkSession, deltaFileIndex, tableSchema, tableSchema, options)
+  with DeltaLogging {
+
+  protected def getDeltaScanGenerator(index: TahoeLogFileIndex): DeltaScanGenerator = {
+    // The first case means that we've fixed the table snapshot for time travel
+    if (index.isTimeTravelQuery) return index.getSnapshot
+    val scanGenerator = OptimisticTransaction.getActive().map(_.getDeltaScanGenerator(index))
+      .getOrElse {
+        val snapshot = index.getSnapshot
+        snapshot
+      }
+    scanGenerator
+  }
+
+  /**
+   * Helper method to generate a [[PreparedDeltaFileIndex]]
+   */
+  protected def getPreparedIndex(
+      preparedScan: DeltaScan,
+      fileIndex: TahoeLogFileIndex): PreparedDeltaFileIndex = {
+    assert(fileIndex.partitionFilters.isEmpty,
+      "Partition filters should have been extracted by DeltaAnalysis.")
+    PreparedDeltaFileIndex(
+      sparkSession,
+      fileIndex.deltaLog,
+      fileIndex.path,
+      preparedScan,
+      fileIndex.partitionSchema,
+      fileIndex.versionToUse)
+  }
+
+  override def build(): Scan = {
+    val parquetScan = super.build().asInstanceOf[ParquetScan]
+    if (deltaFileIndex.isInstanceOf[TahoeLogFileIndex]) {
+      val logFileIndex = deltaFileIndex.asInstanceOf[TahoeLogFileIndex]
+      val scanGenerator = getDeltaScanGenerator(logFileIndex)
+      val preparedScan = scanGenerator.filesForScan(partitionFilters ++ dataFilters)
+      val preparedIndex = getPreparedIndex(preparedScan, logFileIndex)
+      parquetScan.copy(fileIndex = preparedIndex)
+    }
+    parquetScan
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableScan.scala
@@ -16,35 +16,27 @@
 
 package org.apache.spark.sql.delta.catalog
 
-import org.apache.spark.sql.delta.{DeltaColumnMapping, OptimisticTransaction, NoMapping}
-import org.apache.spark.sql.delta.actions.Metadata
+import org.apache.spark.sql.delta.OptimisticTransaction
 import org.apache.spark.sql.delta.metering.DeltaLogging
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.connector.read.PartitionReaderFactory
 import org.apache.spark.sql.execution.datasources.PartitioningAwareFileIndex
-import org.apache.spark.sql.execution.datasources.parquet.ParquetReadSupport
 import org.apache.spark.sql.execution.datasources.v2.FileScan
-import org.apache.spark.sql.execution.datasources.v2.parquet.{ParquetScan, ParquetPartitionReaderFactory}
+import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.util.SerializableConfiguration
 
 import org.apache.hadoop.fs.Path
 
 case class DeltaTableScan(
     sparkSession: SparkSession,
-    metadata: Metadata,
-    referenceSchema: StructType,
     delegatedScan: ParquetScan,
+    readDataSchema: StructType,
+    readPartitionSchema: StructType,
     transaction: Option[OptimisticTransaction])
     extends FileScan
     with DeltaLogging {
-
-  def prepareSchema(inputSchema: StructType): StructType = {
-    DeltaColumnMapping.createPhysicalSchema(inputSchema, referenceSchema,
-      metadata.columnMappingMode)
-  }
 
   override def isSplitable(path: Path): Boolean = delegatedScan.isSplitable(path)
 
@@ -52,34 +44,25 @@ case class DeltaTableScan(
 
   override def dataSchema: StructType = delegatedScan.dataSchema
 
-  override def readSchema(): StructType = delegatedScan.readSchema()
-
-  override def readDataSchema: StructType = delegatedScan.readDataSchema
-
-  override def readPartitionSchema: StructType = delegatedScan.readPartitionSchema
+  /**
+   * Override so that we have the logical schema and not the physical schema.
+   */
+  override def readSchema(): StructType = {
+    if (delegatedScan.pushedAggregate.nonEmpty) readDataSchema else super.readSchema()
+  }
 
   override def partitionFilters: Seq[Expression] = delegatedScan.partitionFilters
 
   override def dataFilters: Seq[Expression] = delegatedScan.dataFilters
 
-  override def createReaderFactory(): PartitionReaderFactory = {
-    val readerFactory = delegatedScan.createReaderFactory()
-      .asInstanceOf[ParquetPartitionReaderFactory]
-    if (metadata.columnMappingMode != NoMapping) {
-      val conf = readerFactory.broadcastedConf.value.value
-      val readDataSchemaAsJson = prepareSchema(readDataSchema).json
-      conf.set(
-        ParquetReadSupport.SPARK_ROW_REQUESTED_SCHEMA,
-        readDataSchemaAsJson)
-      val broadcastedConf = sparkSession.sparkContext.broadcast(
-        new SerializableConfiguration(conf))
-      readerFactory.copy(broadcastedConf = broadcastedConf)
-    } else {
-      readerFactory
-    }
+  override def createReaderFactory(): PartitionReaderFactory = delegatedScan.createReaderFactory()
+
+  override def getMetaData(): Map[String, String] = if (delegatedScan.pushedAggregate.nonEmpty) {
+    // If there is a pushed aggregation, we know column mapping is not enabled so it's safe to
+    // pull the metadata from the delegated scan
+    delegatedScan.getMetaData()
+  } else {
+    // Be safe and use the logical schema for the metadata
+    super.getMetaData()
   }
-
-  override def description(): String = delegatedScan.description()
-
-  override def getMetaData(): Map[String, String] = delegatedScan.getMetaData()
 }

--- a/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableScan.scala
@@ -52,6 +52,8 @@ case class DeltaTableScan(
 
   override def dataSchema: StructType = delegatedScan.dataSchema
 
+  override def readSchema(): StructType = delegatedScan.readSchema()
+
   override def readDataSchema: StructType = delegatedScan.readDataSchema
 
   override def readPartitionSchema: StructType = delegatedScan.readPartitionSchema

--- a/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableScan.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.catalog
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.delta.{ColumnWithDefaultExprUtils, DeltaColumnMapping, DeltaErrors, DeltaLog, DeltaTableUtils, DeltaTimeTravelSpec, Snapshot}
+import org.apache.spark.sql.delta.files.{TahoeFileIndex, TahoeLogFileIndex}
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.sources.DeltaDataSource
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.{Expression, PredicateHelper}
+import org.apache.spark.sql.connector.read.{Scan, ScanBuilder}
+import org.apache.spark.sql.execution.datasources.{LogicalRelation, PartitioningAwareFileIndex}
+import org.apache.spark.sql.execution.datasources.v2.parquet.{ParquetScan, ParquetScanBuilder}
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.sql.delta.stats.PrepareDeltaScanBase
+import org.apache.spark.sql.delta.OptimisticTransaction
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.stats.DeltaScanGenerator
+import org.apache.spark.sql.delta.stats.DeltaScan
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.delta.GeneratedColumn
+import org.apache.spark.sql.delta.stats.PreparedDeltaFileIndex
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.sql.connector.expressions.aggregate.Aggregation
+import org.apache.spark.sql.connector.read.PartitionReaderFactory
+import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetPartitionReaderFactory
+import org.apache.spark.sql.execution.datasources.v2.FileScan
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.delta.actions.Metadata
+import org.apache.spark.sql.delta.NoMapping
+import org.apache.spark.sql.execution.datasources.parquet.ParquetReadSupport
+import org.apache.spark.util.SerializableConfiguration
+
+case class DeltaTableScan(
+    sparkSession: SparkSession,
+    metadata: Metadata,
+    referenceSchema: StructType,
+    delegatedScan: ParquetScan)
+    extends FileScan
+    with DeltaLogging {
+
+  def prepareSchema(inputSchema: StructType): StructType = {
+    DeltaColumnMapping.createPhysicalSchema(inputSchema, referenceSchema,
+      metadata.columnMappingMode)
+  }
+
+  override def isSplitable(path: Path): Boolean = delegatedScan.isSplitable(path)
+
+  override def fileIndex: PartitioningAwareFileIndex = delegatedScan.fileIndex
+
+  override def dataSchema: StructType = delegatedScan.dataSchema
+
+  override def readDataSchema: StructType = delegatedScan.readDataSchema
+
+  override def readPartitionSchema: StructType = delegatedScan.readPartitionSchema
+
+  override def partitionFilters: Seq[Expression] = delegatedScan.partitionFilters
+
+  override def dataFilters: Seq[Expression] = delegatedScan.dataFilters
+
+  override def createReaderFactory(): PartitionReaderFactory = {
+    val readerFactory = delegatedScan.createReaderFactory()
+      .asInstanceOf[ParquetPartitionReaderFactory]
+    if (metadata.columnMappingMode != NoMapping) {
+      val conf = readerFactory.broadcastedConf.value.value
+      val readDataSchemaAsJson = prepareSchema(readDataSchema).json
+      conf.set(
+        ParquetReadSupport.SPARK_ROW_REQUESTED_SCHEMA,
+        readDataSchemaAsJson)
+      val broadcastedConf = sparkSession.sparkContext.broadcast(
+        new SerializableConfiguration(conf))
+      readerFactory.copy(broadcastedConf = broadcastedConf)
+    } else {
+      readerFactory
+    }
+  }
+
+  override def description(): String = delegatedScan.description()
+
+  override def getMetaData(): Map[String, String] = delegatedScan.getMetaData()
+}

--- a/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -52,6 +52,10 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
  *
  * @param path The path to the table
  * @param tableIdentifier The table identifier for this table
+ * @param timeTravelOpt Time travel options for the table
+ * @param options File system options for reading the table
+ * @param cdcOptions Change data capture options
+ * @param pinnedFileIndex Pin the table to a specific listing of files
  */
 case class DeltaTableV2(
     spark: SparkSession,

--- a/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -105,10 +105,6 @@ case class DeltaTableV2(
     timeTravelOpt.orElse(timeTravelByPath)
   }
 
-  def isCDCRead(): Boolean = {
-    !cdcOptions.isEmpty()
-  }
-
   lazy val snapshot: Snapshot = {
     timeTravelSpec.map { spec =>
       val (version, accessType) = DeltaTableUtils.resolveTimeTravelVersion(
@@ -238,9 +234,6 @@ case class DeltaTableV2(
    */
   def withOptions(options: Map[String, String]): DeltaTableV2 = {
     val ttSpec = timeTravelOpt.orElse { DeltaDataSource.getTimeTravelVersion(options) }
-    // if (timeTravelOpt.nonEmpty && ttSpec.nonEmpty) {
-    //   throw DeltaErrors.multipleTimeTravelSyntaxUsed
-    // }
 
     def checkCDCOptionsValidity(options: CaseInsensitiveStringMap): Unit = {
       // check if we have both version and timestamp parameters

--- a/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -237,10 +237,10 @@ case class DeltaTableV2(
    * Check the passed in options and existing timeTravelOpt, set new time travel by options.
    */
   def withOptions(options: Map[String, String]): DeltaTableV2 = {
-    val ttSpec = DeltaDataSource.getTimeTravelVersion(options)
-    if (timeTravelOpt.nonEmpty && ttSpec.nonEmpty) {
-      throw DeltaErrors.multipleTimeTravelSyntaxUsed
-    }
+    val ttSpec = timeTravelOpt.orElse { DeltaDataSource.getTimeTravelVersion(options) }
+    // if (timeTravelOpt.nonEmpty && ttSpec.nonEmpty) {
+    //   throw DeltaErrors.multipleTimeTravelSyntaxUsed
+    // }
 
     def checkCDCOptionsValidity(options: CaseInsensitiveStringMap): Unit = {
       // check if we have both version and timestamp parameters

--- a/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -167,10 +167,8 @@ case class DeltaTableV2(
     // The features v2 reading doesn't currently support
     val columnMappingEnabled = snapshot.metadata.columnMappingMode != NoMapping
     val cdcRead = !cdcOptions.isEmpty()
-    // If there are generated columns, we can't currently optimize them, so skip as well
-    val hasGeneratedColumns = GeneratedColumn.hasGeneratedColumns(snapshot.schema)
 
-    if (v2ReaderEnabled && !columnMappingEnabled && !cdcRead && !hasGeneratedColumns) {
+    if (v2ReaderEnabled && !columnMappingEnabled && !cdcRead) {
       baseCapabilities.add(BATCH_READ)
     }
     baseCapabilities.asJava

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, AddFile, FileAction}
 import org.apache.spark.sql.delta.commands.DeleteCommand.{rewritingFilesMsg, FINDING_TOUCHED_FILES_MSG}
 import org.apache.spark.sql.delta.commands.MergeIntoCommand.totalBytesAndDistinctPartitionValues
-import org.apache.spark.sql.delta.files.TahoeBatchFileIndex
+import org.apache.spark.sql.delta.files.{TahoeBatchFileIndex, TahoeFileIndex}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 
@@ -276,7 +276,8 @@ case class DeleteCommand(
               sparkSession, txn, "delete", deltaLog.dataPath, filesToRewrite, nameToAddFileMap)
             // Keep everything from the resolved target except a new TahoeFileIndex
             // that only involves the affected files instead of all files.
-            val newTarget = DeltaTableUtils.replaceFileIndex(target, baseRelation.location)
+            val newTarget = DeltaTableUtils.replaceFileIndex(target,
+              baseRelation.location.asInstanceOf[TahoeFileIndex])
             val targetDF = Dataset.ofRows(sparkSession, newTarget)
             val filterCond = Not(EqualNullSafe(cond, Literal.TrueLiteral))
             val rewrittenActions = rewriteFiles(txn, targetDF, filterCond, filesToRewrite.length)

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
@@ -248,7 +248,8 @@ case class UpdateCommand(
     // Containing the map from the relative file path to AddFile
     val baseRelation = buildBaseRelation(
       spark, txn, "update", rootPath, inputLeafFiles, nameToAddFileMap)
-    val newTarget = DeltaTableUtils.replaceFileIndex(target, baseRelation.location)
+    val newTarget = DeltaTableUtils.replaceFileIndex(target,
+      baseRelation.location.asInstanceOf[TahoeFileIndex])
     val targetDf = Dataset.ofRows(spark, newTarget)
 
     // Number of total rows that we have seen, i.e. are either copying or updating (sum of both).

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.execution.command.LeafRunnableCommand
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.functions.{array, col, explode, lit, struct}
-import org.apache.spark.sql.types.{StringType, StructType}
+import org.apache.spark.sql.types.StructType
 
 /**
  * Used to write a [[DataFrame]] into a delta table.
@@ -95,6 +95,8 @@ case class WriteIntoDelta(
         return Seq.empty
       }
 
+      // Register any V2 scans of the table we are writing to
+      txn.registerScans(data)
       val actions = write(txn, sparkSession)
       val operation = DeltaOperations.Write(mode, Option(partitionColumns),
         options.replaceWhere, options.userMetadata)

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
@@ -66,7 +66,7 @@ class DeltaDataSource
     val options = new CaseInsensitiveStringMap(properties)
     val path = options.get("path")
     if (path == null) throw DeltaErrors.pathNotSpecifiedException
-    DeltaTableV2(SparkSession.active, new Path(path))
+    DeltaTableV2(SparkSession.active, new Path(path), options = properties.asScala.toMap)
   }
 
   override def sourceSchema(

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -898,6 +898,12 @@ trait DeltaSQLConfBase {
         " concurrent queries accessing the table until the history wipe is complete.")
       .booleanConf
       .createWithDefault(false)
+
+  val V2_READER_ENABLED =
+    buildConf("v2.reader.enabled")
+      .doc("Whether to use the Data Source V2 batch read API.")
+      .booleanConf
+      .createWithDefault(true)
 }
 
 object DeltaSQLConf extends DeltaSQLConfBase

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -903,7 +903,7 @@ trait DeltaSQLConfBase {
     buildConf("v2.reader.enabled")
       .doc("Whether to use the Data Source V2 batch read API.")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 }
 
 object DeltaSQLConf extends DeltaSQLConfBase

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -903,7 +903,7 @@ trait DeltaSQLConfBase {
     buildConf("v2.reader.enabled")
       .doc("Whether to use the Data Source V2 batch read API.")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 }
 
 object DeltaSQLConf extends DeltaSQLConfBase

--- a/core/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
@@ -198,11 +198,6 @@ trait PrepareDeltaScanBase extends Rule[LogicalPlan]
 
   override def apply(_plan: LogicalPlan): LogicalPlan = {
     var plan = _plan
-    // scalastyle:off println
-      // println("applying plan")
-      // println(plan)
-      // println()
-      // scalastyle:on println
 
     val shouldPrepareDeltaScan = (
       spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_STATS_SKIPPING)

--- a/core/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
@@ -159,11 +159,6 @@ trait PrepareDeltaScanBase extends Rule[LogicalPlan]
       transformSubqueries(plan) transform {
         case scan @ DeltaTableScan(canonicalizedPlanWithRemovedProjections, filters, fileIndex,
           limit, delta) =>
-          // scalastyle:off println
-          println()
-          println("Found delta table scan")
-          println(plan)
-          // scalastyle:on println
           val scanGenerator = getDeltaScanGenerator(fileIndex)
           val preparedScan = deltaScans.getOrElseUpdate(canonicalizedPlanWithRemovedProjections,
               filesForScan(scanGenerator, limit, filters, delta))

--- a/core/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
@@ -305,7 +305,7 @@ object PrepareDeltaScanBase {
    * Optional callback function that is called after `getDeltaScanGenerator` is called
    * by the PrepareDeltaScan rule. This is primarily used for testing purposes.
    */
-  @volatile private var onGetDeltaScanGeneratorCallback: DeltaScanGenerator => Unit = _
+  @volatile private[delta] var onGetDeltaScanGeneratorCallback: DeltaScanGenerator => Unit = _
 
   /**
    * Run a thunk of code with the given callback function injected into the PrepareDeltaScan rule.

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
@@ -18,11 +18,15 @@ package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{DataFrame, Row}
 
 class DeleteSQLSuite extends DeleteSuiteBase  with DeltaSQLCommandTest {
 
   import testImplicits._
+
+  override protected def loadTable(path: String): DataFrame = {
+    spark.read.table(s"delta.`$path`")
+  }
 
   override protected def executeDelete(target: String, where: String = null): Unit = {
     val whereClause = Option(where).map(c => s"WHERE $c").getOrElse("")

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeleteScalaSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeleteScalaSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import io.delta.tables.DeltaTableTestUtils
 
-import org.apache.spark.sql.{functions, Row}
+import org.apache.spark.sql.{DataFrame, functions, Row}
 
 class DeleteScalaSuite extends DeleteSuiteBase with DeltaSQLCommandTest {
 
@@ -44,6 +44,10 @@ class DeleteScalaSuite extends DeleteSuiteBase with DeltaSQLCommandTest {
     val table = io.delta.tables.DeltaTable.forPath(tempPath)
     table.delete(functions.expr("key = 1 or key = 2"))
     checkAnswer(readDeltaTable(tempPath), Row(3, 30) :: Row(4, 40) :: Nil)
+  }
+
+  override protected def loadTable(path: String): DataFrame = {
+    spark.read.format("delta").load(path)
   }
 
   override protected def executeDelete(target: String, where: String = null): Unit = {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
@@ -61,6 +61,8 @@ abstract class DeleteSuiteBase extends QueryTest
     }
   }
 
+  protected def loadTable(path: String): DataFrame
+
   protected def executeDelete(target: String, where: String = null): Unit
 
   protected def append(df: DataFrame, partitionBy: Seq[String] = Nil): Unit = {
@@ -248,10 +250,10 @@ abstract class DeleteSuiteBase extends QueryTest
   test("delete cached table by path") {
     Seq((2, 2), (1, 4)).toDF("key", "value")
       .write.mode("overwrite").format("delta").save(tempPath)
-    spark.read.format("delta").load(tempPath).cache()
-    spark.read.format("delta").load(tempPath).collect()
+    loadTable(tempPath).cache()
+    loadTable(tempPath).collect()
     executeDelete(s"delta.`$tempPath`", where = "key = 2")
-    checkAnswer(spark.read.format("delta").load(tempPath), Row(1, 4) :: Nil)
+    checkAnswer(loadTable(tempPath), Row(1, 4) :: Nil)
   }
 
   Seq(true, false).foreach { isPartitioned =>

--- a/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.delta
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest}
 
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.analysis.{Analyzer, ResolveSessionCatalog}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical.{DeltaMergeInto, LogicalPlan}
@@ -48,6 +48,10 @@ class MergeIntoSQLSuite extends MergeIntoSuiteBase  with DeltaSQLCommandTest
        |WHEN MATCHED THEN UPDATE SET $update
        |WHEN NOT MATCHED THEN INSERT $insert
       """.stripMargin
+  }
+
+  override protected def loadTable(path: String): DataFrame = {
+    spark.read.table(s"delta.`$path`")
   }
 
   override def executeMerge(

--- a/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
@@ -575,6 +575,10 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase  with DeltaSQLCommandTest
     }
   }
 
+  override protected def loadTable(path: String): DataFrame = {
+    spark.read.format("delta").load(path)
+  }
+
   override protected def executeMerge(
       target: String,
       source: String,

--- a/core/src/test/scala/org/apache/spark/sql/delta/UpdateSQLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/UpdateSQLSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.{DataFrame, QueryTest, Row}
 
 class UpdateSQLSuite extends UpdateSuiteBase  with DeltaSQLCommandTest {
 
@@ -94,6 +94,10 @@ class UpdateSQLSuite extends UpdateSuiteBase  with DeltaSQLCommandTest {
         }
       }
     }
+  }
+
+  override protected def loadTable(path: String): DataFrame = {
+    spark.read.table(s"delta.`$path`")
   }
 
   override protected def executeUpdate(

--- a/core/src/test/scala/org/apache/spark/sql/delta/UpdateScalaSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/UpdateScalaSuite.scala
@@ -21,7 +21,7 @@ import java.util.Locale
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import io.delta.tables.DeltaTableTestUtils
 
-import org.apache.spark.sql.{functions, Row}
+import org.apache.spark.sql.{DataFrame, functions, Row}
 
 class UpdateScalaSuite extends UpdateSuiteBase  with DeltaSQLCommandTest {
 
@@ -58,6 +58,10 @@ class UpdateScalaSuite extends UpdateSuiteBase  with DeltaSQLCommandTest {
       Map("key" -> functions.expr("100"), "value" -> functions.expr("101")))
     checkAnswer(readDeltaTableByPath(tempPath),
       Row(100, 101) :: Row(100, 101) :: Row(3, 30) :: Row(4, 40) :: Nil)
+  }
+
+  override protected def loadTable(path: String): DataFrame = {
+    spark.read.format("delta").load(path)
   }
 
   override protected def executeUpdate(

--- a/core/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
@@ -71,6 +71,8 @@ abstract class UpdateSuiteBase
     }
   }
 
+  protected def loadTable(path: String): DataFrame
+
   protected def executeUpdate(target: String, set: Seq[String], where: String): Unit = {
     executeUpdate(target, set.mkString(", "), where)
   }
@@ -310,11 +312,11 @@ abstract class UpdateSuiteBase
     Seq((2, 2), (1, 4)).toDF("key", "value")
       .write.mode("overwrite").format("delta").save(tempPath)
 
-    spark.read.format("delta").load(tempPath).cache()
-    spark.read.format("delta").load(tempPath).collect()
+    loadTable(tempPath).cache()
+    loadTable(tempPath).collect()
 
     executeUpdate(s"delta.`$tempPath`", set = "key = 3")
-    checkAnswer(spark.read.format("delta").load(tempPath), Row(3, 2) :: Row(3, 4) :: Nil)
+    checkAnswer(loadTable(tempPath), Row(3, 2) :: Row(3, 4) :: Nil)
   }
 
   test("different variations of column references") {

--- a/core/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
@@ -28,7 +28,7 @@ import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.execution.FileSourceScanExec
-import org.apache.spark.sql.execution.datasources.FileFormat
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.functions.struct
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
@@ -673,6 +673,7 @@ abstract class UpdateSuiteBase
 
     val scans = executedPlans.flatMap(_.collect {
       case f: FileSourceScanExec => f
+      case b: BatchScanExec => b
     })
     // The first scan is for finding files to update. We only are matching against the key
     // so that should be the only field in the schema.

--- a/core/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeCompactionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeCompactionSuite.scala
@@ -432,7 +432,7 @@ trait OptimizeCompactionSuiteBase extends QueryTest
       val df = spark.read.format("delta").load(tempDir.getAbsolutePath)
       val deltaLog = loadDeltaLog(tempDir.getAbsolutePath)
       val part = "part".phy(deltaLog)
-      val files = groupInputFilesByPartition(df.inputFiles, deltaLog)
+      val files = groupInputFilesByPartition(DeltaTestUtils.getInputFiles(df), deltaLog)
       assert(files.filter(_._1._1 == part).minBy(_._2.length)._1 === (part, "3"),
         "part 3 should have been optimized and have least amount of files")
     }
@@ -460,7 +460,7 @@ trait OptimizeCompactionSuiteBase extends QueryTest
       val df = spark.read.format("delta").load(tempDir.getAbsolutePath)
       val deltaLog = loadDeltaLog(tempDir.getAbsolutePath)
       val part = "part".phy(deltaLog)
-      val files = groupInputFilesByPartition(df.inputFiles, deltaLog)
+      val files = groupInputFilesByPartition(DeltaTestUtils.getInputFiles(df), deltaLog)
       assert(files.filter(_._1._1 == part).minBy(_._2.length)._1 === (part, "3"),
         "part 3 should have been optimized and have least amount of files")
     }
@@ -534,7 +534,7 @@ class OptimizeCompactionSQLSuite extends OptimizeCompactionSuiteBase
 
       sql(s"optimize '${tempDir.getAbsolutePath}'")
       val df = spark.read.format("delta").load(tempDir.getAbsolutePath)
-      assert(df.inputFiles.length === 2, "2 files for 2 partitions")
+      assert(DeltaTestUtils.getInputFiles(df).length === 2, "2 files for 2 partitions")
       checkAnswer(
         df,
         baseDf.union(baseDf))

--- a/core/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeZOrderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeZOrderSuite.scala
@@ -93,14 +93,14 @@ trait OptimizeZOrderSuiteBase extends QueryTest
       var df = spark.read.format("delta").load(tempDir.getAbsolutePath)
       val deltaLog = loadDeltaLog(tempDir.getAbsolutePath)
       val part = "part".phy(deltaLog)
-      var preOptInputFiles = groupInputFilesByPartition(df.inputFiles, deltaLog)
+      var preOptInputFiles = groupInputFilesByPartition(DeltaTestUtils.getInputFiles(df), deltaLog)
       assert(preOptInputFiles.forall(_._2.length > 1))
       assert(preOptInputFiles.keys.exists(_ == (part, nullPartitionValue)))
 
       executeOptimizePath(tempDir.getAbsolutePath, Seq("value"))
 
       df = spark.read.format("delta").load(tempDir.getAbsolutePath)
-      preOptInputFiles = groupInputFilesByPartition(df.inputFiles, deltaLog)
+      preOptInputFiles = groupInputFilesByPartition(DeltaTestUtils.getInputFiles(df), deltaLog)
       assert(preOptInputFiles.forall(_._2.length == 1))
       assert(preOptInputFiles.keys.exists(_ == (part, nullPartitionValue)))
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeGeneratedColumnSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeGeneratedColumnSuite.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.execution.{FileSourceScanExec, QueryExecution}
+import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, FileScan}
 import org.apache.spark.sql.types.TimestampType
 import org.apache.spark.util.ThreadUtils
 import org.apache.spark.util.Utils
@@ -45,7 +46,10 @@ class OptimizeGeneratedColumnSuite extends GeneratedColumnTest {
 
   private def getPushedPartitionFilters(queryExecution: QueryExecution): Seq[Expression] = {
     queryExecution.executedPlan.collectFirst {
-      case scan: FileSourceScanExec => scan.partitionFilters
+      case scan: FileSourceScanExec =>
+        scan.partitionFilters
+      case scan: BatchScanExec =>
+        scan.scan.asInstanceOf[FileScan].partitionFilters
     }.getOrElse(Nil)
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/stats/AggregatePushDownSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/stats/AggregatePushDownSuite.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.stats
+
+
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.catalog.DeltaTableScan
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.test.ScanReportHelper
+import org.scalatest.GivenWhenThen
+
+// scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.SparkConf
+import org.apache.spark.sql._
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+trait AggregatePushDownSuiteBase extends QueryTest
+    with SharedSparkSession
+    with DeltaSQLCommandTest
+    with GivenWhenThen
+    with ScanReportHelper {
+
+  import testImplicits._
+
+  protected override def sparkConf: SparkConf =
+    super.sparkConf
+      .set(SQLConf.PARQUET_AGGREGATE_PUSHDOWN_ENABLED.key, "true")
+      .set(DeltaSQLConf.V2_READER_ENABLED.key, "true")
+
+  def checkPushedAggregations(
+    data: DataFrame,
+    aggs: Seq[Column],
+    filter: String = "true",
+    groupBy: Seq[String] = Seq.empty,
+    result: Seq[Row] = Seq.empty,
+    pushedAggString: String = ""
+  ): Unit = {
+    val plans = DeltaTestUtils.withPhysicalPlansCaptured(spark) {
+      checkAnswer(
+        data.filter(filter).groupBy(groupBy.map(col): _*).agg(aggs.head, aggs.tail: _*),
+        result
+      )
+    }
+    val scans = plans.flatMap(_.collect {
+      case BatchScanExec(_, s: DeltaTableScan, _, _) => s
+    })
+    assert(scans.length == 1)
+    assert(scans.head.getMetaData().get("PushedAggregation").get == s"[$pushedAggString]")
+  }
+
+  test("Aggregates are pushed down") {
+    withTempDir { inputDir =>
+      val testPath = inputDir.getCanonicalPath
+      spark.range(10)
+        .withColumn("part", $"id" % 2)
+        .write
+        .format("delta")
+        .partitionBy("part")
+        .mode("append")
+        .save(testPath)
+
+      val df = spark.read.format("delta").load(testPath)
+
+      Given("No filter or group by")
+      checkPushedAggregations(
+        df,
+        Seq(min($"id"), max($"id"), count($"id")),
+        result = Seq(Row(0, 9, 10)),
+        pushedAggString = "MIN(id), MAX(id), COUNT(id)")
+
+      Given("Group by on partition")
+      checkPushedAggregations(
+        df,
+        Seq(min($"id"), max($"id"), count($"id")),
+        groupBy = Seq("part"),
+        result = Seq(Row(0, 0, 8, 5), Row(1, 1, 9, 5)),
+        pushedAggString = "MIN(id), MAX(id), COUNT(id)")
+
+      Given("Filter on partition")
+      checkPushedAggregations(
+        df,
+        Seq(min($"id"), max($"id"), count($"id")),
+        filter = "part = 1",
+        result = Seq(Row(1, 9, 5)),
+        pushedAggString = "MIN(id), MAX(id), COUNT(id)")
+    }
+  }
+}
+
+class AggregatePushDownSuite extends AggregatePushDownSuiteBase

--- a/core/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaTests.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaTests.scala
@@ -786,10 +786,9 @@ trait DataSkippingDeltaTestsBase extends QueryTest
       assert(r1.size.get("scanned").isDefined)
       assert(r1.size.get("scanned").get.files.get == 4)
 
-        val allQuery = "SELECT * from t1"
-        val Seq(r2) = getScanReport {
-          assert(sql(allQuery).collect().length == 10)
-        }
+      val allQuery = "SELECT * from t1"
+      val Seq(r2) = getScanReport {
+        assert(sql(allQuery).collect().length == 10)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaTests.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaTests.scala
@@ -776,19 +776,21 @@ trait DataSkippingDeltaTestsBase extends QueryTest
         .withColumn("col2", 'col1./(3).cast(DataTypes.IntegerType))
       data.write.format("delta").partitionBy("col1")
         .save(tempDir.getCanonicalPath)
-      spark.read.format("delta").load(tempDir.getAbsolutePath).createTempView("t1")
-      val deltaLog = DeltaLog.forTable(spark, tempDir.toString())
+      withTempView("t1") {
+        spark.read.format("delta").load(tempDir.getAbsolutePath).createTempView("t1")
+        val deltaLog = DeltaLog.forTable(spark, tempDir.toString())
 
-      val query = "SELECT * from t1 where col1 > 5"
-      val Seq(r1) = getScanReport {
-        assert(sql(query).collect().length == 4)
-      }
-      assert(r1.size.get("scanned").isDefined)
-      assert(r1.size.get("scanned").get.files.get == 4)
+        val query = "SELECT * from t1 where col1 > 5"
+        val Seq(r1) = getScanReport {
+          assert(sql(query).collect().length == 4)
+        }
+        assert(r1.size.get("scanned").isDefined)
+        assert(r1.size.get("scanned").get.files.get == 4)
 
-      val allQuery = "SELECT * from t1"
-      val Seq(r2) = getScanReport {
-        assert(sql(allQuery).collect().length == 10)
+        val allQuery = "SELECT * from t1"
+        val Seq(r2) = getScanReport {
+          assert(sql(allQuery).collect().length == 10)
+        }
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/delta/test/ScanReportHelper.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/test/ScanReportHelper.scala
@@ -25,9 +25,9 @@ import org.apache.spark.sql.delta.stats.{DataSize, PreparedDeltaFileIndex}
 import org.apache.spark.sql.execution.{FileSourceScanExec, QueryExecution, SparkPlan}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.util.QueryExecutionListener
-import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 
 /**
  * A helper trait used by test classes that want to collect the scans (i.e. [[FileSourceScanExec]])

--- a/core/src/test/scala/org/apache/spark/sql/delta/test/ScanReportHelper.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/test/ScanReportHelper.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.delta.test
 
 import scala.util.control.NonFatal
 
+import org.apache.spark.sql.delta.catalog.DeltaTableScan
 import org.apache.spark.sql.delta.files.TahoeFileIndex
 import org.apache.spark.sql.delta.metering.ScanReport
 import org.apache.spark.sql.delta.stats.{DataSize, PreparedDeltaFileIndex}
@@ -27,7 +28,6 @@ import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.util.QueryExecutionListener
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
-import org.apache.spark.sql.execution.datasources.v2.parquet.ParquetScan
 
 /**
  * A helper trait used by test classes that want to collect the scans (i.e. [[FileSourceScanExec]])
@@ -69,7 +69,8 @@ trait ScanReportHelper extends SharedSparkSession with AdaptiveSparkPlanHelper {
 
         val fileScans = collectScans(qe.executedPlan).map {
           case f: FileSourceScanExec => (f.relation.location, f.metrics)
-          case b: BatchScanExec => (b.scan.asInstanceOf[ParquetScan].fileIndex, b.metrics)
+          case b: BatchScanExec =>
+            (b.scan.asInstanceOf[DeltaTableScan].delegatedScan.fileIndex, b.metrics)
         }
 
         for ((index, metrics) <- fileScans) {

--- a/core/src/test/scala/org/apache/spark/sql/delta/test/TestsStatistics.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/test/TestsStatistics.scala
@@ -20,6 +20,7 @@ import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 
 import org.apache.spark.sql.execution.{ColumnarToRowExec, FileSourceScanExec, InputAdapter, SparkPlan}
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.functions.from_json
 import org.apache.spark.sql.{Column, DataFrame}
 import org.apache.spark.sql.test.SQLTestUtils
@@ -54,10 +55,11 @@ trait TestsStatistics { self: SQLTestUtils =>
    * A util to match a physical file scan node.
    */
   object FileScanExecNode {
-    def unapply(plan: SparkPlan): Option[FileSourceScanExec] = plan match {
+    def unapply(plan: SparkPlan): Option[SparkPlan] = plan match {
       case f: FileSourceScanExec => Some(f)
       case InputAdapter(f: FileSourceScanExec) => Some(f)
       case ColumnarToRowExec(InputAdapter(f: FileSourceScanExec)) => Some(f)
+      case b: BatchScanExec => Some(b)
       case _ => None
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
Adds support for Spark data source V2 batch reads. I've been playing around with this for a while and finally have gotten all the tests to pass. This PR is mostly to see if there's any interest in moving this direction and as a reference. There's a lot going on so if there was interest this could potentially be broken up into multiple PRs or I could try to write a design doc or something. 

The idea was to feature flag this and disable it by default. It is enabled in this PR to show the tests passing. While all the tests are passing, I know there are a few missing features compared to the current V1 reader:
- Snapshot isolation outside of a current transaction (I guess there's no tests for that?)
- Reuse of snapshot scans for the same plan when creating a PreparedDeltaFileIndex
- CDC reads will fallback to the V1 reader

The main benefit or reason this path could be useful is that a good amount of new development happening for data source V2 that could benefit Delta. One example would be aggregate pushdown without having to write custom optimizer rules. This PR has a test demonstrating existing Parquet aggregate pushdown works out of the box (as long as column mapping isn't enabled). I have a separate branch where I have been playing around with custom aggregate pushdown based on the Delta log where I have nearly everything possible working (count/min/max with group by and filtering on partition columns).

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
A lot of the tests had to be updated because they were looking for a `FileSourceScanExec`. I made all these types of things compatible with both v1 and v2 reads. 

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
