### PR TITLE
Support SHALLOW CLONE for Delta Lake

### DIFF
--- a/core/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
+++ b/core/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
@@ -60,6 +60,11 @@ grammar DeltaSqlBase;
       return true;
     }
   }
+
+  /**
+   * When true, double quoted literals are identifiers rather than STRINGs.
+   */
+  public boolean double_quoted_identifiers = false;
 }
 
 tokens {
@@ -91,7 +96,23 @@ statement
         (zorderSpec)?                                                   #optimizeTable
     | SHOW COLUMNS (IN | FROM) tableName=qualifiedName
         ((IN | FROM) schemaName=identifier)?                            #showColumns
+    | cloneTableHeader SHALLOW CLONE source=qualifiedName clause=temporalClause?
+       (TBLPROPERTIES tableProps=propertyList)?
+       (LOCATION location=stringLit)?                                   #clone
     | .*?                                                               #passThrough
+    ;
+
+createTableHeader
+    : CREATE TABLE (IF NOT EXISTS)? table=qualifiedName
+    ;
+
+replaceTableHeader
+    : (CREATE OR)? REPLACE TABLE table=qualifiedName
+    ;
+
+cloneTableHeader
+    : createTableHeader
+    | replaceTableHeader
     ;
 
 zorderSpec
@@ -106,6 +127,36 @@ temporalClause
 
 qualifiedName
     : identifier ('.' identifier)*
+    ;
+
+propertyList
+    : LEFT_PAREN property (COMMA property)* RIGHT_PAREN
+    ;
+
+property
+    : key=propertyKey (EQ? value=propertyValue)?
+    ;
+
+propertyKey
+    : identifier (DOT identifier)*
+    | stringLit
+    ;
+
+propertyValue
+    : INTEGER_VALUE
+    | DECIMAL_VALUE
+    | booleanValue
+    | identifier LEFT_PAREN stringLit COMMA stringLit RIGHT_PAREN
+    | value=stringLit
+    ;
+
+stringLit
+    : STRING
+    | {!double_quoted_identifiers}? DOUBLEQUOTED_STRING
+    ;
+
+booleanValue
+    : TRUE | FALSE
     ;
 
 identifier
@@ -167,6 +218,7 @@ nonReserved
     | RESTORE | AS | OF
     | ZORDER | LEFT_PAREN | RIGHT_PAREN
     | SHOW | COLUMNS | IN | FROM | NO | STATISTICS
+    | CLONE | SHALLOW
     ;
 
 // Define how the keywords above should appear in a user's SQL statement.
@@ -175,18 +227,22 @@ ALTER: 'ALTER';
 AS: 'AS';
 BY: 'BY';
 CHECK: 'CHECK';
+CLONE: 'CLONE';
 COLUMNS: 'COLUMNS';
 COMMA: ',';
 COMMENT: 'COMMENT';
 CONSTRAINT: 'CONSTRAINT';
 CONVERT: 'CONVERT';
+CREATE: 'CREATE';
 DELTA: 'DELTA';
 DESC: 'DESC';
 DESCRIBE: 'DESCRIBE';
 DETAIL: 'DETAIL';
+DOT: '.';
 DROP: 'DROP';
 DRY: 'DRY';
 EXISTS: 'EXISTS';
+FALSE: 'FALSE';
 FOR: 'FOR';
 FROM: 'FROM';
 GENERATE: 'GENERATE';
@@ -196,23 +252,29 @@ IF: 'IF';
 IN: 'IN';
 LEFT_PAREN: '(';
 LIMIT: 'LIMIT';
+LOCATION: 'LOCATION';
 MINUS: '-';
 NO: 'NO';
 NOT: 'NOT' | '!';
 NULL: 'NULL';
 OF: 'OF';
+OR: 'OR';
 OPTIMIZE: 'OPTIMIZE';
 PARTITIONED: 'PARTITIONED';
+REPLACE: 'REPLACE';
 RESTORE: 'RESTORE';
 RETAIN: 'RETAIN';
 RIGHT_PAREN: ')';
 RUN: 'RUN';
+SHALLOW: 'SHALLOW';
 SHOW: 'SHOW';
 SYSTEM_TIME: 'SYSTEM_TIME';
 SYSTEM_VERSION: 'SYSTEM_VERSION';
 TABLE: 'TABLE';
+TBLPROPERTIES: 'TBLPROPERTIES';
 TIMESTAMP: 'TIMESTAMP';
 TO: 'TO';
+TRUE: 'TRUE';
 VACUUM: 'VACUUM';
 VERSION: 'VERSION';
 WHERE: 'WHERE';
@@ -234,6 +296,10 @@ CONCAT_PIPE: '||';
 STRING
     : '\'' ( ~('\''|'\\') | ('\\' .) )* '\''
     | '"' ( ~('"'|'\\') | ('\\' .) )* '"'
+    ;
+
+DOUBLEQUOTED_STRING
+    :'"' ( ~('"'|'\\') | ('\\' .) )* '"'
     ;
 
 BIGINT_LITERAL

--- a/core/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
+++ b/core/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
@@ -60,11 +60,6 @@ grammar DeltaSqlBase;
       return true;
     }
   }
-
-  /**
-   * When true, double quoted literals are identifiers rather than STRINGs.
-   */
-  public boolean double_quoted_identifiers = false;
 }
 
 tokens {
@@ -152,7 +147,7 @@ propertyValue
 
 stringLit
     : STRING
-    | {!double_quoted_identifiers}? DOUBLEQUOTED_STRING
+    | DOUBLEQUOTED_STRING
     ;
 
 booleanValue

--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -278,6 +278,22 @@
     ],
     "sqlState" : "22000"
   },
+  "DELTA_CLONE_AMBIGUOUS_TARGET" : {
+    "message" : [
+      "",
+      "Two paths were provided as the CLONE target so it is ambiguous which to use. An external",
+      "location for CLONE was provided at <externalLocation> at the same time as the path",
+      "<targetIdentifier>."
+    ],
+    "sqlState" : "42000"
+  },
+  "DELTA_CLONE_UNSUPPORTED_SOURCE" : {
+    "message" : [
+      "Unsupported clone source '<name>', whose format is <format>.",
+      "The supported formats are 'delta' and 'parquet'."
+    ],
+    "sqlState" : "0A000"
+  },
   "DELTA_COLUMN_NOT_FOUND" : {
     "message" : [
       "Unable to find the column `<columnName>` given [<columnList>]"
@@ -730,6 +746,13 @@
       "Found invalid character(s) among ' ,;{}()\\n\\t=' in the column names of your schema. <advice>"
     ],
     "sqlState" : "0A000"
+  },
+  "DELTA_INVALID_CLONE_PATH" : {
+    "message" : [
+      "The target location for CLONE needs to be an absolute path or table name. Use an",
+      "absolute path instead of <path>."
+    ],
+    "sqlState" : "22000"
   },
   "DELTA_INVALID_COMMITTED_VERSION" : {
     "message" : [
@@ -1664,6 +1687,15 @@
     ],
     "sqlState" : "0A000"
   },
+  "DELTA_UNSUPPORTED_CLONE_REPLACE_SAME_TABLE" : {
+    "message" : [
+      "",
+      "You tried to REPLACE an existing table (<tableName>) with CLONE. This operation is",
+      "unsupported. Try a different target for CLONE or delete the table at the current target.",
+      ""
+    ],
+    "sqlState" : "0A000"
+  },
   "DELTA_UNSUPPORTED_COLUMN_MAPPING_MODE_CHANGE" : {
     "message" : [
       "Changing column mapping mode from '<oldMode>' to '<newMode>' is not supported."
@@ -1787,6 +1819,12 @@
   "DELTA_UNSUPPORTED_NESTED_FIELD_IN_OPERATION" : {
     "message" : [
       "Nested field is not supported in the <operation> (field = <fieldName>)."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DELTA_UNSUPPORTED_NON_EMPTY_CLONE" : {
+    "message" : [
+      "The clone destination table is non-empty. Please TRUNCATE or DELETE FROM the table before running CLONE."
     ],
     "sqlState" : "0A000"
   },

--- a/core/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
+++ b/core/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
@@ -59,9 +59,11 @@ import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.parser.{ParseErrorListener, ParseException, ParserInterface}
 import org.apache.spark.sql.catalyst.parser.ParserUtils.{string, withOrigin}
-import org.apache.spark.sql.catalyst.plans.logical.{AlterTableAddConstraint, AlterTableDropConstraint, LogicalPlan, RestoreTableStatement}
+import org.apache.spark.sql.catalyst.plans.logical.{AlterTableAddConstraint, AlterTableDropConstraint, CloneTableStatement, LogicalPlan, RestoreTableStatement}
 import org.apache.spark.sql.catalyst.trees.Origin
-import org.apache.spark.sql.internal.VariableSubstitution
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, TableCatalog}
+import org.apache.spark.sql.errors.QueryParsingErrors
+import org.apache.spark.sql.internal.{SQLConf, VariableSubstitution}
 import org.apache.spark.sql.types._
 
 /**
@@ -152,6 +154,147 @@ class DeltaSqlParser(val delegate: ParserInterface) extends ParserInterface {
  * `DeltaSqlBase.g4` (such as `#vacuumTable`).
  */
 class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
+
+  import org.apache.spark.sql.catalyst.parser.ParserUtils._
+
+  /**
+   * Convert a property list into a key-value map.
+   * This should be called through [[visitPropertyKeyValues]] or [[visitPropertyKeys]].
+   */
+  override def visitPropertyList(
+      ctx: PropertyListContext): Map[String, String] = withOrigin(ctx) {
+    val properties = ctx.property.asScala.map { property =>
+      val key = visitPropertyKey(property.key)
+      val value = visitPropertyValue(property.value)
+      key -> value
+    }
+    // Check for duplicate property names.
+    checkDuplicateKeys(properties.toSeq, ctx)
+    properties.toMap
+  }
+
+  /**
+   * Parse a key-value map from a [[PropertyListContext]], assuming all values are specified.
+   */
+  def visitPropertyKeyValues(ctx: PropertyListContext): Map[String, String] = {
+    val props = visitPropertyList(ctx)
+    val badKeys = props.collect { case (key, null) => key }
+    if (badKeys.nonEmpty) {
+      operationNotAllowed(
+        s"Values must be specified for key(s): ${badKeys.mkString("[", ",", "]")}", ctx)
+    }
+    props
+  }
+
+  /**
+   * Parse a list of keys from a [[PropertyListContext]], assuming no values are specified.
+   */
+  def visitPropertyKeys(ctx: PropertyListContext): Seq[String] = {
+    val props = visitPropertyList(ctx)
+    val badKeys = props.filter { case (_, v) => v != null }.keys
+    if (badKeys.nonEmpty) {
+      operationNotAllowed(
+        s"Values should not be specified for key(s): ${badKeys.mkString("[", ",", "]")}", ctx)
+    }
+    props.keys.toSeq
+  }
+
+  /**
+   * A property key can either be String or a collection of dot separated elements. This
+   * function extracts the property key based on whether its a string literal or a property
+   * identifier.
+   */
+  override def visitPropertyKey(key: PropertyKeyContext): String = {
+    if (key.stringLit() != null) {
+      string(visitStringLit(key.stringLit()))
+    } else {
+      key.getText
+    }
+  }
+
+  /**
+   * A property value can be String, Integer, Boolean or Decimal. This function extracts
+   * the property value based on whether its a string, integer, boolean or decimal literal.
+   */
+  override def visitPropertyValue(value: PropertyValueContext): String = {
+    if (value == null) {
+      null
+    } else if (value.identifier != null) {
+      value.identifier.getText
+    } else if (value.value != null) {
+      string(visitStringLit(value.value))
+    } else if (value.booleanValue != null) {
+      value.getText.toLowerCase(Locale.ROOT)
+    } else {
+      value.getText
+    }
+  }
+
+  override def visitStringLit(ctx: StringLitContext): Token = {
+    if (ctx != null) {
+      if (ctx.STRING != null) {
+        ctx.STRING.getSymbol
+      } else {
+        ctx.DOUBLEQUOTED_STRING.getSymbol
+      }
+    } else {
+      null
+    }
+  }
+
+  /**
+   * Parse either create table header or replace table header.
+   * @return TableIdentifier for the target table
+   *         Boolean for whether we are creating a table
+   *         Boolean for whether we are replacing a table
+   *         Boolean for whether we are creating a table if not exists
+   */
+  override def visitCloneTableHeader(
+      ctx: CloneTableHeaderContext): (TableIdentifier, Boolean, Boolean, Boolean) = withOrigin(ctx) {
+    ctx.children.asScala.head match {
+      case createHeader: CreateTableHeaderContext =>
+        (visitTableIdentifier(createHeader.table), true, false, createHeader.EXISTS() != null)
+      case replaceHeader: ReplaceTableHeaderContext =>
+        (visitTableIdentifier(replaceHeader.table), replaceHeader.CREATE() != null, true, false)
+      case _ =>
+        throw new ParseException("Incorrect CLONE header expected REPLACE or CREATE table", ctx)
+    }
+  }
+
+  /**
+   * Creates a [[CloneTableStatement]] logical plan. Example SQL:
+   * {{{
+   *   CREATE [OR REPLACE] TABLE <table-identifier> SHALLOW CLONE <source-table-identifier>
+   *     [TBLPROPERTIES ('propA' = 'valueA', ...)]
+   *     [LOCATION '/path/to/cloned/table']
+   * }}}
+   */
+  override def visitClone(ctx: CloneContext): LogicalPlan = withOrigin(ctx) {
+    val (target, isCreate, isReplace, ifNotExists) = visitCloneTableHeader(ctx.cloneTableHeader())
+
+    if (!isCreate && ifNotExists) {
+      throw new ParseException(
+        "IF NOT EXISTS cannot be used together with REPLACE", ctx.cloneTableHeader())
+    }
+
+    // Get source for clone (and time travel source if necessary)
+    val sourceRelation = UnresolvedRelation(visitTableIdentifier(ctx.source))
+    val maybeTimeTravelSource = maybeTimeTravelChild(ctx.clause, sourceRelation)
+    val targetRelation = UnresolvedRelation(target)
+
+    val tablePropertyOverrides = Option(ctx.tableProps)
+      .map(visitPropertyKeyValues)
+      .getOrElse(Map.empty[String, String])
+
+    CloneTableStatement(
+      maybeTimeTravelSource,
+      targetRelation,
+      ifNotExists,
+      isReplace,
+      isCreate,
+      tablePropertyOverrides,
+      Option(ctx.location).map(s => string(visitStringLit(s))))
+  }
 
   /**
    * Create a [[VacuumTableCommand]] logical plan. Example SQL:

--- a/core/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/CloneTableStatement.scala
+++ b/core/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/CloneTableStatement.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+/**
+ * CLONE TABLE statement, as parsed from SQL
+ *
+ * @param source source plan for table to be cloned
+ * @param target target path or table name where clone should be instantiated
+ * @param ifNotExists if a table exists at the target, we should not go through with the clone
+ * @param isReplaceCommand when true, replace the target table if one exists
+ * @param isCreateCommand when true, create the target table if none exists
+ * @param tablePropertyOverrides user-defined table properties that should override any properties
+ *                        with the same key from the source table
+ * @param targetLocation if target is a table name then user can provide a targetLocation to
+ *                       create an external table with this location
+ */
+case class CloneTableStatement(
+    source: LogicalPlan,
+    target: LogicalPlan,
+    ifNotExists: Boolean,
+    isReplaceCommand: Boolean,
+    isCreateCommand: Boolean,
+    tablePropertyOverrides: Map[String, String],
+    targetLocation: Option[String]) extends BinaryNode {
+  override def output: Seq[Attribute] = Nil
+
+  override def left: LogicalPlan = source
+  override def right: LogicalPlan = target
+  override protected def withNewChildrenInternal(
+      newLeft: LogicalPlan, newRight: LogicalPlan): CloneTableStatement =
+    copy(source = newLeft, target = newRight)
+}

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -22,8 +22,7 @@ import scala.collection.JavaConverters._
 import org.apache.spark.sql.catalyst.TimeTravel
 import org.apache.spark.sql.delta.DeltaErrors.{TemporallyUnstableInputException, TimestampEarlierThanCommitRetentionException}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
-import org.apache.spark.sql.delta.commands.RestoreTableCommand
-import org.apache.spark.sql.delta.commands.WriteIntoDelta
+import org.apache.spark.sql.delta.commands._
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.constraints.{AddConstraint, DropConstraint}
 import org.apache.spark.sql.delta.files.{TahoeFileIndex, TahoeLogFileIndex}
@@ -40,11 +39,16 @@ import org.apache.spark.sql.catalyst.analysis.UnresolvedTableValuedFunction
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType, HiveTableRelation}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.plans.logical.CloneTableStatement
+import org.apache.spark.sql.catalyst.plans.logical.RestoreTableStatement
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
+import org.apache.spark.sql.connector.catalog.{CatalogV2Util, Identifier}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 import org.apache.spark.sql.execution.command.RunnableCommand
+import org.apache.spark.sql.execution.datasources.HadoopFsRelation
 import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DataType, StructField, StructType}
@@ -104,6 +108,59 @@ class DeltaAnalysis(session: SparkSession)
         index.partitionFilters.reduce(And),
         DeltaTableUtils.replaceFileIndex(l, index.copy(partitionFilters = Nil)))
 
+
+    // Here we take advantage of CreateDeltaTableCommand which takes a LogicalPlan for CTAS in order
+    // to perform CLONE. We do this by passing the CloneTableCommand as the query in
+    // CreateDeltaTableCommand and let Create handle the creation + checks of creating a table in
+    // the metastore instead of duplicating that effort in CloneTableCommand.
+    case cloneStatement: CloneTableStatement =>
+      // Get the info necessary to CreateDeltaTableCommand
+      EliminateSubqueryAliases(cloneStatement.source) match {
+        case DataSourceV2Relation(table: DeltaTableV2, _, _, _, _) =>
+          resolveCloneCommand(cloneStatement.target, new CloneDeltaSource(table), cloneStatement)
+
+        // Pass the traveled table if a previous version is to be cloned
+        case tt @ TimeTravel(DataSourceV2Relation(tbl: DeltaTableV2, _, _, _, _), _, _, _)
+            if tt.expressions.forall(_.resolved) =>
+          val ttSpec = DeltaTimeTravelSpec(tt.timestamp, tt.version, tt.creationSource)
+          val traveledTable = tbl.copy(timeTravelOpt = Some(ttSpec))
+          resolveCloneCommand(
+            cloneStatement.target, new CloneDeltaSource(traveledTable), cloneStatement)
+
+
+        case u: UnresolvedRelation =>
+          u.failAnalysis(msg = s"Table not found: ${u.multipartIdentifier.quoted}")
+
+        case TimeTravel(u: UnresolvedRelation, _, _, _) =>
+          u.failAnalysis(msg = s"Table not found: ${u.multipartIdentifier.quoted}")
+
+        case LogicalRelation(
+            HadoopFsRelation(location, _, _, _, _: ParquetFileFormat, _), _, catalogTable, _) =>
+          val tableIdent = catalogTable.map(_.identifier)
+            .getOrElse(TableIdentifier(location.rootPaths.head.toString, Some("parquet")))
+          resolveCloneCommand(
+            cloneStatement.target,
+            new CloneParquetSource(tableIdent, catalogTable, session), cloneStatement)
+
+        case HiveTableRelation(catalogTable, _, _, _, _) =>
+          if (!ConvertToDeltaCommand.isHiveStyleParquetTable(catalogTable)) {
+            throw DeltaErrors.cloneFromUnsupportedSource(
+              catalogTable.identifier.unquotedString,
+              catalogTable.storage.serde.getOrElse("Unknown"))
+          }
+          resolveCloneCommand(
+            cloneStatement.target,
+            new CloneParquetSource(catalogTable.identifier, Some(catalogTable), session),
+            cloneStatement)
+
+        case v: View =>
+            throw DeltaErrors.cloneFromUnsupportedSource(
+              v.desc.identifier.unquotedString, "View")
+
+        case l: LogicalPlan =>
+          throw DeltaErrors.cloneFromUnsupportedSource(
+            l.toString, "Unknown")
+      }
 
     case restoreStatement @ RestoreTableStatement(target) =>
       EliminateSubqueryAliases(target) match {
@@ -231,6 +288,195 @@ class DeltaAnalysis(session: SparkSession)
 
   }
 
+  /**
+   * Creates a catalog table for CreateDeltaTableCommand.
+   *
+   * @param targetPath Target path containing the target path to clone to
+   * @param byPath Whether the target is a path based table
+   * @param tableIdent Table Identifier for the target table
+   * @param existingTable Existing table definition if we're going to be replacing the table
+   * @param srcTable The source table to clone
+   * @return catalog to CreateDeltaTableCommand with
+   */
+  private def createCatalogForCommandForClone(
+      targetPath: Path,
+      byPath: Boolean,
+      tableIdent: TableIdentifier,
+      targetLocation: Option[String],
+      existingTable: Option[CatalogTable],
+      srcTable: CloneSource): CatalogTable = {
+    // If external location is defined then then table is an external table
+    // If the table is a path-based table, we also say that the table is external even if no
+    // metastore table will be created. This is done because we are still explicitly providing a
+    // locationUri which is behavior expected only of external tables
+    // In the case of ifNotExists being true and a table existing at the target destination, create
+    // a managed table so we don't have to pass a fake path
+    val (tableType, storage) = if (targetLocation.isDefined || byPath) {
+      (CatalogTableType.EXTERNAL,
+        CatalogStorageFormat.empty.copy(locationUri = Some(targetPath.toUri)))
+    } else {
+      (CatalogTableType.MANAGED, CatalogStorageFormat.empty)
+    }
+    val properties = srcTable.metadata.configuration
+
+    new CatalogTable(
+      identifier = tableIdent,
+      tableType = tableType,
+      storage = storage,
+      schema = srcTable.schema,
+      properties = properties,
+      provider = Some("delta"),
+      stats = existingTable.flatMap(_.stats)
+    )
+  }
+
+  /**
+   * Instantiates a CreateDeltaTableCommand with CloneTableCommand as the child query.
+   *
+   * @param targetPlan the target of Clone as passed in a LogicalPlan
+   * @param sourceTbl the DeltaTableV2 that was resolved as the source of the clone command
+   * @return Resolve the clone command as the query in a CreateDeltaTableCommand.
+   */
+  private def resolveCloneCommand(
+      targetPlan: LogicalPlan,
+      sourceTbl: CloneSource,
+      statement: CloneTableStatement): LogicalPlan = {
+    val isReplace = statement.isReplaceCommand
+    val isCreate = statement.isCreateCommand
+
+    import session.sessionState.analyzer.SessionCatalogAndIdentifier
+    val targetLocation = statement.targetLocation
+    val saveMode = if (isReplace) {
+      SaveMode.Overwrite
+    } else if (statement.ifNotExists) {
+      SaveMode.Ignore
+    } else {
+      SaveMode.ErrorIfExists
+    }
+
+    val tableCreationMode = if (isCreate && isReplace) {
+      TableCreationModes.CreateOrReplace
+    } else if (isCreate) {
+      TableCreationModes.Create
+    } else {
+      TableCreationModes.Replace
+    }
+    // We don't use information in the catalog if the table is time travelled
+    val sourceCatalogTable = if (sourceTbl.timeTravelOpt.isDefined) None else sourceTbl.catalogTable
+
+    EliminateSubqueryAliases(targetPlan) match {
+      // Target is a path based table
+      case DataSourceV2Relation(targetTbl @ DeltaTableV2(_, path, _, _, _, _, _), _, _, _, _)
+          if !targetTbl.deltaLog.tableExists =>
+        val tblIdent = TableIdentifier(path.toString, Some("delta"))
+        if (!isCreate) {
+          throw DeltaErrors.cannotReplaceMissingTableException(
+            Identifier.of(Array("delta"), path.toString))
+        }
+        // Trying to clone something on itself should be a no-op
+        if (sourceTbl == new CloneDeltaSource(targetTbl)) {
+          return LocalRelation()
+        }
+        // If this is a path based table and an external location is also defined throw an error
+        if (statement.targetLocation.exists(loc => new Path(loc).toString != path.toString)) {
+          throw DeltaErrors.cloneAmbiguousTarget(statement.targetLocation.get, tblIdent)
+        }
+        // We're creating a table by path and there won't be a place to store catalog stats
+        val catalog = createCatalogForCommandForClone(
+          path, byPath = true, tblIdent, targetLocation, sourceCatalogTable, sourceTbl)
+        CreateDeltaTableCommand(
+          catalog,
+          None,
+          saveMode,
+          Some(CloneTableCommand(
+            sourceTbl,
+            tblIdent,
+            statement.tablePropertyOverrides,
+            path)),
+          tableByPath = true,
+          output = CloneTableCommand.output)
+
+      // Target is a metastore table
+      case UnresolvedRelation(SessionCatalogAndIdentifier(catalog, ident), _, _) =>
+        if (!isCreate) {
+          throw DeltaErrors.cannotReplaceMissingTableException(ident)
+        }
+        val tblIdent = ident
+          .asTableIdentifier
+        val finalTarget = new Path(statement.targetLocation.getOrElse(
+          session.sessionState.catalog.defaultTablePath(tblIdent).toString))
+        val catalogTable = createCatalogForCommandForClone(
+          finalTarget, byPath = false, tblIdent, targetLocation, sourceCatalogTable, sourceTbl)
+        val catalogTableWithPath = if (targetLocation.isEmpty) {
+          catalogTable.copy(
+            storage = CatalogStorageFormat.empty.copy(locationUri = Some(finalTarget.toUri)))
+        } else {
+          catalogTable
+        }
+        CreateDeltaTableCommand(
+          catalogTableWithPath,
+          None,
+          saveMode,
+          Some(CloneTableCommand(
+            sourceTbl,
+            tblIdent,
+            statement.tablePropertyOverrides,
+            finalTarget)),
+          operation = tableCreationMode,
+          output = CloneTableCommand.output)
+
+      // Delta metastore table already exists at target
+      case DataSourceV2Relation(
+          deltaTableV2 @ DeltaTableV2(_, path, existingTable, _, _, _, _), _, _, _, _) =>
+        val tblIdent = existingTable match {
+          case Some(existingCatalog) => existingCatalog.identifier
+          case None => TableIdentifier(path.toString, Some("delta"))
+        }
+        val cloneSourceTable = sourceTbl
+
+
+        val catalog = createCatalogForCommandForClone(
+          path,
+          byPath = existingTable.isEmpty,
+          tblIdent,
+          targetLocation,
+          sourceCatalogTable,
+          cloneSourceTable)
+
+        CreateDeltaTableCommand(
+          catalog,
+          existingTable,
+          saveMode,
+          Some(CloneTableCommand(
+            cloneSourceTable,
+            tblIdent,
+            statement.tablePropertyOverrides,
+            path)),
+          tableByPath = existingTable.isEmpty,
+          operation = tableCreationMode,
+          output = CloneTableCommand.output)
+
+      // Non-delta metastore table already exists at target
+      case LogicalRelation(_, _, existingCatalog @ Some(catalog), _) =>
+        val tblIdent = catalog.identifier
+        val path = new Path(catalog.location)
+        val newCatalog = createCatalogForCommandForClone(
+          path, byPath = false, tblIdent, targetLocation, sourceCatalogTable, sourceTbl)
+        CreateDeltaTableCommand(
+          newCatalog,
+          existingCatalog,
+          saveMode,
+          Some(CloneTableCommand(
+            sourceTbl,
+            tblIdent,
+            statement.tablePropertyOverrides,
+            path)),
+          operation = tableCreationMode,
+          output = CloneTableCommand.output)
+
+      case _ => throw DeltaErrors.notADeltaTableException("CLONE")
+    }
+  }
 
   /**
    * Performs the schema adjustment by adding UpCasts (which are safe) and Aliases so that we

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2472,6 +2472,47 @@ trait DeltaErrorsBase
     )
   }
 
+  def shallowCloneFileNotFoundHint(path: String): String = {
+    "A file referenced in the transaction log cannot be found. This can occur when data has been " +
+      "manually deleted from the file system rather than using the table `DELETE` statement. " +
+      "This table appears to be a shallow clone, if that is the case, this error can occur when " +
+      "the original table from which this table was cloned has deleted a file that the clone is " +
+      "still using. "
+  }
+
+  def cloneOnRelativePath(path: String): Throwable = {
+    new DeltaIllegalArgumentException(
+      errorClass = "DELTA_INVALID_CLONE_PATH",
+      messageParameters = Array(path))
+  }
+
+  def cloneAmbiguousTarget(externalLocation: String, targetIdent: TableIdentifier): Throwable = {
+    new DeltaIllegalArgumentException(
+      errorClass = "DELTA_CLONE_AMBIGUOUS_TARGET",
+      messageParameters = Array(externalLocation, s"$targetIdent")
+    )
+  }
+
+  def cloneFromUnsupportedSource(name: String, format: String): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_CLONE_UNSUPPORTED_SOURCE",
+      messageParameters = Array(name, format)
+    )
+  }
+
+  def cloneReplaceUnsupported(tableIdentifier: TableIdentifier): Throwable = {
+    new DeltaIllegalArgumentException(
+      errorClass = "DELTA_UNSUPPORTED_CLONE_REPLACE_SAME_TABLE",
+      messageParameters = Array(s"$tableIdentifier")
+    )
+  }
+
+  def cloneReplaceNonEmptyTable: Throwable = {
+    new DeltaIllegalStateException(
+      errorClass = "DELTA_UNSUPPORTED_NON_EMPTY_CLONE"
+    )
+  }
+
   def partitionSchemaInIcebergTables: Throwable = {
     new DeltaIllegalArgumentException(errorClass = "DELTA_PARTITION_SCHEMA_IN_ICEBERG_TABLES")
   }

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2472,14 +2472,6 @@ trait DeltaErrorsBase
     )
   }
 
-  def shallowCloneFileNotFoundHint(path: String): String = {
-    "A file referenced in the transaction log cannot be found. This can occur when data has been " +
-      "manually deleted from the file system rather than using the table `DELETE` statement. " +
-      "This table appears to be a shallow clone, if that is the case, this error can occur when " +
-      "the original table from which this table was cloned has deleted a file that the clone is " +
-      "still using. "
-  }
-
   def cloneOnRelativePath(path: String): Throwable = {
     new DeltaIllegalArgumentException(
       errorClass = "DELTA_INVALID_CLONE_PATH",

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -427,6 +427,19 @@ object DeltaOperations {
     override val operationMetrics: Set[String] = DeltaOperationMetrics.OPTIMIZE
   }
 
+  /** Recorded when cloning a Delta table into a new location. */
+  case class Clone(
+      source: String,
+      sourceVersion: Long
+  ) extends Operation("CLONE") {
+    override val parameters: Map[String, Any] = Map(
+      "source" -> source,
+      "sourceVersion" -> sourceVersion
+    )
+    override def changesData: Boolean = true
+    override val operationMetrics: Set[String] = DeltaOperationMetrics.CLONE
+  }
+
 
   private def structFieldToMap(colPath: Seq[String], field: StructField): Map[String, Any] = {
     Map(
@@ -623,6 +636,15 @@ private[delta] object DeltaOperationMetrics {
     "numRestoredFiles", // number of files that were added as a result of the restore
     "removedFilesSize", // size in bytes of files removed by the restore
     "restoredFilesSize" // size in bytes of files added by the restore
+  )
+
+  val CLONE = Set(
+    "sourceTableSize", // size in bytes of source table at version
+    "sourceNumOfFiles", // number of files in source table at version
+    "numRemovedFiles", // number of files removed from target table if delta table was replaced
+    "numCopiedFiles", // number of files that were cloned - 0 for shallow tables
+    "removedFilesSize", // size in bytes of files removed from an existing Delta table if one exists
+    "copiedFilesSize" // size of files copied - 0 for shallow tables
   )
 
 }

--- a/core/src/main/scala/org/apache/spark/sql/delta/PreprocessTimeTravel.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/PreprocessTimeTravel.scala
@@ -52,6 +52,15 @@ case class PreprocessTimeTravel(sparkSession: SparkSession) extends Rule[Logical
           tt.version,
           tt.creationSource))
 
+    case ct @ CloneTableStatement(
+        tt @ TimeTravel(ur: UnresolvedRelation, _, _, _), _,
+          _, _, _, _, _) =>
+      val sourceRelation = resolveTimeTravelTable(sparkSession, ur)
+      ct.copy(source = TimeTravel(
+        sourceRelation,
+        tt.timestamp,
+        tt.version,
+        tt.creationSource))
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
@@ -1,0 +1,356 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands
+
+// scalastyle:off import.ordering.noEmptyLine
+import java.io.Closeable
+import java.util.UUID
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.util._
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{Dataset, Row, SparkSession}
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.{Clock, SerializableConfiguration}
+// scalastyle:on import.ordering.noEmptyLine
+
+/**
+ * An interface of the source table to be cloned from.
+ */
+trait CloneSource extends Closeable {
+  /** The format of the source table */
+  def format: String
+
+  /** The source table's protocol */
+  def protocol: Protocol
+
+  /** A system clock */
+  def clock: Clock
+
+  /** The source table name */
+  def name: String
+
+  /** The path of the source table */
+  def dataPath: Path
+
+  /** The source table schema */
+  def schema: StructType
+
+  /** The catalog table of the source table, if exists */
+  def catalogTable: Option[CatalogTable]
+
+  /** The time travel spec of the source table, if exists */
+  def timeTravelOpt: Option[DeltaTimeTravelSpec]
+
+  /** A snapshot of the source table, if exists */
+  def snapshot: Option[Snapshot]
+
+  /** The metadata of the source table */
+  def metadata: Metadata
+
+  /** All of the files present in the source table */
+  def allFiles: Dataset[AddFile]
+
+  /** Total size of data files in bytes */
+  def sizeInBytes: Long
+
+  /** Total number of data files */
+  def numOfFiles: Long
+
+  /** Describe this clone source */
+  def description: String
+}
+
+// Clone source table formats
+object CloneSourceFormat {
+  val DELTA = "Delta"
+  val PARQUET = "Parquet"
+  val UNKNOWN = "Unknown"
+}
+
+trait CloneTableBaseUtils extends DeltaLogging
+{
+
+  import CloneTableCommand._
+
+  /** Make a map of operation metrics for the executed command for DeltaLog commits */
+  protected def getOperationMetricsForDeltaLog(
+      opMetrics: SnapshotOverwriteOperationMetrics): Map[String, Long] = {
+    Map(
+      SOURCE_TABLE_SIZE -> opMetrics.sourceSnapshotSizeInBytes,
+      SOURCE_NUM_OF_FILES -> opMetrics.sourceSnapshotFileCount,
+      NUM_REMOVED_FILES -> opMetrics.destSnapshotRemovedFileCount,
+      NUM_COPIED_FILES -> 0L,
+      REMOVED_FILES_SIZE -> opMetrics.destSnapshotRemovedFilesSizeInBytes,
+      COPIED_FILES_SIZE -> 0L)
+  }
+
+  /**
+   * Make a map of operation metrics for the executed command for recording events.
+   * Any command can extend to overwrite or add new metrics
+   */
+  protected def getOperationMetricsForEventRecord(
+      opMetrics: SnapshotOverwriteOperationMetrics): Map[String, Long] =
+    getOperationMetricsForDeltaLog(opMetrics)
+
+  /** Make a output Seq[Row] of metrics for the executed command */
+  protected def getOutputSeq(operationMetrics: Map[String, Long]): Seq[Row]
+
+
+  protected val fnfExceptionMessage: String = "Tried to clone a version of the table where " +
+    "files have been deleted manually or by VACUUM. To continue with the operation " +
+    "by skipping the missing files set `spark.sql.files.ignoreMissingFiles` to true."
+
+  protected def checkColumnMappingMode(beforeMetadata: Metadata, afterMetadata: Metadata): Unit = {
+    val beforeColumnMappingMode = beforeMetadata.columnMappingMode
+    val afterColumnMappingMode = afterMetadata.columnMappingMode
+    // can't switch column mapping mode
+    if (beforeColumnMappingMode != afterColumnMappingMode) {
+      throw DeltaErrors.changeColumnMappingModeNotSupported(
+        beforeColumnMappingMode.name, afterColumnMappingMode.name)
+    }
+  }
+
+  // Return a copy of the AddFiles with path being absolutized, indicating a SHALLOW CLONE
+  protected def handleNewDataFiles(
+      opName: String,
+      datasetOfNewFilesToAdd: Dataset[AddFile],
+      qualifiedSourceTableBasePath: String,
+      destTable: DeltaLog
+  ): Dataset[AddFile] = {
+    recordDeltaOperation(destTable, s"delta.${opName.toLowerCase()}.makeAbsolute") {
+      val absolutePaths = DeltaFileOperations.makePathsAbsolute(
+        qualifiedSourceTableBasePath,
+        datasetOfNewFilesToAdd)
+      absolutePaths
+    }
+  }
+}
+
+/**
+ * Base Trait for Clone and Restore Commands
+ */
+abstract class CloneTableBase(
+    sourceTable: CloneSource,
+    tablePropertyOverrides: Map[String, String],
+    targetPath: Path)
+  extends LeafRunnableCommand with CloneTableBaseUtils
+{
+
+  import CloneTableBase._
+
+  /**
+   * Run the clone command
+   *
+   * @param spark [[SparkSession]] to use
+   * @param opName Name of the operation used in log4j logs
+   * @param deltaOperation [[DeltaOperations.Operation]] to use when commit changes to DeltaLog
+   * @param fsOptions Extra filesystem options passed to target DeltaLog.
+   * @return
+   */
+  def runInternal(
+      spark: SparkSession,
+      opName: String,
+      hdpConf: Configuration,
+      deltaOperation: DeltaOperations.Operation,
+      fsOptions: Map[String, String]): Seq[Row] = {
+    val targetFs = targetPath.getFileSystem(hdpConf)
+    val qualifiedTarget = targetFs.makeQualified(targetPath).toString
+    val qualifiedSource = {
+      val sourcePath = sourceTable.dataPath
+      val sourceFs = sourcePath.getFileSystem(hdpConf)
+      sourceFs.makeQualified(sourcePath).toString
+    }
+
+    val destinationTable = DeltaLog.forTable(spark, targetPath, fsOptions)
+
+    val txn = destinationTable.startTransaction()
+    if (txn.readVersion < 0) {
+      destinationTable.createLogDirectory()
+    }
+
+    val (datasetOfNewFilesToAdd, newMetadata, datasetOfExistingFileToRemoveOpt) = {
+      // Make sure target table is empty before running clone
+      if (txn.snapshot.allFiles.count() > 0) {
+        throw DeltaErrors.cloneReplaceNonEmptyTable
+      }
+
+      val clonedMetadata = sourceTable.metadata.copy(
+        id = UUID.randomUUID().toString,
+        name = null, // remove the name of the table during cloning
+        description = null) // remove description of table during cloning
+      (sourceTable.allFiles, clonedMetadata, Option.empty[Dataset[AddFile]])
+    }
+
+    // TODO: we have not decided on how to implement switching column mapping modes
+    //  so we block this feature for now
+    // 1. Validate configuration overrides
+    //    this checks if columnMapping.maxId is unexpected set in the properties
+    val validatedConfigurations = DeltaConfigs.validateConfigurations(tablePropertyOverrides)
+    val metadataToUpdate = newMetadata.copy(
+      configuration = newMetadata.configuration ++ validatedConfigurations)
+    // 2. Check for column mapping mode conflict with the source metadata w/ tablePropertyOverrides
+    checkColumnMappingMode(newMetadata, metadataToUpdate)
+    // 3. Checks for column mapping mode conflicts with existing metadata if there's any
+    if (txn.readVersion >= 0) {
+      checkColumnMappingMode(txn.snapshot.metadata, metadataToUpdate)
+    }
+    // Don't merge in the default properties when cloning, or we'll end up with different sets of
+    // properties between source and target.
+    txn.updateMetadata(metadataToUpdate, ignoreDefaultProperties = true)
+
+    val datasetOfCopiedFileList = handleNewDataFiles(
+      opName,
+      datasetOfNewFilesToAdd,
+      qualifiedSource,
+      destinationTable)
+
+    val copiedFileList = datasetOfCopiedFileList.collectAsList()
+
+    val (copiedFileCount, copiedFilesSize) =
+      (copiedFileList.size.toLong, totalDataSize(copiedFileList.iterator))
+
+    val operationTimestamp = sourceTable.clock.getTimeMillis()
+
+    val existingFilesToRemoveOpt =
+      datasetOfExistingFileToRemoveOpt.map(_.collectAsList())
+
+    val existingFileList = existingFilesToRemoveOpt.map {
+      _.iterator.asScala.map { file =>
+        file.removeWithTimestamp(operationTimestamp)
+      }
+    }.getOrElse(Iterator.empty)
+
+    val (removedFileCount, removedFilesSize) = existingFilesToRemoveOpt
+      .map(fileList => (fileList.size.toLong, totalDataSize(fileList.iterator)))
+      .getOrElse(0L, 0L)
+
+    val sourceProtocol = sourceTable.protocol
+    // Pre-transaction version of the target table.
+    val targetProtocol = txn.snapshot.protocol
+    // Overriding properties during the CLONE can change the minimum required protocol for target.
+    // We need to look at the metadata of the transaction to see the entire set of table properties
+    // for the post-transaction state and decide a version based on that.
+    val minRequiredProtocol = Protocol(spark, Some(txn.metadata))
+    // Only upgrade the protocol, never downgrade (unless allowed by flag), since that may break
+    // time travel.
+    val protocolDowngradeAllowed =
+      conf.getConf(DeltaSQLConf.RESTORE_TABLE_PROTOCOL_DOWNGRADE_ALLOWED) ||
+      // It's not a real downgrade if the table doesn't exist before the CLONE.
+      txn.snapshot.version == -1
+    val newProtocol = if (protocolDowngradeAllowed) {
+      sourceProtocol.max(minRequiredProtocol)
+    } else {
+      targetProtocol.max(sourceProtocol).max(minRequiredProtocol)
+    }
+
+    try {
+      var actions = Iterator.single(newProtocol) ++
+        existingFileList.map(a => a.copy(dataChange = true)) ++
+        copiedFileList.iterator.asScala.map(a => a.copy(dataChange = true))
+
+
+      val sourceName = sourceTable.name
+
+      // Override source table metadata with user-defined table properties
+      var context = Map[String, String]()
+      val isReplaceDelta = txn.readVersion >= 0
+
+      val opMetrics = SnapshotOverwriteOperationMetrics(
+        sourceTable.sizeInBytes,
+        sourceTable.numOfFiles,
+        removedFileCount,
+        copiedFileCount,
+        removedFilesSize,
+        copiedFilesSize)
+      val commitOpMetrics = getOperationMetricsForDeltaLog(opMetrics)
+
+        recordDeltaOperation(destinationTable, s"delta.${opName.toLowerCase()}.commit") {
+          txn.commitLarge(
+            spark,
+            actions,
+            deltaOperation,
+            context,
+            commitOpMetrics.mapValues(_.toString()).toMap)
+        }
+
+      val cloneLogData = getOperationMetricsForEventRecord(opMetrics) ++ Map(
+        SOURCE -> sourceName,
+        SOURCE_FORMAT -> sourceTable.format,
+        SOURCE_PATH -> qualifiedSource,
+        TARGET -> qualifiedTarget,
+        IS_REPLACE_DELTA -> isReplaceDelta) ++
+        sourceTable.snapshot.map(s => SOURCE_VERSION -> s.version)
+      recordDeltaEvent(destinationTable, s"delta.${opName.toLowerCase()}", data = cloneLogData)
+
+      getOutputSeq(commitOpMetrics)
+    } finally {
+      sourceTable.close()
+    }
+  }
+}
+
+object CloneTableBase extends Logging {
+
+  val SOURCE = "source"
+  val SOURCE_FORMAT = "sourceFormat"
+  val SOURCE_PATH = "sourcePath"
+  val SOURCE_VERSION = "sourceVersion"
+  val TARGET = "target"
+  val IS_REPLACE_DELTA = "isReplaceDelta"
+
+  /** Utility method returns the total size of all files in the given iterator */
+  private def totalDataSize(fileList: java.util.Iterator[AddFile]): Long = {
+    var totalSize = 0L
+    fileList.asScala.foreach { f =>
+      totalSize += f.size
+    }
+    totalSize
+  }
+}
+
+/**
+ * Metrics of snapshot overwrite operation.
+ * @param sourceSnapshotSizeInBytes Total size of the data in the source snapshot.
+ * @param sourceSnapshotFileCount Number of data files in the source snapshot.
+ * @param destSnapshotRemovedFileCount Number of existing files in destination snapshot
+ *                                     removed as part of the execution.
+ * @param destSnapshotAddedFileCount Number of new data files added to the destination
+ *                                   snapshot as part of the execution.
+ * @param destSnapshotRemovedFilesSizeInBytes Total size (in bytes) of the data files removed
+ *                                            from destination snapshot.
+ * @param destSnapshotAddedFilesSizeInBytes Total size (in bytes) of the data files that were
+ *                                          added to the destination snapshot.
+ */
+case class SnapshotOverwriteOperationMetrics(
+    sourceSnapshotSizeInBytes: Long,
+    sourceSnapshotFileCount: Long,
+    destSnapshotRemovedFileCount: Long,
+    destSnapshotAddedFileCount: Long,
+    destSnapshotRemovedFilesSizeInBytes: Long,
+    destSnapshotAddedFilesSizeInBytes: Long)

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
@@ -103,7 +103,11 @@ trait CloneTableBaseUtils extends DeltaLogging
       opMetrics: SnapshotOverwriteOperationMetrics): Map[String, Long] = {
     Map(
       SOURCE_TABLE_SIZE -> opMetrics.sourceSnapshotSizeInBytes,
-      SOURCE_NUM_OF_FILES -> opMetrics.sourceSnapshotFileCount
+      SOURCE_NUM_OF_FILES -> opMetrics.sourceSnapshotFileCount,
+      NUM_REMOVED_FILES -> 0L,
+      NUM_COPIED_FILES -> 0L,
+      REMOVED_FILES_SIZE -> 0L,
+      COPIED_FILES_SIZE -> 0L
     )
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
@@ -62,7 +62,11 @@ case class CloneTableCommand(
   override protected def getOutputSeq(operationMetrics: Map[String, Long]): Seq[Row] = {
     Seq(Row(
       operationMetrics.get(SOURCE_TABLE_SIZE),
-      operationMetrics.get(SOURCE_NUM_OF_FILES)
+      operationMetrics.get(SOURCE_NUM_OF_FILES),
+      operationMetrics.get(NUM_REMOVED_FILES),
+      operationMetrics.get(NUM_COPIED_FILES),
+      operationMetrics.get(REMOVED_FILES_SIZE),
+      operationMetrics.get(COPIED_FILES_SIZE)
     ))
   }
 
@@ -105,14 +109,26 @@ object CloneTableCommand {
   // Names of the metrics - added to the Delta commit log as part of Clone transaction
   val SOURCE_TABLE_SIZE = "sourceTableSize"
   val SOURCE_NUM_OF_FILES = "sourceNumOfFiles"
+  val NUM_REMOVED_FILES = "numRemovedFiles"
+  val NUM_COPIED_FILES = "numCopiedFiles"
+  val REMOVED_FILES_SIZE = "removedFilesSize"
+  val COPIED_FILES_SIZE = "copiedFilesSize"
 
   // SQL way column names for metrics in command execution output
   private val COLUMN_SOURCE_TABLE_SIZE = "source_table_size"
   private val COLUMN_SOURCE_NUM_OF_FILES = "source_num_of_files"
+  private val COLUMN_NUM_REMOVED_FILES = "num_removed_files"
+  private val COLUMN_NUM_COPIED_FILES = "num_copied_files"
+  private val COLUMN_REMOVED_FILES_SIZE = "removed_files_size"
+  private val COLUMN_COPIED_FILES_SIZE = "copied_files_size"
 
   val output: Seq[Attribute] = Seq(
     AttributeReference(COLUMN_SOURCE_TABLE_SIZE, LongType)(),
-    AttributeReference(COLUMN_SOURCE_NUM_OF_FILES, LongType)()
+    AttributeReference(COLUMN_SOURCE_NUM_OF_FILES, LongType)(),
+    AttributeReference(COLUMN_NUM_REMOVED_FILES, LongType)(),
+    AttributeReference(COLUMN_NUM_COPIED_FILES, LongType)(),
+    AttributeReference(COLUMN_REMOVED_FILES_SIZE, LongType)(),
+    AttributeReference(COLUMN_COPIED_FILES_SIZE, LongType)()
   )
 }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
@@ -1,0 +1,257 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands
+
+// scalastyle:off import.ordering.noEmptyLine
+import java.io.FileNotFoundException
+
+import org.apache.spark.sql.delta.{DeltaErrors, DeltaTimeTravelSpec, Snapshot}
+import org.apache.spark.sql.delta.DeltaOperations.Clone
+import org.apache.spark.sql.delta.actions.{AddFile, Metadata, Protocol}
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.{Column, Dataset, Row, SparkSession}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{LongType, StructType}
+import org.apache.spark.util.{Clock, SerializableConfiguration, SystemClock}
+// scalastyle:on import.ordering.noEmptyLine
+
+/**
+ * Clones a Delta table to a new location with a new table id.
+ * The clone can be performed as a shallow clone (i.e. shallow = true),
+ * where we do not copy the files, but just point to them.
+ * If a table exists at the given targetPath, that table will be replaced.
+ *
+ * @param sourceTable is the table to be cloned
+ * @param targetIdent destination table identifier to clone to
+ * @param tablePropertyOverrides user-defined table properties that should override any properties
+ *                       with the same key from the source table
+ * @param targetPath the actual destination
+ */
+case class CloneTableCommand(
+    sourceTable: CloneSource,
+    targetIdent: TableIdentifier,
+    tablePropertyOverrides: Map[String, String],
+    targetPath: Path)
+  extends CloneTableBase(sourceTable, tablePropertyOverrides, targetPath) {
+
+  import CloneTableCommand._
+
+
+  /** Overwrite the size and count of files added (may or may not be copied) to DeltaLog */
+  override protected def getOperationMetricsForEventRecord(
+      opMetrics: SnapshotOverwriteOperationMetrics): Map[String, Long] = {
+    getOperationMetricsForDeltaLog(opMetrics) ++ Map(
+      // overwrite these two metrics in clone log data:
+      // NUM_COPIED_FILES and COPIED_FILES_SIZE are used internally to track the usage of the clone
+      NUM_COPIED_FILES -> opMetrics.destSnapshotAddedFileCount,
+      COPIED_FILES_SIZE -> opMetrics.destSnapshotAddedFilesSizeInBytes)
+  }
+
+  /** Return the CLONE command output from the execution metrics */
+  override protected def getOutputSeq(operationMetrics: Map[String, Long]): Seq[Row] = {
+    Seq(Row(
+      operationMetrics.get(SOURCE_TABLE_SIZE),
+      operationMetrics.get(SOURCE_NUM_OF_FILES),
+      operationMetrics.get(NUM_REMOVED_FILES),
+      operationMetrics.get(NUM_COPIED_FILES),
+      operationMetrics.get(REMOVED_FILES_SIZE),
+      operationMetrics.get(COPIED_FILES_SIZE)
+    ))
+  }
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    if (!targetPath.isAbsolute) {
+      throw DeltaErrors.cloneOnRelativePath(targetIdent.toString)
+    }
+
+    /** Log clone command information */
+    logInfo("Cloning " + sourceTable.description + s" to $targetPath")
+
+    // scalastyle:off deltahadoopconfiguration
+    val hdpConf = sparkSession.sessionState.newHadoopConf()
+    // scalastyle:on deltahadoopconfiguration
+    if (!sparkSession.sessionState.conf.getConf(DeltaSQLConf.DELTA_CLONE_REPLACE_ENABLED)) {
+      val targetFs = targetPath.getFileSystem(hdpConf)
+      try {
+        val subFiles = targetFs.listStatus(targetPath)
+        if (subFiles.nonEmpty) {
+          throw DeltaErrors.cloneReplaceUnsupported(targetIdent)
+        }
+      } catch {
+        case _: FileNotFoundException => // we want the path to not exist
+          targetFs.mkdirs(targetPath)
+      }
+    }
+
+    runInternal(
+      sparkSession,
+      opName = "CLONE",
+      hdpConf = hdpConf,
+      deltaOperation = Clone(
+        sourceTable.name, sourceTable.snapshot.map(_.version).getOrElse(-1)
+      ),
+      Map.empty)
+  }
+}
+
+object CloneTableCommand {
+  // Names of the metrics - added to the Delta commit log as part of Clone transaction
+  val SOURCE_TABLE_SIZE = "sourceTableSize"
+  val SOURCE_NUM_OF_FILES = "sourceNumOfFiles"
+  val NUM_REMOVED_FILES = "numRemovedFiles"
+  val NUM_COPIED_FILES = "numCopiedFiles"
+  val REMOVED_FILES_SIZE = "removedFilesSize"
+  val COPIED_FILES_SIZE = "copiedFilesSize"
+
+  // SQL way column names for metrics in command execution output
+  private val COLUMN_SOURCE_TABLE_SIZE = "source_table_size"
+  private val COLUMN_SOURCE_NUM_OF_FILES = "source_num_of_files"
+  private val COLUMN_NUM_REMOVED_FILES = "num_removed_files"
+  private val COLUMN_NUM_COPIED_FILES = "num_copied_files"
+  private val COLUMN_REMOVED_FILES_SIZE = "removed_files_size"
+  private val COLUMN_COPIED_FILES_SIZE = "copied_files_size"
+
+  val output: Seq[Attribute] = Seq(
+    AttributeReference(COLUMN_SOURCE_TABLE_SIZE, LongType)(),
+    AttributeReference(COLUMN_SOURCE_NUM_OF_FILES, LongType)(),
+    AttributeReference(COLUMN_NUM_REMOVED_FILES, LongType)(),
+    AttributeReference(COLUMN_NUM_COPIED_FILES, LongType)(),
+    AttributeReference(COLUMN_REMOVED_FILES_SIZE, LongType)(),
+    AttributeReference(COLUMN_COPIED_FILES_SIZE, LongType)()
+  )
+}
+
+/** A delta table source to be cloned from */
+class CloneDeltaSource(
+  sourceTable: DeltaTableV2) extends CloneSource {
+
+  private val deltaLog = sourceTable.deltaLog
+  private val sourceSnapshot = sourceTable.snapshot
+
+  def format: String = CloneSourceFormat.DELTA
+
+  def protocol: Protocol = sourceSnapshot.protocol
+
+  def clock: Clock = deltaLog.clock
+
+  def name: String = sourceTable.name()
+
+  def dataPath: Path = deltaLog.dataPath
+
+  def schema: StructType = sourceTable.schema()
+
+  def catalogTable: Option[CatalogTable] = sourceTable.catalogTable
+
+  def timeTravelOpt: Option[DeltaTimeTravelSpec] = sourceTable.timeTravelOpt
+
+  def snapshot: Option[Snapshot] = Some(sourceSnapshot)
+
+  def metadata: Metadata = sourceSnapshot.metadata
+
+  def allFiles: Dataset[AddFile] = sourceSnapshot.allFiles
+
+  def sizeInBytes: Long = sourceSnapshot.sizeInBytes
+
+  def numOfFiles: Long = sourceSnapshot.numOfFiles
+
+  def description: String = s"${format} table ${name} at version ${sourceSnapshot.version}"
+
+  override def close(): Unit = {}
+}
+
+/** A parquet table source to be cloned from */
+class CloneParquetSource(
+  tableIdentifier: TableIdentifier,
+  override val catalogTable: Option[CatalogTable],
+  spark: SparkSession) extends CloneSource {
+
+  protected lazy val convertTargetTable: ConvertTargetTable = {
+    val baseDir = catalogTable.map(_.location.toString).getOrElse(tableIdentifier.table)
+    val provider = catalogTable.map(_.provider).getOrElse(tableIdentifier.database)
+    ConvertToDeltaCommand.getParquetTable(spark, baseDir, catalogTable, None)
+  }
+
+  def format: String = CloneSourceFormat.PARQUET
+
+  def protocol: Protocol = new Protocol()
+
+  override val clock: Clock = new SystemClock()
+
+  def name: String = catalogTable.map(_.identifier.unquotedString)
+    .getOrElse(s"parquet.`${tableIdentifier.table}`")
+
+  def dataPath: Path = new Path(convertTargetTable.fileManifest.basePath)
+
+  def schema: StructType = convertTargetTable.tableSchema
+
+  def timeTravelOpt: Option[DeltaTimeTravelSpec] = None
+
+  def snapshot: Option[Snapshot] = None
+
+  override lazy val metadata: Metadata = {
+    val conf = catalogTable
+      // Hive adds some transient table properties which should be ignored
+      .map(_.properties.filterKeys(_ != "transient_lastDdlTime").toMap)
+      .foldRight(convertTargetTable.properties.toMap)(_ ++ _)
+
+    {
+      Metadata(
+        schemaString = convertTargetTable.tableSchema.json,
+        partitionColumns = convertTargetTable.partitionSchema.fieldNames,
+        configuration = conf,
+        createdTime = Some(System.currentTimeMillis()))
+    }
+  }
+
+  override lazy val allFiles: Dataset[AddFile] = {
+    import org.apache.spark.sql.delta.implicits._
+
+    // scalastyle:off deltahadoopconfiguration
+    val serializableConf = new SerializableConfiguration(spark.sessionState.newHadoopConf())
+    // scalastyle:on deltahadoopconfiguration
+    val baseDir = dataPath.toString
+    val conf = spark.sparkContext.broadcast(serializableConf)
+    val partitionSchema = convertTargetTable.partitionSchema
+
+    {
+      convertTargetTable.fileManifest.allFiles.mapPartitions { targetFile =>
+        val basePath = new Path(baseDir)
+        val fs = basePath.getFileSystem(conf.value.value)
+        targetFile.map(ConvertToDeltaCommand.createAddFile(
+          _, basePath, fs, SQLConf.get, Some(partitionSchema)))
+      }
+    }
+  }
+
+  private lazy val fileStats = allFiles.select(
+      coalesce(sum("size"), lit(0L)), count(new Column("*"))).first()
+
+  def sizeInBytes: Long = fileStats.getLong(0)
+
+  def numOfFiles: Long = fileStats.getLong(1)
+
+  def description: String = s"${format} table ${name}"
+
+  override def close(): Unit = convertTargetTable.fileManifest.close()
+}

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
@@ -58,25 +58,11 @@ case class CloneTableCommand(
   import CloneTableCommand._
 
 
-  /** Overwrite the size and count of files added (may or may not be copied) to DeltaLog */
-  override protected def getOperationMetricsForEventRecord(
-      opMetrics: SnapshotOverwriteOperationMetrics): Map[String, Long] = {
-    getOperationMetricsForDeltaLog(opMetrics) ++ Map(
-      // overwrite these two metrics in clone log data:
-      // NUM_COPIED_FILES and COPIED_FILES_SIZE are used internally to track the usage of the clone
-      NUM_COPIED_FILES -> opMetrics.destSnapshotAddedFileCount,
-      COPIED_FILES_SIZE -> opMetrics.destSnapshotAddedFilesSizeInBytes)
-  }
-
   /** Return the CLONE command output from the execution metrics */
   override protected def getOutputSeq(operationMetrics: Map[String, Long]): Seq[Row] = {
     Seq(Row(
       operationMetrics.get(SOURCE_TABLE_SIZE),
-      operationMetrics.get(SOURCE_NUM_OF_FILES),
-      operationMetrics.get(NUM_REMOVED_FILES),
-      operationMetrics.get(NUM_COPIED_FILES),
-      operationMetrics.get(REMOVED_FILES_SIZE),
-      operationMetrics.get(COPIED_FILES_SIZE)
+      operationMetrics.get(SOURCE_NUM_OF_FILES)
     ))
   }
 
@@ -119,26 +105,14 @@ object CloneTableCommand {
   // Names of the metrics - added to the Delta commit log as part of Clone transaction
   val SOURCE_TABLE_SIZE = "sourceTableSize"
   val SOURCE_NUM_OF_FILES = "sourceNumOfFiles"
-  val NUM_REMOVED_FILES = "numRemovedFiles"
-  val NUM_COPIED_FILES = "numCopiedFiles"
-  val REMOVED_FILES_SIZE = "removedFilesSize"
-  val COPIED_FILES_SIZE = "copiedFilesSize"
 
   // SQL way column names for metrics in command execution output
   private val COLUMN_SOURCE_TABLE_SIZE = "source_table_size"
   private val COLUMN_SOURCE_NUM_OF_FILES = "source_num_of_files"
-  private val COLUMN_NUM_REMOVED_FILES = "num_removed_files"
-  private val COLUMN_NUM_COPIED_FILES = "num_copied_files"
-  private val COLUMN_REMOVED_FILES_SIZE = "removed_files_size"
-  private val COLUMN_COPIED_FILES_SIZE = "copied_files_size"
 
   val output: Seq[Attribute] = Seq(
     AttributeReference(COLUMN_SOURCE_TABLE_SIZE, LongType)(),
-    AttributeReference(COLUMN_SOURCE_NUM_OF_FILES, LongType)(),
-    AttributeReference(COLUMN_NUM_REMOVED_FILES, LongType)(),
-    AttributeReference(COLUMN_NUM_COPIED_FILES, LongType)(),
-    AttributeReference(COLUMN_REMOVED_FILES_SIZE, LongType)(),
-    AttributeReference(COLUMN_COPIED_FILES_SIZE, LongType)()
+    AttributeReference(COLUMN_SOURCE_NUM_OF_FILES, LongType)()
   )
 }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -946,7 +946,6 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
-  // TODO(SC-109291): Force wipe history, too.
   val RESTORE_TABLE_PROTOCOL_DOWNGRADE_ALLOWED =
     buildConf("restore.protocolDowngradeAllowed")
       .doc("Whether a table may be restored to a lower protocol version than the current." +
@@ -957,6 +956,13 @@ trait DeltaSQLConfBase {
         " concurrent queries accessing the table until the history wipe is complete.")
       .booleanConf
       .createWithDefault(false)
+
+  val DELTA_CLONE_REPLACE_ENABLED =
+    buildConf("clone.replaceEnabled")
+      .internal()
+      .doc("If enabled, the table will be replaced when cloning over an existing Delta table.")
+      .booleanConf
+      .createWithDefault(true)
 
   val DELTA_OPTIMIZE_METADATA_QUERY_ENABLED =
     buildConf("optimizeMetadataQuery.enabled")

--- a/core/src/test/scala/org/apache/spark/sql/delta/CloneTableSQLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/CloneTableSQLSuite.scala
@@ -1,0 +1,231 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.{AnalysisException, Row}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.CatalogTableType
+import org.apache.spark.sql.catalyst.parser.ParseException
+import org.apache.spark.util.Utils
+
+class CloneTableSQLSuite extends CloneTableSuiteBase
+  with DeltaColumnMappingTestUtils
+{
+  // scalastyle:off argcount
+  override protected def cloneTable(
+      source: String,
+      target: String,
+      sourceIsTable: Boolean = false,
+      targetIsTable: Boolean = false,
+      sourceFormat: String = "delta",
+      targetLocation: Option[String] = None,
+      versionAsOf: Option[Long] = None,
+      timestampAsOf: Option[String] = None,
+      isCreate: Boolean = true,
+      isReplace: Boolean = false,
+      tableProperties: Map[String, String] = Map.empty): Unit = {
+    val header = if (isCreate && isReplace) {
+      "CREATE OR REPLACE"
+    } else if (isReplace) {
+      "REPLACE"
+    } else {
+      "CREATE"
+    }
+    // e.g. CREATE TABLE targetTable
+    val createTbl =
+      if (targetIsTable) s"$header TABLE $target" else s"$header TABLE delta.`$target`"
+    // e.g. CREATE TABLE targetTable SHALLOW CLONE
+    val withMethod =
+        createTbl + " SHALLOW CLONE "
+    // e.g. CREATE TABLE targetTable SHALLOW CLONE delta.`/source/table`
+    val withSource = if (sourceIsTable) {
+      withMethod + s"$source "
+    } else {
+      withMethod + s"$sourceFormat.`$source` "
+    }
+    // e.g. CREATE TABLE targetTable SHALLOW CLONE delta.`/source/table` VERSION AS OF 0
+    val withVersion = if (versionAsOf.isDefined) {
+      withSource + s"VERSION AS OF ${versionAsOf.get}"
+    } else if (timestampAsOf.isDefined) {
+      withSource + s"TIMESTAMP AS OF '${timestampAsOf.get}'"
+    } else {
+      withSource
+    }
+    // e.g. CREATE TABLE targetTable SHALLOW CLONE delta.`/source/table` VERSION AS OF 0
+    //      LOCATION '/desired/target/location'
+    val withLocation = if (targetLocation.isDefined) {
+      s" $withVersion LOCATION '${targetLocation.get}'"
+    } else {
+      withVersion
+    }
+    val withProperties = if (tableProperties.nonEmpty) {
+      val props = tableProperties.map(p => s"'${p._1}' = '${p._2}'").mkString(",")
+      s" $withLocation TBLPROPERTIES ($props)"
+    } else {
+      withLocation
+    }
+    sql(withProperties)
+  }
+  // scalastyle:on argcount
+
+  testAllClones(s"table version as of syntax") { (_, target, isShallow) =>
+    val tbl = "source"
+    testSyntax(
+      tbl,
+      target,
+      s"CREATE TABLE delta.`$target` ${cloneTypeStr(isShallow)} CLONE $tbl VERSION AS OF 0"
+    )
+  }
+
+  testAllClones("CREATE OR REPLACE syntax when there is no existing table") {
+    (_, clone, isShallow) =>
+      val tbl = "source"
+      testSyntax(
+        tbl,
+        clone,
+        s"CREATE OR REPLACE TABLE delta.`$clone` ${cloneTypeStr(isShallow)} CLONE $tbl"
+      )
+  }
+
+  cloneTest("REPLACE cannot be used with IF NOT EXISTS") { (shallow, _) =>
+    val tbl = "source"
+    intercept[ParseException] {
+      testSyntax(tbl, shallow,
+        s"CREATE OR REPLACE TABLE IF NOT EXISTS delta.`$shallow` SHALLOW CLONE $tbl")
+    }
+    intercept[ParseException] {
+      testSyntax(tbl, shallow,
+        s"REPLACE TABLE IF NOT EXISTS delta.`$shallow` SHALLOW CLONE $tbl")
+    }
+  }
+
+  testAllClones(
+    "IF NOT EXISTS should not go through with CLONE if table exists") { (tblExt, _, isShallow) =>
+    val sourceTable = "source"
+    val conflictingTable = "conflict"
+    withTable(sourceTable, conflictingTable) {
+      sql(s"CREATE TABLE $conflictingTable " +
+        s"USING PARQUET LOCATION '$tblExt' TBLPROPERTIES ('abc'='def', 'def'='ghi') AS SELECT 1")
+      spark.range(5).write.format("delta").saveAsTable(sourceTable)
+
+      sql(s"CREATE TABLE IF NOT EXISTS " +
+        s"$conflictingTable ${cloneTypeStr(isShallow)} CLONE $sourceTable")
+
+      checkAnswer(sql(s"SELECT COUNT(*) FROM $conflictingTable"), Row(1))
+    }
+  }
+
+  testAllClones("IF NOT EXISTS should throw an error if path exists") { (_, target, isShallow) =>
+    spark.range(5).write.format("delta").save(target)
+
+    val ex = intercept[AnalysisException] {
+      sql(s"CREATE TABLE IF NOT EXISTS " +
+        s"delta.`$target` ${cloneTypeStr(isShallow)} CLONE delta.`$target`")
+    }
+
+    assert(ex.getMessage.contains("is not empty"))
+  }
+
+  cloneTest("Negative test: REPLACE table where there is no existing table") { (shallow, _) =>
+    val tbl = "source"
+    val ex = intercept[AnalysisException] {
+      testSyntax(tbl, shallow, s"REPLACE TABLE delta.`$shallow` SHALLOW CLONE $tbl")
+    }
+
+    assert(ex.getMessage.contains("cannot be replaced as it does not exist."))
+  }
+
+  cloneTest("cloning a table that doesn't exist") { (tblExt, _) =>
+    val ex = intercept[AnalysisException] {
+      sql(s"CREATE TABLE delta.`$tblExt` SHALLOW CLONE not_exists")
+    }
+    assert(ex.getMessage.contains("Table not found"))
+
+    val ex2 = intercept[AnalysisException] {
+      sql(s"CREATE TABLE delta.`$tblExt` SHALLOW CLONE not_exists VERSION AS OF 0")
+    }
+    assert(ex2.getMessage.contains("Table not found"))
+  }
+
+  cloneTest("cloning a view") { (tblExt, _) =>
+    withTempView("tmp") {
+      sql("CREATE OR REPLACE TEMP VIEW tmp AS SELECT * FROM range(10)")
+      val ex = intercept[AnalysisException] {
+        sql(s"CREATE TABLE delta.`$tblExt` SHALLOW CLONE tmp")
+      }
+      assert(ex.errorClass === Some("DELTA_CLONE_UNSUPPORTED_SOURCE"))
+      assert(ex.messageParameters.map(_.toString).exists(_.contains("tmp")))
+      assert(ex.messageParameters.map(_.toString).exists(_.contains("View")))
+    }
+  }
+
+  cloneTest("cloning a view over a Delta table") { (tblExt, _) =>
+    withTable("delta_table") {
+      withView("tmp") {
+        sql("CREATE TABLE delta_table USING delta AS SELECT * FROM range(10)")
+        sql("CREATE VIEW tmp AS SELECT * FROM delta_table")
+        val ex = intercept[AnalysisException] {
+          sql(s"CREATE TABLE delta.`$tblExt` SHALLOW CLONE tmp")
+        }
+        assert(ex.errorClass === Some("DELTA_CLONE_UNSUPPORTED_SOURCE"))
+        assert(ex.messageParameters.map(_.toString).exists(_.contains("tmp")))
+        assert(ex.messageParameters.map(_.toString).exists(_.contains("View")))
+      }
+    }
+  }
+
+  cloneTest("check metrics returned from shallow clone", TAG_HAS_SHALLOW_CLONE) { (_, _) =>
+    val source = "source"
+    val target = "target"
+    withTable(source, target) {
+      spark.range(100).write.format("delta").saveAsTable(source)
+
+      val res = sql(s"CREATE TABLE $target SHALLOW CLONE $source")
+
+      // schema check
+      val expectedColumns = Seq(
+        "source_table_size",
+        "source_num_of_files",
+        "num_removed_files",
+        "num_copied_files",
+        "removed_files_size",
+        "copied_files_size"
+      )
+      assert(expectedColumns == res.columns.toSeq)
+
+      // logic check
+      assert(res.count() == 1)
+      val returnedMetrics = res.first()
+      assert(returnedMetrics.getAs[Long]("source_table_size") != 0L)
+      assert(returnedMetrics.getAs[Long]("source_num_of_files") != 0L)
+      assert(returnedMetrics.getAs[Long]("num_copied_files") == 0L)
+      assert(returnedMetrics.getAs[Long]("copied_files_size") == 0L)
+    }
+  }
+}
+
+
+class CloneTableSQLIdColumnMappingSuite
+  extends CloneTableSQLSuite
+    with CloneTableColumnMappingSuiteBase
+    with DeltaColumnMappingEnableIdMode
+
+class CloneTableSQLNameColumnMappingSuite
+  extends CloneTableSQLSuite
+    with CloneTableColumnMappingNameSuiteBase
+    with DeltaColumnMappingEnableNameMode {
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/CloneTableSQLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/CloneTableSQLSuite.scala
@@ -165,7 +165,11 @@ class CloneTableSQLSuite extends CloneTableSuiteBase
       // schema check
       val expectedColumns = Seq(
         "source_table_size",
-        "source_num_of_files"
+        "source_num_of_files",
+        "num_removed_files",
+        "num_copied_files",
+        "removed_files_size",
+        "copied_files_size"
       )
       assert(expectedColumns == res.columns.toSeq)
 
@@ -174,6 +178,9 @@ class CloneTableSQLSuite extends CloneTableSuiteBase
       val returnedMetrics = res.first()
       assert(returnedMetrics.getAs[Long]("source_table_size") != 0L)
       assert(returnedMetrics.getAs[Long]("source_num_of_files") != 0L)
+      // Delta-OSS doesn't support copied file metrics
+      assert(returnedMetrics.getAs[Long]("num_copied_files") == 0L)
+      assert(returnedMetrics.getAs[Long]("copied_files_size") == 0L)
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/CloneTableSuiteBase.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/CloneTableSuiteBase.scala
@@ -1,0 +1,1029 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+// scalastyle:off import.ordering.noEmptyLine
+import java.io.File
+import java.net.URI
+import java.util.Locale
+
+import com.databricks.spark.util.{Log4jUsageLogger, UsageRecord}
+import org.apache.spark.sql.delta.actions.{FileAction, Metadata, Protocol, SetTransaction, SingleAction}
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.commands._
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.stats.StatisticsCollection
+import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest}
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
+import org.apache.spark.sql.delta.util.FileNames.{checksumFile, deltaFile}
+import org.apache.spark.sql.delta.util.JsonUtils
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{Path, RawLocalFileSystem}
+import org.scalatest.Tag
+
+import org.apache.spark.{DebugFilesystem, SparkException, TaskFailedReason}
+import org.apache.spark.scheduler.{SparkListener, SparkListenerTaskEnd}
+import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, QueryTest, Row}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
+import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.execution.streaming.{CheckpointFileManager, FileSystemBasedCheckpointFileManager, MemoryStream}
+import org.apache.spark.sql.functions.{col, floor, from_json}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.streaming.OutputMode
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{IntegerType, StructType}
+import org.apache.spark.util.Utils
+// scalastyle:on import.ordering.noEmptyLine
+
+trait CloneTableSuiteBase extends QueryTest
+  with SharedSparkSession
+  with DeltaColumnMappingTestUtils
+  with DeltaSQLCommandTest {
+
+  protected val TAG_HAS_SHALLOW_CLONE = new Tag("SHALLOW CLONE")
+  protected val TAG_MODIFY_PROTOCOL = new Tag("CHANGES PROTOCOL")
+  protected val TAG_CHANGE_COLUMN_MAPPING_MODE = new Tag("CHANGES COLUMN MAPPING MODE")
+  protected val TAG_USES_CONVERT_TO_DELTA = new Tag("USES CONVERT TO DELTA")
+
+  protected def withSourceTargetDir(f: (String, String) => Unit): Unit = {
+    withTempDir { dir =>
+      val firstDir = new File(dir, "source").getCanonicalPath
+      val secondDir = new File(dir, "clone").getCanonicalPath
+      f(firstDir, secondDir)
+    }
+  }
+
+  protected def cloneTypeStr(isShallow: Boolean): String = {
+      "SHALLOW"
+  }
+
+  /**
+   * Run the given test function for SHALLOW clone.
+   */
+  protected def testAllClones(testName: String, testTags: org.scalatest.Tag*)
+      (testFunc: (String, String, Boolean) => Unit): Unit = {
+    val tags = Seq(TAG_HAS_SHALLOW_CLONE)
+    cloneTest(s"$testName", testTags ++ tags: _*) {
+      (source, target) => testFunc(source, target, true)
+    }
+  }
+
+  protected def cloneTest(
+      testName: String, testTags: org.scalatest.Tag*)(f: (String, String) => Unit): Unit = {
+    if (testTags.exists(_.name == TAG_CHANGE_COLUMN_MAPPING_MODE.name) &&
+        columnMappingMode != "none") {
+      ignore(testName + " (not supporting changing column mapping mode)") {
+        withSourceTargetDir(f)
+      }
+    } else {
+      test(testName, testTags: _*) {
+        withSourceTargetDir(f)
+      }
+    }
+  }
+
+  // Extracted function so it can be overriden in subclasses.
+  protected def uniqueFileActionGroupBy(action: FileAction): String = action.pathAsUri.toString
+
+  import testImplicits._
+  // scalastyle:off
+  protected def runAndValidateClone(
+      source: String,
+      target: String,
+      sourceIsTable: Boolean = false,
+      targetIsTable: Boolean = false,
+      sourceFormat: String = "delta",
+      targetLocation: Option[String] = None,
+      sourceVersion: Option[Long] = None,
+      sourceTimestamp: Option[String] = None,
+      isCreate: Boolean = true,
+      isReplaceOperation: Boolean = false, // If we are doing a replace on an existing table
+      isReplaceDelta: Boolean = true, // If we are doing a replace, whether it is on a Delta table
+      expectNoCopy: Boolean = false, // If we are expecting no file copy due to deduplication
+      commitLargeMetricsMap: Map[String, String] = Map.empty,
+      expectedDataframe: DataFrame = spark.emptyDataFrame)
+      (f: () => Unit =
+        () => cloneTable(
+          source,
+          target,
+          sourceIsTable,
+          targetIsTable,
+          sourceFormat,
+          targetLocation,
+          sourceVersion,
+          sourceTimestamp,
+          isCreate,
+          isReplaceOperation)): Unit = {
+    // scalastyle:on
+
+    // Truncate table before REPLACE
+    try {
+      if (isReplaceOperation) {
+        val targetTbl = if (targetIsTable) {
+          target
+        } else {
+          s"delta.`$target`"
+        }
+        sql(s"DELETE FROM $targetTbl")
+      }
+    } catch {
+      case _: Throwable =>
+        // ignore all
+    }
+
+    // Check logged blob for expected values
+    val allLogs = Log4jUsageLogger.track {
+      f()
+    }
+    val sourceIsDelta = sourceFormat == "delta"
+    verifyAllCloneOperationsEmitted(allLogs,
+      isReplaceOperation && isReplaceDelta,
+      commitLargeMetricsMap,
+      sourceIsDelta)
+
+    val blob = JsonUtils.fromJson[Map[String, Any]](allLogs
+      .filter(_.metric == "tahoeEvent")
+      .filter(_.tags.get("opType").contains("delta.clone"))
+      .filter(_.blob.contains("source"))
+      .map(_.blob).last)
+
+    val sourceIdent = resolveTableIdentifier(source, Some(sourceFormat), sourceIsTable)
+    val (cloneSource: CloneSource, sourceDf: DataFrame) = if (sourceIsDelta) {
+      val sourceLog = DeltaLog.forTable(spark, sourceIdent)
+      val timeTravelSpec: Option[DeltaTimeTravelSpec] =
+        if (sourceVersion.isDefined || sourceTimestamp.isDefined) {
+          Some(DeltaTimeTravelSpec(sourceTimestamp.map(Literal(_)), sourceVersion, None))
+        } else {
+          None
+        }
+      val deltaTable = DeltaTableV2(spark, sourceLog.dataPath, None, None, timeTravelSpec)
+      val sourceData = Dataset.ofRows(
+        spark,
+        LogicalRelation(sourceLog.createRelation(
+          snapshotToUseOpt = Some(deltaTable.snapshot),
+          isTimeTravelQuery = sourceVersion.isDefined || sourceTimestamp.isDefined)))
+      (new CloneDeltaSource(deltaTable), sourceData)
+    } else {
+      assert(sourceFormat == "parquet")
+      val catalogTable: Option[CatalogTable] = {
+        // Verify the source parquet table is not modified.
+        if (sourceIsTable) {
+          val catalogTable = spark.sessionState.catalog.getTableMetadata(sourceIdent)
+          assert(catalogTable.provider.contains(sourceFormat))
+          Some(spark.sessionState.catalog.getTableMetadata(sourceIdent))
+        } else {
+          assert(!new File(source, "_delta_log").exists())
+          None
+        }
+      }
+      (new CloneParquetSource(sourceIdent, catalogTable, spark), expectedDataframe)
+    }
+
+    val targetLog = if (targetIsTable) {
+      DeltaLog.forTable(spark, TableIdentifier(target))
+    } else {
+      DeltaLog.forTable(spark, target)
+    }
+
+    val sourceSnapshot = cloneSource.snapshot
+
+    val sourcePath = cloneSource.dataPath
+    // scalastyle:off deltahadoopconfiguration
+    val fs = sourcePath.getFileSystem(spark.sessionState.newHadoopConf())
+    // scalastyle:on deltahadoopconfiguration
+    val qualifiedSourcePath = fs.makeQualified(sourcePath)
+    val logSource = if (sourceIsTable) {
+      s"default.$source".toLowerCase(Locale.ROOT)
+    } else {
+      s"$sourceFormat.`$qualifiedSourcePath`"
+    }
+
+    val rawTarget = new Path(targetLocation.getOrElse(targetLog.dataPath.toString))
+    // scalastyle:off deltahadoopconfiguration
+    val targetFs = rawTarget.getFileSystem(targetLog.newDeltaHadoopConf())
+    // scalastyle:on deltahadoopconfiguration
+    val qualifiedTarget = targetFs.makeQualified(rawTarget)
+
+    // Check whether recordEvent operation is of correct form
+    assert(blob("source") != null)
+    val actualLogSource = blob("source").toString
+    assert(actualLogSource === logSource)
+    if (sourceIsDelta && source != target) {
+      assert(blob("sourceVersion") === sourceSnapshot.get.version)
+    }
+    val replacingDeltaTable = isReplaceOperation && isReplaceDelta
+    assert(blob("sourcePath") === qualifiedSourcePath.toString)
+    assert(blob("target") === qualifiedTarget.toString)
+    assert(blob("isReplaceDelta") === replacingDeltaTable)
+    assert(blob("sourceTableSize") === cloneSource.sizeInBytes)
+    assert(blob("sourceNumOfFiles") === cloneSource.numOfFiles)
+
+    verifyNumberFilesClonedAndRemoved(
+      blob,
+      cloneSource,
+      targetLog.unsafeVolatileSnapshot,
+      expectNoCopy)
+
+    // Check whether resulting metadata of target and source at version is the same
+    compareMetadata(
+      cloneSource,
+      targetLog.unsafeVolatileSnapshot,
+      targetLocation.isEmpty && targetIsTable,
+      isReplaceOperation)
+
+    val commit = deltaFile(targetLog.logPath, targetLog.unsafeVolatileSnapshot.version)
+    val hadoopConf = targetLog.newDeltaHadoopConf()
+    val filePaths: Seq[FileAction] = targetLog.store.read(commit, hadoopConf).flatMap { line =>
+      JsonUtils.fromJson[SingleAction](line) match {
+        case a if a.add != null => Some(a.add)
+        case a if a.remove != null => Some(a.remove)
+        case _ => None
+      }
+    }
+    assert(filePaths.groupBy(uniqueFileActionGroupBy(_)).forall(_._2.length === 1),
+      "A file was added and removed in the same commit")
+
+    // Check whether the resulting datasets are the same
+    val targetDf = Dataset.ofRows(
+      spark,
+      LogicalRelation(targetLog.createRelation()))
+    checkAnswer(
+      targetDf,
+      sourceDf)
+  }
+
+  private def verifyNumberFilesClonedAndRemoved(
+      blob: Map[String, Any],
+      cloneSource: CloneSource,
+      targetSnapshot: Snapshot,
+      expectNoCopy: Boolean): Unit = {
+
+    if (targetSnapshot.deltaLog.dataPath == cloneSource.dataPath ||
+        cloneSource.numOfFiles === 0 ||
+        expectNoCopy) {
+      assert(blob("numCopiedFiles") === 0)
+      assert(blob("copiedFilesSize") === 0)
+    } else {
+      assert(blob("numCopiedFiles").toString.toInt > 0)
+      assert(blob("copiedFilesSize").toString.toInt > 0)
+    }
+  }
+
+  protected def verifyAllCloneOperationsEmitted(
+      allLogs: Seq[UsageRecord],
+      emitHandleExistingTable: Boolean,
+      commitLargeMetricsMap: Map[String, String] = Map.empty,
+      sourceIsDelta: Boolean = true): Unit = {
+    val cloneLogs = allLogs
+      .filter(_.metric === "sparkOperationDuration")
+      .filter(_.opType.isDefined)
+      .filter(_.opType.get.typeName.contains("delta.clone"))
+
+
+      assert(cloneLogs.count(_.opType.get.typeName.equals("delta.clone.makeAbsolute")) == 1)
+
+    val commitStatsUsageRecords = allLogs.filter(
+      _.tags.get("opType") === Some("delta.commit.stats"))
+    assert(commitStatsUsageRecords.length === 1)
+    val commitStatsMap = JsonUtils.fromJson[Map[String, Any]](commitStatsUsageRecords.head.blob)
+    commitLargeMetricsMap.foreach { case (name, expectedValue) =>
+      assert(commitStatsMap(name).toString == expectedValue,
+        s"Expected value for $name metrics did not match with the captured value")
+    }
+
+  }
+
+  private def compareMetadata(
+      cloneSource: CloneSource,
+      targetLog: Snapshot,
+      targetIsTable: Boolean,
+      isReplace: Boolean = false): Unit = {
+    val sourceMetadata = cloneSource.metadata
+    val targetMetadata = targetLog.metadata
+
+    assert(sourceMetadata.schema === targetMetadata.schema &&
+      sourceMetadata.configuration === targetMetadata.configuration &&
+      sourceMetadata.dataSchema === targetMetadata.dataSchema &&
+      sourceMetadata.partitionColumns === targetMetadata.partitionColumns &&
+      sourceMetadata.format === sourceMetadata.format)
+
+    // Protocol should be changed, if source.protocol >= target.protocol, otherwise target must
+    // retain it's existing protocol version (i.e. no downgrades).
+    assert(cloneSource.protocol === targetLog.protocol || (
+      cloneSource.protocol.minReaderVersion <= targetLog.protocol.minReaderVersion &&
+        cloneSource.protocol.minWriterVersion <= targetLog.protocol.minWriterVersion))
+
+      assert(targetLog.setTransactions.isEmpty)
+
+    if (!isReplace) {
+      assert(sourceMetadata.id != targetMetadata.id &&
+        targetMetadata.name === null &&
+        targetMetadata.description === null)
+    }
+  }
+
+  protected def deleteSourceAndCompareData(
+      source: String,
+      actual: => DataFrame,
+      expected: DataFrame): Unit = {
+    Utils.deleteRecursively(new File(source))
+    checkAnswer(actual, expected)
+  }
+
+  // scalastyle:off argcount
+  protected def cloneTable(
+      source: String,
+      target: String,
+      sourceIsTable: Boolean = false,
+      targetIsTable: Boolean = false,
+      sourceFormat: String = "delta",
+      targetLocation: Option[String] = None,
+      versionAsOf: Option[Long] = None,
+      timestampAsOf: Option[String] = None,
+      isCreate: Boolean = true,
+      isReplace: Boolean = false,
+      tableProperties: Map[String, String] = Map.empty): Unit
+  // scalastyle:on argcount
+
+  protected def verifyAllFilePaths(
+      table: String,
+      targetIsTable: Boolean = false,
+      expectAbsolute: Boolean): Unit = {
+    val targetLog = if (targetIsTable) {
+      DeltaLog.forTable(spark, TableIdentifier(table))
+    } else {
+      DeltaLog.forTable(spark, table)
+    }
+    assert(targetLog.unsafeVolatileSnapshot.allFiles.collect()
+          .forall(p => new Path(p.pathAsUri).isAbsolute == expectAbsolute))
+  }
+
+  protected def customConvertToDelta(internal: String, external: String): Unit = {
+    ConvertToDeltaCommand(
+      TableIdentifier(external, Some("parquet")),
+      Option(new StructType().add("part", IntegerType)),
+      collectStats = true,
+      Some(internal)).run(spark)
+  }
+
+  protected def resolveTableIdentifier(
+    name: String, format: Option[String], isTable: Boolean): TableIdentifier = {
+    if (isTable) {
+      TableIdentifier(name)
+    } else {
+      TableIdentifier(name, format)
+    }
+  }
+
+   // Test a basic clone with different syntaxes
+  protected def testSyntax(
+      source: String,
+      target: String,
+      sqlString: String,
+      targetIsTable: Boolean = false): Unit = {
+    withTable(source) {
+      spark.range(5).write.format("delta").saveAsTable(source)
+      runAndValidateClone(
+        source,
+        target,
+        sourceIsTable = true,
+        targetIsTable = targetIsTable) {
+        () => sql(sqlString)
+      }
+    }
+  }
+
+  cloneTest("simple shallow clone", TAG_HAS_SHALLOW_CLONE) { (source, clone) =>
+    val df1 = Seq(1, 2, 3, 4, 5).toDF("id").withColumn("part", 'id % 2)
+    val df2 = Seq(8, 9, 10).toDF("id").withColumn("part", 'id % 2)
+    df1.write.format("delta").partitionBy("part").mode("append").save(source)
+    df2.write.format("delta").mode("append").save(source)
+
+    runAndValidateClone(
+      source,
+      clone
+    )()
+    // no files should be copied
+    val cloneDir = new File(clone).list()
+    assert(cloneDir.length === 1,
+      s"There should only be a _delta_log directory but found:\n${cloneDir.mkString("\n")}")
+
+    val cloneLog = DeltaLog.forTable(spark, clone)
+    assert(cloneLog.snapshot.version === 0)
+    assert(cloneLog.snapshot.metadata.partitionColumns === Seq("part"))
+    val files = cloneLog.snapshot.allFiles.collect()
+    assert(files.forall(_.pathAsUri.toString.startsWith("file:/")), "paths must be absolute")
+
+    checkAnswer(
+      spark.read.format("delta").load(clone),
+      df1.union(df2)
+    )
+  }
+
+  cloneTest("shallow clone a shallow clone", TAG_HAS_SHALLOW_CLONE) { (source, clone) =>
+    val shallow1 = new File(clone, "shallow1").getCanonicalPath
+    val shallow2 = new File(clone, "shallow2").getCanonicalPath
+    val df1 = Seq(1, 2, 3, 4, 5).toDF("id").withColumn("part", 'id % 2)
+    df1.write.format("delta").partitionBy("part").mode("append").save(source)
+
+    runAndValidateClone(
+      source,
+      shallow1
+    )()
+
+    runAndValidateClone(
+      shallow1,
+      shallow2
+    )()
+
+    deleteSourceAndCompareData(shallow1, spark.read.format("delta").load(shallow2), df1)
+  }
+
+  testAllClones(s"validate commitLarge usage metrics") { (source, clone, isShallow) =>
+    val df1 = Seq(1, 2, 3, 4, 5).toDF("id").withColumn("part", 'id % 5)
+    df1.write.format("delta").partitionBy("part").mode("append").save(source)
+    val df2 = Seq(1, 2).toDF("id").withColumn("part", 'id % 5)
+    df2.write.format("delta").partitionBy("part").mode("append").save(source)
+
+    val numAbsolutePathsInAdd = if (isShallow) 7 else 0
+    val commitLargeMetricsMap = Map(
+      "numAdd" -> "7",
+      "numRemove" -> "0",
+      "numFilesTotal" -> "7",
+      "numCdcFiles" -> "0",
+      "commitVersion" -> "0",
+      "readVersion" -> "0",
+      "numAbsolutePathsInAdd" -> s"$numAbsolutePathsInAdd",
+      "startVersion" -> "-1",
+      "numDistinctPartitionsInAdd" -> "-1") // distinct Parts are not tracked in commitLarge flow
+    runAndValidateClone(
+      source,
+      clone,
+      commitLargeMetricsMap = commitLargeMetricsMap)()
+
+    checkAnswer(
+      spark.read.format("delta").load(clone),
+      df1.union(df2)
+    )
+  }
+
+  cloneTest("shallow clone across file systems", TAG_HAS_SHALLOW_CLONE) { (source, clone) =>
+    withSQLConf(
+        "fs.s3.impl" -> classOf[S3LikeLocalFileSystem].getName,
+        "fs.s3.impl.disable.cache" -> "true") {
+      val df1 = Seq(1, 2, 3, 4, 5).toDF("id")
+      df1.write.format("delta").mode("append").save(source)
+
+      val baseS3 = new URI("s3", null, source, null, null).toString
+
+      runAndValidateClone(
+        baseS3,
+        s"file:$clone"
+      )()
+
+      checkAnswer(
+        spark.read.format("delta").load(clone),
+        df1
+      )
+
+      val cloneLog = DeltaLog.forTable(spark, clone)
+      assert(cloneLog.snapshot.version === 0)
+      val files = cloneLog.snapshot.allFiles.collect()
+      assert(files.forall(_.pathAsUri.toString.startsWith("s3:/")))
+    }
+  }
+
+  testAllClones("Negative test: clone into a non-empty directory that has a path based " +
+    "delta table") { (source, clone, isShallow) =>
+    // Create table to clone
+    spark.range(5).write.format("delta").mode("append").save(source)
+
+    // Table already exists at destination directory
+    spark.range(5).write.format("delta").mode("append").save(clone)
+
+    // Clone should fail since destination directory is non-empty
+    val ex = intercept[AnalysisException] {
+      runAndValidateClone(
+        source,
+        clone
+      )()
+    }
+    assert(ex.getMessage.contains("is not empty"))
+  }
+
+  cloneTest("Negative test: cloning into a non-empty parquet directory",
+      TAG_HAS_SHALLOW_CLONE) { (source, clone) =>
+    // Create table to clone
+    spark.range(5).write.format("delta").mode("append").save(source)
+
+    // Table already exists at destination directory
+    spark.range(5).write.format("parquet").mode("overwrite").save(clone)
+
+    // Clone should fail since destination directory is non-empty
+    val ex = intercept[AnalysisException] {
+      sql(s"CREATE TABLE delta.`$clone` SHALLOW CLONE delta.`$source`")
+    }
+    assert(ex.getMessage.contains("is not empty but it's not a Delta table"))
+  }
+
+  testAllClones(
+    "Changes to clones only affect the cloned directory") { (source, target, isShallow) =>
+    // Create base directory
+    Seq(1, 2, 3, 4, 5).toDF("id").write.format("delta").save(source)
+
+    // Create a clone
+    runAndValidateClone(
+      source,
+      target
+    )()
+
+    // Write to clone should be visible
+    Seq(6, 7, 8).toDF("id").write.format("delta").mode("append").save(target)
+    assert(spark.read.format("delta").load(target).count() === 8)
+
+    // Write to clone should not be visible in original table
+    assert(spark.read.format("delta").load(source).count() === 5)
+  }
+
+  testAllClones("simple clone of source using table name") { (_, target, isShallow) =>
+    val tableName = "source"
+    withTable(tableName) {
+      spark.range(5).write.format("delta").saveAsTable(tableName)
+      runAndValidateClone(
+        tableName,
+        target,
+        sourceIsTable = true)()
+    }
+  }
+
+  testAllClones("Clone a time traveled source") { (_, target, isShallow) =>
+    val tableName = "source"
+    withTable(tableName) {
+      spark.range(5).write.format("delta").saveAsTable(tableName)
+      spark.range(5).write.format("delta").mode("append").saveAsTable(tableName)
+      spark.range(5).write.format("delta").mode("append").saveAsTable(tableName)
+      spark.range(5).write.format("delta").mode("append").saveAsTable(tableName)
+      assert(DeltaLog.forTable(spark, TableIdentifier(tableName)).snapshot.version === 3)
+
+      runAndValidateClone(
+        tableName,
+        target,
+        sourceIsTable = true,
+        sourceVersion = Some(2))()
+      assert(spark.read.format("delta").load(target).count() === 15)
+    }
+  }
+
+  cloneTest("create or replace table - shallow", TAG_HAS_SHALLOW_CLONE) { (_, _) =>
+    val tbl = "source"
+    val target = "target"
+    Seq(true, false).foreach { isCreate =>
+      withTable(tbl, target) {
+        spark.range(5).write.format("delta").saveAsTable(tbl)
+        spark.range(25).write.format("delta").saveAsTable(target)
+
+        runAndValidateClone(
+          tbl,
+          target,
+          sourceIsTable = true,
+          targetIsTable = true,
+          isCreate = isCreate,
+          isReplaceOperation = true)()
+      }
+    }
+  }
+
+  cloneTest("create or replace non Delta table - shallow", TAG_HAS_SHALLOW_CLONE) { (_, _) =>
+    val tbl = "source"
+    val target = "target"
+    Seq(true, false).foreach { isCreate =>
+      Seq("parquet", "json").foreach { format =>
+        withTable(tbl, target) {
+          spark.range(5).write.format("delta").saveAsTable(tbl)
+          spark.range(25).write.format(format).saveAsTable(target)
+
+          runAndValidateClone(
+            tbl,
+            target,
+            sourceIsTable = true,
+            targetIsTable = true,
+            isCreate = isCreate,
+            isReplaceOperation = true,
+            isReplaceDelta = false)()
+        }
+      }
+    }
+  }
+
+  cloneTest("shallow clone a table unto itself", TAG_HAS_SHALLOW_CLONE) { (_, _) =>
+    val tbl = "source"
+    Seq(true, false).foreach { isCreate =>
+      withTable(tbl) {
+        spark.range(5).write.format("delta").saveAsTable(tbl)
+
+        runAndValidateClone(
+          tbl,
+          tbl,
+          sourceIsTable = true,
+          targetIsTable = true,
+          isCreate = isCreate,
+          isReplaceOperation = true)()
+
+        val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tbl))
+        val allFiles = deltaLog.snapshot.allFiles.collect()
+        allFiles.foreach { file =>
+          assert(!file.pathAsUri.isAbsolute, "File paths should not be absolute")
+        }
+      }
+    }
+  }
+
+  testAllClones("clone a time traveled source using timestamp") { (source, clone, isShallow) =>
+    // Create source
+    spark.range(5).write.format("delta").save(source)
+    spark.range(5).write.format("delta").mode("append").save(source)
+    spark.range(5).write.format("delta").mode("append").save(source)
+    assert(spark.read.format("delta").load(source).count() === 15)
+
+    // Get time corresponding to date
+    val desiredTime = "1996-01-12"
+    val format = new java.text.SimpleDateFormat("yyyy-MM-dd")
+    val time = format.parse(desiredTime).getTime
+
+    // Change modification time of commit
+    val path = new Path(source + "/_delta_log/00000000000000000000.json")
+    // scalastyle:off deltahadoopconfiguration
+    val fs = path.getFileSystem(spark.sessionState.newHadoopConf())
+    // scalastyle:on deltahadoopconfiguration
+    fs.setTimes(path, time, 0)
+
+    runAndValidateClone(
+      source,
+      clone,
+      sourceTimestamp = Some(desiredTime))()
+  }
+
+  cloneTest("clones take protocol from the source",
+    TAG_HAS_SHALLOW_CLONE, TAG_MODIFY_PROTOCOL, TAG_CHANGE_COLUMN_MAPPING_MODE) { (source, clone) =>
+    // Change protocol versions of (read, write) = (2, 3). We cannot initialize this to (0, 0)
+    // because min reader and writer versions are at least 1.
+    val defaultNewTableProtocol = Protocol(spark, metadataOpt = None)
+    val sourceProtocol = Protocol(2, 3)
+    // Make sure this is actually an upgrade. Downgrades are not supported, and if it's the same
+    // version, we aren't testing anything there.
+    assert(sourceProtocol.minWriterVersion > defaultNewTableProtocol.minWriterVersion &&
+      sourceProtocol.minReaderVersion > defaultNewTableProtocol.minReaderVersion)
+    val log = DeltaLog.forTable(spark, source)
+    // make sure to have a dummy schema because we can't have empty schema table by default
+    val newSchema = new StructType().add("id", IntegerType, nullable = true)
+    log.ensureLogDirectoryExist()
+    log.store.write(
+      deltaFile(log.logPath, 0),
+      Iterator(Metadata(schemaString = newSchema.json).json, sourceProtocol.json),
+      overwrite = false,
+      log.newDeltaHadoopConf())
+    log.update()
+
+    // Validate that clone has the new protocol version
+    runAndValidateClone(
+      source,
+      clone
+    )()
+  }
+
+  testAllClones("clones take the set transactions of the source") { (_, target, isShallow) =>
+    withTempDir { dir =>
+      // Create source
+      val path = dir.getCanonicalPath
+      spark.range(5).write.format("delta").save(path)
+
+      // Add a Set Transaction
+      val log = DeltaLog.forTable(spark, path)
+      val txn = log.startTransaction()
+      val setTxn = SetTransaction("app-id", 0, Some(0L)) :: Nil
+      val op = DeltaOperations.StreamingUpdate(OutputMode.Complete(), "app-id", 0L)
+      txn.commit(setTxn, op)
+      log.update()
+
+      runAndValidateClone(
+        path,
+        target
+      )()
+    }
+  }
+
+  testAllClones("clone parquet source using path - non-partitioned") {
+    (source, clone, isShallow) =>
+      val df = spark.range(100)
+        .withColumn("key1", col("id") % 4)
+        .withColumn("key2", col("id") % 7 cast "String")
+      df.write.format("parquet").save(source)
+
+      runAndValidateClone(
+        source, clone,
+        sourceFormat = "parquet",
+        expectedDataframe = df)()
+  }
+
+  // CLONE doesn't support partitioned parquet table using path since it requires customer to
+  // provide the partition schema in the command like `CONVERT TO DELTA`, but such an option is not
+  // available in CLONE yet.
+  testAllClones("clone parquet source using path - partitioned") {
+    (source, clone, isShallow) =>
+      val df = spark.range(100)
+        .withColumn("key1", col("id") % 4)
+        .withColumn("key2", col("id") % 7 cast "String")
+      df.write.format("parquet").partitionBy("key1", "key2").save(source)
+
+      val se = intercept[SparkException] {
+        cloneTable(
+          source,
+          clone,
+          sourceFormat = "parquet")
+      }
+
+      assert(se.getMessage.contains("Expecting 0 partition column(s)"))
+  }
+
+  testAllClones("clone parquet source using table name - non-partitioned") {
+    (_, clone, isShallow) =>
+      val sourceTable = "source"
+      withTable(sourceTable) {
+        val df = spark.range(100)
+          .withColumn("key1", col("id") % 4)
+          .withColumn("key2", col("id") % 7 cast "String")
+
+        df.write.format("parquet").saveAsTable(sourceTable)
+
+        runAndValidateClone(
+          sourceTable,
+          clone,
+          sourceIsTable = true,
+          sourceFormat = "parquet",
+          expectedDataframe = df)()
+      }
+  }
+
+  testAllClones("clone parquet source using table name - partitioned") {
+    (_, clone, isShallow) =>
+      val sourceTable = "source"
+      withTable(sourceTable) {
+        val df = spark.range(100)
+          .withColumn("key1", col("id") % 4)
+          .withColumn("key2", col("id") % 7 cast "String")
+
+        df.write.format("parquet").partitionBy("key1", "key2").saveAsTable(sourceTable)
+
+        runAndValidateClone(
+          sourceTable,
+          clone,
+          sourceIsTable = true,
+          sourceFormat = "parquet",
+          expectedDataframe = df)()
+      }
+  }
+
+  testAllClones("clone parquet source - create or replace existing table using name",
+    TAG_CHANGE_COLUMN_MAPPING_MODE) {
+    (_, _, isShallow) =>
+      val source = "source"
+      val target = "target"
+      Seq(true, false).foreach { isCreate =>
+        withTable(source, target) {
+          val df1 = spark.range(50).toDF()
+          val df2 = spark.range(20).toDF()
+          df1.write.format("parquet").saveAsTable(source)
+          df2.write.format("delta").saveAsTable(target)
+
+          runAndValidateClone(
+            source,
+            target,
+            sourceIsTable = true,
+            targetIsTable = true,
+            isCreate = isCreate,
+            isReplaceOperation = true,
+            sourceFormat = "parquet",
+            expectedDataframe = df1)()
+        }
+      }
+  }
+
+  testAllClones("clone parquet source - create or replace existing table using path",
+    TAG_CHANGE_COLUMN_MAPPING_MODE) {
+    (_, _, isShallow) =>
+      Seq(true, false).foreach { isCreate =>
+        withTempPaths(2) { dirs =>
+          val index = if (isCreate) 1 else 0
+          val dir = dirs(index)
+          val source = new File(dir, "source").getCanonicalPath
+          val target = new File(dir, "target").getCanonicalPath
+
+          val df1 = spark.range(50).toDF()
+          val df2 = spark.range(20).toDF()
+          df1.write.format("parquet").save(source)
+          df2.write.format("delta").save(target)
+
+          runAndValidateClone(
+            source,
+            target,
+            isCreate = isCreate,
+            isReplaceOperation = true,
+            sourceFormat = "parquet",
+            expectedDataframe = df1)()
+        }
+      }
+  }
+
+  testAllClones("clone parquet source - create and update shallow cloned table",
+    TAG_CHANGE_COLUMN_MAPPING_MODE) {
+    (_, _, isShallow) =>
+      val source = "source"
+      val target = "target"
+      withTable(source, target) {
+        val df1 = spark.range(100)
+          .withColumn("key1", col("id") % 4)
+          .withColumn("key2", col("id") % 7 cast "String")
+
+        df1.write.format("parquet").partitionBy("key1", "key2").saveAsTable(source)
+
+        runAndValidateClone(
+          source,
+          target,
+          sourceIsTable = true,
+          targetIsTable = true,
+          sourceFormat = "parquet",
+          expectedDataframe = df1)()
+
+        val df2 = spark.range(100, 200)
+          .withColumn("key1", col("id") % 4)
+          .withColumn("key2", col("id") % 7 cast "String")
+
+        df2.write.format("parquet")
+          .partitionBy("key1", "key2")
+          .mode("append")
+          .saveAsTable(source)
+
+        runAndValidateClone(
+          source,
+          target,
+          sourceIsTable = true,
+          targetIsTable = true,
+          isReplaceOperation = true,
+          sourceFormat = "parquet",
+          expectedDataframe = df1.union(df2))()
+      }
+  }
+
+}
+
+
+trait CloneTableColumnMappingSuiteBase
+  extends CloneTableSuiteBase
+    with DeltaColumnMappingSelectedTestMixin
+{
+
+  override protected def runOnlyTests: Seq[String] = Seq(
+    "simple shallow clone",
+    "shallow clone a shallow clone",
+    "create or replace table - shallow",
+    "shallow clone a table unto itself",
+    "Clone a time traveled source",
+
+    "validate commitLarge usage metrics",
+    "clones take the set transactions of the source",
+    "clone parquet source using path - non-partitioned",
+    "clone parquet source using path - partitioned",
+    "block changing column mapping mode and modify max id modes under CLONE"
+  )
+
+  import testImplicits._
+
+  testAllClones("block changing column mapping mode and modify max id modes under CLONE") {
+    (_, _, isShallow) =>
+      val df1 = Seq(1, 2, 3, 4, 5).toDF("id").withColumn("part", 'id % 2)
+
+      // block setting max id
+      def validateModifyMaxIdError(f: => Any): Unit = {
+        val e = intercept[UnsupportedOperationException] { f }
+        assert(e.getMessage == DeltaErrors.cannotModifyTableProperty(
+          DeltaConfigs.COLUMN_MAPPING_MAX_ID.key
+        ).getMessage)
+      }
+
+      withSourceTargetDir { (source, target) =>
+        df1.write.format("delta").partitionBy("part").mode("append").save(source)
+        // change max id w/ table property should be blocked
+        validateModifyMaxIdError {
+          cloneTable(
+            source,
+            target,
+            tableProperties = Map(
+              DeltaConfigs.COLUMN_MAPPING_MAX_ID.key -> "123123"
+          ))
+        }
+        // change max id w/ SQLConf should be blocked by table property guard
+        validateModifyMaxIdError {
+          withMaxColumnIdConf("123123") {
+            cloneTable(
+              source,
+              target
+            )
+          }
+        }
+      }
+
+      // block changing column mapping mode
+      def validateChangeModeError(f: => Any): Unit = {
+        val e = intercept[ColumnMappingUnsupportedException] { f }
+        assert(e.getMessage.contains("Changing column mapping mode from"))
+      }
+
+      val currentMode = columnMappingModeString
+
+      // currentMode to otherMode
+      val otherMode = if (currentMode == "id") "name" else "id"
+      withSourceTargetDir { (source, target) =>
+        df1.write.format("delta").partitionBy("part").mode("append").save(source)
+        // change mode w/ table property should be blocked
+        validateChangeModeError {
+          cloneTable(
+            source,
+            target,
+            tableProperties = Map(
+              DeltaConfigs.COLUMN_MAPPING_MODE.key -> otherMode
+          ))
+        }
+      }
+
+      withSourceTargetDir { (source, target) =>
+        df1.write.format("delta").partitionBy("part").mode("append").save(source)
+        // change mode w/ SQLConf should have no effects
+        withColumnMappingConf(otherMode) {
+          cloneTable(
+            source,
+            target
+          )
+        }
+        assert(DeltaLog.forTable(spark, target).snapshot.metadata.columnMappingMode.name ==
+          currentMode)
+      }
+
+      // currentMode to none
+      withSourceTargetDir { (source, target) =>
+        df1.write.format("delta").partitionBy("part").mode("append").save(source)
+        // change mode w/ table property
+        validateChangeModeError {
+          cloneTable(
+            source,
+            target,
+            tableProperties = Map(
+              DeltaConfigs.COLUMN_MAPPING_MODE.key -> "none"
+          ))
+        }
+      }
+      withSourceTargetDir { (source, target) =>
+        df1.write.format("delta").partitionBy("part").mode("append").save(source)
+        // change mode w/ SQLConf should have no effects
+        withColumnMappingConf("none") {
+          cloneTable(
+            source,
+            target
+          )
+        }
+        assert(DeltaLog.forTable(spark, target).snapshot.metadata.columnMappingMode.name ==
+          currentMode)
+      }
+  }
+}
+
+trait CloneTableColumnMappingNameSuiteBase extends CloneTableColumnMappingSuiteBase {
+  override protected def customConvertToDelta(internal: String, external: String): Unit = {
+    withColumnMappingConf("none") {
+      super.customConvertToDelta(internal, external)
+      sql(
+        s"""ALTER TABLE delta.`$internal` SET TBLPROPERTIES (
+           |${DeltaConfigs.COLUMN_MAPPING_MODE.key} = 'name',
+           |${DeltaConfigs.MIN_READER_VERSION.key} = '2',
+           |${DeltaConfigs.MIN_WRITER_VERSION.key} = '5'
+           |)""".stripMargin)
+        .collect()
+    }
+  }
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1864,7 +1864,7 @@ trait DeltaErrorsSuiteBase
       assert(e.getErrorClass == "DELTA_SCHEMA_NOT_PROVIDED")
       assert(e.getMessage ==
         "Table schema is not provided. Please provide the schema (column definition) " +
-        "of the table when using REPLACE table and an AS SELECT query is not provided.")
+          "of the table when using REPLACE table and an AS SELECT query is not provided.")
       assert(e.getSqlState == "22000")
     }
     {
@@ -2449,8 +2449,9 @@ trait DeltaErrorsSuiteBase
       }
       assert(e.getErrorClass == "DELTA_UNEXPECTED_CHANGE_FILES_FOUND")
       assert(e.getSqlState == "0A000")
-      assert(e.getMessage == """Change files found in a dataChange = false transaction. Files:
-                               |a.parquet""".stripMargin)
+      assert(e.getMessage ==
+        """Change files found in a dataChange = false transaction. Files:
+          |a.parquet""".stripMargin)
     }
     {
       val e = intercept[DeltaIllegalStateException] {
@@ -2458,7 +2459,7 @@ trait DeltaErrorsSuiteBase
       }
       assert(e.getErrorClass == "DELTA_TXN_LOG_FAILED_INTEGRITY")
       assert(e.getSqlState == "22000")
-      assert(e.getMessage ==  "The transaction log has failed integrity checks. Failed " +
+      assert(e.getMessage == "The transaction log has failed integrity checks. Failed " +
         "verification at version 2 of:\noption1")
     }
     {
@@ -2478,7 +2479,7 @@ trait DeltaErrorsSuiteBase
       }
       assert(e.getErrorClass == "DELTA_UNSUPPORTED_DESCRIBE_DETAIL_VIEW")
       assert(e.getSqlState == "0A000")
-      assert(e.getMessage ==  "`customer` is a view. DESCRIBE DETAIL is only supported for tables.")
+      assert(e.getMessage == "`customer` is a view. DESCRIBE DETAIL is only supported for tables.")
     }
     {
       val e = intercept[DeltaAnalysisException] {
@@ -2737,6 +2738,48 @@ trait DeltaErrorsSuiteBase
       val prefixStr = DeltaTableUtils.validDeltaTableHadoopPrefixes.mkString("[", ",", "]")
       assert(e.getMessage == "Currently DeltaTable.forPath only supports hadoop configuration " +
         s"keys starting with $prefixStr but got ${options.mkString(",")}")
+    }
+    {
+      val e = intercept[DeltaIllegalArgumentException] {
+        throw DeltaErrors.cloneOnRelativePath("path")
+      }
+      assert(e.getMessage ==
+        """The target location for CLONE needs to be an absolute path or table name. Use an
+          |absolute path instead of path.""".stripMargin)
+    }
+    {
+      val e = intercept[AnalysisException] {
+        throw DeltaErrors.cloneFromUnsupportedSource( "table-0", "CSV")
+      }
+      assert(e.getErrorClass == "DELTA_CLONE_UNSUPPORTED_SOURCE")
+      assert(e.getSqlState == "0A000")
+      assert(e.getMessage == "Unsupported clone source 'table-0', whose format is CSV.\n" +
+        "The supported formats are 'delta' and 'parquet'.")
+    }
+    {
+      val e = intercept[DeltaIllegalArgumentException] {
+        throw DeltaErrors.cloneReplaceUnsupported(TableIdentifier("customer"))
+      }
+      assert(e.getErrorClass == "DELTA_UNSUPPORTED_CLONE_REPLACE_SAME_TABLE")
+      assert(e.getSqlState == "0A000")
+      assert(e.getMessage ==
+        s"""
+           |You tried to REPLACE an existing table (`customer`) with CLONE. This operation is
+           |unsupported. Try a different target for CLONE or delete the table at the current target.
+           |""".stripMargin)
+
+    }
+    {
+      val e = intercept[DeltaIllegalArgumentException] {
+        throw DeltaErrors.cloneAmbiguousTarget("external-location", TableIdentifier("table1"))
+      }
+      assert(e.getErrorClass == "DELTA_CLONE_AMBIGUOUS_TARGET")
+      assert(e.getSqlState == "42000")
+      assert(e.getMessage ==
+        s"""
+           |Two paths were provided as the CLONE target so it is ambiguous which to use. An external
+           |location for CLONE was provided at external-location at the same time as the path
+           |`table1`.""".stripMargin)
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

This PR introduces support for **SHALLOW CLONE** for both Delta **and Parquet table** on Delta Lake, specifically the following command:
`CREATE [OR REPLACE] TABLE [IF NOT EXISTS] target SHALLOW CLONE source [VERSION AS OF version | TIMESTAMP AS OF timestamp] [TBLPROPERTIES clause] [LOCATION path]`

This enables the following use cases:
1. Create a `target` table with Delta log pointing to the files from the `source` table. The source table can be either a Delta table or a Parquet table.

You may also specify a custom `path` to create as an external table in a path, a `clause` for additional table properties to append to, or a `version` to create the target table as a time-travelled version of the source table (if is Delta).

E.g. `CREATE TABLE target SHALLOW CLONE source`

2. Replace/restore a table by shallow-cloning itself. This requires the table to be **empty** by the time of cloning to avoid data duplication.

E.g. `REPLACE TABLE source SHALLOW CLONE source VERSION AS OF 1`

## How was this patch tested?

Unit tests.

## Does this PR introduce _any_ user-facing changes?

No.