### PR TITLE
Add support for Structs evolution in MapType value

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -1937,6 +1937,12 @@
     ],
     "sqlState" : "0AKDC"
   },
+  "DELTA_UNSUPPORTED_MAP_KEY_TYPE_CHANGE" : {
+    "message" : [
+      "Changing map key type is not supported: '<fromKT>' to '<toKT>' in <in>."
+    ],
+    "sqlState" : "0AKDC"
+  },
   "DELTA_UNSUPPORTED_MULTI_COL_IN_PREDICATE" : {
     "message" : [
       "Multi-column In predicates are not supported in the <operation> condition."

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2666,6 +2666,14 @@ trait DeltaErrorsBase
       messageParameters = Array(s"$expType", causedBy, supportedTypes.mkString(","))
     )
   }
+
+  def unsupportedMapKeyTypeChange(in: DataType, fromKT: DataType, toKT: DataType): Throwable = {
+
+    new DeltaAnalysisException(
+      errorClass = "DELTA_UNSUPPORTED_MAP_KEY_TYPE_CHANGE",
+      messageParameters = Array(in.catalogString, fromKT.catalogString, toKT.catalogString)
+    )
+  }
 }
 
 object DeltaErrors extends DeltaErrorsBase

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -53,7 +53,7 @@ import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
-import org.apache.spark.sql.types.{CalendarIntervalType, DataTypes, DateType, IntegerType, StringType, StructField, StructType, TimestampNTZType}
+import org.apache.spark.sql.types.{CalendarIntervalType, DataTypes, DateType, IntegerType, MapType, StringType, StructField, StructType, TimestampNTZType}
 
 trait DeltaErrorsSuiteBase
     extends QueryTest
@@ -2813,6 +2813,19 @@ trait DeltaErrorsSuiteBase
       assert(e.getSqlState == "22000")
       assert(e.getMessage ==
         "Function invalid1 is an unsupported table valued function for CDC reads.")
+    }
+    {
+      val e = intercept[DeltaAnalysisException] {
+        throw DeltaErrors.unsupportedMapKeyTypeChange(
+          StringType,
+          IntegerType,
+          MapType(StringType, new StructType().add("a", IntegerType).add("b", IntegerType)))
+      }
+      assert(e.getErrorClass == "DELTA_UNSUPPORTED_MAP_KEY_TYPE_CHANGE")
+      assert(e.getSqlState == "0AKDC")
+      assert(
+        e.getMessage ==
+          "Changing map key type is not supported: 'string' to 'int' in map<string,struct<a:int,b:int>>.")
     }
   }
 }

--- a/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
@@ -637,7 +637,8 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase  with MergeIntoNotMatchedBy
           val setColExprStr = clause.action.trim.stripPrefix("UPDATE SET")
           if (setColExprStr.trim == "*") {          // UPDATE SET *
             actionBuilder.updateAll()
-          } else if (setColExprStr.contains("array_")) { // UPDATE SET x = array_union(..)
+          } else if (setColExprStr.contains("array_") || setColExprStr.contains("map_")) {
+            // UPDATE SET x = array_union(..) / map_concat(..)
             val setColExprPairs = parseUpdate(setColExprStr)
             actionBuilder.updateExpr(setColExprPairs)
           } else {                                 // UPDATE SET x = a, y = b, z = c


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

This PR resolves issue #1641 to allow automatic schema evolution in Structs that are inside MapTypes.

The issue can be replicated with:

```
import scala.collection.JavaConverters._
import org.apache.spark.sql.types._
import io.delta.tables._

val schema = StructType(
    StructField("id", IntegerType) ::
    StructField(
      "map", MapType(
        StringType, StructType(
          StructField("a", IntegerType) ::
            StructField("b", IntegerType) ::
            StructField("c", StringType) ::
            Nil
        )
      )) ::
    Nil
)

val sourceDataFrame = spark.createDataFrame(
  Seq(
    Row.fromSeq(
      Seq(0, Map("key" -> Tuple3(0, 1, "a"), "key1" -> Tuple3(2, 3, "b")))
    )).asJava, schema)

sourceDataFrame.write.format("delta").mode("append").save("delta/test")

val updatedSchema = StructType(
    StructField("id", IntegerType) ::
    StructField(
      "map", MapType(
        StringType, StructType(
          StructField("a", IntegerType) ::
            StructField("b", IntegerType) ::
            Nil
        )
      )) ::
    Nil
)

val updatedSourceDataFrame = spark.createDataFrame(
  Seq(
    Row.fromSeq(
      Seq(0, Map("key" -> Tuple2(0, 1), "key1" -> Tuple2(2, 3)))
    )).asJava, updatedSchema)

val targetDeltaTable = DeltaTable.forPath(spark, "delta/test")

targetDeltaTable.alias("t").merge(
    updatedSourceDataFrame.alias("s"),
    "t.id = s.id")
  .whenMatched().updateAll()
  .whenNotMatched().insertAll()
  .execute()

//AnalysisException: cannot resolve 's.map' due to data type mismatch: cannot cast map<string,struct<a:int,b:int>> to map<string,struct<a:int,b:int,c:string>>;
```


<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Unit tests

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No