### PR TITLE
Port existing features to Table Features

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -614,6 +614,12 @@
     ],
     "sqlState" : "42000"
   },
+  "DELTA_FEATURES_PROTOCOL_METADATA_MISMATCH" : {
+    "message" : [
+      "Unable to operate on this table because the following table features are enabled in metadata but not listed in protocol: <features>."
+    ],
+    "sqlState" : "42000"
+  },
   "DELTA_FEATURE_REQUIRES_HIGHER_READER_VERSION" : {
     "message" : [
       "Unable to enable table feature <feature> because it requires a higher reader protocol version (current <current>). Consider upgrading the table's reader protocol version to <required>, or to a version which supports reader table features. Refer to <docLink> for more information on table protocol versions."

--- a/core/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
@@ -70,11 +70,8 @@ import org.apache.spark.sql.types.{Metadata => FieldMetadata}
  */
 object GeneratedColumn extends DeltaLogging with AnalysisHelper {
 
-  val MIN_WRITER_VERSION = 4
-
-  def satisfyGeneratedColumnProtocol(protocol: Protocol): Boolean = {
-    protocol.minWriterVersion >= MIN_WRITER_VERSION
-  }
+  def satisfyGeneratedColumnProtocol(protocol: Protocol): Boolean =
+    protocol.isFeatureEnabled(GeneratedColumnsTableFeature)
 
   /**
    * Whether the field contains the generation expression. Note: this doesn't mean the column is a
@@ -94,10 +91,10 @@ object GeneratedColumn extends DeltaLogging with AnalysisHelper {
 
   /**
    * Whether any generation expressions exist in the schema. Note: this doesn't mean the table
-   * contains generated columns. A table has generated columns only if its
-   * `minWriterVersion` >= `GeneratedColumn.MIN_WRITER_VERSION` and some of columns in the table
-   * schema contain generation expressions. Use `enforcesGeneratedColumns` to check generated
-   * column tables instead.
+   * contains generated columns. A table has generated columns only if its protocol satisfies
+   * Generated Column (listed in Table Features or supported implicitly) and some of columns in
+   * the table schema contain generation expressions. Use `enforcesGeneratedColumns` to check
+   * generated column tables instead.
    */
   def hasGeneratedColumns(schema: StructType): Boolean = {
     schema.exists(isGeneratedColumn)
@@ -118,8 +115,8 @@ object GeneratedColumn extends DeltaLogging with AnalysisHelper {
 
   /**
    * Whether the table has generated columns. A table has generated columns only if its
-   * `minWriterVersion` >= `GeneratedColumn.MIN_WRITER_VERSION` and some of columns in the table
-   * schema contain generation expressions.
+   * protocol satisfies Generated Column (listed in Table Features or supported implicitly) and
+   * some of columns in the table schema contain generation expressions.
    *
    * As Spark will propagate column metadata storing the generation expression through
    * the entire plan, old versions that don't support generated columns may create tables whose

--- a/core/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -95,6 +95,7 @@ class Snapshot(
   /** Performs validations during initialization */
   protected def init(): Unit = {
     deltaLog.protocolRead(protocol)
+    deltaLog.assertLegacyTableFeaturesMatch(protocol, metadata)
     SchemaUtils.recordUndefinedTypes(deltaLog, metadata.schema)
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -182,8 +182,9 @@ trait TableFeatureSupport { this: Protocol =>
    * `writerFeatures` field. Returns an empty set when this protocol supports none of reader and
    * writer features.
    */
-  def readerAndWriterFeatureDescriptors: Set[TableFeatureDescriptor] =
-    this.readerFeatures.getOrElse(Set()) ++ this.writerFeatures.getOrElse(Set())
+  @JsonIgnore
+  lazy val readerAndWriterFeatureDescriptors: Set[TableFeatureDescriptor] =
+    readerFeatureDescriptors ++ writerFeatureDescriptors
 
   /**
    * Get the [[TableFeatureDescriptor]] if a feature with name `featureName` is explicitly
@@ -260,6 +261,18 @@ trait TableFeatureSupport { this: Protocol =>
     } else {
       mergedProtocol
     }
+  }
+
+  /**
+   * Check if a `feature` is enabled in this protocol. This means either (a) the protocol does not
+   * support table features and implicitly supports the feature, or (b) the protocol supports
+   * table features and references the feature.
+   */
+  def isFeatureEnabled(feature: TableFeature): Boolean = {
+    // legacy feature + legacy protocol
+    (feature.isLegacyFeature && this.implicitlyEnabledFeatures.contains(feature)) ||
+    // new protocol
+    getFeatureDescriptor(feature.name).isDefined
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -305,7 +305,8 @@ case class WriteIntoDelta(
         // the CDF protocol requires either (i) all CDF data are generated explicitly as AddCDCFile,
         // or (ii) all CDF data can be deduced from [[AddFile]] and [[RemoveFile]].
         val dataToWrite =
-          if (containsDataFilters && CDCReader.isCDCEnabledOnTable(txn.metadata) &&
+          if (containsDataFilters &&
+              CDCReader.isCDCEnabledOnTable(txn.metadata, sparkSession) &&
               sparkSession.conf.get(DeltaSQLConf.REPLACEWHERE_DATACOLUMNS_WITH_CDF_ENABLED) &&
               cdcExistsInRemoveOp) {
             var dataWithDefaultExprs = data

--- a/core/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
@@ -226,7 +226,7 @@ trait TransactionalWrite extends DeltaLogging { self: OptimisticTransactionImpl 
     // and will be stripped out later in [[DelayedCommitProtocolEdge]].
     // Note that the ordering of the partition schema is relevant - CDC_PARTITION_COL must
     // come first in order to ensure CDC data lands in the right place.
-    if (CDCReader.isCDCEnabledOnTable(metadata) &&
+    if (CDCReader.isCDCEnabledOnTable(metadata, spark) &&
       inputData.schema.fieldNames.contains(CDCReader.CDC_TYPE_COLUMN_NAME)) {
       val augmentedData = inputData.withColumn(
         CDCReader.CDC_PARTITION_COL, col(CDCReader.CDC_TYPE_COLUMN_NAME).isNotNull)

--- a/core/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -20,6 +20,7 @@ import java.util.UUID
 
 import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.{TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
@@ -159,7 +160,37 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
   testActionSerDe(
     "Protocol - json serialization/deserialization",
     Protocol(minReaderVersion = 1, minWriterVersion = 2),
-    expectedJson = """{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}""".stripMargin)
+    expectedJson = """{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}""")
+
+  testActionSerDe(
+    "Protocol - json serialization/deserialization with writer features",
+    Protocol(minReaderVersion = 1, minWriterVersion = TABLE_FEATURES_MIN_WRITER_VERSION)
+      .withFeature(AppendOnlyTableFeature),
+    expectedJson = """{"protocol":{"minReaderVersion":1,""" +
+      s""""minWriterVersion":$TABLE_FEATURES_MIN_WRITER_VERSION,""" +
+      """"writerFeatures":[{"name":"appendOnly","status":"enabled"}]}}""")
+
+  testActionSerDe(
+    "Protocol - json serialization/deserialization with reader and writer features",
+    Protocol(
+      minReaderVersion = TABLE_FEATURES_MIN_READER_VERSION,
+      minWriterVersion = TABLE_FEATURES_MIN_WRITER_VERSION)
+      .withFeature(TestLegacyReaderWriterFeature),
+    expectedJson =
+      s"""{"protocol":{"minReaderVersion":$TABLE_FEATURES_MIN_READER_VERSION,""" +
+        s""""minWriterVersion":$TABLE_FEATURES_MIN_WRITER_VERSION,""" +
+        """"readerFeatures":[{"name":"testLegacyReaderWriter","status":"enabled"}],""" +
+        """"writerFeatures":[{"name":"testLegacyReaderWriter","status":"enabled"}]}}""")
+
+  testActionSerDe(
+    "Protocol - json serialization/deserialization with empty reader and writer features",
+    Protocol(
+      minReaderVersion = TABLE_FEATURES_MIN_READER_VERSION,
+      minWriterVersion = TABLE_FEATURES_MIN_WRITER_VERSION),
+    expectedJson =
+      s"""{"protocol":{"minReaderVersion":$TABLE_FEATURES_MIN_READER_VERSION,""" +
+        s""""minWriterVersion":$TABLE_FEATURES_MIN_WRITER_VERSION,""" +
+        """"readerFeatures":[],"writerFeatures":[]}}""")
 
   testActionSerDe(
     "SetTransaction (lastUpdated is None) - json serialization/deserialization",
@@ -342,6 +373,8 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
         // Disable different delta validations so that the passed action can be committed in
         // all cases.
         val settings = Seq(
+          DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_READER_VERSION.key -> "1",
+          DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_WRITER_VERSION.key -> "1",
           DeltaSQLConf.DELTA_COMMIT_VALIDATION_ENABLED.key -> "false",
           DeltaSQLConf.DELTA_COMMIT_INFO_ENABLED.key -> "false") ++ extraSettings
         withSQLConf(settings: _*) {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnRenameSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnRenameSuite.scala
@@ -126,8 +126,8 @@ class DeltaColumnRenameSuite extends QueryTest
        val e = intercept[AnalysisException] {
         spark.sql(s"Alter table t1 RENAME COLUMN map to map1")
        }
-      assert(e.getMessage.contains("upgrade your Delta table") &&
-        e.getMessage.contains("change the column mapping mode"))
+      assert(e.getMessage.contains("enable Column Mapping") &&
+        e.getMessage.contains("mapping mode 'name'"))
 
       alterTableWithProps("t1", Map(
         DeltaConfigs.COLUMN_MAPPING_MODE.key -> "name",
@@ -179,8 +179,8 @@ class DeltaColumnRenameSuite extends QueryTest
        val e = intercept[AnalysisException] {
         spark.sql(s"Alter table t1 RENAME COLUMN map to map1")
        }
-      assert(e.getMessage.contains("upgrade your Delta table") &&
-        e.getMessage.contains("change the column mapping mode"))
+      assert(e.getMessage.contains("enable Column Mapping") &&
+        e.getMessage.contains("mapping mode 'name'"))
 
       // Upgrading this schema shouldn't cause any errors even if there are leaf column name
       // duplications such as a.c, b.c.

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -229,7 +229,8 @@ class DeltaLogSuite extends QueryTest
 
         log.store.write(
           FileNames.deltaFile(log.logPath, 0L),
-          Iterator(Protocol(), Metadata(), add).map(a => JsonUtils.toJson(a.wrap)),
+          Iterator(Action.supportedProtocolVersion(), Metadata(), add)
+            .map(a => JsonUtils.toJson(a.wrap)),
           overwrite = false,
           log.newDeltaHadoopConf())
         log.store.write(
@@ -257,7 +258,8 @@ class DeltaLogSuite extends QueryTest
 
         log.store.write(
           FileNames.deltaFile(log.logPath, 0L),
-          Iterator(Protocol(), Metadata(), add).map(a => JsonUtils.toJson(a.wrap)),
+          Iterator(Action.supportedProtocolVersion(), Metadata(), add)
+            .map(a => JsonUtils.toJson(a.wrap)),
           overwrite = false,
           log.newDeltaHadoopConf())
         log.store.write(

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -20,7 +20,7 @@ import java.io.{File, FileNotFoundException}
 import java.util.concurrent.atomic.AtomicInteger
 
 // scalastyle:off import.ordering.noEmptyLine
-import org.apache.spark.sql.delta.actions.{CommitInfo, Protocol}
+import org.apache.spark.sql.delta.actions.Action
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.files.TahoeLogFileIndex
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -2065,7 +2065,7 @@ class DeltaSuite extends QueryTest
 
     // Now make a commit that comes from an "external" writer that deletes existing data and
     // changes the schema
-    val actions = Seq(Protocol(), newMetadata) ++ files.map(_.remove)
+    val actions = Seq(Action.supportedProtocolVersion(), newMetadata) ++ files.map(_.remove)
     deltaLog.store.write(
       FileNames.deltaFile(deltaLog.logPath, snapshot.version + 1),
       actions.map(_.json).iterator,

--- a/core/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
@@ -250,7 +250,7 @@ trait DescribeDeltaDetailSuiteBase extends QueryTest
         Seq(
           TABLE_FEATURES_MIN_READER_VERSION,
           TABLE_FEATURES_MIN_WRITER_VERSION,
-          Array(AppendOnlyTableFeature.name)),
+          Array(AppendOnlyTableFeature.name, InvariantsTableFeature.name)),
         Seq("minReaderVersion", "minWriterVersion", "enabledTableFeatures"))
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
@@ -364,7 +364,9 @@ trait DescribeDeltaHistorySuiteBase
       log.ensureLogDirectoryExist()
       log.store.write(
         FileNames.deltaFile(log.logPath, 0),
-        Iterator(Metadata(schemaString = spark.range(1).schema.json).json, Protocol(1, 1).json),
+        Iterator(
+          Metadata(schemaString = spark.range(1).schema.asNullable.json).json,
+          Protocol(1, 1).json),
         overwrite = false,
         log.newDeltaHadoopConf())
       log.update()

--- a/core/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -215,9 +215,9 @@ class OptimisticTransactionSuite
       t => t.metadata
     ),
     concurrentWrites = Seq(
-      Protocol()),
+      Action.supportedProtocolVersion()),
     actions = Seq(
-      Protocol()))
+      Action.supportedProtocolVersion()))
 
   check(
     "taint whole table",

--- a/core/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -538,7 +538,7 @@ class OptimisticTransactionSuite
         .add("id", "long")
         .add("part", "string")
       deltaLog.withNewTransaction { txn =>
-        val protocol = Protocol()
+        val protocol = Action.supportedProtocolVersion()
         val metadata = Metadata(
           schemaString = schema.json,
           partitionColumns = partitionColumns)

--- a/core/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuiteBase.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuiteBase.scala
@@ -54,7 +54,7 @@ trait OptimisticTransactionSuiteBase
   protected def check(
       name: String,
       conflicts: Boolean,
-      setup: Seq[Action] = Seq(Metadata(), Protocol()),
+      setup: Seq[Action] = Seq(Metadata(), Action.supportedProtocolVersion()),
       reads: Seq[OptimisticTransaction => Unit],
       concurrentWrites: Seq[Action],
       actions: Seq[Action],

--- a/core/src/test/scala/org/apache/spark/sql/delta/test/DeltaTestImplicits.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/test/DeltaTestImplicits.scala
@@ -43,8 +43,11 @@ object DeltaTestImplicits {
         } else {
           // if we don't have an implicit protocol action, make sure the first commit
           // contains one explicitly
-          val protocolOpt =
-            if (!actions.exists(_.isInstanceOf[Protocol])) Some(Protocol()) else None
+          val protocolOpt = if (!actions.exists(_.isInstanceOf[Protocol])) {
+            Some(Action.supportedProtocolVersion())
+          } else {
+            None
+          }
           txn.commit(actions ++ metadataOpt ++ protocolOpt, op)
         }
       } else {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

This PR adapts the following legacy features to Table Features:

- appendOnly
- invariants
- checkConstriants
- changeDataFeed
- generatedColumns
- columnMapping
- identityColumns

Note that Deletion Vector will be ported in a separate PR.

This PR does not modify each feature to check the `protocol` action to determine if it's used. Instead, there's a one-time check (in `Snapshot`) when opening a table for read, to ensure all legacy features implicitly enabled in metadata are referenced in `protocol`.

## How was this patch tested?

Existing tests.

## Does this PR introduce _any_ user-facing changes?

No.