### PR TITLE
[DELETE with DVs] Update `DeleteCommand` to generate DVs instead of rewriting files

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.execution.vectorized.{OffHeapColumnVector, OnHeapColumnVector, WritableColumnVector}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.Filter
-import org.apache.spark.sql.types.{ByteType, StructField, StructType}
+import org.apache.spark.sql.types.{ByteType, LongType, StructField, StructType}
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
 import org.apache.spark.util.SerializableConfiguration
 
@@ -46,25 +46,20 @@ import org.apache.spark.util.SerializableConfiguration
  *    whether the row is deleted or not according to the deletion vector. Consumers
  *    of this scan can use the column values to filter out the deleted rows.
  */
-class DeltaParquetFileFormat(
+case class DeltaParquetFileFormat(
     metadata: Metadata,
-    val isSplittable: Boolean = true,
-    val disablePushDowns: Boolean = false,
-    val tablePath: Option[String] = None,
-    val broadcastDvMap: Option[Broadcast[Map[URI, DeletionVectorDescriptor]]] = None,
-    val broadcastHadoopConf: Option[Broadcast[SerializableConfiguration]] = None)
+    isSplittable: Boolean = true,
+    disablePushDowns: Boolean = false,
+    tablePath: Option[String] = None,
+    broadcastDvMap: Option[Broadcast[Map[URI, DeletionVectorDescriptor]]] = None,
+    broadcastHadoopConf: Option[Broadcast[SerializableConfiguration]] = None)
   extends ParquetFileFormat {
   // Validate either we have all arguments for DV enabled read or none of them.
-  if (broadcastHadoopConf.isDefined) {
+  if (hasDeletionVectorMap()) {
     require(
       broadcastHadoopConf.isDefined && broadcastDvMap.isDefined &&
         tablePath.isDefined && !isSplittable && disablePushDowns,
       "Wrong arguments for Delta table scan with deletion vectors")
-  } else {
-    require(
-      broadcastHadoopConf.isEmpty && broadcastDvMap.isEmpty &&
-        tablePath.isEmpty && isSplittable && !disablePushDowns,
-      "Wrong arguments for Delta table scan with no deletion vectors")
   }
 
   val columnMappingMode: DeltaColumnMappingMode = metadata.columnMappingMode
@@ -125,29 +120,41 @@ class DeltaParquetFileFormat(
         options,
         hadoopConf)
 
-    if (!hasDeletionVectorMap()) {
-      return parquetDataReader
+    val schemaWithIndices = requiredSchema.fields.zipWithIndex
+    def findColumn(name: String): Option[ColumnMetadata] = {
+      if (schemaWithIndices.filter(_._1.name == name).length > 1) {
+        throw new IllegalArgumentException(
+          s"There are more than one column with name=`$name` requested in the reader output")
+      }
+      schemaWithIndices.find(_._1.name == name).map(e => ColumnMetadata(e._2, e._1))
+    }
+    val isRowDeletedColumn = findColumn(IS_ROW_DELETED_COLUMN_NAME)
+    val rowIndexColumn = findColumn(ROW_INDEX_COLUMN_NAME)
+
+    if (isRowDeletedColumn.isEmpty && rowIndexColumn.isEmpty) {
+      return parquetDataReader // no additional metadata is needed.
+    } else {
+      // verify the file splitting and filter pushdown are disabled. The new additional
+      // metadata columns cannot be generated with file splitting and filter pushdowns
+      require(!isSplittable, "Cannot generate row index related metadata with file splitting")
+      require(disablePushDowns, "Cannot generate row index related metadata with filter pushdown")
     }
 
-    val isRowDeletedColumnTypeIdx = requiredSchema.fields.zipWithIndex
-      .find(_._1.name == IS_ROW_DELETED_COLUMN_NAME)
-
-    if (isRowDeletedColumnTypeIdx.isEmpty) {
-      throw new IllegalArgumentException(
-        s"Expected a column $IS_ROW_DELETED_COLUMN_NAME in the schema")
+    if (hasDeletionVectorMap() && isRowDeletedColumn.isEmpty) {
+        throw new IllegalArgumentException(
+          s"Expected a column $IS_ROW_DELETED_COLUMN_NAME in the schema")
     }
 
     val useOffHeapBuffers = sparkSession.sessionState.conf.offHeapColumnVectorEnabled
-
     (partitionedFile: PartitionedFile) => {
       val rowIteratorFromParquet = parquetDataReader(partitionedFile)
       val iterToReturn =
-        iteratorWithIsRowDeletedColumnPopulated(
+        iteratorWithAdditionalMetadataColumns(
           partitionedFile,
           rowIteratorFromParquet,
-          isRowDeletedColumnTypeIdx.get._1,
-          isRowDeletedColumnTypeIdx.get._2,
-          useOffHeapBuffers)
+          isRowDeletedColumn,
+          useOffHeapBuffers = useOffHeapBuffers,
+          rowIndexColumn = rowIndexColumn)
       iterToReturn.asInstanceOf[Iterator[InternalRow]]
     }
   }
@@ -160,66 +167,80 @@ class DeltaParquetFileFormat(
       tablePath: String,
       broadcastDvMap: Broadcast[Map[URI, DeletionVectorDescriptor]],
       broadcastHadoopConf: Broadcast[SerializableConfiguration]): DeltaParquetFileFormat = {
-    new DeltaParquetFileFormat(
-      metadata,
+    this.copy(
       isSplittable = false,
       disablePushDowns = true,
       tablePath = Some(tablePath),
-      Some(broadcastDvMap),
-      Some(broadcastHadoopConf))
+      broadcastDvMap = Some(broadcastDvMap),
+      broadcastHadoopConf = Some(broadcastHadoopConf))
   }
 
   /**
-   * Modifies the data read from underlying Parquet reader by populating the row deleted status from
-   * deletion vector corresponding to this file in the [[IS_ROW_DELETED_COLUMN_NAME]] column.
+   * Modifies the data read from underlying Parquet reader by populating one or both of the
+   * following metadata columns.
+   *   - [[IS_ROW_DELETED_COLUMN_NAME]] - row deleted status from deletion vector corresponding
+   *   to this file
+   *   - [[ROW_INDEX_COLUMN_NAME]] - index of the row within the file.
    */
-  private def iteratorWithIsRowDeletedColumnPopulated(
+  private def iteratorWithAdditionalMetadataColumns(
       partitionedFile: PartitionedFile,
       iterator: Iterator[Object],
-      isRowDeletedColumnType: StructField,
-      isRowDeletedColumnIdx: Int,
+      isRowDeletedColumn: Option[ColumnMetadata],
+      rowIndexColumn: Option[ColumnMetadata],
       useOffHeapBuffers: Boolean): Iterator[Object] = {
     val filePath = partitionedFile.filePath
     val pathUri = new Path(filePath).toUri
 
-    // Fetch the DV descriptor from the broadcast map and create a row index filter
-    val dvDescriptor = broadcastDvMap.get.value.get(pathUri)
-    val rowIndexFilter = DeletedRowsMarkingFilter.createInstance(
-      dvDescriptor.getOrElse(DeletionVectorDescriptor.EMPTY),
-      broadcastHadoopConf.get.value.value,
-      tablePath.map(new Path(_))
-    )
+    val rowIndexFilter = isRowDeletedColumn.map { col =>
+      // Fetch the DV descriptor from the broadcast map and create a row index filter
+      val dvDescriptor = broadcastDvMap.get.value.get(pathUri)
+      DeletedRowsMarkingFilter.createInstance(
+        dvDescriptor.getOrElse(DeletionVectorDescriptor.EMPTY),
+        broadcastHadoopConf.get.value.value,
+        tablePath.map(new Path(_)))
+    }
+
+    val metadataColumns = Seq(isRowDeletedColumn, rowIndexColumn).filter(_.nonEmpty).map(_.get)
 
     // Unfortunately there is no way to verify the Parquet index is starting from 0.
     // We disable the splits, so the assumption is ParquetFileFormat respects that
     var rowIndex: Long = 0
 
-    val newIter = iterator.map { row =>
-      val newRow = row match {
+    // Used only when non-column row batches are received from the Parquet reader
+    val tempVector = new OnHeapColumnVector(1, ByteType)
+
+    iterator.map { row =>
+      row match {
         case batch: ColumnarBatch => // When vectorized Parquet reader is enabled
           val size = batch.numRows()
-          // Create a new vector for the `is row deleted` column. We can't use the one from Parquet
-          // reader as it set the [[WritableColumnVector.isAllNulls]] to true and it can't be reset
-          // with using any public APIs. In this new vector, fill the values using the row index
-          // filter and replace the vector corresponding to `is row deleted` column in ColumnBatch
-          val newBatch = trySafely(newVector(useOffHeapBuffers, size, isRowDeletedColumnType)) {
-            writableVector =>
-              rowIndexFilter.materializeIntoVector(rowIndex, rowIndex + size, writableVector)
-              rowIndex += size
+          // Create vectors for all needed metadata columns.
+          // We can't use the one from Parquet reader as it set the
+          // [[WritableColumnVector.isAllNulls]] to true and it can't be reset with using any
+          // public APIs.
+          trySafely(useOffHeapBuffers, size, metadataColumns) { writableVectors =>
+            val indexVectorTuples = new ArrayBuffer[(Int, ColumnVector)]
+            var index = 0
+            isRowDeletedColumn.foreach{ columnMetadata =>
+              val isRowDeletedVector = writableVectors(index)
+              rowIndexFilter.get
+                .materializeIntoVector(rowIndex, rowIndex + size, isRowDeletedVector)
+              indexVectorTuples += ((columnMetadata.index, isRowDeletedVector))
+              index += 1
+            }
 
-              val vectors = ArrayBuffer[ColumnVector]()
-              for (i <- 0 until batch.numCols()) {
-                if (i == isRowDeletedColumnIdx) {
-                  vectors += writableVector
-                  // Make sure to close the existing vector allocated in the Parquet
-                  batch.column(i).close()
-                } else {
-                  vectors += batch.column(i)
-                }
-              }
-              new ColumnarBatch(vectors.toArray, size)
+            rowIndexColumn.foreach { columnMetadata =>
+              val rowIndexVector = writableVectors(index)
+              // populate the row index column value
+              for (i <- 0 until size) rowIndexVector.putLong(i, rowIndex + i)
+
+              indexVectorTuples += ((columnMetadata.index, rowIndexVector))
+              index += 1
+            }
+
+            val newBatch = replaceVectors(batch, indexVectorTuples.toSeq: _*)
+            rowIndex += size
+            newBatch
           }
-          newBatch
 
         case rest: InternalRow => // When vectorized Parquet reader is disabled
           // Temporary vector variable used to get DV values from RowIndexFilter
@@ -228,19 +249,19 @@ class DeltaParquetFileFormat(
           // TODO: This is not efficient, but it is ok given the default reader is vectorized
           // reader and this will be temporary until Delta upgrades to Spark with Parquet
           // reader that automatically generates the row index column.
-          trySafely(new OnHeapColumnVector(1, ByteType)) { tempVector =>
-            rowIndexFilter.materializeIntoVector(rowIndex, rowIndex + 1, tempVector)
-            rest.setLong(isRowDeletedColumnIdx, tempVector.getByte(0))
-            rowIndex += 1
-            rest
+          isRowDeletedColumn.foreach { columnMetadata =>
+            rowIndexFilter.get.materializeIntoVector(rowIndex, rowIndex + 1, tempVector)
+            rest.setLong(columnMetadata.index, tempVector.getByte(0))
           }
+
+          rowIndexColumn.foreach(columnMetadata => rest.setLong(columnMetadata.index, rowIndex))
+          rowIndex += 1
+          rest
         case others =>
           throw new RuntimeException(
             s"Parquet reader returned an unknown row type: ${others.getClass.getName}")
       }
-      newRow
     }
-    newIter
   }
 }
 
@@ -251,6 +272,10 @@ object DeltaParquetFileFormat {
    */
   val IS_ROW_DELETED_COLUMN_NAME = "__delta_internal_is_row_deleted"
   val IS_ROW_DELETED_STRUCT_FIELD = StructField(IS_ROW_DELETED_COLUMN_NAME, ByteType)
+
+  /** Row index for each column */
+  val ROW_INDEX_COLUMN_NAME = "__delta_internal_row_index"
+  val ROW_INDEX_STRUCT_FILED = StructField(ROW_INDEX_COLUMN_NAME, LongType)
 
   /** Utility method to create a new writable vector */
   private def newVector(
@@ -263,14 +288,55 @@ object DeltaParquetFileFormat {
   }
 
   /** Try the operation, if the operation fails release the created resource */
-  def trySafely[R <: AutoCloseable, T](createResource: => R)(f: R => T): T = {
-    val resource = createResource
+  private def trySafely[R <: WritableColumnVector, T](
+    useOffHeapBuffers: Boolean,
+    size: Int,
+    columns: Seq[ColumnMetadata])(f: Seq[WritableColumnVector] => T): T = {
+    val resources = new ArrayBuffer[WritableColumnVector](columns.size)
     try {
-      f.apply(resource)
+      columns.foreach(col => resources.append(newVector(useOffHeapBuffers, size, col.structField)))
+      f.apply(resources.toSeq)
     } catch {
       case NonFatal(e) =>
-        resource.close()
+        resources.foreach(closeQuietly(_))
         throw e
     }
   }
+
+  /** Utility method to quietly close an [[AutoCloseable]] */
+  private def closeQuietly(closeable: AutoCloseable): Unit = {
+    if (closeable != null) {
+      try {
+        closeable.close()
+      } catch {
+        case NonFatal(_) => // ignore
+      }
+    }
+  }
+
+  /**
+   * Helper method to replace the vectors in given [[ColumnarBatch]].
+   * New vectors and its index in the batch are given as tuples.
+   */
+  private def replaceVectors(
+      batch: ColumnarBatch,
+      indexVectorTuples: (Int, ColumnVector) *): ColumnarBatch = {
+    val vectors = ArrayBuffer[ColumnVector]()
+    for (i <- 0 until batch.numCols()) {
+      var replaced: Boolean = false
+      for (indexVectorTuple <- indexVectorTuples) {
+        if (indexVectorTuple._1 == i) {
+          vectors += indexVectorTuple._2
+          // Make sure to close the existing vector allocated in the Parquet
+          batch.column(i).close()
+          replaced = true
+        }
+      }
+      if (!replaced) vectors += batch.column(i)
+    }
+    new ColumnarBatch(vectors.toArray, batch.numRows())
+  }
+
+  /** Helper class to encapsulate column info */
+  case class ColumnMetadata(index: Int, structField: StructField)
 }

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -406,8 +406,10 @@ case class AddFile(
     // scalastyle:off
     val removedFile = RemoveFile(
       path, Some(timestamp), dataChange,
-      extendedFileMetadata = Some(true), partitionValues, Some(size), newTags
+      extendedFileMetadata = Some(true), partitionValues, Some(size), newTags,
+      deletionVector = deletionVector
     )
+    removedFile.numLogicalRecords = numLogicalRecords
     // scalastyle:on
     removedFile
   }

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/DeleteWithDeletionVectorsHelper.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/DeleteWithDeletionVectorsHelper.scala
@@ -1,0 +1,553 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands
+
+import java.util.UUID
+
+import scala.collection.generic.Sizing
+
+import org.apache.spark.sql.catalyst.expressions.aggregation.BitmapAggregator
+import org.apache.spark.sql.delta.{DeltaLog, DeltaParquetFileFormat, OptimisticTransaction}
+import org.apache.spark.sql.delta.DeltaParquetFileFormat._
+import org.apache.spark.sql.delta.actions.{AddFile, DeletionVectorDescriptor, FileAction}
+import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat, StoredBitmap}
+import org.apache.spark.sql.delta.files.{TahoeBatchFileIndex, TahoeFileIndex}
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
+import org.apache.spark.sql.delta.util.{DeltaEncoder, JsonUtils, PathWithFileSystem, Utils => DeltaUtils}
+import org.apache.spark.sql.delta.util.DeltaFileOperations.absolutePath
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.{Column, DataFrame, Dataset, Encoder, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeMap, AttributeReference, Expression}
+import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.util.CharVarcharCodegenUtils
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
+import org.apache.spark.sql.execution.datasources.FileFormat.{FILE_PATH, METADATA_NAME}
+import org.apache.spark.sql.functions.{col, lit}
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.{SerializableConfiguration, Utils => SparkUtils}
+
+
+/**
+ * Contains utility classes and method to delete rows in a table using the Deletion Vectors.
+ */
+object DeleteWithDeletionVectorsHelper extends DeltaCommand {
+  /**
+   * Creates a DataFrame that can be used to scan for rows matching DELETE condition in given
+   * files. Generally the given file list is a pruned file list using the stats based pruning.
+   */
+  def createTargetDfForScanningForMatches(
+      spark: SparkSession,
+      target: LogicalPlan,
+      fileIndex: TahoeFileIndex): DataFrame = {
+    Dataset.ofRows(spark, replaceFileIndex(target, fileIndex))
+  }
+
+  /**
+   * Replace the file index in a logical plan and return the updated plan.
+   * It's a common pattern that, in Delta commands, we use data skipping to determine a subset of
+   * files that can be affected by the command, so we replace the whole-table file index in the
+   * original logical plan with a new index of potentially affected files, while everything else in
+   * the original plan, e.g., resolved references, remain unchanged.
+   *
+   * In addition we also request a row index column from the Scan to help generate the
+   * Deletion Vectors.
+   *
+   * @param target the logical plan in which we replace the file index
+   * @param fileIndex the new file index
+   */
+  private def replaceFileIndex(target: LogicalPlan, fileIndex: TahoeFileIndex): LogicalPlan = {
+    val rowIndexColumn =
+      AttributeReference(ROW_INDEX_COLUMN_NAME, ROW_INDEX_STRUCT_FILED.dataType)()
+
+    var hasChar = false
+    val newTarget = target transformDown {
+      case l @ LogicalRelation(
+          hfsr @ HadoopFsRelation(_, _, _, _, format: DeltaParquetFileFormat, _), _, _, _) =>
+        // Take the existing schema and add additional metadata columns
+        val newDataSchema = StructType(hfsr.dataSchema).add(ROW_INDEX_STRUCT_FILED)
+        val finalOutput = l.output ++ Seq(rowIndexColumn)
+
+        val newFormat = format.copy(isSplittable = false, disablePushDowns = true)
+
+        val newBaseRelation = hfsr.copy(
+          location = fileIndex,
+          dataSchema = newDataSchema,
+          fileFormat = newFormat)(hfsr.sparkSession)
+
+        l.copy(relation = newBaseRelation, output = finalOutput)
+      case p @ Project(projectList, _) =>
+        def hasCharPadding(e: Expression): Boolean = e.exists {
+          case s: StaticInvoke => s.staticObject == classOf[CharVarcharCodegenUtils] &&
+            s.functionName == "readSidePadding"
+          case _ => false
+        }
+        val _ = AttributeMap(projectList.collect {
+          case a: Alias if hasCharPadding(a.child) && a.references.size == 1 =>
+            hasChar = true
+            val tableCol = a.references.head.asInstanceOf[AttributeReference]
+            a.toAttribute -> tableCol
+        })
+
+        val newProjectList = projectList ++ Seq(rowIndexColumn)
+        p.copy(projectList = newProjectList)
+    }
+    if (hasChar) {
+      newTarget.transformUp {
+        case p @ Project(projectList, child) =>
+          val newProjectList = projectList.filter { e =>
+            // Spark does char type read-side padding via an additional Project over the scan node,
+            // and we need to apply column pruning for the Project as well, otherwise the Project
+            // will contain missing attributes.
+            e.references.subsetOf(child.outputSet)
+          }
+          p.copy(projectList = newProjectList)
+      }
+    } else {
+      newTarget
+    }
+  }
+
+  /**
+   * Find the target table files that contain rows that satisfy the condition and a DV attached
+   * to each file that indicates a the rows marked as deleted from the file
+   */
+  def findTouchedFiles(
+      sparkSession: SparkSession,
+      txn: OptimisticTransaction,
+      hasDVsEnabled: Boolean,
+      deltaLog: DeltaLog,
+      targetDf: DataFrame,
+      fileIndex: TahoeFileIndex,
+      condition: Expression): Seq[TouchedFileWithDV] = {
+    recordDeltaOperation(deltaLog, opType = "DELETE.findTouchedFiles") {
+      val candidateFiles = fileIndex match {
+        case f: TahoeBatchFileIndex => f.addFiles
+        case _ => throw new IllegalArgumentException("Unexpected file index found!")
+      }
+
+      val matchedRowIndexSets =
+        DeletionVectorBitmapGenerator.buildRowIndexSetsForFilesMatchingCondition(
+          sparkSession,
+          txn,
+          hasDVsEnabled,
+          targetDf,
+          candidateFiles,
+          condition)
+
+      val nameToAddFileMap = generateCandidateFileMap(txn.deltaLog.dataPath, candidateFiles)
+      findFilesWithMatchingRows(txn, nameToAddFileMap, matchedRowIndexSets)
+    }
+  }
+
+  /**
+   * Finds the files in nameToAddFileMap in which rows were deleted by checking the row index set.
+   */
+  private def findFilesWithMatchingRows(
+      txn: OptimisticTransaction,
+      nameToAddFileMap: Map[String, AddFile],
+      matchedFileRowIndexSets: Seq[DeletionVectorResult]): Seq[TouchedFileWithDV] = {
+    // Get the AddFiles using the touched file names and group them together with other
+    // information we need for later phases.
+    val dataPath = txn.deltaLog.dataPath
+    val touchedFilesWithMatchedRowIndices = matchedFileRowIndexSets.map { fileRowIndex =>
+      val filePath = fileRowIndex.filePath
+      val addFile = getTouchedFile(dataPath, filePath, nameToAddFileMap)
+      TouchedFileWithDV(
+        filePath,
+        addFile,
+        fileRowIndex.deletionVector,
+        fileRowIndex.matchedRowCount)
+    }
+
+    logTrace("findTouchedFiles: matched files:\n\t" +
+      s"${touchedFilesWithMatchedRowIndices.map(_.inputFilePath).mkString("\n\t")}")
+
+    val (_, changedFiles) = touchedFilesWithMatchedRowIndices.partition(_.isUnchanged)
+    changedFiles
+  }
+
+  def processUnmodifiedData(touchedFiles: Seq[TouchedFileWithDV]): Seq[FileAction] = {
+    val (fullyRemovedFiles, notFullyRemovedFiles) =
+      touchedFiles.partition(_.isFullyReplaced())
+
+    val timestamp = System.currentTimeMillis()
+    val fullyRemoved = fullyRemovedFiles.map(_.fileLogEntry.removeWithTimestamp(timestamp))
+
+    // TODO: How do get the stats for these new actions?
+    val dvUpdates = notFullyRemovedFiles.map { fileWithDVInfo =>
+      fileWithDVInfo.fileLogEntry.removeRows(
+        deletionVector = fileWithDVInfo.newDeletionVector
+      )}
+
+    val (filesWithDeletedRows, newFilesWithDVs) = dvUpdates.unzip
+    fullyRemoved ++ filesWithDeletedRows ++ newFilesWithDVs
+  }
+}
+
+object DeletionVectorBitmapGenerator {
+  final val FILE_NAME_COL = "filePath"
+  final val FILE_DV_ID_COL = "deletionVectorId"
+  final val ROW_INDEX_COL = "rowIndexCol"
+  final val DELETED_ROW_INDEX_BITMAP = "deletedRowIndexSet"
+  final val DELETED_ROW_INDEX_COUNT = "deletedRowIndexCount"
+  final val MAX_ROW_INDEX_COL = "maxRowIndexCol"
+
+  private class DeletionVectorSet(
+    spark: SparkSession,
+    target: DataFrame,
+    targetDeltaLog: DeltaLog,
+    deltaTxn: OptimisticTransaction) {
+
+    case object CardinalityAndBitmapStruct {
+      val name: String = "CardinalityAndBitmapStruct"
+      def cardinality: String = s"$name.cardinality"
+      def bitmap: String = s"$name.bitmap"
+    }
+
+    def computeResult(): Seq[DeletionVectorResult] = {
+      val aggregated = target
+        .groupBy(col(FILE_NAME_COL), col(FILE_DV_ID_COL))
+        .agg(aggColumns.head, aggColumns.tail: _*)
+        .select(outputColumns: _*)
+
+      import DeletionVectorResult.encoder
+      val rowIndexData = aggregated.as[DeletionVectorData]
+      val storedResults = rowIndexData.mapPartitions(bitmapStorageMapper())
+      storedResults.as[DeletionVectorResult].collect()
+    }
+
+    protected def aggColumns: Seq[Column] = {
+      Seq(createBitmapSetAggregator(col(ROW_INDEX_COL)).as(CardinalityAndBitmapStruct.name))
+    }
+
+    /** Create a bitmap set aggregator over the given column */
+    private def createBitmapSetAggregator(indexColumn: Column): Column = {
+      val func = new BitmapAggregator(indexColumn.expr, RoaringBitmapArrayFormat.Portable)
+      new Column(func.toAggregateExpression(isDistinct = false))
+    }
+
+    protected def outputColumns: Seq[Column] =
+      Seq(
+        col(FILE_NAME_COL),
+        col(FILE_DV_ID_COL),
+        col(CardinalityAndBitmapStruct.bitmap).as(DELETED_ROW_INDEX_BITMAP),
+        col(CardinalityAndBitmapStruct.cardinality).as(DELETED_ROW_INDEX_COUNT)
+      )
+
+    protected def bitmapStorageMapper()
+      : Iterator[DeletionVectorData] => Iterator[DeletionVectorResult] = {
+      val prefixLen = DeltaUtils.getRandomPrefixLength(deltaTxn.metadata)
+      DeletionVectorWriter.createMapperToStoreDeletionVectors(
+        spark,
+        targetDeltaLog.newDeltaHadoopConf(),
+        targetDeltaLog.dataPath,
+        prefixLen)
+    }
+  }
+
+  /**
+   * Build bitmap compressed sets of row indices for each file in [[target]] using
+   * [[ROW_INDEX_COL]].
+   * Write those sets out to temporary files and collect the file names,
+   * together with some encoded metadata about the contents.
+   *
+   * @param target  DataFrame with expected schema [[FILE_NAME_COL]], [[ROW_INDEX_COL]],
+   */
+  def buildDeletionVectors(
+      spark: SparkSession,
+      target: DataFrame,
+      targetDeltaLog: DeltaLog,
+      deltaTxn: OptimisticTransaction): Seq[DeletionVectorResult] = {
+    val rowIndexSet = new DeletionVectorSet(spark, target, targetDeltaLog, deltaTxn)
+    rowIndexSet.computeResult()
+  }
+
+  def buildRowIndexSetsForFilesMatchingCondition(
+      sparkSession: SparkSession,
+      txn: OptimisticTransaction,
+      tableHasDVs: Boolean,
+      targetDf: DataFrame,
+      candidateFiles: Seq[AddFile],
+      condition: Expression)
+    : Seq[DeletionVectorResult] = {
+    val matchedRowsDf = targetDf
+      .withColumn(FILE_NAME_COL, col(s"${METADATA_NAME}.${FILE_PATH}"))
+      // Filter after getting input file name as the filter might introduce a join and we
+      // cannot get input file name on join's output.
+      .filter(new Column(condition))
+      .withColumn(ROW_INDEX_COL, col(ROW_INDEX_COLUMN_NAME))
+
+    val df = if (tableHasDVs) {
+      // When the table already has DVs, join the `matchedRowDf` above to attach for each matched
+      // file its existing DeletionVectorDescriptor
+      val basePath = txn.deltaLog.dataPath.toString
+      val filePathToDV = candidateFiles.map { add =>
+        val serializedDV = Option(add.deletionVector).map(dvd => JsonUtils.toJson(dvd))
+        FileToDvDescriptor(absolutePath(basePath, add.path).toString, serializedDV)
+      }
+      val filePathToDVDf = sparkSession.createDataset(filePathToDV)
+
+      val joinExpr = filePathToDVDf("path") === matchedRowsDf(FILE_NAME_COL)
+      matchedRowsDf.join(filePathToDVDf, joinExpr)
+    } else {
+      // When the table has no DVs, just add a column to indicate that the existing dv is null
+      matchedRowsDf.withColumn(FILE_DV_ID_COL, lit(null))
+    }
+
+    DeletionVectorBitmapGenerator.buildDeletionVectors(sparkSession, df, txn.deltaLog, txn)
+  }
+}
+
+/** Holds a mapping from a file path to an (optional) serialized Deletion Vector descriptor. */
+case class FileToDvDescriptor(path: String, deletionVectorId: Option[String])
+
+object FileToDvDescriptor {
+  private lazy val _encoder = new DeltaEncoder[FileToDvDescriptor]
+  implicit def encoder: Encoder[FileToDvDescriptor] = _encoder.get
+}
+
+/**
+ * Row containing the file path and its new deletion vector bitmap in memory
+ *
+ * @param filePath             Absolute path of the data file this DV result is generated for.
+ * @param deletionVectorId     Existing [[DeletionVectorDescriptor]] serialized in JSON format.
+ *                             This info is used to load the existing DV with the new DV.
+ * @param deletedRowIndexSet   In-memory Deletion vector bitmap generated containing the newly
+ *                             deleted row indexes from data file.
+ * @param deletedRowIndexCount Count of rows marked as deleted using the [[deletedRowIndexSet]].
+ */
+case class DeletionVectorData(
+    filePath: String,
+    deletionVectorId: Option[String],
+    deletedRowIndexSet: Array[Byte],
+    deletedRowIndexCount: Long)
+
+object DeletionVectorData {
+  private lazy val _encoder = new DeltaEncoder[DeletionVectorData]
+  implicit def encoder: Encoder[DeletionVectorData] = _encoder.get
+
+  def apply(
+      filePath: String, rowIndexSet: Array[Byte], rowIndexCount: Long): DeletionVectorData = {
+    DeletionVectorData(
+      filePath = filePath,
+      deletionVectorId = None,
+      deletedRowIndexSet = rowIndexSet,
+      deletedRowIndexCount = rowIndexCount)
+  }
+}
+
+/** Final output for each file containing the file path, DeletionVectorDescriptor and how many
+ * rows are marked as deleted in this file as part of the this DELETE (doesn't include already
+ * rows marked as deleted)
+ *
+ * @param filePath        Absolute path of the data file this DV result is generated for.
+ * @param deletionVector  Deletion vector generated containing the newly deleted row indices from
+ *                        data file.
+ * @param matchedRowCount Number of rows marked as deleted using the [[deletionVector]].
+ */
+case class DeletionVectorResult(
+    filePath: String,
+    deletionVector: DeletionVectorDescriptor,
+    matchedRowCount: Long) {
+}
+
+object DeletionVectorResult {
+  private lazy val _encoder = new DeltaEncoder[DeletionVectorResult]
+  implicit def encoder: Encoder[DeletionVectorResult] = _encoder.get
+
+  def fromDeletionVectorData(
+      data: DeletionVectorData,
+      deletionVector: DeletionVectorDescriptor): DeletionVectorResult = {
+    DeletionVectorResult(
+      filePath = data.filePath,
+      deletionVector = deletionVector,
+      matchedRowCount = data.deletedRowIndexCount)
+  }
+}
+
+case class TouchedFileWithDV(
+    inputFilePath: String,
+    fileLogEntry: AddFile,
+    newDeletionVector: DeletionVectorDescriptor,
+    deletedRows: Long) {
+  /**
+   * Checks the *sufficient* condition for a file being fully replaced by the current operation.
+   * (That is, all rows are either being updated or deleted.)
+   */
+  def isFullyReplaced(): Boolean = {
+    fileLogEntry.numLogicalRecords match {
+      case Some(numRecords) => numRecords == numberOfModifiedRows
+      case None => false // must make defensive assumption if no statistics are available
+    }
+  }
+
+  /**
+   * Checks if the file is unchanged by the current operation.
+   * (That is no row has been updated or deleted.)
+   */
+  def isUnchanged: Boolean = {
+    // If the bitmap is empty then no row would be removed during the rewrite,
+    // thus the file is unchanged.
+    numberOfModifiedRows == 0
+  }
+
+  /**
+   * The number of rows that are modified in this file.
+   */
+  def numberOfModifiedRows: Long = newDeletionVector.cardinality - fileLogEntry.numDeletedRecords
+}
+
+/**
+ * Utility methods to write the deletion vector to storage. If a particular file already
+ * has an existing DV, it will be merged with the new deletion vector and written to storage.
+ */
+object DeletionVectorWriter extends DeltaLogging {
+  /**
+   * The context for [[createDeletionVectorMapper]] callback functions. Contains the DV writer that
+   * is used by callback functions to write the new DVs.
+   */
+  case class DeletionVectorMapperContext(
+      dvStore: DeletionVectorStore,
+      writer: DeletionVectorStore.Writer,
+      tablePath: Path,
+      fileId: UUID,
+      prefix: String)
+
+  /**
+   * Prepare a mapper function for storing deletion vectors.
+   *
+   * For each DeletionVector the writer will create a [[DeletionVectorMapperContext]] that contains
+   * a DV writer that is used by to write the DV into a file.
+   *
+   * The result can be used with [[org.apache.spark.sql.Dataset.mapPartitions()]] and must thus be
+   * serialized.
+   */
+  def createDeletionVectorMapper[InputT <: Sizing, OutputT](
+      sparkSession: SparkSession,
+      hadoopConf: Configuration,
+      table: Path,
+      prefixLength: Int)
+      (callbackFn: (DeletionVectorMapperContext, DeletionVectorData) => DeletionVectorResult)
+    : Iterator[DeletionVectorData] => Iterator[DeletionVectorResult] = {
+    val broadcastHadoopConf = sparkSession.sparkContext.broadcast(
+      new SerializableConfiguration(hadoopConf))
+    // hadoop.fs.Path is not Serializable, so close over the String representation instead
+    val tablePathString = DeletionVectorStore.pathToString(table)
+
+    // This is the (partition) mapper function we are returning
+    (rowIterator: Iterator[DeletionVectorData]) => {
+      val dvStore = DeletionVectorStore.createInstance(broadcastHadoopConf.value.value)
+      val tablePath = DeletionVectorStore.stringToPath(tablePathString)
+      val tablePathWithFS = dvStore.pathWithFileSystem(tablePath)
+
+      val storeDVFunction = (row: DeletionVectorData) => {
+        val prefix = DeltaUtils.getRandomPrefix(prefixLength)
+        val (writer, fileId) = createWriter(dvStore, tablePathWithFS, prefix)
+        val ctx = DeletionVectorMapperContext(
+          dvStore,
+          writer,
+          tablePath,
+          fileId,
+          prefix)
+        SparkUtils.tryWithResource(writer) { _ =>
+          callbackFn(ctx, row)
+        }
+      }
+
+      rowIterator.map(storeDVFunction)
+    }
+  }
+
+  /**
+   * Creates a writer for writing multiple DVs in the same file.
+   *
+   * Returns the writer and the UUID of the new file.
+   */
+  def createWriter(
+      dvStore: DeletionVectorStore,
+      tablePath: PathWithFileSystem,
+      prefix: String = ""): (DeletionVectorStore.Writer, UUID) = {
+    val fileId = UUID.randomUUID()
+    val writer = dvStore.createWriter(dvStore.generateFileNameInTable(tablePath, fileId, prefix))
+    (writer, fileId)
+  }
+
+  /** Store the `bitmapData` on cloud storage. */
+  def storeSerializedBitmap(
+      ctx: DeletionVectorMapperContext,
+      bitmapData: Array[Byte],
+      cardinality: Long): DeletionVectorDescriptor = {
+    if (cardinality == 0L) {
+      DeletionVectorDescriptor.EMPTY
+    } else {
+      val dvRange = ctx.writer.write(bitmapData)
+      DeletionVectorDescriptor.onDiskWithRelativePath(
+        id = ctx.fileId,
+        randomPrefix = ctx.prefix,
+        sizeInBytes = bitmapData.length,
+        cardinality = cardinality,
+        offset = Some(dvRange.offset))
+    }
+  }
+
+  /**
+   * Prepares a mapper function that can be used by DELETE command to store the Deletion Vectors
+   * that are in described in [[DeletionVectorData]] and return their descriptors
+   * [[DeletionVectorResult]].
+   */
+  def createMapperToStoreDeletionVectors(
+      sparkSession: SparkSession,
+      hadoopConf: Configuration,
+      table: Path,
+      prefixLength: Int): Iterator[DeletionVectorData] => Iterator[DeletionVectorResult] =
+    createDeletionVectorMapper(sparkSession, hadoopConf, table, prefixLength) {
+      (ctx, row) => storeBitmapAndGenerateResult(ctx, row)
+    }
+
+  /**
+   * Helper to generate and store the deletion vector bitmap. The deletion vector is merged with
+   * the file's already existing deletion vector before being stored.
+   */
+  def storeBitmapAndGenerateResult(ctx: DeletionVectorMapperContext, row: DeletionVectorData)
+    : DeletionVectorResult = {
+    val fileDvDescriptor = row.deletionVectorId.map(DeletionVectorDescriptor.fromJson(_))
+    val finalDvDescriptor = fileDvDescriptor match {
+      case Some(existingDvDescriptor) if row.deletedRowIndexCount > 0 =>
+        // Load the existing bit map
+        val existingBitmap =
+          StoredBitmap.create(existingDvDescriptor, ctx.tablePath).load(ctx.dvStore)
+        val newBitmap = RoaringBitmapArray.readFrom(row.deletedRowIndexSet)
+
+        // Merge both the existing and new bitmaps into one, and finally persist on disk
+        existingBitmap.merge(newBitmap)
+        storeSerializedBitmap(
+          ctx,
+          existingBitmap.serializeAsByteArray(RoaringBitmapArrayFormat.Portable),
+          existingBitmap.cardinality)
+      case Some(existingDvDescriptor) =>
+        existingDvDescriptor // This is already stored.
+      case None =>
+        // Persist the new bitmap
+        storeSerializedBitmap(ctx, row.deletedRowIndexSet, row.deletedRowIndexCount)
+    }
+    DeletionVectorResult.fromDeletionVectorData(row, deletionVector = finalDvDescriptor)
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1099,6 +1099,13 @@ trait DeltaSQLConfBase {
       .checkValue(_ >= 0, "maxDeletedRowsRatio must be in range [0.0, 1.0]")
       .checkValue(_ <= 1, "maxDeletedRowsRatio must be in range [0.0, 1.0]")
       .createWithDefault(0.05d)
+
+  val DELETE_USE_PERSISTENT_DELETION_VECTORS =
+    buildConf("delete.deletionVectors.persistent")
+      .internal()
+      .doc("Enable persistent Deletion Vectors in the Delete command.")
+      .booleanConf
+      .createWithDefault(true)
 }
 
 object DeltaSQLConf extends DeltaSQLConfBase

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
@@ -45,8 +45,8 @@ trait DeletionVectorsTestUtils extends QueryTest with SharedSparkSession {
   def withDeletionVectorsEnabled(enabled: Boolean = true)(thunk: => Unit): Unit = {
     val enabledStr = enabled.toString
     withSQLConf(
-      DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.defaultTablePropertyKey -> enabledStr
-    ) {
+      DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.defaultTablePropertyKey -> enabledStr,
+      DeltaSQLConf.DELETE_USE_PERSISTENT_DELETION_VECTORS.key -> enabledStr) {
       thunk
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
@@ -16,6 +16,7 @@
 
 package org.apache.spark.sql.delta
 
+import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
 import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor
 import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
 import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
@@ -27,7 +28,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.parquet.format.converter.ParquetMetadataConverter
 import org.apache.parquet.hadoop.ParquetFileReader
 
-import org.apache.spark.sql.{Dataset, QueryTest}
+import org.apache.spark.sql.{DataFrame, Dataset, QueryTest}
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.{SerializableConfiguration, Utils}
@@ -38,12 +39,10 @@ class DeltaParquetFileFormatSuite extends QueryTest
 
   // Read with deletion vectors has separate code paths based on vectorized Parquet
   // reader is enabled or not. Test both the combinations
-  for (enableVectorizedParquetReader <- Seq("true", "false")) {
-    test(
-      s"read with DVs (vectorized Parquet reader enabled=$enableVectorizedParquetReader)") {
+  for ((readIsRowDeletedCol, readRowIndexCol) <- Seq((true, true), (true, false), (false, true)))
+    testWithBothParquetReaders("read DV metadata columns: " +
+        s"with isRowDeletedCol=$readIsRowDeletedCol, with rowIndexCol=$readRowIndexCol") {
       withTempDir { tempDir =>
-        spark.conf.set("spark.sql.parquet.enableVectorizedReader", enableVectorizedParquetReader)
-
         val tablePath = tempDir.toString
 
         // Generate a table with one parquet file containing multiple row groups.
@@ -53,11 +52,15 @@ class DeltaParquetFileFormatSuite extends QueryTest
         val metadata = deltaLog.snapshot.metadata
 
         // Add additional field that has the deleted row flag to existing data schema
-        val readingSchema = metadata.schema.add(DeltaParquetFileFormat.IS_ROW_DELETED_STRUCT_FIELD)
+        var readingSchema = metadata.schema
+        if (readIsRowDeletedCol) {
+          readingSchema = readingSchema.add(DeltaParquetFileFormat.IS_ROW_DELETED_STRUCT_FIELD)
+        }
+        if (readRowIndexCol) {
+          readingSchema = readingSchema.add(DeltaParquetFileFormat.ROW_INDEX_STRUCT_FILED)
+        }
 
-        val addFilePath = new Path(
-          tempDir.toString,
-          deltaLog.snapshot.allFiles.collect()(0).path)
+        val addFilePath = new Path(tempDir.toString, deltaLog.snapshot.allFiles.collect()(0).path)
         assertParquetHasMultipleRowGroups(addFilePath)
 
         val dv = generateDV(tablePath, 0, 200, 300, 756, 10352, 19999)
@@ -75,8 +78,8 @@ class DeltaParquetFileFormatSuite extends QueryTest
           isSplittable = false,
           disablePushDowns = true,
           Some(tablePath),
-          Some(broadcastDvMap),
-          Some(broadcastHadoopConf))
+          if (readIsRowDeletedCol) Some(broadcastDvMap) else None,
+          if (readIsRowDeletedCol) Some(broadcastHadoopConf) else None)
 
         val fileIndex = DeltaLogFileIndex(deltaParquetFormat, fs, addFilePath :: Nil)
 
@@ -89,15 +92,41 @@ class DeltaParquetFileFormatSuite extends QueryTest
           options = Map.empty)(spark)
         val plan = LogicalRelation(relation)
 
-        // Select some rows that are deleted and some rows not deleted
-        // Deleted row `value`: 0, 200, 300, 756, 10352, 19999
-        // Not deleted row `value`: 7, 900
-        checkDatasetUnorderly(
-          Dataset.ofRows(spark, plan)
-            .filter("value in (0, 7, 200, 300, 756, 900, 10352, 19999)")
-            .as[(Int, Int)],
-          (0, 1), (7, 0), (200, 1), (300, 1), (756, 1), (900, 0), (10352, 1), (19999, 1)
-        )
+        if (readIsRowDeletedCol) {
+          // Select some rows that are deleted and some rows not deleted
+          // Deleted row `value`: 0, 200, 300, 756, 10352, 19999
+          // Not deleted row `value`: 7, 900
+          checkDatasetUnorderly(
+            Dataset.ofRows(spark, plan)
+              .filter("value in (0, 7, 200, 300, 756, 900, 10352, 19999)")
+              .select("value", DeltaParquetFileFormat.IS_ROW_DELETED_COLUMN_NAME)
+              .as[(Int, Int)],
+            (0, 1), (7, 0), (200, 1), (300, 1), (756, 1), (900, 0), (10352, 1), (19999, 1))
+        }
+
+        if (readRowIndexCol) {
+          def rowIndexes(df: DataFrame): Set[Long] = {
+            val colIndex = if (readIsRowDeletedCol) 2 else 1
+            df.collect().map(_.getLong(colIndex)).toSet
+          }
+
+          val df = Dataset.ofRows(spark, plan)
+          assert(rowIndexes(df) === Seq.range(0, 20000).toSet)
+
+          assert(
+            rowIndexes(
+              df.filter("value in (0, 7, 200, 300, 756, 900, 10352, 19999)")) ===
+            Seq(0, 7, 200, 300, 756, 900, 10352, 19999).toSet)
+        }
+      }
+    }
+
+  /** Helper method to run the test with vectorized and non-vectorized Parquet readers */
+  private def testWithBothParquetReaders(name: String)(funk: => Any): Unit = {
+    for (enableVectorizedParquetReader <- BOOLEAN_DOMAIN) {
+      test(s"$name, with vectorized Parquet reader=$enableVectorizedParquetReader)") {
+        spark.conf.set("spark.sql.parquet.enableVectorizedReader", enableVectorizedParquetReader)
+        funk
       }
     }
   }
@@ -109,8 +138,7 @@ class DeltaParquetFileFormatSuite extends QueryTest
 
     // Keep the number of partitions to 1 to generate a single Parquet data file
     val df = Seq.range(0, 20000).toDF().repartition(1)
-    df.write
-        .format("delta").mode("append").save(tablePath)
+    df.write.format("delta").mode("append").save(tablePath)
 
     // Set DFS block size to be less than Parquet rowgroup size, to allow
     // the file split logic to kick-in, but gets turned off due to the

--- a/core/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
@@ -18,8 +18,9 @@ package org.apache.spark.sql.delta.deletionvectors
 
 import java.io.File
 
-import org.apache.spark.sql.delta.{DeltaLog, DeltaTestUtilsForTempViews}
+import org.apache.spark.sql.delta.{DeletionVectorsTestUtils, DeltaLog, DeltaTestUtilsForTempViews}
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
+import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor
 import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor.EMPTY
 import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsSuite._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -36,6 +37,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 class DeletionVectorsSuite extends QueryTest
   with SharedSparkSession
   with DeltaSQLCommandTest
+  with DeletionVectorsTestUtils
   with DeltaTestUtilsForTempViews {
   import testImplicits._
 
@@ -193,6 +195,74 @@ class DeletionVectorsSuite extends QueryTest
           s"SELECT * FROM delta.`${source1.getAbsolutePath}` UNION ALL " +
           s"SELECT * FROM delta.`${source2.getAbsolutePath}`")
       )
+    }
+  }
+
+  test("DELETE with DVs - on a table with no prior DVs") {
+    withDeletionVectorsEnabled() {
+      withTempDir { dirName =>
+        // Create table with 500 files of 2 rows each.
+        val numFiles = 500
+        val path = dirName.getAbsolutePath
+        spark.range(0, 1000, step = 1, numPartitions = numFiles)
+          .write.format("delta").save(path)
+        val tableName = s"delta.`$path`"
+
+        val beforeDeleteFiles = DeltaLog.forTable(spark, path)
+            .unsafeVolatileSnapshot.allFiles.map(_.path).collect()
+
+        val numFilesWithDVs = 100
+        val numDeletedRows = numFilesWithDVs * 1
+        spark.sql(s"DELETE FROM $tableName WHERE id % 2 = 0 AND id < 200")
+
+        // Verify the expected no. of deletion vectors and deleted rows according to DV cardinality
+        val allFiles = DeltaLog.forTable(spark, path).unsafeVolatileSnapshot.allFiles.collect()
+        assert(allFiles.size === numFiles)
+        assert(allFiles.filter(_.deletionVector != null).size === numFilesWithDVs)
+        assert(
+          allFiles.filter(_.deletionVector != null).map(_.deletionVector.cardinality).sum ==
+          numDeletedRows)
+
+        val afterDeleteFiles = allFiles.map(_.path)
+        // make sure the data file list is the same
+        assert(beforeDeleteFiles === afterDeleteFiles)
+
+        // Contents after the DELETE are as expected
+        checkAnswer(
+          spark.sql(s"SELECT * FROM $tableName"),
+          Seq.range(0, 1000).filterNot(Seq.range(start = 0, end = 200, step = 2).contains(_)).toDF()
+        )
+      }
+    }
+  }
+
+  test("DELETE with DVs - existing table already has DVs") {
+    withSQLConf(DeltaSQLConf.DELETE_USE_PERSISTENT_DELETION_VECTORS.key -> "true") {
+      withTempDir { tempDir =>
+        val source = new File(table1Path)
+        val target = new File(tempDir, "deleteTest")
+
+        // Copy the source DV table to a temporary directory
+        FileUtils.copyDirectory(source, target)
+
+        val targetPath = s"delta.`${target.getAbsolutePath}`"
+        val dataToRemove = Seq(1999, 299, 7, 87, 867, 456)
+        val existingDVs = getFilesWithDeletionVectors(DeltaLog.forTable(spark, target))
+
+        spark.sql(s"DELETE FROM $targetPath WHERE value in (${dataToRemove.mkString(",")})")
+
+        // Check new DVs are created
+        val newDVs = getFilesWithDeletionVectors(DeltaLog.forTable(spark, target))
+        // expect the new DVs contain extra entries for the deleted rows.
+        assert(
+          existingDVs.map(_.deletionVector.cardinality).sum + dataToRemove.size ===
+          newDVs.map(_.deletionVector.cardinality).sum
+        )
+
+        // Check the data is valid
+        val expectedTable1DataV5 = expectedTable1DataV4.filterNot(e => dataToRemove.contains(e))
+        checkAnswer(spark.sql(s"SELECT * FROM $targetPath"), expectedTable1DataV5.toDF())
+      }
     }
   }
 


### PR DESCRIPTION
(This is a PR stacked on top of another PR: delta-io/delta#1593)

This PR is part of [DELETE with Deletion Vector implementation](https://github.com/delta-io/delta/pull/1591).

Detailed overview of changes are described in [feature request issue](https://github.com/delta-io/delta/pull/1591).

