### PR TITLE
[#868] Register VACUUM operation in the _delta_log

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -457,18 +457,10 @@ object DeltaOperations {
       retentionCheckEnabled: Boolean,
       specifiedRetentionMillis: Option[Long],
       defaultRetentionMillis: Long) extends Operation("VACUUM START") {
-    override val parameters: Map[String, Any] = if (specifiedRetentionMillis.isEmpty) {
-      Map(
-        "retentionCheckEnabled" -> retentionCheckEnabled,
-        "defaultRetentionMillis" -> defaultRetentionMillis
-      )
-    } else {
-      Map(
-        "retentionCheckEnabled" -> retentionCheckEnabled,
-        "specifiedRetentionMillis" -> specifiedRetentionMillis.get,
-        "defaultRetentionMillis" -> defaultRetentionMillis
-      )
-    }
+    override val parameters: Map[String, Any] = Map(
+      "retentionCheckEnabled" -> retentionCheckEnabled,
+      "defaultRetentionMillis" -> defaultRetentionMillis
+    ) ++ specifiedRetentionMillis.map("specifiedRetentionMillis" -> _)
 
     override val operationMetrics: Set[String] = DeltaOperationMetrics.VACUUM_START
   }

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -473,6 +473,9 @@ object DeltaOperations {
     override val operationMetrics: Set[String] = DeltaOperationMetrics.VACUUM_START
   }
 
+  /**
+   * @param status - whether the vacuum operation was successful; either "COMPLETED" or "FAILED"
+   */
   case class VacuumEnd(status: String) extends Operation(s"VACUUM END") {
     override val parameters: Map[String, Any] = Map(
       "status" -> status

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
@@ -293,7 +293,7 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
 trait VacuumCommandImpl extends DeltaCommand {
 
   private val supportedFsForLogging = Seq(
-    "wasbs", "wasbss", "abfs", "abfss", "adl", "gs", "file"
+    "wasbs", "wasbss", "abfs", "abfss", "adl", "gs", "file", "hdfs"
   )
 
   private def shouldLogVacuum(
@@ -365,8 +365,10 @@ trait VacuumCommandImpl extends DeltaCommand {
    *
    * @param deltaLog - DeltaLog of the table
    * @param spark - spark session
-   * @param filesDeleted - if the vacuum completed this will contain the number of files deleted
-   * @param dirCounts - if the vacuum completed this will contain the number of directories vacuumed
+   * @param filesDeleted - if the vacuum completed this will contain the number of files deleted.
+   *                       if the vacuum failed, this will be None.
+   * @param dirCounts - if the vacuum completed this will contain the number of directories
+   *                    vacuumed. if the vacuum failed, this will be None.
    */
   protected def logVacuumEnd(
       deltaLog: DeltaLog,

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -294,6 +294,13 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
+  val DELTA_VACUUM_LOGGING_ENABLED =
+    buildConf("vacuum.logging.enabled")
+      .doc("Whether to log vacuum information into the Delta transaction log." +
+        " 'spark.databricks.delta.commitInfo.enabled' should be enabled when using this config.")
+      .booleanConf
+      .createOptional
+
   val DELTA_VACUUM_RETENTION_CHECK_ENABLED =
     buildConf("retentionDurationCheck.enabled")
       .doc("Adds a check preventing users from running vacuum with a very short retention " +

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -297,7 +297,9 @@ trait DeltaSQLConfBase {
   val DELTA_VACUUM_LOGGING_ENABLED =
     buildConf("vacuum.logging.enabled")
       .doc("Whether to log vacuum information into the Delta transaction log." +
-        " 'spark.databricks.delta.commitInfo.enabled' should be enabled when using this config.")
+        " 'spark.databricks.delta.commitInfo.enabled' should be enabled when using this config." +
+        " Users should only set this config to 'true' when the underlying file system safely" +
+        " supports concurrent writes.")
       .booleanConf
       .createOptional
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
@@ -33,7 +33,7 @@ import org.apache.hadoop.fs.Path
 import org.scalatest.GivenWhenThen
 
 import org.apache.spark.{SparkConf, SparkException}
-import org.apache.spark.sql.{AnalysisException, QueryTest, SaveMode}
+import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row, SaveMode}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.util.IntervalUtils
 import org.apache.spark.sql.execution.metric.SQLMetric
@@ -772,6 +772,104 @@ trait DeltaVacuumSuiteBase extends QueryTest
   test("vacuum for cdc - delete tombstones") {
     testCDCVacuumForTombstones()
   }
+
+  private def getFromHistory(history: DataFrame, key: String, pos: Integer): Map[String, String] = {
+    val op = history.select(key).take(pos + 1)
+    if (pos == 0) {
+      op.head.getMap(0).asInstanceOf[Map[String, String]]
+    } else {
+      op.tail.head.getMap(0).asInstanceOf[Map[String, String]]
+    }
+  }
+
+  private def testEventLogging(
+      isDryRun: Boolean,
+      loggingEnabled: Boolean,
+      retentionHours: Long,
+      timeGapHours: Long): Unit = {
+
+    test(s"vacuum event logging dryRun=$isDryRun loggingEnabled=$loggingEnabled" +
+      s" retentionHours=$retentionHours timeGap=$timeGapHours") {
+      withSQLConf(DeltaSQLConf.DELTA_VACUUM_LOGGING_ENABLED.key -> loggingEnabled.toString) {
+
+        withEnvironment { (dir, clock) =>
+          spark.range(2).write.format("delta").save(dir.getAbsolutePath)
+          val deltaLog = DeltaLog.forTable(spark, dir.getAbsolutePath, clock)
+          val expectedReturn = if (isDryRun) {
+            // dry run returns files that will be deleted
+            Seq(new Path(dir.getAbsolutePath, "file1.txt").toString)
+          } else {
+            Seq(dir.getAbsolutePath)
+          }
+
+          gcTest(deltaLog, clock)(
+            CreateFile("file1.txt", commitToActionLog = true),
+            CreateFile("file2.txt", commitToActionLog = true),
+            LogicallyDeleteFile("file1.txt"),
+            AdvanceClock(timeGapHours * 1000 * 60 * 60),
+            GC(dryRun = isDryRun, expectedReturn, Some(retentionHours))
+          )
+          val deltaTable = io.delta.tables.DeltaTable.forPath(deltaLog.dataPath.toString)
+          val history = deltaTable.history()
+          if (isDryRun || !loggingEnabled) {
+            // We do not record stats when logging is disabled or dryRun
+            assert(history.select("operation").head() == Row("DELETE"))
+          } else {
+            assert(history.select("operation").head() == Row("VACUUM END"))
+            assert(history.select("operation").collect()(1) == Row("VACUUM START"))
+
+            val operationParamsBegin = getFromHistory(history, "operationParameters", 1)
+            val operationParamsEnd = getFromHistory(history, "operationParameters", 0)
+            val operationMetricsBegin = getFromHistory(history, "operationMetrics", 1)
+            val operationMetricsEnd = getFromHistory(history, "operationMetrics", 0)
+
+            val filesDeleted = if (retentionHours > timeGapHours) { 0 } else { 1 }
+            assert(operationParamsBegin("retentionCheckEnabled") === "false")
+            assert(operationMetricsBegin("numFilesToDelete") === filesDeleted.toString)
+            assert(operationMetricsBegin("sizeOfDataToDelete") === (filesDeleted * 9).toString)
+            assert(
+              operationParamsBegin("specifiedRetentionMillis") ===
+                (retentionHours * 60 * 60 * 1000).toString)
+            assert(
+              operationParamsBegin("defaultRetentionMillis") ===
+                DeltaLog.tombstoneRetentionMillis(deltaLog.snapshot.metadata).toString)
+
+            assert(operationParamsEnd === Map("status" -> "COMPLETED"))
+            assert(operationMetricsEnd === Map("numDeletedFiles" -> filesDeleted.toString,
+              "numVacuumedDirectories" -> "1"))
+          }
+        }
+      }
+    }
+  }
+
+  testEventLogging(
+    isDryRun = false,
+    loggingEnabled = true,
+    retentionHours = 5,
+    timeGapHours = 10
+  )
+
+  testEventLogging(
+    isDryRun = true, // dry run will not record the vacuum
+    loggingEnabled = true,
+    retentionHours = 5,
+    timeGapHours = 10
+  )
+
+  testEventLogging(
+    isDryRun = false,
+    loggingEnabled = false,
+    retentionHours = 5,
+    timeGapHours = 0
+  )
+
+  testEventLogging(
+    isDryRun = false,
+    loggingEnabled = true,
+    retentionHours = 20, // vacuum will not delete any files
+    timeGapHours = 10
+  )
 }
 
 class DeltaVacuumSuite


### PR DESCRIPTION
## Description

This PR registers the start and end of VACUUM operations in the delta log. This means that we commit a commit with no Add/Remove files, and only a `CommitInfo` file which contains the delta operation info.

`VacuumStart` operation contains metrics: `numFilesToDelete` and `sizeOfDataToDelete`

`VacuumEnd` operation contains metrics: `numDeletedFiles` and `numVacuumedDirectories`

Closes delta-io/delta#868.

## How was this patch tested?

New UTs.

## Does this PR introduce _any_ user-facing changes?

Expose additional metrics and history in the _delta_log for the start and end of VACUUM operations.