### PR TITLE
Fix protocol check in DeltaColumnMapping.verifyAndUpdateMetadataChange

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -27,9 +27,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore
  * Trait to be mixed into the [[Protocol]] case class to enable Table Features.
  *
  * Protocol reader version 3 and writer version 7 start to support reader and writer table
- * features. In such a case, features can be <b>explicitly supported</b> by a protocol's reader
- * and/or writer features sets by adding its name. When read or write a table, clients MUST
- * respect all supported features.
+ * features. Reader version 3 supports only reader-writer features in an <b>explicit</b> way,
+ * by adding its name to `readerFeatures`. Similarly, writer version 7 supports only writer-only
+ * or reader-writer features in an <b>explicit</b> way, by adding its name to `writerFeatures`.
+ * When reading or writing a table, clients MUST respect all supported features.
  *
  * See also the document of [[TableFeature]] for feature-specific terminologies.
  */


### PR DESCRIPTION
## Description

This PR patches the check in DeltaColumnMapping.verifyAndUpdateMetadataChange. Table protocols should not need to support both reader table features and writer table features for it to support Column Mapping.

For example, if a table has protocol version minReaderVersion=2 and minWriterVersion=7, it should be able to upgrade to column mapping. Right now, the system asks the user to upgrade to minReaderVersion=3, which is unnecessary.

## How was this patch tested?

New test.

## Does this PR introduce _any_ user-facing changes?

No
