### PR TITLE
Make checkpointProvider in LogSegment non-optional

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -314,7 +314,7 @@ trait Checkpoints extends DeltaLogging {
    * Finds the first verified, complete checkpoint before the given [[CheckpointInstance]].
    * If `checkpointInstance` is passed as None, then we return the last complete checkpoint in the
    * deltalog directory.
-   * @param cv The checkpoint instance to compare against
+   * @param checkpointInstance The checkpoint instance to compare against
    */
   protected def findLastCompleteCheckpointBefore(
       checkpointInstance: Option[CheckpointInstance] = None): Option[CheckpointInstance] = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -115,9 +115,7 @@ class Snapshot(
   }
 
   protected lazy val fileIndices: Seq[DeltaLogFileIndex] = {
-    val checkpointFileIndexes = getCheckpointProviderOpt
-      .map(_.allActionsFileIndexes())
-      .getOrElse(Nil)
+    val checkpointFileIndexes = getCheckpointProvider.allActionsFileIndexes()
     checkpointFileIndexes ++ deltaFileIndexOpt.toSeq
   }
 
@@ -192,8 +190,7 @@ class Snapshot(
 
   def deltaFileSizeInBytes(): Long = deltaFileIndexOpt.map(_.sizeInBytes).getOrElse(0L)
 
-  def checkpointSizeInBytes(): Long =
-    getCheckpointProviderOpt.map(_.effectiveCheckpointSizeInBytes()).getOrElse(0L)
+  def checkpointSizeInBytes(): Long = getCheckpointProvider.effectiveCheckpointSizeInBytes()
 
   override def metadata: Metadata = _metadata
 
@@ -368,8 +365,7 @@ class Snapshot(
    * Returns the [[CheckpointProvider]] for the underlying checkpoint.
    * Returns None if the Snapshot isn't backed by a checkpoint.
    */
-  def getCheckpointProviderOpt: Option[CheckpointProvider] =
-    logSegment.checkpointProviderOpt
+  def getCheckpointProvider: CheckpointProvider = logSegment.checkpointProvider
 
   def redactedPath: String =
     Utils.redact(spark.sessionState.conf.stringRedactionPattern, path.toUri.toString)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/CheckpointHook.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/CheckpointHook.scala
@@ -36,10 +36,9 @@ object CheckpointHook extends PostCommitHook {
     txn.deltaLog.ensureLogDirectoryExist()
 
     // Since the postCommitSnapshot isn't guaranteed to match committedVersion, we have to
-    // explicitly checkpoint the snapshot at the committedVersion. However, we can speed that
-    // up by providing the postCommitSnapshot's checkpoint as a hint.
-    val checkpointHint =
-      postCommitSnapshot.logSegment.checkpointProviderOpt.map(p => CheckpointInstance(p.version))
-    txn.deltaLog.checkpoint(txn.deltaLog.getSnapshotAt(committedVersion, checkpointHint))
+    // explicitly checkpoint the snapshot at the committedVersion.
+    val cp = postCommitSnapshot.logSegment.checkpointProvider
+    txn.deltaLog.checkpoint(txn.deltaLog.getSnapshotAt(committedVersion, cp)
+    )
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
@@ -151,9 +151,8 @@ class DeltaRetentionSuite extends QueryTest
   }
 
   def removeFileCountFromUnderlyingCheckpoint(snapshot: Snapshot): Long = {
-    val df = snapshot.logSegment.checkpointProviderOpt
-      .map(_.allActionsFileIndexes())
-      .getOrElse(Seq.empty)
+    val df = snapshot.logSegment.checkpointProvider
+      .allActionsFileIndexes()
       .map(snapshot.deltaLog.loadIndex(_))
       .reduce(_.union(_))
     df.where("remove is not null").count()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DomainMetadataSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DomainMetadataSuite.scala
@@ -71,7 +71,7 @@ class DomainMetadataSuite
           DomainMetadata("testDomain2", Map("key1" -> "value1"), false) :: Nil
         deltaLog.startTransaction().commit(domainMetadata, Truncate())
         assertEquals(sortByDomain(domainMetadata), sortByDomain(deltaLog.update().domainMetadata))
-        assert(deltaLog.update().logSegment.checkpointProviderOpt.isEmpty)
+        assert(deltaLog.update().logSegment.checkpointProvider.version === -1)
 
         if (doCheckpoint) {
           deltaLog.checkpoint(deltaLog.unsafeVolatileSnapshot)
@@ -79,7 +79,7 @@ class DomainMetadataSuite
           // the Snapshot from the checkpoint file.
           DeltaLog.clearCache()
           deltaLog = DeltaLog.forTable(spark, TableIdentifier(table))
-          assert(deltaLog.unsafeVolatileSnapshot.logSegment.checkpointProviderOpt.nonEmpty)
+          assert(!deltaLog.unsafeVolatileSnapshot.logSegment.checkpointProvider.isEmpty)
 
           assertEquals(
             sortByDomain(domainMetadata),
@@ -114,7 +114,7 @@ class DomainMetadataSuite
 
         deltaLog.startTransaction().commit(domainMetadata, Truncate())
         assertEquals(sortByDomain(domainMetadata), sortByDomain(deltaLog.update().domainMetadata))
-        assert(deltaLog.unsafeVolatileSnapshot.logSegment.checkpointProviderOpt.isEmpty)
+        assert(deltaLog.update().logSegment.checkpointProvider.version === -1)
 
         // Delete testDomain1.
         deltaLog.startTransaction().commit(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -425,7 +425,7 @@ class OptimisticTransactionSuite
       assert(testTxn.preCommitLogSegment.version == 1)
       assert(testTxn.preCommitLogSegment.lastCommitTimestamp < testTxnStartTs)
       assert(testTxn.preCommitLogSegment.deltas.size == 2)
-      assert(testTxn.preCommitLogSegment.checkpointVersionOpt == None)
+      assert(testTxn.preCommitLogSegment.checkpointProvider.isEmpty)
 
       testTxn.commit(Seq.empty, ManualUpdate)
 
@@ -433,7 +433,7 @@ class OptimisticTransactionSuite
       assert(testTxn.preCommitLogSegment.version == 12)
       assert(testTxn.preCommitLogSegment.lastCommitTimestamp < testTxnEndTs)
       assert(testTxn.preCommitLogSegment.deltas.size == 2)
-      assert(testTxn.preCommitLogSegment.checkpointVersionOpt == Some(10))
+      assert(testTxn.preCommitLogSegment.checkpointProvider.version == 10)
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
@@ -97,8 +97,7 @@ class SnapshotManagementSuite extends QueryTest with SQLTestUtils with SharedSpa
 
       DeltaLog.clearCache()
       deltaLog = DeltaLog.forTable(spark, path)
-      val checkpointParts =
-        deltaLog.snapshot.logSegment.checkpointProviderOpt.get.files.size
+      val checkpointParts = deltaLog.snapshot.logSegment.checkpointProvider.files.size
       val multipart = partToCorrupt.map((_, checkpointParts))
 
       // We have different code paths for empty and non-empty checkpoints
@@ -127,8 +126,7 @@ class SnapshotManagementSuite extends QueryTest with SQLTestUtils with SharedSpa
 
       DeltaLog.clearCache()
       deltaLog = DeltaLog.forTable(spark, path)
-      val checkpointParts =
-        deltaLog.snapshot.logSegment.checkpointProviderOpt.get.files.size
+      val checkpointParts = deltaLog.snapshot.logSegment.checkpointProvider.files.size
       val multipart = partToCorrupt.map((_, checkpointParts))
 
       // We have different code paths for empty and non-empty checkpoints
@@ -154,8 +152,7 @@ class SnapshotManagementSuite extends QueryTest with SQLTestUtils with SharedSpa
       DeltaLog.clearCache()
 
       val deltaLog = DeltaLog.forTable(spark, path)
-      val checkpointParts =
-        deltaLog.snapshot.logSegment.checkpointProviderOpt.get.files.size
+      val checkpointParts = deltaLog.snapshot.logSegment.checkpointProvider.files.size
       val multipart = partToCorrupt.map((_, checkpointParts))
 
       DeltaLog.clearCache()
@@ -202,8 +199,8 @@ class SnapshotManagementSuite extends QueryTest with SQLTestUtils with SharedSpa
       val deltaLog = DeltaLog.forTable(spark, path)
       deltaLog.checkpoint()
       DeltaLog.clearCache()
-      val checkpointParts0 = DeltaLog.forTable(spark, path)
-        .snapshot.logSegment.checkpointProviderOpt.get.files.size
+      val checkpointParts0 =
+        DeltaLog.forTable(spark, path).snapshot.logSegment.checkpointProvider.files.size
 
       spark.range(10).write.format("delta").mode("append").save(path)
       deltaLog.update()
@@ -211,8 +208,8 @@ class SnapshotManagementSuite extends QueryTest with SQLTestUtils with SharedSpa
       deleteLogVersion(path, version = 0)
 
       DeltaLog.clearCache()
-      val checkpointParts1 = DeltaLog.forTable(spark, path)
-        .snapshot.logSegment.checkpointProviderOpt.get.files.size
+      val checkpointParts1 =
+        DeltaLog.forTable(spark, path).snapshot.logSegment.checkpointProvider.files.size
 
       makeCorruptCheckpointFile(path, checkpointVersion = 0, shouldBeEmpty = false,
         multipart = partToCorrupt.map((_, checkpointParts0)))
@@ -448,9 +445,10 @@ class SnapshotManagementSuite extends QueryTest with SQLTestUtils with SharedSpa
       val oldLogSegment = log.snapshot.logSegment
       spark.range(10).write.format("delta").save(path)
       val newLogSegment = log.snapshot.logSegment
-      assert(log.getLogSegmentAfterCommit(oldLogSegment, None) === newLogSegment)
+      assert(log.getLogSegmentAfterCommit(oldLogSegment.checkpointProvider) === newLogSegment)
       spark.range(10).write.format("delta").mode("append").save(path)
-      assert(log.getLogSegmentAfterCommit(newLogSegment, None) === log.snapshot.logSegment)
+      assert(log.getLogSegmentAfterCommit(oldLogSegment.checkpointProvider)
+        === log.snapshot.logSegment)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

This PR makes the LogSegment in CheckpointProvider non-optional by introducing the EmptyCheckpointProvider. This simplifies the code overall.

## How was this patch tested?

Existing UTs
