### PR TITLE
Upgrade to Spark 3.3.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@
 import java.nio.file.Files
 import TestParallelization._
 
-val sparkVersion = "3.3.1"
+val sparkVersion = "3.3.2"
 val scala212 = "2.12.15"
 val scala213 = "2.13.5"
 val default_scala_version = scala212

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
@@ -737,21 +737,18 @@ class DeltaTimeTravelSuite extends QueryTest
     }
   }
 
-
-  // This is currently set up to fail once the bug is fixed (should be when upgrading to Spark 3.4)
-  // See https://github.com/delta-io/delta/issues/1479
-  test("SPARK-41154: Incorrect relation caching for queries with time travel spec") {
+  test("SPARK-41154: Correct relation caching for queries with time travel spec") {
     val tblName = "tab"
     withTable(tblName) {
       sql(s"CREATE TABLE $tblName USING DELTA AS SELECT 1 as c")
       sql(s"INSERT INTO $tblName SELECT 2 as c")
-      assert(
+      checkAnswer(
         sql(s"""
-              |SELECT * FROM $tblName VERSION AS OF '0'
-              |UNION ALL
-              |SELECT * FROM $tblName VERSION AS OF '1'
-              |""".stripMargin
-        ).collect() === Array(Row(1), Row(1))) // this should be Array(Row(1), Row(1), Row(2))
+          |SELECT * FROM $tblName VERSION AS OF '0'
+          |UNION ALL
+          |SELECT * FROM $tblName VERSION AS OF '1'
+          |""".stripMargin),
+        Row(1) :: Row(1) :: Row(2) :: Nil)
     }
   }
 }


### PR DESCRIPTION
Upgrade spark version to 3.3.2. Updates one test for a fix in 3.3.2.

Resolves #1479