### PR TITLE
Add properties to DeltaTableBuilder

### DIFF
--- a/core/src/main/scala/io/delta/tables/DeltaTableBuilder.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaTableBuilder.scala
@@ -297,6 +297,22 @@ class DeltaTableBuilder private[tables](
   /**
    * :: Evolving ::
    *
+   * Specify a group of properties to tag the table definition.
+   *
+   * @param properties key value map properties
+   *
+   * @since 2.3.0
+   */
+  @Evolving
+  def properties(properties: Map[String, String]): DeltaTableBuilder = {
+
+    this.properties = this.properties ++ properties
+    this
+  }
+
+  /**
+   * :: Evolving ::
+   *
    * Execute the command to create / replace a Delta table and returns a instance of [[DeltaTable]].
    *
    * @since 1.0.0

--- a/core/src/test/scala/io/delta/tables/DeltaTableBuilderSuite.scala
+++ b/core/src/test/scala/io/delta/tables/DeltaTableBuilderSuite.scala
@@ -372,8 +372,10 @@ class DeltaTableBuilderSuite extends QueryTest with SharedSparkSession with Delt
   }
 
   test("delta table property case") {
-    val preservedCaseConfig = Map("delta.appendOnly" -> "true", "Foo" -> "Bar", "foo" -> "Bar")
-    val lowerCaseEnforcedConfig = Map("delta.appendOnly" -> "true", "foo" -> "Bar")
+    val preservedCaseConfig = Map("delta.appendOnly" -> "true", "Foo" -> "Bar", "foo" -> "Bar",
+      "key" -> "value")
+    val lowerCaseEnforcedConfig = Map("delta.appendOnly" -> "true", "foo" -> "Bar",
+      "key" -> "value")
 
     sealed trait DeltaTablePropertySetOperation {
       def setTableProperty(tablePath: String): Unit
@@ -391,7 +393,8 @@ class DeltaTableBuilderSuite extends QueryTest with SharedSparkSession with Delt
     case object SetPropertyThroughCreate extends CasePreservingTablePropertySetOperation {
       def setTableProperty(tablePath: String): Unit = sql(
         s"CREATE TABLE delta.`$tablePath`(id INT) " +
-          s"USING delta TBLPROPERTIES('delta.appendOnly'='true', 'Foo'='Bar', 'foo'='Bar' ) "
+          s"USING delta TBLPROPERTIES" +
+          s"('delta.appendOnly'='true', 'Foo'='Bar', 'foo'='Bar', 'key'='value')"
       )
 
       val description = "Setting Table Property at Table Creation"
@@ -401,7 +404,8 @@ class DeltaTableBuilderSuite extends QueryTest with SharedSparkSession with Delt
       def setTableProperty(tablePath: String): Unit = {
         spark.range(1, 10).write.format("delta").save(tablePath)
         sql(s"ALTER TABLE delta.`$tablePath` " +
-          s"SET TBLPROPERTIES('delta.appendOnly'='true', 'Foo'='Bar', 'foo'='Bar')")
+          s"SET TBLPROPERTIES" +
+          s"('delta.appendOnly'='true', 'Foo'='Bar', 'foo'='Bar', 'key'='value')")
       }
 
       val description = "Setting Table Property via Table Alter"
@@ -418,6 +422,7 @@ class DeltaTableBuilderSuite extends QueryTest with SharedSparkSession with Delt
             .property("delta.appendOnly", "true")
             .property("Foo", "Bar")
             .property("foo", "Bar")
+            .properties(Map("key" -> "value"))
             .execute()
         }
       }

--- a/python/delta/tables.py
+++ b/python/delta/tables.py
@@ -1289,6 +1289,31 @@ class DeltaTableBuilder(object):
         self._jbuilder = self._jbuilder.property(key, value)
         return self
 
+    @since(2.3)  # type: ignore[arg-type]
+    def properties(self, properties: Dict[str, str]) -> "DeltaTableBuilder":
+        """
+        Specify a group of table properties
+
+        :param properties: the table properties dictionary
+
+        :return: this builder
+
+        .. note:: Evolving
+        """
+
+        jvm: "JVMView" = self._spark._sc._jvm  # type: ignore[attr-defined]
+
+        jmap: "JavaMap" = jvm.java.util.HashMap()
+
+        for key, value in properties.items():
+            if type(key) is not str or type(value) is not str:
+                self._raise_type_error("Key and value of property must be string.",
+                                       [key, value])
+            jmap.put(key, value)
+
+        self._jbuilder = self._jbuilder.properties(jmap)
+        return self
+
     @since(1.0)  # type: ignore[arg-type]
     def execute(self) -> DeltaTable:
         """

--- a/python/delta/tests/test_deltatable.py
+++ b/python/delta/tests/test_deltatable.py
@@ -923,6 +923,14 @@ class DeltaTableTestsMixin:
         with self.assertRaises(TypeError):
             builder.property("1", 1)  # type: ignore[arg-type]
 
+        # bad property key in dict
+        with self.assertRaises(TypeError):
+            builder.properties({1: '1'})  # type: ignore[arg-type]
+
+        # bad property value in dict
+        with self.assertRaises(TypeError):
+            builder.properties({'1': 1})  # type: ignore[arg-type]
+
     def test_protocolUpgrade(self) -> None:
         try:
             self.spark.conf.set('spark.databricks.delta.minWriterVersion', '2')


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

This PR resolves #1554. Currently, [DeltaTableBuilder](https://github.com/delta-io/delta/blob/master/core/src/main/scala/io/delta/tables/DeltaTableBuilder.scala#L292) only allows users to pass one property at a time. This PR adds the ability to add a group of properties in the form of a map

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Unit tests

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
Yes. Users can now pass multiple table properties at once using scala and python APIs
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
