### PR TITLE
Allow restricting table features to auto-update protocol versions

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -657,6 +657,19 @@
     ],
     "sqlState" : "0AKDE"
   },
+  "DELTA_FEATURES_REQUIRE_MANUAL_ENABLEMENT" : {
+    "message" : [
+      "Your table schema requires the following table feature(s) that require manual enablement: <features>.",
+      "",
+      "To do this, run the following command for each of features listed above:",
+      "  ALTER TABLE table_name SET TBLPROPERTIES ('delta.feature.feature_name' = 'supported')",
+      "Replace \"table_name\" and \"feature_name\" with real values.",
+      "",
+      "Required Delta protocol: <requiredVersion>",
+      "Current Delta protocol: <currentVersion>"
+    ],
+    "sqlState" : "0AKDE"
+  },
   "DELTA_FEATURE_REQUIRES_HIGHER_READER_VERSION" : {
     "message" : [
       "Unable to enable table feature <feature> because it requires a higher reader protocol version (current <current>). Consider upgrading the table's reader protocol version to <required>, or to a version which supports reader table features. Refer to <docLink> for more information on table protocol versions."
@@ -2076,21 +2089,6 @@
       "Cannot time travel views, subqueries, streams or change data feed queries."
     ],
     "sqlState" : "0AKDC"
-  },
-  "DELTA_UNSUPPORTED_TYPE_TIMESTAMP_NTZ" : {
-    "message" : [
-      "Your table schema <schema> contains a column of type TimestampNTZ.",
-      "TimestampNTZ type is not supported by your table's protocol.",
-      "",
-      "Required Delta protocol version and features for TimestampNTZ:",
-      "<requiredVersion>",
-      "Your table's current Delta protocol version and enabled features:",
-      "<currentVersion>",
-      "",
-      "Run the following command to add TimestampNTZ support to your table.",
-      "ALTER TABLE table_name SET TBLPROPERTIES ('delta.feature.timestampNtz' = 'supported')"
-    ],
-    "sqlState" : "0A000"
   },
   "DELTA_UNSUPPORTED_VACUUM_SPECIFIC_PARTITION" : {
     "message" : [

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1720,20 +1720,6 @@ trait DeltaErrorsBase
     )
   }
 
-  def schemaContainsTimestampNTZType(
-      schema: StructType,
-      requiredProtocol: Protocol,
-      currentProtocol: Protocol): Throwable = {
-    new DeltaAnalysisException(
-      errorClass = "DELTA_UNSUPPORTED_TYPE_TIMESTAMP_NTZ",
-      messageParameters = Array(
-        s"${formatSchema(schema)}",
-        s"$requiredProtocol",
-        s"$currentProtocol"
-      )
-    )
-  }
-
   def tableAlreadyExists(table: CatalogTable): Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_TABLE_ALREADY_EXISTS",
@@ -2173,6 +2159,18 @@ trait DeltaErrorsBase
     new DeltaTableFeatureException(
       errorClass = "DELTA_FEATURES_PROTOCOL_METADATA_MISMATCH",
       messageParameters = Array(features.mkString(", ")))
+  }
+
+  def tableFeaturesRequireManualEnablementException(
+      features: Iterable[String],
+      requiredProtocol: Protocol,
+      currentProtocol: Protocol): Throwable = {
+    new DeltaTableFeatureException(
+      errorClass = "DELTA_FEATURES_REQUIRE_MANUAL_ENABLEMENT",
+      messageParameters = Array(
+        features.mkString(", "),
+        requiredProtocol.toString,
+        currentProtocol.toString))
   }
 
   def concurrentAppendException(

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -309,18 +309,15 @@ object TableFeatureProtocolUtils {
   }
 
   /**
-   * Get a set of [[TableFeature]]s representing supported features set in a `config` map (table
-   * properties or Spark session configs).
+   * Get a set of [[TableFeature]]s representing supported features set in a table properties map.
    */
-  def getSupportedFeaturesFromConfigs(
-      configs: Map[String, String],
-      propertyPrefix: String): Set[TableFeature] = {
-    val featureConfigs = configs.filterKeys(_.startsWith(propertyPrefix))
+  def getSupportedFeaturesFromConfigs(configs: Map[String, String]): Set[TableFeature] = {
+    val featureConfigs = configs.filterKeys(_.startsWith(FEATURE_PROP_PREFIX))
     val unsupportedFeatureConfigs = mutable.Set.empty[String]
     val collectedFeatures = featureConfigs.flatMap { case (key, value) =>
       // Feature name is lower cased in table properties but not in Spark session configs.
       // Feature status is not lower cased in any case.
-      val name = key.stripPrefix(propertyPrefix).toLowerCase(Locale.ROOT)
+      val name = key.stripPrefix(FEATURE_PROP_PREFIX).toLowerCase(Locale.ROOT)
       val status = value.toLowerCase(Locale.ROOT)
       if (status != FEATURE_PROP_SUPPORTED && status != FEATURE_PROP_ENABLED) {
         throw DeltaErrors.unsupportedTableFeatureStatusException(name, status)

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaTimestampNTZSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaTimestampNTZSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta
 import java.sql.Timestamp
 import java.time.LocalDateTime
 
-import org.apache.spark.sql.delta.actions.Protocol
+import org.apache.spark.sql.delta.actions.{Protocol, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 import org.apache.spark.SparkThrowable


### PR DESCRIPTION
## Description

This PR allows marking a metadata table feature as "auto-update capable", such that during ALTER TABLE when its metadata requirements are satisfied, the table's protocol will be automatically and silently bumped to the required version.

Note that this mechanism only applies to "metadata requirements". `'delta.feature.featureName' = 'supported'` table prop will still auto-update the table's protocol to support table features.

Also, this mechanism only affects existing tables. For new tables, the protocol is always set to the min version that satisfies all enabled features, aka. all features are auto-update capable.

For compatibility, legacy table features (features supported by `Protocol(2, 6)`) are always auto-update capable. Specifically, Column Mapping implements its own mechanism to block the usage without protocol version bumps.

## How was this patch tested?

New tests.

## Does this PR introduce _any_ user-facing changes?

No. This PR affects only feature developers.