### PR TITLE
[DELETE with DVs] Fix attaching metadata column to files inside subquery

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/DeleteWithDeletionVectorsHelper.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/DeleteWithDeletionVectorsHelper.scala
@@ -306,7 +306,8 @@ object DeletionVectorBitmapGenerator {
       val basePath = txn.deltaLog.dataPath.toString
       val filePathToDV = candidateFiles.map { add =>
         val serializedDV = Option(add.deletionVector).map(dvd => JsonUtils.toJson(dvd))
-        FileToDvDescriptor(absolutePath(basePath, add.path).toString, serializedDV)
+        // Paths in the metadata column are canonicalized. Thus we must canonicalize the DV path.
+        FileToDvDescriptor(absolutePath(basePath, add.path).toUri.toString, serializedDV)
       }
       val filePathToDVDf = sparkSession.createDataset(filePathToDV)
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/DeleteWithDeletionVectorsHelper.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/DeleteWithDeletionVectorsHelper.scala
@@ -75,7 +75,7 @@ object DeleteWithDeletionVectorsHelper extends DeltaCommand {
   private def replaceFileIndex(target: LogicalPlan, fileIndex: TahoeFileIndex): LogicalPlan = {
     val additionalCols = Seq(
       AttributeReference(ROW_INDEX_COLUMN_NAME, ROW_INDEX_STRUCT_FILED.dataType)(),
-      FileFormat.createFileMetadataCol
+      // FileFormat.createFileMetadataCol
     )
 
     val newTarget = target transformDown {

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/DeleteWithDeletionVectorsHelper.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/DeleteWithDeletionVectorsHelper.scala
@@ -75,7 +75,7 @@ object DeleteWithDeletionVectorsHelper extends DeltaCommand {
   private def replaceFileIndex(target: LogicalPlan, fileIndex: TahoeFileIndex): LogicalPlan = {
     val additionalCols = Seq(
       AttributeReference(ROW_INDEX_COLUMN_NAME, ROW_INDEX_STRUCT_FILED.dataType)(),
-      // FileFormat.createFileMetadataCol
+      FileFormat.createFileMetadataCol
     )
 
     val newTarget = target transformDown {

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/DeleteWithDeletionVectorsHelper.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/DeleteWithDeletionVectorsHelper.scala
@@ -35,9 +35,9 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.{Column, DataFrame, Dataset, Encoder, SparkSession}
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, FileSourceMetadataAttribute}
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project}
-import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
+import org.apache.spark.sql.execution.datasources.{FileFormat, HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.execution.datasources.FileFormat.{FILE_PATH, METADATA_NAME}
 import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.types.StructType
@@ -66,22 +66,24 @@ object DeleteWithDeletionVectorsHelper extends DeltaCommand {
    * original logical plan with a new index of potentially affected files, while everything else in
    * the original plan, e.g., resolved references, remain unchanged.
    *
-   * In addition we also request a row index column from the Scan to help generate the
-   * Deletion Vectors.
+   * In addition we also request a metadata column and a row index column from the Scan to help
+   * generate the Deletion Vectors.
    *
    * @param target the logical plan in which we replace the file index
    * @param fileIndex the new file index
    */
   private def replaceFileIndex(target: LogicalPlan, fileIndex: TahoeFileIndex): LogicalPlan = {
-    val rowIndexColumn =
-      AttributeReference(ROW_INDEX_COLUMN_NAME, ROW_INDEX_STRUCT_FILED.dataType)()
+    val additionalCols = Seq(
+      AttributeReference(ROW_INDEX_COLUMN_NAME, ROW_INDEX_STRUCT_FILED.dataType)(),
+      FileFormat.createFileMetadataCol
+    )
 
     val newTarget = target transformDown {
       case l @ LogicalRelation(
         hfsr @ HadoopFsRelation(_, _, _, _, format: DeltaParquetFileFormat, _), _, _, _) =>
         // Take the existing schema and add additional metadata columns
         val newDataSchema = StructType(hfsr.dataSchema).add(ROW_INDEX_STRUCT_FILED)
-        val finalOutput = l.output ++ Seq(rowIndexColumn)
+        val finalOutput = l.output ++ additionalCols
         // Disable splitting and filter pushdown in order to generate the row-indexes
         val newFormat = format.copy(isSplittable = false, disablePushDowns = true)
 
@@ -92,7 +94,7 @@ object DeleteWithDeletionVectorsHelper extends DeltaCommand {
 
         l.copy(relation = newBaseRelation, output = finalOutput)
       case p @ Project(projectList, _) =>
-        val newProjectList = projectList ++ Seq(rowIndexColumn)
+        val newProjectList = projectList ++ additionalCols
         p.copy(projectList = newProjectList)
     }
     newTarget

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
@@ -103,4 +103,18 @@ class DeleteSQLWithDeletionVectorsSuite extends DeleteSQLSuite with DeletionVect
     super.beforeAll()
     enableDeletionVectorsForDeletes(spark)
   }
+
+  override def excluded: Set[String] = super.excluded ++ Set(
+    "data and partition columns - Partition=true Skipping=false",
+    "data and partition columns - Partition=false Skipping=false",
+    "nested schema pruning on data condition",
+  )
+
+  // This works correctly with DVs, but fails in classic DELETE.
+  override def testSuperSetColsTempView(): Unit = {
+    testComplexTempViews("superset cols")(
+      text = "SELECT key, value, 1 FROM tab",
+      expectResult = Row(0, 3, 1) :: Nil
+    )
+  }
 }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
@@ -97,3 +97,10 @@ class DeleteSQLNameColumnMappingSuite extends DeleteSQLSuite
   }
 
 }
+
+class DeleteSQLWithDeletionVectorsSuite extends DeleteSQLSuite with DeletionVectorsTestUtils {
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    enableDeletionVectorsForDeletes(spark)
+  }
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
@@ -107,14 +107,12 @@ class DeleteSQLWithDeletionVectorsSuite extends DeleteSQLSuite with DeletionVect
   override def excluded: Set[String] = super.excluded ++ Set(
     "data and partition columns - Partition=true Skipping=false",
     "data and partition columns - Partition=false Skipping=false",
-    "nested schema pruning on data condition",
-  )
+    "nested schema pruning on data condition")
 
   // This works correctly with DVs, but fails in classic DELETE.
   override def testSuperSetColsTempView(): Unit = {
     testComplexTempViews("superset cols")(
       text = "SELECT key, value, 1 FROM tab",
-      expectResult = Row(0, 3, 1) :: Nil
-    )
+      expectResult = Row(0, 3, 1) :: Nil)
   }
 }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
@@ -105,8 +105,11 @@ class DeleteSQLWithDeletionVectorsSuite extends DeleteSQLSuite with DeletionVect
   }
 
   override def excluded: Set[String] = super.excluded ++ Set(
+    // The following two tests must fail when DV is used. Covered by another test case:
+    // "throw error when non-pinned TahoeFileIndex snapshot is used".
     "data and partition columns - Partition=true Skipping=false",
     "data and partition columns - Partition=false Skipping=false",
+    // The scan schema contains additional row index filter columns.
     "nested schema pruning on data condition")
 
   // This works correctly with DVs, but fails in classic DELETE.

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
@@ -32,7 +32,9 @@ import org.apache.spark.util.Utils
 
 abstract class DeleteSuiteBase extends QueryTest
   with SharedSparkSession
-  with BeforeAndAfterEach  with DeltaTestUtilsForTempViews {
+  with BeforeAndAfterEach
+  with DeltaExcludedTestsHelper
+  with DeltaTestUtilsForTempViews {
 
   import testImplicits._
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
@@ -27,11 +27,18 @@ import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
 import org.apache.spark.sql.delta.util.PathWithFileSystem
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.{DataFrame, QueryTest, SparkSession}
 import org.apache.spark.sql.test.SharedSparkSession
 
 /** Collection of test utilities related with persistent Deletion Vectors. */
 trait DeletionVectorsTestUtils extends QueryTest with SharedSparkSession {
+
+  def enableDeletionVectorsForDeletes(spark: SparkSession, enabled: Boolean = true): Unit = {
+    val enabledStr = enabled.toString
+    spark.conf
+      .set(DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.defaultTablePropertyKey, enabledStr)
+    spark.conf.set(DeltaSQLConf.DELETE_USE_PERSISTENT_DELETION_VECTORS.key, enabledStr)
+  }
 
   def testWithDVs(testName: String, testTags: org.scalatest.Tag*)(thunk: => Unit): Unit = {
     test(testName, testTags : _*) {

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaExcludedTestsHelper.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaExcludedTestsHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (2023) The Delta Lake Project Authors.
+ * Copyright (2021) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaExcludedTestsHelper.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaExcludedTestsHelper.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.QueryTest
+
+import org.scalactic.source.Position
+import org.scalatest.Tag
+
+trait DeltaExcludedTestsHelper extends QueryTest {
+
+  /** Tests to be ignored by the runner. */
+  def excluded: Set[String] = Set.empty
+
+  protected override def test(testName: String, testTags: Tag*)
+    (testFun: => Any)
+    (implicit pos: Position): Unit = {
+    if (excluded.contains(testName)) {
+      super.ignore(testName, testTags: _*)(testFun)
+    } else {
+      super.test(testName, testTags: _*)(testFun)
+    }
+  }
+}


### PR DESCRIPTION
## Description

We found that the metadata column won't be attached to the file source for query plans generated from temp views created by `SELECT`., for example
```scala
sql("CREATE TEMP VIEW v AS SELECT * FROM tab")
sql("DELETE FROM v WHERE key = 1 AND value = 5")
```
corresponding to
```scala
'Project [key#599, value#600, __delta_internal_row_index#785L, '_metadata.file_path AS filePath#792]
+- SubqueryAlias v
   +- Project [cast(key#601 as int) AS key#599, cast(value#602 as int) AS value#600, __delta_internal_row_index#785L]
      +- Project [key#601, value#602, __delta_internal_row_index#785L]
         +- SubqueryAlias spark_catalog.default.tab
            +- Relation default.tab[key#601,value#602,__delta_internal_row_index#785L] parquet
```

When being executed, the above query plan will fail with an error message `_metadata column does not exist`. The possible reason is because of multiple levels of projection, which hides the `_metadata` column from the underlying file scan.

This PR fixes the above issue by attaching the metadata column before sending it to the analyzer. The root issue, however, should be hidden in the Spark library which is hard to fix.

## How was this patch tested?

Adapting existing tests.

## Does this PR introduce _any_ user-facing changes?

No.