### PR TITLE
[BACKPORT] Block writing to Delta tables that supports identity columns

### DIFF
--- a/core/src/main/resources/error/delta-error-classes.json
+++ b/core/src/main/resources/error/delta-error-classes.json
@@ -943,7 +943,7 @@
   },
   "DELTA_INVALID_PROTOCOL_VERSION" : {
     "message" : [
-      "Delta protocol version is too new for this version of Delta Lake: table requires <required>, client supports up to <supported>. Please upgrade to a newer release."
+      "Delta protocol version is not supported by this version of Delta Lake: table requires <required>, client supports <supported>. Please upgrade to a newer release."
     ],
     "sqlState" : "KD004"
   },

--- a/core/src/main/scala/org/apache/spark/sql/delta/ColumnWithDefaultExprUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/ColumnWithDefaultExprUtils.scala
@@ -57,7 +57,7 @@ object ColumnWithDefaultExprUtils extends DeltaLogging {
 
   // Return if `protocol` satisfies the requirement for IDENTITY columns.
   def satisfiesIdentityColumnProtocol(protocol: Protocol): Boolean =
-    protocol.isFeatureSupported(IdentityColumnsTableFeature)
+    protocol.minWriterVersion == 6 || protocol.writerFeatureNames.contains("identityColumns")
 
   // Return true if the column `col` has default expressions (and can thus be omitted from the
   // insertion list).

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -307,8 +307,8 @@ trait DeltaConfigsBase extends DeltaLogging {
     "minReaderVersion",
     Action.supportedProtocolVersion().minReaderVersion.toString,
     _.toInt,
-    v => v > 0 && v <= Action.supportedProtocolVersion().minReaderVersion,
-    s"needs to be an integer between [1, ${Action.supportedProtocolVersion().minReaderVersion}].")
+    v => Action.supportedReaderVersionNumbers.contains(v),
+    s"needs to be one of ${Action.supportedReaderVersionNumbers.toSeq.sorted.mkString(", ")}.")
 
   /**
    * The protocol reader version modelled as a table property. This property is *not* stored as
@@ -319,8 +319,8 @@ trait DeltaConfigsBase extends DeltaLogging {
     "minWriterVersion",
     Action.supportedProtocolVersion().minWriterVersion.toString,
     _.toInt,
-    v => v > 0 && v <= Action.supportedProtocolVersion().minWriterVersion,
-    s"needs to be an integer between [1, ${Action.supportedProtocolVersion().minWriterVersion}].")
+    v => Action.supportedWriterVersionNumbers.contains(v),
+    s"needs to be one of ${Action.supportedWriterVersionNumbers.toSeq.sorted.mkString(", ")}.")
 
   /**
    * Ignore protocol-related configs set in SQL config.

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2239,10 +2239,6 @@ trait DeltaErrorsBase
     new DeltaAnalysisException(errorClass = "DELTA_UNSET_NON_EXISTENT_PROPERTY", Array(key, table))
   }
 
-  def identityColumnNotSupported(): Throwable = {
-    new AnalysisException("IDENTITY column is not supported")
-  }
-
   def identityColumnInconsistentMetadata(
       colName: String,
       hasStart: Boolean,
@@ -2906,10 +2902,10 @@ class DeltaIndexOutOfBoundsException(
 }
 
 /** Thrown when the protocol version of a table is greater than supported by this client. */
-class InvalidProtocolVersionException(requiredVersion: Int, supportedVersion: Int)
+class InvalidProtocolVersionException(requiredVersion: Int, supportedVersions: Seq[Int])
   extends RuntimeException(DeltaThrowableHelper.getMessage(
     errorClass = "DELTA_INVALID_PROTOCOL_VERSION",
-    messageParameters = Array(requiredVersion.toString, supportedVersion.toString)))
+    messageParameters = Array(requiredVersion.toString, supportedVersions.sorted.mkString(", "))))
   with DeltaThrowable {
   override def getErrorClass: String = "DELTA_INVALID_PROTOCOL_VERSION"
 }

--- a/core/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -193,7 +193,6 @@ object TableFeature {
       AppendOnlyTableFeature,
       ChangeDataFeedTableFeature,
       CheckConstraintsTableFeature,
-      IdentityColumnsTableFeature,
       GeneratedColumnsTableFeature,
       InvariantsTableFeature,
       ColumnMappingTableFeature,
@@ -286,13 +285,11 @@ object ColumnMappingTableFeature
   }
 }
 
-object IdentityColumnsTableFeature
-  extends LegacyWriterFeature(name = "identityColumns", minWriterVersion = 6)
-  with FeatureAutomaticallyEnabledByMetadata {
+object TimestampNTZTableFeature extends ReaderWriterFeature(name = "timestampNtz")
+    with FeatureAutomaticallyEnabledByMetadata {
   override def metadataRequiresFeatureToBeEnabled(
-      metadata: Metadata,
-      spark: SparkSession): Boolean = {
-    ColumnWithDefaultExprUtils.hasIdentityColumn(metadata.schema)
+      metadata: Metadata, spark: SparkSession): Boolean = {
+    SchemaUtils.checkForTimestampNTZColumnsRecursively(metadata.schema)
   }
 }
 
@@ -321,7 +318,7 @@ object TestLegacyReaderWriterFeature
   extends LegacyReaderWriterFeature(
     name = "testLegacyReaderWriter",
     minReaderVersion = 2,
-    minWriterVersion = 6)
+    minWriterVersion = 5)
 
 object TestReaderWriterFeature extends ReaderWriterFeature(name = "testReaderWriter")
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -285,14 +285,6 @@ object ColumnMappingTableFeature
   }
 }
 
-object TimestampNTZTableFeature extends ReaderWriterFeature(name = "timestampNtz")
-    with FeatureAutomaticallyEnabledByMetadata {
-  override def metadataRequiresFeatureToBeEnabled(
-      metadata: Metadata, spark: SparkSession): Boolean = {
-    SchemaUtils.checkForTimestampNTZColumnsRecursively(metadata.schema)
-  }
-}
-
 object DeletionVectorsTableFeature
   extends ReaderWriterFeature(name = "deletionVectors")
   with FeatureAutomaticallyEnabledByMetadata {

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -196,6 +196,18 @@ trait TableFeatureSupport { this: Protocol =>
   }
 
   /**
+   * Get all features that are supported by this protocol, implicitly and explicitly. When the
+   * protocol supports table features, this method returns the same set of features as
+   * [[readerAndWriterFeatureNames]]; when the protocol does not support table features, this
+   * method becomes equivalent to [[implicitlySupportedFeatures]].
+   */
+  @JsonIgnore
+  lazy val implicitlyAndExplicitlySupportedFeatures: Set[TableFeature] = {
+    readerAndWriterFeatureNames.flatMap(TableFeature.featureNameToFeature) ++
+      implicitlySupportedFeatures
+  }
+
+  /**
    * Determine whether this protocol can be safely upgraded to a new protocol `to`. This means:
    *   - this protocol has reader protocol version less than or equals to `to`.
    *   - this protocol has writer protocol version less than or equals to `to`.

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -28,7 +28,7 @@ import scala.util.control.NonFatal
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.commands.DeletionVectorUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.util.JsonUtils
+import org.apache.spark.sql.delta.util.{JsonUtils, Utils => DeltaUtils}
 import com.fasterxml.jackson.annotation._
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.core.JsonGenerator
@@ -62,6 +62,30 @@ object Action {
       protocolVersion.withFeatures(TableFeature.allSupportedFeaturesMap.values)
     } else {
       protocolVersion
+    }
+  }
+
+  /** All reader protocol version numbers supported by the system. */
+  private[delta] lazy val supportedReaderVersionNumbers: Set[Int] = {
+    val allVersions =
+      supportedProtocolVersion().implicitlyAndExplicitlySupportedFeatures.map(_.minReaderVersion) +
+      1 // Version 1 does not introduce new feature, it's always supported.
+    if (DeltaUtils.isTesting) {
+      allVersions + 0 // Allow Version 0 in tests
+    } else {
+      allVersions - 0 // Delete 0 produced by writer-only features
+    }
+  }
+
+  /** All writer protocol version numbers supported by the system. */
+  private[delta] lazy val supportedWriterVersionNumbers: Set[Int] = {
+    val allVersions =
+      supportedProtocolVersion().implicitlyAndExplicitlySupportedFeatures.map(_.minWriterVersion) +
+        1 // Version 1 does not introduce new feature, it's always supported.
+    if (DeltaUtils.isTesting) {
+      allVersions + 0 // Allow Version 0 in tests
+    } else {
+      allVersions - 0 // Delete 0 produced by reader-only features - we don't have any - for safety
     }
   }
 
@@ -219,10 +243,6 @@ object Protocol {
           enabledFeatures += feature
         }
       case _ => () // Do nothing. We only care about features that can be activated in metadata.
-    }
-
-    if (IdentityColumnsTableFeature.metadataRequiresFeatureToBeEnabled(metadata, spark)) {
-      throw DeltaErrors.identityColumnNotSupported()
     }
     enabledFeatures.toSet
   }

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -258,7 +258,7 @@ trait DeltaSQLConfBase {
       .doc("The default writer protocol version to create new tables with, unless a feature " +
         "that requires a higher version for correctness is enabled.")
       .intConf
-      .checkValues(Set(1, 2, 3, 4, 5, 6, 7))
+      .checkValues(Set(1, 2, 3, 4, 5, 7))
       .createWithDefault(2)
 
   val DELTA_PROTOCOL_DEFAULT_READER_VERSION =

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
@@ -110,7 +110,6 @@ class DeltaTableFeatureSuite
         CheckConstraintsTableFeature,
         ChangeDataFeedTableFeature,
         GeneratedColumnsTableFeature,
-        IdentityColumnsTableFeature,
         TestLegacyWriterFeature,
         TestLegacyReaderWriterFeature))
     assert(
@@ -121,7 +120,8 @@ class DeltaTableFeatureSuite
         CheckConstraintsTableFeature,
         ChangeDataFeedTableFeature,
         GeneratedColumnsTableFeature,
-        TestLegacyWriterFeature))
+        TestLegacyWriterFeature,
+        TestLegacyReaderWriterFeature))
     assert(Protocol(2, TABLE_FEATURES_MIN_WRITER_VERSION).implicitlySupportedFeatures === Set())
     assert(
       Protocol(
@@ -132,17 +132,17 @@ class DeltaTableFeatureSuite
   test("implicit feature listing") {
     assert(
       intercept[DeltaTableFeatureException] {
-        Protocol(1, 5).withFeature(TestLegacyReaderWriterFeature)
+        Protocol(1, 4).withFeature(TestLegacyReaderWriterFeature)
       }.getMessage.contains(
         "Unable to enable table feature testLegacyReaderWriter because it requires a higher " +
           "reader protocol version (current 1)"))
 
     assert(
       intercept[DeltaTableFeatureException] {
-        Protocol(2, 5).withFeature(TestLegacyReaderWriterFeature)
+        Protocol(2, 4).withFeature(TestLegacyReaderWriterFeature)
       }.getMessage.contains(
         "Unable to enable table feature testLegacyReaderWriter because it requires a higher " +
-          "writer protocol version (current 5)"))
+          "writer protocol version (current 4)"))
 
     assert(
       intercept[DeltaTableFeatureException] {
@@ -175,7 +175,6 @@ class DeltaTableFeatureSuite
           ChangeDataFeedTableFeature,
           CheckConstraintsTableFeature,
           GeneratedColumnsTableFeature,
-          IdentityColumnsTableFeature,
           TestLegacyWriterFeature,
           TestLegacyReaderWriterFeature)))
   }
@@ -203,7 +202,6 @@ class DeltaTableFeatureSuite
               ChangeDataFeedTableFeature,
               GeneratedColumnsTableFeature,
               ColumnMappingTableFeature,
-              IdentityColumnsTableFeature,
               TestLegacyWriterFeature,
               TestLegacyReaderWriterFeature))))
     assert(
@@ -216,7 +214,6 @@ class DeltaTableFeatureSuite
             ChangeDataFeedTableFeature,
             GeneratedColumnsTableFeature,
             ColumnMappingTableFeature,
-            IdentityColumnsTableFeature,
             TestLegacyWriterFeature,
             TestLegacyReaderWriterFeature))))
     // Features are identical but protocol versions are lower, thus `canUpgradeTo` is `false`.
@@ -333,7 +330,8 @@ class DeltaTableFeatureSuite
             ChangeDataFeedTableFeature.name,
             GeneratedColumnsTableFeature.name,
             TestWriterFeature.name,
-            TestLegacyWriterFeature.name))
+            TestLegacyWriterFeature.name,
+            TestLegacyReaderWriterFeature.name))
         }
       }
     }


### PR DESCRIPTION
## Description

This PR fixes an issue described in https://github.com/delta-io/delta/issues/1694, where it is possible to INSERT values into an identity column without updating the high watermark.

This issue is caused by a misplaced check in `actions.scala`. The check didn't fire for INSERTs.

## How was this patch tested?

Added new tests.

## Does this PR introduce _any_ user-facing changes?

Yes. After this PR is merged, it will no longer be possible to write to a table that has `minWriterVersion` = `6`, or has `identityColumns` in `writerFeatures`.

Closes delta-io/delta#1695

Signed-off-by: Paddy Xu <xupaddy@gmail.com>
