### PR TITLE
Resolve `mypy` errors experienced by users

### DIFF
--- a/python/delta/tables.py
+++ b/python/delta/tables.py
@@ -34,6 +34,9 @@ if TYPE_CHECKING:
     from py4j.java_collections import JavaMap  # type: ignore[import]
 
 
+__all__ = ['DeltaTable', "DeltaMergeBuilder", "DeltaTableBuilder", "DeltaOptimizeBuilder"]
+
+
 class DeltaTable(object):
     """
         Main class for programmatically interacting with Delta tables.


### PR DESCRIPTION
## Description

Adds one line to the Python module: `delta.tables` to explicitly export the defined classes.

This is required to resolve the `mypy` errors as outlined in the referenced issue.

Resolves:
- #1777

## How was this patch tested?

No tests were added.

## Does this PR introduce _any_ user-facing changes?

Yes. Resolves any `mypy` errors experienced by the user.