### PR TITLE
Add `DeletionVectorDescriptor` to represent DV metadata in `DeltaLog`

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -170,6 +170,12 @@
     ],
     "sqlState" : "42000"
   },
+  "DELTA_CANNOT_RECONSTRUCT_PATH_FROM_URI" : {
+    "message" : [
+      "A uri (<uri>) which cannot be turned into a relative path was found in the transaction log."
+    ],
+    "sqlState" : "42000"
+  },
   "DELTA_CANNOT_RENAME_PATH" : {
     "message" : [
       "Cannot rename <currentPath> to <newPath>"

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2578,6 +2578,11 @@ trait DeltaErrorsBase
           sparkConf, "/delta-utility.html#convert-a-parquet-table-to-a-delta-table")),
       cause = cause)
   }
+
+  def cannotReconstructPathFromURI(uri: String): Throwable =
+    new DeltaRuntimeException(
+      errorClass = "DELTA_CANNOT_RECONSTRUCT_PATH_FROM_URI",
+      messageParameters = Array(uri))
 }
 
 object DeltaErrors extends DeltaErrorsBase

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptor.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptor.scala
@@ -1,0 +1,254 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.actions
+
+import java.net.URI
+import java.util.UUID
+
+import org.apache.spark.sql.delta.DeltaErrors
+import org.apache.spark.sql.delta.util.{Codec, DeltaEncoder, JsonUtils}
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.{Column, Encoder}
+import org.apache.spark.sql.functions.{concat, lit, when}
+import org.apache.spark.sql.types._
+
+/** Information about a deletion vector attached to a file action. */
+case class DeletionVectorDescriptor(
+    /**
+     * Indicates how the DV is stored.
+     * Should be a single letter (see [[pathOrInlineDv]] below.)
+     */
+    storageType: String,
+
+    /**
+     * Contains the actual data that allows accessing the DV.
+     *
+     * Three options are currently supported:
+     * - `storageType="u"` format: `<random prefix - optional><base85 encoded uuid>`
+     *                            The deletion vector is stored in a file with a path relative to
+     *                            the data directory of this Delta Table, and the file name can be
+     *                            reconstructed from the UUID.
+     *                            The encoded UUID is always exactly 20 characters, so the random
+     *                            prefix length can be determined any characters exceeding 20.
+     * - `storageType="i"` format: `<base85 encoded bytes>`
+     *                            The deletion vector is stored inline in the log.
+     * - `storageType="p"` format: `<absolute path>`
+     *                             The DV is stored in a file with an absolute path given by this
+     *                             url.
+     */
+    pathOrInlineDv: String,
+    /**
+     * Start of the data for this DV in number of bytes from the beginning of the file it is stored
+     * in.
+     *
+     * Always None when storageType = "i".
+     */
+    @JsonDeserialize(contentAs = classOf[java.lang.Integer])
+    offset: Option[Int] = None,
+    /** Size of the serialized DV in bytes (raw data size, i.e. before base85 encoding). */
+    sizeInBytes: Int,
+    /** Number of rows the DV logically removes from the file. */
+    cardinality: Long) {
+
+  import DeletionVectorDescriptor._
+
+  @JsonIgnore
+  @transient
+  lazy val uniqueId: String = {
+    offset match {
+      case Some(offset) => s"$uniqueFileId@$offset"
+      case None => uniqueFileId
+    }
+  }
+
+  @JsonIgnore
+  @transient
+  lazy val uniqueFileId: String = s"$storageType$pathOrInlineDv"
+
+  @JsonIgnore
+  protected[delta] def isOnDisk: Boolean = !isInline
+
+  @JsonIgnore
+  protected[delta] def isInline: Boolean = storageType == INLINE_DV_MARKER
+
+  @JsonIgnore
+  protected[delta] def isRelative: Boolean = storageType == UUID_DV_MARKER
+
+  @JsonIgnore
+  protected[delta] def isAbsolute: Boolean = storageType == PATH_DV_MARKER
+
+  @JsonIgnore
+  protected[delta] def isEmpty: Boolean = cardinality == 0
+
+  def absolutePath(tableLocation: Path): Path = {
+    require(isOnDisk, "Can't get a path for an inline deletion vector")
+    storageType match {
+      case UUID_DV_MARKER =>
+        // If the file was written with a random prefix, we have to extract that,
+        // before decoding the UUID.
+        val randomPrefixLength = pathOrInlineDv.length - Codec.Base85Codec.ENCODED_UUID_LENGTH
+        val (randomPrefix, encodedUuid) = pathOrInlineDv.splitAt(randomPrefixLength)
+        val uuid = Codec.Base85Codec.decodeUUID(encodedUuid)
+        assembleDeletionVectorPath(tableLocation, uuid, randomPrefix)
+      case PATH_DV_MARKER =>
+        // Since there is no need for legacy support for relative paths for DVs,
+        // relative DVs should *always* use the UUID variant.
+        val parsedUri = new URI(pathOrInlineDv)
+        assert(parsedUri.isAbsolute, "Relative URIs are not supported for DVs")
+        new Path(parsedUri)
+      case _ => throw DeltaErrors.cannotReconstructPathFromURI(pathOrInlineDv)
+    }
+  }
+
+  /**
+   * Produce a copy of this DV, but using an absolute path.
+   *
+   * If the DV already has an absolute path or is inline, then this is just a normal copy.
+   */
+  def copyWithAbsolutePath(tableLocation: Path): DeletionVectorDescriptor = {
+    storageType match {
+      case UUID_DV_MARKER =>
+        val absolutePath = this.absolutePath(tableLocation)
+        this.copy(storageType = PATH_DV_MARKER, pathOrInlineDv = absolutePath.toString)
+      case PATH_DV_MARKER | INLINE_DV_MARKER => this.copy()
+    }
+  }
+
+  /**
+   * Produce a copy of this DV, with `pathOrInlineDv` replaced by a relative path based on `id`
+   * and `randomPrefix`.
+   */
+  def copyWithNewRelativePath(id: UUID, randomPrefix: String): DeletionVectorDescriptor = {
+    this.copy(storageType = UUID_DV_MARKER, pathOrInlineDv = encodeUUID(id, randomPrefix))
+  }
+
+  @JsonIgnore
+  def inlineData: Array[Byte] = {
+    require(isInline, "Can't get data for an on-disk DV from the log.")
+    // The sizeInBytes is used to remove any padding that might have been added during encoding.
+    Codec.Base85Codec.decodeBytes(pathOrInlineDv, sizeInBytes)
+  }
+
+  /** Returns the estimated number of bytes required to serialize this object. */
+  @JsonIgnore
+  protected[delta] lazy val estimatedSerializedSize: Int = {
+    // (cardinality(8) + sizeInBytes(4)) + storageType + pathOrInlineDv + option[offset(4)]
+    12 + storageType.length + pathOrInlineDv.length + (if (offset.isDefined) 4 else 0)
+  }
+}
+
+object DeletionVectorDescriptor {
+
+  // TODO: This is a temporary solution that allows us to add new protocol versions for other
+  // things, while DVs are still in development.
+  final val REQUIRED_READER_VERSION = Int.MaxValue
+  final val REQUIRED_WRITER_VERSION = Int.MaxValue
+
+  /** String that is used in all file names generated by deletion vector store */
+  val DELETION_VECTOR_FILE_NAME_CORE = "deletion_vector"
+
+  // Markers to separate different kinds of DV storage.
+  final val PATH_DV_MARKER: String = "p"
+  final val INLINE_DV_MARKER: String = "i"
+  final val UUID_DV_MARKER: String = "u"
+
+  final val STRUCT_TYPE: StructType = new StructType()
+    .add("storageType", StringType)
+    .add("pathOrInlineDv", StringType)
+    .add("offset", IntegerType)
+    .add("sizeInBytes", IntegerType, nullable = false)
+    .add("cardinality", LongType, nullable = false)
+
+  private lazy val _encoder = new DeltaEncoder[DeletionVectorDescriptor]
+  implicit def encoder: Encoder[DeletionVectorDescriptor] = _encoder.get
+
+  /** Utility method to create an on-disk [[DeletionVectorDescriptor]] */
+  def onDiskWithRelativePath(
+      id: UUID,
+      randomPrefix: String = "",
+      sizeInBytes: Int,
+      cardinality: Long,
+      offset: Option[Int] = None): DeletionVectorDescriptor =
+    DeletionVectorDescriptor(
+      storageType = UUID_DV_MARKER,
+      pathOrInlineDv = encodeUUID(id, randomPrefix),
+      offset = offset,
+      sizeInBytes = sizeInBytes,
+      cardinality = cardinality)
+
+  /** Utility method to create an on-disk [[DeletionVectorDescriptor]] */
+  def onDiskWithAbsolutePath(
+      path: String,
+      sizeInBytes: Int,
+      cardinality: Long,
+      offset: Option[Int] = None): DeletionVectorDescriptor =
+    DeletionVectorDescriptor(
+      storageType = PATH_DV_MARKER,
+      pathOrInlineDv = path,
+      offset = offset,
+      sizeInBytes = sizeInBytes,
+      cardinality = cardinality)
+
+  /** Utility method to create an inline [[DeletionVectorDescriptor]] */
+  def inlineInLog(
+      data: Array[Byte],
+      cardinality: Long): DeletionVectorDescriptor =
+    DeletionVectorDescriptor(
+      storageType = INLINE_DV_MARKER,
+      pathOrInlineDv = encodeData(data),
+      sizeInBytes = data.length,
+      cardinality = cardinality)
+
+  /**
+   * Return the unique path under `parentPath` that is based on `id`.
+   *
+   * Optionally, prepend a `prefix` to the name.
+   */
+  def assembleDeletionVectorPath(targetParentPath: Path, id: UUID, prefix: String = ""): Path = {
+    val core = DELETION_VECTOR_FILE_NAME_CORE
+    val fileName = s"${core}_${id}.bin"
+    if (prefix.nonEmpty) {
+      new Path(new Path(targetParentPath, prefix), fileName)
+    } else {
+      new Path(targetParentPath, fileName)
+    }
+  }
+
+  /** Descriptor for an empty stored bitmap. */
+  val EMPTY: DeletionVectorDescriptor = DeletionVectorDescriptor(
+    storageType = INLINE_DV_MARKER,
+    pathOrInlineDv = "",
+    sizeInBytes = 0,
+    cardinality = 0)
+
+  private[delta] def fromJson(jsonString: String): DeletionVectorDescriptor = {
+    JsonUtils.fromJson[DeletionVectorDescriptor](jsonString)
+  }
+
+  private[delta] def encodeUUID(id: UUID, randomPrefix: String): String = {
+    val uuidData = Codec.Base85Codec.encodeUUID(id)
+    // This should always be true and we are relying on it for separating out the
+    // prefix again later without having to spend an extra character as a separator.
+    assert(uuidData.length == 20)
+    s"$randomPrefix$uuidData"
+  }
+
+  private def encodeData(bytes: Array[Byte]): String = Codec.Base85Codec.encodeBytes(bytes)
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptorSuite.scala
@@ -52,16 +52,11 @@ class DeletionVectorDescriptorSuite extends SparkFunSuite {
     // There is no on-disk file name for an inline DV
     intercept[IllegalArgumentException] { dv.absolutePath(testTablePath) }
 
-    // Copy as on-disk DV with absolute path - expect the returned DV is same as
-    // input, since this is inline so paths are irrelevant.
+    // Copy as on-disk DV with absolute path and relative path -
+    // expect the returned DV is same as input, since this is inline
+    // so paths are irrelevant.
     assert(dv.copyWithAbsolutePath(testTablePath) === dv)
-
-    // Copy DV as a relative path DV
-    val uuid = UUID.randomUUID()
-    val dvCopyWithRelativePath = dv.copyWithNewRelativePath(uuid, "prefix")
-    assert(dvCopyWithRelativePath.isRelative)
-    assert(dvCopyWithRelativePath.isOnDisk)
-    assert(dvCopyWithRelativePath.pathOrInlineDv === encodeUUID(uuid, "prefix"))
+    assert(dv.copyWithNewRelativePath(UUID.randomUUID(), "predix2") === dv)
   }
 
   for (offset <- Seq(None, Some(25))) {
@@ -131,12 +126,9 @@ class DeletionVectorDescriptorSuite extends SparkFunSuite {
       assert(
         dvCopyWithAbsPath.pathOrInlineDv === s"$testTablePath/prefix/deletion_vector_$uuid.bin")
 
-      // Copy DV as a relative path DV
-      val uuid2 = UUID.randomUUID()
-      val dvCopyWithRelativePath = dv.copyWithNewRelativePath(uuid2, "prefix2")
-      assert(dvCopyWithRelativePath.isRelative)
-      assert(dvCopyWithRelativePath.isOnDisk)
-      assert(dvCopyWithRelativePath.pathOrInlineDv === encodeUUID(uuid2, "prefix2"))
+      // Copy DV as a relative path DV - expect to return the same DV as the current
+      // DV already contains relative path.
+      assert(dv.copyWithNewRelativePath(UUID.randomUUID(), "predix2") == dv)
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptorSuite.scala
@@ -128,7 +128,7 @@ class DeletionVectorDescriptorSuite extends SparkFunSuite {
 
       // Copy DV as a relative path DV - expect to return the same DV as the current
       // DV already contains relative path.
-      assert(dv.copyWithNewRelativePath(UUID.randomUUID(), "predix2") == dv)
+      assert(dv.copyWithNewRelativePath(UUID.randomUUID(), "predix2") === dv)
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptorSuite.scala
@@ -1,0 +1,154 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.actions
+
+import java.util.UUID
+
+// scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor._
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.SparkFunSuite
+// scalastyle:on import.ordering.noEmptyLine
+
+/**
+ * Test: DV descriptor creation, created DV descriptor properties and utility methods are
+ * working as expected.
+ */
+class DeletionVectorDescriptorSuite extends SparkFunSuite {
+  test("Inline DV") {
+    val dv = inlineInLog(testDVData, cardinality = 3)
+
+    // Make sure the metadata (type, size etc.) in the DV is as expected
+    assert(!dv.isOnDisk && dv.isInline, s"Incorrect DV storage type: $dv")
+    assertCardinality(dv, 3)
+
+    val encodedDVData = "0rJua"
+    assert(dv.pathOrInlineDv === encodedDVData)
+    assert(dv.sizeInBytes === testDVData.size)
+    assert(dv.inlineData === testDVData)
+    assert(dv.estimatedSerializedSize === 18)
+
+    assert(dv.offset.isEmpty) // There shouldn't be an offset for inline DV
+
+    // Unique id to identify the DV
+    assert(dv.uniqueId === s"i$encodedDVData")
+    assert(dv.uniqueFileId === s"i$encodedDVData")
+
+    // There is no on-disk file name for an inline DV
+    intercept[IllegalArgumentException] { dv.absolutePath(testTablePath) }
+
+    // Copy as on-disk DV with absolute path - expect the returned DV is same as
+    // input, since this is inline so paths are irrelevant.
+    assert(dv.copyWithAbsolutePath(testTablePath) === dv)
+
+    // Copy DV as a relative path DV
+    val uuid = UUID.randomUUID()
+    val dvCopyWithRelativePath = dv.copyWithNewRelativePath(uuid, "prefix")
+    assert(dvCopyWithRelativePath.isRelative)
+    assert(dvCopyWithRelativePath.isOnDisk)
+    assert(dvCopyWithRelativePath.pathOrInlineDv === encodeUUID(uuid, "prefix"))
+  }
+
+  for (offset <- Seq(None, Some(25))) {
+    test(s"On disk DV with absolute path with offset=$offset") {
+      val dv = onDiskWithAbsolutePath(testDVAbsPath, sizeInBytes = 15, cardinality = 10, offset)
+
+      // Make sure the metadata (type, size etc.) in the DV is as expected
+      assert(dv.isOnDisk && !dv.isInline, s"Incorrect DV storage type: $dv")
+      assertCardinality(dv, 10)
+
+      assert(dv.pathOrInlineDv === testDVAbsPath)
+      assert(dv.sizeInBytes === 15)
+      intercept[Exception] { dv.inlineData }
+      assert(dv.estimatedSerializedSize === (if (offset.isDefined) 4 else 0) + 37)
+      assert(dv.offset === offset)
+
+      // Unique id to identify the DV
+      val offsetSuffix = offset.map(o => s"@$o").getOrElse("")
+      assert(dv.uniqueId === s"p$testDVAbsPath$offsetSuffix")
+      assert(dv.uniqueFileId === s"p$testDVAbsPath")
+
+      // Given the input already has an absolute path, it should return the path in DV
+      assert(dv.absolutePath(testTablePath) === new Path(testDVAbsPath))
+
+      // Given the input already has an absolute path, expect the output to be same as input
+      assert(dv.copyWithAbsolutePath(testTablePath) === dv)
+
+      // Copy DV as a relative path DV
+      val uuid = UUID.randomUUID()
+      val dvCopyWithRelativePath = dv.copyWithNewRelativePath(uuid, "prefix")
+      assert(dvCopyWithRelativePath.isRelative)
+      assert(dvCopyWithRelativePath.isOnDisk)
+      assert(dvCopyWithRelativePath.pathOrInlineDv === encodeUUID(uuid, "prefix"))
+    }
+  }
+
+  for (offset <- Seq(None, Some(25))) {
+    test(s"On-disk DV with relative path with offset=$offset") {
+      val uuid = UUID.randomUUID()
+      val dv = onDiskWithRelativePath(
+        uuid, randomPrefix = "prefix", sizeInBytes = 15, cardinality = 25, offset)
+
+      // Make sure the metadata (type, size etc.) in the DV is as expected
+      assert(dv.isOnDisk && !dv.isInline, s"Incorrect DV storage type: $dv")
+      assertCardinality(dv, 25)
+
+      assert(dv.pathOrInlineDv === encodeUUID(uuid, "prefix"))
+      assert(dv.sizeInBytes === 15)
+      intercept[Exception] { dv.inlineData }
+      assert(dv.estimatedSerializedSize === (if (offset.isDefined) 4 else 0) + 39)
+      assert(dv.offset === offset)
+
+      // Unique id to identify the DV
+      val offsetSuffix = offset.map(o => s"@$o").getOrElse("")
+      val encodedUUID = encodeUUID(uuid, "prefix")
+      assert(dv.uniqueId === s"u$encodedUUID$offsetSuffix")
+      assert(dv.uniqueFileId === s"u$encodedUUID")
+
+      // Expect the DV final path to be under the given table path
+      assert(dv.absolutePath(testTablePath) ===
+        new Path(s"$testTablePath/prefix/deletion_vector_$uuid.bin"))
+
+      // Copy DV with an absolute path location
+      val dvCopyWithAbsPath = dv.copyWithAbsolutePath(testTablePath)
+      assert(dvCopyWithAbsPath.isAbsolute)
+      assert(dvCopyWithAbsPath.isOnDisk)
+      assert(
+        dvCopyWithAbsPath.pathOrInlineDv === s"$testTablePath/prefix/deletion_vector_$uuid.bin")
+
+      // Copy DV as a relative path DV
+      val uuid2 = UUID.randomUUID()
+      val dvCopyWithRelativePath = dv.copyWithNewRelativePath(uuid2, "prefix2")
+      assert(dvCopyWithRelativePath.isRelative)
+      assert(dvCopyWithRelativePath.isOnDisk)
+      assert(dvCopyWithRelativePath.pathOrInlineDv === encodeUUID(uuid2, "prefix2"))
+    }
+  }
+
+  private def assertCardinality(dv: DeletionVectorDescriptor, expSize: Int): Unit = {
+    if (expSize == 0) {
+      assert(dv.isEmpty, s"Expected DV to be empty: $dv")
+    } else {
+      assert(!dv.isEmpty && dv.cardinality == expSize, s"Invalid size expected: $expSize, $dv")
+    }
+  }
+
+  private val testTablePath = new Path("s3a://table/test")
+  private val testDVAbsPath = "s3a://table/test/dv1.bin"
+  private val testDVData: Array[Byte] = Array(1, 2, 3, 4)
+}


### PR DESCRIPTION
## Description
This PR is part of the feature: Support reading Delta tables with deletion vectors (more details at delta-io/delta#1485)

It adds new class called `DeletionVectorDescriptor` which is used to represent the deletion vector for a given file (`AddFile`) in `DeltaLog`. The format of the metadata is described in the [protocol](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#deletion-vector-descriptor-schema).

## How was this patch tested?
New test suite is added