### PR TITLE
Support Auto Vacuum

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/hooks/DoAutoVacuum.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/hooks/DoAutoVacuum.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.hooks
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.commands.VacuumCommand
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+/**
+ * Post commit hook to trigger vacuum.
+ */
+object DoAutoVacuum extends PostCommitHook
+  with DeltaLogging
+  with Serializable {
+
+  override val name: String = "Triggers vacuum if necessary"
+
+  override def run(
+                    spark: SparkSession,
+                    txn: OptimisticTransactionImpl,
+                    committedVersion: Long,
+                    postCommitSnapshot: Snapshot,
+                    committedActions: Seq[Action]): Unit = {
+
+    val retentionHours = spark.sessionState.conf.getConf(DeltaSQLConf.AUTO_VACUUM_RETENTION_HOURS)
+    VacuumCommand.gc(spark, txn.deltaLog, false, Option(retentionHours))
+  }
+
+  override def handleError(error: Throwable, version: Long): Unit = {
+    throw DeltaErrors.postCommitHookFailedException(this, version, name, error)
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -320,6 +320,25 @@ trait DeltaSQLConfBase {
       .checkValue(_ > 0, "parallelDelete.parallelism must be positive")
       .createOptional
 
+  val AUTO_VACUUM_ENABLED =
+    buildConf("autoVacuum.enabled")
+      .internal()
+      .doc("Enables auto vacuum after table update.")
+      .booleanConf
+      .createWithDefault(false)
+
+  val AUTO_VACUUM_RETENTION_HOURS =
+    buildConf("autoVacuum.retentionHours")
+      .internal()
+      .doc(
+        """
+          |The retention threshold in hours. Files required by the table for reading versions
+          |earlier than this will be preserved and the rest of them will be deleted.
+          |""".stripMargin)
+      .doubleConf
+      .checkValue(_ >= 0, "must not be negative.")
+      .createWithDefault(7 * 24)
+
   val DELTA_SCHEMA_AUTO_MIGRATE =
     buildConf("schema.autoMerge.enabled")
       .doc("If true, enables schema merging on appends and on overwrites.")

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
@@ -1008,6 +1008,25 @@ class DeltaVacuumSuite
     testCDCVacuumForTombstones()
   }
 
+  test("enable auto vacuum") {
+    withEnvironment { (tempDir, clock) =>
+      withSQLConf("spark.databricks.delta.autoVacuum.enabled" -> "true",
+        "spark.databricks.delta.autoVacuum.retentionHours" -> "0") {
+        spark.range(10)
+          .write.mode("overwrite").format("delta")
+          .save(tempDir)
+        val deltaLog = DeltaLog.forTable(spark, tempDir)
+        val files = deltaLog.unsafeVolatileSnapshot.allFiles.collect().toSeq.map(_.path)
+        spark.range(10)
+          .write.mode("overwrite").format("delta")
+          .save(tempDir)
+        gcTest(deltaLog, clock)(
+          CheckFiles(files, false)
+        )
+      }
+    }
+  }
+
   private def getFromHistory(history: DataFrame, key: String, pos: Integer): Map[String, String] = {
     val op = history.select(key).take(pos + 1)
     if (pos == 0) {


### PR DESCRIPTION
## Description

Support auto vacuum after file actions except optimize
`spark.databricks.delta.autoVacuum.enabled (default false)`
`spark.databricks.delta.autoVacuum.retentionHours (default 7*24)`

## How was this patch tested?

UT

## Does this PR introduce _any_ user-facing changes?

Support auto vacuum feature