### PR TITLE
[DO_NOT_MERGE] Check 2.3 compatibility with Spark 3.3.1

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
           pyenv install 3.7.4
           pyenv global system 3.7.4
           pipenv --python 3.7 install
-          pipenv run pip install pyspark==3.3.2
+          pipenv run pip install pyspark==3.3.1
           pipenv run pip install flake8==3.5.0 pypandoc==1.3.3
           pipenv run pip install importlib_metadata==3.10.0
           pipenv run pip install mypy==0.910

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM python:3.7.3-stretch
 
 RUN apt-get update && apt-get -y install openjdk-8-jdk
 
-RUN pip install pyspark==3.3.2
+RUN pip install pyspark==3.3.1
 
 RUN pip install mypy==0.910
 

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@
 import java.nio.file.Files
 import TestParallelization._
 
-val sparkVersion = "3.3.2"
+val sparkVersion = "3.3.1"
 val scala212 = "2.12.15"
 val scala213 = "2.13.5"
 val default_scala_version = scala212

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
@@ -737,19 +737,19 @@ class DeltaTimeTravelSuite extends QueryTest
     }
   }
 
-
-  test("SPARK-41154: Correct relation caching for queries with time travel spec") {
+  // Tests the incorrect behavior that is patch fixed in 3.3.2
+  test("SPARK-41154: Incorrect relation caching for queries with time travel spec") {
     val tblName = "tab"
     withTable(tblName) {
       sql(s"CREATE TABLE $tblName USING DELTA AS SELECT 1 as c")
       sql(s"INSERT INTO $tblName SELECT 2 as c")
-      checkAnswer(
+      assert(
         sql(s"""
-          |SELECT * FROM $tblName VERSION AS OF '0'
-          |UNION ALL
-          |SELECT * FROM $tblName VERSION AS OF '1'
-          |""".stripMargin),
-        Row(1) :: Row(1) :: Row(2) :: Nil)
+               |SELECT * FROM $tblName VERSION AS OF '0'
+               |UNION ALL
+               |SELECT * FROM $tblName VERSION AS OF '1'
+               |""".stripMargin
+        ).collect() === Array(Row(1), Row(1))) // this should be Array(Row(1), Row(1), Row(2))
     }
   }
 }


### PR DESCRIPTION
Verify that `branch-2.3` is compatible with Spark 3.3.1. Reverts one test that was fixed in Spark 3.3.2 (see https://github.com/delta-io/delta/pull/1644)