### PR TITLE
Fix Checkpoint struct column terminology

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -809,7 +809,7 @@ object Checkpoints extends DeltaLogging {
     // opt in our out of the struct conf.
     val includeStructColumns = shouldWriteStatsAsStruct(sessionConf, snapshot)
     if (includeStructColumns) {
-      val partitionValues = CheckpointV2.extractPartitionValues(
+      val partitionValues = Checkpoints.extractPartitionValues(
         snapshot.metadata.partitionSchema, "add.partitionValues")
       additionalCols ++= partitionValues
     }
@@ -829,23 +829,15 @@ object Checkpoints extends DeltaLogging {
   }
 
   def shouldWriteStatsAsStruct(conf: SQLConf, snapshot: Snapshot): Boolean = {
-    DeltaConfigs.CHECKPOINT_WRITE_STATS_AS_STRUCT
-      .fromMetaData(snapshot.metadata)
-      .getOrElse(conf.getConf(DeltaSQLConf.DELTA_CHECKPOINT_V2_ENABLED))
+    DeltaConfigs.CHECKPOINT_WRITE_STATS_AS_STRUCT.fromMetaData(snapshot.metadata)
   }
 
   def shouldWriteStatsAsJson(snapshot: Snapshot): Boolean = {
     DeltaConfigs.CHECKPOINT_WRITE_STATS_AS_JSON.fromMetaData(snapshot.metadata)
   }
-}
 
-/**
- * Utility methods for generating and using V2 checkpoints. V2 checkpoints have partition values and
- * statistics as struct fields of the `add` column.
- */
-object CheckpointV2 {
-  val PARTITIONS_COL_NAME = "partitionValues_parsed"
-  val STATS_COL_NAME = "stats_parsed"
+  val STRUCT_PARTITIONS_COL_NAME = "partitionValues_parsed"
+  val STRUCT_STATS_COL_NAME = "stats_parsed"
 
   /**
    * Creates a nested struct column of partition values that extract the partition values
@@ -865,6 +857,8 @@ object CheckpointV2 {
         ansiEnabled = false)
       ).as(physicalName)
     }
-    if (partitionValues.isEmpty) None else Some(struct(partitionValues: _*).as(PARTITIONS_COL_NAME))
+    if (partitionValues.isEmpty) {
+      None
+    } else Some(struct(partitionValues: _*).as(STRUCT_PARTITIONS_COL_NAME))
   }
 }

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -508,10 +508,10 @@ trait DeltaConfigsBase extends DeltaLogging {
    * "stats_parsed" column. We will also write partition values as a struct as
    * "partitionValues_parsed".
    */
-  val CHECKPOINT_WRITE_STATS_AS_STRUCT = buildConfig[Option[Boolean]](
+  val CHECKPOINT_WRITE_STATS_AS_STRUCT = buildConfig[Boolean](
     "checkpoint.writeStatsAsStruct",
-    null,
-    v => Option(v).map(_.toBoolean),
+    "true",
+    _.toBoolean,
     _ => true,
     "needs to be a boolean.")
 

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -525,13 +525,6 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(false)
 
-  val DELTA_CHECKPOINT_V2_ENABLED =
-    buildConf("checkpointV2.enabled")
-      .internal()
-      .doc("Write checkpoints where the partition values are parsed according to the data type.")
-      .booleanConf
-      .createWithDefault(true)
-
   val CHECKPOINT_SCHEMA_WRITE_THRESHOLD_LENGTH =
     buildConf("checkpointSchema.writeThresholdLength")
       .internal()

--- a/core/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta.stats
 // scalastyle:off import.ordering.noEmptyLine
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.spark.sql.delta.{CheckpointV2, DeletionVectorsTableFeature, DeltaColumnMapping, DeltaErrors, DeltaLog, DeltaUDF}
+import org.apache.spark.sql.delta.{Checkpoints, DeletionVectorsTableFeature, DeltaColumnMapping, DeltaErrors, DeltaLog, DeltaUDF}
 import org.apache.spark.sql.delta.DeltaOperations.ComputeStats
 import org.apache.spark.sql.delta.actions.{AddFile, Protocol}
 import org.apache.spark.sql.delta.commands.DeletionVectorUtils
@@ -194,7 +194,7 @@ trait StatisticsCollection extends DeltaLogging {
     // This may be very expensive because it is rewriting JSON.
     withStats
       .withColumn("stats", when(col(statsColName).isNotNull, to_json(struct(allStatCols: _*))))
-      .drop(col(CheckpointV2.STATS_COL_NAME)) // Note: does not always exist.
+      .drop(col(Checkpoints.STRUCT_STATS_COL_NAME)) // Note: does not always exist.
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingTestUtils.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingTestUtils.scala
@@ -338,8 +338,12 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
       schema: StructType): UnresolvedAttribute = {
     val parts = UnresolvedAttribute.parseAttributeName(col)
     val shouldIgnoreFirstPart = Set(
-      "minValues", "maxValues", "numRecords", CheckpointV2.PARTITIONS_COL_NAME, "partitionValues")
-    val shouldIgnoreSecondPart = Set(CheckpointV2.STATS_COL_NAME, "stats")
+      "minValues",
+      "maxValues",
+      "numRecords",
+      Checkpoints.STRUCT_PARTITIONS_COL_NAME,
+      "partitionValues")
+    val shouldIgnoreSecondPart = Set(Checkpoints.STRUCT_STATS_COL_NAME, "stats")
     val physical = if (shouldIgnoreFirstPart.contains(parts.head)) {
       parts.head +: getPhysicalPathForStats(parts.tail, schema).getOrElse(parts.tail)
     } else if (shouldIgnoreSecondPart.contains(parts.head)) {


### PR DESCRIPTION

## Description

Fix Checkpoint struct column terminology.

The Delta Spec has only 1 version of checkpoint but the delta connector uses the term CheckpointV2 in order to write partition values in struct form (partitionValues_parsed col). This is kind of confusing.
This PR fixes this terminology.

## How was this patch tested?

Existing UTs

## Does this PR introduce _any_ user-facing changes?

No