### PR TITLE
Update `build.sbt` to make release automation smoother

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -396,6 +396,13 @@ lazy val releaseSettings = Seq(
   Test / publishArtifact := false,
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   releaseCrossBuild := true,
+  pgpPassphrase := sys.env.get("PGP_PASSPHRASE").map(_.toArray),
+  credentials += Credentials(
+    "Sonatype Nexus Repository Manager",
+    "oss.sonatype.org",
+    sys.env.getOrElse("SONATYPE_USERNAME", ""),
+    sys.env.getOrElse("SONATYPE_PASSWORD", "")
+  ),
   publishTo := {
     val nexus = "https://oss.sonatype.org/"
     if (isSnapshot.value) {


### PR DESCRIPTION
## Description
This PR lets us get the sonatype credentials and GPG passphrase from environmental variables during releases.

## How was this patch tested?
Locally tests against sonatype.