### PR TITLE
Handle FileAlreadyExistsException in S3DynamoDBLogStore

### DIFF
--- a/storage-s3-dynamodb/src/main/java/io/delta/storage/BaseExternalLogStore.java
+++ b/storage-s3-dynamodb/src/main/java/io/delta/storage/BaseExternalLogStore.java
@@ -402,10 +402,11 @@ public abstract class BaseExternalLogStore extends HadoopFileSystemLogStore {
                     LOG.info("fixed file {}", entry.fileName);
                     return;
                 } catch (java.nio.file.FileAlreadyExistsException e) {
-                    LOG.info("file already copied {}:", e.getClass().getSimpleName(), e);
+                    LOG.info("file {} already copied: {}:",
+                        entry.fileName, e.getClass().getSimpleName(), e);
                     copied = true;
-                    // should we fixDeltaLogPutCompleteDbEntry after this to be safe?
-                    // Don't return so that we mark Db entry as complete
+                    // Don't return since we still need to mark the DB entry as complete. This will
+                    // happen when we execute the main try block on the next while loop iteration
                 } catch (Throwable e) {
                     LOG.info("{}:", e.getClass().getSimpleName(), e);
                     if (retry >= 3) {

--- a/storage-s3-dynamodb/src/test/scala/io/delta/storage/ExternalLogStoreSuite.scala
+++ b/storage-s3-dynamodb/src/test/scala/io/delta/storage/ExternalLogStoreSuite.scala
@@ -263,33 +263,6 @@ class ExternalLogStoreSuite extends org.apache.spark.sql.delta.PublicLogStoreSui
     }
   }
 
-  test("BaseExternalLogStore catches FileAlreadyExistsException on copy") {
-    withTempLogDir { tempLogDir =>
-      val store = createLogStore(spark)
-      val delta0 = getDeltaVersionPath(tempLogDir, 0)
-      val delta1 = getDeltaVersionPath(tempLogDir, 1)
-
-      // write N
-      store.write(delta0, Iterator("one"), overwrite = false, sessionHadoopConf)
-
-      // mark entry N as incomplete in the external store
-      val entry = MemoryLogStore.get(delta0)
-      val key = MemoryLogStore.createKey(delta0.getParent.getParent.toString, delta0.getName)
-      val incompleteEntry = new ExternalCommitEntry(
-        entry.tablePath, entry.fileName, entry.tempPath, false, entry.expireTime)
-      // scalastyle:off
-      println(key)
-      MemoryLogStore.hashMap.put(key, incompleteEntry)
-
-      // write N + 1 and check that recovery does not throw FileAlreadyExistsException
-      // this won't test it since we also check if the file exists before writing
-      store.write(delta1, Iterator("one"), overwrite = false, sessionHadoopConf)
-      assert(delta1.getFileSystem(sessionHadoopConf).exists(delta1))
-      assert(MemoryLogStore.get(delta1).complete)
-      assert(MemoryLogStore.get(delta0).complete) // todo: do we expect it to correct this entry?
-    }
-  }
-
   protected def shouldUseRenameToWriteCheckpoint: Boolean = false
 }
 


### PR DESCRIPTION
## Description

Resolves #1734

It is possible that more than one concurrent reader/writers will try to fix the same incomplete entry in DynamoDB. This could result in some seeing a `FileAlreadyExistsException` when trying to copy the temp file to the delta log. We should not propagate this error to the end user since the recovery operation was successful and we can proceed. See #1734 for more details.

Note, we attempt to copy a temp file in two places:
1. As part of writing N.json [here](https://github.com/delta-io/delta/blob/master/storage-s3-dynamodb/src/main/java/io/delta/storage/BaseExternalLogStore.java#L249)
2. In `fixDeltaLog` when performing a recovery for N-1.json as part of either a write or listFrom

We only need to catch the exception in scenario (2). In scenario (1) we already catch _all_ seen errors.


## How was this patch tested?

This is hard to test without manipulating the FS + external store a lot. We could manipulate `FailingFileSystem` to throw a `FileAlreadyExistsException`.
