### PR TITLE
Expose version as partition col in DeltaLogFileIndex

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -82,6 +82,7 @@ class Snapshot(
   with DeltaLogging {
 
   import Snapshot._
+  import DeltaLogFileIndex.COMMIT_VERSION_COLUMN
   // For implicits which re-use Encoder:
   import org.apache.spark.sql.delta.implicits._
 
@@ -207,10 +208,9 @@ class Snapshot(
     val schemaToUse = Action.logSchema(Set("protocol", "metaData"))
     fileIndices.map(deltaLog.loadIndex(_, schemaToUse))
       .reduceOption(_.union(_)).getOrElse(emptyDF)
-      .withColumn(ACTION_SORT_COL_NAME, input_file_name())
-      .select("protocol", "metaData", ACTION_SORT_COL_NAME)
+      .select("protocol", "metaData", COMMIT_VERSION_COLUMN)
       .where("protocol.minReaderVersion is not null or metaData.id is not null")
-      .as[(Protocol, Metadata, String)]
+      .as[(Protocol, Metadata, Long)]
       .collect()
       .sortBy(_._3)
       .map { case (p, m, _) => p -> m }
@@ -232,7 +232,7 @@ class Snapshot(
       // optimizer can generate a really bad plan that re-evaluates _EVERY_ field of the rewritten
       // struct(...)  projection every time we touch _ANY_ field of the rewritten struct.
       //
-      // NOTE: We sort by [[ACTION_SORT_COL_NAME]] (provided by [[loadActions]]), to ensure that
+      // NOTE: We sort by [[COMMIT_VERSION_COLUMN]] (provided by [[loadActions]]), to ensure that
       // actions are presented to InMemoryLogReplay in the ascending version order it expects.
       val ADD_PATH_CANONICAL_COL_NAME = "add_path_canonical"
       val REMOVE_PATH_CANONICAL_COL_NAME = "remove_path_canonical"
@@ -244,7 +244,7 @@ class Snapshot(
         .repartition(
           getNumPartitions,
           coalesce(col(ADD_PATH_CANONICAL_COL_NAME), col(REMOVE_PATH_CANONICAL_COL_NAME)))
-        .sortWithinPartitions(ACTION_SORT_COL_NAME)
+        .sortWithinPartitions(COMMIT_VERSION_COLUMN)
         .withColumn("add", when(
           col("add.path").isNotNull,
           struct(
@@ -278,7 +278,7 @@ class Snapshot(
    * Loads the file indices into a DataFrame that can be used for LogReplay.
    *
    * In addition to the usual nested columns provided by the SingleAction schema, it should provide
-   * two additional columns to simplify the log replay process: [[ACTION_SORT_COL_NAME]] (which,
+   * two additional columns to simplify the log replay process: [[COMMIT_VERSION_COLUMN]] (which,
    * when sorted in ascending order, will order older actions before newer ones, as required by
    * [[InMemoryLogReplay]]); and [[ADD_STATS_TO_USE_COL_NAME]] (to handle certain combinations of
    * config settings for delta.checkpoint.writeStatsAsJson and delta.checkpoint.writeStatsAsStruct).
@@ -286,7 +286,6 @@ class Snapshot(
   protected def loadActions: DataFrame = {
     fileIndices.map(deltaLog.loadIndex(_))
       .reduceOption(_.union(_)).getOrElse(emptyDF)
-      .withColumn(ACTION_SORT_COL_NAME, input_file_name())
       .withColumn(ADD_STATS_TO_USE_COL_NAME, col("add.stats"))
   }
 
@@ -405,7 +404,6 @@ class Snapshot(
 object Snapshot extends DeltaLogging {
 
   // Used by [[loadActions]] and [[stateReconstruction]]
-  val ACTION_SORT_COL_NAME = "action_sort_column"
   val ADD_STATS_TO_USE_COL_NAME = "add_stats_to_use"
 
   private val defaultNumSnapshotPartitions: Int = 50

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaEncoders.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaEncoders.scala
@@ -70,8 +70,8 @@ private[delta] trait DeltaEncoders {
   private lazy val _removeFileEncoder = new DeltaEncoder[RemoveFile]
   implicit def removeFileEncoder: Encoder[RemoveFile] = _removeFileEncoder.get
 
-  private lazy val _pmfEncoder = new DeltaEncoder[(Protocol, Metadata, String)]
-  implicit def pmfEncoder: Encoder[(Protocol, Metadata, String)] = _pmfEncoder.get
+  private lazy val _pmvEncoder = new DeltaEncoder[(Protocol, Metadata, Long)]
+  implicit def pmvEncoder: Encoder[(Protocol, Metadata, Long)] = _pmvEncoder.get
 
   private lazy val _serializableFileStatusEncoder = new DeltaEncoder[SerializableFileStatus]
   implicit def serializableFileStatusEncoder: Encoder[SerializableFileStatus] =


### PR DESCRIPTION
## Description

This PR changes Delta Log replay to compute the file version only once per delta file, instead of once per every action in the delta files. It does this by exposing the commit version as a "virtual" partition column in `DeltaLogFileIndex`.

## How was this patch tested?

Existing tests to make sure nothing breaks.

## Does this PR introduce _any_ user-facing changes?

No
