### PR TITLE
Use String instead of Map[String, String] for DomainMetadata.configuration

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -574,7 +574,7 @@ The following is an example `rowIdHighWaterMark` action:
 ```
 
 ### Domain Metadata
-The domain metadata action contains a configuration (JSON string) for a named metadata domain. Two overlapping transactions conflict if they both contain a domain metadata action for the same metadata domain.
+The domain metadata action contains a configuration (string) for a named metadata domain. Two overlapping transactions conflict if they both contain a domain metadata action for the same metadata domain.
 
 There are two types of metadata domains:
 1. **User-controlled metadata domains** have names that start with anything other than the `delta.` prefix. Any Delta client implementation or user application can modify these metadata domains, and can allow users to modify them arbitrarily. Delta clients and user applications are encouraged to use a naming convention designed to avoid conflicts with other clients' or users' metadata domains (e.g. `com.databricks.*` or `org.apache.*`).
@@ -585,7 +585,7 @@ The schema of the `domainMetadata` action is as follows:
 Field Name | Data Type | Description
 -|-|-
 domain | String | Identifier for this domain (system- or user-provided)
-configuration | String | JSON string containing configuration for the metadata domain
+configuration | String | String containing configuration for the metadata domain
 removed | Boolean | When `true`, the action serves as a tombstone to logically delete a metadata domain. Writers should preserve an accurate pre-image of the configuration.
 
 Enablement:

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -574,7 +574,7 @@ The following is an example `rowIdHighWaterMark` action:
 ```
 
 ### Domain Metadata
-The domain metadata action contains a configuration (string-string map) for a named metadata domain. Two overlapping transactions conflict if they both contain a domain metadata action for the same metadata domain.
+The domain metadata action contains a configuration (JSON string) for a named metadata domain. Two overlapping transactions conflict if they both contain a domain metadata action for the same metadata domain.
 
 There are two types of metadata domains:
 1. **User-controlled metadata domains** have names that start with anything other than the `delta.` prefix. Any Delta client implementation or user application can modify these metadata domains, and can allow users to modify them arbitrarily. Delta clients and user applications are encouraged to use a naming convention designed to avoid conflicts with other clients' or users' metadata domains (e.g. `com.databricks.*` or `org.apache.*`).
@@ -585,7 +585,7 @@ The schema of the `domainMetadata` action is as follows:
 Field Name | Data Type | Description
 -|-|-
 domain | String | Identifier for this domain (system- or user-provided)
-configuration | Map[String, String] | A map containing configuration for the metadata domain
+configuration | String | JSON string containing configuration for the metadata domain
 removed | Boolean | When `true`, the action serves as a tombstone to logically delete a metadata domain. Writers should preserve an accurate pre-image of the configuration.
 
 Enablement:
@@ -606,7 +606,7 @@ The following is an example `domainMetadata` action:
 {
   "domainMetadata": {
     "domain": "delta.deltaTableFeatureX",
-    "configuration": {"key1": "..."},
+    "configuration": "{\"key1\":\"value1\"}",
     "removed": false
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/JsonMetadataDomain.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/JsonMetadataDomain.scala
@@ -20,7 +20,8 @@ import org.apache.spark.sql.delta.actions.DomainMetadata
 import org.apache.spark.sql.delta.util.JsonUtils
 
 /**
- * A trait for capturing metadata domain of type T and JSON serialize it into DomainMetadata's config.
+ * A trait for capturing metadata domain of type T and JSON serialize it into DomainMetadata's
+ * config.
  */
 trait JsonMetadataDomain[T] {
   val domainName: String

--- a/spark/src/main/scala/org/apache/spark/sql/delta/JsonMetadataDomain.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/JsonMetadataDomain.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.delta.actions.DomainMetadata
 import org.apache.spark.sql.delta.util.JsonUtils
 
 /**
- * A trait for capturing metadata domain of type T.
+ * A trait for capturing metadata domain of type T and JSON serialize it into DomainMetadata's config.
  */
 trait JsonMetadataDomain[T] {
   val domainName: String

--- a/spark/src/main/scala/org/apache/spark/sql/delta/JsonMetadataDomain.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/JsonMetadataDomain.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.delta.util.JsonUtils
 /**
  * A trait for capturing metadata domain of type T.
  */
-trait MetadataDomain[T] {
+trait JsonMetadataDomain[T] {
   val domainName: String
 
   /**
@@ -34,7 +34,7 @@ trait MetadataDomain[T] {
   }
 }
 
-abstract class MetadataDomainUtils[T: Manifest] {
+abstract class JsonMetadataDomainUtils[T: Manifest] {
   protected val domainName: String
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/MetadataDomain.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/MetadataDomain.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.actions.DomainMetadata
+import org.apache.spark.sql.delta.util.JsonUtils
+
+/**
+ * A trait for capturing metadata domain of type T.
+ */
+trait MetadataDomain[T] {
+  val domainName: String
+
+  /**
+   * Creates [[DomainMetadata]] with configuration set as a JSON-serialized value of
+   * the metadata domain of type T.
+   */
+  def toDomainMetadata[T: Manifest]: DomainMetadata = {
+    DomainMetadata(domainName, JsonUtils.toJson(this.asInstanceOf[T]), removed = false)
+  }
+}
+
+abstract class MetadataDomainUtils[T: Manifest] {
+  protected val domainName: String
+
+  /**
+   * Returns the metadata domain's configuration as type T for domain metadata that
+   * matches "domainName" in the given snapshot. Returns None if there is no matching
+   * domain metadata.
+   */
+  def fromSnapshot(snapshot: Snapshot): Option[T] = {
+    snapshot.domainMetadata
+      .find(_.domain == domainName)
+      .map(m => JsonUtils.fromJson[T](m.configuration))
+  }
+}
+

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -552,7 +552,7 @@ case class RowIdHighWaterMark(highWaterMark: Long) extends Action {
  * the same metadata domain.
  *
  * [[domain]]: A string used to identify a specific feature.
- * [[configuration]]: A JSON string containing configuration options for the conflict domain.
+ * [[configuration]]: A string containing configuration options for the conflict domain.
  * [[removed]]: If it is true it serves as a tombstone to logically delete a [[DomainMetadata]]
  *              action.
  */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -552,13 +552,13 @@ case class RowIdHighWaterMark(highWaterMark: Long) extends Action {
  * the same metadata domain.
  *
  * [[domain]]: A string used to identify a specific feature.
- * [[configuration]]: A map containing configuration options for the conflict domain.
+ * [[configuration]]: A JSON string containing configuration options for the conflict domain.
  * [[removed]]: If it is true it serves as a tombstone to logically delete a [[DomainMetadata]]
  *              action.
  */
 case class DomainMetadata(
     domain: String,
-    configuration: Map[String, String],
+    configuration: String,
     removed: Boolean) extends Action {
   override def wrap: SingleAction = SingleAction(domainMetadata = this)
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -349,7 +349,9 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
            |""".stripMargin)
       val deltaLog = DeltaLog.forTable(spark, TableIdentifier(table))
       val domainMetadatas = DomainMetadata(
-        domain = "testDomain", configuration = Map("key1" -> "value1"), removed = false) :: Nil
+        domain = "testDomain",
+        configuration = JsonUtils.toJson(Map("key1" -> "value1")),
+        removed = false) :: Nil
       val version = deltaLog.startTransaction().commit(domainMetadatas, ManualUpdate)
       val committedActions = deltaLog.store.read(
         FileNames.deltaFile(deltaLog.logPath, version),
@@ -360,7 +362,8 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
         """
           |{"domainMetadata":{
           |"domain":"testDomain",
-          |"configuration":{"key1":"value1"},
+          |"configuration":
+          |"{\"key1\":\"value1\"}",
           |"removed":false}
           |}""".stripMargin.replaceAll("\n", "")
       assert(serializedJson === expectedJson)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DomainMetadataSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DomainMetadataSuite.scala
@@ -67,8 +67,8 @@ class DomainMetadataSuite
         var deltaLog = DeltaLog.forTable(spark, TableIdentifier(table))
         assert(deltaLog.unsafeVolatileSnapshot.domainMetadata.isEmpty)
 
-        val domainMetadata = DomainMetadata("testDomain1", Map.empty, false) ::
-          DomainMetadata("testDomain2", Map("key1" -> "value1"), false) :: Nil
+        val domainMetadata = DomainMetadata("testDomain1", "", false) ::
+          DomainMetadata("testDomain2", "{\"key1\":\"value1\"", false) :: Nil
         deltaLog.startTransaction().commit(domainMetadata, Truncate())
         assertEquals(sortByDomain(domainMetadata), sortByDomain(deltaLog.update().domainMetadata))
         assert(deltaLog.update().logSegment.checkpointProviderOpt.isEmpty)
@@ -109,8 +109,8 @@ class DomainMetadataSuite
         var deltaLog = DeltaLog.forTable(spark, TableIdentifier(table))
         assert(deltaLog.unsafeVolatileSnapshot.domainMetadata.isEmpty)
 
-        val domainMetadata = DomainMetadata("testDomain1", Map.empty, false) ::
-          DomainMetadata("testDomain2", Map("key1" -> "value1"), false) :: Nil
+        val domainMetadata = DomainMetadata("testDomain1", "", false) ::
+          DomainMetadata("testDomain2", "{\"key1\":\"value1\"}", false) :: Nil
 
         deltaLog.startTransaction().commit(domainMetadata, Truncate())
         assertEquals(sortByDomain(domainMetadata), sortByDomain(deltaLog.update().domainMetadata))
@@ -118,10 +118,10 @@ class DomainMetadataSuite
 
         // Delete testDomain1.
         deltaLog.startTransaction().commit(
-          DomainMetadata("testDomain1", Map.empty, true) :: Nil, Truncate())
+          DomainMetadata("testDomain1", "", true) :: Nil, Truncate())
         val domainMetadatasAfterDeletion = DomainMetadata(
           "testDomain2",
-          Map("key1" -> "value1"), false) :: Nil
+          "{\"key1\":\"value1\"}", false) :: Nil
         assertEquals(
           sortByDomain(domainMetadatasAfterDeletion),
           sortByDomain(deltaLog.update().domainMetadata))
@@ -195,8 +195,8 @@ class DomainMetadataSuite
       (1 to 100).toDF("id").write.format("delta").mode("append").saveAsTable(table)
       val deltaLog = DeltaLog.forTable(spark, TableIdentifier(table))
       val domainMetadata =
-        DomainMetadata("testDomain1", Map.empty, false) ::
-          DomainMetadata("testDomain1", Map.empty, false) :: Nil
+        DomainMetadata("testDomain1", "", false) ::
+          DomainMetadata("testDomain1", "", false) :: Nil
       val e = intercept[DeltaIllegalArgumentException] {
         deltaLog.startTransaction().commit(domainMetadata, Truncate())
       }
@@ -210,7 +210,7 @@ class DomainMetadataSuite
     withTempDir { dir =>
       (1 to 100).toDF().write.format("delta").save(dir.getAbsolutePath)
       val deltaLog = DeltaLog.forTable(spark, dir)
-      val domainMetadata = DomainMetadata("testDomain1", Map.empty, false) :: Nil
+      val domainMetadata = DomainMetadata("testDomain1", "", false) :: Nil
       val e = intercept[DeltaIllegalArgumentException] {
         deltaLog.startTransaction().commit(domainMetadata, Truncate())
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/JsonMetadataDomainSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/JsonMetadataDomainSuite.scala
@@ -40,6 +40,8 @@ class JsonMetadataDomainSuite extends QueryTest
       val metadataDomain = TestMetadataDomain("key", 1000L, "test1" :: "value1" :: Nil)
       val domainMetadata = metadataDomain.toDomainMetadata
       assert(domainMetadata.configuration === JsonUtils.toJson[TestMetadataDomain](metadataDomain))
+      assert(domainMetadata.domain == metadataDomain.domainName)
+      assert(!domainMetadata.removed)
 
       val deltaLog = DeltaLog.forTable(spark, TableIdentifier(table))
       deltaLog.startTransaction().commit(domainMetadata :: Nil, ManualUpdate)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/JsonMetadataDomainSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/JsonMetadataDomainSuite.scala
@@ -44,9 +44,7 @@ class JsonMetadataDomainSuite extends QueryTest
       val deltaLog = DeltaLog.forTable(spark, TableIdentifier(table))
       deltaLog.startTransaction().commit(domainMetadata :: Nil, ManualUpdate)
 
-      val found =
-        TestMetadataDomain.fromSnapshot(deltaLog.update()).contains(metadataDomain)
-      assert(found)
+      assert(TestMetadataDomain.fromSnapshot(deltaLog.update()).contains(metadataDomain))
     }
 
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/JsonMetadataDomainSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/JsonMetadataDomainSuite.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
+import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.test.{SQLTestUtils, SharedSparkSession}
+
+class JsonMetadataDomainSuite extends QueryTest
+  with SharedSparkSession  with DeltaSQLCommandTest  with SQLTestUtils {
+
+  test("Validate json metadata domain") {
+    val table = "test_table"
+    withTable(table) {
+      sql(
+        s"""
+           | CREATE TABLE $table(id int) USING delta
+           | tblproperties
+           | ('${TableFeatureProtocolUtils.propertyKey(DomainMetadataTableFeature)}' = 'enabled')
+           |""".stripMargin)
+
+      val metadataDomain = TestMetadataDomain("key", 1000L, "test1" :: "value1" :: Nil)
+
+      val deltaLog = DeltaLog.forTable(spark, TableIdentifier(table))
+      deltaLog.startTransaction().commit(metadataDomain.toDomainMetadata :: Nil, ManualUpdate)
+
+      val found =
+        TestMetadataDomain.fromSnapshot(deltaLog.update()).contains(metadataDomain)
+      assert(found)
+    }
+
+  }
+}
+
+case class TestMetadataDomain(
+    key1: String,
+    val1: Long,
+    array: Seq[String]) extends JsonMetadataDomain[TestMetadataDomain] {
+  override val domainName: String = TestMetadataDomain.domainName
+}
+
+object TestMetadataDomain extends JsonMetadataDomainUtils[TestMetadataDomain] {
+  override protected val domainName = "delta.test.testDomain"
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Use String instead of Map[String, String] for DomainMetadata.configuration. The change also provides a generic framework to convert from a scala class to `DomainMetadata`

Also the Delta protocol is changed in this PR.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Existing UTs.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
