### PR TITLE
Support CDF table value function in SQL queries

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -921,6 +921,12 @@
     ],
     "sqlState" : "XXKDS"
   },
+  "DELTA_INVALID_TABLE_VALUE_FUNCTION" : {
+    "message" : [
+      "Function <function> is an unsupported table valued function for CDC reads."
+    ],
+    "sqlState" : "22000"
+  },
   "DELTA_INVALID_TIMESTAMP_FORMAT" : {
     "message" : [
       "The provided timestamp <timestamp> does not match the expected syntax <format>."
@@ -1846,6 +1852,12 @@
     ],
     "sqlState" : "0AKDC"
   },
+  "DELTA_UNSUPPORTED_EXPRESSION" : {
+    "message" : [
+      "Unsupported expression type(<expType>) for <causedBy>. The supported types are [<supportedTypes>]."
+    ],
+    "sqlState" : "0A000"
+  },
   "DELTA_UNSUPPORTED_EXPRESSION_GENERATED_COLUMN" : {
     "message" : [
       "<expression> cannot be used in a generated column"
@@ -2067,6 +2079,12 @@
       "<colName> is a partition column. Z-Ordering can only be performed on data columns"
     ],
     "sqlState" : "42P10"
+  },
+  "INCORRECT_NUMBER_OF_ARGUMENTS" : {
+    "message" : [
+      "<failure>, <functionName> requires at least <minArgs> arguments and at most <maxArgs> arguments."
+    ],
+    "sqlState" : "22023"
   },
   "RESERVED_CDC_COLUMNS_ON_WRITE" : {
     "message" : [

--- a/core/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
+++ b/core/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
@@ -113,5 +113,10 @@ class DeltaSparkSessionExtension extends (SparkSessionExtensions => Unit) {
     extensions.injectPreCBORule { session =>
       new PrepareDeltaScan(session)
     }
+
+    DeltaTableValueFunctions.supportedFnNames.foreach { fnName =>
+      extensions.injectTableFunction(
+        DeltaTableValueFunctions.getTableValueFunctionInjection(fnName))
+    }
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -114,6 +114,15 @@ class DeltaAnalysis(session: SparkSession)
         index.partitionFilters.reduce(And),
         DeltaTableUtils.replaceFileIndex(l, index.copy(partitionFilters = Nil)))
 
+    // SQL CDC table value functions "table_changes" and "table_changes_by_path"
+    case t: DeltaTableValueFunction if t.functionArgs.forall(_.resolved)
+    =>
+      DeltaTableValueFunctions.resolveChangesTableValueFunctions(
+        session,
+        t.fnName,
+        t.functionArgs
+      )
+
 
     // Here we take advantage of CreateDeltaTableCommand which takes a LogicalPlan for CTAS in order
     // to perform CLONE. We do this by passing the CloneTableCommand as the query in

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2634,6 +2634,16 @@ trait DeltaErrorsBase
   def generateNotSupportedWithDeletionVectors(): Throwable =
     new DeltaCommandUnsupportedWithDeletionVectorsException(
       errorClass = "DELTA_UNSUPPORTED_GENERATE_WITH_DELETION_VECTORS")
+
+  def unsupportedExpression(
+    causedBy: String,
+    expType: DataType,
+    supportedTypes: Seq[String]): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_UNSUPPORTED_EXPRESSION",
+      messageParameters = Array(s"$expType", causedBy, supportedTypes.mkString(","))
+    )
+  }
 }
 
 object DeltaErrors extends DeltaErrorsBase

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaTableValueFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaTableValueFunctions.scala
@@ -76,19 +76,19 @@ object DeltaTableValueFunctions {
       throw new DeltaAnalysisException(
         errorClass = "INCORRECT_NUMBER_OF_ARGUMENTS",
         messageParameters = Array(
-          "not enough args",
-          fnName,
-          "2",
-          "3"))
+          "not enough args", // failure
+          fnName, // functionName
+          "2", // minArgs
+          "3")) // maxArgs
     }
     if (args.size > 3) {
       throw new DeltaAnalysisException(
         errorClass = "INCORRECT_NUMBER_OF_ARGUMENTS",
         messageParameters = Array(
-          "too many args",
-          fnName,
-          "2",
-          "3"))
+          "too many args", // failure
+          fnName, // functionName
+          "2", // minArgs
+          "3")) // maxArgs
     }
 
     val tableNameExpr = args.head
@@ -188,5 +188,3 @@ case class CDCNameBased(override val functionArgs: Seq[Expression])
  */
 case class CDCPathBased(override val functionArgs: Seq[Expression])
   extends DeltaTableValueFunction(DeltaTableValueFunctions.CDC_PATH_BASED)
-
-

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaTableValueFunctions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaTableValueFunctions.scala
@@ -1,0 +1,192 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+// scalastyle:off import.ordering.noEmptyLine
+import java.text.SimpleDateFormat
+import java.util.{Date, Locale}
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.sources.DeltaDataSource
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
+import org.apache.spark.sql.catalyst.analysis.{FunctionRegistryBase, TableFunctionRegistry, UnresolvedTableValuedFunction}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression, ExpressionInfo, Literal}
+import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan}
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.types.{IntegerType, LongType, StringType, TimestampType}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+/**
+ * Resolve Delta specific table-value functions.
+ */
+object DeltaTableValueFunctions {
+
+  val CDC_NAME_BASED = "table_changes"
+
+  val CDC_PATH_BASED = "table_changes_by_path"
+
+  val supportedFnNames = Seq(CDC_NAME_BASED, CDC_PATH_BASED)
+
+  // For use with SparkSessionExtensions
+  type TableFunctionDescription =
+    (FunctionIdentifier, ExpressionInfo, TableFunctionRegistry.TableFunctionBuilder)
+
+  /**
+   * For a supported Delta table value function name, get the TableFunctionDescription to be
+   * injected in DeltaSparkSessionExtension
+   */
+  def getTableValueFunctionInjection(fnName: String): TableFunctionDescription = {
+    val (info, builder) = fnName match {
+      case CDC_NAME_BASED => FunctionRegistryBase.build[CDCNameBased](fnName, since = None)
+      case CDC_PATH_BASED => FunctionRegistryBase.build[CDCPathBased](fnName, since = None)
+      case _ => throw DeltaErrors.invalidTableValueFunction(fnName)
+    }
+    val ident = FunctionIdentifier(fnName)
+    (ident, info, builder)
+  }
+
+  /**
+   * Resolution for CDC read table valued functions. Currently we support two apis.
+   *      1. table_changes for CDC reads on metastore tables.
+   *      2. table_changes_by_path for CDC reads on path based tables.
+   */
+  private[delta] def resolveChangesTableValueFunctions(
+    session: SparkSession, fnName: String, args: Seq[Expression]): LogicalPlan = {
+
+    if (args.size < 2) {
+      throw new DeltaAnalysisException(
+        errorClass = "INCORRECT_NUMBER_OF_ARGUMENTS",
+        messageParameters = Array(
+          "not enough args",
+          fnName,
+          "2",
+          "3"))
+    }
+    if (args.size > 3) {
+      throw new DeltaAnalysisException(
+        errorClass = "INCORRECT_NUMBER_OF_ARGUMENTS",
+        messageParameters = Array(
+          "too many args",
+          fnName,
+          "2",
+          "3"))
+    }
+
+    val tableNameExpr = args.head
+
+    def toDeltaOption(keyPrefix: String, value: Expression): (String, String) = {
+      value.dataType match {
+        // We dont need to explicitly handle ShortType as it is parsed as IntegerType.
+        case _: IntegerType | LongType => (keyPrefix + "Version") -> value.eval().toString
+        case _: StringType => (keyPrefix + "Timestamp") -> value.eval().toString
+        case _: TimestampType => (keyPrefix + "Timestamp") -> {
+          val time = value.eval().toString
+          val fmt = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
+          // when evaluated the time is represented with microseconds, which needs to be trimmed.
+          fmt.format(new Date(time.toLong / 1000))
+        }
+        case _ =>
+          throw DeltaErrors.unsupportedExpression(s"${keyPrefix} option", value.dataType,
+            Seq("IntegerType", "LongType", "StringType", "TimestampType"))
+      }
+    }
+
+    val startingOption = toDeltaOption("starting", args(1))
+    val endingOption = args.drop(2).headOption.map(toDeltaOption("ending", _))
+    val options = Map(DeltaDataSource.CDC_ENABLED_KEY -> "true", startingOption) ++ endingOption
+
+    val table = if (fnName.toLowerCase(Locale.ROOT) == CDC_NAME_BASED) {
+      val tableId: TableIdentifier = tableNameExpr match {
+        case l: Literal if l.dataType == StringType =>
+          session.sessionState.sqlParser.parseTableIdentifier(tableNameExpr.eval().toString)
+        case _ =>
+          throw DeltaErrors.unsupportedExpression(
+            "table name", tableNameExpr.dataType, Seq("Literal of type StringType"))
+      }
+      val catalogTable = session.sessionState.catalog.getTableMetadata(tableId)
+      DeltaTableV2(
+        session,
+        path = new Path(catalogTable.location),
+        catalogTable = Some(catalogTable),
+        tableIdentifier = Some(tableId.unquotedString),
+        timeTravelOpt = None,
+        options = Map.empty,
+        cdcOptions = new CaseInsensitiveStringMap(options.asJava))
+    } else if (fnName.toLowerCase(Locale.ROOT) == CDC_PATH_BASED) {
+      val path = tableNameExpr match {
+        case _: Literal  if tableNameExpr.dataType == StringType =>
+          tableNameExpr.eval().toString
+        case _ =>
+          throw DeltaErrors.unsupportedExpression(
+            "table path", tableNameExpr.dataType, Seq("StringType"))
+      }
+      DeltaTableV2(
+        session,
+        path = new Path(path),
+        catalogTable = None,
+        tableIdentifier = None,
+        timeTravelOpt = None,
+        options = Map.empty,
+        cdcOptions = new CaseInsensitiveStringMap(options.asJava))
+    } else {
+      throw DeltaErrors.invalidTableValueFunction(fnName)
+    }
+        val relation = table.toBaseRelation
+        LogicalRelation(
+          relation,
+          relation.schema.toAttributes,
+          // time traveled relations shouldn't pass catalog stats as stats may be incorrect
+          table.catalogTable.map(_.copy(stats = None)),
+          isStreaming = false)
+  }
+
+}
+
+///////////////////////////////////////////////////////////////////////////
+//                     Logical plans for Delta TVFs                      //
+///////////////////////////////////////////////////////////////////////////
+
+/**
+ * Represents an unresolved Delta Table Value Function
+ *
+ * @param fnName  can be one of [[DeltaTableValueFunctions.supportedFnNames]].
+ */
+abstract class DeltaTableValueFunction(val fnName: String) extends LeafNode {
+  override def output: Seq[Attribute] = Nil
+  override lazy val resolved = false
+
+  val functionArgs: Seq[Expression]
+}
+
+/**
+ * Plan for the "table_changes" function
+ */
+case class CDCNameBased(override val functionArgs: Seq[Expression])
+  extends DeltaTableValueFunction(DeltaTableValueFunctions.CDC_NAME_BASED)
+
+/**
+ * Plan for the "table_changes_by_path" function
+ */
+case class CDCPathBased(override val functionArgs: Seq[Expression])
+  extends DeltaTableValueFunction(DeltaTableValueFunctions.CDC_PATH_BASED)
+
+

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSQLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSQLSuite.scala
@@ -285,7 +285,6 @@ class DeltaCDCSQLSuite extends DeltaCDCSuiteBase with DeltaColumnMappingTestUtil
       }
       assert(e.getErrorClass == "MISSING_COLUMN")
       assert(e.getMessage.contains("Column 'id' does not exist"))
-
     }
   }
 
@@ -304,7 +303,7 @@ class DeltaCDCSQLSuite extends DeltaCDCSuiteBase with DeltaColumnMappingTestUtil
   }
 
 
-  test("table_changes and table_changes_by_path with not a delta table") {
+  test("table_changes and table_changes_by_path with a non-delta table") {
     withTempDir { dir =>
       withTable("tbl") {
         spark.range(10).write.format("parquet")

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSQLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSQLSuite.scala
@@ -1,0 +1,305 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.util.Date
+
+import org.apache.spark.sql.delta.actions.Protocol
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
+
+import org.apache.spark.sql.{AnalysisException, DataFrame}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.LongType
+
+class DeltaCDCSQLSuite extends DeltaCDCSuiteBase with DeltaColumnMappingTestUtils {
+
+  /** Single method to do all kinds of CDC reads */
+  def cdcRead(
+    tblId: TblId,
+    start: Boundary,
+    end: Boundary,
+    schemaMode: Option[DeltaBatchCDFSchemaMode] = Some(BatchCDFSchemaLegacy),
+    // SQL API does not support generic reader options, so it's a noop here
+    readerOptions: Map[String, String] = Map.empty): DataFrame = {
+
+    // Set the batch CDF schema mode using SQL conf if we specified it
+    if (schemaMode.isDefined) {
+      var result: DataFrame = null
+      withSQLConf(DeltaSQLConf.DELTA_CDF_DEFAULT_SCHEMA_MODE_FOR_COLUMN_MAPPING_TABLE.key ->
+        schemaMode.get.name) {
+        result = cdcRead(tblId, start, end, None, readerOptions)
+      }
+      return result
+    }
+
+    val startPrefix: String = start match {
+      case startingVersion: StartingVersion =>
+        s"""${startingVersion.value}"""
+
+      case startingTimestamp: StartingTimestamp =>
+        s"""'${startingTimestamp.value}'"""
+
+      case Unbounded =>
+        ""
+    }
+    val endPrefix: String = end match {
+      case endingVersion: EndingVersion =>
+        s"""${endingVersion.value}"""
+
+      case endingTimestamp: EndingTimestamp =>
+        s"""'${endingTimestamp.value}'"""
+
+      case Unbounded =>
+        ""
+    }
+    val fnName = tblId match {
+      case _: TablePath =>
+        DeltaTableValueFunctions.CDC_PATH_BASED
+      case _: TableName =>
+        DeltaTableValueFunctions.CDC_NAME_BASED
+      case _ =>
+        throw new IllegalArgumentException("No table name or path provided")
+    }
+
+    if (endPrefix === "") {
+      sql(s"SELECT * FROM $fnName('${tblId.id}', $startPrefix)")
+    } else {
+      sql(s"SELECT * FROM $fnName('${tblId.id}', $startPrefix, $endPrefix) ")
+    }
+  }
+
+  override def ctas(
+      srcTbl: String,
+      dstTbl: String,
+      disableCDC: Boolean = false): Unit = {
+
+    val prefix = s"CREATE TABLE ${dstTbl} USING DELTA"
+    val suffix = s" AS SELECT * FROM table_changes('${srcTbl}', 0, 1)"
+
+    if (disableCDC) {
+      sql(prefix + s" TBLPROPERTIES (${DeltaConfigs.CHANGE_DATA_FEED.key} = false)" + suffix)
+    } else {
+      sql(prefix + suffix)
+    }
+  }
+
+  test("select individual column should push down filters") {
+    val tblName = "tbl"
+    withTable(tblName) {
+      createTblWithThreeVersions(tblName = Some(tblName))
+
+      val plans = DeltaTestUtils.withAllPlansCaptured(spark) {
+        val res = sql(s"SELECT id, _change_type FROM table_changes('$tblName', 0, 1)")
+          .where(col("id") < lit(5))
+
+        assert(res.columns === Seq("id", "_change_type"))
+        checkAnswer(
+          res,
+          spark.range(5)
+            .withColumn("_change_type", lit("insert")))
+      }
+      assert(plans.map(_.executedPlan).toString
+        .contains("PushedFilters: [IsNotNull(id), LessThan(id,5)]"))
+    }
+  }
+
+  test("use cdc query as a subquery") {
+    val tblName = "tbl"
+    withTable(tblName) {
+      createTblWithThreeVersions(tblName = Some(tblName))
+
+      val res = sql(s"""
+          SELECT * FROM RANGE(30) WHERE id > (
+              SELECT count(*) FROM table_changes('$tblName', 0, 1))
+        """)
+      checkAnswer(
+        res,
+        spark.range(21, 30).toDF())
+    }
+  }
+
+  test("cdc table_changes is not case sensitive") {
+    val tblName = "tbl"
+    withTempDir { dir =>
+      withTable(tblName) {
+        createTblWithThreeVersions(tblName = Some(tblName))
+
+        checkAnswer(
+          spark.sql(s"SELECT * FROM tabLe_chAnges('$tblName', 0, 1)"),
+          spark.sql(s"SELECT * FROM taBle_cHanges('$tblName', 0, 1)")
+        )
+      }
+    }
+  }
+
+  test("cdc table_changes_by_path are not case sensitive") {
+    withTempDir { dir =>
+      createTblWithThreeVersions(path = Some(dir.getAbsolutePath))
+
+      checkAnswer(
+        spark.sql(s"SELECT * FROM tabLe_chaNges_By_pAth('${dir.getAbsolutePath}', 0, 1)"),
+        spark.sql(s"SELECT * FROM taBle_cHanges_bY_paTh('${dir.getAbsolutePath}', 0, 1)")
+      )
+    }
+  }
+
+
+  test("parse multi part table name") {
+    val tblName = "tbl"
+      withTable(tblName) {
+        createTblWithThreeVersions(tblName = Some(tblName))
+
+        checkAnswer(
+          spark.sql(s"SELECT * FROM table_changes('$tblName', 0, 1)"),
+          spark.sql(s"SELECT * FROM table_changes('default.`${tblName}`', 0, 1)")
+        )
+      }
+  }
+
+  test("negative case - invalid number of args") {
+    val tbl = "tbl"
+    withTable(tbl) {
+      spark.range(10).write.format("delta").saveAsTable(tbl)
+
+      val invalidQueries = Seq(
+        s"SELECT * FROM table_changes()",
+        s"SELECT * FROM table_changes('tbl', 1, 2, 3)",
+        s"SELECT * FROM table_changes('tbl')",
+        s"SELECT * FROM table_changes_by_path()",
+        s"SELECT * FROM table_changes_by_path('tbl', 1, 2, 3)",
+        s"SELECT * FROM table_changes_by_path('tbl')"
+      )
+      invalidQueries.foreach { q =>
+        val e = intercept[AnalysisException] {
+          sql(q)
+        }
+        assert(e.getMessage.contains("requires at least 2 arguments and at most 3 arguments"),
+          s"failed query: $q ")
+      }
+    }
+  }
+
+  test("negative case - invalid type of args") {
+    val tbl = "tbl"
+    withTable(tbl) {
+      spark.range(10).write.format("delta").saveAsTable(tbl)
+
+      val invalidQueries = Seq(
+        s"SELECT * FROM table_changes(1, 1)",
+        s"SELECT * FROM table_changes('$tbl', 1.0)",
+        s"SELECT * FROM table_changes_by_path(1, 1)",
+        s"SELECT * FROM table_changes_by_path('$tbl', 1.0)"
+      )
+
+      invalidQueries.foreach { q =>
+        val e = intercept[AnalysisException] {
+          sql(q)
+        }
+        assert(e.getMessage.contains("Unsupported expression type"), s"failed query: $q")
+      }
+    }
+  }
+
+  test("resolve expression for timestamp function - now") {
+    val tbl = "tbl"
+    withTable(tbl) {
+      createTblWithThreeVersions(tblName = Some(tbl))
+
+      val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tbl))
+
+      val currentTime = new Date().getTime
+      modifyDeltaTimestamp(deltaLog, 0, currentTime - 100000)
+      modifyDeltaTimestamp(deltaLog, 1, currentTime)
+      modifyDeltaTimestamp(deltaLog, 2, currentTime + 100000)
+
+      val readDf = sql(s"SELECT * FROM table_changes('$tbl', 0, now())")
+      checkCDCAnswer(
+        DeltaLog.forTable(spark, TableIdentifier("tbl")),
+        readDf,
+        spark.range(20)
+          .withColumn("_change_type", lit("insert"))
+          .withColumn("_commit_version", (col("id") / 10).cast(LongType))
+        )
+
+      // more complex expression
+      val readDf2 = sql(s"SELECT * FROM table_changes('$tbl', 0, now() + interval 5 seconds)")
+      checkCDCAnswer(
+        DeltaLog.forTable(spark, TableIdentifier("tbl")),
+        readDf2,
+        spark.range(20)
+          .withColumn("_change_type", lit("insert"))
+          .withColumn("_commit_version", (col("id") / 10).cast(LongType))
+      )
+    }
+  }
+
+  test("resolve invalid table name should throw error") {
+    var e = intercept[AnalysisException] {
+      sql(s"SELECT * FROM table_changes(now(), 1, 1)")
+    }
+    assert(e.getMessage.contains("Unsupported expression type(TimestampType) for table name." +
+      " The supported types are [Literal of type StringType]"))
+
+    e = intercept[AnalysisException] {
+      sql(s"SELECT * FROM table_changes('invalidtable', 1, 1)")
+    }
+    assert(
+      e.getMessage.contains("Table or view 'invalidtable' not found in database 'default'") ||
+      e.getMessage.contains("Table main.default.invalidtable not found") ||
+      e.getMessage.contains("table or view `default`.`invalidtable` cannot be found") ||
+      e.getMessage.contains("table or view `main`.`default`.`invalidtable` cannot be found"))
+
+    withTable ("tbl") {
+      spark.range(1).write.format("delta").saveAsTable("tbl")
+      val e = intercept[AnalysisException] {
+        sql(s"SELECT * FROM table_changes(concat('tb', 'l'), 1, 1)")
+      }
+      assert(e.getMessage.contains("Unsupported expression type(StringType) for table name." +
+        " The supported types are [Literal of type StringType]"))
+    }
+  }
+
+
+  test("resolution of complex expression should throw an error") {
+    val tbl = "tbl"
+    withTable(tbl) {
+      spark.range(10).write.format("delta").saveAsTable(tbl)
+      val e = intercept[AnalysisException] {
+        sql(s"SELECT * FROM table_changes('$tbl', 0, id)")
+      }
+      assert(e.getErrorClass == "MISSING_COLUMN")
+      assert(e.getMessage.contains("Column 'id' does not exist"))
+
+    }
+  }
+
+  test("protocol version") {
+    withTable("tbl") {
+      spark.range(10).write.format("delta").saveAsTable("tbl")
+      val log = DeltaLog.forTable(spark, TableIdentifier(tableName = "tbl"))
+      // We set CDC to be enabled by default, so this should automatically bump the writer protocol
+      // to the required version.
+      if (columnMappingEnabled) {
+        assert(log.snapshot.protocol == Protocol(2, 5))
+      } else {
+        assert(log.snapshot.protocol == Protocol(1, 4))
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds support for change data feed functions `table_changes` and `table_changes_by_path` in SQL to read CDF data.

This is done by injecting into spark's table function registry in `DeltaSparkSessionExtension`. We then resolve these expressions in `DeltaAnalysis`.

## How was this patch tested?

Adds unit tests in `DeltaCDCSQLSuite`

## Does this PR introduce _any_ user-facing changes?

Yes, users will now be able to use functions `table_changes` and `table_changes_by_path` to read the CDF data from Delta tables.

For example:
```
SELECT * FROM table_changes('tbl', 0, 2)
```
```
+---+------------+---------------+--------------------+
| id|_change_type|_commit_version|   _commit_timestamp|
+---+------------+---------------+--------------------+
|  2|      insert|              1|2023-02-16 14:22:...|
|  3|      insert|              1|2023-02-16 14:22:...|
|  1|      insert|              1|2023-02-16 14:22:...|
|  5|      insert|              2|2023-02-16 14:22:...|
+---+------------+---------------+--------------------+
```