### PR TITLE
Add config validation to upgradeTableProtocol

### DIFF
--- a/core/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -536,9 +536,13 @@ class DeltaTable private[tables](
   def upgradeTableProtocol(readerVersion: Int, writerVersion: Int): Unit = {
     val alterTableCmd = AlterTableSetPropertiesDeltaCommand(
       table,
-      Map(
-        "delta.minReaderVersion" -> readerVersion.toString,
-        "delta.minWriterVersion" -> writerVersion.toString))
+      DeltaConfigs.validateConfigurations(
+        Map(
+          "delta.minReaderVersion" -> readerVersion.toString,
+          "delta.minWriterVersion" -> writerVersion.toString
+        )
+      )
+    )
     toDataset(sparkSession, alterTableCmd)
   }
 }

--- a/core/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -539,10 +539,7 @@ class DeltaTable private[tables](
       DeltaConfigs.validateConfigurations(
         Map(
           "delta.minReaderVersion" -> readerVersion.toString,
-          "delta.minWriterVersion" -> writerVersion.toString
-        )
-      )
-    )
+          "delta.minWriterVersion" -> writerVersion.toString)))
     toDataset(sparkSession, alterTableCmd)
   }
 }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -157,6 +157,16 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
           TABLE_FEATURES_MIN_READER_VERSION,
           TABLE_FEATURES_MIN_WRITER_VERSION - 1)
       }
+      intercept[IllegalArgumentException] {
+        table.upgradeTableProtocol(
+          TABLE_FEATURES_MIN_READER_VERSION + 1,
+          TABLE_FEATURES_MIN_WRITER_VERSION)
+      }
+      intercept[IllegalArgumentException] {
+        table.upgradeTableProtocol(
+          TABLE_FEATURES_MIN_READER_VERSION,
+          TABLE_FEATURES_MIN_WRITER_VERSION + 1)
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

This PR addresses issue #1420 

When we try to update the versions using the [DeltaTable API](https://github.com/delta-io/delta/blob/1c18c1d972e37d314711b3a485e6fb7c98fce96d/core/src/main/scala/io/delta/tables/DeltaTable.scala#L536) `table.upgradeTableProtocol(readerVersion, writerVersion)` it currently is only validated by the [prepareCommit](https://github.com/delta-io/delta/blob/1c18c1d972e37d314711b3a485e6fb7c98fce96d/core/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala#L1147) function that validates and modifies all the actions that will be part of the transaction. Only [non-negative values requirements](https://github.com/delta-io/delta/blob/1c18c1d972e37d314711b3a485e6fb7c98fce96d/core/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala#L1227) are implemented. The solution is to verify the lower and upper bounds with Action.supportedProtocolVersion() using `DeltaConfigs` validation.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

Added unit tests

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
