### PR TITLE
Remove databricks reference

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -416,7 +416,7 @@ object Snapshot extends DeltaLogging {
       if (new Path(filePath.toUri).getParent != new Path(logBasePath.toUri)) {
         // scalastyle:off throwerror
         throw new AssertionError(s"File ($filePath) doesn't belong in the " +
-          s"transaction log at $logBasePath. Please contact Databricks Support.")
+          s"transaction log at $logBasePath.")
         // scalastyle:on throwerror
       }
     }


### PR DESCRIPTION
## Description

Removes a Databricks reference from an error message

## How was this patch tested?

N/A

## Does this PR introduce _any_ user-facing changes?

No. Except by error message changed.