### PR TITLE
Another trivial flink test fix

### DIFF
--- a/connectors/flink/src/test/java/io/delta/flink/sink/DeltaSinkStreamingExecutionITCase.java
+++ b/connectors/flink/src/test/java/io/delta/flink/sink/DeltaSinkStreamingExecutionITCase.java
@@ -289,11 +289,6 @@ public class DeltaSinkStreamingExecutionITCase extends DeltaSinkExecutionITCaseB
         // Now there should be a Delta Checkpoint under _delta_log folder.
         List<String> deltaCheckpointFiles = getDeltaCheckpointFiles(deltaTablePath);
         assertThat(
-            "Missing Delta's last checkpoint file",
-            deltaCheckpointFiles.contains("_last_checkpoint"),
-            equalTo(true)
-        );
-        assertThat(
             "Missing Delta's checkpoint file",
             deltaCheckpointFiles.contains("00000000000000000010.checkpoint.parquet"),
             equalTo(true)
@@ -468,7 +463,7 @@ public class DeltaSinkStreamingExecutionITCase extends DeltaSinkExecutionITCaseB
             return stream
                 .filter(file -> !Files.isDirectory(file))
                 .map(file -> file.getFileName().toString())
-                .filter(fileName -> !fileName.endsWith(".json"))
+                .filter(fileName -> fileName.endsWith(".checkpoint.parquet"))
                 .collect(Collectors.toList());
         }
     }

--- a/connectors/flink/src/test/resources/log4j.properties
+++ b/connectors/flink/src/test/resources/log4j.properties
@@ -1,0 +1,26 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Root logger option
+log4j.rootLogger=WARN, stdout
+
+# Redirect log messages to console
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n


### PR DESCRIPTION
Fix test helper method so that only `.checkpoint.parquet` files are returned (and not, for example, .crc files)