### PR TITLE
fix S3SingleDriverLogStore write method not closing stream on Exception

### DIFF
--- a/storage/src/main/java/io/delta/storage/S3SingleDriverLogStore.java
+++ b/storage/src/main/java/io/delta/storage/S3SingleDriverLogStore.java
@@ -264,10 +264,13 @@ public class S3SingleDriverLogStore extends HadoopFileSystemLogStore {
                 final CountingOutputStream stream =
                     new CountingOutputStream(fs.create(resolvedPath, overwrite));
 
-                while (actions.hasNext()) {
-                    stream.write((actions.next() + "\n").getBytes(StandardCharsets.UTF_8));
+                try {
+                    while (actions.hasNext()) {
+                        stream.write((actions.next() + "\n").getBytes(StandardCharsets.UTF_8));
+                    }
+                } finally {
+                    stream.close();
                 }
-                stream.close();
 
                 // When a Delta log starts afresh, all cached files in that Delta log become
                 // obsolete, so we remove them from the cache.


### PR DESCRIPTION
## Description

Method write in S3SingleDriverLogStore does not close stream on Exception. Added finally block
to handle closing stream. Used the same pattern as in HadoopFileSystemLogStore.

## How was this patch tested?

Only tested by running existing unit tests. 

## Does this PR introduce _any_ user-facing changes?

No
