### PR TITLE
[DELETE with DVs] Implement packing multiple DVs into one file

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -21,6 +21,7 @@ import java.util.Locale
 import java.util.concurrent.TimeUnit
 
 import org.apache.spark.internal.config.ConfigBuilder
+import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.storage.StorageLevel
 
@@ -1145,6 +1146,14 @@ trait DeltaSQLConfBase {
       .doc("Enable persistent Deletion Vectors in the Delete command.")
       .booleanConf
       .createWithDefault(true)
+
+  val DELETION_VECTOR_PACKING_TARGET_SIZE =
+    buildConf("deletionVectors.packing.targetSize")
+      .internal()
+      .doc("Controls the target file deletion vector file size when packing multiple" +
+        "deletion vectors in a single file.")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefault(2L * 1024L * 1024L)
 
   val DELETION_VECTORS_COMMIT_CHECK_ENABLED =
     buildConf("deletionVectors.skipCommitCheck")

--- a/core/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
@@ -18,9 +18,8 @@ package org.apache.spark.sql.delta.deletionvectors
 
 import java.io.File
 
-import org.apache.spark.sql.delta.{DeletionVectorsTestUtils, DeltaLog, DeltaTestUtilsForTempViews}
+import org.apache.spark.sql.delta.{DeletionVectorsTestUtils, DeltaConfigs, DeltaLog, DeltaTestUtilsForTempViews}
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
-import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor
 import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor.EMPTY
 import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsSuite._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -28,6 +27,7 @@ import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.util.JsonUtils
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.apache.commons.io.FileUtils
+import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.{DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.plans.logical.{AppendData, Subquery}
@@ -218,10 +218,12 @@ class DeletionVectorsSuite extends QueryTest
         // Verify the expected no. of deletion vectors and deleted rows according to DV cardinality
         val allFiles = DeltaLog.forTable(spark, path).unsafeVolatileSnapshot.allFiles.collect()
         assert(allFiles.size === numFiles)
-        assert(allFiles.filter(_.deletionVector != null).size === numFilesWithDVs)
-        assert(
-          allFiles.filter(_.deletionVector != null).map(_.deletionVector.cardinality).sum ==
-          numDeletedRows)
+        val addFilesWithDV = allFiles.filter(_.deletionVector != null)
+        assert(addFilesWithDV.size === numFilesWithDVs)
+        assert(addFilesWithDV.map(_.deletionVector.cardinality).sum == numDeletedRows)
+
+        // Expect all DVs are written in one file
+        assert(addFilesWithDV.map(_.deletionVector.absolutePath(new Path(path))).toSet.size == 1)
 
         val afterDeleteFiles = allFiles.map(_.path)
         // make sure the data file list is the same
@@ -262,6 +264,66 @@ class DeletionVectorsSuite extends QueryTest
         // Check the data is valid
         val expectedTable1DataV5 = expectedTable1DataV4.filterNot(e => dataToRemove.contains(e))
         checkAnswer(spark.sql(s"SELECT * FROM $targetPath"), expectedTable1DataV5.toDF())
+      }
+    }
+  }
+
+  for(targetDVFileSize <- Seq(2, 200, 2000000)) {
+    test(s"DELETE with DVs - packing multiple DVs into one file: target max DV file " +
+      s"size=$targetDVFileSize") {
+      withSQLConf(
+        DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.defaultTablePropertyKey -> "true",
+        DeltaSQLConf.DELETE_USE_PERSISTENT_DELETION_VECTORS.key -> "true",
+        DeltaSQLConf.DELETION_VECTOR_PACKING_TARGET_SIZE.key -> targetDVFileSize.toString) {
+        withTempDir { dirName =>
+          // Create table with 100 files of 2 rows each.
+          val numFiles = 100
+          val path = dirName.getAbsolutePath
+          spark.range(0, 200, step = 1, numPartitions = numFiles)
+            .write.format("delta").save(path)
+          val tableName = s"delta.`$path`"
+
+          val beforeDeleteFiles = DeltaLog.forTable(spark, path)
+            .unsafeVolatileSnapshot.allFiles.collect().map(_.path)
+
+          val numFilesWithDVs = 10
+          val numDeletedRows = numFilesWithDVs * 1
+          spark.sql(s"DELETE FROM $tableName WHERE id % 2 = 0 AND id < 20")
+
+          // Verify the expected number of AddFiles with DVs
+          val allFiles = DeltaLog.forTable(spark, path).unsafeVolatileSnapshot.allFiles.collect()
+          assert(allFiles.size === numFiles)
+          val addFilesWithDV = allFiles.filter(_.deletionVector != null)
+          assert(addFilesWithDV.size === numFilesWithDVs)
+          assert(addFilesWithDV.map(_.deletionVector.cardinality).sum == numDeletedRows)
+
+          var expectedDVFileCount = 0
+          targetDVFileSize match {
+            // Each AddFile will have its own DV file
+            case 2 => expectedDVFileCount = numFilesWithDVs
+            // Each DV size is about 34bytes according the latest format.
+            case 200 => expectedDVFileCount = numFilesWithDVs / (200 / 34).floor.toInt
+            // Expect all DVs in one file
+            case 2000000 => expectedDVFileCount = 1
+            case default =>
+              throw new IllegalStateException(s"Unknown target DV file size: $default")
+          }
+          // Expect all DVs are written in one file
+          assert(
+            addFilesWithDV.map(_.deletionVector.absolutePath(new Path(path))).toSet.size ===
+            expectedDVFileCount
+          )
+
+          val afterDeleteFiles = allFiles.map(_.path)
+          // make sure the data file list is the same
+          assert(beforeDeleteFiles === afterDeleteFiles)
+
+          // Contents after the DELETE are as expected
+          checkAnswer(
+            spark.sql(s"SELECT * FROM $tableName"),
+            Seq.range(0, 200).filterNot(Seq.range(start = 0, end = 20, step = 2).contains(_)).toDF()
+          )
+        }
       }
     }
   }


### PR DESCRIPTION
This PR is part of [DELETE with Deletion Vector implementation](https://github.com/delta-io/delta/pull/1591).

It adds support of combining multiple DVs, each belonging to different data files, into a one DV file. This helps reduce the number of DV files created. Config that controls the max DV file size is `DeltaSQLConf.DELETION_VECTOR_PACKING_TARGET_SIZE` (default value is 2MB)