### PR TITLE
[Spark] Support dryRun for VACUUM Scala/Python API

### DIFF
--- a/python/delta/tables.py
+++ b/python/delta/tables.py
@@ -223,7 +223,7 @@ class DeltaTable(object):
         return DeltaMergeBuilder(self._spark, jbuilder)
 
     @since(0.4)  # type: ignore[arg-type]
-    def vacuum(self, retentionHours: Optional[float] = None) -> DataFrame:
+    def vacuum(self, retentionHours: Optional[float] = None, dryRun: bool = False) -> DataFrame:
         """
         Recursively delete files and directories in the table that are not needed by the table for
         maintaining older versions up to the given retention threshold. This method will return an
@@ -241,12 +241,12 @@ class DeltaTable(object):
         jdt = self._jdt
         if retentionHours is None:
             return DataFrame(
-                jdt.vacuum(),
+                jdt.vacuum(dryRun),
                 getattr(self._spark, "_wrapped", self._spark)  # type: ignore[attr-defined]
             )
         else:
             return DataFrame(
-                jdt.vacuum(float(retentionHours)),
+                jdt.vacuum(float(retentionHours), dryRun),
                 getattr(self._spark, "_wrapped", self._spark)  # type: ignore[attr-defined]
             )
 

--- a/spark/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/spark/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -97,7 +97,7 @@ class DeltaTable private[tables](
    * @since 0.3.0
    */
   def vacuum(retentionHours: Double): DataFrame = {
-    executeVacuum(deltaLog, Some(retentionHours), table.getTableIdentifierIfExists)
+    executeVacuum(deltaLog, Some(retentionHours), false)
   }
 
   /**
@@ -110,7 +110,38 @@ class DeltaTable private[tables](
    * @since 0.3.0
    */
   def vacuum(): DataFrame = {
-    executeVacuum(deltaLog, None, table.getTableIdentifierIfExists)
+    executeVacuum(deltaLog, None, false)
+  }
+
+  /**
+   * Recursively delete files and directories in the table that are not needed by the table for
+   * maintaining older versions up to the given retention threshold. This method will return an
+   * empty DataFrame on successful completion.
+   *
+   * @param retentionHours The retention threshold in hours. Files required by the table for
+   *                       reading versions earlier than this will be preserved and the
+   *                       rest of them will be deleted.
+   * @param dryRun If set to true, no files will be deleted. Instead, we will list all files and
+   *               directories that will be cleared.
+   * @since 0.3.0
+   */
+  def vacuum(retentionHours: Double, dryRun: Boolean): DataFrame = {
+    executeVacuum(deltaLog, Some(retentionHours), dryRun)
+  }
+
+  /**
+   * Recursively delete files and directories in the table that are not needed by the table for
+   * maintaining older versions up to the given retention threshold. This method will return an
+   * empty DataFrame on successful completion.
+   *
+   * note: This will use the default retention period of 7 days.
+   *
+   * @param dryRun If set to true, no files will be deleted. Instead, we will list all files and
+   *               directories that will be cleared.
+   * @since 0.3.0
+   */
+  def vacuum(dryRun: Boolean): DataFrame = {
+    executeVacuum(deltaLog, None, dryRun)
   }
 
   /**

--- a/spark/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/spark/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -97,7 +97,7 @@ class DeltaTable private[tables](
    * @since 0.3.0
    */
   def vacuum(retentionHours: Double): DataFrame = {
-    executeVacuum(deltaLog, Some(retentionHours), false)
+    executeVacuum(deltaLog, Some(retentionHours), dryRun = false)
   }
 
   /**
@@ -110,20 +110,21 @@ class DeltaTable private[tables](
    * @since 0.3.0
    */
   def vacuum(): DataFrame = {
-    executeVacuum(deltaLog, None, false)
+    executeVacuum(deltaLog, retentionHours = None, dryRun = false)
   }
 
   /**
    * Recursively delete files and directories in the table that are not needed by the table for
    * maintaining older versions up to the given retention threshold. This method will return an
-   * empty DataFrame on successful completion.
+   * empty DataFrame on successful completion. If dryRun is true, return list of files to be
+   * deleted.
    *
    * @param retentionHours The retention threshold in hours. Files required by the table for
    *                       reading versions earlier than this will be preserved and the
    *                       rest of them will be deleted.
-   * @param dryRun If set to true, no files will be deleted. Instead, we will list all files and
-   *               directories that will be cleared.
-   * @since 0.3.0
+   * @param dryRun If set to true, no files will be deleted. Instead, returns a DataFrame
+   *               with "path" column containing files to be deleted.
+   * @since 3.1.0
    */
   def vacuum(retentionHours: Double, dryRun: Boolean): DataFrame = {
     executeVacuum(deltaLog, Some(retentionHours), dryRun)
@@ -132,16 +133,17 @@ class DeltaTable private[tables](
   /**
    * Recursively delete files and directories in the table that are not needed by the table for
    * maintaining older versions up to the given retention threshold. This method will return an
-   * empty DataFrame on successful completion.
+   * empty DataFrame on successful completion. If dryRun is true, return list of files to be
+   * deleted.
    *
    * note: This will use the default retention period of 7 days.
    *
-   * @param dryRun If set to true, no files will be deleted. Instead, we will list all files and
-   *               directories that will be cleared.
-   * @since 0.3.0
+   * @param dryRun If set to true, no files will be deleted. Instead, returns a DataFrame
+   *               with "path" column containing files to be deleted.
+   * @since 3.1.0
    */
   def vacuum(dryRun: Boolean): DataFrame = {
-    executeVacuum(deltaLog, None, dryRun)
+    executeVacuum(deltaLog, retentionHours = None, dryRun)
   }
 
   /**

--- a/spark/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
+++ b/spark/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
@@ -85,13 +85,20 @@ trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
       retentionHours: Option[Double],
       tableId: Option[TableIdentifier] = None): DataFrame = {
     VacuumCommand.gc(sparkSession, deltaLog, false, retentionHours)
+    sparkSession.emptyDataFrame
   }
 
   protected def executeVacuum(
       deltaLog: DeltaLog,
       retentionHours: Option[Double],
       dryRun: Boolean): DataFrame = {
-    VacuumCommand.gc(sparkSession, deltaLog, dryRun, retentionHours)
+    val ret = VacuumCommand.gc(sparkSession, deltaLog, dryRun, retentionHours)
+    if (dryRun) {
+      ret
+    } else {
+      // Return empty dataframe for successful vacuum command.
+      sparkSession.emptyDataFrame
+    }
   }
 
   protected def executeRestore(

--- a/spark/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
+++ b/spark/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
@@ -83,8 +83,15 @@ trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
   protected def executeVacuum(
       deltaLog: DeltaLog,
       retentionHours: Option[Double],
-      dryRun: Boolean,
       tableId: Option[TableIdentifier] = None): DataFrame = {
+    VacuumCommand.gc(sparkSession, deltaLog, false, retentionHours)
+    sparkSession.emptyDataFrame
+  }
+
+  protected def executeVacuum(
+      deltaLog: DeltaLog,
+      retentionHours: Option[Double],
+      dryRun: Boolean): DataFrame = {
     VacuumCommand.gc(sparkSession, deltaLog, dryRun, retentionHours)
     sparkSession.emptyDataFrame
   }

--- a/spark/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
+++ b/spark/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
@@ -85,7 +85,6 @@ trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
       retentionHours: Option[Double],
       tableId: Option[TableIdentifier] = None): DataFrame = {
     VacuumCommand.gc(sparkSession, deltaLog, false, retentionHours)
-    sparkSession.emptyDataFrame
   }
 
   protected def executeVacuum(
@@ -93,7 +92,6 @@ trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
       retentionHours: Option[Double],
       dryRun: Boolean): DataFrame = {
     VacuumCommand.gc(sparkSession, deltaLog, dryRun, retentionHours)
-    sparkSession.emptyDataFrame
   }
 
   protected def executeRestore(

--- a/spark/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
+++ b/spark/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
@@ -83,8 +83,9 @@ trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
   protected def executeVacuum(
       deltaLog: DeltaLog,
       retentionHours: Option[Double],
+      dryRun: Boolean,
       tableId: Option[TableIdentifier] = None): DataFrame = {
-    VacuumCommand.gc(sparkSession, deltaLog, false, retentionHours)
+    VacuumCommand.gc(sparkSession, deltaLog, dryRun, retentionHours)
     sparkSession.emptyDataFrame
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
@@ -274,8 +274,10 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
             timeTakenForDelete = 0L)
 
           recordDeltaEvent(deltaLog, "delta.gc.stats", data = stats)
-          logConsole(s"Found $numFiles files ($sizeOfDataToDelete bytes) and directories in " +
-            s"a total of $dirCounts directories that are safe to delete.")
+          val msg = s"Found $numFiles files ($sizeOfDataToDelete bytes) and directories in " +
+            s"a total of $dirCounts directories that are safe to delete."
+          logConsole(msg)
+          logInfo(msg) // For Python API
 
           return diffFiles.map(f => stringToPath(f).toString).toDF("path")
         }
@@ -310,7 +312,6 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
           timeTakenForDelete = timeTakenForDelete)
         recordDeltaEvent(deltaLog, "delta.gc.stats", data = stats)
         logVacuumEnd(deltaLog, spark, path, Some(filesDeleted), Some(dirCounts))
-
 
         spark.createDataset(Seq(basePath)).toDF("path")
       } finally {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
@@ -128,7 +128,8 @@ trait DeltaVacuumSuiteBase extends QueryTest
   case class ExecuteVacuumInScala(
       deltaTable: io.delta.tables.DeltaTable,
       expectedDf: Seq[String],
-      retentionHours: Option[Double] = None) extends Operation
+      retentionHours: Option[Double] = None,
+      dryRun: Option[Boolean] = None) extends Operation
   /** Advance the time. */
   case class AdvanceClock(timeToAdd: Long) extends Operation
   /** Execute SQL command */
@@ -224,13 +225,15 @@ trait DeltaVacuumSuiteBase extends QueryTest
         val result = VacuumCommand.gc(spark, deltaLog, dryRun, retention, clock = clock)
         val qualified = expectedDf.map(p => fs.makeQualified(new Path(p)).toString)
         checkDatasetUnorderly(result.as[String], qualified: _*)
-      case ExecuteVacuumInScala(deltaTable, expectedDf, retention) =>
-        Given("*** Garbage collecting Reservoir using Scala")
-        val result = if (retention.isDefined) {
-          deltaTable.vacuum(retention.get)
-        } else {
-          deltaTable.vacuum()
+      case ExecuteVacuumInScala(deltaTable, expectedDf, retention, dryRun) =>
+        Given(s"*** Garbage collecting Reservoir using Scala. DryRun = $dryRun")
+        val result = (dryRun, retention) match {
+          case (Some(dryRun), Some(retention)) => deltaTable.vacuum(retention, dryRun)
+          case (Some(dryRun), None) => deltaTable.vacuum(dryRun)
+          case (None, Some(retention)) => deltaTable.vacuum(retention)
+          case (None, None) => deltaTable.vacuum()
         }
+
         if(expectedDf == Seq()) {
           assert(result === spark.emptyDataFrame)
         } else {
@@ -294,10 +297,25 @@ trait DeltaVacuumSuiteBase extends QueryTest
       CreateFile(notCommittedFile, commitToActionLog = false),
       CheckFiles(Seq(committedFile, notCommittedFile)),
 
+      // Dry run should not delete the not committed file and but not delete files
+      ExecuteVacuumInScala(
+        deltaTable,
+        Seq(),
+        dryRun = Some(true)),
+      CheckFiles(Seq(committedFile, notCommittedFile)),
+
       // Actual run should delete the not committed file and but not delete files
       ExecuteVacuumInScala(deltaTable, Seq()),
       CheckFiles(Seq(committedFile)),
       CheckFiles(Seq(notCommittedFile), exist = false), // file ts older than default retention
+
+      // Dry run should not delete the not committed file and but not delete files
+      ExecuteVacuumInScala(
+        deltaTable,
+        Seq(),
+        Some(0),
+        dryRun = Some(true)),
+      CheckFiles(Seq(committedFile)),
 
       // Logically delete the file.
       LogicallyDeleteFile(committedFile),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
@@ -297,19 +297,19 @@ trait DeltaVacuumSuiteBase extends QueryTest
       CreateFile(notCommittedFile, commitToActionLog = false),
       CheckFiles(Seq(committedFile, notCommittedFile)),
 
-      // Dry run should not delete the not committed file and but not delete files
+      // Dry run should not delete any file.
       ExecuteVacuumInScala(
         deltaTable,
         Seq(),
         dryRun = Some(true)),
       CheckFiles(Seq(committedFile, notCommittedFile)),
 
-      // Actual run should delete the not committed file and but not delete files
+      // Actual run should delete the not committed file and but not delete files.
       ExecuteVacuumInScala(deltaTable, Seq()),
       CheckFiles(Seq(committedFile)),
       CheckFiles(Seq(notCommittedFile), exist = false), // file ts older than default retention
 
-      // Dry run should not delete the not committed file and but not delete files
+      // Dry run should not delete any file.
       ExecuteVacuumInScala(
         deltaTable,
         Seq(),


### PR DESCRIPTION
## Description

Add dryRun parameter to vacuum Scala/Python API. 
Fixes #454  and can close #605.

## How was this patch tested?
Unit tests

## Does this PR introduce _any_ user-facing changes?
Scala / Python API supports dryRun option.
