### PR TITLE
Fix & Add test badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <img src="https://docs.delta.io/latest/_static/delta-lake-white.png" width="200" alt="Delta Lake Logo"></img>
 
-[![Test](https://github.com/delta-io/delta/actions/workflows/test.yaml/badge.svg)](https://github.com/delta-io/delta/actions/workflows/test.yaml)
+[![Connectors Test](https://github.com/delta-io/delta/actions/workflows/connectors_test.yaml/badge.svg)](https://github.com/delta-io/delta/actions/workflows/connectors_test.yaml)
+[![Kernel Test](https://github.com/delta-io/delta/actions/workflows/kernel_test.yaml/badge.svg)](https://github.com/delta-io/delta/actions/workflows/kernel_test.yaml)
+[![Spark Test](https://github.com/delta-io/delta/actions/workflows/spark_test.yaml/badge.svg)](https://github.com/delta-io/delta/actions/workflows/spark_test.yaml)
 [![License](https://img.shields.io/badge/license-Apache%202-brightgreen.svg)](https://github.com/delta-io/delta/blob/master/LICENSE.txt)
 [![PyPI](https://img.shields.io/pypi/v/delta-spark.svg)](https://pypi.org/project/delta-spark/)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/delta-spark)](https://pypistats.org/packages/delta-spark)


### PR DESCRIPTION
## Description

Existing `test.yaml` workflow has been [renamed](https://github.com/delta-io/delta/commit/60a582b51fff28aa73b34153b3450c136e1ce96b#diff-fa52fbfa002ceb18546f168981cb804575585fff5790257dadcf9f38abcfe1ef) and so the test badge is broken

![CleanShot_2023-06-29_at_10 26 08](https://github.com/delta-io/delta/assets/3671582/9517e8f4-48e1-4510-8e04-e2ea8edd8bb0)

In addition, two other tests have recently been added.  

This PR replaces the broken badge with the three tests - kernel, spark, and connectors.

![CleanShot_2023-06-29_at_10 27 36](https://github.com/delta-io/delta/assets/3671582/72cf13ed-eb7c-4088-80ea-967e6b83fec1)
