### PR TITLE
Enable ability to read stream from delta table without duplicates. Skip commit with removeFileAction.

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOptions.scala
@@ -163,6 +163,8 @@ trait DeltaReadOptions extends DeltaOptionParser {
 
   val ignoreDeletes = options.get(IGNORE_DELETES_OPTION).exists(toBoolean(_, IGNORE_DELETES_OPTION))
 
+  val onlyAppends = options.get(ONLY_APPENDS_OPTION).exists(toBoolean(_, ONLY_APPENDS_OPTION))
+
   val failOnDataLoss = options.get(FAIL_ON_DATA_LOSS_OPTION)
     .forall(toBoolean(_, FAIL_ON_DATA_LOSS_OPTION)) // thanks to forall: by default true
 
@@ -235,6 +237,7 @@ object DeltaOptions extends DeltaLogging {
   val IGNORE_FILE_DELETION_OPTION = "ignoreFileDeletion"
   val IGNORE_CHANGES_OPTION = "ignoreChanges"
   val IGNORE_DELETES_OPTION = "ignoreDeletes"
+  val ONLY_APPENDS_OPTION = "onlyAppends"
   val FAIL_ON_DATA_LOSS_OPTION = "failOnDataLoss"
   val OPTIMIZE_WRITE_OPTION = "optimizeWrite"
   val DATA_CHANGE_OPTION = "dataChange"

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -37,6 +37,7 @@ import org.apache.spark.{SparkException, SparkThrowable}
 import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, Row}
 import org.apache.spark.sql.catalyst.util.IntervalUtils
 import org.apache.spark.sql.execution.streaming._
+import org.apache.spark.sql.functions._
 import org.apache.spark.sql.streaming.{OutputMode, StreamingQuery, StreamingQueryException, Trigger}
 import org.apache.spark.sql.streaming.util.StreamManualClock
 import org.apache.spark.sql.types.StructType
@@ -100,6 +101,50 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         AddToReservoir(inputDir, Seq("keep7", "drop8", "keep9").toDF),
         AssertOnQuery { q => q.processAllAvailable(); true },
         CheckAnswer("keep1", "keep2", "keep5", "keep6", "keep7", "keep9")
+      )
+    }
+  }
+
+  test("appendOnly: ignore non append commit") {
+    withTempDir { inputDir =>
+      val deltaLog = DeltaLog.forTable(spark, new Path(inputDir.toURI))
+      withMetadata(deltaLog, StructType.fromDDL("value STRING"))
+
+      val df = spark.readStream
+        .format("delta")
+        .option(DeltaOptions.ONLY_APPENDS_OPTION, true)
+        .load(inputDir.getCanonicalPath)
+
+      testStream(df)(
+        AddToReservoir(inputDir, Seq("toBeUpdate", "toBeDelete").toDF),
+        AssertOnQuery { q => q.processAllAvailable(); true },
+        CheckAnswer("toBeUpdate", "toBeDelete"),
+        AddUpdatesToReservoir(
+          inputDir,
+          Map("value" ->  when($"value" === "toBeUpdate", "update1").otherwise($"value"))
+        ),
+        AddDeletesToReservoir(inputDir, $"value" === "toBeDelete"),
+        CheckAnswer("toBeUpdate", "toBeDelete"),
+        StopStream,
+        AddToReservoir(inputDir, Seq("append1", "append2").toDF),
+        AddUpdatesToReservoir(
+          inputDir,
+          Map("value" ->  when($"value" === "toBeUpdate", "update1").otherwise($"value"))
+        ),
+        AddMergeWithOnlyInsertsToReservoir(
+          inputDir,
+          dfToMerge = Seq("toBeUpdate", "toBeDelete", "mergeInsert").toDF("value").as("changes"),
+          mergeCondition = $"table.value" === $"changes.value"
+        ),
+        AddDeletesToReservoir(inputDir, $"value" === "toBeDelete"),
+        StartStream(),
+        AssertOnQuery { q => q.processAllAvailable(); true },
+        CheckAnswer(
+          "append1", "append2",
+          "mergeInsert",
+          "toBeUpdate", "toBeUpdate",
+          "toBeDelete", "toBeDelete"
+          )
       )
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuiteBase.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuiteBase.scala
@@ -17,11 +17,9 @@
 package org.apache.spark.sql.delta
 
 import java.io.File
-
 import org.apache.spark.sql.delta.actions.Format
 import org.apache.spark.sql.delta.schema.{SchemaMergingUtils, SchemaUtils}
-
-import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.{Column, DataFrame, SaveMode}
 import org.apache.spark.sql.streaming.StreamTest
 import org.apache.spark.sql.types.StructType
 
@@ -91,6 +89,36 @@ trait DeltaSourceSuiteBase extends StreamTest {
     def apply(path: File, data: DataFrame): AssertOnQuery =
       AssertOnQuery { _ =>
         data.write.format("delta").mode("append").save(path.getAbsolutePath)
+        true
+      }
+  }
+
+  object AddUpdatesToReservoir {
+    def apply(path: File, updateExpression: Map[String, Column]): AssertOnQuery =
+      AssertOnQuery { _ =>
+        io.delta.tables.DeltaTable.forPath(path.getAbsolutePath).update(updateExpression)
+        true
+      }
+  }
+
+  object AddDeletesToReservoir {
+    def apply(path: File, deleteCondition: Column): AssertOnQuery =
+      AssertOnQuery { _ =>
+        io.delta.tables.DeltaTable.forPath(path.getAbsolutePath).delete(deleteCondition)
+        true
+      }
+  }
+
+  object AddMergeWithOnlyInsertsToReservoir {
+    def apply(path: File, dfToMerge: DataFrame, mergeCondition: Column): AssertOnQuery =
+      AssertOnQuery { _ =>
+        io.delta.tables.DeltaTable
+          .forPath(path.getAbsolutePath)
+          .as("table")
+          .merge(dfToMerge, mergeCondition)
+          .whenNotMatched()
+          .insertAll()
+          .execute()
         true
       }
   }


### PR DESCRIPTION
## Description

- Add an appendOnly:Boolean option to the stream source. When the option applies stream source will skip all commits with RemoveFileAction.
- To understand motivation, please refer to the `motivation` part from issue #1490.
 
Resolves #1490

## How was this patch tested?

There is a unit test for this patch.
And also similar changes work in production for the last 2 weeks.

## Does this PR introduce _any_ user-facing changes?

Yes, it's introducing a new option for the delta Structure Stream.
