### PR TITLE
Make test cases portable with resource path

### DIFF
--- a/core/src/test/scala/io/delta/tables/DeltaTableBuilderSuite.scala
+++ b/core/src/test/scala/io/delta/tables/DeltaTableBuilderSuite.scala
@@ -337,7 +337,7 @@ class DeltaTableBuilderSuite extends QueryTest with SharedSparkSession with Delt
       val e = intercept[AnalysisException] {
         io.delta.tables.DeltaTable.create().tableName(s"delta.`$path`")
           .addColumn("c1", "int")
-          .location("src/test/resources/delta/dbr_8_0_non_generated_columns")
+          .location(getTestResourcePath("delta/dbr_8_0_non_generated_columns"))
           .execute()
       }
       assert(e.getMessage.startsWith(

--- a/core/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
@@ -44,7 +44,7 @@ trait DescribeDeltaHistorySuiteBase
   import testImplicits._
 
   protected val evolvabilityResource = {
-    new File("src/test/resources/delta/history/delta-0.2.0").getAbsolutePath()
+    getTestResourcePath("delta/history/delta-0.2.0")
   }
 
   protected val evolvabilityLastOp = Seq("STREAMING UPDATE", null, null)

--- a/core/src/test/scala/org/apache/spark/sql/delta/EvolvabilitySuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/EvolvabilitySuite.scala
@@ -35,12 +35,12 @@ class EvolvabilitySuite extends EvolvabilitySuiteBase with DeltaSQLCommandTest {
   import testImplicits._
 
   test("delta 0.1.0") {
-    testEvolvability("src/test/resources/delta/delta-0.1.0")
+    testEvolvability(getTestResourcePath("delta/delta-0.1.0"))
   }
 
   test("delta 0.1.0 - case sensitivity enabled") {
     withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
-      testEvolvability("src/test/resources/delta/delta-0.1.0")
+      testEvolvability(getTestResourcePath("delta/delta-0.1.0"))
     }
   }
 
@@ -245,7 +245,7 @@ class EvolvabilitySuite extends EvolvabilitySuiteBase with DeltaSQLCommandTest {
     // table created using Delta 1.2.1 which has additional field `numRecords` in
     // checkpoint schema. It is removed in version after 1.2.1.
     // Make sure we are able to read the Delta table in the latest version.
-    val tablePath = "src/test/resources/delta/delta-1.2.1"
+    val tablePath = getTestResourcePath("delta/delta-1.2.1")
     assert(
       spark.read.format("delta")
         .load(tablePath).where("col1 = 8").count() === 9L)

--- a/core/src/test/scala/org/apache/spark/sql/delta/EvolvabilitySuiteBase.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/EvolvabilitySuiteBase.scala
@@ -72,7 +72,7 @@ abstract class EvolvabilitySuiteBase extends QueryTest with SharedSparkSession
     withTempDir { tempDir =>
       // copy the existing dir to the temp data dir.
       FileUtils.copyDirectory(
-        new File("src/test/resources/delta/transaction_log_schema_evolvability"), tempDir)
+        getTestResourceFile("delta/transaction_log_schema_evolvability"), tempDir)
       DeltaLog.clearCache()
       operation(tempDir.getAbsolutePath)
     }

--- a/core/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnCompatibilitySuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnCompatibilitySuite.scala
@@ -66,10 +66,10 @@ class GeneratedColumnCompatibilitySuite extends GeneratedColumnTest {
    * or writing this table.
    */
   def withDBR8_0Table(func: String => Unit): Unit = {
-    val resourcePath = "src/test/resources/delta/dbr_8_0_non_generated_columns"
+    val resourceFile = getTestResourceFile("delta/dbr_8_0_non_generated_columns")
     withTempDir { tempDir =>
       // Prepare a table that has the old writer version and generation expressions
-      FileUtils.copyDirectory(new File(resourcePath), tempDir)
+      FileUtils.copyDirectory(resourceFile, tempDir)
       val path = tempDir.getCanonicalPath
       val deltaLog = DeltaLog.forTable(spark, path)
       // Verify the test table has the old writer version and generation expressions

--- a/core/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
@@ -569,7 +569,7 @@ class DeletionVectorsSuite extends QueryTest
 }
 
 object DeletionVectorsSuite {
-  val table1Path = "src/test/resources/delta/table-with-dv-large"
+  val table1Path = getTestResourcePath("delta/table-with-dv-large")
   // Table at version 0: contains [0, 2000)
   val expectedTable1DataV0 = Seq.range(0, 2000)
   // Table at version 1: removes rows with id = 0, 180, 300, 700, 1800
@@ -585,13 +585,13 @@ object DeletionVectorsSuite {
   val v4Added = Set(900, 1567)
   val expectedTable1DataV4 = expectedTable1DataV3 ++ v4Added
 
-  val table2Path = "src/test/resources/delta/table-with-dv-small"
+  val table2Path = getTestResourcePath("delta/table-with-dv-small")
   // Table at version 0: contains 0 - 9
   val expectedTable2DataV0 = Seq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
   // Table at version 1: removes rows 0 and 9
   val expectedTable2DataV1 = Seq(1, 2, 3, 4, 5, 6, 7, 8)
 
-  val table3Path = "src/test/resources/delta/partitioned-table-with-dv-large"
+  val table3Path = getTestResourcePath("delta/partitioned-table-with-dv-large")
   // Table at version 0: contains [0, 2000)
   val expectedTable3DataV0 = Seq.range(0, 2000)
   // Table at version 1: removes rows with id = (0, 180, 308, 225, 756, 1007, 1503)
@@ -620,9 +620,13 @@ object DeletionVectorsSuite {
   // All "id % 1000 = 0" rows are marked as deleted.
   // Column "value" ranges from 0 to 21.
   // 99900000 rows with values 0 to 20 each, and 47436174 rows with value 21.
-  val table5Path = "src/test/resources/delta/table-with-dv-gigantic"
+  val table5Path = getTestResourcePath("delta/table-with-dv-gigantic")
   val table5Count = 2145336174L
   val table5Sum = 21975159654L
   val table5CountByValues = (0 to 20).map(_ -> 99900000L).toMap + (21 -> 47436174L)
   val table5SumByValues = (0 to 20).map(v => v -> v * 99900000L).toMap + (21 -> 21 * 47436174L)
+
+  def getTestResourcePath(file: String): String = {
+    new File(getClass.getClassLoader.getResource(file).getFile).getCanonicalPath
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->
Fix ut failures in IntelliJ

## Description
Use resource path in unit tests to make the code portable (even in IntelliJ).
Leverage the helper functions in SparkFunSuit
```
  // helper function
  protected final def getTestResourceFile(file: String): File = {
    new File(getClass.getClassLoader.getResource(file).getFile)
  }

  protected final def getTestResourcePath(file: String): String = {
    getTestResourceFile(file).getCanonicalPath
  }
```
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Unit test
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
