### PR TITLE
Basic functionality of Delta Table Features

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -574,6 +574,18 @@
     ],
     "sqlState" : "42000"
   },
+  "DELTA_FEATURE_REQUIRES_HIGHER_READER_VERSION" : {
+    "message" : [
+      "Unable to enable table feature <feature> because it requires a higher reader protocol version (current <current>). Consider upgrading the table's reader protocol version to <required>, or to a version which supports reader table features. Refer to <docLink> for more information on table protocol versions."
+    ],
+    "sqlState" : "42000"
+  },
+  "DELTA_FEATURE_REQUIRES_HIGHER_WRITER_VERSION" : {
+    "message" : [
+      "Unable to enable table feature <feature> because it requires a higher writer protocol version (current <current>). Consider upgrading the table's writer protocol version to <required>, or to a version which supports writer table features. Refer to <docLink> for more information on table protocol versions."
+    ],
+    "sqlState" : "42000"
+  },
   "DELTA_FILE_ALREADY_EXISTS" : {
     "message" : [
       "Existing file path <path>"
@@ -826,6 +838,12 @@
   "DELTA_INVALID_PROTOCOL_DOWNGRADE" : {
     "message" : [
       "Protocol version cannot be downgraded from <oldProtocol> to <newProtocol>"
+    ],
+    "sqlState" : "42000"
+  },
+  "DELTA_INVALID_PROTOCOL_VERSION" : {
+    "message" : [
+      "Delta protocol version is too new for this version of Delta Lake: table requires <required>, client supports up to <supported>. Please upgrade to a newer release."
     ],
     "sqlState" : "42000"
   },
@@ -1243,6 +1261,12 @@
       "Protocol property <key> needs to be an integer. Found <value>"
     ],
     "sqlState" : "22000"
+  },
+  "DELTA_READ_FEATURE_PROTOCOL_REQUIRES_WRITE" : {
+    "message" : [
+      "Unable to upgrade only the reader protocol version to use table features. Writer protocol version must be at least <writerVersion> to proceed. Refer to <docLink> for more information on table protocol versions."
+    ],
+    "sqlState" : "42000"
   },
   "DELTA_READ_TABLE_WITHOUT_COLUMNS" : {
     "message" : [
@@ -1747,6 +1771,30 @@
       "<expression> cannot be used in a generated column"
     ],
     "sqlState" : "0A000"
+  },
+  "DELTA_UNSUPPORTED_FEATURES_FOR_READ" : {
+    "message" : [
+      "Unable to read this table because it requires reader table features that are unsupported by this version of Delta Lake: <unsupported>."
+    ],
+    "sqlState" : "42000"
+  },
+  "DELTA_UNSUPPORTED_FEATURES_FOR_WRITE" : {
+    "message" : [
+      "Unable to write this table because it requires writer table features that are unsupported by this version of Delta Lake: <unsupported>."
+    ],
+    "sqlState" : "42000"
+  },
+  "DELTA_UNSUPPORTED_FEATURES_IN_CONFIG" : {
+    "message" : [
+      "Table features configured in the following Spark configs or Delta table properties are not recognized by this version of Delta Lake: <configs>."
+    ],
+    "sqlState" : "42000"
+  },
+  "DELTA_UNSUPPORTED_FEATURE_STATUS" : {
+    "message" : [
+      "Expecting the status for table feature <feature> to be \"enabled\", but got \"<status>\"."
+    ],
+    "sqlState" : "42000"
   },
   "DELTA_UNSUPPORTED_FIELD_UPDATE_NON_STRUCT" : {
     "message" : [

--- a/core/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -161,10 +161,8 @@ private[delta] class ConflictChecker(
         deltaLog.protocolRead(p)
         deltaLog.protocolWrite(p)
       }
-      currentTransactionInfo.actions.foreach {
-        case Protocol(_, _) =>
-          throw DeltaErrors.protocolChangedException(winningCommitSummary.commitInfo)
-        case _ =>
+      if (currentTransactionInfo.actions.exists(_.isInstanceOf[Protocol])) {
+        throw DeltaErrors.protocolChangedException(winningCommitSummary.commitInfo)
       }
     }
   }

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
@@ -121,7 +121,7 @@ trait DeltaColumnMappingBase extends DeltaLogging {
       } else {
         // legal mode change, now check if protocol is upgraded before or part of this txn
         val caseInsensitiveMap = CaseInsensitiveMap(newMetadata.configuration)
-        val newProtocol = new Protocol(
+        val newProtocol = Protocol(
           minReaderVersion = caseInsensitiveMap
             .get(Protocol.MIN_READER_VERSION_PROP).map(_.toInt)
             .getOrElse(oldProtocol.minReaderVersion),

--- a/core/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -286,8 +286,8 @@ class Snapshot(
   lazy val numIndexedCols: Int = DeltaConfigs.DATA_SKIPPING_NUM_INDEXED_COLS.fromMetaData(metadata)
 
   /** Return the set of properties of the table. */
-  def getProperties: mutable.HashMap[String, String] = {
-    val base = new mutable.HashMap[String, String]()
+  def getProperties: mutable.Map[String, String] = {
+    val base = new mutable.LinkedHashMap[String, String]()
     metadata.configuration.foreach { case (k, v) =>
       if (k != "path") {
         base.put(k, v)
@@ -295,7 +295,13 @@ class Snapshot(
     }
     base.put(Protocol.MIN_READER_VERSION_PROP, protocol.minReaderVersion.toString)
     base.put(Protocol.MIN_WRITER_VERSION_PROP, protocol.minWriterVersion.toString)
-    base
+    if (protocol.supportsReaderFeatures || protocol.supportsWriterFeatures) {
+      val descriptors = protocol.writerFeatureDescriptors.map(desc =>
+        s"${TableFeatureProtocolUtils.FEATURE_PROP_PREFIX}${desc.name}" -> desc.status.toString)
+      base ++ descriptors.toSeq.sorted
+    } else {
+      base
+    }
   }
 
   // Given the list of files from `LogSegment`, create respective file indices to help create

--- a/core/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -23,59 +23,6 @@ import org.apache.spark.sql.delta.util.{Utils => DeltaUtils}
 
 import org.apache.spark.sql.SparkSession
 
-object TableFeatureStore {
-
-  /**
-   * All table features recognized by this client. Update this set when you added a new Table
-   * Feature.
-   */
-  val allSupportedFeaturesMap: Map[String, TableFeature] = {
-    var features = Set[TableFeature](AppendOnlyTableFeature)
-    if (DeltaUtils.isTesting) {
-      features ++= Set(
-        TestLegacyWriterFeature,
-        TestWriterFeature,
-        TestLegacyReaderWriterFeature,
-        TestReaderWriterFeature)
-    }
-    val featureMap = features.map(f => f.name.toLowerCase(Locale.ROOT) -> f).toMap
-    require(features.size == featureMap.size, "Lowercase feature names must not duplicate.")
-    featureMap
-  }
-}
-
-/* ---------------------------------------- *
- |  All table features known to the client  |
- * ---------------------------------------- */
-
-object AppendOnlyTableFeature
-  extends LegacyWriterFeature(name = "appendOnly", minWriterVersion = 2)
-  with FeatureAutomaticallyEnabledByMetadata {
-  override def metadataRequiresFeatureToBeEnabled(
-      metadata: Metadata,
-      spark: SparkSession): Boolean = {
-    DeltaConfigs.IS_APPEND_ONLY.fromMetaData(metadata)
-  }
-}
-
-/**
- * Features below are for testing only, and are being registered to the system only in the testing
- * environment. See [[TableFeatureStore.allSupportedFeaturesMap]] for the registration.
- */
-
-object TestLegacyWriterFeature
-  extends LegacyWriterFeature(name = "testLegacyWriter", minWriterVersion = 5)
-
-object TestWriterFeature extends WriterFeature(name = "testWriter")
-
-object TestLegacyReaderWriterFeature
-  extends LegacyReaderWriterFeature(
-    name = "testLegacyReaderWriter",
-    minReaderVersion = 2,
-    minWriterVersion = 6)
-
-object TestReaderWriterFeature extends ReaderWriterFeature(name = "testReaderWriter")
-
 /* --------------------------------------- *
  |  Table features base class definitions  |
  * --------------------------------------- */
@@ -235,3 +182,56 @@ sealed abstract class LegacyReaderWriterFeature(
     minWriterVersion: Int)
   extends LegacyWriterFeature(name, minWriterVersion)
   with ReaderWriterFeatureType
+
+object TableFeature {
+
+  /**
+   * All table features recognized by this client. Update this set when you added a new Table
+   * Feature.
+   */
+  val allSupportedFeaturesMap: Map[String, TableFeature] = {
+    var features = Set[TableFeature](AppendOnlyTableFeature)
+    if (DeltaUtils.isTesting) {
+      features ++= Set(
+        TestLegacyWriterFeature,
+        TestWriterFeature,
+        TestLegacyReaderWriterFeature,
+        TestReaderWriterFeature)
+    }
+    val featureMap = features.map(f => f.name.toLowerCase(Locale.ROOT) -> f).toMap
+    require(features.size == featureMap.size, "Lowercase feature names must not duplicate.")
+    featureMap
+  }
+}
+
+/* ---------------------------------------- *
+ |  All table features known to the client  |
+ * ---------------------------------------- */
+
+object AppendOnlyTableFeature
+  extends LegacyWriterFeature(name = "appendOnly", minWriterVersion = 2)
+  with FeatureAutomaticallyEnabledByMetadata {
+  override def metadataRequiresFeatureToBeEnabled(
+      metadata: Metadata,
+      spark: SparkSession): Boolean = {
+    DeltaConfigs.IS_APPEND_ONLY.fromMetaData(metadata)
+  }
+}
+
+/**
+ * Features below are for testing only, and are being registered to the system only in the testing
+ * environment. See [[TableFeature.allSupportedFeaturesMap]] for the registration.
+ */
+
+object TestLegacyWriterFeature
+  extends LegacyWriterFeature(name = "testLegacyWriter", minWriterVersion = 5)
+
+object TestWriterFeature extends WriterFeature(name = "testWriter")
+
+object TestLegacyReaderWriterFeature
+  extends LegacyReaderWriterFeature(
+    name = "testLegacyReaderWriter",
+    minReaderVersion = 2,
+    minWriterVersion = 6)
+
+object TestReaderWriterFeature extends ReaderWriterFeature(name = "testReaderWriter")

--- a/core/src/main/scala/org/apache/spark/sql/delta/TableFeatureStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/TableFeatureStore.scala
@@ -1,0 +1,237 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.util.Locale
+
+import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.util.{Utils => DeltaUtils}
+
+import org.apache.spark.sql.SparkSession
+
+object TableFeatureStore {
+
+  /**
+   * All table features recognized by this client. Update this set when you added a new Table
+   * Feature.
+   */
+  val allSupportedFeaturesMap: Map[String, TableFeature] = {
+    var features = Set[TableFeature](AppendOnlyTableFeature)
+    if (DeltaUtils.isTesting) {
+      features ++= Set(
+        TestLegacyWriterFeature,
+        TestWriterFeature,
+        TestLegacyReaderWriterFeature,
+        TestReaderWriterFeature)
+    }
+    val featureMap = features.map(f => f.name.toLowerCase(Locale.ROOT) -> f).toMap
+    require(features.size == featureMap.size, "Lowercase feature names must not duplicate.")
+    featureMap
+  }
+}
+
+/* ---------------------------------------- *
+ |  All table features known to the client  |
+ * ---------------------------------------- */
+
+object AppendOnlyTableFeature
+  extends LegacyWriterFeature(name = "appendOnly", minWriterVersion = 2)
+  with FeatureAutomaticallyEnabledByMetadata {
+  override def metadataRequiresFeatureToBeEnabled(
+      metadata: Metadata,
+      spark: SparkSession): Boolean = {
+    DeltaConfigs.IS_APPEND_ONLY.fromMetaData(metadata)
+  }
+}
+
+/**
+ * Features below are for testing only, and are being registered to the system only in the testing
+ * environment. See [[TableFeatureStore.allSupportedFeaturesMap]] for the registration.
+ */
+
+object TestLegacyWriterFeature
+  extends LegacyWriterFeature(name = "testLegacyWriter", minWriterVersion = 5)
+
+object TestWriterFeature extends WriterFeature(name = "testWriter")
+
+object TestLegacyReaderWriterFeature
+  extends LegacyReaderWriterFeature(
+    name = "testLegacyReaderWriter",
+    minReaderVersion = 2,
+    minWriterVersion = 6)
+
+object TestReaderWriterFeature extends ReaderWriterFeature(name = "testReaderWriter")
+
+/* --------------------------------------- *
+ |  Table features base class definitions  |
+ * --------------------------------------- */
+
+/**
+ * A base class for all table features.
+ *
+ * A feature can be <b>explicitly enabled</b> by a table's protocol when the protocol contains a
+ * [[TableFeatureDescriptor]] that has the feature's `name` listed. Writers (for writer-only
+ * features) or readers and writers (for reader-writer features) must recognize enabled features
+ * and must handle them appropriately.
+ *
+ * A table feature that released before Delta Table Features (reader version 3 and writer version
+ * 7) is considered as a <b>legacy feature</b>. Legacy features are <b>implicitly enabled</b> when
+ * (a) the protocol does not support table features, i.e., has reader version less than 3 or
+ * writer version less than 7 and (b) the feature's minimum reader/writer version is less than or
+ * equal to the current protocol's reader/writer version.
+ *
+ * Separately, a feature can be automatically enabled in a table's metadata when certain
+ * feature-specific table properties are set. For example, `changeDataFeed` is automatically
+ * enabled when there's a table property `delta.enableChangeDataFeed=true`. This is independent of
+ * the table's enabled features. When a feature is enabled (explicitly or implicitly) by the table
+ * protocol but its metadata requirements are not satisfied, then clients still have to understand
+ * the feature (at least to the extent that they can read and preserve the existing data in the
+ * table that uses the feature). See the documentation of
+ * [[FeatureAutomaticallyEnabledByMetadata]] for more information.
+ *
+ * @param name
+ *   a globally-unique string indicator to represent the feature. All characters must be letters
+ *   (a-z, A-Z), digits (0-9), '-', or '_'. Words must be in camelCase.
+ * @param minReaderVersion
+ *   the minimum reader version this feature requires. For a feature that can only be explicitly
+ *   enabled, this is either `0` or `3` (the reader protocol version that supports table
+ *   features), depending on the feature is writer-only or reader-writer. For a legacy feature
+ *   that can be implicitly enabled, this is the first protocol version which the feature is
+ *   introduced.
+ * @param minWriterVersion
+ *   the minimum writer version this feature requires. For a feature that can only be explicitly
+ *   enabled, this is the writer protocol `7` that supports table features. For a legacy feature
+ *   that can be implicitly enabled, this is the first protocol version which the feature is
+ *   introduced.
+ */
+// @TODO: distinguish Delta and 3rd-party features and give appropriate error messages
+sealed abstract class TableFeature(
+    val name: String,
+    val minReaderVersion: Int,
+    val minWriterVersion: Int) {
+
+  require(name.forall(c => c.isLetterOrDigit || c == '-' || c == '_'))
+
+  /**
+   * Get a [[Protocol]] object stating the minimum reader and writer versions this feature
+   * requires. For a feature that can only be explicitly enabled, this method returns a protocol
+   * version that supports table features, either `(0,7)` or `(3,7)` depending on the feature is
+   * writer-only or reader-writer. For a legacy feature that can be implicitly enabled, this
+   * method returns the first protocol version which introduced the said feature.
+   *
+   * For all features, if the table's protocol version does not support table features, then the
+   * minimum protocol version is enough. However, if the protocol version supports table features
+   * for the feature type (writer-only or reader-writer), then the minimum protocol version is not
+   * enough to enable a feature. In this case the feature must also be explicitly enabled in the
+   * appropriate feature sets in the [[Protocol]].
+   */
+  def minProtocolVersion: Protocol = Protocol(minReaderVersion, minWriterVersion)
+
+  /** Determine if this feature applies to both readers and writers. */
+  def isReaderWriterFeature: Boolean = this.isInstanceOf[ReaderWriterFeatureType]
+
+  /**
+   * Determine if this feature is a legacy feature. See the documentation of [[TableFeature]] for
+   * more information.
+   */
+  def isLegacyFeature: Boolean = this.isInstanceOf[LegacyFeatureType]
+
+  /** Convert this feature to a [[TableFeatureDescriptor]]. */
+  def toDescriptor: TableFeatureDescriptor =
+    TableFeatureDescriptor(name, TableFeatureStatus.ENABLED)
+}
+
+/** A trait to indicate a feature applies to readers and writers. */
+sealed trait ReaderWriterFeatureType
+
+/** A trait to indicate a feature is legacy, i.e., released before Table Features. */
+sealed trait LegacyFeatureType
+
+/**
+ * A trait indicating this feature can be automatically enabled via a change in a table's
+ * metadata, e.g., through setting particular values of certain feature-specific table properties.
+ *
+ * When the feature's metadata requirements are satisfied during table creation
+ * ([[actions.Protocol.forNewTable]]) or commit ([[OptimisticTransaction.updateMetadata]]), the
+ * client will silently add the feature to the protocol's `readerFeatures` and/or `writerFeatures`
+ * with `status` = `enabled`.
+ */
+sealed trait FeatureAutomaticallyEnabledByMetadata {
+
+  /**
+   * Determine whether the feature must be enabled because its metadata requirements are
+   * satisfied.
+   */
+  def metadataRequiresFeatureToBeEnabled(metadata: Metadata, spark: SparkSession): Boolean
+}
+
+/**
+ * A base class for all writer-only table features that can only be explicitly enabled.
+ *
+ * @param name
+ *   a globally-unique string indicator to represent the feature. All characters must be letters
+ *   (a-z, A-Z), digits (0-9), '-', or '_'. Words must be in camelCase.
+ */
+sealed abstract class WriterFeature(name: String)
+  extends TableFeature(
+    name,
+    minReaderVersion = 0,
+    minWriterVersion = TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION)
+
+/**
+ * A base class for all reader-writer table features that can only be explicitly enabled.
+ *
+ * @param name
+ *   a globally-unique string indicator to represent the feature. All characters must be letters
+ *   (a-z, A-Z), digits (0-9), '-', or '_'. Words must be in camelCase.
+ */
+sealed abstract class ReaderWriterFeature(name: String)
+  extends WriterFeature(name)
+  with ReaderWriterFeatureType {
+  override val minReaderVersion: Int = TableFeatureProtocolUtils.TABLE_FEATURES_MIN_READER_VERSION
+}
+
+/**
+ * A base class for all table legacy writer-only features.
+ *
+ * @param name
+ *   a globally-unique string indicator to represent the feature. Allowed characters are letters
+ *   (a-z, A-Z), digits (0-9), '-', and '_'. Words must be in camelCase.
+ * @param minWriterVersion
+ *   the minimum writer protocol version that supports this feature.
+ */
+sealed abstract class LegacyWriterFeature(name: String, minWriterVersion: Int)
+  extends TableFeature(name, minReaderVersion = 0, minWriterVersion = minWriterVersion)
+  with LegacyFeatureType
+
+/**
+ * A base class for all legacy writer-only table features.
+ *
+ * @param name
+ *   a globally-unique string indicator to represent the feature. Allowed characters are letters
+ *   (a-z, A-Z), digits (0-9), '-', and '_'. Words must be in camelCase.
+ * @param minReaderVersion
+ *   the minimum reader protocol version that supports this feature.
+ * @param minWriterVersion
+ *   the minimum writer protocol version that supports this feature.
+ */
+sealed abstract class LegacyReaderWriterFeature(
+    name: String,
+    override val minReaderVersion: Int,
+    minWriterVersion: Int)
+  extends LegacyWriterFeature(name, minWriterVersion)
+  with ReaderWriterFeatureType

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -207,7 +207,7 @@ trait TableFeatureSupport { this: Protocol =>
       // this protocol uses both reader and writer features, no feature can be implicitly enabled
       Set()
     } else {
-      TableFeatureStore.allSupportedFeaturesMap.values
+      TableFeature.allSupportedFeaturesMap.values
         .filter(_.isLegacyFeature)
         .filterNot(supportsReaderFeatures || this.minReaderVersion < _.minReaderVersion)
         .filterNot(supportsWriterFeatures || this.minWriterVersion < _.minWriterVersion)
@@ -285,7 +285,7 @@ case class TableFeatureDescriptor(
 
   /** Get the actual [[TableFeature]] object represented by this descriptor. */
   def toFeature: Option[TableFeature] =
-    TableFeatureStore.allSupportedFeaturesMap.get(name.toLowerCase(Locale.ROOT))
+    TableFeature.allSupportedFeaturesMap.get(name.toLowerCase(Locale.ROOT))
 }
 
 object TableFeatureStatus extends Enumeration {
@@ -346,7 +346,7 @@ object TableFeatureProtocolUtils {
       if (status != TableFeatureStatus.ENABLED.toString) {
         throw DeltaErrors.unsupportedTableFeatureStatusException(name, status)
       }
-      val featureOpt = TableFeatureStore.allSupportedFeaturesMap.get(name)
+      val featureOpt = TableFeature.allSupportedFeaturesMap.get(name)
       if (!featureOpt.isDefined) {
         unsupportedFeatureConfigs += key
       }

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -1,0 +1,360 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.actions
+
+import java.util.Locale
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.delta._
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.core.`type`.TypeReference
+import com.fasterxml.jackson.module.scala.JsonScalaEnumeration
+
+import org.apache.spark.util.Utils
+
+/**
+ * Trait to be mixed into the [[Protocol]] case class to enable Table Features.
+ *
+ * Protocol reader version 3 and writer version 7 start to support reader and writer table
+ * features. In such a case, features can be <b>explicitly enabled</b> by a protocol's reader
+ * and/or writer features sets by having a [[TableFeatureDescriptor]], in which the feature's name
+ * is listed. When read or write a table, clients MUST respect all enabled features.
+ *
+ * See also the document of [[TableFeature]] for feature-specific terminologies.
+ */
+trait TableFeatureSupport { this: Protocol =>
+
+  /** Check if this protocol is capable of adding features into its `readerFeatures` field. */
+  def supportsReaderFeatures: Boolean =
+    TableFeatureProtocolUtils.supportsReaderFeatures(minReaderVersion)
+
+  /** Check if this protocol is capable of adding features into its `writerFeatures` field. */
+  def supportsWriterFeatures: Boolean =
+    TableFeatureProtocolUtils.supportsWriterFeatures(minWriterVersion)
+
+  /**
+   * Get a new Protocol object that has `feature` enabled. Writer-only features will be enabled by
+   * `writerFeatures` field, and reader-writer features will be enabled by `readerFeatures` and
+   * `writerFeatures` fields.
+   *
+   * If `feature` is already implicitly enabled in the current protocol's legacy reader or writer
+   * protocol version, the new protocol will not modify the original protocol version,
+   * i.e., the feature will not be explicitly enabled by the protocol's `readerFeatures` or
+   * `writerFeatures`. This is to avoid unnecessary protocol upgrade to enable a feature that it
+   * already supports.
+   */
+  def withFeature(feature: TableFeature): Protocol = {
+    def shouldAddRead: Boolean = {
+      if (supportsReaderFeatures) return true
+      if (feature.minReaderVersion <= minReaderVersion) return false
+
+      throw DeltaErrors.tableFeatureRequiresHigherReaderProtocolVersion(
+        feature.name,
+        minReaderVersion,
+        feature.minReaderVersion)
+    }
+
+    def shouldAddWrite: Boolean = {
+      if (supportsWriterFeatures) return true
+      if (feature.minWriterVersion <= minWriterVersion) return false
+
+      throw DeltaErrors.tableFeatureRequiresHigherWriterProtocolVersion(
+        feature.name,
+        minWriterVersion,
+        feature.minWriterVersion)
+    }
+
+    var shouldAddToReaderFeatures = feature.isReaderWriterFeature
+    var shouldAddToWriterFeatures = true
+    if (feature.isLegacyFeature) {
+      if (feature.isReaderWriterFeature) {
+        shouldAddToReaderFeatures = shouldAddRead
+      }
+      shouldAddToWriterFeatures = shouldAddWrite
+    }
+
+    withFeatureDescriptor(
+      feature.toDescriptor,
+      addToReaderFeatures = shouldAddToReaderFeatures,
+      addToWriterFeatures = shouldAddToWriterFeatures)
+  }
+
+  /**
+   * Get a new Protocol object with multiple features enabled.
+   *
+   * See the documentation of [[withFeature]] for more information.
+   */
+  def withFeatures(features: Iterable[TableFeature]): Protocol = {
+    features.foldLeft(this)(_.withFeature(_))
+  }
+
+  /**
+   * Get a new Protocol object with an additional feature descriptor. If `addToReaderFeatures` is
+   * set to `true`, the descriptor will be added to the protocol's `readerFeatures` field. If
+   * `addToWriterFeatures` is set to `true`, the descriptor will be added to the protocol's
+   * `writerFeatures` field.
+   *
+   * The method does not require the feature to be recognized by the client.
+   */
+  private[actions] def withFeatureDescriptor(
+      desc: TableFeatureDescriptor,
+      addToReaderFeatures: Boolean,
+      addToWriterFeatures: Boolean): Protocol = {
+    // When the feature has been enabled by this protocol, no work is needed.
+    if (getFeatureDescriptor(desc.name).isDefined) return this
+
+    if (addToReaderFeatures && !supportsReaderFeatures) {
+      throw DeltaErrors.tableFeatureRequiresHigherReaderProtocolVersion(
+        desc.name,
+        currentVersion = minReaderVersion,
+        requiredVersion = TableFeatureProtocolUtils.TABLE_FEATURES_MIN_READER_VERSION)
+    }
+    if (addToWriterFeatures && !supportsWriterFeatures) {
+      throw DeltaErrors.tableFeatureRequiresHigherWriterProtocolVersion(
+        desc.name,
+        currentVersion = minWriterVersion,
+        requiredVersion = TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION)
+    }
+
+    val addedReaderFeatureOpt = if (addToReaderFeatures) Some(desc) else None
+    val addedWriterFeatureOpt = if (addToWriterFeatures) Some(desc) else None
+
+    copy(
+      readerFeatures = this.readerFeatures.map(_ ++ addedReaderFeatureOpt),
+      writerFeatures = this.writerFeatures.map(_ ++ addedWriterFeatureOpt))
+  }
+
+  /**
+   * Get a new Protocol object with additional feature descriptors added to the protocol's
+   * `readerFeatures` field.
+   *
+   * The method does not require the features to be recognized by the client, therefore will not
+   * try keeping the protocol's `readerFeatures` and `writerFeatures` in sync. Use with caution.
+   */
+  private[delta] def withReaderFeatureDescriptors(
+      descriptors: Iterable[TableFeatureDescriptor]): Protocol = {
+    descriptors.foldLeft(this)(
+      _.withFeatureDescriptor(_, addToReaderFeatures = true, addToWriterFeatures = false))
+  }
+
+  /**
+   * Get a new Protocol object with additional feature descriptors added to the protocol's
+   * `writerFeatures` field.
+   *
+   * The method does not require the features to be recognized by the client, therefore will not
+   * try keeping the protocol's `readerFeatures` and `writerFeatures` in sync. Use with caution.
+   */
+  private[delta] def withWriterFeatureDescriptors(
+      descriptors: Iterable[TableFeatureDescriptor]): Protocol = {
+    descriptors.foldLeft(this)(
+      _.withFeatureDescriptor(_, addToReaderFeatures = false, addToWriterFeatures = true))
+  }
+
+  /**
+   * Get all [[TableFeatureDescriptor]] in this protocol's `readerFeatures` field. Returns an
+   * empty set when this protocol does not support reader features.
+   */
+  def readerFeatureDescriptors: Set[TableFeatureDescriptor] =
+    this.readerFeatures.getOrElse(Set())
+
+  /**
+   * Get a set of all [[TableFeatureDescriptor]] in this protocol's `writerFeatures` field.
+   * Returns an empty set when this protocol does not support writer features.
+   */
+  def writerFeatureDescriptors: Set[TableFeatureDescriptor] =
+    this.writerFeatures.getOrElse(Set())
+
+  /**
+   * Get a set of all [[TableFeatureDescriptor]] in this protocol's `readerFeatures` and
+   * `writerFeatures` field. Returns an empty set when this protocol supports none of reader and
+   * writer features.
+   */
+  def readerAndWriterFeatureDescriptors: Set[TableFeatureDescriptor] =
+    this.readerFeatures.getOrElse(Set()) ++ this.writerFeatures.getOrElse(Set())
+
+  /**
+   * Get the [[TableFeatureDescriptor]] if a feature with name `featureName` is explicitly
+   * required by this protocol. Returns `None` if it isn't explicitly required.
+   *
+   * The method does not require the feature to be recognized by the client.
+   */
+  def getFeatureDescriptor(featureName: String): Option[TableFeatureDescriptor] =
+    readerAndWriterFeatureDescriptors.find(_.name == featureName)
+
+  /**
+   * Get all features that are implicitly enabled by this protocol, for example, `Protocol(1,2)`
+   * implicitly enables `appendOnly` and `invariants`. When this protocol is capable of requiring
+   * writer features, no feature can be implicitly enabled.
+   */
+  @JsonIgnore
+  lazy val implicitlyEnabledFeatures: Set[TableFeature] = {
+    if (supportsReaderFeatures && supportsWriterFeatures) {
+      // this protocol uses both reader and writer features, no feature can be implicitly enabled
+      Set()
+    } else {
+      TableFeatureStore.allSupportedFeaturesMap.values
+        .filter(_.isLegacyFeature)
+        .filterNot(supportsReaderFeatures || this.minReaderVersion < _.minReaderVersion)
+        .filterNot(supportsWriterFeatures || this.minWriterVersion < _.minWriterVersion)
+        .toSet
+    }
+  }
+
+  /**
+   * Determine whether this protocol can be safely upgraded to a new protocol `to`. This means:
+   *   - this protocol has reader protocol version less than or equals to `to`.
+   *   - this protocol has writer protocol version less than or equals to `to`.
+   *   - all features enabled in this protocol are enabled in `to`.
+   *
+   * Examples regarding feature status:
+   *   - from `[{appendOnly, enabled}]` to `[{appendOnly, enabled}]` => allowed
+   *   - from `[{appendOnly, enabled}, {changeDataFeed, enabled}]` to `[{appendOnly, enabled}]` =>
+   *     not allowed
+   *   - from `[{appendOnly, enabled}]` to `[{appendOnly, enabled}, {changeDataFeed, enabled}]` =>
+   *     allowed
+   */
+  def canUpgradeTo(to: Protocol): Boolean = {
+    if (to.minReaderVersion < this.minReaderVersion) return false
+    if (to.minWriterVersion < this.minWriterVersion) return false
+
+    val thisDescriptors =
+      this.readerAndWriterFeatureDescriptors ++ this.implicitlyEnabledFeatures.map(_.toDescriptor)
+    val toDescriptors =
+      to.readerAndWriterFeatureDescriptors ++ to.implicitlyEnabledFeatures.map(_.toDescriptor)
+
+    // all features enabled in `this` are enabled in `to`
+    thisDescriptors.subsetOf(toDescriptors)
+  }
+
+  /**
+   * Merge this protocol with multiple `protocols` to have the highest reader and writer versions
+   * plus all explicitly and implicitly enabled features.
+   */
+  def merge(others: Protocol*): Protocol = {
+    val protocols = this +: others
+    val mergedReaderVersion = protocols.map(_.minReaderVersion).max
+    val mergedWriterVersion = protocols.map(_.minWriterVersion).max
+    val mergedReaderDescriptors = protocols.flatMap(_.readerFeatureDescriptors)
+    val mergedWriterDescriptors = protocols.flatMap(_.writerFeatureDescriptors)
+    val mergedImplicitFeatures = protocols.flatMap(_.implicitlyEnabledFeatures)
+
+    val mergedProtocol = Protocol(mergedReaderVersion, mergedWriterVersion)
+      .withReaderFeatureDescriptors(mergedReaderDescriptors)
+      .withWriterFeatureDescriptors(mergedWriterDescriptors)
+
+    if (mergedProtocol.supportsReaderFeatures || mergedProtocol.supportsWriterFeatures) {
+      mergedProtocol.withFeatures(mergedImplicitFeatures)
+    } else {
+      mergedProtocol
+    }
+  }
+}
+
+/**
+ * A representation of a feature with a specific `status`.
+ *
+ * When reading or writing a table, clients MUST respect all requirements of features that have an
+ * `enabled` status.
+ *
+ * @param name
+ *   a feature name as defined by [[TableFeature.name]].
+ * @param status
+ *   a [[TableFeatureStatus]], currently the only allowed value is `enabled`.
+ */
+case class TableFeatureDescriptor(
+    name: String,
+    @JsonScalaEnumeration(classOf[TableFeatureStatusType])
+    status: TableFeatureStatus.TableFeatureStatus) {
+
+  def simpleString: String = name // no `status` because it can only be `enabled`
+
+  /** Get the actual [[TableFeature]] object represented by this descriptor. */
+  def toFeature: Option[TableFeature] =
+    TableFeatureStore.allSupportedFeaturesMap.get(name.toLowerCase(Locale.ROOT))
+}
+
+object TableFeatureStatus extends Enumeration {
+  type TableFeatureStatus = Value
+  val ENABLED = Value("enabled")
+}
+
+// Type definition for Jackson to map strings to enum items
+class TableFeatureStatusType extends TypeReference[TableFeatureStatus.type]
+
+object TableFeatureProtocolUtils {
+
+  /** Prop prefix in table properties. */
+  val FEATURE_PROP_PREFIX = "delta.feature."
+
+  /** Prop prefix in Spark sessions configs. */
+  val DEFAULT_FEATURE_PROP_PREFIX = "spark.databricks.delta.properties.defaults.feature."
+
+  // TODO: Switch to (3, 7) once the implementation is done
+  /** Min reader version that supports reader features. */
+  val TABLE_FEATURES_MIN_READER_VERSION = Int.MaxValue / 2
+
+  /** Min reader version that supports writer features. */
+  val TABLE_FEATURES_MIN_WRITER_VERSION = Int.MaxValue / 2
+
+  /**
+   * Determine whether a [[Protocol]] with the given reader protocol version is capable of adding
+   * features into its `readerFeatures` field.
+   */
+  def supportsReaderFeatures(readerVersion: Int): Boolean = {
+    // TODO: To be modified to ">=". Now limited to `==` to not break tests of legacy features.
+    readerVersion == TABLE_FEATURES_MIN_READER_VERSION
+  }
+
+  /**
+   * Determine whether a [[Protocol]] with the given writer protocol version is capable of adding
+   * features into its `writerFeatures` field.
+   */
+  def supportsWriterFeatures(writerVersion: Int): Boolean = {
+    // TODO: To be modified to ">=". Now limited to `==` to not break tests of legacy features.
+    writerVersion == TABLE_FEATURES_MIN_WRITER_VERSION
+  }
+
+  /**
+   * Get a set of [[TableFeature]]s representing enabled features set in a `config` map (table
+   * properties or Spark session configs).
+   */
+  def getEnabledFeaturesFromConfigs(
+      configs: Map[String, String],
+      propertyPrefix: String): Set[TableFeature] = {
+    val featureConfigs = configs.filterKeys(_.startsWith(propertyPrefix))
+    val unsupportedFeatureConfigs = mutable.Set.empty[String]
+    val collectedFeatures = featureConfigs.flatMap { case (key, value) =>
+      // Feature name is lower cased in table properties but not in Spark session configs.
+      // Feature status is not lower cased in any case.
+      val name = key.stripPrefix(propertyPrefix).toLowerCase(Locale.ROOT)
+      val status = value.toLowerCase(Locale.ROOT)
+      if (status != TableFeatureStatus.ENABLED.toString) {
+        throw DeltaErrors.unsupportedTableFeatureStatusException(name, status)
+      }
+      val featureOpt = TableFeatureStore.allSupportedFeaturesMap.get(name)
+      if (!featureOpt.isDefined) {
+        unsupportedFeatureConfigs += key
+      }
+      featureOpt
+    }
+    if (unsupportedFeatureConfigs.nonEmpty) {
+      throw DeltaErrors.unsupportedTableFeatureConfigsException(unsupportedFeatureConfigs)
+    }
+    collectedFeatures.toSet
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -71,7 +71,7 @@ object Action {
       conf: Option[SQLConf] = None,
       withAllFeatures: Boolean = true): Protocol = {
       if (withAllFeatures) {
-        protocolVersion.withFeatures(TableFeatureStore.allSupportedFeaturesMap.values)
+        protocolVersion.withFeatures(TableFeature.allSupportedFeaturesMap.values)
       } else {
         protocolVersion
       }
@@ -275,7 +275,7 @@ object Protocol {
   def minProtocolFromActiveFeatures(spark: SparkSession, metadata: Metadata): Protocol = {
     var minimumRequired = Protocol(0, 0)
 
-    TableFeatureStore.allSupportedFeaturesMap.values.foreach {
+    TableFeature.allSupportedFeaturesMap.values.foreach {
       case feature: TableFeature with FeatureAutomaticallyEnabledByMetadata =>
         if (feature.metadataRequiresFeatureToBeEnabled(metadata, spark)) {
           // bump the protocol version to which the feature requires

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -22,14 +22,14 @@ import java.sql.Timestamp
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
-import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
 
-import org.apache.spark.sql.delta.{ColumnWithDefaultExprUtils, DeltaColumnMapping, DeltaColumnMappingMode, DeltaConfigs, DeltaErrors, DeltaThrowable, DeltaThrowableHelper, GeneratedColumn, OptimizablePartitionExpression, Snapshot}
+import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.constraints.{Constraints, Invariants}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.JsonUtils
 import com.fasterxml.jackson.annotation._
+import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind._
 import com.fasterxml.jackson.databind.annotation.{JsonDeserialize, JsonSerialize}
@@ -43,27 +43,16 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DataType, StructField, StructType}
 import org.apache.spark.util.Utils
 
-/** Thrown when the protocol version of a table is greater than supported by this client. */
-class InvalidProtocolVersionException extends RuntimeException(
-    "Delta protocol version is too new for this version of the Databricks Runtime. " +
-    "Please upgrade to a newer release.")
-
-class ProtocolDowngradeException(oldProtocol: Protocol, newProtocol: Protocol)
-  extends RuntimeException(DeltaThrowableHelper.getMessage(
-    errorClass = "DELTA_INVALID_PROTOCOL_DOWNGRADE",
-    messageParameters = Array(oldProtocol.simpleString, newProtocol.simpleString)
-  )) with DeltaThrowable {
-  override def getErrorClass: String = "DELTA_INVALID_PROTOCOL_DOWNGRADE"
-}
-
 object Action {
   /**
    * The maximum version of the protocol that this version of Delta understands by default.
    *
    * Use [[supportedProtocolVersion()]] instead, except to define new feature-gated versions.
    */
-  private[actions] val readerVersion = 2
-  private[actions] val writerVersion = 6
+  private[actions] val readerVersion =
+    TableFeatureProtocolUtils.TABLE_FEATURES_MIN_READER_VERSION
+  private[actions] val writerVersion =
+    TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION
   private[actions] val protocolVersion: Protocol = Protocol(readerVersion, writerVersion)
 
   /**
@@ -78,8 +67,14 @@ object Action {
    * In all places in the code where we are validating which version can be read, or which version
    * we are currently writing, pass in `conf` so that features are correctly enabled.
    */
-  private[delta] def supportedProtocolVersion(conf: Option[SQLConf] = None): Protocol = {
-      protocolVersion
+  private[delta] def supportedProtocolVersion(
+      conf: Option[SQLConf] = None,
+      withAllFeatures: Boolean = true): Protocol = {
+      if (withAllFeatures) {
+        protocolVersion.withFeatures(TableFeatureStore.allSupportedFeaturesMap.values)
+      } else {
+        protocolVersion
+      }
   }
 
   def fromJson(json: String): Action = {
@@ -101,98 +96,219 @@ sealed trait Action {
 }
 
 /**
- * Used to block older clients from reading or writing the log when backwards
- * incompatible changes are made to the protocol. Readers and writers are
- * responsible for checking that they meet the minimum versions before performing
- * any other operations.
+ * Used to block older clients from reading or writing the log when backwards incompatible changes
+ * are made to the protocol. Readers and writers are responsible for checking that they meet the
+ * minimum versions before performing any other operations.
  *
- * Since this action allows us to explicitly block older clients in the case of a
- * breaking change to the protocol, clients should be tolerant of messages and
- * fields that they do not understand.
+ * This action allows us to explicitly block older clients in the case of a breaking change to the
+ * protocol. Absent a protocol change, Clients MUST silently ignore messages and fields that they
+ * do not understand.
+ *
+ * Note: Please initialize this class using the companion object's `apply` method, which will
+ * assign correct values (`Set()` vs `None`) to [[readerFeatures]] and [[writerFeatures]].
  */
-case class Protocol(
-    minReaderVersion: Int = Action.readerVersion,
-    minWriterVersion: Int = Action.writerVersion) extends Action {
-  override def wrap: SingleAction = SingleAction(protocol = this)
-  @JsonIgnore
-  def simpleString: String = s"($minReaderVersion,$minWriterVersion)"
+case class Protocol private (
+    minReaderVersion: Int,
+    minWriterVersion: Int,
+    @JsonInclude(Include.NON_ABSENT) // write to JSON only when the field is not `None`
+    readerFeatures: Option[Set[TableFeatureDescriptor]],
+    @JsonInclude(Include.NON_ABSENT)
+    writerFeatures: Option[Set[TableFeatureDescriptor]])
+  extends Action
+  with TableFeatureSupport {
+  // Correctness check
+  // Reader and writer versions must match the status of reader and writer features
+  require(
+    supportsReaderFeatures == readerFeatures.isDefined,
+    "Mismatched minReaderVersion and readerFeatures.")
+  require(
+    supportsWriterFeatures == writerFeatures.isDefined,
+    "Mismatched minWriterVersion and writerFeatures.")
 
-  def max(other: Protocol): Protocol = Protocol(
-    minReaderVersion = this.minReaderVersion.max(other.minReaderVersion),
-    minWriterVersion = this.minWriterVersion.max(other.minWriterVersion)
-  )
+  // When reader is on table features, writer must be on table features too
+  if (supportsReaderFeatures && !supportsWriterFeatures) {
+    throw DeltaErrors.tableFeatureReadRequiresWriteException(
+      TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION)
+  }
+
+  override def wrap: SingleAction = SingleAction(protocol = this)
+
+  /**
+   * Return a reader-friendly string representation of this Protocol.
+   *
+   * Returns the protocol versions and referenced features when the protocol does support table
+   * features, such as `3,7,{},{appendOnly}` and `2,7,None,{appendOnly}`. Otherwise returns only
+   * the protocol version such as `2,6`.
+   */
+  @JsonIgnore
+  lazy val simpleString: String = {
+    if (!supportsReaderFeatures && !supportsWriterFeatures) {
+      s"$minReaderVersion,$minWriterVersion"
+    } else {
+      val readerFeaturesStr = readerFeatures
+        .map(_.map(_.simpleString).toSeq.sorted.mkString("{", ",", "}"))
+        .getOrElse("None")
+      val writerFeaturesStr = writerFeatures
+        .map(_.map(_.simpleString).toSeq.sorted.mkString("{", ",", "}"))
+        .getOrElse("None")
+      s"$minReaderVersion,$minWriterVersion,$readerFeaturesStr,$writerFeaturesStr"
+    }
+  }
+
+  override def toString: String = s"Protocol($simpleString)"
 }
 
 object Protocol {
+  import TableFeatureProtocolUtils._
+
   val MIN_READER_VERSION_PROP = "delta.minReaderVersion"
   val MIN_WRITER_VERSION_PROP = "delta.minWriterVersion"
 
-  def apply(spark: SparkSession, metadataOpt: Option[Metadata]): Protocol = {
-    val conf = spark.sessionState.conf
-    val minimumOpt = metadataOpt.map(m => requiredMinimumProtocol(spark, m)._1)
-    val configs = metadataOpt.map(_.configuration.map {
-      case (k, v) => k.toLowerCase(Locale.ROOT) -> v }
-    ).getOrElse(Map.empty[String, String])
-    // Check if the protocol version is provided as a table property, or get it from the SQL confs
-    val readerVersion = configs.get(MIN_READER_VERSION_PROP.toLowerCase(Locale.ROOT))
-      .map(getVersion(MIN_READER_VERSION_PROP, _))
-      .getOrElse(conf.getConf(DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_READER_VERSION))
-    val writerVersion = configs.get(MIN_WRITER_VERSION_PROP.toLowerCase(Locale.ROOT))
-      .map(getVersion(MIN_WRITER_VERSION_PROP, _))
-      .getOrElse(conf.getConf(DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_WRITER_VERSION))
-
-    Protocol(
-      minReaderVersion = math.max(minimumOpt.map(_.minReaderVersion).getOrElse(0), readerVersion),
-      minWriterVersion = math.max(minimumOpt.map(_.minWriterVersion).getOrElse(0), writerVersion))
+  /**
+   * Construct a [[Protocol]] case class of the given reader and writer versions. This method will
+   * initialize table features fields when reader and writer versions are capable.
+   *
+   * Until table features is released, this method will return the highest protocol version that
+   * does not support table features. This is to prevent users from accidentally creating tables
+   * using unreleased table features.
+   */
+  def apply(minReaderVersion: Int = 2, minWriterVersion: Int = 6): Protocol = {
+    new Protocol(
+      minReaderVersion = minReaderVersion,
+      minWriterVersion = minWriterVersion,
+      readerFeatures = if (supportsReaderFeatures(minReaderVersion)) Some(Set()) else None,
+      writerFeatures = if (supportsWriterFeatures(minWriterVersion)) Some(Set()) else None)
   }
 
-  /** Picks the protocol version for a new table given potential feature usage. */
+  /**
+   * Given the Delta table metadata, returns the minimum required table protocol that satisfies
+   * all active features in the metadata plus protocol-related configs in table properties or
+   * session defaults, i.e., configs with keys [[MIN_READER_VERSION_PROP]],
+   * [[MIN_WRITER_VERSION_PROP]], [[FEATURE_PROP_PREFIX]], and [[DEFAULT_FEATURE_PROP_PREFIX]].
+   */
+  def apply(spark: SparkSession, metadataOpt: Option[Metadata]): Protocol = {
+    val sessionConf = spark.sessionState.conf
+    val tableConf = metadataOpt.map(_.configuration).getOrElse(Map.empty[String, String])
+
+    val minProtocolFromActiveFeaturesOpt =
+      metadataOpt.map(m => minProtocolFromActiveFeatures(spark, m))
+
+    // There might be features enabled by the table properties aka
+    // `CREATE TABLE ... TBLPROPERTIES ...` or by session defaults.
+    val tablePropEnabledFeatures =
+      getEnabledFeaturesFromConfigs(tableConf, FEATURE_PROP_PREFIX)
+    val sessionEnabledFeatures =
+      getEnabledFeaturesFromConfigs(sessionConf.getAllConfs, DEFAULT_FEATURE_PROP_PREFIX)
+    val tablePropAndSessionEnabledFeatures = tablePropEnabledFeatures ++ sessionEnabledFeatures
+
+    // Determine the min reader and writer version required by features in table properties or
+    // session defaults. If all features are legacy, we start from (0, 0). If any feature is
+    // native and reader-writer, we start from (3, 7). Otherwise we start from (0, 7) because
+    // there must exist a native writer-only feature.
+    val initialProtocol = if (tablePropAndSessionEnabledFeatures.forall(_.isLegacyFeature)) {
+      Protocol(0, 0)
+    } else if (tablePropAndSessionEnabledFeatures.exists(f =>
+        !f.isLegacyFeature && f.isReaderWriterFeature)) {
+      Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION)
+    } else {
+      Protocol(0, TABLE_FEATURES_MIN_WRITER_VERSION)
+    }
+    val minProtocolFromFeaturesInTablePropAndSession = initialProtocol.merge(
+      tablePropAndSessionEnabledFeatures.map(_.minProtocolVersion).toSeq: _*)
+
+    // If the protocol version is provided in table properties, they will take priority over
+    // versions in `minProtocolFromTablePropAndSession`.
+    val readerVersionFromTableConfOpt = tableConf
+      .get(MIN_READER_VERSION_PROP)
+      .map(getVersion(MIN_READER_VERSION_PROP, _))
+    val writerVersionFromTableConfOpt = tableConf
+      .get(MIN_WRITER_VERSION_PROP)
+      .map(getVersion(MIN_WRITER_VERSION_PROP, _))
+
+    // Priority to decide the final protocol version:
+    // 1. protocol version defined in table properties
+    // 2. max of:
+    //    a. protocol version defined in session defaults
+    //    b. min version required by automatically-enabled features
+    //    c. min version required by features configured in table properties and session defaults
+    val finalReaderVersion = readerVersionFromTableConfOpt.getOrElse {
+      val candidates = Seq(
+        sessionConf.getConf(DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_READER_VERSION),
+        minProtocolFromActiveFeaturesOpt.map(_.minReaderVersion).getOrElse(0),
+        minProtocolFromFeaturesInTablePropAndSession.minReaderVersion)
+      candidates.max
+    }
+    val finalWriterVersion = writerVersionFromTableConfOpt.getOrElse {
+      val candidates = Seq(
+        sessionConf.getConf(DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_WRITER_VERSION),
+        minProtocolFromActiveFeaturesOpt.map(_.minWriterVersion).getOrElse(0),
+        minProtocolFromFeaturesInTablePropAndSession.minWriterVersion)
+      candidates.max
+    }
+    val minActiveFeatures = minProtocolFromActiveFeaturesOpt
+      .map(_.readerAndWriterFeatureDescriptors.flatMap(_.toFeature))
+      .getOrElse(Set())
+
+    Protocol(finalReaderVersion, finalWriterVersion)
+      .withFeatures(minActiveFeatures)
+      .withFeatures(tablePropAndSessionEnabledFeatures)
+  }
+
+  /**
+   * Picks the protocol version for a new table given potential feature usage. The result
+   * satisfies all active features in the metadata and protocol-related configs in table
+   * properties or session defaults, i.e., configs with keys [[MIN_READER_VERSION_PROP]],
+   * [[MIN_WRITER_VERSION_PROP]], [[FEATURE_PROP_PREFIX]], and [[DEFAULT_FEATURE_PROP_PREFIX]].
+   */
   def forNewTable(spark: SparkSession, metadata: Metadata): Protocol = {
     Protocol(spark, Some(metadata))
   }
 
   /**
-   * Given the Delta table metadata, returns the minimum required table protocol version
-   * and the features used that require the protocol.
+   * Given the Delta table metadata, returns the minimum required table protocol that satisfies
+   * all active features in the metadata.
+   *
+   * This method does not process protocol-related configs in table properties or session
+   * defaults, i.e., configs with keys [[MIN_READER_VERSION_PROP]], [[MIN_WRITER_VERSION_PROP]],
+   * [[FEATURE_PROP_PREFIX]], and [[DEFAULT_FEATURE_PROP_PREFIX]].
    */
-  private def requiredMinimumProtocol(
-      spark: SparkSession,
-      metadata: Metadata): (Protocol, Seq[String]) = {
-    val featuresUsed = new ArrayBuffer[String]()
+  def minProtocolFromActiveFeatures(spark: SparkSession, metadata: Metadata): Protocol = {
     var minimumRequired = Protocol(0, 0)
+
+    TableFeatureStore.allSupportedFeaturesMap.values.foreach {
+      case feature: TableFeature with FeatureAutomaticallyEnabledByMetadata =>
+        if (feature.metadataRequiresFeatureToBeEnabled(metadata, spark)) {
+          // bump the protocol version to which the feature requires
+          minimumRequired = minimumRequired.merge(feature.minProtocolVersion)
+          // and if `minimumRequired` supports table features, require the feature explicitly
+          if (minimumRequired.supportsReaderFeatures || minimumRequired.supportsWriterFeatures) {
+            minimumRequired = minimumRequired.withFeature(feature)
+          }
+        }
+      case _ => () // Do nothing. We only care about features that can be activated in metadata.
+    }
+
     // Check for invariants in the schema
     if (Invariants.getFromSchema(metadata.schema, spark).nonEmpty) {
       minimumRequired = Protocol(0, minWriterVersion = 2)
-      featuresUsed.append("Setting column level invariants")
-    }
-
-    val configs = metadata.configuration.map { case (k, v) => k.toLowerCase(Locale.ROOT) -> v }
-    if (configs.contains(DeltaConfigs.IS_APPEND_ONLY.key.toLowerCase(Locale.ROOT))) {
-      minimumRequired = Protocol(0, minWriterVersion = 2)
-      featuresUsed.append(s"Append only tables (${DeltaConfigs.IS_APPEND_ONLY.key})")
     }
 
     if (Constraints.getCheckConstraints(metadata, spark).nonEmpty) {
       minimumRequired = Protocol(0, minWriterVersion = 3)
-      featuresUsed.append("Setting CHECK constraints")
     }
 
     if (GeneratedColumn.hasGeneratedColumns(metadata.schema)) {
       minimumRequired = Protocol(0, minWriterVersion = GeneratedColumn.MIN_WRITER_VERSION)
-      featuresUsed.append("Using Generated Columns")
     }
 
     if (DeltaConfigs.CHANGE_DATA_FEED.fromMetaData(metadata)) {
       minimumRequired = Protocol(0, minWriterVersion = 4)
-      featuresUsed.append("Change data feed")
     }
 
     if (ColumnWithDefaultExprUtils.hasIdentityColumn(metadata.schema)) {
       minimumRequired = Protocol(
         minReaderVersion = 0,
-        minWriterVersion = ColumnWithDefaultExprUtils.IDENTITY_MIN_WRITER_VERSION
-      )
-      featuresUsed.append("Using IDENTITY Columns")
+        minWriterVersion = ColumnWithDefaultExprUtils.IDENTITY_MIN_WRITER_VERSION)
       throw DeltaErrors.identityColumnNotSupported()
     }
 
@@ -201,7 +317,7 @@ object Protocol {
     }
 
 
-    minimumRequired -> featuresUsed.toSeq
+    minimumRequired
   }
 
   /** Cast the table property for the protocol version to an integer. */
@@ -219,17 +335,21 @@ object Protocol {
       spark: SparkSession,
       metadata: Metadata,
       current: Protocol): Option[Protocol] = {
-    assert(!metadata.configuration.contains(MIN_READER_VERSION_PROP), s"Should not have the " +
-      s"protocol version ($MIN_READER_VERSION_PROP) as part of table properties")
-    assert(!metadata.configuration.contains(MIN_WRITER_VERSION_PROP), s"Should not have the " +
-      s"protocol version ($MIN_WRITER_VERSION_PROP) as part of table properties")
-    val (required, features) = requiredMinimumProtocol(spark, metadata)
-    if (current.minWriterVersion < required.minWriterVersion ||
-        current.minReaderVersion < required.minReaderVersion) {
-      Some(required.copy(
-        minReaderVersion = math.max(current.minReaderVersion, required.minReaderVersion),
-        minWriterVersion = math.max(current.minWriterVersion, required.minWriterVersion))
-      )
+    assert(
+      !metadata.configuration.contains(MIN_READER_VERSION_PROP),
+      "Should not have the " +
+        s"protocol version ($MIN_READER_VERSION_PROP) as part of table properties")
+    assert(
+      !metadata.configuration.contains(MIN_WRITER_VERSION_PROP),
+      "Should not have the " +
+        s"protocol version ($MIN_WRITER_VERSION_PROP) as part of table properties")
+    assert(
+      !metadata.configuration.keys.exists(_.startsWith(FEATURE_PROP_PREFIX)),
+      "Should not have " +
+        s"table features (starts with '$FEATURE_PROP_PREFIX') as part of table properties")
+    val required = minProtocolFromActiveFeatures(spark, metadata)
+    if (!required.canUpgradeTo(current)) {
+      Some(required.merge(current))
     } else {
       None
     }

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
@@ -248,9 +248,9 @@ abstract class CloneTableBase(
       // It's not a real downgrade if the table doesn't exist before the CLONE.
       txn.snapshot.version == -1
     val newProtocol = if (protocolDowngradeAllowed) {
-      sourceProtocol.max(minRequiredProtocol)
+      sourceProtocol.merge(minRequiredProtocol)
     } else {
-      targetProtocol.max(sourceProtocol).max(minRequiredProtocol)
+      targetProtocol.merge(sourceProtocol, minRequiredProtocol)
     }
 
     try {

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
@@ -184,7 +184,7 @@ class CloneParquetSource(
 
   def format: String = CloneSourceFormat.PARQUET
 
-  def protocol: Protocol = new Protocol()
+  def protocol: Protocol = Protocol()
 
   override val clock: Clock = new SystemClock()
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -258,7 +258,8 @@ trait DeltaSQLConfBase {
       .doc("The default writer protocol version to create new tables with, unless a feature " +
         "that requires a higher version for correctness is enabled.")
       .intConf
-      .checkValues(Set(1, 2, 3, 4, 5, 6))
+      // TODO: Int.MaxValue / 2 is the temporary version for table features. To be changed to 7.
+      .checkValues(Set(1, 2, 3, 4, 5, 6, Int.MaxValue / 2))
       .createWithDefault(2)
 
   val DELTA_PROTOCOL_DEFAULT_READER_VERSION =
@@ -266,7 +267,8 @@ trait DeltaSQLConfBase {
       .doc("The default reader protocol version to create new tables with, unless a feature " +
         "that requires a higher version for correctness is enabled.")
       .intConf
-      .checkValues(Set(1, 2))
+      // TODO: Int.MaxValue / 2 is the temporary version for table features. To be changed to 3.
+      .checkValues(Set(1, 2, Int.MaxValue / 2))
       .createWithDefault(1)
 
   val DELTA_MAX_SNAPSHOT_LINEAGE_LENGTH =

--- a/core/src/main/scala/org/apache/spark/sql/delta/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/util/Utils.scala
@@ -35,4 +35,11 @@ object Utils {
   def getRandomPrefix(numChars: Int): String = {
     Random.alphanumeric.take(numChars).mkString
   }
+
+  /**
+   * Indicates whether Delta is currently running unit tests.
+   */
+  def isTesting: Boolean = {
+    System.getenv("DELTA_TESTING") != null
+  }
 }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingTestUtils.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingTestUtils.scala
@@ -18,6 +18,8 @@ package org.apache.spark.sql.delta
 
 import java.io.File
 
+import scala.collection.mutable
+
 import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaColumnMappingSelectedTestMixin
@@ -415,20 +417,29 @@ trait DeltaColumnMappingEnableNameMode extends SharedSparkSession
       super.convertToDelta(tableOrPath)
     }
 
-    val deltaPath = if (tableOrPath.contains("parquet") && tableOrPath.contains("`")) {
-      // parquet.`PATH`
-      s"""delta.${tableOrPath.split('.').last}"""
-    } else {
-      tableOrPath
-    }
+    val (deltaPath, deltaLog) =
+      if (tableOrPath.contains("parquet") && tableOrPath.contains("`")) {
+        // parquet.`PATH`
+        val plainPath = tableOrPath.split('.').last.drop(1).dropRight(1)
+        (s"delta.`$plainPath`", DeltaLog.forTable(spark, plainPath))
+      } else {
+        (tableOrPath, DeltaLog.forTable(spark, TableIdentifier(tableOrPath)))
+      }
 
+    val tableReaderVersion = deltaLog.unsafeVolatileSnapshot.protocol.minReaderVersion
+    val tableWriterVersion = deltaLog.unsafeVolatileSnapshot.protocol.minWriterVersion
     val readerVersion = spark.conf.get(DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_READER_VERSION).max(2)
     val writerVersion = spark.conf.get(DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_WRITER_VERSION).max(5)
-    sql(s"""ALTER TABLE $deltaPath SET TBLPROPERTIES (
-         |${DeltaConfigs.COLUMN_MAPPING_MODE.key} = 'name',
-         |${DeltaConfigs.MIN_READER_VERSION.key} = '$readerVersion',
-         |${DeltaConfigs.MIN_WRITER_VERSION.key} = '$writerVersion'
-         |)""".stripMargin)
+
+    val properties = mutable.ListBuffer(DeltaConfigs.COLUMN_MAPPING_MODE.key -> "name")
+    if (tableReaderVersion < readerVersion) {
+      properties += DeltaConfigs.MIN_READER_VERSION.key -> readerVersion.toString
+    }
+    if (tableWriterVersion < writerVersion) {
+      properties += DeltaConfigs.MIN_WRITER_VERSION.key -> writerVersion.toString
+    }
+    val propertiesStr = properties.map(kv => s"'${kv._1}' = '${kv._2}'").mkString(", ")
+    sql(s"ALTER TABLE $deltaPath SET TBLPROPERTIES ($propertiesStr)")
   }
 
 }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -26,7 +26,7 @@ import scala.sys.process.Process
 
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.DeltaErrors.generateDocsLink
-import org.apache.spark.sql.delta.actions.{Action, Protocol, ProtocolDowngradeException}
+import org.apache.spark.sql.delta.actions.{Action, Protocol}
 import org.apache.spark.sql.delta.catalog.DeltaCatalog
 import org.apache.spark.sql.delta.constraints.CharVarcharConstraint
 import org.apache.spark.sql.delta.constraints.Constraints
@@ -84,7 +84,19 @@ trait DeltaErrorsSuiteBase
       DeltaErrors.sourceNotDeterministicInMergeException(spark),
     "columnMappingAdviceMessage" ->
       DeltaErrors.columnRenameNotSupported,
-    "icebergClassMissing" -> DeltaErrors.icebergClassMissing(sparkConf, new Throwable())
+    "icebergClassMissing" -> DeltaErrors.icebergClassMissing(sparkConf, new Throwable()),
+    "tableFeatureReadRequiresWriteException" ->
+      DeltaErrors.tableFeatureReadRequiresWriteException(requiredWriterVersion = 7),
+    "tableFeatureRequiresHigherReaderProtocolVersion" ->
+      DeltaErrors.tableFeatureRequiresHigherReaderProtocolVersion(
+        feature = "feature",
+        currentVersion = 1,
+        requiredVersion = 7),
+    "tableFeatureRequiresHigherWriterProtocolVersion" ->
+      DeltaErrors.tableFeatureRequiresHigherReaderProtocolVersion(
+        feature = "feature",
+        currentVersion = 1,
+        requiredVersion = 7)
   )
 
   def otherMessagesToTest: Map[String, String] = Map(
@@ -1325,8 +1337,8 @@ trait DeltaErrorsSuiteBase
     }
     {
       val e = intercept[ProtocolDowngradeException] {
-        val p1 = new Protocol(1, 1)
-        val p2 = new Protocol(2, 2)
+        val p1 = Protocol(1, 1)
+        val p2 = Protocol(2, 2)
         throw new ProtocolDowngradeException(p1, p2)
       }
       assert(e.getErrorClass == "DELTA_INVALID_PROTOCOL_DOWNGRADE")

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -1002,8 +1002,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     for (row <- rows) {
       val name = row.getAs[String]("key").substring(FEATURE_PROP_PREFIX.length)
       val status = row.getAs[String]("value")
-      assert(
-        TableFeatureStore.allSupportedFeaturesMap.contains(name.toLowerCase(Locale.ROOT)))
+      assert(TableFeature.allSupportedFeaturesMap.contains(name.toLowerCase(Locale.ROOT)))
       assert(status == "enabled")
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -22,9 +22,9 @@ import java.util.Locale
 
 import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
-import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.FileNames.deltaFile
 
 import org.apache.spark.SparkConf
@@ -36,7 +36,9 @@ import org.apache.spark.sql.types.StructType
 trait DeltaProtocolVersionSuiteBase extends QueryTest
   with SharedSparkSession  with DeltaSQLCommandTest {
 
-  private lazy val testTableSchema = spark.range(1).schema
+  // `.schema` generates NOT NULL columns which requires writer protocol 2. We convert all to
+  // NULLable to avoid silent writer protocol version bump.
+  private lazy val testTableSchema = spark.range(1).schema.asNullable
 
   // This is solely a test hook. Users cannot create new Delta tables with protocol lower than
   // that of their current version.
@@ -58,21 +60,112 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
   test("upgrade to current version") {
     withTempDir { path =>
       val log = createTableWithProtocol(Protocol(1, 1), path)
-      assert(log.snapshot.protocol == Protocol(1, 1))
-      log.upgradeProtocol()
-      assert(log.snapshot.protocol == Protocol())
+      assert(log.snapshot.protocol === Protocol(1, 1))
+      log.upgradeProtocol(Action.supportedProtocolVersion())
+      assert(log.snapshot.protocol === Action.supportedProtocolVersion())
     }
   }
 
   test("upgrade to a version with DeltaTable API") {
     withTempDir { path =>
       val log = createTableWithProtocol(Protocol(0, 0), path)
-      assert(log.snapshot.protocol == Protocol(0, 0))
+      assert(log.snapshot.protocol === Protocol(0, 0))
       val table = io.delta.tables.DeltaTable.forPath(spark, path.getCanonicalPath)
+      table.upgradeTableProtocol(1, 1)
+      assert(log.snapshot.protocol === Protocol(1, 1))
       table.upgradeTableProtocol(1, 2)
-      assert(log.snapshot.protocol == Protocol(1, 2))
+      assert(log.snapshot.protocol === Protocol(1, 2))
       table.upgradeTableProtocol(1, 3)
-      assert(log.snapshot.protocol == Protocol(1, 3))
+      assert(log.snapshot.protocol === Protocol(1, 3))
+      intercept[DeltaTableFeatureException] {
+        table.upgradeTableProtocol(
+          TABLE_FEATURES_MIN_READER_VERSION,
+          TABLE_FEATURES_MIN_WRITER_VERSION - 1)
+      }
+    }
+  }
+
+  test("upgrade to support table features - no feature") {
+    withTempDir { path =>
+      val log = createTableWithProtocol(Protocol(1, 1), path)
+      assert(log.snapshot.protocol === Protocol(1, 1))
+      val table = io.delta.tables.DeltaTable.forPath(spark, path.getCanonicalPath)
+      table.upgradeTableProtocol(1, TABLE_FEATURES_MIN_WRITER_VERSION)
+      assert(
+        log.snapshot.protocol === Protocol(
+          minReaderVersion = 1,
+          minWriterVersion = TABLE_FEATURES_MIN_WRITER_VERSION,
+          readerFeatures = None,
+          writerFeatures = Some(Set())))
+      table.upgradeTableProtocol(
+        TABLE_FEATURES_MIN_READER_VERSION,
+        TABLE_FEATURES_MIN_WRITER_VERSION)
+      assert(
+        log.snapshot.protocol === Protocol(
+          minReaderVersion = TABLE_FEATURES_MIN_READER_VERSION,
+          minWriterVersion = TABLE_FEATURES_MIN_WRITER_VERSION,
+          readerFeatures = Some(Set()),
+          writerFeatures = Some(Set())))
+    }
+  }
+
+  test("upgrade to support table features - writer-only feature") {
+    withTempDir { path =>
+      val log = createTableWithProtocol(Protocol(1, 2), path)
+      assert(log.snapshot.protocol === Protocol(1, 2))
+      val table = io.delta.tables.DeltaTable.forPath(spark, path.getCanonicalPath)
+      table.upgradeTableProtocol(1, TABLE_FEATURES_MIN_WRITER_VERSION)
+      assert(
+        log.snapshot.protocol === Protocol(
+          minReaderVersion = 1,
+          minWriterVersion = TABLE_FEATURES_MIN_WRITER_VERSION,
+          readerFeatures = None,
+          writerFeatures = Some(Set(AppendOnlyTableFeature.toDescriptor))))
+      table.upgradeTableProtocol(
+        TABLE_FEATURES_MIN_READER_VERSION,
+        TABLE_FEATURES_MIN_WRITER_VERSION)
+      assert(
+        log.snapshot.protocol === Protocol(
+          minReaderVersion = TABLE_FEATURES_MIN_READER_VERSION,
+          minWriterVersion = TABLE_FEATURES_MIN_WRITER_VERSION,
+          readerFeatures = Some(Set()),
+          writerFeatures = Some(Set(AppendOnlyTableFeature.toDescriptor))))
+    }
+  }
+
+  test("upgrade to support table features - many features") {
+    withTempDir { path =>
+      val log = createTableWithProtocol(Protocol(2, 6), path)
+      assert(log.snapshot.protocol === Protocol(2, 6))
+      val table = io.delta.tables.DeltaTable.forPath(spark, path.getCanonicalPath)
+      table.upgradeTableProtocol(2, TABLE_FEATURES_MIN_WRITER_VERSION)
+      assert(
+        log.snapshot.protocol === Protocol(
+          minReaderVersion = 2,
+          minWriterVersion = TABLE_FEATURES_MIN_WRITER_VERSION,
+          readerFeatures = None,
+          writerFeatures = Some(
+            Set(AppendOnlyTableFeature, TestLegacyWriterFeature, TestLegacyReaderWriterFeature)
+              .map(_.toDescriptor))))
+      spark.sql(
+        s"ALTER TABLE delta.`${path.getPath}` SET TBLPROPERTIES (" +
+          s"  delta.feature.${TestWriterFeature.name}='enabled'" +
+          s")")
+      table.upgradeTableProtocol(
+        TABLE_FEATURES_MIN_READER_VERSION,
+        TABLE_FEATURES_MIN_WRITER_VERSION)
+      assert(
+        log.snapshot.protocol === Protocol(
+          minReaderVersion = TABLE_FEATURES_MIN_READER_VERSION,
+          minWriterVersion = TABLE_FEATURES_MIN_WRITER_VERSION,
+          readerFeatures = Some(Set()),
+          writerFeatures = Some(
+            Set(
+              AppendOnlyTableFeature,
+              TestLegacyWriterFeature,
+              TestLegacyReaderWriterFeature,
+              TestWriterFeature)
+              .map(_.toDescriptor))))
     }
   }
 
@@ -81,10 +174,29 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       val log = createTableWithProtocol(Protocol(1, 2), path)
 
       assert(log.snapshot.protocol === Protocol(1, 2))
-      sql(s"ALTER TABLE delta.`${path.getCanonicalPath}` " +
-        "SET TBLPROPERTIES (delta.minWriterVersion = 3)")
+      sql(
+        s"ALTER TABLE delta.`${path.getCanonicalPath}` " +
+          "SET TBLPROPERTIES (delta.minWriterVersion = 3)")
       assert(log.snapshot.protocol === Protocol(1, 3))
-      assertPropertiesDontContainProtocolVersions(log)
+      assertPropertiesAndShowTblProperties(log)
+      sql(s"ALTER TABLE delta.`${path.getCanonicalPath}` " +
+        s"SET TBLPROPERTIES (delta.minWriterVersion=${TABLE_FEATURES_MIN_WRITER_VERSION})")
+      assert(
+        log.snapshot.protocol === Protocol(
+          minReaderVersion = 1,
+          minWriterVersion = TABLE_FEATURES_MIN_WRITER_VERSION,
+          readerFeatures = None,
+          writerFeatures = Some(Set(AppendOnlyTableFeature.toDescriptor))))
+      assertPropertiesAndShowTblProperties(log, tableHasFeatures = true)
+      sql(s"ALTER TABLE delta.`${path.getCanonicalPath}` " +
+        s"SET TBLPROPERTIES (delta.minReaderVersion=${TABLE_FEATURES_MIN_READER_VERSION})")
+      assert(
+        log.snapshot.protocol === Protocol(
+          minReaderVersion = TABLE_FEATURES_MIN_READER_VERSION,
+          minWriterVersion = TABLE_FEATURES_MIN_WRITER_VERSION,
+          readerFeatures = Some(Set()),
+          writerFeatures = Some(Set(AppendOnlyTableFeature.toDescriptor))))
+      assertPropertiesAndShowTblProperties(log, tableHasFeatures = true)
     }
   }
 
@@ -97,7 +209,80 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         .mode("overwrite")
         .save(path.getCanonicalPath)
       log.update()
-      assert(log.snapshot.protocol == Protocol(0, 0))
+      assert(log.snapshot.protocol === Protocol(0, 0))
+    }
+  }
+
+  test("overwrite keeps the same table properties") {
+    withTempDir { path =>
+      val log = createTableWithProtocol(Protocol(0, 0), path)
+      spark.sql(
+        s"ALTER TABLE delta.`${path.getCanonicalPath}` SET TBLPROPERTIES ('myProp'='true')")
+      spark
+        .range(1)
+        .write
+        .format("delta")
+        .option("anotherProp", "true")
+        .mode("overwrite")
+        .save(path.getCanonicalPath)
+      log.update()
+      assert(log.snapshot.metadata.configuration.size === 1)
+      assert(log.snapshot.metadata.configuration("myProp") === "true")
+    }
+  }
+
+  test("overwrite keeps the same protocol version and features") {
+    withTempDir { path =>
+      val protocol = Protocol(0, TABLE_FEATURES_MIN_WRITER_VERSION)
+        .withFeature(AppendOnlyTableFeature)
+      val log = createTableWithProtocol(protocol, path)
+      spark
+        .range(1)
+        .write
+        .format("delta")
+        .mode("overwrite")
+        .save(path.getCanonicalPath)
+      log.update()
+      assert(log.snapshot.protocol === protocol)
+    }
+  }
+
+  test("overwrite with additional configs keeps the same protocol version and features") {
+    withTempDir { path =>
+      val protocol = Protocol(1, TABLE_FEATURES_MIN_WRITER_VERSION)
+        .withFeature(AppendOnlyTableFeature)
+      val log = createTableWithProtocol(protocol, path)
+      spark
+        .range(1)
+        .write
+        .format("delta")
+        .option("delta.feature.testWriter", "enabled")
+        .option("delta.feature.testReaderWriter", "enabled")
+        .mode("overwrite")
+        .save(path.getCanonicalPath)
+      log.update()
+      assert(log.snapshot.protocol === protocol)
+    }
+  }
+
+  test("overwrite with additional session defaults keeps the same protocol version and features") {
+    withTempDir { path =>
+      val protocol = Protocol(1, TABLE_FEATURES_MIN_WRITER_VERSION)
+        .withFeature(AppendOnlyTableFeature)
+      val log = createTableWithProtocol(protocol, path)
+      withSQLConf(
+        s"$DEFAULT_FEATURE_PROP_PREFIX${TestLegacyWriterFeature.name}" -> "enabled") {
+        spark
+          .range(1)
+          .write
+          .format("delta")
+          .option("delta.feature.testWriter", "enabled")
+          .option("delta.feature.testReaderWriter", "enabled")
+          .mode("overwrite")
+          .save(path.getCanonicalPath)
+      }
+      log.update()
+      assert(log.snapshot.protocol === protocol)
     }
   }
 
@@ -208,7 +393,58 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_READER_VERSION.key -> readerVersion.toString) {
         sql(s"CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta")
         val deltaLog = DeltaLog.forTable(spark, dir)
-        assert(deltaLog.snapshot.protocol === Action.supportedProtocolVersion())
+        assert(deltaLog.snapshot.protocol ===
+               Action.supportedProtocolVersion(withAllFeatures = false))
+      }
+    }
+  }
+
+  test("can create table using features configured in session") {
+    val readerVersion = Action.supportedProtocolVersion().minReaderVersion
+    val writerVersion = Action.supportedProtocolVersion().minWriterVersion
+    withTempDir { dir =>
+      withSQLConf(
+        DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_WRITER_VERSION.key -> writerVersion.toString,
+        DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_READER_VERSION.key -> readerVersion.toString,
+        s"$DEFAULT_FEATURE_PROP_PREFIX${AppendOnlyTableFeature.name}" -> "enabled",
+        s"$DEFAULT_FEATURE_PROP_PREFIX${TestReaderWriterFeature.name}" -> "enabled") {
+        sql(s"CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta")
+        val deltaLog = DeltaLog.forTable(spark, dir)
+        assert(
+          deltaLog.snapshot.protocol ===
+            Action
+              .supportedProtocolVersion(withAllFeatures = false)
+              .withFeatures(Set(AppendOnlyTableFeature, TestReaderWriterFeature)))
+      }
+    }
+  }
+
+  test("can create table using features configured in table properties and session") {
+    withTempDir { dir =>
+      withSQLConf(
+        s"$DEFAULT_FEATURE_PROP_PREFIX${TestWriterFeature.name}" -> "enabled") {
+        sql(
+          s"CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta " +
+            "TBLPROPERTIES (" +
+            s"  delta.feature.${AppendOnlyTableFeature.name}='enabled'," +
+            s"  delta.feature.${TestLegacyReaderWriterFeature.name}='enabled'" +
+            s")")
+        val deltaLog = DeltaLog.forTable(spark, dir)
+        assert(
+          deltaLog.snapshot.protocol.minReaderVersion ===
+            TestLegacyReaderWriterFeature.minReaderVersion,
+          "reader protocol version should not support table features because we use " +
+            "only a legacy reader-writer feature.")
+        assert(
+          deltaLog.snapshot.protocol.minWriterVersion ===
+            TABLE_FEATURES_MIN_WRITER_VERSION,
+          "writer protocol version must support table features because a native feature" +
+            "is enabled.")
+        assert(
+          deltaLog.snapshot.protocol.readerAndWriterFeatureDescriptors === Set(
+            AppendOnlyTableFeature,
+            TestLegacyReaderWriterFeature,
+            TestWriterFeature).map(_.toDescriptor))
       }
     }
   }
@@ -403,15 +639,162 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         sql(s"CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta " +
           "TBLPROPERTIES (delta.minWriterVersion=3)")
 
+        assert(deltaLog.snapshot.protocol.minReaderVersion === 1)
         assert(deltaLog.snapshot.protocol.minWriterVersion === 3)
-        assertPropertiesDontContainProtocolVersions(deltaLog)
+        assertPropertiesAndShowTblProperties(deltaLog)
 
         // Can downgrade using REPLACE
         sql(s"REPLACE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta " +
           "TBLPROPERTIES (delta.MINWRITERVERSION=1)")
+        assert(deltaLog.snapshot.protocol.minReaderVersion === 1)
         assert(deltaLog.snapshot.protocol.minWriterVersion === 1)
-        assertPropertiesDontContainProtocolVersions(deltaLog)
+        assertPropertiesAndShowTblProperties(deltaLog)
       }
+    }
+  }
+
+  test("table creation with writer-only features as table property") {
+    withTempDir { dir =>
+      val deltaLog = DeltaLog.forTable(spark, dir)
+      sql(
+        s"CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta " +
+          "TBLPROPERTIES (" +
+          "  DeLtA.fEaTurE.APPendONly='eNAbled'," +
+          "  delta.feature.testWriter='enabled'" +
+          ")")
+
+      assert(deltaLog.snapshot.protocol.minReaderVersion === 1)
+      assert(
+        deltaLog.snapshot.protocol.minWriterVersion === TABLE_FEATURES_MIN_WRITER_VERSION)
+      assert(
+        deltaLog.snapshot.protocol.readerAndWriterFeatureDescriptors === Set(
+          AppendOnlyTableFeature, TestWriterFeature).map(_.toDescriptor))
+      assertPropertiesAndShowTblProperties(deltaLog, tableHasFeatures = true)
+    }
+  }
+
+  test("table creation with legacy reader-writer features as table property") {
+    withTempDir { dir =>
+      val deltaLog = DeltaLog.forTable(spark, dir)
+      sql(
+        s"CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta " +
+          "TBLPROPERTIES (DeLtA.fEaTurE.testLEGACYReaderWritER='eNAbled')")
+
+      assert(
+        deltaLog.snapshot.protocol.minReaderVersion ===
+          TestLegacyReaderWriterFeature.minReaderVersion)
+      assert(
+        deltaLog.snapshot.protocol.minWriterVersion ===
+          TestLegacyReaderWriterFeature.minWriterVersion)
+      assertPropertiesAndShowTblProperties(deltaLog)
+    }
+  }
+
+  test("table creation with native writer-only features as table property") {
+    withTempDir { dir =>
+      val deltaLog = DeltaLog.forTable(spark, dir)
+      sql(
+        s"CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta " +
+          "TBLPROPERTIES (DeLtA.fEaTurE.testWritER='eNAbled')")
+
+      assert(
+        deltaLog.snapshot.protocol.minReaderVersion === 1)
+      assert(
+        deltaLog.snapshot.protocol.minWriterVersion ===
+          TABLE_FEATURES_MIN_WRITER_VERSION)
+      assert(
+        deltaLog.snapshot.protocol.readerAndWriterFeatureDescriptors === Set(
+          TestWriterFeature.toDescriptor))
+      assertPropertiesAndShowTblProperties(deltaLog, tableHasFeatures = true)
+    }
+  }
+
+  test("table creation with reader-writer features as table property") {
+    withTempDir { dir =>
+      val deltaLog = DeltaLog.forTable(spark, dir)
+      sql(
+        s"CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta " +
+          "TBLPROPERTIES (" +
+          "  DeLtA.fEaTurE.testLEGACYReaderWritER='eNAbled'," +
+          "  DeLtA.fEaTurE.testReaderWritER='enabled'" +
+          ")")
+
+      assert(
+        deltaLog.snapshot.protocol.minReaderVersion === TABLE_FEATURES_MIN_READER_VERSION)
+      assert(
+        deltaLog.snapshot.protocol.minWriterVersion === TABLE_FEATURES_MIN_WRITER_VERSION)
+      assert(
+        deltaLog.snapshot.protocol.readerAndWriterFeatureDescriptors === Set(
+          TestLegacyReaderWriterFeature, TestReaderWriterFeature).map(_.toDescriptor))
+      assertPropertiesAndShowTblProperties(deltaLog, tableHasFeatures = true)
+    }
+  }
+
+  test("table creation with feature as table property and supported protocol version") {
+    withTempDir { dir =>
+      val deltaLog = DeltaLog.forTable(spark, dir)
+      sql(
+        s"CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta " +
+          "TBLPROPERTIES (" +
+          s"  DEltA.MINREADERversion='${TABLE_FEATURES_MIN_READER_VERSION}'," +
+          s"  DEltA.MINWRITERversion='${TABLE_FEATURES_MIN_WRITER_VERSION}'," +
+          "  DeLtA.fEaTurE.testLEGACYReaderWriter='eNAbled'" +
+          ")")
+
+      assert(
+        deltaLog.snapshot.protocol === Protocol(
+          minReaderVersion = TABLE_FEATURES_MIN_READER_VERSION,
+          minWriterVersion = TABLE_FEATURES_MIN_WRITER_VERSION,
+          readerFeatures =
+            Some(Set(TestLegacyReaderWriterFeature.toDescriptor)),
+          writerFeatures =
+            Some(Set(TestLegacyReaderWriterFeature.toDescriptor))))
+      assertPropertiesAndShowTblProperties(deltaLog, tableHasFeatures = true)
+    }
+  }
+
+  test("table creation with feature as table property and supported writer protocol version") {
+    withTempDir { dir =>
+      val deltaLog = DeltaLog.forTable(spark, dir)
+      sql(
+        s"CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta " +
+          s"TBLPROPERTIES (" +
+          s"  delta.minWriterVersion='${TABLE_FEATURES_MIN_WRITER_VERSION}'," +
+          s"  delta.feature.testLegacyReaderWriter='enabled'" +
+          s")")
+
+      assert(
+        deltaLog.snapshot.protocol === Protocol(
+          minReaderVersion = 2,
+          minWriterVersion = TABLE_FEATURES_MIN_WRITER_VERSION,
+          readerFeatures = None,
+          writerFeatures =
+            Some(Set(TestLegacyReaderWriterFeature.toDescriptor))))
+      assertPropertiesAndShowTblProperties(deltaLog, tableHasFeatures = true)
+    }
+  }
+
+  test("table creation with automatically-enabled feature and unsupported protocol") {
+    withTempDir { dir =>
+      val deltaLog = DeltaLog.forTable(spark, dir)
+      sql(
+        s"CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta TBLPROPERTIES (" +
+          "  delta.minReaderVersion='1'," +
+          "  delta.minWriterVersion='2'," +
+          "  delta.enableChangeDataFeed='true'" +
+          ")")
+      assert(deltaLog.snapshot.protocol.minReaderVersion === 1)
+      assert(deltaLog.snapshot.protocol.minWriterVersion === 4)
+    }
+  }
+
+  test("table creation with feature as table property and unsupported protocol version") {
+    withTempDir { dir =>
+      val deltaLog = DeltaLog.forTable(spark, dir)
+      intercept[Exception] {
+        sql(s"CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta " +
+            "TBLPROPERTIES (delta.minWriterVersion='2',delta.feature.testWriter='enabled')")
+      }.getMessage.contains("Writer Table Features must be supported to add a writer feature")
     }
   }
 
@@ -423,7 +806,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
           "TBLPROPERTIES (delta.MINwriterVERsion=2)")
 
         assert(deltaLog.snapshot.protocol.minWriterVersion === 2)
-        assertPropertiesDontContainProtocolVersions(deltaLog)
+        assertPropertiesAndShowTblProperties(deltaLog)
       }
     }
   }
@@ -436,18 +819,19 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
           "TBLPROPERTIES (delta.minWriterVersion=1, delta.appendOnly=true)")
 
         assert(deltaLog.snapshot.protocol.minWriterVersion === 2)
-        assertPropertiesDontContainProtocolVersions(deltaLog)
+        assertPropertiesAndShowTblProperties(deltaLog)
 
         sql(s"REPLACE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta " +
           "TBLPROPERTIES (delta.minWriterVersion=1)")
 
         assert(deltaLog.snapshot.protocol.minWriterVersion === 1)
-        assertPropertiesDontContainProtocolVersions(deltaLog)
+        assertPropertiesAndShowTblProperties(deltaLog)
 
         // Works with REPLACE too
         sql(s"REPLACE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta " +
           "TBLPROPERTIES (delta.minWriterVersion=1, delta.appendOnly=true)")
         assert(deltaLog.snapshot.protocol.minWriterVersion === 2)
+        assertPropertiesAndShowTblProperties(deltaLog)
       }
     }
   }
@@ -463,7 +847,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
           .create()
 
         assert(deltaLog.snapshot.protocol.minWriterVersion === 2)
-        assertPropertiesDontContainProtocolVersions(deltaLog)
+        assertPropertiesAndShowTblProperties(deltaLog)
       }
     }
   }
@@ -477,7 +861,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
           .create()
 
         assert(deltaLog.snapshot.protocol.minWriterVersion === 3)
-        assertPropertiesDontContainProtocolVersions(deltaLog)
+        assertPropertiesAndShowTblProperties(deltaLog)
       }
     }
   }
@@ -492,7 +876,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
           .create()
 
         assert(deltaLog.snapshot.protocol.minWriterVersion === 2)
-        assertPropertiesDontContainProtocolVersions(deltaLog)
+        assertPropertiesAndShowTblProperties(deltaLog)
       }
     }
   }
@@ -563,12 +947,65 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     }
   }
 
-  private def assertPropertiesDontContainProtocolVersions(deltaLog: DeltaLog): Unit = {
-    val configs = deltaLog.snapshot.metadata.configuration.map {
-      case (k, v) => k.toLowerCase(Locale.ROOT) -> v
+  test("auto upgrade protocol version even with explicit protocol version configs") {
+    withTempDir { path =>
+      val log = createTableWithProtocol(Protocol(1, 1), path)
+      spark.sql(s"""
+                   |ALTER TABLE delta.`${log.dataPath.toString}` SET TBLPROPERTIES (
+                   |  'delta.minWriterVersion' = '2',
+                   |  'delta.enableChangeDataFeed' = 'true'
+                   |)""".stripMargin)
+      assert(log.snapshot.protocol.minWriterVersion === 4)
+
     }
-    assert(!configs.contains(Protocol.MIN_READER_VERSION_PROP.toLowerCase(Locale.ROOT)))
-    assert(!configs.contains(Protocol.MIN_WRITER_VERSION_PROP.toLowerCase(Locale.ROOT)))
+  }
+
+  test("feature can be implicit listed during alter table") {
+    withTempDir { path =>
+      val log = createTableWithProtocol(Protocol(2, TABLE_FEATURES_MIN_WRITER_VERSION), path)
+      spark.sql(s"""
+                   |ALTER TABLE delta.`${log.dataPath.toString}` SET TBLPROPERTIES (
+                   |  'delta.feature.testLegacyReaderWriter' = 'enabled'
+                   |)""".stripMargin)
+      assert(log.snapshot.protocol.minReaderVersion === 2)
+      assert(!log.snapshot.protocol.readerFeatures.isDefined)
+      assert(
+        log.snapshot.protocol.writerFeatures === Some(
+          Set(TestLegacyReaderWriterFeature.toDescriptor)))
+
+    }
+  }
+
+  private def assertPropertiesAndShowTblProperties(
+      deltaLog: DeltaLog,
+      tableHasFeatures: Boolean = false): Unit = {
+    val configs = deltaLog.snapshot.metadata.configuration.map { case (k, v) =>
+      k.toLowerCase(Locale.ROOT) -> v
+    }
+    assert(!configs.contains(Protocol.MIN_READER_VERSION_PROP))
+    assert(!configs.contains(Protocol.MIN_WRITER_VERSION_PROP))
+    assert(!configs.exists(_._1.startsWith(FEATURE_PROP_PREFIX)))
+
+    val tblProperties =
+      sql(s"SHOW TBLPROPERTIES delta.`${deltaLog.dataPath.toString}`").collect()
+
+    assert(
+      tblProperties.exists(row => row.getAs[String]("key") == Protocol.MIN_READER_VERSION_PROP))
+    assert(
+      tblProperties.exists(row => row.getAs[String]("key") == Protocol.MIN_WRITER_VERSION_PROP))
+
+    assert(tableHasFeatures === tblProperties.exists(row =>
+      row.getAs[String]("key").startsWith(FEATURE_PROP_PREFIX)))
+    val rows =
+      tblProperties.filter(row =>
+        row.getAs[String]("key").startsWith(FEATURE_PROP_PREFIX))
+    for (row <- rows) {
+      val name = row.getAs[String]("key").substring(FEATURE_PROP_PREFIX.length)
+      val status = row.getAs[String]("value")
+      assert(
+        TableFeatureStore.allSupportedFeaturesMap.contains(name.toLowerCase(Locale.ROOT)))
+      assert(status == "enabled")
+    }
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeoutException
 import scala.concurrent.duration._
 import scala.language.implicitConversions
 
-import org.apache.spark.sql.delta.actions.{AddFile, InvalidProtocolVersionException, Protocol}
+import org.apache.spark.sql.delta.actions.{AddFile, Protocol}
 import org.apache.spark.sql.delta.sources.{DeltaSourceOffset, DeltaSQLConf}
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
@@ -65,7 +65,7 @@ class DeltaTableFeatureSuite
     }
     collect(ru.typeOf[TableFeature].typeSymbol)
 
-    val registeredFeatures = TableFeatureStore.allSupportedFeaturesMap.values
+    val registeredFeatures = TableFeature.allSupportedFeaturesMap.values
       .map(_.getClass.getSimpleName.stripSuffix("$")) // remove '$' from object names
       .toSet
     val notRegisteredFeatures = subClassNames.diff(registeredFeatures)

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
@@ -1,0 +1,164 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.io.File
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils._
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.util.FileNames.deltaFile
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.StructType
+
+class DeltaTableFeatureSuite
+  extends QueryTest
+  with SharedSparkSession  with DeltaSQLCommandTest {
+
+  private lazy val testTableSchema = spark.range(1).schema
+
+  // This is solely a test hook. Users cannot create new Delta tables with protocol lower than
+  // that of their current version.
+  protected def createTableWithProtocol(
+      protocol: Protocol,
+      path: File,
+      schema: StructType = testTableSchema): DeltaLog = {
+    val log = DeltaLog.forTable(spark, path)
+    log.ensureLogDirectoryExist()
+    log.store.write(
+      deltaFile(log.logPath, 0),
+      Iterator(Metadata(schemaString = schema.json).json, protocol.json),
+      overwrite = false,
+      log.newDeltaHadoopConf())
+    log.update()
+    log
+  }
+
+  test("all defined table features are registered") {
+    import scala.reflect.runtime.{universe => ru}
+
+    val subClassNames = mutable.Set[String]()
+    def collect(clazz: ru.Symbol): Unit = {
+      val collected = clazz.asClass.knownDirectSubclasses
+      // add only table feature objects to the result set
+      subClassNames ++= collected.filter(_.isModuleClass).map(_.name.toString)
+      collected.filter(_.isAbstract).foreach(collect)
+    }
+    collect(ru.typeOf[TableFeature].typeSymbol)
+
+    val registeredFeatures = TableFeatureStore.allSupportedFeaturesMap.values
+      .map(_.getClass.getSimpleName.stripSuffix("$")) // remove '$' from object names
+      .toSet
+    val notRegisteredFeatures = subClassNames.diff(registeredFeatures)
+
+    assert(
+      notRegisteredFeatures.isEmpty,
+      "Expecting all defined table features are registered (either as prod or testing-only) " +
+        s"but the followings are not: $notRegisteredFeatures")
+  }
+
+  test("adding feature requires supported protocol version") {
+    assert(
+      intercept[DeltaTableFeatureException] {
+        Protocol(1, TABLE_FEATURES_MIN_WRITER_VERSION)
+          .withFeature(TestLegacyReaderWriterFeature)
+      }.getMessage.contains("Unable to enable table feature testLegacyReaderWriter because it " +
+        "requires a higher reader protocol version"))
+
+    assert(intercept[DeltaTableFeatureException] {
+      Protocol(TABLE_FEATURES_MIN_READER_VERSION, 6)
+    }.getMessage.contains("Unable to upgrade only the reader protocol version"))
+
+    assert(
+      Protocol(2, TABLE_FEATURES_MIN_WRITER_VERSION)
+        .withFeature(AppendOnlyTableFeature)
+        .readerAndWriterFeatureDescriptors === Set(
+        TableFeatureDescriptor(AppendOnlyTableFeature.name, TableFeatureStatus.ENABLED)))
+
+    assert(
+      Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION)
+        .withFeature(TestReaderWriterFeature)
+        .readerAndWriterFeatureDescriptors === Set(
+        TableFeatureDescriptor(TestReaderWriterFeature.name, TableFeatureStatus.ENABLED)))
+  }
+
+  test("implicitly-enabled features") {
+    assert(
+      Protocol(2, 6).implicitlyEnabledFeatures === Set(
+        AppendOnlyTableFeature,
+        TestLegacyWriterFeature,
+        TestLegacyReaderWriterFeature))
+    assert(
+      Protocol(2, 5).implicitlyEnabledFeatures === Set(
+        AppendOnlyTableFeature,
+        TestLegacyWriterFeature))
+    assert(Protocol(2, TABLE_FEATURES_MIN_WRITER_VERSION).implicitlyEnabledFeatures === Set())
+    assert(
+      Protocol(
+        TABLE_FEATURES_MIN_READER_VERSION,
+        TABLE_FEATURES_MIN_WRITER_VERSION).implicitlyEnabledFeatures === Set())
+  }
+
+  test("implicit feature listing") {
+    assert(
+      intercept[DeltaTableFeatureException] {
+        Protocol(1, 5).withFeature(TestLegacyReaderWriterFeature)
+      }.getMessage.contains(
+        "Unable to enable table feature testLegacyReaderWriter because it requires a higher " +
+          "reader protocol version (current 1)"))
+
+    assert(
+      intercept[DeltaTableFeatureException] {
+        Protocol(2, 5).withFeature(TestLegacyReaderWriterFeature)
+      }.getMessage.contains(
+        "Unable to enable table feature testLegacyReaderWriter because it requires a higher " +
+          "writer protocol version (current 5)"))
+
+    assert(
+      intercept[DeltaTableFeatureException] {
+        Protocol(1, TABLE_FEATURES_MIN_WRITER_VERSION).withFeature(TestLegacyReaderWriterFeature)
+      }.getMessage.contains(
+        "Unable to enable table feature testLegacyReaderWriter because it requires a higher " +
+          "reader protocol version (current 1)"))
+
+    val protocol =
+      Protocol(2, TABLE_FEATURES_MIN_WRITER_VERSION).withFeature(TestLegacyReaderWriterFeature)
+    assert(!protocol.readerFeatures.isDefined)
+    assert(
+      protocol.writerFeatures.get === Set(
+        TableFeatureDescriptor(TestLegacyReaderWriterFeature.name, TableFeatureStatus.ENABLED)))
+  }
+
+  test("merge protocols") {
+    val tfProtocol1 = Protocol(1, TABLE_FEATURES_MIN_WRITER_VERSION)
+    val tfProtocol2 =
+      Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION)
+
+    assert(
+      tfProtocol1.merge(Protocol(1, 2)) ===
+        tfProtocol1.withFeature(AppendOnlyTableFeature))
+    assert(
+      tfProtocol2.merge(Protocol(2, 6)) ===
+        tfProtocol2.withFeatures(
+          Set(AppendOnlyTableFeature, TestLegacyWriterFeature, TestLegacyReaderWriterFeature)))
+  }
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.execution.{FileSourceScanExec, QueryExecution, RDDSc
 import org.apache.spark.sql.execution.aggregate.HashAggregateExec
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.util.QueryExecutionListener
+import org.apache.spark.util.Utils
 
 trait DeltaTestUtilsBase {
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
@@ -368,7 +368,7 @@ trait DescribeDeltaHistorySuiteBase
         overwrite = false,
         log.newDeltaHadoopConf())
       log.update()
-      log.upgradeProtocol()
+      log.upgradeProtocol(Action.supportedProtocolVersion())
       checkLastOperation(
         path.toString,
         Seq("UPGRADE PROTOCOL",

--- a/core/src/test/scala/org/apache/spark/sql/delta/RestoreTableSuiteBase.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/RestoreTableSuiteBase.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.delta
 
 import java.io.File
 
+import org.apache.spark.sql.delta.actions.Protocol
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
@@ -201,7 +202,7 @@ trait RestoreTableSuiteBase extends QueryTest with SharedSparkSession  with Delt
       val deltaLog = DeltaLog.forTable(spark, path)
       val oldProtocolVersion = deltaLog.snapshot.protocol
       // Update table to latest version.
-      deltaLog.upgradeProtocol()
+      deltaLog.upgradeProtocol(Protocol())
       val newProtocolVersion = deltaLog.snapshot.protocol
       assert(newProtocolVersion.minReaderVersion > oldProtocolVersion.minReaderVersion &&
         newProtocolVersion.minWriterVersion > oldProtocolVersion.minWriterVersion,

--- a/run-tests.py
+++ b/run-tests.py
@@ -46,7 +46,7 @@ def run_sbt_tests(root_dir, coverage, scala_version=None):
         cmd += ["++ %s test" % scala_version]
     if coverage:
         cmd += ["coverageAggregate", "coverageOff"]
-    run_cmd(cmd, stream_output=True)
+    run_cmd(cmd, env={"DELTA_TESTING": "1"}, stream_output=True)
 
 
 def run_python_tests(root_dir):


### PR DESCRIPTION
This PR implements Table Features proposed in the feature request [[Feature Request] Table Features to specify the features needed to read/write to a table](https://github.com/delta-io/delta/issues/1408) and the PROTOCOL doc: [Protocol update for Table Features](https://github.com/delta-io/delta/pull/1450).

This PR implements the basic functionality, including
- The protocol structure and necessary APIs
- Protocol upgrade logic
- Append-only feature ported to Table Features
- Protocol upgrade path
- User-facing APIs, such as allowing referencing features manually
- Partial test coverage

Not covered by this PR:
- Adapt all features
- Full test coverage
- Make `DESCRIBE TABLE` show referenced features
- Enable table clone and time travel paths

### Introduction

Table Features support starts from reader protocol version `3` and writer version `7`. When supported, features can be **referenced** by a protocol by placing a `DeltaFeatureDescriptor` into the protocol's `readerFeatures` and/or `writerFeatures`.

A feature can be one of two types: writer-only and reader-writer. The first type means that only writers must care about such a feature, while the latter means that in addition to writers, readers must also be aware of the feature to read the data correctly. We now have the following features released:

- `appendOnly`: legacy, writer-only
- `invariants`: legacy, writer-only
- `checkConstriants`: legacy, writer-only
- `changeDataFeed`: legacy, writer-only
- `generatedColumns`: legacy, writer-only
- `columnMapping`: legacy, reader-writer
- `identityColumn`: legacy, writer-only
- `deletionVector`: native, reader-writer

Some examples of the `protocol` action:

```scala
// Valid protocol. Both reader and writer versions are capable.
Protocol(
  minReaderVersion = 3,
  minWriterVersion = 7,
  readerFeatures = {(columnMapping,enabled), (changeDataFeed,enabled)},
  writerFeatures = {(appendOnly,enabled), (columnMapping,enabled), (changeDataFeed,enabled)})

// Valid protocol. Only writer version is capable. "columnMapping" is implicitly enabled by readers.
Protocol(
  minReaderVersion = 2,
  minWriterVersion = 7,
  readerFeatures = None,
  writerFeatures = {(columnMapping,enabled)})

// Invalid protocol. Reader version does enable "columnMapping" implicitly.
Protocol(
  minReaderVersion = 1,
  minWriterVersion = 7,
  readerFeatures = None,
  writerFeatures = {(columnMapping,enabled)})
```

When reading or writing a table, clients MUST respect all enabled features.

Upon table creation, the system assigns the table a minimum protocol that satisfies all features that are **automatically enabled** in the table's metadata. This means the table can be on a "legacy" protocol with both `readerFeatures` and `writerFeatures` set to `None` (if all active features are legacy, which is the current behavior) or be on a Table Features-capable protocol with all active features explicitly referenced in `readerFeatures` and/or `writerFeatures` (if one of the active features is Table Features-native or the user has specified a Table Features-capable protocol version).

It's possible to upgrade an existing table to support table features. The update can be either for writers or for both readers and writers. During the upgrade, the system will explicitly reference all legacy features that are implicitly supported by the old protocol.

Users can mark a feature to be required by a table by using the following commands:
```sql
-- for an existing table
ALTER TABLE table_name SET TBLPROPERTIES (delta.feature.featureName = 'enabled')
-- for a new table
CREATE TABLE table_name ... TBLPROPERTIES (delta.feature.featureName = 'enabled')
-- for all new tables
SET spark.databricks.delta.properties.defaults.feature.featureName = 'enabled'
```
When some features are set to `enabled` in table properties and some others in Spark sessions, the final table will enable all features defined in two places:
```sql
SET spark.databricks.delta.properties.defaults.feature.featureA = 'enabled';
CREATE TABLE table_name ... TBLPROPERTIES (delta.feature.featureB = 'enabled')
--- 'table_name' will have 'featureA' and 'featureB' enabled.
```

## How was this patch tested?

New unit tests.

## Does this PR introduce _any_ user-facing changes?

No.