### PR TITLE
Add Iceberg to the table feature appendix and fix Timestamp NTZ link

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1130,8 +1130,9 @@ Feature | Name | Readers or Writers?
 [Identity Columns](#identity-columns) | `identityColumns` | Writers only
 [Deletion Vectors](#deletion-vectors) | `deletionVectors` | Readers and writers
 [Row Tracking](#row-tracking) | `rowTracking` | Writers only
-[Timestamp without Timezone](#timestamp-ntz) | `timestampNtz` | Readers and writers
+[Timestamp without Timezone](#timestamp-without-timezone-timestampntz) | `timestampNtz` | Readers and writers
 [Domain Metadata](#domain-metadata) | `domainMetadata` | Writers only
+[Iceberg Compatibility V1](#iceberg-compatibility-v1) | `icebergCompatV1` | Writers only
 
 ## Deletion Vector Format
 


### PR DESCRIPTION
## Description

Adds icebergCompatV1 to the table features in the appendix. And fix the Timestamp NTZ link

## How was this patch tested?

N/A

## Does this PR introduce _any_ user-facing changes?

Docs only
