### PR TITLE
Fix TimestampNTZ section location

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -36,7 +36,6 @@
   - [Writer Requirements for Column Mapping](#writer-requirements-for-column-mapping)
   - [Reader Requirements for Column Mapping](#reader-requirements-for-column-mapping)
 - [Deletion Vectors](#deletion-vectors)
-- [Timestamp without timezone (TimestampNTZ)](#timestamp-without-timezone-timestampntz)
   - [Deletion Vector Descriptor Schema](#deletion-vector-descriptor-schema)
     - [Derived Fields](#derived-fields)
     - [JSON Example 1 — On Disk with Relative Path (with Random Prefix)](#json-example-1--on-disk-with-relative-path-with-random-prefix)
@@ -44,6 +43,7 @@
     - [JSON Example 3 — Inline](#json-example-3--inline)
   - [Reader Requirements for Deletion Vectors](#reader-requirements-for-deletion-vectors)
   - [Writer Requirement for Deletion Vectors](#writer-requirement-for-deletion-vectors)
+- [Timestamp without timezone (TimestampNTZ)](#timestamp-without-timezone-timestampntz)
 - [Row Tracking](#row-tracking)
   - [Row IDs](#row-ids)
   - [Row Commit Versions](#row-commit-versions)
@@ -727,14 +727,6 @@ When enabled:
 
 DVs can be stored and accessed in different ways, indicated by the `storageType` field. The Delta protocol currently supports inline or on-disk storage, where the latter can be accessed either by a relative path derived from a UUID or an absolute path.
 
-# Timestamp without timezone (TimestampNTZ)
-This feature introduces a new data type to support timestamps without timezone information. For example: `1970-01-01 00:00:00`, or `1970-01-01 00:00:00.123456`.
-The serialization method is described in Sections [Partition Value Serialization](#partition-value-serialization) and [Schema Serialization Format](#schema-serialization-format).
-
-Enablement:
- - To have a column of TimestampNTZ type in a table, the table must have Reader Version 3 and Writer Version 7. A feature name `timestampNTZ` must exist in the table's `readerFeatures` and `writerFeatures`.
-
-
 ## Deletion Vector Descriptor Schema
 
 The schema of the `DeletionVectorDescriptor` struct is as follows:
@@ -797,6 +789,13 @@ If a snapshot contains logical files with records that are invalidated by a DV, 
 
 ## Writer Requirement for Deletion Vectors
 When adding a logical file with a deletion vector, then that logical file must have correct `numRecords` information for the data file in the `stats` field.
+
+# Timestamp without timezone (TimestampNTZ)
+This feature introduces a new data type to support timestamps without timezone information. For example: `1970-01-01 00:00:00`, or `1970-01-01 00:00:00.123456`.
+The serialization method is described in Sections [Partition Value Serialization](#partition-value-serialization) and [Schema Serialization Format](#schema-serialization-format).
+
+Enablement:
+ - To have a column of TimestampNTZ type in a table, the table must have Reader Version 3 and Writer Version 7. A feature name `timestampNTZ` must exist in the table's `readerFeatures` and `writerFeatures`.
 
 # Row Tracking
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

The TimestampNTZ section in the protocol somehow ended up within the DV section. I moved it to after the end of the DV section instead.

## How was this patch tested?

n/a

## Does this PR introduce _any_ user-facing changes?

No
