### PR TITLE
Fix formatting and missing CDF feature name in PROTOCOL.md 

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -888,6 +888,7 @@ Feature | Name | Readers or Writers?
 [Column Invariants](#column-invariants) | `invariants` | Writers only
 [`CHECK` constraints](#check-constraints) | `checkConstraints` | Writers only
 [Generated Columns](#generated-columns) | `generatedColumns` | Writers only
+[Change Data Feed](#add-cdc-file) | `changeDataFeed` | Writers only
 [Column Mapping](#column-mapping) | `columnMapping` | Readers and writers
 [Identity Columns](#identity-columns) | `identityColumns` | Writers only
 [Deletion Vectors](#deletion-vectors) | `deletionVectors` | Readers and writers

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -883,7 +883,7 @@ Reader Version 3 | Respect [Table Features](#table-features) for readers<br> - W
 ## Valid Feature Names in Table Features
 
 Feature | Name | Readers or Writers?
--|-|-|-
+-|-|-
 [Append-only Tables](#append-only-tables) | `appendOnly` | Writers only
 [Column Invariants](#column-invariants) | `invariants` | Writers only
 [`CHECK` constraints](#check-constraints) | `checkConstraints` | Writers only


### PR DESCRIPTION
## Description

This PR fixes a formatting issue that causes the Markdown engine fails to render a table ,and an issue where CDF feature name is missing from a table.

## How was this patch tested?

See the renendered HTML file.