### PR TITLE
Set Table Features Protocol Version to (3, 7)

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -302,12 +302,11 @@ object TableFeatureProtocolUtils {
   /** Prop prefix in Spark sessions configs. */
   val DEFAULT_FEATURE_PROP_PREFIX = "spark.databricks.delta.properties.defaults.feature."
 
-  // TODO: Switch to (3, 7) once the implementation is done
   /** Min reader version that supports reader features. */
-  val TABLE_FEATURES_MIN_READER_VERSION = Int.MaxValue / 2
+  val TABLE_FEATURES_MIN_READER_VERSION = 3
 
   /** Min reader version that supports writer features. */
-  val TABLE_FEATURES_MIN_WRITER_VERSION = Int.MaxValue / 2
+  val TABLE_FEATURES_MIN_WRITER_VERSION = 7
 
   /**
    * Determine whether a [[Protocol]] with the given reader protocol version is capable of adding

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -258,8 +258,7 @@ trait DeltaSQLConfBase {
       .doc("The default writer protocol version to create new tables with, unless a feature " +
         "that requires a higher version for correctness is enabled.")
       .intConf
-      // TODO: Int.MaxValue / 2 is the temporary version for table features. To be changed to 7.
-      .checkValues(Set(1, 2, 3, 4, 5, 6, Int.MaxValue / 2))
+      .checkValues(Set(1, 2, 3, 4, 5, 6, 7))
       .createWithDefault(2)
 
   val DELTA_PROTOCOL_DEFAULT_READER_VERSION =
@@ -267,8 +266,7 @@ trait DeltaSQLConfBase {
       .doc("The default reader protocol version to create new tables with, unless a feature " +
         "that requires a higher version for correctness is enabled.")
       .intConf
-      // TODO: Int.MaxValue / 2 is the temporary version for table features. To be changed to 3.
-      .checkValues(Set(1, 2, Int.MaxValue / 2))
+      .checkValues(Set(1, 2, 3))
       .createWithDefault(1)
 
   val DELTA_MAX_SNAPSHOT_LINEAGE_LENGTH =


### PR DESCRIPTION
## Description

This PR changes the protocol version of Table Features to (3, 7) because all features are now adapted (see https://github.com/delta-io/delta/pull/1530).

## How was this patch tested?

Existing tests.

## Does this PR introduce _any_ user-facing changes?

No.