### PR TITLE
[DELETE with DVs] Make sure DML commands work with DVs

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
@@ -18,9 +18,9 @@ package org.apache.spark.sql.delta.deletionvectors
 
 import java.io.File
 
-import org.apache.spark.sql.delta.{CheckpointV2, DeletionVectorsTestUtils, DeltaConfigs, DeltaLog, DeltaTestUtilsForTempViews}
+import org.apache.spark.sql.delta.{DeletionVectorsTableFeature, DeletionVectorsTestUtils, DeltaConfigs, DeltaLog, DeltaTestUtilsForTempViews, Snapshot}
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
-import org.apache.spark.sql.delta.actions.{AddFile, DeletionVectorDescriptor}
+import org.apache.spark.sql.delta.actions.{AddFile, RemoveFile}
 import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor.EMPTY
 import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsSuite._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -391,9 +391,16 @@ class DeletionVectorsSuite extends QueryTest
 
       val snapshot = DeltaLog.forTable(spark, target).update()
       val allFiles = snapshot.allFiles.collect()
+      val tombstones = snapshot.tombstones.collect()
+      // DVs are removed
+      for (ts <- tombstones) {
+        assert(ts.deletionVector != null)
+      }
       // target log should not contain DVs
-      assert(allFiles.forall(_.deletionVector == null))
-      assert(allFiles.forall(_.stats.contains("\"tightBounds\":true")))
+      for (f <- allFiles) {
+        assert(f.deletionVector == null)
+        assert(f.stats.contains("\"tightBounds\":true"))
+      }
 
       // Target table should contain "table2 records + 10000" and "table1 records \ table2 records".
       checkAnswer(
@@ -402,6 +409,153 @@ class DeletionVectorsSuite extends QueryTest
           expectedTable1DataV4.filterNot(expectedTable2DataV1.contains)).toDF()
       )
     }
+  }
+
+  test("UPDATE with DVs - update rewrite files with DVs") {
+    withTempDir { tempDir =>
+      FileUtils.copyDirectory(new File(table2Path), tempDir)
+
+      io.delta.tables.DeltaTable.forPath(spark, tempDir.getAbsolutePath)
+        .update(col("value") === 1, Map("value" -> (col("value") + 1)))
+
+      val snapshot = DeltaLog.forTable(spark, tempDir).update()
+      val allFiles = snapshot.allFiles.collect()
+      val tombstones = snapshot.tombstones.collect()
+      // DVs are removed
+      for (ts <- tombstones) {
+        assert(ts.deletionVector != null)
+      }
+      // target log should not contain DVs
+      for (f <- allFiles) {
+        assert(f.deletionVector == null)
+        assert(f.stats.contains("\"tightBounds\":true"))
+      }
+    }
+  }
+
+  test("UPDATE with DVs - update deleted rows updates nothing") {
+    withTempDir { tempDir =>
+      FileUtils.copyDirectory(new File(table2Path), tempDir)
+
+      val snapshotBeforeUpdate = DeltaLog.forTable(spark, tempDir).update()
+      val allFilesBeforeUpdate = snapshotBeforeUpdate.allFiles.collect()
+
+      io.delta.tables.DeltaTable.forPath(spark, tempDir.getAbsolutePath)
+        .update(col("value")  === 0, Map("value" -> (col("value") + 1)))
+
+      val snapshot = DeltaLog.forTable(spark, tempDir).update()
+      val allFiles = snapshot.allFiles.collect()
+      val tombstones = snapshot.tombstones.collect()
+      // nothing changed
+      assert(tombstones.length === 0)
+      assert(allFiles === allFilesBeforeUpdate)
+
+      checkAnswer(
+        spark.read.format("delta").load(tempDir.getAbsolutePath),
+        expectedTable2DataV1.toDF()
+      )
+    }
+  }
+
+  test("INSERT + DELETE + MERGE + UPDATE with DVs") {
+    withTempDir { tempDir =>
+      val path = tempDir.getAbsolutePath
+      val log = DeltaLog.forTable(spark, path)
+
+      def checkTableContents(rows: DataFrame): Unit =
+        checkAnswer(sql(s"SELECT * FROM delta.`$path`"), rows)
+
+      // Version 0: DV is enabled on table
+      {
+        withSQLConf(
+          DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.defaultTablePropertyKey -> "true") {
+          spark.range(10).repartition(2).write.format("delta").save(path)
+        }
+        val snapshot = log.update()
+        assert(snapshot.protocol.isFeatureSupported(DeletionVectorsTableFeature))
+        for (f <- snapshot.allFiles.collect()) {
+          assert(f.stats.contains("\"tightBounds\":true"))
+        }
+      }
+      // Version 1: DELETE one row from each file
+      {
+        withSQLConf(DeltaSQLConf.DELETE_USE_PERSISTENT_DELETION_VECTORS.key -> "true") {
+          sql(s"DELETE FROM delta.`$path` WHERE id IN (1, 8)")
+        }
+        val (add, _) = getFileActionsInLastVersion(log)
+        for (a <- add) {
+          assert(a.deletionVector !== null)
+          assert(a.deletionVector.cardinality === 1)
+          assert(a.numPhysicalRecords.get === a.numLogicalRecords.get + 1)
+          assert(a.stats.contains("\"tightBounds\":false"))
+        }
+
+        checkTableContents(Seq(0, 2, 3, 4, 5, 6, 7, 9).toDF())
+      }
+      // Version 2: UPDATE one row in the first file
+      {
+        sql(s"UPDATE delta.`$path` SET id = -1 WHERE id = 0")
+        val (added, removed) = getFileActionsInLastVersion(log)
+        assert(added.length === 1)
+        assert(removed.length === 1)
+        // Removed files must contain DV, added files must not
+        for (a <- added) {
+          assert(a.deletionVector === null)
+          assert(a.stats.contains("\"tightBounds\":true"))
+        }
+        for (r <- removed) {
+          assert(r.deletionVector !== null)
+        }
+
+        checkTableContents(Seq(-1, 2, 3, 4, 5, 6, 7, 9).toDF())
+      }
+      // Version 3: MERGE into the table using table2
+      {
+        io.delta.tables.DeltaTable.forPath(spark, path).as("target")
+          .merge(
+            spark.read.format("delta").load(table2Path).as("source"),
+            "source.value = target.id")
+          .whenMatched()
+          .updateExpr(Map("id" -> "source.value"))
+          .whenNotMatchedBySource().delete().execute()
+        val (added, removed) = getFileActionsInLastVersion(log)
+        assert(added.length === 2)
+        assert(removed.length === 2)
+        for (a <- added) {
+          assert(a.deletionVector === null)
+          assert(a.stats.contains("\"tightBounds\":true"))
+        }
+        // One of two removed files has DV
+        assert(removed.count(_.deletionVector != null) === 1)
+
+        // -1 and 9 are deleted by "when not matched by source"
+        checkTableContents(Seq(2, 3, 4, 5, 6, 7).toDF())
+      }
+      // Version 4: DELETE one row again
+      {
+        withSQLConf(DeltaSQLConf.DELETE_USE_PERSISTENT_DELETION_VECTORS.key -> "true") {
+          sql(s"DELETE FROM delta.`$path` WHERE id IN (4)")
+        }
+        val (add, _) = getFileActionsInLastVersion(log)
+        for (a <- add) {
+          assert(a.deletionVector !== null)
+          assert(a.deletionVector.cardinality === 1)
+          assert(a.numPhysicalRecords.get === a.numLogicalRecords.get + 1)
+          assert(a.stats.contains("\"tightBounds\":false"))
+        }
+
+        // -1 and 9 are deleted by "when not matched by source"
+        checkTableContents(Seq(2, 3, 5, 6, 7).toDF())
+      }
+    }
+  }
+
+  private def getFileActionsInLastVersion(log: DeltaLog): (Seq[AddFile], Seq[RemoveFile]) = {
+    val version = log.update().version
+    val (add, remove) = log.getChanges(version).toSeq.head._2
+      .filter(a => a.isInstanceOf[AddFile] || a.isInstanceOf[RemoveFile])
+      .partition(_.isInstanceOf[AddFile])
+    (add.map(_.asInstanceOf[AddFile]), remove.map(_.asInstanceOf[RemoveFile]))
   }
 
   private def assertPlanContains(queryDf: DataFrame, expected: String): Unit = {

--- a/core/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.util.JsonUtils
 import com.fasterxml.jackson.databind.node.ObjectNode
+import io.delta.tables.DeltaTable
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.fs.Path
 
@@ -379,7 +380,7 @@ class DeletionVectorsSuite extends QueryTest
       val target = new File(tempDir, "mergeTest")
       FileUtils.copyDirectory(new File(table2Path), target)
 
-      io.delta.tables.DeltaTable.forPath(spark, target.getAbsolutePath).as("target")
+      DeltaTable.forPath(spark, target.getAbsolutePath).as("target")
         .merge(
           spark.read.format("delta").load(source.getAbsolutePath).as("source"),
           "source.value = target.value")
@@ -416,7 +417,7 @@ class DeletionVectorsSuite extends QueryTest
       FileUtils.copyDirectory(new File(table2Path), tempDir)
       val deltaLog = DeltaLog.forTable(spark, tempDir)
 
-      io.delta.tables.DeltaTable.forPath(spark, tempDir.getAbsolutePath)
+      DeltaTable.forPath(spark, tempDir.getAbsolutePath)
         .update(col("value") === 1, Map("value" -> (col("value") + 1)))
 
       val snapshot = deltaLog.update()
@@ -442,7 +443,7 @@ class DeletionVectorsSuite extends QueryTest
       val snapshotBeforeUpdate = deltaLog.update()
       val allFilesBeforeUpdate = snapshotBeforeUpdate.allFiles.collect()
 
-      io.delta.tables.DeltaTable.forPath(spark, tempDir.getAbsolutePath)
+      DeltaTable.forPath(spark, tempDir.getAbsolutePath)
         .update(col("value")  === 0, Map("value" -> (col("value") + 1)))
 
       val snapshot = deltaLog.update()
@@ -513,7 +514,7 @@ class DeletionVectorsSuite extends QueryTest
       }
       // Version 3: MERGE into the table using table2
       {
-        io.delta.tables.DeltaTable.forPath(spark, path).as("target")
+        DeltaTable.forPath(spark, path).as("target")
           .merge(
             spark.read.format("delta").load(table2Path).as("source"),
             "source.value = target.id")

--- a/core/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
@@ -472,7 +472,7 @@ class DeletionVectorsSuite extends QueryTest
       {
         withSQLConf(
           DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.defaultTablePropertyKey -> "true") {
-          spark.range(10).repartition(2).write.format("delta").save(path)
+          spark.range(0, 10, 1, numPartitions = 2).write.format("delta").save(path)
         }
         val snapshot = deltaLog.update()
         assert(snapshot.protocol.isFeatureSupported(DeletionVectorsTableFeature))


### PR DESCRIPTION
## Description

This PR adds some tests to make sure that DML commands are able to read Delta tables having DVs. Specifically:

- `UPDATE` and `MERGE` can read DVs, and will re-write a file to materialize DV if rows within are modified.
- `DELETE` can write DVs.

## How was this patch tested?

New tests.

## Does this PR introduce _any_ user-facing changes?
No, this is a test-only PR.