### PR TITLE
[Kernel] Add Default client implementations

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/data/ColumnarBatch.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/data/ColumnarBatch.java
@@ -19,7 +19,7 @@ package io.delta.kernel.data;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
 
-import io.delta.kernel.internal.ColumnarBatchRow;
+import io.delta.kernel.internal.data.ColumnarBatchRow;
 
 /**
  * Represents zero or more rows of records with same schema type.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/data/ColumnarBatch.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/data/ColumnarBatch.java
@@ -19,6 +19,8 @@ package io.delta.kernel.data;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
 
+import io.delta.kernel.internal.ColumnarBatchRow;
+
 /**
  * Represents zero or more rows of records with same schema type.
  */
@@ -55,8 +57,30 @@ public interface ColumnarBatch {
     /**
      * @return iterator of {@link Row}s in this batch
      */
-    default CloseableIterator<Row> getRows() {
-        // TODO needs io.delta.kernel.internal.ColumnarBatchRow
-        throw new UnsupportedOperationException("Not yet implemented!");
+    default CloseableIterator<Row> getRows()
+    {
+        final ColumnarBatch batch = this;
+        return new CloseableIterator<Row>()
+        {
+            int rowId = 0;
+            int maxRowId = getSize();
+
+            @Override
+            public boolean hasNext()
+            {
+                return rowId < maxRowId;
+            }
+
+            @Override
+            public Row next()
+            {
+                Row row = new ColumnarBatchRow(batch, rowId);
+                rowId += 1;
+                return row;
+            }
+
+            @Override
+            public void close() {}
+        };
     }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/data/Row.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/data/Row.java
@@ -24,7 +24,8 @@ import io.delta.kernel.types.StructType;
 /**
  * Represent a single record
  */
-public interface Row {
+public interface Row
+{
 
     /**
      * @return Schema of the record.
@@ -44,6 +45,18 @@ public interface Row {
     boolean getBoolean(int ordinal);
 
     /**
+     * Return byte value of the column located at the given ordinal.
+     * Throws error if the column at given ordinal is not of boolean type,
+     */
+    byte getByte(int ordinal);
+
+    /**
+     * Return short value of the column located at the given ordinal.
+     * Throws error if the column at given ordinal is not of boolean type,
+     */
+    short getShort(int ordinal);
+
+    /**
      * Return integer value of the column located at the given ordinal.
      * Throws error if the column at given ordinal is not of integer type,
      */
@@ -56,10 +69,28 @@ public interface Row {
     long getLong(int ordinal);
 
     /**
+     * Return float value of the column located at the given ordinal.
+     * Throws error if the column at given ordinal is not of long type,
+     */
+    float getFloat(int ordinal);
+
+    /**
+     * Return double value of the column located at the given ordinal.
+     * Throws error if the column at given ordinal is not of long type,
+     */
+    double getDouble(int ordinal);
+
+    /**
      * Return string value of the column located at the given ordinal.
      * Throws error if the column at given ordinal is not of varchar type,
      */
     String getString(int ordinal);
+
+    /**
+     * Return binary value of the column located at the given ordinal.
+     * Throws error if the column at given ordinal is not of varchar type,
+     */
+    byte[] getBinary(int ordinal);
 
     /**
      * Return struct value of the column located at the given ordinal.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/Literal.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/Literal.java
@@ -16,14 +16,12 @@
 
 package io.delta.kernel.expressions;
 
+import java.sql.Date;
+import java.sql.Timestamp;
 import java.util.Objects;
 
 import io.delta.kernel.data.Row;
-import io.delta.kernel.types.BooleanType;
-import io.delta.kernel.types.DataType;
-import io.delta.kernel.types.IntegerType;
-import io.delta.kernel.types.LongType;
-import io.delta.kernel.types.StringType;
+import io.delta.kernel.types.*;
 
 /**
  * A literal value.
@@ -31,93 +29,174 @@ import io.delta.kernel.types.StringType;
  * Only supports primitive data types, see
  * <a href="https://github.com/delta-io/delta/blob/master/PROTOCOL.md#primitive-types">Delta Transaction Log Protocol: Primitive Types</a>.
  */
-public final class Literal extends LeafExpression {
-
-    ////////////////////////////////////////////////////////////////////////////////
-    // Static Fields / Methods
-    ////////////////////////////////////////////////////////////////////////////////
-
+public final class Literal extends LeafExpression
+{
     public static final Literal TRUE = Literal.of(true);
     public static final Literal FALSE = Literal.of(false);
 
     /**
-     * Create an integer {@link Literal} object
-     * @param value integer value
-     * @return a {@link Literal} with data type {@link IntegerType}
-     */
-    public static Literal of(int value) {
-        return new Literal(value, IntegerType.INSTANCE);
-    }
-
-    /**
      * Create a boolean {@link Literal} object
+     *
      * @param value boolean value
      * @return a {@link Literal} with data type {@link BooleanType}
      */
-    public static Literal of(boolean value) {
+    public static Literal of(boolean value)
+    {
         return new Literal(value, BooleanType.INSTANCE);
     }
 
     /**
+     * @return a {@link Literal} with data type {@link ByteType}
+     */
+    public static Literal of(byte value)
+    {
+        return new Literal(value, ByteType.INSTANCE);
+    }
+
+    /**
+     * @return a {@link Literal} with data type {@link ShortType}
+     */
+    public static Literal of(short value)
+    {
+        return new Literal(value, ShortType.INSTANCE);
+    }
+
+    /**
+     * Create an integer {@link Literal} object
+     *
+     * @param value integer value
+     * @return a {@link Literal} with data type {@link IntegerType}
+     */
+    public static Literal of(int value)
+    {
+        return new Literal(value, IntegerType.INSTANCE);
+    }
+
+    /**
      * Create a long {@link Literal} object
+     *
      * @param value long value
      * @return a {@link Literal} with data type {@link LongType}
      */
-    public static Literal of(long value) {
+    public static Literal of(long value)
+    {
         return new Literal(value, LongType.INSTANCE);
     }
 
     /**
+     * @return a {@link Literal} with data type {@link FloatType}
+     */
+    public static Literal of(float value)
+    {
+        return new Literal(value, FloatType.INSTANCE);
+    }
+
+    /**
+     * @return a {@link Literal} with data type {@link DoubleType}
+     */
+    public static Literal of(double value)
+    {
+        return new Literal(value, DoubleType.INSTANCE);
+    }
+
+    /**
      * Create a string {@link Literal} object
+     *
      * @param value string value
      * @return a {@link Literal} with data type {@link StringType}
      */
-    public static Literal of(String value) {
+    public static Literal of(String value)
+    {
         return new Literal(value, StringType.INSTANCE);
     }
 
-    ////////////////////////////////////////////////////////////////////////////////
-    // Instance Fields / Methods
-    ////////////////////////////////////////////////////////////////////////////////
+    /**
+     * @return a {@link Literal} with data type {@link BinaryType}
+     */
+    public static Literal of(byte[] value)
+    {
+        return new Literal(value, BinaryType.INSTANCE);
+    }
+
+    /**
+     * @return a {@link Literal} with data type {@link DateType}
+     */
+    public static Literal of(Date value)
+    {
+        return new Literal(value, DateType.INSTANCE);
+    }
+
+    /**
+     * @return a {@link Literal} with data type {@link TimestampType}
+     */
+    public static Literal of(Timestamp value)
+    {
+        return new Literal(value, TimestampType.INSTANCE);
+    }
+
+    /**
+     * @return a null {@link Literal} with the given data type
+     */
+    public static Literal ofNull(DataType dataType)
+    {
+        if (dataType instanceof ArrayType
+            || dataType instanceof MapType
+            || dataType instanceof StructType) {
+            throw new IllegalArgumentException(
+                dataType + " is an invalid data type for Literal.");
+        }
+        return new Literal(null, dataType);
+    }
 
     private final Object value;
     private final DataType dataType;
 
-    private Literal(Object value, DataType dataType) {
+    private Literal(Object value, DataType dataType)
+    {
         this.value = value;
         this.dataType = dataType;
     }
 
-    public Object value() {
+    public Object value()
+    {
         return value;
     }
 
     @Override
-    public Object eval(Row record) {
+    public Object eval(Row record)
+    {
         return value;
     }
 
     @Override
-    public DataType dataType() {
+    public DataType dataType()
+    {
         return dataType;
     }
 
     @Override
-    public String toString() {
+    public String toString()
+    {
         return String.valueOf(value);
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         Literal literal = (Literal) o;
         return Objects.equals(value, literal.value) &&
             Objects.equals(dataType, literal.dataType);
     }
 
     @Override
-    public int hashCode() {
+    public int hashCode()
+    {
         return Objects.hash(value, dataType);
     }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ColumnarBatchRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ColumnarBatchRow.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.types.StructType;
+
+/**
+ * Row abstraction around a columnar batch and a particular row within the columnar batch.
+ */
+public class ColumnarBatchRow
+    implements Row
+{
+    private final ColumnarBatch columnarBatch;
+    private final int rowId;
+
+    public ColumnarBatchRow(ColumnarBatch columnarBatch, int rowId)
+    {
+        this.columnarBatch = Objects.requireNonNull(columnarBatch, "columnarBatch is null");
+        this.rowId = rowId;
+    }
+
+    @Override
+    public StructType getSchema()
+    {
+        return columnarBatch.getSchema();
+    }
+
+    @Override
+    public boolean isNullAt(int ordinal)
+    {
+        return columnVector(ordinal).isNullAt(rowId);
+    }
+
+    @Override
+    public boolean getBoolean(int ordinal)
+    {
+        return columnVector(ordinal).getBoolean(rowId);
+    }
+
+    @Override
+    public byte getByte(int ordinal)
+    {
+        return columnVector(ordinal).getByte(rowId);
+    }
+
+    @Override
+    public short getShort(int ordinal)
+    {
+        return columnVector(ordinal).getShort(rowId);
+    }
+
+    @Override
+    public int getInt(int ordinal)
+    {
+        return columnVector(ordinal).getInt(rowId);
+    }
+
+    @Override
+    public long getLong(int ordinal)
+    {
+        return columnVector(ordinal).getLong(rowId);
+    }
+
+    @Override
+    public float getFloat(int ordinal)
+    {
+        return columnVector(ordinal).getFloat(rowId);
+    }
+
+    @Override
+    public double getDouble(int ordinal)
+    {
+        return columnVector(ordinal).getDouble(rowId);
+    }
+
+    @Override
+    public String getString(int ordinal)
+    {
+        return columnVector(ordinal).getString(rowId);
+    }
+
+    @Override
+    public byte[] getBinary(int ordinal)
+    {
+        return columnVector(ordinal).getBinary(rowId);
+    }
+
+    @Override
+    public Row getStruct(int ordinal)
+    {
+        return columnVector(ordinal).getStruct(rowId);
+    }
+
+    @Override
+    public <T> List<T> getArray(int ordinal)
+    {
+        return columnVector(ordinal).getArray(rowId);
+    }
+
+    @Override
+    public <K, V> Map<K, V> getMap(int ordinal)
+    {
+        return columnVector(ordinal).getMap(rowId);
+    }
+
+    private ColumnVector columnVector(int ordinal)
+    {
+        return columnarBatch.getColumnVector(ordinal);
+    }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ColumnarBatchRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ColumnarBatchRow.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.delta.kernel.internal;
+package io.delta.kernel.internal.data;
 
 import java.util.List;
 import java.util.Map;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/utils/CloseableIterator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/utils/CloseableIterator.java
@@ -24,9 +24,11 @@ import java.util.function.Function;
 
 public interface CloseableIterator<T> extends Iterator<T>, Closeable
 {
-    default <U> CloseableIterator<U> map(Function<T, U> mapper) {
+    default <U> CloseableIterator<U> map(Function<T, U> mapper)
+    {
         CloseableIterator<T> delegate = this;
-        return new CloseableIterator<U>() {
+        return new CloseableIterator<U>()
+        {
             @Override
             public void remove()
             {
@@ -53,7 +55,7 @@ public interface CloseableIterator<T> extends Iterator<T>, Closeable
 
             @Override
             public void close()
-                    throws IOException
+                throws IOException
             {
                 delegate.close();
             }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/utils/Utils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/utils/Utils.java
@@ -214,4 +214,16 @@ public class Utils
             throw exception;
         }
     }
+
+    /**
+     * Close the given list of {@link Closeable} objects. Any exception thrown is silently ignored.
+     * @param closeables
+     */
+    public static void closeCloseablesSilently(Closeable... closeables) {
+        try {
+            closeCloseables(closeables);
+        } catch (Throwable throwable) {
+            // ignore
+        }
+    }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/utils/Utils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/utils/Utils.java
@@ -16,6 +16,7 @@
 
 package io.delta.kernel.utils;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
 
@@ -182,22 +183,23 @@ public class Utils
     }
 
     /**
-     * Close the given one or more {@link CloseableIterator}s. {@link CloseableIterator#close()}
-     * will be called on all given non-null iterators. Will throw unchecked {@link RuntimeException}
-     * if an error occurs while closing. If multiple iterators causes exceptions in closing, the
-     * exceptions will be added as suppressed to the main exception that is thrown.
+     * Close the given one or more {@link Closeable}s. {@link Closeable#close()}
+     * will be called on all given non-null closeables. Will throw unchecked
+     * {@link RuntimeException} if an error occurs while closing. If multiple closeables causes
+     * exceptions in closing, the exceptions will be added as suppressed to the main exception
+     * that is thrown.
      *
-     * @param iters
+     * @param closeables
      */
-    public static void closeIterators(CloseableIterator<? extends Object>... iters)
+    public static void closeCloseables(Closeable... closeables)
     {
         RuntimeException exception = null;
-        for (CloseableIterator<? extends Object> iter : iters) {
-            if (iter == null) {
+        for (Closeable closeable : closeables) {
+            if (closeable == null) {
                 continue;
             }
             try {
-                iter.close();
+                closeable.close();
             }
             catch (Exception ex) {
                 if (exception == null) {

--- a/kernel/kernel-api/src/test/java/io/delta/kernel/internal/types/JsonHandlerTestImpl.java
+++ b/kernel/kernel-api/src/test/java/io/delta/kernel/internal/types/JsonHandlerTestImpl.java
@@ -231,6 +231,18 @@ public class JsonHandlerTestImpl
         }
 
         @Override
+        public byte getByte(int ordinal)
+        {
+            throw new UnsupportedOperationException("not yet implemented - test only");
+        }
+
+        @Override
+        public short getShort(int ordinal)
+        {
+            throw new UnsupportedOperationException("not yet implemented - test only");
+        }
+
+        @Override
         public int getInt(int ordinal)
         {
             return (int) parsedValues[ordinal];
@@ -243,9 +255,27 @@ public class JsonHandlerTestImpl
         }
 
         @Override
+        public float getFloat(int ordinal)
+        {
+            throw new UnsupportedOperationException("not yet implemented - test only");
+        }
+
+        @Override
+        public double getDouble(int ordinal)
+        {
+            throw new UnsupportedOperationException("not yet implemented - test only");
+        }
+
+        @Override
         public String getString(int ordinal)
         {
             return (String) parsedValues[ordinal];
+        }
+
+        @Override
+        public byte[] getBinary(int ordinal)
+        {
+            throw new UnsupportedOperationException("not yet implemented - test only");
         }
 
         @Override

--- a/kernel/kernel-default/src/main/java/io/delta/kernel/DefaultKernelUtils.java
+++ b/kernel/kernel-default/src/main/java/io/delta/kernel/DefaultKernelUtils.java
@@ -15,7 +15,9 @@
  */
 package io.delta.kernel;
 
-import java.util.ArrayList;
+import java.sql.Date;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -29,6 +31,8 @@ import io.delta.kernel.types.StructType;
 
 public class DefaultKernelUtils
 {
+    private static final LocalDate EPOCH = LocalDate.ofEpochDay(0);
+
     private DefaultKernelUtils() {}
 
     /**
@@ -160,5 +164,16 @@ public class DefaultKernelUtils
         if (!isValid) {
             throw new IllegalStateException(message);
         }
+    }
+
+    /**
+     * Utility method to get the number of days since epoch this given date is.
+     *
+     * @param date
+     */
+    public static int daysSinceEpoch(Date date)
+    {
+        LocalDate localDate = date.toLocalDate();
+        return (int) ChronoUnit.DAYS.between(EPOCH, localDate);
     }
 }

--- a/kernel/kernel-default/src/main/java/io/delta/kernel/client/DefaultExpressionHandler.java
+++ b/kernel/kernel-default/src/main/java/io/delta/kernel/client/DefaultExpressionHandler.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.client;
+
+import static io.delta.kernel.DefaultKernelUtils.checkArgument;
+import static io.delta.kernel.DefaultKernelUtils.daysSinceEpoch;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.util.Optional;
+
+import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.data.vector.DefaultBooleanVector;
+import io.delta.kernel.data.vector.DefaultConstantVector;
+import io.delta.kernel.expressions.Expression;
+import io.delta.kernel.expressions.ExpressionEvaluator;
+import io.delta.kernel.expressions.Literal;
+import io.delta.kernel.types.*;
+import io.delta.kernel.utils.CloseableIterator;
+
+public class DefaultExpressionHandler
+    implements ExpressionHandler
+{
+    @Override
+    public ExpressionEvaluator getEvaluator(StructType batchSchema, Expression expression)
+    {
+        return new DefaultExpressionEvaluator(expression);
+    }
+
+    private static class DefaultExpressionEvaluator
+        implements ExpressionEvaluator
+    {
+        private final Expression expression;
+
+        private DefaultExpressionEvaluator(Expression expression)
+        {
+            this.expression = expression;
+        }
+
+        @Override
+        public ColumnVector eval(ColumnarBatch input)
+        {
+            if (expression instanceof Literal) {
+                return evalLiteralExpression(input, (Literal) expression);
+            }
+
+            if (expression.dataType().equals(BooleanType.INSTANCE)) {
+                return evalBooleanOutputExpression(input, expression);
+            }
+            // TODO: Boolean output type expressions are good enough for first preview release
+            // which enables partition pruning and file skipping using file stats.
+
+            throw new UnsupportedOperationException("not yet implemented");
+        }
+
+        @Override
+        public void close() { /* nothing to close */ }
+    }
+
+    private static ColumnVector evalBooleanOutputExpression(
+        ColumnarBatch input, Expression expression)
+    {
+        checkArgument(expression.dataType().equals(BooleanType.INSTANCE),
+            "expression should return a boolean");
+
+        final int batchSize = input.getSize();
+        boolean[] result = new boolean[batchSize];
+        boolean[] nullResult = new boolean[batchSize];
+        CloseableIterator<Row> rows = input.getRows();
+        for (int currentIndex = 0; currentIndex < batchSize; currentIndex++) {
+            Object evalResult = expression.eval(rows.next());
+            if (evalResult == null) {
+                nullResult[currentIndex] = true;
+            }
+            else {
+                result[currentIndex] = ((Boolean) evalResult).booleanValue();
+            }
+        }
+        return new DefaultBooleanVector(batchSize, Optional.of(nullResult), result);
+    }
+
+    private static ColumnVector evalLiteralExpression(ColumnarBatch input, Literal literal)
+    {
+        Object result = literal.value();
+        DataType dataType = literal.dataType();
+        int size = input.getSize();
+
+        if (result == null) {
+            return new DefaultConstantVector(dataType, size, null);
+        }
+
+        if (dataType instanceof BooleanType ||
+            dataType instanceof ByteType ||
+            dataType instanceof ShortType ||
+            dataType instanceof IntegerType ||
+            dataType instanceof LongType ||
+            dataType instanceof FloatType ||
+            dataType instanceof DoubleType ||
+            dataType instanceof StringType ||
+            dataType instanceof BinaryType) {
+            return new DefaultConstantVector(dataType, size, result);
+        }
+        else if (dataType instanceof DateType) {
+            int numOfDaysSinceEpoch = daysSinceEpoch((Date) result);
+            return new DefaultConstantVector(dataType, size, numOfDaysSinceEpoch);
+        }
+        else if (dataType instanceof TimestampType) {
+            Timestamp timestamp = (Timestamp) result;
+            long micros = timestamp.getTime() * 1000;
+            return new DefaultConstantVector(dataType, size, micros);
+        }
+
+        throw new UnsupportedOperationException(
+            "unsupported expression encountered: " + literal);
+    }
+}

--- a/kernel/kernel-default/src/main/java/io/delta/kernel/client/DefaultFileHandler.java
+++ b/kernel/kernel-default/src/main/java/io/delta/kernel/client/DefaultFileHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.client;
+
+import static java.util.Objects.requireNonNull;
+
+import io.delta.kernel.data.Row;
+import io.delta.kernel.expressions.Expression;
+import io.delta.kernel.utils.CloseableIterator;
+
+/**
+ * Default client implementation of {@link FileHandler}. It splits file as one split.
+ */
+public class DefaultFileHandler
+    implements FileHandler
+{
+    @Override
+    public CloseableIterator<FileReadContext> contextualizeFileReads(
+        CloseableIterator<Row> fileIter, Expression filter)
+    {
+        requireNonNull(fileIter, "fileIter is null");
+        requireNonNull(filter, "filter is null");
+        // TODO: we are not using the filter now, will be used later.
+        return fileIter.map(scanFileRow -> new DefaultFileReadContext(scanFileRow));
+    }
+}

--- a/kernel/kernel-default/src/main/java/io/delta/kernel/client/DefaultFileReadContext.java
+++ b/kernel/kernel-default/src/main/java/io/delta/kernel/client/DefaultFileReadContext.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.client;
+
+import static java.util.Objects.requireNonNull;
+
+import io.delta.kernel.data.Row;
+
+public class DefaultFileReadContext
+    implements FileReadContext
+{
+    private final Row scanFileRow;
+
+    public DefaultFileReadContext(Row scanFileRow)
+    {
+        this.scanFileRow = requireNonNull(scanFileRow, "scanFileRow is null");
+    }
+
+    @Override
+    public Row getScanFileRow()
+    {
+        return this.scanFileRow;
+    }
+}

--- a/kernel/kernel-default/src/main/java/io/delta/kernel/client/DefaultFileSystemClient.java
+++ b/kernel/kernel-default/src/main/java/io/delta/kernel/client/DefaultFileSystemClient.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.client;
+
+import java.io.FileNotFoundException;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Iterator;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import io.delta.kernel.fs.FileStatus;
+import io.delta.kernel.utils.CloseableIterator;
+import io.delta.kernel.utils.Utils;
+
+public class DefaultFileSystemClient
+    implements FileSystemClient
+{
+    private final Configuration hadoopConf;
+
+    public DefaultFileSystemClient(Configuration hadoopConf)
+    {
+        this.hadoopConf = hadoopConf;
+    }
+
+    @Override
+    public CloseableIterator<FileStatus> listFrom(String filePath)
+    {
+        try {
+            Iterator<org.apache.hadoop.fs.FileStatus> iter;
+
+            Path path = new Path(filePath);
+            FileSystem fs = path.getFileSystem(hadoopConf);
+            if (!fs.exists(path.getParent())) {
+                throw new FileNotFoundException(
+                    String.format("No such file or directory: %s", path.getParent())
+                );
+            }
+            org.apache.hadoop.fs.FileStatus[] files = fs.listStatus(path.getParent());
+            iter = Arrays.stream(files)
+                .filter(f -> f.getPath().getName().compareTo(path.getName()) >= 0)
+                .sorted(Comparator.comparing(o -> o.getPath().getName()))
+                .iterator();
+
+            return Utils.toCloseableIterator(iter)
+                .map(hadoopFileStatus ->
+                    FileStatus.of(
+                        hadoopFileStatus.getPath().toString(),
+                        hadoopFileStatus.getLen(),
+                        hadoopFileStatus.getModificationTime())
+                );
+        }
+        catch (Exception ex) {
+            throw new RuntimeException("Could not resolve the FileSystem", ex);
+        }
+    }
+}

--- a/kernel/kernel-default/src/main/java/io/delta/kernel/client/DefaultJsonHandler.java
+++ b/kernel/kernel-default/src/main/java/io/delta/kernel/client/DefaultJsonHandler.java
@@ -167,7 +167,7 @@ public class DefaultJsonHandler
                         currentFileReader = new BufferedReader(
                             new InputStreamReader(stream, StandardCharsets.UTF_8));
                     } catch (Exception e){
-                        Utils.closeCloseables(stream); // close it avoid leaking resources
+                        Utils.closeCloseablesSilently(stream); // close it avoid leaking resources
                     }
                 }
             }

--- a/kernel/kernel-default/src/main/java/io/delta/kernel/client/DefaultJsonHandler.java
+++ b/kernel/kernel-default/src/main/java/io/delta/kernel/client/DefaultJsonHandler.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.client;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.NoSuchElementException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.data.DefaultRowBasedColumnarBatch;
+import io.delta.kernel.data.FileDataReadResult;
+import io.delta.kernel.data.DefaultJsonRow;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.fs.FileStatus;
+import io.delta.kernel.types.StructType;
+import io.delta.kernel.utils.CloseableIterator;
+import io.delta.kernel.utils.Utils;
+
+public class DefaultJsonHandler
+    extends DefaultFileHandler
+    implements JsonHandler
+{
+    private final ObjectMapper objectMapper;
+    private final Configuration hadoopConf;
+    private final int maxBatchSize;
+
+    public DefaultJsonHandler(Configuration hadoopConf)
+    {
+        this.objectMapper = new ObjectMapper();
+        this.hadoopConf = hadoopConf;
+        this.maxBatchSize =
+            hadoopConf.getInt("delta.kernel.default.json.reader.batch-size", 1024);
+    }
+
+    @Override
+    public ColumnarBatch parseJson(ColumnVector jsonStringVector, StructType outputSchema)
+    {
+        List<Row> rows = new ArrayList<>();
+        for (int i = 0; i < jsonStringVector.getSize(); i++) {
+            rows.add(parseJson(jsonStringVector.getString(i), outputSchema));
+        }
+        return new DefaultRowBasedColumnarBatch(outputSchema, rows);
+    }
+
+    @Override
+    public CloseableIterator<FileDataReadResult> readJsonFiles(
+        CloseableIterator<FileReadContext> fileIter,
+        StructType physicalSchema) throws IOException
+    {
+        return new CloseableIterator<FileDataReadResult>()
+        {
+            private FileReadContext currentFile;
+            private BufferedReader currentFileReader;
+            private String nextLine;
+
+            @Override
+            public void close()
+                throws IOException
+            {
+                Utils.closeCloseables(currentFileReader, fileIter);
+            }
+
+            @Override
+            public boolean hasNext()
+            {
+                if (nextLine != null) {
+                    return true; // we have un-consumed last read line
+                }
+
+                // There is no file in reading or the current file being read has no more data
+                // initialize the next file reader or return false if there are no more files to
+                // read.
+                try {
+                    if (currentFileReader == null ||
+                        (nextLine = currentFileReader.readLine()) == null) {
+
+                        tryOpenNextFile();
+                        if (currentFileReader != null) {
+                            nextLine = currentFileReader.readLine();
+                        }
+                    }
+                }
+                catch (IOException ex) {
+                    throw new RuntimeException(ex);
+                }
+
+                return nextLine != null;
+            }
+
+            @Override
+            public FileDataReadResult next()
+            {
+                if (nextLine == null) {
+                    throw new NoSuchElementException();
+                }
+
+                List<Row> rows = new ArrayList<>();
+                int currentBatchSize = 0;
+                do {
+                    // hasNext already reads the next one and keeps it in member variable `nextLine`
+                    rows.add(parseJson(nextLine, physicalSchema));
+                    nextLine = null;
+                    currentBatchSize++;
+                }
+                while (currentBatchSize < maxBatchSize && hasNext());
+
+                ColumnarBatch batch = new DefaultRowBasedColumnarBatch(physicalSchema, rows);
+                Row scanFileRow = currentFile.getScanFileRow();
+                return new FileDataReadResult()
+                {
+                    @Override
+                    public ColumnarBatch getData()
+                    {
+                        return batch;
+                    }
+
+                    @Override
+                    public Row getScanFileRow()
+                    {
+                        return scanFileRow;
+                    }
+                };
+            }
+
+            private void tryOpenNextFile()
+                throws IOException
+            {
+                Utils.closeCloseables(currentFileReader); // close the current opened file
+                currentFileReader = null;
+
+                if (fileIter.hasNext()) {
+                    currentFile = fileIter.next();
+                    FileStatus fileStatus =
+                        Utils.getFileStatus(currentFile.getScanFileRow());
+                    Path filePath = new Path(fileStatus.getPath());
+                    FileSystem fs = filePath.getFileSystem(hadoopConf);
+                    FSDataInputStream stream = null;
+                    try {
+                        stream = fs.open(filePath);
+                        currentFileReader = new BufferedReader(
+                            new InputStreamReader(stream, StandardCharsets.UTF_8));
+                    } catch (Exception e){
+                        Utils.closeCloseables(stream); // close it avoid leaking resources
+                    }
+                }
+            }
+        };
+    }
+
+    private Row parseJson(String json, StructType readSchema)
+    {
+        try {
+            final JsonNode jsonNode = objectMapper.readTree(json);
+            return new DefaultJsonRow((ObjectNode) jsonNode, readSchema);
+        }
+        catch (JsonProcessingException ex) {
+            throw new RuntimeException(String.format("Could not parse JSON: %s", json), ex);
+        }
+    }
+}

--- a/kernel/kernel-default/src/main/java/io/delta/kernel/client/DefaultJsonHandler.java
+++ b/kernel/kernel-default/src/main/java/io/delta/kernel/client/DefaultJsonHandler.java
@@ -168,6 +168,7 @@ public class DefaultJsonHandler
                             new InputStreamReader(stream, StandardCharsets.UTF_8));
                     } catch (Exception e){
                         Utils.closeCloseablesSilently(stream); // close it avoid leaking resources
+                        throw e;
                     }
                 }
             }

--- a/kernel/kernel-default/src/main/java/io/delta/kernel/client/DefaultTableClient.java
+++ b/kernel/kernel-default/src/main/java/io/delta/kernel/client/DefaultTableClient.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.client;
+
+import org.apache.hadoop.conf.Configuration;
+
+public class DefaultTableClient
+        implements TableClient
+{
+    private final Configuration hadoopConf;
+
+    private DefaultTableClient(Configuration hadoopConf)
+    {
+        this.hadoopConf = hadoopConf;
+    }
+
+    @Override
+    public ExpressionHandler getExpressionHandler()
+    {
+        return new DefaultExpressionHandler();
+    }
+
+    @Override
+    public JsonHandler getJsonHandler()
+    {
+        return new DefaultJsonHandler(hadoopConf);
+    }
+
+    @Override
+    public FileSystemClient getFileSystemClient()
+    {
+        return new DefaultFileSystemClient(hadoopConf);
+    }
+
+    @Override
+    public ParquetHandler getParquetHandler()
+    {
+        return new DefaultParquetHandler(hadoopConf);
+    }
+
+    /**
+     * Create an instance of {@link DefaultTableClient}.
+     * @param hadoopConf Hadoop configuration to use.
+     * @return
+     */
+    public static DefaultTableClient create(Configuration hadoopConf) {
+        return new DefaultTableClient(hadoopConf);
+    }
+}

--- a/kernel/kernel-default/src/main/java/io/delta/kernel/data/DefaultJsonRow.java
+++ b/kernel/kernel-default/src/main/java/io/delta/kernel/data/DefaultJsonRow.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.data;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import io.delta.kernel.types.ArrayType;
+import io.delta.kernel.types.BooleanType;
+import io.delta.kernel.types.DataType;
+import io.delta.kernel.types.IntegerType;
+import io.delta.kernel.types.LongType;
+import io.delta.kernel.types.MapType;
+import io.delta.kernel.types.MixedDataType;
+import io.delta.kernel.types.StringType;
+import io.delta.kernel.types.StructField;
+import io.delta.kernel.types.StructType;
+
+public class DefaultJsonRow implements Row
+{
+    private final Object[] parsedValues;
+    private final StructType readSchema;
+
+    public DefaultJsonRow(ObjectNode rootNode, StructType readSchema)
+    {
+        this.readSchema = readSchema;
+        this.parsedValues = new Object[readSchema.length()];
+
+        for (int i = 0; i < readSchema.length(); i++) {
+            final StructField field = readSchema.at(i);
+            final Object parsedValue = decodeField(rootNode, field);
+            parsedValues[i] = parsedValue;
+        }
+    }
+
+    @Override
+    public StructType getSchema()
+    {
+        return readSchema;
+    }
+
+    @Override
+    public boolean isNullAt(int ordinal)
+    {
+        return parsedValues[ordinal] == null;
+    }
+
+    @Override
+    public boolean getBoolean(int ordinal)
+    {
+        return (boolean) parsedValues[ordinal];
+    }
+
+    @Override
+    public byte getByte(int ordinal)
+    {
+        throw new UnsupportedOperationException("not yet implemented");
+    }
+
+    @Override
+    public short getShort(int ordinal)
+    {
+        throw new UnsupportedOperationException("not yet implemented");
+    }
+
+    @Override
+    public int getInt(int ordinal)
+    {
+        return (int) parsedValues[ordinal];
+    }
+
+    @Override
+    public long getLong(int ordinal)
+    {
+        return (long) parsedValues[ordinal];
+    }
+
+    @Override
+    public float getFloat(int ordinal)
+    {
+        throw new UnsupportedOperationException("not yet implemented");
+    }
+
+    @Override
+    public double getDouble(int ordinal)
+    {
+        throw new UnsupportedOperationException("not yet implemented");
+    }
+
+    @Override
+    public String getString(int ordinal)
+    {
+        return (String) parsedValues[ordinal];
+    }
+
+    @Override
+    public byte[] getBinary(int ordinal)
+    {
+        throw new UnsupportedOperationException("not yet implemented");
+    }
+
+    @Override
+    public Row getStruct(int ordinal)
+    {
+        return (DefaultJsonRow) parsedValues[ordinal];
+    }
+
+    @Override
+    public <T> List<T> getArray(int ordinal)
+    {
+        return (List<T>) parsedValues[ordinal];
+    }
+
+    @Override
+    public <K, V> Map<K, V> getMap(int ordinal)
+    {
+        return (Map<K, V>) parsedValues[ordinal];
+    }
+
+    private static void throwIfTypeMismatch(String expType, boolean hasExpType, JsonNode jsonNode)
+    {
+        if (!hasExpType) {
+            throw new RuntimeException(
+                String.format("Couldn't decode %s, expected a %s", jsonNode, expType));
+        }
+    }
+
+    private static Object decodeElement(JsonNode jsonValue, DataType dataType)
+    {
+        if (jsonValue.isNull()) {
+            return null;
+        }
+
+        if (dataType.equals(MixedDataType.INSTANCE)) {
+            if (jsonValue.isTextual()) {
+                return jsonValue.textValue();
+            }
+            else if (jsonValue instanceof ObjectNode) {
+                return jsonValue.toString();
+            }
+            throwIfTypeMismatch("object or string", false, jsonValue);
+        }
+
+        if (dataType instanceof BooleanType) {
+            throwIfTypeMismatch("boolean", jsonValue.isBoolean(), jsonValue);
+            return jsonValue.booleanValue();
+        }
+
+        if (dataType instanceof IntegerType) {
+            throwIfTypeMismatch(
+                "integer", jsonValue.isIntegralNumber() && !jsonValue.isLong(), jsonValue);
+            return jsonValue.intValue();
+        }
+
+        if (dataType instanceof LongType) {
+            throwIfTypeMismatch("long", jsonValue.isIntegralNumber(), jsonValue);
+            return jsonValue.numberValue().longValue();
+        }
+
+        if (dataType instanceof StringType) {
+            throwIfTypeMismatch("string", jsonValue.isTextual(), jsonValue);
+            return jsonValue.asText();
+        }
+
+        if (dataType instanceof StructType) {
+            throwIfTypeMismatch("object", jsonValue.isObject(), jsonValue);
+            return new DefaultJsonRow((ObjectNode) jsonValue, (StructType) dataType);
+        }
+
+        if (dataType instanceof ArrayType) {
+            throwIfTypeMismatch("array", jsonValue.isArray(), jsonValue);
+            final ArrayType arrayType = ((ArrayType) dataType);
+            final ArrayNode jsonArray = (ArrayNode) jsonValue;
+            final List<Object> output = new ArrayList<>();
+
+            for (Iterator<JsonNode> it = jsonArray.elements(); it.hasNext(); ) {
+                final JsonNode element = it.next();
+                final Object parsedElement = decodeElement(element, arrayType.getElementType());
+                if (parsedElement == null && !arrayType.containsNull()) {
+                    throw new RuntimeException("Array type expects no nulls as elements, but " +
+                        "received `null` as array element");
+                }
+                output.add(parsedElement);
+            }
+            return output;
+        }
+
+        if (dataType instanceof MapType) {
+            throwIfTypeMismatch("map", jsonValue.isObject(), jsonValue);
+            final MapType mapType = (MapType) dataType;
+            if (!(mapType.getKeyType() instanceof StringType)) {
+                throw new RuntimeException("MapType with a key type of `String` is supported, " +
+                    "received a key type: " + mapType.getKeyType());
+            }
+            final Iterator<Map.Entry<String, JsonNode>> iter = jsonValue.fields();
+            final Map<Object, Object> output = new HashMap<>();
+
+            while (iter.hasNext()) {
+                Map.Entry<String, JsonNode> entry = iter.next();
+                String keyParsed = entry.getKey();
+                Object valueParsed = decodeElement(entry.getValue(), mapType.getValueType());
+                if (valueParsed == null && !mapType.isValueContainsNull()) {
+                    throw new RuntimeException("Map type expects no nulls in values, but " +
+                        "received `null` as value");
+                }
+                output.put(keyParsed, valueParsed);
+            }
+
+            return output;
+        }
+
+        throw new UnsupportedOperationException(
+            String.format("Unsupported DataType %s for RootNode %s", dataType, jsonValue)
+        );
+    }
+
+    private static Object decodeField(ObjectNode rootNode, StructField field)
+    {
+        if (rootNode.get(field.getName()) == null) {
+            if (field.isNullable()) {
+                return null;
+            }
+
+            throw new RuntimeException(String.format(
+                "Root node at key %s is null but field isn't nullable. Root node: %s",
+                field.getName(),
+                rootNode));
+        }
+
+        return decodeElement(rootNode.get(field.getName()), field.getDataType());
+    }
+}

--- a/kernel/kernel-default/src/main/java/io/delta/kernel/data/DefaultJsonRow.java
+++ b/kernel/kernel-default/src/main/java/io/delta/kernel/data/DefaultJsonRow.java
@@ -235,7 +235,7 @@ public class DefaultJsonRow implements Row
 
     private static Object decodeField(ObjectNode rootNode, StructField field)
     {
-        if (rootNode.get(field.getName()) == null) {
+        if (rootNode.get(field.getName()) == null || rootNode.get(field.getName()).isNull()) {
             if (field.isNullable()) {
                 return null;
             }

--- a/kernel/kernel-default/src/main/java/io/delta/kernel/data/DefaultRowBasedColumnarBatch.java
+++ b/kernel/kernel-default/src/main/java/io/delta/kernel/data/DefaultRowBasedColumnarBatch.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.data;
+
+import static io.delta.kernel.DefaultKernelUtils.checkArgument;
+import java.util.List;
+import java.util.Map;
+
+import io.delta.kernel.types.DataType;
+import io.delta.kernel.types.StructField;
+import io.delta.kernel.types.StructType;
+
+/**
+ * {@link ColumnarBatch} wrapper around list of {@link Row} objects.
+ */
+public class DefaultRowBasedColumnarBatch
+    implements ColumnarBatch
+{
+    private final StructType schema;
+    private final List<Row> rows;
+
+    public DefaultRowBasedColumnarBatch(StructType schema, List<Row> rows)
+    {
+        this.schema = schema;
+        this.rows = rows;
+    }
+
+    @Override
+    public StructType getSchema()
+    {
+        return schema;
+    }
+
+    @Override
+    public int getSize()
+    {
+        return rows.size();
+    }
+
+    @Override
+    public ColumnarBatch slice(int start, int end)
+    {
+        throw new UnsupportedOperationException("not yet implemented");
+    }
+
+    @Override
+    public ColumnVector getColumnVector(int ordinal)
+    {
+        StructField field = schema.at(ordinal);
+        return new DefaultColumnVector(field.getDataType(), rows, ordinal);
+    }
+
+    /**
+     * Wrapper around list of {@link Row}s to expose the rows as a columnar vector
+     */
+    private static class DefaultColumnVector implements ColumnVector
+    {
+        private final DataType dataType;
+        private final List<Row> rows;
+        private final int columnOrdinal;
+
+        DefaultColumnVector(DataType dataType, List<Row> rows, int columnOrdinal)
+        {
+            this.dataType = dataType;
+            this.rows = rows;
+            this.columnOrdinal = columnOrdinal;
+        }
+
+        @Override
+        public DataType getDataType()
+        {
+            return dataType;
+        }
+
+        @Override
+        public int getSize()
+        {
+            return rows.size();
+        }
+
+        @Override
+        public void close() { /* nothing to close */ }
+
+        @Override
+        public boolean isNullAt(int rowId)
+        {
+            assertValidRowId(rowId);
+            return rows.get(rowId).isNullAt(columnOrdinal);
+        }
+
+        @Override
+        public boolean getBoolean(int rowId)
+        {
+            assertValidRowId(rowId);
+            return rows.get(rowId).getBoolean(columnOrdinal);
+        }
+
+        @Override
+        public byte getByte(int rowId)
+        {
+            assertValidRowId(rowId);
+            return rows.get(rowId).getByte(columnOrdinal);
+        }
+
+        @Override
+        public short getShort(int rowId)
+        {
+            assertValidRowId(rowId);
+            return rows.get(rowId).getShort(columnOrdinal);
+        }
+
+        @Override
+        public int getInt(int rowId)
+        {
+            assertValidRowId(rowId);
+            return rows.get(rowId).getInt(columnOrdinal);
+        }
+
+        @Override
+        public long getLong(int rowId)
+        {
+            assertValidRowId(rowId);
+            return rows.get(rowId).getLong(columnOrdinal);
+        }
+
+        @Override
+        public float getFloat(int rowId)
+        {
+            assertValidRowId(rowId);
+            return rows.get(rowId).getFloat(columnOrdinal);
+        }
+
+        @Override
+        public double getDouble(int rowId)
+        {
+            assertValidRowId(rowId);
+            return rows.get(rowId).getDouble(columnOrdinal);
+        }
+
+        @Override
+        public String getString(int rowId)
+        {
+            assertValidRowId(rowId);
+            return rows.get(rowId).getString(columnOrdinal);
+        }
+
+        @Override
+        public byte[] getBinary(int rowId)
+        {
+            assertValidRowId(rowId);
+            return rows.get(rowId).getBinary(columnOrdinal);
+        }
+
+        @Override
+        public <K, V> Map<K, V> getMap(int rowId)
+        {
+            assertValidRowId(rowId);
+            return rows.get(rowId).getMap(columnOrdinal);
+        }
+
+        @Override
+        public Row getStruct(int rowId)
+        {
+            assertValidRowId(rowId);
+            return rows.get(rowId).getStruct(columnOrdinal);
+        }
+
+        @Override
+        public <T> List<T> getArray(int rowId)
+        {
+            assertValidRowId(rowId);
+            return rows.get(rowId).getArray(columnOrdinal);
+        }
+
+        private void assertValidRowId(int rowId)
+        {
+            checkArgument(rowId < rows.size(),
+                "Invalid rowId: " + rowId + ", max allowed rowId is: " + (rows.size() - 1));
+        }
+    }
+}

--- a/kernel/kernel-default/src/main/java/io/delta/kernel/data/vector/AbstractColumnVector.java
+++ b/kernel/kernel-default/src/main/java/io/delta/kernel/data/vector/AbstractColumnVector.java
@@ -39,6 +39,10 @@ public abstract class AbstractColumnVector
     protected AbstractColumnVector(int size, DataType dataType, Optional<boolean[]> nullability)
     {
         checkArgument(size >= 0, "invalid size: %s", size);
+        nullability.ifPresent(array ->
+            checkArgument(array.length >= size,
+                "invalid number of values (%s) for given size (%s)", array.length, size)
+        );
         this.size = size;
         this.dataType = requireNonNull(dataType);
         this.nullability = requireNonNull(nullability);
@@ -165,7 +169,7 @@ public abstract class AbstractColumnVector
     protected void checkValidRowId(int rowId)
     {
         if (rowId < 0 || rowId >= size) {
-            throw new IllegalArgumentException("invalid row access");
+            throw new IllegalArgumentException("invalid row access: " + rowId);
         }
     }
 }

--- a/kernel/kernel-default/src/main/java/io/delta/kernel/data/vector/DefaultBooleanVector.java
+++ b/kernel/kernel-default/src/main/java/io/delta/kernel/data/vector/DefaultBooleanVector.java
@@ -43,13 +43,6 @@ public class DefaultBooleanVector
         this.values = requireNonNull(values, "values is null");
         checkArgument(values.length >= size,
             "invalid number of values (%s) for given size (%s)", values.length, size);
-        if (nullability.isPresent()) {
-            checkArgument(values.length == nullability.get().length,
-                "vector element components are not of same size" +
-                    "value array size = %s, nullability array size = %s",
-                values.length, nullability.get().length
-            );
-        }
     }
 
     /**

--- a/kernel/kernel-default/src/main/java/io/delta/kernel/data/vector/DefaultStructVector.java
+++ b/kernel/kernel-default/src/main/java/io/delta/kernel/data/vector/DefaultStructVector.java
@@ -33,7 +33,6 @@ public class DefaultStructVector
     extends AbstractColumnVector
 {
     private final ColumnVector[] memberVectors;
-    private final int size;
 
     /**
      * Create an instance of {@link ColumnVector} for {@code struct} type.
@@ -57,7 +56,6 @@ public class DefaultStructVector
             structType.length() == memberVectors.length,
             "expected a one column vector for each member");
         this.memberVectors = memberVectors;
-        this.size = size;
     }
 
     @Override
@@ -107,6 +105,18 @@ public class DefaultStructVector
         }
 
         @Override
+        public byte getByte(int ordinal)
+        {
+            return structVector.memberVectors[ordinal].getByte(rowId);
+        }
+
+        @Override
+        public short getShort(int ordinal)
+        {
+            return structVector.memberVectors[ordinal].getShort(rowId);
+        }
+
+        @Override
         public int getInt(int ordinal)
         {
             return structVector.memberVectors[ordinal].getInt(rowId);
@@ -119,9 +129,27 @@ public class DefaultStructVector
         }
 
         @Override
+        public float getFloat(int ordinal)
+        {
+            return structVector.memberVectors[ordinal].getFloat(rowId);
+        }
+
+        @Override
+        public double getDouble(int ordinal)
+        {
+            return structVector.memberVectors[ordinal].getDouble(rowId);
+        }
+
+        @Override
         public String getString(int ordinal)
         {
             return structVector.memberVectors[ordinal].getString(rowId);
+        }
+
+        @Override
+        public byte[] getBinary(int ordinal)
+        {
+            return structVector.memberVectors[ordinal].getBinary(rowId);
         }
 
         @Override

--- a/kernel/kernel-default/src/test/java/io/delta/kernel/client/TestDefaultExpressionHandler.java
+++ b/kernel/kernel-default/src/test/java/io/delta/kernel/client/TestDefaultExpressionHandler.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.client;
+
+import static io.delta.kernel.DefaultKernelUtils.daysSinceEpoch;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.data.DefaultColumnarBatch;
+import io.delta.kernel.data.vector.DefaultIntVector;
+import io.delta.kernel.data.vector.DefaultLongVector;
+import io.delta.kernel.expressions.And;
+import io.delta.kernel.expressions.Column;
+import io.delta.kernel.expressions.EqualTo;
+import io.delta.kernel.expressions.Expression;
+import io.delta.kernel.expressions.Literal;
+import io.delta.kernel.types.*;
+
+public class TestDefaultExpressionHandler
+{
+    /**
+     * Evaluate literal expressions. This is used to populate the partition column vectors.
+     */
+    @Test
+    public void evalLiterals()
+    {
+        StructType inputSchema = new StructType();
+        ColumnVector[] data = new ColumnVector[0];
+
+        List<Literal> testCases = new ArrayList<>();
+        testCases.add(Literal.of(true));
+        testCases.add(Literal.of(false));
+        testCases.add(Literal.ofNull(BooleanType.INSTANCE));
+        testCases.add(Literal.of((byte) 24));
+        testCases.add(Literal.ofNull(ByteType.INSTANCE));
+        testCases.add(Literal.of((short) 876));
+        testCases.add(Literal.ofNull(ShortType.INSTANCE));
+        testCases.add(Literal.of(2342342));
+        testCases.add(Literal.ofNull(IntegerType.INSTANCE));
+        testCases.add(Literal.of(234234223L));
+        testCases.add(Literal.ofNull(LongType.INSTANCE));
+        testCases.add(Literal.of(23423.4223f));
+        testCases.add(Literal.ofNull(FloatType.INSTANCE));
+        testCases.add(Literal.of(23423.422233d));
+        testCases.add(Literal.ofNull(DoubleType.INSTANCE));
+        testCases.add(Literal.of("string_val"));
+        testCases.add(Literal.ofNull(StringType.INSTANCE));
+        testCases.add(Literal.of("binary_val".getBytes()));
+        testCases.add(Literal.ofNull(BinaryType.INSTANCE));
+        testCases.add(Literal.of(new Date(234234234)));
+        testCases.add(Literal.ofNull(DateType.INSTANCE));
+        testCases.add(Literal.of(new Timestamp(2342342342232L)));
+        testCases.add(Literal.ofNull(TimestampType.INSTANCE));
+
+        ColumnarBatch[] inputBatches = new ColumnarBatch[] {
+            new DefaultColumnarBatch(0, inputSchema, data),
+            new DefaultColumnarBatch(25, inputSchema, data),
+            new DefaultColumnarBatch(128, inputSchema, data)
+        };
+
+        for (Literal expression : testCases) {
+            DataType outputDataType = expression.dataType();
+
+            for (ColumnarBatch inputBatch : inputBatches) {
+                ColumnVector outputVector = eval(inputSchema, inputBatch, expression);
+                assertEquals(inputBatch.getSize(), outputVector.getSize());
+                assertEquals(outputDataType, outputVector.getDataType());
+                for (int rowId = 0; rowId < outputVector.getSize(); rowId++) {
+                    if (expression.value() == null) {
+                        assertTrue(outputVector.isNullAt(rowId));
+                        continue;
+                    }
+                    Object expRowValue = expression.value();
+                    if (outputDataType instanceof BooleanType) {
+                        assertEquals(expRowValue, outputVector.getBoolean(rowId));
+                    }
+                    else if (outputDataType instanceof ByteType) {
+                        assertEquals(expRowValue, outputVector.getByte(rowId));
+                    }
+                    else if (outputDataType instanceof ShortType) {
+                        assertEquals(expRowValue, outputVector.getShort(rowId));
+                    }
+                    else if (outputDataType instanceof IntegerType) {
+                        assertEquals(expRowValue, outputVector.getInt(rowId));
+                    }
+                    else if (outputDataType instanceof LongType) {
+                        assertEquals(expRowValue, outputVector.getLong(rowId));
+                    }
+                    else if (outputDataType instanceof FloatType) {
+                        assertEquals(expRowValue, outputVector.getFloat(rowId));
+                    }
+                    else if (outputDataType instanceof DoubleType) {
+                        assertEquals(expRowValue, outputVector.getDouble(rowId));
+                    }
+                    else if (outputDataType instanceof StringType) {
+                        assertEquals(expRowValue, outputVector.getString(rowId));
+                    }
+                    else if (outputDataType instanceof BinaryType) {
+                        assertEquals(expRowValue, outputVector.getBinary(rowId));
+                    }
+                    else if (outputDataType instanceof DateType) {
+                        assertEquals(
+                            daysSinceEpoch((Date) expRowValue), outputVector.getInt(rowId));
+                    }
+                    else if (outputDataType instanceof TimestampType) {
+                        Timestamp timestamp = (Timestamp) expRowValue;
+                        long micros = timestamp.getTime() * 1000;
+                        assertEquals(micros, outputVector.getLong(rowId));
+                    }
+                    else {
+                        throw new UnsupportedOperationException(
+                            "unsupported output type encountered: " + outputDataType);
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void evalBooleanExpressionSimple()
+    {
+        Expression expression = new EqualTo(
+            new Column(0, "intType", IntegerType.INSTANCE),
+            Literal.of(3));
+
+        for (int size : Arrays.asList(26, 234, 567)) {
+            StructType inputSchema = new StructType()
+                .add("intType", IntegerType.INSTANCE);
+            ColumnVector[] data = new ColumnVector[] {
+                intVector(size)
+            };
+
+            ColumnarBatch inputBatch = new DefaultColumnarBatch(size, inputSchema, data);
+
+            ColumnVector output = eval(inputSchema, inputBatch, expression);
+            for (int rowId = 0; rowId < size; rowId++) {
+                if (data[0].isNullAt(rowId)) {
+                    // expect the output to be null as well
+                    assertTrue(output.isNullAt(rowId));
+                }
+                else {
+                    assertFalse(output.isNullAt(rowId));
+                    boolean expValue = rowId % 7 == 3;
+                    assertEquals(expValue, output.getBoolean(rowId));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void evalBooleanExpressionComplex()
+    {
+        Expression expression = new And(
+            new EqualTo(new Column(0, "intType", IntegerType.INSTANCE), Literal.of(3)),
+            new EqualTo(new Column(1, "longType", LongType.INSTANCE), Literal.of(4L))
+        );
+
+        for (int size : Arrays.asList(26, 234, 567)) {
+            StructType inputSchema = new StructType()
+                .add("intType", IntegerType.INSTANCE)
+                .add("longType", LongType.INSTANCE);
+            ColumnVector[] data = new ColumnVector[] {
+                intVector(size),
+                longVector(size),
+            };
+
+            ColumnarBatch inputBatch = new DefaultColumnarBatch(size, inputSchema, data);
+
+            ColumnVector output = eval(inputSchema, inputBatch, expression);
+            for (int rowId = 0; rowId < size; rowId++) {
+                if (data[0].isNullAt(rowId) || data[1].isNullAt(rowId)) {
+                    // expect the output to be null as well
+                    assertTrue(output.isNullAt(rowId));
+                }
+                else {
+                    assertFalse(output.isNullAt(rowId));
+                    boolean expValue = (rowId % 7 == 3) && (rowId * 200L / 87 == 4);
+                    assertEquals(expValue, output.getBoolean(rowId));
+                }
+            }
+        }
+    }
+
+    private static ColumnVector eval(
+        StructType inputSchema, ColumnarBatch input, Expression expression)
+    {
+        return new DefaultExpressionHandler()
+            .getEvaluator(inputSchema, expression)
+            .eval(input);
+    }
+
+    private static ColumnVector intVector(int size)
+    {
+        int[] values = new int[size];
+        boolean[] nullability = new boolean[size];
+
+        for (int rowId = 0; rowId < size; rowId++) {
+            if (rowId % 5 == 0) {
+                nullability[rowId] = true;
+            }
+            else {
+                values[rowId] = rowId % 7;
+            }
+        }
+
+        return new DefaultIntVector(
+            IntegerType.INSTANCE, size, Optional.of(nullability), values);
+    }
+
+    private static ColumnVector longVector(int size)
+    {
+        long[] values = new long[size];
+        boolean[] nullability = new boolean[size];
+
+        for (int rowId = 0; rowId < size; rowId++) {
+            if (rowId % 5 == 0) {
+                nullability[rowId] = true;
+            }
+            else {
+                values[rowId] = rowId * 200L % 87;
+            }
+        }
+
+        return new DefaultLongVector(size, Optional.of(nullability), values);
+    }
+}

--- a/kernel/kernel-default/src/test/java/io/delta/kernel/client/TestDefaultFileSystemClient.java
+++ b/kernel/kernel-default/src/test/java/io/delta/kernel/client/TestDefaultFileSystemClient.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.client;
+
+import static io.delta.kernel.utils.DefaultKernelTestUtils.getTestResourceFilePath;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+import io.delta.kernel.fs.FileStatus;
+import io.delta.kernel.utils.CloseableIterator;
+
+public class TestDefaultFileSystemClient
+{
+    @Test
+    public void listFrom() throws Exception
+    {
+        String basePath = getTestResourceFilePath("json-files");
+        String listFrom = getTestResourceFilePath("json-files/2.json");
+
+        List<String> actListOutput = new ArrayList<>();
+        try (CloseableIterator<FileStatus> files = fsClient().listFrom(listFrom)) {
+            while (files.hasNext()) {
+                actListOutput.add(files.next().getPath());
+            }
+        }
+
+        List<String> expListOutput = Arrays.asList(
+            "file:" + basePath + "/2.json",
+            "file:" + basePath + "/3.json");
+
+        assertEquals(expListOutput, actListOutput);
+    }
+
+    private static DefaultFileSystemClient fsClient()
+    {
+        return new DefaultFileSystemClient(new Configuration());
+    }
+}

--- a/kernel/kernel-default/src/test/java/io/delta/kernel/client/TestDefaultJsonHandler.java
+++ b/kernel/kernel-default/src/test/java/io/delta/kernel/client/TestDefaultJsonHandler.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import static io.delta.kernel.utils.DefaultKernelTestUtils.getTestResourceFilePath;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.data.DefaultJsonRow;
+import io.delta.kernel.data.FileDataReadResult;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.expressions.Literal;
+import io.delta.kernel.fs.FileStatus;
+import io.delta.kernel.types.BooleanType;
+import io.delta.kernel.types.LongType;
+import io.delta.kernel.types.MapType;
+import io.delta.kernel.types.StringType;
+import io.delta.kernel.types.StructType;
+import io.delta.kernel.utils.CloseableIterator;
+import io.delta.kernel.utils.Utils;
+
+public class TestDefaultJsonHandler
+{
+    private static final JsonHandler JSON_HANDLER = new DefaultJsonHandler(new Configuration());
+    private static final FileSystemClient FS_CLIENT =
+        new DefaultFileSystemClient(new Configuration());
+
+    @Test
+    public void contextualizeFiles()
+        throws Exception
+    {
+        try (CloseableIterator<Row> inputScanFiles = testFiles();
+            CloseableIterator<FileReadContext> fileReadContexts =
+                JSON_HANDLER.contextualizeFileReads(testFiles(), Literal.TRUE)) {
+            while (inputScanFiles.hasNext() || fileReadContexts.hasNext()) {
+                assertEquals(inputScanFiles.hasNext(), fileReadContexts.hasNext());
+                Row inputScanFile = inputScanFiles.next();
+                FileReadContext outputScanContext = fileReadContexts.next();
+                compareScanFileRows(inputScanFile, outputScanContext.getScanFileRow());
+            }
+        }
+    }
+
+    @Test
+    public void readJsonFiles()
+        throws Exception
+    {
+        CloseableIterator<FileDataReadResult> data =
+            JSON_HANDLER.readJsonFiles(
+                JSON_HANDLER.contextualizeFileReads(testFiles(), Literal.TRUE),
+                new StructType()
+                    .add("path", StringType.INSTANCE)
+                    .add("size", LongType.INSTANCE)
+                    .add("dataChange", BooleanType.INSTANCE)
+            );
+
+        List<String> actPaths = new ArrayList<>();
+        List<Long> actSizes = new ArrayList<>();
+        List<Boolean> actDataChanges = new ArrayList<>();
+        while (data.hasNext()) {
+            ColumnarBatch dataBatch = data.next().getData();
+            CloseableIterator<Row> dataBatchRows = dataBatch.getRows();
+            while (dataBatchRows.hasNext()) {
+                Row row = dataBatchRows.next();
+                actPaths.add(row.getString(0));
+                actSizes.add(row.getLong(1));
+                actDataChanges.add(row.getBoolean(2));
+            }
+        }
+
+        List<String> expPaths = Arrays.asList(
+            "part-00000-d83dafd8-c344-49f0-ab1c-acd944e32493-c000.snappy.parquet",
+            "part-00000-cb078bc1-0aeb-46ed-9cf8-74a843b32c8c-c000.snappy.parquet",
+            "part-00001-9bf4b8f8-1b95-411b-bf10-28dc03aa9d2f-c000.snappy.parquet",
+            "part-00000-0441e99a-c421-400e-83a1-212aa6c84c73-c000.snappy.parquet",
+            "part-00001-34c8c673-3f44-4fa7-b94e-07357ec28a7d-c000.snappy.parquet",
+            "part-00000-842017c2-3e02-44b5-a3d6-5b9ae1745045-c000.snappy.parquet",
+            "part-00001-e62ca5a1-923c-4ee6-998b-c61d1cfb0b1c-c000.snappy.parquet"
+        );
+        List<Long> expSizes = Arrays.asList(348L, 687L, 705L, 650L, 650L, 649L, 649L);
+        List<Boolean> expDataChanges = Arrays.asList(true, true, true, true, true, true, true);
+
+        assertEquals(expPaths, actPaths);
+        assertEquals(expSizes, actSizes);
+        assertEquals(actDataChanges, expDataChanges);
+    }
+
+    @Test
+    public void parseJsonContent()
+        throws Exception
+    {
+        String input =
+            "{" +
+                "   \"path\":\"part-00000-d83dafd8-c344-49f0-ab1c-acd944e32493-c000.snappy.parquet\", " +
+                "   \"partitionValues\":{\"p1\" : \"0\", \"p2\" : \"str\"}," +
+                "   \"size\":348," +
+                "   \"modificationTime\":1603723974000, " +
+                "   \"dataChange\":true" +
+                "   }";
+        StructType readSchema = new StructType()
+            .add("path", StringType.INSTANCE)
+            .add("partitionValues",
+                new MapType(StringType.INSTANCE, StringType.INSTANCE, false))
+            .add("size", LongType.INSTANCE)
+            .add("dataChange", BooleanType.INSTANCE);
+
+        ColumnarBatch batch =
+            JSON_HANDLER.parseJson(Utils.singletonColumnVector(input), readSchema);
+        assertEquals(1, batch.getSize());
+
+        try (CloseableIterator<Row> rows = batch.getRows()) {
+            Row row = rows.next();
+            assertEquals(
+                "part-00000-d83dafd8-c344-49f0-ab1c-acd944e32493-c000.snappy.parquet",
+                row.getString(0)
+            );
+
+            Map<String, String> expPartitionValues = new HashMap<String, String>() {{
+                put("p1", "0");
+                put("p2", "str");
+            }};
+            assertEquals(expPartitionValues, row.getMap(1));
+            assertEquals(348L, row.getLong(2));
+            assertEquals(true, row.getBoolean(3));
+        }
+    }
+
+    private static CloseableIterator<Row> testFiles()
+        throws Exception
+    {
+        String listFrom = getTestResourceFilePath("json-files/1.json");
+        CloseableIterator<FileStatus> list = FS_CLIENT.listFrom(listFrom);
+        return list.map(fileStatus ->
+            new DefaultJsonRow(
+                addFileJsonFromPath(fileStatus.getPath()),
+                new StructType()
+                    .add("path", StringType.INSTANCE)
+                    .add("dataChange", BooleanType.INSTANCE)
+                    .add("size", LongType.INSTANCE)
+            )
+        );
+    }
+
+    private static final ObjectNode addFileJsonFromPath(String path)
+    {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode object = objectMapper.createObjectNode();
+        object.put("path", path);
+        object.put("dataChange", true);
+        object.put("size", 234L);
+        return object;
+    }
+
+    private static void compareScanFileRows(Row expected, Row actual)
+    {
+        // basically compare the paths
+        assertEquals(expected.getString(0), actual.getString(0));
+    }
+}

--- a/kernel/kernel-default/src/test/resources/json-files/1.json
+++ b/kernel/kernel-default/src/test/resources/json-files/1.json
@@ -1,0 +1,3 @@
+{"path":"part-00000-d83dafd8-c344-49f0-ab1c-acd944e32493-c000.snappy.parquet","partitionValues":{},"size":348,"modificationTime":1603723974000,"dataChange":true}
+{"path":"part-00000-cb078bc1-0aeb-46ed-9cf8-74a843b32c8c-c000.snappy.parquet","partitionValues":{},"size":687,"modificationTime":1603723972000,"dataChange":true}
+{"path":"part-00001-9bf4b8f8-1b95-411b-bf10-28dc03aa9d2f-c000.snappy.parquet","partitionValues":{},"size":705,"modificationTime":1603723972000,"dataChange":true}

--- a/kernel/kernel-default/src/test/resources/json-files/2.json
+++ b/kernel/kernel-default/src/test/resources/json-files/2.json
@@ -1,0 +1,2 @@
+{"path":"part-00000-0441e99a-c421-400e-83a1-212aa6c84c73-c000.snappy.parquet","partitionValues":{},"size":650,"modificationTime":1603723967000,"dataChange":true}
+{"path":"part-00001-34c8c673-3f44-4fa7-b94e-07357ec28a7d-c000.snappy.parquet","partitionValues":{},"size":650,"modificationTime":1603723967000,"dataChange":true}

--- a/kernel/kernel-default/src/test/resources/json-files/3.json
+++ b/kernel/kernel-default/src/test/resources/json-files/3.json
@@ -1,0 +1,2 @@
+{"path":"part-00000-842017c2-3e02-44b5-a3d6-5b9ae1745045-c000.snappy.parquet","partitionValues":{},"size":649,"modificationTime":1603723970000,"dataChange":true}
+{"path":"part-00001-e62ca5a1-923c-4ee6-998b-c61d1cfb0b1c-c000.snappy.parquet","partitionValues":{},"size":649,"modificationTime":1603723970000,"dataChange":true}


### PR DESCRIPTION
## Context
This PR is part of delta-io/delta#1783. 

## Description 
Following client implementations for the default module are added:

     * `JsonHandler`
     * `ExpressionHandler`
     * `FileSystemClient`

    and the supporting classes.

## How was this patch tested?
UTs