### PR TITLE
Use "supported" to replace "enabled" for table feature configs

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -1872,7 +1872,7 @@
   },
   "DELTA_UNSUPPORTED_FEATURE_STATUS" : {
     "message" : [
-      "Expecting the status for table feature <feature> to be \"enabled\", but got \"<status>\"."
+      "Expecting the status for table feature <feature> to be \"supported\", but got \"<status>\"."
     ],
     "sqlState" : "0AKDE"
   },

--- a/core/src/main/scala/org/apache/spark/sql/delta/ColumnWithDefaultExprUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/ColumnWithDefaultExprUtils.scala
@@ -57,7 +57,7 @@ object ColumnWithDefaultExprUtils extends DeltaLogging {
 
   // Return if `protocol` satisfies the requirement for IDENTITY columns.
   def satisfiesIdentityColumnProtocol(protocol: Protocol): Boolean =
-    protocol.isFeatureEnabled(IdentityColumnsTableFeature)
+    protocol.isFeatureSupported(IdentityColumnsTableFeature)
 
   // Return true if the column `col` has default expressions (and can thus be omitted from the
   // insertion list).

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
@@ -63,7 +63,7 @@ trait DeltaColumnMappingBase extends DeltaLogging {
     .contains(field.name.toLowerCase(Locale.ROOT))
 
   def satisfiesColumnMappingProtocol(protocol: Protocol): Boolean =
-    protocol.isFeatureEnabled(ColumnMappingTableFeature)
+    protocol.isFeatureSupported(ColumnMappingTableFeature)
 
   /**
    * The only allowed mode change is from NoMapping to NameMapping. Other changes

--- a/core/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
@@ -71,7 +71,7 @@ import org.apache.spark.sql.types.{Metadata => FieldMetadata}
 object GeneratedColumn extends DeltaLogging with AnalysisHelper {
 
   def satisfyGeneratedColumnProtocol(protocol: Protocol): Boolean =
-    protocol.isFeatureEnabled(GeneratedColumnsTableFeature)
+    protocol.isFeatureSupported(GeneratedColumnsTableFeature)
 
   /**
    * Whether the field contains the generation expression. Note: this doesn't mean the column is a

--- a/core/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -483,10 +483,10 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       }
     }
 
-    // Enabling table features Part 1: add manually-enabled features in table properties start
+    // Enabling table features Part 1: add manually-supported features in table properties start
     // with [[FEATURE_PROP_PREFIX]].
     //
-    // This transaction's new metadata might contain some table properties to enable some
+    // This transaction's new metadata might contain some table properties to support some
     // features (props start with [[FEATURE_PROP_PREFIX]]). We silently add them to the `protocol`
     // action.
     // Unlike auto-enabled features, the following logic will not auto upgrade protocol version
@@ -496,7 +496,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
     // upgrade their table.
     val newProtocolBeforeAddingFeatures = newProtocol.getOrElse(protocolBeforeUpdate)
     val newFeaturesFromTableConf =
-      TableFeatureProtocolUtils.getEnabledFeaturesFromConfigs(
+      TableFeatureProtocolUtils.getSupportedFeaturesFromConfigs(
         latestMetadata.configuration,
         TableFeatureProtocolUtils.FEATURE_PROP_PREFIX)
     val featuresFromTableConf = newFeaturesFromTableConf.map(_.name)

--- a/core/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -385,7 +385,7 @@ class Snapshot(
     if (protocol.supportsReaderFeatures || protocol.supportsWriterFeatures) {
       val features = protocol.readerAndWriterFeatureNames.map(name =>
         s"${TableFeatureProtocolUtils.FEATURE_PROP_PREFIX}$name" ->
-          TableFeatureProtocolUtils.FEATURE_PROP_ENABLED)
+          TableFeatureProtocolUtils.FEATURE_PROP_SUPPORTED)
       base ++ features.toSeq.sorted
     } else {
       base

--- a/core/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -31,23 +31,23 @@ import org.apache.spark.sql.SparkSession
 /**
  * A base class for all table features.
  *
- * A feature can be <b>explicitly enabled</b> by a table's protocol when the protocol contains a
+ * A feature can be <b>explicitly supported</b> by a table's protocol when the protocol contains a
  * feature's `name`. Writers (for writer-only features) or readers and writers (for reader-writer
- * features) must recognize enabled features and must handle them appropriately.
+ * features) must recognize supported features and must handle them appropriately.
  *
  * A table feature that released before Delta Table Features (reader version 3 and writer version
- * 7) is considered as a <b>legacy feature</b>. Legacy features are <b>implicitly enabled</b> when
- * (a) the protocol does not support table features, i.e., has reader version less than 3 or
+ * 7) is considered as a <b>legacy feature</b>. Legacy features are <b>implicitly supported</b>
+ * when (a) the protocol does not support table features, i.e., has reader version less than 3 or
  * writer version less than 7 and (b) the feature's minimum reader/writer version is less than or
  * equal to the current protocol's reader/writer version.
  *
- * Separately, a feature can be automatically enabled in a table's metadata when certain
+ * Separately, a feature can be automatically supported by a table's metadata when certain
  * feature-specific table properties are set. For example, `changeDataFeed` is automatically
- * enabled when there's a table property `delta.enableChangeDataFeed=true`. This is independent of
- * the table's enabled features. When a feature is enabled (explicitly or implicitly) by the table
- * protocol but its metadata requirements are not satisfied, then clients still have to understand
- * the feature (at least to the extent that they can read and preserve the existing data in the
- * table that uses the feature). See the documentation of
+ * supported when there's a table property `delta.enableChangeDataFeed=true`. This is independent
+ * of the table's enabled features. When a feature is supported (explicitly or implicitly) by the
+ * table protocol but its metadata requirements are not satisfied, then clients still have to
+ * understand the feature (at least to the extent that they can read and preserve the existing
+ * data in the table that uses the feature). See the documentation of
  * [[FeatureAutomaticallyEnabledByMetadata]] for more information.
  *
  * @param name
@@ -55,14 +55,14 @@ import org.apache.spark.sql.SparkSession
  *   (a-z, A-Z), digits (0-9), '-', or '_'. Words must be in camelCase.
  * @param minReaderVersion
  *   the minimum reader version this feature requires. For a feature that can only be explicitly
- *   enabled, this is either `0` or `3` (the reader protocol version that supports table
+ *   supported, this is either `0` or `3` (the reader protocol version that supports table
  *   features), depending on the feature is writer-only or reader-writer. For a legacy feature
- *   that can be implicitly enabled, this is the first protocol version which the feature is
+ *   that can be implicitly supported, this is the first protocol version which the feature is
  *   introduced.
  * @param minWriterVersion
  *   the minimum writer version this feature requires. For a feature that can only be explicitly
- *   enabled, this is the writer protocol `7` that supports table features. For a legacy feature
- *   that can be implicitly enabled, this is the first protocol version which the feature is
+ *   supported, this is the writer protocol `7` that supports table features. For a legacy feature
+ *   that can be implicitly supported, this is the first protocol version which the feature is
  *   introduced.
  */
 // @TODO: distinguish Delta and 3rd-party features and give appropriate error messages
@@ -75,15 +75,15 @@ sealed abstract class TableFeature(
 
   /**
    * Get a [[Protocol]] object stating the minimum reader and writer versions this feature
-   * requires. For a feature that can only be explicitly enabled, this method returns a protocol
+   * requires. For a feature that can only be explicitly supported, this method returns a protocol
    * version that supports table features, either `(0,7)` or `(3,7)` depending on the feature is
-   * writer-only or reader-writer. For a legacy feature that can be implicitly enabled, this
+   * writer-only or reader-writer. For a legacy feature that can be implicitly supported, this
    * method returns the first protocol version which introduced the said feature.
    *
    * For all features, if the table's protocol version does not support table features, then the
    * minimum protocol version is enough. However, if the protocol version supports table features
    * for the feature type (writer-only or reader-writer), then the minimum protocol version is not
-   * enough to enable a feature. In this case the feature must also be explicitly enabled in the
+   * enough to support a feature. In this case the feature must also be explicitly listed in the
    * appropriate feature sets in the [[Protocol]].
    */
   def minProtocolVersion: Protocol = Protocol(minReaderVersion, minWriterVersion)
@@ -110,20 +110,20 @@ sealed trait LegacyFeatureType
  *
  * When the feature's metadata requirements are satisfied during table creation
  * ([[actions.Protocol.forNewTable]]) or commit ([[OptimisticTransaction.updateMetadata]]), the
- * client will silently add the feature to the protocol's `readerFeatures` and/or `writerFeatures`
- * with `status` = `enabled`.
+ * client will silently add the feature to the protocol's `readerFeatures` and/or
+ * `writerFeatures`.
  */
 sealed trait FeatureAutomaticallyEnabledByMetadata {
 
   /**
-   * Determine whether the feature must be enabled because its metadata requirements are
-   * satisfied.
+   * Determine whether the feature must be supported and enabled because its metadata requirements
+   * are satisfied.
    */
   def metadataRequiresFeatureToBeEnabled(metadata: Metadata, spark: SparkSession): Boolean
 }
 
 /**
- * A base class for all writer-only table features that can only be explicitly enabled.
+ * A base class for all writer-only table features that can only be explicitly supported.
  *
  * @param name
  *   a globally-unique string indicator to represent the feature. All characters must be letters
@@ -136,7 +136,7 @@ sealed abstract class WriterFeature(name: String)
     minWriterVersion = TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION)
 
 /**
- * A base class for all reader-writer table features that can only be explicitly enabled.
+ * A base class for all reader-writer table features that can only be explicitly supported.
  *
  * @param name
  *   a globally-unique string indicator to represent the feature. All characters must be letters

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -320,7 +320,7 @@ object TableFeatureProtocolUtils {
       // Feature status is not lower cased in any case.
       val name = key.stripPrefix(propertyPrefix).toLowerCase(Locale.ROOT)
       val status = value.toLowerCase(Locale.ROOT)
-      if (status != FEATURE_PROP_SUPPORTED || status != FEATURE_PROP_ENABLED) {
+      if (status != FEATURE_PROP_SUPPORTED && status != FEATURE_PROP_ENABLED) {
         throw DeltaErrors.unsupportedTableFeatureStatusException(name, status)
       }
       val featureOpt = TableFeature.featureNameToFeature(name)

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -31,9 +31,9 @@ import org.apache.spark.util.Utils
  * Trait to be mixed into the [[Protocol]] case class to enable Table Features.
  *
  * Protocol reader version 3 and writer version 7 start to support reader and writer table
- * features. In such a case, features can be <b>explicitly enabled</b> by a protocol's reader
+ * features. In such a case, features can be <b>explicitly supported</b> by a protocol's reader
  * and/or writer features sets by adding its name. When read or write a table, clients MUST
- * respect all enabled features.
+ * respect all supported features.
  *
  * See also the document of [[TableFeature]] for feature-specific terminologies.
  */
@@ -48,15 +48,15 @@ trait TableFeatureSupport { this: Protocol =>
     TableFeatureProtocolUtils.supportsWriterFeatures(minWriterVersion)
 
   /**
-   * Get a new Protocol object that has `feature` enabled. Writer-only features will be enabled by
-   * `writerFeatures` field, and reader-writer features will be enabled by `readerFeatures` and
+   * Get a new Protocol object that has `feature` supported. Writer-only features will be added to
+   * `writerFeatures` field, and reader-writer features will be added to `readerFeatures` and
    * `writerFeatures` fields.
    *
-   * If `feature` is already implicitly enabled in the current protocol's legacy reader or writer
-   * protocol version, the new protocol will not modify the original protocol version,
-   * i.e., the feature will not be explicitly enabled by the protocol's `readerFeatures` or
-   * `writerFeatures`. This is to avoid unnecessary protocol upgrade to enable a feature that it
-   * already supports.
+   * If `feature` is already implicitly supported in the current protocol's legacy reader or
+   * writer protocol version, the new protocol will not modify the original protocol version,
+   * i.e., the feature will not be explicitly added to the protocol's `readerFeatures` or
+   * `writerFeatures`. This is to avoid unnecessary protocol upgrade for feature that it already
+   * supports.
    */
   def withFeature(feature: TableFeature): Protocol = {
     def shouldAddRead: Boolean = {
@@ -95,7 +95,7 @@ trait TableFeatureSupport { this: Protocol =>
   }
 
   /**
-   * Get a new Protocol object with multiple features enabled.
+   * Get a new Protocol object with multiple features supported.
    *
    * See the documentation of [[withFeature]] for more information.
    */
@@ -181,14 +181,14 @@ trait TableFeatureSupport { this: Protocol =>
   lazy val readerAndWriterFeatureNames: Set[String] = readerFeatureNames ++ writerFeatureNames
 
   /**
-   * Get all features that are implicitly enabled by this protocol, for example, `Protocol(1,2)`
-   * implicitly enables `appendOnly` and `invariants`. When this protocol is capable of requiring
-   * writer features, no feature can be implicitly enabled.
+   * Get all features that are implicitly supported by this protocol, for example, `Protocol(1,2)`
+   * implicitly supports `appendOnly` and `invariants`. When this protocol is capable of requiring
+   * writer features, no feature can be implicitly supported.
    */
   @JsonIgnore
-  lazy val implicitlyEnabledFeatures: Set[TableFeature] = {
+  lazy val implicitlySupportedFeatures: Set[TableFeature] = {
     if (supportsReaderFeatures && supportsWriterFeatures) {
-      // this protocol uses both reader and writer features, no feature can be implicitly enabled
+      // this protocol uses both reader and writer features, no feature can be implicitly supported
       Set()
     } else {
       TableFeature.allSupportedFeaturesMap.values
@@ -203,29 +203,27 @@ trait TableFeatureSupport { this: Protocol =>
    * Determine whether this protocol can be safely upgraded to a new protocol `to`. This means:
    *   - this protocol has reader protocol version less than or equals to `to`.
    *   - this protocol has writer protocol version less than or equals to `to`.
-   *   - all features enabled in this protocol are enabled in `to`.
+   *   - all features supported by this protocol are supported by `to`.
    *
    * Examples regarding feature status:
-   *   - from `[{appendOnly, enabled}]` to `[{appendOnly, enabled}]` => allowed
-   *   - from `[{appendOnly, enabled}, {changeDataFeed, enabled}]` to `[{appendOnly, enabled}]` =>
-   *     not allowed
-   *   - from `[{appendOnly, enabled}]` to `[{appendOnly, enabled}, {changeDataFeed, enabled}]` =>
-   *     allowed
+   *   - from `[appendOnly]` to `[appendOnly]` => allowed
+   *   - from `[appendOnly, changeDataFeed]` to `[appendOnly]` => not allowed
+   *   - from `[appendOnly]` to `[appendOnly, changeDataFeed]` => allowed
    */
   def canUpgradeTo(to: Protocol): Boolean = {
     if (to.minReaderVersion < this.minReaderVersion) return false
     if (to.minWriterVersion < this.minWriterVersion) return false
 
     val thisFeatures =
-      this.readerAndWriterFeatureNames ++ this.implicitlyEnabledFeatures.map(_.name)
-    val toFeatures = to.readerAndWriterFeatureNames ++ to.implicitlyEnabledFeatures.map(_.name)
-    // all features enabled in `this` are enabled in `to`
+      this.readerAndWriterFeatureNames ++ this.implicitlySupportedFeatures.map(_.name)
+    val toFeatures = to.readerAndWriterFeatureNames ++ to.implicitlySupportedFeatures.map(_.name)
+    // all features supported by `this` are supported by `to`
     thisFeatures.subsetOf(toFeatures)
   }
 
   /**
    * Merge this protocol with multiple `protocols` to have the highest reader and writer versions
-   * plus all explicitly and implicitly enabled features.
+   * plus all explicitly and implicitly supported features.
    */
   def merge(others: Protocol*): Protocol = {
     val protocols = this +: others
@@ -233,7 +231,7 @@ trait TableFeatureSupport { this: Protocol =>
     val mergedWriterVersion = protocols.map(_.minWriterVersion).max
     val mergedReaderFeatures = protocols.flatMap(_.readerFeatureNames)
     val mergedWriterFeatures = protocols.flatMap(_.writerFeatureNames)
-    val mergedImplicitFeatures = protocols.flatMap(_.implicitlyEnabledFeatures)
+    val mergedImplicitFeatures = protocols.flatMap(_.implicitlySupportedFeatures)
 
     val mergedProtocol = Protocol(mergedReaderVersion, mergedWriterVersion)
       .withReaderFeatures(mergedReaderFeatures)
@@ -247,13 +245,13 @@ trait TableFeatureSupport { this: Protocol =>
   }
 
   /**
-   * Check if a `feature` is enabled in this protocol. This means either (a) the protocol does not
-   * support table features and implicitly supports the feature, or (b) the protocol supports
+   * Check if a `feature` is supported by this protocol. This means either (a) the protocol does
+   * not support table features and implicitly supports the feature, or (b) the protocol supports
    * table features and references the feature.
    */
-  def isFeatureEnabled(feature: TableFeature): Boolean = {
+  def isFeatureSupported(feature: TableFeature): Boolean = {
     // legacy feature + legacy protocol
-    (feature.isLegacyFeature && this.implicitlyEnabledFeatures.contains(feature)) ||
+    (feature.isLegacyFeature && this.implicitlySupportedFeatures.contains(feature)) ||
       // new protocol
       readerAndWriterFeatureNames.contains(feature.name)
   }
@@ -267,8 +265,16 @@ object TableFeatureProtocolUtils {
   /** Prop prefix in Spark sessions configs. */
   val DEFAULT_FEATURE_PROP_PREFIX = "spark.databricks.delta.properties.defaults.feature."
 
-  /** The string constant "enabled" for uses in table properties. */
+  /**
+   * The string constant "enabled" for uses in table properties.
+   * @deprecated
+   *   This value is deprecated to avoid confusion with features that are actually enabled by
+   *   table metadata. Use [[FEATURE_PROP_SUPPORTED]] instead.
+   */
   val FEATURE_PROP_ENABLED = "enabled"
+
+  /** The string constant "supported" for uses in table properties. */
+  val FEATURE_PROP_SUPPORTED = "supported"
 
   /** Min reader version that supports reader features. */
   val TABLE_FEATURES_MIN_READER_VERSION = 3
@@ -301,10 +307,10 @@ object TableFeatureProtocolUtils {
   }
 
   /**
-   * Get a set of [[TableFeature]]s representing enabled features set in a `config` map (table
+   * Get a set of [[TableFeature]]s representing supported features set in a `config` map (table
    * properties or Spark session configs).
    */
-  def getEnabledFeaturesFromConfigs(
+  def getSupportedFeaturesFromConfigs(
       configs: Map[String, String],
       propertyPrefix: String): Set[TableFeature] = {
     val featureConfigs = configs.filterKeys(_.startsWith(propertyPrefix))
@@ -314,7 +320,7 @@ object TableFeatureProtocolUtils {
       // Feature status is not lower cased in any case.
       val name = key.stripPrefix(propertyPrefix).toLowerCase(Locale.ROOT)
       val status = value.toLowerCase(Locale.ROOT)
-      if (status != FEATURE_PROP_ENABLED) {
+      if (status != FEATURE_PROP_SUPPORTED || status != FEATURE_PROP_ENABLED) {
         throw DeltaErrors.unsupportedTableFeatureStatusException(name, status)
       }
       val featureOpt = TableFeature.featureNameToFeature(name)

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -217,9 +217,9 @@ object Protocol {
     // There might be features enabled by the table properties aka
     // `CREATE TABLE ... TBLPROPERTIES ...` or by session defaults.
     val tablePropEnabledFeatures =
-      getEnabledFeaturesFromConfigs(tableConf, FEATURE_PROP_PREFIX)
+      getSupportedFeaturesFromConfigs(tableConf, FEATURE_PROP_PREFIX)
     val sessionEnabledFeatures =
-      getEnabledFeaturesFromConfigs(sessionConf.getAllConfs, DEFAULT_FEATURE_PROP_PREFIX)
+      getSupportedFeaturesFromConfigs(sessionConf.getAllConfs, DEFAULT_FEATURE_PROP_PREFIX)
     val featuresFromMetadata =
       metadataOpt.map(extractAutomaticallyEnabledFeatures(spark, _)).getOrElse(Set[TableFeature]())
     val allEnabledFeatures =

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/DeletionVectorUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/DeletionVectorUtils.scala
@@ -64,7 +64,7 @@ trait DeletionVectorUtils {
       metadata = newMetadata.getOrElse(snapshot.metadata))
 
   def deletionVectorsWritable(protocol: Protocol, metadata: Metadata): Boolean =
-    protocol.isFeatureEnabled(DeletionVectorsTableFeature) &&
+    protocol.isFeatureSupported(DeletionVectorsTableFeature) &&
       DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.fromMetaData(metadata)
 
   def deletionVectorsReadable(
@@ -79,7 +79,7 @@ trait DeletionVectorUtils {
   def deletionVectorsReadable(
       protocol: Protocol,
       metadata: Metadata): Boolean = {
-    protocol.isFeatureEnabled(DeletionVectorsTableFeature) &&
+    protocol.isFeatureSupported(DeletionVectorsTableFeature) &&
       metadata.format.provider == "parquet" // DVs are only supported on parquet tables.
   }
 }

--- a/core/src/test/scala/org/apache/spark/sql/delta/CloneTableSuiteBase.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/CloneTableSuiteBase.scala
@@ -896,7 +896,7 @@ trait CloneTableSuiteBase extends QueryTest
         tableProperties = tblPropertyOverrides)
 
       val targetLog = DeltaLog.forTable(spark, target)
-      assert(targetLog.update().protocol.isFeatureEnabled(TestWriterFeature))
+      assert(targetLog.update().protocol.isFeatureSupported(TestWriterFeature))
   }
 }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingTestUtils.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingTestUtils.scala
@@ -262,7 +262,7 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
         Protocol.minProtocolComponentsFromAutomaticallyEnabledFeatures(spark, metadata)._3
           .map(f => (
             s"${TableFeatureProtocolUtils.FEATURE_PROP_PREFIX}${f.name}",
-            TableFeatureProtocolUtils.FEATURE_PROP_ENABLED))
+            TableFeatureProtocolUtils.FEATURE_PROP_SUPPORTED))
     }
     props
   }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -1267,6 +1267,21 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     }
   }
 
+  test("table feature status") {
+    withTempDir { path =>
+      withSQLConf(
+        defaultPropertyKey(ChangeDataFeedTableFeature) -> FEATURE_PROP_SUPPORTED,
+        defaultPropertyKey(GeneratedColumnsTableFeature) -> FEATURE_PROP_ENABLED) {
+        spark.range(10).write.format("delta").save(path.getCanonicalPath)
+        val log = DeltaLog.forTable(spark, path)
+        val protocol = log.update().protocol
+
+        assert(protocol.isFeatureSupported(ChangeDataFeedTableFeature))
+        assert(protocol.isFeatureSupported(GeneratedColumnsTableFeature))
+      }
+    }
+  }
+
   private def assertPropertiesAndShowTblProperties(
       deltaLog: DeltaLog,
       tableHasFeatures: Boolean = false): Unit = {
@@ -1294,7 +1309,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       val name = row.getAs[String]("key").substring(FEATURE_PROP_PREFIX.length)
       val status = row.getAs[String]("value")
       assert(TableFeature.featureNameToFeature(name).isDefined)
-      assert(status == FEATURE_PROP_ENABLED)
+      assert(status == FEATURE_PROP_SUPPORTED)
     }
   }
 }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
@@ -103,7 +103,7 @@ class DeltaTableFeatureSuite
 
   test("implicitly-enabled features") {
     assert(
-      Protocol(2, 6).implicitlyEnabledFeatures === Set(
+      Protocol(2, 6).implicitlySupportedFeatures === Set(
         AppendOnlyTableFeature,
         ColumnMappingTableFeature,
         InvariantsTableFeature,
@@ -114,7 +114,7 @@ class DeltaTableFeatureSuite
         TestLegacyWriterFeature,
         TestLegacyReaderWriterFeature))
     assert(
-      Protocol(2, 5).implicitlyEnabledFeatures === Set(
+      Protocol(2, 5).implicitlySupportedFeatures === Set(
         AppendOnlyTableFeature,
         ColumnMappingTableFeature,
         InvariantsTableFeature,
@@ -122,11 +122,11 @@ class DeltaTableFeatureSuite
         ChangeDataFeedTableFeature,
         GeneratedColumnsTableFeature,
         TestLegacyWriterFeature))
-    assert(Protocol(2, TABLE_FEATURES_MIN_WRITER_VERSION).implicitlyEnabledFeatures === Set())
+    assert(Protocol(2, TABLE_FEATURES_MIN_WRITER_VERSION).implicitlySupportedFeatures === Set())
     assert(
       Protocol(
         TABLE_FEATURES_MIN_READER_VERSION,
-        TABLE_FEATURES_MIN_WRITER_VERSION).implicitlyEnabledFeatures === Set())
+        TABLE_FEATURES_MIN_WRITER_VERSION).implicitlySupportedFeatures === Set())
   }
 
   test("implicit feature listing") {
@@ -238,7 +238,7 @@ class DeltaTableFeatureSuite
 
   test("native automatically-enabled feature can't be implicitly enabled") {
     val p = Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION)
-    assert(p.implicitlyEnabledFeatures.isEmpty)
+    assert(p.implicitlySupportedFeatures.isEmpty)
   }
 
   test("Can enable legacy metadata table feature by setting default table property key") {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
@@ -242,7 +242,7 @@ trait DescribeDeltaDetailSuiteBase extends QueryTest
     withTable("t1") {
       Seq(1, 2, 3).toDF().write.format("delta").saveAsTable("t1")
       val p = DeltaLog.forTable(spark, TableIdentifier("t1")).snapshot.protocol
-      val features = p.readerAndWriterFeatureNames ++ p.implicitlyEnabledFeatures.map(_.name)
+      val features = p.readerAndWriterFeatureNames ++ p.implicitlySupportedFeatures.map(_.name)
       sql(s"""ALTER TABLE t1 SET TBLPROPERTIES (
              |  delta.minReaderVersion = $TABLE_FEATURES_MIN_READER_VERSION,
              |  delta.minWriterVersion = $TABLE_FEATURES_MIN_WRITER_VERSION,

--- a/core/src/test/scala/org/apache/spark/sql/delta/RestoreTableSuiteBase.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/RestoreTableSuiteBase.scala
@@ -236,7 +236,7 @@ trait RestoreTableSuiteBase extends QueryTest with SharedSparkSession  with Delt
         deltaLog.upgradeProtocol(
           Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION)
             .withFeatures(Seq(TestLegacyReaderWriterFeature))
-            .withFeatures(oldProtocolVersion.implicitlyEnabledFeatures))
+            .withFeatures(oldProtocolVersion.implicitlySupportedFeatures))
         val newProtocolVersion = deltaLog.snapshot.protocol
         assert(
           newProtocolVersion.minReaderVersion > oldProtocolVersion.minReaderVersion &&

--- a/delta-iceberg/src/test/scala/org/apache/spark/sql/delta/CloneIcebergSuite.scala
+++ b/delta-iceberg/src/test/scala/org/apache/spark/sql/delta/CloneIcebergSuite.scala
@@ -394,7 +394,7 @@ trait CloneIcebergSuiteBase extends QueryTest
       spark.sql(s"CREATE TABLE $cloneTable $mode CLONE $source")
       val log = DeltaLog.forTable(spark, TableIdentifier(cloneTable))
       val protocol = log.update().protocol
-      assert(protocol.isFeatureEnabled(ColumnMappingTableFeature))
+      assert(protocol.isFeatureSupported(ColumnMappingTableFeature))
     }
   }
 }


### PR DESCRIPTION
## Description

This PR changes the value of table feature configs to be `supported` instead of `enabled`, to avoid confusion with the same word in the sentence `Change Data Feed is enabled on a table when delta.enableChangeDataFeed=true`. The old value `enabled` will still work.

Before this change:
```sql
CREATE TABLE tbl ... TBLPROPERTIES ('delta.feature.featureName' = 'enabled')
```
After this change, both of the following will work:
```sql
CREATE TABLE tbl ... TBLPROPERTIES ('delta.feature.featureName' = 'enabled');
CREATE TABLE tbl ... TBLPROPERTIES ('delta.feature.featureName' = 'supported');
```

New terminology:

- `supported` means a feature is listed in the protocol, and can be enabled when its metadata requirement is satisfied. For example, `changeDataFeed` is supported when the feature name is in the protocol's `writerFeatures`, but no CDF is captured unless `delta.enableChangeDataFeed` is set to `true`.
- `enabled` means a feature's metadata requirement is satisfied. For example, `changeDataFeed` is enabled when `delta.enableChangeDataFeed` is set to `true`, and there are CDFs captured.

## How was this patch tested?

Existing changes and a new test.

## Does this PR introduce _any_ user-facing changes?

Yes, see the above "Description" section.
