### PR TITLE
Correctly recurse into nested arrays & maps in add/drop columns

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1959,7 +1959,7 @@ trait DeltaErrorsBase
     new DeltaAnalysisException("DELTA_UNSUPPORTED_DROP_COLUMN", Array(adviceMsg))
   }
 
-  def dropNestedColumnsFromNonStructTypeException(struct : StructField) : Throwable = {
+  def dropNestedColumnsFromNonStructTypeException(struct : DataType) : Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_UNSUPPORTED_DROP_NESTED_COLUMN_FROM_NON_STRUCT_TYPE",
       messageParameters = Array(s"$struct")

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -219,15 +219,19 @@ case class AlterTableAddColumnsDeltaCommand(
       val resolver = sparkSession.sessionState.conf.resolver
       val newSchema = colsToAddWithPosition.foldLeft(oldSchema) {
         case (schema, QualifiedColTypeWithPosition(columnPath, column, None)) =>
-          val (parentPosition, lastSize) =
-            SchemaUtils.findColumnPosition(columnPath, schema, resolver)
+          val parentPosition = SchemaUtils.findColumnPosition(columnPath, schema, resolver)
+          val lastSize = SchemaUtils.getNestedTypeFromPosition(schema, parentPosition) match {
+            case s: StructType => s.size
+            case other =>
+               throw DeltaErrors.addColumnParentNotStructException(column, other)
+          }
           SchemaUtils.addColumn(schema, column, parentPosition :+ lastSize)
         case (schema, QualifiedColTypeWithPosition(columnPath, column, Some(_: First))) =>
-          val (parentPosition, _) = SchemaUtils.findColumnPosition(columnPath, schema, resolver)
+          val parentPosition = SchemaUtils.findColumnPosition(columnPath, schema, resolver)
           SchemaUtils.addColumn(schema, column, parentPosition :+ 0)
         case (schema,
         QualifiedColTypeWithPosition(columnPath, column, Some(after: After))) =>
-          val (prevPosition, _) =
+          val prevPosition =
             SchemaUtils.findColumnPosition(columnPath :+ after.column, schema, resolver)
           val position = prevPosition.init :+ (prevPosition.last + 1)
           SchemaUtils.addColumn(schema, column, position)
@@ -294,7 +298,7 @@ case class AlterTableDropColumnsDeltaCommand(
         throw DeltaErrors.dropColumnNotSupported(suggestUpgrade = true)
       }
       val newSchema = columnsToDrop.foldLeft(metadata.schema) { case (schema, columnPath) =>
-        val (parentPosition, _) =
+        val parentPosition =
           SchemaUtils.findColumnPosition(
             columnPath, schema, sparkSession.sessionState.conf.resolver)
         SchemaUtils.dropColumn(schema, parentPosition)._1

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -220,12 +220,12 @@ case class AlterTableAddColumnsDeltaCommand(
       val newSchema = colsToAddWithPosition.foldLeft(oldSchema) {
         case (schema, QualifiedColTypeWithPosition(columnPath, column, None)) =>
           val parentPosition = SchemaUtils.findColumnPosition(columnPath, schema, resolver)
-          val lastSize = SchemaUtils.getNestedTypeFromPosition(schema, parentPosition) match {
+          val insertPosition = SchemaUtils.getNestedTypeFromPosition(schema, parentPosition) match {
             case s: StructType => s.size
             case other =>
                throw DeltaErrors.addColumnParentNotStructException(column, other)
           }
-          SchemaUtils.addColumn(schema, column, parentPosition :+ lastSize)
+          SchemaUtils.addColumn(schema, column, parentPosition :+ insertPosition)
         case (schema, QualifiedColTypeWithPosition(columnPath, column, Some(_: First))) =>
           val parentPosition = SchemaUtils.findColumnPosition(columnPath, schema, resolver)
           SchemaUtils.addColumn(schema, column, parentPosition :+ 0)

--- a/core/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -518,8 +518,8 @@ object SchemaUtils extends DeltaLogging {
   }
 
   /**
-   * Returns the given column's ordinal within the given `schema` and the size of the last schema
-   * size. The length of the returned position will be as long as how nested the column is.
+   * Returns the path of the given column in `schema` as a list of ordinals (0-based), each value
+   * representing the position at the current nesting level starting from the root.
    *
    * For ArrayType: accessing the array's element adds a position 0 to the position list.
    * e.g. accessing a.element.y would have the result -> Seq(..., positionOfA, 0, positionOfY)
@@ -538,57 +538,53 @@ object SchemaUtils extends DeltaLogging {
   def findColumnPosition(
       column: Seq[String],
       schema: StructType,
-      resolver: Resolver = DELTA_COL_RESOLVER): (Seq[Int], Int) = {
-    def find(column: Seq[String], schema: StructType, stack: Seq[String]): (Seq[Int], Int) = {
-      if (column.isEmpty) return (Nil, schema.size)
-      val thisCol = column.head
-      lazy val columnPath = UnresolvedAttribute(stack :+ thisCol).name
-      val pos = schema.indexWhere(f => resolver(f.name, thisCol))
-      if (pos == -1) {
-        throw new IndexOutOfBoundsException(columnPath)
-      }
-      val colTail = column.tail
-      val (children, lastSize) = (colTail, schema(pos).dataType) match {
-        case (_, s: StructType) =>
-          find(colTail, s, stack :+ thisCol)
-        case (Seq("element", _ @ _*), ArrayType(s: StructType, _)) =>
-          val (child, size) = find(colTail.tail, s, stack :+ thisCol)
-          (ARRAY_ELEMENT_INDEX +: child, size)
-        case (Seq(), ArrayType(s: StructType, _)) =>
-          find(colTail, s, stack :+ thisCol)
-        case (Seq(), ArrayType(_, _)) =>
-          (Nil, 0)
-        case (_, ArrayType(_, _)) =>
-          throw DeltaErrors.incorrectArrayAccessByName(
-            prettyFieldName(stack ++ Seq(thisCol, "element")),
-            prettyFieldName(stack ++ Seq(thisCol)))
-        case (Seq(), MapType(_, _, _)) =>
-          (Nil, 2)
-        case (Seq("key", _ @ _*), MapType(keyType: StructType, _, _)) =>
-          val (child, size) = find(colTail.tail, keyType, stack :+ thisCol)
-          (MAP_KEY_INDEX +: child, size)
-        case (Seq("key"), MapType(_, _, _)) =>
-          (Seq(MAP_KEY_INDEX), 0)
-        case (Seq("value", _ @ _*), MapType(_, valueType: StructType, _)) =>
-          val (child, size) = find(colTail.tail, valueType, stack :+ thisCol)
-          (MAP_VALUE_INDEX +: child, size)
-        case (Seq("value"), MapType(_, _, _)) =>
-          (Seq(MAP_VALUE_INDEX), 0)
-        case (_, MapType(_, _, _)) =>
-          throw DeltaErrors.foundMapTypeColumnException(
-            prettyFieldName(stack ++ Seq(thisCol, "key")),
-            prettyFieldName(stack ++ Seq(thisCol, "value")))
-        case (_, o) =>
-          if (column.length > 1) {
-            throw DeltaErrors.columnPathNotNested(columnPath, o, column)
+      resolver: Resolver = DELTA_COL_RESOLVER): Seq[Int] = {
+    def find(
+        searchPath: Seq[String],
+        currentType: DataType,
+        currentPath: Seq[String] = Nil): Seq[Int] = {
+      if (searchPath.isEmpty) return Nil
+
+      val currentFieldName = searchPath.head
+      val path = currentPath :+ currentFieldName
+      (currentType, currentFieldName) match {
+        case (struct: StructType, _) =>
+          lazy val columnPath = UnresolvedAttribute(path).name
+          val pos = struct.indexWhere(f => resolver(f.name, currentFieldName))
+          if (pos == -1) {
+            throw new IndexOutOfBoundsException(columnPath)
           }
-          (Nil, 0)
+          val childPath = find(searchPath.tail, struct(pos).dataType, path)
+          pos +: childPath
+
+        case (map: MapType, "key") =>
+          val childPath = find(searchPath.tail, map.keyType, path)
+          MAP_KEY_INDEX +: childPath
+
+        case (map: MapType, "value") =>
+          val childPath = find(searchPath.tail, map.valueType, path)
+          MAP_VALUE_INDEX +: childPath
+
+        case (_: MapType, _) =>
+          throw DeltaErrors.foundMapTypeColumnException(
+            prettyFieldName(currentPath :+ "key"),
+            prettyFieldName(currentPath :+ "value"))
+
+        case (array: ArrayType, "element") =>
+          val childPath = find(searchPath.tail, array.elementType, path)
+          ARRAY_ELEMENT_INDEX +: childPath
+
+        case (_: ArrayType, _) =>
+          throw DeltaErrors.incorrectArrayAccessByName(
+            prettyFieldName(currentPath :+ "element"),
+            prettyFieldName(currentPath))
+        case _ =>
+          throw DeltaErrors.columnPathNotNested(currentFieldName, currentType, currentPath)
       }
-      (Seq(pos) ++ children, lastSize)
     }
 
     try {
-      find(column, schema, Nil)
+      find(column, schema)
     } catch {
       case i: IndexOutOfBoundsException =>
         throw DeltaErrors.columnNotInSchemaException(i.getMessage, schema)
@@ -596,6 +592,44 @@ object SchemaUtils extends DeltaLogging {
         throw new AnalysisException(e.getMessage + s":\n${schema.treeString}")
     }
   }
+
+  /**
+   * Returns the nested field at the given position in `parent`. See [[findColumnPosition]] for the
+   * representation used for `position`.
+   * @param parent The field used for the lookup.
+   * @param position A list of ordinals (0-based) representing the path to the nested field in
+   *                 `parent`.
+   */
+  def getNestedFieldFromPosition(parent: StructField, position: Seq[Int]): StructField = {
+    if (position.isEmpty) return parent
+
+    val fieldPos = position.head
+    parent.dataType match {
+      case struct: StructType if fieldPos >= 0 && fieldPos < struct.size =>
+        getNestedFieldFromPosition(struct(fieldPos), position.tail)
+      case map: MapType if fieldPos == MAP_KEY_INDEX =>
+        getNestedFieldFromPosition(StructField("key", map.keyType), position.tail)
+      case map: MapType if fieldPos == MAP_VALUE_INDEX =>
+        getNestedFieldFromPosition(StructField("value", map.valueType), position.tail)
+      case array: ArrayType if fieldPos == ARRAY_ELEMENT_INDEX =>
+        getNestedFieldFromPosition(StructField("element", array.elementType), position.tail)
+      case _: StructType | _: ArrayType | _: MapType =>
+        throw new IllegalArgumentException(
+          s"Invalid child position $fieldPos in ${parent.dataType}")
+      case other =>
+        throw new IllegalArgumentException(s"Invalid indexing into non-nested type $other")
+    }
+  }
+
+  /**
+   * Returns the nested type at the given position in `schema`. See [[findColumnPosition]] for the
+   * representation used for `position`.
+   * @param parent The root schema used for the lookup.
+   * @param position A list of ordinals (0-based) representing the path to the nested field in
+   *                 `parent`.
+   */
+  def getNestedTypeFromPosition(schema: StructType, position: Seq[Int]): DataType =
+    getNestedFieldFromPosition(StructField("schema", schema), position).dataType
 
   /**
    * Pretty print the column path passed in.
@@ -616,6 +650,24 @@ object SchemaUtils extends DeltaLogging {
    *                 result: <a:STRUCT<a1,a2,a3>, b,c:STRUCT<c1,**c2**,c3>>
    */
   def addColumn(schema: StructType, column: StructField, position: Seq[Int]): StructType = {
+    def addColumnInChild(parent: DataType, column: StructField, position: Seq[Int]): DataType = {
+      require(position.nonEmpty, s"Don't know where to add the column $column")
+      parent match {
+        case struct: StructType =>
+          addColumn(struct, column, position)
+        case map: MapType if position.head == MAP_KEY_INDEX =>
+          map.copy(keyType = addColumnInChild(map.keyType, column, position.tail))
+        case map: MapType if position.head == MAP_VALUE_INDEX =>
+          map.copy(valueType = addColumnInChild(map.valueType, column, position.tail))
+        case array: ArrayType if position.head == ARRAY_ELEMENT_INDEX =>
+          array.copy(elementType = addColumnInChild(array.elementType, column, position.tail))
+        case _: ArrayType =>
+          throw DeltaErrors.incorrectArrayAccess()
+        case other =>
+          throw DeltaErrors.addColumnParentNotStructException(column, other)
+      }
+    }
+
     require(position.nonEmpty, s"Don't know where to add the column $column")
     val slicePosition = position.head
     if (slicePosition < 0) {
@@ -634,51 +686,14 @@ object SchemaUtils extends DeltaLogging {
     }
     val pre = schema.take(slicePosition)
     if (position.length > 1) {
-      val posTail = position.tail
-      val mid = schema(slicePosition) match {
-        case StructField(name, f: StructType, nullable, metadata) =>
-          if (!column.nullable && nullable) {
-            throw DeltaErrors.nullableParentWithNotNullNestedField
-          }
-          StructField(
-            name,
-            addColumn(f, column, posTail),
-            nullable,
-            metadata)
-        case StructField(name, ArrayType(f: StructType, containsNull), nullable, metadata) =>
-          if (!column.nullable && nullable) {
-            throw DeltaErrors.nullableParentWithNotNullNestedField
-          }
-
-          if (posTail.head != ARRAY_ELEMENT_INDEX) {
-            throw DeltaErrors.incorrectArrayAccess()
-          }
-
-          StructField(
-            name,
-            ArrayType(addColumn(f, column, posTail.tail), containsNull),
-            nullable,
-            metadata)
-        case StructField(name, map @ MapType(_, _, _), nullable, metadata) =>
-          if (!column.nullable && nullable) {
-            throw DeltaErrors.nullableParentWithNotNullNestedField
-          }
-
-          val addedMap = (posTail.head, map) match {
-            case (MAP_KEY_INDEX, MapType(key: StructType, v, nullability)) =>
-              MapType(addColumn(key, column, posTail.tail), v, nullability)
-            case (MAP_VALUE_INDEX, MapType(k, value: StructType, nullability)) =>
-              MapType(k, addColumn(value, column, posTail.tail), nullability)
-            case _ =>
-              throw DeltaErrors.addColumnParentNotStructException(column, IntegerType)
-          }
-          StructField(name, addedMap, nullable, metadata)
-        case o =>
-          throw DeltaErrors.addColumnParentNotStructException(column, o.dataType)
+      val field = schema(slicePosition)
+      if (!column.nullable && field.nullable) {
+        throw DeltaErrors.nullableParentWithNotNullNestedField
       }
-      StructType(pre ++ Seq(mid) ++ schema.slice(slicePosition + 1, length))
+      val mid = field.copy(dataType = addColumnInChild(field.dataType, column, position.tail))
+      StructType(pre ++ Seq(mid) ++ schema.drop(slicePosition + 1))
     } else {
-      StructType(pre ++ Seq(column) ++ schema.slice(slicePosition, length))
+      StructType(pre ++ Seq(column) ++ schema.drop(slicePosition))
     }
   }
 
@@ -693,6 +708,27 @@ object SchemaUtils extends DeltaLogging {
    *                 result: <a:STRUCT<a1,a2,a3>, b,c:STRUCT<c1,c3>>
    */
   def dropColumn(schema: StructType, position: Seq[Int]): (StructType, StructField) = {
+    def dropColumnInChild(parent: DataType, position: Seq[Int]): (DataType, StructField) = {
+      require(position.nonEmpty, s"Don't know where to drop the column")
+      parent match {
+        case struct: StructType =>
+          dropColumn(struct, position)
+        case map: MapType if position.head == MAP_KEY_INDEX =>
+          val (newKeyType, droppedColumn) = dropColumnInChild(map.keyType, position.tail)
+          map.copy(keyType = newKeyType) -> droppedColumn
+        case map: MapType if position.head == MAP_VALUE_INDEX =>
+          val (newValueType, droppedColumn) = dropColumnInChild(map.valueType, position.tail)
+          map.copy(valueType = newValueType) -> droppedColumn
+        case array: ArrayType if position.head == ARRAY_ELEMENT_INDEX =>
+          val (newElementType, droppedColumn) = dropColumnInChild(array.elementType, position.tail)
+          array.copy(elementType = newElementType) -> droppedColumn
+        case _: ArrayType =>
+          throw DeltaErrors.incorrectArrayAccess()
+        case other =>
+          throw DeltaErrors.dropNestedColumnsFromNonStructTypeException(other)
+      }
+    }
+
     require(position.nonEmpty, "Don't know where to drop the column")
     val slicePosition = position.head
     if (slicePosition < 0) {
@@ -703,21 +739,18 @@ object SchemaUtils extends DeltaLogging {
       throw DeltaErrors.indexLargerOrEqualThanStruct(slicePosition, length)
     }
     val pre = schema.take(slicePosition)
+    val field = schema(slicePosition)
     if (position.length > 1) {
-      val (mid, original) = schema(slicePosition) match {
-        case StructField(name, f: StructType, nullable, metadata) =>
-          val (dropped, original) = dropColumn(f, position.tail)
-          (StructField(name, dropped, nullable, metadata), original)
-        case o =>
-          throw DeltaErrors.dropNestedColumnsFromNonStructTypeException(o)
-      }
-      (StructType(pre ++ Seq(mid) ++ schema.slice(slicePosition + 1, length)), original)
+      val (newType, droppedColumn) = dropColumnInChild(field.dataType, position.tail)
+      val mid = field.copy(dataType = newType)
+
+      (StructType(pre ++ Seq(mid) ++ schema.drop(slicePosition + 1)), droppedColumn)
     } else {
       if (length == 1) {
         throw new AnalysisException(
           "Cannot drop column from a struct type with a single field: " + schema)
       }
-      (StructType(pre ++ schema.slice(slicePosition + 1, length)), schema(slicePosition))
+      (StructType(pre ++ schema.drop(slicePosition + 1)), schema(slicePosition))
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnRenameSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnRenameSuite.scala
@@ -21,7 +21,7 @@ import scala.collection.JavaConverters._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.scalatest.GivenWhenThen
 
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.types._
 
 class DeltaColumnRenameSuite extends QueryTest
@@ -415,4 +415,59 @@ class DeltaColumnRenameSuite extends QueryTest
       }
     }
   }
+
+  /**
+   * Covers renaming a nested field using the ALTER TABLE command.
+   * @param initialColumnType Type of the single column used to create the initial test table.
+   * @param fieldToRename     Old and new name of the field to rename.
+   * @param updatedColumnType Expected type of the single column after renaming the nested field.
+   */
+  def testRenameNestedField(testName: String)(
+      initialColumnType: String,
+      fieldToRename: (String, String),
+      updatedColumnType: String): Unit = {
+    for {
+      columnMapping <- Seq(NameMapping, IdMapping)
+    } test(s"ALTER TABLE RENAME COLUMN - nested $testName - columnMapping: ${columnMapping.name}") {
+      withTempDir { dir =>
+        withTable("delta_test") {
+          sql(
+            s"""
+               |CREATE TABLE delta_test (data $initialColumnType)
+               |USING delta
+               |TBLPROPERTIES (${DeltaConfigs.COLUMN_MAPPING_MODE.key} = '${columnMapping.name}')
+               |OPTIONS('path'='${dir.getCanonicalPath}')""".stripMargin)
+
+          val expectedInitialType = initialColumnType.filterNot(_.isWhitespace)
+          val expectedUpdatedType = updatedColumnType.filterNot(_.isWhitespace)
+          val fieldName = s"data.${fieldToRename._1}"
+
+          def columnType: DataFrame =
+            sql("DESCRIBE TABLE delta_test")
+              .filter("col_name = 'data'")
+              .select("data_type")
+          checkAnswer(columnType, Row(expectedInitialType))
+
+          sql(s"ALTER TABLE delta_test RENAME COLUMN $fieldName TO ${fieldToRename._2}")
+          checkAnswer(columnType, Row(expectedUpdatedType))
+        }
+      }
+    }
+  }
+
+  testRenameNestedField("struct in map key")(
+    initialColumnType = "map<struct<a: int, b: string>, int>",
+    fieldToRename = "key.b" -> "c",
+    updatedColumnType = "map<struct<a: int, c: string>, int>")
+
+  testRenameNestedField("struct in map value")(
+    initialColumnType = "map<int, struct<a: int, b: string>>",
+    fieldToRename = "value.b" -> "c",
+    updatedColumnType = "map<int, struct<a: int, c: string>>")
+
+  testRenameNestedField("struct in array")(
+    initialColumnType = "array<struct<a: int, b: string>>",
+    fieldToRename = "element.b" -> "c",
+    updatedColumnType = "array<struct<a: int, c: string>>")
+
 }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnRenameSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnRenameSuite.scala
@@ -425,17 +425,15 @@ class DeltaColumnRenameSuite extends QueryTest
   def testRenameNestedField(testName: String)(
       initialColumnType: String,
       fieldToRename: (String, String),
-      updatedColumnType: String): Unit = {
-    for {
-      columnMapping <- Seq(NameMapping, IdMapping)
-    } test(s"ALTER TABLE RENAME COLUMN - nested $testName - columnMapping: ${columnMapping.name}") {
+      updatedColumnType: String): Unit =
+    testColumnMapping(s"ALTER TABLE RENAME COLUMN - nested $testName") { mode =>
       withTempDir { dir =>
         withTable("delta_test") {
           sql(
             s"""
                |CREATE TABLE delta_test (data $initialColumnType)
                |USING delta
-               |TBLPROPERTIES (${DeltaConfigs.COLUMN_MAPPING_MODE.key} = '${columnMapping.name}')
+               |TBLPROPERTIES (${DeltaConfigs.COLUMN_MAPPING_MODE.key} = '${mode}')
                |OPTIONS('path'='${dir.getCanonicalPath}')""".stripMargin)
 
           val expectedInitialType = initialColumnType.filterNot(_.isWhitespace)
@@ -453,7 +451,6 @@ class DeltaColumnRenameSuite extends QueryTest
         }
       }
     }
-  }
 
   testRenameNestedField("struct in map key")(
     initialColumnType = "map<struct<a: int, b: string>, int>",

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaDDLSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaDDLSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkEnv
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.NoSuchPartitionException
 import org.apache.spark.sql.catalyst.catalog.CatalogUtils
@@ -332,6 +332,63 @@ abstract class DeltaDDLTestBase extends QueryTest with SQLTestUtils {
       }
     }
   }
+
+  /**
+   * Covers adding and changing a nested field using the ALTER TABLE command.
+   * @param initialColumnType Type of the single column used to create the initial test table.
+   * @param fieldToAdd        Tuple (name, type) of the nested field to add and change.
+   * @param updatedColumnType Expected type of the single column after adding the nested field.
+   */
+  def testAlterTableNestedFields(testName: String)(
+      initialColumnType: String,
+      fieldToAdd: (String, String),
+      updatedColumnType: String): Unit = {
+    test(s"ALTER TABLE ADD/CHANGE COLUMNS - nested $testName") {
+      withTempDir { dir =>
+        withTable("delta_test") {
+          sql(
+            s"""
+               |CREATE TABLE delta_test (data $initialColumnType)
+               |USING delta
+               |TBLPROPERTIES (${DeltaConfigs.COLUMN_MAPPING_MODE.key} = 'name')
+               |OPTIONS('path'='${dir.getCanonicalPath}')""".stripMargin)
+
+          val expectedInitialType = initialColumnType.filterNot(_.isWhitespace)
+          val expectedUpdatedType = updatedColumnType.filterNot(_.isWhitespace)
+          val fieldName = s"data.${fieldToAdd._1}"
+          val fieldType = fieldToAdd._2
+
+          def columnType: DataFrame =
+            sql("DESCRIBE TABLE delta_test")
+              .where("col_name = 'data'")
+              .select("data_type")
+          checkAnswer(columnType, Row(expectedInitialType))
+
+          sql(s"ALTER TABLE delta_test ADD COLUMNS ($fieldName $fieldType)")
+          checkAnswer(columnType, Row(expectedUpdatedType))
+
+          sql(s"ALTER TABLE delta_test CHANGE COLUMN $fieldName TYPE $fieldType")
+          checkAnswer(columnType, Row(expectedUpdatedType))
+        }
+      }
+    }
+  }
+
+  testAlterTableNestedFields("struct in map key")(
+    initialColumnType = "map<struct<a: int>, int>",
+    fieldToAdd = "key.b" -> "string",
+    updatedColumnType = "map<struct<a: int, b: string>, int>")
+
+  testAlterTableNestedFields("struct in map value")(
+    initialColumnType = "map<int, struct<a: int>>",
+    fieldToAdd = "value.b" -> "string",
+    updatedColumnType = "map<int, struct<a: int, b: string>>")
+
+  testAlterTableNestedFields("struct in array")(
+    initialColumnType = "array<struct<a: int>>",
+    fieldToAdd = "element.b" -> "string",
+    updatedColumnType = "array<struct<a: int, b: string>>")
+
 
   test("ALTER TABLE CHANGE COLUMN with nullability change in struct type - not supported") {
     withTempDir { dir =>

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaDropColumnSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaDropColumnSuite.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.types.{ArrayType, IntegerType, MapType, StringType, StructType}
 
@@ -355,5 +355,60 @@ class DeltaDropColumnSuite extends QueryTest
       assert(e.getMessage.contains("Dropping partition columns (a) is not allowed"))
     }
   }
+
+
+  /**
+   * Covers dropping a nested field using the ALTER TABLE command.
+   * @param initialColumnType Type of the single column used to create the initial test table.
+   * @param fieldToDrop       Name of the field to drop from the initial column type.
+   * @param updatedColumnType Expected type of the single column after dropping the nested field.
+   */
+  def testDropNestedField(testName: String)(
+      initialColumnType: String,
+      fieldToDrop: String,
+      updatedColumnType: String): Unit = {
+    for {
+      columnMapping <- Seq(NameMapping, IdMapping)
+    } test(s"ALTER TABLE DROP COLUMNS - nested $testName - columnMapping: ${columnMapping.name}") {
+      withTempDir { dir =>
+        withTable("delta_test") {
+          sql(
+            s"""
+               |CREATE TABLE delta_test (data $initialColumnType)
+               |USING delta
+               |TBLPROPERTIES (${DeltaConfigs.COLUMN_MAPPING_MODE.key} = '${columnMapping.name}')
+               |OPTIONS('path'='${dir.getCanonicalPath}')""".stripMargin)
+
+          val expectedInitialType = initialColumnType.filterNot(_.isWhitespace)
+          val expectedUpdatedType = updatedColumnType.filterNot(_.isWhitespace)
+          val fieldName = s"data.${fieldToDrop}"
+
+          def columnType: DataFrame =
+            sql("DESCRIBE TABLE delta_test")
+              .filter("col_name = 'data'")
+              .select("data_type")
+          checkAnswer(columnType, Row(expectedInitialType))
+
+          sql(s"ALTER TABLE delta_test DROP COLUMNS ($fieldName)")
+          checkAnswer(columnType, Row(expectedUpdatedType))
+        }
+      }
+    }
+  }
+
+  testDropNestedField("struct in map key")(
+    initialColumnType = "map<struct<a: int, b: string>, int>",
+    fieldToDrop = "key.b",
+    updatedColumnType = "map<struct<a: int>, int>")
+
+  testDropNestedField("struct in map value")(
+    initialColumnType = "map<int, struct<a: int, b: string>>",
+    fieldToDrop = "value.b",
+    updatedColumnType = "map<int, struct<a: int>>")
+
+  testDropNestedField("struct in array")(
+    initialColumnType = "array<struct<a: int, b: string>>",
+    fieldToDrop = "element.b",
+    updatedColumnType = "array<struct<a: int>>")
 
 }

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaDropColumnSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaDropColumnSuite.scala
@@ -366,17 +366,15 @@ class DeltaDropColumnSuite extends QueryTest
   def testDropNestedField(testName: String)(
       initialColumnType: String,
       fieldToDrop: String,
-      updatedColumnType: String): Unit = {
-    for {
-      columnMapping <- Seq(NameMapping, IdMapping)
-    } test(s"ALTER TABLE DROP COLUMNS - nested $testName - columnMapping: ${columnMapping.name}") {
+      updatedColumnType: String): Unit =
+    testColumnMapping(s"ALTER TABLE DROP COLUMNS - nested $testName") { mode =>
       withTempDir { dir =>
         withTable("delta_test") {
           sql(
             s"""
                |CREATE TABLE delta_test (data $initialColumnType)
                |USING delta
-               |TBLPROPERTIES (${DeltaConfigs.COLUMN_MAPPING_MODE.key} = '${columnMapping.name}')
+               |TBLPROPERTIES (${DeltaConfigs.COLUMN_MAPPING_MODE.key} = '$mode')
                |OPTIONS('path'='${dir.getCanonicalPath}')""".stripMargin)
 
           val expectedInitialType = initialColumnType.filterNot(_.isWhitespace)
@@ -394,7 +392,6 @@ class DeltaDropColumnSuite extends QueryTest
         }
       }
     }
-  }
 
   testDropNestedField("struct in map key")(
     initialColumnType = "map<struct<a: int, b: string>, int>",

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2660,14 +2660,12 @@ trait DeltaErrorsSuiteBase
       assert(e.getMessage == "operation1 is only supported for Delta tables.")
     }
     {
-      val invalidStruct = StructField("invalid1", StringType)
       val e = intercept[DeltaAnalysisException] {
-        throw DeltaErrors.dropNestedColumnsFromNonStructTypeException(invalidStruct)
+        throw DeltaErrors.dropNestedColumnsFromNonStructTypeException(StringType)
       }
       assert(e.getErrorClass == "DELTA_UNSUPPORTED_DROP_NESTED_COLUMN_FROM_NON_STRUCT_TYPE")
       assert(e.getSqlState == "0AKDC")
-      assert(e.getMessage ==
-        "Can only drop nested columns from StructType. Found StructField(invalid1,StringType,true)")
+      assert(e.getMessage == s"Can only drop nested columns from StructType. Found $StringType")
     }
     {
       val columnsThatNeedRename = Set("c0", "c1")

--- a/core/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
@@ -805,52 +805,78 @@ class SchemaUtilsSuite extends QueryTest
 
   test("findColumnPosition") {
     val schema = new StructType()
-      .add("a", new StructType()
-        .add("b", IntegerType)
-        .add("c", IntegerType))
-      .add("d", ArrayType(new StructType()
-        .add("b", IntegerType)
-        .add("c", IntegerType)))
-      .add("e", StringType)
-      .add("f", MapType(
+      .add("struct", new StructType()
+        .add("a", IntegerType)
+        .add("b", IntegerType))
+      .add("array", ArrayType(new StructType()
+        .add("c", IntegerType)
+        .add("d", IntegerType)))
+      .add("field", StringType)
+      .add("map", MapType(
         new StructType()
-          .add("g", IntegerType),
+          .add("e", IntegerType),
         new StructType()
-          .add("h", IntegerType)))
-      .add("i", MapType(
+          .add("f", IntegerType)))
+      .add("mapStruct", MapType(
         IntegerType,
         new StructType()
-          .add("k", new StructType()
-          .add("l", IntegerType))))
-      .add("m", ArrayType(
-        MapType(StringType, StringType)))
-    assert(SchemaUtils.findColumnPosition(Seq("a"), schema) === ((Seq(0), 2)))
-    assert(SchemaUtils.findColumnPosition(Seq("A"), schema) === ((Seq(0), 2)))
+          .add("g", new StructType()
+          .add("h", IntegerType))))
+      .add("arrayMap", ArrayType(
+        MapType(
+          new StructType()
+            .add("i", IntegerType),
+          new StructType()
+            .add("j", IntegerType))))
+
+    val List(structIdx, arrayIdx, fieldIdx, mapIdx, mapStructIdx, arrayMapIdx) = (0 to 5).toList
+    val ARRAY_ELEMENT_INDEX = 0
+    val MAP_KEY_INDEX = 0
+    val MAP_VALUE_INDEX = 1
+
+    def checkPosition(column: Seq[String], position: Seq[Int]): Unit =
+      assert(SchemaUtils.findColumnPosition(column, schema) === position)
+
+    checkPosition(Seq("struct"), Seq(structIdx))
+    checkPosition(Seq("STRucT"), Seq(structIdx))
     expectFailure("Couldn't find", schema.treeString) {
-      SchemaUtils.findColumnPosition(Seq("a", "d"), schema)
+      SchemaUtils.findColumnPosition(Seq("struct", "array"), schema)
     }
-    assert(SchemaUtils.findColumnPosition(Seq("a", "b"), schema) === ((Seq(0, 0), 0)))
-    assert(SchemaUtils.findColumnPosition(Seq("A", "b"), schema) === ((Seq(0, 0), 0)))
-    assert(SchemaUtils.findColumnPosition(Seq("a", "B"), schema) === ((Seq(0, 0), 0)))
-    assert(SchemaUtils.findColumnPosition(Seq("A", "B"), schema) === ((Seq(0, 0), 0)))
-    assert(SchemaUtils.findColumnPosition(Seq("a", "c"), schema) === ((Seq(0, 1), 0)))
-    assert(SchemaUtils.findColumnPosition(Seq("d"), schema) === ((Seq(1), 2)))
-    assert(SchemaUtils.findColumnPosition(Seq("d", "element", "B"), schema) === ((Seq(1, 0, 0), 0)))
-    assert(SchemaUtils.findColumnPosition(Seq("d", "element", "c"), schema) === ((Seq(1, 0, 1), 0)))
-    assert(SchemaUtils.findColumnPosition(Seq("e"), schema) === ((Seq(2), 0)))
-    assert(SchemaUtils.findColumnPosition(Seq("f"), schema) === ((Seq(3), 2)))
-    assert(SchemaUtils.findColumnPosition(Seq("f", "key", "g"), schema) === ((Seq(3, 0, 0), 0)))
-    assert(SchemaUtils.findColumnPosition(Seq("f", "value", "h"), schema) === ((Seq(3, 1, 0), 0)))
-    assert(SchemaUtils.findColumnPosition(Seq("f", "value", "H"), schema) === ((Seq(3, 1, 0), 0)))
-    assert(SchemaUtils.findColumnPosition(Seq("i", "key"), schema) === ((Seq(4, 0), 0)))
-    assert(SchemaUtils.findColumnPosition(Seq("i", "value", "k"), schema) === ((Seq(4, 1, 0), 1)))
-    assert(SchemaUtils.findColumnPosition(Seq("i", "key"), schema) === ((Seq(4, 0), 0)))
-    assert(SchemaUtils.findColumnPosition(Seq("i", "value"), schema) === ((Seq(4, 1), 1)))
-    assert(SchemaUtils.findColumnPosition(Seq("m"), schema) === ((Seq(5), 0)))
+    checkPosition(Seq("struct", "a"), Seq(structIdx, 0))
+    checkPosition(Seq("STRucT", "a"), Seq(structIdx, 0))
+    checkPosition(Seq("struct", "A"), Seq(structIdx, 0))
+    checkPosition(Seq("STRucT", "A"), Seq(structIdx, 0))
+    checkPosition(Seq("struct", "b"), Seq(structIdx, 1))
+    checkPosition(Seq("array"), Seq(arrayIdx))
+    checkPosition(Seq("array", "element", "C"), Seq(arrayIdx, ARRAY_ELEMENT_INDEX, 0))
+    checkPosition(Seq("array", "element", "d"), Seq(arrayIdx, ARRAY_ELEMENT_INDEX, 1))
+    checkPosition(Seq("field"), Seq(fieldIdx))
+    checkPosition(Seq("map"), Seq(mapIdx))
+    checkPosition(Seq("map", "key", "e"), Seq(mapIdx, MAP_KEY_INDEX, 0))
+    checkPosition(Seq("map", "value", "f"), Seq(mapIdx, MAP_VALUE_INDEX, 0))
+    checkPosition(Seq("map", "value", "F"), Seq(mapIdx, MAP_VALUE_INDEX, 0))
+    checkPosition(Seq("mapStruct", "key"), Seq(mapStructIdx, MAP_KEY_INDEX))
+    checkPosition(Seq("mapStruct", "value", "g"), Seq(mapStructIdx, MAP_VALUE_INDEX, 0))
+    checkPosition(Seq("mapStruct", "key"), Seq(mapStructIdx, MAP_KEY_INDEX))
+    checkPosition(Seq("mapStruct", "value"), Seq(mapStructIdx, MAP_VALUE_INDEX))
+    checkPosition(Seq("arrayMap"), Seq(arrayMapIdx))
+    checkPosition(Seq("arrayMap", "element"), Seq(arrayMapIdx, ARRAY_ELEMENT_INDEX))
+    checkPosition(
+      Seq("arrayMap", "element", "key"),
+      Seq(arrayMapIdx, ARRAY_ELEMENT_INDEX, MAP_KEY_INDEX))
+    checkPosition(
+      Seq("arrayMap", "element", "value"),
+      Seq(arrayMapIdx, ARRAY_ELEMENT_INDEX, MAP_VALUE_INDEX))
+    checkPosition(
+      Seq("arrayMap", "element", "key", "i"),
+      Seq(arrayMapIdx, ARRAY_ELEMENT_INDEX, MAP_KEY_INDEX, 0))
+    checkPosition(
+      Seq("arrayMap", "element", "value", "j"),
+      Seq(arrayMapIdx, ARRAY_ELEMENT_INDEX, MAP_VALUE_INDEX, 0))
 
     val resolver = org.apache.spark.sql.catalyst.analysis.caseSensitiveResolution
-    Seq(Seq("A", "b"), Seq("a", "B"), Seq("d", "element", "B"), Seq("f", "key", "H"))
-        .foreach { column =>
+    Seq(Seq("STRucT", "b"), Seq("struct", "B"), Seq("array", "element", "C"),
+        Seq("map", "key", "E")).foreach { column =>
       expectFailure("Couldn't find", schema.treeString) {
         SchemaUtils.findColumnPosition(column, schema, resolver)
       }
@@ -869,7 +895,98 @@ class SchemaUtilsSuite extends QueryTest
       SchemaUtils.findColumnPosition(Seq("b", "c"), schema)
     }
     expectFailure("An ArrayType was found", "arrayType", schema.treeString) {
-      SchemaUtils.findColumnPosition(Seq("c", "element"), schema)
+      SchemaUtils.findColumnPosition(Seq("c", "b"), schema)
+    }
+  }
+
+  ////////////////////////////
+  // getNestedFieldFromPosition
+  ////////////////////////////
+
+  test("getNestedFieldFromPosition") {
+    val a = StructField("a", IntegerType)
+    val b = StructField("b", IntegerType)
+    val c = StructField("c", IntegerType)
+    val d = StructField("d", IntegerType)
+    val e = StructField("e", IntegerType)
+    val f = StructField("f", IntegerType)
+    val g = StructField("g", IntegerType)
+
+    val field = StructField("field", StringType)
+    val struct = StructField("struct", new StructType().add(a).add(b))
+    val arrayElement = StructField("element", new StructType().add(c))
+    val array = StructField("array", ArrayType(arrayElement.dataType))
+    val mapKey = StructField("key", new StructType().add(d))
+    val mapValue = StructField("value", new StructType().add(e))
+    val map = StructField("map", MapType(
+      keyType = mapKey.dataType,
+      valueType = mapValue.dataType))
+    val arrayMapKey = StructField("key", new StructType().add(f))
+    val arrayMapValue = StructField("value", new StructType().add(g))
+    val arrayMapElement = StructField("element", MapType(
+      keyType = arrayMapKey.dataType,
+      valueType = arrayMapValue.dataType))
+    val arrayMap = StructField("arrayMap", ArrayType(arrayMapElement.dataType))
+
+    val root = StructField("root", StructType(Seq(field, struct, array, map, arrayMap)))
+
+    val List(fieldIdx, structIdx, arrayIdx, mapIdx, arrayMapIdx) = (0 to 4).toList
+    val ARRAY_ELEMENT_INDEX = 0
+    val MAP_KEY_INDEX = 0
+    val MAP_VALUE_INDEX = 1
+
+    def checkField(position: Seq[Int], expected: StructField): Unit =
+      assert(getNestedFieldFromPosition(root, position) === expected)
+
+    checkField(Seq.empty, root)
+    checkField(Seq(fieldIdx), field)
+    checkField(Seq(structIdx), struct)
+    checkField(Seq(structIdx, 0), a)
+    checkField(Seq(structIdx, 1), b)
+    checkField(Seq(arrayIdx), array)
+    checkField(Seq(arrayIdx, ARRAY_ELEMENT_INDEX), arrayElement)
+    checkField(Seq(arrayIdx, ARRAY_ELEMENT_INDEX, 0), c)
+    checkField(Seq(mapIdx), map)
+    checkField(Seq(mapIdx, MAP_KEY_INDEX), mapKey)
+    checkField(Seq(mapIdx, MAP_VALUE_INDEX), mapValue)
+    checkField(Seq(mapIdx, MAP_KEY_INDEX, 0), d)
+    checkField(Seq(mapIdx, MAP_VALUE_INDEX, 0), e)
+    checkField(Seq(arrayMapIdx), arrayMap)
+    checkField(Seq(arrayMapIdx, ARRAY_ELEMENT_INDEX), arrayMapElement)
+    checkField(Seq(arrayMapIdx, ARRAY_ELEMENT_INDEX, MAP_KEY_INDEX), arrayMapKey)
+    checkField(Seq(arrayMapIdx, ARRAY_ELEMENT_INDEX, MAP_VALUE_INDEX), arrayMapValue)
+    checkField(Seq(arrayMapIdx, ARRAY_ELEMENT_INDEX, MAP_KEY_INDEX, 0), f)
+    checkField(Seq(arrayMapIdx, ARRAY_ELEMENT_INDEX, MAP_VALUE_INDEX, 0), g)
+
+    def checkError(position: Seq[Int]): Unit =
+      assertThrows[IllegalArgumentException] {
+        getNestedFieldFromPosition(root, position)
+      }
+
+    checkError(Seq(-1))
+    checkError(Seq(fieldIdx, 0))
+    checkError(Seq(structIdx, -1))
+    checkError(Seq(structIdx, 2))
+    checkError(Seq(arrayIdx, ARRAY_ELEMENT_INDEX - 1))
+    checkError(Seq(arrayIdx, ARRAY_ELEMENT_INDEX + 1))
+    checkError(Seq(mapIdx, MAP_KEY_INDEX - 1))
+    checkError(Seq(mapIdx, MAP_VALUE_INDEX + 1))
+    checkError(Seq(arrayMapIdx, ARRAY_ELEMENT_INDEX - 1))
+    checkError(Seq(arrayMapIdx, ARRAY_ELEMENT_INDEX + 1))
+    checkError(Seq(arrayMapIdx, ARRAY_ELEMENT_INDEX, MAP_KEY_INDEX - 1))
+    checkError(Seq(arrayMapIdx, ARRAY_ELEMENT_INDEX, MAP_VALUE_INDEX + 1))
+    checkError(Seq(arrayMapIdx + 1))
+  }
+
+  test("getNestedTypeFromPosition") {
+    val schema = new StructType().add("a", IntegerType)
+    assert(getNestedTypeFromPosition(schema, Seq.empty) === schema)
+    assert(getNestedTypeFromPosition(schema, Seq(0)) === IntegerType)
+    assertThrows[IllegalArgumentException] {
+      getNestedTypeFromPosition(schema, Seq(-1))
+    }
+    assertThrows[IllegalArgumentException] {
+      getNestedTypeFromPosition(schema, Seq(1))
     }
   }
 
@@ -901,16 +1018,31 @@ class SchemaUtilsSuite extends QueryTest
   test("addColumn - nested struct") {
     val a = StructField("a", IntegerType)
     val b = StructField("b", StringType)
-    val s = StructField("s", new StructType().add(a).add(b))
-    val schema = new StructType().add(s)
+    val first = StructField("first", new StructType().add(a).add(b))
+    val middle = StructField("middle", new StructType().add(a).add(b))
+    val last = StructField("last", new StructType().add(a).add(b))
+    val schema = new StructType().add(first).add(middle).add(last)
 
     val x = StructField("x", LongType)
-    assert(SchemaUtils.addColumn(schema, x, Seq(0)) === new StructType().add(x).add(s))
-    assert(SchemaUtils.addColumn(schema, x, Seq(0, 0)) ===
-      new StructType().add("s", new StructType().add(x).add(a).add(b)))
+    assert(SchemaUtils.addColumn(schema, x, Seq(0)) ===
+      new StructType().add(x).add(first).add(middle).add(last))
+    assert(SchemaUtils.addColumn(schema, x, Seq(1)) ===
+      new StructType().add(first).add(x).add(middle).add(last))
+    assert(SchemaUtils.addColumn(schema, x, Seq(2)) ===
+      new StructType().add(first).add(middle).add(x).add(last))
+    assert(SchemaUtils.addColumn(schema, x, Seq(3)) ===
+      new StructType().add(first).add(middle).add(last).add(x))
+
     assert(SchemaUtils.addColumn(schema, x, Seq(0, 2)) ===
-      new StructType().add("s", new StructType().add(a).add(b).add(x)))
-    assert(SchemaUtils.addColumn(schema, x, Seq(1)) === new StructType().add(s).add(x))
+      new StructType().add("first", new StructType().add(a).add(b).add(x)).add(middle).add(last))
+    assert(SchemaUtils.addColumn(schema, x, Seq(0, 1)) ===
+      new StructType().add("first", new StructType().add(a).add(x).add(b)).add(middle).add(last))
+    assert(SchemaUtils.addColumn(schema, x, Seq(0, 0)) ===
+      new StructType().add("first", new StructType().add(x).add(a).add(b)).add(middle).add(last))
+    assert(SchemaUtils.addColumn(schema, x, Seq(1, 0)) ===
+      new StructType().add(first).add("middle", new StructType().add(x).add(a).add(b)).add(last))
+    assert(SchemaUtils.addColumn(schema, x, Seq(2, 0)) ===
+      new StructType().add(first).add(middle).add("last", new StructType().add(x).add(a).add(b)))
 
     expectFailure("Index -1", "lower than 0") {
       SchemaUtils.addColumn(schema, x, Seq(0, -1))
@@ -923,6 +1055,152 @@ class SchemaUtilsSuite extends QueryTest
     }
     expectFailure("parent is not a structtype") {
       SchemaUtils.addColumn(schema, x, Seq(0, 0, 0))
+    }
+  }
+
+  test("addColumn - nested map") {
+    val k = StructField("k", IntegerType)
+    val v = StructField("v", StringType)
+    val schema = new StructType().add("m", MapType(
+      keyType = new StructType().add(k),
+      valueType = new StructType().add(v)))
+
+    val MAP_KEY_INDEX = 0
+    val MAP_VALUE_INDEX = 1
+
+    val x = StructField("x", LongType)
+    assert(SchemaUtils.addColumn(schema, x, Seq(0, MAP_KEY_INDEX, 0)) ===
+      new StructType().add("m", MapType(
+        keyType = new StructType().add(x).add(k),
+        valueType = new StructType().add(v))))
+
+    assert(SchemaUtils.addColumn(schema, x, Seq(0, MAP_KEY_INDEX, 1)) ===
+      new StructType().add("m", MapType(
+        keyType = new StructType().add(k).add(x),
+        valueType = new StructType().add(v))))
+
+    assert(SchemaUtils.addColumn(schema, x, Seq(0, MAP_VALUE_INDEX, 0)) ===
+      new StructType().add("m", MapType(
+        keyType = new StructType().add(k),
+        valueType = new StructType().add(x).add(v))))
+
+    assert(SchemaUtils.addColumn(schema, x, Seq(0, MAP_VALUE_INDEX, 1)) ===
+      new StructType().add("m", MapType(
+        keyType = new StructType().add(k),
+        valueType = new StructType().add(v).add(x))))
+
+    expectFailure("parent is not a structtype") {
+      SchemaUtils.addColumn(schema, x, Seq(0, MAP_KEY_INDEX - 1, 0))
+    }
+    expectFailure("parent is not a structtype") {
+      SchemaUtils.addColumn(schema, x, Seq(0, MAP_VALUE_INDEX + 1, 0))
+    }
+  }
+
+  test("addColumn - nested maps") {
+    // Helper method to create a 2-level deep nested map of structs. The tests below each cover
+    // adding a field to one of the leaf struct.
+    def schema(
+        kk: StructType = new StructType().add("kk", IntegerType),
+        kv: StructType = new StructType().add("kv", IntegerType),
+        vk: StructType = new StructType().add("vk", IntegerType),
+        vv: StructType = new StructType().add("vv", IntegerType))
+      : StructType = new StructType().add("m", MapType(
+        keyType = MapType(
+          keyType = kk,
+          valueType = kv),
+        valueType = MapType(
+          keyType = vk,
+          valueType = vv)))
+
+    val MAP_KEY_INDEX = 0
+    val MAP_VALUE_INDEX = 1
+
+    val x = StructField("x", LongType)
+    // Add field `x` at the front of each leaf struct.
+    assert(SchemaUtils.addColumn(schema(), x, Seq(0, MAP_KEY_INDEX, MAP_KEY_INDEX, 0)) ===
+      schema(kk = new StructType().add(x).add("kk", IntegerType)))
+    assert(SchemaUtils.addColumn(schema(), x, Seq(0, MAP_VALUE_INDEX, MAP_KEY_INDEX, 0)) ===
+      schema(vk = new StructType().add(x).add("vk", IntegerType)))
+    assert(SchemaUtils.addColumn(schema(), x, Seq(0, MAP_KEY_INDEX, MAP_VALUE_INDEX, 0)) ===
+      schema(kv = new StructType().add(x).add("kv", IntegerType)))
+    assert(SchemaUtils.addColumn(schema(), x, Seq(0, MAP_VALUE_INDEX, MAP_VALUE_INDEX, 0)) ===
+      schema(vv = new StructType().add(x).add("vv", IntegerType)))
+
+    // Add field `x` at the back of each leaf struct.
+    assert(SchemaUtils.addColumn(schema(), x, Seq(0, MAP_KEY_INDEX, MAP_KEY_INDEX, 1)) ===
+      schema(kk = new StructType().add("kk", IntegerType).add(x)))
+    assert(SchemaUtils.addColumn(schema(), x, Seq(0, MAP_VALUE_INDEX, MAP_KEY_INDEX, 1)) ===
+      schema(vk = new StructType().add("vk", IntegerType).add(x)))
+    assert(SchemaUtils.addColumn(schema(), x, Seq(0, MAP_KEY_INDEX, MAP_VALUE_INDEX, 1)) ===
+      schema(kv = new StructType().add("kv", IntegerType).add(x)))
+    assert(SchemaUtils.addColumn(schema(), x, Seq(0, MAP_VALUE_INDEX, MAP_VALUE_INDEX, 1)) ===
+      schema(vv = new StructType().add("vv", IntegerType).add(x)))
+
+    // Invalid map access.
+    expectFailure("parent is not a structtype") {
+      SchemaUtils.addColumn(schema(), x, Seq(0, MAP_KEY_INDEX, MAP_KEY_INDEX - 1, 0))
+    }
+    expectFailure("parent is not a structtype") {
+      SchemaUtils.addColumn(schema(), x, Seq(0, MAP_KEY_INDEX - 1, MAP_KEY_INDEX, 0))
+    }
+    expectFailure("parent is not a structtype") {
+      SchemaUtils.addColumn(schema(), x, Seq(0, MAP_KEY_INDEX, MAP_VALUE_INDEX + 1, 0))
+    }
+    expectFailure("parent is not a structtype") {
+      SchemaUtils.addColumn(schema(), x, Seq(0, MAP_VALUE_INDEX + 1, MAP_KEY_INDEX, 0))
+    }
+  }
+
+  test("addColumn - nested array") {
+    val e = StructField("e", IntegerType)
+    val schema = new StructType().add("a", ArrayType(new StructType().add(e)))
+    val x = StructField("x", LongType)
+
+    val ARRAY_ELEMENT_INDEX = 0
+
+    // Add field `x` at the front of the leaf struct.
+    assert(SchemaUtils.addColumn(schema, x, Seq(0, ARRAY_ELEMENT_INDEX, 0)) ===
+      new StructType().add("a", ArrayType(new StructType().add(x).add(e))))
+    // Add field `x` at the back of the leaf struct.
+    assert(SchemaUtils.addColumn(schema, x, Seq(0, ARRAY_ELEMENT_INDEX, 1)) ===
+      new StructType().add("a", ArrayType(new StructType().add(e).add(x))))
+
+    // Invalid array access.
+    expectFailure("Incorrectly accessing an ArrayType") {
+      SchemaUtils.addColumn(schema, x, Seq(0, ARRAY_ELEMENT_INDEX - 1, 0))
+    }
+    expectFailure("Incorrectly accessing an ArrayType") {
+      SchemaUtils.addColumn(schema, x, Seq(0, ARRAY_ELEMENT_INDEX + 1, 0))
+    }
+  }
+
+  test("addColumn - nested arrays") {
+    val e = StructField("e", IntegerType)
+    val schema = new StructType().add("a", ArrayType(ArrayType(new StructType().add(e))))
+    val x = StructField("x", LongType)
+
+    val ARRAY_ELEMENT_INDEX = 0
+
+    // Add field `x` at the front of the leaf struct.
+    assert(SchemaUtils.addColumn(schema, x, Seq(0, ARRAY_ELEMENT_INDEX, ARRAY_ELEMENT_INDEX, 0)) ===
+      new StructType().add("a", ArrayType(ArrayType(new StructType().add(x).add(e)))))
+    // Add field `x` at the back of the leaf struct.
+    assert(SchemaUtils.addColumn(schema, x, Seq(0, ARRAY_ELEMENT_INDEX, ARRAY_ELEMENT_INDEX, 1)) ===
+      new StructType().add("a", ArrayType(ArrayType(new StructType().add(e).add(x)))))
+
+    // Invalid array access.
+    expectFailure("Incorrectly accessing an ArrayType") {
+      SchemaUtils.addColumn(schema, x, Seq(0, ARRAY_ELEMENT_INDEX, ARRAY_ELEMENT_INDEX - 1, 0))
+    }
+    expectFailure("Incorrectly accessing an ArrayType") {
+      SchemaUtils.addColumn(schema, x, Seq(0, ARRAY_ELEMENT_INDEX - 1, ARRAY_ELEMENT_INDEX, 0))
+    }
+    expectFailure("Incorrectly accessing an ArrayType") {
+      SchemaUtils.addColumn(schema, x, Seq(0, ARRAY_ELEMENT_INDEX, ARRAY_ELEMENT_INDEX + 1, 0))
+    }
+    expectFailure("Incorrectly accessing an ArrayType") {
+      SchemaUtils.addColumn(schema, x, Seq(0, ARRAY_ELEMENT_INDEX + 1, ARRAY_ELEMENT_INDEX, 0))
     }
   }
 
@@ -953,23 +1231,206 @@ class SchemaUtilsSuite extends QueryTest
     val a = StructField("a", IntegerType)
     val b = StructField("b", StringType)
     val c = StructField("c", StringType)
-    val s = StructField("s", new StructType().add(a).add(b))
-    val schema = new StructType().add(s).add(c)
+    val first = StructField("first", new StructType().add(a).add(b).add(c))
+    val middle = StructField("middle", new StructType().add(a).add(b).add(c))
+    val last = StructField("last", new StructType().add(a).add(b).add(c))
+    val schema = new StructType().add(first).add(middle).add(last)
 
-    assert(SchemaUtils.dropColumn(schema, Seq(0)) === ((new StructType().add(c), s)))
-    assert(SchemaUtils.dropColumn(schema, Seq(0, 0)) ===
-      ((new StructType().add("s", new StructType().add(b)).add(c), a)))
+    assert(SchemaUtils.dropColumn(schema, Seq(0)) ===
+      new StructType().add(middle).add(last) -> first)
+    assert(SchemaUtils.dropColumn(schema, Seq(1)) ===
+      new StructType().add(first).add(last) -> middle)
+    assert(SchemaUtils.dropColumn(schema, Seq(2)) ===
+      new StructType().add(first).add(middle) -> last)
+
+    assert(SchemaUtils.dropColumn(schema, Seq(0, 2)) ===
+      new StructType().add("first", new StructType().add(a).add(b)).add(middle).add(last) -> c)
     assert(SchemaUtils.dropColumn(schema, Seq(0, 1)) ===
-      ((new StructType().add("s", new StructType().add(a)).add(c), b)))
+      new StructType().add("first", new StructType().add(a).add(c)).add(middle).add(last) -> b)
+    assert(SchemaUtils.dropColumn(schema, Seq(0, 0)) ===
+      new StructType().add("first", new StructType().add(b).add(c)).add(middle).add(last) -> a)
+    assert(SchemaUtils.dropColumn(schema, Seq(1, 0)) ===
+      new StructType().add(first).add("middle", new StructType().add(b).add(c)).add(last) -> a)
+    assert(SchemaUtils.dropColumn(schema, Seq(2, 0)) ===
+      new StructType().add(first).add(middle).add("last", new StructType().add(b).add(c)) -> a)
 
     expectFailure("Index -1", "lower than 0") {
       SchemaUtils.dropColumn(schema, Seq(0, -1))
     }
-    expectFailure("Index 2", "equals to or is larger than struct length: 2") {
-      SchemaUtils.dropColumn(schema, Seq(0, 2))
+    expectFailure("Index 3", "equals to or is larger than struct length: 3") {
+      SchemaUtils.dropColumn(schema, Seq(0, 3))
     }
     expectFailure("Can only drop nested columns from StructType") {
       SchemaUtils.dropColumn(schema, Seq(0, 0, 0))
+    }
+  }
+
+  test("dropColumn - nested map") {
+    val a = StructField("a", IntegerType)
+    val b = StructField("b", StringType)
+    val c = StructField("c", LongType)
+    val d = StructField("d", DateType)
+    val schema = new StructType().add("m", MapType(
+      keyType = new StructType().add(a).add(b),
+      valueType = new StructType().add(c).add(d)))
+
+    val MAP_KEY_INDEX = 0
+    val MAP_VALUE_INDEX = 1
+
+    assert(SchemaUtils.dropColumn(schema, Seq(0, MAP_KEY_INDEX, 0)) ===
+      (new StructType().add("m", MapType(
+        keyType = new StructType().add(b),
+        valueType = new StructType().add(c).add(d))),
+      a))
+
+    assert(SchemaUtils.dropColumn(schema, Seq(0, MAP_KEY_INDEX, 1)) ===
+      (new StructType().add("m", MapType(
+        keyType = new StructType().add(a),
+        valueType = new StructType().add(c).add(d))),
+      b))
+
+    assert(SchemaUtils.dropColumn(schema, Seq(0, MAP_VALUE_INDEX, 0)) ===
+      (new StructType().add("m", MapType(
+        keyType = new StructType().add(a).add(b),
+        valueType = new StructType().add(d))),
+      c))
+
+    assert(SchemaUtils.dropColumn(schema, Seq(0, MAP_VALUE_INDEX, 1)) ===
+      (new StructType().add("m", MapType(
+        keyType = new StructType().add(a).add(b),
+        valueType = new StructType().add(c))),
+      d))
+
+    expectFailure("can only drop nested columns from structtype") {
+      SchemaUtils.dropColumn(schema, Seq(0, MAP_KEY_INDEX - 1, 0))
+    }
+    expectFailure("can only drop nested columns from structtype") {
+      SchemaUtils.dropColumn(schema, Seq(0, MAP_VALUE_INDEX + 1, 0))
+    }
+  }
+
+  test("dropColumn - nested maps") {
+    // Helper method to create a 2-level deep nested map of structs. The tests below each cover
+    // dropping a field to one of the leaf struct. Each test adds an extra field `a` at a specific
+    // position then drops it to end up with the default schema returned by `schema()`
+    def schema(
+        kk: StructType = new StructType().add("kk", IntegerType),
+        kv: StructType = new StructType().add("kv", IntegerType),
+        vk: StructType = new StructType().add("vk", IntegerType),
+        vv: StructType = new StructType().add("vv", IntegerType))
+      : StructType = new StructType().add("m", MapType(
+        keyType = MapType(
+          keyType = kk,
+          valueType = kv),
+        valueType = MapType(
+          keyType = vk,
+          valueType = vv)))
+
+    val a = StructField("a", LongType)
+
+    val MAP_KEY_INDEX = 0
+    val MAP_VALUE_INDEX = 1
+
+    def checkDrop(initialSchema: StructType, position: Seq[Int]): Unit =
+      assert(SchemaUtils.dropColumn(initialSchema, position) === (schema(), a))
+    // Drop field `a` from the front of each leaf struct.
+    checkDrop(
+      initialSchema = schema(kk = new StructType().add(a).add("kk", IntegerType)),
+      position = Seq(0, MAP_KEY_INDEX, MAP_KEY_INDEX, 0))
+
+    checkDrop(
+      initialSchema = schema(kv = new StructType().add(a).add("kv", IntegerType)),
+      position = Seq(0, MAP_KEY_INDEX, MAP_VALUE_INDEX, 0))
+
+    checkDrop(
+      initialSchema = schema(vk = new StructType().add(a).add("vk", IntegerType)),
+      position = Seq(0, MAP_VALUE_INDEX, MAP_KEY_INDEX, 0))
+
+    checkDrop(
+      initialSchema = schema(vv = new StructType().add(a).add("vv", IntegerType)),
+      position = Seq(0, MAP_VALUE_INDEX, MAP_VALUE_INDEX, 0))
+
+    // Drop field `a` from the back of each leaf struct.
+    checkDrop(
+      initialSchema = schema(kk = new StructType().add("kk", IntegerType).add(a)),
+      position = Seq(0, MAP_KEY_INDEX, MAP_KEY_INDEX, 1))
+
+    checkDrop(
+      initialSchema = schema(kv = new StructType().add("kv", IntegerType).add(a)),
+      position = Seq(0, MAP_KEY_INDEX, MAP_VALUE_INDEX, 1))
+
+    checkDrop(
+      initialSchema = schema(vk = new StructType().add("vk", IntegerType).add(a)),
+      position = Seq(0, MAP_VALUE_INDEX, MAP_KEY_INDEX, 1))
+
+    checkDrop(
+      initialSchema = schema(vv = new StructType().add("vv", IntegerType).add(a)),
+      position = Seq(0, MAP_VALUE_INDEX, MAP_VALUE_INDEX, 1))
+
+    // Invalid map access.
+    expectFailure("can only drop nested columns from structtype") {
+      SchemaUtils.dropColumn(schema(), Seq(0, MAP_KEY_INDEX, MAP_KEY_INDEX - 1, 0))
+    }
+    expectFailure("can only drop nested columns from structtype") {
+      SchemaUtils.dropColumn(schema(), Seq(0, MAP_KEY_INDEX - 1, MAP_KEY_INDEX, 0))
+    }
+    expectFailure("can only drop nested columns from structtype") {
+      SchemaUtils.dropColumn(schema(), Seq(0, MAP_KEY_INDEX, MAP_VALUE_INDEX + 1, 0))
+    }
+    expectFailure("can only drop nested columns from structtype") {
+      SchemaUtils.dropColumn(schema(), Seq(0, MAP_VALUE_INDEX + 1, MAP_KEY_INDEX, 0))
+    }
+  }
+
+  test("dropColumn - nested array") {
+    val e = StructField("e", IntegerType)
+    val f = StructField("f", IntegerType)
+    val schema = new StructType().add("a", ArrayType(new StructType().add(e).add(f)))
+
+    val ARRAY_ELEMENT_INDEX = 0
+
+    // Drop field from the front of the leaf struct.
+    assert(SchemaUtils.dropColumn(schema, Seq(0, ARRAY_ELEMENT_INDEX, 0)) ===
+      (new StructType().add("a", ArrayType(new StructType().add(f))), e))
+    // Drop field from the back of the leaf struct.
+    assert(SchemaUtils.dropColumn(schema, Seq(0, ARRAY_ELEMENT_INDEX, 1)) ===
+      (new StructType().add("a", ArrayType(new StructType().add(e))), f))
+
+    // Invalid array access.
+    expectFailure("Incorrectly accessing an ArrayType") {
+      SchemaUtils.dropColumn(schema, Seq(0, ARRAY_ELEMENT_INDEX - 1, 0))
+    }
+    expectFailure("Incorrectly accessing an ArrayType") {
+      SchemaUtils.dropColumn(schema, Seq(0, ARRAY_ELEMENT_INDEX + 1, 0))
+    }
+  }
+
+  test("dropColumn - nested arrays") {
+    val e = StructField("e", IntegerType)
+    val f = StructField("f", IntegerType)
+    val schema = new StructType().add("a", ArrayType(ArrayType(new StructType().add(e).add(f))))
+
+    val ARRAY_ELEMENT_INDEX = 0
+
+    // Drop field `x` from the front of the leaf struct.
+    assert(SchemaUtils.dropColumn(schema, Seq(0, ARRAY_ELEMENT_INDEX, ARRAY_ELEMENT_INDEX, 0)) ===
+      (new StructType().add("a", ArrayType(ArrayType(new StructType().add(f)))), e))
+    // Drop field `x` from the back of the leaf struct.
+    assert(SchemaUtils.dropColumn(schema, Seq(0, ARRAY_ELEMENT_INDEX, ARRAY_ELEMENT_INDEX, 1)) ===
+      (new StructType().add("a", ArrayType(ArrayType(new StructType().add(e)))), f))
+
+    // Invalid array access.
+    expectFailure("Incorrectly accessing an ArrayType") {
+      SchemaUtils.dropColumn(schema, Seq(0, ARRAY_ELEMENT_INDEX, ARRAY_ELEMENT_INDEX - 1, 0))
+    }
+    expectFailure("Incorrectly accessing an ArrayType") {
+      SchemaUtils.dropColumn(schema, Seq(0, ARRAY_ELEMENT_INDEX - 1, ARRAY_ELEMENT_INDEX, 0))
+    }
+    expectFailure("Incorrectly accessing an ArrayType") {
+      SchemaUtils.dropColumn(schema, Seq(0, ARRAY_ELEMENT_INDEX, ARRAY_ELEMENT_INDEX + 1, 0))
+    }
+    expectFailure("Incorrectly accessing an ArrayType") {
+      SchemaUtils.dropColumn(schema, Seq(0, ARRAY_ELEMENT_INDEX + 1, ARRAY_ELEMENT_INDEX, 0))
     }
   }
 


### PR DESCRIPTION
## Description

It is not possible today in Delta tables to add or drop nested fields under two or more levels of directly nested arrays or maps.
The following is a valid use case but fails today:
```
CREATE TABLE test (data array<array<struct<a: int>>>)
ALTER TABLE test ADD COLUMNS (data.element.element.b string)
```

This change updates helper methods `findColumnPosition`, `addColumn` and `dropColumn` in `SchemaUtils` to correctly recurse into directly nested maps and arrays.

Note that changes in Spark are also required for `ALTER TABLE ADD/CHANGE/DROP COLUMN`  to work: https://github.com/apache/spark/pull/40879. The fix is merged in Spark but will only be available in Delta in the next Spark release.

In addition, `findColumnPosition` which currently both returns the position of nested field and the size of its parent, making it overly complex, is split into two distinct and generic methods: `findColumnPosition` and `getNestedTypeFromPosition`.

## How was this patch tested?
- Tests for `findColumnPosition`, `addColumn` and `dropColumn` with two levels of nested maps and arrays are added to `SchemaUtilsSuite`. Other cases for these methods are already covered by existing tests.
- Tested locally that  ALTER TABLE ADD/CHANGE/DROP COLUMN(S) works correctly with Spark fix https://github.com/apache/spark/pull/40879
- Added missing tests coverage for ALTER TABLE ADD/CHANGE/DROP COLUMN(S) with a single map or array.


## Does this PR introduce _any_ user-facing changes?
This change only fixes half of the issue with adding and dropping fields inside nested maps/arrays. This other part is already fixed in Spark (https://github.com/apache/spark/pull/40879) and will be picked in the next Spark release.
When the Spark fix is available in Delta, users will be able to correctly add, change and drop nested fields inside nested maps and arrays.