### PR TITLE
WHEN NOT MATCHED BY SOURCE - Python API

### DIFF
--- a/python/delta/tables.py
+++ b/python/delta/tables.py
@@ -723,7 +723,7 @@ class DeltaMergeBuilder(object):
 
       - When there are two ``whenMatched`` clauses and there are conditions (or the lack of)
         such that a row matches both clauses, then the first clause/action is executed.
-        In other words, the order of the ``whenMatched`` clauses matter.
+        In other words, the order of the ``whenMatched`` clauses matters.
 
       - If none of the ``whenMatched`` clauses match a source-target row pair that satisfy
         the merge condition, then the target rows will not be updated or deleted.
@@ -757,18 +757,16 @@ class DeltaMergeBuilder(object):
 
     - Constraints in the ``whenNotMatchedBySource`` clauses:
 
-      - There can be at most one ``update`` action and one ``delete`` action in
-        `whenNotMatchedBySource` clauses.
-
-      - Each ``whenNotMatchedBySource`` clause can have an optional condition. However, if there are
-        two ``whenNotMatchedBySource`` clauses, then the first one must have a condition.
+      - Each ``whenNotMatchedBySource`` clause can have an optional condition. However, only the
+        last ``whenNotMatchedBySource`` clause may omit the condition.
 
       - Conditions and update expressions  in ``whenNotMatchedBySource`` clauses may only refer to
         columns from the target Delta table.
 
-      - When there are two ``whenNotMatchedBySource`` clauses and there are conditions (or the lack
-        of) such that a row satisfies both clauses, then the first clause/action is executed.
-        In other words, the order of the ``whenNotMatchedBySource`` clauses matter.
+      - When there are more than one ``whenNotMatchedBySource`` clauses and there are conditions (or
+        the lack of) such that a row satisfies multiple clauses, then the first clause/action
+        satisfied is executed. In other words, the order of the ``whenNotMatchedBySource`` clauses
+        matters.
 
       - If no ``whenNotMatchedBySource`` clause is present or if it is present but the
         non-matching target row does not satisfy any of the ``whenNotMatchedBySource`` clause
@@ -792,7 +790,7 @@ class DeltaMergeBuilder(object):
               "count": "1",
               "missed_count": "0"
             }
-          ).whenNotMatchedBySourceUpdate(values =
+          ).whenNotMatchedBySourceUpdate(set =
             {
               "missed_count": "events.missed_count + 1"
             }
@@ -818,7 +816,7 @@ class DeltaMergeBuilder(object):
               "count": lit("1"),
               "missed_count": lit("0")
             }
-          ).whenNotMatchedBySourceUpdate(values =
+          ).whenNotMatchedBySourceUpdate(set =
             {
               "missed_count": col("events.missed_count") + 1
             }

--- a/python/delta/tests/test_deltatable.py
+++ b/python/delta/tests/test_deltatable.py
@@ -192,6 +192,16 @@ class DeltaTableTests(DeltaTestCase):
             .execute()
         self.__checkAnswer(dt.toDF(), ([('a', 1), ('b', 2), ('c', 5), ('d', 6)]))
 
+        # Interleaved update and delete clauses
+        reset_table()
+        dt.merge(source, expr("key = k")) \
+            .whenNotMatchedBySourceDelete(condition="key = 'c'") \
+            .whenNotMatchedBySourceUpdate(condition="key = 'c'", set={"value": "5"}) \
+            .whenNotMatchedBySourceDelete(condition="key = 'd'") \
+            .whenNotMatchedBySourceUpdate(set={"value": "6"}) \
+            .execute()
+        self.__checkAnswer(dt.toDF(), ([('a', 1), ('b', 2)]))
+
         # ============== Test clause conditions ==============
 
         # String expressions in all conditions and dicts


### PR DESCRIPTION
## Description
Extend the existing Python Delta Table API to expose WHEN NOT MATCHED BY SOURCE clause in merge commands.
Support for the clause was introduced in https://github.com/delta-io/delta/pull/1511 using the Scala Delta Table API, this patch extends the Python API to support the new clause.

See corresponding feature request: https://github.com/delta-io/delta/issues/1364

## How was this patch tested?
Adding python tests covering WHEN NOT MATCHED BY SOURCE to test_deltatable.py.

## Does this PR introduce _any_ user-facing changes?
The extended API for NOT MATCHED BY SOURCE mirrors existing clauses (MATCHED/NOT MATCHED).
Usage:
```
        dt.merge(source, "key = k")
            .whenNotMatchedBySourceDelete(condition="value > 0")
            .whenNotMatchedBySourceUpdate(set={"value": "value + 0"})
            .execute()
```
