### PR TITLE
Add Merge benchmarks

### DIFF
--- a/benchmarks/run-benchmark.py
+++ b/benchmarks/run-benchmark.py
@@ -19,7 +19,7 @@
 import argparse
 from scripts.benchmarks import *
 
-delta_version = "2.1.0"
+delta_version = "2.3.0"
 
 # Benchmark name to their specifications. See the imported benchmarks.py for details of benchmark.
 
@@ -42,6 +42,14 @@ benchmarks = {
     "tpcds-3tb-delta": DeltaTPCDSBenchmarkSpec(delta_version=delta_version, scale_in_gb=3000),
     "tpcds-1gb-parquet": ParquetTPCDSBenchmarkSpec(scale_in_gb=1),
     "tpcds-3tb-parquet": ParquetTPCDSBenchmarkSpec(scale_in_gb=3000),
+
+    # Merge data load
+    "merge-1gb-delta-load": DeltaMergeDataLoadSpec(delta_version=delta_version, scale_in_gb=1),
+    "merge-3tb-delta-load": DeltaMergeDataLoadSpec(delta_version=delta_version, scale_in_gb=3000),
+
+    # Merge benchmark
+    "merge-1gb-delta": DeltaMergeBenchmarkSpec(delta_version=delta_version, scale_in_gb=1),
+    "merge-3tb-delta": DeltaMergeBenchmarkSpec(delta_version=delta_version, scale_in_gb=3000),
 
 }
 

--- a/benchmarks/run-benchmark.py
+++ b/benchmarks/run-benchmark.py
@@ -43,11 +43,11 @@ benchmarks = {
     "tpcds-1gb-parquet": ParquetTPCDSBenchmarkSpec(scale_in_gb=1),
     "tpcds-3tb-parquet": ParquetTPCDSBenchmarkSpec(scale_in_gb=3000),
 
-    # Merge data load
+    # Merge data load.
     "merge-1gb-delta-load": DeltaMergeDataLoadSpec(delta_version=delta_version, scale_in_gb=1),
     "merge-3tb-delta-load": DeltaMergeDataLoadSpec(delta_version=delta_version, scale_in_gb=3000),
 
-    # Merge benchmark
+    # Merge benchmark.
     "merge-1gb-delta": DeltaMergeBenchmarkSpec(delta_version=delta_version, scale_in_gb=1),
     "merge-3tb-delta": DeltaMergeBenchmarkSpec(delta_version=delta_version, scale_in_gb=3000),
 

--- a/benchmarks/scripts/benchmarks.py
+++ b/benchmarks/scripts/benchmarks.py
@@ -105,7 +105,7 @@ class TPCDSDataLoadSpec(BenchmarkSpec):
 
 class TPCDSBenchmarkSpec(BenchmarkSpec):
     """
-    Specifications of TPC-DS benchmark
+    Specifications of TPC-DS benchmark.
     """
     def __init__(self, scale_in_gb, **kwargs):
         # forward all keyword args to next constructor
@@ -134,7 +134,7 @@ class MergeDataLoadSpec(BenchmarkSpec):
 
 class MergeBenchmarkSpec(BenchmarkSpec):
     """
-    Specifications of Merge benchmark
+    Specifications of Merge benchmark.
     """
     def __init__(self, scale_in_gb, **kwargs):
         # forward all keyword args to next constructor
@@ -151,7 +151,7 @@ class MergeBenchmarkSpec(BenchmarkSpec):
 
 class DeltaBenchmarkSpec(BenchmarkSpec):
     """
-    Specification of a benchmark using the Delta format
+    Specification of a benchmark using the Delta format.
     """
     def __init__(self, delta_version, benchmark_main_class, main_class_args=None, scala_version="2.12", **kwargs):
         delta_spark_confs = [
@@ -207,7 +207,7 @@ class DeltaMergeBenchmarkSpec(MergeBenchmarkSpec, DeltaBenchmarkSpec):
 
 class ParquetBenchmarkSpec(BenchmarkSpec):
     """
-    Specification of a benchmark using the Parquet format
+    Specification of a benchmark using the Parquet format.
     """
     def __init__(self, benchmark_main_class, main_class_args=None, **kwargs):
         super().__init__(

--- a/benchmarks/scripts/benchmarks.py
+++ b/benchmarks/scripts/benchmarks.py
@@ -117,6 +117,34 @@ class TPCDSBenchmarkSpec(BenchmarkSpec):
         ])
 
 
+class MergeDataLoadSpec(BenchmarkSpec):
+    """
+    Specifications of Merge data load process.
+    Always mixin in this first before the base benchmark class.
+    """
+    def __init__(self, scale_in_gb, exclude_nulls=True, **kwargs):
+        # forward all keyword args to next constructor
+        super().__init__(benchmark_main_class="benchmark.MergeDataLoad", **kwargs)
+        self.benchmark_main_class_args.extend([
+            "--scale-in-gb", str(scale_in_gb),
+        ])
+        # To access the public TPCDS parquet files on S3
+        self.spark_confs.extend(["spark.hadoop.fs.s3.useRequesterPaysHeader=true"])
+
+
+class MergeBenchmarkSpec(BenchmarkSpec):
+    """
+    Specifications of Merge benchmark
+    """
+    def __init__(self, scale_in_gb, **kwargs):
+        # forward all keyword args to next constructor
+        super().__init__(benchmark_main_class="benchmark.MergeBenchmark", **kwargs)
+        # after init of super class, use the format to add main class args
+        self.benchmark_main_class_args.extend([
+            "--scale-in-gb", str(scale_in_gb)
+        ])
+
+
 
 # ============== Delta benchmark specifications ==============
 
@@ -160,6 +188,16 @@ class DeltaTPCDSDataLoadSpec(TPCDSDataLoadSpec, DeltaBenchmarkSpec):
 
 
 class DeltaTPCDSBenchmarkSpec(TPCDSBenchmarkSpec, DeltaBenchmarkSpec):
+    def __init__(self, delta_version, scale_in_gb=1):
+        super().__init__(delta_version=delta_version, scale_in_gb=scale_in_gb)
+
+
+class DeltaMergeDataLoadSpec(MergeDataLoadSpec, DeltaBenchmarkSpec):
+    def __init__(self, delta_version, scale_in_gb=1):
+        super().__init__(delta_version=delta_version, scale_in_gb=scale_in_gb)
+
+
+class DeltaMergeBenchmarkSpec(MergeBenchmarkSpec, DeltaBenchmarkSpec):
     def __init__(self, delta_version, scale_in_gb=1):
         super().__init__(delta_version=delta_version, scale_in_gb=scale_in_gb)
 

--- a/benchmarks/src/main/scala/benchmark/Benchmark.scala
+++ b/benchmarks/src/main/scala/benchmark/Benchmark.scala
@@ -31,8 +31,8 @@ import com.fasterxml.jackson.databind.{DeserializationFeature, MapperFeature, Ob
 import com.fasterxml.jackson.module.scala.{DefaultScalaModule, ScalaObjectMapper}
 
 import org.apache.spark.SparkUtils
-import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.apache.spark.sql.functions.{col}
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.functions.col
 
 trait BenchmarkConf extends Product {
   /** Cloud path where benchmark data is going to be written. */
@@ -131,7 +131,7 @@ abstract class Benchmark(private val conf: BenchmarkConf) {
       queryName: String = "",
       iteration: Option[Int] = None,
       printRows: Boolean = false,
-      ignoreError: Boolean = true): DataFrame = synchronized {
+      ignoreError: Boolean = true): Seq[Row] = synchronized {
     val iterationStr = iteration.map(i => s" - iteration $i").getOrElse("")
     var banner = s"$queryName$iterationStr"
     if (banner.trim.isEmpty) {
@@ -151,13 +151,13 @@ abstract class Benchmark(private val conf: BenchmarkConf) {
       queryResults += QueryResult(queryName, iteration, Some(durationMs), errorMsg = None)
       log(s"END took $durationMs ms: $banner")
       log("=" * 80)
-      df
+      r
     } catch {
       case NonFatal(e) =>
         log(s"ERROR: $banner\n${e.getMessage}")
         queryResults +=
           QueryResult(queryName, iteration, durationMs = None, errorMsg = Some(e.getMessage))
-        if (!ignoreError) throw e else spark.emptyDataFrame
+        if (!ignoreError) throw e else spark.empty
     }
   }
 

--- a/benchmarks/src/main/scala/benchmark/MergeBenchmark.scala
+++ b/benchmarks/src/main/scala/benchmark/MergeBenchmark.scala
@@ -1,0 +1,137 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package benchmark
+
+import java.util.UUID
+
+import org.apache.spark.sql.Row
+
+trait MergeConf extends BenchmarkConf {
+  def scaleInGB: Int
+  def tableName: String = "web_returns"
+  def userDefinedDbName: Option[String]
+  def dbName: String = userDefinedDbName.getOrElse(s"merge_sf${scaleInGB}")
+  def dbLocation: String = dbLocation(dbName)
+}
+
+case class MergeBenchmarkConf(
+     scaleInGB: Int = 0,
+     userDefinedDbName: Option[String] = None,
+     iterations: Int = 3,
+     benchmarkPath: Option[String] = None) extends MergeConf {
+}
+
+object MergeBenchmarkConf {
+  import scopt.OParser
+  private val builder = OParser.builder[MergeBenchmarkConf]
+  private val argParser = {
+    import builder._
+    OParser.sequence(
+      programName("Merge Benchmark"),
+      opt[String]("scale-in-gb")
+        .required()
+        .valueName("<scale of benchmark in GBs>")
+        .action((x, c) => c.copy(scaleInGB = x.toInt))
+        .text("Scale factor of the TPCDS benchmark"),
+      opt[String]("benchmark-path")
+        .required()
+        .valueName("<cloud storage path>")
+        .action((x, c) => c.copy(benchmarkPath = Some(x)))
+        .text("Cloud path to be used for creating table and generating reports"),
+      opt[String]("iterations")
+        .optional()
+        .valueName("<number of iterations>")
+        .action((x, c) => c.copy(iterations = x.toInt))
+        .text("Number of times to run the queries"),
+    )
+  }
+
+  def parse(args: Array[String]): Option[MergeBenchmarkConf] = {
+    OParser.parse(argParser, args, MergeBenchmarkConf())
+  }
+}
+
+class MergeBenchmark(conf: MergeBenchmarkConf) extends Benchmark(conf) {
+  val extraConfs: Map[String, String] = Map(
+    "spark.sql.broadcastTimeout" -> "7200",
+    "spark.sql.crossJoin.enabled" -> "true"
+  )
+
+  def runInternal(): Unit = {
+    for ((k, v) <- extraConfs) spark.conf.set(k, v)
+    spark.sparkContext.setLogLevel("WARN")
+    log("All configs:\n\t" + spark.conf.getAll.toSeq.sortBy(_._1).mkString("\n\t"))
+    spark.sql(s"USE ${conf.dbName}")
+
+    val targetRowCount = spark.read.table(s"`${conf.dbName}`.`target_${conf.tableName}`").count
+
+    for (iteration <- 1 to conf.iterations) {
+      MergeTestCases.testCases.foreach { runMerge(_, targetRowCount, iteration = Some(iteration)) }
+    }
+    val results = getQueryResults().filter(_.name.startsWith("q"))
+    if (results.forall(x => x.errorMsg.isEmpty && x.durationMs.nonEmpty) ) {
+      val medianDurationSecPerQuery = results.groupBy(_.name).map { case (q, results) =>
+        assert(results.size == conf.iterations)
+        val medianMs = results.map(_.durationMs.get).sorted
+            .drop(math.floor(conf.iterations / 2.0).toInt).head
+        (q, medianMs / 1000.0)
+      }
+      val sumOfMedians = medianDurationSecPerQuery.map(_._2).sum
+      reportExtraMetric("merge-result-seconds", sumOfMedians)
+    }
+  }
+
+  protected def runMerge(
+      testCase: MergeTestCase,
+      targetRowCount: Long,
+      iteration: Option[Int] = None,
+      printRows: Boolean = false,
+      ignoreError: Boolean = true): Seq[Row] = synchronized {
+    withCloneTargetTable(testCase.name) { targetTable =>
+      val result = super.runQuery(
+        testCase.sqlCmd(targetTable),
+        testCase.name,
+        iteration,
+        printRows,
+        ignoreError)
+      testCase.validate(result, targetRowCount)
+      result
+    }
+  }
+
+  protected def withCloneTargetTable[T](testCaseName: String)(f: String => T): T = {
+    val target = s"`${conf.dbName}`.`target_${conf.tableName}`"
+    val clonedTableName = s"`${conf.dbName}`.`${conf.tableName}_${generateUUID()}`"
+    runQuery(s"CREATE TABLE $clonedTableName SHALLOW CLONE $target", s"clone-target-$testCaseName")
+    try {
+      f(clonedTableName)
+    } finally {
+      runQuery(s"DROP TABLE IF EXISTS $clonedTableName", s"drop-target-clone-$testCaseName")
+    }
+  }
+
+  protected def generateUUID(): String =
+    UUID.randomUUID.toString.replace("-", "_").take(8)
+}
+
+object MergeBenchmark {
+  def main(args: Array[String]): Unit = {
+    MergeBenchmarkConf.parse(args).foreach { conf =>
+      new MergeBenchmark(conf).run()
+    }
+  }
+}

--- a/benchmarks/src/main/scala/benchmark/MergeBenchmark.scala
+++ b/benchmarks/src/main/scala/benchmark/MergeBenchmark.scala
@@ -71,7 +71,10 @@ class MergeBenchmark(conf: MergeBenchmarkConf) extends Benchmark(conf) {
     "spark.sql.crossJoin.enabled" -> "true"
   )
 
-  def runInternal(): Unit = {
+  /**
+   * Runs every merge test case multiple times and records the duration.
+   */
+  override def runInternal(): Unit = {
     for ((k, v) <- extraConfs) spark.conf.set(k, v)
     spark.sparkContext.setLogLevel("WARN")
     log("All configs:\n\t" + spark.conf.getAll.toSeq.sortBy(_._1).mkString("\n\t"))
@@ -95,6 +98,10 @@ class MergeBenchmark(conf: MergeBenchmarkConf) extends Benchmark(conf) {
     }
   }
 
+  /**
+   * Merge test runner: clone a fresh target table, run the merge test case, checks invariants then
+   * drops the cloned table.
+   */
   protected def runMerge(
       testCase: MergeTestCase,
       targetRowCount: Long,
@@ -113,6 +120,10 @@ class MergeBenchmark(conf: MergeBenchmarkConf) extends Benchmark(conf) {
     }
   }
 
+  /**
+   * Clones the target table before each test case to use a fresh target table and drops the clone
+   * afterwards.
+   */
   protected def withCloneTargetTable[T](testCaseName: String)(f: String => T): T = {
     val target = s"`${conf.dbName}`.`target_${conf.tableName}`"
     val clonedTableName = s"`${conf.dbName}`.`${conf.tableName}_${generateUUID()}`"

--- a/benchmarks/src/main/scala/benchmark/MergeDataLoad.scala
+++ b/benchmarks/src/main/scala/benchmark/MergeDataLoad.scala
@@ -1,0 +1,188 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package benchmark
+
+import java.util.Locale
+
+import org.apache.spark.sql.functions.{col, countDistinct, hash, isnull, max, rand}
+
+
+case class MergeDataLoadConf(
+    scaleInGB: Int = 0,
+    userDefinedDbName: Option[String] = None,
+    sourcePath: Option[String] = None,
+    benchmarkPath: Option[String] = None,
+    excludeNulls: Boolean = true) extends MergeConf {
+}
+
+/**
+ * Represents a source table configuration used in merge benchmarks. Each [[MergeTestCase]] has one
+ * [[MergeSourceTable]] associated with it, the data loader will collect all source table
+ * configurations for all tests and create the required source tables.
+ * @param fileMatchedFraction Fraction of files from the target table that will get sampled to
+ *                            create the source table.
+ * @param rowMatchedFraction Fraction of rows from the selected files that will get sampled to form
+ *                           the part of the source table that matches the merge condition.
+ * @param rowNotMatchedFraction Fraction of rows from the selected files that will get sampled to
+ *                              form the part of the source table that doesn't match the merge
+ *                              condition.
+ */
+case class MergeSourceTable(
+    fileMatchedFraction: Double,
+    rowMatchedFraction: Double,
+    rowNotMatchedFraction: Double) {
+  def name: String = formatTableName(s"source_" +
+    s"_fileMatchedFraction_$fileMatchedFraction" +
+    s"_rowMatchedFraction_$rowMatchedFraction" +
+    s"_rowNotMatchedFraction_$rowNotMatchedFraction")
+
+  protected def formatTableName(s: String): String = {
+    s.toLowerCase(Locale.ROOT).replaceAll("\\s+", "_").replaceAll("[-,.]", "_")
+  }
+}
+
+object MergeDataLoadConf {
+  import scopt.OParser
+  private val builder = OParser.builder[MergeDataLoadConf]
+  private val argParser = {
+    import builder._
+    OParser.sequence(
+      programName("Merge Data Load"),
+      opt[String]("scale-in-gb")
+        .required()
+        .valueName("<scale of benchmark in GBs>")
+        .action((x, c) => c.copy(scaleInGB = x.toInt))
+        .text("Scale factor of the Merge benchmark"),
+      opt[String]("benchmark-path")
+        .required()
+        .valueName("<cloud storage path>")
+        .action((x, c) => c.copy(benchmarkPath = Some(x)))
+        .text("Cloud storage path to be used for creating table and generating reports"),
+      opt[String]("db-name")
+        .optional()
+        .valueName("<database name>")
+        .action((x, c) => c.copy(userDefinedDbName = Some(x)))
+        .text("Name of the target database to create with TPC-DS tables in necessary format"),
+      opt[String]("source-path")
+        .optional()
+        .valueName("<path to the TPC-DS raw input data>")
+        .action((x, c) => c.copy(sourcePath = Some(x)))
+        .text("The location of the TPC-DS raw input data"),
+      opt[String]("exclude-nulls")
+        .optional()
+        .valueName("true/false")
+        .action((x, c) => c.copy(excludeNulls = x.toBoolean))
+        .text("Whether to remove null primary keys when loading data, default = false"),                                                                                                                                                          )
+  }
+
+  def parse(args: Array[String]): Option[MergeDataLoadConf] = {
+    OParser.parse(argParser, args, MergeDataLoadConf())
+  }
+}
+
+class MergeDataLoad(conf: MergeDataLoadConf) extends Benchmark(conf) {
+
+  protected def targetTableFullName = s"`${conf.dbName}`.`target_${conf.tableName}`"
+
+  protected def dataSourceLocation: String = conf.sourcePath.getOrElse {
+    s"s3://devrel-delta-datasets/tpcds-2.13/tpcds_sf${conf.scaleInGB}_parquet/${conf.tableName}/"
+  }
+
+  def runInternal(): Unit = {
+    val dbName = conf.dbName
+    val dbLocation = conf.dbLocation(dbName, suffix = benchmarkId.replace("-", "_"))
+    val dbCatalog = "spark_catalog"
+
+    require(conf.scaleInGB > 0)
+    require(Seq(1, 3000).contains(conf.scaleInGB), "")
+
+    log(s"====== Creating database =======")
+    runQuery(s"DROP DATABASE IF EXISTS ${dbName} CASCADE", s"drop-database")
+    runQuery(s"CREATE DATABASE IF NOT EXISTS ${dbName}", s"create-database")
+
+    log(s"====== Creating target table =======")
+    loadTargetTable()
+    log(s"====== Creating source tables =======")
+    MergeTestCases.testCases.map(_.sourceTable).distinct.foreach(loadSourceTable)
+    log(s"====== Created all tables in database ${dbName} at '${dbLocation}' =======")
+
+    runQuery(s"USE $dbCatalog.$dbName;")
+    runQuery("SHOW TABLES", printRows = true)
+  }
+
+  protected def loadTargetTable(): Unit = {
+    val dbLocation = conf.dbLocation(conf.dbName, suffix = benchmarkId.replace("-", "_"))
+    val location = s"${dbLocation}/${conf.tableName}/"
+    val sourceFormat = "parquet"
+
+    runQuery(s"DROP TABLE IF EXISTS $targetTableFullName", s"drop-table-$targetTableFullName")
+
+    runQuery(
+      s"""CREATE TABLE $targetTableFullName
+                 USING DELTA
+                 LOCATION '$location'
+                 SELECT * FROM `${sourceFormat}`.`$dataSourceLocation`
+              """, s"create-table-$targetTableFullName", ignoreError = true)
+
+    val sourceRowCount =
+      spark.sql(s"SELECT * FROM `${sourceFormat}`.`$dataSourceLocation`").count()
+    val targetRowCount = spark.table(targetTableFullName).count()
+    val targetFileCount =
+      spark.table(targetTableFullName).select(countDistinct("_metadata.file_path"))
+    log(s"Target file count: $targetFileCount")
+    log(s"Target row count: $targetRowCount")
+
+    assert(targetRowCount == sourceRowCount,
+      s"Row count mismatch: source table = $sourceRowCount, " +
+      s"target $targetTableFullName = $targetRowCount")
+  }
+
+  protected def loadSourceTable(sourceTable: MergeSourceTable): Unit = {
+    val fullTableName = s"`${conf.dbName}`.`${sourceTable.name}`"
+    val dbLocation = conf.dbLocation(conf.dbName, suffix = benchmarkId.replace("-", "_"))
+
+    runQuery(s"DROP TABLE IF EXISTS $fullTableName", s"drop-table-${sourceTable.name}")
+
+    val deltaDf = spark.read.format("delta")
+      .load(s"${dbLocation}/${conf.tableName}/")
+      // Sample files by hashing their paths.
+      .filter(hash(col("_metadata.file_path")) * 0.5 / Integer.MAX_VALUE + 0.5 < sourceTable.fileMatchedFraction)
+    log(s"Matching files row count: ${deltaDf.count}")
+
+    val numberOfNulls = deltaDf.filter(isnull(col("wr_order_number"))).count
+    log(s"wr_order_number contains $numberOfNulls null values")
+    val matchedData = deltaDf.sample(sourceTable.rowMatchedFraction)
+    val notMatchedData = deltaDf.sample(sourceTable.rowNotMatchedFraction)
+      .withColumn("wr_order_number", rand())
+      .withColumn("wr_item_sk", rand())
+
+
+    val data = matchedData.union(notMatchedData)
+
+    val dupes = data.groupBy("wr_order_number", "wr_item_sk").count.filter("count > 1")
+    log(s"Duplicates: ${dupes.collect().mkString("Array(", ",\n", ")")}")
+    data.write.format("delta").saveAsTable(fullTableName)
+  }
+}
+
+object MergeDataLoad {
+  def main(args: Array[String]): Unit = {
+    MergeDataLoadConf.parse(args).foreach { conf =>
+      new MergeDataLoad(conf).run()
+    }
+  }
+}

--- a/benchmarks/src/main/scala/benchmark/MergeDataLoad.scala
+++ b/benchmarks/src/main/scala/benchmark/MergeDataLoad.scala
@@ -33,22 +33,22 @@ case class MergeDataLoadConf(
  * Represents a table configuration used as a source in merge test cases. Each [[MergeTestCase]] has
  * one [[MergeSourceTable]] associated with it, the data loader will collect all source table
  * configurations for all tests and create the required source tables.
- * @param fileMatchedFraction Fraction of files from the base table that will get sampled to
- *                            create the source table.
- * @param rowMatchedFraction Fraction of rows from the selected files that will get sampled to form
- *                           the part of the source table that matches the merge condition.
- * @param rowNotMatchedFraction Fraction of rows from the selected files that will get sampled to
- *                              form the part of the source table that doesn't match the merge
- *                              condition.
+ * @param filesMatchedFraction Fraction of files from the base table that will get sampled to
+ *                             create the source table.
+ * @param rowsMatchedFraction Fraction of rows from the selected files that will get sampled to form
+ *                            the part of the source table that matches the merge condition.
+ * @param rowsNotMatchedFraction Fraction of rows from the selected files that will get sampled to
+ *                               form the part of the source table that doesn't match the merge
+ *                               condition.
  */
 case class MergeSourceTable(
-    fileMatchedFraction: Double,
-    rowMatchedFraction: Double,
-    rowNotMatchedFraction: Double) {
+    filesMatchedFraction: Double,
+    rowsMatchedFraction: Double,
+    rowsNotMatchedFraction: Double) {
   def name: String = formatTableName(s"source_" +
-    s"_fileMatchedFraction_$fileMatchedFraction" +
-    s"_rowMatchedFraction_$rowMatchedFraction" +
-    s"_rowNotMatchedFraction_$rowNotMatchedFraction")
+    s"_filesMatchedFraction_$filesMatchedFraction" +
+    s"_rowsMatchedFraction_$rowsMatchedFraction" +
+    s"_rowsNotMatchedFraction_$rowsNotMatchedFraction")
 
   protected def formatTableName(s: String): String = {
     s.toLowerCase(Locale.ROOT).replaceAll("\\s+", "_").replaceAll("[-,.]", "_")
@@ -175,7 +175,7 @@ class MergeDataLoad(conf: MergeDataLoadConf) extends Benchmark(conf) {
     val sampledFilesDF = fullTableDF
       .select("_metadata.file_path")
       .distinct
-      .sample(sourceTableConf.fileMatchedFraction)
+      .sample(sourceTableConf.filesMatchedFraction)
 
     // Read the data from the sampled files and sample two sets of rows for MATCHED clauses and
     // NOT MATCHED clauses respectively.
@@ -186,8 +186,8 @@ class MergeDataLoad(conf: MergeDataLoadConf) extends Benchmark(conf) {
 
     val numberOfNulls = sampledDataDF.filter(isnull(col("wr_order_number"))).count
     log(s"wr_order_number contains $numberOfNulls null values")
-    val matchedData = sampledDataDF.sample(sourceTableConf.rowMatchedFraction)
-    val notMatchedData = sampledDataDF.sample(sourceTableConf.rowNotMatchedFraction)
+    val matchedData = sampledDataDF.sample(sourceTableConf.rowsMatchedFraction)
+    val notMatchedData = sampledDataDF.sample(sourceTableConf.rowsNotMatchedFraction)
       .withColumn("wr_order_number", rand())
       .withColumn("wr_item_sk", rand())
 

--- a/benchmarks/src/main/scala/benchmark/MergeDataLoad.scala
+++ b/benchmarks/src/main/scala/benchmark/MergeDataLoad.scala
@@ -102,6 +102,9 @@ class MergeDataLoad(conf: MergeDataLoadConf) extends Benchmark(conf) {
     s"s3://devrel-delta-datasets/tpcds-2.13/tpcds_sf${conf.scaleInGB}_parquet/${conf.tableName}/"
   }
 
+  /**
+   * Creates the target table and all source table configuration used in merge test cases.
+   */
   def runInternal(): Unit = {
     val dbName = conf.dbName
     val dbLocation = conf.dbLocation(dbName, suffix = benchmarkId.replace("-", "_"))
@@ -124,6 +127,9 @@ class MergeDataLoad(conf: MergeDataLoadConf) extends Benchmark(conf) {
     runQuery("SHOW TABLES", printRows = true)
   }
 
+  /**
+   * Creates the target Delta table and performs sanity checks.
+   */
   protected def loadTargetTable(): Unit = {
     val dbLocation = conf.dbLocation(conf.dbName, suffix = benchmarkId.replace("-", "_"))
     val location = s"${dbLocation}/${conf.tableName}/"
@@ -151,6 +157,9 @@ class MergeDataLoad(conf: MergeDataLoadConf) extends Benchmark(conf) {
       s"target $targetTableFullName = $targetRowCount")
   }
 
+  /**
+   * Creates a source table for the given source table configuration by sampling the target table.
+   */
   protected def loadSourceTable(sourceTable: MergeSourceTable): Unit = {
     val fullTableName = s"`${conf.dbName}`.`${sourceTable.name}`"
     val dbLocation = conf.dbLocation(conf.dbName, suffix = benchmarkId.replace("-", "_"))

--- a/benchmarks/src/main/scala/benchmark/MergeTestCases.scala
+++ b/benchmarks/src/main/scala/benchmark/MergeTestCases.scala
@@ -47,13 +47,13 @@ trait MergeTestCase {
  * Trait shared by all insert-only merge test cases.
  */
 trait InsertOnlyTestCase extends MergeTestCase {
-    val fileMatchedFraction: Double
-    val rowNotMatchedFraction: Double
+    val filesMatchedFraction: Double
+    val rowsNotMatchedFraction: Double
 
   override def sourceTable: MergeSourceTable = MergeSourceTable(
-    fileMatchedFraction,
-    rowMatchedFraction = 0,
-    rowNotMatchedFraction)
+    filesMatchedFraction,
+    rowsMatchedFraction = 0,
+    rowsNotMatchedFraction)
 
   override def validate(mergeStats: Seq[Row], targetRowCount: Long): Unit = {
     assert(mergeStats.length == 1)
@@ -66,12 +66,12 @@ trait InsertOnlyTestCase extends MergeTestCase {
  * A merge test case with a single WHEN NOT MATCHED THEN INSERT * clause.
  */
 case class SingleInsertOnlyTestCase(
-    fileMatchedFraction: Double,
-    rowNotMatchedFraction: Double) extends InsertOnlyTestCase {
+    filesMatchedFraction: Double,
+    rowsNotMatchedFraction: Double) extends InsertOnlyTestCase {
 
   override val name: String = "single_insert_only" +
-    s"_fileMatchedFraction_$fileMatchedFraction" +
-    s"_rowNotMatchedFraction_$rowNotMatchedFraction"
+    s"_filesMatchedFraction_$filesMatchedFraction" +
+    s"_rowsNotMatchedFraction_$rowsNotMatchedFraction"
 
 
   override def sqlCmd(targetTable: String): String = {
@@ -86,12 +86,12 @@ case class SingleInsertOnlyTestCase(
  * A merge test case with two WHEN NOT MATCHED (AND condition) THEN INSERT * clauses.
  */
 case class MultipleInsertOnlyTestCase(
-    fileMatchedFraction: Double,
-    rowNotMatchedFraction: Double) extends InsertOnlyTestCase {
+    filesMatchedFraction: Double,
+    rowsNotMatchedFraction: Double) extends InsertOnlyTestCase {
 
   override val name: String = "multiple_insert_only" +
-    s"_fileMatchedFraction_$fileMatchedFraction" +
-    s"_rowNotMatchedFraction_$rowNotMatchedFraction"
+    s"_filesMatchedFraction_$filesMatchedFraction" +
+    s"_rowsNotMatchedFraction_$rowsNotMatchedFraction"
 
   override def sqlCmd(targetTable: String): String = {
     s"""MERGE INTO $targetTable t
@@ -106,17 +106,17 @@ case class MultipleInsertOnlyTestCase(
  * A merge test case with a single WHEN MATCHED THEN DELETED clause.
  */
 case class DeleteOnlyTestCase(
-    fileMatchedFraction: Double,
-    rowMatchedFraction: Double) extends MergeTestCase {
+    filesMatchedFraction: Double,
+    rowsMatchedFraction: Double) extends MergeTestCase {
 
   override val name: String = "delete_only" +
-    s"_fileMatchedFraction_$fileMatchedFraction" +
-    s"_rowMatchedFraction_$rowMatchedFraction"
+    s"_filesMatchedFraction_$filesMatchedFraction" +
+    s"_rowsMatchedFraction_$rowsMatchedFraction"
 
   override def sourceTable: MergeSourceTable = MergeSourceTable(
-    fileMatchedFraction,
-    rowMatchedFraction,
-    rowNotMatchedFraction = 0)
+    filesMatchedFraction,
+    rowsMatchedFraction,
+    rowsNotMatchedFraction = 0)
 
   override def sqlCmd(targetTable: String): String = {
     s"""MERGE INTO $targetTable t
@@ -136,19 +136,19 @@ case class DeleteOnlyTestCase(
  * A merge test case with a MATCHED UPDATE and a NOT MATCHED INSERT clause.
  */
 case class UpsertTestCase(
-    fileMatchedFraction: Double,
-    rowMatchedFraction: Double,
-    rowNotMatchedFraction: Double) extends MergeTestCase {
+    filesMatchedFraction: Double,
+    rowsMatchedFraction: Double,
+    rowsNotMatchedFraction: Double) extends MergeTestCase {
 
   override val name: String = "upsert" +
-    s"_fileMatchedFraction_$fileMatchedFraction" +
-    s"_rowMatchedFraction_$rowMatchedFraction" +
-    s"_rowNotMatchedFraction_$rowNotMatchedFraction"
+    s"_filesMatchedFraction_$filesMatchedFraction" +
+    s"_rowsMatchedFraction_$rowsMatchedFraction" +
+    s"_rowsNotMatchedFraction_$rowsNotMatchedFraction"
 
   override def sourceTable: MergeSourceTable = MergeSourceTable(
-    fileMatchedFraction,
-    rowMatchedFraction,
-    rowNotMatchedFraction)
+    filesMatchedFraction,
+    rowsMatchedFraction,
+    rowsNotMatchedFraction)
 
   override def sqlCmd(targetTable: String): String = {
     s"""MERGE INTO $targetTable t
@@ -171,53 +171,53 @@ object MergeTestCases {
     upsertTestCases
 
   def insertOnlyTestCases: Seq[MergeTestCase] =
-    Seq(0.05, 0.5, 1.0).flatMap { rowNotMatchedFraction =>
+    Seq(0.05, 0.5, 1.0).flatMap { rowsNotMatchedFraction =>
       Seq(
         SingleInsertOnlyTestCase(
-          fileMatchedFraction = 0.05,
-          rowNotMatchedFraction),
+          filesMatchedFraction = 0.05,
+          rowsNotMatchedFraction),
 
         MultipleInsertOnlyTestCase(
-          fileMatchedFraction = 0.05,
-          rowNotMatchedFraction)
+          filesMatchedFraction = 0.05,
+          rowsNotMatchedFraction)
       )
     }
 
   def deleteOnlyTestCases: Seq[MergeTestCase] = Seq(
     DeleteOnlyTestCase(
-      fileMatchedFraction = 0.05,
-      rowMatchedFraction = 0.05))
+      filesMatchedFraction = 0.05,
+      rowsMatchedFraction = 0.05))
 
   def upsertTestCases: Seq[MergeTestCase] = Seq(
-    Seq(0.0, 0.01, 0.1).map { rowMatchedFraction =>
+    Seq(0.0, 0.01, 0.1).map { rowsMatchedFraction =>
       UpsertTestCase(
-        fileMatchedFraction = 0.05,
-        rowMatchedFraction,
-        rowNotMatchedFraction = 0.1)
+        filesMatchedFraction = 0.05,
+        rowsMatchedFraction,
+        rowsNotMatchedFraction = 0.1)
     },
 
-    Seq(0.5, 0.99, 1.0).map { rowMatchedFraction =>
+    Seq(0.5, 0.99, 1.0).map { rowsMatchedFraction =>
       UpsertTestCase(
-        fileMatchedFraction = 0.05,
-        rowMatchedFraction,
-        rowNotMatchedFraction = 0.001)
+        filesMatchedFraction = 0.05,
+        rowsMatchedFraction,
+        rowsNotMatchedFraction = 0.001)
     },
 
     Seq(
       UpsertTestCase(
-        fileMatchedFraction = 0.05,
-        rowMatchedFraction = 0.1,
-        rowNotMatchedFraction = 0.0),
+        filesMatchedFraction = 0.05,
+        rowsMatchedFraction = 0.1,
+        rowsNotMatchedFraction = 0.0),
 
       UpsertTestCase(
-        fileMatchedFraction = 0.5,
-        rowMatchedFraction = 0.01,
-        rowNotMatchedFraction = 0.001),
+        filesMatchedFraction = 0.5,
+        rowsMatchedFraction = 0.01,
+        rowsNotMatchedFraction = 0.001),
 
       UpsertTestCase(
-        fileMatchedFraction = 1.0,
-        rowMatchedFraction = 0.01,
-        rowNotMatchedFraction = 0.001)
+        filesMatchedFraction = 1.0,
+        rowsMatchedFraction = 0.01,
+        rowsNotMatchedFraction = 0.001)
     )
   ).flatten
 }

--- a/benchmarks/src/main/scala/benchmark/MergeTestCases.scala
+++ b/benchmarks/src/main/scala/benchmark/MergeTestCases.scala
@@ -1,0 +1,238 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package benchmark
+
+import org.apache.spark.sql.Row
+
+trait MergeTestCase {
+  def name: String
+  def sourceTable: MergeSourceTable
+  def sqlCmd(targetTable: String): String
+  def validate(mergeStats: Seq[Row], targetRowCount: Long): Unit
+}
+
+trait InsertOnlyTestCase extends MergeTestCase {
+    val fileMatchedFraction: Double
+    val rowNotMatchedFraction: Double
+
+  override def sourceTable: MergeSourceTable = MergeSourceTable(
+    fileMatchedFraction,
+    rowMatchedFraction = 0,
+    rowNotMatchedFraction)
+
+  override def validate(mergeStats: Seq[Row], targetRowCount: Long): Unit = {
+    assert(mergeStats.length == 1)
+    assert(mergeStats.head.getAs[Long]("num_updated_rows") == 0)
+    assert(mergeStats.head.getAs[Long]("num_deleted_rows") == 0)
+  }
+}
+
+case class SingleInsertOnlyTestCase(
+    fileMatchedFraction: Double,
+    rowNotMatchedFraction: Double) extends InsertOnlyTestCase {
+
+  override val name: String = "single_insert_only" +
+    s"_fileMatchedFraction_$fileMatchedFraction" +
+    s"_rowNotMatchedFraction_$rowNotMatchedFraction"
+
+
+  override def sqlCmd(targetTable: String): String = {
+    s"""MERGE INTO $targetTable t
+        |USING ${sourceTable.name} s
+        |ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk
+        |WHEN NOT MATCHED THEN INSERT *""".stripMargin
+   }
+}
+
+case class MultipleInsertOnlyTestCase(
+    fileMatchedFraction: Double,
+    rowNotMatchedFraction: Double) extends InsertOnlyTestCase {
+
+  override val name: String = "multiple_insert_only" +
+    s"_fileMatchedFraction_$fileMatchedFraction" +
+    s"_rowNotMatchedFraction_$rowNotMatchedFraction"
+
+  override def sqlCmd(targetTable: String): String = {
+    s"""MERGE INTO $targetTable t
+        |USING ${sourceTable.name} s
+        |ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk
+        |WHEN NOT MATCHED AND s.wr_item_sk % 2 = 0 THEN INSERT *
+        |WHEN NOT MATCHED THEN INSERT *""".stripMargin
+   }
+}
+
+case class DeleteOnlyTestCase(
+    fileMatchedFraction: Double,
+    rowMatchedFraction: Double) extends MergeTestCase {
+
+  override val name: String = "delete_only" +
+    s"_fileMatchedFraction_$fileMatchedFraction" +
+    s"_rowMatchedFraction_$rowMatchedFraction"
+
+  override def sourceTable: MergeSourceTable = MergeSourceTable(
+    fileMatchedFraction,
+    rowMatchedFraction,
+    rowNotMatchedFraction = 0)
+
+  override def sqlCmd(targetTable: String): String = {
+    s"""MERGE INTO $targetTable t
+        |USING ${sourceTable.name} s
+        |ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk
+        |WHEN MATCHED THEN DELETE""".stripMargin
+   }
+
+  override def validate(mergeStats: Seq[Row], targetRowCount: Long): Unit = {
+    assert(mergeStats.length == 1)
+    assert(mergeStats.head.getAs[Long]("num_updated_rows") == 0)
+    assert(mergeStats.head.getAs[Long]("num_inserted_rows") == 0)
+  }
+}
+
+case class UpsertTestCase(
+    fileMatchedFraction: Double,
+    rowMatchedFraction: Double,
+    rowNotMatchedFraction: Double) extends MergeTestCase {
+
+  override val name: String = "upsert" +
+    s"_fileMatchedFraction_$fileMatchedFraction" +
+    s"_rowMatchedFraction_$rowMatchedFraction" +
+    s"_rowNotMatchedFraction_$rowNotMatchedFraction"
+
+  override def sourceTable: MergeSourceTable = MergeSourceTable(
+    fileMatchedFraction,
+    rowMatchedFraction,
+    rowNotMatchedFraction)
+
+  override def sqlCmd(targetTable: String): String = {
+    s"""MERGE INTO $targetTable t
+        |USING ${sourceTable.name} s
+        |ON t.wr_order_number = s.wr_order_number AND t.wr_item_sk = s.wr_item_sk
+        |WHEN MATCHED THEN UPDATE SET *
+        |WHEN NOT MATCHED THEN INSERT *""".stripMargin
+   }
+
+  override def validate(mergeStats: Seq[Row], targetRowCount: Long): Unit = {
+    assert(mergeStats.length == 1)
+    assert(mergeStats.head.getAs[Long]("num_deleted_rows") == 0)
+  }
+}
+
+object MergeTestCases {
+  def testCases: Seq[MergeTestCase] =
+    insertOnlyTestCases ++
+    deleteOnlyTestCases ++
+    upsertTestCases
+
+  def insertOnlyTestCases: Seq[MergeTestCase] = Seq(
+    SingleInsertOnlyTestCase(
+      fileMatchedFraction = 0.005,
+      rowNotMatchedFraction = 0.005),
+    SingleInsertOnlyTestCase(
+      fileMatchedFraction = 0.005,
+      rowNotMatchedFraction = 0.05),
+    SingleInsertOnlyTestCase(
+      fileMatchedFraction = 0.005,
+      rowNotMatchedFraction = 0.5),
+    SingleInsertOnlyTestCase(
+      fileMatchedFraction = 0.005,
+      rowNotMatchedFraction = 1.0),
+    SingleInsertOnlyTestCase(
+      fileMatchedFraction = 0.1,
+      rowNotMatchedFraction = 0.005),
+
+    MultipleInsertOnlyTestCase(
+      fileMatchedFraction = 0.005,
+      rowNotMatchedFraction = 0.005),
+    MultipleInsertOnlyTestCase(
+      fileMatchedFraction = 0.005,
+      rowNotMatchedFraction = 0.05),
+    MultipleInsertOnlyTestCase(
+      fileMatchedFraction = 0.005,
+      rowNotMatchedFraction = 0.5),
+    MultipleInsertOnlyTestCase(
+      fileMatchedFraction = 0.005,
+      rowNotMatchedFraction = 1.0),
+    MultipleInsertOnlyTestCase(
+      fileMatchedFraction = 0.1,
+      rowNotMatchedFraction = 0.005))
+
+  def deleteOnlyTestCases: Seq[MergeTestCase] = Seq(
+    DeleteOnlyTestCase(
+      fileMatchedFraction = 0.005,
+      rowMatchedFraction = 0.005))
+
+  def upsertTestCases: Seq[MergeTestCase] = Seq(
+    UpsertTestCase(
+      fileMatchedFraction = 0.005,
+      rowMatchedFraction = 0.005,
+      rowNotMatchedFraction = 0.005),
+
+    UpsertTestCase(
+      fileMatchedFraction = 0.05,
+      rowMatchedFraction = 0.1,
+      rowNotMatchedFraction = 0.01),
+
+    UpsertTestCase(
+      fileMatchedFraction = 0.01,
+      rowMatchedFraction = 0.1,
+      rowNotMatchedFraction = 0.01),
+
+    UpsertTestCase(
+      fileMatchedFraction = 0.05,
+      rowMatchedFraction = 0.0,
+      rowNotMatchedFraction = 0.1),
+
+    UpsertTestCase(
+      fileMatchedFraction = 0.05,
+      rowMatchedFraction = 0.01,
+      rowNotMatchedFraction = 0.1),
+
+    UpsertTestCase(
+      fileMatchedFraction = 0.05,
+      rowMatchedFraction = 0.1,
+      rowNotMatchedFraction = 0.0),
+
+    UpsertTestCase(
+      fileMatchedFraction = 0.5,
+      rowMatchedFraction = 0.01,
+      rowNotMatchedFraction = 0.001),
+
+    UpsertTestCase(
+      fileMatchedFraction = 1.0,
+      rowMatchedFraction = 0.01,
+      rowNotMatchedFraction = 0.001),
+
+    UpsertTestCase(
+      fileMatchedFraction = 0.01,
+      rowMatchedFraction = 0.5,
+      rowNotMatchedFraction = 0.001),
+
+    UpsertTestCase(
+      fileMatchedFraction = 0.05,
+      rowMatchedFraction = 0.5,
+      rowNotMatchedFraction = 0.001),
+
+    UpsertTestCase(
+      fileMatchedFraction = 0.05,
+      rowMatchedFraction = 0.99,
+      rowNotMatchedFraction = 0.001),
+
+    UpsertTestCase(
+      fileMatchedFraction = 0.05,
+      rowMatchedFraction = 1.0,
+      rowNotMatchedFraction = 0.001))
+}

--- a/benchmarks/src/main/scala/benchmark/MergeTestCases.scala
+++ b/benchmarks/src/main/scala/benchmark/MergeTestCases.scala
@@ -174,9 +174,11 @@ object MergeTestCases {
     SingleInsertOnlyTestCase(
       fileMatchedFraction = 0.05,
       rowNotMatchedFraction = 0.05),
+
     SingleInsertOnlyTestCase(
       fileMatchedFraction = 0.05,
       rowNotMatchedFraction = 0.5),
+
     SingleInsertOnlyTestCase(
       fileMatchedFraction = 0.05,
       rowNotMatchedFraction = 1.0),
@@ -184,9 +186,11 @@ object MergeTestCases {
     MultipleInsertOnlyTestCase(
       fileMatchedFraction = 0.05,
       rowNotMatchedFraction = 0.05),
+
     MultipleInsertOnlyTestCase(
       fileMatchedFraction = 0.05,
       rowNotMatchedFraction = 0.5),
+
     MultipleInsertOnlyTestCase(
       fileMatchedFraction = 0.05,
       rowNotMatchedFraction = 1.0),

--- a/benchmarks/src/main/scala/benchmark/MergeTestCases.scala
+++ b/benchmarks/src/main/scala/benchmark/MergeTestCases.scala
@@ -170,82 +170,54 @@ object MergeTestCases {
     deleteOnlyTestCases ++
     upsertTestCases
 
-  def insertOnlyTestCases: Seq[MergeTestCase] = Seq(
-    SingleInsertOnlyTestCase(
-      fileMatchedFraction = 0.05,
-      rowNotMatchedFraction = 0.05),
+  def insertOnlyTestCases: Seq[MergeTestCase] =
+    Seq(0.05, 0.5, 1.0).flatMap { rowNotMatchedFraction =>
+      Seq(
+        SingleInsertOnlyTestCase(
+          fileMatchedFraction = 0.05,
+          rowNotMatchedFraction),
 
-    SingleInsertOnlyTestCase(
-      fileMatchedFraction = 0.05,
-      rowNotMatchedFraction = 0.5),
-
-    SingleInsertOnlyTestCase(
-      fileMatchedFraction = 0.05,
-      rowNotMatchedFraction = 1.0),
-
-    MultipleInsertOnlyTestCase(
-      fileMatchedFraction = 0.05,
-      rowNotMatchedFraction = 0.05),
-
-    MultipleInsertOnlyTestCase(
-      fileMatchedFraction = 0.05,
-      rowNotMatchedFraction = 0.5),
-
-    MultipleInsertOnlyTestCase(
-      fileMatchedFraction = 0.05,
-      rowNotMatchedFraction = 1.0),
-  )
+        MultipleInsertOnlyTestCase(
+          fileMatchedFraction = 0.05,
+          rowNotMatchedFraction)
+      )
+    }
 
   def deleteOnlyTestCases: Seq[MergeTestCase] = Seq(
     DeleteOnlyTestCase(
       fileMatchedFraction = 0.05,
-      rowMatchedFraction = 0.05),
-  )
+      rowMatchedFraction = 0.05))
 
   def upsertTestCases: Seq[MergeTestCase] = Seq(
+    Seq(0.0, 0.01, 0.1).map { rowMatchedFraction =>
+      UpsertTestCase(
+        fileMatchedFraction = 0.05,
+        rowMatchedFraction,
+        rowNotMatchedFraction = 0.1)
+    },
 
-    UpsertTestCase(
-      fileMatchedFraction = 0.05,
-      rowMatchedFraction = 0.1,
-      rowNotMatchedFraction = 0.01),
+    Seq(0.5, 0.99, 1.0).map { rowMatchedFraction =>
+      UpsertTestCase(
+        fileMatchedFraction = 0.05,
+        rowMatchedFraction,
+        rowNotMatchedFraction = 0.001)
+    },
 
-    UpsertTestCase(
-      fileMatchedFraction = 0.05,
-      rowMatchedFraction = 0.0,
-      rowNotMatchedFraction = 0.1),
+    Seq(
+      UpsertTestCase(
+        fileMatchedFraction = 0.05,
+        rowMatchedFraction = 0.1,
+        rowNotMatchedFraction = 0.0),
 
-    UpsertTestCase(
-      fileMatchedFraction = 0.05,
-      rowMatchedFraction = 0.01,
-      rowNotMatchedFraction = 0.1),
+      UpsertTestCase(
+        fileMatchedFraction = 0.5,
+        rowMatchedFraction = 0.01,
+        rowNotMatchedFraction = 0.001),
 
-    UpsertTestCase(
-      fileMatchedFraction = 0.05,
-      rowMatchedFraction = 0.1,
-      rowNotMatchedFraction = 0.0),
-
-    UpsertTestCase(
-      fileMatchedFraction = 0.5,
-      rowMatchedFraction = 0.01,
-      rowNotMatchedFraction = 0.001),
-
-    UpsertTestCase(
-      fileMatchedFraction = 1.0,
-      rowMatchedFraction = 0.01,
-      rowNotMatchedFraction = 0.001),
-
-    UpsertTestCase(
-      fileMatchedFraction = 0.05,
-      rowMatchedFraction = 0.5,
-      rowNotMatchedFraction = 0.001),
-
-    UpsertTestCase(
-      fileMatchedFraction = 0.05,
-      rowMatchedFraction = 0.99,
-      rowNotMatchedFraction = 0.001),
-
-    UpsertTestCase(
-      fileMatchedFraction = 0.05,
-      rowMatchedFraction = 1.0,
-      rowNotMatchedFraction = 0.001))
+      UpsertTestCase(
+        fileMatchedFraction = 1.0,
+        rowMatchedFraction = 0.01,
+        rowNotMatchedFraction = 0.001)
+    )
+  ).flatten
 }

--- a/benchmarks/src/main/scala/benchmark/TPCDSBenchmark.scala
+++ b/benchmarks/src/main/scala/benchmark/TPCDSBenchmark.scala
@@ -80,10 +80,6 @@ class TPCDSBenchmark(conf: TPCDSBenchmarkConf) extends Benchmark(conf) {
   }
 
   val dbName = conf.dbName
-  val extraConfs: Map[String, String] = Map(
-    "spark.sql.broadcastTimeout" -> "7200",
-    "spark.sql.crossJoin.enabled" -> "true"
-  )
 
   def runInternal(): Unit = {
     for ((k, v) <- extraConfs) spark.conf.set(k, v)


### PR DESCRIPTION
## Description

This PR extends the existing benchmarks with new test cases dedicated to the MERGE INTO command, with two scale factors: 1GB & 3TB.
The following type of test cases are created and can be extended in the future:
- `SingleInsertOnlyTestCase`
- `MultipleInsertOnlyTestCase`
- `DeleteOnlyTestCase`
- `UpsertTestCase`

Each test case uses the same (cloned) target table and defines its source table using the following parameters:
- `fileMatchedFraction`: The fraction of target files sampled to create the source table.
- `rowMatchedFraction: The fraction of rows sampled in each selected target file to form the rows that match the `ON` condition.
- `rowNotMatchedFraction`: The fraction of rows sampled in each selected target file to form the rows that don't match the `ON` condition.

The target and source tables are created using the `merge-1gb-delta-load`/`merge-3tb-delta-load`, which collect all the source table configurations used in merge test cases and creates the required source tables.

## How was this patch tested?

This benchmark is added to measure the impact of a series of changes to the merge command, see https://github.com/delta-io/delta/issues/1827

I followed the instructions in https://github.com/delta-io/delta/tree/master/benchmarks to create an EMR cluster and run the new benchmarks. Here are the result comparing the impact of https://github.com/delta-io/delta/issues/1827:

Test case  | Base duration (s) | Test duration (s)  |  Improvement ratio
-- | -- | -- | --
delete_only_fileMatchedFraction_0.05_rowMatchedFraction_0.05 | 26,1 | 20,5 | 1,27
multiple_insert_only_fileMatchedFraction_0.05_rowNotMatchedFraction_0.05 | 8,8 | 15,2 | 0,58
multiple_insert_only_fileMatchedFraction_0.05_rowNotMatchedFraction_0.5 | 27,7 | 17,5 | 1,58
multiple_insert_only_fileMatchedFraction_0.05_rowNotMatchedFraction_1.0 | 36,3 | 21,2 | 1,71
single_insert_only_fileMatchedFraction_0.05_rowNotMatchedFraction_0.05 | 14,9 | 14,8 | 1,01
single_insert_only_fileMatchedFraction_0.05_rowNotMatchedFraction_0.5 | 17,5 | 17,3 | 1,01
single_insert_only_fileMatchedFraction_0.05_rowNotMatchedFraction_1.0 | 20,3 | 20,7 | 0,98
upsert_fileMatchedFraction_0.05_rowMatchedFraction_0.01_rowNotMatchedFraction_0.1 | 39,5 | 28,8 | 1,37
upsert_fileMatchedFraction_0.05_rowMatchedFraction_0.0_rowNotMatchedFraction_0.1 | 19,9 | 19,3 | 1,03
upsert_fileMatchedFraction_0.05_rowMatchedFraction_0.1_rowNotMatchedFraction_0.0 | 39,1 | 29,9 | 1,31
upsert_fileMatchedFraction_0.05_rowMatchedFraction_0.1_rowNotMatchedFraction_0.01 | 39,1 | 31 | 1,26
upsert_fileMatchedFraction_0.05_rowMatchedFraction_0.5_rowNotMatchedFraction_0.001 | 41,9 | 32,5 | 1,29
upsert_fileMatchedFraction_0.05_rowMatchedFraction_0.99_rowNotMatchedFraction_0.001 | 43,3 | 33,8 | 1,28
upsert_fileMatchedFraction_0.05_rowMatchedFraction_1.0_rowNotMatchedFraction_0.001 | 43,8 | 34,1 | 1,28
upsert_fileMatchedFraction_0.5_rowMatchedFraction_0.01_rowNotMatchedFraction_0.001 | 147,9 | 84,8 | 1,74
upsert_fileMatchedFraction_1.0_rowMatchedFraction_0.01_rowNotMatchedFraction_0.001 | 266,9 | 142,5 | 1,87

