### PR TITLE
Adopt sbt version to PEP440 compatible python package version

### DIFF
--- a/run-integration-tests.py
+++ b/run-integration-tests.py
@@ -17,6 +17,8 @@
 #
 
 import os
+import pathlib
+import re
 import subprocess
 from os import path
 import shutil
@@ -323,8 +325,15 @@ if __name__ == "__main__":
 
     # get the version of the package
     root_dir = path.dirname(__file__)
-    with open(path.join(root_dir, "version.sbt")) as fd:
-        default_version = fd.readline().split('"')[1]
+
+    default_version = re.sub(
+        "-SNAPSHOT",
+        ".dev",
+        re.search(
+            '"(?P<version>\d+\.\d+\.\d+(-\w+)?)"',
+            (pathlib.Path(root_dir) / "version.sbt").read_text(),
+        ).group("version"),
+    )
 
     parser = argparse.ArgumentParser()
     parser.add_argument(

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import os
+import pathlib
+import re
 import sys
 
 from setuptools import setup
@@ -9,9 +11,11 @@ from setuptools.command.install import install
 
 # delta.io version
 def get_version_from_sbt():
-    with open("version.sbt") as fp:
-        version = fp.read().strip()
-    return version.split('"')[1]
+    version = re.search(
+        '"(?P<version>\d+\.\d+\.\d+(-\w+)?)"',
+        pathlib.Path("version.sbt").read_text(),
+    ).group("version")
+    return re.sub("-SNAPSHOT", ".dev", version)
 
 
 VERSION = get_version_from_sbt()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

See https://peps.python.org/pep-0440/#developmental-releases

With this change sbt version `2.4.0-SNAPSHOT` will be translated to python `2.4.0-dev0`. This allows to install dev version of the package directly from the repository. Previously it failed

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

I tested it with the following content of the version.sbt:
```
ThisBuild / version := "2.4.0-SNAPSHOT" -> "2.4.0.dev0"
ThisBuild / version := "2.4.0" -> "2.4.0"
```
Also tested the installation from my fork:
```
pip install git+https://github.com/zhukovgreen/delta.git@0307d8ac06e747221b79897f3c6da1b7f4eb8855
```

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

Seems not. Only if user would be installing the package using:
```
 pip install git+https://github.com/delta-io/delta.git@master
```

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
