### PR TITLE
Drop stats for streaming source file index

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.delta.sources
 import java.io.FileNotFoundException
 import java.sql.Timestamp
 
-import scala.collection.mutable
 import scala.util.{Success, Try}
 import scala.util.control.NonFatal
 import scala.util.matching.Regex

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -764,7 +764,7 @@ case class DeltaSource(
         case _ => false
       }
     Iterator.single(IndexedFile(version, -1, null)) ++ filteredIterator
-      .map(_.asInstanceOf[AddFile])
+      .map(_.asInstanceOf[AddFile].copy(stats = null))
       .zipWithIndex.map { case (action, index) =>
       IndexedFile(version, index.toLong, action, isLast = !iterator.hasNext)
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Related to https://github.com/delta-io/delta/issues/1699

Drops the stats for file metadata for creating streaming batch file indices. As far as I can tell, stats are not used on the streaming read path. And the current implementation for starting a new stream from a Delta table requires loading all file metadata on the driver and keeping it there until the stream is "caught up". I plan to investigate doing this more incrementally in a follow on but this seemed like a quick win to drastically reduce the driver memory requirements to start a new stream from a Delta table.

In practice we've had to use upwards of 60-100 GiB of driver memory to start some of our new streaming jobs and not have them go OOM.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
New and existing UTs.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No change, just memory usage improvement.