### PR TITLE
Make numRecords statistic mandatory in files with Deletion Vectors

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -707,6 +707,9 @@ The row indexes encoded in this DV are: 3, 4, 7, 11, 18, 29.
 ## Reader Requirements for Deletion Vectors
 If a snapshot contains logical files with records that are invalidated by a DV, then these records *must not* be returned in the output.
 
+## Writer Requirement for Deletion Vectors
+When adding a logical file with a deletion vector, then that logical file must have correct `numRecords` information for the data file in the `stats` field.
+
 # Requirements for Writers
 This section documents additional requirements that writers must follow in order to preserve some of the higher level guarantees that Delta provides.
 
@@ -954,9 +957,10 @@ The following global statistic is currently supported:
 
 Name | Description
 -|-
-numRecords | The number of records in this file.
+numRecords | The number of records in this data file.
 tightBounds | Whether per-column statistics are currently **tight** or **wide** (see below).
 
+For any logical file where `deletionVector` is not `null`, the `numRecords` statistic *must* be present and accurate. That is, it must equal the number of records in the data file, not the valid records in the logical file.
 In the presence of [Deletion Vectors](#Deletion-Vectors) the statistics may be somewhat outdated, i.e. not reflecting deleted rows yet. The flag `stats.tightBounds` indicates whether we have **tight bounds** (i.e. the min/maxValue exists[^1] in the valid state of the file) or **wide bounds** (i.e. the minValue is <= all valid values in the file, and the maxValue >= all valid values in the file). These upper/lower bounds are sufficient information for data skipping.
 
 Per-column statistics record information for each column in the file and they are encoded, mirroring the schema of the actual data.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

Update the protocol to reflect that for all files with deletion vectors the `numRecords` statistic is mandatory.

## How was this patch tested?

n/a

## Does this PR introduce _any_ user-facing changes?

No
