### PR TITLE
Validate operation name in Optimize command tests

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeMetricsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/optimize/OptimizeMetricsSuite.scala
@@ -272,7 +272,7 @@ trait OptimizeMetricsSuiteBase extends QueryTest
             "operationParameters.zOrderBy",
             "operationMetrics",
             "operation")
-          .take(1).head
+          .head
 
         // Verify ZOrder operation parameters
         val actualOpParameters = actualOperation.getString(0)
@@ -402,7 +402,6 @@ trait OptimizeMetricsSuiteBase extends QueryTest
 
         // Check DV metrics in the Delta history.
         val opMetricsAndName = deltaTable.history.select("operationMetrics", "operation")
-          .take(1)
           .head
 
         val opMetrics = opMetricsAndName


### PR DESCRIPTION
## Description

Validate the operation name for optimize command - Fixes #1756 
Also changed DeltaLog.snapshot to DeltaLog.unsafeVolatileSnapshot, as snapshot field is deprecated.

## How was this patch tested?

Run tests locally

## Does this PR introduce _any_ user-facing changes?

No
