### PR TITLE
Support idempotent write using SQL options for INSERTS/DELETE/UPDATE/MERGE

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -29,9 +29,8 @@ import org.apache.spark.sql.catalyst.analysis.EliminateSubqueryAliases
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, EqualNullSafe, Expression, If, Literal, Not}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.{DeltaDelete, LogicalPlan}
-import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
-import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.metric.SQLMetrics.{createMetric, createTimingMetric}
 import org.apache.spark.sql.functions.{input_file_name, lit, typedLit, udf}
 import org.apache.spark.sql.types.LongType
@@ -91,6 +90,10 @@ case class DeleteCommand(
     recordDeltaOperation(deltaLog, "delta.dml.delete") {
       deltaLog.assertRemovable()
       deltaLog.withNewTransaction { txn =>
+        if (hasBeenExecuted(txn, sparkSession)) {
+          sendDriverMetrics(sparkSession, metrics)
+          return Seq.empty
+        }
         val deleteActions = performDelete(sparkSession, deltaLog, txn)
         if (deleteActions.nonEmpty) {
           txn.commit(deleteActions, DeltaOperations.Delete(condition.map(_.sql).toSeq))
@@ -291,10 +294,7 @@ case class DeleteCommand(
     numPartitionsRemovedFrom.foreach(metrics("numPartitionsRemovedFrom").set)
     numCopiedRows.foreach(metrics("numCopiedRows").set)
     txn.registerSQLMetrics(sparkSession, metrics)
-    // This is needed to make the SQL metrics visible in the Spark UI
-    val executionId = sparkSession.sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
-    SQLMetrics.postDriverMetricUpdates(
-      sparkSession.sparkContext, executionId, metrics.values.toSeq)
+    sendDriverMetrics(sparkSession, metrics)
 
     recordDeltaEvent(
       deltaLog,
@@ -323,7 +323,11 @@ case class DeleteCommand(
         rewriteTimeMs)
     )
 
-    deleteActions
+    if (deleteActions.nonEmpty) {
+      createSetTransaction(sparkSession, deltaLog).toSeq ++ deleteActions
+    } else {
+      Seq.empty
+    }
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
@@ -21,11 +21,11 @@ import java.util.concurrent.TimeUnit.NANOSECONDS
 
 import scala.util.control.NonFatal
 
-import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaTableIdentifier, OptimisticTransaction}
+import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaOptions, DeltaTableIdentifier, OptimisticTransaction}
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.files.TahoeBatchFileIndex
 import org.apache.spark.sql.delta.metering.DeltaLogging
-import org.apache.spark.sql.delta.sources.DeltaSourceUtils
+import org.apache.spark.sql.delta.sources.{DeltaSourceUtils, DeltaSQLConf}
 import org.apache.spark.sql.delta.util.DeltaFileOperations
 import org.apache.hadoop.fs.Path
 
@@ -36,7 +36,9 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTableType
 import org.apache.spark.sql.catalyst.expressions.{Expression, SubqueryExpression}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 
 /**
  * Helper trait for all delta commands.
@@ -257,6 +259,109 @@ trait DeltaCommand extends DeltaLogging {
         DeltaTableIdentifier(path, tableIdentifier))
     }
     deltaLog
+  }
+
+  /**
+   * Send the driver-side metrics.
+   *
+   * This is needed to make the SQL metrics visible in the Spark UI.
+   * All metrics are default initialized with 0 so that's what we're
+   * reporting in case we skip an already executed action.
+   */
+  protected def sendDriverMetrics(spark: SparkSession, metrics: Map[String, SQLMetric]): Unit = {
+    val executionId = spark.sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
+    SQLMetrics.postDriverMetricUpdates(spark.sparkContext, executionId, metrics.values.toSeq)
+  }
+
+  /**
+   * Returns true if there is information in the spark session that indicates that this write
+   * has already been successfully written.
+   */
+  protected def hasBeenExecuted(txn: OptimisticTransaction, sparkSession: SparkSession,
+    options: Option[DeltaOptions] = None): Boolean = {
+    val (txnVersionOpt, txnAppIdOpt, isFromSessionConf) = getTxnVersionAndAppId(
+      sparkSession, options)
+    // only enter if both txnVersion and txnAppId are set
+    for (version <- txnVersionOpt; appId <- txnAppIdOpt) {
+      val currentVersion = txn.txnVersion(appId)
+      if (currentVersion >= version) {
+        logInfo(s"Already completed batch $version in application $appId. This will be skipped.")
+        if (isFromSessionConf && sparkSession.sessionState.conf.getConf(
+          DeltaSQLConf.DELTA_IDEMPOTENT_DML_AUTO_RESET_ENABLED)) {
+          // if we got txnAppId and txnVersion from the session config, we reset the
+          // version here, after skipping the current transaction, as a safety measure to
+          // prevent data loss if the user forgets to manually reset txnVersion
+          sparkSession.sessionState.conf.unsetConf(DeltaSQLConf.DELTA_IDEMPOTENT_DML_TXN_VERSION)
+        }
+        return true
+      }
+    }
+    false
+  }
+
+  /**
+   * Returns SetTransaction if a valid app ID and version are present. Otherwise returns
+   * an empty list.
+   */
+  protected def createSetTransaction(
+    sparkSession: SparkSession,
+    deltaLog: DeltaLog,
+    options: Option[DeltaOptions] = None): Option[SetTransaction] = {
+    val (txnVersionOpt, txnAppIdOpt, isFromSessionConf) = getTxnVersionAndAppId(
+      sparkSession, options)
+    // only enter if both txnVersion and txnAppId are set
+    for (version <- txnVersionOpt; appId <- txnAppIdOpt) {
+      if (isFromSessionConf && sparkSession.sessionState.conf.getConf(
+        DeltaSQLConf.DELTA_IDEMPOTENT_DML_AUTO_RESET_ENABLED)) {
+        // if we got txnAppID and txnVersion from the session config, we reset the
+        // version here as a safety measure to prevent data loss if the user forgets
+        // to manually reset txnVersion
+        sparkSession.sessionState.conf.unsetConf(DeltaSQLConf.DELTA_IDEMPOTENT_DML_TXN_VERSION)
+      }
+      return Some(SetTransaction(appId, version, Some(deltaLog.clock.getTimeMillis())))
+    }
+    None
+  }
+
+  /**
+   * Helper method to retrieve the current txn version and app ID. These are either
+   * retrieved from user-provided write options or from session configurations.
+   */
+  private def getTxnVersionAndAppId(
+    sparkSession: SparkSession,
+    options: Option[DeltaOptions]): (Option[Long], Option[String], Boolean) = {
+    var txnVersion: Option[Long] = None
+    var txnAppId: Option[String] = None
+    for (o <- options) {
+      txnVersion = o.txnVersion
+      txnAppId = o.txnAppId
+    }
+
+    var numOptions = txnVersion.size + txnAppId.size
+    // numOptions can only be 0 or 2, as enforced by
+    // DeltaWriteOptionsImpl.validateIdempotentWriteOptions so this
+    // assert should never be triggered
+    assert(numOptions == 0 || numOptions == 2, s"Only one of txnVersion and txnAppId " +
+      s"has been set via dataframe writer options: txnVersion = $txnVersion txnAppId = $txnAppId")
+    var fromSessionConf = false
+    if (numOptions == 0) {
+      txnVersion = sparkSession.sessionState.conf.getConf(
+        DeltaSQLConf.DELTA_IDEMPOTENT_DML_TXN_VERSION)
+      // don't need to check for valid conversion to Long here as that
+      // is already enforced at set time
+      txnAppId = sparkSession.sessionState.conf.getConf(
+        DeltaSQLConf.DELTA_IDEMPOTENT_DML_TXN_APP_ID)
+      // check that both session configs are set
+      numOptions = txnVersion.size + txnAppId.size
+      if (numOptions != 0 && numOptions != 2) {
+        throw DeltaErrors.invalidIdempotentWritesOptionsException(
+          "Both spark.databricks.delta.write.txnAppId and " +
+            "spark.databricks.delta.write.txnVersion must be specified for " +
+            "idempotent Delta writes")
+      }
+      fromSessionConf = true
+    }
+    (txnVersion, txnAppId, fromSessionConf)
   }
 
 }

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
@@ -38,7 +38,6 @@ import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeRef
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
-import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
@@ -317,6 +316,10 @@ case class MergeIntoCommand(
     recordDeltaOperation(targetDeltaLog, "delta.dml.merge") {
       val startTime = System.nanoTime()
       targetDeltaLog.withNewTransaction { deltaTxn =>
+        if (hasBeenExecuted(deltaTxn, spark)) {
+          sendDriverMetrics(spark, metrics)
+          return Seq.empty
+        }
         if (target.schema.size != deltaTxn.metadata.schema.size) {
           throw DeltaErrors.schemaChangedSinceAnalysis(
             atAnalysis = target.schema, latestSchema = deltaTxn.metadata.schema)
@@ -341,6 +344,7 @@ case class MergeIntoCommand(
           }
         }
 
+        val finalActions = createSetTransaction(spark, targetDeltaLog).toSeq ++ deltaActions
         // Metrics should be recorded before commit (where they are written to delta logs).
         metrics("executionTimeMs").set((System.nanoTime() - startTime) / 1000 / 1000)
         deltaTxn.registerSQLMetrics(spark, metrics)
@@ -356,7 +360,7 @@ case class MergeIntoCommand(
         }
 
         deltaTxn.commit(
-          deltaActions,
+          finalActions,
           DeltaOperations.Merge(
             Option(condition.sql),
             matchedClauses.map(DeltaOperations.MergePredicate(_)),
@@ -371,10 +375,7 @@ case class MergeIntoCommand(
       }
       spark.sharedState.cacheManager.recacheByPlan(spark, target)
     }
-    // This is needed to make the SQL metrics visible in the Spark UI. Also this needs
-    // to be outside the recordMergeOperation because this method will update some metric.
-    val executionId = spark.sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
-    SQLMetrics.postDriverMetricUpdates(spark.sparkContext, executionId, metrics.values.toSeq)
+    sendDriverMetrics(spark, metrics)
     Seq(Row(metrics("numTargetRowsUpdated").value + metrics("numTargetRowsDeleted").value +
             metrics("numTargetRowsInserted").value, metrics("numTargetRowsUpdated").value,
             metrics("numTargetRowsDeleted").value, metrics("numTargetRowsInserted").value))

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
@@ -29,9 +29,8 @@ import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, Expression, If, Literal}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
-import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
+import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.metric.SQLMetrics.{createMetric, createTimingMetric}
 import org.apache.spark.sql.functions.{array, col, explode, input_file_name, lit, struct, typedLit, udf}
 import org.apache.spark.sql.types.LongType
@@ -81,6 +80,10 @@ case class UpdateCommand(
       val deltaLog = tahoeFileIndex.deltaLog
       deltaLog.assertRemovable()
       deltaLog.withNewTransaction { txn =>
+        if (hasBeenExecuted(txn, sparkSession)) {
+          sendDriverMetrics(sparkSession, metrics)
+          return Seq.empty
+        }
         performUpdate(sparkSession, deltaLog, txn)
       }
       // Re-cache all cached plans(including this relation itself, if it's cached) that refer to
@@ -208,11 +211,9 @@ case class UpdateCommand(
           metrics("numTouchedRows").value - metrics("numUpdatedRows").value)
       }
       txn.registerSQLMetrics(sparkSession, metrics)
-      txn.commit(totalActions, DeltaOperations.Update(condition.map(_.toString)))
-      // This is needed to make the SQL metrics visible in the Spark UI
-      val executionId = sparkSession.sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
-      SQLMetrics.postDriverMetricUpdates(
-        sparkSession.sparkContext, executionId, metrics.values.toSeq)
+      val finalActions = createSetTransaction(sparkSession, deltaLog).toSeq ++ totalActions
+      txn.commit(finalActions, DeltaOperations.Update(condition.map(_.toString)))
+      sendDriverMetrics(sparkSession, metrics)
     }
 
     recordDeltaEvent(

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -89,9 +89,7 @@ case class WriteIntoDelta(
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     deltaLog.withNewTransaction { txn =>
-      // If this batch has already been executed within this query, then return.
-      var skipExecution = hasBeenExecuted(txn)
-      if (skipExecution) {
+      if (hasBeenExecuted(txn, sparkSession, Some(options))) {
         return Seq.empty
       }
 
@@ -351,8 +349,7 @@ case class WriteIntoDelta(
     } else {
       newFiles ++ deletedFiles
     }
-    var setTxns = createSetTransaction()
-    setTxns.toSeq ++ fileActions
+    createSetTransaction(sparkSession, deltaLog, Some(options)).toSeq ++ fileActions
   }
 
   private def extractConstraints(
@@ -386,37 +383,5 @@ case class WriteIntoDelta(
       DeleteFromTable(relation, processedCondition.getOrElse(Literal.TrueLiteral)))
     spark.sessionState.analyzer.checkAnalysis(command)
     command.asInstanceOf[DeleteCommand].performDelete(spark, txn.deltaLog, txn)
-  }
-
-  /**
-   * Returns true if there is information in the spark session that indicates that this write, which
-   * is part of a streaming query and a batch, has already been successfully written.
-   */
-  private def hasBeenExecuted(txn: OptimisticTransaction): Boolean = {
-    val txnVersion = options.txnVersion
-    val txnAppId = options.txnAppId
-    for (v <- txnVersion; a <- txnAppId) {
-      val currentVersion = txn.txnVersion(a)
-      if (currentVersion >= v) {
-        logInfo(s"Transaction write of version $v for application id $a " +
-          s"has already been committed in Delta table id ${txn.deltaLog.tableId}. " +
-          s"Skipping this write.")
-        return true
-      }
-    }
-    false
-  }
-
-  /**
-   * Returns SetTransaction if a valid app ID and version are present. Otherwise returns
-   * an empty list.
-   */
-  private def createSetTransaction(): Option[SetTransaction] = {
-    val txnVersion = options.txnVersion
-    val txnAppId = options.txnAppId
-    for (v <- txnVersion; a <- txnAppId) {
-      return Some(SetTransaction(a, v, Some(deltaLog.clock.getTimeMillis())))
-    }
-    None
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -870,6 +870,43 @@ trait DeltaSQLConfBase {
         " concurrent queries accessing the table until the history wipe is complete.")
       .booleanConf
       .createWithDefault(false)
+
+  //////////////////
+  // Idempotent DML
+  //////////////////
+
+  val DELTA_IDEMPOTENT_DML_TXN_APP_ID =
+    buildConf("write.txnAppId")
+      .internal()
+      .doc("""
+             |The application ID under which this write will be committed.
+             | If specified, spark.databricks.delta.write.txnVersion also needs to
+             | be set.
+             |""".stripMargin)
+      .stringConf
+      .createOptional
+
+  val DELTA_IDEMPOTENT_DML_TXN_VERSION =
+    buildConf("write.txnVersion")
+      .internal()
+      .doc("""
+             |The user-defined version under which this write will be committed.
+             | If specified, spark.databricks.delta.write.txnAppId also needs to
+             | be set. To ensure idempotency, txnVersions across different writes
+             | need to be monotonically increasing.
+             |""".stripMargin)
+      .longConf
+      .createOptional
+
+  val DELTA_IDEMPOTENT_DML_AUTO_RESET_ENABLED =
+    buildConf("write.txnVersion.autoReset.enabled")
+      .internal()
+      .doc("""
+             |If true, will automatically reset spark.databricks.delta.write.txnVersion
+             |after every write. This is false by default.
+             |""".stripMargin)
+      .booleanConf
+      .createWithDefault(false)
 }
 
 object DeltaSQLConf extends DeltaSQLConfBase

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.catalyst.plans.logical.Filter
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.execution.streaming.MemoryStream
-import org.apache.spark.sql.functions.struct
+import org.apache.spark.sql.functions.{asc, expr, struct}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.StreamingQuery
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
@@ -2216,6 +2216,514 @@ class DeltaSuite extends QueryTest
       // Third time without failure. Both the tables should be consistently updated.
       shouldFail = false
       runQuery(dataToAdd = 2, expectedTable1Count = 3, expectedTable2Count = 3)
+    }
+  }
+
+  test("idempotent write: idempotent DataFrame insert") {
+    withTempDir { tableDir =>
+      spark.conf.set("spark.databricks.delta.write.txnAppId", "insertTest")
+
+      io.delta.tables.DeltaTable.createOrReplace(spark)
+        .addColumn("col1", "INT")
+        .addColumn("col2", "INT")
+        .location(tableDir.getCanonicalPath)
+        .execute()
+      val deltaTable = io.delta.tables.DeltaTable.forPath(spark, tableDir.getCanonicalPath)
+
+      def runInsert(data: (Int, Int)): Unit = {
+        Seq(data).toDF("col1", "col2")
+          .write
+          .format("delta")
+          .mode("append")
+          .save(tableDir.getCanonicalPath)
+      }
+
+      def assertTable(numRows: Int): Unit = {
+        val count = deltaTable.toDF.count()
+        assert(count == numRows)
+      }
+
+      // run insert (1,1), table should have 1 row (1,1)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "1")
+      runInsert((1, 1))
+      assertTable(1)
+      // run insert (2,2), table should have 2 rows (1,1),(2,2)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "2")
+      runInsert((2, 2))
+      assertTable(2)
+      // retry update 2, table should have 2 rows (1,1),(2,2)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "2")
+      runInsert((2, 2))
+      assertTable(2)
+      // run insert (3,3), table should have 3 rows (1,1),(2,2),(3,3)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "3")
+      runInsert((3, 3))
+      assertTable(3)
+
+      // clean up
+      spark.conf.unset("spark.databricks.delta.write.txnAppId")
+      spark.conf.unset("spark.databricks.delta.write.txnVersion")
+    }
+  }
+
+  test("idempotent write: idempotent SQL insert") {
+    withTempDir { tableDir =>
+      val tableName = "myInsertTable"
+      spark.conf.set("spark.databricks.delta.write.txnAppId", "insertTestSQL")
+
+      spark.sql(s"CREATE TABLE $tableName (col1 INT, col2 INT) USING DELTA LOCATION '" +
+        tableDir.getCanonicalPath + "'")
+
+      def runInsert(data: (Int, Int)): Unit = {
+        spark.sql(s"INSERT INTO $tableName (col1, col2) VALUES (${data._1}, ${data._2})")
+      }
+
+      def assertTable(numRows: Int): Unit = {
+        val count = spark.sql(s"SELECT * FROM $tableName").count()
+        assert(count == numRows)
+      }
+
+      // run insert (1,1), table should have 1 row (1,1)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "1")
+      runInsert((1, 1))
+      assertTable(1)
+      // run insert (2,2), table should have 2 rows (1,1),(2,2)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "2")
+      runInsert((2, 2))
+      assertTable(2)
+      // retry update 2, table should have 2 rows (1,1),(2,2)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "2")
+      runInsert((2, 2))
+      assertTable(2)
+      // run insert (3,3), table should have 3 rows (1,1),(2,2),(3,3)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "3")
+      runInsert((3, 3))
+      assertTable(3)
+
+      // clean up
+      spark.conf.unset("spark.databricks.delta.write.txnAppId")
+      spark.conf.unset("spark.databricks.delta.write.txnVersion")
+    }
+  }
+
+  test("idempotent write: idempotent DeltaTable merge") {
+    withTempDir { tableDir =>
+      spark.conf.set("spark.databricks.delta.write.txnAppId", "mergeTest")
+
+      io.delta.tables.DeltaTable.createOrReplace(spark)
+        .addColumn("col1", "INT")
+        .addColumn("col2", "INT")
+        .location(tableDir.getCanonicalPath)
+        .execute()
+      val deltaTable = io.delta.tables.DeltaTable.forPath(spark, tableDir.getCanonicalPath)
+
+      def runMerge(data: (Int, Int)): Unit = {
+        val df = Seq(data).toDF("col1", "col2")
+        deltaTable.as("t")
+          .merge(
+            df.as("s"),
+            "t.col1 = s.col1")
+          .whenMatched.updateExpr(Map("t.col2" -> "t.col2 + s.col2"))
+          .whenNotMatched().insertAll()
+          .execute()
+      }
+
+      def assertTable(col2Val: Int, numRows: Int): Unit = {
+        val res1 = deltaTable.toDF.select("col2").where("col1 = 1").collect()
+        assert(res1.length == numRows)
+        assert(res1(0).getInt(0) == col2Val)
+      }
+
+      // merge (1,0) into empty table, table should have 1 row (1,0)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "1")
+      runMerge((1, 0))
+      assertTable(0, 1)
+      // merge (1,2) into table, table should have 1 row (1,2)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "2")
+      runMerge((1, 2))
+      assertTable(2, 1)
+      // retry merge 2, table should have 1 row (1,2)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "2")
+      runMerge((1, 2))
+      assertTable(2, 1)
+      // merge (1,3) into table, table should have 1 row (1,5)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "3")
+      runMerge((1, 3))
+      assertTable(5, 1)
+
+      // clean up
+      spark.conf.unset("spark.databricks.delta.write.txnAppId")
+      spark.conf.unset("spark.databricks.delta.write.txnVersion")
+    }
+  }
+
+  test("idempotent write: idempotent SQL merge") {
+    def withTempDirs(f: (File, File) => Unit): Unit = {
+      withTempDir { file1 =>
+        withTempDir { file2 =>
+          f(file1, file2)
+        }
+      }
+    }
+
+    withTempDirs { (tableDir, updateTableDir) =>
+      val targetTableName = "myMergeTable"
+      val sourceTableName = "updates"
+      spark.conf.set("spark.databricks.delta.write.txnAppId", "mergeTestSQL")
+
+      spark.sql(s"CREATE TABLE $targetTableName (col1 INT, col2 INT) USING DELTA LOCATION '" +
+        tableDir.getCanonicalPath + "'")
+      spark.sql(s"CREATE TABLE $sourceTableName (col1 INT, col2 INT) USING DELTA LOCATION '" +
+        updateTableDir.getCanonicalPath + "'")
+
+      def runMerge(data: (Int, Int), txnVersion: Int): Unit = {
+        val df = Seq(data).toDF("col1", "col2")
+        spark.conf.set("spark.databricks.delta.write.txnVersion", s"$txnVersion")
+        df.write.format("delta").mode("overwrite").save(updateTableDir.getCanonicalPath)
+        spark.conf.set("spark.databricks.delta.write.txnVersion", s"$txnVersion")
+        spark.sql(s"""
+                     |MERGE INTO $targetTableName AS t USING $sourceTableName AS s
+                     | ON t.col1 = s.col1
+                     | WHEN MATCHED THEN UPDATE SET t.col2 = t.col2 + s.col2
+                     | WHEN NOT MATCHED THEN INSERT (col1, col2) VALUES (col1, col2)
+                     |""".stripMargin)
+      }
+
+      def assertTable(col2Val: Int, numRows: Int): Unit = {
+        val res1 = spark.sql(s"SELECT col2 FROM $targetTableName WHERE col1 = 1").collect()
+        assert(res1.length == numRows)
+        assert(res1(0).getInt(0) == col2Val)
+      }
+
+      // merge (1,0) into empty table, table should have 1 row (1,0)
+      runMerge((1, 0), 1)
+      assertTable(0, 1)
+      // merge (1,2) into table, table should have 1 row (1,2)
+      runMerge((1, 2), 2)
+      assertTable(2, 1)
+      // retry merge 2, table should have 1 row (1,2)
+      runMerge((1, 2), 2)
+      assertTable( 2, 1)
+      // merge (1,3) into table, table should have 1 row (1,5)
+      runMerge((1, 3), 3)
+      assertTable(5, 1)
+
+      // clean up
+      spark.conf.unset("spark.databricks.delta.write.txnAppId")
+      spark.conf.unset("spark.databricks.delta.write.txnVersion")
+    }
+  }
+
+  test("idempotent write: idempotent DeltaTable update") {
+    withTempDir { tableDir =>
+      spark.conf.set("spark.databricks.delta.write.txnAppId", "updateTest")
+
+      io.delta.tables.DeltaTable.createOrReplace(spark)
+        .addColumn("col1", "INT")
+        .addColumn("col2", "INT")
+        .location(tableDir.getCanonicalPath)
+        .execute()
+      val deltaTable = io.delta.tables.DeltaTable.forPath(spark, tableDir.getCanonicalPath)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "0")
+      Seq((1, 0)).toDF("col1", "col2")
+        .write.format("delta").mode("append").save(tableDir.getCanonicalPath)
+
+      def runUpdate(data: (Int, Int)): Unit = {
+        deltaTable.update(
+          condition = expr(s"col1 == ${data._1}"),
+          set = Map("col2" -> expr(s"col2 + ${data._2}"))
+        )
+      }
+
+      def assertTable(col2Val: Int, numRows: Int): Unit = {
+        val res1 = deltaTable.toDF.select("col2").where("col1 = 1").collect()
+        assert(res1.length == numRows)
+        assert(res1(0).getInt(0) == col2Val)
+      }
+
+      // run update (1,1), table should have 1 row (1,1)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "1")
+      runUpdate((1, 1))
+      assertTable(1, 1)
+      // run update (1,2), table should have 1 row (1,3)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "2")
+      runUpdate((1, 2))
+      assertTable(3, 1)
+      // retry update 2, table should have 1 row (1,3)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "2")
+      runUpdate((1, 2))
+      assertTable(3, 1)
+      // retry update 1, table should have 1 row (1,3)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "1")
+      runUpdate((1, 1))
+      assertTable(3, 1)
+      // run update (1,3) into table, table should have 1 row (1,6)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "3")
+      runUpdate((1, 3))
+      assertTable(6, 1)
+
+      // clean up
+      spark.conf.unset("spark.databricks.delta.write.txnAppId")
+      spark.conf.unset("spark.databricks.delta.write.txnVersion")
+    }
+  }
+
+  test("idempotent write: idempotent SQL update") {
+    withTempDir { tableDir =>
+      val tableName = "myUpdateTable"
+      spark.conf.set("spark.databricks.delta.write.txnAppId", "updateTestSQL")
+
+      spark.sql(s"CREATE TABLE $tableName (col1 INT, col2 INT) USING DELTA LOCATION '" +
+        tableDir.getCanonicalPath + "'")
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "0")
+      spark.sql(s"INSERT INTO $tableName (col1, col2) VALUES (1, 0)")
+
+      def runUpdate(data: (Int, Int)): Unit = {
+        spark.sql(s"""
+                     |UPDATE $tableName SET
+                     | col2 = col2 + ${data._2} WHERE col1 = ${data._1}
+              """.stripMargin)
+      }
+
+      def assertTable(col2Val: Int, numRows: Int): Unit = {
+        val res1 = spark.sql(s"SELECT col2 FROM $tableName WHERE col1 = 1").collect()
+        assert(res1.length == numRows)
+        assert(res1(0).getInt(0) == col2Val)
+      }
+
+      // run update (1,1), table should have 1 row (1,1)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "1")
+      runUpdate((1, 1))
+      assertTable(1, 1)
+      // run update (1,2), table should have 1 row (1,3)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "2")
+      runUpdate((1, 2))
+      assertTable(3, 1)
+      // retry update 2, table should have 1 row (1,3)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "2")
+      runUpdate((1, 2))
+      assertTable(3, 1)
+      // retry update 1, table should have 1 row (1,3)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "1")
+      runUpdate((1, 1))
+      assertTable(3, 1)
+      // run update (1,3) into table, table should have 1 row (1,6)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "3")
+      runUpdate((1, 3))
+      assertTable(6, 1)
+
+      // clean up
+      spark.conf.unset("spark.databricks.delta.write.txnAppId")
+      spark.conf.unset("spark.databricks.delta.write.txnVersion")
+    }
+  }
+
+  test("idempotent write: idempotent DeltaTable delete") {
+    withTempDir { tableDir =>
+      spark.conf.set("spark.databricks.delta.write.txnAppId", "deleteTest")
+
+      io.delta.tables.DeltaTable.createOrReplace(spark)
+        .addColumn("col1", "INT")
+        .addColumn("col2", "INT")
+        .location(tableDir.getCanonicalPath)
+        .execute()
+      val deltaTable = io.delta.tables.DeltaTable.forPath(spark, tableDir.getCanonicalPath)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "0")
+      Seq((1, 0), (2, 0), (3, 0), (4, 0)).toDF("col1", "col2")
+        .write.format("delta").mode("append").save(tableDir.getCanonicalPath)
+
+      def runDelete(toDelete: Int): Unit = {
+        deltaTable.delete(s"col1 = $toDelete")
+      }
+
+      def assertTable(numRows: Int): Unit = {
+        val rows = deltaTable.toDF.count()
+        assert(rows == numRows)
+      }
+
+      // run delete (1), table should have 3 rows (2,0),(3,0),(4,0)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "1")
+      runDelete(1)
+      assertTable(3)
+      // add (1,0) back to table
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "2")
+      Seq((1, 0)).toDF("col1", "col2")
+        .write.format("delta").mode("append").save(tableDir.getCanonicalPath)
+      assertTable(4)
+      // retry delete 1, table should have 4 rows (2,0),(3,0),(4,0)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "1")
+      runDelete(1)
+      assertTable(4)
+      // run delete (1), table should have 3 rows (2,0),(3,0),(4,0)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "3")
+      runDelete(1)
+      assertTable(3)
+
+      // clean up
+      spark.conf.unset("spark.databricks.delta.write.txnAppId")
+      spark.conf.unset("spark.databricks.delta.write.txnVersion")
+    }
+  }
+
+  test("idempotent write: idempotent SQL delete") {
+    withTempDir { tableDir =>
+      val tableName = "myDeleteTable"
+      spark.conf.set("spark.databricks.delta.write.txnAppId", "deleteTestSQL")
+
+      spark.sql(s"CREATE TABLE $tableName (col1 INT, col2 INT) USING DELTA LOCATION '" +
+        tableDir.getCanonicalPath + "'")
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "0")
+      spark.sql(s"INSERT INTO $tableName (col1, col2) VALUES (1, 0), (2, 0), (3, 0), (4, 0)")
+
+      def runDelete(toDelete: Int): Unit = {
+        spark.sql(s"DELETE FROM $tableName WHERE col1 = $toDelete")
+      }
+
+      def assertTable(numRows: Long): Unit = {
+        val res1 = spark.sql(s"SELECT COUNT(*) FROM $tableName").collect()
+        assert(res1.length == 1)
+        assert(res1(0).getLong(0) == numRows)
+      }
+
+      // run delete (1), table should have 3 rows (2,0),(3,0),(4,0)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "1")
+      runDelete(1)
+      assertTable(3)
+      // add (1,0) back to table
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "2")
+      spark.sql(s"INSERT INTO $tableName (col1, col2) VALUES (1, 0)")
+      assertTable(4)
+      // retry delete (1), table should have 4 rows (2,0),(3,0),(4,0)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "1")
+      runDelete(1)
+      assertTable(4)
+      // run delete (1), table should have 3 rows (2,0),(3,0),(4,0)
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "3")
+      runDelete(1)
+      assertTable(3)
+
+      // clean up
+      spark.conf.unset("spark.databricks.delta.write.txnAppId")
+      spark.conf.unset("spark.databricks.delta.write.txnVersion")
+    }
+  }
+
+  test("idempotent write: valid txnVersion") {
+    spark.conf.set("spark.databricks.delta.write.txnAppId", "deleteTestSQL")
+    val e = intercept[IllegalArgumentException] {
+      spark.sessionState.conf.setConfString(
+        "spark.databricks.delta.write.txnVersion", "someVersion")
+    }
+    assert(e.getMessage == "spark.databricks.delta.write.txnVersion should be " +
+      "long, but was someVersion")
+
+    // clean up
+    spark.conf.unset("spark.databricks.delta.write.txnAppId")
+    spark.conf.unset("spark.databricks.delta.write.txnVersion")
+  }
+
+  Seq("REPLACE", "CREATE OR REPLACE").foreach { command =>
+    test(s"Idempotent $command command") {
+      withTempDir { tableDir =>
+        val tableName = "myIdempotentReplaceTable"
+        withTable(tableName) {
+          spark.conf.set("spark.databricks.delta.write.txnAppId", "replaceTestSQL")
+          spark.sql(s"CREATE TABLE $tableName(c1 INT, c2 INT, c3 INT)" +
+            s"USING DELTA LOCATION '" + tableDir.getCanonicalPath + "'")
+
+          def runReplace(data: (Int, Int, Int)): Unit = {
+            spark.sql(s"$command table $tableName USING DELTA " +
+              s"as SELECT ${data._1} as c1, ${data._2} as c2, ${data._3} as c3")
+          }
+
+          def assertTable(numRows: Int, commitVersion: Int, data: (Int, Int, Int)): Unit = {
+            val count = spark.sql(s"SELECT * FROM $tableName").count()
+            assert(count == numRows)
+            val snapshot = DeltaLog.forTable(spark, tableDir.getCanonicalPath).update()
+            assert(snapshot.version == commitVersion)
+            val tableContent = spark.sql(s"SELECT * FROM $tableName").collect().head
+            assert(tableContent.getInt(0) == data._1)
+            assert(tableContent.getInt(1) == data._2)
+            assert(tableContent.getInt(2) == data._3)
+          }
+
+          // run replace (1,1,1) with version 1, table should have 1 row (1,1,1).
+          spark.conf.set("spark.databricks.delta.write.txnVersion", "1")
+          runReplace((1, 1, 1))
+          assertTable(1, 1, (1, 1, 1))
+          // run replace (2,2,2) with version 2, table should have 1 row (2,2,2)
+          spark.conf.set("spark.databricks.delta.write.txnVersion", "2")
+          runReplace((2, 2, 2))
+          assertTable(1, 2, (2, 2, 2))
+          // retry replace (3,3,3) with version 2, table should have 1 row (2,2,2).
+          spark.conf.set("spark.databricks.delta.write.txnVersion", "2")
+          runReplace((3, 3, 3))
+          assertTable(1, 2, (2, 2, 2))
+          // run replace (4,4,4) with version 3, table should have 1 row (4,4,4).
+          spark.conf.set("spark.databricks.delta.write.txnVersion", "3")
+          runReplace((4, 4, 4))
+          assertTable(1, 3, (4, 4, 4))
+          // run replace (5,5,5) with version 3, table should have 1 row (4,4,4).
+          spark.conf.set("spark.databricks.delta.write.txnVersion", "3")
+          runReplace((5, 5, 5))
+          assertTable(1, 3, (4, 4, 4))
+          // clean up
+          spark.conf.unset("spark.databricks.delta.write.txnAppId")
+          spark.conf.unset("spark.databricks.delta.write.txnVersion")
+        }
+      }
+    }
+  }
+
+  test("idempotent write: auto reset txnVersion") {
+    withTempDir { tableDir =>
+      val tableName = "myAutoResetTable"
+      spark.conf.set("spark.databricks.delta.write.txnAppId", "autoReset")
+      spark.sql(s"CREATE TABLE $tableName (col1 INT, col2 INT) USING DELTA LOCATION '" +
+        tableDir.getCanonicalPath + "'")
+
+      // this write is done with txn version 0
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "0")
+      spark.sql(s"INSERT INTO $tableName (col1, col2) VALUES (1, 0)")
+      // this write should be skipped as the version is not reset so it will be applied
+      // with the same version
+      spark.sql(s"INSERT INTO $tableName (col1, col2) VALUES (2, 0)")
+      assert(spark.sql(s"SELECT * FROM $tableName").count() == 1)
+
+      // now enable auto reset
+      spark.conf.set("spark.databricks.delta.write.txnVersion.autoReset.enabled", "true")
+
+      // this write should be skipped as it is using the same txnVersion as the first write
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "0")
+      spark.sql(s"INSERT INTO $tableName (col1, col2) VALUES (3, 0)")
+      // this should throw an exception as the txn version is automatically reset
+      val e1 = intercept[IllegalArgumentException] {
+        spark.sql(s"INSERT INTO $tableName (col1, col2) VALUES (4, 0)")
+      }
+      assert(e1.getMessage == "Invalid options for idempotent Dataframe writes: " +
+        "Both spark.databricks.delta.write.txnAppId and spark.databricks.delta.write.txnVersion " +
+        "must be specified for idempotent Delta writes")
+      // this write should succeed as it's using a newer version than the latest
+      spark.conf.set("spark.databricks.delta.write.txnVersion", "10")
+      spark.sql(s"INSERT INTO $tableName (col1, col2) VALUES (2, 0)")
+      // this should throw an exception as the txn version is automatically reset
+      val e2 = intercept[IllegalArgumentException] {
+        spark.sql(s"INSERT INTO $tableName (col1, col2) VALUES (3, 0)")
+      }
+      assert(e2.getMessage == "Invalid options for idempotent Dataframe writes: " +
+        "Both spark.databricks.delta.write.txnAppId and spark.databricks.delta.write.txnVersion " +
+        "must be specified for idempotent Delta writes")
+
+      val res = spark.sql(s"SELECT col1 FROM $tableName")
+        .orderBy(asc("col1"))
+        .collect()
+      assert(res.length == 2)
+      assert(res(0).getInt(0) == 1)
+      assert(res(1).getInt(0) == 2)
+
+      // clean up
+      spark.conf.unset("spark.databricks.delta.write.txnAppId")
+      spark.conf.unset("spark.databricks.delta.write.txnVersion")
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
(Cherry-pick https://github.com/delta-io/delta/commit/ed1599da6faf7e3dab762a7a703e14971761b93a to branch-2.1)

Currently, delta supports idempotent write using Dataframe writer options. These writer options are applicable to inserts only. This PR adds support for idempotency using SQL options(DELTA_IDEMPOTENT_DML_TXN_APP_ID and DELTA_IDEMPOTENT_DML_TXN_VERSION) to INSERTS/DELETE/UPDATE/MERGE etc. When both writer options and SQL conf are specified, we will use the writer option values.

Idempotent write works by checking the txnVersion and txnAppId from user-provided write options or from session configurations(as a SQL conf). If the same or higher txnVersion has been recorded, then it will skip the write.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
New unit tests.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
