### PR TITLE
Allow `delta.feature.xxx` table property to bump protocol silently

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -468,21 +468,20 @@ trait OptimisticTransactionImpl extends TransactionalWrite
     //
     // This transaction's new metadata might contain some table properties to enable some
     // features (props start with [[FEATURE_PROP_PREFIX]]). We silently add them to the `protocol`
-    // action.
-    // Unlike auto-enabled features, the following logic will not auto upgrade protocol version
-    // silently to which the feature requests. In other words, here we will explicitly list the
-    // table features that are required to be added, and assume it's supported by the protocol.
-    // When this turns out to be not true, the `withFeatures` method will fail and ask users to
-    // upgrade their table.
+    // action, and if necessary, bump the protocol version to (3, 7).
     val newProtocolBeforeAddingFeatures = newProtocol.getOrElse(protocolBeforeUpdate)
     val newFeaturesFromTableConf =
       TableFeatureProtocolUtils.getEnabledFeaturesFromConfigs(
         latestMetadata.configuration,
         TableFeatureProtocolUtils.FEATURE_PROP_PREFIX)
-    val featuresFromTableConf = newFeaturesFromTableConf.map(_.name)
-    val existingFeatures = newProtocolBeforeAddingFeatures.readerAndWriterFeatureNames
-    if (!featuresFromTableConf.subsetOf(existingFeatures)) {
-      newProtocol = Some(newProtocolBeforeAddingFeatures.withFeatures(newFeaturesFromTableConf))
+    val existingFeatureNames = newProtocolBeforeAddingFeatures.readerAndWriterFeatureNames
+    if (!newFeaturesFromTableConf.map(_.name).subsetOf(existingFeatureNames)) {
+      newProtocol = Some(
+        Protocol(
+          TableFeatureProtocolUtils.TABLE_FEATURES_MIN_READER_VERSION,
+          TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION)
+          .merge(newProtocolBeforeAddingFeatures)
+          .withFeatures(newFeaturesFromTableConf))
     }
 
     // We are done with protocol versions and features, time to remove related table properties.

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -221,19 +221,25 @@ object Protocol {
       getEnabledFeaturesFromConfigs(tableConf, FEATURE_PROP_PREFIX)
     val sessionEnabledFeatures =
       getEnabledFeaturesFromConfigs(sessionConf.getAllConfs, DEFAULT_FEATURE_PROP_PREFIX)
-    val featuresFromMetadata =
+    val tablePropOrSessionEnabledFeatures = tablePropEnabledFeatures ++ sessionEnabledFeatures
+    val metadataEnabledFeatures =
       metadataOpt.map(extractAutomaticallyEnabledFeatures(spark, _)).getOrElse(Set[TableFeature]())
-    val allEnabledFeatures =
-      tablePropEnabledFeatures ++ sessionEnabledFeatures ++ featuresFromMetadata
+    val allEnabledFeatures = tablePropOrSessionEnabledFeatures ++ metadataEnabledFeatures
 
     // Determine the min reader and writer version required by features in table properties,
-    // session defaults or metadata. If all features are legacy, we start from (0, 0). If any
-    // feature is native and reader-writer, we start from (3, 7). Otherwise we start from (0, 7)
+    // session defaults or metadata. If any table property or session default is specified, we
+    // start from (3, 7) or (0, 7) depending on the existence of any writer-only feature.
+    // If there's no table property or session default, we look at metadata-enabled features:
+    // if no feature is enabled or all features are legacy, we start from (0, 0). If any feature
+    // is native and is reader-writer, we start from (3, 7). Otherwise we start from (0, 7)
     // because there must exist a native writer-only feature.
-    val initialProtocol = if (allEnabledFeatures.forall(_.isLegacyFeature)) {
+    val initialProtocol = if (tablePropOrSessionEnabledFeatures.exists(_.isReaderWriterFeature)) {
+        Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION)
+    } else if (tablePropOrSessionEnabledFeatures.nonEmpty) {
+      Protocol(0, TABLE_FEATURES_MIN_WRITER_VERSION)
+    } else if (metadataEnabledFeatures.forall(_.isLegacyFeature)) { // also true for empty set
       Protocol(0, 0)
-    } else if (allEnabledFeatures.exists(f =>
-        !f.isLegacyFeature && f.isReaderWriterFeature)) {
+    } else if (metadataEnabledFeatures.exists(f => !f.isLegacyFeature && f.isReaderWriterFeature)) {
       Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION)
     } else {
       Protocol(0, TABLE_FEATURES_MIN_WRITER_VERSION)


### PR DESCRIPTION
## Description

This PR allows the table property `delta.feature.featureName = 'enabled'` to silently bump protocol version to support table features. Therefore, no manual version bump is required.

Note that even if the feature being enabled is a legacy feature, the final table will still have `Protocol(3, 7)` becuase the `delta.feature.` prefix is exclusively used by table features, and once used, we assume that the user is explicitly asking to bump the table to support table features.


Before:
```sql
-- assume tbl is on Protocol(1, 1)

ALTER TABLE tbl SET TBLPROPERTIES (
  delta.feature.columnMapping = 'enabled'
)
-- Exception: "table features are required but not supported"

ALTER TABLE tbl SET TBLPROPERTIES (
  delta.minReaderVersion = '3',
  delta.minReaderVersion = '7',
  delta.feature.columnMapping = 'enabled'
)
-- tbl will have Protocol(3, 7, [columnMapping], [columnMapping])
```

After:
```sql
-- assume tbl is on Protocol(1, 1)

ALTER TABLE tbl SET TBLPROPERTIES (
  delta.feature.columnMapping = 'enabled'
)
-- tbl will have Protocol(3, 7, [columnMapping], [columnMapping])

ALTER TABLE tbl SET TBLPROPERTIES (
  delta.feature.deletionVectors = 'enabled'
)
-- tbl will have Protocol(3, 7, [deletionVectors], [deletionVectors])

ALTER TABLE tbl SET TBLPROPERTIES (
  delta.minReaderVersion = '3',
  delta.minReaderVersion = '7',
  delta.feature.columnMapping = 'enabled'
)
-- tbl will have Protocol(3, 7, [columnMapping], [columnMapping])
```

## How was this patch tested?

Modified existing tests.

## Does this PR introduce _any_ user-facing changes?

Yes. Before this change, `SET delta.feature.featureName = 'enabled'` will throw an error when being executed on a Delta table of a legacy protocol. After this change, no error will be thrown, and the table will be upgraded to support table features plus have `featureName` enabled in the protocol.