### PR TITLE
[1686] Disable docs tests due to broken docs.delta.io cert

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -144,7 +144,7 @@ trait DeltaErrorsSuiteBase
     }
   }
 
-  test("Validate that links to docs in DeltaErrors are correct") {
+  ignore("Validate that links to docs in DeltaErrors are correct") {
     // verify DeltaErrors.errorsWithDocsLinks is consistent with DeltaErrorsSuite
     assert(errorsToTest.keySet ++ otherMessagesToTest.keySet ==
       DeltaErrors.errorsWithDocsLinks.toSet


### PR DESCRIPTION
## Description

Resolves #1686. docs.delta.io cert is outdated causing docs tests to fail. let's disable this test for now.