### PR TITLE
[1602] Set environmental variable `DELTA_TESTING=1` in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -101,6 +101,9 @@ lazy val core = (project in file("core"))
       "-Xmx1024m"
     ),
 
+    // Required for testing table features see https://github.com/delta-io/delta/issues/1602
+    Test / envVars += ("DELTA_TESTING", "1"),
+
     // Hack to avoid errors related to missing repo-root/target/scala-2.12/classes/
     createTargetClassesDir := {
       val dir = baseDirectory.value.getParentFile / "target" / "scala-2.12" / "classes"

--- a/run-tests.py
+++ b/run-tests.py
@@ -53,7 +53,6 @@ def run_sbt_tests(root_dir, coverage, scala_version=None):
     cmd += ["-J-XX:+UseG1GC"]
     # 4x the default heap size (set in delta/built.sbt)
     cmd += ["-J-Xmx4G"]
-    run_cmd(cmd, env={"DELTA_TESTING": "1"}, stream_output=True)
 
 
 def run_python_tests(root_dir):


### PR DESCRIPTION
Resolves #1602 

Some table features tests rely on some "test table features" that are only supported when `DELTA_TESTING=1`. Otherwise tests fail with
```
[info]   org.apache.spark.sql.delta.DeltaTableFeatureException: Table features configured in the following Spark configs or Delta table properties are not recognized by this version of Delta Lake: delta.feature.testwriter.
```

This PR sets this in `build.sbt` and also removes setting it from `run-tests.py` since it should no longer be needed.

