### PR TITLE
Allow ignoring protocol-related configs in Spark session defaults when creating a table

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -63,11 +63,19 @@ import org.apache.spark.util._
  * Internally, this class implements an optimistic concurrency control
  * algorithm to handle multiple readers or writers. Any single read
  * is guaranteed to see a consistent snapshot of the table.
+ *
+ * @param logPath Path of the Delta log JSONs.
+ * @param dataPath Path of the data files.
+ * @param options Filesystem options filtered from `allOptions`.
+ * @param allOptions All options provided by the user, for example via `df.write.option()`. This
+ *                   includes but not limited to filesystem and table properties.
+ * @param clock Clock to be used when starting a new transaction.
  */
 class DeltaLog private(
     val logPath: Path,
     val dataPath: Path,
     val options: Map[String, String],
+    val allOptions: Map[String, String],
     val clock: Clock
   ) extends Checkpoints
   with MetadataCleanup
@@ -785,6 +793,7 @@ object DeltaLog extends DeltaLogging {
             logPath = path,
             dataPath = path.getParent,
             options = fileSystemOptions,
+            allOptions = options,
             clock = clock
           )
         }

--- a/core/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -544,11 +544,8 @@ trait OptimisticTransactionImpl extends TransactionalWrite
     }
 
     // We are done with protocol versions and features, time to remove related table properties.
-    val configsWithoutProtocolProps = newMetadataTmp.configuration.filter {
-      case (Protocol.MIN_READER_VERSION_PROP, _) => false
-      case (Protocol.MIN_WRITER_VERSION_PROP, _) => false
-      case (k, _) if k.startsWith(TableFeatureProtocolUtils.FEATURE_PROP_PREFIX) => false
-      case _ => true
+    val configsWithoutProtocolProps = newMetadataTmp.configuration.filterNot {
+      case (k, _) => TableFeatureProtocolUtils.isTableProtocolProperty(k)
     }
     newMetadataTmp = newMetadataTmp.copy(configuration = configsWithoutProtocolProps)
     assertMetadata(newMetadataTmp)

--- a/core/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -536,9 +536,13 @@ class InitialSnapshot(
     deltaLog,
     Metadata(
       configuration = DeltaConfigs.mergeGlobalConfigs(
-        SparkSession.active.sessionState.conf, Map.empty),
-      createdTime = Some(System.currentTimeMillis()))
-  )
+        sqlConfs = SparkSession.active.sessionState.conf,
+        tableConf = Map.empty,
+        ignoreProtocolConfsOpt = Some(
+          DeltaConfigs.ignoreProtocolDefaultsIsSet(
+            sqlConfs = SparkSession.active.sessionState.conf,
+            tableConf = deltaLog.allOptions))),
+      createdTime = Some(System.currentTimeMillis())))
 
   override def stateDS: Dataset[SingleAction] = emptyDF.as[SingleAction]
   override def stateDF: DataFrame = emptyDF

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -22,10 +22,6 @@ import scala.collection.mutable
 
 import org.apache.spark.sql.delta._
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.fasterxml.jackson.core.`type`.TypeReference
-import com.fasterxml.jackson.module.scala.JsonScalaEnumeration
-
-import org.apache.spark.util.Utils
 
 /**
  * Trait to be mixed into the [[Protocol]] case class to enable Table Features.
@@ -337,11 +333,13 @@ object TableFeatureProtocolUtils {
 
   /**
    * Checks if the the given table property key is a Table Protocol property, i.e.,
-   * `delta.minReaderVersion`, `delta.minWriterVersion`, or anything starts with `delta.feature.`
+   * `delta.minReaderVersion`, `delta.minWriterVersion`, ``delta.ignoreProtocolDefaults``, or
+   * anything that starts with `delta.feature.`
    */
   def isTableProtocolProperty(key: String): Boolean = {
     key == Protocol.MIN_READER_VERSION_PROP ||
     key == Protocol.MIN_WRITER_VERSION_PROP ||
+    key == DeltaConfigs.CREATE_TABLE_IGNORE_PROTOCOL_DEFAULTS.key ||
     key.startsWith(TableFeatureProtocolUtils.FEATURE_PROP_PREFIX)
   }
 }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
@@ -1702,8 +1702,6 @@ class DeltaTableCreationSuite
   override protected def getTableProperties(tableName: String): Map[String, String] = {
     loadTable(tableName).properties().asScala.toMap
       .filterKeys(!CatalogV2Util.TABLE_RESERVED_PROPERTIES.contains(_))
-      .filterKeys(k =>
-        k != Protocol.MIN_READER_VERSION_PROP &&  k != Protocol.MIN_WRITER_VERSION_PROP)
       .filterKeys(!TableFeatureProtocolUtils.isTableProtocolProperty(_))
       .toMap
   }


### PR DESCRIPTION
## Description

This PR introduces a Spark SQL config `delta.ignoreProtocolDefaults` that affects `CREATE TABLE` and `REPLACE AS` commands to ignore protocol-related Spark session defaults, including:

- `spark.databricks.delta.properties.defaults.minReaderVersion`
- `spark.databricks.delta.properties.defaults.minWriterVersion`
- configs with keys start with `spark.databricks.delta.properties.defaults.feature.`

When these session defaults are ignored, the user must specify the protocol versions and table features manually, or the table will get a min protocol that satisfies its metadata. For example, an empty table will get `Protocol(1, 1)`, regardless of the default protocol version `(1, 2)`.

## How was this patch tested?

New tests.

## Does this PR introduce _any_ user-facing changes?

Yes, see the previous section.
