### PR TITLE
Optimize Min/Max using Delta metadata

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -528,7 +528,7 @@ object Protocol {
     }
     if (manifestGenerationEnabled) {
       // Only allow enabling this, if there are no DVs present.
-      if (!DeletionVectorUtils.isTableDVFree(spark, snapshot)) {
+      if (!DeletionVectorUtils.isTableDVFree(snapshot)) {
         throw new DeltaTablePropertyValidationFailedException(
           table = tableName,
           subClass = ExistingDeletionVectorsWithIncrementalManifestGeneration)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeletionVectorUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeletionVectorUtils.scala
@@ -33,7 +33,7 @@ trait DeletionVectorUtils {
    * Run a query on the delta log to determine if the given snapshot contains no deletion vectors.
    * Return `false` if it does contain deletion vectors.
    */
-  def isTableDVFree(spark: SparkSession, snapshot: Snapshot): Boolean = {
+  def isTableDVFree(snapshot: Snapshot): Boolean = {
     val dvsReadable = deletionVectorsReadable(snapshot)
 
     if (dvsReadable) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
@@ -245,7 +245,7 @@ trait GenerateSymlinkManifestImpl extends PostCommitHook with DeltaLogging with 
   }
 
   protected def assertTableIsDVFree(spark: SparkSession, snapshot: Snapshot): Unit = {
-    if (!isTableDVFree(spark, snapshot)) {
+    if (!isTableDVFree(snapshot)) {
       throw DeltaErrors.generateNotSupportedWithDeletionVectors()
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuery.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuery.scala
@@ -48,7 +48,7 @@ import java.util.Locale
 trait OptimizeMetadataOnlyDeltaQuery extends Logging {
   def optimizeQueryWithMetadata(plan: LogicalPlan): LogicalPlan = {
     plan.transformUpWithSubqueries {
-      case agg@AggregateDeltaTable(tahoeLogFileIndex) =>
+      case agg@MetadataOptimizableAggregate(tahoeLogFileIndex) =>
         createLocalRelationPlan(agg, tahoeLogFileIndex)
     }
   }
@@ -309,7 +309,7 @@ trait OptimizeMetadataOnlyDeltaQuery extends Logging {
     (rowCount, CaseInsensitiveMap(columnStats ++ partitionedValues))
   }
 
-  object AggregateDeltaTable {
+  object MetadataOptimizableAggregate {
 
     /** Only data type that are stored in stats without any loss of precision are supported. */
     def isSupportedDataType(dataType: DataType): Boolean = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuery.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuery.scala
@@ -137,8 +137,6 @@ trait OptimizeMetadataOnlyDeltaQuery {
   private def extractCountMinMaxFromStats(
     deltaScanGenerator: DeltaScanGenerator,
     lowerCaseColumnNames: Set[String]): (Option[Long], Map[String, DeltaColumnStat]) = {
-    // TODO Update this to work with DV (https://github.com/delta-io/delta/issues/1485)
-
     val snapshot = deltaScanGenerator.snapshotToScan
 
     // Count - account for deleted rows according to deletion vectors
@@ -170,7 +168,7 @@ trait OptimizeMetadataOnlyDeltaQuery {
     lazy val files = filesWithStatsForScan.filter(col("stats.numRecords") > 0)
     lazy val statsMinMaxNullColumns = files.select(col("stats.*"))
     if (dataColumns.isEmpty
-      || !isTableDVFree(snapshot)
+      || !isTableDVFree(snapshot) // When DV enabled we can't rely on stats values easily
       || numFiles == 0
       || !statsMinMaxNullColumns.columns.contains("minValues")
       || !statsMinMaxNullColumns.columns.contains("maxValues")

--- a/spark/src/main/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuery.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuery.scala
@@ -17,35 +17,102 @@
 package org.apache.spark.sql.delta.perf
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Alias, Literal, ToPrettyString}
-import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Complete, Count}
+import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Literal, ToPrettyString}
+import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.delta.DeltaTable
+import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateTimeUtils}
+import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaTable, Snapshot}
+import org.apache.spark.sql.delta.commands.DeletionVectorUtils.isTableDVFree
 import org.apache.spark.sql.delta.files.TahoeLogFileIndex
 import org.apache.spark.sql.delta.stats.DeltaScanGenerator
-import org.apache.spark.sql.functions.{coalesce, col, count, lit, sum, when}
-import org.apache.spark.sql.types.StringType
-import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types._
+
+import java.sql.Date
+import scala.collection.immutable.HashSet
 
 trait OptimizeMetadataOnlyDeltaQuery {
   def optimizeQueryWithMetadata(plan: LogicalPlan): LogicalPlan = {
     plan.transformUpWithSubqueries {
-      case agg@CountStarDeltaTable(countValue) =>
-        LocalRelation(agg.output, Seq(InternalRow(countValue)))
-      case agg@ShowCountStarDeltaTable(countValue) =>
-        LocalRelation(agg.output, Seq(InternalRow(countValue)))
+      case agg@AggregateDeltaTable(tahoeLogFileIndex) =>
+        createLocalRelationPlan(agg, tahoeLogFileIndex)
     }
   }
 
   protected def getDeltaScanGenerator(index: TahoeLogFileIndex): DeltaScanGenerator
+
+  protected def createLocalRelationPlan(
+    plan: Aggregate,
+    tahoeLogFileIndex: TahoeLogFileIndex): LogicalPlan = {
+    val rowCount = extractGlobalCount(tahoeLogFileIndex)
+
+    if (rowCount.isDefined) {
+      lazy val columnStats = extractGlobalColumnStats(tahoeLogFileIndex)
+
+      def checkStatsExists(reference: AttributeReference): Boolean = {
+        columnStats.contains(reference.name) &&
+          // Avoid StructType, it is not supported by this optimization
+          // Sanity check only. If reference is nested column it would be GetStructType
+          // instead of AttributeReference
+          reference.references.size == 1 &&
+          reference.references.head.dataType != StructType
+      }
+
+      def convertValueIfRequired(reference: AttributeReference, value: Any): Any = {
+        if (reference.dataType == DateType && value != null) {
+          DateTimeUtils.fromJavaDate(value.asInstanceOf[Date])
+        } else {
+          value
+        }
+      }
+
+      val aggregatedValues = plan.aggregateExpressions.collect {
+        case Alias(AggregateExpression(
+        Count(Seq(Literal(1, _))), Complete, false, None, _), _) =>
+          rowCount.get
+        case Alias(tps@ToPrettyString(AggregateExpression(
+        Count(Seq(Literal(1, _))), Complete, false, None, _), _), _) =>
+          tps.copy(child = Literal(rowCount.get)).eval()
+        case Alias(AggregateExpression(
+        Min(minReference: AttributeReference), Complete, false, None, _), _)
+          if checkStatsExists(minReference) =>
+          convertValueIfRequired(minReference, columnStats(minReference.name).min)
+        case Alias(tps@ToPrettyString(AggregateExpression(
+        Min(minReference: AttributeReference), Complete, false, None, _), _), _)
+          if checkStatsExists(minReference) =>
+            val v = columnStats(minReference.name).min
+            tps.copy(child = Literal(v)).eval()
+        case Alias(AggregateExpression(
+        Max(maxReference: AttributeReference), Complete, false, None, _), _)
+          if checkStatsExists(maxReference) =>
+          convertValueIfRequired(maxReference, columnStats(maxReference.name).max)
+        case Alias(tps@ToPrettyString(AggregateExpression(
+        Max(maxReference: AttributeReference), Complete, false, None, _), _), _)
+          if checkStatsExists(maxReference) =>
+            val v = columnStats(maxReference.name).max
+            tps.copy(child = Literal(v)).eval()
+      }
+
+      if (plan.aggregateExpressions.size == aggregatedValues.size) {
+        val r = LocalRelation(
+          plan.output,
+          Seq(InternalRow.fromSeq(aggregatedValues)))
+        r
+      } else {
+        plan
+      }
+    }
+    else {
+      plan
+    }
+  }
 
   /** Return the number of rows in the table or `None` if we cannot calculate it from stats */
   private def extractGlobalCount(tahoeLogFileIndex: TahoeLogFileIndex): Option[Long] = {
     // account for deleted rows according to deletion vectors
     val dvCardinality = coalesce(col("deletionVector.cardinality"), lit(0))
     val numLogicalRecords = (col("stats.numRecords") - dvCardinality).as("numLogicalRecords")
-
     val row = getDeltaScanGenerator(tahoeLogFileIndex).filesWithStatsForScan(Nil)
       .agg(
         sum(numLogicalRecords),
@@ -60,37 +127,199 @@ trait OptimizeMetadataOnlyDeltaQuery {
     Some(numRecords)
   }
 
-  /** e.g. sql("SELECT COUNT(*) FROM <deta-table>").collect() */
-  object CountStarDeltaTable {
-    def unapply(plan: Aggregate): Option[Long] = plan match {
-      case Aggregate(
-          Nil,
-          Seq(Alias(AggregateExpression(Count(Seq(Literal(1, _))), Complete, false, None, _), _)),
-          PhysicalOperation(_, Nil, DeltaTable(i: TahoeLogFileIndex))) if i.partitionFilters.isEmpty
-        => extractGlobalCount(i)
-      case _ => None
+  val columnStatsSupportedDataTypes: HashSet[DataType] = HashSet(
+    ByteType,
+    ShortType,
+    IntegerType,
+    LongType,
+    FloatType,
+    DoubleType,
+    DateType)
+
+  case class DeltaColumnStat(
+    min: Any,
+    max: Any)
+
+  def extractGlobalColumnStats(tahoeLogFileIndex: TahoeLogFileIndex):
+  CaseInsensitiveMap[DeltaColumnStat] = {
+
+    // TODO Update this to work with DV (https://github.com/delta-io/delta/issues/1485)
+
+    val deltaScanGenerator = getDeltaScanGenerator(tahoeLogFileIndex)
+    val snapshot = deltaScanGenerator.snapshotToScan
+
+    def extractGlobalColumnStatsDeltaLog(snapshot: Snapshot):
+    Map[String, DeltaColumnStat] = {
+
+      val dataColumns = snapshot.statCollectionPhysicalSchema
+        .filter(col => columnStatsSupportedDataTypes.contains(col.dataType))
+
+      // Validate all the files has stats
+      lazy val filesStatsCount = deltaScanGenerator.filesWithStatsForScan(Nil).select(
+        count(when(col("stats.numRecords").isNull, 1)).as("missingNumRecords"),
+        count(when(col("stats.numRecords") > 0, 1)).as("countNonEmptyFiles")).head
+
+      lazy val allRecordsHasStats = filesStatsCount.getAs[Long]("missingNumRecords") == 0
+      lazy val numFiles: Long = filesStatsCount.getAs[Long]("countNonEmptyFiles")
+
+      // DELETE operations creates AddFile records with 0 rows, and no column stats.
+      // We can safely ignore it since there is no data.
+      lazy val files = deltaScanGenerator.filesWithStatsForScan(Nil)
+        .filter(col("stats.numRecords") > 0)
+      lazy val statsMinMaxNullColumns = files.select(col("stats.*"))
+      if (!isTableDVFree(snapshot)
+        || dataColumns.isEmpty
+        || !allRecordsHasStats
+        || numFiles == 0
+        || !statsMinMaxNullColumns.columns.contains("minValues")
+        || !statsMinMaxNullColumns.columns.contains("maxValues")
+        || !statsMinMaxNullColumns.columns.contains("nullCount")) {
+        Map.empty
+      } else {
+        // dataColumns can contain columns without stats if dataSkippingNumIndexedCols
+        // has been increased
+        val columnsWithStats = files.select(
+          col("stats.minValues.*"),
+          col("stats.maxValues.*"),
+          col("stats.nullCount.*"))
+          .columns.groupBy(identity).mapValues(_.size)
+          .filter(x => x._2 == 3) // 3: minValues, maxValues, nullCount
+          .map(x => x._1).toSet
+
+        // Creates a tuple with physical name to avoid recalculating it multiple times
+        val dataColumnsWithStats = dataColumns.map(x => (x, DeltaColumnMapping.getPhysicalName(x)))
+          .filter(x => columnsWithStats.contains(x._2))
+
+        val columnsToQuery = dataColumnsWithStats.flatMap { columnAndPhysicalName =>
+          val dataType = columnAndPhysicalName._1.dataType
+          val physicalName = columnAndPhysicalName._2
+
+          Seq(col(s"stats.minValues.`$physicalName`").cast(dataType).as(s"min.$physicalName"),
+            col(s"stats.maxValues.`$physicalName`").cast(dataType).as(s"max.$physicalName"),
+            col(s"stats.nullCount.`$physicalName`").as(s"nullCount.$physicalName"))
+        } ++ Seq(col(s"stats.numRecords").as(s"numRecords"))
+
+        val minMaxExpr = dataColumnsWithStats.flatMap { columnAndPhysicalName =>
+          val physicalName = columnAndPhysicalName._2
+
+          // To validate if the column has stats we do two validation:
+          // 1-) COUNT(nullCount.columnName) should be equals to numFiles,
+          // since nullCount is always non-null.
+          // 2-) The number of files with non-null min/max:
+          // a. count(min.columnName)|count(max.columnName) +
+          // the number of files where all rows are NULL:
+          // b. count of (ISNULL(min.columnName) and nullCount.columnName == numRecords)
+          // should be equals to numFiles
+          Seq(
+            s"""case when $numFiles = count(`nullCount.$physicalName`)
+               | AND $numFiles = (count(`min.$physicalName`) + sum(case when
+               |  ISNULL(`min.$physicalName`) and `nullCount.$physicalName` = numRecords
+               |   then 1 else 0 end))
+               | AND $numFiles = (count(`max.$physicalName`) + sum(case when
+               |  ISNULL(`max.$physicalName`) AND `nullCount.$physicalName` = numRecords
+               |   then 1 else 0 end))
+               | then TRUE else FALSE end as `complete_$physicalName`""".stripMargin,
+            s"min(`min.$physicalName`) as `min_$physicalName`",
+            s"max(`max.$physicalName`) as `max_$physicalName`")
+        }
+
+        val statsResults = files.select(columnsToQuery: _*).selectExpr(minMaxExpr: _*).head
+
+        dataColumnsWithStats
+          .filter(x => statsResults.getAs[Boolean](s"complete_${x._2}"))
+          .map { columnAndPhysicalName =>
+            val column = columnAndPhysicalName._1
+            val physicalName = columnAndPhysicalName._2
+            column.name ->
+              DeltaColumnStat(
+                statsResults.getAs(s"min_$physicalName"),
+                statsResults.getAs(s"max_$physicalName"))
+          }.toMap
+      }
     }
+
+    def extractGlobalPartitionedColumnStatsDeltaLog(snapshot: Snapshot):
+    Map[String, DeltaColumnStat] = {
+
+      val partitionedColumns = snapshot.metadata.partitionSchema
+        .filter(x => columnStatsSupportedDataTypes.contains(x.dataType))
+        .map(x => (x, DeltaColumnMapping.getPhysicalName(x)))
+
+      if (partitionedColumns.isEmpty) {
+        Map.empty
+      } else {
+        val partitionedColumnsValues = partitionedColumns.map { partitionedColumn =>
+          val physicalName = partitionedColumn._2
+          col(s"partitionValues.`$physicalName`")
+            .cast(partitionedColumn._1.dataType).as(physicalName)
+        }
+
+        val partitionedColumnsAgg = partitionedColumns.flatMap { partitionedColumn =>
+          val physicalName = partitionedColumn._2
+
+          Seq(min(s"`$physicalName`").as(s"min_$physicalName"),
+            max(s"`$physicalName`").as(s"max_$physicalName"))
+        }
+
+        val partitionedColumnsQuery = snapshot.allFiles
+          .select(partitionedColumnsValues: _*)
+          .agg(partitionedColumnsAgg.head, partitionedColumnsAgg.tail: _*)
+          .head()
+
+        partitionedColumns.map { partitionedColumn =>
+          val physicalName = partitionedColumn._2
+
+          partitionedColumn._1.name ->
+            DeltaColumnStat(
+              partitionedColumnsQuery.getAs(s"min_$physicalName"),
+              partitionedColumnsQuery.getAs(s"max_$physicalName"))
+        }.toMap
+      }
+    }
+
+    CaseInsensitiveMap(
+      extractGlobalColumnStatsDeltaLog(snapshot).++
+      (extractGlobalPartitionedColumnStatsDeltaLog(snapshot)))
   }
 
-  /** e.g. sql("SELECT COUNT(*) FROM <delta-table>").show() */
-  object ShowCountStarDeltaTable {
-    def unapply(plan: Aggregate): Option[UTF8String] = plan match {
+
+  object AggregateDeltaTable {
+    def unapply(plan: Aggregate): Option[TahoeLogFileIndex] = plan match {
       case Aggregate(
-        Nil,
-        Seq(
-          Alias(
-            ToPrettyString(
-              AggregateExpression(Count(Seq(Literal(1, _))), Complete, false, None, _),
-              _),
-            _)
-        ),
-        PhysicalOperation(_, Nil, DeltaTable(i: TahoeLogFileIndex))
-      ) if i.partitionFilters.isEmpty =>
-        extractGlobalCount(i).map { count =>
-          // The following code is following how Spark casts a long type to a string type.
-          // See org.apache.spark.sql.catalyst.expressions.Cast#castToString.
-          UTF8String.fromString(count.toString)
+      Nil,
+      aggExpr: Seq[Alias],
+      // Fields should be AttributeReference to avoid getting the incorrect column name from stats
+      // when we create the Local Relation, example
+      // SELECT MAX(Column2) FROM (SELECT Column1 AS Column2 FROM TableName)
+      // the AggregateExpression contains a reference to Column2, instead of Column1
+      PhysicalOperation(fields, Nil, DeltaTable(i: TahoeLogFileIndex)))
+        if i.partitionFilters.isEmpty
+          && fields.forall {
+          case _: AttributeReference => true
+          case _ => false
         }
+          && aggExpr.forall {
+          case Alias(AggregateExpression(
+            Count(Seq(Literal(1, _))) | Min(_) | Max(_), Complete, false, None, _), _) => true
+          case Alias(ToPrettyString(AggregateExpression(
+            Count(Seq(Literal(1, _))) | Min(_) | Max(_), Complete, false, None, _), _), _) => true
+          case _ => false
+        } =>
+        Some(i)
+      // When all columns are selected, there are no Project/PhysicalOperation
+      case Aggregate(
+      Nil,
+      aggExpr: Seq[Alias],
+      DeltaTable(i: TahoeLogFileIndex))
+        if i.partitionFilters.isEmpty
+          && aggExpr.forall {
+          case Alias(AggregateExpression(
+            Count(Seq(Literal(1, _))) | Min(_) | Max(_), Complete, false, None, _), _) => true
+          case Alias(ToPrettyString(AggregateExpression(
+            Count(Seq(Literal(1, _))) | Min(_) | Max(_), Complete, false, None, _), _), _) => true
+          case _ => false
+        } =>
+        Some(i)
       case _ => None
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuerySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuerySuite.scala
@@ -89,10 +89,12 @@ class OptimizeMetadataOnlyDeltaQuerySuite
       spark.sql(s"DELETE FROM $testTableName WHERE id = 11")
     }
 
-    val result = spark.sql(s"SELECT COUNT(*), MIN(id), MAX(id) FROM $testTableName").head
-    totalRows = result.getLong(0)
-    minId = result.getLong(1)
-    maxId = result.getLong(2)
+    withSQLConf(DeltaSQLConf.DELTA_OPTIMIZE_METADATA_QUERY_ENABLED.key -> "false") {
+      val result = spark.sql(s"SELECT COUNT(*), MIN(id), MAX(id) FROM $testTableName").head
+      totalRows = result.getLong(0)
+      minId = result.getLong(1)
+      maxId = result.getLong(2)
+    }
   }
 
   /** Class to hold test parameters */

--- a/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuerySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuerySuite.scala
@@ -725,6 +725,17 @@ class OptimizeMetadataOnlyDeltaQuerySuite
     )
   }
 
+  test("optimization not supported - min-max column without stats") {
+    val tableName = "TestColumnWithoutStats"
+
+    spark.sql(s"CREATE TABLE $tableName (Column1 INT, Column2 INT) USING DELTA" +
+      s" TBLPROPERTIES('delta.dataSkippingNumIndexedCols' = 1)")
+    spark.sql(s"INSERT INTO $tableName (Column1, Column2) VALUES (1, 2);")
+
+    checkOptimizationIsNotTriggered(
+      s"SELECT MAX(Column2) FROM $tableName")
+  }
+
   test("optimization not supported - filter on partitioned column") {
     val tableName = "TestPartitionedFilter"
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuerySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuerySuite.scala
@@ -16,21 +16,21 @@
 
 package org.apache.spark.sql.delta.perf
 
-import io.delta.tables.DeltaTable
-import org.apache.spark.sql.Dataset
-
 import scala.collection.mutable
-
-// scalastyle:off import.ordering.noEmptyLine
-import org.apache.spark.sql.delta.DeltaTestUtils
+import io.delta.tables.DeltaTable
+import org.apache.spark.sql.{DataFrame, Dataset, QueryTest, Row, SaveMode}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
+import org.apache.spark.sql.delta.{DeltaLog, DeltaTestUtils}
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.PrepareDeltaScanBase
+import org.apache.spark.sql.delta.stats.StatisticsCollection
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
-import org.scalatest.BeforeAndAfterAll
-
-import org.apache.spark.sql.{DataFrame, QueryTest, SaveMode}
-import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
+import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSparkSession
+import org.scalatest.BeforeAndAfterAll
 
 class OptimizeMetadataOnlyDeltaQuerySuite
   extends QueryTest
@@ -82,36 +82,95 @@ class OptimizeMetadataOnlyDeltaQuerySuite
     }
   }
 
-  test("Select Count: basic") {
+  test("count - simple query") {
+    val expectedPlan = "LocalRelation [none#0L]"
+
     checkResultsAndOptimizedPlan(
       s"SELECT COUNT(*) FROM $testTableName",
-      "LocalRelation [none#0L]")
-  }
+      expectedPlan)
 
-  test("Select Count: column alias") {
     checkResultsAndOptimizedPlan(
-      s"SELECT COUNT(*) as MyColumn FROM $testTableName",
-      "LocalRelation [none#0L]")
+      () => spark.read.format("delta").table(testTableName)
+        .agg(count(col("*"))),
+      expectedPlan)
   }
 
-  test("Select Count: table alias") {
+  test("min-max - simple query") {
+    val expectedPlan = "LocalRelation [none#0L, none#1L, none#2, none#3, none#4, none#5, none#6" +
+      ", none#7, none#8L, none#9L, none#10, none#11, none#12, none#13, none#14, none#15]"
+
     checkResultsAndOptimizedPlan(
-      s"SELECT COUNT(*) FROM $testTableName MyTable",
+      s"SELECT MIN(id), MAX(id)" +
+        s", MIN(TinyIntColumn), MAX(TinyIntColumn)" +
+        s", MIN(SmallIntColumn), MAX(SmallIntColumn)" +
+        s", MIN(IntColumn), MAX(IntColumn)" +
+        s", MIN(BigIntColumn), MAX(BigIntColumn)" +
+        s", MIN(FloatColumn), MAX(FloatColumn)" +
+        s", MIN(DoubleColumn), MAX(DoubleColumn)" +
+        s", MIN(DateColumn), MAX(DateColumn)" +
+        s"FROM $testTableName",
+      expectedPlan)
+
+    checkResultsAndOptimizedPlan(() => spark.read.format("delta").table(testTableName)
+      .agg(min(col("id")), max(col("id")),
+        min(col("TinyIntColumn")), max(col("TinyIntColumn")),
+        min(col("SmallIntColumn")), max(col("SmallIntColumn")),
+        min(col("IntColumn")), max(col("IntColumn")),
+        min(col("BigIntColumn")), max(col("BigIntColumn")),
+        min(col("FloatColumn")), max(col("FloatColumn")),
+        min(col("DoubleColumn")), max(col("DoubleColumn")),
+        min(col("DateColumn")), max(col("DateColumn"))),
+      expectedPlan)
+  }
+
+  test("min-max - column name non-matching case") {
+    checkResultsAndOptimizedPlan(
+      s"SELECT MIN(ID), MAX(iD)" +
+        s", MIN(tINYINTCOLUMN), MAX(tinyintcolumN)" +
+        s", MIN(sMALLINTCOLUMN), MAX(smallintcolumN)" +
+        s", MIN(iNTCOLUMN), MAX(intcolumN)" +
+        s", MIN(bIGINTCOLUMN), MAX(bigintcolumN)" +
+        s", MIN(fLOATCOLUMN), MAX(floatcolumN)" +
+        s", MIN(dOUBLECOLUMN), MAX(doublecolumN)" +
+        s", MIN(dATECOLUMN), MAX(datecolumN)" +
+        s"FROM $testTableName",
+      "LocalRelation [none#0L, none#1L, none#2, none#3, none#4, none#5, none#6" +
+        ", none#7, none#8L, none#9L, none#10, none#11, none#12, none#13, none#14, none#15]")
+  }
+
+  test ("count with column name alias") {
+    checkResultsAndOptimizedPlan(
+      s"SELECT COUNT(*) as MyCount FROM $testTableName",
       "LocalRelation [none#0L]")
   }
 
-  test("Select Count: time travel") {
-    checkResultsAndOptimizedPlan(s"SELECT COUNT(*) FROM $testTableName VERSION AS OF 0",
-      "LocalRelation [none#0L]")
-
-    checkResultsAndOptimizedPlan(s"SELECT COUNT(*) FROM $testTableName VERSION AS OF 1",
-      "LocalRelation [none#0L]")
-
-    checkResultsAndOptimizedPlan(s"SELECT COUNT(*) FROM $testTableName VERSION AS OF 2",
-      "LocalRelation [none#0L]")
+  test("count-min-max with column name alias") {
+    checkResultsAndOptimizedPlan(
+      s"SELECT COUNT(*) as MyCount, MIN(id) as MyMinId, MAX(id) as MyMaxId FROM $testTableName",
+      "LocalRelation [none#0L, none#1L, none#2L]")
   }
 
-  test("Select Count: external") {
+  test("count-min-max - table name with alias") {
+    checkResultsAndOptimizedPlan(
+      s"SELECT COUNT(*), MIN(id), MAX(id) FROM $testTableName MyTable",
+      "LocalRelation [none#0L, none#1L, none#2L]")
+  }
+
+  test("count-min-max - query using time travel") {
+    checkResultsAndOptimizedPlan(s"SELECT COUNT(*), MIN(id), MAX(id) " +
+      s"FROM $testTableName VERSION AS OF 0",
+      "LocalRelation [none#0L, none#1L, none#2L]")
+
+    checkResultsAndOptimizedPlan(s"SELECT COUNT(*), MIN(id), MAX(id) " +
+      s"FROM $testTableName VERSION AS OF 1",
+      "LocalRelation [none#0L, none#1L, none#2L]")
+
+    checkResultsAndOptimizedPlan(s"SELECT COUNT(*), MIN(id), MAX(id) " +
+      s"FROM $testTableName VERSION AS OF 2",
+      "LocalRelation [none#0L, none#1L, none#2L]")
+  }
+
+  test("count-min-max - external table") {
     withTempDir { dir =>
       val testTablePath = dir.getAbsolutePath
       dfPart1.write.format("delta").mode("overwrite").save(testTablePath)
@@ -119,41 +178,433 @@ class OptimizeMetadataOnlyDeltaQuerySuite
       dfPart2.write.format("delta").mode(SaveMode.Append).save(testTablePath)
 
       checkResultsAndOptimizedPlan(
-        s"SELECT COUNT(*) FROM delta.`$testTablePath`",
-        "LocalRelation [none#0L]")
+        s"SELECT COUNT(*), MIN(id), MAX(id) FROM delta.`$testTablePath`",
+        "LocalRelation [none#0L, none#1L, none#2L]")
     }
   }
 
-  test("Select Count: sub-query") {
+  test("count-min-max - sub-query") {
     checkResultsAndOptimizedPlan(
       s"SELECT (SELECT COUNT(*) FROM $testTableName)",
       "Project [scalar-subquery#0 [] AS #0L]\n:  +- LocalRelation [none#0L]\n+- OneRowRelation")
+
+    checkResultsAndOptimizedPlan(
+      s"SELECT (SELECT MIN(id) FROM $testTableName)",
+      "Project [scalar-subquery#0 [] AS #0L]\n:  +- LocalRelation [none#0L]\n+- OneRowRelation")
+
+    checkResultsAndOptimizedPlan(
+      s"SELECT (SELECT MAX(id) FROM $testTableName)",
+      "Project [scalar-subquery#0 [] AS #0L]\n:  +- LocalRelation [none#0L]\n+- OneRowRelation")
   }
 
-  test("Select Count: as sub-query filter") {
-    val result = spark.sql(s"SELECT COUNT(*) FROM $testTableName").head
+  test("count-min-max - sub-query filter") {
+    val result = spark.sql(s"SELECT COUNT(*), MIN(id), MAX(id) FROM $testTableName").head
     val totalRows = result.getLong(0)
+    val minId = result.getLong(1)
+    val maxId = result.getLong(2)
 
     checkResultsAndOptimizedPlan(
       s"SELECT 'ABC' WHERE" +
         s" (SELECT COUNT(*) FROM $testTableName) = $totalRows",
       "Project [ABC AS #0]\n+- Filter (scalar-subquery#0 [] = " +
         totalRows + ")\n   :  +- LocalRelation [none#0L]\n   +- OneRowRelation")
-  }
 
-  test("Select Count: limit") {
-    // Limit doesn't affect COUNT results
     checkResultsAndOptimizedPlan(
-      s"SELECT COUNT(*) FROM $testTableName LIMIT 3",
-      "LocalRelation [none#0L]")
+      s"SELECT 'ABC' WHERE" +
+        s" (SELECT MIN(id) FROM $testTableName) = $minId",
+      "Project [ABC AS #0]\n+- Filter (scalar-subquery#0 [] = " +
+        minId + ")\n   :  +- LocalRelation [none#0L]\n   +- OneRowRelation")
+
+    checkResultsAndOptimizedPlan(
+      s"SELECT 'ABC' WHERE" +
+        s" (SELECT MAX(id) FROM $testTableName) = $maxId",
+      "Project [ABC AS #0]\n+- Filter (scalar-subquery#0 [] = " +
+        maxId + ")\n   :  +- LocalRelation [none#0L]\n   +- OneRowRelation")
   }
 
-  test("Select Count: empty table") {
+  test("count-min-max - query with limit") {
+    // Limit doesn't affect aggregation results
+    checkResultsAndOptimizedPlan(
+      s"SELECT COUNT(*), MIN(id), MAX(id) FROM $testTableName LIMIT 3",
+      "LocalRelation [none#0L, none#1L, none#2L]")
+  }
+
+  test("count - empty table") {
     sql(s"CREATE TABLE TestEmpty (c1 int) USING DELTA")
 
     val query = "SELECT COUNT(*) FROM TestEmpty"
 
     checkResultsAndOptimizedPlan(query, "LocalRelation [none#0L]")
+  }
+
+  test("count-min-max - duplicated functions") {
+    checkResultsAndOptimizedPlan(
+      s"SELECT COUNT(*), COUNT(*), MIN(id), MIN(id), MAX(id), MAX(id) FROM $testTableName",
+      "LocalRelation [none#0L, none#1L, none#2L, none#3L, none#4L, none#5L]")
+  }
+
+  /** Dates are stored as Int in literals. This test make sure Date columns works
+   * and NULL are handled correctly
+   */
+  test("min-max - date columns") {
+    val tableName = "TestDateValues"
+
+    spark.sql(s"CREATE TABLE $tableName (Column1 DATE, Column2 DATE, Column3 DATE) USING DELTA")
+
+    spark.sql(s"INSERT INTO $tableName" +
+      s" (Column1, Column2, Column3) VALUES (NULL, current_date(), current_date());")
+    spark.sql(s"INSERT INTO $tableName" +
+      s" (Column1, Column2, Column3) VALUES (NULL, NULL, current_date());")
+
+    checkResultsAndOptimizedPlan(
+      s"SELECT COUNT(*), MIN(Column1), MAX(Column1), MIN(Column2)" +
+        s", MAX(Column2), MIN(Column3), MAX(Column3) FROM $tableName",
+      "LocalRelation [none#0L, none#1, none#2, none#3, none#4, none#5, none#6]")
+  }
+
+  test("min-max - floating point infinity and NaN values") {
+    val tableName = "TestFloatValues"
+
+    spark.sql(s"CREATE TABLE $tableName (FloatColumn Float, DoubleColumn Double) USING DELTA")
+
+    spark.sql(s"INSERT INTO $tableName (FloatColumn, DoubleColumn) VALUES (1, 1);")
+    spark.sql(s"INSERT INTO $tableName (FloatColumn, DoubleColumn) VALUES (NULL, NULL);")
+    spark.sql(s"INSERT INTO $tableName (FloatColumn, DoubleColumn) VALUES " +
+      s"(float('inf'), double('inf'))" +
+      s", (float('+inf'), double('+inf'))" +
+      s", (float('infinity'), double('infinity'))" +
+      s", (float('+infinity'), double('+infinity'))" +
+      s", (float('-inf'), double('-inf'))" +
+      s", (float('-infinity'), double('-infinity'))")
+
+    checkResultsAndOptimizedPlan(
+      s"SELECT COUNT(*), MIN(FloatColumn), MAX(FloatColumn), MIN(DoubleColumn)" +
+        s", MAX(DoubleColumn) FROM $tableName",
+      "LocalRelation [none#0L, none#1, none#2, none#3, none#4]")
+
+    // NaN is larger than any other value, including Infinity
+    spark.sql(s"INSERT INTO $tableName (FloatColumn, DoubleColumn) VALUES " +
+      s"(float('NaN'), double('NaN'));")
+
+    checkResultsAndOptimizedPlan(
+      s"SELECT COUNT(*), MIN(FloatColumn), MAX(FloatColumn), MIN(DoubleColumn)" +
+        s", MAX(DoubleColumn) FROM $tableName",
+      "LocalRelation [none#0L, none#1, none#2, none#3, none#4]")
+  }
+
+  test("min-max - floating point min positive value") {
+    val tableName = "TestFloatPrecision"
+
+    spark.sql(s"CREATE TABLE $tableName (FloatColumn Float, DoubleColumn Double) USING DELTA")
+
+    spark.sql(s"INSERT INTO $tableName (FloatColumn, DoubleColumn) VALUES " +
+      s"(CAST('1.4E-45' as FLOAT), CAST('4.9E-324' as DOUBLE))" +
+      s", (CAST('-1.4E-45' as FLOAT), CAST('-4.9E-324' as DOUBLE))" +
+      s", (0, 0);")
+
+    checkResultsAndOptimizedPlan(
+      s"SELECT COUNT(*), MIN(FloatColumn), MAX(FloatColumn), MIN(DoubleColumn)" +
+        s", MAX(DoubleColumn) FROM $tableName",
+      "LocalRelation [none#0L, none#1, none#2, none#3, none#4]")
+  }
+
+  test("min-max - NULL and non-NULL values") {
+    val tableName = "TestNullValues"
+
+    spark.sql(s"CREATE TABLE $tableName (Column1 INT, Column2 INT, Column3 INT) USING DELTA")
+
+    spark.sql(s"INSERT INTO $tableName (Column1, Column2, Column3) VALUES (NULL, 1, 1);")
+    spark.sql(s"INSERT INTO $tableName (Column1, Column2, Column3) VALUES (NULL, NULL, 1);")
+
+    checkResultsAndOptimizedPlan(
+      s"SELECT COUNT(*), MIN(Column1), MAX(Column1) FROM $tableName",
+      "LocalRelation [none#0L, none#1, none#2]")
+
+    checkResultsAndOptimizedPlan(
+      s"SELECT COUNT(*), MIN(Column2), MAX(Column2) FROM $tableName",
+      "LocalRelation [none#0L, none#1, none#2]")
+  }
+
+  test("min-max - only NULL values") {
+    val tableName = "TestOnlyNullValues"
+
+    spark.sql(s"CREATE TABLE $tableName (Column1 INT, Column2 INT, Column3 INT) USING DELTA")
+
+    spark.sql(s"INSERT INTO $tableName (Column1, Column2, Column3) VALUES (NULL, NULL, 1);")
+    spark.sql(s"INSERT INTO $tableName (Column1, Column2, Column3) VALUES (NULL, NULL, 2);")
+
+    checkResultsAndOptimizedPlan(
+      s"SELECT COUNT(*), MIN(Column1), MAX(Column1), MIN(Column2), MAX(Column2), " +
+        s"MIN(Column3), MAX(Column3) FROM $tableName",
+      "LocalRelation [none#0L, none#1, none#2, none#3, none#4, none#5, none#6]")
+  }
+
+  test("min-max - all supported data types") {
+    val tableName = "TestMinMaxValues"
+
+    spark.sql(s"CREATE TABLE $tableName (" +
+      s"TINYINTColumn TINYINT, SMALLINTColumn SMALLINT, INTColumn INT, BIGINTColumn BIGINT, " +
+      s"FLOATColumn FLOAT, DOUBLEColumn DOUBLE, DATEColumn DATE) USING DELTA")
+
+    spark.sql(s"INSERT INTO $tableName (TINYINTColumn, SMALLINTColumn, INTColumn, BIGINTColumn," +
+      s" FLOATColumn, DOUBLEColumn, DATEColumn)" +
+      s" VALUES (-128, -32768, -2147483648, -9223372036854775808," +
+      s" -3.4028235E38, -1.7976931348623157E308, CAST('1582-10-15' AS DATE));")
+    spark.sql(s"INSERT INTO $tableName (TINYINTColumn, SMALLINTColumn, INTColumn, BIGINTColumn," +
+      s" FLOATColumn, DOUBLEColumn, DATEColumn)" +
+      s" VALUES (127, 32767, 2147483647, 9223372036854775807," +
+      s" 3.4028235E38, 1.7976931348623157E308, CAST('9999-12-31' AS DATE));")
+
+    checkResultsAndOptimizedPlan(
+      s"SELECT COUNT(*)," +
+        s"MIN(TINYINTColumn), MAX(TINYINTColumn)" +
+        s", MIN(SMALLINTColumn), MAX(SMALLINTColumn)" +
+        s", MIN(INTColumn), MAX(INTColumn)" +
+        s", MIN(BIGINTColumn), MAX(BIGINTColumn)" +
+        s", MIN(FLOATColumn), MAX(FLOATColumn)" +
+        s", MIN(DOUBLEColumn), MAX(DOUBLEColumn)" +
+        s", MIN(DATEColumn), MAX(DATEColumn)" +
+        s" FROM $tableName",
+      "LocalRelation [none#0L, none#1, none#2, none#3, none#4, none#5, none#6, none#7L" +
+        ", none#8L, none#9, none#10, none#11, none#12, none#13, none#14]")
+  }
+
+  test("count-min-max - partitioned table - simple query") {
+    val tableName = "TestPartitionedTable"
+
+    spark.sql(s"CREATE TABLE $tableName (Column1 INT, Column2 INT, Column3 INT, Column4 INT)" +
+      s" USING DELTA PARTITIONED BY (Column2, Column3)")
+
+    spark.sql(s"INSERT INTO $tableName (Column1, Column2, Column3, Column4) VALUES (1, 2, 3, 4);")
+    spark.sql(s"INSERT INTO $tableName (Column1, Column2, Column3, Column4) VALUES (2, 2, 3, 5);")
+    spark.sql(s"INSERT INTO $tableName (Column1, Column2, Column3, Column4) VALUES (3, 3, 2, 6);")
+    spark.sql(s"INSERT INTO $tableName (Column1, Column2, Column3, Column4) VALUES (4, 3, 2, 7);")
+
+    checkResultsAndOptimizedPlan(
+      s"SELECT COUNT(*)" +
+        s", MIN(Column1), MAX(Column1)" +
+        s", MIN(Column2), MAX(Column2)" +
+        s", MIN(Column3), MAX(Column3)" +
+        s", MIN(Column4), MAX(Column4)" +
+        s" FROM $tableName",
+      "LocalRelation [none#0L, none#1, none#2, none#3, none#4, none#5, none#6, none#7, none#8]")
+  }
+
+  /** Partitioned columns should be able to return MIN and MAX data
+   * even when there are no column stats */
+  test("count-min-max - partitioned table - no stats") {
+    val tableName = "TestPartitionedTableNoStats"
+
+    spark.sql(s"CREATE TABLE $tableName (Column1 INT, Column2 INT, Column3 INT, Column4 INT)" +
+      s" USING DELTA PARTITIONED BY (Column2, Column3)" +
+      s" TBLPROPERTIES('delta.dataSkippingNumIndexedCols' = 0)")
+
+    spark.sql(s"INSERT INTO $tableName (Column1, Column2, Column3, Column4) VALUES (1, 2, 3, 4);")
+    spark.sql(s"INSERT INTO $tableName (Column1, Column2, Column3, Column4) VALUES (2, 2, 3, 5);")
+    spark.sql(s"INSERT INTO $tableName (Column1, Column2, Column3, Column4) VALUES (3, 3, 2, 6);")
+    spark.sql(s"INSERT INTO $tableName (Column1, Column2, Column3, Column4) VALUES (4, 3, 2, 7);")
+
+    checkResultsAndOptimizedPlan(
+      s"SELECT COUNT(*)" +
+        s", MIN(Column2), MAX(Column2)" +
+        s", MIN(Column3), MAX(Column3)" +
+        s" FROM $tableName",
+      "LocalRelation [none#0L, none#1, none#2, none#3, none#4]")
+  }
+
+  test("min-max - partitioned table - all supported data types") {
+    val tableName = "TestAllTypesPartitionedTable"
+
+    spark.sql(s"CREATE TABLE $tableName (" +
+      s"TINYINTColumn TINYINT, SMALLINTColumn SMALLINT, INTColumn INT, BIGINTColumn BIGINT, " +
+      s"FLOATColumn FLOAT, DOUBLEColumn DOUBLE, DATEColumn DATE, Data INT) USING DELTA" +
+      s"  PARTITIONED BY (TINYINTColumn, SMALLINTColumn, INTColumn, BIGINTColumn," +
+      s" FLOATColumn, DOUBLEColumn, DATEColumn)")
+
+    spark.sql(s"INSERT INTO $tableName (TINYINTColumn, SMALLINTColumn, INTColumn, BIGINTColumn," +
+      s" FLOATColumn, DOUBLEColumn, DATEColumn, Data)" +
+      s" VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);")
+
+    checkResultsAndOptimizedPlan(
+      s"SELECT COUNT(*)," +
+        s"MIN(TINYINTColumn), MAX(TINYINTColumn)" +
+        s", MIN(SMALLINTColumn), MAX(SMALLINTColumn)" +
+        s", MIN(INTColumn), MAX(INTColumn)" +
+        s", MIN(BIGINTColumn), MAX(BIGINTColumn)" +
+        s", MIN(FLOATColumn), MAX(FLOATColumn)" +
+        s", MIN(DOUBLEColumn), MAX(DOUBLEColumn)" +
+        s", MIN(DATEColumn), MAX(DATEColumn)" +
+        s", MIN(Data), MAX(Data)" +
+        s" FROM $tableName",
+      "LocalRelation [none#0L, none#1, none#2, none#3, none#4, none#5, none#6, none#7L" +
+        ", none#8L, none#9, none#10, none#11, none#12, none#13, none#14, none#15, none#16]")
+
+    spark.sql(s"INSERT INTO $tableName (TINYINTColumn, SMALLINTColumn, INTColumn, BIGINTColumn," +
+      s" FLOATColumn, DOUBLEColumn, DATEColumn, Data)" +
+      s" VALUES (-128, -32768, -2147483648, -9223372036854775808," +
+      s" -3.4028235E38, -1.7976931348623157E308, CAST('1582-10-15' AS DATE), 1);")
+
+    checkResultsAndOptimizedPlan(
+      s"SELECT COUNT(*)," +
+        s"MIN(TINYINTColumn), MAX(TINYINTColumn)" +
+        s", MIN(SMALLINTColumn), MAX(SMALLINTColumn)" +
+        s", MIN(INTColumn), MAX(INTColumn)" +
+        s", MIN(BIGINTColumn), MAX(BIGINTColumn)" +
+        s", MIN(FLOATColumn), MAX(FLOATColumn)" +
+        s", MIN(DOUBLEColumn), MAX(DOUBLEColumn)" +
+        s", MIN(DATEColumn), MAX(DATEColumn)" +
+        s", MIN(Data), MAX(Data)" +
+        s" FROM $tableName",
+      "LocalRelation [none#0L, none#1, none#2, none#3, none#4, none#5, none#6, none#7L" +
+        ", none#8L, none#9, none#10, none#11, none#12, none#13, none#14, none#15, none#16]")
+  }
+
+  test("min-max - partitioned table - only NULL values") {
+    val tableName = "TestOnlyNullValuesPartitioned"
+
+    spark.sql(s"CREATE TABLE $tableName (Column1 INT, Column2 INT, Column3 INT) " +
+      s"USING DELTA PARTITIONED BY (Column2, Column3)")
+
+    spark.sql(s"INSERT INTO $tableName (Column1, Column2, Column3) VALUES (NULL, NULL, 1);")
+    spark.sql(s"INSERT INTO $tableName (Column1, Column2, Column3) VALUES (NULL, NULL, NULL);")
+    spark.sql(s"INSERT INTO $tableName (Column1, Column2, Column3) VALUES (NULL, NULL, 2);")
+
+    checkResultsAndOptimizedPlan(
+      s"SELECT COUNT(*), MIN(Column1), MAX(Column1), MIN(Column2), MAX(Column2), " +
+        s"MIN(Column3), MAX(Column3) FROM $tableName",
+      "LocalRelation [none#0L, none#1, none#2, none#3, none#4, none#5, none#6]")
+  }
+
+  test("min-max - column name containing punctuation") {
+    val tableName = "TestPunctuationColumnName"
+
+    spark.sql(s"CREATE TABLE $tableName (`My.!?Column` INT) USING DELTA")
+
+    spark.sql(s"INSERT INTO $tableName (`My.!?Column`) VALUES (1), (2), (3);")
+
+    checkResultsAndOptimizedPlan(
+      s"SELECT COUNT(*), MIN(`My.!?Column`), MAX(`My.!?Column`) FROM $tableName",
+      "LocalRelation [none#0L, none#1, none#2]")
+  }
+
+  test("min-max - partitioned table - column name containing punctuation") {
+    val tableName = "TestPartitionedPunctuationColumnName"
+
+    spark.sql(s"CREATE TABLE $tableName (`My.!?Column` INT, Data INT)" +
+      s" USING DELTA PARTITIONED BY (`My.!?Column`)")
+
+    spark.sql(s"INSERT INTO $tableName (`My.!?Column`, Data) VALUES (1, 1), (2, 1), (3, 1);")
+
+    checkResultsAndOptimizedPlan(
+      s"SELECT COUNT(*), MIN(`My.!?Column`), MAX(`My.!?Column`) FROM $tableName",
+      "LocalRelation [none#0L, none#1, none#2]")
+  }
+
+  test("min-max - column mapping enabled") {
+    val tableName = "TestColumnMapping"
+
+    spark.sql(
+      s"""CREATE TABLE $tableName (`My Column` INT) USING DELTA
+         | TBLPROPERTIES('delta.columnMapping.mode' = 'name')""".stripMargin)
+
+    spark.sql(s"INSERT INTO $tableName (`My Column`) VALUES (1);")
+    spark.sql(s"INSERT INTO $tableName (`My Column`) VALUES (2);")
+    spark.sql(s"INSERT INTO $tableName (`My Column`) VALUES (3);")
+
+    checkResultsAndOptimizedPlan(
+      s"SELECT COUNT(*), MIN(`My Column`), MAX(`My Column`) FROM $tableName",
+      "LocalRelation [none#0L, none#1, none#2]")
+  }
+
+  test("min-max - partitioned table - column mapping enabled") {
+    val tableName = "TestColumnMappingPartitioned"
+
+    spark.sql(s"CREATE TABLE $tableName" +
+      s" (Column1 INT, Column2 INT, `Column3 .,;{}()\n\t=` INT, Column4 INT)" +
+      s" USING DELTA PARTITIONED BY (Column2, `Column3 .,;{}()\n\t=`)" +
+      s" TBLPROPERTIES('delta.columnMapping.mode' = 'name')")
+
+    spark.sql(s"INSERT INTO $tableName (Column1, Column2, `Column3 .,;{}()\n\t=`, Column4)" +
+      s" VALUES (1, 2, 3, 4);")
+    spark.sql(s"INSERT INTO $tableName (Column1, Column2, `Column3 .,;{}()\n\t=`, Column4)" +
+      s" VALUES (2, 2, 3, 5);")
+    spark.sql(s"INSERT INTO $tableName (Column1, Column2, `Column3 .,;{}()\n\t=`, Column4)" +
+      s" VALUES (3, 3, 2, 6);")
+    spark.sql(s"INSERT INTO $tableName (Column1, Column2, `Column3 .,;{}()\n\t=`, Column4)" +
+      s" VALUES (4, 3, 2, 7);")
+
+    checkResultsAndOptimizedPlan(
+      s"SELECT COUNT(*)" +
+        s", MIN(Column1), MAX(Column1)" +
+        s", MIN(Column2), MAX(Column2)" +
+        s", MIN(`Column3 .,;{}()\n\t=`), MAX(`Column3 .,;{}()\n\t=`)" +
+        s", MIN(Column4), MAX(Column4)" +
+        s" FROM $tableName",
+      "LocalRelation [none#0L, none#1, none#2, none#3, none#4, none#5, none#6, none#7, none#8]")
+  }
+
+  test("min-max - recompute column missing stats") {
+    val tableName = "TestRecomputeMissingStat"
+
+    spark.sql(s"CREATE TABLE $tableName (Column1 INT, Column2 INT) USING DELTA" +
+      s" TBLPROPERTIES('delta.dataSkippingNumIndexedCols' = 0)")
+
+    spark.sql(s"INSERT INTO $tableName (Column1, Column2) VALUES (1, 4);")
+    spark.sql(s"INSERT INTO $tableName (Column1, Column2) VALUES (2, 5);")
+    spark.sql(s"INSERT INTO $tableName (Column1, Column2) VALUES (3, 6);")
+
+    checkOptimizationIsNotTriggered(s"SELECT COUNT(*), MIN(Column1), MAX(Column1) FROM $tableName")
+
+    spark.sql(s"ALTER TABLE $tableName SET TBLPROPERTIES('delta.dataSkippingNumIndexedCols' = 1);")
+
+    StatisticsCollection.recompute(
+      spark,
+      DeltaLog.forTable(spark, TableIdentifier(tableName)),
+      DeltaTableV2(spark, TableIdentifier(tableName)).catalogTable)
+
+    checkResultsAndOptimizedPlan(
+      s"SELECT COUNT(*), MIN(Column1), MAX(Column1) FROM $tableName",
+      "LocalRelation [none#0L, none#1, none#2]")
+
+    checkOptimizationIsNotTriggered(s"SELECT COUNT(*), MIN(Column2), MAX(Column2) FROM $tableName")
+
+    spark.sql(s"ALTER TABLE $tableName SET TBLPROPERTIES('delta.dataSkippingNumIndexedCols' = 2);")
+
+    StatisticsCollection.recompute(
+      spark,
+      DeltaLog.forTable(spark, TableIdentifier(tableName)),
+      DeltaTableV2(spark, TableIdentifier(tableName)).catalogTable)
+
+    checkResultsAndOptimizedPlan(
+      s"SELECT COUNT(*), MIN(Column2), MAX(Column2) FROM $tableName",
+      "LocalRelation [none#0L, none#1, none#2]")
+  }
+
+  test("min-max - recompute added column") {
+    val tableName = "TestRecomputeAddedColumn"
+
+    spark.sql(s"CREATE TABLE $tableName (Column1 INT) USING DELTA")
+    spark.sql(s"INSERT INTO $tableName (Column1) VALUES (1);")
+
+    spark.sql(s"ALTER TABLE $tableName ADD COLUMN (Column2 INT)")
+
+    spark.sql(s"INSERT INTO $tableName (Column1, Column2) VALUES (2, 5);")
+
+    checkResultsAndOptimizedPlan(
+      s"SELECT COUNT(*), MIN(Column1), MAX(Column1) FROM $tableName",
+      "LocalRelation [none#0L, none#1, none#2]")
+
+    checkOptimizationIsNotTriggered(s"SELECT COUNT(*), " +
+      s"MIN(Column1), MAX(Column1), MIN(Column2), MAX(Column2) FROM $tableName")
+
+    StatisticsCollection.recompute(
+      spark,
+      DeltaLog.forTable(spark, TableIdentifier(tableName)),
+      DeltaTableV2(spark, TableIdentifier(tableName)).catalogTable)
+
+    checkResultsAndOptimizedPlan(s"SELECT COUNT(*), " +
+      s"MIN(Column1), MAX(Column1), MIN(Column2), MAX(Column2) FROM $tableName",
+      "LocalRelation [none#0L, none#1, none#2, none#3, none#4]")
   }
 
   test("Select Count: snapshot isolation") {
@@ -189,71 +640,223 @@ class OptimizeMetadataOnlyDeltaQuerySuite
     }
   }
 
+  test(".collect() and .show() both use this optimization") {
+    var resultRow: Row = null
+    withSQLConf(DeltaSQLConf.DELTA_OPTIMIZE_METADATA_QUERY_ENABLED.key -> "false") {
+      resultRow = spark.sql(s"SELECT COUNT(*), MIN(id), MAX(id) FROM $testTableName").head
+    }
+
+    val totalRows = resultRow.getLong(0)
+    val minId = resultRow.getLong(1)
+    val maxId = resultRow.getLong(2)
+
+    val collectPlans = DeltaTestUtils.withLogicalPlansCaptured(spark, optimizedPlan = true) {
+      spark.sql(s"SELECT COUNT(*) FROM $testTableName").collect()
+    }
+    val collectResultData = collectPlans.collect { case x: LocalRelation => x.data }
+    assert(collectResultData.size === 1)
+    assert(collectResultData.head.head.getLong(0) === totalRows)
+
+    val showPlans = DeltaTestUtils.withLogicalPlansCaptured(spark, optimizedPlan = true) {
+      spark.sql(s"SELECT COUNT(*) FROM $testTableName").show()
+    }
+    val showResultData = showPlans.collect { case x: LocalRelation => x.data }
+    assert(showResultData.size === 1)
+    assert(showResultData.head.head.getString(0).toLong === totalRows)
+
+    val showMultAggPlans = DeltaTestUtils.withLogicalPlansCaptured(spark, optimizedPlan = true) {
+      spark.sql(s"SELECT COUNT(*), MIN(id), MAX(id) FROM $testTableName").show()
+    }
+
+    val showMultipleAggResultData = showMultAggPlans.collect { case x: LocalRelation => x.data }
+    assert(showMultipleAggResultData.size === 1)
+    val firstRow = showMultipleAggResultData.head.head
+    assert(firstRow.getString(0).toLong === totalRows)
+    assert(firstRow.getString(1).toLong === minId)
+    assert(firstRow.getString(2).toLong === maxId)
+  }
+
+  test("min-max .show() - only NULL values") {
+    val tableName = "TestOnlyNullValuesShow"
+
+    spark.sql(s"CREATE TABLE $tableName (Column1 INT) USING DELTA")
+    spark.sql(s"INSERT INTO $tableName (Column1) VALUES (NULL);")
+
+    val showMultAggPlans = DeltaTestUtils.withLogicalPlansCaptured(spark, optimizedPlan = true) {
+      spark.sql(s"SELECT MIN(Column1), MAX(Column1) FROM $tableName").show()
+    }
+
+    val showMultipleAggResultData = showMultAggPlans.collect { case x: LocalRelation => x.data }
+    assert(showMultipleAggResultData.size === 1)
+    val firstRow = showMultipleAggResultData.head.head
+    assert(firstRow.getString(0) === "NULL")
+    assert(firstRow.getString(1) === "NULL")
+  }
+
+  test("min-max .show() - Date Columns") {
+    val tableName = "TestDateColumnsShow"
+
+    spark.sql(s"CREATE TABLE $tableName (Column1 DATE, Column2 DATE) USING DELTA")
+    spark.sql(s"INSERT INTO $tableName (Column1, Column2) VALUES " +
+      s"(CAST('1582-10-15' AS DATE), NULL);")
+
+    val showMultAggPlans = DeltaTestUtils.withLogicalPlansCaptured(spark, optimizedPlan = true) {
+      spark.sql(s"SELECT MIN(Column1), MIN(Column2) FROM $tableName").show()
+    }
+
+    val showMultipleAggResultData = showMultAggPlans.collect { case x: LocalRelation => x.data }
+    assert(showMultipleAggResultData.size === 1)
+    val firstRow = showMultipleAggResultData.head.head
+    assert(firstRow.getString(0) === "1582-10-15")
+    assert(firstRow.getString(1) === "NULL")
+  }
+
   // Tests to validate the optimizer won't use missing or partial stats
-  test("Select Count: missing stats") {
+  test("count-min-max - not supported - missing stats") {
     checkOptimizationIsNotTriggered(
       s"SELECT COUNT(*) FROM $mixedStatsTableName")
 
     checkOptimizationIsNotTriggered(
       s"SELECT COUNT(*) FROM $noStatsTableName")
+
+    checkOptimizationIsNotTriggered(
+      s"SELECT MIN(id), MAX(id) FROM $mixedStatsTableName")
+
+    checkOptimizationIsNotTriggered(
+      s"SELECT MIN(id), MAX(id) FROM $noStatsTableName")
   }
 
   // Tests to validate the optimizer won't incorrectly change queries it can't correctly handle
-  test("Select Count: multiple aggregations") {
-    checkOptimizationIsNotTriggered(
-      s"SELECT COUNT(*) AS MyCount, MAX(id) FROM $testTableName")
+
+  test("min-max - not supported - data types") {
+    val tableName = "TestUnsupportedTypes"
+
+    spark.sql(s"CREATE TABLE $tableName " +
+      s"(STRINGColumn STRING, DECIMALColumn DECIMAL(38,0)" +
+      s", TIMESTAMPColumn TIMESTAMP, BINARYColumn BINARY, " +
+      s"BOOLEANColumn BOOLEAN, ARRAYColumn ARRAY<INT>, MAPColumn MAP<INT, INT>, " +
+      s"STRUCTColumn STRUCT<Id: INT, Name: STRING>) USING DELTA")
+
+    spark.sql(s"INSERT INTO $tableName" +
+      s" (STRINGColumn, DECIMALColumn, TIMESTAMPColumn, BINARYColumn" +
+      s", BOOLEANColumn, ARRAYColumn, MAPColumn, STRUCTColumn) VALUES " +
+      s"('A', -99999999999999999999999999999999999999, CAST('1900-01-01 00:00:00.0' AS TIMESTAMP)" +
+      s", X'1ABF', TRUE, ARRAY(1, 2, 3), MAP(1, 10, 2, 20), STRUCT(1, 'Spark'));")
+
+    val columnNames = List("STRINGColumn", "DECIMALColumn", "TIMESTAMPColumn",
+      "BINARYColumn", "BOOLEANColumn", "ARRAYColumn", "STRUCTColumn")
+
+    columnNames.foreach(colName =>
+      checkOptimizationIsNotTriggered(s"SELECT MAX($colName) FROM $tableName")
+    )
   }
 
-  test("Select Count: group by") {
+  test("min-max - not supported - sub-query with column alias") {
+    val tableName = "TestColumnAliasSubQuery"
+
+    spark.sql(s"CREATE TABLE $tableName (Column1 INT, Column2 INT, Column3 INT) USING DELTA")
+
+    spark.sql(s"INSERT INTO $tableName (Column1, Column2, Column3) VALUES (1, 2, 3);")
+
+    checkOptimizationIsNotTriggered(
+      s"SELECT MAX(Column2) FROM (SELECT Column1 AS Column2 FROM $tableName)")
+
+    checkOptimizationIsNotTriggered(
+      s"SELECT MAX(Column1), MAX(Column2), MAX(Column3) FROM " +
+        s"(SELECT Column1 AS Column2, Column2 AS Column3, Column3 AS Column1 FROM $tableName)")
+  }
+
+  test("min-max - not supported - nested columns") {
+    val tableName = "TestNestedColumns"
+
+    spark.sql(s"CREATE TABLE $tableName " +
+      s"(Column1 STRUCT<Id: INT>, " +
+      s"`Column1.Id` INT) USING DELTA")
+
+    spark.sql(s"INSERT INTO $tableName" +
+      s" (Column1, `Column1.Id`) VALUES " +
+      s"(STRUCT(1), 2);")
+
+    // Nested Column
+    checkOptimizationIsNotTriggered(
+      s"SELECT MAX(Column1.Id) FROM $tableName")
+
+    checkOptimizationIsNotTriggered(
+      s"SELECT MAX(Column1.Id) AS XYZ FROM $tableName")
+
+    // Validate the scenario where all the columns are read
+    // since it creates a different query plan
+    checkOptimizationIsNotTriggered(
+      s"SELECT MAX(Column1.Id), " +
+        s"MAX(`Column1.Id`) FROM $tableName")
+
+    // The optimization for columns with dots should still work
+    checkResultsAndOptimizedPlan(s"SELECT MAX(`Column1.Id`) FROM $tableName",
+      "LocalRelation [none#0]")
+  }
+
+  test("count-min-max - not supported - group by") {
     checkOptimizationIsNotTriggered(
       s"SELECT group, COUNT(*) FROM $testTableName GROUP BY group")
-  }
 
-  test("Select Count: count twice") {
     checkOptimizationIsNotTriggered(
-      s"SELECT COUNT(*), COUNT(*) FROM $testTableName")
+      s"SELECT group, MIN(id), MAX(id) FROM $testTableName GROUP BY group")
   }
 
-  test("Select Count: plus literal") {
+  test("count-min-max - not supported - plus literal") {
     checkOptimizationIsNotTriggered(
       s"SELECT COUNT(*) + 1 FROM $testTableName")
+
+    checkOptimizationIsNotTriggered(
+      s"SELECT MAX(id) + 1 FROM $testTableName")
   }
 
-  test("Select Count: distinct") {
+  test("count - not supported - distinct count") {
     checkOptimizationIsNotTriggered(
       s"SELECT COUNT(DISTINCT data) FROM $testTableName")
   }
 
-  test("Select Count: filter") {
+  test("count-min-max - not supported - filter") {
     checkOptimizationIsNotTriggered(
       s"SELECT COUNT(*) FROM $testTableName WHERE id > 0")
+
+    checkOptimizationIsNotTriggered(
+      s"SELECT MAX(id) FROM $testTableName WHERE id > 0")
   }
 
-  test("Select Count: sub-query with filter") {
+  test("count-min-max - not supported - sub-query with filter") {
     checkOptimizationIsNotTriggered(
       s"SELECT (SELECT COUNT(*) FROM $testTableName WHERE id > 0)")
+
+    checkOptimizationIsNotTriggered(
+      s"SELECT (SELECT MAX(id) FROM $testTableName WHERE id > 0)")
   }
 
-  test("Select Count: non-null") {
+  test("count - not supported - non-null") {
     checkOptimizationIsNotTriggered(
       s"SELECT COUNT(ALL data) FROM $testTableName")
     checkOptimizationIsNotTriggered(
       s"SELECT COUNT(data) FROM $testTableName")
   }
 
-  test("Select Count: join") {
+  test("count-min-max - not supported - join") {
     checkOptimizationIsNotTriggered(
       s"SELECT COUNT(*) FROM $testTableName A, $testTableName B")
+
+    checkOptimizationIsNotTriggered(
+      s"SELECT MAX(A.id) FROM $testTableName A, $testTableName B")
   }
 
-  test("Select Count: over") {
+  test("count-min-max - not supported - over") {
     checkOptimizationIsNotTriggered(
       s"SELECT COUNT(*) OVER() FROM $testTableName LIMIT 1")
+
+    checkOptimizationIsNotTriggered(
+      s"SELECT MAX(id) OVER() FROM $testTableName LIMIT 1")
   }
 
   private def generateRowsDataFrame(source: Dataset[java.lang.Long]): DataFrame = {
     import testImplicits._
-    import org.apache.spark.sql.functions._
 
     source.select('id,
       'id.cast("tinyint") as 'TinyIntColumn,
@@ -282,7 +885,7 @@ class OptimizeMetadataOnlyDeltaQuerySuite
   private def checkResultsAndOptimizedPlan(
     generateQueryDf: () => DataFrame,
     expectedOptimizedPlan: String): Unit = {
-    var expectedAnswer: scala.Seq[org.apache.spark.sql.Row] = null
+    var expectedAnswer: scala.Seq[Row] = null
     withSQLConf(DeltaSQLConf.DELTA_OPTIMIZE_METADATA_QUERY_ENABLED.key -> "false") {
       expectedAnswer = generateQueryDf().collect()
     }
@@ -307,7 +910,7 @@ class OptimizeMetadataOnlyDeltaQuerySuite
    */
   private def checkOptimizationIsNotTriggered(query: String) {
     var expectedOptimizedPlan: String = null
-    var expectedAnswer: scala.Seq[org.apache.spark.sql.Row] = null
+    var expectedAnswer: scala.Seq[Row] = null
 
     withSQLConf(DeltaSQLConf.DELTA_OPTIMIZE_METADATA_QUERY_ENABLED.key -> "false") {
 
@@ -329,22 +932,5 @@ class OptimizeMetadataOnlyDeltaQuerySuite
         optimizationEnabledQueryPlan
       }
     }
-  }
-
-  // scalastyle:off println
-  test(".collect() and .show() both use this optimization") {
-    val collectPlans = DeltaTestUtils.withLogicalPlansCaptured(spark, optimizedPlan = true) {
-      spark.sql(s"SELECT COUNT(*) FROM $testTableName").collect()
-    }
-    val collectResultData = collectPlans.collect { case x: LocalRelation => x.data }
-    assert(collectResultData.size === 1)
-    assert(collectResultData.head.head.getLong(0) === totalRows)
-
-    val showPlans = DeltaTestUtils.withLogicalPlansCaptured(spark, optimizedPlan = true) {
-      spark.sql(s"SELECT COUNT(*) FROM $testTableName").show()
-    }
-    val showResultData = showPlans.collect { case x: LocalRelation => x.data }
-    assert(showResultData.size === 1)
-    assert(showResultData.head.head.getString(0).toLong === totalRows)
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuerySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuerySuite.scala
@@ -17,13 +17,8 @@
 package org.apache.spark.sql.delta.perf
 
 import scala.collection.mutable
-import io.delta.tables.DeltaTable
-import org.apache.hadoop.fs.Path
-import org.apache.spark.sql.{DataFrame, Dataset, QueryTest, Row, SaveMode}
-import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
-import org.apache.spark.sql.delta.{DeltaColumnMappingEnableIdMode,
-  DeltaColumnMappingEnableNameMode, DeletionVectorsTestUtils, DeltaLog, DeltaTestUtils}
+
+import org.apache.spark.sql.delta.{DeletionVectorsTestUtils, DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode, DeltaLog, DeltaTestUtils}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.PrepareDeltaScanBase
@@ -31,9 +26,15 @@ import org.apache.spark.sql.delta.stats.StatisticsCollection
 import org.apache.spark.sql.delta.test.DeltaColumnMappingSelectedTestMixin
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
+import io.delta.tables.DeltaTable
+import org.apache.hadoop.fs.Path
+import org.scalatest.BeforeAndAfterAll
+
+import org.apache.spark.sql.{DataFrame, Dataset, QueryTest, Row, SaveMode}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSparkSession
-import org.scalatest.BeforeAndAfterAll
 
 class OptimizeMetadataOnlyDeltaQuerySuite
   extends QueryTest

--- a/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuerySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuerySuite.scala
@@ -21,7 +21,7 @@ import io.delta.tables.DeltaTable
 import org.apache.spark.sql.{DataFrame, Dataset, QueryTest, Row, SaveMode}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.plans.logical.LocalRelation
-import org.apache.spark.sql.delta.{DeltaColumnMappingEnableIdMode, 
+import org.apache.spark.sql.delta.{DeltaColumnMappingEnableIdMode,
   DeltaColumnMappingEnableNameMode, DeltaLog, DeltaTestUtils}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -114,11 +114,10 @@ class OptimizeMetadataOnlyDeltaQuerySuite
         min(col("DoubleColumn")), max(col("DoubleColumn")),
         min(col("DateColumn")), max(col("DateColumn"))),
       expectedPlan = "LocalRelation [none#0L, none#1L, none#2, none#3, none#4, none#5, none#6" +
-      ", none#7, none#8L, none#9L, none#10, none#11, none#12, none#13, none#14, none#15]"),
-    )
+      ", none#7, none#8L, none#9L, none#10, none#11, none#12, none#13, none#14, none#15]"))
     .foreach { testParams =>
       test(s"optimization supported - Scala - ${testParams.name}") {
-        checkResultsAndOptimizedPlan(testParams.queryScala, testParams.expectedPlan)     
+        checkResultsAndOptimizedPlan(testParams.queryScala, testParams.expectedPlan)
     }
   }
 
@@ -228,7 +227,8 @@ class OptimizeMetadataOnlyDeltaQuerySuite
       expectedPlan = "LocalRelation [none#0L, none#1L, none#2L]"),
     new SqlTestParams(
       name = "count-min-max - duplicated functions",
-      querySql = s"SELECT COUNT(*), COUNT(*), MIN(id), MIN(id), MAX(id), MAX(id) FROM $testTableName",
+      querySql = s"SELECT COUNT(*), COUNT(*), MIN(id), MIN(id), MAX(id), MAX(id)" +
+        s" FROM $testTableName",
       expectedPlan = "LocalRelation [none#0L, none#1L, none#2L, none#3L, none#4L, none#5L]"),
     new SqlTestParams(
       name = "count - empty table",
@@ -241,9 +241,12 @@ class OptimizeMetadataOnlyDeltaQuerySuite
     new SqlTestParams(
       name = "min-max - date columns",
       querySetup = Some(Seq(
-        "CREATE TABLE TestDateValues (Column1 DATE, Column2 DATE, Column3 DATE) USING DELTA;",
-        "INSERT INTO TestDateValues (Column1, Column2, Column3) VALUES (NULL, current_date(), current_date());",
-        "INSERT INTO TestDateValues (Column1, Column2, Column3) VALUES (NULL, NULL, current_date());")),
+        "CREATE TABLE TestDateValues" +
+        " (Column1 DATE, Column2 DATE, Column3 DATE) USING DELTA;",
+        "INSERT INTO TestDateValues" +
+        " (Column1, Column2, Column3) VALUES (NULL, current_date(), current_date());",
+        "INSERT INTO TestDateValues" +
+        " (Column1, Column2, Column3) VALUES (NULL, NULL, current_date());")),
       querySql = "SELECT COUNT(*), MIN(Column1), MAX(Column1), MIN(Column2)" +
       ", MAX(Column2), MIN(Column3), MAX(Column3) FROM TestDateValues",
       expectedPlan = "LocalRelation [none#0L, none#1, none#2, none#3, none#4, none#5, none#6]"),
@@ -347,10 +350,14 @@ class OptimizeMetadataOnlyDeltaQuerySuite
       querySetup = Some(Seq(
         "CREATE TABLE TestPartitionedTable (Column1 INT, Column2 INT, Column3 INT, Column4 INT)" +
         " USING DELTA PARTITIONED BY (Column2, Column3)",
-        "INSERT INTO TestPartitionedTable (Column1, Column2, Column3, Column4) VALUES (1, 2, 3, 4);",
-        "INSERT INTO TestPartitionedTable (Column1, Column2, Column3, Column4) VALUES (2, 2, 3, 5);",
-        "INSERT INTO TestPartitionedTable (Column1, Column2, Column3, Column4) VALUES (3, 3, 2, 6);",
-        "INSERT INTO TestPartitionedTable (Column1, Column2, Column3, Column4) VALUES (4, 3, 2, 7);"
+        "INSERT INTO TestPartitionedTable" +
+        " (Column1, Column2, Column3, Column4) VALUES (1, 2, 3, 4);",
+        "INSERT INTO TestPartitionedTable" +
+        " (Column1, Column2, Column3, Column4) VALUES (2, 2, 3, 5);",
+        "INSERT INTO TestPartitionedTable" +
+        " (Column1, Column2, Column3, Column4) VALUES (3, 3, 2, 6);",
+        "INSERT INTO TestPartitionedTable" +
+        " (Column1, Column2, Column3, Column4) VALUES (4, 3, 2, 7);"
       )),
       querySql = "SELECT COUNT(*)" +
         ", MIN(Column1), MAX(Column1)" +
@@ -365,13 +372,18 @@ class OptimizeMetadataOnlyDeltaQuerySuite
     new SqlTestParams(
       name = "count-min-max - partitioned table - no stats",
       querySetup = Some(Seq(
-        "CREATE TABLE TestPartitionedTableNoStats (Column1 INT, Column2 INT, Column3 INT, Column4 INT)" +
+        "CREATE TABLE TestPartitionedTableNoStats" +
+        " (Column1 INT, Column2 INT, Column3 INT, Column4 INT)" +
         " USING DELTA PARTITIONED BY (Column2, Column3)" +
         " TBLPROPERTIES('delta.dataSkippingNumIndexedCols' = 0)",
-        "INSERT INTO TestPartitionedTableNoStats (Column1, Column2, Column3, Column4) VALUES (1, 2, 3, 4);",
-        "INSERT INTO TestPartitionedTableNoStats (Column1, Column2, Column3, Column4) VALUES (2, 2, 3, 5);",
-        "INSERT INTO TestPartitionedTableNoStats (Column1, Column2, Column3, Column4) VALUES (3, 3, 2, 6);",
-        "INSERT INTO TestPartitionedTableNoStats (Column1, Column2, Column3, Column4) VALUES (4, 3, 2, 7);"
+        "INSERT INTO TestPartitionedTableNoStats" +
+        " (Column1, Column2, Column3, Column4) VALUES (1, 2, 3, 4);",
+        "INSERT INTO TestPartitionedTableNoStats" +
+        " (Column1, Column2, Column3, Column4) VALUES (2, 2, 3, 5);",
+        "INSERT INTO TestPartitionedTableNoStats" +
+        " (Column1, Column2, Column3, Column4) VALUES (3, 3, 2, 6);",
+        "INSERT INTO TestPartitionedTableNoStats" +
+        " (Column1, Column2, Column3, Column4) VALUES (4, 3, 2, 7);"
       )),
       querySql = "SELECT COUNT(*)" +
         ", MIN(Column2), MAX(Column2)" +
@@ -386,10 +398,12 @@ class OptimizeMetadataOnlyDeltaQuerySuite
         "FLOATColumn FLOAT, DOUBLEColumn DOUBLE, DATEColumn DATE, Data INT) USING DELTA" +
         "  PARTITIONED BY (TINYINTColumn, SMALLINTColumn, INTColumn, BIGINTColumn," +
         " FLOATColumn, DOUBLEColumn, DATEColumn)",
-        "INSERT INTO TestAllTypesPartitionedTable (TINYINTColumn, SMALLINTColumn, INTColumn, BIGINTColumn," +
+        "INSERT INTO TestAllTypesPartitionedTable" +
+        " (TINYINTColumn, SMALLINTColumn, INTColumn, BIGINTColumn," +
         " FLOATColumn, DOUBLEColumn, DATEColumn, Data)" +
         " VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);",
-        "INSERT INTO TestAllTypesPartitionedTable (TINYINTColumn, SMALLINTColumn, INTColumn, BIGINTColumn," +
+        "INSERT INTO TestAllTypesPartitionedTable" +
+        " (TINYINTColumn, SMALLINTColumn, INTColumn, BIGINTColumn," +
         " FLOATColumn, DOUBLEColumn, DATEColumn, Data)" +
         " VALUES (-128, -32768, -2147483648, -9223372036854775808," +
         " -3.4028235E38, -1.7976931348623157E308, CAST('1582-10-15' AS DATE), 1);"
@@ -414,7 +428,8 @@ class OptimizeMetadataOnlyDeltaQuerySuite
         "FLOATColumn FLOAT, DOUBLEColumn DOUBLE, DATEColumn DATE, Data INT) USING DELTA" +
         "  PARTITIONED BY (TINYINTColumn, SMALLINTColumn, INTColumn, BIGINTColumn," +
         " FLOATColumn, DOUBLEColumn, DATEColumn)",
-        "INSERT INTO TestOnlyNullValuesPartitioned (TINYINTColumn, SMALLINTColumn, INTColumn, BIGINTColumn," +
+        "INSERT INTO TestOnlyNullValuesPartitioned" +
+        " (TINYINTColumn, SMALLINTColumn, INTColumn, BIGINTColumn," +
         " FLOATColumn, DOUBLEColumn, DATEColumn, Data)" +
         " VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);"
       )),
@@ -448,16 +463,19 @@ class OptimizeMetadataOnlyDeltaQuerySuite
         "CREATE TABLE TestPunctuationColumnName (`My.!?Column` INT) USING DELTA",
         "INSERT INTO TestPunctuationColumnName (`My.!?Column`) VALUES (1), (2), (3);"
       )),
-      querySql = "SELECT COUNT(*), MIN(`My.!?Column`), MAX(`My.!?Column`) FROM TestPunctuationColumnName",
+      querySql = "SELECT COUNT(*), MIN(`My.!?Column`), MAX(`My.!?Column`)" +
+        " FROM TestPunctuationColumnName",
       expectedPlan = "LocalRelation [none#0L, none#1, none#2]"),
     new SqlTestParams(
       name = "min-max - partitioned table - column name containing punctuation",
       querySetup = Some(Seq(
         "CREATE TABLE TestPartitionedPunctuationColumnName (`My.!?Column` INT, Data INT)" +
         " USING DELTA PARTITIONED BY (`My.!?Column`)",
-        "INSERT INTO TestPartitionedPunctuationColumnName (`My.!?Column`, Data) VALUES (1, 1), (2, 1), (3, 1);"
+        "INSERT INTO TestPartitionedPunctuationColumnName" +
+        " (`My.!?Column`, Data) VALUES (1, 1), (2, 1), (3, 1);"
       )),
-      querySql = "SELECT COUNT(*), MIN(`My.!?Column`), MAX(`My.!?Column`) FROM TestPartitionedPunctuationColumnName",
+      querySql = "SELECT COUNT(*), MIN(`My.!?Column`), MAX(`My.!?Column`)" +
+        " FROM TestPartitionedPunctuationColumnName",
       expectedPlan = "LocalRelation [none#0L, none#1, none#2]"),
     new SqlTestParams(
       name = "min-max - partitioned table - special characters in column name",
@@ -466,15 +484,18 @@ class OptimizeMetadataOnlyDeltaQuerySuite
         " (Column1 INT, Column2 INT, `Column3 .,;{}()\n\t=` INT, Column4 INT)" +
         " USING DELTA PARTITIONED BY (Column2, `Column3 .,;{}()\n\t=`)" +
         " TBLPROPERTIES('delta.columnMapping.mode' = 'name')",
-        "INSERT INTO TestColumnMappingPartitioned (Column1, Column2, `Column3 .,;{}()\n\t=`, Column4)" +
+        "INSERT INTO TestColumnMappingPartitioned" +
+        " (Column1, Column2, `Column3 .,;{}()\n\t=`, Column4)" +
         " VALUES (1, 2, 3, 4);",
-        "INSERT INTO TestColumnMappingPartitioned (Column1, Column2, `Column3 .,;{}()\n\t=`, Column4)" +
+        "INSERT INTO TestColumnMappingPartitioned" +
+        " (Column1, Column2, `Column3 .,;{}()\n\t=`, Column4)" +
         " VALUES (2, 2, 3, 5);",
-        "INSERT INTO TestColumnMappingPartitioned (Column1, Column2, `Column3 .,;{}()\n\t=`, Column4)" +
+        "INSERT INTO TestColumnMappingPartitioned" +
+        " (Column1, Column2, `Column3 .,;{}()\n\t=`, Column4)" +
         " VALUES (3, 3, 2, 6);",
-        "INSERT INTO TestColumnMappingPartitioned (Column1, Column2, `Column3 .,;{}()\n\t=`, Column4)" +
-        " VALUES (4, 3, 2, 7);",
-      )),
+        "INSERT INTO TestColumnMappingPartitioned" +
+        " (Column1, Column2, `Column3 .,;{}()\n\t=`, Column4)" +
+        " VALUES (4, 3, 2, 7);")),
       querySql = "SELECT COUNT(*)" +
         ", MIN(Column1), MAX(Column1)" +
         ", MIN(Column2), MAX(Column2)" +
@@ -482,11 +503,10 @@ class OptimizeMetadataOnlyDeltaQuerySuite
         ", MIN(Column4), MAX(Column4)" +
         " FROM TestColumnMappingPartitioned",
       expectedPlan = "LocalRelation [none#0L, none#1, none#2, none#3," +
-        " none#4, none#5, none#6, none#7, none#8]"),
-    )
+        " none#4, none#5, none#6, none#7, none#8]"))
     .foreach { testParams =>
       test(s"optimization supported - SQL - ${testParams.name}") {
-        if(testParams.querySetup.isDefined) {
+        if (testParams.querySetup.isDefined) {
           testParams.querySetup.get.foreach(spark.sql)
         }
         checkResultsAndOptimizedPlan(testParams.querySql, testParams.expectedPlan)
@@ -503,6 +523,27 @@ class OptimizeMetadataOnlyDeltaQuerySuite
       checkResultsAndOptimizedPlan(
         s"SELECT COUNT(*), MIN(id), MAX(id) FROM delta.`$testTablePath`",
         "LocalRelation [none#0L, none#1L, none#2L]")
+    }
+  }
+
+  test("min-max - partitioned column stats disabled") {
+    withSQLConf(DeltaSQLConf.DELTA_COLLECT_STATS.key -> "false") {
+      val tableName = "TestPartitionedNoStats"
+
+      spark.sql(s"CREATE TABLE $tableName (Column1 INT, Column2 INT)" +
+        " USING DELTA PARTITIONED BY (Column2)")
+
+      spark.sql(s"INSERT INTO $tableName (Column1, Column2) VALUES (1, 3);")
+      spark.sql(s"INSERT INTO $tableName (Column1, Column2) VALUES (2, 4);")
+
+      // Has no stats, including COUNT
+      checkOptimizationIsNotTriggered(
+        s"SELECT COUNT(*), MIN(Column2), MAX(Column2) FROM $tableName")
+
+      // Should work for partitioned columns even without stats
+      checkResultsAndOptimizedPlan(
+        s"SELECT MIN(Column2), MAX(Column2) FROM $tableName",
+        "LocalRelation [none#0, none#1]")
     }
   }
 
@@ -747,14 +788,14 @@ class OptimizeMetadataOnlyDeltaQuerySuite
     spark.sql(s"INSERT INTO $tableName (Column1, Column2) VALUES (3, 3);")
     spark.sql(s"INSERT INTO $tableName (Column1, Column2) VALUES (4, 3);")
 
-    //Filter by partition column
+    // Filter by partition column
     checkOptimizationIsNotTriggered(
       "SELECT COUNT(*)" +
         ", MIN(Column1), MAX(Column1)" +
         ", MIN(Column2), MAX(Column2)" +
         s" FROM $tableName WHERE Column2 = 2")
 
-    //Filter both partition and data columns
+    // Filter both partition and data columns
     checkOptimizationIsNotTriggered(
       "SELECT COUNT(*)" +
         ", MIN(Column1), MAX(Column1)" +
@@ -886,14 +927,17 @@ class OptimizeMetadataOnlyDeltaQuerySuite
   }
 }
 
-trait OptimizeMetadataOnlyDeltaQueryColumnMappingSuiteBase extends DeltaColumnMappingSelectedTestMixin {
+trait OptimizeMetadataOnlyDeltaQueryColumnMappingSuiteBase
+  extends DeltaColumnMappingSelectedTestMixin {
   override protected def runAllTests = true
 }
 
-class OptimizeMetadataOnlyDeltaQueryIdColumnMappingSuite extends OptimizeMetadataOnlyDeltaQuerySuite
+class OptimizeMetadataOnlyDeltaQueryIdColumnMappingSuite
+  extends OptimizeMetadataOnlyDeltaQuerySuite
   with DeltaColumnMappingEnableIdMode
   with OptimizeMetadataOnlyDeltaQueryColumnMappingSuiteBase
 
-class OptimizeMetadataOnlyDeltaQueryNameColumnMappingSuite extends OptimizeMetadataOnlyDeltaQuerySuite
+class OptimizeMetadataOnlyDeltaQueryNameColumnMappingSuite
+  extends OptimizeMetadataOnlyDeltaQuerySuite
   with DeltaColumnMappingEnableNameMode
   with OptimizeMetadataOnlyDeltaQueryColumnMappingSuiteBase

--- a/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuerySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuerySuite.scala
@@ -839,7 +839,7 @@ class OptimizeMetadataOnlyDeltaQuerySuite
       spark.range(1, 10, 1, 1).write.format("delta").save(tempPath)
       val querySql = s"SELECT MIN(id), MAX(id) FROM delta.`$tempPath`"
       checkResultsAndOptimizedPlan(querySql, "LocalRelation [none#0L, none#1L]")
-        
+
       enableDeletionVectorsInTable(new Path(tempPath), true)
       DeltaTable.forPath(spark, tempPath).delete("id = 1")
       assert(!getFilesWithDeletionVectors(DeltaLog.forTable(spark, new Path(tempPath))).isEmpty)


### PR DESCRIPTION
## Description

Follow up of https://github.com/delta-io/delta/issues/1192, which optimizes COUNT. This PR adds support for MIN/MAX as well.

Fix #2092

## How was this patch tested?

Created additional unit tests to cover MIN/MAX.

## Does this PR introduce _any_ user-facing changes?

Only performance improvement
