### PR TITLE
Add RoaringBitmapArray to store indices of rows deleted in a data file

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/deletionvectors/RoaringBitmapArray.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/deletionvectors/RoaringBitmapArray.scala
@@ -1,0 +1,481 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.deletionvectors
+
+import java.io.IOException
+import java.nio.{ByteBuffer, ByteOrder}
+
+import scala.collection.immutable.NumericRange
+
+import com.google.common.primitives.{Ints, UnsignedInts}
+import org.roaringbitmap.{RelativeRangeConsumer, RoaringBitmap}
+
+/**
+ * A 64-bit extension of [[RoaringBitmap]] that is optimized for cases that usually fit within
+ * a 32-bit bitmap, but may run over by a few bits on occasion.
+ *
+ * This focus makes it different from [[org.roaringbitmap.longlong.Roaring64NavigableMap]] and
+ * [[org.roaringbitmap.longlong.Roaring64Bitmap]] which focus on sparse bitmaps over the whole
+ * 64-bit range.
+ *
+ * Structurally, this implementation simply uses the most-significant 4 bytes to index into
+ * an array of 32-bit [[RoaringBitmap]] instances.
+ * The array is grown as necessary to accommodate the largest value in the bitmap.
+ *
+ * *Note:* As opposed to the other two 64-bit bitmap implementations mentioned above,
+ *         this implementation cannot accommodate `Long` values where the most significant
+ *         bit is non-zero (i.e., negative `Long` values).
+ *         It cannot even accommodate values where the 4 high-order bytes are `Int.MaxValue`,
+ *         because then the length of the `bitmaps` array would be a negative number
+ *         (`Int.MaxValue + 1`).
+ */
+final class RoaringBitmapArray extends Equals {
+  import RoaringBitmapArray._
+
+  private var bitmaps: Array[RoaringBitmap] = Array.empty
+
+  /**
+   * Add the value to the container (set the value to `true`),
+   * whether it already appears or not.
+   */
+  def add(value: Long): Unit = {
+    require(value >= 0 && value <= MAX_REPRESENTABLE_VALUE)
+    val (high, low) = decomposeHighLowBytes(value)
+    if (high >= bitmaps.length) {
+      extendBitmaps(newLength = high + 1)
+    }
+    val highBitmap = bitmaps(high)
+    highBitmap.add(low)
+  }
+
+  /** Add all `values` to the container. */
+  def addAll(values: Long*): Unit = values.foreach(add)
+
+  /** Add all values in `range` to the container. */
+  def addRange(range: Range): Unit = {
+    require(0 <= range.start && range.start <= range.end)
+    if (range.isEmpty) return // Nothing to do.
+    if (range.step != 1) {
+      // Can't optimize in this case.
+      range.foreach(i => add(UnsignedInts.toLong(i)))
+      return
+    }
+    // This is an Int range, so it must fit completely into the first bitmap.
+    if (bitmaps.isEmpty) {
+      extendBitmaps(newLength = 1)
+    }
+    val end = if (range.isInclusive) range.end + 1 else range.end
+    bitmaps.head.add(range.start, end)
+  }
+
+  /** Add all values in `range` to the container. */
+  def addRange(range: NumericRange[Long]): Unit = {
+    require(0L <= range.start && range.start <= range.end && range.end <= MAX_REPRESENTABLE_VALUE)
+    if (range.isEmpty) return // Nothing to do.
+    if (range.step != 1L) {
+      // Can't optimize in this case.
+      range.foreach(add)
+      return
+    }
+    // Decompose into sub-ranges that target a single bitmap,
+    // to use the range adds within a bitmap for efficiency.
+    val (startHigh, startLow) = decomposeHighLowBytes(range.start)
+    val (endHigh, endLow) = decomposeHighLowBytes(range.end)
+    val lastHigh = if (endLow == 0 && !range.isInclusive) endHigh - 1 else endHigh
+    if (lastHigh >= bitmaps.length) {
+      extendBitmaps(newLength = lastHigh + 1)
+    }
+    var currentHigh = startHigh
+    while (currentHigh <= lastHigh) {
+      val start = if (currentHigh == startHigh) UnsignedInts.toLong(startLow) else 0L
+      // RoaringBitmap.add is exclusive the end boundary.
+      val end = if (currentHigh == lastHigh) {
+        if (range.isInclusive) UnsignedInts.toLong(endLow) + 1L else UnsignedInts.toLong(endLow)
+      } else {
+        0xFFFFFFFFL + 1L
+      }
+      bitmaps(currentHigh).add(start, end)
+      currentHigh += 1
+    }
+  }
+
+  /**
+   * If present, remove the `value` (effectively, sets its bit value to false).
+   *
+   * @param value The index in a bitmap.
+   */
+  def remove(value: Long): Unit = {
+    require(value >= 0 && value <= MAX_REPRESENTABLE_VALUE)
+    val (high, low) = decomposeHighLowBytes(value)
+    if (high < bitmaps.length) {
+      val highBitmap = bitmaps(high)
+      highBitmap.remove(low)
+      if (highBitmap.isEmpty) {
+        // Clean up all bitmaps that are now empty (from the end).
+        var latestNonEmpty = bitmaps.length - 1
+        var done = false
+        while (!done && latestNonEmpty >= 0) {
+          if (bitmaps(latestNonEmpty).isEmpty) {
+            latestNonEmpty -= 1
+          } else {
+            done = true
+          }
+        }
+        shrinkBitmaps(latestNonEmpty + 1)
+      }
+    }
+  }
+
+  /** Remove all values from the bitmap. */
+  def clear(): Unit = {
+    bitmaps = Array.empty
+  }
+
+  /**
+   * Checks whether the value is included,
+   * which is equivalent to checking if the corresponding bit is set.
+   */
+  def contains(value: Long): Boolean = {
+    require(value >= 0 && value <= MAX_REPRESENTABLE_VALUE)
+    val high = highBytes(value)
+    if (high >= bitmaps.length) {
+      false
+    } else {
+      val highBitmap = bitmaps(high)
+      val low = lowBytes(value)
+      highBitmap.contains(low)
+    }
+  }
+
+  /**
+   * Return the set values as an array, if the cardinality is smaller than 2147483648.
+   *
+   * The integer values are in sorted order.
+   */
+  def toArray: Array[Long] = {
+    val cardinality = this.cardinality
+    require(cardinality <= Int.MaxValue)
+    val values = Array.ofDim[Long](cardinality.toInt)
+    var valuesIndex = 0
+    for ((bitmap, bitmapIndex) <- bitmaps.zipWithIndex) {
+      bitmap.forEach((value: Int) => {
+        values(valuesIndex) = composeFromHighLowBytes(bitmapIndex, value)
+        valuesIndex += 1
+      })
+    }
+    values
+  }
+
+  /** Materialise the whole set into an array */
+  def values: Array[Long] = toArray
+
+  /** Returns the number of distinct integers added to the bitmap (e.g., number of bits set). */
+  def cardinality: Long = bitmaps.foldLeft(0L)((sum, bitmap) => sum + bitmap.getLongCardinality)
+
+  /**
+   * Use a run-length encoding where it is more space efficient.
+   *
+   * @return `true` if a change was applied
+   */
+  def runOptimize(): Boolean = {
+    var changeApplied = false
+    for (bitmap <- bitmaps) {
+      changeApplied |= bitmap.runOptimize()
+    }
+    changeApplied
+  }
+
+  /**
+   * In-place bitwise OR (union) operation.
+   *
+   * The current bitmap is modified.
+   */
+  def or(that: RoaringBitmapArray): Unit = {
+    if (this.bitmaps.length < that.bitmaps.length) {
+      extendBitmaps(newLength = that.bitmaps.length)
+    }
+    for (index <- that.bitmaps.indices) {
+      val thisBitmap = this.bitmaps(index)
+      val thatBitmap = that.bitmaps(index)
+      thisBitmap.or(thatBitmap)
+    }
+  }
+
+  /** Merges the `other` set into this one. */
+  def merge(other: RoaringBitmapArray): Unit = this.or(other)
+
+  /** Get values in `this` but not `that`. */
+  def diff(other: RoaringBitmapArray): Unit = this.andNot(other)
+
+  /** Copy `this` along with underlying bitmaps to a new instance. */
+  def copy(): RoaringBitmapArray = {
+    val newBitmap = new RoaringBitmapArray()
+    newBitmap.merge(this)
+    newBitmap
+  }
+
+  /**
+   * In-place bitwise AND-NOT (this & ~that) operation.
+   *
+   * The current bitmap is modified.
+   */
+  def andNot(that: RoaringBitmapArray): Unit = {
+    val validLength = math.min(this.bitmaps.length, that.bitmaps.length)
+    for (index <- 0 until validLength) {
+      val thisBitmap = this.bitmaps(index)
+      val thatBitmap = that.bitmaps(index)
+      thisBitmap.andNot(thatBitmap)
+    }
+  }
+
+  /**
+   * Report the number of bytes required to serialize this bitmap.
+   *
+   * This is the number of bytes written out when using the [[serialize]] method.
+   */
+  def serializedSizeInBytes: Long = {
+    val magicNumberSize = 4
+    val bitmapCountSize = 4
+
+    val individualBitmapLengthSize = 4
+    val bitmapSizes = bitmaps.foldLeft(0L) { (sum, bitmap) =>
+      sum + bitmap.serializedSizeInBytes() + individualBitmapLengthSize
+    }
+
+    magicNumberSize + bitmapCountSize + bitmapSizes
+  }
+
+  /**
+   * Serialize this [[RoaringBitmapArray]] into the `buffer`.
+   *
+   * == Format ==
+   * - Magic Number (4 bytes)
+   * - Number of bitmaps (4 bytes)
+   * - The data for each individual bitmap using the standard format
+   *   (see https://github.com/RoaringBitmap/RoaringFormatSpec)
+   *
+   */
+  def serialize(buffer: ByteBuffer): Unit = {
+    require(ByteOrder.LITTLE_ENDIAN == buffer.order(),
+      "RoaringBitmapArray has to be serialized using a little endian buffer")
+
+    // Magic number to make sure we don't try to deserialize a simple RoaringBitmap later.
+    buffer.putInt(MAGIC_NUMBER)
+    buffer.putInt(bitmaps.length)
+    for (bitmap <- bitmaps) {
+      val placeholderPos = buffer.position()
+      buffer.putInt(-1) // Placeholder for the serialized size
+      val startPos = placeholderPos + 4
+      bitmap.serialize(buffer)
+      val endPos = buffer.position()
+      val writtenBytes = endPos - startPos
+      buffer.putInt(placeholderPos, writtenBytes)
+    }
+  }
+
+  /** Serializes this [[RoaringBitmapArray]] and returns the serialized form as a byte array. */
+  def serializeAsByteArray: Array[Byte] = {
+    // reduce the serialized size via RLE optimisation
+    runOptimize()
+    val size = serializedSizeInBytes
+    if (!size.isValidInt) {
+      throw new IOException(
+        s"A bitmap was too big to be serialized into an array ($size bytes)")
+    }
+    val buffer = ByteBuffer.allocate(size.toInt)
+    buffer.order(ByteOrder.LITTLE_ENDIAN)
+    // This is faster than Java serialization.
+    // See: https://richardstartin.github.io/posts/roaringbitmap-performance-tricks#serialisation
+    serialize(buffer)
+    buffer.array()
+  }
+
+  /**
+   * Deserialize the contents of `buffer` into this [[RoaringBitmapArray]].
+   *
+   * All existing content will be discarded!
+   *
+   * See [[serialize]] for the expected serialization format.
+   */
+  def deserialize(buffer: ByteBuffer): Unit = {
+    require(ByteOrder.LITTLE_ENDIAN == buffer.order(),
+      "RoaringBitmapArray has to be deserialized using a little endian buffer")
+
+    val magicNumber = buffer.getInt
+    if (magicNumber != MAGIC_NUMBER) {
+      throw new IOException(s"Unexpected RoaringBitmapArray magic number" +
+        s" ($magicNumber != $MAGIC_NUMBER)")
+    }
+    val newLength = buffer.getInt
+    if (newLength < 0) {
+      throw new IOException(s"Invalid RoaringBitmapArray length" +
+        s" ($newLength < 0)")
+    }
+    if (newLength < bitmaps.length) {
+      shrinkBitmaps(newLength)
+    } else if (newLength > bitmaps.length) {
+      extendBitmaps(newLength)
+    }
+    for (index <- 0 until newLength) {
+      val bitmapSize = buffer.getInt
+      bitmaps(index).deserialize(buffer)
+      // RoaringBitmap.deserialize doesn't move the buffer's pointer
+      buffer.position(buffer.position() + bitmapSize)
+    }
+  }
+
+  /**
+   * Consume presence information for all values in the range `[start, start + length)`.
+   *
+   * @param start Lower bound of values to consume.
+   * @param length Maximum number of values to consume.
+   * @param rrc Code to be executed for each present or absent value.
+   */
+  def forAllInRange(start: Long, length: Int, rrc: RelativeRangeConsumer): Unit = {
+    // This one is complicated and deserves its own PR,
+    // when we actually want to enable it.
+    throw new UnsupportedOperationException
+  }
+
+  /** Execute the `consume` function for every value in the set represented by this bitmap. */
+  def forEach(consume: Long => Unit): Unit = {
+    for ((bitmap, high) <- bitmaps.zipWithIndex) {
+      bitmap.forEach { low: Int =>
+        val value = composeFromHighLowBytes(high, low)
+        consume(value)
+      }
+    }
+  }
+
+  override def canEqual(that: Any): Boolean = that.isInstanceOf[RoaringBitmapArray]
+
+  override def equals(other: Any): Boolean = {
+    other match {
+      case that: RoaringBitmapArray =>
+        (this eq that) || // don't need to check canEqual because class is final
+          java.util.Arrays.deepEquals(
+            this.bitmaps.asInstanceOf[Array[AnyRef]],
+            that.bitmaps.asInstanceOf[Array[AnyRef]])
+      case _ => false
+    }
+  }
+
+  override def hashCode: Int = 131 * java.util.Arrays.deepHashCode(
+    bitmaps.asInstanceOf[Array[AnyRef]])
+
+  def mkString(start: String = "", sep: String = "", end: String = ""): String =
+    toArray.mkString(start, sep, end)
+
+  private def extendBitmaps(newLength: Int): Unit = {
+    // Optimization for the most common case
+    if (bitmaps.isEmpty && newLength == 1) {
+      bitmaps = Array(new RoaringBitmap())
+      return
+    }
+    val newBitmaps = Array.ofDim[RoaringBitmap](newLength)
+    System.arraycopy(
+      bitmaps, // source
+      0, // source start pos
+      newBitmaps, // dest
+      0, // dest start pos
+      bitmaps.length) // number of entries to copy
+    for (i <- bitmaps.length until newLength) {
+      newBitmaps(i) = new RoaringBitmap()
+    }
+    bitmaps = newBitmaps
+  }
+
+  private def shrinkBitmaps(newLength: Int): Unit = {
+    if (newLength == 0) {
+      bitmaps = Array.empty
+    } else {
+      val newBitmaps = Array.ofDim[RoaringBitmap](newLength)
+      System.arraycopy(
+        bitmaps, // source
+        0, // source start pos
+        newBitmaps, // dest
+        0, // dest start pos
+        newLength) // number of entries to copy
+      bitmaps = newBitmaps
+    }
+  }
+
+  // For testing purposes
+  protected[delta] def toBitmap32Bit(): RoaringBitmap = {
+    val bitmap32 = new RoaringBitmap()
+    forEach { value =>
+      val value32 = Ints.checkedCast(value)
+      bitmap32.add(value32)
+    }
+    bitmap32.runOptimize()
+    bitmap32
+  }
+}
+
+object RoaringBitmapArray {
+
+  /** Magic number prefix for serialization of this type. */
+  final val MAGIC_NUMBER = 1681511376
+
+  /** The largest value a [[RoaringBitmapArray]] can possibly represent. */
+  final val MAX_REPRESENTABLE_VALUE = composeFromHighLowBytes(Int.MaxValue - 1, Int.MinValue)
+
+  /** Create a new [[RoaringBitmapArray]] with the given `values`. */
+  def apply(values: Long*): RoaringBitmapArray = {
+    val bitmap = new RoaringBitmapArray
+    bitmap.addAll(values: _*)
+    bitmap
+  }
+
+  /**
+   *
+   * @param value Any `Long`; positive or negative.
+   * @return An `Int` holding the 4 high-order bytes of information of the input `value`.
+   */
+  def highBytes(value: Long): Int = (value >> 32).toInt
+
+  /**
+   *
+   * @param value Any `Long`; positive or negative.
+   * @return An `Int` holding the 4 low-order bytes of information of the input `value`.
+   */
+  def lowBytes(value: Long): Int = value.toInt
+
+  /** Separate high and low 4 bytes into a pair of `Int`s (high, low). */
+  def decomposeHighLowBytes(value: Long): (Int, Int) = (highBytes(value), lowBytes(value))
+
+  /**
+   * Combine high and low 4 bytes of a pair of `Int`s into a `Long`.
+   *
+   * This is essentially the inverse of [[decomposeHighLowBytes()]].
+   *
+   * @param high An `Int` representing the 4 high-order bytes of the output `Long`
+   * @param low An `Int` representing the 4 low-order bytes of the output `Long`
+   * @return A `Long` composing the `high` and `low` bytes.
+   */
+  def composeFromHighLowBytes(high: Int, low: Int): Long =
+    (high.toLong << 32) | (low.toLong & 0xFFFFFFFFL) // Must bitmask to avoid sign extension.
+
+  /** Deserialize the right instance from the given bytes */
+  def readFrom(bytes: Array[Byte]): RoaringBitmapArray = {
+    val buffer = ByteBuffer.wrap(bytes)
+    buffer.order(ByteOrder.LITTLE_ENDIAN)
+    val bitmap = new RoaringBitmapArray()
+    bitmap.deserialize(buffer)
+    bitmap
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/delta/deletionvectors/RoaringBitmapArray.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/deletionvectors/RoaringBitmapArray.scala
@@ -62,11 +62,11 @@ final class RoaringBitmapArray extends Equals {
     highBitmap.add(low)
   }
 
-  /** Add all `values` to the container. */
-  def addAll(values: Long*): Unit = values.foreach(add)
+  /** Add all `values` to the container. For testing purposes only. */
+  protected[delta] def addAll(values: Long*): Unit = values.foreach(add)
 
   /** Add all values in `range` to the container. */
-  def addRange(range: Range): Unit = {
+  protected[delta] def addRange(range: Range): Unit = {
     require(0 <= range.start && range.start <= range.end)
     if (range.isEmpty) return // Nothing to do.
     if (range.step != 1) {
@@ -83,7 +83,7 @@ final class RoaringBitmapArray extends Equals {
   }
 
   /** Add all values in `range` to the container. */
-  def addRange(range: NumericRange[Long]): Unit = {
+  protected[delta] def addRange(range: NumericRange[Long]): Unit = {
     require(0L <= range.start && range.start <= range.end && range.end <= MAX_REPRESENTABLE_VALUE)
     if (range.isEmpty) return // Nothing to do.
     if (range.step != 1L) {
@@ -118,7 +118,7 @@ final class RoaringBitmapArray extends Equals {
    *
    * @param value The index in a bitmap.
    */
-  def remove(value: Long): Unit = {
+  protected[deletionvectors] def remove(value: Long): Unit = {
     require(value >= 0 && value <= MAX_REPRESENTABLE_VALUE)
     val (high, low) = decomposeHighLowBytes(value)
     if (high < bitmaps.length) {
@@ -380,6 +380,10 @@ final class RoaringBitmapArray extends Equals {
   def mkString(start: String = "", sep: String = "", end: String = ""): String =
     toArray.mkString(start, sep, end)
 
+  /**
+   * Utility method to extend the array of [[RoaringBitmap]] to given length, keeping
+   * the existing elements in place.
+   */
   private def extendBitmaps(newLength: Int): Unit = {
     // Optimization for the most common case
     if (bitmaps.isEmpty && newLength == 1) {
@@ -399,6 +403,7 @@ final class RoaringBitmapArray extends Equals {
     bitmaps = newBitmaps
   }
 
+  /** Utility method to shrink the array of [[RoaringBitmap]] to given length. */
   private def shrinkBitmaps(newLength: Int): Unit = {
     if (newLength == 0) {
       bitmaps = Array.empty

--- a/core/src/test/scala/org/apache/spark/sql/delta/deletionvectors/RoaringBitmapArraySuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/deletionvectors/RoaringBitmapArraySuite.scala
@@ -1,0 +1,460 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.deletionvectors
+
+import java.nio.{ByteBuffer, ByteOrder}
+
+import scala.collection.immutable.TreeSet
+
+import com.google.common.primitives.Ints
+
+import org.apache.spark.SparkFunSuite
+
+class RoaringBitmapArraySuite extends SparkFunSuite {
+
+  final val BITMAP2_NUMBER = Int.MaxValue.toLong * 3L
+  /** RoaringBitmap containers mostly use `Char` constants internally, so this is consistent. */
+  final val CONTAINER_BOUNDARY = Char.MaxValue.toLong + 1L
+  final val BITMAP_BOUNDARY = 0xFFFFFFFFL + 1L
+
+  private def testEquality(referenceResult: Seq[Long])(
+    testOps: (RoaringBitmapArray => Unit)*): Unit = {
+    val referenceBitmap = RoaringBitmapArray(referenceResult: _*)
+    val testBitmap = RoaringBitmapArray()
+    testOps.foreach(op => op(testBitmap))
+    assert(testBitmap === referenceBitmap)
+    assert(testBitmap.## === referenceBitmap.##)
+    assert(testBitmap.toArray === referenceBitmap.toArray)
+  }
+
+  test("equality") {
+    testEquality(Seq(1))(_.add(1))
+    testEquality(Nil)(_.add(1), _.remove(1))
+    testEquality(Seq(1))(_.add(1), _.add(1))
+    testEquality(Nil)(_.add(1), _.add(1), _.remove(1))
+    testEquality(Nil)(_.add(1), _.remove(1), _.remove(1))
+    testEquality(Nil)(_.add(1), _.add(1), _.remove(1), _.remove(1))
+    testEquality(Seq(1))(_.add(1), _.remove(1), _.add(1))
+    testEquality(Nil)(_.add(1), _.remove(1), _.add(1), _.remove(1))
+
+    testEquality(Seq(BITMAP2_NUMBER))(_.add(BITMAP2_NUMBER))
+    testEquality(Nil)(_.add(BITMAP2_NUMBER), _.remove(BITMAP2_NUMBER))
+    testEquality(Seq(BITMAP2_NUMBER))(_.add(BITMAP2_NUMBER), _.add(BITMAP2_NUMBER))
+    testEquality(Nil)(_.add(BITMAP2_NUMBER), _.add(BITMAP2_NUMBER), _.remove(BITMAP2_NUMBER))
+    testEquality(Nil)(_.add(BITMAP2_NUMBER), _.remove(BITMAP2_NUMBER), _.remove(BITMAP2_NUMBER))
+    testEquality(Nil)(
+      _.add(BITMAP2_NUMBER),
+      _.add(BITMAP2_NUMBER),
+      _.remove(BITMAP2_NUMBER),
+      _.remove(BITMAP2_NUMBER))
+    testEquality(Seq(BITMAP2_NUMBER))(
+      _.add(BITMAP2_NUMBER),
+      _.remove(BITMAP2_NUMBER),
+      _.add(BITMAP2_NUMBER))
+    testEquality(Nil)(
+      _.add(BITMAP2_NUMBER),
+      _.remove(BITMAP2_NUMBER),
+      _.add(BITMAP2_NUMBER),
+      _.remove(BITMAP2_NUMBER))
+
+    testEquality(Seq(1, BITMAP2_NUMBER))(_.add(1), _.add(BITMAP2_NUMBER))
+    testEquality(Seq(BITMAP2_NUMBER))(_.add(1), _.add(BITMAP2_NUMBER), _.remove(1))
+    testEquality(Seq(1, BITMAP2_NUMBER))(_.add(BITMAP2_NUMBER), _.add(1))
+    testEquality(Seq(BITMAP2_NUMBER))(_.add(BITMAP2_NUMBER), _.add(1), _.remove(1))
+    testEquality(Seq(BITMAP2_NUMBER))(_.add(1), _.remove(1), _.add(BITMAP2_NUMBER))
+    testEquality(Nil)(_.add(1), _.remove(1), _.add(BITMAP2_NUMBER), _.remove(BITMAP2_NUMBER))
+    testEquality(Nil)(_.add(1), _.add(BITMAP2_NUMBER), _.remove(1), _.remove(BITMAP2_NUMBER))
+    testEquality(Nil)(_.add(BITMAP2_NUMBER), _.add(1), _.remove(1), _.remove(BITMAP2_NUMBER))
+    testEquality(Nil)(_.add(BITMAP2_NUMBER), _.add(1), _.remove(BITMAP2_NUMBER), _.remove(1))
+
+    val denseSequence = 1L to (3L * CONTAINER_BOUNDARY)
+    def addAll(v: Long): RoaringBitmapArray => Unit = rb => rb.add(v)
+    testEquality(denseSequence)(denseSequence.map(addAll): _*)
+    testEquality(denseSequence)(denseSequence.reverse.map(addAll): _*)
+
+    val sparseSequence = 1L to BITMAP2_NUMBER by CONTAINER_BOUNDARY
+    testEquality(sparseSequence)(sparseSequence.map(addAll): _*)
+    testEquality(sparseSequence)(sparseSequence.reverse.map(addAll): _*)
+  }
+
+  /**
+   * A [[RoaringBitmapArray]] that contains all 3 container types
+   * in two [[org.roaringbitmap.RoaringBitmap]] instances.
+   */
+  lazy val allContainerTypesBitmap: RoaringBitmapArray = {
+    val bitmap = RoaringBitmapArray()
+    // RoaringBitmap 1 Container 1 (Array)
+    bitmap.addAll(1L, 17L, 63000L, CONTAINER_BOUNDARY - 1)
+    // RoaringBitmap 1 Container 2 (RLE)
+    bitmap.addRange((CONTAINER_BOUNDARY + 500L) until (CONTAINER_BOUNDARY + 1200L))
+    // RoaringBitmap 1 Container 3 (Bitset)
+    bitmap.addRange((2L * CONTAINER_BOUNDARY) until (3L * CONTAINER_BOUNDARY - 1L) by 3L)
+
+    // RoaringBitmap 2 Container 1 (Array)
+    bitmap.addAll(
+      BITMAP_BOUNDARY, BITMAP_BOUNDARY + 17L,
+      BITMAP_BOUNDARY + 63000L,
+      BITMAP_BOUNDARY + CONTAINER_BOUNDARY - 1)
+    // RoaringBitmap 2 Container 2 (RLE)
+    bitmap.addRange((BITMAP_BOUNDARY + CONTAINER_BOUNDARY + 500L) until
+      (BITMAP_BOUNDARY + CONTAINER_BOUNDARY + 1200L))
+    // RoaringBitmap 2 Container 3 (Bitset)
+    bitmap.addRange((BITMAP_BOUNDARY + 2L * CONTAINER_BOUNDARY) until
+      (BITMAP_BOUNDARY + 3L * CONTAINER_BOUNDARY - 1L) by 3L)
+
+    // Check that RLE containers are actually created.
+    assert(bitmap.runOptimize())
+
+    bitmap
+  }
+
+  test("serialization") {
+    checkSerializeDeserialize(RoaringBitmapArray())
+    checkSerializeDeserialize(RoaringBitmapArray(1L))
+    checkSerializeDeserialize(RoaringBitmapArray(BITMAP2_NUMBER))
+    checkSerializeDeserialize(RoaringBitmapArray(1L, BITMAP2_NUMBER))
+    checkSerializeDeserialize(allContainerTypesBitmap)
+  }
+
+  private def checkSerializeDeserialize(input: RoaringBitmapArray): Unit = {
+    val serializedSize = Ints.checkedCast(input.serializedSizeInBytes)
+    val buffer = ByteBuffer.allocate(serializedSize).order(ByteOrder.LITTLE_ENDIAN)
+    input.serialize(buffer)
+    val output = RoaringBitmapArray()
+    buffer.flip()
+    output.deserialize(buffer)
+    assert(input === output)
+  }
+
+  test("serialization and deserialization with big endian buffers throws") {
+    val roaringBitmapArray = RoaringBitmapArray(1L)
+    val bigEndianBuffer = ByteBuffer
+      .allocate(roaringBitmapArray.serializedSizeInBytes.toInt)
+      .order(ByteOrder.BIG_ENDIAN)
+
+    assertThrows[IllegalArgumentException] {
+      roaringBitmapArray.serialize(bigEndianBuffer)
+    }
+
+    assertThrows[IllegalArgumentException] {
+      roaringBitmapArray.deserialize(bigEndianBuffer)
+    }
+  }
+
+  test("empty") {
+    val bitmap = RoaringBitmapArray()
+    assert(bitmap.cardinality === 0L)
+    assert(!bitmap.contains(0L))
+    assert(bitmap.toArray === Array.empty[Long])
+    var hadValue = false
+    bitmap.forEach(_ => hadValue = true)
+    assert(!hadValue)
+  }
+
+  test("special values") {
+    testSpecialValue(0L)
+    testSpecialValue(Int.MaxValue.toLong)
+    testSpecialValue(CONTAINER_BOUNDARY - 1L)
+    testSpecialValue(CONTAINER_BOUNDARY)
+    testSpecialValue(BITMAP_BOUNDARY - 1L)
+    testSpecialValue(BITMAP_BOUNDARY)
+    testSpecialValue(3L * BITMAP_BOUNDARY + 42L)
+  }
+
+  private def testSpecialValue(value: Long): Unit = {
+    val bitmap = RoaringBitmapArray(value)
+    assert(bitmap.cardinality === 1L)
+    assert(bitmap.contains(value))
+    assert(bitmap.toArray === Array(value))
+    var valueCount = 0
+    bitmap.forEach { v =>
+      valueCount += 1
+      assert(v === value)
+    }
+    assert(valueCount === 1)
+    bitmap.remove(value)
+    assert(!bitmap.contains(value))
+    assert(bitmap.cardinality === 0L)
+  }
+
+  test("negative numbers") {
+    assertThrows[IllegalArgumentException] {
+      val bitmap = RoaringBitmapArray()
+      bitmap.add(-1L)
+    }
+    assertThrows[IllegalArgumentException] {
+      RoaringBitmapArray(-1L)
+    }
+    assertThrows[IllegalArgumentException] {
+      val bitmap = RoaringBitmapArray(1L)
+      bitmap.remove(-1L)
+    }
+    assertThrows[IllegalArgumentException] {
+      val bitmap = RoaringBitmapArray()
+      bitmap.add(Long.MaxValue)
+    }
+    assertThrows[IllegalArgumentException] {
+      RoaringBitmapArray(Long.MaxValue)
+    }
+    assertThrows[IllegalArgumentException] {
+      val bitmap = RoaringBitmapArray(1L)
+      bitmap.remove(Long.MaxValue)
+    }
+    assertThrows[IllegalArgumentException] {
+      val bitmap = RoaringBitmapArray()
+      bitmap.addAll(-1L, 1L)
+    }
+    assertThrows[IllegalArgumentException] {
+      val bitmap = RoaringBitmapArray()
+      bitmap.addRange(-3 to 1)
+    }
+    assertThrows[IllegalArgumentException] {
+      val bitmap = RoaringBitmapArray()
+      bitmap.addRange(-3L to 1L)
+    }
+  }
+
+  private def testContainsButNoSimilarValues(value: Long, bitmap: RoaringBitmapArray): Unit = {
+    assert(bitmap.contains(value))
+    for (i <- 1 to 3) {
+      assert(!bitmap.contains(value + i * CONTAINER_BOUNDARY))
+      assert(!bitmap.contains(value + i * BITMAP_BOUNDARY))
+    }
+  }
+
+  test("small integers") {
+    val bitmap = RoaringBitmapArray(
+      3L, 4L, CONTAINER_BOUNDARY - 1L, CONTAINER_BOUNDARY, Int.MaxValue.toLong)
+    assert(bitmap.cardinality === 5L)
+    testContainsButNoSimilarValues(3L, bitmap)
+    testContainsButNoSimilarValues(4L, bitmap)
+    testContainsButNoSimilarValues(CONTAINER_BOUNDARY - 1L, bitmap)
+    testContainsButNoSimilarValues(CONTAINER_BOUNDARY, bitmap)
+    testContainsButNoSimilarValues(Int.MaxValue.toLong, bitmap)
+    assert(bitmap.toArray ===
+      Array(3L, 4L, CONTAINER_BOUNDARY - 1L, CONTAINER_BOUNDARY, Int.MaxValue.toLong))
+    var values: List[Long] = Nil
+    bitmap.forEach { value =>
+      values ::= value
+    }
+    assert(values.reverse ===
+      List(3L, 4L, CONTAINER_BOUNDARY - 1L, CONTAINER_BOUNDARY, Int.MaxValue.toLong))
+    bitmap.remove(CONTAINER_BOUNDARY)
+    assert(!bitmap.contains(CONTAINER_BOUNDARY))
+    assert(bitmap.cardinality === 4L)
+    testContainsButNoSimilarValues(3L, bitmap)
+    testContainsButNoSimilarValues(4L, bitmap)
+    testContainsButNoSimilarValues(CONTAINER_BOUNDARY - 1L, bitmap)
+    testContainsButNoSimilarValues(Int.MaxValue.toLong, bitmap)
+  }
+
+  test("large integers") {
+    val container1Number = Int.MaxValue.toLong + 1L
+    val container3Number = 2 * BITMAP_BOUNDARY + 1L
+    val bitmap = RoaringBitmapArray(
+      3L, 4L, container1Number, BITMAP_BOUNDARY, BITMAP2_NUMBER, container3Number)
+    assert(bitmap.cardinality === 6L)
+    testContainsButNoSimilarValues(3L, bitmap)
+    testContainsButNoSimilarValues(4L, bitmap)
+    testContainsButNoSimilarValues(container1Number, bitmap)
+    testContainsButNoSimilarValues(BITMAP_BOUNDARY, bitmap)
+    testContainsButNoSimilarValues(BITMAP2_NUMBER, bitmap)
+    testContainsButNoSimilarValues(container3Number, bitmap)
+    assert(bitmap.toArray ===
+      Array(3L, 4L, container1Number, BITMAP_BOUNDARY, BITMAP2_NUMBER, container3Number))
+    var values: List[Long] = Nil
+    bitmap.forEach { value =>
+      values ::= value
+    }
+    assert(values.reverse ===
+      List(3L, 4L, container1Number, BITMAP_BOUNDARY, BITMAP2_NUMBER, container3Number))
+    bitmap.remove(BITMAP_BOUNDARY)
+    assert(!bitmap.contains(BITMAP_BOUNDARY))
+    assert(bitmap.cardinality === 5L)
+    testContainsButNoSimilarValues(3L, bitmap)
+    testContainsButNoSimilarValues(4L, bitmap)
+    testContainsButNoSimilarValues(container1Number, bitmap)
+    testContainsButNoSimilarValues(BITMAP2_NUMBER, bitmap)
+    testContainsButNoSimilarValues(container3Number, bitmap)
+  }
+
+  test("add/remove round-trip") {
+    // Single value in the second bitmap
+    val bitmap = RoaringBitmapArray(BITMAP2_NUMBER)
+    assert(bitmap.contains(BITMAP2_NUMBER))
+    bitmap.remove(BITMAP2_NUMBER)
+    assert(!bitmap.contains(BITMAP2_NUMBER))
+    bitmap.add(BITMAP2_NUMBER)
+    assert(bitmap.contains(BITMAP2_NUMBER))
+
+    // Two values in two bitmaps
+    bitmap.add(CONTAINER_BOUNDARY)
+    assert(bitmap.contains(CONTAINER_BOUNDARY))
+    assert(bitmap.contains(BITMAP2_NUMBER))
+    bitmap.remove(CONTAINER_BOUNDARY)
+    assert(!bitmap.contains(CONTAINER_BOUNDARY))
+    assert(bitmap.contains(BITMAP2_NUMBER))
+    bitmap.add(CONTAINER_BOUNDARY)
+    assert(bitmap.contains(CONTAINER_BOUNDARY))
+    assert(bitmap.contains(BITMAP2_NUMBER))
+  }
+
+  test("or") {
+    testOr(left = TreeSet.empty, right = TreeSet.empty)
+    testOr(left = TreeSet(1L), right = TreeSet.empty)
+    testOr(left = TreeSet.empty, right = TreeSet(1L))
+    testOr(left = TreeSet(0L, CONTAINER_BOUNDARY), right = TreeSet(1L, BITMAP_BOUNDARY - 1L))
+    testOr(
+      left = TreeSet(0L, CONTAINER_BOUNDARY, BITMAP2_NUMBER),
+      right = TreeSet(1L, BITMAP_BOUNDARY - 1L))
+    testOr(
+      left = TreeSet(0L, CONTAINER_BOUNDARY),
+      right = TreeSet(1L, BITMAP_BOUNDARY - 1L, BITMAP2_NUMBER))
+  }
+
+  private def testOr(left: TreeSet[Long], right: TreeSet[Long]): Unit = {
+    val leftBitmap = RoaringBitmapArray(left.toSeq: _*)
+    val rightBitmap = RoaringBitmapArray(right.toSeq: _*)
+
+    val expected = left.union(right).toSeq
+
+    leftBitmap.or(rightBitmap)
+
+    assert(leftBitmap.toArray.toSeq === expected)
+  }
+
+  test("andNot") {
+    testAndNot(left = TreeSet.empty, right = TreeSet.empty)
+    testAndNot(left = TreeSet(1L), right = TreeSet.empty)
+    testAndNot(left = TreeSet.empty, right = TreeSet(1L))
+    testAndNot(left = TreeSet(0L, CONTAINER_BOUNDARY), right = TreeSet(1L, BITMAP_BOUNDARY - 1L))
+    testAndNot(
+      left = TreeSet(0L, CONTAINER_BOUNDARY, BITMAP2_NUMBER),
+      right = TreeSet(1L, BITMAP_BOUNDARY - 1L))
+    testAndNot(
+      left = TreeSet(0L, CONTAINER_BOUNDARY),
+      right = TreeSet(1L, BITMAP_BOUNDARY - 1L, BITMAP2_NUMBER))
+  }
+
+  private def testAndNot(left: TreeSet[Long], right: TreeSet[Long]): Unit = {
+    val leftBitmap = RoaringBitmapArray()
+    left.foreach(leftBitmap.add)
+    val rightBitmap = RoaringBitmapArray()
+    right.foreach(rightBitmap.add)
+
+    val expected = left.diff(right).toArray
+
+    leftBitmap.andNot(rightBitmap)
+
+    assert(leftBitmap.toArray === expected)
+  }
+
+  test("clear") {
+    testEquality(Nil)(_.add(1), _.clear())
+    testEquality(Nil)(_.add(1), _.add(1), _.clear())
+    testEquality(Nil)(_.add(1), _.clear(), _.clear())
+    testEquality(Nil)(_.add(1), _.add(1), _.clear(), _.clear())
+    testEquality(Seq(1))(_.add(1), _.clear(), _.add(1))
+    testEquality(Nil)(_.add(1), _.clear(), _.add(1), _.clear())
+
+    testEquality(Nil)(_.add(BITMAP2_NUMBER), _.clear())
+    testEquality(Nil)(_.add(BITMAP2_NUMBER), _.add(BITMAP2_NUMBER), _.clear())
+    testEquality(Nil)(_.add(BITMAP2_NUMBER), _.clear(), _.clear())
+    testEquality(Nil)(_.add(BITMAP2_NUMBER), _.add(BITMAP2_NUMBER), _.clear(), _.clear())
+    testEquality(Seq(BITMAP2_NUMBER))(_.add(BITMAP2_NUMBER), _.clear(), _.add(BITMAP2_NUMBER))
+    testEquality(Nil)(_.add(BITMAP2_NUMBER), _.clear(), _.add(BITMAP2_NUMBER), _.clear())
+
+    testEquality(Nil)(_.add(1), _.add(BITMAP2_NUMBER), _.clear())
+    testEquality(Nil)(_.add(BITMAP2_NUMBER), _.add(1), _.clear())
+    testEquality(Seq(BITMAP2_NUMBER))(_.add(1), _.clear(), _.add(BITMAP2_NUMBER))
+    testEquality(Nil)(_.add(1), _.clear(), _.add(BITMAP2_NUMBER), _.clear())
+    testEquality(Nil)(_.add(1), _.add(BITMAP2_NUMBER), _.clear(), _.clear())
+
+    val denseSequence = 1L to (3L * CONTAINER_BOUNDARY)
+    testEquality(Nil)(_.addAll(denseSequence: _*), _.clear())
+
+    val sparseSequence = 1L to BITMAP2_NUMBER by CONTAINER_BOUNDARY
+    testEquality(Nil)(_.addAll(sparseSequence: _*), _.clear())
+  }
+
+  test("bulk adds") {
+
+    def testArrayEquality(referenceResult: Seq[Long], command: RoaringBitmapArray => Unit): Unit = {
+      val testBitmap = RoaringBitmapArray()
+      command(testBitmap)
+      assert(testBitmap.toArray.toSeq === referenceResult)
+    }
+
+    val bitmap = RoaringBitmapArray(1L, 5L, CONTAINER_BOUNDARY, BITMAP_BOUNDARY)
+    assert(bitmap.toArray.toSeq === Seq(1L, 5L, CONTAINER_BOUNDARY, BITMAP_BOUNDARY))
+
+    testArrayEquality(
+      referenceResult = Seq(1L, 5L, CONTAINER_BOUNDARY, BITMAP_BOUNDARY),
+      command = _.addAll(1L, 5L, CONTAINER_BOUNDARY, BITMAP_BOUNDARY))
+
+    testArrayEquality(
+      referenceResult = (CONTAINER_BOUNDARY - 5L) to (CONTAINER_BOUNDARY + 5L),
+      command = _.addRange((CONTAINER_BOUNDARY - 5L) to (CONTAINER_BOUNDARY + 5L)))
+
+    testArrayEquality(
+      referenceResult = (CONTAINER_BOUNDARY - 5L) to (CONTAINER_BOUNDARY + 5L) by 3L,
+      command = _.addRange((CONTAINER_BOUNDARY - 5L) to (CONTAINER_BOUNDARY + 5L) by 3L))
+
+    // Int ranges call a different method.
+    testArrayEquality(
+      referenceResult = (CONTAINER_BOUNDARY - 5L) to (CONTAINER_BOUNDARY + 5L),
+      command = _.addRange((CONTAINER_BOUNDARY - 5L).toInt to (CONTAINER_BOUNDARY + 5L).toInt))
+
+    testArrayEquality(
+      referenceResult = (CONTAINER_BOUNDARY - 5L) to (CONTAINER_BOUNDARY + 5L) by 3L,
+      command = _.addRange((CONTAINER_BOUNDARY - 5L).toInt to (CONTAINER_BOUNDARY + 5L).toInt by 3))
+
+    testArrayEquality(
+      referenceResult = (BITMAP_BOUNDARY - 5L) to BITMAP_BOUNDARY,
+      command = _.addRange((BITMAP_BOUNDARY - 5L) to BITMAP_BOUNDARY))
+
+    testArrayEquality(
+      referenceResult = (BITMAP_BOUNDARY - 5L) to (BITMAP_BOUNDARY + 5L),
+      command = _.addRange((BITMAP_BOUNDARY - 5L) to (BITMAP_BOUNDARY + 5L)))
+
+    testArrayEquality(
+      referenceResult = BITMAP_BOUNDARY to (BITMAP_BOUNDARY + 5L),
+      command = _.addRange(BITMAP_BOUNDARY to (BITMAP_BOUNDARY + 5L)))
+  }
+
+  test("large cardinality") {
+    val bitmap = RoaringBitmapArray()
+    // We can't produce ranges in Scala whose lengths would be greater than Int.MaxValue
+    // so we add them in stages of Int.MaxValue / 2 instead.
+    for (index <- 0 until 6) {
+      val start = index.toLong * Int.MaxValue.toLong / 2L
+      val end = (index.toLong + 1L) * Int.MaxValue.toLong / 2L
+      bitmap.addRange(start until end)
+    }
+    assert(bitmap.cardinality === (3L * Int.MaxValue.toLong))
+    for (index <- 0 until 6) {
+      val start = index.toLong * Int.MaxValue.toLong / 2L
+      val end = (index.toLong + 1L) * Int.MaxValue.toLong / 2L
+      val stride = 1023
+      for (pos <- start until end by stride) {
+        assert(bitmap.contains(pos))
+      }
+    }
+    assert(!bitmap.contains(3L * Int.MaxValue.toLong))
+    assert(!bitmap.contains(3L * Int.MaxValue.toLong + 42L))
+  }
+}


### PR DESCRIPTION
## Description
This PR is part of the feature: Support reading Delta tables with deletion vectors (more at delta-io/delta#1485)

Adds a new bitmap implementation called `RoaringBitmapArray`. This will be used to encode the deleted row indices. There already exists a `Roaring64Bitmap` provided by the `org.roaringbitmap` library , but this implementation is optimized for use case of handling row indices, which are always clustered between 0 and the index of the last row number of a file, as opposed to being arbitrarily sparse over the whole `Long` space.

## How was this patch tested?
Unit tests

## Does this PR introduce _any_ user-facing changes?
No