### PR TITLE
Add support for `LIMIT` push down during query planning to reduce number of files scanned

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
@@ -17,8 +17,12 @@
 package org.apache.spark.sql.delta.stats
 
 // scalastyle:off import.ordering.noEmptyLine
+import java.io.Closeable
+
+import scala.collection.mutable.ArrayBuffer
+
 import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaLog, DeltaTableUtils}
-import org.apache.spark.sql.delta.actions.{AddFile, Metadata, SingleAction}
+import org.apache.spark.sql.delta.actions.{AddFile, Metadata}
 import org.apache.spark.sql.delta.implicits._
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -36,6 +40,23 @@ import org.apache.spark.sql.expressions.SparkUserDefinedFunction
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{AtomicType, BooleanType, CalendarIntervalType, DataType, DateType, NumericType, StringType, StructField, StructType, TimestampType}
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
+
+/**
+ * Used to hold the list of files and scan stats after pruning files using the limit.
+ */
+case class ScanAfterLimit(
+    files: Seq[AddFile],
+    byteSize: Option[Long],
+    numPhysicalRecords: Option[Long],
+    numLogicalRecords: Option[Long])
+
+/**
+ * Used in getFilesAndNumRecords iterator for grouping physical and logical number of records.
+ *
+ * @param numPhysicalRecords The number of records physically present in the file.
+ * @param numLogicalRecords The physical number of records minus the Deletion Vector cardinality.
+ */
+case class NumRecords(numPhysicalRecords: java.lang.Long, numLogicalRecords: java.lang.Long)
 
 /**
  * Represents a stats column (MIN, MAX, etc) for a given (nested) user table column name. Used to
@@ -919,6 +940,84 @@ trait DataSkippingReaderBase
   }
 
   /**
+   * Gathers files that should be included in a scan based on the limit clause, when there is
+   * no filter or projection present. Statistics about the amount of data that will be read
+   * are gathered and returned.
+   */
+  override def filesForScan(limit: Long): DeltaScan =
+    recordDeltaOperation(deltaLog, "delta.skipping.limit") {
+      val startTime = System.currentTimeMillis()
+      val scan = pruneFilesByLimit(withStats, limit)
+
+      val totalDataSize = new DataSize(
+        bytesCompressed = Some(sizeInBytes),
+        rows = None,
+        files = Some(numOfFiles)
+      )
+
+      val scannedDataSize = new DataSize(
+        bytesCompressed = scan.byteSize,
+        rows = scan.numPhysicalRecords,
+        files = Some(scan.files.size)
+      )
+
+      DeltaScan(
+        version = version,
+        files = scan.files,
+        total = totalDataSize,
+        partition = null,
+        scanned = scannedDataSize)(
+        scannedSnapshot = snapshotToScan,
+        partitionFilters = ExpressionSet(Nil),
+        dataFilters = ExpressionSet(Nil),
+        unusedFilters = ExpressionSet(Nil),
+        scanDurationMs = System.currentTimeMillis() - startTime,
+        dataSkippingType = DeltaDataSkippingType.limit
+      )
+    }
+
+  /**
+   * Gathers files that should be included in a scan based on the given predicates and limit.
+   * This will be called only when all predicates are on partitioning columns.
+   * Statistics about the amount of data that will be read are gathered and returned.
+   */
+  override def filesForScan(limit: Long, partitionFilters: Seq[Expression]): DeltaScan =
+    recordDeltaOperation(deltaLog, "delta.skipping.filteredLimit") {
+      val startTime = System.currentTimeMillis()
+      val finalPartitionFilters = constructPartitionFilters(partitionFilters)
+
+      val scan = {
+        pruneFilesByLimit(withStats.where(finalPartitionFilters), limit)
+      }
+
+      val totalDataSize = new DataSize(
+        bytesCompressed = Some(sizeInBytes),
+        rows = None,
+        files = Some(numOfFiles)
+      )
+
+      val scannedDataSize = new DataSize(
+        bytesCompressed = scan.byteSize,
+        rows = scan.numPhysicalRecords,
+        files = Some(scan.files.size)
+      )
+
+      DeltaScan(
+        version = version,
+        files = scan.files,
+        total = totalDataSize,
+        partition = null,
+        scanned = scannedDataSize)(
+        scannedSnapshot = snapshotToScan,
+        partitionFilters = ExpressionSet(partitionFilters),
+        dataFilters = ExpressionSet(Nil),
+        unusedFilters = ExpressionSet(Nil),
+        scanDurationMs = System.currentTimeMillis() - startTime,
+        dataSkippingType = DeltaDataSkippingType.filteredLimit
+      )
+    }
+
+  /**
    * Get AddFile (with stats) actions corresponding to given set of paths in the Snapshot.
    * If a path doesn't exist in snapshot, it will be ignored and no [[AddFile]] will be returned
    * for it.
@@ -933,8 +1032,85 @@ trait DataSkippingReaderBase
     }
   }
 
+  /** Get the files and number of records within each file, to perform limit pushdown. */
+  def getFilesAndNumRecords(
+      df: DataFrame): Iterator[(AddFile, NumRecords)] with Closeable = recordFrameProfile(
+    "Delta", "DataSkippingReaderEdge.getFilesAndNumRecords") {
+    import org.apache.spark.sql.delta.implicits._
+
+    val numLogicalRecords = col("stats.numRecords")
+
+    val result = df.withColumn("numPhysicalRecords", col("stats.numRecords")) // Physical
+      .withColumn("numLogicalRecords", numLogicalRecords) // Logical
+      .withColumn("stats", nullStringLiteral)
+      .select(struct(col("*")).as[AddFile],
+        col("numPhysicalRecords").as[java.lang.Long], col("numLogicalRecords").as[java.lang.Long])
+      .collectAsList()
+
+    new Iterator[(AddFile, NumRecords)] with Closeable {
+      private val underlying = result.iterator
+      override def hasNext: Boolean = underlying.hasNext
+      override def next(): (AddFile, NumRecords) = {
+        val next = underlying.next()
+        (next._1, NumRecords(numPhysicalRecords = next._2, numLogicalRecords = next._3))
+      }
+
+      override def close(): Unit = {
+      }
+
+    }
+  }
+
   protected def convertDataFrameToAddFiles(df: DataFrame): Array[AddFile] = {
     df.as[AddFile].collect()
+  }
+
+  protected def pruneFilesByLimit(df: DataFrame, limit: Long): ScanAfterLimit = {
+    val withNumRecords = {
+      getFilesAndNumRecords(df)
+    }
+
+    var logicalRowsToScan = 0L
+    var physicalRowsToScan = 0L
+    var bytesToScan = 0L
+    var bytesToIgnore = 0L
+    var rowsUnknown = false
+
+    val filesAfterLimit = try {
+      val iter = withNumRecords
+      val filesToScan = ArrayBuffer[AddFile]()
+      val filesToIgnore = ArrayBuffer[AddFile]()
+      while (iter.hasNext && logicalRowsToScan < limit) {
+        val file = iter.next
+        if (file._2.numPhysicalRecords == null || file._2.numLogicalRecords == null) {
+          // this file has no stats, ignore for now
+          bytesToIgnore += file._1.size
+          filesToIgnore += file._1
+        } else {
+          physicalRowsToScan += file._2.numPhysicalRecords.toLong
+          logicalRowsToScan += file._2.numLogicalRecords.toLong
+          bytesToScan += file._1.size
+          filesToScan += file._1
+        }
+      }
+
+      // If the files that have stats do not contain enough rows, fall back to reading all files
+      if (logicalRowsToScan < limit && filesToIgnore.nonEmpty) {
+        filesToScan ++= filesToIgnore
+        bytesToScan += bytesToIgnore
+        rowsUnknown = true
+      }
+      filesToScan.toSeq
+    } finally {
+      withNumRecords.close()
+    }
+
+    if (rowsUnknown) {
+      ScanAfterLimit(filesAfterLimit, Some(bytesToScan), None, None)
+    } else {
+      ScanAfterLimit(filesAfterLimit, Some(bytesToScan),
+        Some(physicalRowsToScan), Some(logicalRowsToScan))
+    }
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/stats/DeltaScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/stats/DeltaScan.scala
@@ -16,15 +16,13 @@
 
 package org.apache.spark.sql.delta.stats
 
+// scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.Snapshot
 import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.spark.sql.delta.stats.DeltaDataSkippingType.DeltaDataSkippingType
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.execution.command.DDLUtils
-import org.apache.spark.sql.execution.datasources.PartitioningUtils
 
 /**
  * DataSize describes following attributes for data that consists of a list of input files
@@ -42,7 +40,7 @@ case class DataSize(
     rows: Option[Long] = None,
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
     files: Option[Long] = None
-    )
+)
 
 object DataSize {
   def apply(a: ArrayAccumulator): DataSize = {

--- a/core/src/main/scala/org/apache/spark/sql/delta/stats/DeltaScanGenerator.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/stats/DeltaScanGenerator.scala
@@ -21,8 +21,8 @@ import org.apache.spark.sql.delta.Snapshot
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 
-/** Trait representing a class that can generate [[DeltaScan]] given filters, etc. */
-trait DeltaScanGeneratorBase {
+/** Trait representing a class that can generate [[DeltaScan]] given filters and a limit. */
+trait DeltaScanGenerator {
   /** The snapshot that the scan is being generated on. */
   val snapshotToScan: Snapshot
 
@@ -34,7 +34,11 @@ trait DeltaScanGeneratorBase {
 
   /** Returns a [[DeltaScan]] based on the given filters. */
   def filesForScan(filters: Seq[Expression], keepNumRecords: Boolean = false): DeltaScan
+
+  /** Returns a[[DeltaScan]] based on the limit clause when there are no filters or projections. */
+  def filesForScan(limit: Long): DeltaScan
+
+  /** Returns a [[DeltaScan]] based on the given partition filters and limits. */
+  def filesForScan(limit: Long, partitionFilters: Seq[Expression]): DeltaScan
 }
 
-
-trait DeltaScanGenerator extends DeltaScanGeneratorBase

--- a/core/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
@@ -109,6 +109,9 @@ trait PrepareDeltaScanBase extends Rule[LogicalPlan]
 
   /**
    * Scan files using the given `filters` and return `DeltaScan`.
+   *
+   * Note: when `limitOpt` is non empty, `filters` must contain only partition filters. Otherwise,
+   * it can contain arbitrary filters. See `DeltaTableScan` for more details.
    */
   protected def filesForScan(
       scanGenerator: DeltaScanGenerator,
@@ -116,6 +119,12 @@ trait PrepareDeltaScanBase extends Rule[LogicalPlan]
       filters: Seq[Expression],
       delta: LogicalRelation): DeltaScan = {
     withStatusCode("DELTA", "Filtering files for query") {
+      if (limitOpt.nonEmpty) {
+        // If we trigger limit push down, the filters must be partition filters. Since
+        // there are no data filters, we don't need to apply Generated Columns
+        // optimization. See `DeltaTableScan` for more details.
+        return scanGenerator.filesForScan(limitOpt.get, filters)
+      }
       val filtersForScan =
         if (!GeneratedColumn.partitionFilterOptimizationEnabled(spark)) {
           filters
@@ -174,6 +183,12 @@ trait PrepareDeltaScanBase extends Rule[LogicalPlan]
       filters: Seq[Expression],
       limit: Option[Int],
       delta: LogicalRelation): LogicalPlan = {
+    if (limit.nonEmpty) {
+      // If we trigger limit push down, the filters must be partition filters. Since
+      // there are no data filters, we don't need to apply Generated Columns
+      // optimization. See `DeltaTableScan` for more details.
+      return DeltaTableUtils.replaceFileIndex(scan, preparedIndex)
+    }
     if (!GeneratedColumn.partitionFilterOptimizationEnabled(spark)) {
       DeltaTableUtils.replaceFileIndex(scan, preparedIndex)
     } else {
@@ -248,6 +263,7 @@ trait PrepareDeltaScanBase extends Rule[LogicalPlan]
      * object `plan` and tries to give back the arguments as a [[DeltaTableScanType]].
      */
     def unapply(plan: LogicalPlan): Option[DeltaTableScanType] = {
+      val limitPushdownEnabled = spark.conf.get(DeltaSQLConf.DELTA_LIMIT_PUSHDOWN_ENABLED)
 
       // Remove projections as a plan differentiator because it does not affect file listing
       // results. Plans with the same filters but different projections therefore will not have
@@ -260,6 +276,10 @@ trait PrepareDeltaScanBase extends Rule[LogicalPlan]
       }
 
       plan match {
+        case LocalLimit(IntegerLiteral(limit),
+          PhysicalOperation(_, filters, delta @ DeltaTable(fileIndex: TahoeLogFileIndex)))
+            if limitPushdownEnabled && containsPartitionFiltersOnly(filters, fileIndex) =>
+          Some((canonicalizePlanForDeltaFileListing(plan), filters, fileIndex, Some(limit), delta))
         case PhysicalOperation(
             _,
             filters,

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaLimitPushDownSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaLimitPushDownSuite.scala
@@ -1,0 +1,239 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+// scalastyle:off import.ordering.noEmptyLine
+import com.databricks.spark.util.DatabricksLogging
+import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.stats.StatsUtils
+import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, ScanReportHelper}
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.util.Utils
+
+trait DeltaLimitPushDownTests extends QueryTest
+    with SharedSparkSession
+    with DatabricksLogging
+    with ScanReportHelper
+    with StatsUtils
+    with DeltaSQLCommandTest {
+
+  import testImplicits._
+
+
+  test("no filter or projection") {
+    val dir = Utils.createTempDir()
+    val ds = Seq(1, 1, 2, 2, 3, 3).toDS().repartition(5, $"value")
+    ds.write.format("delta").save(dir.toString)
+
+    val Seq(deltaScan, deltaScanWithLimit) = getScanReport {
+      spark.read.format("delta").load(dir.toString).collect()
+      val res = spark.read.format("delta").load(dir.toString).limit(3).collect()
+      assert(res.size == 3)
+    }
+
+    assert(deltaScan.size("total").bytesCompressed ===
+      deltaScanWithLimit.size("total").bytesCompressed)
+
+    assert(deltaScan.size("scanned").bytesCompressed !=
+      deltaScanWithLimit.size("scanned").bytesCompressed)
+
+    assert(deltaScanWithLimit.size("scanned").rows === Some(4L))
+  }
+
+  test("limit larger than total") {
+    val dir = Utils.createTempDir()
+    val data = Seq(1, 1, 2, 2)
+    val ds = data.toDS().repartition($"value")
+    ds.write.format("delta").save(dir.toString)
+
+    val Seq(deltaScan, deltaScanWithLimit) = getScanReport {
+      spark.read.format("delta").load(dir.toString).collect()
+      checkAnswer(spark.read.format("delta").load(dir.toString).limit(5), data.toDF())
+    }
+
+    assert(deltaScan.size("total").bytesCompressed ===
+      deltaScanWithLimit.size("total").bytesCompressed)
+
+    assert(deltaScan.size("scanned").bytesCompressed ===
+      deltaScanWithLimit.size("scanned").bytesCompressed)
+  }
+
+  test("limit 0") {
+    val records = getScanReport {
+      val dir = Utils.createTempDir()
+      val ds = Seq(1, 1, 2, 2, 3, 3).toDS().repartition($"value")
+      ds.write.format("delta").save(dir.toString)
+      val res = spark.read.format("delta")
+        .load(dir.toString)
+        .limit(0)
+
+      checkAnswer(res, Seq())
+    }
+  }
+
+  test("insufficient rows have stats") {
+    val tempDir = Utils.createTempDir()
+    val deltaLog = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
+
+    val file = Seq(1, 2).toDS().coalesce(1)
+
+    withSQLConf(DeltaSQLConf.DELTA_COLLECT_STATS.key -> "false") {
+      file.write.format("delta").mode("append").save(deltaLog.dataPath.toString)
+    }
+    withSQLConf(DeltaSQLConf.DELTA_COLLECT_STATS.key -> "false") {
+      file.write.format("delta").mode("append").save(deltaLog.dataPath.toString)
+    }
+    withSQLConf(DeltaSQLConf.DELTA_COLLECT_STATS.key -> "true") {
+      file.write.format("delta").mode("append").save(deltaLog.dataPath.toString)
+    }
+
+    val deltaScan = deltaLog.snapshot.filesForScan(3)
+
+    assert(deltaScan.scanned.bytesCompressed === deltaScan.total.bytesCompressed)
+  }
+
+  test("sufficient rows have stats") {
+    val tempDir = Utils.createTempDir()
+    val deltaLog = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
+
+    val file = Seq(1, 2).toDS().coalesce(1)
+
+    withSQLConf(DeltaSQLConf.DELTA_COLLECT_STATS.key -> "false") {
+      file.write.format("delta").mode("append").save(deltaLog.dataPath.toString)
+    }
+    withSQLConf(DeltaSQLConf.DELTA_COLLECT_STATS.key -> "true") {
+      file.write.format("delta").mode("append").save(deltaLog.dataPath.toString)
+    }
+    withSQLConf(DeltaSQLConf.DELTA_COLLECT_STATS.key -> "true") {
+      file.write.format("delta").mode("append").save(deltaLog.dataPath.toString)
+    }
+
+    val deltaScan = deltaLog.snapshot.filesForScan(3)
+
+    assert(deltaScan.scanned.rows === Some(4))
+    assert(deltaScan.scanned.bytesCompressed != deltaScan.total.bytesCompressed)
+  }
+
+  test("with projection only") {
+    val dir = Utils.createTempDir()
+    val ds = Seq((1, 1), (2, 1), (3, 1)).toDF("key", "value").as[(Int, Int)]
+    ds.write.format("delta").partitionBy("key").save(dir.toString)
+
+    val Seq(deltaScan) = getScanReport {
+      val res = spark.read.format("delta").load(dir.toString).select("value").limit(1).collect()
+      assert(res === Seq(Row(1)))
+    }
+
+    assert(deltaScan.size("scanned").rows === Some(1L))
+  }
+
+  test("with partition filter only") {
+    val dir = Utils.createTempDir()
+    val ds = Seq((1, 4), (2, 5), (3, 6)).toDF("key", "value").as[(Int, Int)]
+    ds.write.format("delta").partitionBy("key").save(dir.toString)
+
+    val Seq(deltaScan, deltaScanWithLimit, deltaScanWithLimit2) = getScanReport {
+      spark.read.format("delta").load(dir.toString).where("key > 1").collect()
+      val res1 = spark.read.format("delta").load(dir.toString).where("key > 1").limit(1).collect()
+      assert(res1 === Seq(Row(2, 5)) || res1 === Seq(Row(3, 6)))
+      val res2 = spark.read.format("delta").load(dir.toString).where("key == 1").limit(2).collect()
+      assert(res2 === Seq(Row(1, 4)))
+    }
+
+    assert(deltaScan.size("total").bytesCompressed ===
+      deltaScanWithLimit.size("total").bytesCompressed)
+
+    assert(deltaScan.size("scanned").bytesCompressed !=
+      deltaScanWithLimit.size("scanned").bytesCompressed)
+
+    assert(deltaScan.size("scanned").bytesCompressed.get <
+      deltaScan.size("total").bytesCompressed.get)
+    assert(deltaScanWithLimit.size("scanned").rows === Some(1L))
+    assert(deltaScanWithLimit2.size("scanned").rows === Some(1L))
+  }
+
+  test("with non-partition filter") {
+    val dir = Utils.createTempDir()
+    val ds = Seq((1, 4), (2, 5), (3, 6)).toDF("key", "value").as[(Int, Int)]
+    ds.write.format("delta").partitionBy("key").save(dir.toString)
+
+    val Seq(deltaScan) = getScanReport { // this query should not trigger limit push-down
+      spark.read.format("delta").load(dir.toString)
+        .where("key > 1")
+        .where("value > 4")
+        .limit(1)
+        .collect()
+    }
+    assert(deltaScan.size("scanned").rows === Some(2L))
+  }
+
+  test("limit push-down flag") {
+    val dir = Utils.createTempDir()
+    val ds = Seq((1, 4), (2, 5), (3, 6)).toDF("key", "value").as[(Int, Int)]
+    ds.write.format("delta").partitionBy("key").save(dir.toString)
+
+    val Seq(baseline, scan, scan2) = getScanReport {
+      withSQLConf(DeltaSQLConf.DELTA_LIMIT_PUSHDOWN_ENABLED.key -> "true") {
+        spark.read.format("delta").load(dir.toString).where("key > 1").limit(1).collect()
+      }
+      withSQLConf(DeltaSQLConf.DELTA_LIMIT_PUSHDOWN_ENABLED.key -> "false") {
+        spark.read.format("delta").load(dir.toString).where("key > 1").limit(1).collect()
+        spark.read.format("delta").load(dir.toString).limit(2).collect()
+      }
+    }
+    assert(scan.size("scanned").bytesCompressed.get > baseline.size("scanned").bytesCompressed.get)
+    assert(scan2.size("scanned").bytesCompressed === scan2.size("total").bytesCompressed)
+  }
+
+  test("GlobalLimit should be kept") {
+    val dir = Utils.createTempDir()
+    (1 to 10).toDF.repartition(5).write.format("delta").save(dir.toString)
+    assert(spark.read.format("delta").load(dir.toString).limit(5).collect().size == 5)
+  }
+
+  test("Works with union") {
+    val dir = Utils.createTempDir()
+    (1 to 10).toDF.repartition(5).write.format("delta").save(dir.toString)
+    val t1 = spark.read.format("delta").load(dir.toString)
+    val t2 = spark.read.format("delta").load(dir.toString)
+    val union = t1.union(t2)
+
+    withSQLConf(DeltaSQLConf.DELTA_LIMIT_PUSHDOWN_ENABLED.key -> "true") {
+      val Seq(scanFull1, scanFull2) = getScanReport {
+        union.collect()
+      }
+      val Seq(scanLimit1, scanLimit2) = getScanReport {
+        union.limit(1).collect()
+      }
+
+      assert(scanFull1.size("scanned").bytesCompressed.get >
+        scanLimit1.size("scanned").bytesCompressed.get)
+      assert(scanFull2.size("scanned").bytesCompressed.get >
+        scanLimit2.size("scanned").bytesCompressed.get)
+    }
+  }
+
+}
+
+class DeltaLimitPushDownV1Suite extends DeltaLimitPushDownTests
+


### PR DESCRIPTION
## Description

This PR adds support for limit pushdown, where we will "push down" any `LIMIT`s during query planning so that we scan the minimum number of files necessary.

## How was this patch tested?

New test suite.

## Does this PR introduce _any_ user-facing changes?

No.