### PR TITLE
Support passing Hadoop configurations via DeltaTable

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -1233,6 +1233,12 @@
     ],
     "sqlState" : "42000"
   },
+  "DELTA_TABLE_FOR_PATH_UNSUPPORTED_HADOOP_CONF" : {
+    "message" : [
+      "Currently DeltaTable.forPath only supports hadoop configuration keys starting with <allowedPrefixes> but got <unsupportedOptions>"
+    ],
+    "sqlState" : "0A000"
+  },
   "DELTA_TABLE_FOUND_IN_EXECUTOR" : {
     "message" : [
       "DeltaTable cannot be used in executors"

--- a/core/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
+++ b/core/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
@@ -199,14 +199,15 @@ class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
     OptimizeTableCommand(
       Option(ctx.path).map(string),
       Option(ctx.table).map(visitTableIdentifier),
-      Option(ctx.partitionPredicate).map(extractRawText(_)))(interleaveBy)
+      Option(ctx.partitionPredicate).map(extractRawText(_)), Map.empty)(interleaveBy)
   }
 
   override def visitDescribeDeltaDetail(
       ctx: DescribeDeltaDetailContext): LogicalPlan = withOrigin(ctx) {
     DescribeDeltaDetailCommand(
       Option(ctx.path).map(string),
-      Option(ctx.table).map(visitTableIdentifier))
+      Option(ctx.table).map(visitTableIdentifier),
+      Map.empty)
   }
 
   override def visitDescribeDeltaHistory(
@@ -214,13 +215,15 @@ class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
     DescribeDeltaHistoryCommand(
       Option(ctx.path).map(string),
       Option(ctx.table).map(visitTableIdentifier),
-      Option(ctx.limit).map(_.getText.toInt))
+      Option(ctx.limit).map(_.getText.toInt),
+      Map.empty)
   }
 
   override def visitGenerate(ctx: GenerateContext): LogicalPlan = withOrigin(ctx) {
     DeltaGenerateCommand(
       modeName = ctx.modeName.getText,
-      tableId = visitTableIdentifier(ctx.table))
+      tableId = visitTableIdentifier(ctx.table),
+      Map.empty)
   }
 
   override def visitConvert(ctx: ConvertContext): LogicalPlan = withOrigin(ctx) {

--- a/core/src/main/scala/io/delta/tables/DeltaOptimizeBuilder.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaOptimizeBuilder.scala
@@ -32,11 +32,13 @@ import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
  * @param sparkSession SparkSession to use for execution
  * @param tableIdentifier Id of the table on which to
  *        execute the optimize
+ * @param options Hadoop file system options for read and write.
  * @since 2.0.0
  */
 class DeltaOptimizeBuilder private(
     sparkSession: SparkSession,
-    tableIdentifier: String) extends AnalysisHelper {
+    tableIdentifier: String,
+    options: Map[String, String]) extends AnalysisHelper {
   @volatile private var partitionFilter: Option[String] = None
 
   /**
@@ -77,7 +79,8 @@ class DeltaOptimizeBuilder private(
       .sessionState
       .sqlParser
       .parseTableIdentifier(tableIdentifier)
-    val optimize = OptimizeTableCommand(None, Some(tableId), partitionFilter)(zOrderBy = zOrderBy)
+    val optimize =
+      OptimizeTableCommand(None, Some(tableId), partitionFilter, options)(zOrderBy = zOrderBy)
     toDataset(sparkSession, optimize)
   }
 }
@@ -91,7 +94,8 @@ private[delta] object DeltaOptimizeBuilder {
   @Unstable
   private[delta] def apply(
       sparkSession: SparkSession,
-      tableIdentifier: String): DeltaOptimizeBuilder = {
-    new DeltaOptimizeBuilder(sparkSession, tableIdentifier)
+      tableIdentifier: String,
+      options: Map[String, String]): DeltaOptimizeBuilder = {
+    new DeltaOptimizeBuilder(sparkSession, tableIdentifier, options)
   }
 }

--- a/core/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
+++ b/core/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
@@ -57,7 +57,7 @@ trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
   protected def executeDetails(
       path: String,
       tableIdentifier: Option[TableIdentifier]): DataFrame = {
-    val details = DescribeDeltaDetailCommand(Option(path), tableIdentifier)
+    val details = DescribeDeltaDetailCommand(Option(path), tableIdentifier, self.deltaLog.options)
     toDataset(sparkSession, details)
   }
 
@@ -66,7 +66,7 @@ trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
       .sessionState
       .sqlParser
       .parseTableIdentifier(tblIdentifier)
-    val generate = DeltaGenerateCommand(mode, tableId)
+    val generate = DeltaGenerateCommand(mode, tableId, self.deltaLog.options)
     toDataset(sparkSession, generate)
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2288,6 +2288,15 @@ trait DeltaErrorsBase
     new AnalysisException(
       s"SHOW COLUMNS with conflicting databases: '$db' != '${tableID.database.get}'")
   }
+
+  def unsupportedDeltaTableForPathHadoopConf(unsupportedOptions: Map[String, String]): Throwable = {
+    new DeltaIllegalArgumentException(
+      errorClass = "DELTA_TABLE_FOR_PATH_UNSUPPORTED_HADOOP_CONF",
+      messageParameters = Array(
+        DeltaTableUtils.validDeltaTableHadoopPrefixes.mkString("[", ",", "]"),
+        unsupportedOptions.mkString(","))
+    )
+  }
 }
 
 object DeltaErrors extends DeltaErrorsBase

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -86,6 +86,9 @@ object NodeWithOnlyDeterministicProjectAndFilter {
 object DeltaTableUtils extends PredicateHelper
   with DeltaLogging {
 
+  // The valid hadoop prefixes passed through `DeltaTable.forPath` or DataFrame APIs.
+  val validDeltaTableHadoopPrefixes: List[String] = List("fs.", "dfs.")
+
   /** Check whether this table is a Delta table based on information from the Catalog. */
   def isDeltaTable(table: CatalogTable): Boolean = DeltaSourceUtils.isDeltaTable(table.provider)
 
@@ -104,8 +107,11 @@ object DeltaTableUtils extends PredicateHelper
   }
 
   /** Check if the provided path is the root or the children of a Delta table. */
-  def isDeltaTable(spark: SparkSession, path: Path): Boolean = {
-    findDeltaTableRoot(spark, path).isDefined
+  def isDeltaTable(
+      spark: SparkSession,
+      path: Path,
+      options: Map[String, String] = Map.empty): Boolean = {
+    findDeltaTableRoot(spark, path, options).isDefined
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
@@ -219,6 +219,7 @@ trait DeltaCommand extends DeltaLogging {
    * @param path Table location. Expects a non-empty [[tableIdentifier]] or [[path]].
    * @param tableIdentifier Table identifier. Expects a non-empty [[tableIdentifier]] or [[path]].
    * @param operationName Operation that is getting the DeltaLog, used in error messages.
+   * @param hadoopConf Hadoop file system options used to build DeltaLog.
    * @return DeltaLog of the table
    * @throws AnalysisException If either no Delta table exists at the given path/identifier or
    *                           there is neither [[path]] nor [[tableIdentifier]] is provided.
@@ -227,7 +228,8 @@ trait DeltaCommand extends DeltaLogging {
       spark: SparkSession,
       path: Option[String],
       tableIdentifier: Option[TableIdentifier],
-      operationName: String): DeltaLog = {
+      operationName: String,
+      hadoopConf: Map[String, String] = Map.empty): DeltaLog = {
     val tablePath =
       if (path.nonEmpty) {
         new Path(path.get)
@@ -250,7 +252,7 @@ trait DeltaCommand extends DeltaLogging {
         throw DeltaErrors.missingTableIdentifierException(operationName)
       }
 
-    val deltaLog = DeltaLog.forTable(spark, tablePath)
+    val deltaLog = DeltaLog.forTable(spark, tablePath, hadoopConf)
     if (deltaLog.snapshot.version < 0) {
       throw DeltaErrors.notADeltaTableException(
         operationName,

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/DeltaGenerateCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/DeltaGenerateCommand.scala
@@ -26,7 +26,10 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
 
-case class DeltaGenerateCommand(modeName: String, tableId: TableIdentifier)
+case class DeltaGenerateCommand(
+    modeName: String,
+    tableId: TableIdentifier,
+    options: Map[String, String])
   extends LeafRunnableCommand {
 
   import DeltaGenerateCommand._
@@ -43,7 +46,7 @@ case class DeltaGenerateCommand(modeName: String, tableId: TableIdentifier)
         new Path(sparkSession.sessionState.catalog.getTableMetadata(tableId).location)
     }
 
-    val deltaLog = DeltaLog.forTable(sparkSession, tablePath)
+    val deltaLog = DeltaLog.forTable(sparkSession, tablePath, options)
     if (!deltaLog.tableExists) {
       throw DeltaErrors.notADeltaTableException("GENERATE")
     }

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/DescribeDeltaDetailsCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/DescribeDeltaDetailsCommand.scala
@@ -66,14 +66,15 @@ object TableDetail {
  */
 case class DescribeDeltaDetailCommand(
     path: Option[String],
-    tableIdentifier: Option[TableIdentifier]) extends LeafRunnableCommand with DeltaLogging {
+    tableIdentifier: Option[TableIdentifier],
+    hadoopConf: Map[String, String]) extends LeafRunnableCommand with DeltaLogging {
 
   override val output: Seq[Attribute] = TableDetail.schema.toAttributes
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val (basePath, tableMetadata) = getPathAndTableMetadata(sparkSession, path, tableIdentifier)
 
-    val deltaLog = DeltaLog.forTable(sparkSession, basePath)
+    val deltaLog = DeltaLog.forTable(sparkSession, basePath, hadoopConf)
     recordDeltaOperation(deltaLog, "delta.ddl.describeDetails") {
       val snapshot = deltaLog.update()
       if (snapshot.version == -1) {

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/DescribeDeltaHistoryCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/DescribeDeltaHistoryCommand.scala
@@ -33,11 +33,14 @@ import org.apache.spark.sql.execution.command.LeafRunnableCommand
 /**
  * A logical placeholder for describing a Delta table's history, so that the history can be
  * leveraged in subqueries. Replaced with `DescribeDeltaHistoryCommand` during planning.
+ *
+ * @param options: Hadoop file system options used for read and write.
  */
 case class DescribeDeltaHistory(
     path: Option[String],
     tableIdentifier: Option[TableIdentifier],
     limit: Option[Int],
+    options: Map[String, String],
     output: Seq[Attribute] = ExpressionEncoder[DeltaHistory]().schema.toAttributes)
   extends LeafNode with MultiInstanceRelation  {
   override def computeStats(): Statistics = Statistics(sizeInBytes = conf.defaultSizeInBytes)
@@ -47,11 +50,14 @@ case class DescribeDeltaHistory(
 
 /**
  * A command for describing the history of a Delta table.
+ *
+ * @param options: Hadoop file system options used for read and write.
  */
 case class DescribeDeltaHistoryCommand(
     path: Option[String],
     tableIdentifier: Option[TableIdentifier],
     limit: Option[Int],
+    options: Map[String, String],
     override val output: Seq[Attribute] = ExpressionEncoder[DeltaHistory]().schema.toAttributes)
   extends LeafRunnableCommand with DeltaLogging {
 
@@ -83,7 +89,7 @@ case class DescribeDeltaHistoryCommand(
       throw DeltaErrors.maxArraySizeExceeded()
     }
 
-    val deltaLog = DeltaLog.forTable(sparkSession, basePath)
+    val deltaLog = DeltaLog.forTable(sparkSession, basePath, options)
     recordDeltaOperation(deltaLog, "delta.ddl.describeHistory") {
       if (!deltaLog.tableExists) {
         throw DeltaErrors.notADeltaTableException("DESCRIBE HISTORY")

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -108,13 +108,14 @@ abstract class OptimizeTableCommandBase extends RunnableCommand with DeltaComman
 case class OptimizeTableCommand(
     path: Option[String],
     tableId: Option[TableIdentifier],
-    partitionPredicate: Option[String])(val zOrderBy: Seq[UnresolvedAttribute])
+    partitionPredicate: Option[String],
+    options: Map[String, String])(val zOrderBy: Seq[UnresolvedAttribute])
   extends OptimizeTableCommandBase with LeafRunnableCommand {
 
   override val otherCopyArgs: Seq[AnyRef] = zOrderBy :: Nil
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    val deltaLog = getDeltaLog(sparkSession, path, tableId, "OPTIMIZE")
+    val deltaLog = getDeltaLog(sparkSession, path, tableId, "OPTIMIZE", options)
 
     val txn = deltaLog.startTransaction()
     if (txn.readVersion == -1) {

--- a/core/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
@@ -199,7 +199,11 @@ trait GenerateSymlinkManifestImpl extends PostCommitHook with DeltaLogging with 
     val existingManifestPartitionRelativePaths = {
       val manifestRootDirAbsPath = fs.makeQualified(new Path(manifestRootDirPath))
       if (fs.exists(manifestRootDirAbsPath)) {
-        val index = new InMemoryFileIndex(spark, Seq(manifestRootDirAbsPath), Map.empty, None)
+        val index = new InMemoryFileIndex(
+          spark,
+          Seq(manifestRootDirAbsPath),
+          deltaLog.options,
+          None)
         val prefixToStrip = manifestRootDirAbsPath.toUri.getPath
         index.inputFiles.map { p =>
           // Remove root directory "rootDir" path from the manifest file paths like

--- a/core/src/test/scala/io/delta/sql/parser/DeltaSqlParserSuite.scala
+++ b/core/src/test/scala/io/delta/sql/parser/DeltaSqlParserSuite.scala
@@ -47,49 +47,49 @@ class DeltaSqlParserSuite extends SparkFunSuite with SQLHelper {
   test("OPTIMIZE command is parsed as expected") {
     val parser = new DeltaSqlParser(null)
     assert(parser.parsePlan("OPTIMIZE tbl") ===
-      OptimizeTableCommand(None, Some(tblId("tbl")), None)(Seq()))
+      OptimizeTableCommand(None, Some(tblId("tbl")), None, Map.empty)(Seq()))
 
     assert(parser.parsePlan("OPTIMIZE db.tbl") ===
-      OptimizeTableCommand(None, Some(tblId("tbl", "db")), None)(Seq()))
+      OptimizeTableCommand(None, Some(tblId("tbl", "db")), None, Map.empty)(Seq()))
 
     assert(parser.parsePlan("OPTIMIZE tbl_${system:spark.testing}") ===
-      OptimizeTableCommand(None, Some(tblId("tbl_true")), None)(Seq()))
+      OptimizeTableCommand(None, Some(tblId("tbl_true")), None, Map.empty)(Seq()))
 
     withSQLConf("tbl_var" -> "tbl") {
       assert(parser.parsePlan("OPTIMIZE ${tbl_var}") ===
-        OptimizeTableCommand(None, Some(tblId("tbl")), None)(Seq()))
+        OptimizeTableCommand(None, Some(tblId("tbl")), None, Map.empty)(Seq()))
 
       assert(parser.parsePlan("OPTIMIZE ${spark:tbl_var}") ===
-        OptimizeTableCommand(None, Some(tblId("tbl")), None)(Seq()))
+        OptimizeTableCommand(None, Some(tblId("tbl")), None, Map.empty)(Seq()))
 
       assert(parser.parsePlan("OPTIMIZE ${sparkconf:tbl_var}") ===
-        OptimizeTableCommand(None, Some(tblId("tbl")), None)(Seq()))
+        OptimizeTableCommand(None, Some(tblId("tbl")), None, Map.empty)(Seq()))
 
       assert(parser.parsePlan("OPTIMIZE ${hiveconf:tbl_var}") ===
-        OptimizeTableCommand(None, Some(tblId("tbl")), None)(Seq()))
+        OptimizeTableCommand(None, Some(tblId("tbl")), None, Map.empty)(Seq()))
 
       assert(parser.parsePlan("OPTIMIZE ${hivevar:tbl_var}") ===
-        OptimizeTableCommand(None, Some(tblId("tbl")), None)(Seq()))
+        OptimizeTableCommand(None, Some(tblId("tbl")), None, Map.empty)(Seq()))
     }
 
     assert(parser.parsePlan("OPTIMIZE '/path/to/tbl'") ===
-      OptimizeTableCommand(Some("/path/to/tbl"), None, None)(Seq()))
+      OptimizeTableCommand(Some("/path/to/tbl"), None, None, Map.empty)(Seq()))
 
     assert(parser.parsePlan("OPTIMIZE delta.`/path/to/tbl`") ===
-      OptimizeTableCommand(None, Some(tblId("/path/to/tbl", "delta")), None)(Seq()))
+      OptimizeTableCommand(None, Some(tblId("/path/to/tbl", "delta")), None, Map.empty)(Seq()))
 
     assert(parser.parsePlan("OPTIMIZE tbl WHERE part = 1") ===
-      OptimizeTableCommand(None, Some(tblId("tbl")), Some("part = 1"))(Seq()))
+      OptimizeTableCommand(None, Some(tblId("tbl")), Some("part = 1"), Map.empty)(Seq()))
 
     assert(parser.parsePlan("OPTIMIZE tbl ZORDER BY (col1)") ===
-      OptimizeTableCommand(None, Some(tblId("tbl")), None)(Seq(unresolvedAttr("col1"))))
+      OptimizeTableCommand(None, Some(tblId("tbl")), None, Map.empty)(Seq(unresolvedAttr("col1"))))
 
     assert(parser.parsePlan("OPTIMIZE tbl WHERE part = 1 ZORDER BY col1, col2.subcol") ===
-      OptimizeTableCommand(None, Some(tblId("tbl")), Some("part = 1"))(
+      OptimizeTableCommand(None, Some(tblId("tbl")), Some("part = 1"), Map.empty)(
         Seq(unresolvedAttr("col1"), unresolvedAttr("col2", "subcol"))))
 
     assert(parser.parsePlan("OPTIMIZE tbl WHERE part = 1 ZORDER BY (col1, col2.subcol)") ===
-      OptimizeTableCommand(None, Some(tblId("tbl")), Some("part = 1"))(
+      OptimizeTableCommand(None, Some(tblId("tbl")), Some("part = 1"), Map.empty)(
         Seq(unresolvedAttr("col1"), unresolvedAttr("col2", "subcol"))))
   }
 
@@ -99,17 +99,18 @@ class DeltaSqlParserSuite extends SparkFunSuite with SQLHelper {
 
     // Use the new keywords in table name
     assert(parser.parsePlan("OPTIMIZE optimize") ===
-      OptimizeTableCommand(None, Some(tblId("optimize")), None)(Seq()))
+      OptimizeTableCommand(None, Some(tblId("optimize")), None, Map.empty)(Seq()))
 
     assert(parser.parsePlan("OPTIMIZE zorder") ===
-      OptimizeTableCommand(None, Some(tblId("zorder")), None)(Seq()))
+      OptimizeTableCommand(None, Some(tblId("zorder")), None, Map.empty)(Seq()))
 
     // Use the new keywords in column name
     assert(parser.parsePlan("OPTIMIZE tbl WHERE zorder = 1 and optimize = 2") ===
-      OptimizeTableCommand(None, Some(tblId("tbl")), Some("zorder = 1 and optimize = 2"))(Seq()))
+      OptimizeTableCommand(None,
+        Some(tblId("tbl")), Some("zorder = 1 and optimize = 2"), Map.empty)(Seq()))
 
     assert(parser.parsePlan("OPTIMIZE tbl ZORDER BY (optimize, zorder)") ===
-      OptimizeTableCommand(None, Some(tblId("tbl")), None)(
+      OptimizeTableCommand(None, Some(tblId("tbl")), None, Map.empty)(
         Seq(unresolvedAttr("optimize"), unresolvedAttr("zorder"))))
   }
 

--- a/core/src/test/scala/io/delta/tables/DeltaTableSuite.scala
+++ b/core/src/test/scala/io/delta/tables/DeltaTableSuite.scala
@@ -22,11 +22,18 @@ import java.util.Locale
 import scala.language.postfixOps
 
 // scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.sql.delta.{DeltaIllegalArgumentException, DeltaLog, FakeFileSystem}
+import org.apache.spark.sql.delta.actions.{ Metadata, Protocol }
+import org.apache.spark.sql.delta.storage.LocalLogStore
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.util.FileNames
+import org.apache.commons.io.FileUtils
+import org.apache.hadoop.fs.{Path, UnsupportedFileSystemException}
 
 import org.apache.spark.SparkException
 import org.apache.spark.network.util.JavaUtils
-import org.apache.spark.sql.{AnalysisException, QueryTest}
+import org.apache.spark.sql.{functions, AnalysisException, DataFrame, Dataset, QueryTest, Row}
+import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.test.SharedSparkSession
 
 class DeltaTableSuite extends QueryTest
@@ -190,5 +197,369 @@ class DeltaTableSuite extends QueryTest
       }
     }.getMessage
     assert(e.contains("DeltaTable cannot be used in executors"))
+  }
+}
+
+class DeltaTableHadoopOptionsSuite extends QueryTest
+  with SharedSparkSession  with DeltaSQLCommandTest {
+
+  import testImplicits._
+
+  protected override def sparkConf =
+    super.sparkConf.set("spark.delta.logStore.fake.impl", classOf[LocalLogStore].getName)
+
+  /**
+   * Create Hadoop file system options for `FakeFileSystem`. If Delta doesn't pick up them,
+   * it won't be able to read/write any files using `fake://`.
+   */
+  private def fakeFileSystemOptions: Map[String, String] = {
+    Map(
+      "fs.fake.impl" -> classOf[FakeFileSystem].getName,
+      "fs.fake.impl.disable.cache" -> "true"
+    )
+  }
+
+  /** Create a fake file system path to test from the dir path. */
+  private def fakeFileSystemPath(dir: File): String = s"fake://${dir.getCanonicalPath}"
+
+  private def readDeltaTableByPath(path: String): DataFrame = {
+    spark.read.options(fakeFileSystemOptions).format("delta").load(path)
+  }
+
+  // Ensure any new API from [[DeltaTable]] has to verify it can work with custom file system
+  // options.
+  private val publicMethods =
+  scala.reflect.runtime.universe.typeTag[io.delta.tables.DeltaTable].tpe.decls
+    .filter(_.isPublic)
+    .map(_.name.toString).toSet
+
+  private val ignoreMethods = Seq()
+
+  private val testedMethods = Seq(
+    "as",
+    "alias",
+    "delete",
+    "detail",
+    "generate",
+    "history",
+    "merge",
+    "optimize",
+    "restoreToVersion",
+    "restoreToTimestamp",
+    "toDF",
+    "update",
+    "updateExpr",
+    "upgradeTableProtocol",
+    "vacuum"
+  )
+
+  val untestedMethods = publicMethods -- ignoreMethods -- testedMethods
+  assert(
+    untestedMethods.isEmpty,
+    s"Found new methods added to DeltaTable: $untestedMethods. " +
+      "Please make sure you add a new test to verify it works with file system " +
+      "options in this file, and update the `testedMethods` list. " +
+      "If this new method doesn't need to support file system options, " +
+      "you can add it to the `ignoredMethods` list")
+
+  test("forPath: as/alias/toDF with filesystem options.") {
+    withTempDir { dir =>
+      val path = fakeFileSystemPath(dir)
+      val fsOptions = fakeFileSystemOptions
+      testData.write.options(fsOptions).format("delta").save(path)
+
+      checkAnswer(
+        DeltaTable.forPath(spark, path, fsOptions).as("tbl").toDF.select("tbl.value"),
+        testData.select("value").collect().toSeq)
+
+      checkAnswer(
+        DeltaTable.forPath(spark, path, fsOptions).alias("tbl").toDF.select("tbl.value"),
+        testData.select("value").collect().toSeq)
+    }
+  }
+
+  test("forPath with unsupported options") {
+    withTempDir { dir =>
+      val path = fakeFileSystemPath(dir)
+      val fsOptions = fakeFileSystemOptions
+      testData.write.options(fsOptions).format("delta").save(path)
+
+      val finalOptions = fsOptions + ("otherKey" -> "otherVal")
+      assertThrows[DeltaIllegalArgumentException] {
+        io.delta.tables.DeltaTable.forPath(spark, path, finalOptions)
+      }
+    }
+  }
+
+  test("forPath error out without filesystem options passed in.") {
+    withTempDir { dir =>
+      val path = fakeFileSystemPath(dir)
+      val fsOptions = fakeFileSystemOptions
+      testData.write.options(fsOptions).format("delta").save(path)
+
+      val e = intercept[UnsupportedFileSystemException] {
+        io.delta.tables.DeltaTable.forPath(spark, path)
+      }.getMessage
+
+      assert(e.contains("""No FileSystem for scheme "fake""""))
+    }
+  }
+
+  test("forPath - with filesystem options") {
+    withTempDir { dir =>
+      val path = fakeFileSystemPath(dir)
+      val fsOptions = fakeFileSystemOptions
+      testData.write.options(fsOptions).format("delta").save(path)
+
+      val deltaTable =
+        io.delta.tables.DeltaTable.forPath(spark, path, fsOptions)
+
+      val testDataSeq = testData.collect().toSeq
+
+      // verify table can be read
+      checkAnswer(deltaTable.toDF, testDataSeq)
+
+      // verify java friendly API.
+      import scala.collection.JavaConverters._
+      val deltaTable2 = io.delta.tables.DeltaTable.forPath(
+        spark, path, new java.util.HashMap[String, String](fsOptions.asJava))
+      checkAnswer(deltaTable2.toDF, testDataSeq)
+    }
+  }
+
+  test("updateExpr - with filesystem options") {
+    withTempDir { dir =>
+      val path = fakeFileSystemPath(dir)
+      val fsOptions = fakeFileSystemOptions
+      val df = Seq((1, 10), (2, 20), (3, 30), (4, 40)).toDF("key", "value")
+      df.write.options(fsOptions).format("delta").save(path)
+
+      val table = io.delta.tables.DeltaTable.forPath(spark, path, fsOptions)
+
+      table.updateExpr(Map("key" -> "100"))
+
+      checkAnswer(readDeltaTableByPath(path),
+        Row(100, 10) :: Row(100, 20) :: Row(100, 30) :: Row(100, 40) :: Nil)
+    }
+  }
+
+  test("update - with filesystem options") {
+    withTempDir { dir =>
+      val path = fakeFileSystemPath(dir)
+      val df = Seq((1, 10), (2, 20), (3, 30), (4, 40)).toDF("key", "value")
+      df.write.options(fakeFileSystemOptions).format("delta").save(path)
+
+      val table = io.delta.tables.DeltaTable.forPath(spark, path, fakeFileSystemOptions)
+
+      table.update(Map("key" -> functions.expr("100")))
+
+      checkAnswer(readDeltaTableByPath(path),
+        Row(100, 10) :: Row(100, 20) :: Row(100, 30) :: Row(100, 40) :: Nil)
+    }
+  }
+
+  test("delete - with filesystem options") {
+    withTempDir { dir =>
+      val path = fakeFileSystemPath(dir)
+      val df = Seq((1, 10), (2, 20), (3, 30), (4, 40)).toDF("key", "value")
+      df.write.options(fakeFileSystemOptions).format("delta").save(path)
+
+      val table = io.delta.tables.DeltaTable.forPath(spark, path, fakeFileSystemOptions)
+
+      table.delete(functions.expr("key = 1 or key = 2"))
+
+      checkAnswer(readDeltaTableByPath(path), Row(3, 30) :: Row(4, 40) :: Nil)
+    }
+  }
+
+  test("merge - with filesystem options") {
+    withTempDir { dir =>
+      val path = fakeFileSystemPath(dir)
+      val target = Seq((1, 10), (2, 20)).toDF("key1", "value1")
+      target.write.options(fakeFileSystemOptions).format("delta").save(path)
+      val source = Seq((1, 100), (3, 30)).toDF("key2", "value2")
+
+      val table = io.delta.tables.DeltaTable.forPath(spark, path, fakeFileSystemOptions)
+
+      table.merge(source, "key1 = key2")
+        .whenMatched().updateExpr(Map("key1" -> "key2", "value1" -> "value2"))
+        .whenNotMatched().insertExpr(Map("key1" -> "key2", "value1" -> "value2"))
+        .execute()
+
+      checkAnswer(readDeltaTableByPath(path), Row(1, 100) :: Row(2, 20) :: Row(3, 30) :: Nil)
+    }
+  }
+
+  test("vacuum - with filesystem options") {
+    // Note: verify that [DeltaTableUtils.findDeltaTableRoot] works when either
+    // DELTA_FORMAT_CHECK_CACHE_ENABLED is on or off.
+    Seq("true", "false").foreach{ deltaFormatCheckEnabled =>
+      withSQLConf(
+        "spark.databricks.delta.formatCheck.cache.enabled" -> deltaFormatCheckEnabled) {
+        withTempDir { dir =>
+          val path = fakeFileSystemPath(dir)
+          testData.write.options(fakeFileSystemOptions).format("delta").save(path)
+          val table = io.delta.tables.DeltaTable.forPath(spark, path, fakeFileSystemOptions)
+
+          // create a uncommitted file.
+          val notCommittedFile = "notCommittedFile.json"
+          val file = new File(dir, notCommittedFile)
+          FileUtils.write(file, "gibberish")
+          // set to ancient time so that the file is eligible to be vacuumed.
+          file.setLastModified(0)
+          assert(file.exists())
+
+          table.vacuum()
+
+          val file2 = new File(dir, notCommittedFile)
+          assert(!file2.exists())
+        }
+      }
+    }
+  }
+
+
+  test("optimize - with filesystem options") {
+    withTempDir { dir =>
+      val path = fakeFileSystemPath(dir)
+      val fsOptions = fakeFileSystemOptions
+
+      Seq(1, 2, 3).toDF().write.options(fsOptions).format("delta").save(path)
+      Seq(4, 5, 6)
+        .toDF().write.options(fsOptions).format("delta").mode("append").save(path)
+
+      val origData: DataFrame = spark.read.options(fsOptions).format("delta").load(path)
+
+      val deltaLog = DeltaLog.forTable(spark, path, fsOptions)
+      val table = io.delta.tables.DeltaTable.forPath(spark, path, fsOptions)
+      val versionBeforeOptimize = deltaLog.snapshot.version
+
+      table.optimize().executeCompaction()
+      deltaLog.update()
+      assert(deltaLog.snapshot.version == versionBeforeOptimize + 1)
+      checkDatasetUnorderly(origData.as[Int], 1, 2, 3, 4, 5, 6)
+    }
+  }
+
+  test("history - with filesystem options") {
+    withTempDir { dir =>
+      val path = fakeFileSystemPath(dir)
+      val fsOptions = fakeFileSystemOptions
+
+      Seq(1, 2, 3).toDF().write.options(fsOptions).format("delta").save(path)
+
+      val table = io.delta.tables.DeltaTable.forPath(spark, path, fsOptions)
+      table.history().collect()
+    }
+  }
+
+  test("generate - with filesystem options") {
+    withSQLConf("spark.databricks.delta.symlinkFormatManifest.fileSystemCheck.enabled" -> "false") {
+      withTempDir { dir =>
+        val path = fakeFileSystemPath(dir)
+        val fsOptions = fakeFileSystemOptions
+
+        Seq(1, 2, 3).toDF().write.options(fsOptions).format("delta").save(path)
+
+        val table = io.delta.tables.DeltaTable.forPath(spark, path, fsOptions)
+        table.generate("symlink_format_manifest")
+      }
+    }
+  }
+
+  test("restoreTable - with filesystem options") {
+    withSQLConf("spark.databricks.service.checkSerialization" -> "false") {
+      withTempDir { dir =>
+        val path = fakeFileSystemPath(dir)
+        val fsOptions = fakeFileSystemOptions
+
+        val df1 = Seq(1, 2, 3).toDF("id")
+        val df2 = Seq(4, 5).toDF("id")
+        val df3 = Seq(6, 7).toDF("id")
+
+        // version 0.
+        df1.write.format("delta").options(fsOptions).save(path)
+        val deltaLog = DeltaLog.forTable(spark, path, fsOptions)
+        assert(deltaLog.snapshot.version == 0)
+
+        // version 1.
+        df2.write.format("delta").options(fsOptions).mode("append").save(path)
+        deltaLog.update()
+        assert(deltaLog.snapshot.version == 1)
+
+        // version 2.
+        df3.write.format("delta").options(fsOptions).mode("append").save(path)
+        deltaLog.update()
+        assert(deltaLog.snapshot.version == 2)
+
+        checkAnswer(
+          spark.read.format("delta").options(fsOptions).load(path),
+          df1.union(df2).union(df3))
+
+        val deltaTable = io.delta.tables.DeltaTable.forPath(spark, path, fsOptions)
+        deltaTable.restoreToVersion(1)
+
+        checkAnswer(
+          spark.read.format("delta").options(fsOptions).load(path),
+          df1.union(df2)
+        )
+
+        // set the time to first file with a early time and verify the delta table can be restored
+        // to it.
+        val desiredTime = "1996-01-12"
+        val format = new java.text.SimpleDateFormat("yyyy-MM-dd")
+        val time = format.parse(desiredTime).getTime
+
+        val logPath = new Path(dir.getCanonicalPath, "_delta_log")
+        val file = new File(FileNames.deltaFile(logPath, 0).toString)
+        assert(file.setLastModified(time))
+
+        val deltaTable2 = io.delta.tables.DeltaTable.forPath(spark, path, fsOptions)
+        deltaTable2.restoreToTimestamp(desiredTime)
+
+        checkAnswer(
+          spark.read.format("delta").options(fsOptions).load(path),
+          df1
+        )
+      }
+    }
+  }
+
+  test("upgradeTableProtocol - with filesystem options.") {
+    withTempDir { dir =>
+      val path = fakeFileSystemPath(dir)
+      val fsOptions = fakeFileSystemOptions
+
+      // create a table with a default Protocol.
+      val testSchema = spark.range(1).schema
+      val log = DeltaLog.forTable(spark, path, fsOptions)
+      log.ensureLogDirectoryExist()
+      log.store.write(
+        FileNames.deltaFile(log.logPath, 0),
+        Iterator(Metadata(schemaString = testSchema.json).json, Protocol(0, 0).json),
+        overwrite = false,
+        log.newDeltaHadoopConf())
+      log.update()
+
+      // update the protocol.
+      val table = DeltaTable.forPath(spark, path, fsOptions)
+      table.upgradeTableProtocol(1, 2)
+
+      assert(log.snapshot.protocol == Protocol(1, 2))
+    }
+  }
+
+  test("detail - with filesystem options.") {
+    withTempDir{ dir =>
+      val path = fakeFileSystemPath(dir)
+      val fsOptions = fakeFileSystemOptions
+      Seq(1, 2, 3).toDF().write.format("delta").options(fsOptions).save(path)
+
+      val deltaTable = DeltaTable.forPath(spark, path, fsOptions)
+      checkAnswer(
+        deltaTable.detail().select("format"),
+        Seq(Row("delta"))
+      )
+    }
   }
 }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2269,6 +2269,20 @@ trait DeltaErrorsSuiteBase
         "enabled change data feed (CDF) and has undergone schema changes using DROP COLUMN or " +
         "RENAME COLUMN.")
     }
+    {
+      val options = Map(
+        "foo" -> "1",
+        "bar" -> "2"
+      )
+      val e = intercept[DeltaIllegalArgumentException] {
+        throw DeltaErrors.unsupportedDeltaTableForPathHadoopConf(options)
+      }
+      assert(e.getErrorClass == "DELTA_TABLE_FOR_PATH_UNSUPPORTED_HADOOP_CONF")
+      assert(e.getSqlState == "0A000")
+      val prefixStr = DeltaTableUtils.validDeltaTableHadoopPrefixes.mkString("[", ",", "]")
+      assert(e.getMessage == "Currently DeltaTable.forPath only supports hadoop configuration " +
+        s"keys starting with $prefixStr but got ${options.mkString(",")}")
+    }
   }
 }
 

--- a/python/delta/tests/test_deltatable.py
+++ b/python/delta/tests/test_deltatable.py
@@ -37,6 +37,14 @@ class DeltaTableTests(DeltaTestCase):
         dt = DeltaTable.forPath(self.spark, self.tempFile).toDF()
         self.__checkAnswer(dt, [('a', 1), ('b', 2), ('c', 3)])
 
+    def test_forPathWithOptions(self) -> None:
+        path = self.tempFile
+        fsOptions = {"fs.fake.impl": "org.apache.spark.sql.delta.FakeFileSystem",
+                     "fs.fake.impl.disable.cache": "true"}
+        self.__writeDeltaTable([('a', 1), ('b', 2), ('c', 3)])
+        dt = DeltaTable.forPath(self.spark, path, fsOptions).toDF()
+        self.__checkAnswer(dt, [('a', 1), ('b', 2), ('c', 3)])
+
     def test_forName(self) -> None:
         self.__writeAsTable([('a', 1), ('b', 2), ('c', 3)], "test")
         df = DeltaTable.forName(self.spark, "test").toDF()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
(Cherry-pick https://github.com/delta-io/delta/commit/f1ec3a0d77a2ab2701fbc8170adae3d5d7d10d90 to branch-2.1)

This PR makes DeltaTable support reading Hadoop configuration. It adds a new public API to the DeltaTable in both Scala and Python:
    ```
        def forPath(
          sparkSession: SparkSession,
          path: String,
          hadoopConf: scala.collection.Map[String, String])
    ```
    
    Along with the API change, it adds the necessary change to make operations on `DeltaTable` work:
    ```
        def as()
        def alias()
        def toDF()
        def optimize()
        def upgradeTableProtocol()
        def vacuum(...)
        def history()
        def generate(...)
        def update(...)
        def updateExpr(...)
        def delete(...)
        def merge(...)
        def clone(...)
        def cloneAtVersion(...)
        def restoreToVersion(...)
    ```
    With the change in this PR, the above functions work and are verified in a new unit test. Some commands such as Merge/Vacuum/restoreToVersion etc don't pick up the Hadoop configurations even though they are passed to DeltaTableV2 through new forPath(..., options) API. Note that the unit test is written first by verifying that it fails without the change and passes with the change.


## How was this patch tested?

New unit tests.