### PR TITLE
Block writing to Delta tables that supports identity columns

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -948,7 +948,7 @@
   },
   "DELTA_INVALID_PROTOCOL_VERSION" : {
     "message" : [
-      "Delta protocol version is too new for this version of Delta Lake: table requires <required>, client supports up to <supported>. Please upgrade to a newer release."
+      "Delta protocol version is not supported by this version of Delta Lake: table requires <required>, client supports <supported>. Please upgrade to a newer release."
     ],
     "sqlState" : "KD004"
   },

--- a/core/src/main/scala/org/apache/spark/sql/delta/ColumnWithDefaultExprUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/ColumnWithDefaultExprUtils.scala
@@ -57,7 +57,7 @@ object ColumnWithDefaultExprUtils extends DeltaLogging {
 
   // Return if `protocol` satisfies the requirement for IDENTITY columns.
   def satisfiesIdentityColumnProtocol(protocol: Protocol): Boolean =
-    protocol.isFeatureSupported(IdentityColumnsTableFeature)
+    protocol.minWriterVersion == 6 || protocol.writerFeatureNames.contains("identityColumns")
 
   // Return true if the column `col` has default expressions (and can thus be omitted from the
   // insertion list).

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -298,14 +298,6 @@ trait DeltaConfigsBase extends DeltaLogging {
     i.months == 0 && getMicroSeconds(i) >= 0
   }
 
-  private case class VersionNumbers(reader: Set[Int], writer: Set[Int])
-
-  private lazy val supportedProtocolVersionNumbers: VersionNumbers = {
-    val features = Action.supportedProtocolVersion().implicitlyAndExplicitlySupportedFeatures
-    VersionNumbers(features.map(_.minReaderVersion),
-      features.map(_.minWriterVersion))
-  }
-
   /**
    * The protocol reader version modelled as a table property. This property is *not* stored as
    * a table property in the `Metadata` action. It is stored as its own action. Having it modelled
@@ -315,8 +307,8 @@ trait DeltaConfigsBase extends DeltaLogging {
     "minReaderVersion",
     Action.supportedProtocolVersion().minReaderVersion.toString,
     _.toInt,
-    v => supportedProtocolVersionNumbers.reader.contains(v),
-    s"needs to be one of ${supportedProtocolVersionNumbers.reader.mkString(", ")}.")
+    v => Action.supportedReaderVersionNumbers.contains(v),
+    s"needs to be one of ${Action.supportedReaderVersionNumbers.mkString(", ")}.")
 
   /**
    * The protocol reader version modelled as a table property. This property is *not* stored as
@@ -327,8 +319,8 @@ trait DeltaConfigsBase extends DeltaLogging {
     "minWriterVersion",
     Action.supportedProtocolVersion().minWriterVersion.toString,
     _.toInt,
-    v => supportedProtocolVersionNumbers.writer.contains(v),
-    s"needs to be one of ${supportedProtocolVersionNumbers.writer.mkString(", ")}.")
+    v => Action.supportedWriterVersionNumbers.contains(v),
+    s"needs to be one of ${Action.supportedWriterVersionNumbers.mkString(", ")}.")
 
   /**
    * Ignore protocol-related configs set in SQL config.

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -308,7 +308,7 @@ trait DeltaConfigsBase extends DeltaLogging {
     Action.supportedProtocolVersion().minReaderVersion.toString,
     _.toInt,
     v => Action.supportedReaderVersionNumbers.contains(v),
-    s"needs to be one of ${Action.supportedReaderVersionNumbers.mkString(", ")}.")
+    s"needs to be one of ${Action.supportedReaderVersionNumbers.toSeq.sorted.mkString(", ")}.")
 
   /**
    * The protocol reader version modelled as a table property. This property is *not* stored as
@@ -320,7 +320,7 @@ trait DeltaConfigsBase extends DeltaLogging {
     Action.supportedProtocolVersion().minWriterVersion.toString,
     _.toInt,
     v => Action.supportedWriterVersionNumbers.contains(v),
-    s"needs to be one of ${Action.supportedWriterVersionNumbers.mkString(", ")}.")
+    s"needs to be one of ${Action.supportedWriterVersionNumbers.toSeq.sorted.mkString(", ")}.")
 
   /**
    * Ignore protocol-related configs set in SQL config.

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -298,6 +298,14 @@ trait DeltaConfigsBase extends DeltaLogging {
     i.months == 0 && getMicroSeconds(i) >= 0
   }
 
+  private case class VersionNumbers(reader: Set[Int], writer: Set[Int])
+
+  private lazy val supportedProtocolVersionNumbers: VersionNumbers = {
+    val features = Action.supportedProtocolVersion().implicitlyAndExplicitlySupportedFeatures
+    VersionNumbers(features.map(_.minReaderVersion),
+      features.map(_.minWriterVersion))
+  }
+
   /**
    * The protocol reader version modelled as a table property. This property is *not* stored as
    * a table property in the `Metadata` action. It is stored as its own action. Having it modelled
@@ -307,8 +315,8 @@ trait DeltaConfigsBase extends DeltaLogging {
     "minReaderVersion",
     Action.supportedProtocolVersion().minReaderVersion.toString,
     _.toInt,
-    v => v > 0 && v <= Action.supportedProtocolVersion().minReaderVersion,
-    s"needs to be an integer between [1, ${Action.supportedProtocolVersion().minReaderVersion}].")
+    v => supportedProtocolVersionNumbers.reader.contains(v),
+    s"needs to be one of ${supportedProtocolVersionNumbers.reader.mkString(", ")}.")
 
   /**
    * The protocol reader version modelled as a table property. This property is *not* stored as
@@ -319,8 +327,8 @@ trait DeltaConfigsBase extends DeltaLogging {
     "minWriterVersion",
     Action.supportedProtocolVersion().minWriterVersion.toString,
     _.toInt,
-    v => v > 0 && v <= Action.supportedProtocolVersion().minWriterVersion,
-    s"needs to be an integer between [1, ${Action.supportedProtocolVersion().minWriterVersion}].")
+    v => supportedProtocolVersionNumbers.writer.contains(v),
+    s"needs to be one of ${supportedProtocolVersionNumbers.writer.mkString(", ")}.")
 
   /**
    * Ignore protocol-related configs set in SQL config.

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2249,10 +2249,6 @@ trait DeltaErrorsBase
     new DeltaAnalysisException(errorClass = "DELTA_UNSET_NON_EXISTENT_PROPERTY", Array(key, table))
   }
 
-  def identityColumnNotSupported(): Throwable = {
-    new AnalysisException("IDENTITY column is not supported")
-  }
-
   def identityColumnInconsistentMetadata(
       colName: String,
       hasStart: Boolean,

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2961,10 +2961,10 @@ class DeltaIndexOutOfBoundsException(
 }
 
 /** Thrown when the protocol version of a table is greater than supported by this client. */
-class InvalidProtocolVersionException(requiredVersion: Int, supportedVersion: Int)
+class InvalidProtocolVersionException(requiredVersion: Int, supportedVersions: Seq[Int])
   extends RuntimeException(DeltaThrowableHelper.getMessage(
     errorClass = "DELTA_INVALID_PROTOCOL_VERSION",
-    messageParameters = Array(requiredVersion.toString, supportedVersion.toString)))
+    messageParameters = Array(requiredVersion.toString, supportedVersions.sorted.mkString(", "))))
   with DeltaThrowable {
   override def getErrorClass: String = "DELTA_INVALID_PROTOCOL_VERSION"
 }

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -327,13 +327,11 @@ class DeltaLog private(
     // `getEnabledFeatures` is a pointer to pull reader/writer features out of a Protocol.
     val (clientSupportedVersions, tableRequiredVersion, getEnabledFeatures) = readOrWrite match {
       case "read" => (
-        clientSupportedProtocol.implicitlyAndExplicitlySupportedFeatures.map(_.minReaderVersion)
-          + 1, // Version 1 does not introduce new feature, it's always supported.
+        Action.supportedReaderVersionNumbers,
         tableProtocol.minReaderVersion,
         (f: Protocol) => f.readerFeatureNames)
       case "write" => (
-        clientSupportedProtocol.implicitlyAndExplicitlySupportedFeatures.map(_.minWriterVersion)
-          + 1, // Version 1 does not introduce new feature, it's always supported.
+        Action.supportedWriterVersionNumbers,
         tableProtocol.minWriterVersion,
         (f: Protocol) => f.writerFeatureNames)
       case _ =>

--- a/core/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -351,7 +351,7 @@ object TestLegacyReaderWriterFeature
   extends LegacyReaderWriterFeature(
     name = "testLegacyReaderWriter",
     minReaderVersion = 2,
-    minWriterVersion = 6)
+    minWriterVersion = 5)
 
 object TestReaderWriterFeature extends ReaderWriterFeature(name = "testReaderWriter")
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -210,7 +210,6 @@ object TableFeature {
       AppendOnlyTableFeature,
       ChangeDataFeedTableFeature,
       CheckConstraintsTableFeature,
-      IdentityColumnsTableFeature,
       GeneratedColumnsTableFeature,
       InvariantsTableFeature,
       ColumnMappingTableFeature,
@@ -303,16 +302,6 @@ object ColumnMappingTableFeature
       case NoMapping => false
       case _ => true
     }
-  }
-}
-
-object IdentityColumnsTableFeature
-  extends LegacyWriterFeature(name = "identityColumns", minWriterVersion = 6)
-  with FeatureAutomaticallyEnabledByMetadata {
-  override def metadataRequiresFeatureToBeEnabled(
-      metadata: Metadata,
-      spark: SparkSession): Boolean = {
-    ColumnWithDefaultExprUtils.hasIdentityColumn(metadata.schema)
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -199,7 +199,7 @@ trait TableFeatureSupport { this: Protocol =>
    * Get all features that are supported by this protocol, implicitly and explicitly. When the
    * protocol supports table features, this method returns the same set of features as
    * [[readerAndWriterFeatureNames]]; when the protocol does not support table features, this
-   * method become equivalent to [[implicitlySupportedFeatures]].
+   * method becomes equivalent to [[implicitlySupportedFeatures]].
    */
   @JsonIgnore
   lazy val implicitlyAndExplicitlySupportedFeatures: Set[TableFeature] = {

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -195,6 +195,12 @@ trait TableFeatureSupport { this: Protocol =>
     }
   }
 
+  /**
+   * Get all features that are supported by this protocol, implicitly and explicitly. When the
+   * protocol supports table features, this method returns the same set of features as
+   * [[readerAndWriterFeatureNames]]; when the protocol does not support table features, this
+   * method become equivalent to [[implicitlySupportedFeatures]].
+   */
   @JsonIgnore
   lazy val implicitlyAndExplicitlySupportedFeatures: Set[TableFeature] = {
     readerAndWriterFeatureNames.flatMap(TableFeature.featureNameToFeature) ++

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -67,16 +67,18 @@ object Action {
     }
   }
 
-  /** All reader protocol version numbers (including 0) supported by the system. */
+  /** All reader protocol version numbers supported by the system. */
   private[delta] lazy val supportedReaderVersionNumbers: Set[Int] = {
-    Set(0, 1) ++ // Version 1 does not introduce new feature, it's always supported.
-      supportedProtocolVersion().implicitlyAndExplicitlySupportedFeatures.map(_.minReaderVersion)
+    supportedProtocolVersion().implicitlyAndExplicitlySupportedFeatures.map(_.minReaderVersion) ++
+      Set(1) -- // Version 1 does not introduce new feature, it's always supported.
+      Set(0) // Version 0 is not intended to be used
   }
 
-  /** All writer protocol version numbers (including 0) supported by the system. */
+  /** All writer protocol version numbers supported by the system. */
   private[delta] lazy val supportedWriterVersionNumbers: Set[Int] = {
-    Set(0, 1) ++ // Version 1 does not introduce new feature, it's always supported.
-      supportedProtocolVersion().implicitlyAndExplicitlySupportedFeatures.map(_.minWriterVersion)
+    supportedProtocolVersion().implicitlyAndExplicitlySupportedFeatures.map(_.minWriterVersion) ++
+      Set(1) -- // Version 1 does not introduce new feature, it's always supported.
+      Set(0) // Version 0 is not intended to be used
   }
 
   def fromJson(json: String): Action = {

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -221,10 +221,6 @@ object Protocol {
         }
       case _ => () // Do nothing. We only care about features that can be activated in metadata.
     }
-
-    if (IdentityColumnsTableFeature.metadataRequiresFeatureToBeEnabled(metadata, spark)) {
-      throw DeltaErrors.identityColumnNotSupported()
-    }
     enabledFeatures.toSet
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -67,6 +67,18 @@ object Action {
     }
   }
 
+  /** All reader protocol version numbers (including 0) supported by the system. */
+  private[delta] lazy val supportedReaderVersionNumbers: Set[Int] = {
+    Set(0, 1) ++ // Version 1 does not introduce new feature, it's always supported.
+      supportedProtocolVersion().implicitlyAndExplicitlySupportedFeatures.map(_.minReaderVersion)
+  }
+
+  /** All writer protocol version numbers (including 0) supported by the system. */
+  private[delta] lazy val supportedWriterVersionNumbers: Set[Int] = {
+    Set(0, 1) ++ // Version 1 does not introduce new feature, it's always supported.
+      supportedProtocolVersion().implicitlyAndExplicitlySupportedFeatures.map(_.minWriterVersion)
+  }
+
   def fromJson(json: String): Action = {
     JsonUtils.mapper.readValue[SingleAction](json).unwrap
   }

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -253,7 +253,7 @@ trait DeltaSQLConfBase {
       .doc("The default writer protocol version to create new tables with, unless a feature " +
         "that requires a higher version for correctness is enabled.")
       .intConf
-      .checkValues(Set(1, 2, 3, 4, 5, 6, 7))
+      .checkValues(Set(1, 2, 3, 4, 5, 7))
       .createWithDefault(2)
 
   val DELTA_PROTOCOL_DEFAULT_READER_VERSION =

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -1549,7 +1549,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
 
       val e3 = intercept[IllegalArgumentException] {
         sql(s"CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta " +
-          "TBLPROPERTIES (delta.minWriterVersion=0)")
+          "TBLPROPERTIES (delta.minWriterVersion='-1')")
       }
       assert(e3.getMessage.contains(" one of "))
     }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -213,8 +213,8 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
 
   test("upgrade to support table features - many features") {
     withTempDir { path =>
-      val log = createTableWithProtocol(Protocol(2, 6), path)
-      assert(log.snapshot.protocol === Protocol(2, 6))
+      val log = createTableWithProtocol(Protocol(2, 5), path)
+      assert(log.snapshot.protocol === Protocol(2, 5))
       val table = io.delta.tables.DeltaTable.forPath(spark, path.getCanonicalPath)
       table.upgradeTableProtocol(2, TABLE_FEATURES_MIN_WRITER_VERSION)
       assert(
@@ -1714,7 +1714,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_WRITER_VERSION.key -> "5") {
         replaceTableAs(path)
       }
-      assert(log.update().protocol === Protocol(2, 6))
+      assert(log.update().protocol === Protocol(2, 5))
       withSQLConf(
         DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_READER_VERSION.key -> "3",
         DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_WRITER_VERSION.key -> "7",
@@ -1723,11 +1723,11 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       }
       assert(
         log.update().protocol ===
-          Protocol(2, 6).merge(Protocol(3, 7)).withFeature(TestReaderWriterFeature))
+          Protocol(2, 5).merge(Protocol(3, 7)).withFeature(TestReaderWriterFeature))
     }
   }
 
-  for (p <- Seq(Protocol(2, 6), Protocol(3, 7).withFeature(TestReaderWriterFeature)))
+  for (p <- Seq(Protocol(2, 5), Protocol(3, 7).withFeature(TestReaderWriterFeature)))
     test(s"REPLACE AS keeps protocol when defaults are lower ($p)") {
       withTempDir { path =>
         spark

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -1539,7 +1539,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         sql(s"CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta " +
           "TBLPROPERTIES (delta.minWriterVersion='delta rulz')")
       }
-      assert(e.getMessage.contains("integer"))
+      assert(e.getMessage.contains(" one of "))
 
       val e2 = intercept[AnalysisException] {
         sql(s"CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta " +
@@ -1551,7 +1551,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         sql(s"CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta " +
           "TBLPROPERTIES (delta.minWriterVersion=0)")
       }
-      assert(e3.getMessage.contains("integer"))
+      assert(e3.getMessage.contains(" one of "))
     }
   }
 
@@ -1711,7 +1711,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       assert(log.update().protocol === Protocol(1, 2))
       withSQLConf(
         DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_READER_VERSION.key -> "2",
-        DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_WRITER_VERSION.key -> "6") {
+        DeltaSQLConf.DELTA_PROTOCOL_DEFAULT_WRITER_VERSION.key -> "5") {
         replaceTableAs(path)
       }
       assert(log.update().protocol === Protocol(2, 6))

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -228,7 +228,6 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
             CheckConstraintsTableFeature,
             ColumnMappingTableFeature,
             GeneratedColumnsTableFeature,
-            IdentityColumnsTableFeature,
             InvariantsTableFeature,
             TestLegacyWriterFeature,
             TestLegacyReaderWriterFeature)
@@ -252,7 +251,6 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
               CheckConstraintsTableFeature,
               ColumnMappingTableFeature,
               GeneratedColumnsTableFeature,
-              IdentityColumnsTableFeature,
               InvariantsTableFeature,
               TestLegacyWriterFeature,
               TestLegacyReaderWriterFeature,

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
@@ -335,13 +335,6 @@ class DeltaTableFeatureSuite
     }
   }
 
-  test("can't write to a table with identity columns") {
-    val p = "/Users/pengfei.xu/runtime/sql/core/src/test/resources/tables-by-dbr-version/11.3-checkConstraints-changeDataFeed-generatedColumns-identityColumns"
-    val table0 = sql(s"select * from delta.`$p`").collect()
-    sql(s"insert into delta.`$p` (id, date, idCol) values (999, from_unixtime(999), 888)")
-
-  }
-
   private def buildTablePropertyModifyingCommand(
       commandName: String,
       targetTableName: String,

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
@@ -139,7 +139,7 @@ class DeltaTableFeatureSuite
 
     assert(
       intercept[DeltaTableFeatureException] {
-        Protocol(1, 4).withFeature(TestLegacyReaderWriterFeature)
+        Protocol(2, 4).withFeature(TestLegacyReaderWriterFeature)
       }.getMessage.contains(
         "Unable to enable table feature testLegacyReaderWriter because it requires a higher " +
           "writer protocol version (current 4)"))

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
@@ -110,7 +110,6 @@ class DeltaTableFeatureSuite
         CheckConstraintsTableFeature,
         ChangeDataFeedTableFeature,
         GeneratedColumnsTableFeature,
-        IdentityColumnsTableFeature,
         TestLegacyWriterFeature,
         TestLegacyReaderWriterFeature))
     assert(
@@ -175,7 +174,6 @@ class DeltaTableFeatureSuite
           ChangeDataFeedTableFeature,
           CheckConstraintsTableFeature,
           GeneratedColumnsTableFeature,
-          IdentityColumnsTableFeature,
           TestLegacyWriterFeature,
           TestLegacyReaderWriterFeature)))
   }
@@ -203,7 +201,6 @@ class DeltaTableFeatureSuite
               ChangeDataFeedTableFeature,
               GeneratedColumnsTableFeature,
               ColumnMappingTableFeature,
-              IdentityColumnsTableFeature,
               TestLegacyWriterFeature,
               TestLegacyReaderWriterFeature))))
     assert(
@@ -216,7 +213,6 @@ class DeltaTableFeatureSuite
             ChangeDataFeedTableFeature,
             GeneratedColumnsTableFeature,
             ColumnMappingTableFeature,
-            IdentityColumnsTableFeature,
             TestLegacyWriterFeature,
             TestLegacyReaderWriterFeature))))
     // Features are identical but protocol versions are lower, thus `canUpgradeTo` is `false`.
@@ -337,6 +333,13 @@ class DeltaTableFeatureSuite
         }
       }
     }
+  }
+
+  test("can't write to a table with identity columns") {
+    val p = "/Users/pengfei.xu/runtime/sql/core/src/test/resources/tables-by-dbr-version/11.3-checkConstraints-changeDataFeed-generatedColumns-identityColumns"
+    val table0 = sql(s"select * from delta.`$p`").collect()
+    sql(s"insert into delta.`$p` (id, date, idCol) values (999, from_unixtime(999), 888)")
+
   }
 
   private def buildTablePropertyModifyingCommand(

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
@@ -120,7 +120,8 @@ class DeltaTableFeatureSuite
         CheckConstraintsTableFeature,
         ChangeDataFeedTableFeature,
         GeneratedColumnsTableFeature,
-        TestLegacyWriterFeature))
+        TestLegacyWriterFeature,
+        TestLegacyReaderWriterFeature))
     assert(Protocol(2, TABLE_FEATURES_MIN_WRITER_VERSION).implicitlySupportedFeatures === Set())
     assert(
       Protocol(
@@ -131,17 +132,17 @@ class DeltaTableFeatureSuite
   test("implicit feature listing") {
     assert(
       intercept[DeltaTableFeatureException] {
-        Protocol(1, 5).withFeature(TestLegacyReaderWriterFeature)
+        Protocol(1, 4).withFeature(TestLegacyReaderWriterFeature)
       }.getMessage.contains(
         "Unable to enable table feature testLegacyReaderWriter because it requires a higher " +
           "reader protocol version (current 1)"))
 
     assert(
       intercept[DeltaTableFeatureException] {
-        Protocol(2, 5).withFeature(TestLegacyReaderWriterFeature)
+        Protocol(1, 4).withFeature(TestLegacyReaderWriterFeature)
       }.getMessage.contains(
         "Unable to enable table feature testLegacyReaderWriter because it requires a higher " +
-          "writer protocol version (current 5)"))
+          "writer protocol version (current 4)"))
 
     assert(
       intercept[DeltaTableFeatureException] {
@@ -329,7 +330,8 @@ class DeltaTableFeatureSuite
             ChangeDataFeedTableFeature.name,
             GeneratedColumnsTableFeature.name,
             TestWriterFeature.name,
-            TestLegacyWriterFeature.name))
+            TestLegacyWriterFeature.name,
+            TestLegacyReaderWriterFeature.name))
         }
       }
     }


### PR DESCRIPTION
## Description

This PR fixes an issue described in https://github.com/delta-io/delta/issues/1694, where it is possible to INSERT values into an identity column without updating the high watermark.

This issue is caused by a misplaced check in `actions.scala`. The check didn't fire for INSERTs.

## How was this patch tested?

Added new tests.

## Does this PR introduce _any_ user-facing changes?

Yes. After this PR is merged, it will no longer be possible to write to a table that has `minWriterVersion` = `6`, or has `identityColumns` in `writerFeatures`.