### PR TITLE
Dependencies between Delta Table Features

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -386,7 +386,7 @@ class DeltaLog private(
     val protocolEnabledFeatures = targetProtocol.writerFeatureNames
       .flatMap(TableFeature.featureNameToFeature)
     val activeFeatures =
-      Protocol.extractAutomaticallyEnabledFeatures(spark, targetProtocol, targetMetadata)
+      Protocol.extractAutomaticallyEnabledFeatures(spark, targetMetadata, Some(targetProtocol))
     val activeButNotEnabled = activeFeatures.diff(protocolEnabledFeatures)
     if (activeButNotEnabled.nonEmpty) {
       throw DeltaErrors.tableFeatureMismatchException(activeButNotEnabled.map(_.name))

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -385,12 +385,7 @@ class DeltaLog private(
 
     val protocolEnabledFeatures = targetProtocol.writerFeatureNames
       .flatMap(TableFeature.featureNameToFeature)
-    val activeFeatures: Set[TableFeature] =
-      TableFeature.allSupportedFeaturesMap.values.collect {
-        case f: TableFeature with FeatureAutomaticallyEnabledByMetadata
-            if f.metadataRequiresFeatureToBeEnabled(targetMetadata, spark) =>
-          f
-      }.toSet
+    val activeFeatures = Protocol.extractRequiredFeatures(spark, targetProtocol, targetMetadata)
     val activeButNotEnabled = activeFeatures.diff(protocolEnabledFeatures)
     if (activeButNotEnabled.nonEmpty) {
       throw DeltaErrors.tableFeatureMismatchException(activeButNotEnabled.map(_.name))

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -385,7 +385,7 @@ class DeltaLog private(
 
     val protocolEnabledFeatures = targetProtocol.writerFeatureNames
       .flatMap(TableFeature.featureNameToFeature)
-    val activeFeatures = Protocol.extractRequiredFeatures(spark, targetProtocol, targetMetadata)
+    val activeFeatures = Protocol.extractAutomaticallyEnabledFeatures(spark, targetProtocol, targetMetadata)
     val activeButNotEnabled = activeFeatures.diff(protocolEnabledFeatures)
     if (activeButNotEnabled.nonEmpty) {
       throw DeltaErrors.tableFeatureMismatchException(activeButNotEnabled.map(_.name))

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -385,7 +385,8 @@ class DeltaLog private(
 
     val protocolEnabledFeatures = targetProtocol.writerFeatureNames
       .flatMap(TableFeature.featureNameToFeature)
-    val activeFeatures = Protocol.extractAutomaticallyEnabledFeatures(spark, targetProtocol, targetMetadata)
+    val activeFeatures =
+      Protocol.extractAutomaticallyEnabledFeatures(spark, targetProtocol, targetMetadata)
     val activeButNotEnabled = activeFeatures.diff(protocolEnabledFeatures)
     if (activeButNotEnabled.nonEmpty) {
       throw DeltaErrors.tableFeatureMismatchException(activeButNotEnabled.map(_.name))

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -84,7 +84,8 @@ trait TableFeatureSupport { this: Protocol =>
       shouldAddToWriterFeatures = shouldAddWrite
     }
 
-    withFeature(
+    val protocolWithDependencies = withFeatures(feature.requiredFeatures)
+    protocolWithDependencies.withFeature(
       feature.name,
       addToReaderFeatures = shouldAddToReaderFeatures,
       addToWriterFeatures = shouldAddToWriterFeatures)

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -255,8 +255,10 @@ object Protocol {
    */
   def extractAutomaticallyEnabledFeatures(
       spark: SparkSession, metadata: Metadata, protocol: Option[Protocol]): Set[TableFeature] = {
-    val protocolEnabledFeatures =
-      protocol.flatMap(_.writerFeatureNames).toSet.flatMap(TableFeature.featureNameToFeature)
+    val protocolEnabledFeatures = protocol
+      .map(_.writerFeatureNames)
+      .getOrElse(Set.empty)
+      .flatMap(TableFeature.featureNameToFeature)
     val metadataEnabledFeatures = TableFeature
       .allSupportedFeaturesMap.values
       .collect {

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -254,7 +254,9 @@ object Protocol {
    * directly by metadata, and all of their (transitive) dependencies.
    */
   def extractAutomaticallyEnabledFeatures(
-      spark: SparkSession, metadata: Metadata, protocol: Option[Protocol]): Set[TableFeature] = {
+      spark: SparkSession,
+      metadata: Metadata,
+      protocol: Option[Protocol] = None): Set[TableFeature] = {
     val protocolEnabledFeatures = protocol
       .map(_.writerFeatureNames)
       .getOrElse(Set.empty)
@@ -293,7 +295,7 @@ object Protocol {
     // There might be features enabled by the table properties aka
     // `CREATE TABLE ... TBLPROPERTIES ...`.
     val tablePropEnabledFeatures = getSupportedFeaturesFromTableConfigs(tableConf)
-    val metaEnabledFeatures = extractAutomaticallyEnabledFeatures(spark, metadata, protocol = None)
+    val metaEnabledFeatures = extractAutomaticallyEnabledFeatures(spark, metadata)
     val allEnabledFeatures = tablePropEnabledFeatures ++ metaEnabledFeatures
 
     // Determine the min reader and writer version required by features in table properties or
@@ -355,7 +357,7 @@ object Protocol {
   def minProtocolComponentsFromAutomaticallyEnabledFeatures(
       spark: SparkSession,
       metadata: Metadata): (Int, Int, Set[TableFeature]) = {
-    val enabledFeatures = extractAutomaticallyEnabledFeatures(spark, metadata, protocol = None)
+    val enabledFeatures = extractAutomaticallyEnabledFeatures(spark)
     var (readerVersion, writerVersion) = (0, 0)
     enabledFeatures.foreach { feature =>
       readerVersion = math.max(readerVersion, feature.minReaderVersion)

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
@@ -188,7 +188,7 @@ abstract class CloneConvertedSource(spark: SparkSession) extends CloneSource {
   def protocol: Protocol = {
     // This is quirky but necessary to add table features such as column mapping if the default
     // protocol version supports table features.
-    Protocol().withFeatures(extractAutomaticallyEnabledFeatures(spark, metadata)
+    Protocol().withFeatures(extractAutomaticallyEnabledFeatures(spark, metadata))
   }
 
   override val clock: Clock = new SystemClock()

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
@@ -22,7 +22,7 @@ import java.io.FileNotFoundException
 import org.apache.spark.sql.delta.{DeltaErrors, DeltaTimeTravelSpec, Snapshot}
 import org.apache.spark.sql.delta.DeltaOperations.Clone
 import org.apache.spark.sql.delta.actions.{AddFile, Metadata, Protocol}
-import org.apache.spark.sql.delta.actions.Protocol.extractRequiredFeatures
+import org.apache.spark.sql.delta.actions.Protocol.extractAutomaticallyEnabledFeatures
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.convert.{ConvertTargetTable, ConvertUtils}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -188,7 +188,7 @@ abstract class CloneConvertedSource(spark: SparkSession) extends CloneSource {
   def protocol: Protocol = {
     // This is quirky but necessary to add table features such as column mapping if the default
     // protocol version supports table features.
-    Protocol().withFeatures(extractRequiredFeatures(spark, Protocol(), metadata))
+    Protocol().withFeatures(extractAutomaticallyEnabledFeatures(spark, Protocol(), metadata))
   }
 
   override val clock: Clock = new SystemClock()

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
@@ -188,7 +188,7 @@ abstract class CloneConvertedSource(spark: SparkSession) extends CloneSource {
   def protocol: Protocol = {
     // This is quirky but necessary to add table features such as column mapping if the default
     // protocol version supports table features.
-    Protocol().withFeatures(extractAutomaticallyEnabledFeatures(spark, Protocol(), metadata))
+    Protocol().withFeatures(extractAutomaticallyEnabledFeatures(spark, metadata, protocol = None))
   }
 
   override val clock: Clock = new SystemClock()

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
@@ -22,7 +22,7 @@ import java.io.FileNotFoundException
 import org.apache.spark.sql.delta.{DeltaErrors, DeltaTimeTravelSpec, Snapshot}
 import org.apache.spark.sql.delta.DeltaOperations.Clone
 import org.apache.spark.sql.delta.actions.{AddFile, Metadata, Protocol}
-import org.apache.spark.sql.delta.actions.Protocol.extractAutomaticallyEnabledFeatures
+import org.apache.spark.sql.delta.actions.Protocol.extractRequiredFeatures
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.convert.{ConvertTargetTable, ConvertUtils}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -188,7 +188,7 @@ abstract class CloneConvertedSource(spark: SparkSession) extends CloneSource {
   def protocol: Protocol = {
     // This is quirky but necessary to add table features such as column mapping if the default
     // protocol version supports table features.
-    Protocol().withFeatures(extractAutomaticallyEnabledFeatures(spark, metadata))
+    Protocol().withFeatures(extractRequiredFeatures(spark, Protocol(), metadata))
   }
 
   override val clock: Clock = new SystemClock()

--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
@@ -188,7 +188,7 @@ abstract class CloneConvertedSource(spark: SparkSession) extends CloneSource {
   def protocol: Protocol = {
     // This is quirky but necessary to add table features such as column mapping if the default
     // protocol version supports table features.
-    Protocol().withFeatures(extractAutomaticallyEnabledFeatures(spark, metadata, protocol = None))
+    Protocol().withFeatures(extractAutomaticallyEnabledFeatures(spark, metadata)
   }
 
   override val clock: Clock = new SystemClock()

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -1214,7 +1214,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     props = Map(
       DeltaConfigs.MIN_READER_VERSION.key -> TABLE_FEATURES_MIN_READER_VERSION.toString,
       DeltaConfigs.MIN_WRITER_VERSION.key -> TABLE_FEATURES_MIN_WRITER_VERSION.toString,
-      s"delta.feature.${TestFeatureWithDependency.name}" -> "enabled"),
+      s"delta.feature.${TestFeatureWithDependency.name}" -> "supported"),
     expectedFinalProtocol = Some(
       Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION)
         .withFeatures(Seq(TestFeatureWithDependency, TestReaderWriterFeature))))
@@ -1234,7 +1234,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     props = Map(
       DeltaConfigs.MIN_READER_VERSION.key -> TABLE_FEATURES_MIN_READER_VERSION.toString,
       DeltaConfigs.MIN_WRITER_VERSION.key -> TABLE_FEATURES_MIN_WRITER_VERSION.toString,
-      s"delta.feature.${TestFeatureWithTransitiveDependency.name}" -> "enabled"),
+      s"delta.feature.${TestFeatureWithTransitiveDependency.name}" -> "supported"),
     expectedFinalProtocol = Some(
       Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION)
         .withFeatures(Seq(
@@ -1430,7 +1430,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
   testAlterTable(
     name = "feature with a dependency",
     tableProtocol = Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION),
-    props = Map(s"delta.feature.${TestFeatureWithDependency.name}" -> "enabled"),
+    props = Map(s"delta.feature.${TestFeatureWithDependency.name}" -> "supported"),
     expectedFinalProtocol = Some(
       Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION)
         .withFeatures(Seq(TestFeatureWithDependency, TestReaderWriterFeature))))
@@ -1446,7 +1446,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
   testAlterTable(
     name = "feature with a dependency that has a dependency",
     tableProtocol = Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION),
-    props = Map(s"delta.feature.${TestFeatureWithTransitiveDependency.name}" -> "enabled"),
+    props = Map(s"delta.feature.${TestFeatureWithTransitiveDependency.name}" -> "supported"),
     expectedFinalProtocol = Some(
       Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION)
         .withFeatures(Seq(

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -1209,6 +1209,39 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION)
         .withFeature(TestReaderWriterMetadataNoAutoUpdateFeature)))
 
+  testCreateTable(
+    name = "feature with a dependency",
+    props = Map(
+      DeltaConfigs.MIN_READER_VERSION.key -> TABLE_FEATURES_MIN_READER_VERSION.toString,
+      DeltaConfigs.MIN_WRITER_VERSION.key -> TABLE_FEATURES_MIN_WRITER_VERSION.toString,
+      s"delta.feature.${TestFeatureWithDependency.name}" -> "enabled"),
+    expectedFinalProtocol = Some(
+      Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION)
+        .withFeatures(Seq(TestFeatureWithDependency, TestReaderWriterFeature))))
+
+  testCreateTable(
+    name = "feature with a dependency, enabled using a feature property",
+    props = Map(
+      DeltaConfigs.MIN_READER_VERSION.key -> TABLE_FEATURES_MIN_READER_VERSION.toString,
+      DeltaConfigs.MIN_WRITER_VERSION.key -> TABLE_FEATURES_MIN_WRITER_VERSION.toString,
+      TestFeatureWithDependency.TABLE_PROP_KEY -> "true"),
+    expectedFinalProtocol = Some(
+      Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION)
+        .withFeatures(Seq(TestFeatureWithDependency, TestReaderWriterFeature))))
+
+  testCreateTable(
+    name = "feature with a dependency that has a dependency",
+    props = Map(
+      DeltaConfigs.MIN_READER_VERSION.key -> TABLE_FEATURES_MIN_READER_VERSION.toString,
+      DeltaConfigs.MIN_WRITER_VERSION.key -> TABLE_FEATURES_MIN_WRITER_VERSION.toString,
+      s"delta.feature.${TestFeatureWithTransitiveDependency.name}" -> "enabled"),
+    expectedFinalProtocol = Some(
+      Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION)
+        .withFeatures(Seq(
+          TestFeatureWithTransitiveDependency,
+          TestFeatureWithDependency,
+          TestReaderWriterFeature))))
+
   def testAlterTable(
       name: String,
       props: Map[String, String],
@@ -1393,6 +1426,33 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION)
         .withFeature(TestReaderWriterMetadataAutoUpdateFeature).merge(Protocol(1, 2))),
     tableProtocol = Protocol(1, 2))
+
+  testAlterTable(
+    name = "feature with a dependency",
+    tableProtocol = Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION),
+    props = Map(s"delta.feature.${TestFeatureWithDependency.name}" -> "enabled"),
+    expectedFinalProtocol = Some(
+      Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION)
+        .withFeatures(Seq(TestFeatureWithDependency, TestReaderWriterFeature))))
+
+  testAlterTable(
+    name = "feature with a dependency, enabled using a feature property",
+    tableProtocol = Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION),
+    props = Map(TestFeatureWithDependency.TABLE_PROP_KEY -> "true"),
+    expectedFinalProtocol = Some(
+      Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION)
+        .withFeatures(Seq(TestFeatureWithDependency, TestReaderWriterFeature))))
+
+  testAlterTable(
+    name = "feature with a dependency that has a dependency",
+    tableProtocol = Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION),
+    props = Map(s"delta.feature.${TestFeatureWithTransitiveDependency.name}" -> "enabled"),
+    expectedFinalProtocol = Some(
+      Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION)
+        .withFeatures(Seq(
+          TestFeatureWithTransitiveDependency,
+          TestFeatureWithDependency,
+          TestReaderWriterFeature))))
 
   test("non-auto-update capable feature requires manual enablement (via feature prop)") {
     withTempDir { dir =>

--- a/core/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
@@ -101,6 +101,23 @@ class DeltaTableFeatureSuite
         .readerAndWriterFeatureNames === Set(TestReaderWriterFeature.name))
   }
 
+  test("adding feature automatically adds all dependencies") {
+    assert(
+      Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION)
+        .withFeature(TestFeatureWithDependency)
+        .readerAndWriterFeatureNames ===
+        Set(TestFeatureWithDependency.name, TestReaderWriterFeature.name))
+
+    assert(
+      Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION)
+        .withFeature(TestFeatureWithTransitiveDependency)
+        .readerAndWriterFeatureNames ===
+        Set(
+          TestFeatureWithTransitiveDependency.name,
+          TestFeatureWithDependency.name,
+          TestReaderWriterFeature.name))
+  }
+
   test("implicitly-enabled features") {
     assert(
       Protocol(2, 6).implicitlySupportedFeatures === Set(


### PR DESCRIPTION
## Description

This PR adds the ability to specify dependencies between Delta table features. When enabling a table feature all dependent table features will automatically be enabled as well. This will be used by Row Tracking to add a dependency on the Domain Metadata feature (which will be used to store the high water mark).

## How was this patch tested?

Added tests to `DeltaTableFeatureSuite` and `DeltaProtocolVersionSuite`.

## Does this PR introduce _any_ user-facing changes?

No
