### PR TITLE
[DELETE with DVs] Update `DeltaParquetFileFormat` to return a row index

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.execution.vectorized.{OffHeapColumnVector, OnHeapColumnVector, WritableColumnVector}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.Filter
-import org.apache.spark.sql.types.{ByteType, StructField, StructType}
+import org.apache.spark.sql.types.{ByteType, LongType, StructField, StructType}
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
 import org.apache.spark.util.SerializableConfiguration
 
@@ -46,25 +46,20 @@ import org.apache.spark.util.SerializableConfiguration
  *    whether the row is deleted or not according to the deletion vector. Consumers
  *    of this scan can use the column values to filter out the deleted rows.
  */
-class DeltaParquetFileFormat(
+case class DeltaParquetFileFormat(
     metadata: Metadata,
-    val isSplittable: Boolean = true,
-    val disablePushDowns: Boolean = false,
-    val tablePath: Option[String] = None,
-    val broadcastDvMap: Option[Broadcast[Map[URI, DeletionVectorDescriptor]]] = None,
-    val broadcastHadoopConf: Option[Broadcast[SerializableConfiguration]] = None)
+    isSplittable: Boolean = true,
+    disablePushDowns: Boolean = false,
+    tablePath: Option[String] = None,
+    broadcastDvMap: Option[Broadcast[Map[URI, DeletionVectorDescriptor]]] = None,
+    broadcastHadoopConf: Option[Broadcast[SerializableConfiguration]] = None)
   extends ParquetFileFormat {
   // Validate either we have all arguments for DV enabled read or none of them.
-  if (broadcastHadoopConf.isDefined) {
+  if (hasDeletionVectorMap()) {
     require(
       broadcastHadoopConf.isDefined && broadcastDvMap.isDefined &&
         tablePath.isDefined && !isSplittable && disablePushDowns,
       "Wrong arguments for Delta table scan with deletion vectors")
-  } else {
-    require(
-      broadcastHadoopConf.isEmpty && broadcastDvMap.isEmpty &&
-        tablePath.isEmpty && isSplittable && !disablePushDowns,
-      "Wrong arguments for Delta table scan with no deletion vectors")
   }
 
   val columnMappingMode: DeltaColumnMappingMode = metadata.columnMappingMode
@@ -125,29 +120,41 @@ class DeltaParquetFileFormat(
         options,
         hadoopConf)
 
-    if (!hasDeletionVectorMap()) {
-      return parquetDataReader
+    val schemaWithIndices = requiredSchema.fields.zipWithIndex
+    def findColumn(name: String): Option[ColumnMetadata] = {
+      if (schemaWithIndices.filter(_._1.name == name).length > 1) {
+        throw new IllegalArgumentException(
+          s"There are more than one column with name=`$name` requested in the reader output")
+      }
+      schemaWithIndices.find(_._1.name == name).map(e => ColumnMetadata(e._2, e._1))
+    }
+    val isRowDeletedColumn = findColumn(IS_ROW_DELETED_COLUMN_NAME)
+    val rowIndexColumn = findColumn(ROW_INDEX_COLUMN_NAME)
+
+    if (isRowDeletedColumn.isEmpty && rowIndexColumn.isEmpty) {
+      return parquetDataReader // no additional metadata is needed.
+    } else {
+      // verify the file splitting and filter pushdown are disabled. The new additional
+      // metadata columns cannot be generated with file splitting and filter pushdowns
+      require(!isSplittable, "Cannot generate row index related metadata with file splitting")
+      require(disablePushDowns, "Cannot generate row index related metadata with filter pushdown")
     }
 
-    val isRowDeletedColumnTypeIdx = requiredSchema.fields.zipWithIndex
-      .find(_._1.name == IS_ROW_DELETED_COLUMN_NAME)
-
-    if (isRowDeletedColumnTypeIdx.isEmpty) {
-      throw new IllegalArgumentException(
-        s"Expected a column $IS_ROW_DELETED_COLUMN_NAME in the schema")
+    if (hasDeletionVectorMap() && isRowDeletedColumn.isEmpty) {
+        throw new IllegalArgumentException(
+          s"Expected a column $IS_ROW_DELETED_COLUMN_NAME in the schema")
     }
 
     val useOffHeapBuffers = sparkSession.sessionState.conf.offHeapColumnVectorEnabled
-
     (partitionedFile: PartitionedFile) => {
       val rowIteratorFromParquet = parquetDataReader(partitionedFile)
       val iterToReturn =
-        iteratorWithIsRowDeletedColumnPopulated(
+        iteratorWithAdditionalMetadataColumns(
           partitionedFile,
           rowIteratorFromParquet,
-          isRowDeletedColumnTypeIdx.get._1,
-          isRowDeletedColumnTypeIdx.get._2,
-          useOffHeapBuffers)
+          isRowDeletedColumn,
+          useOffHeapBuffers = useOffHeapBuffers,
+          rowIndexColumn = rowIndexColumn)
       iterToReturn.asInstanceOf[Iterator[InternalRow]]
     }
   }
@@ -160,66 +167,80 @@ class DeltaParquetFileFormat(
       tablePath: String,
       broadcastDvMap: Broadcast[Map[URI, DeletionVectorDescriptor]],
       broadcastHadoopConf: Broadcast[SerializableConfiguration]): DeltaParquetFileFormat = {
-    new DeltaParquetFileFormat(
-      metadata,
+    this.copy(
       isSplittable = false,
       disablePushDowns = true,
       tablePath = Some(tablePath),
-      Some(broadcastDvMap),
-      Some(broadcastHadoopConf))
+      broadcastDvMap = Some(broadcastDvMap),
+      broadcastHadoopConf = Some(broadcastHadoopConf))
   }
 
   /**
-   * Modifies the data read from underlying Parquet reader by populating the row deleted status from
-   * deletion vector corresponding to this file in the [[IS_ROW_DELETED_COLUMN_NAME]] column.
+   * Modifies the data read from underlying Parquet reader by populating one or both of the
+   * following metadata columns.
+   *   - [[IS_ROW_DELETED_COLUMN_NAME]] - row deleted status from deletion vector corresponding
+   *   to this file
+   *   - [[ROW_INDEX_COLUMN_NAME]] - index of the row within the file.
    */
-  private def iteratorWithIsRowDeletedColumnPopulated(
+  private def iteratorWithAdditionalMetadataColumns(
       partitionedFile: PartitionedFile,
       iterator: Iterator[Object],
-      isRowDeletedColumnType: StructField,
-      isRowDeletedColumnIdx: Int,
+      isRowDeletedColumn: Option[ColumnMetadata],
+      rowIndexColumn: Option[ColumnMetadata],
       useOffHeapBuffers: Boolean): Iterator[Object] = {
     val filePath = partitionedFile.filePath
     val pathUri = new Path(filePath).toUri
 
-    // Fetch the DV descriptor from the broadcast map and create a row index filter
-    val dvDescriptor = broadcastDvMap.get.value.get(pathUri)
-    val rowIndexFilter = DeletedRowsMarkingFilter.createInstance(
-      dvDescriptor.getOrElse(DeletionVectorDescriptor.EMPTY),
-      broadcastHadoopConf.get.value.value,
-      tablePath.map(new Path(_))
-    )
+    val rowIndexFilter = isRowDeletedColumn.map { col =>
+      // Fetch the DV descriptor from the broadcast map and create a row index filter
+      val dvDescriptor = broadcastDvMap.get.value.get(pathUri)
+      DeletedRowsMarkingFilter.createInstance(
+        dvDescriptor.getOrElse(DeletionVectorDescriptor.EMPTY),
+        broadcastHadoopConf.get.value.value,
+        tablePath.map(new Path(_)))
+    }
+
+    val metadataColumns = Seq(isRowDeletedColumn, rowIndexColumn).filter(_.nonEmpty).map(_.get)
 
     // Unfortunately there is no way to verify the Parquet index is starting from 0.
     // We disable the splits, so the assumption is ParquetFileFormat respects that
     var rowIndex: Long = 0
 
-    val newIter = iterator.map { row =>
-      val newRow = row match {
+    // Used only when non-column row batches are received from the Parquet reader
+    val tempVector = new OnHeapColumnVector(1, ByteType)
+
+    iterator.map { row =>
+      row match {
         case batch: ColumnarBatch => // When vectorized Parquet reader is enabled
           val size = batch.numRows()
-          // Create a new vector for the `is row deleted` column. We can't use the one from Parquet
-          // reader as it set the [[WritableColumnVector.isAllNulls]] to true and it can't be reset
-          // with using any public APIs. In this new vector, fill the values using the row index
-          // filter and replace the vector corresponding to `is row deleted` column in ColumnBatch
-          val newBatch = trySafely(newVector(useOffHeapBuffers, size, isRowDeletedColumnType)) {
-            writableVector =>
-              rowIndexFilter.materializeIntoVector(rowIndex, rowIndex + size, writableVector)
-              rowIndex += size
+          // Create vectors for all needed metadata columns.
+          // We can't use the one from Parquet reader as it set the
+          // [[WritableColumnVector.isAllNulls]] to true and it can't be reset with using any
+          // public APIs.
+          trySafely(useOffHeapBuffers, size, metadataColumns) { writableVectors =>
+            val indexVectorTuples = new ArrayBuffer[(Int, ColumnVector)]
+            var index = 0
+            isRowDeletedColumn.foreach{ columnMetadata =>
+              val isRowDeletedVector = writableVectors(index)
+              rowIndexFilter.get
+                .materializeIntoVector(rowIndex, rowIndex + size, isRowDeletedVector)
+              indexVectorTuples += ((columnMetadata.index, isRowDeletedVector))
+              index += 1
+            }
 
-              val vectors = ArrayBuffer[ColumnVector]()
-              for (i <- 0 until batch.numCols()) {
-                if (i == isRowDeletedColumnIdx) {
-                  vectors += writableVector
-                  // Make sure to close the existing vector allocated in the Parquet
-                  batch.column(i).close()
-                } else {
-                  vectors += batch.column(i)
-                }
-              }
-              new ColumnarBatch(vectors.toArray, size)
+            rowIndexColumn.foreach { columnMetadata =>
+              val rowIndexVector = writableVectors(index)
+              // populate the row index column value
+              for (i <- 0 until size) rowIndexVector.putLong(i, rowIndex + i)
+
+              indexVectorTuples += ((columnMetadata.index, rowIndexVector))
+              index += 1
+            }
+
+            val newBatch = replaceVectors(batch, indexVectorTuples.toSeq: _*)
+            rowIndex += size
+            newBatch
           }
-          newBatch
 
         case rest: InternalRow => // When vectorized Parquet reader is disabled
           // Temporary vector variable used to get DV values from RowIndexFilter
@@ -228,19 +249,19 @@ class DeltaParquetFileFormat(
           // TODO: This is not efficient, but it is ok given the default reader is vectorized
           // reader and this will be temporary until Delta upgrades to Spark with Parquet
           // reader that automatically generates the row index column.
-          trySafely(new OnHeapColumnVector(1, ByteType)) { tempVector =>
-            rowIndexFilter.materializeIntoVector(rowIndex, rowIndex + 1, tempVector)
-            rest.setLong(isRowDeletedColumnIdx, tempVector.getByte(0))
-            rowIndex += 1
-            rest
+          isRowDeletedColumn.foreach { columnMetadata =>
+            rowIndexFilter.get.materializeIntoVector(rowIndex, rowIndex + 1, tempVector)
+            rest.setLong(columnMetadata.index, tempVector.getByte(0))
           }
+
+          rowIndexColumn.foreach(columnMetadata => rest.setLong(columnMetadata.index, rowIndex))
+          rowIndex += 1
+          rest
         case others =>
           throw new RuntimeException(
             s"Parquet reader returned an unknown row type: ${others.getClass.getName}")
       }
-      newRow
     }
-    newIter
   }
 }
 
@@ -251,6 +272,10 @@ object DeltaParquetFileFormat {
    */
   val IS_ROW_DELETED_COLUMN_NAME = "__delta_internal_is_row_deleted"
   val IS_ROW_DELETED_STRUCT_FIELD = StructField(IS_ROW_DELETED_COLUMN_NAME, ByteType)
+
+  /** Row index for each column */
+  val ROW_INDEX_COLUMN_NAME = "__delta_internal_row_index"
+  val ROW_INDEX_STRUCT_FILED = StructField(ROW_INDEX_COLUMN_NAME, LongType)
 
   /** Utility method to create a new writable vector */
   private def newVector(
@@ -263,14 +288,55 @@ object DeltaParquetFileFormat {
   }
 
   /** Try the operation, if the operation fails release the created resource */
-  def trySafely[R <: AutoCloseable, T](createResource: => R)(f: R => T): T = {
-    val resource = createResource
+  private def trySafely[R <: WritableColumnVector, T](
+    useOffHeapBuffers: Boolean,
+    size: Int,
+    columns: Seq[ColumnMetadata])(f: Seq[WritableColumnVector] => T): T = {
+    val resources = new ArrayBuffer[WritableColumnVector](columns.size)
     try {
-      f.apply(resource)
+      columns.foreach(col => resources.append(newVector(useOffHeapBuffers, size, col.structField)))
+      f.apply(resources.toSeq)
     } catch {
       case NonFatal(e) =>
-        resource.close()
+        resources.foreach(closeQuietly(_))
         throw e
     }
   }
+
+  /** Utility method to quietly close an [[AutoCloseable]] */
+  private def closeQuietly(closeable: AutoCloseable): Unit = {
+    if (closeable != null) {
+      try {
+        closeable.close()
+      } catch {
+        case NonFatal(_) => // ignore
+      }
+    }
+  }
+
+  /**
+   * Helper method to replace the vectors in given [[ColumnarBatch]].
+   * New vectors and its index in the batch are given as tuples.
+   */
+  private def replaceVectors(
+      batch: ColumnarBatch,
+      indexVectorTuples: (Int, ColumnVector) *): ColumnarBatch = {
+    val vectors = ArrayBuffer[ColumnVector]()
+    for (i <- 0 until batch.numCols()) {
+      var replaced: Boolean = false
+      for (indexVectorTuple <- indexVectorTuples) {
+        if (indexVectorTuple._1 == i) {
+          vectors += indexVectorTuple._2
+          // Make sure to close the existing vector allocated in the Parquet
+          batch.column(i).close()
+          replaced = true
+        }
+      }
+      if (!replaced) vectors += batch.column(i)
+    }
+    new ColumnarBatch(vectors.toArray, batch.numRows())
+  }
+
+  /** Helper class to encapsulate column info */
+  case class ColumnMetadata(index: Int, structField: StructField)
 }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
@@ -16,6 +16,7 @@
 
 package org.apache.spark.sql.delta
 
+import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
 import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor
 import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
 import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
@@ -27,7 +28,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.parquet.format.converter.ParquetMetadataConverter
 import org.apache.parquet.hadoop.ParquetFileReader
 
-import org.apache.spark.sql.{Dataset, QueryTest}
+import org.apache.spark.sql.{DataFrame, Dataset, QueryTest}
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.{SerializableConfiguration, Utils}
@@ -38,12 +39,10 @@ class DeltaParquetFileFormatSuite extends QueryTest
 
   // Read with deletion vectors has separate code paths based on vectorized Parquet
   // reader is enabled or not. Test both the combinations
-  for (enableVectorizedParquetReader <- Seq("true", "false")) {
-    test(
-      s"read with DVs (vectorized Parquet reader enabled=$enableVectorizedParquetReader)") {
+  for ((readIsRowDeletedCol, readRowIndexCol) <- Seq((true, true), (true, false), (false, true)))
+    testWithBothParquetReaders("read DV metadata columns: " +
+        s"with isRowDeletedCol=$readIsRowDeletedCol, with rowIndexCol=$readRowIndexCol") {
       withTempDir { tempDir =>
-        spark.conf.set("spark.sql.parquet.enableVectorizedReader", enableVectorizedParquetReader)
-
         val tablePath = tempDir.toString
 
         // Generate a table with one parquet file containing multiple row groups.
@@ -53,11 +52,15 @@ class DeltaParquetFileFormatSuite extends QueryTest
         val metadata = deltaLog.snapshot.metadata
 
         // Add additional field that has the deleted row flag to existing data schema
-        val readingSchema = metadata.schema.add(DeltaParquetFileFormat.IS_ROW_DELETED_STRUCT_FIELD)
+        var readingSchema = metadata.schema
+        if (readIsRowDeletedCol) {
+          readingSchema = readingSchema.add(DeltaParquetFileFormat.IS_ROW_DELETED_STRUCT_FIELD)
+        }
+        if (readRowIndexCol) {
+          readingSchema = readingSchema.add(DeltaParquetFileFormat.ROW_INDEX_STRUCT_FILED)
+        }
 
-        val addFilePath = new Path(
-          tempDir.toString,
-          deltaLog.snapshot.allFiles.collect()(0).path)
+        val addFilePath = new Path(tempDir.toString, deltaLog.snapshot.allFiles.collect()(0).path)
         assertParquetHasMultipleRowGroups(addFilePath)
 
         val dv = generateDV(tablePath, 0, 200, 300, 756, 10352, 19999)
@@ -75,8 +78,8 @@ class DeltaParquetFileFormatSuite extends QueryTest
           isSplittable = false,
           disablePushDowns = true,
           Some(tablePath),
-          Some(broadcastDvMap),
-          Some(broadcastHadoopConf))
+          if (readIsRowDeletedCol) Some(broadcastDvMap) else None,
+          if (readIsRowDeletedCol) Some(broadcastHadoopConf) else None)
 
         val fileIndex = DeltaLogFileIndex(deltaParquetFormat, fs, addFilePath :: Nil)
 
@@ -89,15 +92,41 @@ class DeltaParquetFileFormatSuite extends QueryTest
           options = Map.empty)(spark)
         val plan = LogicalRelation(relation)
 
-        // Select some rows that are deleted and some rows not deleted
-        // Deleted row `value`: 0, 200, 300, 756, 10352, 19999
-        // Not deleted row `value`: 7, 900
-        checkDatasetUnorderly(
-          Dataset.ofRows(spark, plan)
-            .filter("value in (0, 7, 200, 300, 756, 900, 10352, 19999)")
-            .as[(Int, Int)],
-          (0, 1), (7, 0), (200, 1), (300, 1), (756, 1), (900, 0), (10352, 1), (19999, 1)
-        )
+        if (readIsRowDeletedCol) {
+          // Select some rows that are deleted and some rows not deleted
+          // Deleted row `value`: 0, 200, 300, 756, 10352, 19999
+          // Not deleted row `value`: 7, 900
+          checkDatasetUnorderly(
+            Dataset.ofRows(spark, plan)
+              .filter("value in (0, 7, 200, 300, 756, 900, 10352, 19999)")
+              .select("value", DeltaParquetFileFormat.IS_ROW_DELETED_COLUMN_NAME)
+              .as[(Int, Int)],
+            (0, 1), (7, 0), (200, 1), (300, 1), (756, 1), (900, 0), (10352, 1), (19999, 1))
+        }
+
+        if (readRowIndexCol) {
+          def rowIndexes(df: DataFrame): Set[Long] = {
+            val colIndex = if (readIsRowDeletedCol) 2 else 1
+            df.collect().map(_.getLong(colIndex)).toSet
+          }
+
+          val df = Dataset.ofRows(spark, plan)
+          assert(rowIndexes(df) === Seq.range(0, 20000).toSet)
+
+          assert(
+            rowIndexes(
+              df.filter("value in (0, 7, 200, 300, 756, 900, 10352, 19999)")) ===
+            Seq(0, 7, 200, 300, 756, 900, 10352, 19999).toSet)
+        }
+      }
+    }
+
+  /** Helper method to run the test with vectorized and non-vectorized Parquet readers */
+  private def testWithBothParquetReaders(name: String)(funk: => Any): Unit = {
+    for (enableVectorizedParquetReader <- BOOLEAN_DOMAIN) {
+      test(s"$name, with vectorized Parquet reader=$enableVectorizedParquetReader)") {
+        spark.conf.set("spark.sql.parquet.enableVectorizedReader", enableVectorizedParquetReader)
+        funk
       }
     }
   }
@@ -109,8 +138,7 @@ class DeltaParquetFileFormatSuite extends QueryTest
 
     // Keep the number of partitions to 1 to generate a single Parquet data file
     val df = Seq.range(0, 20000).toDF().repartition(1)
-    df.write
-        .format("delta").mode("append").save(tablePath)
+    df.write.format("delta").mode("append").save(tablePath)
 
     // Set DFS block size to be less than Parquet rowgroup size, to allow
     // the file split logic to kick-in, but gets turned off due to the


### PR DESCRIPTION
This PR is part of [DELETE with Deletion Vector implementation](https://github.com/delta-io/delta/pull/1591).

It updates the `DeltaParquetFileFormat` to populate row index when the schema contains the columns. In order to generate the row_index, we disable file splitting and filter pushdown into reader. This is temporary until we upgrade to Parquet reader in Spark 3.4 that generates the row_indexes with file splitting and filter pushdown.