### PR TITLE
S3DynamoDBLogStore::read: use a ThrowingSupplier to correctly propagate the FileNotFoundException

### DIFF
--- a/storage-s3-dynamodb/src/main/java/io/delta/storage/RetryableCloseableIterator.java
+++ b/storage-s3-dynamodb/src/main/java/io/delta/storage/RetryableCloseableIterator.java
@@ -6,6 +6,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.function.Supplier;
 
+import io.delta.storage.utils.ThrowingSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,7 +28,7 @@ public class RetryableCloseableIterator implements CloseableIterator<String> {
 
     public static final int DEFAULT_MAX_RETRIES = 3;
 
-    private final Supplier<CloseableIterator<String>> iterSupplier;
+    private final ThrowingSupplier<CloseableIterator<String>, IOException> iterSupplier;
 
     private final int maxRetries;
 
@@ -42,8 +43,8 @@ public class RetryableCloseableIterator implements CloseableIterator<String> {
     private CloseableIterator<String> currentIter;
 
     public RetryableCloseableIterator(
-            Supplier<CloseableIterator<String>> iterSupplier,
-            int maxRetries) {
+            ThrowingSupplier<CloseableIterator<String>, IOException> iterSupplier,
+            int maxRetries) throws IOException {
         if (maxRetries < 0) throw new IllegalArgumentException("maxRetries can't be negative");
 
         this.iterSupplier = Objects.requireNonNull(iterSupplier);
@@ -52,7 +53,10 @@ public class RetryableCloseableIterator implements CloseableIterator<String> {
         this.currentIter = this.iterSupplier.get();
     }
 
-    public RetryableCloseableIterator(Supplier<CloseableIterator<String>> iterSupplier) {
+    public RetryableCloseableIterator(
+            ThrowingSupplier<CloseableIterator<String>, IOException> iterSupplier)
+        throws IOException {
+
         this(iterSupplier, DEFAULT_MAX_RETRIES);
     }
 

--- a/storage-s3-dynamodb/src/main/java/io/delta/storage/S3DynamoDBLogStore.java
+++ b/storage-s3-dynamodb/src/main/java/io/delta/storage/S3DynamoDBLogStore.java
@@ -154,18 +154,7 @@ public class S3DynamoDBLogStore extends BaseExternalLogStore {
             )
         );
 
-        return new RetryableCloseableIterator(
-            () -> {
-                try {
-                    return super.read(path, hadoopConf);
-                } catch (IOException e) {
-                    // There was an issue resolving the file system. Nothing to do with a
-                    // RemoteFileChangedException.
-                    throw new UncheckedIOException(e);
-                }
-            },
-            maxRetries
-        );
+        return new RetryableCloseableIterator(() -> super.read(path, hadoopConf), maxRetries);
     }
 
     @Override

--- a/storage-s3-dynamodb/src/main/java/io/delta/storage/utils/ThrowingSupplier.java
+++ b/storage-s3-dynamodb/src/main/java/io/delta/storage/utils/ThrowingSupplier.java
@@ -1,0 +1,6 @@
+package io.delta.storage.utils;
+
+@FunctionalInterface
+public interface ThrowingSupplier<T, E extends Exception> {
+    T get() throws E;
+}


### PR DESCRIPTION
## Description

Previously, we were wrapping `super.read` calls in the Supplier to RetryableCloseableIterator with a try-catch statement, and re-threw IOExceptions as UncheckedIOExceptions.

This could cause downstream readers who are catching `FileNotFoundException` to fail, as instead of a `FileNotFoundException` we were throwing an `UncheckedIOException`.

Instead, this PR creates a `ThrowingSupplier` class so that `super.read` calls don't need to be caught and re-thrown.

## How was this patch tested?

New UTs and tested with a real S3 bucket and DDB table:

```
spark-shell --packages io.delta:delta-core_2.12:2.3.0,org.apache.hadoop:hadoop-aws:3.3.1 \
--jars /Users/scott.sandre/.m2/repository/io/delta/delta-storage-s3-dynamodb/2.4.0-SNAPSHOT/delta-storage-s3-dynamodb-2.4.0-SNAPSHOT.jar,/Users/scott.sandre/.m2/repository/io/delta/delta-storage/2.4.0-SNAPSHOT/delta-storage-2.4.0-SNAPSHOT.jar \
--conf spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension \
--conf spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog \
--conf spark.delta.logStore.s3a.impl=io.delta.storage.S3DynamoDBLogStore \
--conf spark.io.delta.storage.S3DynamoDBLogStore.ddb.region=XXXX \
--conf spark.io.delta.storage.S3DynamoDBLogStore.ddb.tableName=YYYY \
--conf spark.io.delta.storage.S3DynamoDBLogStore.credentials.provider=com.amazonaws.auth.profile.ProfileCredentialsProvider \
--conf spark.hadoop.fs.s3a.aws.credentials.provider=com.amazonaws.auth.profile.ProfileCredentialsProvider

> spark.range(100).write.format("delta").save(tablePath)
23/05/01 15:54:52 INFO S3DynamoDBLogStore: using tableName YYYY
23/05/01 15:54:52 INFO S3DynamoDBLogStore: using credentialsProviderName com.amazonaws.auth.profile.ProfileCredentialsProvider
23/05/01 15:54:52 INFO S3DynamoDBLogStore: using regionName XXXX
23/05/01 15:54:52 INFO S3DynamoDBLogStore: using ttl (seconds) 86400
23/05/01 15:54:52 INFO S3DynamoDBLogStore: Table `YYYY` already exists
23/05/01 15:54:52 INFO DelegatingLogStore: LogStore `LogStoreAdapter(io.delta.storage.S3DynamoDBLogStore)` is used for scheme `s3a`

> spark.read.format("delta").load(tablePath).show()
// shows valid output
```
## Does this PR introduce _any_ user-facing changes?

No
