### PR TITLE
Add varargs annotation to executeZOrderBy

### DIFF
--- a/core/src/main/scala/io/delta/tables/DeltaOptimizeBuilder.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaOptimizeBuilder.scala
@@ -69,6 +69,7 @@ class DeltaOptimizeBuilder private(
    * @return DataFrame containing the OPTIMIZE execution metrics
    * @since 2.0.0
    */
+  @scala.annotation.varargs
   def executeZOrderBy(columns: String *): DataFrame = {
     val attrs = columns.map(c => UnresolvedAttribute(c))
     execute(attrs)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
Using the current API from Java land means you have to use JavaConverters to massage a List into a Seq. Adding varargs exposes a new API that can take a String...

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
`sbt compile` shows the newly overloaded method in the `target` output.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
Introduces a public overloaded method for executeZOrderBy with the following signature:
`executeZOrderBy (java.lang.String... columns)`
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
