### PR TITLE
[DELETE with DVs] Add a bitmap aggegator UDAF

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregation/BitmapAggregator.scala
+++ b/core/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregation/BitmapAggregator.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions.aggregation
+
+import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Expression, GenericInternalRow, ImplicitCastInputTypes}
+import org.apache.spark.sql.catalyst.expressions.aggregate.{ImperativeAggregate, TypedImperativeAggregate}
+import org.apache.spark.sql.catalyst.trees.UnaryLike
+import org.apache.spark.sql.types._
+
+/**
+ * This function returns a bitmap representing the set of values of the underlying column.
+ *
+ * The bitmap is simply a compressed representation of the set of all integral values that
+ * appear in the column being aggregated over.
+ *
+ * @param child child expression that can produce a column value with `child.eval(inputRow)`
+ */
+case class BitmapAggregator(
+    child: Expression,
+    override val mutableAggBufferOffset: Int,
+    override val inputAggBufferOffset: Int,
+    // Take the format as string instead of [[RoaringBitmapArrayFormat.Value]],
+    // because String is safe to serialize.
+    serializationFormatString: String)
+  extends TypedImperativeAggregate[RoaringBitmapArray] with ImplicitCastInputTypes
+  with UnaryLike[Expression] {
+
+  def this(child: Expression, serializationFormat: RoaringBitmapArrayFormat.Value) =
+    this(child, 0, 0, serializationFormat.toString)
+
+  override def createAggregationBuffer(): RoaringBitmapArray = new RoaringBitmapArray()
+
+  override def update(buffer: RoaringBitmapArray, input: InternalRow): RoaringBitmapArray = {
+    val value = child.eval(input)
+    // Ignore empty rows
+    if (value != null) {
+      buffer.add(value.asInstanceOf[Long])
+    }
+    buffer
+  }
+
+  override def merge(buffer: RoaringBitmapArray, input: RoaringBitmapArray): RoaringBitmapArray = {
+    buffer.merge(input)
+    buffer
+  }
+
+  /**
+   * Return bitmap cardinality and serialized bitmap.
+   */
+  override def eval(bitmapIntegerSet: RoaringBitmapArray): GenericInternalRow = {
+    // reduce the serialized size via RLE optimisation
+    bitmapIntegerSet.runOptimize()
+    new GenericInternalRow(Array(bitmapIntegerSet.cardinality, serialize(bitmapIntegerSet)))
+  }
+
+  override def serialize(buffer: RoaringBitmapArray): Array[Byte] = {
+    val serializationFormat = RoaringBitmapArrayFormat.withName(serializationFormatString)
+    buffer.serializeAsByteArray(serializationFormat)
+  }
+
+  override def deserialize(storageFormat: Array[Byte]): RoaringBitmapArray = {
+    RoaringBitmapArray.readFrom(storageFormat)
+  }
+
+  override def withNewMutableAggBufferOffset(newMutableAggBufferOffset: Int)
+    : ImperativeAggregate = copy(mutableAggBufferOffset = newMutableAggBufferOffset)
+
+  override def withNewInputAggBufferOffset(newInputAggBufferOffset: Int)
+    : ImperativeAggregate = copy(inputAggBufferOffset = newInputAggBufferOffset)
+
+  override def nullable: Boolean = false
+
+  override def dataType: StructType = StructType(
+    Seq(
+      StructField("cardinality", LongType),
+      StructField("bitmap", BinaryType)
+    )
+  )
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(LongType)
+
+  override protected def withNewChildInternal(newChild: Expression): BitmapAggregator =
+    copy(child = newChild)
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/expressions/aggregation/BitmapAggregatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/expressions/aggregation/BitmapAggregatorSuite.scala
@@ -1,0 +1,159 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.expressions.aggregation
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.catalyst.expressions.aggregation.BitmapAggregator
+import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.BoundReference
+import org.apache.spark.sql.types.LongType
+
+class BitmapAggregatorSuite extends SparkFunSuite {
+
+  import BitmapAggregatorSuite._
+
+  private val childExpression = BoundReference(0, LongType, nullable = true)
+
+  /** Creates a bitmap aggregate expression, using the child expression defined above. */
+  private def newBitmapAgg(format: RoaringBitmapArrayFormat.Value): BitmapAggregator =
+    new BitmapAggregator(childExpression, format)
+
+  for (serializationFormat <- RoaringBitmapArrayFormat.values)
+  test(s"Bitmap serialization - $serializationFormat") {
+    val bitmapSet = fillSetWithAggregator(newBitmapAgg(serializationFormat), Array(1L, 2L, 3L, 4L))
+    val serialized = bitmapSet.serializeAsByteArray(serializationFormat)
+    val deserialized = RoaringBitmapArray.readFrom(serialized)
+    assert(bitmapSet === deserialized)
+    assert(bitmapSet.## === deserialized.##)
+  }
+
+  for (serializationFormat <- RoaringBitmapArrayFormat.values)
+  test(s"Aggregator serialization - $serializationFormat") {
+    val aggregator = newBitmapAgg(serializationFormat)
+    val bitmapSet = fillSetWithAggregator(aggregator, Array(1L, 2L, 3L, 4L))
+    val deserialized = aggregator.deserialize(aggregator.serialize(bitmapSet))
+    assert(bitmapSet === deserialized)
+    assert(bitmapSet.## === deserialized.##)
+  }
+
+  for (serializationFormat <- RoaringBitmapArrayFormat.values)
+  test(s"Bitmap Aggregator merge no duplicates - $serializationFormat") {
+    val (dataset1, dataset2) = createDatasetsNoDuplicates
+
+    val finalResult =
+      fillSetWithAggregatorAndMerge(
+        newBitmapAgg(serializationFormat),
+        dataset1,
+        dataset2)
+
+    verifyContainsAll(finalResult, dataset1)
+    verifyContainsAll(finalResult, dataset2)
+  }
+
+  for (serializationFormat <- RoaringBitmapArrayFormat.values)
+  test(s"Bitmap Aggregator with duplicates - $serializationFormat") {
+    val (dataset1, dataset2) = createDatasetsWithDuplicates
+
+    val finalResult =
+      fillSetWithAggregatorAndMerge(
+        newBitmapAgg(serializationFormat),
+        dataset1,
+        dataset2)
+
+    verifyContainsAll(finalResult, dataset1)
+    verifyContainsAll(finalResult, dataset2)
+  }
+
+  private lazy val createDatasetsNoDuplicates: (List[Long], List[Long]) = {
+    val primeSet = primes(DATASET_SIZE).toSet
+    val notPrime = (0 until DATASET_SIZE).filterNot(primeSet.contains).toList
+    (primeSet.map(_.toLong).toList, notPrime.map(_.toLong))
+  }
+
+  private def createDatasetsWithDuplicates: (List[Long], List[Long]) = {
+    var (primes, notPrimes) = createDatasetsNoDuplicates
+    // duplicate all powers of 3 (powers of 2 might align with container boundaries)
+    notPrimes ::= 3L
+    var value = 3L
+    while (value < DATASET_SIZE.toLong) {
+      value *= 3L
+      primes ::= value
+    }
+    (primes, notPrimes)
+  }
+
+  // List the first primes smaller than `end`
+  private def primes(end: Int): List[Int] = {
+    // scalastyle:off
+    // Basically https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes#Algorithm_and_variants
+    // but concretely the implementation is adapted from:
+    // https://medium.com/coding-with-clarity/functional-vs-iterative-prime-numbers-in-scala-7e22447146f0
+    // scalastyle:on
+    val primeIndices = mutable.ArrayBuffer.fill((end + 1) / 2)(true)
+
+    val intSqrt = Math.sqrt(end).toInt
+    for {
+      i <- 3 to end by 2 if i <= intSqrt
+      nonPrime <- i * i to end by 2 * i
+    } primeIndices.update(nonPrime / 2, false)
+
+
+    (for (i <- primeIndices.indices if primeIndices(i)) yield 2 * i + 1).tail.toList
+  }
+
+  private def fillSetWithAggregatorAndMerge(
+    aggregator: BitmapAggregator,
+    dataset1: Seq[Long],
+    dataset2: Seq[Long]): RoaringBitmapArray = {
+    val buffer1 = fillSetWithAggregator(aggregator, dataset1)
+    val buffer2 = fillSetWithAggregator(aggregator, dataset2)
+    val merged = aggregator.merge(buffer1, buffer2)
+    val fieldIndex = aggregator.dataType.fieldIndex("bitmap")
+    val result = aggregator.eval(merged).getBinary(fieldIndex)
+    RoaringBitmapArray.readFrom(result)
+  }
+
+  private def fillSetWithAggregator(
+    aggregator: BitmapAggregator,
+    dataset: Seq[Long]): RoaringBitmapArray = {
+    val buffer = aggregator.createAggregationBuffer()
+    for (entry <- dataset) {
+      val row = InternalRow(entry)
+      aggregator.update(buffer, row)
+    }
+    buffer
+  }
+
+  private def verifyContainsAll(
+    aggregator: RoaringBitmapArray,
+    dataset: Seq[Long]): Unit = {
+    for (entry <- dataset) {
+      assert(aggregator.contains(entry),
+        s"Aggregator did not contain file $entry")
+    }
+  }
+}
+
+object BitmapAggregatorSuite {
+  // Pick something over 64k to make sure we fill a few different bitmap containers
+  val DATASET_SIZE: Int = 100000
+}
+

--- a/core/src/test/scala/org/apache/spark/sql/delta/util/BitmapAggregatorE2ESuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/util/BitmapAggregatorE2ESuite.scala
@@ -1,0 +1,203 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.util
+
+import java.io.{File, IOException}
+import java.net.URI
+import java.nio.{ByteBuffer, ByteOrder}
+import java.nio.file.Files
+
+import org.apache.spark.sql.catalyst.expressions.aggregation.BitmapAggregator
+import org.apache.spark.sql.delta.deletionvectors.{PortableRoaringBitmapArraySerializationFormat, RoaringBitmapArray, RoaringBitmapArrayFormat}
+
+import org.apache.spark.sql.{Column, QueryTest}
+import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
+
+class BitmapAggregatorE2ESuite extends QueryTest
+  with SharedSparkSession
+  with SQLTestUtils {
+
+  import BitmapAggregatorE2ESuite._
+  import testImplicits._
+  import org.apache.spark.sql.functions._
+
+  for (serializationFormat <- RoaringBitmapArrayFormat.values) {
+    test(s"DataFrame bitmap groupBy aggregate no duplicates - $serializationFormat") {
+      dataFrameBitmapGroupByAggregateWithoutDuplicates(format = serializationFormat)
+    }
+  }
+
+  for (serializationFormat <- RoaringBitmapArrayFormat.values) {
+    test("DataFrame bitmap groupBy aggregate no duplicates - invalid Int ids" +
+        s" - $serializationFormat") {
+      dataFrameBitmapGroupByAggregateWithoutDuplicates(
+        offset = INVALID_INT_OFFSET,
+        format = serializationFormat)
+    }
+  }
+
+  for (serializationFormat <- RoaringBitmapArrayFormat.values) {
+    test("DataFrame bitmap groupBy aggregate no duplicates - invalid unsigned Int ids" +
+        s" - $serializationFormat") {
+      dataFrameBitmapGroupByAggregateWithoutDuplicates(
+        offset = UNSIGNED_INT_OFFSET,
+        format = serializationFormat)
+    }
+  }
+
+  private def dataFrameBitmapGroupByAggregateWithoutDuplicates(
+      offset: Long = 0L,
+      format: RoaringBitmapArrayFormat.Value): Unit = {
+    val baseDF = spark
+      .range(DATASET_SIZE)
+      .map { id =>
+        val newId = id + offset
+        // put 2 adjacent and one with gap
+        (newId % 6) match {
+          case 0 | 1 | 4 => ("file1" -> newId)
+          case 2 | 3 | 5 => ("file2" -> newId)
+        }
+      }
+      .toDF("file", "id")
+      .cache()
+
+    val bitmapAgg = bitmapAggColumn(baseDF("id"), format)
+    val aggregationOutput = baseDF
+      .groupBy("file")
+      .agg(bitmapAgg)
+      .as[(String, (Long, Array[Byte]))]
+      .collect()
+      .toMap
+      .mapValues(v => RoaringBitmapArray.readFrom(v._2))
+
+    val dfFile1 = baseDF
+      .select("id")
+      .where("file = 'file1'")
+      .as[Long]
+      .collect()
+    val dfFile2 = baseDF
+      .select("id")
+      .where("file = 'file2'")
+      .as[Long]
+      .collect()
+
+    assertEqualContents(aggregationOutput("file1"), dfFile1)
+    assertEqualContents(aggregationOutput("file2"), dfFile2)
+    baseDF.unpersist()
+  }
+
+  for (serializationFormat <- RoaringBitmapArrayFormat.values) {
+    test("DataFrame bitmap groupBy aggregate with duplicates" +
+        s" - $serializationFormat") {
+      dataFrameBitmapGroupAggregateWithDuplicates(format = serializationFormat)
+    }
+  }
+
+  for (serializationFormat <- RoaringBitmapArrayFormat.values) {
+    test("DataFrame bitmap groupBy aggregate with duplicates - invalid Int ids" +
+        s" - $serializationFormat") {
+      dataFrameBitmapGroupAggregateWithDuplicates(
+        offset = INVALID_INT_OFFSET,
+        format = serializationFormat)
+    }
+  }
+
+  for (serializationFormat <- RoaringBitmapArrayFormat.values) {
+    test("DataFrame bitmap groupBy aggregate with duplicates - invalid unsigned Int ids" +
+        s" - $serializationFormat") {
+      dataFrameBitmapGroupAggregateWithDuplicates(
+        offset = UNSIGNED_INT_OFFSET,
+        format = serializationFormat)
+    }
+  }
+
+  def dataFrameBitmapGroupAggregateWithDuplicates(
+      offset: Long = 0L,
+      format: RoaringBitmapArrayFormat.Value) {
+    val baseDF = spark
+      .range(DATASET_SIZE)
+      .flatMap { id =>
+        val newId = id + offset
+        // put two adjacent and duplicate the one after a gap
+        (newId % 6) match {
+          case 0 | 1 => Seq("file1" -> newId)
+          case 2 | 3 => Seq("file2" -> newId)
+          case 4 => Seq("file1" -> newId, "file1" -> newId) // duplicate in file1
+          case 5 => Seq("file2" -> newId, "file2" -> newId) // duplicate in file2
+        }
+      }
+      .toDF("file", "id")
+      .cache()
+
+    val bitmapAgg = bitmapAggColumn(baseDF("id"), format)
+    // scalastyle:off countstring
+    val aggregationOutput = baseDF
+      .groupBy("file")
+      .agg(bitmapAgg, count("id"))
+      .as[(String, (Long, Array[Byte]), Long)]
+      .collect()
+      .map(t => (t._1 -> (RoaringBitmapArray.readFrom(t._2._2), t._3)))
+      .toMap
+    // scalastyle:on countstring
+
+    val dfFile1 = baseDF
+      .select("id")
+      .where("file = 'file1'")
+      .distinct()
+      .as[Long]
+      .collect()
+    val dfFile2 = baseDF
+      .select("id")
+      .where("file = 'file2'")
+      .distinct()
+      .as[Long]
+      .collect()
+
+    val file1Value = aggregationOutput("file1")
+    assert(file1Value._2 > file1Value._1.cardinality)
+    val file2Value = aggregationOutput("file2")
+    assert(file2Value._2 > file2Value._1.cardinality)
+
+    assertEqualContents(file1Value._1, dfFile1)
+    assertEqualContents(file2Value._1, dfFile2)
+  }
+
+  // modulo ordering
+  private def assertEqualContents(aggregator: RoaringBitmapArray, dataset: Array[Long]): Unit = {
+    // make sure they are in the same order
+    val aggregatorArray = aggregator.values.sorted
+    assert(aggregatorArray === dataset.sorted)
+  }
+}
+
+object BitmapAggregatorE2ESuite {
+  // Pick something large enough hat 2 files have at least 64k entries each
+  final val DATASET_SIZE: Long = 1000000L
+
+  // Cross the `isValidInt` threshold
+  final val INVALID_INT_OFFSET: Long = Int.MaxValue.toLong - DATASET_SIZE / 2
+
+  // Cross the 32bit threshold
+  final val UNSIGNED_INT_OFFSET: Long = (1L << 32) - DATASET_SIZE / 2
+
+  private[delta] def bitmapAggColumn(
+      column: Column,
+      format: RoaringBitmapArrayFormat.Value): Column = {
+    val func = new BitmapAggregator(column.expr, format);
+    new Column(func.toAggregateExpression(isDistinct = false))
+  }
+}


### PR DESCRIPTION
This PR is part of [DELETE with Deletion Vector implementation](https://github.com/delta-io/delta/pull/1591).

It adds a UDAF implementation that takes a column of longs (basically the row indexes) and generates a `RoaringBitmapArray`.
