### PR TITLE
Disable reading CDC from DV-supported Delta tables

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -1782,6 +1782,12 @@
     ],
     "sqlState" : "0AKDC"
   },
+  "DELTA_UNSUPPORTED_CHANGE_DATA_FEED_WITH_DELETION_VECTORS" : {
+    "message" : [
+      "Reading Change Data Feed from Version {version}, which contains Deletion Vectors, is unsupported by this version of Delta Lake."
+    ],
+    "sqlState" : "0AKDC"
+  },
   "DELTA_UNSUPPORTED_CLONE_REPLACE_SAME_TABLE" : {
     "message" : [
       "",

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2653,6 +2653,12 @@ trait DeltaErrorsBase
       pos = 0)
   }
 
+  def changeDataFeedNotSupportedWithDeletionVectors(version: Long): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_UNSUPPORTED_CHANGE_DATA_FEED_WITH_DELETION_VECTORS",
+      messageParameters = Array(version.toString))
+  }
+
   def generateNotSupportedWithDeletionVectors(): Throwable =
     new DeltaCommandUnsupportedWithDeletionVectorsException(
       errorClass = "DELTA_UNSUPPORTED_GENERATE_WITH_DELETION_VECTORS")

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
@@ -386,6 +386,10 @@ trait CDCReaderImpl extends DeltaLogging {
       throw DeltaErrors.changeDataNotRecordedException(start, start, end)
     }
 
+    if(startVersionSnapshot.protocol.isFeatureSupported(DeletionVectorsTableFeature)) {
+      throw DeltaErrors.changeDataFeedNotSupportedWithDeletionVectors(start)
+    }
+
     // Check schema read-compatibility
     val forceEnableUnsafeBatchReadOnIncompatibleSchemaChanges =
       spark.sessionState.conf.getConf(
@@ -501,11 +505,9 @@ trait CDCReaderImpl extends DeltaLogging {
             totalFiles += 1L
             totalBytes += c.size
           case a: AddFile =>
-            assertNoDeletionVectors(v, a)
             totalFiles += 1L
             totalBytes += a.size
           case r: RemoveFile =>
-            assertNoDeletionVectors(v, r)
             totalFiles += 1L
             totalBytes += r.size.getOrElse(0L)
           case i: CommitInfo => commitInfo = Some(i)
@@ -709,17 +711,6 @@ trait CDCReaderImpl extends DeltaLogging {
    */
   def isCDCEnabledOnTable(metadata: Metadata, spark: SparkSession): Boolean = {
     ChangeDataFeedTableFeature.metadataRequiresFeatureToBeEnabled(metadata, spark)
-  }
-
-  def assertNoDeletionVectors(version: Long, file: FileAction): Unit = {
-    val dv = file match {
-      case a: AddFile => a.deletionVector
-      case r: RemoveFile => r.deletionVector
-      case _ => null
-    }
-    if (dv != null) {
-      throw DeltaErrors.changeDataFeedNotSupportedWithDeletionVectors(version)
-    }
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
@@ -31,6 +31,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession, SQLContext}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
+import org.apache.spark.sql.delta.commands.DeletionVectorUtils
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.{BaseRelation, Filter, PrunedFilteredScan}
@@ -386,7 +387,7 @@ trait CDCReaderImpl extends DeltaLogging {
       throw DeltaErrors.changeDataNotRecordedException(start, start, end)
     }
 
-    if(startVersionSnapshot.protocol.isFeatureSupported(DeletionVectorsTableFeature)) {
+    if (DeletionVectorUtils.deletionVectorsReadable(startVersionSnapshot)) {
       throw DeltaErrors.changeDataFeedNotSupportedWithDeletionVectors(start)
     }
 


### PR DESCRIPTION
## Description

This PR adds a check to disable reading CDC from a table that have DV marked as `supported` in the protocol. Reading CDC with DV is not yet supported in the current version of Delta Lake.

## How was this patch tested?

Not needed. Trivial change.
