### PR TITLE
[WIP] Escape or not-escape DV path according to Spark

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/DeleteWithDeletionVectorsHelper.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/DeleteWithDeletionVectorsHelper.scala
@@ -35,7 +35,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.{Column, DataFrame, Dataset, Encoder, SparkSession}
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, FileSourceMetadataAttribute}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, FileSourceMetadataAttribute, GenericInternalRow}
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project}
 import org.apache.spark.sql.execution.datasources.{FileFormat, HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.execution.datasources.FileFormat.{FILE_PATH, METADATA_NAME}
@@ -294,13 +294,8 @@ object DeletionVectorBitmapGenerator {
       candidateFiles: Seq[AddFile],
       condition: Expression)
     : Seq[DeletionVectorResult] = {
-    // TODO: fix this to work regardless of whether Spark encodes or doesn't encode
-    //  _metadata.file_path. See https://github.com/delta-io/delta/issues/1725
-    val uriEncode = DeltaUDF.stringFromString(path => {
-      new Path(path).toUri.toString
-    })
     val matchedRowsDf = targetDf
-      .withColumn(FILE_NAME_COL, uriEncode(col(s"${METADATA_NAME}.${FILE_PATH}")))
+      .withColumn(FILE_NAME_COL, col(s"${METADATA_NAME}.${FILE_PATH}"))
       // Filter after getting input file name as the filter might introduce a join and we
       // cannot get input file name on join's output.
       .filter(new Column(condition))
@@ -312,8 +307,10 @@ object DeletionVectorBitmapGenerator {
       val basePath = txn.deltaLog.dataPath.toString
       val filePathToDV = candidateFiles.map { add =>
         val serializedDV = Option(add.deletionVector).map(dvd => JsonUtils.toJson(dvd))
-        // Paths in the metadata column are canonicalized. Thus we must canonicalize the DV path.
-        FileToDvDescriptor(absolutePath(basePath, add.path).toUri.toString, serializedDV)
+        // Transform file path to match FILE_NAME_COL format (both or none canonicalized).
+        FileToDvDescriptor(
+          toMetadataFilePathFormat(absolutePath(basePath, add.path)),
+          serializedDV)
       }
       val filePathToDVDf = sparkSession.createDataset(filePathToDV)
 
@@ -333,6 +330,26 @@ object DeletionVectorBitmapGenerator {
     }
 
     DeletionVectorBitmapGenerator.buildDeletionVectors(sparkSession, df, txn.deltaLog, txn)
+  }
+
+  /**
+   * In Spark 3.4 the file path metadata column is not canonicalized but it is in Spark 3.4.1. To
+   * make Delta Lake works with both Spark versions, we must use Spark's internal path
+   * transformation method to transform our paths here. This method will return a un-canonicalized
+   * path in Spark 3.4 and a canonicalized one in Spark 3.4.1.
+   *
+   * Related issue: https://github.com/delta-io/delta/issues/1725.
+   */
+  private def toMetadataFilePathFormat(path: Path): String = {
+    val row = FileFormat.updateMetadataInternalRow(
+      new GenericInternalRow(size = 1),
+      Seq(FileFormat.FILE_PATH),
+      filePath = path,
+      fileSize = 0L,
+      fileBlockStart = 0L,
+      fileBlockLength = 0L,
+      fileModificationTime = 0L)
+    row.getUTF8String(0).toString
   }
 }
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/util/DeltaFileOperations.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/util/DeltaFileOperations.scala
@@ -53,18 +53,16 @@ object DeltaFileOperations extends DeltaLogging {
    *                 Note: It is assumed that the basePath do not have any escaped characters and
    *                 is directly readable by Hadoop APIs.
    * @param child    Child path to append to `basePath` if child is a relative path.
-   *                 Note: t is assumed that the child is escaped, that is, all special chars that
-   *                 need escaping by URI standards are already escaped.
    * @return Absolute path without escaped chars that is directly readable by Hadoop APIs.
    */
   def absolutePath(basePath: String, child: String): Path = {
     // scalastyle:off pathfromuri
-    val p = new Path(new URI(child))
+    val p = new Path(child)
     if (p.isAbsolute) {
       p
     } else {
-      val merged = new Path(basePath, p)
-      // URI resolution strips the final `/` in `p` if it exists
+      val merged = new Path(basePath, child)
+      // URI resolution strips the final `/` in `child` if it exists
       val mergedUri = merged.toUri.toString
       if (child.endsWith("/") && !mergedUri.endsWith("/")) {
         new Path(new URI(mergedUri + "/"))


### PR DESCRIPTION
## Description

This issue fixes #1725.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
