### PR TITLE
Update `DeltaParquetFileFormat` to add `isRowDeleted` column populated from DV

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -217,7 +217,7 @@ their content, e.g. `"hello%20world"`
    * Connect path segments by `+`, e.g. `"b"+"y"`
    * Connect path and value pairs by `=`, e.g. `"b"+"y"=null`
    * Sort canonicalized path/value pairs using a byte-order sort on paths. The byte-order sort can be done by converting paths to byte array using UTF-8 charset\
-    and then comparing them, e.g. `"a" < "b"."x" < "b"."y"`
+    and then comparing them, e.g. `"a" < "b"+"x" < "b"+"y"`
    * Separate ordered pairs by `,`, e.g. `"a"=10,"b"+"x"="https%3A%2F%2Fdelta.io","b"+"y"=null`
 
 5. Array values (e.g. `[null, "hi ho", 2.71]`) are canonicalized as if they were objects, except the "name" has numeric type instead of string type, and gives the (0-based) 

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
@@ -53,7 +53,7 @@ class DeltaParquetFileFormat(
     val broadcastHadoopConf: Option[Broadcast[SerializableConfiguration]] = None)
   extends ParquetFileFormat {
   // Validate either we have all arguments for DV enabled read or none of them.
-  require(!(broadcastHadoopConf.isDefined ^ broadcastDvMap.isDefined ^ tablePath .isDefined ^
+  require(!(broadcastHadoopConf.isDefined ^ broadcastDvMap.isDefined ^ tablePath.isDefined ^
     !isSplittable ^ disablePushDowns))
 
   val columnMappingMode: DeltaColumnMappingMode = metadata.columnMappingMode
@@ -185,7 +185,7 @@ class DeltaParquetFileFormat(
 
     val newIter = iterator.map { row =>
       val newRow = row match {
-        case batch: ColumnarBatch =>
+        case batch: ColumnarBatch => // When vectorized Parquet reader is enabled
           val size = batch.numRows()
           // Create a new vector for the `is row deleted` column. We can't use the one from Parquet
           // reader as it set the [[WritableColumnVector.isAllNulls]] to true and it can't be reset
@@ -210,7 +210,7 @@ class DeltaParquetFileFormat(
           }
           newBatch
 
-        case rest: InternalRow =>
+        case rest: InternalRow => // When vectorized Parquet reader is disabled
           // Temporary vector variable used to get DV values from RowIndexFilter
           // Currently the RowIndexFilter only supports writing into a columnar vector
           // and doesn't have methods to get DV value for a specific row index.

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
@@ -16,19 +16,37 @@
 
 package org.apache.spark.sql.delta
 
-import org.apache.spark.sql.delta.actions.Metadata
-import org.apache.hadoop.conf.Configuration
+import scala.collection.mutable.ArrayBuffer
+import scala.util.control.NonFatal
 
+import org.apache.spark.sql.delta.DeltaParquetFileFormat.newVector
+import org.apache.spark.sql.delta.DeltaParquetFileFormat.trySafely
+import org.apache.spark.sql.delta.actions.{DeletionVectorDescriptor, Metadata}
+import org.apache.spark.sql.delta.deletionvectors.DeletedRowsMarkingFilter
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.execution.vectorized.{OffHeapColumnVector, OnHeapColumnVector, WritableColumnVector}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.Filter
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{ByteType, StructField, StructType}
+import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
+import org.apache.spark.util.SerializableConfiguration
 
 /** A thin wrapper over the Parquet file format to support columns names without restrictions. */
-class DeltaParquetFileFormat(metadata: Metadata) extends ParquetFileFormat {
+class DeltaParquetFileFormat(
+    metadata: Metadata,
+    val isSplittable: Boolean = true,
+    val disablePushDowns: Boolean = false,
+    val tablePath: Option[String] = None,
+    val broadcastDvMap: Option[Broadcast[Map[String, DeletionVectorDescriptor]]] = None,
+    val broadcastHadoopConf: Option[Broadcast[SerializableConfiguration]] = None)
+  extends ParquetFileFormat {
 
   val columnMappingMode: DeltaColumnMappingMode = metadata.columnMappingMode
   val referenceSchema: StructType = metadata.schema
@@ -46,14 +64,22 @@ class DeltaParquetFileFormat(metadata: Metadata) extends ParquetFileFormat {
     DeltaColumnMapping.createPhysicalSchema(inputSchema, referenceSchema, columnMappingMode)
   }
 
+  override def isSplitable(
+    sparkSession: SparkSession, options: Map[String, String], path: Path): Boolean = isSplittable
+
+  def hasDeletionVectorMap(): Boolean = broadcastDvMap.isDefined && broadcastHadoopConf.isDefined
+
   /**
    * We sometimes need to replace FileFormat within LogicalPlans, so we have to override
    * `equals` to ensure file format changes are captured
    */
   override def equals(other: Any): Boolean = {
     other match {
-      case ff: DeltaParquetFileFormat
-        => ff.columnMappingMode == columnMappingMode && ff.referenceSchema == referenceSchema
+      case ff: DeltaParquetFileFormat =>
+        ff.columnMappingMode == columnMappingMode &&
+        ff.referenceSchema == referenceSchema &&
+        ff.isSplittable == isSplittable &&
+        ff.disablePushDowns == disablePushDowns
       case _ => false
     }
   }
@@ -68,17 +94,159 @@ class DeltaParquetFileFormat(metadata: Metadata) extends ParquetFileFormat {
       filters: Seq[Filter],
       options: Map[String, String],
       hadoopConf: Configuration): PartitionedFile => Iterator[InternalRow] = {
-    super.buildReaderWithPartitionValues(
-      sparkSession,
-      prepareSchema(dataSchema),
-      prepareSchema(partitionSchema),
-      prepareSchema(requiredSchema),
-      filters,
-      options,
-      hadoopConf)
+    val pushdownFilters = if (disablePushDowns) Seq.empty else filters
+
+    val parquetDataReader: PartitionedFile => Iterator[InternalRow] =
+      super.buildReaderWithPartitionValues(
+        sparkSession,
+        prepareSchema(dataSchema),
+        prepareSchema(partitionSchema),
+        prepareSchema(requiredSchema),
+        pushdownFilters,
+        options,
+        hadoopConf)
+
+    if (!hasDeletionVectorMap()) {
+      return parquetDataReader
+    }
+
+    val skipRowColumnTypeIdx = requiredSchema.fields.zipWithIndex
+      .find(_._1.name == DeltaParquetFileFormat.SKIP_ROW_NAME)
+
+    if (skipRowColumnTypeIdx.isEmpty) {
+      throw new IllegalArgumentException("Expected a column for skipping row in reader output")
+    }
+
+    val useOffHeapBuffers = sparkSession.sessionState.conf.offHeapColumnVectorEnabled
+
+    (partitionedFile: PartitionedFile) => {
+      val rowIteratorFromParquet = parquetDataReader(partitionedFile)
+      val iterToReturn =
+        iteratorWithRowIndexColumnAppended(
+          partitionedFile,
+          rowIteratorFromParquet,
+          skipRowColumnTypeIdx.get._1,
+          skipRowColumnTypeIdx.get._2,
+          useOffHeapBuffers)
+      iterToReturn.asInstanceOf[Iterator[InternalRow]]
+    }
   }
 
   override def supportFieldName(name: String): Boolean = {
     if (columnMappingMode != NoMapping) true else super.supportFieldName(name)
+  }
+
+  def copyWithDVInfo(
+      tablePath: String,
+      broadcastDvMap: Broadcast[Map[String, DeletionVectorDescriptor]],
+      broadcastHadoopConf: Broadcast[SerializableConfiguration]): DeltaParquetFileFormat = {
+    new DeltaParquetFileFormat(
+      metadata,
+      isSplittable = false,
+      disablePushDowns = true,
+      tablePath = Some(tablePath),
+      Some(broadcastDvMap),
+      Some(broadcastHadoopConf))
+  }
+
+  private def iteratorWithRowIndexColumnAppended(
+      partitionedFile: PartitionedFile,
+      iterator: Iterator[Object],
+      skipRowColumnType: StructField,
+      skipRowColumnIndex: Int,
+      useOffHeapBuffers: Boolean): Iterator[Object] = {
+    val filePath = partitionedFile.filePath
+    val absolutePath = new Path(filePath).toString
+
+    // Fetch the DV descriptor from the broadcast map and create a row index filter
+    val dvDescriptor = broadcastDvMap.get.value.get(absolutePath)
+    val rowIndexFilter = DeletedRowsMarkingFilter.createInstance(
+      dvDescriptor.getOrElse(DeletionVectorDescriptor.EMPTY),
+      broadcastHadoopConf.get.value.value,
+      tablePath.map(new Path(_))
+    )
+
+    // Unfortunately there is no way to verify the Parquet index is starting from 0.
+    // We disable the splits, so the assumption is ParquetFileFormat respects that
+    var rowIndex: Long = 0
+
+    val newIter = iterator.map { row =>
+      val newRow = row match {
+        case batch: ColumnarBatch =>
+          val size = batch.numRows()
+          // Create a new vector for the skip row column. We can't use the one from Parquet reader
+          // as it set the [[WritableColumnVector.isAllNulls]] to true and it can't be reset
+          // with using any public APIs. In this new vector, fill the values using the row
+          // index filter and replace the vector corresponding to skip row column in ColumnBatch
+          val newBatch = trySafely(newVector(useOffHeapBuffers, size, skipRowColumnType)) {
+            writableVector =>
+              rowIndexFilter.materializeIntoVector(rowIndex, rowIndex + size, writableVector)
+              rowIndex += size
+
+              val vectors = ArrayBuffer[ColumnVector]()
+              for (i <- 0 until batch.numCols()) {
+                if (i == skipRowColumnIndex) {
+                  vectors += writableVector
+                  // Make sure to close the existing vector allocated in the Parquet
+                  batch.column(i).close()
+                } else {
+                  vectors += batch.column(i)
+                }
+              }
+              new ColumnarBatch(vectors.toArray, size)
+          }
+          newBatch
+
+        case rest: InternalRow =>
+          // Temporary vector variable used to get DV values from RowIndexFilter
+          // Currently the RowIndexFilter only supports writing into a columnar vector
+          // and doesn't have methods to get DV value for a specific row index.
+          // TODO: This is not efficient, but it is ok given the default reader is vectorized
+          // reader and this will be temporary until Delta upgrades to Spark with Parquet
+          // reader that automatically generates the row index column.
+          trySafely(new OnHeapColumnVector(1, ByteType)) { tempVector =>
+            rowIndexFilter.materializeIntoVector(rowIndex, rowIndex + 1, tempVector)
+            rest.setLong(skipRowColumnIndex, tempVector.getByte(0))
+            rowIndex += 1
+            rest
+          }
+        case others =>
+          throw new RuntimeException(
+            s"Parquet reader returned an unknown row type: ${others.getClass.getName}")
+      }
+      newRow
+    }
+    newIter
+  }
+}
+
+object DeltaParquetFileFormat {
+  /**
+   * Column name used to identify whether the row read from the parquet file is marked
+   * as deleted according to the Delta table deletion vectors
+   */
+  val SKIP_ROW_NAME = "__delta_internal_skip_row__"
+  val SKIP_ROW_STRUCT_FIELD = StructField(SKIP_ROW_NAME, ByteType)
+
+  /** Utility method to create a new writable vector */
+  private def newVector(
+      useOffHeapBuffers: Boolean, size: Int, dataType: StructField): WritableColumnVector = {
+    if (useOffHeapBuffers) {
+      OffHeapColumnVector.allocateColumns(size, Seq(dataType).toArray)(0)
+    } else {
+      OnHeapColumnVector.allocateColumns(size, Seq(dataType).toArray)(0)
+    }
+  }
+
+  /** Try the operation, if the operation fails release the created resource */
+  def trySafely[R <: AutoCloseable, T](createResource: => R)(f: R => T): T = {
+    val resource = createResource
+    try {
+      f.apply(resource)
+    } catch {
+      case NonFatal(e) =>
+        resource.close()
+        throw e
+    }
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
@@ -448,10 +448,15 @@ case class MergeIntoCommand(
       1
     }.asNondeterministic()
 
-    // Skip data based on the merge condition
-    val targetOnlyPredicates =
-      splitConjunctivePredicates(condition).filter(_.references.subsetOf(target.outputSet))
-    val dataSkippedFiles = deltaTxn.filterFiles(targetOnlyPredicates)
+    // Prune non-matching files if we don't need to collect them for NOT MATCHED BY SOURCE clauses.
+    val dataSkippedFiles =
+      if (notMatchedBySourceClauses.isEmpty) {
+        val targetOnlyPredicates =
+          splitConjunctivePredicates(condition).filter(_.references.subsetOf(target.outputSet))
+        deltaTxn.filterFiles(targetOnlyPredicates)
+      } else {
+        deltaTxn.filterFiles()
+      }
 
     // UDF to increment metrics
     val incrSourceRowCountExpr = makeMetricUpdateUDF("numSourceRows")

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -223,7 +223,7 @@ case class WriteIntoDelta(
       CharVarcharUtils.replaceCharVarcharWithStringInSchema(
         replaceCharWithVarchar(CharVarcharUtils.getRawSchema(data.schema)).asInstanceOf[StructType])
     }
-    var finalSchema = schemaInCatalog.getOrElse(dataSchema)
+    val finalSchema = schemaInCatalog.getOrElse(dataSchema)
     updateMetadata(data.sparkSession, txn, finalSchema,
       partitionColumns, configuration, isOverwriteOperation, rearrangeOnly)
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/schema/ImplicitMetadataOperation.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/schema/ImplicitMetadataOperation.scala
@@ -60,7 +60,8 @@ trait ImplicitMetadataOperation extends DeltaLogging {
     // To support the new column mapping mode, we drop existing metadata on data schema
     // so that all the column mapping related properties can be reinitialized in
     // OptimisticTransaction.updateMetadata
-    val dataSchema = DeltaColumnMapping.dropColumnMappingMetadata(schema.asNullable)
+    val dataSchema =
+      DeltaColumnMapping.dropColumnMappingMetadata(schema.asNullable)
     val mergedSchema = mergeSchema(txn, dataSchema, isOverwriteMode, canOverwriteSchema)
     val normalizedPartitionCols =
       normalizePartitionColumns(spark, partitionColumns, dataSchema)

--- a/core/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -29,6 +29,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.Utils
 
 // scalastyle:off: removeFile
 class ActionSerializerSuite extends QueryTest with SharedSparkSession with DeltaSQLCommandTest {
@@ -367,6 +368,7 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
       expectedJson: String,
       extraSettings: Seq[(String, String)] = Seq.empty,
       testTags: Seq[org.scalatest.Tag] = Seq.empty): Unit = {
+    import org.apache.spark.sql.delta.test.DeltaTestImplicits._
     test(name, testTags: _*) {
       withTempDir { tempDir =>
         val deltaLog = DeltaLog.forTable(spark, new Path(tempDir.getAbsolutePath))
@@ -383,7 +385,7 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
           val protocol = Protocol(
             minReaderVersion = spark.conf.get(DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_READER_VERSION),
             minWriterVersion = spark.conf.get(DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_WRITER_VERSION))
-          deltaLog.startTransaction().commit(Seq(protocol, Metadata()), ManualUpdate)
+          deltaLog.startTransaction().commitManually(protocol, Metadata())
 
           // Commit the actual action.
           val version = deltaLog.startTransaction().commit(Seq(action), ManualUpdate)

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor
+import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
+import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
+import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore.pathToString
+import org.apache.spark.sql.delta.util.PathWithFileSystem
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.parquet.format.converter.ParquetMetadataConverter
+import org.apache.parquet.hadoop.ParquetFileReader
+
+import org.apache.spark.sql.{Dataset, QueryTest}
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.{SerializableConfiguration, Utils}
+
+class DeltaParquetFileFormatSuite extends QueryTest
+  with SharedSparkSession {
+  import testImplicits._
+
+  test("Read with DV") {
+    withTempDir { tempDir =>
+      val tablePath = tempDir.toString
+
+      // Generate a table with one parquet file containing multiple row groups.
+      generateData(tablePath)
+
+      val deltaLog = DeltaLog.forTable(spark, tempDir)
+      val metadata = deltaLog.snapshot.metadata
+
+      // Add additional field that has the deleted row flag to existing data schema
+      val readingSchema = new StructType(
+        metadata.schema.fields :+ DeltaParquetFileFormat.SKIP_ROW_STRUCT_FIELD)
+
+      val addFilePath = new Path(
+        tempDir.toString,
+        deltaLog.snapshot.allFiles.collect()(0).path)
+      assertParquetHasMultipleRowGroups(addFilePath)
+
+      val dv = generateDV(tablePath, 0, 200, 300, 756, 10352, 19999)
+
+      val fs = addFilePath.getFileSystem(hadoopConf)
+      val broadcastDvMap = spark.sparkContext.broadcast(
+        Map(fs.getFileStatus(addFilePath).getPath().toString() -> dv)
+      )
+
+      val broadcastHadoopConf = spark.sparkContext.broadcast(
+        new SerializableConfiguration(spark.sessionState.newHadoopConf()))
+
+      val deltaParquetFormat = new DeltaParquetFileFormat(
+        metadata,
+        isSplittable = false,
+        disablePushDowns = false,
+        Some(tablePath),
+        Some(broadcastDvMap),
+        Some(broadcastHadoopConf))
+
+      val fileIndex = DeltaLogFileIndex(deltaParquetFormat, fs, addFilePath :: Nil)
+
+      val relation = HadoopFsRelation(
+        fileIndex,
+        fileIndex.partitionSchema,
+        readingSchema,
+        bucketSpec = None,
+        deltaParquetFormat,
+        options = Map.empty)(spark)
+      val plan = LogicalRelation(relation)
+
+      // Select some rows that are deleted and some rows not deleted
+      // Deleted row `value`: 0, 200, 300, 756, 10352, 19999
+      // Not deleted row `value`: 7, 900
+      checkDatasetUnorderly(
+        Dataset.ofRows(spark, plan)
+          .filter("value in (0, 7, 200, 300, 756, 900, 10352, 19999)")
+          .as[(Int, Int)],
+        (0, 1), (7, 0), (200, 1), (300, 1), (756, 1), (900, 0), (10352, 1), (19999, 1)
+      )
+    }
+  }
+
+  /** Helper method to generate a table with single Parquet file with multiple rowgroups */
+  private def generateData(tablePath: String): Unit = {
+    // This is to generate a Parquet file with two row groups
+    hadoopConf().set("parquet.block.size", (1024 * 50).toString)
+
+    // Keep the number of partitions to 1 to generate a single Parquet data file
+    val df = Seq.range(0, 20000).toDF().repartition(1)
+    df.write
+        .format("delta").mode("append").save(tablePath)
+
+    // Set DFS block size to be less than Parquet rowgroup size, to allow
+    // the file split logic to kick-in, but gets turned off due to the
+    // disabling of file splitting in DeltaParquetFileFormat when DVs are present.
+    hadoopConf().set("dfs.block.size", (1024 * 20).toString)
+  }
+
+  /** Utility method that generates deletion vector based on the given row indexes */
+  private def generateDV(tablePath: String, rowIndexes: Long *): DeletionVectorDescriptor = {
+    val bitmap = RoaringBitmapArray(rowIndexes: _*)
+    val tableWithFS = PathWithFileSystem.withConf(new Path(tablePath), hadoopConf)
+    val dvPath = dvStore.generateUniqueNameInTable(tableWithFS)
+    val serializedBitmap = bitmap.serializeAsByteArray(RoaringBitmapArrayFormat.Portable)
+    val dvRange = Utils.tryWithResource(dvStore.createWriter(dvPath)) { writer =>
+      writer.write(serializedBitmap)
+    }
+    DeletionVectorDescriptor.onDiskWithAbsolutePath(
+      pathToString(dvPath.makeQualified().path),
+      dvRange.length,
+      rowIndexes.size,
+      Some(dvRange.offset))
+  }
+
+  private def assertParquetHasMultipleRowGroups(filePath: Path): Unit = {
+    val parquetMetadata = ParquetFileReader.readFooter(
+      spark.sessionState.newHadoopConf(),
+      filePath,
+      ParquetMetadataConverter.NO_FILTER)
+    assert(parquetMetadata.getBlocks.size() > 1)
+  }
+
+  private def hadoopConf(): Configuration = {
+    // scalastyle:off hadoopconfiguration
+    // This is to generate a Parquet file with two row groups
+    spark.sparkContext.hadoopConfiguration
+    // scalastyle:on hadoopconfiguration
+  }
+
+  lazy val dvStore: DeletionVectorStore = DeletionVectorStore.createInstance(hadoopConf)
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
@@ -47,7 +47,7 @@ class DeltaParquetFileFormatSuite extends QueryTest
       val metadata = deltaLog.snapshot.metadata
 
       // Add additional field that has the deleted row flag to existing data schema
-      val readingSchema = metadata.schema.add(DeltaParquetFileFormat.SKIP_ROW_STRUCT_FIELD)
+      val readingSchema = metadata.schema.add(DeltaParquetFileFormat.IS_ROW_DELETED_STRUCT_FIELD)
 
       val addFilePath = new Path(
         tempDir.toString,

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
@@ -29,7 +29,6 @@ import org.apache.parquet.hadoop.ParquetFileReader
 import org.apache.spark.sql.{Dataset, QueryTest}
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.{SerializableConfiguration, Utils}
 
 class DeltaParquetFileFormatSuite extends QueryTest
@@ -47,8 +46,7 @@ class DeltaParquetFileFormatSuite extends QueryTest
       val metadata = deltaLog.snapshot.metadata
 
       // Add additional field that has the deleted row flag to existing data schema
-      val readingSchema = new StructType(
-        metadata.schema.fields :+ DeltaParquetFileFormat.SKIP_ROW_STRUCT_FIELD)
+      val readingSchema = metadata.schema.add(DeltaParquetFileFormat.SKIP_ROW_STRUCT_FIELD)
 
       val addFilePath = new Path(
         tempDir.toString,
@@ -130,7 +128,7 @@ class DeltaParquetFileFormatSuite extends QueryTest
 
   private def assertParquetHasMultipleRowGroups(filePath: Path): Unit = {
     val parquetMetadata = ParquetFileReader.readFooter(
-      spark.sessionState.newHadoopConf(),
+      hadoopConf,
       filePath,
       ParquetMetadataConverter.NO_FILTER)
     assert(parquetMetadata.getBlocks.size() > 1)

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
@@ -20,6 +20,7 @@ import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor
 import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
 import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
 import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore.pathToString
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.util.PathWithFileSystem
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
@@ -27,7 +28,6 @@ import org.apache.parquet.format.converter.ParquetMetadataConverter
 import org.apache.parquet.hadoop.ParquetFileReader
 
 import org.apache.spark.sql.{Dataset, QueryTest}
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.{SerializableConfiguration, Utils}

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
@@ -63,7 +63,7 @@ class DeltaParquetFileFormatSuite extends QueryTest
       )
 
       val broadcastHadoopConf = spark.sparkContext.broadcast(
-        new SerializableConfiguration(spark.sessionState.newHadoopConf()))
+        new SerializableConfiguration(hadoopConf))
 
       val deltaParquetFormat = new DeltaParquetFileFormat(
         metadata,

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
@@ -27,12 +27,13 @@ import org.apache.parquet.format.converter.ParquetMetadataConverter
 import org.apache.parquet.hadoop.ParquetFileReader
 
 import org.apache.spark.sql.{Dataset, QueryTest}
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.{SerializableConfiguration, Utils}
 
 class DeltaParquetFileFormatSuite extends QueryTest
-  with SharedSparkSession {
+  with SharedSparkSession with DeltaSQLCommandTest {
   import testImplicits._
 
   test("Read with DV") {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.delta
 import java.io.File
 import java.io.FileNotFoundException
 
+
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.{TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION}
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest

--- a/core/src/test/scala/org/apache/spark/sql/delta/UpdateMetricsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/UpdateMetricsSuite.scala
@@ -21,6 +21,7 @@ import com.databricks.spark.util.DatabricksLogging
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
 import org.apache.spark.sql.{Dataset, QueryTest}
 import org.apache.spark.sql.functions.expr
 import org.apache.spark.sql.test.SharedSparkSession

--- a/run-tests.py
+++ b/run-tests.py
@@ -46,6 +46,13 @@ def run_sbt_tests(root_dir, coverage, scala_version=None):
         cmd += ["++ %s test" % scala_version]
     if coverage:
         cmd += ["coverageAggregate", "coverageOff"]
+    cmd += ["-v"]  # show java options used
+
+    # https://docs.oracle.com/javase/7/docs/technotes/guides/vm/G1.html
+    # a GC that is optimized for larger multiprocessor machines with large memory
+    cmd += ["-J-XX:+UseG1GC"]
+    # 4x the default heap size (set in delta/built.sbt)
+    cmd += ["-J-Xmx4G"]
     run_cmd(cmd, env={"DELTA_TESTING": "1"}, stream_output=True)
 
 


### PR DESCRIPTION
This PR is part of the feature: Support reading Delta tables with deletion vectors (more details at https://github.com/delta-io/delta/issues/1485)

It modifies the `DeltaParquetFileFormat` to append an additional column called `__delta_internal_skip_row__`. This column is populated by reading the DV associated with the Parquet file. We assume the rows returned are in order given in the file. To ensure the order we disable file splitting and filter pushdown to Parquet reader. This has performance penalty for Delta tables with deletion vectors until we upgrade Delta to Spark version to 3.4 (which has Parquet reader that can generate row-indexes correctly with file splitting and filter pushdown).

Currently added a single test. There will be e2e tests that cover the code better.

GitOrigin-RevId: 2067958ffc770a89df15fd165c9999d49b2dd1c4
