### PR TITLE
Use Merge Insert-only path with multiple NOT MATCHED clauses and merges with only inserted rows.

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -29,8 +29,10 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{NoSuchTableException, UnresolvedTable}
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, SessionCatalog}
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.catalyst.planning.NodeWithOnlyDeterministicProjectAndFilter
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LeafNode, LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.util.CharVarcharCodegenUtils
 import org.apache.spark.sql.connector.expressions.{FieldReference, IdentityTransform}
 import org.apache.spark.sql.execution.datasources.{FileFormat, FileIndex, HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.internal.SQLConf
@@ -325,6 +327,84 @@ object DeltaTableUtils extends PredicateHelper
     }
   }
 
+  /**
+   * Replace the file index in a logical plan and return the updated plan.
+   * It's a common pattern that, in Delta commands, we use data skipping to determine a subset of
+   * files that can be affected by the command, so we replace the whole-table file index in the
+   * original logical plan with a new index of potentially affected files, while everything else in
+   * the original plan, e.g., resolved references, remain unchanged.
+   *
+   * Many Delta meta-queries involve nondeterminstic functions, which interfere with automatic
+   * column pruning, so columns can be manually pruned from the new scan. Note that partition
+   * columns can never be dropped even if they're not referenced in the rest of the query.
+   *
+   * @param spark the spark session to use
+   * @param target the logical plan in which we replace the file index
+   * @param fileIndex the new file index
+   * @param columnsToDrop columns to drop from the scan
+   * @param newOutput If specified, new logical output to replace the current LogicalRelation.
+   *                  Used for schema evolution to produce the new schema-evolved types from
+   *                  old files, because `target` will have the old types.
+   */
+  def replaceFileIndex(
+      spark: SparkSession,
+      target: LogicalPlan,
+      fileIndex: FileIndex,
+      columnsToDrop: Seq[String],
+      newOutput: Option[Seq[AttributeReference]]): LogicalPlan = {
+    val resolver = spark.sessionState.analyzer.resolver
+
+    var actualNewOutput = newOutput
+    var hasChar = false
+    var newTarget = target transformDown {
+      case l @ LogicalRelation(hfsr: HadoopFsRelation, _, _, _) =>
+        val finalOutput = actualNewOutput.getOrElse(l.output).filterNot { col =>
+          columnsToDrop.exists(resolver(_, col.name))
+        }
+
+        // If the output columns were changed e.g. by schema evolution, we need to update
+        // the relation to expose all the columns that are expected after schema evolution.
+        val newDataSchema = StructType(finalOutput.map(attr =>
+          StructField(attr.name, attr.dataType, attr.nullable, attr.metadata)))
+        val newBaseRelation = hfsr.copy(
+          location = fileIndex, dataSchema = newDataSchema)(
+          hfsr.sparkSession)
+        l.copy(relation = newBaseRelation, output = finalOutput)
+
+      case p @ Project(projectList, _) =>
+        def hasCharPadding(e: Expression): Boolean = e.exists {
+          case s: StaticInvoke => s.staticObject == classOf[CharVarcharCodegenUtils] &&
+            s.functionName == "readSidePadding"
+          case _ => false
+        }
+        val charColMapping = AttributeMap(projectList.collect {
+          case a: Alias if hasCharPadding(a.child) && a.references.size == 1 =>
+            hasChar = true
+            val tableCol = a.references.head.asInstanceOf[AttributeReference]
+            a.toAttribute -> tableCol
+        })
+        actualNewOutput = newOutput.map(_.map { attr =>
+          charColMapping.get(attr).map { tableCol =>
+            attr.withExprId(tableCol.exprId)
+          }.getOrElse(attr)
+        })
+        p
+    }
+
+    if (hasChar) {
+      newTarget = newTarget.transformUp {
+        case p @ Project(projectList, child) =>
+          val newProjectList = projectList.filter { e =>
+            // Spark does char type read-side padding via an additional Project over the scan node,
+            // and we need to apply column pruning for the Project as well, otherwise the Project
+            // will contain missing attributes.
+            e.references.subsetOf(child.outputSet)
+          }
+          p.copy(projectList = newProjectList)
+      }
+    }
+    newTarget
+  }
 
   /**
    * Update FileFormat for a plan and return the updated plan

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.delta.metric.IncrementMetric
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, AddFile, FileAction}
 import org.apache.spark.sql.delta.commands.DeleteCommand.{rewritingFilesMsg, FINDING_TOUCHED_FILES_MSG}
-import org.apache.spark.sql.delta.commands.MergeIntoCommand.totalBytesAndDistinctPartitionValues
+import org.apache.spark.sql.delta.commands.MergeIntoCommandBase.totalBytesAndDistinctPartitionValues
 import org.apache.spark.sql.delta.files.TahoeBatchFileIndex
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
@@ -381,12 +381,10 @@ object MergeIntoCommandBase {
   def totalBytesAndDistinctPartitionValues(files: Seq[FileAction]): (Long, Int) = {
     val distinctValues = new mutable.HashSet[Map[String, String]]()
     var bytes = 0L
-    val iter = files.collect { case a: AddFile => a }.iterator
-    while (iter.hasNext) {
-      val file = iter.next()
+    files.collect { case file: AddFile =>
       distinctValues += file.partitionValues
       bytes += file.size
-    }
+    }.toList
     // If the only distinct value map is an empty map, then it must be an unpartitioned table.
     // Return 0 in that case.
     val numDistinctValues =

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
@@ -19,18 +19,18 @@ package org.apache.spark.sql.delta.commands
 import java.util.concurrent.TimeUnit
 
 import org.apache.spark.sql.delta.metric.IncrementMetric
-import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaOperations, OptimisticTransaction}
-import org.apache.spark.sql.delta.actions.Action
-import org.apache.spark.sql.delta.actions.FileAction
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.actions.{Action, AddFile, FileAction}
 import org.apache.spark.sql.delta.commands.merge.{MergeIntoMaterializeSource, MergeIntoMaterializeSourceReason, MergeStats}
-import org.apache.spark.sql.delta.files.TahoeFileIndex
+import org.apache.spark.sql.delta.files.{TahoeBatchFileIndex, TahoeFileIndex}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
-import org.apache.spark.sql.catalyst.plans.logical.{DeltaMergeIntoMatchedClause, DeltaMergeIntoNotMatchedBySourceClause, DeltaMergeIntoNotMatchedClause, LogicalPlan}
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
 import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.types.StructType
@@ -38,6 +38,7 @@ import org.apache.spark.sql.types.StructType
 abstract class MergeIntoCommandBase extends LeafRunnableCommand
   with DeltaCommand
   with DeltaLogging
+  with PredicateHelper
   with MergeIntoMaterializeSource {
 
   @transient val source: LogicalPlan
@@ -53,6 +54,24 @@ abstract class MergeIntoCommandBase extends LeafRunnableCommand
   @transient protected lazy val sc: SparkContext = SparkContext.getOrCreate()
   @transient protected lazy val targetDeltaLog: DeltaLog = targetFileIndex.deltaLog
 
+  /**
+   * Map to get target output attributes by name.
+   * The case sensitivity of the map is set accordingly to Spark configuration.
+   */
+  @transient private lazy val targetOutputAttributesMap: Map[String, Attribute] = {
+    val attrMap: Map[String, Attribute] = target
+      .outputSet.view
+      .map(attr => attr.name -> attr).toMap
+    if (conf.caseSensitiveAnalysis) {
+      attrMap
+    } else {
+      CaseInsensitiveMap(attrMap)
+    }
+  }
+
+  /** Whether this merge statement has only MATCHED clauses. */
+  protected def isMatchedOnly: Boolean = notMatchedClauses.isEmpty && matchedClauses.nonEmpty &&
+    notMatchedBySourceClauses.isEmpty
   import SQLMetrics._
 
   override lazy val metrics: Map[String, SQLMetric] = baseMetrics
@@ -147,9 +166,132 @@ abstract class MergeIntoCommandBase extends LeafRunnableCommand
       materializeSourceReason = Some(materializeSourceReason.toString),
       materializeSourceAttempts = Some(attempt))
   }
+
+  protected def shouldOptimizeMatchedOnlyMerge(spark: SparkSession): Boolean = {
+    isMatchedOnly && spark.conf.get(DeltaSQLConf.MERGE_MATCHED_ONLY_ENABLED)
+  }
+  /**
+   * Build a new logical plan to read the given `files` instead of the whole target table.
+   * The plan returned has the same output columns (exprIds) as the `target` logical plan, so that
+   * existing update/insert expressions can be applied on this new plan. Unneeded non-partition
+   * columns may be dropped.
+   */
+  protected def buildTargetPlanWithFiles(
+      spark: SparkSession,
+      deltaTxn: OptimisticTransaction,
+      files: Seq[AddFile],
+      columnsToDrop: Seq[String]): LogicalPlan = {
+    // Action type "batch" is a historical artifact; the original implementation used it.
+    val fileIndex = new TahoeBatchFileIndex(
+      spark,
+      actionType = "batch",
+      files,
+      deltaTxn.deltaLog,
+      targetFileIndex.path,
+      deltaTxn.snapshot)
+
+    buildTargetPlanWithIndex(
+      spark,
+      deltaTxn,
+      fileIndex,
+      columnsToDrop
+    )
+  }
+
+  /**
+   * Build a new logical plan to read the target table using the given `fileIndex`.
+   * The plan returned has the same output columns (exprIds) as the `target` logical plan, so that
+   * existing update/insert expressions can be applied on this new plan. Unneeded non-partition
+   * columns may be dropped.
+   */
+  protected def buildTargetPlanWithIndex(
+    spark: SparkSession,
+    deltaTxn: OptimisticTransaction,
+    fileIndex: TahoeFileIndex,
+    columnsToDrop: Seq[String]): LogicalPlan = {
+
+    val targetOutputCols = getTargetOutputCols(deltaTxn)
+
+    val plan = {
+
+      // In case of schema evolution & column mapping, we need to rebuild the file format
+      // because under column mapping, the reference schema within DeltaParquetFileFormat
+      // that is used to populate metadata needs to be updated.
+      //
+      // WARNING: We must do this before replacing the file index, or we risk invalidating the
+      // metadata column expression ids that replaceFileIndex might inject into the plan.
+      val planWithReplacedFileFormat = if (deltaTxn.metadata.columnMappingMode != NoMapping) {
+        val updatedFileFormat = deltaTxn.deltaLog.fileFormat(deltaTxn.protocol, deltaTxn.metadata)
+        DeltaTableUtils.replaceFileFormat(target, updatedFileFormat)
+      } else {
+        target
+      }
+
+      // We have to do surgery to use the attributes from `targetOutputCols` to scan the table.
+      // In cases of schema evolution, they may not be the same type as the original attributes.
+      // We can ignore the new columns which aren't yet AttributeReferences.
+      val newReadCols = targetOutputCols.collect { case a: AttributeReference => a }
+      DeltaTableUtils.replaceFileIndex(
+        spark,
+        planWithReplacedFileFormat,
+        fileIndex,
+        columnsToDrop,
+        newOutput = Some(newReadCols))
+    }
+
+    // Add back the null expression aliases for columns that are new to the target schema
+    // and don't exist in the input snapshot.
+    // These have been added in `getTargetOutputCols` but have been removed in `newReadCols` above
+    // and are thus not in `plan.output`.
+    val newColumnsWithNulls = targetOutputCols.filter(_.isInstanceOf[Alias])
+    Project(plan.output ++ newColumnsWithNulls, plan)
+  }
+
+  /**
+   * Get the expression references for the output columns of the target table relative to
+   * the transaction. Due to schema evolution, there are two kinds of expressions here:
+   *  * References to columns in the target dataframe. Note that these references may have a
+   *    different data type than they originally did due to schema evolution, but the exprId
+   *    will be the same. These references will be marked as nullable if `makeNullable` is set
+   *    to true.
+   *  * Literal nulls, for new columns which are being added to the target table as part of
+   *    this transaction, since new columns will have a value of null for all existing rows.
+   */
+  protected def getTargetOutputCols(
+      txn: OptimisticTransaction, makeNullable: Boolean = false): Seq[NamedExpression] = {
+    txn.metadata.schema.map { col =>
+      targetOutputAttributesMap
+        .get(col.name)
+        .map { a =>
+          AttributeReference(col.name, col.dataType, makeNullable || col.nullable)(a.exprId)
+        }
+        .getOrElse(Alias(Literal(null), col.name)())
+    }
+  }
+
   /** Expressions to increment SQL metrics */
   protected def incrementMetricAndReturnBool(name: String, valueToReturn: Boolean): Expression =
     IncrementMetric(Literal(valueToReturn), metrics(name))
+
+  protected def getTargetOnlyPredicates(spark: SparkSession): Seq[Expression] = {
+    val targetOnlyPredicatesOnCondition =
+      splitConjunctivePredicates(condition).filter(_.references.subsetOf(target.outputSet))
+
+    if (!isMatchedOnly) {
+      targetOnlyPredicatesOnCondition
+    } else {
+      val targetOnlyMatchedPredicate = matchedClauses
+        .map(clause => clause.condition.getOrElse(Literal(true)))
+        .map { condition =>
+          splitConjunctivePredicates(condition)
+            .filter(_.references.subsetOf(target.outputSet))
+            .reduceOption(And)
+            .getOrElse(Literal(true))
+        }
+        .reduceOption(Or)
+      targetOnlyPredicatesOnCondition ++ targetOnlyMatchedPredicate
+    }
+  }
   /**
    * Execute the given `thunk` and return its result while recording the time taken to do it
    * and setting additional local properties for better UI visibility.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/InsertOnlyMergeExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/InsertOnlyMergeExecutor.scala
@@ -1,0 +1,263 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands.merge
+
+import org.apache.spark.sql.delta.metric.IncrementMetric
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.actions.{AddFile, FileAction}
+import org.apache.spark.sql.delta.commands.MergeIntoCommandBase
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.expressions.{Alias, CaseWhen, Expression, Literal}
+import org.apache.spark.sql.catalyst.plans.logical._
+
+/**
+ * Trait with optimized execution for merges that only inserts new data.
+ * There are two cases for inserts only: when there are no matched clauses for the merge command
+ * and when there is nothing matched for the merge command even if there are matched clauses.
+ */
+trait InsertOnlyMergeExecutor extends MergeOutputGeneration {
+  self: MergeIntoCommandBase =>
+  import MergeIntoCommandBase._
+
+  /**
+   * Optimization to write new files by inserting only new data.
+   *
+   * When there are no matched clauses for the merge command, data is skipped
+   * based on the merge condition and left anti join is performed on the source
+   * data to find the rows to be inserted.
+   *
+   * When there is nothing matched for the merge command even if there are matched clauses,
+   * the source table is used to perform inserting.
+   *
+   * @param spark The spark session.
+   * @param deltaTxn The existing transaction.
+   * @param filterMatchedRows Whether to filter away matched data or not.
+   * @param numSourceRowsMetric The name of the metric in which to record the number of source rows
+   */
+  protected def writeOnlyInserts(
+      spark: SparkSession,
+      deltaTxn: OptimisticTransaction,
+      filterMatchedRows: Boolean,
+      numSourceRowsMetric: String): Seq[FileAction] = {
+    val extraOpType = if (filterMatchedRows) {
+      "writeInsertsOnlyWhenNoMatchedClauses"
+    } else "writeInsertsOnlyWhenNoMatches"
+    recordMergeOperation(
+      extraOpType = extraOpType,
+      status = "MERGE operation - writing new files for only inserts",
+      sqlMetricName = "rewriteTimeMs") {
+
+      // If nothing to do when not matched, then nothing to insert, that is, no new files to write
+      if (notMatchedClauses.isEmpty && !filterMatchedRows) {
+        metrics("numSourceRowsInSecondScan").set(-1)
+        return Seq.empty
+      }
+
+      // Expression to update metrics
+      val incrSourceRowCountExpr = incrementMetricAndReturnBool(numSourceRowsMetric, true)
+      // source DataFrame
+      var sourceDF = getSourceDF().filter(new Column(incrSourceRowCountExpr))
+      if (notMatchedClauses.size == 1) {
+        // If there is only one insert clause, then filter out the source rows that do not
+        // satisfy the clause condition because those rows will not be written out.
+        sourceDF =
+          sourceDF.filter(new Column(notMatchedClauses.head.condition.getOrElse(Literal(true))))
+      }
+
+      var dataSkippedFiles: Option[Seq[AddFile]] = None
+      val preparedSourceDF = if (filterMatchedRows) {
+        // This is an optimization of the case when there is no update clause for the merge.
+        // We perform an left anti join on the source data to find the rows to be inserted.
+
+        // Skip data based on the merge condition
+        val conjunctivePredicates = splitConjunctivePredicates(condition)
+        val targetOnlyPredicates =
+          conjunctivePredicates.filter(_.references.subsetOf(target.outputSet))
+        dataSkippedFiles = Some(deltaTxn.filterFiles(targetOnlyPredicates))
+
+        val targetPlan = buildTargetPlanWithFiles(
+          spark,
+          deltaTxn,
+          dataSkippedFiles.get,
+          columnsToDrop = Nil)
+        val targetDF = Dataset.ofRows(spark, targetPlan)
+        sourceDF.join(targetDF, new Column(condition), "leftanti")
+      } else {
+        sourceDF
+      }
+
+      val outputDF = generateInsertsOnlyOutputDF(preparedSourceDF, deltaTxn)
+      logDebug(s"$extraOpType: output plan:\n" + outputDF.queryExecution)
+
+      val newFiles = writeFiles(spark, deltaTxn, outputDF)
+
+      // Update metrics
+      if (filterMatchedRows) {
+        metrics("numTargetFilesBeforeSkipping") += deltaTxn.snapshot.numOfFiles
+        metrics("numTargetBytesBeforeSkipping") += deltaTxn.snapshot.sizeInBytes
+        if (dataSkippedFiles.nonEmpty) {
+          val (afterSkippingBytes, afterSkippingPartitions) =
+            totalBytesAndDistinctPartitionValues(dataSkippedFiles.get)
+          metrics("numTargetFilesAfterSkipping") += dataSkippedFiles.get.size
+          metrics("numTargetBytesAfterSkipping") += afterSkippingBytes
+          metrics("numTargetPartitionsAfterSkipping") += afterSkippingPartitions
+        }
+        metrics("numTargetFilesRemoved") += 0
+        metrics("numTargetBytesRemoved") += 0
+        metrics("numTargetPartitionsRemovedFrom") += 0
+      }
+      metrics("numTargetFilesAdded") += newFiles.count(_.isInstanceOf[AddFile])
+      val (addedBytes, addedPartitions) = totalBytesAndDistinctPartitionValues(newFiles)
+      metrics("numTargetBytesAdded") += addedBytes
+      metrics("numTargetPartitionsAddedTo") += addedPartitions
+      newFiles
+    }
+  }
+
+  /**
+   * Generate the DataFrame to write out for merges that contains only inserts - either, insert-only
+   * clauses or inserts when no matches were found.
+   *
+   * Specifically, it handles insert clauses in two cases: when there is only one insert clause,
+   * and when there are multiple insert clauses.
+   */
+  private def generateInsertsOnlyOutputDF(
+      preparedSourceDF: DataFrame,
+      deltaTxn: OptimisticTransaction): DataFrame = {
+
+    val targetOutputColNames = getTargetOutputCols(deltaTxn).map(_.name)
+
+    // When there is only one insert clause, there is no need for ROW_DROPPED_COL and
+    // output df can be generated without CaseWhen.
+    if (notMatchedClauses.size == 1) {
+      val outputCols = generateOneInsertOutputCols(targetOutputColNames)
+      return preparedSourceDF.select(outputCols: _*)
+    }
+
+    // Precompute conditions in insert clauses and generate source data frame with precomputed
+    // boolean columns and insert clauses with rewritten conditions.
+    val (sourceWithPrecompConditions, insertClausesWithPrecompConditions) =
+      generatePrecomputedConditionsAndDF(preparedSourceDF, notMatchedClauses)
+
+    // Generate output cols.
+    val outputCols = generateInsertsOnlyOutputCols(
+      targetOutputColNames,
+      insertClausesWithPrecompConditions.collect{case c: DeltaMergeIntoNotMatchedInsertClause => c})
+
+    sourceWithPrecompConditions
+      .select(outputCols: _*)
+      .filter(s"$ROW_DROPPED_COL = false")
+      .drop(ROW_DROPPED_COL)
+  }
+
+  /**
+   * Generate output columns when there is only one insert clause.
+   *
+   * It assumes that the caller has already filtered out the source rows (`preparedSourceDF`)
+   * that do not satisfy the insert clause condition (if any).
+   * Then it simply applies the insertion action expression to generate
+   * the output target table rows.
+   */
+  private def generateOneInsertOutputCols(
+      targetOutputColNames: Seq[String]
+    ): Seq[Column] = {
+
+    val outputColNames = targetOutputColNames
+    val outputExprs = notMatchedClauses.head.resolvedActions.map(_.expr)
+    assert(outputExprs.nonEmpty)
+    // generate the outputDF without `CaseWhen` expressions.
+    outputExprs.zip(outputColNames).zipWithIndex.map { case ((expr, name), i) =>
+      val exprAfterPassthru = if (i == 0) {
+        IncrementMetric(expr, metrics("numTargetRowsInserted"))
+      } else {
+        expr
+      }
+      new Column(Alias(exprAfterPassthru, name)())
+    }
+  }
+
+  /**
+   * Generate the output columns for inserts only when there are multiple insert clauses.
+   *
+   * It combines all the conditions and corresponding actions expressions
+   * into complicated CaseWhen expressions - one CaseWhen expression for
+   * each column in the target row. If a source row does not match any of the clause conditions,
+   * then the row will be dropped. These CaseWhen expressions basically look like this.
+   *
+   *    For the i-th output column,
+   *    CASE
+   *        WHEN [insert condition 1] THEN [execute i-th expression of insert action 1]
+   *        WHEN [insert condition 2] THEN [execute i-th expression of insert action 2]
+   *        ELSE [mark the source row to be dropped]
+   */
+  private def generateInsertsOnlyOutputCols(
+      targetOutputColNames: Seq[String],
+      insertClausesWithPrecompConditions: Seq[DeltaMergeIntoNotMatchedClause]
+    ): Seq[Column] = {
+    // ==== Generate the expressions to generate the target rows from the source rows ====
+    // If there are N columns in the target table, there will be N + 1 columns generated
+    // - N columns for target table
+    // - ROW_DROPPED_COL to define whether the generated row should dropped or written out
+    // To generate these N + 1 columns, we will generate N + 1 expressions
+
+    val outputColNames = targetOutputColNames :+ ROW_DROPPED_COL
+    val numOutputCols = outputColNames.size
+
+    // Generate the sequence of N + 1 expressions from the sequence of INSERT clauses
+    val allInsertExprs: Seq[Seq[Expression]] =
+      insertClausesWithPrecompConditions.map { clause =>
+        clause.resolvedActions.map(_.expr) :+ incrementMetricAndReturnBool(
+          "numTargetRowsInserted", false)
+      }
+
+    // Expressions to drop the source row when it does not match any of the insert clause
+    // conditions. Note that it sets the N+1-th column ROW_DROPPED_COL to true.
+    val dropSourceRowExprs =
+      targetOutputColNames.map { _ => Literal(null)} :+ Literal(true)
+
+    // Generate the final N + 1 expressions to generate the final target output rows.
+    // There are multiple not match clauses. Use `CaseWhen` to conditionally evaluate the right
+    // action expressions to output columns.
+    val outputExprs: Seq[Expression] = {
+      val allInsertConditions =
+        insertClausesWithPrecompConditions.map(_.condition.getOrElse(Literal(true)))
+
+      (0 until numOutputCols).map { i =>
+        // For the i-th output column, generate
+        // CASE
+        //     WHEN <not match condition 1> THEN <execute i-th expression of action 1>
+        //     WHEN <not match condition 2> THEN <execute i-th expression of action 2>
+        //     ...
+        //
+        val conditionalBranches = allInsertConditions.zip(allInsertExprs).map {
+          case (notMatchCond, notMatchActionExprs) => notMatchCond -> notMatchActionExprs(i)
+        }
+        CaseWhen(conditionalBranches, dropSourceRowExprs(i))
+      }
+    }
+
+    assert(outputExprs.size == numOutputCols,
+      s"incorrect # not matched expressions:\n\t" + seqToString(outputExprs))
+    logDebug("prepareInsertsOnlyOutputDF: not matched expressions\n\t" +
+      seqToString(outputExprs))
+
+    outputExprs.zip(outputColNames).map { case (expr, name) =>
+      new Column(Alias(expr, name)())
+    }
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeOutputGeneration.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeOutputGeneration.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands.merge
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.delta.commands.MergeIntoCommandBase
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.functions._
+
+/**
+ * Contains logic to transform the merge clauses into expressions that can be evaluated to obtain
+ * the output of the merge operation.
+ */
+trait MergeOutputGeneration { self: MergeIntoCommandBase =>
+  import MergeIntoCommandBase._
+
+  /**
+   * Precompute conditions in MATCHED and NOT MATCHED clauses and generate the source
+   * data frame with precomputed boolean columns.
+   * @param sourceDF the source DataFrame.
+   * @param clauses the merge clauses to precompute.
+   * @return Generated sourceDF with precomputed boolean columns, matched clauses with
+   *         possible rewritten clause conditions, insert clauses with possible rewritten
+   *         clause conditions
+   */
+  protected def generatePrecomputedConditionsAndDF(
+      sourceDF: DataFrame,
+      clauses: Seq[DeltaMergeIntoClause])
+  : (DataFrame, Seq[DeltaMergeIntoClause]) = {
+    //
+    // ==== Precompute conditions in MATCHED and NOT MATCHED clauses ====
+    // If there are conditions in the clauses, each condition will be computed once for every
+    // column (and obviously for every row) within the per-column CaseWhen expressions. Since, the
+    // conditions can be arbitrarily expensive, it is likely to be more efficient to
+    // precompute them into boolean columns and use these new columns in the CaseWhen exprs.
+    // Then each condition will be computed only once per row, and the resultant boolean reused
+    // for all the columns in the row.
+    //
+    val preComputedClauseConditions = new mutable.ArrayBuffer[(String, Expression)]()
+
+    // Rewrite clause condition into a simple lookup of precomputed column
+    def rewriteCondition[T <: DeltaMergeIntoClause](clause: T): T = {
+      clause.condition match {
+        case Some(clauseCondition) =>
+          val colName =
+            s"""_${clause.clauseType}${PRECOMPUTED_CONDITION_COL}
+            |${preComputedClauseConditions.length}_
+            |""".stripMargin.replaceAll("\n", "") // ex: _update_condition_0_
+          preComputedClauseConditions += ((colName, clauseCondition))
+          clause.makeCopy(Array(Some(UnresolvedAttribute(colName)), clause.actions)).asInstanceOf[T]
+        case None => clause
+      }
+    }
+
+    // Get the clauses with possible rewritten clause conditions.
+    // This will automatically populate the `preComputedClauseConditions`
+    val clausesWithPrecompConditions = clauses.map(rewriteCondition)
+
+    // Add the columns to precompute clause conditions
+    val sourceWithPrecompConditions = {
+      val newCols = preComputedClauseConditions.map { case (colName, conditionExpr) =>
+        new Column(conditionExpr).as(colName)
+      }
+      sourceDF.select(Seq(col("*"))  ++ newCols : _*)
+    }
+    (sourceWithPrecompConditions, clausesWithPrecompConditions)
+  }
+
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -300,17 +300,6 @@ trait DeltaTestUtilsForTempViews
     }
   }
 
-  def testOssOnlyWithTempView(testName: String)(testFun: Boolean => Any): Unit = {
-    Seq(true, false).foreach { isSQLTempView =>
-      val tempViewUsed = if (isSQLTempView) "SQL TempView" else "Dataset TempView"
-      test(s"$testName - $tempViewUsed") {
-        withTempView("v") {
-          testFun(isSQLTempView)
-        }
-      }
-    }
-  }
-
   def testQuietlyWithTempView(testName: String)(testFun: Boolean => Any): Unit = {
     Seq(true, false).foreach { isSQLTempView =>
       val tempViewUsed = if (isSQLTempView) "SQL TempView" else "Dataset TempView"

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
@@ -22,13 +22,17 @@ import java.util.Locale
 
 import scala.language.implicitConversions
 
-import com.databricks.spark.util.{Log4jUsageLogger, UsageRecord}
+import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions, UsageRecord}
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
+import org.apache.spark.sql.delta.commands.merge.MergeStats
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
+import org.apache.spark.sql.delta.test.ScanReportHelper
+import org.apache.spark.sql.delta.util.JsonUtils
+import org.apache.hadoop.fs.Path
 import org.scalatest.BeforeAndAfterEach
 
-import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
+import org.apache.spark.sql.{functions, AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, UnsafeArrayData}
 import org.apache.spark.sql.catalyst.util.FailFastMode
@@ -43,6 +47,7 @@ abstract class MergeIntoSuiteBase
     extends QueryTest
     with SharedSparkSession
     with BeforeAndAfterEach    with SQLTestUtils
+    with ScanReportHelper
     with DeltaTestUtilsForTempViews
     with MergeHelpers {
 
@@ -2453,6 +2458,210 @@ abstract class MergeIntoSuiteBase
       (1, 10) // update
     )
   )
+
+  test("data skipping - target-only condition") {
+    withKeyValueData(
+      source = (1, 10) :: Nil,
+      target = (1, 1) :: (2, 2) :: Nil,
+      isKeyPartitioned = true) { case (sourceName, targetName) =>
+
+      val report = getScanReport {
+        executeMerge(
+          target = s"$targetName t",
+          source = s"$sourceName s",
+          condition = "s.key = t.key AND t.key <= 1",
+          update = "t.key = s.key, t.value = s.value",
+          insert = "(key, value) VALUES (s.key, s.value)")
+      }.head
+
+      checkAnswer(sql(getDeltaFileStmt(tempPath)),
+        Row(1, 10) ::  // Updated
+        Row(2, 2) ::   // File should be skipped
+        Nil)
+
+      assert(report.size("scanned").bytesCompressed != report.size("total").bytesCompressed)
+    }
+  }
+
+  test("insert only merge - target data skipping") {
+    val tblName = "merge_target"
+    withTable(tblName) {
+      spark.range(10).withColumn("part", 'id % 5).withColumn("value", 'id + 'id)
+        .write.format("delta").partitionBy("part").mode("append").saveAsTable(tblName)
+
+      val source = "source"
+      withTable(source) {
+        spark.range(20).withColumn("part", functions.lit(1)).withColumn("value", 'id + 'id)
+          .write.format("delta").saveAsTable(source)
+
+        val scans = getScanReport {
+          withSQLConf(DeltaSQLConf.MERGE_INSERT_ONLY_ENABLED.key -> "true") {
+            executeMerge(
+              s"$tblName t",
+              s"$source s",
+              "s.id = t.id AND t.part = 1",
+              insert(condition = "s.id % 5 = s.part", values = "*"))
+          }
+        }
+        checkAnswer(
+          spark.table(tblName).where("part = 1"),
+          Row(1, 1, 2) :: Row(6, 1, 12) :: Row(11, 1, 22) :: Row(16, 1, 32) :: Nil
+        )
+
+        assert(scans.length === 2, "We should scan the source and target " +
+          "data once in an insert only optimization")
+
+        // check if the source and target tables are scanned just once
+        val sourceRoot = DeltaTableUtils.findDeltaTableRoot(
+          spark, new Path(spark.table(source).inputFiles.head)).get.toString
+        val targetRoot = DeltaTableUtils.findDeltaTableRoot(
+          spark, new Path(spark.table(tblName).inputFiles.head)).get.toString
+        assert(scans.map(_.path).toSet == Set(sourceRoot, targetRoot))
+
+        // check scanned files
+        val targetScans = scans.find(_.path == targetRoot)
+        val deltaLog = DeltaLog.forTable(spark, targetScans.get.path)
+        val numTargetFiles = deltaLog.snapshot.numOfFiles
+        assert(targetScans.get.metrics("numFiles") < numTargetFiles)
+        // check scanned sizes
+        val scanSizes = targetScans.head.size
+        assert(scanSizes("total").bytesCompressed.get > scanSizes("scanned").bytesCompressed.get,
+          "Should have partition pruned target table")
+      }
+    }
+  }
+
+  /**
+   * Test whether data skipping on matched predicates of a merge command is performed.
+   * @param name The name of the test case.
+   * @param source The source for merge.
+   * @param target The target for merge.
+   * @param dataSkippingOnTargetOnly The boolean variable indicates whether
+   *                                 when matched clauses are on target fields only.
+   *                                 Data Skipping should be performed before inner join if
+   *                                 this variable is true.
+   * @param isMatchedOnly The boolean variable indicates whether the merge command only
+   *                      contains when matched clauses.
+   * @param mergeClauses Merge Clauses.
+   */
+  protected def testMergeDataSkippingOnMatchPredicates(
+      name: String)(
+      source: Seq[(Int, Int)],
+      target: Seq[(Int, Int)],
+      dataSkippingOnTargetOnly: Boolean,
+      isMatchedOnly: Boolean,
+      mergeClauses: MergeClause*)(
+      result: Seq[(Int, Int)]): Unit = {
+    test(s"data skipping with matched predicates - $name") {
+      withKeyValueData(source, target) { case (sourceName, targetName) =>
+        val stats = performMergeAndCollectStatsForDataSkippingOnMatchPredicates(
+          sourceName,
+          targetName,
+          result,
+          mergeClauses)
+        // Data skipping on match predicates should only be performed when it's a
+        // matched only merge.
+        if (isMatchedOnly) {
+          // The number of files removed/added should be 0 because of the additional predicates.
+          assert(stats.targetFilesRemoved == 0)
+          assert(stats.targetFilesAdded == 0)
+          // Verify that the additional predicates on data skipping
+          // before inner join filters file out for match predicates only
+          // on target.
+          if (dataSkippingOnTargetOnly) {
+            assert(stats.targetBeforeSkipping.files.get > stats.targetAfterSkipping.files.get)
+          }
+        } else {
+          assert(stats.targetFilesRemoved > 0)
+          // If there is no insert clause and the flag is enabled, data skipping should be
+          // performed on targetOnly predicates.
+          // However, with insert clauses, it's expected that no additional data skipping
+          // is performed on matched clauses.
+          assert(stats.targetBeforeSkipping.files.get == stats.targetAfterSkipping.files.get)
+          assert(stats.targetRowsUpdated == 0)
+        }
+      }
+    }
+  }
+
+  protected def performMergeAndCollectStatsForDataSkippingOnMatchPredicates(
+      sourceName: String,
+      targetName: String,
+      result: Seq[(Int, Int)],
+      mergeClauses: Seq[MergeClause]): MergeStats = {
+    var events: Seq[UsageRecord] = Seq.empty
+    // Perform merge on merge condition with matched clauses.
+    events = Log4jUsageLogger.track {
+      executeMerge(s"$targetName t", s"$sourceName s", "s.key = t.key", mergeClauses: _*)
+    }
+    val deltaPath = if (targetName.startsWith("delta.`")) {
+      targetName.stripPrefix("delta.`").stripSuffix("`")
+    } else targetName
+
+    checkAnswer(
+      readDeltaTable(deltaPath),
+      result.map { case (k, v) => Row(k, v) })
+
+    // Verify merge stats from usage events
+    val mergeStats = events.filter { e =>
+      e.metric == MetricDefinitions.EVENT_TAHOE.name &&
+        e.tags.get("opType").contains("delta.dml.merge.stats")
+    }
+
+    assert(mergeStats.size == 1)
+
+    JsonUtils.fromJson[MergeStats](mergeStats.head.blob)
+  }
+
+  testMergeDataSkippingOnMatchPredicates("match conditions on target fields only")(
+    source = Seq((1, 100), (3, 300), (5, 500)),
+    target = Seq((1, 10), (2, 20), (3, 30)),
+    dataSkippingOnTargetOnly = true,
+    isMatchedOnly = true,
+    update(condition = "t.key == 10", set = "*"),
+    update(condition = "t.value == 100", set = "*"))(
+    result = Seq((1, 10), (2, 20), (3, 30))
+  )
+
+  testMergeDataSkippingOnMatchPredicates("match conditions on source fields only")(
+    source = Seq((1, 100), (3, 300), (5, 500)),
+    target = Seq((1, 10), (2, 20), (3, 30)),
+    dataSkippingOnTargetOnly = false,
+    isMatchedOnly = true,
+    update(condition = "s.key == 10", set = "*"),
+    update(condition = "s.value == 10", set = "*"))(
+    result = Seq((1, 10), (2, 20), (3, 30))
+  )
+
+  testMergeDataSkippingOnMatchPredicates("match on source and target fields")(
+    source = Seq((1, 100), (3, 300), (5, 500)),
+    target = Seq((1, 10), (2, 20), (3, 30)),
+    dataSkippingOnTargetOnly = false,
+    isMatchedOnly = true,
+    update(condition = "s.key == 10", set = "*"),
+    update(condition = "s.value == 10", set = "*"),
+    delete(condition = "t.key == 4"))(
+    result = Seq((1, 10), (2, 20), (3, 30))
+  )
+
+  testMergeDataSkippingOnMatchPredicates("with insert clause")(
+    source = Seq((1, 100), (3, 300), (5, 500)),
+    target = Seq((1, 10), (2, 20), (3, 30)),
+    dataSkippingOnTargetOnly = false,
+    isMatchedOnly = false,
+    update(condition = "t.key == 10", set = "*"),
+    insert(condition = null, values = "(key, value) VALUES (s.key, s.value)"))(
+    result = Seq((1, 10), (2, 20), (3, 30), (5, 500))
+  )
+
+  testMergeDataSkippingOnMatchPredicates("when matched and conjunction")(
+    source = Seq((1, 100), (3, 300), (5, 500)),
+    target = Seq((1, 10), (2, 20), (3, 30)),
+    dataSkippingOnTargetOnly = true,
+    isMatchedOnly = true,
+    update(condition = "t.key == 1 AND t.value == 5", set = "*"))(
+    result = Seq((1, 10), (2, 20), (3, 30)))
+
 
   /**
    * Parse the input JSON data into a dataframe, one row per input element.
@@ -5202,34 +5411,16 @@ abstract class MergeIntoSuiteBase
       "The schema of your Delta table has changed in an incompatible way"
   )
 
-
-  private def testComplexTempViewOnMerge(name: String)(text: String, expectedResult: Seq[Row]) = {
-    testOssOnlyWithTempView(s"test merge on temp view - $name") { isSQLTempView =>
-      withTable("tab") {
-        withTempView("src") {
-          Seq((0, 3), (1, 2)).toDF("key", "value").write.format("delta").saveAsTable("tab")
-          createTempViewFromSelect(text, isSQLTempView)
-          sql("CREATE TEMP VIEW src AS SELECT * FROM VALUES (1, 2), (3, 4) AS t(a, b)")
-          executeMerge(
-            target = "v",
-            source = "src",
-            condition = "src.a = v.key AND src.b = v.value",
-            update = "v.value = src.b + 1",
-            insert = "(v.key, v.value) VALUES (src.a, src.b)")
-          checkAnswer(spark.table("v"), expectedResult)
-        }
-      }
-    }
-  }
-
-  testComplexTempViewOnMerge("nontrivial projection")(
-    "SELECT value as key, key as value FROM tab",
-    Seq(Row(3, 0), Row(3, 1), Row(4, 3))
+  testInvalidTempViews("nontrivial projection")(
+    text = "SELECT value as key, key as value FROM tab",
+    expectedErrorMsgForSQLTempView = "Attribute(s) with the same name appear",
+    expectedErrorMsgForDataSetTempView = "Attribute(s) with the same name appear"
   )
 
-  testComplexTempViewOnMerge("view with too many internal aliases")(
-    "SELECT * FROM (SELECT * FROM tab AS t1) AS t2",
-    Seq(Row(0, 3), Row(1, 3), Row(3, 4))
+  testInvalidTempViews("view with too many internal aliases")(
+    text = "SELECT * FROM (SELECT * FROM tab AS t1) AS t2",
+    expectedErrorMsgForSQLTempView = "Attribute(s) with the same name appear",
+    expectedErrorMsgForDataSetTempView = null
   )
 
   test("UDT Data Types - simple and nested") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/test/ScanReportHelper.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/test/ScanReportHelper.scala
@@ -110,7 +110,8 @@ trait ScanReportHelper extends SharedSparkSession with AdaptiveSparkPlanHelper {
                 unusedFilters = Nil,
                 size = Map(
                   "total" -> DataSize(
-                    bytesCompressed = Some(deltaTable.deltaLog.unsafeVolatileSnapshot.sizeInBytes))
+                    bytesCompressed = Some(deltaTable.deltaLog.unsafeVolatileSnapshot.sizeInBytes)),
+                  "scanned" -> DataSize(bytesCompressed = Some(deltaTable.sizeInBytes))
                 ),
                 metrics = scanExec.metrics.mapValues(_.value).toMap,
                 versionScanned = None,


### PR DESCRIPTION
Note: This PR is based on https://github.com/delta-io/delta/pull/1851 and includes its changes in the first commit. Actual change can be seen [starting from commit Improve Merge Insert-only](https://github.com/delta-io/delta/pull/1852/files/411eed08a55a6a9a98d33fde85137ea3306e6bfc..95542aa2b5d46da4a51043942dacc645f4435c99)

## Description

This change improves the insert-only code path in merge to be able to support more than one `NOT MATCHED clause`. It also leverages the insert-only path for merges that have arbitrary clauses but effectively only have rows inserted after the `findTouchedFiles` step.

## How was this patch tested?
- Added test cases specifically covering merge with multiple `NOT MATCHED` clauses and merge with `MATCHED`/`NOT MATCHED` where only the `NOT MATCHED` clause is satisfied.
- Added a test to check that the insert-only code path is used when there are only inserted rows after `findTouchedFiles` by looking at the recorded operations.
- Insert-only merge are otherwise already covered by a number of different existing tests.
