### PR TITLE
Rewrite OPTIMIZE to use Spark Table Resolution

### DIFF
--- a/core/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
+++ b/core/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
@@ -346,8 +346,7 @@ class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
     OptimizeTableCommand(
       Option(ctx.path).map(string),
       Option(ctx.table).map(visitTableIdentifier),
-      Option(ctx.partitionPredicate).map(extractRawText(_)).toSeq,
-      Map.empty)(interleaveBy)
+      Option(ctx.partitionPredicate).map(extractRawText(_)).toSeq)(interleaveBy)
   }
 
   /**

--- a/core/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -214,10 +214,7 @@ class DeltaTable private[tables](
    *
    * @since 2.0.0
    */
-  def optimize(): DeltaOptimizeBuilder = {
-    DeltaOptimizeBuilder(sparkSession,
-      table.tableIdentifier.getOrElse(s"delta.`${deltaLog.dataPath.toString}`"), table.options)
-  }
+  def optimize(): DeltaOptimizeBuilder = DeltaOptimizeBuilder(table)
 
   /**
    * Update rows in the table based on the rules defined by `set`.

--- a/core/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeCompactionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeCompactionSuite.scala
@@ -610,6 +610,18 @@ class OptimizeCompactionSQLSuite extends OptimizeCompactionSuiteBase
         baseDf.union(baseDf))
     }
   }
+
+  test("optimize command: subquery predicate") {
+    val tableName = "myTable"
+    withTable(tableName) {
+      spark.sql(s"create table $tableName (p int, id int) using delta partitioned by(p)")
+      val e = intercept[DeltaAnalysisException] {
+        spark.sql(s"optimize $tableName where p >= (select p from $tableName where id > 5)")
+      }
+      checkError(e, "DELTA_UNSUPPORTED_SUBQUERY_IN_PARTITION_PREDICATES",
+        "0AKDC", Map.empty[String, String])
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## Description

This PR is part of #1705.

It rewrites the Delta OPTIMIZE command to use Spark's table resolution logic instead of resolving the target table manually at command execution time. For that, it changes OptimizeTableCommand from a LeafRunnableCommand to a UnaryLike command that takes a UnresolvedTable as a child plan node, which will be resolved by Spark. In addition, it also introduces a UnresolvedPathBasedDeltaTable LogicalPlan for the case that OPTIMIZE is run against a raw path. This new logical plan is an indication that the target table specified as a path so no table resolution is necessary.

## How was this patch tested?

Through the large set of existing unit tests that OPTIMIZE already has + adapted the DeltaSqlParserSuite to work with the new OptimizeTableCommand.

## Does this PR introduce _any_ user-facing changes?

N/A
