### PR TITLE
Incremental loading for DeltaSourceSnapshot actions

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -305,7 +305,7 @@ class Snapshot(
     DeltaLog.minSetTransactionRetentionInterval(metadata).map(deltaLog.clock.getTimeMillis() - _)
   }
 
-  protected def getNumPartitions: Int = {
+  private[delta] def getNumPartitions: Int = {
     spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_SNAPSHOT_PARTITIONS)
       .getOrElse(Snapshot.defaultNumSnapshotPartitions)
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -851,7 +851,7 @@ case class DeltaSource(
     Iterator.single(IndexedFile(version, DeltaSourceOffset.BASE_INDEX, null)) ++
     getSchemaChangeIndexedFileIterator(metadataOpt, version) ++
     filteredIterator
-      .map(_.asInstanceOf[AddFile])
+      .map(_.asInstanceOf[AddFile].copy(stats = null))
       .zipWithIndex
       .sliding(size = 2)
       .flatMap {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -848,12 +848,13 @@ case class DeltaSource(
     Iterator.single(IndexedFile(version, DeltaSourceOffset.BASE_INDEX, null)) ++
     getSchemaChangeIndexedFileIterator(metadataOpt, version) ++
     filteredIterator
-      .map(_.asInstanceOf[AddFile].copy(stats = null))
+      .map(_.asInstanceOf[AddFile])
       .zipWithIndex
       .sliding(size = 2)
       .flatMap {
         case Seq((action, index), (secondAction, _)) =>
-          Some(IndexedFile(version, index.toLong, action, isLast = secondAction.eq(sentinelFile)))
+          Some(IndexedFile(version, index.toLong, action.copy(stats = null),
+            isLast = secondAction.eq(sentinelFile)))
         // Only sentinel left in iterator, do not return it.
         case Seq(_) => None
       }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -626,8 +626,7 @@ case class DeltaSource(
     options: DeltaOptions,
     snapshotAtSourceInit: Snapshot,
     metadataPath: String,
-    schemaTrackingLog: Option[DeltaSourceSchemaTrackingLog] = None,
-    filters: Seq[Expression] = Nil)
+    schemaTrackingLog: Option[DeltaSourceSchemaTrackingLog] = None)
   extends DeltaSourceBase
   with DeltaSourceCDCSupport
   with DeltaSourceSchemaEvolutionSupport {
@@ -658,8 +657,6 @@ case class DeltaSource(
   // A metadata snapshot when starting the query.
   protected var initialState: DeltaSourceSnapshot = null
   protected var initialStateVersion: Long = -1L
-
-  logInfo(s"Filters being pushed down: $filters")
 
   /**
    * Get the changes starting from (startVersion, startIndex). The start point should not be
@@ -743,7 +740,7 @@ case class DeltaSource(
       super[DeltaSourceBase].cleanUpSnapshotResources()
       val snapshot = getSnapshotFromDeltaLog(version)
 
-      initialState = new DeltaSourceSnapshot(spark, snapshot, filters)
+      initialState = new DeltaSourceSnapshot(spark, snapshot)
       initialStateVersion = version
     }
     initialState.iterator()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -856,8 +856,8 @@ case class DeltaSource(
       .sliding(size = 2)
       .flatMap {
         case Seq((action, index), (secondAction, _)) =>
-          Some(IndexedFile(version, index.toLong, action.copy(stats = null),
-            isLast = secondAction.eq(sentinelFile)))
+          val isLast = secondAction.eq(sentinelFile)
+          Some(IndexedFile(version, index.toLong, action.copy(stats = null), isLast = isLast))
         // Only sentinel left in iterator, do not return it.
         case Seq(_) => None
       }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -626,7 +626,8 @@ case class DeltaSource(
     options: DeltaOptions,
     snapshotAtSourceInit: Snapshot,
     metadataPath: String,
-    schemaTrackingLog: Option[DeltaSourceSchemaTrackingLog] = None)
+    schemaTrackingLog: Option[DeltaSourceSchemaTrackingLog] = None,
+    filters: Seq[Expression] = Nil)
   extends DeltaSourceBase
   with DeltaSourceCDCSupport
   with DeltaSourceSchemaEvolutionSupport {
@@ -657,6 +658,8 @@ case class DeltaSource(
   // A metadata snapshot when starting the query.
   protected var initialState: DeltaSourceSnapshot = null
   protected var initialStateVersion: Long = -1L
+
+  logInfo(s"Filters being pushed down: $filters")
 
   /**
    * Get the changes starting from (startVersion, startIndex). The start point should not be
@@ -740,7 +743,7 @@ case class DeltaSource(
       super[DeltaSourceBase].cleanUpSnapshotResources()
       val snapshot = getSnapshotFromDeltaLog(version)
 
-      initialState = new DeltaSourceSnapshot(spark, snapshot)
+      initialState = new DeltaSourceSnapshot(spark, snapshot, filters)
       initialStateVersion = version
     }
     initialState.iterator()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
Resolves https://github.com/delta-io/delta/issues/1699

Updates `DeltaSourceSnapshot` with a few improvements, most notably loading actions for the snapshot incrementally using `toLocalIterator` instead of `collect`'ing the entire snapshot on the driver and keeping it there. If we're worried about performance aspects of `toLocalIterator` I can put the two different methods behind a feature flag.

Additionally:
- Adds a `repartitionByRange` before the sort on time and path to control the number of output partitions of the sort. Without this the default shuffle partitions are used, which can be large for large datasets and make `toLocalIterator` as well as `collect` take longer.
- Skip encoding the cached dataset as an `IndexedRow` because it is immediately converted back to a DataFrame to create the iterator.
- Includes the same updates as https://github.com/delta-io/delta/pull/1703 to drop stats before creating streaming file indices
- Uncaches the `Delta Source Snapshot` in addition to the underlying `Snapshot` on close

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Existing UTs, shouldn't change any behavior.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No, just resource requirement changes.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
