### PR TITLE
[DO NOT MERGE] [1455] Remove `databricks` prefix from delta configs

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -53,6 +53,12 @@
     ],
     "sqlState" : "42837"
   },
+  "DELTA_AMBIGUOUS_CONFIGURATION_KEYS" : {
+    "message" : [
+      "Ambiguous configurations were specified: <key1>=<value1>, <key2>=<value2>"
+    ],
+    "sqlState" : "TODO"
+  },
   "DELTA_AMBIGUOUS_PARTITION_COLUMN" : {
     "message" : [
       "Ambiguous partition column <column> can be <colMatches>."

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -109,14 +109,15 @@ trait DeltaConfigsBase extends DeltaLogging {
   /**
    * A global default value set as a SQLConf will overwrite the default value of a DeltaConfig.
    * For example, user can run:
-   *   set spark.databricks.delta.properties.defaults.randomPrefixLength = 5
+   *   set spark.delta.properties.defaults.randomPrefixLength = 5
    * This setting will be populated to a Delta table during its creation time and overwrites
    * the default value of delta.randomPrefixLength.
    *
    * We accept these SQLConfs as strings and only perform validation in DeltaConfig. All the
    * DeltaConfigs set in SQLConf should adopt the same prefix.
    */
-  val sqlConfPrefix = "spark.databricks.delta.properties.defaults."
+  val sqlConfPrefix = "spark.delta.properties.defaults."
+  val deprecatedSqlConfPrefix = "spark.databricks.delta.properties.defaults."
 
   private val entries = new HashMap[String, DeltaConfig[_]]
 
@@ -182,18 +183,33 @@ trait DeltaConfigsBase extends DeltaLogging {
 
   /**
    * Table properties for new tables can be specified through SQL Configurations using the
-   * `sqlConfPrefix`. This method checks to see if any of the configurations exist among the SQL
-   * configurations and merges them with the user provided configurations. User provided configs
-   * take precedence.
+   * [[sqlConfPrefix]] (though, we must also support [[deprecatedSqlConfPrefix]].
+   *
+   * This method checks to see if any of the configurations exist among the SQL configurations and
+   * merges them with the user provided configurations. User provided configs (`tableConf`) take
+   * precedence.
    */
   def mergeGlobalConfigs(sqlConfs: SQLConf, tableConf: Map[String, String]): Map[String, String] = {
     import collection.JavaConverters._
 
     val globalConfs = entries.asScala.flatMap { case (key, config) =>
       val sqlConfKey = sqlConfPrefix + config.key.stripPrefix("delta.")
-      Option(sqlConfs.getConfString(sqlConfKey, null)) match {
-        case Some(default) => Some(config(default))
-        case _ => None
+      val deprecatedSqlConfKey = deprecatedSqlConfPrefix + config.key.stripPrefix("delta.")
+
+      val sqlConf = Option(sqlConfs.getConfString(sqlConfKey, null))
+      val deprecatedSqlConf = Option(sqlConfs.getConfString(deprecatedSqlConfKey, null))
+
+      (sqlConf, deprecatedSqlConf) match {
+        case (None, None) => None
+        case (Some(default), None) => Some(config(default))
+        case (None, Some(default)) => Some(config(default))
+        case (Some(sqlConfVal), Some(deprecatedSqlConfVal)) =>
+          if (sqlConfVal == deprecatedSqlConfVal) {
+            Some(config(sqlConfVal))
+          } else {
+            throw DeltaErrors.ambiguousConfigurationKeysException(sqlConfKey, sqlConfVal,
+              deprecatedSqlConfKey, deprecatedSqlConfVal)
+          }
       }
     }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -699,6 +699,16 @@ trait DeltaErrorsBase
       messageParameters = Array(confKey, DeltaSQLConf.ALLOW_ARBITRARY_TABLE_PROPERTIES.key))
   }
 
+  def ambiguousConfigurationKeysException(
+      confKeyA: String,
+      valueA: String,
+      confKeyB: String,
+      valueB: String): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_AMBIGUOUS_CONFIGURATION_KEYS",
+      messageParameters = Array(confKeyA, valueA, confKeyB, valueB))
+  }
+
   def cdcNotAllowedInThisVersion(): Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_CDC_NOT_ALLOWED_IN_THIS_VERSION",

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -28,13 +28,9 @@ import org.apache.spark.storage.StorageLevel
  * [[SQLConf]] entries for Delta features.
  */
 trait DeltaSQLConfBase {
-  def buildConf(key: String): ConfigBuilder = SQLConf
-    .buildConf(s"spark.delta.$key")
-    .withAlternative(s"spark.databricks.delta.$key")
-
-  def buildStaticConf(key: String): ConfigBuilder = SQLConf
-    .buildStaticConf(s"spark.delta.$key")
-    .withAlternative(s"spark.databricks.delta.$key")
+  def buildConf(key: String): ConfigBuilder = SQLConf.buildConf(s"spark.databricks.delta.$key")
+  def buildStaticConf(key: String): ConfigBuilder =
+    SQLConf.buildStaticConf(s"spark.databricks.delta.$key")
 
   val RESOLVE_TIME_TRAVEL_ON_IDENTIFIER =
     buildConf("timeTravel.resolveOnIdentifier.enabled")

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -28,9 +28,13 @@ import org.apache.spark.storage.StorageLevel
  * [[SQLConf]] entries for Delta features.
  */
 trait DeltaSQLConfBase {
-  def buildConf(key: String): ConfigBuilder = SQLConf.buildConf(s"spark.databricks.delta.$key")
-  def buildStaticConf(key: String): ConfigBuilder =
-    SQLConf.buildStaticConf(s"spark.databricks.delta.$key")
+  def buildConf(key: String): ConfigBuilder = SQLConf
+    .buildConf(s"spark.delta.$key")
+    .withAlternative(s"spark.databricks.delta.$key")
+
+  def buildStaticConf(key: String): ConfigBuilder = SQLConf
+    .buildStaticConf(s"spark.delta.$key")
+    .withAlternative(s"spark.databricks.delta.$key")
 
   val RESOLVE_TIME_TRAVEL_ON_IDENTIFIER =
     buildConf("timeTravel.resolveOnIdentifier.enabled")


### PR DESCRIPTION
DO NOT MERGE. We should think of a solution for #1384 (Delta SQL confs) at the same time.

## Description
Resolves #1455 

This PR removes the `databricks` prefix from Delta Configs (e.g. `spark.delta.properties.defaults.$config` instead of `spark.databricks.delta.properties.defaults.$config`). If both config keys are used, and with different values, an exception is thrown.

## How was this patch tested?
New unit test, and existing tests pass.

## Does this PR introduce _any_ user-facing changes?
Yes. Users should now use prefix `spark.delta.properties.defaults` instead of `spark.databricks.delta.properties.defaults` when setting global default delta config values.
