### PR TITLE
[Kernel] Hide internal packages from java doc generation

### DIFF
--- a/kernel/build.sbt
+++ b/kernel/build.sbt
@@ -60,6 +60,11 @@ lazy val kernelApi = (project in file("kernel-api"))
       "-Xdoclint:all"
       // TODO: exclude internal packages
     ),
+    Compile / doc / sources := {
+      (Compile / doc / sources).value
+        // exclude internal classes
+        .filterNot(_.getCanonicalPath.contains("/internal/"))
+    },
     // Ensure doc is run with tests. Must be cleaned before test for docs to be generated
     (Test / test) := ((Test / test) dependsOn (Compile / doc)).value
   )


### PR DESCRIPTION
This is used by the github action to publish the API docs

Ran `build/sbt kernelApi/doc` locally and checked the index.