### PR TITLE
Add more DDL test coverage and support ALTER TABLE REPLACE COLUMNS

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -65,6 +65,12 @@
     ],
     "sqlState" : "42837"
   },
+  "DELTA_AMBIGUOUS_DATA_TYPE_CHANGE" : {
+    "message" : [
+      "Cannot change data type of <column> from <from> to <to>. This change contains column removals and additions, therefore they are ambiguous. Please make these changes individually using ALTER TABLE [ADD | DROP | RENAME] COLUMN."
+    ],
+    "sqlState" : "429BQ"
+  },
   "DELTA_AMBIGUOUS_PARTITION_COLUMN" : {
     "message" : [
       "Ambiguous partition column <column> can be <colMatches>."

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -415,6 +415,11 @@ class DeltaAnalysis(session: SparkSession)
     case dsv2 @ DataSourceV2Relation(d: DeltaTableV2, _, _, _, options) =>
       DeltaRelation.fromV2Relation(d, dsv2, options)
 
+    case ResolvedTable(_, _, d: DeltaTableV2, _)
+        if d.catalogTable.isEmpty && d.snapshot.version < 0 =>
+      // This is DDL on a path based table
+      throw DeltaErrors.notADeltaTableException(DeltaTableIdentifier(path = Some(d.path.toString)))
+
     // DML - TODO: Remove these Delta-specific DML logical plans and use Spark's plans directly
 
     case d @ DeleteFromTable(table, condition) if d.childrenResolved =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -417,7 +417,8 @@ class DeltaAnalysis(session: SparkSession)
 
     case ResolvedTable(_, _, d: DeltaTableV2, _)
         if d.catalogTable.isEmpty && d.snapshot.version < 0 =>
-      // This is DDL on a path based table
+      // This is DDL on a path based table that doesn't exist. CREATE will not hit this path, most
+      // SHOW / DESC code paths will hit this
       throw DeltaErrors.notADeltaTableException(DeltaTableIdentifier(path = Some(d.path.toString)))
 
     // DML - TODO: Remove these Delta-specific DML logical plans and use Spark's plans directly

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1712,6 +1712,13 @@ trait DeltaErrorsBase
     )
   }
 
+  def ambiguousDataTypeChange(column: String, from: StructType, to: StructType): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_AMBIGUOUS_DATA_TYPE_CHANGE",
+      messageParameters = Array(column, from.toDDL, to.toDDL)
+    )
+  }
+
   def unsupportedDataTypes(
       unsupportedDataType: UnsupportedDataTypeInfo,
       moreUnsupportedDataTypes: UnsupportedDataTypeInfo*): Throwable = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
@@ -552,11 +552,10 @@ class DeltaCatalog extends DelegatingCatalogExtension
     val columnUpdates = new mutable.HashMap[Seq[String], (StructField, Option[ColumnPosition])]()
     val isReplaceColumnsCommand = grouped.get(classOf[DeleteColumn]) match {
       case Some(deletes: Seq[DeleteColumn]) if grouped.contains(classOf[AddColumn]) =>
-        // Normally we can do a zip, but using a zip and ensuring that all columns in the table
-        // are removed to decide whether this is a replace columns command
-        val tableSchema = table.schema().fieldNames
-        val deleteSet = deletes.map(_.fieldNames()).toSet
-        tableSchema.forall(f => deleteSet.contains(Array(f)))
+        // Convert to Seq so that contains method works
+        val deleteSet = deletes.map(_.fieldNames().toSeq).toSet
+        // Ensure that all the table top level columns are being deleted
+        table.schema().fieldNames.forall(f => deleteSet.contains(Seq(f)))
       case _ =>
         false
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
@@ -553,7 +553,7 @@ class DeltaCatalog extends DelegatingCatalogExtension
     val isReplaceColumnsCommand = {
       // Decide from the provided table change operations, whether this is a replace columns
       // command. Replace columns is represented as removing all existing columns and then adding
-      // all new columns.
+      // one or more new columns.
       if (!grouped.contains(classOf[AddColumn]) || !grouped.contains(classOf[DeleteColumn])) {
         false
       } else {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ShowTableColumnsCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ShowTableColumnsCommand.scala
@@ -48,7 +48,7 @@ case class ShowTableColumnsCommand(tableID: DeltaTableIdentifier)
     val (deltaLog, snapshot) = DeltaLog.forTableWithSnapshot(sparkSession, tableID)
     recordDeltaOperation(deltaLog, "delta.ddl.showColumns") {
       if (snapshot.version < 0) {
-        throw DeltaErrors.notADeltaTableException("SHOW COLUMNS")
+        throw DeltaErrors.notADeltaTableException(tableID)
       } else {
         snapshot.schema.fieldNames.map { x => Row(x) }.toSeq
       }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -557,8 +557,7 @@ case class AlterTableReplaceColumnsDeltaCommand(
   extends LeafRunnableCommand with AlterDeltaTableCommand with IgnoreCachedData {
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    val deltaLog = table.deltaLog
-    recordDeltaOperation(deltaLog, "delta.ddl.alter.replaceColumns") {
+    recordDeltaOperation(table.deltaLog, "delta.ddl.alter.replaceColumns") {
       val txn = startTransaction(sparkSession)
 
       val metadata = txn.metadata
@@ -583,7 +582,7 @@ case class AlterTableReplaceColumnsDeltaCommand(
       txn.updateMetadata(newMetadata)
       txn.commit(Nil, DeltaOperations.ReplaceColumns(columns))
 
-      Seq.empty[Row]
+      Nil
     }
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -777,7 +777,7 @@ object SchemaUtils extends DeltaLogging {
       to: DataType,
       resolver: Resolver,
       columnMappingMode: DeltaColumnMappingMode,
-      columnPath: Seq[String] = Seq.empty,
+      columnPath: Seq[String] = Nil,
       failOnAmbiguousChanges: Boolean = false): Option[String] = {
     def verify(cond: Boolean, err: => String): Unit = {
       if (!cond) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -778,7 +778,7 @@ object SchemaUtils extends DeltaLogging {
       resolver: Resolver,
       columnMappingMode: DeltaColumnMappingMode,
       columnPath: Seq[String] = Seq.empty,
-      failOnAmbiguousChanges: Boolean): Option[String] = {
+      failOnAmbiguousChanges: Boolean = false): Option[String] = {
     def verify(cond: Boolean, err: => String): Unit = {
       if (!cond) {
         throw DeltaErrors.cannotChangeDataType(err)
@@ -800,7 +800,7 @@ object SchemaUtils extends DeltaLogging {
           check(fromKey, toKey, columnPath :+ "key")
           check(fromValue, toValue, columnPath :+ "value")
 
-        case (StructType(fromFields), StructType(toFields)) =>
+        case (f @ StructType(fromFields), t @ StructType(toFields)) =>
           val remainingFields = mutable.Set[StructField]()
           remainingFields ++= fromFields
           var addingColumns = false

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -275,6 +275,14 @@ trait DeltaSQLConfBase {
       .checkValue(_ > 0, "maxSnapshotLineageLength must be positive.")
       .createWithDefault(50)
 
+  val DELTA_REPLACE_COLUMNS_SAFE =
+    buildConf("alter.replaceColumns.safe.enabled")
+      .internal()
+      .doc("Prevents an ALTER TABLE REPLACE COLUMNS method from dropping all columns, which " +
+        "leads to losing all data. It will only allow safe, unambiguous column changes.")
+      .booleanConf
+      .createWithDefault(true)
+
   val DELTA_HISTORY_PAR_SEARCH_THRESHOLD =
     buildConf("history.maxKeysPerList")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableReplaceTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableReplaceTests.scala
@@ -630,54 +630,54 @@ trait DeltaAlterTableReplaceTests extends DeltaAlterTableTestBase {
       // trying to add not-null column, but it should fail because adding not-null column is
       // not supported.
       assertNotSupported(s"""
-                            |ALTER TABLE $tableName REPLACE COLUMNS (
-                            |  v1 int,
-                            |  v2 string,
-                            |  v3 long NOT NULL,
-                            |  s STRUCT<v1:int, v2:string>,
-                            |  a ARRAY<STRUCT<v1:int, v2:string>>,
-                            |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
-                            |)""".stripMargin,
+        |ALTER TABLE $tableName REPLACE COLUMNS (
+        |  v1 int,
+        |  v2 string,
+        |  v3 long NOT NULL,
+        |  s STRUCT<v1:int, v2:string>,
+        |  a ARRAY<STRUCT<v1:int, v2:string>>,
+        |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+        |)""".stripMargin,
         "NOT NULL is not supported in Hive-style REPLACE COLUMNS")
       // s.v3
       assertNotSupported(s"""
-                            |ALTER TABLE $tableName REPLACE COLUMNS (
-                            |  v1 int,
-                            |  v2 string,
-                            |  s STRUCT<v1:int, v2:string, v3:long NOT NULL>,
-                            |  a ARRAY<STRUCT<v1:int, v2:string>>,
-                            |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
-                            |)""".stripMargin,
+        |ALTER TABLE $tableName REPLACE COLUMNS (
+        |  v1 int,
+        |  v2 string,
+        |  s STRUCT<v1:int, v2:string, v3:long NOT NULL>,
+        |  a ARRAY<STRUCT<v1:int, v2:string>>,
+        |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+        |)""".stripMargin,
         "adding non-nullable column", "s.v3")
       // a.element.v3
       assertNotSupported(s"""
-                            |ALTER TABLE $tableName REPLACE COLUMNS (
-                            |  v1 int,
-                            |  v2 string,
-                            |  s STRUCT<v1:int, v2:string>,
-                            |  a ARRAY<STRUCT<v1:int, v2:string, v3:long NOT NULL>>,
-                            |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
-                            |)""".stripMargin,
+        |ALTER TABLE $tableName REPLACE COLUMNS (
+        |  v1 int,
+        |  v2 string,
+        |  s STRUCT<v1:int, v2:string>,
+        |  a ARRAY<STRUCT<v1:int, v2:string, v3:long NOT NULL>>,
+        |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+        |)""".stripMargin,
         "adding non-nullable column", "a.element.v3")
       // m.key.v3
       assertNotSupported(s"""
-                            |ALTER TABLE $tableName REPLACE COLUMNS (
-                            |  v1 int,
-                            |  v2 string,
-                            |  s STRUCT<v1:int, v2:string>,
-                            |  a ARRAY<STRUCT<v1:int, v2:string>>,
-                            |  m MAP<STRUCT<v1:int, v2:string, v3:long NOT NULL>, STRUCT<v1:int, v2:string>>
-                            |)""".stripMargin,
+        |ALTER TABLE $tableName REPLACE COLUMNS (
+        |  v1 int,
+        |  v2 string,
+        |  s STRUCT<v1:int, v2:string>,
+        |  a ARRAY<STRUCT<v1:int, v2:string>>,
+        |  m MAP<STRUCT<v1:int, v2:string, v3:long NOT NULL>, STRUCT<v1:int, v2:string>>
+        |)""".stripMargin,
         "adding non-nullable column", "m.key.v3")
       // m.value.v3
       assertNotSupported(s"""
-                            |ALTER TABLE $tableName REPLACE COLUMNS (
-                            |  v1 int,
-                            |  v2 string,
-                            |  s STRUCT<v1:int, v2:string>,
-                            |  a ARRAY<STRUCT<v1:int, v2:string>>,
-                            |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string, v3:long NOT NULL>>
-                            |)""".stripMargin,
+        |ALTER TABLE $tableName REPLACE COLUMNS (
+        |  v1 int,
+        |  v2 string,
+        |  s STRUCT<v1:int, v2:string>,
+        |  a ARRAY<STRUCT<v1:int, v2:string>>,
+        |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string, v3:long NOT NULL>>
+        |)""".stripMargin,
         "adding non-nullable column", "m.value.v3")
     }
   }
@@ -692,53 +692,53 @@ trait DeltaAlterTableReplaceTests extends DeltaAlterTableTestBase {
       // trying to change the data type of v1 of each struct to not null, but it should fail because
       // tightening nullability is not supported.
       assertNotSupported(s"""
-                            |ALTER TABLE $tableName REPLACE COLUMNS (
-                            |  v1 int NOT NULL,
-                            |  v2 string,
-                            |  s STRUCT<v1:int, v2:string>,
-                            |  a ARRAY<STRUCT<v1:int, v2:string>>,
-                            |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
-                            |)""".stripMargin,
+        |ALTER TABLE $tableName REPLACE COLUMNS (
+        |  v1 int NOT NULL,
+        |  v2 string,
+        |  s STRUCT<v1:int, v2:string>,
+        |  a ARRAY<STRUCT<v1:int, v2:string>>,
+        |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+        |)""".stripMargin,
         "NOT NULL is not supported in Hive-style REPLACE COLUMNS")
       // s.v1
       assertNotSupported(s"""
-                            |ALTER TABLE $tableName REPLACE COLUMNS (
-                            |  v1 int,
-                            |  v2 string,
-                            |  s STRUCT<v1:int NOT NULL, v2:string>,
-                            |  a ARRAY<STRUCT<v1:int, v2:string>>,
-                            |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
-                            |)""".stripMargin,
+        |ALTER TABLE $tableName REPLACE COLUMNS (
+        |  v1 int,
+        |  v2 string,
+        |  s STRUCT<v1:int NOT NULL, v2:string>,
+        |  a ARRAY<STRUCT<v1:int, v2:string>>,
+        |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+        |)""".stripMargin,
         "tightening nullability", "s.v1")
       // a.element.v1
       assertNotSupported(s"""
-                            |ALTER TABLE $tableName REPLACE COLUMNS (
-                            |  v1 int,
-                            |  v2 string,
-                            |  s STRUCT<v1:int, v2:string>,
-                            |  a ARRAY<STRUCT<v1:int NOT NULL, v2:string>>,
-                            |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
-                            |)""".stripMargin,
+        |ALTER TABLE $tableName REPLACE COLUMNS (
+        |  v1 int,
+        |  v2 string,
+        |  s STRUCT<v1:int, v2:string>,
+        |  a ARRAY<STRUCT<v1:int NOT NULL, v2:string>>,
+        |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+        |)""".stripMargin,
         "tightening nullability", "a.element.v1")
       // m.key.v1
       assertNotSupported(s"""
-                            |ALTER TABLE $tableName REPLACE COLUMNS (
-                            |  v1 int,
-                            |  v2 string,
-                            |  s STRUCT<v1:int, v2:string>,
-                            |  a ARRAY<STRUCT<v1:int, v2:string>>,
-                            |  m MAP<STRUCT<v1:int NOT NULL, v2:string>, STRUCT<v1:int, v2:string>>
-                            |)""".stripMargin,
+        |ALTER TABLE $tableName REPLACE COLUMNS (
+        |  v1 int,
+        |  v2 string,
+        |  s STRUCT<v1:int, v2:string>,
+        |  a ARRAY<STRUCT<v1:int, v2:string>>,
+        |  m MAP<STRUCT<v1:int NOT NULL, v2:string>, STRUCT<v1:int, v2:string>>
+        |)""".stripMargin,
         "tightening nullability", "m.key.v1")
       // m.value.v1
       assertNotSupported(s"""
-                            |ALTER TABLE $tableName REPLACE COLUMNS (
-                            |  v1 int,
-                            |  v2 string,
-                            |  s STRUCT<v1:int, v2:string>,
-                            |  a ARRAY<STRUCT<v1:int, v2:string>>,
-                            |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int NOT NULL, v2:string>>
-                            |)""".stripMargin,
+        |ALTER TABLE $tableName REPLACE COLUMNS (
+        |  v1 int,
+        |  v2 string,
+        |  s STRUCT<v1:int, v2:string>,
+        |  a ARRAY<STRUCT<v1:int, v2:string>>,
+        |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int NOT NULL, v2:string>>
+        |)""".stripMargin,
         "tightening nullability", "m.value.v1")
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableReplaceTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableReplaceTests.scala
@@ -212,18 +212,18 @@ trait DeltaAlterTableReplaceTests extends DeltaAlterTableTestBase {
   ddlTest("REPLACE COLUMNS - drop column") {
     // Column Mapping allows columns to be dropped
     def checkReplace(
-                      text: String,
-                      tableName: String,
-                      columnDropped: Seq[String],
-                      messages: String*): Unit = {
-      if (!columnMappingEnabled) {
-        assertNotSupported(text, messages: _*)
-      } else {
+        text: String,
+        tableName: String,
+        columnDropped: Seq[String],
+        messages: String*): Unit = {
+      if (columnMappingEnabled) {
         spark.sql(text)
         val deltaLog = getDeltaLog(tableName)
         val field = deltaLog.snapshot.schema
           .findNestedField(columnDropped, includeCollections = true)
         assert(field.isEmpty, "Column was not deleted")
+      } else {
+        assertNotSupported(text, messages: _*)
       }
     }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableReplaceTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableReplaceTests.scala
@@ -1,0 +1,745 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.functions.{array, col, map, struct}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{ArrayType, MapType, StructType}
+
+trait DeltaAlterTableReplaceTests extends DeltaAlterTableTestBase {
+
+  import testImplicits._
+
+  ddlTest("REPLACE COLUMNS - add a comment") {
+    val df = Seq((1, "a"), (2, "b")).toDF("v1", "v2")
+      .withColumn("s", struct("v1", "v2"))
+      .withColumn("a", array("s"))
+      .withColumn("m", map(col("s"), col("s")))
+
+    withDeltaTable(df) { tableName =>
+
+      sql(s"""
+             |ALTER TABLE $tableName REPLACE COLUMNS (
+             |  v1 int COMMENT 'a comment for v1',
+             |  v2 string COMMENT 'a comment for v2',
+             |  s STRUCT<
+             |    v1:int COMMENT 'a comment for s.v1',
+             |    v2:string COMMENT 'a comment for s.v2'> COMMENT 'a comment for s',
+             |  a ARRAY<STRUCT<
+             |    v1:int COMMENT 'a comment for a.v1',
+             |    v2:string COMMENT 'a comment for a.v2'>> COMMENT 'a comment for a',
+             |  m MAP<STRUCT<
+             |      v1:int COMMENT 'a comment for m.key.v1',
+             |      v2:string COMMENT 'a comment for m.key.v2'>,
+             |    STRUCT<
+             |      v1:int COMMENT 'a comment for m.value.v1',
+             |      v2:string COMMENT 'a comment for m.value.v2'>> COMMENT 'a comment for m'
+             |)""".stripMargin)
+
+      val deltaLog = getDeltaLog(tableName)
+      val expectedSchema = new StructType()
+        .add("v1", "integer", true, "a comment for v1")
+        .add("v2", "string", true, "a comment for v2")
+        .add("s", new StructType()
+          .add("v1", "integer", true, "a comment for s.v1")
+          .add("v2", "string", true, "a comment for s.v2"), true, "a comment for s")
+        .add("a", ArrayType(new StructType()
+          .add("v1", "integer", true, "a comment for a.v1")
+          .add("v2", "string", true, "a comment for a.v2")), true, "a comment for a")
+        .add("m", MapType(
+          new StructType()
+            .add("v1", "integer", true, "a comment for m.key.v1")
+            .add("v2", "string", true, "a comment for m.key.v2"),
+          new StructType()
+            .add("v1", "integer", true, "a comment for m.value.v1")
+            .add("v2", "string", true, "a comment for m.value.v2")), true, "a comment for m")
+      assertEqual(deltaLog.snapshot.schema, expectedSchema)
+
+      implicit val ordering = Ordering.by[
+        (Int, String, (Int, String), Seq[(Int, String)], Map[(Int, String), (Int, String)]), Int] {
+        case (v1, _, _, _, _) => v1
+      }
+      checkDatasetUnorderly(
+        spark.table(tableName)
+          .as[(Int, String, (Int, String), Seq[(Int, String)], Map[(Int, String), (Int, String)])],
+        (1, "a", (1, "a"), Seq((1, "a")), Map((1, "a") -> ((1, "a")))),
+        (2, "b", (2, "b"), Seq((2, "b")), Map((2, "b") -> ((2, "b")))))
+
+      // REPLACE COLUMNS doesn't remove metadata.
+      sql(s"""
+             |ALTER TABLE $tableName REPLACE COLUMNS (
+             |  v1 int,
+             |  v2 string,
+             |  s STRUCT<v1:int, v2:string>,
+             |  a ARRAY<STRUCT<v1:int, v2:string>>,
+             |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+             |)""".stripMargin)
+      assertEqual(deltaLog.snapshot.schema, expectedSchema)
+    }
+  }
+
+  ddlTest("REPLACE COLUMNS - reorder") {
+    val df = Seq((1, "a"), (2, "b")).toDF("v1", "v2")
+      .withColumn("s", struct("v1", "v2"))
+      .withColumn("a", array("s"))
+      .withColumn("m", map(col("s"), col("s")))
+    withDeltaTable(df) { tableName =>
+
+      sql(s"""
+             |ALTER TABLE $tableName REPLACE COLUMNS (
+             |  m MAP<STRUCT<v2:string, v1:int>, STRUCT<v2:string, v1:int>>,
+             |  v2 string,
+             |  a ARRAY<STRUCT<v2:string, v1:int>>,
+             |  v1 int,
+             |  s STRUCT<v2:string, v1:int>
+             |)""".stripMargin)
+
+      val deltaLog = getDeltaLog(tableName)
+      assertEqual(deltaLog.snapshot.schema, new StructType()
+        .add("m", MapType(
+          new StructType().add("v2", "string").add("v1", "integer"),
+          new StructType().add("v2", "string").add("v1", "integer")))
+        .add("v2", "string")
+        .add("a", ArrayType(new StructType().add("v2", "string").add("v1", "integer")))
+        .add("v1", "integer")
+        .add("s", new StructType().add("v2", "string").add("v1", "integer")))
+
+      implicit val ordering = Ordering.by[
+        (Map[(String, Int), (String, Int)], String, Seq[(String, Int)], Int, (String, Int)), Int] {
+        case (_, _, _, v1, _) => v1
+      }
+      checkDatasetUnorderly(
+        spark.table(tableName)
+          .as[(Map[(String, Int), (String, Int)], String, Seq[(String, Int)], Int, (String, Int))],
+        (Map(("a", 1) -> (("a", 1))), "a", Seq(("a", 1)), 1, ("a", 1)),
+        (Map(("b", 2) -> (("b", 2))), "b", Seq(("b", 2)), 2, ("b", 2)))
+    }
+  }
+
+  ddlTest("REPLACE COLUMNS - add columns") {
+    val df = Seq((1, "a"), (2, "b")).toDF("v1", "v2")
+      .withColumn("s", struct("v1", "v2"))
+      .withColumn("a", array("s"))
+      .withColumn("m", map(col("s"), col("s")))
+    withDeltaTable(df) { tableName =>
+
+      sql(s"""
+             |ALTER TABLE $tableName REPLACE COLUMNS (
+             |  v1 int,
+             |  v2 string,
+             |  v3 long,
+             |  s STRUCT<v1:int, v2:string, v3:long>,
+             |  a ARRAY<STRUCT<v1:int, v2:string, v3:long>>,
+             |  m MAP<STRUCT<v1:int, v2:string, v3:long>, STRUCT<v1:int, v2:string, v3:long>>
+             |)""".stripMargin)
+
+      val deltaLog = getDeltaLog(tableName)
+      assertEqual(deltaLog.snapshot.schema, new StructType()
+        .add("v1", "integer")
+        .add("v2", "string")
+        .add("v3", "long")
+        .add("s", new StructType()
+          .add("v1", "integer").add("v2", "string").add("v3", "long"))
+        .add("a", ArrayType(new StructType()
+          .add("v1", "integer").add("v2", "string").add("v3", "long")))
+        .add("m", MapType(
+          new StructType().add("v1", "integer").add("v2", "string").add("v3", "long"),
+          new StructType().add("v1", "integer").add("v2", "string").add("v3", "long"))))
+
+      implicit val ordering = Ordering.by[
+        (Int, String, Option[Long],
+          (Int, String, Option[Long]),
+          Seq[(Int, String, Option[Long])],
+          Map[(Int, String, Option[Long]), (Int, String, Option[Long])]), Int] {
+        case (v1, _, _, _, _, _) => v1
+      }
+      checkDatasetUnorderly(
+        spark.table(tableName).as[
+          (Int, String, Option[Long],
+            (Int, String, Option[Long]),
+            Seq[(Int, String, Option[Long])],
+            Map[(Int, String, Option[Long]), (Int, String, Option[Long])])],
+        (1, "a", None, (1, "a", None),
+          Seq((1, "a", None)), Map((1, "a", Option.empty[Long]) -> ((1, "a", None)))),
+        (2, "b", None, (2, "b", None),
+          Seq((2, "b", None)), Map((2, "b", Option.empty[Long]) -> ((2, "b", None)))))
+    }
+  }
+
+  ddlTest("REPLACE COLUMNS - special column names") {
+    val df = Seq((1, "a"), (2, "b")).toDF("x.x", "y.y")
+      .withColumn("s.s", struct("`x.x`", "`y.y`"))
+      .withColumn("a.a", array("`s.s`"))
+      .withColumn("m.m", map(col("`s.s`"), col("`s.s`")))
+    withDeltaTable(df) { tableName =>
+
+      sql(s"""
+             |ALTER TABLE $tableName REPLACE COLUMNS (
+             |  `m.m` MAP<STRUCT<`y.y`:string, `x.x`:int>, STRUCT<`y.y`:string, `x.x`:int>>,
+             |  `y.y` string,
+             |  `a.a` ARRAY<STRUCT<`y.y`:string, `x.x`:int>>,
+             |  `x.x` int,
+             |  `s.s` STRUCT<`y.y`:string, `x.x`:int>
+             |)""".stripMargin)
+
+      val deltaLog = getDeltaLog(tableName)
+      assertEqual(deltaLog.snapshot.schema, new StructType()
+        .add("m.m", MapType(
+          new StructType().add("y.y", "string").add("x.x", "integer"),
+          new StructType().add("y.y", "string").add("x.x", "integer")))
+        .add("y.y", "string")
+        .add("a.a", ArrayType(new StructType().add("y.y", "string").add("x.x", "integer")))
+        .add("x.x", "integer")
+        .add("s.s", new StructType().add("y.y", "string").add("x.x", "integer")))
+    }
+  }
+
+  ddlTest("REPLACE COLUMNS - drop column") {
+    // Column Mapping allows columns to be dropped
+    def checkReplace(
+                      text: String,
+                      tableName: String,
+                      columnDropped: Seq[String],
+                      messages: String*): Unit = {
+      if (!columnMappingEnabled) {
+        assertNotSupported(text, messages: _*)
+      } else {
+        spark.sql(text)
+        val deltaLog = getDeltaLog(tableName)
+        val field = deltaLog.snapshot.schema
+          .findNestedField(columnDropped, includeCollections = true)
+        assert(field.isEmpty, "Column was not deleted")
+      }
+    }
+
+    val df = Seq((1, "a"), (2, "b")).toDF("v1", "v2")
+      .withColumn("s", struct("v1", "v2"))
+      .withColumn("a", array("s"))
+      .withColumn("m", map(col("s"), col("s")))
+    withDeltaTable(df) { tableName =>
+
+      // trying to drop v1 of each struct, but it should fail because dropping column is
+      // not supported unless column mapping is enabled
+      checkReplace(
+        s"""
+           |ALTER TABLE $tableName REPLACE COLUMNS (
+           |  v2 string,
+           |  s STRUCT<v1:int, v2:string>,
+           |  a ARRAY<STRUCT<v1:int, v2:string>>,
+           |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+           |)""".stripMargin,
+        tableName, Seq("v1"), "dropping column(s)", "v1")
+      // s.v1
+      checkReplace(
+        s"""
+           |ALTER TABLE $tableName REPLACE COLUMNS (
+           |  v1 int,
+           |  v2 string,
+           |  s STRUCT<v2:string>,
+           |  a ARRAY<STRUCT<v1:int, v2:string>>,
+           |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+           |)""".stripMargin,
+        tableName, Seq("s", "v1"), "dropping column(s)", "v1", "from s")
+      // a.v1
+      checkReplace(
+        s"""
+           |ALTER TABLE $tableName REPLACE COLUMNS (
+           |  v1 int,
+           |  v2 string,
+           |  s STRUCT<v1:int, v2:string>,
+           |  a ARRAY<STRUCT<v2:string>>,
+           |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+           |)""".stripMargin,
+        tableName, Seq("a", "element", "v1"), "dropping column(s)", "v1", "from a")
+      // m.key.v1
+      checkReplace(
+        s"""
+           |ALTER TABLE $tableName REPLACE COLUMNS (
+           |  v1 int,
+           |  v2 string,
+           |  s STRUCT<v1:int, v2:string>,
+           |  a ARRAY<STRUCT<v1:int, v2:string>>,
+           |  m MAP<STRUCT<v2:string>, STRUCT<v1:int, v2:string>>
+           |)""".stripMargin,
+        tableName, Seq("m", "key", "v1"), "dropping column(s)", "v1", "from m.key")
+      // m.value.v1
+      checkReplace(
+        s"""
+           |ALTER TABLE $tableName REPLACE COLUMNS (
+           |  v1 int,
+           |  v2 string,
+           |  s STRUCT<v1:int, v2:string>,
+           |  a ARRAY<STRUCT<v1:int, v2:string>>,
+           |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v2:string>>
+           |)""".stripMargin,
+        tableName, Seq("m", "value", "v1"), "dropping column(s)", "v1", "from m.value")
+    }
+  }
+
+  ddlTest("REPLACE COLUMNS - incompatible data type") {
+    val df = Seq((1, "a"), (2, "b")).toDF("v1", "v2")
+      .withColumn("s", struct("v1", "v2"))
+      .withColumn("a", array("s"))
+      .withColumn("m", map(col("s"), col("s")))
+    withDeltaTable(df) { tableName =>
+
+      // trying to change the data type of v1 of each struct to long, but it should fail because
+      // changing data type is not supported.
+      assertNotSupported(s"""
+                            |ALTER TABLE $tableName REPLACE COLUMNS (
+                            |  v1 long,
+                            |  v2 string,
+                            |  s STRUCT<v1:int, v2:string>,
+                            |  a ARRAY<STRUCT<v1:int, v2:string>>,
+                            |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+                            |)""".stripMargin,
+        "changing data type", "v1", "from IntegerType to LongType")
+      // s.v1
+      assertNotSupported(s"""
+                            |ALTER TABLE $tableName REPLACE COLUMNS (
+                            |  v1 int,
+                            |  v2 string,
+                            |  s STRUCT<v1:long, v2:string>,
+                            |  a ARRAY<STRUCT<v1:int, v2:string>>,
+                            |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+                            |)""".stripMargin,
+        "changing data type", "s.v1", "from IntegerType to LongType")
+      // a.element.v1
+      assertNotSupported(s"""
+                            |ALTER TABLE $tableName REPLACE COLUMNS (
+                            |  v1 int,
+                            |  v2 string,
+                            |  s STRUCT<v1:int, v2:string>,
+                            |  a ARRAY<STRUCT<v1:long, v2:string>>,
+                            |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+                            |)""".stripMargin,
+        "changing data type", "a.element.v1", "from IntegerType to LongType")
+      // m.key.v1
+      assertNotSupported(s"""
+                            |ALTER TABLE $tableName REPLACE COLUMNS (
+                            |  v1 int,
+                            |  v2 string,
+                            |  s STRUCT<v1:int, v2:string>,
+                            |  a ARRAY<STRUCT<v1:int, v2:string>>,
+                            |  m MAP<STRUCT<v1:long, v2:string>, STRUCT<v1:int, v2:string>>
+                            |)""".stripMargin,
+        "changing data type", "m.key.v1", "from IntegerType to LongType")
+      // m.value.v1
+      assertNotSupported(s"""
+                            |ALTER TABLE $tableName REPLACE COLUMNS (
+                            |  v1 int,
+                            |  v2 string,
+                            |  s STRUCT<v1:int, v2:string>,
+                            |  a ARRAY<STRUCT<v1:int, v2:string>>,
+                            |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:long, v2:string>>
+                            |)""".stripMargin,
+        "changing data type", "m.value.v1", "from IntegerType to LongType")
+    }
+  }
+
+  ddlTest("REPLACE COLUMNS - case insensitive") {
+    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
+      val df = Seq((1, "a"), (2, "b")).toDF("v1", "v2")
+        .withColumn("s", struct("v1", "v2"))
+        .withColumn("a", array("s"))
+        .withColumn("m", map(col("s"), col("s")))
+      withDeltaTable(df) { tableName =>
+
+        val deltaLog = getDeltaLog(tableName)
+        def checkSchema(command: String): Unit = {
+          sql(command)
+
+          assertEqual(deltaLog.update().schema, new StructType()
+            .add("v1", "integer")
+            .add("v2", "string")
+            .add("s", new StructType().add("v1", "integer").add("v2", "string"))
+            .add("a", ArrayType(new StructType().add("v1", "integer").add("v2", "string")))
+            .add("m", MapType(
+              new StructType().add("v1", "integer").add("v2", "string"),
+              new StructType().add("v1", "integer").add("v2", "string"))))
+        }
+
+        // trying to use V1 instead of v1 of each struct.
+        checkSchema(s"""
+                       |ALTER TABLE $tableName REPLACE COLUMNS (
+                       |  V1 int,
+                       |  v2 string,
+                       |  s STRUCT<v1:int, v2:string>,
+                       |  a ARRAY<STRUCT<v1:int, v2:string>>,
+                       |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+                       |)""".stripMargin)
+        // s.V1
+        checkSchema(s"""
+                       |ALTER TABLE $tableName REPLACE COLUMNS (
+                       |  v1 int,
+                       |  v2 string,
+                       |  s STRUCT<V1:int, v2:string>,
+                       |  a ARRAY<STRUCT<v1:int, v2:string>>,
+                       |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+                       |)""".stripMargin)
+        // a.V1
+        checkSchema(s"""
+                       |ALTER TABLE $tableName REPLACE COLUMNS (
+                       |  v1 int,
+                       |  v2 string,
+                       |  s STRUCT<v1:int, v2:string>,
+                       |  a ARRAY<STRUCT<V1:int, v2:string>>,
+                       |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+                       |)""".stripMargin)
+        // m.key.V1
+        checkSchema(s"""
+                       |ALTER TABLE $tableName REPLACE COLUMNS (
+                       |  v1 int,
+                       |  v2 string,
+                       |  s STRUCT<v1:int, v2:string>,
+                       |  a ARRAY<STRUCT<v1:int, v2:string>>,
+                       |  m MAP<STRUCT<V1:int, v2:string>, STRUCT<v1:int, v2:string>>
+                       |)""".stripMargin)
+        // m.value.V1
+        checkSchema(s"""
+                       |ALTER TABLE $tableName REPLACE COLUMNS (
+                       |  v1 int,
+                       |  v2 string,
+                       |  s STRUCT<v1:int, v2:string>,
+                       |  a ARRAY<STRUCT<v1:int, v2:string>>,
+                       |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<V1:int, v2:string>>
+                       |)""".stripMargin)
+      }
+    }
+  }
+
+  ddlTest("REPLACE COLUMNS - case sensitive") {
+    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
+      val df = Seq((1, "a"), (2, "b")).toDF("v1", "v2")
+        .withColumn("s", struct("v1", "v2"))
+        .withColumn("a", array("s"))
+        .withColumn("m", map(col("s"), col("s")))
+      withDeltaTable(df) { tableName =>
+
+        // trying to use V1 instead of v1 of each struct, but it should fail because case sensitive.
+        assertNotSupported(s"""
+                              |ALTER TABLE $tableName REPLACE COLUMNS (
+                              |  V1 int,
+                              |  v2 string,
+                              |  s STRUCT<v1:int, v2:string>,
+                              |  a ARRAY<STRUCT<v1:int, v2:string>>,
+                              |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+                              |)""".stripMargin,
+          "ambiguous", "v1")
+        // s.V1
+        assertNotSupported(s"""
+                              |ALTER TABLE $tableName REPLACE COLUMNS (
+                              |  v1 int,
+                              |  v2 string,
+                              |  s STRUCT<V1:int, v2:string>,
+                              |  a ARRAY<STRUCT<v1:int, v2:string>>,
+                              |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+                              |)""".stripMargin,
+          "ambiguous", "data type of s")
+        // a.V1
+        assertNotSupported(s"""
+                              |ALTER TABLE $tableName REPLACE COLUMNS (
+                              | v1 int,
+                              | v2 string,
+                              | s STRUCT<v1:int, v2:string>,
+                              | a ARRAY<STRUCT<V1:int, v2:string>>,
+                              | m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+                              |)""".stripMargin,
+          "ambiguous", "data type of a.element")
+        // m.key.V1
+        assertNotSupported(s"""
+                              |ALTER TABLE $tableName REPLACE COLUMNS (
+                              |  v1 int,
+                              |  v2 string,
+                              |  s STRUCT<v1:int, v2:string>,
+                              |  a ARRAY<STRUCT<v1:int, v2:string>>,
+                              |  m MAP<STRUCT<V1:int, v2:string>, STRUCT<v1:int, v2:string>>
+                              |)""".stripMargin,
+          "ambiguous", "data type of m.key")
+        // m.value.V1
+        assertNotSupported(s"""
+                              |ALTER TABLE $tableName REPLACE COLUMNS (
+                              |  v1 int,
+                              |  v2 string,
+                              |  s STRUCT<v1:int, v2:string>,
+                              |  a ARRAY<STRUCT<v1:int, v2:string>>,
+                              |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<V1:int, v2:string>>
+                              |)""".stripMargin,
+          "ambiguous", "data type of m.value")
+      }
+    }
+  }
+
+  ddlTest("REPLACE COLUMNS - duplicate") {
+    withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
+      val df = Seq((1, "a"), (2, "b")).toDF("v1", "v2")
+        .withColumn("s", struct("v1", "v2"))
+        .withColumn("a", array("s"))
+        .withColumn("m", map(col("s"), col("s")))
+      withDeltaTable(df) { tableName =>
+        def assertDuplicate(command: String): Unit = {
+          val ex = intercept[AnalysisException] {
+            sql(command)
+          }
+          assert(ex.getMessage.contains("duplicate column(s)"))
+        }
+
+        // trying to add a V1 column, but it should fail because Delta doesn't allow columns
+        // at the same level of nesting that differ only by case.
+        assertDuplicate(s"""
+                           |ALTER TABLE $tableName REPLACE COLUMNS (
+                           |  v1 int,
+                           |  V1 int,
+                           |  v2 string,
+                           |  s STRUCT<v1:int, v2:string>,
+                           |  a ARRAY<STRUCT<v1:int, v2:string>>,
+                           |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+                           |)""".stripMargin)
+        // s.V1
+        assertDuplicate(s"""
+                           |ALTER TABLE $tableName REPLACE COLUMNS (
+                           |  v1 int,
+                           |  v2 string,
+                           |  s STRUCT<v1:int, V1:int, v2:string>,
+                           |  a ARRAY<STRUCT<v1:int, v2:string>>,
+                           |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+                           |)""".stripMargin)
+        // a.V1
+        assertDuplicate(s"""
+                           |ALTER TABLE $tableName REPLACE COLUMNS (
+                           |  v1 int,
+                           |  v2 string,
+                           |  s STRUCT<v1:int, v2:string>,
+                           |  a ARRAY<STRUCT<v1:int, V1:int, v2:string>>,
+                           |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+                           |)""".stripMargin)
+        // m.key.V1
+        assertDuplicate(s"""
+                           |ALTER TABLE $tableName REPLACE COLUMNS (
+                           |   v1 int,
+                           |   v2 string,
+                           |   s STRUCT<v1:int, v2:string>,
+                           |   a ARRAY<STRUCT<v1:int, v2:string>>,
+                           |   m MAP<STRUCT<v1:int, V1:int, v2:string>, STRUCT<v1:int, v2:string>>
+                           |)""".stripMargin)
+        // m.value.V1
+        assertDuplicate(s"""
+                           |ALTER TABLE $tableName REPLACE COLUMNS (
+                           |  v1 int,
+                           |  v2 string,
+                           |  s STRUCT<v1:int, v2:string>,
+                           |  a ARRAY<STRUCT<v1:int, v2:string>>,
+                           |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, V1:int, v2:string>>
+                           |)""".stripMargin)
+      }
+    }
+  }
+
+  test("REPLACE COLUMNS - loosen nullability with unenforced allowed") {
+    withSQLConf(("spark.databricks.delta.constraints.allowUnenforcedNotNull.enabled", "true")) {
+      val schema =
+        """
+          |  v1 int NOT NULL,
+          |  v2 string,
+          |  s STRUCT<v1:int NOT NULL, v2:string>,
+          |  a ARRAY<STRUCT<v1:int NOT NULL, v2:string>>,
+          |  m MAP<STRUCT<v1:int NOT NULL, v2:string>, STRUCT<v1:int NOT NULL, v2:string>>
+        """.stripMargin
+      withDeltaTable(schema) { tableName =>
+
+        sql(
+          s"""
+             |ALTER TABLE $tableName REPLACE COLUMNS (
+             |  v1 int,
+             |  v2 string,
+             |  s STRUCT<v1:int, v2:string>,
+             |  a ARRAY<STRUCT<v1:int, v2:string>>,
+             |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+             |)""".stripMargin)
+
+        val deltaLog = getDeltaLog(tableName)
+        assertEqual(deltaLog.snapshot.schema, new StructType()
+          .add("v1", "integer")
+          .add("v2", "string")
+          .add("s", new StructType()
+            .add("v1", "integer").add("v2", "string"))
+          .add("a", ArrayType(new StructType()
+            .add("v1", "integer").add("v2", "string")))
+          .add("m", MapType(
+            new StructType().add("v1", "integer").add("v2", "string"),
+            new StructType().add("v1", "integer").add("v2", "string"))))
+      }
+    }
+  }
+
+  test("REPLACE COLUMNS - loosen nullability") {
+    val schema =
+      """
+        |  v1 int NOT NULL,
+        |  v2 string,
+        |  s STRUCT<v1:int NOT NULL, v2:string>,
+        |  a ARRAY<STRUCT<v1:int, v2:string>> NOT NULL,
+        |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>> NOT NULL
+      """.stripMargin
+    withDeltaTable(schema) { tableName =>
+
+      sql(s"""
+             |ALTER TABLE $tableName REPLACE COLUMNS (
+             |  v1 int,
+             |  v2 string,
+             |  s STRUCT<v1:int, v2:string>,
+             |  a ARRAY<STRUCT<v1:int, v2:string>>,
+             |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+             |)""".stripMargin)
+
+      val deltaLog = getDeltaLog(tableName)
+      assertEqual(deltaLog.snapshot.schema, new StructType()
+        .add("v1", "integer")
+        .add("v2", "string")
+        .add("s", new StructType()
+          .add("v1", "integer").add("v2", "string"))
+        .add("a", ArrayType(new StructType()
+          .add("v1", "integer").add("v2", "string")))
+        .add("m", MapType(
+          new StructType().add("v1", "integer").add("v2", "string"),
+          new StructType().add("v1", "integer").add("v2", "string"))))
+    }
+  }
+
+  test("REPLACE COLUMNS - add not-null column") {
+    val df = Seq((1, "a"), (2, "b")).toDF("v1", "v2")
+      .withColumn("s", struct("v1", "v2"))
+      .withColumn("a", array("s"))
+      .withColumn("m", map(col("s"), col("s")))
+    withDeltaTable(df) { tableName =>
+      // trying to add not-null column, but it should fail because adding not-null column is
+      // not supported.
+      assertNotSupported(s"""
+                            |ALTER TABLE $tableName REPLACE COLUMNS (
+                            |  v1 int,
+                            |  v2 string,
+                            |  v3 long NOT NULL,
+                            |  s STRUCT<v1:int, v2:string>,
+                            |  a ARRAY<STRUCT<v1:int, v2:string>>,
+                            |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+                            |)""".stripMargin,
+        "NOT NULL is not supported in Hive-style REPLACE COLUMNS")
+      // s.v3
+      assertNotSupported(s"""
+                            |ALTER TABLE $tableName REPLACE COLUMNS (
+                            |  v1 int,
+                            |  v2 string,
+                            |  s STRUCT<v1:int, v2:string, v3:long NOT NULL>,
+                            |  a ARRAY<STRUCT<v1:int, v2:string>>,
+                            |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+                            |)""".stripMargin,
+        "adding non-nullable column", "s.v3")
+      // a.element.v3
+      assertNotSupported(s"""
+                            |ALTER TABLE $tableName REPLACE COLUMNS (
+                            |  v1 int,
+                            |  v2 string,
+                            |  s STRUCT<v1:int, v2:string>,
+                            |  a ARRAY<STRUCT<v1:int, v2:string, v3:long NOT NULL>>,
+                            |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+                            |)""".stripMargin,
+        "adding non-nullable column", "a.element.v3")
+      // m.key.v3
+      assertNotSupported(s"""
+                            |ALTER TABLE $tableName REPLACE COLUMNS (
+                            |  v1 int,
+                            |  v2 string,
+                            |  s STRUCT<v1:int, v2:string>,
+                            |  a ARRAY<STRUCT<v1:int, v2:string>>,
+                            |  m MAP<STRUCT<v1:int, v2:string, v3:long NOT NULL>, STRUCT<v1:int, v2:string>>
+                            |)""".stripMargin,
+        "adding non-nullable column", "m.key.v3")
+      // m.value.v3
+      assertNotSupported(s"""
+                            |ALTER TABLE $tableName REPLACE COLUMNS (
+                            |  v1 int,
+                            |  v2 string,
+                            |  s STRUCT<v1:int, v2:string>,
+                            |  a ARRAY<STRUCT<v1:int, v2:string>>,
+                            |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string, v3:long NOT NULL>>
+                            |)""".stripMargin,
+        "adding non-nullable column", "m.value.v3")
+    }
+  }
+
+  test("REPLACE COLUMNS - incompatible nullability") {
+    val df = Seq((1, "a"), (2, "b")).toDF("v1", "v2")
+      .withColumn("s", struct("v1", "v2"))
+      .withColumn("a", array("s"))
+      .withColumn("m", map(col("s"), col("s")))
+    withDeltaTable(df) { tableName =>
+
+      // trying to change the data type of v1 of each struct to not null, but it should fail because
+      // tightening nullability is not supported.
+      assertNotSupported(s"""
+                            |ALTER TABLE $tableName REPLACE COLUMNS (
+                            |  v1 int NOT NULL,
+                            |  v2 string,
+                            |  s STRUCT<v1:int, v2:string>,
+                            |  a ARRAY<STRUCT<v1:int, v2:string>>,
+                            |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+                            |)""".stripMargin,
+        "NOT NULL is not supported in Hive-style REPLACE COLUMNS")
+      // s.v1
+      assertNotSupported(s"""
+                            |ALTER TABLE $tableName REPLACE COLUMNS (
+                            |  v1 int,
+                            |  v2 string,
+                            |  s STRUCT<v1:int NOT NULL, v2:string>,
+                            |  a ARRAY<STRUCT<v1:int, v2:string>>,
+                            |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+                            |)""".stripMargin,
+        "tightening nullability", "s.v1")
+      // a.element.v1
+      assertNotSupported(s"""
+                            |ALTER TABLE $tableName REPLACE COLUMNS (
+                            |  v1 int,
+                            |  v2 string,
+                            |  s STRUCT<v1:int, v2:string>,
+                            |  a ARRAY<STRUCT<v1:int NOT NULL, v2:string>>,
+                            |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int, v2:string>>
+                            |)""".stripMargin,
+        "tightening nullability", "a.element.v1")
+      // m.key.v1
+      assertNotSupported(s"""
+                            |ALTER TABLE $tableName REPLACE COLUMNS (
+                            |  v1 int,
+                            |  v2 string,
+                            |  s STRUCT<v1:int, v2:string>,
+                            |  a ARRAY<STRUCT<v1:int, v2:string>>,
+                            |  m MAP<STRUCT<v1:int NOT NULL, v2:string>, STRUCT<v1:int, v2:string>>
+                            |)""".stripMargin,
+        "tightening nullability", "m.key.v1")
+      // m.value.v1
+      assertNotSupported(s"""
+                            |ALTER TABLE $tableName REPLACE COLUMNS (
+                            |  v1 int,
+                            |  v2 string,
+                            |  s STRUCT<v1:int, v2:string>,
+                            |  a ARRAY<STRUCT<v1:int, v2:string>>,
+                            |  m MAP<STRUCT<v1:int, v2:string>, STRUCT<v1:int NOT NULL, v2:string>>
+                            |)""".stripMargin,
+        "tightening nullability", "m.value.v1")
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
@@ -1409,7 +1409,7 @@ trait DeltaAlterTableTests extends DeltaAlterTableTestBase {
   }
 }
 
-trait DeltaAlterTableByNameTests extends DeltaAlterTableTests {
+trait DeltaAlterTableByNameTests extends DeltaAlterTableTests with DeltaAlterTableReplaceTests {
   import testImplicits._
 
   override protected def createTable(schema: String, tblProperties: Map[String, String]): String = {
@@ -1693,6 +1693,7 @@ class DeltaAlterTableByNameSuite
 }
 
 class DeltaAlterTableByPathSuite extends DeltaAlterTableByPathTests with DeltaSQLCommandTest
+  with DeltaAlterTableReplaceTests
 
 
 trait DeltaAlterTableColumnMappingSelectedTests extends DeltaColumnMappingSelectedTestMixin {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDDLUsingPathSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDDLUsingPathSuite.scala
@@ -219,7 +219,7 @@ trait DeltaDDLUsingPathTests extends QueryTest
     val e = intercept[AnalysisException] {
       sql(s"SHOW TBLPROPERTIES delta.`/path/to/delta`").as[(String, String)]
     }
-    assert(e.getMessage.contains(s"doesn't exist"))
+    assert(e.getMessage.contains(s"not a Delta table"))
   }
 
   testUsingPath("SHOW COLUMNS") { (table, path) =>
@@ -243,9 +243,10 @@ trait DeltaDDLUsingPathTests extends QueryTest
     checkDatasetUnorderly(
       sql(s"SHOW COLUMNS IN delta.`$path` IN delta").as[String],
       "v1", "v2", "struct")
-    intercept[DeltaAnalysisException] {
+    val e = intercept[AnalysisException] {
       sql("SHOW COLUMNS IN delta.`/path/to/delta`")
     }
+    assert(e.getMessage.contains(s"not a Delta table"))
   }
 
   testUsingPath("DESCRIBE COLUMN") { (table, path) =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDDLUsingPathSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDDLUsingPathSuite.scala
@@ -38,6 +38,9 @@ trait DeltaDDLUsingPathTests extends QueryTest
 
   import testImplicits._
 
+  protected def catalogName: String = {
+    CatalogManager.SESSION_CATALOG_NAME
+  }
 
   protected def testUsingPath(command: String, tags: Tag*)(f: (String, String) => Unit): Unit = {
     test(s"$command - using path", tags: _*) {
@@ -146,6 +149,137 @@ trait DeltaDDLUsingPathTests extends QueryTest
     }
   }
 
+  testUsingPath("SHOW TBLPROPERTIES") { (table, path) =>
+    sql(s"ALTER TABLE $table SET TBLPROPERTIES " +
+      "('delta.logRetentionDuration' = '2 weeks', 'key' = 'value')")
+
+    val metadata = loadDeltaLog(path).snapshot.metadata
+
+    Seq(table, s"delta.`$path`").foreach { tableOrPath =>
+      checkDatasetUnorderly(
+        dropColumnMappingConfigurations(
+          sql(s"SHOW TBLPROPERTIES $tableOrPath('delta.logRetentionDuration')")
+            .as[(String, String)]),
+        "delta.logRetentionDuration" -> "2 weeks")
+      checkDatasetUnorderly(
+        dropColumnMappingConfigurations(
+          sql(s"SHOW TBLPROPERTIES $tableOrPath('key')").as[(String, String)]),
+        "key" -> "value")
+    }
+
+    checkDatasetUnorderly(
+      dropColumnMappingConfigurations(
+        sql(s"SHOW TBLPROPERTIES $table").as[(String, String)]),
+      "delta.logRetentionDuration" -> "2 weeks",
+      "delta.minReaderVersion" ->
+        Protocol.forNewTable(spark, Some(metadata)).minReaderVersion.toString,
+      "delta.minWriterVersion" ->
+        Protocol.forNewTable(spark, Some(metadata)).minWriterVersion.toString,
+      "key" -> "value")
+
+    checkDatasetUnorderly(
+      dropColumnMappingConfigurations(
+        sql(s"SHOW TBLPROPERTIES delta.`$path`").as[(String, String)]),
+      "delta.logRetentionDuration" -> "2 weeks",
+      "delta.minReaderVersion" ->
+        Protocol.forNewTable(spark, Some(metadata)).minReaderVersion.toString,
+      "delta.minWriterVersion" ->
+        Protocol.forNewTable(spark, Some(metadata)).minWriterVersion.toString,
+      "key" -> "value")
+
+    if (table == "`delta_test`") {
+      val tableName = s"$catalogName.default.delta_test"
+      checkDatasetUnorderly(
+        dropColumnMappingConfigurations(
+          sql(s"SHOW TBLPROPERTIES $table('dEltA.lOgrEteNtiOndURaTion')").as[(String, String)]),
+        "dEltA.lOgrEteNtiOndURaTion" ->
+          s"Table $tableName does not have property: dEltA.lOgrEteNtiOndURaTion")
+      checkDatasetUnorderly(
+        dropColumnMappingConfigurations(
+          sql(s"SHOW TBLPROPERTIES $table('kEy')").as[(String, String)]),
+        "kEy" -> s"Table $tableName does not have property: kEy")
+    } else {
+      checkDatasetUnorderly(
+        dropColumnMappingConfigurations(
+          sql(s"SHOW TBLPROPERTIES $table('kEy')").as[(String, String)]),
+        "kEy" -> s"Table $catalogName.delta.delta_test does not have property: kEy")
+    }
+    checkDatasetUnorderly(
+      dropColumnMappingConfigurations(
+        sql(s"SHOW TBLPROPERTIES delta.`$path`('dEltA.lOgrEteNtiOndURaTion')")
+          .as[(String, String)]),
+      "dEltA.lOgrEteNtiOndURaTion" ->
+        s"Table $catalogName.delta.`$path` does not have property: dEltA.lOgrEteNtiOndURaTion")
+    checkDatasetUnorderly(
+      dropColumnMappingConfigurations(
+        sql(s"SHOW TBLPROPERTIES delta.`$path`('kEy')").as[(String, String)]),
+      "kEy" ->
+        s"Table $catalogName.delta.`$path` does not have property: kEy")
+
+    val e = intercept[AnalysisException] {
+      sql(s"SHOW TBLPROPERTIES delta.`/path/to/delta`").as[(String, String)]
+    }
+    assert(e.getMessage.contains(s"doesn't exist"))
+  }
+
+  testUsingPath("SHOW COLUMNS") { (table, path) =>
+    Seq(table, s"delta.`$path`").foreach { tableOrPath =>
+      checkDatasetUnorderly(
+        sql(s"SHOW COLUMNS IN $tableOrPath").as[String],
+        "v1", "v2", "struct")
+    }
+    if (table == "`delta_test`") {
+      checkDatasetUnorderly(
+        sql(s"SHOW COLUMNS IN $table").as[String],
+        "v1", "v2", "struct")
+    } else {
+      checkDatasetUnorderly(
+        sql(s"SHOW COLUMNS IN $table IN delta").as[String],
+        "v1", "v2", "struct")
+    }
+    checkDatasetUnorderly(
+      sql(s"SHOW COLUMNS IN `$path` IN delta").as[String],
+      "v1", "v2", "struct")
+    checkDatasetUnorderly(
+      sql(s"SHOW COLUMNS IN delta.`$path` IN delta").as[String],
+      "v1", "v2", "struct")
+    intercept[DeltaAnalysisException] {
+      sql("SHOW COLUMNS IN delta.`/path/to/delta`")
+    }
+  }
+
+  testUsingPath("DESCRIBE COLUMN") { (table, path) =>
+    Seq(table, s"delta.`$path`").foreach { tableOrPath =>
+      checkDatasetUnorderly(
+        sql(s"DESCRIBE $tableOrPath v1").as[(String, String)],
+        "col_name" -> "v1",
+        "data_type" -> "int",
+        "comment" -> "NULL")
+      checkDatasetUnorderly(
+        sql(s"DESCRIBE $tableOrPath struct").as[(String, String)],
+        "col_name" -> "struct",
+        "data_type" -> "struct<x:int,y:string>",
+        "comment" -> "NULL")
+      checkDatasetUnorderly(
+        sql(s"DESCRIBE EXTENDED $tableOrPath v1").as[(String, String)],
+        "col_name" -> "v1",
+        "data_type" -> "int",
+        "comment" -> "NULL"
+      )
+      val ex1 = intercept[AnalysisException] {
+        sql(s"DESCRIBE $tableOrPath unknown")
+      }
+      assert(ex1.getErrorClass() === "UNRESOLVED_COLUMN.WITH_SUGGESTION")
+      val ex2 = intercept[AnalysisException] {
+        sql(s"DESCRIBE $tableOrPath struct.x")
+      }
+      assert(ex2.getMessage.contains("DESC TABLE COLUMN does not support nested column: struct.x"))
+    }
+    val ex = intercept[AnalysisException] {
+      sql("DESCRIBE delta.`/path/to/delta` v1")
+    }
+    assert(ex.getMessage.contains("not a Delta table"), s"Original message: ${ex.getMessage()}")
+  }
 }
 
 class DeltaDDLUsingPathSuite extends DeltaDDLUsingPathTests with DeltaSQLCommandTest {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

This PR adds more DDL test coverage around commands like SHOW TBLPROPERTIES, SHOW COLUMNS, DESC COLUMN and also adds support for ALTER TABLE REPLACE COLUMNS.

REPLACE COLUMNS as it is implemented today drops all columns and then adds all new columns. This is actually undesirable for a Delta table, as it will cause all data to be dropped when column mapping is enabled. Therefore the way we implement is to look at the final schema, which is provided by all the ADD COLUMN table changes that are provided and try to resolve the differences. If a difference is ambiguous, then we will throw an error.

A column being dropped and added would lead to an ambiguous change, because we don't know if we should be treating that as a column rename or literally a drop + add. Users should explicitly call ALTER TABLE drop columns + ALTER TABLE add columns instead.

## How was this patch tested?

This patch introduces many new unit tests

## Does this PR introduce _any_ user-facing changes?

Yes, this PR may start throwing ambiguous change errors for ALTER TABLE REPLACE COLUMNS. I doubt that it is used as much, but it would prevent accidental deletion of data. Users can do a REPLACE TABLE if they really wanted to replace the table with empty data.