### PR TITLE
Add required/optional column to transaction and protocol action description

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -465,11 +465,11 @@ The Delta transaction protocol does not, for example, assume monotonicity of the
 
 The schema of the `txn` action is as follows:
 
-Field Name | Data Type | Description
--|-|-
-appId | String | A unique identifier for the application performing the transaction
-version | Long | An application-specific numeric identifier for this transaction
-lastUpdated | Option[Long] | The time when this transaction action is created, in milliseconds since the Unix epoch
+Field Name | Data Type | Description | optional/required
+-|-|-|-
+appId | String | A unique identifier for the application performing the transaction | required
+version | Long | An application-specific numeric identifier for this transaction | required
+lastUpdated | Option[Long] | The time when this transaction action is created, in milliseconds since the Unix epoch | optional
 
 The following is an example `txn` action:
 ```json
@@ -493,12 +493,12 @@ Reader Version 3 and Writer Version 7 add two lists of table features to the pro
 
 The schema of the `protocol` action is as follows:
 
-Field Name | Data Type | Description
--|-|-
-minReaderVersion | Int | The minimum version of the Delta read protocol that a client must implement in order to correctly *read* this table
-minWriterVersion | Int | The minimum version of the Delta write protocol that a client must implement in order to correctly *write* this table
-readerFeatures | Array[String] | A collection of features that a client must implement in order to correctly read this table (exist only when `minReaderVersion` is set to `3`)
-writerFeatures | Array[String] | A collection of features that a client must implement in order to correctly write this table (exist only when `minWriterVersion` is set to `7`)
+Field Name | Data Type | Description | optional/required
+-|-|-|-
+minReaderVersion | Int | The minimum version of the Delta read protocol that a client must implement in order to correctly *read* this table | required
+minWriterVersion | Int | The minimum version of the Delta write protocol that a client must implement in order to correctly *write* this table | required
+readerFeatures | Array[String] | A collection of features that a client must implement in order to correctly read this table (exist only when `minReaderVersion` is set to `3`) | optional
+writerFeatures | Array[String] | A collection of features that a client must implement in order to correctly write this table (exist only when `minWriterVersion` is set to `7`) | optional
 
 Some example Delta protocols:
 ```json


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

Adds a optional/required column to the tables describing the fields of transaction and protocol actions, similar to what we have for the other actions. This clarifies which fields of the transactions and protocol actions are required or optional.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
