### PR TITLE
Use DomainMetadata to store Row ID High Water Mark

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
@@ -54,7 +54,6 @@ case class VersionChecksum(
     numMetadata: Long,
     numProtocol: Long,
     setTransactions: Option[Seq[SetTransaction]],
-    rowIdHighWaterMark: Option[RowIdHighWaterMark] = None,
     domainMetadata: Option[Seq[DomainMetadata]],
     metadata: Metadata,
     protocol: Protocol,

--- a/core/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -327,7 +327,6 @@ class Snapshot(
     numMetadata = numOfMetadata,
     numProtocol = numOfProtocol,
     setTransactions = checksumOpt.flatMap(_.setTransactions),
-    rowIdHighWaterMark = rowIdHighWaterMarkOpt,
     domainMetadata = checksumOpt.flatMap(_.domainMetadata),
     metadata = metadata,
     protocol = protocol,

--- a/core/src/main/scala/org/apache/spark/sql/delta/SnapshotState.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/SnapshotState.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.delta
 
 // scalastyle:off import.ordering.noEmptyLine
-import org.apache.spark.sql.delta.actions.{Metadata, Protocol, RowIdHighWaterMark, SetTransaction}
+import org.apache.spark.sql.delta.actions.{Metadata, Protocol, SetTransaction}
 import org.apache.spark.sql.delta.actions.DomainMetadata
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -52,7 +52,6 @@ case class SnapshotState(
   numOfMetadata: Long,
   numOfProtocol: Long,
   setTransactions: Seq[SetTransaction],
-  rowIdHighWaterMark: RowIdHighWaterMark,
   domainMetadata: Seq[DomainMetadata],
   metadata: Metadata,
   protocol: Protocol,
@@ -146,7 +145,6 @@ trait SnapshotStateManager extends DeltaLogging { self: Snapshot =>
       "numOfMetadata" -> count(col("metaData")),
       "numOfProtocol" -> count(col("protocol")),
       "setTransactions" -> collect_set(col("txn")),
-      "rowIdHighWaterMark" -> last(col("rowIdHighWaterMark"), ignoreNulls = true),
       "domainMetadata" -> collect_list(col("domainMetadata")),
       "metadata" -> last(col("metaData"), ignoreNulls = true),
       "protocol" -> last(col("protocol"), ignoreNulls = true),
@@ -169,8 +167,6 @@ trait SnapshotStateManager extends DeltaLogging { self: Snapshot =>
   protected[delta] def sizeInBytesIfKnown: Option[Long] = Some(sizeInBytes)
   protected[delta] def setTransactionsIfKnown: Option[Seq[SetTransaction]] = Some(setTransactions)
   protected[delta] def numOfFilesIfKnown: Option[Long] = Some(numOfFiles)
-  protected[delta] def rowIdHighWaterMarkOpt: Option[RowIdHighWaterMark] =
-    Option(computedState.rowIdHighWaterMark)
   protected[delta] def domainMetadatasIfKnown: Option[Seq[DomainMetadata]] = Some(domainMetadata)
 
   /** Generate a default SnapshotState of a new table, given the table metadata */
@@ -185,7 +181,6 @@ trait SnapshotStateManager extends DeltaLogging { self: Snapshot =>
       numOfMetadata = 1L,
       numOfProtocol = 1L,
       setTransactions = Nil,
-      rowIdHighWaterMark = null,
       domainMetadata = Nil,
       metadata = metadata,
       protocol = protocol

--- a/core/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -344,6 +344,8 @@ object RowTrackingFeature extends WriterFeature(name = "rowTracking")
   override def metadataRequiresFeatureToBeEnabled(
       metadata: Metadata,
       spark: SparkSession): Boolean = DeltaConfigs.ROW_TRACKING_ENABLED.fromMetaData(metadata)
+
+  override def requiredFeatures: Set[TableFeature] = Set(DomainMetadataTableFeature)
 }
 
 object DomainMetadataTableFeature extends WriterFeature(name = "domainMetadata")

--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -540,13 +540,6 @@ case class SetTransaction(
 }
 
 /**
- * Stores the highest (inclusive) ID that has been assigned to a row in during history of the table.
- */
-case class RowIdHighWaterMark(highWaterMark: Long) extends Action {
-  override def wrap: SingleAction = SingleAction(rowIdHighWaterMark = this)
-}
-
-/**
  * The domain metadata action contains a configuration (string-string map) for a named metadata
  * domain. Two overlapping transactions conflict if they both contain a domain metadata action for
  * the same metadata domain.
@@ -1165,7 +1158,6 @@ case class SingleAction(
     metaData: Metadata = null,
     protocol: Protocol = null,
     cdc: AddCDCFile = null,
-    rowIdHighWaterMark: RowIdHighWaterMark = null,
     domainMetadata: DomainMetadata = null,
     commitInfo: CommitInfo = null) {
 
@@ -1182,8 +1174,6 @@ case class SingleAction(
       protocol
     } else if (cdc != null) {
       cdc
-    } else if (rowIdHighWaterMark != null) {
-      rowIdHighWaterMark
     } else if (domainMetadata != null) {
       domainMetadata
     } else if (commitInfo != null) {

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceCDCSupport.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceCDCSupport.scala
@@ -16,10 +16,9 @@
 
 package org.apache.spark.sql.delta.sources
 
-import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, AddFile, CommitInfo, FileAction, Metadata, Protocol, RemoveFile, RowIdHighWaterMark, SetTransaction}
+import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.actions.DomainMetadata
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
-import org.apache.spark.sql.delta.storage.ClosableIterator._
 
 import org.apache.spark.sql.DataFrame
 
@@ -333,7 +332,7 @@ trait DeltaSourceCDCSupport { self: DeltaSource =>
         case commitInfo: CommitInfo =>
           shouldSkipIndexedFile = CDCReader.shouldSkipFileActionsInCommit(commitInfo)
           false
-        case _: AddCDCFile | _: RowIdHighWaterMark | _: SetTransaction | _: DomainMetadata =>
+        case _: AddCDCFile | _: SetTransaction | _: DomainMetadata =>
           false
         case null => // Some crazy future feature. Ignore
           false

--- a/core/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
@@ -57,7 +57,7 @@ class CheckpointsSuite extends QueryTest
       assert(lastCheckpointOpt.nonEmpty)
       assert(lastCheckpointOpt.get.checkpointSchema.nonEmpty)
       val expectedCheckpointSchema =
-        Seq("txn", "add", "remove", "metaData", "protocol", "rowIdHighWaterMark", "domainMetadata")
+        Seq("txn", "add", "remove", "metaData", "protocol", "domainMetadata")
       assert(lastCheckpointOpt.get.checkpointSchema.get.fieldNames.toSeq ===
         expectedCheckpointSchema)
 
@@ -215,7 +215,6 @@ class CheckpointsSuite extends QueryTest
               "remove",
               "metaData",
               "protocol",
-              "rowIdHighWaterMark",
               "domainMetadata")
           assert(checkpointSchema.fieldNames.toSeq == expectedCheckpointSchema)
         }

--- a/core/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdSuite.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta.rowid
 
 import org.apache.spark.sql.delta.{DeltaConfigs, DeltaIllegalStateException, DeltaLog, RowId}
 import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
-import org.apache.spark.sql.delta.actions.RowIdHighWaterMark
+import org.apache.spark.sql.delta.RowId.RowIdHighWaterMark
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.FileNames
@@ -174,7 +174,7 @@ class RowIdSuite extends QueryTest
           .write.mode("append").format("delta").save(dir.getAbsolutePath)
         assertHighWatermarkIsCorrectAfterUpdate(
           log,
-          highWatermarkBeforeUpdate = highWatermarkAfterRestore.get.highWaterMark,
+          highWatermarkBeforeUpdate = highWatermarkAfterRestore.get,
           expectedNumRecordsWritten = 10)
         assertRowIdsDoNotOverlap(log)
         val highWatermarkWithNewData = RowId.extractHighWatermark(log.update())

--- a/core/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.delta.rowtracking
 
-import org.apache.spark.sql.delta.{DeltaLog, DeltaOperations, RowTrackingFeature}
+import org.apache.spark.sql.delta.{DeltaLog, DeltaOperations, RowId, RowTrackingFeature}
 import org.apache.spark.sql.delta.actions.{Action, AddFile}
 import org.apache.spark.sql.delta.rowid.RowIdTestUtils
 

--- a/core/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.delta.rowtracking
 
 import org.apache.spark.sql.delta.{DeltaLog, DeltaOperations, RowTrackingFeature}
-import org.apache.spark.sql.delta.actions.{Action, AddFile, RowIdHighWaterMark}
+import org.apache.spark.sql.delta.actions.{Action, AddFile}
 import org.apache.spark.sql.delta.rowid.RowIdTestUtils
 
 import org.apache.spark.sql.QueryTest
@@ -125,7 +125,7 @@ class RowTrackingConflictResolutionSuite extends QueryTest
       val committedAddFile = latestSnapshot.allFiles.collect().filter(_.path == filePath)
       assert(committedAddFile.size === 1)
       assert(committedAddFile.head.baseRowId === Some(numInitialRecords + numConcurrentRecords))
-      val currentHighWaterMark = latestSnapshot.rowIdHighWaterMarkOpt.get.highWaterMark
+      val currentHighWaterMark = RowId.extractHighWatermark(latestSnapshot).get
       assert(currentHighWaterMark === numInitialRecords + numConcurrentRecords)
     }
   }


### PR DESCRIPTION
## Description

This PR removes the RowIdHighWaterMark action by using the DomainMetadata action instead. This allows us to get rid of the special `DomainMetadata`, which simplifies and speeds up log replay. As part of doing this it adds a dependency between the row tracking and domain metadata table features.

## How was this patch tested?

Existing tests to make sure nothing breaks.

## Does this PR introduce _any_ user-facing changes?

No
