### PR TITLE
Improve Z-Order Python tests

### DIFF
--- a/python/delta/tests/test_deltatable.py
+++ b/python/delta/tests/test_deltatable.py
@@ -1053,7 +1053,7 @@ class DeltaTableTests(DeltaTestCase):
         self.assertEqual(0, metrics.totalFilesSkipped)
         self.assertEqual(numDataFilesPreZOrder, metrics.totalConsideredFiles)
         self.assertEqual('all', metrics.zOrderStats.strategyName)
-        self.assertEqual(10, metrics.zOrderStats.numOutputCubes) # one for each partition
+        self.assertEqual(10, metrics.zOrderStats.numOutputCubes)  # one for each partition
 
         # negative test: Z-Order on partition column
         def optimize() -> None:
@@ -1094,7 +1094,7 @@ class DeltaTableTests(DeltaTestCase):
         # expected to consider all input files for Z-Order
         self.assertEqual(numDataFilesPreZOrder, metrics.totalConsideredFiles)
         self.assertEqual('all', metrics.zOrderStats.strategyName)
-        self.assertEqual(1, metrics.zOrderStats.numOutputCubes) # one per each affected partition
+        self.assertEqual(1, metrics.zOrderStats.numOutputCubes)  # one per each affected partition
 
     def __checkAnswer(self, df: DataFrame,
                       expectedAnswer: List[Any],


### PR DESCRIPTION
## Description
Followup from test failures in [2.1 branch](https://github.com/delta-io/delta/commit/d8c4fc17c25d6b5e0e9b3ebe1ff4cba39ecb39c5)
- The expected number of files added/removed is hard coded which could change depending upon the Spark version (For example [change](https://issues.apache.org/jira/browse/SPARK-40407) causes different number of output files between Spark 3.3.0 and Spark 3.3.1 Update the test to get the number of files from query.
- Change `assertTrue` to `assertEqual`.

## How was this patch tested?
Existing tests