### PR TITLE
Add `DeletionVectorStore` to read from and write DVs to storage

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -492,6 +492,18 @@
     ],
     "sqlState" : "42000"
   },
+  "DELTA_DELETION_VECTOR_CHECKSUM_MISMATCH" : {
+    "message" : [
+      "Could not verify deletion vector integrity, CRC checksum verification failed."
+    ],
+    "sqlState" : "22000"
+  },
+  "DELTA_DELETION_VECTOR_SIZE_MISMATCH" : {
+    "message" : [
+      "Deletion vector integrity check failed. Encountered a size mismatch."
+    ],
+    "sqlState" : "22000"
+  },
   "DELTA_DROP_COLUMN_AT_INDEX_LESS_THAN_ZERO" : {
     "message" : [
       "Index <columnIndex> to drop column is lower than 0"

--- a/core/src/main/scala/org/apache/spark/sql/delta/deletionvectors/StoredBitmap.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/deletionvectors/StoredBitmap.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.deletionvectors
+
+import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor
+import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
+import org.apache.spark.sql.delta.util.JsonUtils
+import org.apache.hadoop.fs.Path
+
+
+/**
+ * Bitmap for a Deletion Vector, implemented as a thin wrapper around a Deletion Vector
+ * Descriptor. The bitmap can be empty, inline or on-disk. In case of on-disk deletion
+ * vectors, `tableDataPath` must be set to the data path of the Delta table, which is where
+ * deletion vectors are stored.
+ */
+case class StoredBitmap(
+    dvDescriptor: DeletionVectorDescriptor,
+    tableDataPath: Option[Path] = None) {
+  require(tableDataPath.isDefined || !dvDescriptor.isOnDisk,
+    "Table path is required for on-disk deletion vectors")
+
+  /**
+   * Load this bitmap into memory.
+   *
+   * Use `dvStore` if this variant is in cloud storage, otherwise just deserialize.
+   */
+  def load(dvStore: DeletionVectorStore): RoaringBitmapArray = {
+    if (isEmpty) {
+      new RoaringBitmapArray()
+    } else if (isInline) {
+      RoaringBitmapArray.readFrom(dvDescriptor.inlineData)
+    } else {
+      assert(isOnDisk)
+      dvStore.read(onDiskPath.get, dvDescriptor.offset.getOrElse(0), dvDescriptor.sizeInBytes)
+    }
+  }
+
+  /**
+   * The serialized size of the stored bitmap in bytes.
+   *
+   * Can be used for planning memory management without a round-trip to cloud storage.
+   */
+  def size: Int = dvDescriptor.sizeInBytes
+
+  /**
+   * Number of entries in the bitmap.
+   */
+  def cardinality: Long = dvDescriptor.cardinality
+
+  /** Returns a unique identifier for this bitmap (Deletion Vector serialized as a JSON object. */
+  def getUniqueId(): String = JsonUtils.toJson(dvDescriptor)
+
+  private def isEmpty: Boolean = dvDescriptor.isEmpty
+
+  private def isInline: Boolean = dvDescriptor.isInline
+
+  private def isOnDisk: Boolean = dvDescriptor.isOnDisk
+
+  /** The absolute path for on-disk deletion vectors. */
+  private lazy val onDiskPath: Option[Path] = tableDataPath.map(dvDescriptor.absolutePath(_))
+}
+
+object StoredBitmap {
+  /** The stored bitmap of an empty deletion vector. */
+  final val EMPTY = new StoredBitmap(DeletionVectorDescriptor.EMPTY, None)
+
+
+  /** Factory for inline deletion vectors. */
+  def inline(dvDescriptor: DeletionVectorDescriptor): StoredBitmap = {
+    require(dvDescriptor.isInline)
+    new StoredBitmap(dvDescriptor, None)
+  }
+
+  /** Factory for deletion vectors. */
+  def create(dvDescriptor: DeletionVectorDescriptor, tablePath: Path): StoredBitmap = {
+    if (dvDescriptor.isOnDisk) {
+      new StoredBitmap(dvDescriptor, Some(tablePath))
+    } else {
+      new StoredBitmap(dvDescriptor, None)
+    }
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorStore.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorStore.scala
@@ -1,0 +1,231 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.storage.dv
+
+import java.io.{Closeable, DataInputStream}
+import java.net.URI
+import java.nio.charset.StandardCharsets.UTF_8
+import java.util.UUID
+import java.util.zip.CRC32
+
+import org.apache.spark.sql.delta.DeltaErrors
+import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor
+import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, StoredBitmap}
+import org.apache.spark.sql.delta.util.PathWithFileSystem
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, FSDataOutputStream, Path}
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.util.Utils
+
+trait DeletionVectorStore extends Logging {
+  /**
+   * Read a Deletion Vector and parse it as [[RoaringBitmapArray]].
+   */
+  def read(
+      dvDescriptor: DeletionVectorDescriptor,
+      tablePath: Path): RoaringBitmapArray =
+    StoredBitmap.create(dvDescriptor, tablePath).load(this)
+
+  /**
+   * Read Deletion Vector and parse it as [[RoaringBitmapArray]].
+   */
+  def read(path: Path, offset: Int, size: Int): RoaringBitmapArray
+
+  /**
+   * Returns a writer that can be used to write multiple deletion vectors to the file at `path`.
+   */
+  def createWriter(path: PathWithFileSystem): DeletionVectorStore.Writer
+
+  /**
+   * Returns full path for a DV with `filedId` UUID under `targetPath`.
+   *
+   * Optionally, prepend a `prefix` to the name.
+   */
+  def generateFileNameInTable(
+      targetPath: PathWithFileSystem,
+      fileId: UUID,
+      prefix: String = ""): PathWithFileSystem = {
+    DeletionVectorStore.assembleDeletionVectorPathWithFileSystem(targetPath, fileId, prefix)
+  }
+
+  /**
+   * Return a new unique path under `targetPath`.
+   *
+   * Optionally, prepend a `prefix` to the name.
+   */
+  def generateUniqueNameInTable(
+      targetPath: PathWithFileSystem,
+      prefix: String = ""): PathWithFileSystem =
+    generateFileNameInTable(targetPath, UUID.randomUUID(), prefix)
+
+  /**
+   * Creates a [[PathWithFileSystem]] instance
+   * by using the configuration of this `DeletionVectorStore` instance
+   */
+  def pathWithFileSystem(path: Path): PathWithFileSystem
+}
+
+/**
+ * Trait containing the utility and constants needed for [[DeletionVectorStore]]
+ */
+trait DeletionVectorStoreUtils {
+  final val DV_FILE_FORMAT_VERSION_ID_V1: Byte = 1
+
+  /** The length of a DV checksum. See [[calculateChecksum()]]. */
+  final val CHECKSUM_LEN = 4
+  /** The size of the stored length of a DV. */
+  final val DATA_SIZE_LEN = 4
+
+  /** Convert the given String path to a Hadoop Path, handing special characters properly. */
+  def stringToPath(path: String): Path = new Path(new URI(path))
+
+  /** Convert the given Hadoop path to a String Path, handing special characters properly. */
+  def pathToString(path: Path): String = path.toUri.toString
+
+  /**
+   * Calculate checksum of a serialized deletion vector. We are using CRC32 which has 4bytes size,
+   * but CRC32 implementation conforms to Java Checksum interface which requires a long. However,
+   * the high-order bytes are zero, so here is safe to cast to Int. This will result in negative
+   * checksums, but this is not a problem because we only care about equality.
+   */
+  def calculateChecksum(data: Array[Byte]): Int = {
+    val crc = new CRC32()
+    crc.update(data)
+    crc.getValue.toInt
+  }
+
+  /**
+   * Read a serialized deletion vector from a data stream.
+   */
+  def readRangeFromStream(reader: DataInputStream, size: Int): Array[Byte] = {
+    val sizeAccordingToFile = reader.readInt()
+    if (size != sizeAccordingToFile) {
+      throw DeltaErrors.deletionVectorSizeMismatch()
+    }
+
+    val buffer = new Array[Byte](size)
+    reader.readFully(buffer)
+
+    val expectedChecksum = reader.readInt()
+    val actualChecksum = calculateChecksum(buffer)
+    if (expectedChecksum != actualChecksum) {
+      throw DeltaErrors.deletionVectorChecksumMismatch()
+    }
+
+    buffer
+  }
+
+  /**
+   * Same as `assembleDeletionVectorPath`, but keeps the new path bundled with the fs.
+   */
+  def assembleDeletionVectorPathWithFileSystem(
+      targetParentPathWithFileSystem: PathWithFileSystem,
+      id: UUID,
+      prefix: String = ""): PathWithFileSystem = {
+    targetParentPathWithFileSystem.copy(path =
+      DeletionVectorDescriptor.assembleDeletionVectorPath(
+        targetParentPathWithFileSystem.path, id, prefix))
+  }
+
+  /** Descriptor for a serialized Deletion Vector in a file. */
+  case class DVRangeDescriptor(offset: Int, length: Int, checksum: Int)
+
+  trait Writer extends Closeable {
+    /**
+     * Appends the serialized deletion vector in `data` to the file, and returns the offset in the
+     * file that the deletion vector was written to and its checksum.
+     */
+    def write(data: Array[Byte]): DVRangeDescriptor
+
+    /**
+     * Returns UTF-8 encoded path of the file that is being written by this writer.
+     */
+    def serializedPath: Array[Byte]
+
+    /**
+     * Closes this writer. After calling this method it is no longer valid to call write (or close).
+     * This method must always be called when the owner of this writer is done writing deletion
+     * vectors.
+     */
+    def close(): Unit
+  }
+}
+
+object DeletionVectorStore extends DeletionVectorStoreUtils {
+  /** Create a new instance of [[DeletionVectorStore]] from the given Hadoop configuration. */
+  private[delta] def createInstance(
+      hadoopConf: Configuration): DeletionVectorStore =
+    new HadoopFileSystemDVStore(hadoopConf)
+}
+
+/**
+ * Default [[DeletionVectorStore]] implementation for Hadoop [[FileSystem]] implementations.
+ *
+ * Note: This class must be thread-safe,
+ * because we sometimes write multiple deletion vectors in parallel through the same store.
+ */
+class HadoopFileSystemDVStore(hadoopConf: Configuration)
+    extends DeletionVectorStore {
+
+  override def read(path: Path, offset: Int, size: Int): RoaringBitmapArray = {
+    val fs = path.getFileSystem(hadoopConf)
+    val buffer = Utils.tryWithResource(fs.open(path)) { reader =>
+      reader.seek(offset)
+      DeletionVectorStore.readRangeFromStream(reader, size)
+    }
+    RoaringBitmapArray.readFrom(buffer)
+  }
+
+  override def createWriter(path: PathWithFileSystem): DeletionVectorStore.Writer = {
+    new DeletionVectorStore.Writer {
+      // Lazily create the writer for the deletion vectors, so that we don't write an empty file
+      // in case all deletion vectors are empty.
+      private var outputStream: FSDataOutputStream = _
+
+      override def write(data: Array[Byte]): DeletionVectorStore.DVRangeDescriptor = {
+        if (outputStream == null) {
+          val overwrite = false // `create` Java API does not support named parameters
+          outputStream = path.fs.create(path.path, overwrite)
+          outputStream.writeByte(DeletionVectorStore.DV_FILE_FORMAT_VERSION_ID_V1)
+        }
+        val dvRange = DeletionVectorStore.DVRangeDescriptor(
+          offset = outputStream.size(),
+          length = data.length,
+          checksum = DeletionVectorStore.calculateChecksum(data)
+          )
+        log.debug(s"Writing DV range to file: Path=${path.path}, Range=${dvRange}")
+        outputStream.writeInt(data.length)
+        outputStream.write(data)
+        outputStream.writeInt(dvRange.checksum)
+        dvRange
+      }
+
+      override val serializedPath: Array[Byte] =
+        DeletionVectorStore.pathToString(path.path).getBytes(UTF_8)
+
+      override def close(): Unit = {
+        if (outputStream != null) {
+          outputStream.close()
+        }
+      }
+    }
+  }
+
+  override def pathWithFileSystem(path: Path): PathWithFileSystem =
+    PathWithFileSystem.withConf(path, hadoopConf)
+}

--- a/core/src/main/scala/org/apache/spark/sql/delta/util/PathWithFileSystem.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/util/PathWithFileSystem.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.util
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+/**
+ * Bundling the `Path` with the `FileSystem` instance ensures
+ * that we never pass the wrong file system with the path to a function
+ * at compile time.
+ */
+case class PathWithFileSystem private (path: Path, fs: FileSystem) {
+
+  /**
+   * Extends the path with `s`
+   *
+   * The resulting path must be on the same filesystem.
+   */
+  def withSuffix(s: String): PathWithFileSystem = new PathWithFileSystem(new Path(path, s), fs)
+
+  /**
+   * Qualify `path`` using `fs`
+   */
+  def makeQualified(): PathWithFileSystem = {
+    val qualifiedPath = fs.makeQualified(path)
+    PathWithFileSystem(qualifiedPath, fs)
+  }
+}
+
+object PathWithFileSystem {
+
+  /**
+   * Create a new `PathWithFileSystem` instance by calling `getFileSystem`
+   * on `path` with the given `hadoopConf`.
+   */
+  def withConf(path: Path, hadoopConf: Configuration): PathWithFileSystem = {
+    val fs = path.getFileSystem(hadoopConf)
+    PathWithFileSystem(path, fs)
+  }
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorStoreSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorStoreSuite.scala
@@ -1,0 +1,188 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.storage.dv
+
+import java.io.{DataInputStream, DataOutputStream, File}
+
+import org.apache.spark.sql.delta.DeltaChecksumException
+import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
+import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore.{CHECKSUM_LEN, DATA_SIZE_LEN}
+import org.apache.spark.sql.delta.util.PathWithFileSystem
+import com.google.common.primitives.Ints
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.util.Utils
+
+trait DeletionVectorStoreSuiteBase
+  extends QueryTest
+  with SharedSparkSession {
+
+  lazy val dvStore: DeletionVectorStore =
+    DeletionVectorStore.createInstance(newHadoopConf)
+
+  protected def newHadoopConf: Configuration = {
+    // scalastyle:off deltahadoopconfiguration
+    spark.sessionState.newHadoopConf()
+    // scalastyle:on deltahadoopconfiguration
+  }
+
+  // Test bitmaps
+  protected lazy val simpleBitmap = {
+    val data = Seq(1L, 5L, 6L, 7L, 1000L, 8000000L, 8000001L)
+    RoaringBitmapArray(data: _*)
+  }
+
+  protected lazy val simpleBitmap2 = {
+    val data = Seq(78L, 256L, 998L, 1000002L, 22623423L)
+    RoaringBitmapArray(data: _*)
+  }
+
+
+  def withTempHadoopFileSystemPath[T](f: Path => T): T = {
+    val dir: File = Utils.createTempDir()
+    dir.delete()
+    val tempPath = DeletionVectorStore.stringToPath(dir.toString)
+    try f(tempPath) finally Utils.deleteRecursively(dir)
+  }
+
+  testWithAllSerializationFormats("Write simple DV directly to disk") { serializationFormat =>
+    val readDV =
+      withTempHadoopFileSystemPath { tableDir =>
+        val tableWithFS = PathWithFileSystem.withConf(tableDir, newHadoopConf)
+        val dvPath = dvStore.generateUniqueNameInTable(tableWithFS)
+        val serializedBitmap = simpleBitmap.serializeAsByteArray(serializationFormat)
+        val dvRange = Utils.tryWithResource(dvStore.createWriter(dvPath)) { writer =>
+          writer.write(serializedBitmap)
+        }
+        assert(dvRange.offset === 1) // there's a version id at byte 0
+        assert(dvRange.length === serializedBitmap.length)
+        dvStore.read(dvPath.path, dvRange.offset, dvRange.length)
+      }
+    assert(simpleBitmap === readDV)
+  }
+
+
+  testWithAllSerializationFormats("Detect corrupted DV checksum ") { serializationFormat =>
+    withTempHadoopFileSystemPath { tableDir =>
+      val tableWithFS = PathWithFileSystem.withConf(tableDir, newHadoopConf)
+      val dvPath = dvStore.generateUniqueNameInTable(tableWithFS)
+      val dvBytes = simpleBitmap.serializeAsByteArray(serializationFormat)
+      val dvRange = Utils.tryWithResource(dvStore.createWriter(dvPath)) {
+        writer => writer.write(dvBytes)
+      }
+      assert(dvRange.offset === 1) // there's a version id at byte 0
+      assert(dvRange.length === dvBytes.length)
+      // corrupt 1 byte in the middle of the stored DV (after the checksum)
+      corruptByte(dvPath, byteToCorrupt = DeletionVectorStore.CHECKSUM_LEN + dvRange.length / 2)
+      val e = intercept[DeltaChecksumException] {
+        dvStore.read(dvPath.path, dvRange.offset, dvRange.length)
+      }
+      // make sure this is our exception not ChecksumFileSystem's
+      assert(e.getErrorClass == "DELTA_DELETION_VECTOR_CHECKSUM_MISMATCH")
+      assert(e.getSqlState == "22000")
+      assert(e.getMessage ==
+        "Could not verify deletion vector integrity, CRC checksum verification failed.")
+    }
+  }
+
+  testWithAllSerializationFormats("Detect corrupted DV size") { serializationFormat =>
+    withTempHadoopFileSystemPath { tableDir =>
+      val tableWithFS = PathWithFileSystem.withConf(tableDir, newHadoopConf)
+      val dvPath = dvStore.generateUniqueNameInTable(tableWithFS)
+      val dvBytes = simpleBitmap.serializeAsByteArray(serializationFormat)
+      val dvRange = Utils.tryWithResource(dvStore.createWriter(dvPath)) {
+        writer => writer.write(dvBytes)
+      }
+      assert(dvRange.offset === 1) // there's a version id at byte 0
+      assert(dvRange.length === dvBytes.length)
+
+      // Corrupt 1 byte in the part where the serialized DV size is stored.
+      // Format:<Version - 1byte> <SerializedDV Size> <SerializedDV Bytes> <DV Checksum>
+      corruptByte(dvPath, byteToCorrupt = 2)
+      val e = intercept[DeltaChecksumException] {
+        dvStore.read(dvPath.path, dvRange.offset, dvRange.length)
+      }
+      assert(e.getErrorClass == "DELTA_DELETION_VECTOR_SIZE_MISMATCH")
+      assert(e.getSqlState == "22000")
+      assert(e.getMessage == "Deletion vector integrity check failed. Encountered a size mismatch.")
+    }
+  }
+
+  testWithAllSerializationFormats("Multiple DVs in one file") { serializationFormat =>
+    withTempHadoopFileSystemPath { tableDir =>
+      val tableWithFS = PathWithFileSystem.withConf(tableDir, newHadoopConf)
+      val dvPath = dvStore.generateUniqueNameInTable(tableWithFS)
+      val dvBytes1 = simpleBitmap.serializeAsByteArray(serializationFormat)
+      val dvBytes2 = simpleBitmap2.serializeAsByteArray(serializationFormat)
+      val (dvRange1, dvRange2) = Utils.tryWithResource(dvStore.createWriter(dvPath)) {
+        writer =>
+          (writer.write(dvBytes1), writer.write(dvBytes2))
+      }
+      assert(dvRange1.offset === 1) // there's a version id at byte 0
+      assert(dvRange1.length === dvBytes1.length)
+
+      // DV2 should be written immediately after the DV1
+      // DV Format:<SerializedDV Size> <SerializedDV Bytes> <DV Checksum>
+      val totalDV1Size = DATA_SIZE_LEN + dvBytes1.length + CHECKSUM_LEN
+      assert(dvRange2.offset === 1 + totalDV1Size) // 1byte for file format version
+      assert(dvRange2.length === dvBytes2.length)
+
+      // Read back DVs from the file and verify
+      assert(dvStore.read(dvPath.path, dvRange1.offset, dvRange1.length) === simpleBitmap)
+      assert(dvStore.read(dvPath.path, dvRange2.offset, dvRange2.length) === simpleBitmap2)
+    }
+  }
+
+  /** Helper method to run the test using all DV serialization formats */
+  protected def testWithAllSerializationFormats(name: String)
+      (func: RoaringBitmapArrayFormat.Value => Unit): Unit = {
+    for (serializationFormat <- RoaringBitmapArrayFormat.values) {
+      test(s"$name - $serializationFormat") {
+        func(serializationFormat)
+      }
+    }
+  }
+
+  /** Helper to method to simulate data corruption in on-disk DV */
+  private def corruptByte(pathWithFS: PathWithFileSystem, byteToCorrupt: Int): Unit = {
+    val fs = pathWithFS.fs
+    val path = pathWithFS.path
+    val status = fs.getFileStatus(path)
+    val len = Ints.checkedCast(status.getLen)
+
+    val bytes = Utils.tryWithResource(fs.open(path)) { stream =>
+      val reader = new DataInputStream(stream)
+      // readAllBytes is not available in 1.8, yet
+      val buffer = new Array[Byte](len)
+      reader.readFully(buffer)
+      buffer
+    }
+    bytes(byteToCorrupt) = (bytes(byteToCorrupt) + 1).toByte
+    val overwrite = true
+    Utils.tryWithResource(fs.create(path, overwrite)) { stream =>
+      val writer = new DataOutputStream(stream)
+      writer.write(bytes)
+      writer.flush()
+    }
+  }
+}
+
+class DeletionVectorStoreSuite
+  extends DeletionVectorStoreSuiteBase


### PR DESCRIPTION
This PR is part of the feature: Support reading Delta tables with deletion vectors (more details at https://github.com/delta-io/delta/issues/1485)

It adds a `DeletionVectorStore` which contains APIs to load DVs from and write DVs to Hadoop FS compliant file system.  The format of the DV file is described in the protocol [here](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#deletion-vector-file-storage-format).

Added a test suite.

GitOrigin-RevId: 72340c9854f7d0376ea2aeec0c4bbba08ce78259