### PR TITLE
Resolve merge actions in batch

### DIFF
--- a/spark/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
+++ b/spark/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
@@ -275,7 +275,7 @@ class DeltaMergeBuilder private(
     // in the function `mergePlan` and https://issues.apache.org/jira/browse/SPARK-34962.
     val resolvedMergeInto =
       DeltaMergeInto.resolveReferencesAndSchema(mergePlan, sparkSession.sessionState.conf)(
-        tryResolveReferencesForExpressions(sparkSession) _)
+        tryResolveReferencesForExpressions(sparkSession))
     if (!resolvedMergeInto.resolved) {
       throw DeltaErrors.analysisException("Failed to resolve\n", plan = Some(resolvedMergeInto))
     }

--- a/spark/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
+++ b/spark/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
@@ -275,7 +275,7 @@ class DeltaMergeBuilder private(
     // in the function `mergePlan` and https://issues.apache.org/jira/browse/SPARK-34962.
     val resolvedMergeInto =
       DeltaMergeInto.resolveReferencesAndSchema(mergePlan, sparkSession.sessionState.conf)(
-        tryResolveReferences(sparkSession) _)
+        tryResolveReferencesForExpressions(sparkSession) _)
     if (!resolvedMergeInto.resolved) {
       throw DeltaErrors.analysisException("Failed to resolve\n", plan = Some(resolvedMergeInto))
     }

--- a/spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/deltaMerge.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/deltaMerge.scala
@@ -152,7 +152,7 @@ object DeltaMergeIntoClause {
     if (colNames.isEmpty && isEmptySeqEqualToStar) {
       Seq[Expression](UnresolvedStar(None))
     } else {
-      colNames.zip(exprs).map { case (col, expr) => DeltaMergeAction(col.nameParts, expr) }
+      (colNames, exprs).zipped.map { (col, expr) => DeltaMergeAction(col.nameParts, expr) }
     }
   }
 
@@ -488,10 +488,11 @@ object DeltaMergeInto {
             val unresolvedExprs = target.output.map { attr =>
               UnresolvedAttribute.quotedString(s"`${attr.name}`")
             }
-            resolveOrFail(unresolvedExprs, Seq(source), s"$typ clause")
-              .zip(target.output.map(_.name))
-              .map { case (resolvedExpr, tgtColName) =>
-                DeltaMergeAction(Seq(tgtColName), resolvedExpr, targetColNameResolved = true)
+            val resolvedExprs = resolveOrFail(unresolvedExprs, Seq(source), s"$typ clause")
+            (resolvedExprs, target.output.map(_.name))
+              .zipped
+              .map { (resolvedExpr, targetColName) =>
+                DeltaMergeAction(Seq(targetColName), resolvedExpr, targetColNameResolved = true)
               }
           case _: UnresolvedStar if canAutoMigrate =>
             clause match {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -498,7 +498,8 @@ class DeltaAnalysis(session: SparkSession)
         matchedActions ++ notMatchedActions ++ notMatchedBySourceActions
       )
 
-      DeltaMergeInto.resolveReferencesAndSchema(deltaMerge, conf)(tryResolveReferences(session))
+      DeltaMergeInto.resolveReferencesAndSchema(deltaMerge, conf)(
+        tryResolveReferencesForExpressions(session))
 
     case reorg @ DeltaReorgTable(resolved @ ResolvedTable(_, _, _: DeltaTableV2, _)) =>
       DeltaReorgTableCommand(resolved)(reorg.predicates)
@@ -508,7 +509,8 @@ class DeltaAnalysis(session: SparkSession)
 
     case deltaMerge: DeltaMergeInto =>
       val d = if (deltaMerge.childrenResolved && !deltaMerge.resolved) {
-        DeltaMergeInto.resolveReferencesAndSchema(deltaMerge, conf)(tryResolveReferences(session))
+        DeltaMergeInto.resolveReferencesAndSchema(deltaMerge, conf)(
+          tryResolveReferencesForExpressions(session))
       } else deltaMerge
       d.copy(target = stripTempViewForMergeWrapper(d.target))
 


### PR DESCRIPTION
## Description

This change improves the time required to resolve assignment expressions in merge UPDATE SET * and INSERT * by grouping the resolution of all column assignments in one batch instead of processing each column assignment separately.

As a result, the analysis time of merge commands with UPDATE SET * or INSERT * actions on thousands of columns is reduced from minutes to seconds.

In addition, the logic to pass the plans that should be used for resolution is simplified. Instead of passing a dummy plan with the right children - either the source only, the target only or both - we directly pass the list of plans to use to the resolution helper.

## How was this patch tested?
- Confirmed locally that the analysis time is orders of magnitude faster when the source and table contain 5000 columns.
