### PR TITLE
Allow supporting table features via `DeltaTable` user-facing API

### DIFF
--- a/core/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -19,7 +19,7 @@ package io.delta.tables
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.delta._
-import org.apache.spark.sql.delta.actions.Protocol
+import org.apache.spark.sql.delta.actions.{Protocol, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.AlterTableSetPropertiesDeltaCommand
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -539,6 +539,27 @@ class DeltaTable private[tables](
       Map(
         "delta.minReaderVersion" -> readerVersion.toString,
         "delta.minWriterVersion" -> writerVersion.toString))
+    toDataset(sparkSession, alterTableCmd)
+  }
+
+  /**
+   * Modify the protocol to add a supported feature, and if the table does not support table
+   * features, upgrade the protocol automatically. In such a case when the provided feature is
+   * writer-only, the table's writer version will be upgraded to `7`, and when the provided
+   * feature is reader-writer, both reader and writer versions will be upgraded, to `(3, 7)`.
+   *
+   * See online documentation and Delta's protocol specification at PROTOCOL.md for more details.
+   *
+   * @since 2.3.0
+   */
+  def addFeatureSupport(featureName: String): Unit = {
+    // Do not check for the correctness of the provided feature name. The ALTER TABLE command will
+    // do that in a transaction.
+    val alterTableCmd = AlterTableSetPropertiesDeltaCommand(
+      table,
+      Map(
+        TableFeatureProtocolUtils.propertyKey(featureName) ->
+          TableFeatureProtocolUtils.FEATURE_PROP_SUPPORTED))
     toDataset(sparkSession, alterTableCmd)
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -283,12 +283,18 @@ object TableFeatureProtocolUtils {
   val TABLE_FEATURES_MIN_WRITER_VERSION = 7
 
   /** Get the table property config key for the `feature`. */
-  def propertyKey(feature: TableFeature): String =
-    s"$FEATURE_PROP_PREFIX${feature.name}"
+  def propertyKey(feature: TableFeature): String = propertyKey(feature.name)
+
+  /** Get the table property config key for the `featureName`. */
+  def propertyKey(featureName: String): String =
+    s"$FEATURE_PROP_PREFIX$featureName"
 
   /** Get the session default config key for the `feature`. */
-  def defaultPropertyKey(feature: TableFeature): String =
-    s"$DEFAULT_FEATURE_PROP_PREFIX${feature.name}"
+  def defaultPropertyKey(feature: TableFeature): String = defaultPropertyKey(feature.name)
+
+  /** Get the session default config key for the `featureName`. */
+  def defaultPropertyKey(featureName: String): String =
+    s"$DEFAULT_FEATURE_PROP_PREFIX$featureName"
 
   /**
    * Determine whether a [[Protocol]] with the given reader protocol version is capable of adding

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -334,11 +334,11 @@ object TableFeatureProtocolUtils {
         unsupportedFeatureConfigs += key
       }
       featureOpt
-    }
+    }.toSet
     if (unsupportedFeatureConfigs.nonEmpty) {
       throw DeltaErrors.unsupportedTableFeatureConfigsException(unsupportedFeatureConfigs)
     }
-    collectedFeatures.toSet
+    collectedFeatures
   }
 
   /**

--- a/core/src/test/scala/io/delta/tables/DeltaTableSuite.scala
+++ b/core/src/test/scala/io/delta/tables/DeltaTableSuite.scala
@@ -22,7 +22,7 @@ import java.util.Locale
 import scala.language.postfixOps
 
 // scalastyle:off import.ordering.noEmptyLine
-import org.apache.spark.sql.delta.{DeltaIllegalArgumentException, DeltaLog, FakeFileSystem}
+import org.apache.spark.sql.delta.{DeltaIllegalArgumentException, DeltaLog, DeltaTableFeatureException, FakeFileSystem, TestReaderWriterFeature, TestWriterFeature}
 import org.apache.spark.sql.delta.actions.{ Metadata, Protocol }
 import org.apache.spark.sql.delta.storage.LocalLogStore
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
@@ -238,6 +238,7 @@ class DeltaTableHadoopOptionsSuite extends QueryTest
   private val ignoreMethods = Seq()
 
   private val testedMethods = Seq(
+    "addFeatureSupport",
     "as",
     "alias",
     "delete",
@@ -549,6 +550,39 @@ class DeltaTableHadoopOptionsSuite extends QueryTest
 
       val expectedProtocol = Protocol(1, 2)
       assert(log.snapshot.protocol === expectedProtocol)
+    }
+  }
+
+  test(
+    "addFeatureSupport - with filesystem options.") {
+    withTempDir { dir =>
+      val path = fakeFileSystemPath(dir)
+      val fsOptions = fakeFileSystemOptions
+
+      // create a table with a default Protocol.
+      val testSchema = spark.range(1).schema.asNullable
+      val log = DeltaLog.forTable(spark, path, fsOptions)
+      log.ensureLogDirectoryExist()
+      log.store.write(
+        FileNames.deltaFile(log.logPath, 0),
+        Iterator(Metadata(schemaString = testSchema.json).json, Protocol(1, 1).json),
+        overwrite = false,
+        log.newDeltaHadoopConf())
+      log.update()
+
+      // update the protocol to support a writer feature.
+      val table = DeltaTable.forPath(spark, path, fsOptions)
+      table.addFeatureSupport(TestWriterFeature.name)
+      assert(log.update().protocol === Protocol(1, 7).withFeature(TestWriterFeature))
+      table.addFeatureSupport(TestReaderWriterFeature.name)
+      assert(
+        log.update().protocol === Protocol(3, 7)
+          .withFeatures(Seq(TestWriterFeature, TestReaderWriterFeature)))
+
+      // update the protocol again with invalid feature name.
+      assert(intercept[DeltaTableFeatureException] {
+        table.addFeatureSupport("__invalid_feature__")
+      }.getErrorClass === "DELTA_UNSUPPORTED_FEATURES_IN_CONFIG")
     }
   }
 


### PR DESCRIPTION
## Description

This PR adds a new user-facing API `addFeatureSupport`, allowing users to add table features to a table's `protocol` action. Along with an existing API `upgradeTableProtocol`, we now provide sufficient API to manipulate table protocol.

## How was this patch tested?

A new test.

## Does this PR introduce _any_ user-facing changes?

Yes, see the first section.