### PR TITLE
Add show partitions for delta table

### DIFF
--- a/core/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
+++ b/core/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
@@ -94,6 +94,8 @@ statement
     | cloneTableHeader SHALLOW CLONE source=qualifiedName clause=temporalClause?
        (TBLPROPERTIES tableProps=propertyList)?
        (LOCATION location=stringLit)?                                   #clone
+    | SHOW PARTITIONS DETAIL? (path=STRING | table=qualifiedName)
+     partitionSpec?                                                     #showPartitions
     | .*?                                                               #passThrough
     ;
 
@@ -113,6 +115,14 @@ cloneTableHeader
 zorderSpec
     : ZORDER BY LEFT_PAREN interleave+=qualifiedName (COMMA interleave+=qualifiedName)* RIGHT_PAREN
     | ZORDER BY interleave+=qualifiedName (COMMA interleave+=qualifiedName)*
+    ;
+
+partitionSpec
+    : PARTITION LEFT_PAREN partitionVal (COMMA partitionVal)* RIGHT_PAREN
+    ;
+
+partitionVal
+    : identifier EQ constant
     ;
 
 temporalClause
@@ -143,6 +153,13 @@ propertyValue
     | booleanValue
     | identifier LEFT_PAREN stringLit COMMA stringLit RIGHT_PAREN
     | value=stringLit
+    ;
+
+constant
+    : NULL
+    | number
+    | booleanValue
+    | stringLit+
     ;
 
 stringLit
@@ -214,6 +231,7 @@ nonReserved
     | ZORDER | LEFT_PAREN | RIGHT_PAREN
     | SHOW | COLUMNS | IN | FROM | NO | STATISTICS
     | CLONE | SHALLOW
+    | PARTITIONS | PARTITION
     ;
 
 // Define how the keywords above should appear in a user's SQL statement.
@@ -275,6 +293,8 @@ VERSION: 'VERSION';
 WHERE: 'WHERE';
 ZORDER: 'ZORDER';
 STATISTICS: 'STATISTICS';
+PARTITIONS: 'PARTITIONS';
+PARTITION: 'PARTITION';
 
 // Multi-character operator tokens need to be defined even though we don't explicitly reference
 // them so that they can be recognized as single tokens when parsing. If we split them up and

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/ShowTablePartitionsCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/ShowTablePartitionsCommand.scala
@@ -1,0 +1,118 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.delta.{DeltaErrors, DeltaTableIdentifier}
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{Row, SparkSession}
+
+/**
+ * A command lists partitions of a table (optionally add detail(files, modification_ts, size)).
+ *
+ * The syntax of using this command in SQL is:
+ * {{{
+ *   SHOW PARTITIONS [DETAIL] (db.table|'/path/to/dir'|delta.`/path/to/dir`) [PARTITION(clause)];
+ * }}}
+ *
+ * @param tableIdentifier the identifier of the Delta table
+ * @param partitionSpec   partition predicate
+ * @param addDetail       add partition details to results
+ */
+case class ShowTablePartitionsCommand(
+  tableIdentifier: DeltaTableIdentifier,
+  partitionSpec: Map[String, String],
+  addDetail: Boolean
+) extends LeafRunnableCommand with DeltaCommand {
+
+  private val (deltaLog, snapshot) = tableIdentifier.getDeltaLogWithSnapshot(SparkSession.active)
+
+  private val partitionSchema = snapshot.metadata.partitionSchema
+
+  private val partitionDetailsField = StructField(
+    "partition_detail",
+    StructType(
+      Seq(
+        StructField("files", ArrayType(StringType, containsNull = false), nullable = false),
+        StructField("size", LongType, nullable = false),
+        StructField("modificationTime", LongType, nullable = false)
+      )
+    ),
+    nullable = false
+  )
+
+  private val outputSchema = if (addDetail) {
+    partitionSchema.add(partitionDetailsField)
+  } else {
+    partitionSchema
+  }
+
+  override val output: Seq[Attribute] = outputSchema.toAttributes
+
+  override def run(sparkSession: SparkSession): Seq[Row] =
+    recordDeltaOperation(deltaLog, "delta.ddl.showPartitions") {
+
+      val partitionColumns = snapshot.metadata.partitionColumns
+
+      if (partitionColumns.isEmpty) {
+        throw DeltaErrors.showPartitionInNotPartitionedTable(tableIdentifier.unquotedString)
+      }
+      val nonPartitionColumns = partitionSpec.keySet.diff(partitionColumns.toSet)
+      if (nonPartitionColumns.nonEmpty) {
+        throw DeltaErrors.showPartitionInNotPartitionedColumn(nonPartitionColumns)
+      }
+
+      val partitionValuesProjection = partitionSchema
+        .map { case StructField(name, dataType, _, _) =>
+          col(s"partitionValues.$name").cast(dataType).as(name)
+        }
+
+      val partitionFilter = partitionSpec
+        .map { case (k, v) => expr(s"$k <=> $v") }
+        .foldLeft(lit(true))(_ && _)
+
+      withStatusCode("DELTA", s"ShowTablePartitionsCommand: ${tableIdentifier.unquotedString}") {
+
+        val partitionsDf = tableIdentifier
+          .getDeltaLog(sparkSession)
+          .unsafeVolatileSnapshot
+          .allFiles
+          .select(
+            partitionValuesProjection :+
+              col("path") :+
+              col("size") :+
+              col("modificationTime"): _*)
+          .where(partitionFilter)
+
+        if (addDetail) {
+          partitionsDf
+            .groupBy(partitionColumns.map(col): _*)
+            .agg(
+              struct(
+                collect_set(col("path")).as("files"),
+                sum(col("size")).as("size"),
+                max(col("modificationTime")).as("modificationTime")
+              ).as("partition_detail")
+            ).collect()
+        } else {
+          partitionsDf.select(partitionColumns.map(col): _*).distinct().collect()
+        }
+      }
+    }
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/ShowTablePartitionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/ShowTablePartitionsSuite.scala
@@ -1,0 +1,251 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{LongType, StringType}
+import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
+
+import java.io.File
+
+trait ShowTablePartitionsSuiteBase extends QueryTest with SharedSparkSession {
+
+  import testImplicits._
+
+  protected def checkResult(
+    result: DataFrame,
+    expected: Seq[Row],
+    columns: Seq[String]): Unit = {
+    checkAnswer(
+      result.select(columns.head, columns.tail: _*),
+      expected
+    )
+  }
+
+  def withPartitionedDeltaPath(multiParts: Boolean = true)(f: File => Unit): Unit =
+    withTempDir { tempDir =>
+      val partitionBy = if (multiParts) Seq("partition1", "partition2") else Seq("partition1")
+      spark.range(1, 6)
+        .withColumn("partition1", col("id") % 3)
+        .withColumn("partition2", when(col("partition1") % 2 === 0, lit(0)).cast(StringType))
+        .write
+        .format("delta")
+        .partitionBy(partitionBy: _*)
+        .save(tempDir.toString)
+
+      f(tempDir)
+    }
+
+  def withPartitionedDeltaTable(
+    table: String,
+    multiParts: Boolean = true
+  )(f: String => Unit): Unit =
+    withTable(table) {
+      withPartitionedDeltaPath(multiParts) { location =>
+        sql(s"CREATE TABLE $table USING DELTA LOCATION '${location.toString}'")
+        f(table)
+      }
+    }
+
+  test("delta table: path") {
+    withPartitionedDeltaPath() { path =>
+      checkResult(
+        sql(s"SHOW PARTITIONS '$path'"),
+        Seq(Row(0, "0"), Row(1, null), Row(2, "0")),
+        Seq("partition1", "partition2"))
+    }
+  }
+
+  test("delta table: table identifier") {
+    withPartitionedDeltaPath() { path =>
+      checkResult(
+        sql(s"SHOW PARTITIONS delta.`$path`"),
+        Seq(Row(0, "0"), Row(1, null), Row(2, "0")),
+        Seq("partition1", "partition2"))
+    }
+  }
+
+  test("delta table: delta table") {
+    withPartitionedDeltaTable("show_partitions") { table =>
+      checkResult(
+        sql(s"SHOW PARTITIONS $table"),
+        Seq(Row(0, "0"), Row(1, null), Row(2, "0")),
+        Seq("partition1", "partition2"))
+    }
+  }
+
+  test("show partition single level of partitioning") {
+    withPartitionedDeltaTable("show_partitions", multiParts = false) { table =>
+      checkResult(
+        sql(s"SHOW PARTITIONS $table"),
+        Seq(Row(0), Row(1), Row(2)),
+        Seq("partition1"))
+    }
+  }
+
+  test("show partitions with partition spec") {
+    withPartitionedDeltaPath() { path =>
+      checkResult(
+        sql(s"SHOW PARTITIONS delta.`$path` PARTITION (partition1=2)"),
+        Seq(Row(2, "0")),
+        Seq("partition1", "partition2"))
+    }
+
+    withPartitionedDeltaPath() { path =>
+      checkResult(
+        sql(s"SHOW PARTITIONS delta.`$path` PARTITION (partition2='0')"),
+        Seq(Row(0, "0"), Row(2, "0")),
+        Seq("partition1", "partition2"))
+    }
+
+    withPartitionedDeltaPath() { path =>
+      checkResult(
+        sql(s"SHOW PARTITIONS delta.`$path` PARTITION (partition1=2, partition2='0')"),
+        Seq(Row(2, "0")),
+        Seq("partition1", "partition2"))
+    }
+
+    withPartitionedDeltaPath() { path =>
+      checkResult(
+        sql(s"SHOW PARTITIONS delta.`$path` PARTITION (partition1=1, partition2=null)"),
+        Seq(Row(1, null)),
+        Seq("partition1", "partition2"))
+    }
+  }
+
+  test("show partitions with partition spec for non-existent partition") {
+    withPartitionedDeltaPath() { path =>
+      checkResult(
+        sql(s"SHOW PARTITIONS delta.`$path` PARTITION (partition2='NotExist')"),
+        Seq.empty[Row],
+        Seq("partition1", "partition2"))
+    }
+  }
+
+  test("show partitions with incorrect partition spec") {
+    withPartitionedDeltaPath() { path =>
+      val e = intercept[AnalysisException] {
+        sql(s"SHOW PARTITIONS delta.`$path` PARTITION (col1=0)")
+      }
+
+      assert(e.getMessage.contains(
+        s"Non-partitioning column(s) [col1] are specified for SHOW PARTITIONS"))
+    }
+  }
+
+  test("show partitions of non-partitioned delta table") {
+    withTempDir { tempDir =>
+      spark
+        .range(0, 2)
+        .write
+        .format("delta")
+        .mode("overwrite")
+        .save(tempDir.toString)
+
+      val e = intercept[AnalysisException] {
+        sql(s"SHOW PARTITIONS delta.`$tempDir`")
+      }
+      assert(e.getMessage.contains(
+        "SHOW PARTITIONS is not allowed on a table that is not partitioned"))
+    }
+  }
+
+  test("show partitions on permanent view") {
+    withPartitionedDeltaTable("show_partitions") { table =>
+      val viewName = "show_partition_view"
+      withView(viewName) {
+        sql(s"CREATE VIEW $viewName AS SELECT * FROM $table")
+
+        val e = intercept[AnalysisException] {
+          sql(s"SHOW PARTITIONS $viewName")
+        }
+        assert(e.getMessage.contains(
+          s"$viewName is a view. 'SHOW PARTITIONS' expects a table"))
+      }
+    }
+  }
+
+  test("show partitions on temporary view") {
+    withPartitionedDeltaTable("show_partitions") { table =>
+      val viewName = "show_partition_temp_view"
+      withTempView(viewName) {
+        sql(s"CREATE TEMPORARY VIEW $viewName AS SELECT * FROM $table")
+
+        val e = intercept[AnalysisException] {
+          sql(s"SHOW PARTITIONS $viewName")
+        }
+        assert(e.getMessage.contains(
+          s"$viewName is a temp view. 'SHOW PARTITIONS' expects a table"))
+      }
+    }
+  }
+
+  test("show partitions detail") {
+    withPartitionedDeltaPath(multiParts = false) { path =>
+      val expected = DeltaLog.forTable(spark, path)
+        .unsafeVolatileSnapshot
+        .allFiles
+        .withColumn("partition1", col("partitionValues.partition1").cast(LongType))
+        .groupBy("partition1")
+        .agg(
+          struct(
+            collect_set(col("path")).as("files"),
+            sum("size").as("size"),
+            max(col("modificationTime")).as("modificationTime")
+          ).as("partition_detail")
+        ).collect()
+
+      checkResult(
+        sql(s"SHOW PARTITIONS DETAIL delta.`$path`"),
+        expected,
+        Seq("partition1", "partition_detail"))
+
+      checkResult(
+        sql(s"SHOW PARTITIONS DETAIL delta.`$path` PARTITION(partition1=0)"),
+        expected.filter(r => r.getAs[Long]("partition1") == 0),
+        Seq("partition1", "partition_detail"))
+    }
+  }
+
+  test("show partitions for non-delta table") {
+    withTable("show_partition_parquet") {
+      withTempDir { tempPath =>
+
+        sql(s"""CREATE TABLE show_partition_parquet(
+           id bigint,
+           partition_col int
+          ) USING PARQUET PARTITIONED BY (partition_col) LOCATION '$tempPath'""")
+
+        spark
+          .range(10)
+          .withColumn("partition_col", col("id") % 2)
+          .write
+          .insertInto("show_partition_parquet")
+
+        checkResult(
+          sql(s"SHOW PARTITIONS show_partition_parquet"),
+          Seq(Row("partition_col=0"), Row("partition_col=1")),
+          Seq("partition"))
+      }
+    }
+  }
+}
+
+class ShowTablePartitionsSuite
+  extends ShowTablePartitionsSuiteBase with DeltaSQLCommandTest


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
This PR introduces `SHOW PARTITIONS` command for delta table.
The output of the command is different from Apache Spark. In the delta, the output contains all partition columns and their values instead of one `partition` column with partition paths.

Syntax:
```SQL 
SHOW PARTITIONS [DETAIL] (db.table|'/path/to/dir'|delta.`/path/to/dir`) [PARTITION(clause)]; 
```
 `DETAIL` an optional parameter adds `partition_detail` which contains additional information about the partition like a list of files, last modification time, and size in bytes.
 `PARTITION` an optional parameter that specifies a partition. If not specified then returns all partitions

The schema of output (partition_detail included only with `DETAIL` option): 
```bash
 root
 |-- c1: long (nullable = true)
 |-- c2: date (nullable = true)
 |-- partition_detail: struct (nullable = false)
 |    |-- files: array (nullable = false)
 |    |    |-- element: string (containsNull = false)
 |    |-- size: long (nullable = false)
 |    |-- modificationTime: long (nullable = false) 
```
 where  `c1`, `c2` - name of partition column,
`partition_detail` - synthetic column with partition detail (`files` - list of files in partition, `size` - total size of all files in the partition, `modificationTime` - last modification time of files in the partition).

Resolves #996

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Tested by unit tests `ShowTablePartitionsSuite` and using spark-shell command: 
```bash 
spark-shell --packages io.delta:delta-core_2.12:2.3.1-SNAPSHOT --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog" 
```
spark-shell commands:
```bash
scala> spark.range(1, 4).selectExpr("id as c1", "current_date() as c2", "id as c3").write.mode("overwrite").format("delta").partitionBy("c1", "c2").save("/tmp/showpartitions")                                                                         
scala> spark.sql("CREATE TABLE showpartitions_tbl USING DELTA LOCATION '/tmp/showpartitions'")
scala> spark.sql("SHOW PARTITIONS '/tmp/showpartitions'").show(false)
+---+----------+
|c1 |c2        |
+---+----------+
|2  |2023-03-27|
|1  |2023-03-27|
|3  |2023-03-27|
+---+----------+
scala> spark.sql("SHOW PARTITIONS delta.`/tmp/showpartitions`").show(false)
+---+----------+
|c1 |c2        |
+---+----------+
|2  |2023-03-27|
|1  |2023-03-27|
|3  |2023-03-27|
+---+----------+
scala> spark.sql("SHOW PARTITIONS showpartitions_tbl").show(false)
+---+----------+
|c1 |c2        |
+---+----------+
|2  |2023-03-27|
|1  |2023-03-27|
|3  |2023-03-27|
+---+----------+
scala> spark.sql("SHOW PARTITIONS delta.`/tmp/showpartitions` PARTITION(c2='2023-03-27')").show(false)
+---+----------+
|c1 |c2        |
+---+----------+
|2  |2023-03-27|
|1  |2023-03-27|
|3  |2023-03-27|
+---+----------+
scala> spark.sql("SHOW PARTITIONS delta.`/tmp/showpartitions` PARTITION(c1=1)").show(false)
+---+----------+
|c1 |c2        |
+---+----------+
|1  |2023-03-27|
+---+----------+
scala> spark.sql("SHOW PARTITIONS DETAIL delta.`/tmp/showpartitions`").show(false)
+---+----------+--------------------------------------------------------------------------------------------------------------+
|c1 |c2        |partition_detail                                                                                              |
+---+----------+--------------------------------------------------------------------------------------------------------------+
|2  |2023-03-27|{[c1=2/c2=2023-03-27/part-00007-08e9ea97-aead-4b48-8461-8b8672343500.c000.snappy.parquet], 478, 1679921947875}|
|1  |2023-03-27|{[c1=1/c2=2023-03-27/part-00003-6143c246-6ca3-4e60-870c-4e76da276aeb.c000.snappy.parquet], 478, 1679921947875}|
|3  |2023-03-27|{[c1=3/c2=2023-03-27/part-00011-084a999a-8fbe-44e9-8116-7c552255f26f.c000.snappy.parquet], 478, 1679921947875}|
+---+----------+--------------------------------------------------------------------------------------------------------------+
scala> spark.sql("SHOW PARTITIONS DETAIL delta.`/tmp/showpartitions` PARTITION(c1=1)").show(false)
+---+----------+--------------------------------------------------------------------------------------------------------------+
|c1 |c2        |partition_detail                                                                                              |
+---+----------+--------------------------------------------------------------------------------------------------------------+
|1  |2023-03-27|{[c1=1/c2=2023-03-27/part-00003-6143c246-6ca3-4e60-870c-4e76da276aeb.c000.snappy.parquet], 478, 1679921947875}|
+---+----------+--------------------------------------------------------------------------------------------------------------+
scala> spark.sql("SHOW PARTITIONS DETAIL delta.`/tmp/showpartitions` PARTITION(c1=1)").printSchema
root
 |-- c1: long (nullable = true)
 |-- c2: date (nullable = true)
 |-- partition_detail: struct (nullable = false)
 |    |-- files: array (nullable = false)
 |    |    |-- element: string (containsNull = false)
 |    |-- size: long (nullable = false)
 |    |-- modificationTime: long (nullable = false)
```
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
