### PR TITLE
Updated scala to 2.13.10 and junit to 4.13.2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        scala: [2.12.15, 2.13.5]
+        scala: [2.12.15, 2.13.10]
     env:
       SCALA_VERSION: ${{ matrix.scala }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ import TestParallelization._
 
 val sparkVersion = "3.3.1"
 val scala212 = "2.12.15"
-val scala213 = "2.13.5"
+val scala213 = "2.13.10"
 val default_scala_version = scala212
 val all_scala_versions = Seq(scala212, scala213)
 
@@ -59,7 +59,7 @@ lazy val core = (project in file("core"))
       // Test deps
       "org.scalatest" %% "scalatest" % "3.2.9" % "test",
       "org.scalatestplus" %% "scalacheck-1-15" % "3.2.9.0" % "test",
-      "junit" % "junit" % "4.12" % "test",
+      "junit" % "junit" % "4.13.2" % "test",
       "com.novocode" % "junit-interface" % "0.11" % "test",
       "org.apache.spark" %% "spark-catalyst" % sparkVersion % "test" classifier "tests",
       "org.apache.spark" %% "spark-core" % sparkVersion % "test" classifier "tests",

--- a/examples/scala/build.sbt
+++ b/examples/scala/build.sbt
@@ -19,7 +19,7 @@ organization := "com.example"
 organizationName := "example"
 
 val scala212 = "2.12.15"
-val scala213 = "2.13.8"
+val scala213 = "2.13.10"
 val deltaVersion = "2.1.0"
 
 def getMajorMinor(version: String): (Int, Int) = {


### PR DESCRIPTION
Signed-off-by: Marcus Åberg <marcussaberg12@gmail.com>

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

- Updated scala to 2.13.10 and junit to 4.13.2.
- Resolves #1518 the current versions of these packages have security issues according to Maven.

## How was this patch tested?

Set up a working copy of this repository and run the examples Apache Spark version 3.3 and made sure you could do https://docs.delta.io/latest/quick-start.html#language-python, Python 3.11.2, jre1.8.0_351, spark-3.3.1-bin-hadoop3
on Windows 11 following the guide here https://phoenixnap.com/kb/install-spark-on-windows-10 but with newer specs. 

## Does this PR introduce _any_ user-facing changes?

'No'.
