### PR TITLE
[1571] Fix `COUNT(*)` aggregate queries to use metadata-only optimization for `.show()` command

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuery.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuery.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.delta.perf
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Alias, Literal}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Cast, Literal}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Complete, Count}
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -25,17 +25,42 @@ import org.apache.spark.sql.delta.DeltaTable
 import org.apache.spark.sql.delta.files.TahoeLogFileIndex
 import org.apache.spark.sql.delta.stats.DeltaScanGenerator
 import org.apache.spark.sql.functions.{coalesce, col, count, lit, sum, when}
+import org.apache.spark.sql.types.StringType
+import org.apache.spark.unsafe.types.UTF8String
 
 trait OptimizeMetadataOnlyDeltaQuery {
   def optimizeQueryWithMetadata(plan: LogicalPlan): LogicalPlan = {
     plan.transformUpWithSubqueries {
       case agg@CountStarDeltaTable(countValue) =>
         LocalRelation(agg.output, Seq(InternalRow(countValue)))
+      case agg@ShowCountStarDeltaTable(countValue) =>
+        LocalRelation(agg.output, Seq(InternalRow(countValue)))
     }
   }
 
   protected def getDeltaScanGenerator(index: TahoeLogFileIndex): DeltaScanGenerator
 
+  /** Return the number of rows in the table or `None` if we cannot calculate it from stats */
+  private def extractGlobalCount(tahoeLogFileIndex: TahoeLogFileIndex): Option[Long] = {
+    // account for deleted rows according to deletion vectors
+    val dvCardinality = coalesce(col("deletionVector.cardinality"), lit(0))
+    val numLogicalRecords = (col("stats.numRecords") - dvCardinality).as("numLogicalRecords")
+
+    val row = getDeltaScanGenerator(tahoeLogFileIndex).filesWithStatsForScan(Nil)
+      .agg(
+        sum(numLogicalRecords),
+        // Calculate the number of files missing `numRecords`
+        count(when(col("stats.numRecords").isNull, 1)))
+      .first
+
+    // The count agg is never null. A non-zero value means we have incomplete stats; otherwise,
+    // the sum agg is either null (for an empty table) or gives an accurate record count.
+    if (row.getLong(1) > 0) return None
+    val numRecords = if (row.isNullAt(0)) 0 else row.getLong(0)
+    Some(numRecords)
+  }
+
+  /** e.g. sql("SELECT COUNT(*) FROM <deta-table>").collect() */
   object CountStarDeltaTable {
     def unapply(plan: Aggregate): Option[Long] = plan match {
       case Aggregate(
@@ -45,25 +70,24 @@ trait OptimizeMetadataOnlyDeltaQuery {
         => extractGlobalCount(i)
       case _ => None
     }
+  }
 
-    /** Return the number of rows in the table or `None` if we cannot calculate it from stats */
-    private def extractGlobalCount(tahoeLogFileIndex: TahoeLogFileIndex): Option[Long] = {
-      // account for deleted rows according to deletion vectors
-      val dvCardinality = coalesce(col("deletionVector.cardinality"), lit(0))
-      val numLogicalRecords = (col("stats.numRecords") - dvCardinality).as("numLogicalRecords")
-
-      val row = getDeltaScanGenerator(tahoeLogFileIndex).filesWithStatsForScan(Nil)
-        .agg(
-          sum(numLogicalRecords),
-          // Calculate the number of files missing `numRecords`
-          count(when(col("stats.numRecords").isNull, 1)))
-        .first
-
-      // The count agg is never null. A non-zero value means we have incomplete stats; otherwise,
-      // the sum agg is either null (for an empty table) or gives an accurate record count.
-      if (row.getLong(1) > 0) return None
-      val numRecords = if (row.isNullAt(0)) 0 else row.getLong(0)
-      Some(numRecords)
+  /** e.g. sql("SELECT COUNT(*) FROM <delta-table>").show() */
+  object ShowCountStarDeltaTable {
+    def unapply(plan: Aggregate): Option[UTF8String] = plan match {
+      case Aggregate(
+        Nil,
+        Seq(
+          Alias(
+            Cast(
+              AggregateExpression(Count(Seq(Literal(1, _))), Complete, false, None, _),
+              StringType, _, _),
+          _)
+        ),
+        PhysicalOperation(_, Nil, DeltaTable(i: TahoeLogFileIndex))
+      ) if i.partitionFilters.isEmpty =>
+        extractGlobalCount(i).map { count => UTF8String.fromString(count.toString) }
+      case _ => None
     }
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuery.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuery.scala
@@ -86,7 +86,11 @@ trait OptimizeMetadataOnlyDeltaQuery {
         ),
         PhysicalOperation(_, Nil, DeltaTable(i: TahoeLogFileIndex))
       ) if i.partitionFilters.isEmpty =>
-        extractGlobalCount(i).map { count => UTF8String.fromString(count.toString) }
+        extractGlobalCount(i).map { count =>
+          // The following code is following how Spark casts a long type to a string type.
+          // See org.apache.spark.sql.catalyst.expressions.Cast#castToString.
+          UTF8String.fromString(count.toString)
+        }
       case _ => None
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuerySuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuerySuite.scala
@@ -322,16 +322,20 @@ class OptimizeMetadataOnlyDeltaQuerySuite
     }
   }
 
+  // scalastyle:off println
   test(".collect() and .show() both use this optimization") {
     val collectPlans = DeltaTestUtils.withLogicalPlansCaptured(spark, optimizedPlan = true) {
-      val result = spark.sql(s"SELECT COUNT(*) FROM $testTableName").collect()
-      assert(result(0)(0) === totalRows)
+      spark.sql(s"SELECT COUNT(*) FROM $testTableName").collect()
     }
-    assert(collectPlans.collect { case x: LocalRelation => x }.size === 1)
+    val collectResultData = collectPlans.collect { case x: LocalRelation => x.data }
+    assert(collectResultData.size === 1)
+    assert(collectResultData.head.head.getLong(0) === totalRows)
 
     val showPlans = DeltaTestUtils.withLogicalPlansCaptured(spark, optimizedPlan = true) {
       spark.sql(s"SELECT COUNT(*) FROM $testTableName").show()
     }
-    assert(showPlans.collect { case x: LocalRelation => x }.size === 1)
+    val showResultData = showPlans.collect { case x: LocalRelation => x.data }
+    assert(showResultData.size === 1)
+    assert(showResultData.head.head.getString(0).toLong === totalRows)
   }
 }

--- a/core/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuerySuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuerySuite.scala
@@ -324,7 +324,8 @@ class OptimizeMetadataOnlyDeltaQuerySuite
 
   test(".collect() and .show() both use this optimization") {
     val collectPlans = DeltaTestUtils.withLogicalPlansCaptured(spark, optimizedPlan = true) {
-      spark.sql(s"SELECT COUNT(*) FROM $testTableName").collect()
+      val result = spark.sql(s"SELECT COUNT(*) FROM $testTableName").collect()
+      assert(result(0)(0) === totalRows)
     }
     assert(collectPlans.collect { case x: LocalRelation => x }.size === 1)
 


### PR DESCRIPTION
## Description

Resolves delta-io/delta#1571. Previously, metadata-only aggregate pushdown was only working for `COUNT(*)` queries when you were collecting the result, as opposed to calling `.show()`. This PR fixes that bug.

## How was this patch tested?

Added a UT that captures the optimized logical plan and checks that it is using the LocalRelation created by OptimizeMetadataOnlyDeltaQuery.

Also did a performance test locally. Created a table with 100M rows and 100K files and ran the query `sql("SELECT COUNT(*) FROM <delta-table>").show()`
- master took ms ~161 seconds.
- this PR took ~16 seconds. Thus, this is a ~10x improvement.