### PR TITLE
[Backport][2.2.x] Reliably obtain retention timestamps from Metadata

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -127,32 +127,9 @@ class DeltaLog private(
   def maxSnapshotLineageLength: Int =
     spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_MAX_SNAPSHOT_LINEAGE_LENGTH)
 
-  /** How long to keep around logically deleted files before physically deleting them. */
-  private[delta] def tombstoneRetentionMillis: Long =
-    DeltaConfigs.getMilliSeconds(DeltaConfigs.TOMBSTONE_RETENTION.fromMetaData(metadata))
-
   // TODO: There is a race here where files could get dropped when increasing the
   // retention interval...
   protected def metadata = Option(unsafeVolatileSnapshot).map(_.metadata).getOrElse(Metadata())
-
-  /**
-   * Tombstones before this timestamp will be dropped from the state and the files can be
-   * garbage collected.
-   */
-  def minFileRetentionTimestamp: Long = {
-    // TODO (Fred): Get rid of this FrameProfiler record once SC-94033 is addressed
-    recordFrameProfile("Delta", "DeltaLog.minFileRetentionTimestamp") {
-      clock.getTimeMillis() - tombstoneRetentionMillis
-    }
-  }
-
-  /**
-   * [[SetTransaction]]s before this timestamp will be considered expired and dropped from the
-   * state, but no files will be deleted.
-   */
-  def minSetTransactionRetentionTimestamp: Option[Long] = {
-    DeltaLog.minSetTransactionRetentionInterval(metadata).map { clock.getTimeMillis() - _ }
-  }
 
   /**
    * Checks whether this table only accepts appends. If so it will throw an error in operations that
@@ -217,6 +194,16 @@ class DeltaLog private(
     val fsRelation = HadoopFsRelation(
       index, index.partitionSchema, schema, None, index.format, allOptions)(spark)
     LogicalRelation(fsRelation)
+  }
+
+  /**
+   * Load the data using the FileIndex. This allows us to skip many checks that add overhead, e.g.
+   * file existence checks, partitioning schema inference.
+   */
+  def loadIndex(
+      index: DeltaLogFileIndex,
+      schema: StructType = Action.logSchema): DataFrame = {
+    Dataset.ofRows(spark, indexToRelation(index, schema))
   }
 
   /* ------------------ *
@@ -861,10 +848,15 @@ object DeltaLog extends DeltaLogging {
     })
   }
 
+  /** How long to keep around SetTransaction actions before physically deleting them. */
   def minSetTransactionRetentionInterval(metadata: Metadata): Option[Long] = {
     DeltaConfigs.TRANSACTION_ID_RETENTION_DURATION
       .fromMetaData(metadata)
       .map(DeltaConfigs.getMilliSeconds)
+  }
+  /** How long to keep around logically deleted files before physically deleting them. */
+  def tombstoneRetentionMillis(metadata: Metadata): Long = {
+    DeltaConfigs.getMilliSeconds(DeltaConfigs.TOMBSTONE_RETENTION.fromMetaData(metadata))
   }
 
   /** Get a function that canonicalizes a given `path`. */

--- a/core/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -67,11 +67,9 @@ class Snapshot(
     val path: Path,
     override val version: Long,
     val logSegment: LogSegment,
-    val minFileRetentionTimestamp: Long,
     override val deltaLog: DeltaLog,
     val timestamp: Long,
     val checksumOpt: Option[VersionChecksum],
-    val minSetTransactionRetentionTimestamp: Option[Long] = None,
     checkpointMetadataOpt: Option[CheckpointMetaData] = None)
   extends SnapshotDescriptor
   with StateCache
@@ -155,6 +153,26 @@ class Snapshot(
     }
   }
 
+  /**
+   * Pulls the protocol and metadata of the table from the files that are used to compute the
+   * Snapshot directly--without triggering a full state reconstruction. This is important, because
+   * state reconstruction depends on protocol and metadata for correctness.
+   */
+  protected def protocolAndMetadataReconstruction(): Array[(Protocol, Metadata)] = {
+    import implicits._
+
+    val schemaToUse = Action.logSchema(Set("protocol", "metaData"))
+    fileIndices.map(deltaLog.loadIndex(_, schemaToUse))
+      .reduceOption(_.union(_)).getOrElse(emptyDF)
+      .withColumn(ACTION_SORT_COL_NAME, input_file_name())
+      .select("protocol", "metaData", ACTION_SORT_COL_NAME)
+      .where("protocol.minReaderVersion is not null or metaData.id is not null")
+      .as[(Protocol, Metadata, String)]
+      .collect()
+      .sortBy(_._3)
+      .map { case (p, m, _) => p -> m }
+  }
+
   def redactedPath: String =
     Utils.redact(spark.sessionState.conf.stringRedactionPattern, path.toUri.toString)
 
@@ -213,7 +231,17 @@ class Snapshot(
             data = Map(
               "version" -> version.toString, "action" -> "Protocol", "source" -> "Snapshot"))
           throw DeltaErrors.actionNotFoundException("protocol", version)
+        } else if (_computedState.protocol != protocol) {
+          recordDeltaEvent(
+            deltaLog,
+            opType = "delta.assertions.mismatchedAction",
+            data = Map(
+              "version" -> version.toString, "action" -> "Protocol", "source" -> "Snapshot",
+              "computedState.protocol" -> _computedState.protocol,
+              "extracted.protocol" -> protocol))
+          throw DeltaErrors.actionNotFoundException("protocol", version)
         }
+
         if (_computedState.metadata == null) {
           recordDeltaEvent(
             deltaLog,
@@ -221,11 +249,52 @@ class Snapshot(
             data = Map(
               "version" -> version.toString, "action" -> "Metadata", "source" -> "Metadata"))
           throw DeltaErrors.actionNotFoundException("metadata", version)
-        } else {
-          _computedState
+        } else if (_computedState.metadata != metadata) {
+          recordDeltaEvent(
+            deltaLog,
+            opType = "delta.assertions.mismatchedAction",
+            data = Map(
+              "version" -> version.toString, "action" -> "Metadata", "source" -> "Snapshot",
+              "computedState.metadata" -> _computedState.metadata,
+              "extracted.metadata" -> metadata))
+          throw DeltaErrors.actionNotFoundException("metadata", version)
         }
+
+        _computedState
       }
     }
+  }
+
+  // Used by [[protocol]] and [[metadata]] below
+  private lazy val (_protocol, _metadata): (Protocol, Metadata) = {
+    // Should be small. At most 'checkpointInterval' rows, unless new commits are coming
+    // in before a checkpoint can be written
+    var protocol: Protocol = null
+    var metadata: Metadata = null
+    protocolAndMetadataReconstruction().foreach {
+      case (p: Protocol, _) => protocol = p
+      case (_, m: Metadata) => metadata = m
+    }
+
+    if (protocol == null) {
+      recordDeltaEvent(
+        deltaLog,
+        opType = "delta.assertions.missingAction",
+        data = Map(
+          "version" -> version.toString, "action" -> "Protocol", "source" -> "Snapshot"))
+      throw DeltaErrors.actionNotFoundException("protocol", version)
+    }
+
+    if (metadata == null) {
+      recordDeltaEvent(
+        deltaLog,
+        opType = "delta.assertions.missingAction",
+        data = Map(
+          "version" -> version.toString, "action" -> "Metadata", "source" -> "Snapshot"))
+      throw DeltaErrors.actionNotFoundException("metadata", version)
+    }
+
+    protocol -> metadata
   }
 
   def sizeInBytes: Long = computedState.sizeInBytes
@@ -235,12 +304,28 @@ class Snapshot(
   def numOfMetadata: Long = computedState.numOfMetadata
   def numOfProtocol: Long = computedState.numOfProtocol
   def setTransactions: Seq[SetTransaction] = computedState.setTransactions
-  override def metadata: Metadata = computedState.metadata
-  override def protocol: Protocol = computedState.protocol
+  override def metadata: Metadata = _metadata
+  override def protocol: Protocol = _protocol
   def fileSizeHistogram: Option[FileSizeHistogram] = computedState.fileSizeHistogram
   private[delta] def sizeInBytesOpt: Option[Long] = Some(sizeInBytes)
   private[delta] def setTransactionsOpt: Option[Seq[SetTransaction]] = Some(setTransactions)
   private[delta] def numOfFilesOpt: Option[Long] = Some(numOfFiles)
+
+  /**
+   * Tombstones before the [[minFileRetentionTimestamp]] timestamp will be dropped from the
+   * checkpoint.
+   */
+  private[delta] def minFileRetentionTimestamp: Long = {
+    deltaLog.clock.getTimeMillis() - DeltaLog.tombstoneRetentionMillis(metadata)
+  }
+
+  /**
+   * [[SetTransaction]]s before [[minSetTransactionRetentionTimestamp]] will be considered expired
+   * and dropped from the snapshot.
+   */
+  private[delta] def minSetTransactionRetentionTimestamp: Option[Long] = {
+    DeltaLog.minSetTransactionRetentionInterval(metadata).map(deltaLog.clock.getTimeMillis() - _)
+  }
 
   /**
    * Computes all the information that is needed by the checksum for the current snapshot.
@@ -330,8 +415,8 @@ class Snapshot(
    * config settings for delta.checkpoint.writeStatsAsJson and delta.checkpoint.writeStatsAsStruct).
    */
   protected def loadActions: DataFrame = {
-    val dfs = fileIndices.map { index => Dataset.ofRows(spark, deltaLog.indexToRelation(index)) }
-    dfs.reduceOption(_.union(_)).getOrElse(emptyDF)
+    fileIndices.map(deltaLog.loadIndex(_))
+      .reduceOption(_.union(_)).getOrElse(emptyDF)
       .withColumn(ACTION_SORT_COL_NAME, input_file_name())
       .withColumn(ADD_STATS_TO_USE_COL_NAME, col("add.stats"))
   }
@@ -431,11 +516,10 @@ class InitialSnapshot(
     path = logPath,
     version = -1,
     logSegment = LogSegment.empty(logPath),
-    minFileRetentionTimestamp = -1,
     deltaLog = deltaLog,
     timestamp = -1,
-    checksumOpt = None,
-    minSetTransactionRetentionTimestamp = None) {
+    checksumOpt = None
+  ) {
 
   def this(logPath: Path, deltaLog: DeltaLog) = this(
     logPath,
@@ -449,6 +533,7 @@ class InitialSnapshot(
   override def stateDS: Dataset[SingleAction] = emptyDF.as[SingleAction]
   override def stateDF: DataFrame = emptyDF
   override protected lazy val computedState: Snapshot.State = initialState
+  override def protocol: Protocol = computedState.protocol
   private def initialState: Snapshot.State = {
     val protocol = Protocol.forNewTable(spark, metadata)
     Snapshot.State(

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
@@ -111,12 +111,13 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
       require(snapshot.version >= 0, "No state defined for this table. Is this really " +
         "a Delta table? Refusing to garbage collect.")
 
+      val snapshotTombstoneRetentionMillis = DeltaLog.tombstoneRetentionMillis(snapshot.metadata)
       val retentionMillis = retentionHours.map(h => TimeUnit.HOURS.toMillis(math.round(h)))
-      checkRetentionPeriodSafety(spark, retentionMillis, deltaLog.tombstoneRetentionMillis)
+      checkRetentionPeriodSafety(spark, retentionMillis, snapshotTombstoneRetentionMillis)
 
       val deleteBeforeTimestamp = retentionMillis.map { millis =>
         clock.getTimeMillis() - millis
-      }.getOrElse(deltaLog.minFileRetentionTimestamp)
+      }.getOrElse(snapshot.minFileRetentionTimestamp)
       logInfo(s"Starting garbage collection (dryRun = $dryRun) of untracked files older than " +
         s"${new Date(deleteBeforeTimestamp).toGMTString} in $path")
       val hadoopConf = spark.sparkContext.broadcast(
@@ -232,7 +233,7 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
           val stats = DeltaVacuumStats(
             isDryRun = true,
             specifiedRetentionMillis = retentionMillis,
-            defaultRetentionMillis = deltaLog.tombstoneRetentionMillis,
+            defaultRetentionMillis = snapshotTombstoneRetentionMillis,
             minRetainedTimestamp = deleteBeforeTimestamp,
             dirsPresentBeforeDelete = dirCounts,
             objectsDeleted = numFiles,
@@ -253,7 +254,7 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
           diffFiles,
           sizeOfDataToDelete,
           retentionMillis,
-          deltaLog.tombstoneRetentionMillis)
+          snapshotTombstoneRetentionMillis)
 
         val deleteStartTime = System.currentTimeMillis()
         val filesDeleted = try {
@@ -268,7 +269,7 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
         val stats = DeltaVacuumStats(
           isDryRun = false,
           specifiedRetentionMillis = retentionMillis,
-          defaultRetentionMillis = deltaLog.tombstoneRetentionMillis,
+          defaultRetentionMillis = snapshotTombstoneRetentionMillis,
           minRetainedTimestamp = deleteBeforeTimestamp,
           dirsPresentBeforeDelete = dirCounts,
           objectsDeleted = filesDeleted,

--- a/core/src/main/scala/org/apache/spark/sql/delta/util/DeltaEncoders.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/util/DeltaEncoders.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta.util
 import scala.reflect.runtime.universe.TypeTag
 
 import org.apache.spark.sql.delta.{DeltaHistory, DeltaHistoryManager, SerializableFileStatus, Snapshot}
-import org.apache.spark.sql.delta.actions.{AddFile, RemoveFile, SingleAction}
+import org.apache.spark.sql.delta.actions.{AddFile, Metadata, Protocol, RemoveFile, SingleAction}
 import org.apache.spark.sql.delta.commands.ConvertTargetFile
 import org.apache.spark.sql.delta.sources.IndexedFile
 
@@ -69,6 +69,9 @@ private[delta] trait DeltaEncoders {
 
   private lazy val _removeFileEncoder = new DeltaEncoder[RemoveFile]
   implicit def removeFileEncoder: Encoder[RemoveFile] = _removeFileEncoder.get
+
+  private lazy val _pmfEncoder = new DeltaEncoder[(Protocol, Metadata, String)]
+  implicit def pmfEncoder: Encoder[(Protocol, Metadata, String)] = _pmfEncoder.get
 
   private lazy val _serializableFileStatusEncoder = new DeltaEncoder[SerializableFileStatus]
   implicit def serializableFileStatusEncoder: Encoder[SerializableFileStatus] =

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaConfigSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaConfigSuite.scala
@@ -83,8 +83,8 @@ class DeltaConfigSuite extends SparkFunSuite
     withTempDir { dir =>
       sql(s"CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta")
 
-      val retentionTimestampOpt =
-        DeltaLog.forTable(spark, dir.getCanonicalPath, clock).minSetTransactionRetentionTimestamp
+      val retentionTimestampOpt = DeltaLog.forTable(spark, dir.getCanonicalPath, clock)
+        .snapshot.minSetTransactionRetentionTimestamp
 
       assert(retentionTimestampOpt.isEmpty)
     }
@@ -99,7 +99,7 @@ class DeltaConfigSuite extends SparkFunSuite
       DeltaLog.clearCache() // we want to ensure we can use the ManualClock we pass in
 
       val log = DeltaLog.forTable(spark, dir.getCanonicalPath, clock)
-      val retentionTimestampOpt = log.minSetTransactionRetentionTimestamp
+      val retentionTimestampOpt = log.snapshot.minSetTransactionRetentionTimestamp
       assert(log.clock.getTimeMillis() == clock.getTimeMillis())
       val expectedRetentionTimestamp =
         clock.getTimeMillis() - getMilliSeconds(parseCalendarInterval("interval 1 days"))


### PR DESCRIPTION
Today, Delta log replay filters out expired `RemoveFile` tombstones and `SetTransaction` actions – but those retention periods are controlled by table properties and so log replay is required in order to properly access them.

Delta has no code to break that cycle, and so on cold start it will access an empty/defaulted metadata and thus ends up using default values for both retention periods – even if the user set the table property to something longer.

The solution is to craft a "miniature" version of log replay that only fetches protocol and metadata. The mini-replay can then run first, ensuring that the retention period table properties are reliably available during state reconstruction. This will add a small amount of latency to snapshot creation, but enforces correct behavior.

(cherry picked from commit 9fc7da818b0c5aa97756b8db2d4bdf2a5e6e147c)
