### PR TITLE
Fix getPrevVersion with Delta 3.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1025,9 +1025,10 @@ def getPrevVersion(currentVersion: String): String = {
 
   val lastVersionInMajorVersion = Map(
     0 -> "0.8.0",
-    1 -> "1.2.1"
+    1 -> "1.2.1",
+    2 -> "2.4.0"
   )
-  if (minor == 0) {  // 1.0.0 or 2.0.0
+  if (minor == 0) {  // 1.0.0, 2.0.0 or 3.0.0
     lastVersionInMajorVersion.getOrElse(major - 1, {
       throw new Exception(s"Last version of ${major - 1}.x.x not configured.")
     })


### PR DESCRIPTION
## Description
https://github.com/delta-io/delta/commit/a2be73a9fa17dd56a5573565735af6d44d97f6cf bumped the current Delta version to 3.0.0 but the method used to get the previous version wasn't updated to support this new major version change which is causing CI to fail.
