### PR TITLE
Support unblocking non-additive schema tracking with SQL conf

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -1557,6 +1557,17 @@
     ],
     "sqlState" : "XXKDS"
   },
+  "DELTA_STREAMING_CANNOT_CONTINUE_PROCESSING_POST_SCHEMA_EVOLUTION" : {
+    "message" : [
+      "We've detected a non-additive schema change (<opType>) at Delta version <schemaChangeVersion> in the Delta streaming source. Please check if you want to manually propagate this schema change to the sink table before we proceed with stream processing.",
+      "Once you have fixed the schema of the sink table or have decided there is no need to fix, you can set (one of) the following SQL configurations to unblock this non-additive schema change and continue stream processing.",
+      "To unblock for this particular stream just for this single schema change: set `<allowCkptVerKey> = <allowCkptVerValue>`.",
+      "To unblock for this particular stream: set `<allowCkptKey> = <allowCkptValue>`",
+      "To unblock for all streams: set `<allowAllKey> = <allowAllValue>`.",
+      "Alternatively if applicable, you may replace the `<allowAllMode>` with `<opSpecificMode>` in the SQL conf to unblock stream for just this schema change type."
+    ],
+    "sqlState" : "KD002"
+  },
   "DELTA_STREAMING_CHECK_COLUMN_MAPPING_NO_SNAPSHOT" : {
     "message" : [
       "Failed to obtain Delta log snapshot for the start version when checking column mapping schema changes. Please choose a different start version, or force enable streaming read at your own risk by setting '<config>' to 'true'."

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
@@ -513,8 +513,12 @@ trait DeltaColumnMappingBase extends DeltaLogging {
       return false
     }
 
-    val newPhysicalToLogicalMap = getPhysicalNameFieldMap(newMetadata.schema)
-    val currentPhysicalToLogicalMap = getPhysicalNameFieldMap(currentMetadata.schema)
+    isDropColumnOperation(newSchema = newMetadata.schema, currentSchema = currentMetadata.schema)
+  }
+
+  def isDropColumnOperation(newSchema: StructType, currentSchema: StructType): Boolean = {
+    val newPhysicalToLogicalMap = getPhysicalNameFieldMap(newSchema)
+    val currentPhysicalToLogicalMap = getPhysicalNameFieldMap(currentSchema)
 
     // are any of the current physical names missing in the new schema?
     currentPhysicalToLogicalMap
@@ -538,8 +542,12 @@ trait DeltaColumnMappingBase extends DeltaLogging {
       return false
     }
 
-    val newPhysicalToLogicalMap = getPhysicalNameFieldMap(newMetadata.schema)
-    val currentPhysicalToLogicalMap = getPhysicalNameFieldMap(currentMetadata.schema)
+    isRenameColumnOperation(newSchema = newMetadata.schema, currentSchema = currentMetadata.schema)
+  }
+
+  def isRenameColumnOperation(newSchema: StructType, currentSchema: StructType): Boolean = {
+    val newPhysicalToLogicalMap = getPhysicalNameFieldMap(newSchema)
+    val currentPhysicalToLogicalMap = getPhysicalNameFieldMap(currentSchema)
 
     // do any two columns with the same physical name have different logical names?
     currentPhysicalToLogicalMap

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
@@ -137,7 +137,8 @@ class DeltaDataSource
       deltaLog,
       options,
       snapshot,
-      schemaTrackingLog = schemaTrackingLogOpt
+      metadataPath,
+      schemaTrackingLogOpt
     )
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -29,7 +29,9 @@ import org.apache.spark.storage.StorageLevel
  * [[SQLConf]] entries for Delta features.
  */
 trait DeltaSQLConfBase {
-  def buildConf(key: String): ConfigBuilder = SQLConf.buildConf(s"spark.databricks.delta.$key")
+  val SQL_CONF_PREFIX = "spark.databricks.delta"
+
+  def buildConf(key: String): ConfigBuilder = SQLConf.buildConf(s"$SQL_CONF_PREFIX.$key")
   def buildStaticConf(key: String): ConfigBuilder =
     SQLConf.buildStaticConf(s"spark.databricks.delta.$key")
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
A follow up PR to https://github.com/delta-io/delta/pull/1690 to support safe unblock streaming with SQL conf.

## How was this patch tested?
New unit tests.

## Does this PR introduce _any_ user-facing changes?
No.