### PR TITLE
Trivial flink test fix

### DIFF
--- a/connectors/flink/src/test/java/io/delta/flink/sink/DeltaSinkStreamingExecutionITCase.java
+++ b/connectors/flink/src/test/java/io/delta/flink/sink/DeltaSinkStreamingExecutionITCase.java
@@ -468,7 +468,7 @@ public class DeltaSinkStreamingExecutionITCase extends DeltaSinkExecutionITCaseB
             return stream
                 .filter(file -> !Files.isDirectory(file))
                 .map(file -> file.getFileName().toString())
-                .filter(fileName -> !fileName.endsWith(".json"))
+                .filter(fileName -> fileName.endsWith(".checkpoint.parquet"))
                 .collect(Collectors.toList());
         }
     }


### PR DESCRIPTION
`getDeltaCheckpointFiles` should just explicitly filter for file names that end with `.checkpoint.parquet`. We don't want to accidentally read `.crc` files and return `true`.