### PR TITLE
Probe whether the metadata path is canonicalized in Spark (#1725)

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/DeleteWithDeletionVectorsHelper.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/DeleteWithDeletionVectorsHelper.scala
@@ -362,16 +362,22 @@ object DeletionVectorBitmapGenerator {
    * Related issue: https://github.com/delta-io/delta/issues/1725.
    */
   private lazy val sparkMetadataFilePathIsCanonicalized: Boolean = {
-    val probeString = "file:/path with space/data.parquet"
-    val row = FileFormat.updateMetadataInternalRow(
-      new GenericInternalRow(size = 1),
-      Seq(FileFormat.FILE_PATH),
-      filePath = new Path(probeString),
-      fileSize = 0L,
-      fileBlockStart = 0L,
-      fileBlockLength = 0L,
-      fileModificationTime = 0L)
-    !row.getUTF8String(0).toString.equals(probeString)
+    try {
+      val probeString = "file:/path with space/data.parquet"
+      val row = FileFormat.updateMetadataInternalRow(
+        new GenericInternalRow(size = 1),
+        Seq(FileFormat.FILE_PATH),
+        filePath = new Path(probeString),
+        fileSize = 0L,
+        fileBlockStart = 0L,
+        fileBlockLength = 0L,
+        fileModificationTime = 0L)
+      row.getUTF8String(0).toString != probeString
+    } catch {
+      // method has changed (for example in Spark 3.5 onwards which does not have this bug).
+      // Return true in this case.
+      case _: NoSuchMethodError | _: NoClassDefFoundError => true
+    }
   }
 }
 


### PR DESCRIPTION
## Description

(Cherry-pick of e0f0e91c80b431ee47861c49bd21ff5ac0294cc3 to branch-2.4)

This issue fixes https://github.com/delta-io/delta/issues/1725.

The mechanism of this fix is to call the Spark internal method, which is used to generate metadata columns, to see if it will canonicalize spaces in a crafted path string. If the answer is yes, then we don't need to do anything on the Delta side; otherwise, we manually canonicalize the obtained metadata column.

Why don't use the Spark internal method on `FileToDvDescriptor`, so both sides of the join are either canonicalized or not-canonicalized? Because most Delta methods are expecting a canonicalized path, thus the returned DF must be canonicalized in all cases.

## How was this patch tested?

Existing tests didn't fail.
