### PR TITLE
Enable ability to read stream from delta table without duplicates. Only blind commits.

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -163,6 +163,8 @@ trait DeltaReadOptions extends DeltaOptionParser {
 
   val ignoreDeletes = options.get(IGNORE_DELETES_OPTION).exists(toBoolean(_, IGNORE_DELETES_OPTION))
 
+  val onlyAppends = options.get(ONLY_APPENDS_OPTION).exists(toBoolean(_, ONLY_APPENDS_OPTION))
+
   val failOnDataLoss = options.get(FAIL_ON_DATA_LOSS_OPTION)
     .forall(toBoolean(_, FAIL_ON_DATA_LOSS_OPTION)) // thanks to forall: by default true
 
@@ -235,6 +237,7 @@ object DeltaOptions extends DeltaLogging {
   val IGNORE_FILE_DELETION_OPTION = "ignoreFileDeletion"
   val IGNORE_CHANGES_OPTION = "ignoreChanges"
   val IGNORE_DELETES_OPTION = "ignoreDeletes"
+  val ONLY_APPENDS_OPTION = "onlyAppends"
   val FAIL_ON_DATA_LOSS_OPTION = "failOnDataLoss"
   val OPTIMIZE_WRITE_OPTION = "optimizeWrite"
   val DATA_CHANGE_OPTION = "dataChange"

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuiteBase.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuiteBase.scala
@@ -17,11 +17,9 @@
 package org.apache.spark.sql.delta
 
 import java.io.File
-
 import org.apache.spark.sql.delta.actions.Format
 import org.apache.spark.sql.delta.schema.{SchemaMergingUtils, SchemaUtils}
-
-import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.{Column, DataFrame, SaveMode}
 import org.apache.spark.sql.streaming.StreamTest
 import org.apache.spark.sql.types.StructType
 
@@ -91,6 +89,22 @@ trait DeltaSourceSuiteBase extends StreamTest {
     def apply(path: File, data: DataFrame): AssertOnQuery =
       AssertOnQuery { _ =>
         data.write.format("delta").mode("append").save(path.getAbsolutePath)
+        true
+      }
+  }
+
+  object AddUpdatesToReservoir {
+    def apply(path: File, updateExpression: Map[String, Column]): AssertOnQuery =
+      AssertOnQuery { _ =>
+        io.delta.tables.DeltaTable.forPath(path.getAbsolutePath).update(updateExpression)
+        true
+      }
+  }
+
+  object AddDeletesToReservoir {
+    def apply(path: File, deleteCondition: Column): AssertOnQuery =
+      AssertOnQuery { _ =>
+        io.delta.tables.DeltaTable.forPath(path.getAbsolutePath).delete(deleteCondition)
         true
       }
   }


### PR DESCRIPTION
## Description

- Add an appendOnly:Boolean option to the stream source. When the option applies stream source will skip all commits, except `blind Append` commits.
- To understand motivation, please refer to the `motivation` part from issue #1490.
 
Resolves #1490

## How was this patch tested?

There is a unit test for this patch.
And also similar changes work in production for the last 2 weeks.

## Does this PR introduce _any_ user-facing changes?

Yes, it's introducing a new option for the delta Structure Stream.
