### PR TITLE
Implement automated partition filters for TruncTimestamp (date_trunc)

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
@@ -362,7 +362,19 @@ object GeneratedColumn extends DeltaLogging with AnalysisHelper {
                   createExpr(name)(SubstringPartitionExpr(partColName, pos, len))
                 case TruncTimestamp(
                   StringLiteral(format), ExtractBaseColumn(name, TimestampType), _) =>
-                    createExpr(name)(DateTruncPartitionExpr(format, partColName))
+                    createExpr(name)(TimestampTruncPartitionExpr(format, partColName))
+                case TruncTimestamp(
+                  StringLiteral(format),
+                  Cast(ExtractBaseColumn(name, DateType), TimestampType, _, _), _) =>
+                  format match {
+                    case "YEAR" | "YYYY" | "YY"
+                         | "QUARTER"
+                         | "MONTH" | "MM" | "MON"
+                         | "WEEK"
+                         | "DAY" | "DD" =>
+                      createExpr(name)(TimestampTruncPartitionExpr(format, partColName))
+                    case _ => None
+                  }
                 case ExtractBaseColumn(name, _) =>
                   createExpr(name)(IdentityPartitionExpr(partColName))
                 case _ => None

--- a/core/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
@@ -366,15 +366,7 @@ object GeneratedColumn extends DeltaLogging with AnalysisHelper {
                 case TruncTimestamp(
                   StringLiteral(format),
                   Cast(ExtractBaseColumn(name, DateType), TimestampType, _, _), _) =>
-                  format match {
-                    case "YEAR" | "YYYY" | "YY"
-                         | "QUARTER"
-                         | "MONTH" | "MM" | "MON"
-                         | "WEEK"
-                         | "DAY" | "DD" =>
-                      createExpr(name)(TimestampTruncPartitionExpr(format, partColName))
-                    case _ => None
-                  }
+                    createExpr(name)(TimestampTruncPartitionExpr(format, partColName))
                 case ExtractBaseColumn(name, _) =>
                   createExpr(name)(IdentityPartitionExpr(partColName))
                 case _ => None

--- a/core/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
@@ -360,6 +360,9 @@ object GeneratedColumn extends DeltaLogging with AnalysisHelper {
                 case Substring(ExtractBaseColumn(name, StringType), IntegerLiteral(pos),
                     IntegerLiteral(len)) =>
                   createExpr(name)(SubstringPartitionExpr(partColName, pos, len))
+                case TruncTimestamp(
+                  StringLiteral(format), ExtractBaseColumn(name, TimestampType), _) =>
+                    createExpr(name)(DateTruncPartitionExpr(format, partColName))
                 case ExtractBaseColumn(name, _) =>
                   createExpr(name)(IdentityPartitionExpr(partColName))
                 case _ => None

--- a/core/src/main/scala/org/apache/spark/sql/delta/optimizablePartitionExpressions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/optimizablePartitionExpressions.scala
@@ -17,10 +17,9 @@
 package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.delta.OptimizablePartitionExpression._
-
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.catalyst.dsl.expressions._
-import org.apache.spark.sql.catalyst.expressions.{Cast, DateFormatClass, DayOfMonth, Expression, Hour, IsNull, Literal, Month, Or, Substring, UnixTimestamp, Year}
+import org.apache.spark.sql.catalyst.expressions.{Cast, DateFormatClass, DayOfMonth, Expression, Hour, IsNull, Literal, Month, Or, Substring, TruncTimestamp, UnixTimestamp, Year}
 import org.apache.spark.sql.catalyst.util.quoteIfNeeded
 import org.apache.spark.sql.types.{DateType, StringType, TimestampType}
 
@@ -545,6 +544,49 @@ case class DateFormatPartitionExpr(
   override def isNull(): Option[Expression] = {
     Some(partitionColumn.toPartCol.isNull)
   }
+}
+
+/** The rules for the generation expression `date_trunc(field, col)`. */
+case class DateTruncPartitionExpr(format: String, partitionColumn: String)
+  extends OptimizablePartitionExpression {
+  override def lessThan(lit: Literal): Option[Expression] = {
+    // As the partition column has truncated information, we need to turn "<" to "<=".
+    lessThanOrEqual(lit)
+  }
+
+  override def lessThanOrEqual(lit: Literal): Option[Expression] = {
+    val expr = lit.dataType match {
+      case TimestampType => Some(partitionColumn.toPartCol <= TruncTimestamp(format, lit))
+      case _ => None
+    }
+    // to avoid any expression which yields null
+    expr.map(e => Or(e, IsNull(e)))
+  }
+
+  override def equalTo(lit: Literal): Option[Expression] = {
+    val expr = lit.dataType match {
+      case TimestampType => Some(partitionColumn.toPartCol === TruncTimestamp(format, lit))
+      case _ => None
+    }
+    // to avoid any expression which yields null
+    expr.map(e => Or(e, IsNull(e)))
+  }
+
+  override def greaterThan(lit: Literal): Option[Expression] = {
+    // As the partition column has truncated information, we need to turn ">" to ">=".
+    greaterThanOrEqual(lit)
+  }
+
+  override def greaterThanOrEqual(lit: Literal): Option[Expression] = {
+    val expr = lit.dataType match {
+      case TimestampType => Some(partitionColumn.toPartCol >= TruncTimestamp(format, lit))
+      case _ => None
+    }
+    // to avoid any expression which yields null
+    expr.map(e => Or(e, IsNull(e)))
+  }
+
+  override def isNull(): Option[Expression] = Some(partitionColumn.toPartCol.isNull)
 }
 
 /**

--- a/core/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeGeneratedColumnSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeGeneratedColumnSuite.scala
@@ -16,8 +16,6 @@
 
 package org.apache.spark.sql.delta.perf
 
-import org.apache.spark.sql.catalyst.expressions.TruncTimestamp
-
 import java.sql.Timestamp
 import java.util.Locale
 import java.util.concurrent.{CountDownLatch, TimeUnit}


### PR DESCRIPTION
## Description

Adding automated partition filter creation for generated columns using TruncTimestamp (date_trunc)

Implements #1445 

## How was this patch tested?

Test case was added

## Does this PR introduce _any_ user-facing changes?

