### PR TITLE
Block manifest file generation when DVs are present

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -1882,6 +1882,13 @@
     ],
     "sqlState" : "0AKDC"
   },
+  "DELTA_UNSUPPORTED_GENERATE_WITH_DELETION_VECTORS" : {
+    "message" : [
+      "The 'GENERATE symlink_format_manifest' command is not supported on table versions with deletion vectors.",
+      "If you need to generate manifests, consider disabling deletion vectors on this table using 'ALTER TABLE table SET TBLPROPERTIES (delta.enableDeletionVectors = false)'."
+    ],
+    "sqlState" : "0A000"
+  },
   "DELTA_UNSUPPORTED_INVARIANT_NON_STRUCT" : {
     "message" : [
       "Invariants on nested fields other than StructTypes are not supported."
@@ -2014,6 +2021,30 @@
       "<values>"
     ],
     "sqlState" : "23001"
+  },
+  "DELTA_VIOLATE_TABLE_PROPERTY_VALIDATION_FAILED" : {
+    "message" : [
+      "The validation of the properties of table <table> has been violated:"
+    ],
+    "subClass" : {
+      "EXISTING_DELETION_VECTORS_WITH_INCREMENTAL_MANIFEST_GENERATION" : {
+        "message" : [
+          "Symlink manifest generation is unsupported while deletion vectors are present in the table.",
+          "In order to produce a version of the table without deletion vectors, run 'REORG TABLE <table> APPLY (PURGE)'."
+        ]
+      },
+      "PERSISTENT_DELETION_VECTORS_IN_NON_PARQUET_TABLE" : {
+        "message" : [
+          "Persistent deletion vectors are only supported on Parquet-based Delta tables."
+        ]
+      },
+      "PERSISTENT_DELETION_VECTORS_WITH_INCREMENTAL_MANIFEST_GENERATION" : {
+        "message" : [
+          "Persistent deletion vectors and incremental symlink manifest generation are mutually exclusive."
+        ]
+      }
+    },
+    "sqlState" : "0A000"
   },
   "DELTA_ZORDERING_COLUMN_DOES_NOT_EXIST" : {
     "message" : [

--- a/core/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -563,6 +563,9 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       }
     }
 
+    if (spark.conf.get(DeltaSQLConf.DELTA_TABLE_PROPERTY_CONSTRAINTS_CHECK_ENABLED)) {
+      Protocol.assertTablePropertyConstraintsSatisfied(spark, metadata, snapshot)
+    }
   }
 
   private def setNewProtocolWithFeaturesEnabledByMetadata(metadata: Metadata): Unit = {

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -315,9 +315,7 @@ class OptimizeExecutor(
           bin.size > 1 || // bin has more than one file or
           (bin.size == 1 && bin(0).deletionVector != null) || // single file in the bin has a DV or
           isMultiDimClustering // multi-clustering
-        }
-
-        bins.map(b => (partition, b))
+        }.map(b => (partition, b))
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -311,10 +311,13 @@ class OptimizeExecutor(
           bins += currentBin.toVector
         }
 
+        bins.filter { bin =>
+          bin.size > 1 || // bin has more than one file or
+          (bin.size == 1 && bin(0).deletionVector != null) || // single file in the bin has a DV or
+          isMultiDimClustering // multi-clustering
+        }
+
         bins.map(b => (partition, b))
-          // select bins that have at least two files or in case of multi-dim clustering
-          // select all bins
-          .filter(_._2.size > 1 || isMultiDimClustering)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1099,6 +1099,15 @@ trait DeltaSQLConfBase {
       .checkValue(_ >= 0, "maxDeletedRowsRatio must be in range [0.0, 1.0]")
       .checkValue(_ <= 1, "maxDeletedRowsRatio must be in range [0.0, 1.0]")
       .createWithDefault(0.05d)
+
+  val DELTA_TABLE_PROPERTY_CONSTRAINTS_CHECK_ENABLED =
+    buildConf("tablePropertyConstraintsCheck.enabled")
+      .internal()
+      .doc(
+        """Check that all table-properties satisfy validity constraints.
+          |Only change this for testing!""".stripMargin)
+      .booleanConf
+      .createWithDefault(true)
 }
 
 object DeltaSQLConf extends DeltaSQLConfBase

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
@@ -104,6 +104,13 @@ trait DeletionVectorsTestUtils extends QueryTest with SharedSparkSession {
     }
   }
 
+  /** Enable persistent Deletion Vectors in a Delta table. */
+  def enableDeletionVectorsInTable(tablePath: Path, enable: Boolean): Unit =
+    spark.sql(
+      s"""ALTER TABLE delta.`$tablePath`
+         |SET TBLPROPERTIES ('${DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.key}' = '$enable')
+         |""".stripMargin)
+
   // ======== HELPER METHODS TO WRITE DVs ==========
   /** Helper method to remove the specified rows in the given file using DVs */
   protected def removeRowsFromFileUsingDV(

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaGenerateSymlinkManifestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaGenerateSymlinkManifestSuite.scala
@@ -19,8 +19,6 @@ package org.apache.spark.sql.delta
 import java.io.File
 import java.net.URI
 
-import org.apache.spark.SparkThrowable
-
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.DeltaOperations.Delete
 import org.apache.spark.sql.delta.commands.DeltaGenerateCommand
@@ -33,10 +31,12 @@ import org.apache.hadoop.fs._
 import org.apache.hadoop.fs.permission.FsPermission
 import org.apache.hadoop.util.Progressable
 
+import org.apache.spark.SparkThrowable
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSparkSession
+// scalastyle:on import.ordering.noEmptyLine
 
 class DeltaGenerateSymlinkManifestSuite
   extends DeltaGenerateSymlinkManifestSuiteBase
@@ -601,7 +601,6 @@ trait DeltaGenerateSymlinkManifestSuiteBase extends QueryTest
             subClass = ExistingDeletionVectorsWithIncrementalManifestGeneration)  {
           setEnabledIncrementalManifest(tablePath, enabled = true)
         }
-
         // Run optimize to delete the DVs and rewrite the data files
         withSQLConf(DeltaSQLConf.DELTA_OPTIMIZE_MAX_DELETED_ROWS_RATIO.key -> "0.00001") {
           spark.sql(s"OPTIMIZE delta.`$tablePath`")

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaGenerateSymlinkManifestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaGenerateSymlinkManifestSuite.scala
@@ -19,10 +19,14 @@ package org.apache.spark.sql.delta
 import java.io.File
 import java.net.URI
 
+import org.apache.spark.SparkThrowable
+
+// scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.sql.delta.DeltaOperations.Delete
 import org.apache.spark.sql.delta.commands.DeltaGenerateCommand
 import org.apache.spark.sql.delta.hooks.GenerateSymlinkManifest
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
-import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.DeltaFileOperations
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
@@ -39,7 +43,8 @@ class DeltaGenerateSymlinkManifestSuite
   with DeltaSQLCommandTest
 
 trait DeltaGenerateSymlinkManifestSuiteBase extends QueryTest
-  with SharedSparkSession  with DeltaTestUtilsForTempViews {
+  with SharedSparkSession  with DeletionVectorsTestUtils
+  with DeltaTestUtilsForTempViews {
 
   import testImplicits._
 
@@ -483,6 +488,171 @@ trait DeltaGenerateSymlinkManifestSuiteBase extends QueryTest
       generateSymlinkManifest(tablePath.toString)
       assertManifest(tablePath, expectSameFiles = true, expectedNumFiles = 2)
     }
+  }
+
+  test("block manifest generation with persistent DVs") {
+    withDeletionVectorsEnabled() {
+      val rowsToBeRemoved = Seq(1L, 42L, 43L)
+
+      withTempDir { dir =>
+        val tablePath = dir.getAbsolutePath
+        // Write in 2 files.
+        spark.range(end = 50L).toDF("id").coalesce(1)
+          .write.format("delta").mode("overwrite").save(tablePath)
+        spark.range(start = 50L, end = 100L).toDF("id").coalesce(1)
+          .write.format("delta").mode("append").save(tablePath)
+        val deltaLog = DeltaLog.forTable(spark, tablePath)
+        assert(deltaLog.snapshot.allFiles.count() === 2L)
+        enableDeletionVectorsInTable(new Path(tablePath), enable = true)
+
+        // Step 1: Make sure generation works on DV enabled tables without a DV in the snapshot.
+        // Delete an entire file, which can't produce DVs.
+        spark.sql(s"""DELETE FROM delta.`$tablePath` WHERE id BETWEEN 0 and 49""")
+        val remainingFiles = deltaLog.snapshot.allFiles.collect()
+        assert(remainingFiles.size === 1L)
+        assert(remainingFiles(0).deletionVector === null)
+        // Should work fine, since the snapshot doesn't contain DVs.
+        spark.sql(s"""GENERATE symlink_format_manifest FOR TABLE delta.`$tablePath`""")
+
+        // Step 2: Make sure generation fails if there are DVs in the snapshot.
+
+        // This is needed to make the manual commit work correctly, since we are not actually
+        // running a command that produces metrics.
+        withSQLConf(DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "false") {
+          val txn = deltaLog.startTransaction()
+          assert(txn.snapshot.allFiles.count() === 1)
+          val file = txn.snapshot.allFiles.collect().head
+          val actions = removeRowsFromFileUsingDV(deltaLog, file, rowIds = rowsToBeRemoved)
+          txn.commit(actions, Delete(predicate = Seq.empty))
+        }
+        val e = intercept[DeltaCommandUnsupportedWithDeletionVectorsException] {
+          spark.sql(s"""GENERATE symlink_format_manifest FOR TABLE delta.`$tablePath`""")
+        }
+        checkErrorHelper(
+          exception = e,
+          errorClass = "DELTA_UNSUPPORTED_GENERATE_WITH_DELETION_VECTORS")
+      }
+    }
+  }
+
+  private def setEnabledIncrementalManifest(tablePath: String, enabled: Boolean): Unit = {
+    spark.sql(s"ALTER TABLE delta.`$tablePath` " +
+      s"SET TBLPROPERTIES('${DeltaConfigs.SYMLINK_FORMAT_MANIFEST_ENABLED.key}'='$enabled')")
+  }
+
+  test("block incremental manifest generation with persistent DVs") {
+    import DeltaTablePropertyValidationFailedSubClass._
+
+    def expectConstraintViolation(subClass: DeltaTablePropertyValidationFailedSubClass)
+        (thunk: => Unit): Unit = {
+      val e = intercept[DeltaTablePropertyValidationFailedException] {
+        thunk
+      }
+      checkErrorHelper(
+        exception = e,
+        errorClass = "DELTA_VIOLATE_TABLE_PROPERTY_VALIDATION_FAILED." + subClass.tag
+      )
+    }
+
+    withDeletionVectorsEnabled() {
+      val rowsToBeRemoved = Seq(1L, 42L, 43L)
+
+      withTempDir { dir =>
+        val tablePath = dir.getAbsolutePath
+        spark.range(end = 100L).toDF("id").coalesce(1)
+          .write.format("delta").mode("overwrite").save(tablePath)
+        val deltaLog = DeltaLog.forTable(spark, tablePath)
+
+        // Make sure both properties can't be enabled together.
+        enableDeletionVectorsInTable(new Path(tablePath), enable = true)
+        expectConstraintViolation(
+            subClass = PersistentDeletionVectorsWithIncrementalManifestGeneration) {
+          setEnabledIncrementalManifest(tablePath, enabled = true)
+        }
+        // Or in the other order.
+        enableDeletionVectorsInTable(new Path(tablePath), enable = false)
+        setEnabledIncrementalManifest(tablePath, enabled = true)
+        expectConstraintViolation(
+            subClass = PersistentDeletionVectorsWithIncrementalManifestGeneration)  {
+          enableDeletionVectorsInTable(new Path(tablePath), enable = true)
+        }
+        setEnabledIncrementalManifest(tablePath, enabled = false)
+        // Or both at once.
+        expectConstraintViolation(
+            subClass = PersistentDeletionVectorsWithIncrementalManifestGeneration)  {
+          spark.sql(s"ALTER TABLE delta.`$tablePath` " +
+            s"SET TBLPROPERTIES('${DeltaConfigs.SYMLINK_FORMAT_MANIFEST_ENABLED.key}'='true'," +
+            s" '${DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.key}' = 'true')")
+        }
+
+        // If DVs were allowed at some point and are still present in the table,
+        // enabling incremental manifest generation must still fail.
+        enableDeletionVectorsInTable(new Path(tablePath), enable = true)
+        withSQLConf(DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "false") {
+          val txn = deltaLog.startTransaction()
+          assert(txn.snapshot.allFiles.count() === 1)
+          val file = txn.snapshot.allFiles.collect().head
+          val actions = removeRowsFromFileUsingDV(deltaLog, file, rowIds = rowsToBeRemoved)
+          txn.commit(actions, Delete(predicate = Seq.empty))
+        }
+        assert(getFilesWithDeletionVectors(deltaLog).nonEmpty)
+        enableDeletionVectorsInTable(new Path(tablePath), enable = false)
+        expectConstraintViolation(
+            subClass = ExistingDeletionVectorsWithIncrementalManifestGeneration)  {
+          setEnabledIncrementalManifest(tablePath, enabled = true)
+        }
+
+        // Run optimize to delete the DVs and rewrite the data files
+        withSQLConf(DeltaSQLConf.DELTA_OPTIMIZE_MAX_DELETED_ROWS_RATIO.key -> "0.00001") {
+          spark.sql(s"OPTIMIZE delta.`$tablePath`")
+        }
+        assert(getFilesWithDeletionVectors(deltaLog).isEmpty)
+        // Now it should work.
+        setEnabledIncrementalManifest(tablePath, enabled = true)
+
+        // As a last fallback, in case some other writer put the table into an illegal state,
+        // we still need to fail the manifest generation if there are DVs.
+        // Reset table.
+        setEnabledIncrementalManifest(tablePath, enabled = false)
+        enableDeletionVectorsInTable(new Path(tablePath), enable = false)
+        spark.range(end = 100L).toDF("id").coalesce(1)
+          .write.format("delta").mode("overwrite").save(tablePath)
+        // Add DVs
+        enableDeletionVectorsInTable(new Path(tablePath), enable = true)
+        withSQLConf(DeltaSQLConf.DELTA_HISTORY_METRICS_ENABLED.key -> "false") {
+          val txn = deltaLog.startTransaction()
+          assert(txn.snapshot.allFiles.count() === 1)
+          val file = txn.snapshot.allFiles.collect().head
+          val actions = removeRowsFromFileUsingDV(deltaLog, file, rowIds = rowsToBeRemoved)
+          txn.commit(actions, Delete(predicate = Seq.empty))
+        }
+        // Force enable manifest generation.
+        withSQLConf(DeltaSQLConf.DELTA_TABLE_PROPERTY_CONSTRAINTS_CHECK_ENABLED.key -> "false") {
+          setEnabledIncrementalManifest(tablePath, enabled = true)
+        }
+        val e2 = intercept[DeltaCommandUnsupportedWithDeletionVectorsException] {
+          spark.range(10).write.format("delta").mode("append").save(tablePath)
+        }
+        checkErrorHelper(
+          exception = e2,
+          errorClass = "DELTA_UNSUPPORTED_GENERATE_WITH_DELETION_VECTORS")
+        // This is fine, since the new snapshot won't contain DVs.
+        spark.range(10).write.format("delta").mode("overwrite").save(tablePath)
+
+        // Make sure we can get the table back into a consistent state, as well
+        setEnabledIncrementalManifest(tablePath, enabled = false)
+        // No more exception.
+        spark.range(10).write.format("delta").mode("append").save(tablePath)
+      }
+    }
+  }
+
+  private def checkErrorHelper(
+      exception: SparkThrowable,
+      errorClass: String
+  ): Unit = {
+    assert(exception.getErrorClass === errorClass,
+      s"Expected errorClass $errorClass, but got $exception")
   }
 
   Seq(true, false).foreach { useIncremental =>


### PR DESCRIPTION
This PR is part of the feature: Support reading Delta tables with deletion vectors (more details at https://github.com/delta-io/delta/issues/1485)

Manifest file contains the list of Parquet data files paths that can be consumed by clients with symlink table type reading capability. However when DVs are present on top of the Parquet data files, there is no way to expose the DVs to symlink table reader. It is best to block manifest file generation when DVs are present in the table.