### PR TITLE
support write all data files to "data" subdir with sql conf

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
@@ -61,8 +61,13 @@ trait TransactionalWrite extends DeltaLogging { self: OptimisticTransactionImpl 
 
   protected var hasWritten = false
 
+  private[delta] val deltaDataSubdir =
+    if (spark.sessionState.conf.getConf(DeltaSQLConf.WRITE_DATA_FILES_TO_SUBDIR)) {
+      Some("data")
+    } else None
+
   protected def getCommitter(outputPath: Path): DelayedCommitProtocol =
-    new DelayedCommitProtocol("delta", outputPath.toString, None)
+    new DelayedCommitProtocol("delta", outputPath.toString, None, deltaDataSubdir)
 
   /** Makes the output attributes nullable, so that we don't write unreadable parquet files. */
   protected def makeOutputNullable(output: Seq[Attribute]): Seq[Attribute] = {

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1202,6 +1202,12 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(false)
 
+  val WRITE_DATA_FILES_TO_SUBDIR = buildConf("write.dataFilesToSubdir")
+    .internal()
+    .doc("Delta will write all data files to subdir 'data/' under table dir if enabled")
+    .booleanConf
+    .createWithDefault(false)
+
   val DELETION_VECTORS_COMMIT_CHECK_ENABLED =
     buildConf("deletionVectors.skipCommitCheck")
       .internal()

--- a/core/src/main/scala/org/apache/spark/sql/delta/util/PartitionUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/util/PartitionUtils.scala
@@ -390,7 +390,7 @@ private[delta] object PartitionUtils {
    * `Seq(("fieldOne", "1"), ("fieldTwo", "2"))`.
    */
   def parsePathFragmentAsSeq(pathFragment: String): Seq[(String, String)] = {
-    pathFragment.split("/").map { kv =>
+    pathFragment.stripPrefix("data/").split("/").map { kv =>
       val pair = kv.split("=", 2)
       (unescapePathName(pair(0)), unescapePathName(pair(1)))
     }

--- a/core/src/test/scala/org/apache/spark/sql/delta/cdc/CDCReaderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/cdc/CDCReaderSuite.scala
@@ -75,7 +75,7 @@ class CDCReaderSuite
       }
 
       SQLExecution.withNewExecutionId(qe) {
-        var committer = new DelayedCommitProtocol("delta", basePath, randomPrefixes)
+        var committer = new DelayedCommitProtocol("delta", basePath, randomPrefixes, None)
         FileFormatWriter.write(
           sparkSession = spark,
           plan = qe.executedPlan,

--- a/core/src/test/scala/org/apache/spark/sql/delta/files/TransactionalWriteSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/files/TransactionalWriteSuite.scala
@@ -17,9 +17,11 @@
 package org.apache.spark.sql.delta.files
 
 import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.functions.column
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StringType, StructType}
 
@@ -33,6 +35,38 @@ class TransactionalWriteSuite extends QueryTest with SharedSparkSession with Del
       val schema = new StructType().add("id", StringType)
       val emptyDf = spark.createDataFrame(spark.sparkContext.emptyRDD[Row], schema)
       assert(log.startTransaction().writeFiles(emptyDf).isEmpty)
+    }
+  }
+
+  test("write data files to the data subdir") {
+    withSQLConf(DeltaSQLConf.WRITE_DATA_FILES_TO_SUBDIR.key -> "true") {
+      def validateDataSubdir(tablePath: String): Unit = {
+        val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, tablePath)
+        snapshot.allFiles.collect().foreach { f =>
+          assert(f.path.startsWith("data/"))
+        }
+      }
+
+      withTempDir { dir =>
+        spark.range(100).toDF("id").write.format("delta").save(dir.getCanonicalPath)
+        validateDataSubdir(dir.getCanonicalPath)
+      }
+
+      withTempDir { dir =>
+        spark.range(100).toDF("id").withColumn("id1", column("id")).write.format("delta")
+          .partitionBy("id").save(dir.getCanonicalPath)
+        validateDataSubdir(dir.getCanonicalPath)
+      }
+    }
+
+    withSQLConf(DeltaSQLConf.WRITE_DATA_FILES_TO_SUBDIR.key -> "false") {
+      withTempDir { dir =>
+        spark.range(100).toDF("id").write.format("delta").save(dir.getCanonicalPath)
+        val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, dir.getCanonicalPath)
+        snapshot.allFiles.collect().foreach { f =>
+          assert(!f.path.startsWith("data/"))
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

Add the support to write parquet data files to data/ subdir for Delta table via sql conf.

## How was this patch tested?

unit test