### PR TITLE
Implement PURGE to remove DVs from Delta tables

### DIFF
--- a/core/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
+++ b/core/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
@@ -87,8 +87,11 @@ statement
     | ALTER TABLE table=qualifiedName
         DROP CONSTRAINT (IF EXISTS)? name=identifier                    #dropTableConstraint
     | OPTIMIZE (path=STRING | table=qualifiedName)
-        (WHERE partitionPredicate = predicateToken)?
+        (WHERE partitionPredicate=predicateToken)?
         (zorderSpec)?                                                   #optimizeTable
+    | REORG TABLE table=qualifiedName
+        (WHERE partitionPredicate=predicateToken)?
+        APPLY LEFT_PAREN PURGE RIGHT_PAREN                              #reorgTable
     | SHOW COLUMNS (IN | FROM) tableName=qualifiedName
         ((IN | FROM) schemaName=identifier)?                            #showColumns
     | cloneTableHeader SHALLOW CLONE source=qualifiedName clause=temporalClause?
@@ -210,6 +213,7 @@ nonReserved
     | CONVERT | TO | DELTA | PARTITIONED | BY
     | DESC | DESCRIBE | LIMIT | DETAIL
     | GENERATE | FOR | TABLE | CHECK | EXISTS | OPTIMIZE
+    | REORG | APPLY | PURGE
     | RESTORE | AS | OF
     | ZORDER | LEFT_PAREN | RIGHT_PAREN
     | SHOW | COLUMNS | IN | FROM | NO | STATISTICS
@@ -219,6 +223,7 @@ nonReserved
 // Define how the keywords above should appear in a user's SQL statement.
 ADD: 'ADD';
 ALTER: 'ALTER';
+APPLY: 'APPLY';
 AS: 'AS';
 BY: 'BY';
 CHECK: 'CHECK';
@@ -255,7 +260,9 @@ NULL: 'NULL';
 OF: 'OF';
 OR: 'OR';
 OPTIMIZE: 'OPTIMIZE';
+REORG: 'REORG';
 PARTITIONED: 'PARTITIONED';
+PURGE: 'PURGE';
 REPLACE: 'REPLACE';
 RESTORE: 'RESTORE';
 RETAIN: 'RETAIN';

--- a/core/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
+++ b/core/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
@@ -354,7 +354,7 @@ class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
    * Creates a [[ReorgTable]] logical plan.
    * Examples:
    * {{{
-   *   -- Physically delete dropped columns of target table
+   *   -- Physically delete dropped rows and columns of target table
    *   REORG TABLE (delta.`/path/to/table` | delta_table_name)
    *    [WHERE partition_predicate] APPLY (PURGE)
    * }}}
@@ -364,8 +364,9 @@ class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
       throw new ParseException("REORG command requires a file path or table name.", ctx)
     }
 
-    val targetIdentifier = visitMultipartIdentifier(ctx.table)
-    val targetTable = createUnresolvedTable(targetIdentifier, "REORG")
+    val targetIdentifier = visitTableIdentifier(ctx.table)
+    val tableNameParts = targetIdentifier.database.toSeq :+ targetIdentifier.table
+    val targetTable = createUnresolvedTable(tableNameParts, "REORG")
 
     ReorgTable(targetTable)(Option(ctx.partitionPredicate).map(extractRawText(_)).toSeq)
   }

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -433,6 +433,14 @@ class DeltaAnalysis(session: SparkSession)
 
       DeltaMergeInto.resolveReferencesAndSchema(deltaMerge, conf)(tryResolveReferences(session))
 
+    case reorg@ReorgTable(_@ResolvedTable(_, _, t, _)) =>
+      t match {
+        case table: DeltaTableV2 =>
+          ReorgTableCommand(table)(reorg.predicates)
+        case _ =>
+          throw DeltaErrors.notADeltaTable(t.name())
+      }
+
     case deltaMerge: DeltaMergeInto =>
       val d = if (deltaMerge.childrenResolved && !deltaMerge.resolved) {
         DeltaMergeInto.resolveReferencesAndSchema(deltaMerge, conf)(tryResolveReferences(session))

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -110,7 +110,7 @@ case class OptimizeTableCommand(
     tableId: Option[TableIdentifier],
     userPartitionPredicates: Seq[String],
     options: Map[String, String],
-    isPurge: Boolean = false)(val zOrderBy: Seq[UnresolvedAttribute])
+    optimizeContext: OptimizeContext = OptimizeContext())(val zOrderBy: Seq[UnresolvedAttribute])
   extends OptimizeTableCommandBase with LeafRunnableCommand {
 
   override val otherCopyArgs: Seq[AnyRef] = zOrderBy :: Nil
@@ -139,8 +139,34 @@ case class OptimizeTableCommand(
     validateZorderByColumns(sparkSession, txn, zOrderBy)
     val zOrderByColumns = zOrderBy.map(_.name).toSeq
 
-    new OptimizeExecutor(sparkSession, txn, partitionPredicates, zOrderByColumns, isPurge)
+    new OptimizeExecutor(sparkSession, txn, partitionPredicates, zOrderByColumns, optimizeContext)
       .optimize()
+  }
+}
+
+/**
+ * Stored all runtime context information that can control the execution of optimize.
+ *
+ * @param isPurge Whether the rewriting task is only for purging soft-deleted data instead of
+ *                for compaction. If [[isPurge]] is true, only files with DVs will be selected
+ *                for compaction.
+ * @param minFileSize Files which are smaller than this threshold will be selected for compaction.
+ *                    If not specified, [[DeltaSQLConf.DELTA_OPTIMIZE_MIN_FILE_SIZE]] will be used.
+ *                    This parameter must be set to `0` when [[isPurge]] is true.
+ * @param maxDeletedRowsRatio Files with a ratio of soft-deleted rows to the total rows larger than
+ *                            this threshold will be rewritten by the OPTIMIZE command. If not
+ *                            specified, [[DeltaSQLConf.DELTA_OPTIMIZE_MAX_DELETED_ROWS_RATIO]]
+ *                            will be used. This parameter must be set to `0` when [[isPurge]] is
+ *                            true.
+ */
+case class OptimizeContext(
+    isPurge: Boolean = false,
+    minFileSize: Option[Long] = None,
+    maxDeletedRowsRatio: Option[Double] = None) {
+  if (isPurge) {
+    require(
+      minFileSize.contains(0L) && maxDeletedRowsRatio.contains(0d),
+      "minFileSize and maxDeletedRowsRatio must be 0 when running PURGE.")
   }
 }
 
@@ -157,7 +183,7 @@ class OptimizeExecutor(
     txn: OptimisticTransaction,
     partitionPredicate: Seq[Expression],
     zOrderByColumns: Seq[String],
-    isPurge: Boolean = false)
+    optimizeContext: OptimizeContext)
   extends DeltaCommand with SQLMetricsReporting with Serializable {
 
   /** Timestamp to use in [[FileAction]] */
@@ -167,19 +193,13 @@ class OptimizeExecutor(
 
   def optimize(): Seq[Row] = {
     recordDeltaOperation(txn.deltaLog, "delta.optimize") {
-      val maxFileSize = sparkSession.sessionState.conf.getConf(
-        DeltaSQLConf.DELTA_OPTIMIZE_MAX_FILE_SIZE)
-      require(maxFileSize > 0, "maxFileSize must be > 0")
-      val (minFileSize, maxDeletedRowsRatio) = if (isPurge) {
-        (0L, 0d) // Only selects files with DV
-      } else {
-        val minFileSize = sparkSession.sessionState.conf.getConf(
-          DeltaSQLConf.DELTA_OPTIMIZE_MIN_FILE_SIZE)
-        val maxDeletedRowsRatio = sparkSession.sessionState.conf.getConf(
-          DeltaSQLConf.DELTA_OPTIMIZE_MAX_DELETED_ROWS_RATIO)
-        require(minFileSize > 0, "minFileSize must be > 0")
-        (minFileSize, maxDeletedRowsRatio)
-      }
+      val minFileSize = optimizeContext.minFileSize.getOrElse(
+        sparkSession.sessionState.conf.getConf(DeltaSQLConf.DELTA_OPTIMIZE_MIN_FILE_SIZE))
+      val maxFileSize =
+        sparkSession.sessionState.conf.getConf(DeltaSQLConf.DELTA_OPTIMIZE_MAX_FILE_SIZE)
+      val maxDeletedRowsRatio = optimizeContext.maxDeletedRowsRatio.getOrElse(
+        sparkSession.sessionState.conf.getConf(DeltaSQLConf.DELTA_OPTIMIZE_MAX_DELETED_ROWS_RATIO))
+
       val candidateFiles = txn.filterFiles(partitionPredicate, keepNumRecords = true)
       val partitionSchema = txn.metadata.partitionSchema
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/ReorgTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/ReorgTableCommand.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands
+
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.catalyst.plans.logical.{IgnoreCachedData, LeafCommand, LogicalPlan, UnaryCommand}
+import org.apache.spark.sql.catalyst.TableIdentifier
+
+case class ReorgTable(target: LogicalPlan)(val predicates: Seq[String]) extends UnaryCommand {
+
+  def child: LogicalPlan = target
+
+  protected def withNewChildInternal(newChild: LogicalPlan): LogicalPlan =
+    copy(target = newChild)(predicates)
+
+  override val otherCopyArgs: Seq[AnyRef] = predicates :: Nil
+}
+
+case class ReorgTableCommand(target: DeltaTableV2)(val predicates: Seq[String])
+  extends OptimizeTableCommandBase with LeafCommand with IgnoreCachedData {
+
+  override val otherCopyArgs: Seq[AnyRef] = predicates :: Nil
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val command = OptimizeTableCommand(
+      Option(target.path.toString),
+      target.catalogTable.map(_.identifier),
+      predicates,
+      options = Map.empty,
+      isPurge = true)(zOrderBy = Nil)
+    command.run(sparkSession)
+  }
+}

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/ReorgTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/ReorgTableCommand.scala
@@ -31,6 +31,9 @@ case class ReorgTable(target: LogicalPlan)(val predicates: Seq[String]) extends 
   override val otherCopyArgs: Seq[AnyRef] = predicates :: Nil
 }
 
+/**
+ * The PURGE command.
+ */
 case class ReorgTableCommand(target: DeltaTableV2)(val predicates: Seq[String])
   extends OptimizeTableCommandBase with LeafCommand with IgnoreCachedData {
 
@@ -42,7 +45,11 @@ case class ReorgTableCommand(target: DeltaTableV2)(val predicates: Seq[String])
       target.catalogTable.map(_.identifier),
       predicates,
       options = Map.empty,
-      isPurge = true)(zOrderBy = Nil)
+      optimizeContext = OptimizeContext(
+        isPurge = true,
+        minFileSize = Some(0L),
+        maxDeletedRowsRatio = Some(0d))
+    )(zOrderBy = Nil)
     command.run(sparkSession)
   }
 }

--- a/core/src/test/scala/io/delta/sql/parser/DeltaSqlParserSuite.scala
+++ b/core/src/test/scala/io/delta/sql/parser/DeltaSqlParserSuite.scala
@@ -19,11 +19,10 @@ package io.delta.sql.parser
 import io.delta.tables.execution.VacuumTableCommand
 
 import org.apache.spark.sql.delta.CloneTableSQLTestUtils
-import org.apache.spark.sql.delta.commands.OptimizeTableCommand
-
+import org.apache.spark.sql.delta.commands.{OptimizeTableCommand, ReorgTable}
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.{TableIdentifier, TimeTravel}
-import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedRelation}
+import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedRelation, UnresolvedTable}
 import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.SQLHelper
@@ -118,6 +117,60 @@ class DeltaSqlParserSuite extends SparkFunSuite with SQLHelper {
     assert(parser.parsePlan("OPTIMIZE tbl ZORDER BY (optimize, zorder)") ===
       OptimizeTableCommand(None, Some(tblId("tbl")), Seq.empty, Map.empty)(
         Seq(unresolvedAttr("optimize"), unresolvedAttr("zorder"))))
+  }
+
+  private def targetPlanForTable(tableParts: String*): UnresolvedTable =
+    UnresolvedTable(tableParts.toSeq, "REORG", relationTypeMismatchHint = None)
+
+  test("REORG command is parsed as expected") {
+    val parser = new DeltaSqlParser(null)
+
+    assert(parser.parsePlan("REORG TABLE tbl APPLY (PURGE)") ===
+      ReorgTable(targetPlanForTable("tbl"))(Seq.empty))
+
+    assert(parser.parsePlan("REORG TABLE tbl_${system:spark.testing} APPLY (PURGE)") ===
+      ReorgTable(targetPlanForTable("tbl_true"))(Seq.empty))
+
+    withSQLConf("tbl_var" -> "tbl") {
+      assert(parser.parsePlan("REORG TABLE ${tbl_var} APPLY (PURGE)") ===
+        ReorgTable(targetPlanForTable("tbl"))(Seq.empty))
+
+      assert(parser.parsePlan("REORG TABLE ${spark:tbl_var} APPLY (PURGE)") ===
+        ReorgTable(targetPlanForTable("tbl"))(Seq.empty))
+
+      assert(parser.parsePlan("REORG TABLE ${sparkconf:tbl_var} APPLY (PURGE)") ===
+        ReorgTable(targetPlanForTable("tbl"))(Seq.empty))
+
+      assert(parser.parsePlan("REORG TABLE ${hiveconf:tbl_var} APPLY (PURGE)") ===
+        ReorgTable(targetPlanForTable("tbl"))(Seq.empty))
+
+      assert(parser.parsePlan("REORG TABLE ${hivevar:tbl_var} APPLY (PURGE)") ===
+        ReorgTable(targetPlanForTable("tbl"))(Seq.empty))
+    }
+
+    assert(parser.parsePlan("REORG TABLE delta.`/path/to/tbl` APPLY (PURGE)") ===
+      ReorgTable(targetPlanForTable("delta", "/path/to/tbl"))(Seq.empty))
+
+    assert(parser.parsePlan("REORG TABLE tbl WHERE part = 1 APPLY (PURGE)") ===
+      ReorgTable(targetPlanForTable("tbl"))(Seq("part = 1")))
+  }
+
+  test("REORG command new tokens are non-reserved keywords") {
+    // new keywords: REORG, APPLY, PURGE
+    val parser = new DeltaSqlParser(null)
+
+    // Use the new keywords in table name
+    assert(parser.parsePlan("REORG TABLE reorg APPLY (PURGE)") ===
+      ReorgTable(targetPlanForTable("reorg"))(Seq.empty))
+    assert(parser.parsePlan("REORG TABLE apply APPLY (PURGE)") ===
+      ReorgTable(targetPlanForTable("apply"))(Seq.empty))
+    assert(parser.parsePlan("REORG TABLE purge APPLY (PURGE)") ===
+      ReorgTable(targetPlanForTable("purge"))(Seq.empty))
+
+    // Use the new keywords in column name
+    assert(parser.parsePlan(
+      "REORG TABLE tbl WHERE reorg = 1 AND apply = 2 AND purge = 3 APPLY (PURGE)") ===
+    ReorgTable(targetPlanForTable("tbl"))(Seq("reorg = 1 AND apply =2 AND purge = 3")))
   }
 
   // scalastyle:off argcount

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
@@ -161,6 +161,14 @@ trait DeletionVectorsTestUtils extends QueryTest with SharedSparkSession {
     txn.commit(actions, Truncate())
   }
 
+  protected def getFileActionsInLastVersion(log: DeltaLog): (Seq[AddFile], Seq[RemoveFile]) = {
+    val version = log.update().version
+    val allFiles = log.getChanges(version).toSeq.head._2
+    val add = allFiles.collect { case a: AddFile => a }
+    val remove = allFiles.collect { case r: RemoveFile => r }
+    (add, remove)
+  }
+
   protected def serializeRoaringBitmapArrayWithDefaultFormat(
       dv: RoaringBitmapArray): Array[Byte] = {
     val serializationFormat = RoaringBitmapArrayFormat.Portable

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaGenerateSymlinkManifestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaGenerateSymlinkManifestSuite.scala
@@ -600,10 +600,8 @@ trait DeltaGenerateSymlinkManifestSuiteBase extends QueryTest
             subClass = ExistingDeletionVectorsWithIncrementalManifestGeneration)  {
           setEnabledIncrementalManifest(tablePath, enabled = true)
         }
-        // Run optimize to delete the DVs and rewrite the data files
-        withSQLConf(DeltaSQLConf.DELTA_OPTIMIZE_MAX_DELETED_ROWS_RATIO.key -> "0.00001") {
-          spark.sql(s"OPTIMIZE delta.`$tablePath`")
-        }
+        // Run PURGE to delete the DVs and rewrite the data files
+        spark.sql(s"REORG TABLE delta.`$tablePath` APPLY (REORG)")
         assert(getFilesWithDeletionVectors(deltaLog).isEmpty)
         // Now it should work.
         setEnabledIncrementalManifest(tablePath, enabled = true)

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaGenerateSymlinkManifestSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaGenerateSymlinkManifestSuite.scala
@@ -601,7 +601,7 @@ trait DeltaGenerateSymlinkManifestSuiteBase extends QueryTest
           setEnabledIncrementalManifest(tablePath, enabled = true)
         }
         // Run PURGE to delete the DVs and rewrite the data files
-        spark.sql(s"REORG TABLE delta.`$tablePath` APPLY (REORG)")
+        spark.sql(s"REORG TABLE delta.`$tablePath` APPLY (PURGE)")
         assert(getFilesWithDeletionVectors(deltaLog).isEmpty)
         // Now it should work.
         setEnabledIncrementalManifest(tablePath, enabled = true)

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaPurgeSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaPurgeSuite.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+class DeltaPurgeSuite extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest
+  with DeletionVectorsTestUtils {
+
+  import testImplicits._
+
+  def executePurge(table: String, condition: Option[String] = None): Unit = {
+    condition match {
+      case Some(cond) => sql(s"REORG TABLE delta.`$table` WHERE $cond APPLY (PURGE)")
+      case None => sql(s"REORG TABLE delta.`$table` APPLY (PURGE)")
+    }
+  }
+
+  testWithDVs("Purge DVs will combine small files") {
+    withTempDir { tempDir =>
+      val path = tempDir.getCanonicalPath
+      val log = DeltaLog.forTable(spark, path)
+      spark
+        .range(0, 100, 1, numPartitions = 5)
+        .write
+        .format("delta")
+        .save(path)
+      sql(s"DELETE FROM delta.`$path` WHERE id IN (0, 99)")
+      assert(log.update().allFiles.filter(_.deletionVector != null).count() === 2)
+      executePurge(path)
+      val (addFiles, _) = getFileActionsInLastVersion(log)
+      assert(addFiles.forall(_.deletionVector === null))
+      checkAnswer(
+        sql(s"SELECT * FROM delta.`$path`"),
+        (1 to 98).toDF())
+    }
+  }
+
+  testWithDVs("Purge DVs") {
+    withTempDir { tempDir =>
+      val path = tempDir.getCanonicalPath
+      val log = DeltaLog.forTable(spark, path)
+      spark
+        .range(0, 100, 1, numPartitions = 5)
+        .write
+        .format("delta")
+        .save(path)
+      sql(s"DELETE FROM delta.`$path` WHERE id IN (0, 99)")
+      assert(log.update().allFiles.filter(_.deletionVector != null).count() === 2)
+
+      // First purge
+      executePurge(path)
+      val (addFiles, _) = getFileActionsInLastVersion(log)
+      assert(addFiles.size === 1) // two files are combined
+      assert(addFiles.forall(_.deletionVector === null))
+      checkAnswer(
+        sql(s"SELECT * FROM delta.`$path`"),
+        (1 to 98).toDF())
+
+      // Second purge is a noop
+      val versionBefore = log.update().version
+      executePurge(path)
+      val versionAfter = log.update().version
+      assert(versionBefore === versionAfter)
+    }
+  }
+
+  test("Purge a non-DV table is a noop") {
+    withTempDir { tempDir =>
+      val path = tempDir.getCanonicalPath
+      val log = DeltaLog.forTable(spark, path)
+      spark
+        .range(0, 100, 1, numPartitions = 5)
+        .write
+        .format("delta")
+        .save(path)
+      val versionBefore = log.update().version
+      executePurge(path)
+      val versionAfter = log.update().version
+      assert(versionBefore === versionAfter)
+    }
+  }
+}

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
@@ -831,12 +831,10 @@ class DeltaVacuumSuite
   // Helper method to remove the DVs in Delta table and rewrite the data files
   def purgeDVs(tableName: String): Unit = {
     withSQLConf(
-      DeltaSQLConf.DELTA_OPTIMIZE_MAX_DELETED_ROWS_RATIO.key -> "0.0001",
-      DeltaSQLConf.DELTA_OPTIMIZE_MIN_FILE_SIZE.key -> "2",
       // Set the max file size to low so that we always rewrite the single file without DVs
       // and not combining with other data files.
       DeltaSQLConf.DELTA_OPTIMIZE_MAX_FILE_SIZE.key -> "2") {
-      spark.sql(s"OPTIMIZE $tableName")
+      spark.sql(s"REORG TABLE $tableName APPLY (PURGE)")
     }
   }
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
@@ -551,14 +551,6 @@ class DeletionVectorsSuite extends QueryTest
     }
   }
 
-  private def getFileActionsInLastVersion(log: DeltaLog): (Seq[AddFile], Seq[RemoveFile]) = {
-    val version = log.update().version
-    val allFiles = log.getChanges(version).toSeq.head._2
-    val add = allFiles.collect { case a: AddFile => a }
-    val remove = allFiles.collect { case r: RemoveFile => r }
-    (add, remove)
-  }
-
   private def assertPlanContains(queryDf: DataFrame, expected: String): Unit = {
     val optimizedPlan = queryDf.queryExecution.analyzed.toString()
     assert(optimizedPlan.contains(expected), s"Plan is missing `$expected`: $optimizedPlan")


### PR DESCRIPTION
## Description

This PR introduces a `REORG TABLE ... APPLY (PURGE)` SQL command that can materialize soft-delete operations by DVs.

The command works by rewriting and bin-packing (if applicable) only files that have DVs attached, which is different from the `OPTIMIZE` command where all files (with and without) DV will be bin-packed. To achieve this, we hack the `OPTIMIZE` logic so files of any size with DVs will be rewritten.

Follow-up:
- Set the correct commit info. Now the resulting version is marked as `optimize` rather than `purge`.
- Clean up DVs from the filesystem.

## How was this patch tested?

New tests.
