### PR TITLE
Assert DV does not exist during CLONE and table prop overrides

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -11,6 +11,12 @@
     ],
     "sqlState" : "0B000"
   },
+  "DELTA_ADDING_DELETION_VECTORS_DISALLOWED" : {
+    "message" : [
+      "The current operation attempted to add a deletion vector to a table that does not permit the creation of new deletion vectors. Please file a bug report."
+    ],
+    "sqlState" : "0A000"
+  },
   "DELTA_ADD_COLUMN_AT_INDEX_LESS_THAN_ZERO" : {
     "message" : [
       "Index <columnIndex> to add column <columnName> is lower than 0"

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2657,6 +2657,10 @@ trait DeltaErrorsBase
     new DeltaCommandUnsupportedWithDeletionVectorsException(
       errorClass = "DELTA_UNSUPPORTED_GENERATE_WITH_DELETION_VECTORS")
 
+  def addingDeletionVectorsDisallowedException(): Throwable =
+    new DeltaCommandUnsupportedWithDeletionVectorsException(
+      errorClass = "DELTA_ADDING_DELETION_VECTORS_DISALLOWED")
+
   def unsupportedExpression(
     causedBy: String,
     expType: DataType,

--- a/core/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1054,12 +1054,14 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       var bytesNew: Long = 0L
       var addFilesHistogram: Option[FileSizeHistogram] = None
       var removeFilesHistogram: Option[FileSizeHistogram] = None
+      val assertDeletionVectorWellFormed = getAssertDeletionVectorWellFormedFunc(spark, op)
       var allActions = (extraActions.toIterator ++ actions).map { action =>
         commitSize += 1
         action match {
           case a: AddFile =>
             numAddFiles += 1
             if (a.pathAsUri.isAbsolute) numAbsolutePaths += 1
+            assertDeletionVectorWellFormed(a)
             if (a.dataChange) bytesNew += a.size
             addFilesHistogram.foreach(_.insert(a.size))
           case r: RemoveFile =>

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1134,6 +1134,16 @@ trait DeltaSQLConfBase {
       .doc("Enable persistent Deletion Vectors in the Delete command.")
       .booleanConf
       .createWithDefault(true)
+
+  val DELETION_VECTORS_COMMIT_CHECK_ENABLED =
+    buildConf("deletionVectors.skipCommitCheck")
+      .internal()
+      .doc(
+        """Check the table-property and verify that deletion vectors may be added
+          |to this table.
+          |Only change this for testing!""".stripMargin)
+      .booleanConf
+      .createWithDefault(true)
 }
 
 object DeltaSQLConf extends DeltaSQLConfBase

--- a/core/src/test/scala/org/apache/spark/sql/delta/CloneTableSuiteBase.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/CloneTableSuiteBase.scala
@@ -119,6 +119,7 @@ trait CloneTableSuiteBase extends QueryTest
       isReplaceOperation: Boolean = false,
       // If we are doing a replace, whether it is on a Delta table
       isReplaceDelta: Boolean = true,
+      tableProperties: Map[String, String] = Map.empty,
       commitLargeMetricsMap: Map[String, String] = Map.empty,
       expectedDataframe: DataFrame = spark.emptyDataFrame)
       (f: () => Unit =
@@ -132,7 +133,8 @@ trait CloneTableSuiteBase extends QueryTest
           sourceVersion,
           sourceTimestamp,
           isCreate,
-          isReplaceOperation)): Unit = {
+          isReplaceOperation,
+          tableProperties)): Unit = {
     // scalastyle:on
 
     // Truncate table before REPLACE
@@ -810,6 +812,19 @@ trait CloneTableSuiteBase extends QueryTest
           sourceFormat = "parquet",
           expectedDataframe = df)()
       }
+  }
+
+  testAllClones("CLONE with table properties to disable DV") { (source, target, isShallow) =>
+    withSQLConf(DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.defaultTablePropertyKey -> "true") {
+      spark.range(10).write.format("delta").save(source)
+      spark.sql(s"DELETE FROM delta.`$source` WHERE id = 1")
+    }
+    intercept[DeltaCommandUnsupportedWithDeletionVectorsException] {
+      runAndValidateClone(
+        source,
+        target,
+        tableProperties = Map(DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.key -> "false"))()
+    }.getErrorClass === "DELTA_ADDING_DELETION_VECTORS_DISALLOWED"
   }
 
   testAllClones("clone parquet source - create or replace existing table using name",


### PR DESCRIPTION
## Description

This PR adds a check to `txn.commitLarge` to avoid cloning DVs to a table while disabling DV table prop:

```sql
CREATE TABLE tbl SHALLOW CLONE tbl_dv TBLPROPERTIES('delta.enableDeletionVectors'='false')
```

Before: `tbl_dv` will have DVs.
After: the transaction will fail.

## How was this patch tested?

New tests.

## Does this PR introduce _any_ user-facing changes?

No.