### PR TITLE
Resolves external catalog integration issue

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -415,6 +415,12 @@ case class CreateDeltaTableCommand(
       table.schema.copy()
     }
 
+    val newProvider = if (conf.getConf(DeltaSQLConf.DELTA_CREATE_TABLE_USE_PARQUET_PROVIDER)) {
+      Some("parquet")
+    } else {
+      table.provider
+    }
+
     // These actually have no effect on the usability of Delta, but feature flagging legacy
     // behavior for now
     val storageProps = if (conf.getConf(DeltaSQLConf.DELTA_LEGACY_STORE_WRITER_OPTIONS_AS_PROPS)) {
@@ -426,6 +432,7 @@ case class CreateDeltaTableCommand(
 
     table.copy(
       schema = newSchema,
+      provider = newProvider,
       properties = Map.empty,
       partitionColumnNames = Nil,
       // Remove write specific options when updating the catalog

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -409,6 +409,12 @@ case class CreateDeltaTableCommand(
   /** Clean up the information we pass on to store in the catalog. */
   private def cleanupTableDefinition(spark: SparkSession, table: CatalogTable, snapshot: Snapshot)
       : CatalogTable = {
+    val newSchema = if (conf.getConf(DeltaSQLConf.DELTA_CREATE_TABLE_CLEANUP_SCHEMA)) {
+      new StructType()
+    } else {
+      table.schema.copy()
+    }
+
     // These actually have no effect on the usability of Delta, but feature flagging legacy
     // behavior for now
     val storageProps = if (conf.getConf(DeltaSQLConf.DELTA_LEGACY_STORE_WRITER_OPTIONS_AS_PROPS)) {
@@ -419,7 +425,7 @@ case class CreateDeltaTableCommand(
     }
 
     table.copy(
-      schema = new StructType(),
+      schema = newSchema,
       properties = Map.empty,
       partitionColumnNames = Nil,
       // Remove write specific options when updating the catalog

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -852,6 +852,19 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(false)
 
+  val DELTA_CREATE_TABLE_CLEANUP_SCHEMA =
+    buildConf("createTable.cleanupSchema")
+      .internal()
+      .doc(
+        """
+          |Given a CREATE TABLE command, cleanup schema of the table definition.
+          |
+          |This is a safety switch - we should only turn this off when there is an issue with
+          |table creation logic that prevents a valid column schema.
+          |""".stripMargin)
+      .booleanConf
+      .createWithDefault(true)
+
   val DELTA_ALTER_TABLE_CHANGE_COLUMN_CHECK_EXPRESSIONS =
     buildConf("alterTable.changeColumn.checkExpressions")
       .internal()

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -865,6 +865,19 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
+  val DELTA_CREATE_TABLE_USE_PARQUET_PROVIDER =
+    buildConf("createTable.useParquetProvider")
+      .internal()
+      .doc(
+        """
+          |Given a CREATE TABLE command, use parquet instead of delta as a provider.
+          |
+          |This is a safety switch - we should only turn this on when there is an issue with
+          |table creation.
+          |""".stripMargin)
+      .booleanConf
+      .createWithDefault(false)
+
   val DELTA_ALTER_TABLE_CHANGE_COLUMN_CHECK_EXPRESSIONS =
     buildConf("alterTable.changeColumn.checkExpressions")
       .internal()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR resolves following issues when creating Delta table definition in an external catalog.

- Issue 1: Schema cannot be recognized and automatically falls back to `col (array)`
- Issue 2: The error `IllegalArgumentException: Can not create a Path from an empty string` occurs when database does not have its location

The PR has two new options:
- `spark.databricks.delta.createTable.cleanupSchema` (default: True)
- `spark.databricks.delta.createTable.useParquetProvider` (default: False)

When you configure both two options, then you can avoid Issue 1 and Issue 2 explained below.
- `spark.databricks.delta.createTable.cleanupSchema=False`
- `spark.databricks.delta.createTable.useParquetProvider`=True

### Issue 1: Schema cannot be recognized and automatically falls back to `col (array)`

#### Issue description
When calling `saveAsTable` for a table, it causes incorrect schema (Name=`col`, Type=`array<string>`) in the external catalog.

For example, with AWS Glue Data Catalog, the table definition becomes following:

```
$ aws glue get-table --database-name delta_catalog_write_test --name test03
{
    "Table": {
        "Name": "test03",
        "DatabaseName": "delta_catalog_write_test",
        "Owner": "spark",
        "CreateTime": "2023-01-25T19:21:01+09:00",
        "UpdateTime": "2023-01-25T19:21:01+09:00",
        "LastAccessTime": "1970-01-01T09:00:00+09:00",
        "Retention": 0,
        "StorageDescriptor": {
            "Columns": [
                {
                    "Name": "col",
                    "Type": "array<string>",
                    "Comment": "from deserializer"
                }
            ],
            "Location": "s3://bucket_name/data/delta_catalog_write_test/test03-__PLACEHOLDER__",
            "InputFormat": "org.apache.hadoop.mapred.SequenceFileInputFormat",
            "OutputFormat": "org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat",
            "Compressed": false,
            "NumberOfBuckets": -1,
            "SerdeInfo": {
                "SerializationLibrary": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
                "Parameters": {
                    "serialization.format": "1",
                    "path": "s3://bucket_name/data/delta_catalog_write_test/test03"
                }
            },
            "BucketColumns": [],
            "SortColumns": [],
            "Parameters": {},
            "SkewedInfo": {
                "SkewedColumnNames": [],
                "SkewedColumnValues": [],
                "SkewedColumnValueLocationMaps": {}
            },
            "StoredAsSubDirectories": false
        },
        "PartitionKeys": [],
        "TableType": "EXTERNAL_TABLE",
        "Parameters": {
            "transient_lastDdlTime": "1674642060",
            "spark.sql.sources.schema": "{\"type\":\"struct\",\"fields\":[]}",
            "spark.sql.partitionProvider": "catalog",
            "EXTERNAL": "TRUE",
            "spark.sql.sources.provider": "delta",
            "spark.sql.create.version": "3.3.0-amzn-1"
        },
        "CreatedBy": "arn:aws:sts::123456789101:assumed-role/AWSGlueServiceRole-Default/GlueJobRunnerSession",
        "IsRegisteredWithLakeFormation": false,
        "CatalogId": "123456789101",
        "IsRowFilteringEnabled": false,
        "VersionId": "0",
        "DatabaseId": "xxxxxxxxxxxx"
    }
}
```

Note: Spark SQL's `SHOW COLUMNS` or `DESCRIBE TABLE` do not cause this issue.

#### RCA
The reason why schema becomes col is: 

* [CreateDeltaTableCommand.updateTable](https://github.com/delta-io/delta/blob/master/core/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala#L382) (https://github.com/delta-io/delta/blob/master/core/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala#L382) is called to write table definition
* Then [cleanupTableDefinition](https://github.com/delta-io/delta/blob/master/core/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala#L410) (https://github.com/delta-io/delta/blob/master/core/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala#L410) is called in updateTable
* Then empty StructType is passed to schema instead of the existing schema
* Then SerDe cannot recognize the schema and then overwrites it with default schema col

#### Options to fix the issue
Here's possible options to fix the issue 1.

* Option 1-1. Replace the empty schema with actual existing schema
    * Pros: Simple and Easy
    * Cons: It can break existing workload
* Option 1-2. Introduce a new option `createTable.cleanupSchema` to change the behavior to use the existing schema
    * Pros: Won’t break any existing workload

Option 1-2 will be much safer.


#### Issue reports

Same issues were reported in following links.

* https://github.com/delta-io/delta/issues/609

### Issue 2: The error `IllegalArgumentException: Can not create a Path from an empty string` occurs when database does not have its location

#### Issue description

When calling `saveAsTable` with a database which does not have location, it causes following exception even though table has absolute location.

```
2023-01-27 09:12:29,904 ERROR [Thread-9] util.Utils (Logging.scala:logError(98)): Aborting task
java.lang.IllegalArgumentException: Can not create a Path from an empty string
    at org.apache.hadoop.fs.Path.checkPathArg(Path.java:172) ~[hadoop-client-api-3.3.3-amzn-0.jar:?]
    at org.apache.hadoop.fs.Path.<init>(Path.java:184) ~[hadoop-client-api-3.3.3-amzn-0.jar:?]
    at org.apache.spark.sql.catalyst.catalog.CatalogUtils$.stringToURI(ExternalCatalogUtils.scala:259) ~[spark-catalyst_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.hive.client.HiveClientImpl.$anonfun$getDatabase$2(HiveClientImpl.scala:388) ~[spark-hive_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at scala.Option.map(Option.scala:146) ~[scala-library.jar:?]
    at org.apache.spark.sql.hive.client.HiveClientImpl.$anonfun$getDatabase$1(HiveClientImpl.scala:381) ~[spark-hive_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.hive.client.HiveClientImpl.$anonfun$withHiveState$1(HiveClientImpl.scala:294) ~[spark-hive_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.hive.client.HiveClientImpl.liftedTree1$1(HiveClientImpl.scala:225) ~[spark-hive_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.hive.client.HiveClientImpl.retryLocked(HiveClientImpl.scala:224) ~[spark-hive_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.hive.client.HiveClientImpl.withHiveState(HiveClientImpl.scala:274) ~[spark-hive_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.hive.client.HiveClientImpl.getDatabase(HiveClientImpl.scala:390) ~[spark-hive_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.hive.HiveExternalCatalog.$anonfun$getDatabase$1(HiveExternalCatalog.scala:244) ~[spark-hive_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.hive.HiveExternalCatalog.withClient(HiveExternalCatalog.scala:104) ~[spark-hive_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.hive.HiveExternalCatalog.getDatabase(HiveExternalCatalog.scala:244) ~[spark-hive_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.hive.HiveExternalCatalog.saveTableIntoHive(HiveExternalCatalog.scala:528) ~[spark-hive_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.hive.HiveExternalCatalog.createDataSourceTable(HiveExternalCatalog.scala:436) ~[spark-hive_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.hive.HiveExternalCatalog.$anonfun$createTable$1(HiveExternalCatalog.scala:298) ~[spark-hive_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12) ~[scala-library.jar:?]
    at org.apache.spark.sql.hive.HiveExternalCatalog.withClient(HiveExternalCatalog.scala:104) ~[spark-hive_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.hive.HiveExternalCatalog.createTable(HiveExternalCatalog.scala:269) ~[spark-hive_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.catalyst.catalog.ExternalCatalogWithListener.createTable(ExternalCatalogWithListener.scala:94) ~[spark-catalyst_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.catalyst.catalog.SessionCatalog.createTable(SessionCatalog.scala:373) ~[spark-catalyst_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.delta.commands.CreateDeltaTableCommand.updateCatalog(CreateDeltaTableCommand.scala:417) ~[delta-core_2.12-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
    at org.apache.spark.sql.delta.commands.CreateDeltaTableCommand.$anonfun$run$3(CreateDeltaTableCommand.scala:241) ~[delta-core_2.12-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
    at org.apache.spark.sql.delta.metering.DeltaLogging.recordFrameProfile(DeltaLogging.scala:140) ~[delta-core_2.12-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
    at org.apache.spark.sql.delta.metering.DeltaLogging.recordFrameProfile$(DeltaLogging.scala:138) ~[delta-core_2.12-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
    at org.apache.spark.sql.delta.commands.CreateDeltaTableCommand.recordFrameProfile(CreateDeltaTableCommand.scala:49) ~[delta-core_2.12-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
    at org.apache.spark.sql.delta.metering.DeltaLogging.$anonfun$recordDeltaOperationInternal$1(DeltaLogging.scala:133) ~[delta-core_2.12-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
    at com.databricks.spark.util.DatabricksLogging.recordOperation(DatabricksLogging.scala:128) ~[delta-core_2.12-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
    at com.databricks.spark.util.DatabricksLogging.recordOperation$(DatabricksLogging.scala:117) ~[delta-core_2.12-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
    at org.apache.spark.sql.delta.commands.CreateDeltaTableCommand.recordOperation(CreateDeltaTableCommand.scala:49) ~[delta-core_2.12-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
    at org.apache.spark.sql.delta.metering.DeltaLogging.recordDeltaOperationInternal(DeltaLogging.scala:132) ~[delta-core_2.12-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
    at org.apache.spark.sql.delta.metering.DeltaLogging.recordDeltaOperation(DeltaLogging.scala:122) ~[delta-core_2.12-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
    at org.apache.spark.sql.delta.metering.DeltaLogging.recordDeltaOperation$(DeltaLogging.scala:112) ~[delta-core_2.12-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
    at org.apache.spark.sql.delta.commands.CreateDeltaTableCommand.recordDeltaOperation(CreateDeltaTableCommand.scala:49) ~[delta-core_2.12-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
    at org.apache.spark.sql.delta.commands.CreateDeltaTableCommand.run(CreateDeltaTableCommand.scala:107) ~[delta-core_2.12-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
    at org.apache.spark.sql.delta.catalog.DeltaCatalog.$anonfun$createDeltaTable$1(DeltaCatalog.scala:164) ~[delta-core_2.12-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
    at org.apache.spark.sql.delta.metering.DeltaLogging.recordFrameProfile(DeltaLogging.scala:140) ~[delta-core_2.12-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
    at org.apache.spark.sql.delta.metering.DeltaLogging.recordFrameProfile$(DeltaLogging.scala:138) ~[delta-core_2.12-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
    at org.apache.spark.sql.delta.catalog.DeltaCatalog.recordFrameProfile(DeltaCatalog.scala:57) ~[delta-core_2.12-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
    at org.apache.spark.sql.delta.catalog.DeltaCatalog.org$apache$spark$sql$delta$catalog$DeltaCatalog$$createDeltaTable(DeltaCatalog.scala:85) ~[delta-core_2.12-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
    at org.apache.spark.sql.delta.catalog.DeltaCatalog$StagedDeltaTableV2.$anonfun$commitStagedChanges$1(DeltaCatalog.scala:453) ~[delta-core_2.12-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
    at org.apache.spark.sql.delta.metering.DeltaLogging.recordFrameProfile(DeltaLogging.scala:140) ~[delta-core_2.12-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
    at org.apache.spark.sql.delta.metering.DeltaLogging.recordFrameProfile$(DeltaLogging.scala:138) ~[delta-core_2.12-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
    at org.apache.spark.sql.delta.catalog.DeltaCatalog.recordFrameProfile(DeltaCatalog.scala:57) ~[delta-core_2.12-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
    at org.apache.spark.sql.delta.catalog.DeltaCatalog$StagedDeltaTableV2.commitStagedChanges(DeltaCatalog.scala:413) ~[delta-core_2.12-2.3.0-SNAPSHOT.jar:2.3.0-SNAPSHOT]
    at org.apache.spark.sql.execution.datasources.v2.TableWriteExecHelper.$anonfun$writeToTable$1(WriteToDataSourceV2Exec.scala:507) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.util.Utils$.tryWithSafeFinallyAndFailureCallbacks(Utils.scala:1550) ~[spark-core_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.execution.datasources.v2.TableWriteExecHelper.writeToTable(WriteToDataSourceV2Exec.scala:491) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.execution.datasources.v2.TableWriteExecHelper.writeToTable$(WriteToDataSourceV2Exec.scala:486) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.execution.datasources.v2.AtomicCreateTableAsSelectExec.writeToTable(WriteToDataSourceV2Exec.scala:108) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.execution.datasources.v2.AtomicCreateTableAsSelectExec.run(WriteToDataSourceV2Exec.scala:131) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.execution.datasources.v2.V2CommandExec.result$lzycompute(V2CommandExec.scala:43) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.execution.datasources.v2.V2CommandExec.result(V2CommandExec.scala:43) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.execution.datasources.v2.V2CommandExec.executeCollect(V2CommandExec.scala:49) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.execution.QueryExecution$$anonfun$eagerlyExecuteCommands$1.$anonfun$applyOrElse$1(QueryExecution.scala:103) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.catalyst.QueryPlanningTracker$.withTracker(QueryPlanningTracker.scala:107) ~[spark-catalyst_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.execution.SQLExecution$.withTracker(SQLExecution.scala:224) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.execution.SQLExecution$.executeQuery$1(SQLExecution.scala:114) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$7(SQLExecution.scala:139) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.catalyst.QueryPlanningTracker$.withTracker(QueryPlanningTracker.scala:107) ~[spark-catalyst_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.execution.SQLExecution$.withTracker(SQLExecution.scala:224) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$6(SQLExecution.scala:139) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.execution.SQLExecution$.withSQLConfPropagated(SQLExecution.scala:245) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$1(SQLExecution.scala:138) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:779) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.execution.SQLExecution$.withNewExecutionId(SQLExecution.scala:68) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.execution.QueryExecution$$anonfun$eagerlyExecuteCommands$1.applyOrElse(QueryExecution.scala:100) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.execution.QueryExecution$$anonfun$eagerlyExecuteCommands$1.applyOrElse(QueryExecution.scala:96) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.catalyst.trees.TreeNode.$anonfun$transformDownWithPruning$1(TreeNode.scala:615) ~[spark-catalyst_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.catalyst.trees.CurrentOrigin$.withOrigin(TreeNode.scala:177) ~[spark-catalyst_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.catalyst.trees.TreeNode.transformDownWithPruning(TreeNode.scala:615) ~[spark-catalyst_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.org$apache$spark$sql$catalyst$plans$logical$AnalysisHelper$$super$transformDownWithPruning(LogicalPlan.scala:30) ~[spark-catalyst_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.transformDownWithPruning(AnalysisHelper.scala:267) ~[spark-catalyst_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.catalyst.plans.logical.AnalysisHelper.transformDownWithPruning$(AnalysisHelper.scala:263) ~[spark-catalyst_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.transformDownWithPruning(LogicalPlan.scala:30) ~[spark-catalyst_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.transformDownWithPruning(LogicalPlan.scala:30) ~[spark-catalyst_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.catalyst.trees.TreeNode.transformDown(TreeNode.scala:591) ~[spark-catalyst_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.execution.QueryExecution.eagerlyExecuteCommands(QueryExecution.scala:96) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.execution.QueryExecution.commandExecuted$lzycompute(QueryExecution.scala:83) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.execution.QueryExecution.commandExecuted(QueryExecution.scala:81) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.execution.QueryExecution.assertCommandExecuted(QueryExecution.scala:124) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.DataFrameWriter.runCommand(DataFrameWriter.scala:860) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.DataFrameWriter.saveAsTable(DataFrameWriter.scala:636) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at org.apache.spark.sql.DataFrameWriter.saveAsTable(DataFrameWriter.scala:570) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_352]
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_352]
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_352]
    at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_352]
    at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244) ~[py4j-0.10.9.5.jar:?]
    at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357) ~[py4j-0.10.9.5.jar:?]
    at py4j.Gateway.invoke(Gateway.java:282) ~[py4j-0.10.9.5.jar:?]
    at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132) ~[py4j-0.10.9.5.jar:?]
    at py4j.commands.CallCommand.execute(CallCommand.java:79) ~[py4j-0.10.9.5.jar:?]
    at py4j.ClientServerConnection.waitForCommands(ClientServerConnection.java:182) ~[py4j-0.10.9.5.jar:?]
    at py4j.ClientServerConnection.run(ClientServerConnection.java:106) ~[py4j-0.10.9.5.jar:?]
    at java.lang.Thread.run(Thread.java:750) ~[?:1.8.0_352]
```

#### RCA

* The exception happens in Spark’s [saveTableIntoHive](https://github.com/apache/spark/blob/v3.3.0/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala#L503) (https://github.com/apache/spark/blob/v3.3.0/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala#L503). This is coming from [createDatasourceTable](https://github.com/apache/spark/blob/v3.3.0/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala#L290) (https://github.com/apache/spark/blob/v3.3.0/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveExternalCatalog.scala#L290).
* In Delta Table, table.provider is delta. Since [HiveSerDe](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/main/scala/org/apache/spark/sql/internal/HiveSerDe.scala#L83) (https://github.com/apache/spark/blob/v3.3.0/sql/core/src/main/scala/org/apache/spark/sql/internal/HiveSerDe.scala#L83) does not have mapping for delta, it recognizes the table as non-compatible table.
    * val maybeSerde = HiveSerDe.sourceToSerDe(provider)

* When there is no mapped SerDe, then [LazySimpleSerde is automatically chosen](https://github.com/apache/spark/blob/v3.3.0/sql/core/src/main/scala/org/apache/spark/sql/internal/HiveSerDe.scala#L107) (https://github.com/apache/spark/blob/v3.3.0/sql/core/src/main/scala/org/apache/spark/sql/internal/HiveSerDe.scala#L107).
* The special name column col with array type came from this `LazySimpleSerDe`.

#### Options to fix the issue

* Option 2-1. Replace the logic to update the provider from delta to parquet.
    * Pros: Simple and Easy
    * Cons: It may break existing workload (I guess there won’t be any issue, but I am not 100% sure).
* Option 2-2. Introduce a new option `createTable.useParquetProvider` to change the behavior to update the provider from delta to parquet.
* Option 2-3. Override `HiveSerde` class to include delta as Hive compatible format.
    * Pros: Simple and Easy
    * Cons: It can cause future maintainability issue.

Option 2-2 will be safer.

The reason why I chose `parquet` to replace the `delta` provider is just that Delta Lake is built on top of parquet files. It is totally fine to set any Hive compatible provider.

Technically there are more possible options like
* Allow users to provide any provider

However, I could not come up with any real world scenario where we need it. That's the reason why I chose static provider `parquet`.

#### Issue reports

Same issues were reported in following links.

* https://stackoverflow.com/questions/64459472/can-not-create-a-path-from-an-empty-string-error-for-create-table-as-in-hive
* https://github.com/awslabs/aws-glue-data-catalog-client-for-apache-hive-metastore/issues/29
* (Written in Japanese) https://qiita.com/taka_yayoi/items/2cacbcaf9d70bfe80926

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

I have tested with following Spark code on Spark 3.3.0 backed by AWS Glue version 4.0.

```
import sys
from pyspark.context import SparkContext
from pyspark.sql import Row
from pyspark.sql import SparkSession
import time

spark = SparkSession.builder \
    .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
    .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog") \
    .config("spark.databricks.delta.createTable.cleanupSchema", False) \
    .config("spark.databricks.delta.createTable.useParquetProvider", True) \
    .getOrCreate()
     
ut = time.time()

product = [
    {'product_id': '00001', 'product_name': 'Heater', 'price': 250, 'category': 'Electronics', 'updated_at': ut},
    {'product_id': '00002', 'product_name': 'Thermostat', 'price': 400, 'category': 'Electronics', 'updated_at': ut},
    {'product_id': '00003', 'product_name': 'Television', 'price': 600, 'category': 'Electronics', 'updated_at': ut},
    {'product_id': '00004', 'product_name': 'Blender', 'price': 100, 'category': 'Electronics', 'updated_at': ut},
    {'product_id': '00005', 'product_name': 'USB charger', 'price': 50, 'category': 'Electronics', 'updated_at': ut}
]

df_products = spark.createDataFrame(Row(**x) for x in product)

base_location = "s3://bucket_name/data"
database_name = "delta_catalog_write_test_with_location"
table_name = "test22"
additional_options = {
    "path": f"{base_location}/{database_name}/{table_name}/"
}
df_products.write \
    .format("delta") \
    .options(**additional_options) \
    .mode("append") \
    .partitionBy("category") \
    .saveAsTable(f"{database_name}.{table_name}")
```

Note: Both issues need to be fixed all together. Even if we patch only for Issue 1, the schema still becomes `col` because of `LazySimpleSerde`.

The reason why I was not able to add unit tests for this PR is:

-  The incorrect schema `col` can be found in external catalog like Glue catalog, but not in Spark side column information.
-  The exception `Can not create a Path...` happens in `spark.sql("CREATE DATABASE database_name LOCATION ''")`. This is before table creation, and I was not able to reach table creation logic due to this. It seems that the database needs to be created outside of the unit test, but it is too complicated to achieve in the current test suite.

If anyone have better idea to write tests, I would like to get the advice.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No. It is because that this PR introduces two options but it keeps compatible behavior by default.