### PR TITLE
Add WHEN NOT MATCHED BY SOURCE support

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -1068,6 +1068,12 @@
     ],
     "sqlState" : "42000"
   },
+  "DELTA_NON_LAST_NOT_MATCHED_BY_SOURCE_CLAUSE_OMIT_CONDITION" : {
+    "message" : [
+      "When there are more than one NOT MATCHED BY SOURCE clauses in a MERGE statement, only the last NOT MATCHED BY SOURCE clause can omit the condition."
+    ],
+    "sqlState" : "42000"
+  },
   "DELTA_NON_LAST_NOT_MATCHED_CLAUSE_OMIT_CONDITION" : {
     "message" : [
       "When there are more than one NOT MATCHED clauses in a MERGE statement, only the last NOT MATCHED clause can omit the condition"

--- a/core/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/deltaMerge.scala
+++ b/core/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/deltaMerge.scala
@@ -199,7 +199,6 @@ case class DeltaMergeIntoMatchedUpdateClause(
 case class DeltaMergeIntoMatchedDeleteClause(condition: Option[Expression])
     extends DeltaMergeIntoMatchedClause {
   def this(condition: Option[Expression], actions: Seq[DeltaMergeAction]) = this(condition)
-  children
 
   override def clauseType: String = "Delete"
   override def actions: Seq[Expression] = Seq.empty
@@ -232,6 +231,45 @@ case class DeltaMergeIntoNotMatchedInsertClause(
     }
 }
 
+/** Trait that represents WHEN NOT MATCHED BY SOURCE clause in MERGE. See [[DeltaMergeInto]]. */
+sealed trait DeltaMergeIntoNotMatchedBySourceClause extends DeltaMergeIntoClause
+
+/** Represents the clause WHEN NOT MATCHED BY SOURCE THEN UPDATE in MERGE. See
+ * [[DeltaMergeInto]]. */
+case class DeltaMergeIntoNotMatchedBySourceUpdateClause(
+    condition: Option[Expression],
+    actions: Seq[Expression])
+  extends DeltaMergeIntoNotMatchedBySourceClause {
+
+  def this(cond: Option[Expression], cols: Seq[UnresolvedAttribute], exprs: Seq[Expression]) =
+    this(cond, DeltaMergeIntoClause.toActions(cols, exprs))
+
+  override def clauseType: String = "Update"
+
+  override protected def withNewChildrenInternal(
+      newChildren: IndexedSeq[Expression]): DeltaMergeIntoNotMatchedBySourceUpdateClause = {
+    if (condition.isDefined) {
+      copy(condition = Some(newChildren.head), actions = newChildren.tail)
+    } else {
+      copy(condition = None, actions = newChildren)
+    }
+  }
+}
+
+/** Represents the clause WHEN NOT MATCHED BY SOURCE THEN DELETE in MERGE. See
+ * [[DeltaMergeInto]]. */
+case class DeltaMergeIntoNotMatchedBySourceDeleteClause(condition: Option[Expression])
+  extends DeltaMergeIntoNotMatchedBySourceClause {
+  def this(condition: Option[Expression], actions: Seq[DeltaMergeAction]) = this(condition)
+
+  override def clauseType: String = "Delete"
+  override def actions: Seq[Expression] = Seq.empty
+
+  override protected def withNewChildrenInternal(
+      newChildren: IndexedSeq[Expression]): DeltaMergeIntoNotMatchedBySourceDeleteClause =
+    copy(condition = if (condition.isDefined) Some(newChildren.head) else None)
+}
+
 /**
  * Merges changes specified in the source plan into a target table, based on the given search
  * condition and the actions to perform when the condition is matched or not matched by the rows.
@@ -244,9 +282,13 @@ case class DeltaMergeIntoNotMatchedInsertClause(
  *    [ WHEN MATCHED [ AND <condition> ] THEN <matched_action> ]
  *    [ WHEN MATCHED [ AND <condition> ] THEN <matched_action> ]
  *    ...
- *    [ WHEN NOT MATCHED [ AND <condition> ] THEN <not_matched_action> ]
- *    [ WHEN NOT MATCHED [ AND <condition> ] THEN <not_matched_action> ]
+ *    [ WHEN NOT MATCHED [BY TARGET] [ AND <condition> ] THEN <not_matched_action> ]
+ *    [ WHEN NOT MATCHED [BY TARGET] [ AND <condition> ] THEN <not_matched_action> ]
  *    ...
+ *    [ WHEN NOT MATCHED BY SOURCE [ AND <condition> ] THEN <not_matched_by_source_action> ]
+ *    [ WHEN NOT MATCHED BY SOURCE [ AND <condition> ] THEN <not_matched_by_source_action> ]
+ *    ...
+ *
  *
  *    where
  *    <matched_action> =
@@ -254,6 +296,9 @@ case class DeltaMergeIntoNotMatchedInsertClause(
  *      UPDATE SET column1 = value1 [, column2 = value2 ...] |
  *      UPDATE SET * [EXCEPT (column1, ...)]
  *    <not_matched_action> = INSERT (column1 [, column2 ...]) VALUES (expr1 [, expr2 ...])
+ *    <not_matched_by_source_action> =
+ *      DELETE |
+ *      UPDATE SET column1 = value1 [, column2 = value2 ...]
  * }}}
  *
  * - There can be any number of WHEN clauses.
@@ -268,6 +313,11 @@ case class DeltaMergeIntoNotMatchedInsertClause(
  * clauses, only the last can omit the condition.
  *    - WHEN NOT MATCHED clauses are dependent on their ordering; that is, the first clause that
  * satisfies the clause's condition has its corresponding action executed.
+ * - WHEN NOT MATCHED BY SOURCE clauses:
+ *    - Each WHEN NOT MATCHED BY SOURCE clause can have an optional condition. However, if there are
+ * multiple WHEN NOT MATCHED BY SOURCE clauses, only the last can omit the condition.
+ *    - WHEN NOT MATCHED BY SOURCE clauses are dependent on their ordering; that is, the first
+ * clause that satisfies the clause's condition has its corresponding action executed.
  */
 case class DeltaMergeInto(
     target: LogicalPlan,
@@ -275,11 +325,12 @@ case class DeltaMergeInto(
     condition: Expression,
     matchedClauses: Seq[DeltaMergeIntoMatchedClause],
     notMatchedClauses: Seq[DeltaMergeIntoNotMatchedClause],
+    notMatchedBySourceClauses: Seq[DeltaMergeIntoNotMatchedBySourceClause],
     migrateSchema: Boolean,
     finalSchema: Option[StructType])
   extends Command with SupportsSubquery {
 
-  (matchedClauses ++ notMatchedClauses).foreach(_.verifyActions())
+  (matchedClauses ++ notMatchedClauses ++ notMatchedBySourceClauses).foreach(_.verifyActions())
 
   // TODO: extend BinaryCommand once the new Spark version is released
   override def children: Seq[LogicalPlan] = Seq(target, source)
@@ -297,6 +348,8 @@ object DeltaMergeInto {
       whenClauses: Seq[DeltaMergeIntoClause]): DeltaMergeInto = {
     val notMatchedClauses = whenClauses.collect { case x: DeltaMergeIntoNotMatchedClause => x }
     val matchedClauses = whenClauses.collect { case x: DeltaMergeIntoMatchedClause => x }
+    val notMatchedBySourceClauses =
+      whenClauses.collect { case x: DeltaMergeIntoNotMatchedBySourceClause => x }
 
     // grammar enforcement goes here.
     if (whenClauses.isEmpty) {
@@ -306,17 +359,25 @@ object DeltaMergeInto {
       )
     }
 
-    // check that only last MATCHED clause omits the condition
+    // Check that only the last MATCHED clause omits the condition.
     if (matchedClauses.length > 1 && !matchedClauses.init.forall(_.condition.nonEmpty)) {
       throw new DeltaAnalysisException(
         errorClass = "DELTA_NON_LAST_MATCHED_CLAUSE_OMIT_CONDITION",
         messageParameters = Array.empty)
     }
 
-    // check that only last NOT MATCHED clause omits the condition
+    // Check that only the last NOT MATCHED clause omits the condition.
     if (notMatchedClauses.length > 1 && !notMatchedClauses.init.forall(_.condition.nonEmpty)) {
       throw new DeltaAnalysisException(
         errorClass = "DELTA_NON_LAST_NOT_MATCHED_CLAUSE_OMIT_CONDITION",
+        messageParameters = Array.empty)
+    }
+
+    // Check that only the last NOT MATCHED BY SOURCE clause omits the condition.
+    if (notMatchedBySourceClauses.length > 1 &&
+      !notMatchedBySourceClauses.init.forall(_.condition.nonEmpty)) {
+      throw new DeltaAnalysisException(
+        errorClass = "DELTA_NON_LAST_NOT_MATCHED_BY_SOURCE_CLAUSE_OMIT_CONDITION",
         messageParameters = Array.empty)
     }
 
@@ -326,13 +387,22 @@ object DeltaMergeInto {
       condition,
       matchedClauses,
       notMatchedClauses,
+      notMatchedBySourceClauses,
       migrateSchema = false,
       finalSchema = Some(target.schema))
   }
 
   def resolveReferencesAndSchema(merge: DeltaMergeInto, conf: SQLConf)(
       resolveExpr: (Expression, LogicalPlan) => Expression): DeltaMergeInto = {
-    val DeltaMergeInto(target, source, condition, matchedClauses, notMatchedClauses, _, _) = merge
+    val DeltaMergeInto(
+      target,
+      source,
+      condition,
+      matchedClauses,
+      notMatchedClauses,
+      notMatchedBySourceClauses,
+      _,
+      _) = merge
 
     // We must do manual resolution as the expressions in different clauses of the MERGE have
     // visibility of the source, the target or both. Additionally, the resolution logic operates
@@ -475,7 +545,11 @@ object DeltaMergeInto {
     val resolvedNotMatchedClauses = notMatchedClauses.map {
       resolveClause(_, fakeSourcePlan)
     }
-    val actions = (matchedClauses ++ notMatchedClauses).flatMap(_.actions)
+    val resolvedNotMatchedBySourceClauses = notMatchedBySourceClauses.map {
+      resolveClause(_, fakeTargetPlan)
+    }
+    val actions = (matchedClauses ++ notMatchedClauses ++ notMatchedBySourceClauses)
+      .flatMap(_.actions)
     val containsStarAction = actions.exists(_.isInstanceOf[UnresolvedStar])
 
     val migrateSchema = canAutoMigrate && containsStarAction
@@ -493,8 +567,12 @@ object DeltaMergeInto {
     }
 
     val resolvedMerge = DeltaMergeInto(
-      target, source, resolvedCond,
-      resolvedMatchedClauses, resolvedNotMatchedClauses,
+      target,
+      source,
+      resolvedCond,
+      resolvedMatchedClauses,
+      resolvedNotMatchedClauses,
+      resolvedNotMatchedBySourceClauses,
       migrateSchema = migrateSchema,
       finalSchema = Some(finalSchema))
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -183,15 +183,18 @@ object DeltaOperations {
    * Recorded when a merge operation is committed to the table.
    *
    * `updatePredicate`, `deletePredicate`, and `insertPredicate` are DEPRECATED.
-   * Only use `predicate`, `matchedPredicates`, and `notMatchedPredicates` to record the merge.
+   * Only use `predicate`, `matchedPredicates`, `notMatchedPredicates` and
+   * `notMatchedBySourcePredicates` to record the merge.
    */
+  val OP_MERGE = "MERGE"
   case class Merge(
       predicate: Option[String],
       updatePredicate: Option[String],
       deletePredicate: Option[String],
       insertPredicate: Option[String],
       matchedPredicates: Seq[MergePredicate],
-      notMatchedPredicates: Seq[MergePredicate]) extends Operation("MERGE") {
+      notMatchedPredicates: Seq[MergePredicate],
+      notMatchedBySourcePredicates: Seq[MergePredicate]) extends Operation(OP_MERGE) {
 
     override val parameters: Map[String, Any] = {
       predicate.map("predicate" -> _).toMap ++
@@ -199,7 +202,8 @@ object DeltaOperations {
         deletePredicate.map("deletePredicate" -> _).toMap ++
         insertPredicate.map("insertPredicate" -> _).toMap +
         ("matchedPredicates" -> JsonUtils.toJson(matchedPredicates)) +
-        ("notMatchedPredicates" -> JsonUtils.toJson(notMatchedPredicates))
+        ("notMatchedPredicates" -> JsonUtils.toJson(notMatchedPredicates)) +
+        ("notMatchedBySourcePredicates" -> JsonUtils.toJson(notMatchedBySourcePredicates))
     }
     override val operationMetrics: Set[String] = DeltaOperationMetrics.MERGE
 
@@ -228,13 +232,15 @@ object DeltaOperations {
     def apply(
         predicate: Option[String],
         matchedPredicates: Seq[MergePredicate],
-        notMatchedPredicates: Seq[MergePredicate]): Merge = Merge(
+        notMatchedPredicates: Seq[MergePredicate],
+        notMatchedBySourcePredicates: Seq[MergePredicate]): Merge = Merge(
           predicate,
           updatePredicate = None,
           deletePredicate = None,
           insertPredicate = None,
           matchedPredicates,
-          notMatchedPredicates)
+          notMatchedPredicates,
+          notMatchedBySourcePredicates)
   }
 
   /** Recorded when an update operation is committed to the table. */

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
@@ -244,7 +244,7 @@ trait CDCReaderImpl extends DeltaLogging {
    * shouldn't be produced.
    */
   def shouldSkipFileActionsInCommit(commitInfo: CommitInfo): Boolean = {
-    val isMerge = commitInfo.operation == DeltaOperations.Merge(None, Nil, Nil).name
+    val isMerge = commitInfo.operation == DeltaOperations.OP_MERGE
     val knownToHaveNoChangedRows = {
       val metrics = commitInfo.operationMetrics.getOrElse(Map.empty)
       // Note that if any metrics are missing, this condition will be false and we won't skip.

--- a/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoNotMatchedBySourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoNotMatchedBySourceSuite.scala
@@ -1,0 +1,411 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
+import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.sql.Row
+
+trait MergeIntoNotMatchedBySourceSuite extends MergeIntoSuiteBase {
+
+  import testImplicits._
+
+  // All CDC suites run using MergeIntoSQLSuite only. The SQL API for NOT MATCHED BY SOURCE will
+  // only be available with Spark 3.4. In the meantime, we explicitly run NOT MATCHED BY SOURCE
+  // tests with CDF enabled and disabled against the Scala API. Use [[testExtendedMerge]
+  // instead once we can run tests against the SQL API.
+  protected def testExtendedMergeWithCDC(
+      name: String,
+      namePrefix: String = "not matched by source")(
+      source: Seq[(Int, Int)],
+      target: Seq[(Int, Int)],
+      mergeOn: String,
+      mergeClauses: MergeClause*)(
+      result: Seq[(Int, Int)],
+      cdc: Seq[(Int, Int, String)]): Unit = {
+
+    for {
+      isPartitioned <- BOOLEAN_DOMAIN
+      cdcEnabled <- BOOLEAN_DOMAIN
+    } {
+      test(s"$namePrefix - $name - isPartitioned: $isPartitioned - cdcEnabled: $cdcEnabled") {
+        withSQLConf(
+          DeltaConfigs.CHANGE_DATA_FEED.defaultTablePropertyKey -> cdcEnabled.toString) {
+          withKeyValueData(source, target, isPartitioned) { case (sourceName, targetName) =>
+            withSQLConf(DeltaSQLConf.MERGE_INSERT_ONLY_ENABLED.key -> "true") {
+              executeMerge(s"$targetName t", s"$sourceName s", mergeOn, mergeClauses: _*)
+            }
+            val deltaPath = if (targetName.startsWith("delta.`")) {
+              targetName.stripPrefix("delta.`").stripSuffix("`")
+            } else targetName
+            checkAnswer(readDeltaTable(deltaPath), result.map { case (k, v) => Row(k, v) })
+          }
+          if (cdcEnabled) {
+            val latestVersion = DeltaLog.forTable(spark, tempPath).snapshot.version
+            checkAnswer(
+              CDCReader
+                .changesToBatchDF(
+                  DeltaLog.forTable(spark, tempPath),
+                  latestVersion,
+                  latestVersion,
+                  spark)
+                .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+                .drop(CDCReader.CDC_COMMIT_VERSION),
+              cdc.toDF())
+          }
+        }
+      }
+    }
+  }
+
+  // Test analysis errors with NOT MATCHED BY SOURCE clauses.
+  testAnalysisErrorsInUnlimitedClauses(
+    "error on multiple not matched by source update clauses without condition")(
+    mergeOn = "s.key = t.key",
+    updateNotMatched(condition = "t.key == 3", set = "value = 2 * value"),
+    updateNotMatched(set = "value = 3 * value"),
+    updateNotMatched(set = "value = 4 * value"))(
+    errorStrs = "when there are more than one not matched by source clauses in a merge " +
+      "statement, only the last not matched by source clause can omit the condition" :: Nil)
+
+  testAnalysisErrorsInUnlimitedClauses(
+    "error on multiple not matched by source update/delete clauses without condition")(
+    mergeOn = "s.key = t.key",
+    updateNotMatched(condition = "t.key == 3", set = "value = 2 * value"),
+    deleteNotMatched(),
+    updateNotMatched(set = "value = 4 * value"))(
+    errorStrs = "when there are more than one not matched by source clauses in a merge " +
+      "statement, only the last not matched by source clause can omit the condition" :: Nil)
+
+  testAnalysisErrorsInUnlimitedClauses(
+    "error on non-empty condition following empty condition in not matched by source " +
+      "update clauses")(
+    mergeOn = "s.key = t.key",
+    updateNotMatched(set = "value = 2 * value"),
+    updateNotMatched(condition = "t.key < 3", set = "value = value"))(
+    errorStrs = "when there are more than one not matched by source clauses in a merge " +
+      "statement, only the last not matched by source clause can omit the condition" :: Nil)
+
+  testAnalysisErrorsInUnlimitedClauses(
+    "error on non-empty condition following empty condition in not matched by source " +
+      "delete clauses")(
+    mergeOn = "s.key = t.key",
+    deleteNotMatched(),
+    deleteNotMatched(condition = "t.key < 3"))(
+    errorStrs = "when there are more than one not matched by source clauses in a merge " +
+      "statement, only the last not matched by source clause can omit the condition" :: Nil)
+
+  testAnalysisErrorsInExtendedMerge("update not matched condition - unknown reference")(
+    mergeOn = "s.key = t.key",
+    updateNotMatched(condition = "unknownAttrib > 1", set = "tgtValue = tgtValue + 1"))(
+    // Should show unknownAttrib as invalid ref and (key, tgtValue, srcValue) as valid column names.
+    errorStrs = "UPDATE condition" :: "unknownAttrib" :: "key" :: "tgtValue" :: Nil)
+
+  testAnalysisErrorsInExtendedMerge("update not matched condition - aggregation function")(
+    mergeOn = "s.key = t.key",
+    updateNotMatched(condition = "max(0) > 0", set = "tgtValue = tgtValue + 1"))(
+    errorStrs = "UPDATE condition" :: "aggregate functions are not supported" :: Nil)
+
+  testAnalysisErrorsInExtendedMerge("update not matched condition - subquery")(
+    mergeOn = "s.key = t.key",
+    updateNotMatched(condition = "s.value in (select value from t)", set = "tgtValue = 1"))(
+    errorStrs = Nil
+  ) // subqueries fail for unresolved reference to `t`
+
+  testAnalysisErrorsInExtendedMerge("delete not matched condition - unknown reference")(
+    mergeOn = "s.key = t.key",
+    deleteNotMatched(condition = "unknownAttrib > 1"))(
+    // Should show unknownAttrib as invalid ref and (key, tgtValue, srcValue) as valid column names.
+    errorStrs = "DELETE condition" :: "unknownAttrib" :: "key" :: "tgtValue" :: Nil)
+
+  testAnalysisErrorsInExtendedMerge("delete not matched condition - aggregation function")(
+    mergeOn = "s.key = t.key",
+    deleteNotMatched(condition = "max(0) > 0"))(
+    errorStrs = "DELETE condition" :: "aggregate functions are not supported" :: Nil)
+
+  testAnalysisErrorsInExtendedMerge("delete not matched condition - subquery")(
+    mergeOn = "s.key = t.key",
+    deleteNotMatched(condition = "s.srcValue in (select tgtValue from t)"))(
+    errorStrs = Nil) // subqueries fail for unresolved reference to `t`
+
+  // Test correctness with NOT MATCHED BY SOURCE clauses.
+  testExtendedMergeWithCDC("all 3 types of match clauses without conditions")(
+    source = (0, 0) :: (1, 1) :: (5, 5) :: Nil,
+    target = (2, 20) :: (1, 10) :: (5, 50) :: Nil,
+    mergeOn = "s.key = t.key",
+    update(set = "*"),
+    insert(values = "*"),
+    deleteNotMatched())(
+    result = Seq(
+      (0, 0), // No matched by target, inserted
+      (1, 1), // Matched, updated
+      // (2, 20) Not matched by source, deleted
+      (5, 5) // Matched, updated
+    ),
+    cdc = Seq(
+      (0, 0, "insert"),
+      (1, 10, "update_preimage"),
+      (1, 1, "update_postimage"),
+      (2, 20, "delete"),
+      (5, 50, "update_preimage"),
+      (5, 5, "update_postimage")))
+
+  testExtendedMergeWithCDC("all 3 types of match clauses with conditions")(
+    source = (0, 0) :: (1, 1) :: (5, 5) :: (6, 6) :: Nil,
+    target = (1, 10) :: (2, 20) :: (5, 50) :: (7, 70) :: Nil,
+    mergeOn = "s.key = t.key",
+    update(set = "*", condition = "t.value < 30"),
+    insert(values = "*", condition = "s.value < 4"),
+    deleteNotMatched(condition = "t.value > 40"))(
+    result = Seq(
+      (0, 0), // Not matched by target, inserted
+      (1, 1), // Matched, updated
+      (2, 20), // Not matched by source, no change
+      (5, 50) // Matched, not updated
+      // (6, 6) Not matched by target, no change
+      // (7, 7) Not matched by source, deleted
+    ),
+    cdc = Seq(
+      (0, 0, "insert"),
+      (1, 10, "update_preimage"),
+      (1, 1, "update_postimage"),
+      (7, 70, "delete")))
+
+  testExtendedMergeWithCDC("unconditional delete only when not matched by source")(
+    source = (0, 0) :: (1, 1) :: (5, 5) :: Nil,
+    target = (2, 20) :: (1, 10) :: (5, 50) :: (6, 60) :: Nil,
+    mergeOn = "s.key = t.key",
+    deleteNotMatched())(
+    result = Seq(
+      (1, 10), // Matched, no change
+      // (2, 20) Not matched by source, deleted
+      (5, 50) // Matched, no change
+      // (6, 60) Not matched by source, deleted
+    ),
+    cdc = Seq((2, 20, "delete"), (6, 60, "delete")))
+
+  testExtendedMergeWithCDC("conditional delete only when not matched by source")(
+    source = (0, 0) :: (1, 1) :: (5, 5) :: Nil,
+    target = (1, 10) :: (2, 20) :: (5, 50) :: (6, 60) :: Nil,
+    mergeOn = "s.key = t.key",
+    deleteNotMatched(condition = "t.value > 40"))(
+    result = Seq(
+      (1, 10), // Matched, no change
+      (2, 20), // Not matched by source, no change
+      (5, 50) // Matched, no change
+      // (6, 60) Not matched by source, deleted
+    ),
+    cdc = Seq((6, 60, "delete")))
+
+  testExtendedMergeWithCDC("delete only matched and not matched by source")(
+    source = (1, 1) :: (2, 2) :: (5, 5) :: (6, 6) :: Nil,
+    target = (1, 10) :: (2, 20) :: (3, 30) :: (4, 40) :: Nil,
+    mergeOn = "s.key = t.key",
+    delete("s.value % 2 = 0"),
+    deleteNotMatched("t.value % 20 = 0"))(
+    result = Seq(
+      (1, 10), // Matched, no change
+      // (2, 20) Matched, deleted
+      (3, 30) // Not matched by source, no change
+      // (4, 40) Not matched by source, deleted
+    ),
+    cdc = Seq((2, 20, "delete"), (4, 40, "delete")))
+
+  testExtendedMergeWithCDC("unconditionally delete matched and not matched by source")(
+    source = (0, 0) :: (1, 1) :: (5, 5) :: (6, 6) :: Nil,
+    target = (1, 10) :: (2, 20) :: (5, 50) :: Nil,
+    mergeOn = "s.key = t.key",
+    delete(),
+    deleteNotMatched())(
+    result = Seq.empty,
+    cdc = Seq((1, 10, "delete"), (2, 20, "delete"), (5, 50, "delete")))
+
+  testExtendedMergeWithCDC("unconditional not matched by source update")(
+    source = (0, 0) :: (1, 1) :: (5, 5) :: Nil,
+    target = (1, 10) :: (2, 20) :: (4, 40) :: (5, 50) :: Nil,
+    mergeOn = "s.key = t.key",
+    updateNotMatched(set = "t.value = t.value + 1"))(
+    result = Seq(
+      (1, 10), // Matched, no change
+      (2, 21), // Not matched by source, updated
+      (4, 41), // Not matched by source, updated
+      (5, 50) // Matched, no change
+    ),
+    cdc = Seq(
+      (2, 20, "update_preimage"),
+      (2, 21, "update_postimage"),
+      (4, 40, "update_preimage"),
+      (4, 41, "update_postimage")))
+
+  testExtendedMergeWithCDC("conditional not matched by source update")(
+    source = (0, 0) :: (1, 1) :: (5, 5) :: Nil,
+    target = (1, 10) :: (2, 20) :: (4, 40) :: (5, 50) :: Nil,
+    mergeOn = "s.key = t.key",
+    updateNotMatched(condition = "t.value = 20", set = "t.value = t.value + 1"))(
+    result = Seq(
+      (1, 10), // Matched, no change
+      (2, 21), // Not matched by source, updated
+      (4, 40), // Not matched by source, no change
+      (5, 50) // Matched, no change
+    ),
+    cdc = Seq((2, 20, "update_preimage"), (2, 21, "update_postimage")))
+
+  testExtendedMergeWithCDC("not matched by source update + delete clauses")(
+    source = (0, 0) :: (1, 1) :: (5, 5) :: Nil,
+    target = (1, 10) :: (2, 20) :: (7, 70) :: Nil,
+    mergeOn = "s.key = t.key",
+    deleteNotMatched("t.value % 20 = 0"),
+    updateNotMatched(set = "t.value = t.value + 1"))(
+    result = Seq(
+      (1, 10), // Matched, no change
+      // (2, 20) Not matched by source, deleted
+      (7, 71) // Not matched by source, updated
+    ),
+    cdc = Seq((2, 20, "delete"), (7, 70, "update_preimage"), (7, 71, "update_postimage")))
+
+  testExtendedMergeWithCDC("unconditional not matched by source update + not matched insert")(
+    source = (0, 0) :: (1, 1) :: (4, 4) :: (5, 5) :: Nil,
+    target = (1, 10) :: (2, 20) :: (4, 40) :: (7, 70) :: Nil,
+    mergeOn = "s.key = t.key",
+    insert("*"),
+    updateNotMatched(set = "t.value = t.value + 1"))(
+    result = Seq(
+      (0, 0), // Not matched by target, inserted
+      (1, 10), // Matched, no change
+      (2, 21), // Not matched by source, updated
+      (4, 40), // Matched, no change
+      (5, 5), // Not matched by target, inserted
+      (7, 71) // Not matched by source, updated
+    ),
+    cdc = Seq(
+      (0, 0, "insert"),
+      (2, 20, "update_preimage"),
+      (2, 21, "update_postimage"),
+      (5, 5, "insert"),
+      (7, 70, "update_preimage"),
+      (7, 71, "update_postimage")))
+
+  testExtendedMergeWithCDC("not matched by source delete + not matched insert")(
+    source = (0, 0) :: (1, 1) :: (5, 5) :: Nil,
+    target = (1, 10) :: (2, 20) :: (7, 70) :: Nil,
+    mergeOn = "s.key = t.key",
+    insert("*"),
+    deleteNotMatched("t.value % 20 = 0"))(
+    result = Seq(
+      (0, 0), // Not matched by target, inserted
+      (1, 10), // Matched, no change
+      // (2, 20), Not matched by source, deleted
+      (5, 5), // Not matched by target, inserted
+      (7, 70) // Not matched by source, no change
+    ),
+    cdc = Seq((0, 0, "insert"), (2, 20, "delete"), (5, 5, "insert")))
+
+  testExtendedMergeWithCDC("multiple not matched by source clauses")(
+    source = (0, 0) :: (1, 1) :: (5, 5) :: Nil,
+    target = (6, 6) :: (7, 7) :: (8, 8) :: (9, 9) :: (10, 10) :: (11, 11) :: Nil,
+    mergeOn = "s.key = t.key",
+    updateNotMatched(condition = "t.key % 6 = 0", set = "t.value = t.value + 5"),
+    updateNotMatched(condition = "t.key % 6 = 1", set = "t.value = t.value + 4"),
+    updateNotMatched(condition = "t.key % 6 = 2", set = "t.value = t.value + 3"),
+    updateNotMatched(condition = "t.key % 6 = 3", set = "t.value = t.value + 2"),
+    updateNotMatched(condition = "t.key % 6 = 4", set = "t.value = t.value + 1"),
+    deleteNotMatched())(
+    result = Seq(
+      (6, 11), // Not matched by source, updated
+      (7, 11), // Not matched by source, updated
+      (8, 11), // Not matched by source, updated
+      (9, 11), // Not matched by source, updated
+      (10, 11) // Not matched by source, updated
+      // (11, 11) Not matched by source, deleted
+    ),
+    cdc = Seq(
+      (6, 6, "update_preimage"),
+      (6, 11, "update_postimage"),
+      (7, 7, "update_preimage"),
+      (7, 11, "update_postimage"),
+      (8, 8, "update_preimage"),
+      (8, 11, "update_postimage"),
+      (9, 9, "update_preimage"),
+      (9, 11, "update_postimage"),
+      (10, 10, "update_preimage"),
+      (10, 11, "update_postimage"),
+      (11, 11, "delete")))
+
+  // Test schema evolution with NOT MATCHED BY SOURCE clauses.
+  testEvolution("new column with insert * and delete not matched by source")(
+    sourceData = Seq((1, 1, "extra1"), (2, 2, "extra2")).toDF("key", "value", "extra"),
+    targetData = Seq((0, 0), (1, 10), (3, 30)).toDF("key", "value"),
+    clauses = insert("*") ::
+      deleteNotMatched() :: Nil,
+    expected = Seq(
+      // (0, 0) Not matched by source, deleted
+      (1, 10, null), // Matched, updated
+      (2, 2, "extra2") // Not matched by target, inserted
+      // (3, 30) Not matched by source, deleted
+    ).toDF("key", "value", "extra"),
+    expectedWithoutEvolution = Seq((1, 10), (2, 2)).toDF("key", "value"))
+
+  testEvolution("new column with insert * and conditional update not matched by source")(
+    targetData = Seq((0, 0), (1, 10), (3, 30)).toDF("key", "value"),
+    sourceData = Seq((1, 1, "extra1"), (2, 2, "extra2")).toDF("key", "value", "extra"),
+    clauses = insert("*") ::
+      updateNotMatched(condition = "key > 0", set = "value = value + 1") :: Nil,
+    expected = Seq(
+      (0, 0, null), // Not matched by source, no change
+      (1, 10, null), // Matched, no change
+      (2, 2, "extra2"), // Not matched by target, inserted
+      (3, 31, null) // Not matched by source, updated
+    ).toDF("key", "value", "extra"),
+    expectedWithoutEvolution = Seq((0, 0), (1, 10), (2, 2), (3, 31)).toDF("key", "value"))
+
+  testEvolution("new column not inserted and conditional update not matched by source")(
+    targetData = Seq((0, 0), (1, 10), (3, 30)).toDF("key", "value"),
+    sourceData = Seq((1, 1, "extra1"), (2, 2, "extra2")).toDF("key", "value", "extra"),
+    clauses = updateNotMatched(condition = "key > 0", set = "value = value + 1") :: Nil,
+    expected = Seq(
+      (0, 0), // Not matched by source, no change
+      (1, 10), // Matched, no change
+      (3, 31) // Not matched by source, updated
+    ).toDF("key", "value"),
+    expectedWithoutEvolution = Seq((0, 0), (1, 10), (3, 31)).toDF("key", "value"))
+
+  testEvolution("new column referenced in matched condition but not inserted")(
+    targetData = Seq((0, 0), (1, 10), (3, 30)).toDF("key", "value"),
+    sourceData = Seq((1, 1, "extra1"), (2, 2, "extra2")).toDF("key", "value", "extra"),
+    clauses = delete(condition = "extra = 'extra1'") ::
+      updateNotMatched(condition = "key > 0", set = "value = value + 1") :: Nil,
+    expected = Seq(
+      (0, 0), // Not matched by source, no change
+      // (1, 10), Matched, deleted
+      (3, 31) // Not matched by source, updated
+    ).toDF("key", "value"),
+    expectedWithoutEvolution = Seq((0, 0), (3, 31)).toDF("key", "value"))
+
+  testEvolution("matched update * and conditional update not matched by source")(
+    targetData = Seq((0, 0), (1, 10), (3, 30)).toDF("key", "value"),
+    sourceData = Seq((1, 1, "extra1"), (2, 2, "extra2")).toDF("key", "value", "extra"),
+    clauses = update("*") ::
+      updateNotMatched(condition = "key > 0", set = "value = value + 1") :: Nil,
+    expected = Seq(
+      (0, 0, null), // Not matched by source, no change
+      (1, 1, "extra1"), // Matched, updated
+      (3, 31, null) // Not matched by source, updated
+    ).toDF("key", "value", "extra"),
+    expectedWithoutEvolution = Seq((0, 0), (1, 1), (3, 31)).toDF("key", "value"))
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
@@ -5019,6 +5019,11 @@ trait MergeHelpers {
     override def clause: String = "NOT MATCHED"
   }
 
+  protected case class NotMatchedBySourceClause(condition: String, action: String)
+    extends MergeClause {
+    override def clause: String = "NOT MATCHED BY SOURCE"
+  }
+
   protected def update(set: String = null, condition: String = null): MergeClause = {
     MatchedClause(condition, s"UPDATE SET $set")
   }
@@ -5029,5 +5034,13 @@ trait MergeHelpers {
 
   protected def insert(values: String = null, condition: String = null): MergeClause = {
     NotMatchedClause(condition, s"INSERT $values")
+  }
+
+  protected def updateNotMatched(set: String = null, condition: String = null): MergeClause = {
+    NotMatchedBySourceClause(condition, s"UPDATE SET $set")
+  }
+
+  protected def deleteNotMatched(condition: String = null): MergeClause = {
+    NotMatchedBySourceClause(condition, s"DELETE")
   }
 }


### PR DESCRIPTION
## Description
Add `WHEN NOT MATCHED BY SOURCE` to MergeIntoCommand

This PR adds support for `WHEN NOT MATCHED BY SOURCE` clauses in merge into command using the Scala/Java Delta table API. Support for `WHEN NOT MATCHED BY SOURCE` using SQL will be available with Spark 3.4 release and python support will follow up in a different PR.

Changes:

- Extend Delta Merge API with support for `NOT MATCHED BY SOURCE` clause.
- Extend Delta analyzer to support the new type of clause:
  - Resolve target column references in `NOT MATCHED BY SOURCE` conditions and update actions
  - Handle schema evolution (same as `MATCHED` clause): generate update expressions to align with the expected target schema
- Implement support for `NOT MATCHED BY SOURCE` in MergeIntoCommand.

## How was this patch tested?
New test trait `MergeIntoNotMatchedBySourceSuite` is added and collects all tests covering this feature. It is mixed into the Merge Scala test class to run tests against the Delta API and will be mixed in the Merge base test class to also cover the Spark SQL API once Spark 3.4 is released.

Test coverage:
- Analysis errors: invalid clauses or conditions, invalid column references.
- Correctness with various combination of clauses.
- Schema evolution.

## Does this PR introduce _any_ user-facing changes?
This change extends the existing Delta Merge API to allow specifying `WHEN NOT MATCHED BY SOURCE` clauses and their corresponding optional condition and actions. The new API follows the existing APIs for `MATCHED` and `NOT MATCHED` clauses.
Usage - Scala:
```
targetDeltaTable.merge(sourceTable, "targetKey = sourceKey")
    .whenNotMatchedBySource("targetValue > 0").updateExpr(Map("targetValue" -> "targetValue + 1"))
    .whenNotMatchedBySource().delete()
    .execute();
```