### PR TITLE
[PROTOTYPE] Support `delta.enableFastS3AListFrom` with hadoop-aws:3.3.2 for Flink 1.16.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -171,10 +171,14 @@ lazy val storage = (project in file("storage"))
     commonSettings,
     javaOnlyReleaseSettings,
     libraryDependencies ++= Seq(
-      // User can provide any 2.x or 3.x version. We don't use any new fancy APIs. Watch out for
-      // versions with known vulnerabilities.
-      "org.apache.hadoop" % "hadoop-common" % "3.3.1" % "provided",
-      "org.apache.hadoop" % "hadoop-aws" % "3.3.1" % "provided",
+      // For hadoop-common, user can provide any 2.x or 3.x version. We don't use any new fancy
+      // APIs. Watch out for versions with known vulnerabilities.
+      "org.apache.hadoop" % "hadoop-common" % "3.3.2" % "provided",
+
+      // For hadoop-aws, this is only used by `S3LogStoreUtil` when the `delta.fastS3AListFrom`
+      // feature flag is enabled, and uses specific hadoop-aws:3.3.2  APIs that are not, for
+      // example, compatible with hadoop-aws:3.3.1.
+      "org.apache.hadoop" % "hadoop-aws" % "3.3.2" % "provided",
 
       // Test Deps
       "org.scalatest" %% "scalatest" % "3.2.11" % "test",

--- a/storage/src/main/java/io/delta/storage/internal/S3LogStoreUtil.java
+++ b/storage/src/main/java/io/delta/storage/internal/S3LogStoreUtil.java
@@ -28,12 +28,11 @@ import static org.apache.hadoop.fs.s3a.Constants.DEFAULT_MAX_PAGING_KEYS;
 import static org.apache.hadoop.fs.s3a.Constants.MAX_PAGING_KEYS;
 import static org.apache.hadoop.fs.s3a.S3AUtils.iteratorToStatuses;
 
-
 /**
  * Static utility methods for the S3SingleDriverLogStore.
  *
- * Used to trick the class loader so we can use methods of org.apache.hadoop:hadoop-aws without needing to load this as
- * a dependency for tests in core.
+ * Used to trick the class loader so we can use methods of org.apache.hadoop:hadoop-aws without
+ * needing to load this as a dependency for tests in core.
  */
 public final class S3LogStoreUtil {
     private S3LogStoreUtil() {}
@@ -61,7 +60,8 @@ public final class S3LogStoreUtil {
         int maxKeys = S3AUtils.intOption(s3afs.getConf(), MAX_PAGING_KEYS, DEFAULT_MAX_PAGING_KEYS, 1);
         Listing listing = s3afs.getListing();
         // List files lexicographically after resolvedPath inclusive within the same directory
-        return listing.createFileStatusListingIterator(resolvedPath,
+        return listing.createFileStatusListingIterator(
+                resolvedPath,
                 S3ListRequest.v2(
                         new ListObjectsV2Request()
                                 .withBucketName(s3afs.getBucket())
@@ -69,7 +69,9 @@ public final class S3LogStoreUtil {
                                 .withPrefix(s3afs.pathToKey(parentPath))
                                 .withStartAfter(keyBefore(s3afs.pathToKey(resolvedPath)))
                 ), ACCEPT_ALL,
-                new Listing.AcceptAllButSelfAndS3nDirs(parentPath)
+                new Listing.AcceptAllButSelfAndS3nDirs(parentPath),
+                // This is required in hadoop-aws 3.3.2 but doesn't exist in 3.3.1
+                listing.getAuditSpan()
         );
     }
 

--- a/storage/src/main/java/io/delta/storage/internal/S3LogStoreUtil.java
+++ b/storage/src/main/java/io/delta/storage/internal/S3LogStoreUtil.java
@@ -19,6 +19,8 @@ package io.delta.storage.internal;
 import com.amazonaws.services.s3.model.ListObjectsV2Request;
 import org.apache.hadoop.fs.*;
 import org.apache.hadoop.fs.s3a.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -35,6 +37,9 @@ import static org.apache.hadoop.fs.s3a.S3AUtils.iteratorToStatuses;
  * needing to load this as a dependency for tests in core.
  */
 public final class S3LogStoreUtil {
+
+    private static final Logger LOG = LoggerFactory.getLogger(S3LogStoreUtil.class);
+
     private S3LogStoreUtil() {}
 
     private static PathFilter ACCEPT_ALL = new PathFilter() {
@@ -57,6 +62,14 @@ public final class S3LogStoreUtil {
             S3AFileSystem s3afs,
             Path resolvedPath,
             Path parentPath) throws IOException {
+        final String prefixKey = s3afs.pathToKey(parentPath);
+        final String startAfterKey = keyBefore(s3afs.pathToKey(resolvedPath));
+        LOG.info(
+            "Performing fast S3 LIST with prefixKey {} and startAfterKey {}",
+            prefixKey,
+            startAfterKey
+        );
+
         int maxKeys = S3AUtils.intOption(s3afs.getConf(), MAX_PAGING_KEYS, DEFAULT_MAX_PAGING_KEYS, 1);
         Listing listing = s3afs.getListing();
         // List files lexicographically after resolvedPath inclusive within the same directory
@@ -66,8 +79,8 @@ public final class S3LogStoreUtil {
                         new ListObjectsV2Request()
                                 .withBucketName(s3afs.getBucket())
                                 .withMaxKeys(maxKeys)
-                                .withPrefix(s3afs.pathToKey(parentPath))
-                                .withStartAfter(keyBefore(s3afs.pathToKey(resolvedPath)))
+                                .withPrefix(prefixKey)
+                                .withStartAfter(startAfterKey)
                 ), ACCEPT_ALL,
                 new Listing.AcceptAllButSelfAndS3nDirs(parentPath),
                 // This is required in hadoop-aws 3.3.2 but doesn't exist in 3.3.1
@@ -91,6 +104,7 @@ public final class S3LogStoreUtil {
         S3AFileSystem s3afs;
         try {
              s3afs = (S3AFileSystem) fs;
+             Log
         } catch (ClassCastException e) {
             throw new UnsupportedOperationException(
                     "The Hadoop file system used for the S3LogStore must be castable to " +


### PR DESCRIPTION
## Description

Flink 1.16.1 uses hadoop-aws:3.3.2 (for S3 operations). Configuring Flink to also work with hadoop-aws:3.3.1 takes a lot of work. Also, the `delta.enableFastS3AListFrom` feature (which uses hadoop-aws APIs) uses one such API that changed between 3.3.1 and 3.3.2. Let's prototype getting this feature to work with 3.3.2.

## How was this patch tested?
TODO