### PR TITLE
Support limit pushdown on Delta tables with DVs.

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/stats/DeltaScan.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/stats/DeltaScan.scala
@@ -39,7 +39,9 @@ case class DataSize(
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
     rows: Option[Long] = None,
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
-    files: Option[Long] = None
+    files: Option[Long] = None,
+    @JsonDeserialize(contentAs = classOf[java.lang.Long])
+    logicalRows: Option[Long] = None
 )
 
 object DataSize {
@@ -47,7 +49,8 @@ object DataSize {
     DataSize(
       Option(a.value(0)).filterNot(_ == -1),
       Option(a.value(1)).filterNot(_ == -1),
-      Option(a.value(2)).filterNot(_ == -1)
+      Option(a.value(2)).filterNot(_ == -1),
+      Option(a.value(3)).filterNot(_ == -1)
     )
   }
 }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
@@ -1,0 +1,202 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.io.File
+import java.util.UUID
+
+import org.apache.spark.sql.delta.actions.{Action, AddFile, DeletionVectorDescriptor, RemoveFile}
+import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
+import org.apache.spark.sql.delta.util.PathWithFileSystem
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.test.SharedSparkSession
+
+/** Collection of test utilities related with persistent Deletion Vectors. */
+trait DeletionVectorsTestUtils extends QueryTest with SharedSparkSession {
+
+  /** Run a thunk with Deletion Vectors enabled/disabled. */
+  def withDeletionVectorsEnabled(enabled: Boolean = true)(thunk: => Unit): Unit = {
+    val enabledStr = enabled.toString
+    withSQLConf(
+      DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.defaultTablePropertyKey -> enabledStr
+    ) {
+      thunk
+    }
+  }
+
+  /** Helper to run 'fn' with a temporary Delta table. */
+  def withTempDeltaTable(
+      dataDF: DataFrame,
+      partitionBy: Seq[String] = Seq.empty,
+      enableDVs: Boolean = true)(fn: (io.delta.tables.DeltaTable, DeltaLog) => Unit): Unit = {
+    withTempPath { path =>
+      val tablePath = new Path(path.getAbsolutePath)
+      dataDF.write
+        .option(DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.key, enableDVs.toString)
+        .partitionBy(partitionBy: _*)
+        .format("delta")
+        .save(tablePath.toString)
+      val targetTable = io.delta.tables.DeltaTable.forPath(tablePath.toString)
+      val targetLog = DeltaLog.forTable(spark, tablePath)
+      fn(targetTable, targetLog)
+    }
+  }
+
+  /** Helper that verifies whether a defined number of DVs exist */
+  def verifyDVsExist(targetLog: DeltaLog, filesWithDVsSize: Int): Unit = {
+    val filesWithDVs = getFilesWithDeletionVectors(targetLog)
+    assert(filesWithDVs.size === filesWithDVsSize)
+    assertDeletionVectorsExist(targetLog, filesWithDVs)
+  }
+
+  /** Returns all [[AddFile]] actions of a Delta table that contain Deletion Vectors. */
+  def getFilesWithDeletionVectors(log: DeltaLog): Seq[AddFile] =
+    log.unsafeVolatileSnapshot.allFiles.collect().filter(_.deletionVector != null).toSeq
+
+  /** Helper to check that the Deletion Vectors of the provided file actions exist on disk. */
+  def assertDeletionVectorsExist(log: DeltaLog, filesWithDVs: Seq[AddFile]): Unit = {
+    val tablePath = new Path(log.dataPath.toUri.getPath)
+    for (file <- filesWithDVs) {
+      val dv = file.deletionVector
+      assert(dv != null)
+      assert(dv.isOnDisk && !dv.isInline)
+      assert(dv.offset.isDefined)
+
+      // Check that DV exists.
+      val dvPath = dv.absolutePath(tablePath)
+      val dvPathStr = DeletionVectorStore.pathToString(dvPath)
+      assert(new File(dvPathStr).exists(), s"DV not found $dvPath")
+
+      // Check that cardinality is correct.
+      val bitmap = newDVStore.read(dvPath, dv.offset.get, dv.sizeInBytes)
+      assert(dv.cardinality === bitmap.cardinality)
+    }
+  }
+
+  // ======== HELPER METHODS TO WRITE DVs ==========
+  protected def serializeRoaringBitmapArrayWithDefaultFormat(
+      dv: RoaringBitmapArray): Array[Byte] = {
+    val serializationFormat = RoaringBitmapArrayFormat.Portable
+    dv.serializeAsByteArray(serializationFormat)
+  }
+
+  /**
+   * Produce a new [[AddFile]] that will store `dv` in the log using default settings for choosing
+   * inline or on-disk storage.
+   *
+   * Also returns the corresponding [[RemoveFile]] action for `currentFile`.
+   *
+   * TODO: Always on-disk for now. Inline support comes later.
+   */
+  protected def writeFileWithDV(
+      log: DeltaLog,
+      currentFile: AddFile,
+      dv: RoaringBitmapArray): Seq[Action] = {
+    writeFileWithDVOnDisk(log, currentFile, dv)
+  }
+
+  /**
+   * Produce a new [[AddFile]] that will reference the `dv` in the log while storing it on-disk.
+   *
+   * Also returns the corresponding [[RemoveFile]] action for `currentFile`.
+   */
+  protected def writeFileWithDVOnDisk(
+      log: DeltaLog,
+      currentFile: AddFile,
+      dv: RoaringBitmapArray): Seq[Action] = writeFilesWithDVsOnDisk(log, Seq((currentFile, dv)))
+
+  protected def withDVWriter[T](
+      log: DeltaLog,
+      dvFileID: UUID)(fn: DeletionVectorStore.Writer => T): T = {
+    val dvStore = newDVStore
+    // scalastyle:off deltahadoopconfiguration
+    val conf = spark.sessionState.newHadoopConf()
+    // scalastyle:on deltahadoopconfiguration
+    val tableWithFS = PathWithFileSystem.withConf(log.dataPath, conf)
+    val dvPath =
+      DeletionVectorStore.assembleDeletionVectorPathWithFileSystem(tableWithFS, dvFileID)
+    val writer = dvStore.createWriter(dvPath)
+    try {
+      fn(writer)
+    } finally {
+      writer.close()
+    }
+  }
+
+  /**
+   * Produce new [[AddFile]] actions that will reference associated DVs in the log while storing
+   * all DVs in the same file on-disk.
+   *
+   * Also returns the corresponding [[RemoveFile]] actions for the original file entries.
+   */
+  protected def writeFilesWithDVsOnDisk(
+      log: DeltaLog,
+      filesWithDVs: Seq[(AddFile, RoaringBitmapArray)]): Seq[Action] = {
+    val dvFileId = UUID.randomUUID()
+    withDVWriter(log, dvFileId) { writer =>
+      filesWithDVs.flatMap { case (currentFile, dv) =>
+        val range = writer.write(serializeRoaringBitmapArrayWithDefaultFormat(dv))
+        val dvData = DeletionVectorDescriptor.onDiskWithRelativePath(
+          id = dvFileId,
+          sizeInBytes = range.length,
+          cardinality = dv.cardinality,
+          offset = Some(range.offset))
+        val (add, remove) = currentFile.removeRows(
+          dvData
+        )
+        Seq(add, remove)
+      }
+    }
+  }
+
+  /**
+   * Removes the `numRowsToRemovePerFile` from each file via DV.
+   * Returns the total number of rows removed.
+   */
+  protected def removeRowsFromAllFilesInLog(
+      log: DeltaLog,
+      numRowsToRemovePerFile: Long): Long = {
+    var numFiles: Option[Int] = None
+    // This is needed to make the manual commit work correctly, since we are not actually
+    // running a command that produces metrics.
+    withSQLConf(DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "false") {
+      val txn = log.startTransaction()
+      val allAddFiles = txn.snapshot.allFiles.collect()
+      numFiles = Some(allAddFiles.length)
+      val bitmap = RoaringBitmapArray(0L until numRowsToRemovePerFile: _*)
+      val actions = allAddFiles.flatMap { file =>
+        if (file.numPhysicalRecords.isDefined) {
+          // Only when stats are enabled. Can't check when stats are disabled
+          assert(file.numPhysicalRecords.get > numRowsToRemovePerFile)
+        }
+        writeFileWithDV(log, file, bitmap)
+      }
+      txn.commit(actions, DeltaOperations.Delete(predicate = Seq.empty))
+    }
+    numFiles.get * numRowsToRemovePerFile
+  }
+
+  def newDVStore(): DeletionVectorStore = {
+    // scalastyle:off deltahadoopconfiguration
+    DeletionVectorStore.createInstance(spark.sessionState.newHadoopConf())
+    // scalastyle:on deltahadoopconfiguration
+  }
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaLimitPushDownSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaLimitPushDownSuite.scala
@@ -34,6 +34,7 @@ trait DeltaLimitPushDownTests extends QueryTest
     with SharedSparkSession
     with DatabricksLogging
     with ScanReportHelper
+    with DeletionVectorsTestUtils
     with StatsUtils
     with DeltaSQLCommandTest {
 
@@ -233,6 +234,68 @@ trait DeltaLimitPushDownTests extends QueryTest
     }
   }
 
+  private def withDVSettings(thunk: => Unit): Unit = {
+    withSQLConf(
+      DeltaSQLConf.DELTA_OPTIMIZE_METADATA_QUERY_ENABLED.key -> "false"
+    ) {
+      withDeletionVectorsEnabled() {
+        thunk
+      }
+    }
+  }
+
+  for (statsCollectionEnabled <- BOOLEAN_DOMAIN) {
+    test(s"Verify limit correctness in the presence of DVs " +
+      s"statsCollectionEnabled: $statsCollectionEnabled") {
+      withDVSettings {
+        withSQLConf(DeltaSQLConf.DELTA_COLLECT_STATS.key -> statsCollectionEnabled.toString) {
+          val targetDF = spark.range(start = 0, end = 100, step = 1, numPartitions = 2)
+            .withColumn("value", col("id"))
+
+          withTempDeltaTable(targetDF) { (targetTable, targetLog) =>
+            removeRowsFromAllFilesInLog(targetLog, numRowsToRemovePerFile = 10)
+            verifyDVsExist(targetLog, 2)
+
+            val targetDF = targetTable.toDF
+
+            // We have 2 files 50 rows each. We deleted 10 rows from the first file. The first file
+            // now contains 50 physical rows and 40 logical. Failing to take into account the DVs in
+            // the first file results into prematurely terminating the scan and returning an
+            // incorrect result. Note, the corner case in terms of correctness is when the limit is
+            // set to 50. When statistics collection is disabled, we read both files.
+            val limitToExpectedNumberOfFilesReadSeq = Range(10, 90, 10)
+              .map(n => (n, if (n < 50 && statsCollectionEnabled) 1 else 2))
+
+            for ((limit, expectedNumberOfFilesRead) <- limitToExpectedNumberOfFilesReadSeq) {
+              val df = targetDF.limit(limit)
+
+              // Assess correctness.
+              assert(df.count === limit)
+
+              val scanStats = getStats(df)
+
+              // Check we do not read more files than needed.
+              assert(scanStats.scanned.files === Some(expectedNumberOfFilesRead))
+
+              // Verify physical and logical rows are updated correctly.
+              val numDeletedRows = 10
+              val numPhysicalRowsPerFile = 50
+              val numTotalPhysicalRows = numPhysicalRowsPerFile * expectedNumberOfFilesRead
+              val numTotalLogicalRows = numTotalPhysicalRows -
+                (numDeletedRows * expectedNumberOfFilesRead)
+              val expectedNumTotalPhysicalRows =
+                if (statsCollectionEnabled) Some(numTotalPhysicalRows) else None
+              val expectedNumTotalLogicalRows =
+                if (statsCollectionEnabled) Some(numTotalLogicalRows) else None
+
+              assert(scanStats.scanned.rows === expectedNumTotalPhysicalRows)
+              assert(scanStats.scanned.logicalRows === expectedNumTotalLogicalRows)
+            }
+          }
+        }
+      }
+    }
+  }
 }
 
 class DeltaLimitPushDownV1Suite extends DeltaLimitPushDownTests


### PR DESCRIPTION
This PR is part of the feature: Support reading Delta tables with deletion vectors (more details at https://github.com/delta-io/delta/issues/1485)

Currently the limit pushdown code doesn't take into account the DVs when pruning the list of files based on the `limit` value. This will result in wrong results for `LIMIT` queries. Update the code to take `dv.cardinality` when finding the number of rows in a `AddFile`. 

It also adds
 * comments around data skipping code and how data skipping continue to work without giving wrong results (with a bit performance overhead) when querying tables with DVs
 * test utilities to associate DVs with `AddFile` for testing purposes.