### PR TITLE
[Backport][2.0.x] Reliably obtain retention timestamps from Metadata

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -124,38 +124,9 @@ class DeltaLog private(
   def maxSnapshotLineageLength: Int =
     spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_MAX_SNAPSHOT_LINEAGE_LENGTH)
 
-  /** How long to keep around logically deleted files before physically deleting them. */
-  private[delta] def tombstoneRetentionMillis: Long =
-    DeltaConfigs.getMilliSeconds(DeltaConfigs.TOMBSTONE_RETENTION.fromMetaData(metadata))
-
   // TODO: There is a race here where files could get dropped when increasing the
   // retention interval...
   protected def metadata = if (snapshot == null) Metadata() else snapshot.metadata
-
-  /**
-   * Tombstones before this timestamp will be dropped from the state and the files can be
-   * garbage collected.
-   */
-  def minFileRetentionTimestamp: Long = {
-    // TODO (Fred): Get rid of this FrameProfiler record once SC-94033 is addressed
-    recordFrameProfile("Delta", "DeltaLog.minFileRetentionTimestamp") {
-      clock.getTimeMillis() - tombstoneRetentionMillis
-    }
-  }
-
-  /**
-   * [[SetTransaction]]s before this timestamp will be considered expired and dropped from the
-   * state, but no files will be deleted.
-   */
-  def minSetTransactionRetentionTimestamp: Option[Long] = {
-    val intervalOpt = DeltaConfigs.TRANSACTION_ID_RETENTION_DURATION.fromMetaData(metadata)
-
-    if (intervalOpt.isDefined) {
-      Some(clock.getTimeMillis() - DeltaConfigs.getMilliSeconds(intervalOpt.get))
-    } else {
-      None
-    }
-  }
 
   /**
    * Checks whether this table only accepts appends. If so it will throw an error in operations that
@@ -221,6 +192,16 @@ class DeltaLog private(
     val fsRelation = HadoopFsRelation(
       index, index.partitionSchema, schema, None, index.format, allOptions)(spark)
     LogicalRelation(fsRelation)
+  }
+
+  /**
+   * Load the data using the FileIndex. This allows us to skip many checks that add overhead, e.g.
+   * file existence checks, partitioning schema inference.
+   */
+  def loadIndex(
+      index: DeltaLogFileIndex,
+      schema: StructType = Action.logSchema): DataFrame = {
+    Dataset.ofRows(spark, indexToRelation(index, schema))
   }
 
   /* ------------------ *
@@ -753,5 +734,16 @@ object DeltaLog extends DeltaLogging {
             UnresolvedAttribute(partitionColumnPrefixes ++ Seq("partitionValues", a.name))
         }
     })
+  }
+
+  /** How long to keep around SetTransaction actions before physically deleting them. */
+  def minSetTransactionRetentionInterval(metadata: Metadata): Option[Long] = {
+    DeltaConfigs.TRANSACTION_ID_RETENTION_DURATION
+      .fromMetaData(metadata)
+      .map(DeltaConfigs.getMilliSeconds)
+  }
+  /** How long to keep around logically deleted files before physically deleting them. */
+  def tombstoneRetentionMillis(metadata: Metadata): Long = {
+    DeltaConfigs.getMilliSeconds(DeltaConfigs.TOMBSTONE_RETENTION.fromMetaData(metadata))
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -35,6 +35,7 @@ import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
 
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import org.apache.spark.sql.Encoder
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions._
@@ -60,11 +61,9 @@ class Snapshot(
     val path: Path,
     val version: Long,
     val logSegment: LogSegment,
-    val minFileRetentionTimestamp: Long,
     val deltaLog: DeltaLog,
     val timestamp: Long,
     val checksumOpt: Option[VersionChecksum],
-    val minSetTransactionRetentionTimestamp: Option[Long] = None,
     checkpointMetadataOpt: Option[CheckpointMetaData] = None)
   extends StateCache
   with StatisticsCollection
@@ -159,6 +158,32 @@ class Snapshot(
     }
   }
 
+  private lazy val _pmfEncoder: ExpressionEncoder[(Protocol, Metadata, String)] =
+    ExpressionEncoder[(Protocol, Metadata, String)]()
+
+  implicit private def pmfEncoder: Encoder[(Protocol, Metadata, String)] = {
+    _pmfEncoder.copy()
+  }
+
+  /**
+   * Pulls the protocol and metadata of the table from the files that are used to compute the
+   * Snapshot directly--without triggering a full state reconstruction. This is important, because
+   * state reconstruction depends on protocol and metadata for correctness.
+   */
+  protected def protocolAndMetadataReconstruction(): Array[(Protocol, Metadata)] = {
+
+    val schemaToUse = Action.logSchema(Set("protocol", "metaData"))
+    fileIndices.map(deltaLog.loadIndex(_, schemaToUse))
+      .reduceOption(_.union(_)).getOrElse(emptyDF)
+      .withColumn(ACTION_SORT_COL_NAME, input_file_name())
+      .select("protocol", "metaData", ACTION_SORT_COL_NAME)
+      .where("protocol.minReaderVersion is not null or metaData.id is not null")
+      .as[(Protocol, Metadata, String)]
+      .collect()
+      .sortBy(_._3)
+      .map { case (p, m, _) => p -> m }
+  }
+
   def redactedPath: String =
     Utils.redact(spark.sessionState.conf.stringRedactionPattern, path.toUri.toString)
 
@@ -230,7 +255,17 @@ class Snapshot(
             if (stateReconstructionCheck) {
               throw DeltaErrors.actionNotFoundException("protocol", version)
             }
+          } else if (_computedState.protocol != protocol) {
+            recordDeltaEvent(
+              deltaLog,
+              opType = "delta.assertions.mismatchedAction",
+              data = Map(
+                "version" -> version.toString, "action" -> "Protocol", "source" -> "Snapshot",
+                "computedState.protocol" -> _computedState.protocol,
+                "extracted.protocol" -> protocol))
+            throw DeltaErrors.actionNotFoundException("protocol", version)
           }
+
           if (_computedState.metadata == null) {
             recordDeltaEvent(
               deltaLog,
@@ -242,16 +277,56 @@ class Snapshot(
             }
             logMissingActionWarning("metadata")
             _computedState.copy(metadata = Metadata())
-          } else {
-            _computedState
+          } else if (_computedState.metadata != metadata) {
+            recordDeltaEvent(
+              deltaLog,
+              opType = "delta.assertions.mismatchedAction",
+              data = Map(
+                "version" -> version.toString, "action" -> "Metadata", "source" -> "Snapshot",
+                "computedState.metadata" -> _computedState.metadata,
+                "extracted.metadata" -> metadata))
+            throw DeltaErrors.actionNotFoundException("metadata", version)
           }
+          _computedState
         }
       }
     }
   }
 
-  def protocol: Protocol = computedState.protocol
-  def metadata: Metadata = computedState.metadata
+  // Used by [[protocol]] and [[metadata]] below
+  private lazy val (_protocol, _metadata): (Protocol, Metadata) = {
+    // Should be small. At most 'checkpointInterval' rows, unless new commits are coming
+    // in before a checkpoint can be written
+    var protocol: Protocol = null
+    var metadata: Metadata = null
+    protocolAndMetadataReconstruction().foreach {
+      case (p: Protocol, _) => protocol = p
+      case (_, m: Metadata) => metadata = m
+    }
+
+    if (protocol == null) {
+      recordDeltaEvent(
+        deltaLog,
+        opType = "delta.assertions.missingAction",
+        data = Map(
+          "version" -> version.toString, "action" -> "Protocol", "source" -> "Snapshot"))
+      throw DeltaErrors.actionNotFoundException("protocol", version)
+    }
+
+    if (metadata == null) {
+      recordDeltaEvent(
+        deltaLog,
+        opType = "delta.assertions.missingAction",
+        data = Map(
+          "version" -> version.toString, "action" -> "Metadata", "source" -> "Snapshot"))
+      throw DeltaErrors.actionNotFoundException("metadata", version)
+    }
+
+    protocol -> metadata
+  }
+
+  def metadata: Metadata = _metadata
+  def protocol: Protocol = _protocol
   def setTransactions: Seq[SetTransaction] = computedState.setTransactions
   def sizeInBytes: Long = computedState.sizeInBytes
   def numOfFiles: Long = computedState.numOfFiles
@@ -260,6 +335,22 @@ class Snapshot(
   def numOfProtocol: Long = computedState.numOfProtocol
   def numOfRemoves: Long = computedState.numOfRemoves
   def numOfSetTransactions: Long = computedState.numOfSetTransactions
+
+  /**
+   * Tombstones before the [[minFileRetentionTimestamp]] timestamp will be dropped from the
+   * checkpoint.
+   */
+  private[delta] def minFileRetentionTimestamp: Long = {
+    deltaLog.clock.getTimeMillis() - DeltaLog.tombstoneRetentionMillis(metadata)
+  }
+
+  /**
+   * [[SetTransaction]]s before [[minSetTransactionRetentionTimestamp]] will be considered expired
+   * and dropped from the snapshot.
+   */
+  private[delta] def minSetTransactionRetentionTimestamp: Option[Long] = {
+    DeltaLog.minSetTransactionRetentionInterval(metadata).map(deltaLog.clock.getTimeMillis() - _)
+  }
 
   /**
    * Computes all the information that is needed by the checksum for the current snapshot.
@@ -349,8 +440,8 @@ class Snapshot(
    * config settings for delta.checkpoint.writeStatsAsJson and delta.checkpoint.writeStatsAsStruct).
    */
   protected def loadActions: DataFrame = {
-    val dfs = fileIndices.map { index => Dataset.ofRows(spark, deltaLog.indexToRelation(index)) }
-    dfs.reduceOption(_.union(_)).getOrElse(emptyDF)
+    fileIndices.map(deltaLog.loadIndex(_))
+      .reduceOption(_.union(_)).getOrElse(emptyDF)
       .withColumn(ACTION_SORT_COL_NAME, input_file_name())
       .withColumn(ADD_STATS_TO_USE_COL_NAME, col("add.stats"))
   }
@@ -476,11 +567,10 @@ class InitialSnapshot(
     path = logPath,
     version = -1,
     logSegment = LogSegment.empty(logPath),
-    minFileRetentionTimestamp = -1,
     deltaLog = deltaLog,
     timestamp = -1,
-    checksumOpt = None,
-    minSetTransactionRetentionTimestamp = None) {
+    checksumOpt = None
+  ) {
 
   def this(logPath: Path, deltaLog: DeltaLog) = this(
     logPath,
@@ -494,6 +584,7 @@ class InitialSnapshot(
   override def stateDS: Dataset[SingleAction] = emptyDF.as[SingleAction]
   override def stateDF: DataFrame = emptyDF
   override protected lazy val computedState: Snapshot.State = initialState
+  override def protocol: Protocol = computedState.protocol
   private def initialState: Snapshot.State = {
     val protocol = Protocol.forNewTable(spark, metadata)
     Snapshot.State(protocol, metadata, Nil, 0L, 0L, 1L, 1L, 0L, 0L, None)

--- a/core/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -255,6 +255,7 @@ class Snapshot(
             if (stateReconstructionCheck) {
               throw DeltaErrors.actionNotFoundException("protocol", version)
             }
+            logMissingActionWarning("protocol")
           } else if (_computedState.protocol != protocol) {
             recordDeltaEvent(
               deltaLog,
@@ -263,7 +264,10 @@ class Snapshot(
                 "version" -> version.toString, "action" -> "Protocol", "source" -> "Snapshot",
                 "computedState.protocol" -> _computedState.protocol,
                 "extracted.protocol" -> protocol))
-            throw DeltaErrors.actionNotFoundException("protocol", version)
+            if (stateReconstructionCheck) {
+              throw DeltaErrors.actionNotFoundException("protocol", version)
+            }
+            logMissingActionWarning("protocol")
           }
 
           if (_computedState.metadata == null) {
@@ -285,7 +289,11 @@ class Snapshot(
                 "version" -> version.toString, "action" -> "Metadata", "source" -> "Snapshot",
                 "computedState.metadata" -> _computedState.metadata,
                 "extracted.metadata" -> metadata))
-            throw DeltaErrors.actionNotFoundException("metadata", version)
+            if (stateReconstructionCheck) {
+              throw DeltaErrors.actionNotFoundException("metadata", version)
+            }
+            logMissingActionWarning("metadata")
+            _computedState.copy(metadata = Metadata())
           }
           _computedState
         }
@@ -303,6 +311,8 @@ class Snapshot(
       case (p: Protocol, _) => protocol = p
       case (_, m: Metadata) => metadata = m
     }
+    val stateReconstructionCheck = spark.sessionState.conf.getConf(
+      DeltaSQLConf.DELTA_STATE_RECONSTRUCTION_VALIDATION_ENABLED)
 
     if (protocol == null) {
       recordDeltaEvent(
@@ -310,8 +320,10 @@ class Snapshot(
         opType = "delta.assertions.missingAction",
         data = Map(
           "version" -> version.toString, "action" -> "Protocol", "source" -> "Snapshot"))
-      throw DeltaErrors.actionNotFoundException("protocol", version)
-    }
+      if (stateReconstructionCheck) {
+        throw DeltaErrors.actionNotFoundException("protocol", version)
+      }
+      logMissingActionWarning("protocol")    }
 
     if (metadata == null) {
       recordDeltaEvent(
@@ -319,7 +331,11 @@ class Snapshot(
         opType = "delta.assertions.missingAction",
         data = Map(
           "version" -> version.toString, "action" -> "Metadata", "source" -> "Snapshot"))
-      throw DeltaErrors.actionNotFoundException("metadata", version)
+      if (stateReconstructionCheck) {
+        throw DeltaErrors.actionNotFoundException("metadata", version)
+      }
+      logMissingActionWarning("metadata")
+      metadata = Metadata()
     }
 
     protocol -> metadata

--- a/core/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -265,7 +265,6 @@ trait SnapshotManagement { self: DeltaLog =>
         logInfo(s"Loading version ${segment.version}$startCheckpoint")
         val snapshot = createSnapshot(
           initSegment = segment,
-          minFileRetentionTimestamp = minFileRetentionTimestamp,
           checkpointMetadataOptHint = lastCheckpointOpt)
 
         logInfo(s"Returning initial snapshot $snapshot")
@@ -282,7 +281,6 @@ trait SnapshotManagement { self: DeltaLog =>
 
   protected def createSnapshot(
       initSegment: LogSegment,
-      minFileRetentionTimestamp: Long,
       checkpointMetadataOptHint: Option[CheckpointMetaData]): Snapshot = {
     val checksumOpt = readChecksum(initSegment.version)
     createSnapshotFromGivenOrEquivalentLogSegment(initSegment) { segment =>
@@ -290,11 +288,9 @@ trait SnapshotManagement { self: DeltaLog =>
         path = logPath,
         version = segment.version,
         logSegment = segment,
-        minFileRetentionTimestamp = minFileRetentionTimestamp,
         deltaLog = this,
         timestamp = segment.lastCommitTimestamp,
         checksumOpt = checksumOpt,
-        minSetTransactionRetentionTimestamp = minSetTransactionRetentionTimestamp,
         checkpointMetadataOpt = getCheckpointMetadataForSegment(segment, checkpointMetadataOptHint))
     }
   }
@@ -566,7 +562,6 @@ trait SnapshotManagement { self: DeltaLog =>
 
         val newSnapshot = createSnapshot(
           initSegment = segment,
-          minFileRetentionTimestamp = minFileRetentionTimestamp,
           checkpointMetadataOptHint = snapshot.getCheckpointMetadataOpt)
 
         if (previousSnapshot.version > -1 &&
@@ -616,7 +611,6 @@ trait SnapshotManagement { self: DeltaLog =>
     getLogSegmentForVersion(startingCheckpoint.map(_.version), Some(version)).map { segment =>
       createSnapshot(
         initSegment = segment,
-        minFileRetentionTimestamp = minFileRetentionTimestamp,
         checkpointMetadataOptHint = None)
     }.getOrElse {
       // We can't return InitialSnapshot because our caller asked for a specific snapshot version.

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
@@ -117,12 +117,13 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
       require(snapshot.version >= 0, "No state defined for this table. Is this really " +
         "a Delta table? Refusing to garbage collect.")
 
+      val snapshotTombstoneRetentionMillis = DeltaLog.tombstoneRetentionMillis(snapshot.metadata)
       val retentionMillis = retentionHours.map(h => TimeUnit.HOURS.toMillis(math.round(h)))
-      checkRetentionPeriodSafety(spark, retentionMillis, deltaLog.tombstoneRetentionMillis)
+      checkRetentionPeriodSafety(spark, retentionMillis, snapshotTombstoneRetentionMillis)
 
       val deleteBeforeTimestamp = retentionMillis.map { millis =>
         clock.getTimeMillis() - millis
-      }.getOrElse(deltaLog.minFileRetentionTimestamp)
+      }.getOrElse(snapshot.minFileRetentionTimestamp)
       logInfo(s"Starting garbage collection (dryRun = $dryRun) of untracked files older than " +
         s"${new Date(deleteBeforeTimestamp).toGMTString} in $path")
       val hadoopConf = spark.sparkContext.broadcast(
@@ -247,7 +248,7 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
           val stats = DeltaVacuumStats(
             isDryRun = true,
             specifiedRetentionMillis = retentionMillis,
-            defaultRetentionMillis = deltaLog.tombstoneRetentionMillis,
+            defaultRetentionMillis = snapshotTombstoneRetentionMillis,
             minRetainedTimestamp = deleteBeforeTimestamp,
             dirsPresentBeforeDelete = dirCounts,
             objectsDeleted = numFiles,
@@ -266,7 +267,7 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
           diffFiles,
           sizeOfDataToDelete,
           retentionMillis,
-          deltaLog.tombstoneRetentionMillis)
+          snapshotTombstoneRetentionMillis)
 
         val filesDeleted = try {
           delete(diffFiles, spark, basePath, hadoopConf, parallelDeleteEnabled,
@@ -278,7 +279,7 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
         val stats = DeltaVacuumStats(
           isDryRun = false,
           specifiedRetentionMillis = retentionMillis,
-          defaultRetentionMillis = deltaLog.tombstoneRetentionMillis,
+          defaultRetentionMillis = snapshotTombstoneRetentionMillis,
           minRetainedTimestamp = deleteBeforeTimestamp,
           dirsPresentBeforeDelete = dirCounts,
           objectsDeleted = filesDeleted,

--- a/core/src/main/scala/org/apache/spark/sql/delta/files/TahoeFileIndex.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/files/TahoeFileIndex.scala
@@ -200,7 +200,7 @@ case class TahoeLogFileIndex(
   }
 
   override def refresh(): Unit = {}
-  override val sizeInBytes: Long = deltaLog.snapshot.sizeInBytes
+  override def sizeInBytes: Long = deltaLog.snapshot.sizeInBytes
 
   override def equals(that: Any): Boolean = that match {
     case t: TahoeLogFileIndex =>

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaConfigSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaConfigSuite.scala
@@ -82,8 +82,8 @@ class DeltaConfigSuite extends SparkFunSuite
     withTempDir { dir =>
       sql(s"CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta")
 
-      val retentionTimestampOpt =
-        DeltaLog.forTable(spark, dir.getCanonicalPath, clock).minSetTransactionRetentionTimestamp
+      val retentionTimestampOpt = DeltaLog.forTable(spark, dir.getCanonicalPath, clock)
+        .snapshot.minSetTransactionRetentionTimestamp
 
       assert(retentionTimestampOpt.isEmpty)
     }
@@ -98,7 +98,7 @@ class DeltaConfigSuite extends SparkFunSuite
       DeltaLog.clearCache() // we want to ensure we can use the ManualClock we pass in
 
       val log = DeltaLog.forTable(spark, dir.getCanonicalPath, clock)
-      val retentionTimestampOpt = log.minSetTransactionRetentionTimestamp
+      val retentionTimestampOpt = log.snapshot.minSetTransactionRetentionTimestamp
       assert(log.clock.getTimeMillis() == clock.getTimeMillis())
       val expectedRetentionTimestamp =
         clock.getTimeMillis() - getMilliSeconds(parseCalendarInterval("interval 1 days"))

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
@@ -150,6 +150,82 @@ class DeltaRetentionSuite extends QueryTest
     }
   }
 
+  def removeFileCountFromUnderlyingCheckpoint(snapshot: Snapshot): Long = {
+    assert(snapshot.logSegment.checkpoint.size === 1)
+    val checkpointFilePath = snapshot.logSegment.checkpoint.head.getPath.toString
+    spark.read.parquet(checkpointFilePath).where("remove is not null").count()
+  }
+
+  testQuietly("retention timestamp is picked properly by the cold snapshot initialization") {
+    withTempDir { dir =>
+      val clock = new ManualClock(System.currentTimeMillis())
+      def deltaLog: DeltaLog = DeltaLog.forTable(spark, new Path(dir.getCanonicalPath), clock)
+
+      // Create table with 30 day tombstone retention.
+      sql(
+        s"""CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta
+           |TBLPROPERTIES ('delta.deletedFileRetentionDuration' = 'interval 30 days')
+       """.stripMargin)
+
+
+      // 1st day - commit 10 new files and remove them also same day.
+      clock.advance(intervalStringToMillis("interval 1 days"))
+      val files1 = (1 to 4).map(f => AddFile(f.toString, Map.empty, 1, 1, true))
+      deltaLog.startTransaction().commit(files1, testOp)
+      val files2 = (1 to 4).map(f => RemoveFile(f.toString, Some(clock.getTimeMillis())))
+      deltaLog.startTransaction().commit(files2, testOp)
+
+      // Advance clock by 10 days.
+      clock.advance(intervalStringToMillis("interval 10 days"))
+      DeltaLog.clearCache()
+      deltaLog.checkpoint()
+      DeltaLog.clearCache() // Clear cache and reinitialize snapshot with latest checkpoint.
+      assert(removeFileCountFromUnderlyingCheckpoint(deltaLog.snapshot) === 4)
+
+      // Advance clock by 21 more days. Now checkpoint should stop tracking remove tombstones.
+      clock.advance(intervalStringToMillis("interval 21 days"))
+      deltaLog.startTransaction().commit(Seq.empty, testOp)
+      DeltaLog.clearCache()
+      deltaLog.checkpoint(deltaLog.snapshot)
+      DeltaLog.clearCache() // Clear cache and reinitialize snapshot with latest checkpoint.
+      assert(removeFileCountFromUnderlyingCheckpoint(deltaLog.snapshot) === 0)
+    }
+  }
+
+
+  testQuietly("retention timestamp is lesser than the default value") {
+    withTempDir { dir =>
+      val clock = new ManualClock(System.currentTimeMillis())
+      def deltaLog: DeltaLog = DeltaLog.forTable(spark, new Path(dir.getCanonicalPath), clock)
+
+      // Create table with 2 day tombstone retention.
+      sql(
+        s"""CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta
+           |TBLPROPERTIES ('delta.deletedFileRetentionDuration' = 'interval 2 days')
+       """.stripMargin)
+
+
+      // 1st day - commit 10 new files and remove them also same day.
+      {
+        clock.advance(intervalStringToMillis("interval 1 days"))
+        val txn = deltaLog.startTransaction()
+        val files1 = (1 to 4).map(f => AddFile(f.toString, Map.empty, 1, 1, true))
+        txn.commit(files1, testOp)
+        val txn2 = deltaLog.startTransaction()
+        val files2 = (1 to 4).map(f => RemoveFile(f.toString, Some(clock.getTimeMillis())))
+        txn2.commit(files2, testOp)
+      }
+
+
+      // Advance clock by 4 days.
+      clock.advance(intervalStringToMillis("interval 4 days"))
+      DeltaLog.clearCache()
+      deltaLog.checkpoint(deltaLog.snapshot)
+      DeltaLog.clearCache() // Clear cache and reinitialize snapshot with latest checkpoint.
+      assert(removeFileCountFromUnderlyingCheckpoint(deltaLog.snapshot) === 0)
+    }
+  }
+
   testQuietly("RemoveFiles get deleted during checkpoint if retention time has passed") {
     withTempDir { tempDir =>
       val clock = new ManualClock(System.currentTimeMillis())

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
@@ -831,7 +831,7 @@ trait DeltaVacuumSuiteBase extends QueryTest
                 (retentionHours * 60 * 60 * 1000).toString)
             assert(
               operationParamsBegin("defaultRetentionMillis") ===
-                deltaLog.tombstoneRetentionMillis.toString)
+                DeltaLog.tombstoneRetentionMillis(deltaLog.snapshot.metadata).toString)
 
             assert(operationParamsEnd === Map("status" -> "COMPLETED"))
             assert(operationMetricsEnd === Map("numDeletedFiles" -> filesDeleted.toString,


### PR DESCRIPTION
Today, Delta log replay filters out expired `RemoveFile` tombstones and `SetTransaction` actions – but those retention periods are controlled by table properties and so log replay is required in order to properly access them.

Delta has no code to break that cycle, and so on cold start it will access an empty/defaulted metadata and thus ends up using default values for both retention periods – even if the user set the table property to something longer.

The solution is to craft a "miniature" version of log replay that only fetches protocol and metadata. The mini-replay can then run first, ensuring that the retention period table properties are reliably available during state reconstruction. This will add a small amount of latency to snapshot creation, but enforces correct behavior.

(cherry picked from commit 9fc7da818b0c5aa97756b8db2d4bdf2a5e6e147c)