### PR TITLE
Make examples/scala compile -- detail() is available since v2.1

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,3 +52,4 @@ jobs:
       - name: Run Scala/Java and Python tests
         run: |
           pipenv run python run-tests.py --coverage
+          cd examples/scala && build/sbt "++ $SCALA_VERSION compile"

--- a/examples/scala/build.sbt
+++ b/examples/scala/build.sbt
@@ -20,7 +20,7 @@ organizationName := "example"
 
 val scala212 = "2.12.15"
 val scala213 = "2.13.8"
-val deltaVersion = "2.0.0"
+val deltaVersion = "2.1.0"
 
 def getMajorMinor(version: String): (Int, Int) = {
   val majorMinor = Try {
@@ -77,7 +77,7 @@ getDeltaVersion := {
       println(s"Using Delta version $v")
       v
     case None =>
-      "1.2.0"
+      deltaVersion
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Slim Ouertani <ouertani@gmail.com>

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

This Pr makes `examples/scala` compile and run with `sbt compile` and `sbt run`. By default this error is raised

```
[info] compiling 6 Scala sources to /private/tmp/delta/examples/scala/target/scala-2.13/classes ...
[error] /private/tmp/delta/examples/scala/src/main/scala/example/Utilities.scala:67:16: value detail is not a member of io.delta.tables.DeltaTable
[error]     deltaTable.detail().show()
[error]                ^
[error] one error found
[error] (Compile / compileIncremental) Compilation failed
```

## How was this patch tested?
This is tested by making sure that `sbt compile` and `sbt run` commands works are expected.


## Does this PR introduce _any_ user-facing changes?

No changes, this is part of the build of example dir.
