### PR TITLE
Correct the two-stage parsing strategy of antlr parser

### DIFF
--- a/spark/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
+++ b/spark/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
@@ -89,10 +89,10 @@ statement
     | ALTER TABLE table=qualifiedName
         DROP FEATURE featureName=featureNameValue (TRUNCATE HISTORY)?   #alterTableDropFeature
     | OPTIMIZE (path=STRING | table=qualifiedName)
-        (WHERE partitionPredicate=predicateToken)?
+        (WHERE partitionPredicate=exprToken)?
         (zorderSpec)?                                                   #optimizeTable
     | REORG TABLE table=qualifiedName
-        (WHERE partitionPredicate=predicateToken)?
+        (WHERE partitionPredicate=exprToken)?
         APPLY LEFT_PAREN PURGE RIGHT_PAREN                              #reorgTable
     | cloneTableHeader SHALLOW CLONE source=qualifiedName clause=temporalClause?
        (TBLPROPERTIES tableProps=propertyList)?
@@ -196,13 +196,6 @@ number
 
 constraint
     : CHECK '(' exprToken+ ')'                                 #checkConstraint
-    ;
-
-// We don't have an expression rule in our grammar here, so we just grab the tokens and defer
-// parsing them to later. Although this is the same as `exprToken`, we have to re-define it to
-// workaround an ANTLR issue (https://github.com/delta-io/delta/issues/1205)
-predicateToken
-    :  .+?
     ;
 
 // We don't have an expression rule in our grammar here, so we just grab the tokens and defer

--- a/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
+++ b/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
@@ -106,18 +106,22 @@ class DeltaSqlParser(val delegate: ParserInterface) extends ParserInterface {
     parser.removeErrorListeners()
     parser.addErrorListener(ParseErrorListener)
 
+    // https://github.com/antlr/antlr4/issues/192#issuecomment-15238595
+    // Save a great deal of time on correct inputs by using a two-stage parsing strategy.
     try {
       try {
-        // first, try parsing with potentially faster SLL mode
+        // first, try parsing with potentially faster SLL mode and BailErrorStrategy
+        parser.setErrorHandler(new BailErrorStrategy)
         parser.getInterpreter.setPredictionMode(PredictionMode.SLL)
         toResult(parser)
       } catch {
         case e: ParseCancellationException =>
-          // if we fail, parse with LL mode
+          // if we fail, parse with LL mode with DefaultErrorStrategy
           tokenStream.seek(0) // rewind input stream
           parser.reset()
 
           // Try Again.
+          parser.setErrorHandler(new DefaultErrorStrategy)
           parser.getInterpreter.setPredictionMode(PredictionMode.LL)
           toResult(parser)
       }
@@ -469,7 +473,7 @@ class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
     tokens.map(_.getText).mkString(" ")
   }
 
-  private def extractRawText(exprContext: ParserRuleContext): String = {
+  private def extractRawText(exprContext: ExprTokenContext): String = {
     // Extract the raw expression which will be parsed later
     exprContext.getStart.getInputStream.getText(new Interval(
       exprContext.getStart.getStartIndex,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

to fix #1205 and revert the changes in #1206


As mentioned in https://github.com/antlr/antlr4/issues/192#issuecomment-15238595

> You can save a great deal of time on correct inputs by using a two-stage parsing strategy.
>
> 1. Attempt to parse the input using `BailErrorStrategy` and `PredictionMode.SLL`. If no exception is thrown, you know the answer is correct.
> 2. If a `ParseCancellationException` is thrown, retry the parse using the default settings (`DefaultErrorStrategy` and `PredictionMode.LL`).


Delta's antlr parser code is derived from Spark, and Spark's one is derived from Presto, the original implementation in Presto is wrong.

It was identified on Spark and got fixed in SPARK-42552 apache/spark#40835



## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

existing UT

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No