### PR TITLE
Assign materialized Row ID and Row commit version column names

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -11,6 +11,12 @@
     ],
     "sqlState" : "0B000"
   },
+  "DELTA_ADDING_COLUMN_WITH_INTERNAL_NAME_FAILED" : {
+    "message" : [
+      "Failed to add column <colName> because the name is reserved."
+    ],
+    "sqlState" : "42000"
+  },
   "DELTA_ADDING_DELETION_VECTORS_DISALLOWED" : {
     "message" : [
       "The current operation attempted to add a deletion vector to a table that does not permit the creation of new deletion vectors. Please file a bug report."
@@ -1078,6 +1084,12 @@
       "If you never deleted it, it's likely your query is lagging behind. Please delete its checkpoint to restart from scratch. To avoid this happening again, you can update your retention policy of your Delta table"
     ],
     "sqlState" : "42K03"
+  },
+  "DELTA_MATERIALIZED_ROW_ID_COLUMN_NAME_MISSING" : {
+    "message" : [
+      "Materialized Row ID column name missing for <tableName>."
+    ],
+    "sqlState" : "22000"
   },
   "DELTA_MAX_ARRAY_SIZE_EXCEEDED" : {
     "message" : [

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -1085,9 +1085,9 @@
     ],
     "sqlState" : "42K03"
   },
-  "DELTA_MATERIALIZED_ROW_ID_COLUMN_NAME_MISSING" : {
+  "DELTA_MATERIALIZED_ROW_TRACKING_COLUMN_NAME_MISSING" : {
     "message" : [
-      "Materialized Row ID column name missing for <tableName>."
+      "Materialized <rowTrackingColumn> column name missing for <tableName>."
     ],
     "sqlState" : "22000"
   },

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -141,10 +141,10 @@ class DeltaAnalysis(session: SparkSession)
         if (src.provider.exists(DeltaSourceUtils.isDeltaDataSourceName)) {
           val deltaLogSrc = DeltaTableV2(session, new Path(src.location))
 
-          // maxColumnId field cannot be set externally. If column-mapping is
-          // used on the source delta table, then maxColumnId would be set for the sourceTable
-          // and needs to be removed from the targetTable's configuration
-          // maxColumnId will be set in the targetTable's configuration internally after
+          // Column mapping and row tracking fields cannot be set externally. If the features are
+          // used on the source delta table, then the corresponding fields would be set for the
+          // sourceTable and needs to be removed from the targetTable's configuration. The fields
+          // will then be set in the targetTable's configuration internally after.
           val config =
             deltaLogSrc.snapshot.metadata.configuration.-("delta.columnMapping.maxColumnId")
               .-(MaterializedRowId.MATERIALIZED_COLUMN_NAME_PROP)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -147,6 +147,8 @@ class DeltaAnalysis(session: SparkSession)
           // maxColumnId will be set in the targetTable's configuration internally after
           val config =
             deltaLogSrc.snapshot.metadata.configuration.-("delta.columnMapping.maxColumnId")
+              .-(MaterializedRowId.MATERIALIZED_COLUMN_NAME_PROP)
+              .-(MaterializedRowCommitVersion.MATERIALIZED_COLUMN_NAME_PROP)
 
           new CatalogTable(
             identifier = targetTableIdentifier,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2814,8 +2814,15 @@ trait DeltaErrorsBase
 
   def materializedRowIdMetadataMissing(tableName: String): Throwable = {
     new DeltaIllegalStateException(
-      errorClass = "DELTA_MATERIALIZED_ROW_ID_COLUMN_NAME_MISSING",
-      messageParameters = Array(tableName)
+      errorClass = "DELTA_MATERIALIZED_ROW_TRACKING_COLUMN_NAME_MISSING",
+      messageParameters = Array("Row ID", tableName)
+    )
+  }
+
+  def materializedRowCommitVersionMetadataMissing(tableName: String): Throwable = {
+    new DeltaIllegalStateException(
+      errorClass = "DELTA_MATERIALIZED_ROW_TRACKING_COLUMN_NAME_MISSING",
+      messageParameters = Array("Row Commit Version", tableName)
     )
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2805,6 +2805,20 @@ trait DeltaErrorsBase
     new DeltaIllegalStateException(errorClass = "DELTA_ROW_ID_ASSIGNMENT_WITHOUT_STATS")
   }
 
+  def addingColumnWithInternalNameFailed(colName: String): Throwable = {
+    new DeltaRuntimeException(
+      errorClass = "DELTA_ADDING_COLUMN_WITH_INTERNAL_NAME_FAILED",
+      messageParameters = Array(colName)
+    )
+  }
+
+  def materializedRowIdMetadataMissing(tableName: String): Throwable = {
+    new DeltaIllegalStateException(
+      errorClass = "DELTA_MATERIALIZED_ROW_ID_COLUMN_NAME_MISSING",
+      messageParameters = Array(tableName)
+    )
+  }
+
   def domainMetadataDuplicate(domainName: String): Throwable = {
     new DeltaIllegalArgumentException(
       errorClass = "DELTA_DUPLICATE_DOMAIN_METADATA_INTERNAL_ERROR",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/MaterializedRowTrackingColumn.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/MaterializedRowTrackingColumn.scala
@@ -1,0 +1,148 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.util.UUID
+
+import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+/**
+ * Represents a materialized row tracking column. Concrete implementations are [[MaterializedRowId]]
+ * and [[MaterializedRowCommitVersion]].
+ */
+abstract class MaterializedRowTrackingColumn {
+  /**
+   * Table metadata configuration property name storing the name of this materialized row tracking
+   * column.
+   */
+  val MATERIALIZED_COLUMN_NAME_PROP: String
+
+  /** Prefix to use for the name of this materialized row tracking column */
+  val MATERIALIZED_COLUMN_NAME_PREFIX: String
+
+  /**
+   * Generate a random name for a materialized row tracking column. The generated name contains a
+   * unique UUID, we assume it shall not conflict with existing column.
+   */
+  private def generateMaterializedColumnName: String =
+    MATERIALIZED_COLUMN_NAME_PREFIX + UUID.randomUUID().toString
+
+  /**
+   * Update this materialized row tracking column name in the metadata.
+   *   - If row tracking is not allowed or not supported, this operation is a noop.
+   *   - If row tracking is supported on the table and no name is assigned to the old metadata, we
+   *   assign a name. If a name was already assigned, we copy over this name.
+   * Throws in case the assignment of a new name fails due to a conflict.
+   */
+  private[delta] def updateMaterializedColumnName(
+      protocol: Protocol,
+      oldMetadata: Metadata,
+      newMetadata: Metadata): Metadata = {
+    if (!RowTracking.isSupported(protocol)) {
+      // During a CLONE we might not enable row tracking, but still receive the materialized column
+      // name from the source. In this case, we need to remove the column name to not have the same
+      // column name in two different tables.
+      return newMetadata.copy(
+        configuration = newMetadata.configuration - MATERIALIZED_COLUMN_NAME_PROP)
+    }
+
+    // Take the materialized column name from the old metadata, as this is the materialized column
+    // name of the current table. We overwrite the materialized column name of the new metadata as
+    // it could contain a materialized column name from another table, e.g. the source table during
+    // a CLONE.
+    val materializedColumnName = oldMetadata.configuration
+      .getOrElse(MATERIALIZED_COLUMN_NAME_PROP, generateMaterializedColumnName)
+    newMetadata.copy(configuration = newMetadata.configuration +
+      (MATERIALIZED_COLUMN_NAME_PROP -> materializedColumnName))
+  }
+
+  /**
+   * Throws an exception if row tracking is allowed and the materialized column name conflicts with
+   * another column name.
+   */
+  private[delta] def throwIfMaterializedColumnNameConflictsWithSchema(metadata: Metadata): Unit = {
+    val logicalColumnNames = metadata.schema.fields.map(_.name)
+    val physicalColumnNames = metadata.schema.fields
+      .map(field => DeltaColumnMapping.getPhysicalName(field))
+
+    metadata.configuration.get(MATERIALIZED_COLUMN_NAME_PROP).foreach { columnName =>
+      if (logicalColumnNames.contains(columnName) || physicalColumnNames.contains(columnName)) {
+        throw DeltaErrors.addingColumnWithInternalNameFailed(columnName)
+      }
+    }
+  }
+
+  /** Extract the materialized column name from the [[Metadata]] of a [[DeltaLog]]. */
+  def getMaterializedColumnName(protocol: Protocol, metadata: Metadata): Option[String] = {
+    if (RowTracking.isEnabled(protocol, metadata)) {
+      metadata.configuration.get(MATERIALIZED_COLUMN_NAME_PROP)
+    } else {
+      None
+    }
+  }
+
+  /** Convenience method that throws if the materialized column name cannot be extracted. */
+  def getMaterializedColumnNameOrThrow(
+      protocol: Protocol, metadata: Metadata, tableId: String): String = {
+    getMaterializedColumnName(protocol, metadata).getOrElse {
+      throw DeltaErrors.materializedRowIdMetadataMissing(tableId)
+    }
+  }
+
+  /**
+   * If Row tracking is enabled, return an Expression referencing this Row tracking column Attribute
+   * in 'dataFrame' if one is available. Otherwise returns None.
+   */
+  private[delta] def getAttribute(
+      snapshot: Snapshot, dataFrame: DataFrame): Option[Attribute] = {
+    if (!RowTracking.isEnabled(snapshot.protocol, snapshot.metadata)) {
+      return None
+    }
+
+    val materializedColumnName = getMaterializedColumnNameOrThrow(
+      snapshot.protocol, snapshot.metadata, snapshot.deltaLog.tableId)
+
+    val analyzedPlan = dataFrame.queryExecution.analyzed
+    analyzedPlan.outputSet.view.find(attr => materializedColumnName == attr.name)
+  }
+}
+
+object MaterializedRowId extends MaterializedRowTrackingColumn {
+  /**
+   * Table metadata configuration property name storing the name of the column in which the
+   * Row IDs are materialized.
+   */
+  val MATERIALIZED_COLUMN_NAME_PROP = "delta.rowTracking.materializedRowIdColumnName"
+
+  /** Prefix to use for the name of the materialized Row ID column */
+  val MATERIALIZED_COLUMN_NAME_PREFIX = "_row-id-col-"
+
+}
+
+object MaterializedRowCommitVersion extends MaterializedRowTrackingColumn {
+  /**
+   * Table metadata configuration property name storing the name of the column in which the
+   * Row commit versions are materialized.
+   */
+  val MATERIALIZED_COLUMN_NAME_PROP = "delta.rowTracking.materializedRowCommitVersionColumnName"
+
+  /** Prefix to use for the name of the materialized Row commit version column */
+  val MATERIALIZED_COLUMN_NAME_PREFIX = "_row-commit-version-col-"
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/MaterializedRowTrackingColumn.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/MaterializedRowTrackingColumn.scala
@@ -38,6 +38,12 @@ abstract class MaterializedRowTrackingColumn {
   val MATERIALIZED_COLUMN_NAME_PREFIX: String
 
   /**
+   * Returns the exception to throw when the materialized column name is not set in the table
+   * metadata. The table name is passed as argument.
+   */
+  def missingMetadataException: String => Throwable
+
+  /**
    * Generate a random name for a materialized row tracking column. The generated name contains a
    * unique UUID, we assume it shall not conflict with existing column.
    */
@@ -102,7 +108,7 @@ abstract class MaterializedRowTrackingColumn {
   def getMaterializedColumnNameOrThrow(
       protocol: Protocol, metadata: Metadata, tableId: String): String = {
     getMaterializedColumnName(protocol, metadata).getOrElse {
-      throw DeltaErrors.materializedRowIdMetadataMissing(tableId)
+      throw missingMetadataException(tableId)
     }
   }
 
@@ -134,6 +140,7 @@ object MaterializedRowId extends MaterializedRowTrackingColumn {
   /** Prefix to use for the name of the materialized Row ID column */
   val MATERIALIZED_COLUMN_NAME_PREFIX = "_row-id-col-"
 
+  def missingMetadataException: String => Throwable = DeltaErrors.materializedRowIdMetadataMissing
 }
 
 object MaterializedRowCommitVersion extends MaterializedRowTrackingColumn {
@@ -145,4 +152,7 @@ object MaterializedRowCommitVersion extends MaterializedRowTrackingColumn {
 
   /** Prefix to use for the name of the materialized Row commit version column */
   val MATERIALIZED_COLUMN_NAME_PREFIX = "_row-commit-version-col-"
+
+  def missingMetadataException: String => Throwable =
+    DeltaErrors.materializedRowCommitVersionMetadataMissing
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -575,6 +575,10 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       setNewProtocolWithFeaturesEnabledByMetadata(newMetadataTmp)
     }
 
+    newMetadataTmp = MaterializedRowId.updateMaterializedColumnName(
+      protocol, oldMetadata = snapshot.metadata, newMetadataTmp)
+    newMetadataTmp = MaterializedRowCommitVersion.updateMaterializedColumnName(
+      protocol, oldMetadata = snapshot.metadata, newMetadataTmp)
 
     RowId.verifyMetadata(
       snapshot.protocol, protocol, snapshot.metadata, newMetadataTmp, isCreatingNewTable)
@@ -652,6 +656,8 @@ trait OptimisticTransactionImpl extends TransactionalWrite
     if (spark.conf.get(DeltaSQLConf.DELTA_TABLE_PROPERTY_CONSTRAINTS_CHECK_ENABLED)) {
       Protocol.assertTablePropertyConstraintsSatisfied(spark, metadata, snapshot)
     }
+    MaterializedRowId.throwIfMaterializedColumnNameConflictsWithSchema(metadata)
+    MaterializedRowCommitVersion.throwIfMaterializedColumnNameConflictsWithSchema(metadata)
   }
 
   private def setNewProtocolWithFeaturesEnabledByMetadata(metadata: Metadata): Unit = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowId.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowId.scala
@@ -127,20 +127,4 @@ object RowId {
    */
   private[delta] def extractHighWatermark(snapshot: Snapshot): Option[Long] =
     RowTrackingMetadataDomain.fromSnapshot(snapshot).map(_.rowIdHighWaterMark)
-
-  /**
-   * Checks whether CONVERT TO DELTA collects statistics if row tracking is supported. If it does
-   * not collect statistics, we cannot assign fresh row IDs, hence we throw an error to either rerun
-   * the command without enabling the row tracking table feature, or to enable the necessary
-   * flags to collect statistics.
-   */
-  private[delta] def checkStatsCollectedIfRowTrackingSupported(
-      protocol: Protocol,
-      convertToDeltaShouldCollectStats: Boolean,
-      statsCollectionEnabled: Boolean): Unit = {
-    if (!isSupported(protocol)) return
-    if (!convertToDeltaShouldCollectStats || !statsCollectionEnabled) {
-      throw DeltaErrors.convertToDeltaRowTrackingEnabledWithoutStatsCollection
-    }
-  }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
@@ -369,7 +369,7 @@ abstract class ConvertToDeltaCommandBase(
       // TODO: we have not decided on how to implement CONVERT TO DELTA under column mapping modes
       //  for some convert targets so we block this feature for them here
       checkColumnMapping(txn.metadata, targetTable)
-      RowId.checkStatsCollectedIfRowTrackingSupported(
+      RowTracking.checkStatsCollectedIfRowTrackingSupported(
         txn.protocol,
         collectStats,
         statsEnabled)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1875,6 +1875,30 @@ trait DeltaErrorsSuiteBase
       assert(e.getErrorClass == "DELTA_ZORDERING_ON_COLUMN_WITHOUT_STATS")
       assert(e.getSqlState == "KD00D")
     }
+    {
+      checkError(
+        exception = intercept[DeltaIllegalStateException] {
+          throw MaterializedRowId.missingMetadataException("table_name")
+        },
+        errorClass = "DELTA_MATERIALIZED_ROW_TRACKING_COLUMN_NAME_MISSING",
+        parameters = Map(
+          "rowTrackingColumn" -> "Row ID",
+          "tableName" -> "table_name"
+        )
+      )
+    }
+    {
+      checkError(
+        exception = intercept[DeltaIllegalStateException] {
+          throw MaterializedRowCommitVersion.missingMetadataException("table_name")
+        },
+        errorClass = "DELTA_MATERIALIZED_ROW_TRACKING_COLUMN_NAME_MISSING",
+        parameters = Map(
+          "rowTrackingColumn" -> "Row Commit Version",
+          "tableName" -> "table_name"
+        )
+      )
+    }
   }
 
   // Complier complains the lambda function is too large if we put all tests in one lambda

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/MaterializedColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/MaterializedColumnSuite.scala
@@ -1,0 +1,187 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rowtracking
+
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog, DeltaRuntimeException, MaterializedRowCommitVersion, MaterializedRowId, RowTracking}
+import org.apache.spark.sql.delta.rowid.RowIdTestUtils
+
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.execution.datasources.parquet.ParquetTest
+
+class MaterializedColumnSuite extends RowIdTestUtils
+  with ParquetTest {
+
+  private val testTableName = "target"
+  private val testDataColumnName = "test_data"
+
+  private def withTestTable(testFunction: => Unit): Unit = {
+    withTable(testTableName) {
+      spark.range(end = 10).toDF(testDataColumnName)
+        .write.format("delta").saveAsTable(testTableName)
+      testFunction
+    }
+  }
+
+  private def getMaterializedRowIdColumnName(tableName: String): Option[String] = {
+    val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
+    deltaLog.update().metadata.configuration.get(MaterializedRowId.MATERIALIZED_COLUMN_NAME_PROP)
+  }
+
+  private def getMaterializedRowCommitVersionColumnName(tableName: String): Option[String] = {
+    val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
+    deltaLog.update().metadata.configuration.get(
+      MaterializedRowCommitVersion.MATERIALIZED_COLUMN_NAME_PROP)
+  }
+
+  for ((name, getMaterializedColumnName) <- Map(
+    "row ids" -> getMaterializedRowIdColumnName _,
+    "row commit versions" -> getMaterializedRowCommitVersionColumnName _
+  )) {
+    test(s"materialized $name column name is stored when row tracking is enabled") {
+      withRowTrackingEnabled(enabled = true) {
+        withTestTable {
+          assert(getMaterializedColumnName(testTableName).isDefined)
+        }
+      }
+    }
+
+    test(s"materialized $name column name is not stored when row tracking is disabled") {
+      withRowTrackingEnabled(enabled = false) {
+        withTestTable {
+          assert(getMaterializedColumnName(testTableName).isEmpty)
+        }
+      }
+    }
+
+    test(s"adding a column with the same name as the materialized $name column name fails") {
+      withRowTrackingEnabled(enabled = true) {
+        withTestTable {
+          val materializedColumnName = getMaterializedColumnName(testTableName).get
+          val error = intercept[DeltaRuntimeException] {
+            sql(s"ALTER TABLE $testTableName ADD COLUMN (`$materializedColumnName` BIGINT)")
+          }
+          checkError(error, "DELTA_ADDING_COLUMN_WITH_INTERNAL_NAME_FAILED",
+            parameters = Map("colName" -> materializedColumnName))
+        }
+      }
+    }
+
+    test(s"renaming a column to the materialized $name column name fails") {
+      withRowTrackingEnabled(enabled = true) {
+        withSQLConf(DeltaConfigs.COLUMN_MAPPING_MODE.defaultTablePropertyKey -> "name") {
+          withTestTable {
+            val materializedColumnName = getMaterializedColumnName(testTableName).get
+            val error = intercept[DeltaRuntimeException] {
+              sql(s"ALTER TABLE $testTableName " +
+                s"RENAME COLUMN $testDataColumnName TO `$materializedColumnName`")
+            }
+            checkError(error, errorClass = "DELTA_ADDING_COLUMN_WITH_INTERNAL_NAME_FAILED",
+              parameters = Map("colName" -> materializedColumnName))
+          }
+        }
+      }
+    }
+
+    test(s"cloning a table with a column equal to the materialized $name column name fails") {
+      val targetName = "target"
+      val sourceName = "source"
+      withTable(targetName, sourceName) {
+        withRowTrackingEnabled(enabled = true) {
+          spark.range(0).toDF("val")
+            .write.format("delta").saveAsTable(targetName)
+
+          val materializedColumnName = getMaterializedColumnName(targetName).get
+          spark.range(0).toDF(materializedColumnName)
+            .write.format("delta").saveAsTable(sourceName)
+
+          val error = intercept[DeltaRuntimeException] {
+            sql(s"CREATE OR REPLACE TABLE $targetName SHALLOW CLONE $sourceName")
+          }
+          checkError(error, errorClass = "DELTA_ADDING_COLUMN_WITH_INTERNAL_NAME_FAILED",
+            parameters = Map("colName" -> materializedColumnName))
+        }
+      }
+    }
+
+    test(s"replace keeps the materialized $name column name") {
+      withRowTrackingEnabled(enabled = true) {
+        withTestTable {
+          val materializedColumnNameBefore = getMaterializedColumnName(testTableName)
+          sql(
+            s"""
+               |CREATE OR REPLACE TABLE $testTableName
+               |USING delta AS
+               |SELECT * FROM VALUES (0), (1)
+               |""".stripMargin)
+          val materializedColumnNameAfter = getMaterializedColumnName(testTableName)
+          assert(materializedColumnNameBefore == materializedColumnNameAfter)
+        }
+      }
+    }
+
+    test(s"restore keeps the materialized $name column name") {
+      withRowTrackingEnabled(enabled = true) {
+        withTestTable {
+          spark.range(end = 100).toDF(testDataColumnName)
+            .write.format("delta").mode("overwrite").saveAsTable(testTableName)
+
+          val materializedColumnNameBefore = getMaterializedColumnName(testTableName)
+          io.delta.tables.DeltaTable.forName(testTableName).restoreToVersion(0)
+          val materializedColumnNameAfter = getMaterializedColumnName(testTableName)
+          assert(materializedColumnNameBefore == materializedColumnNameAfter)
+        }
+      }
+    }
+
+    test(s"clone assigns a materialized $name column when table property is set") {
+      val sourceTableName = "source"
+      val targetTableName = "target"
+
+      withTable(sourceTableName, targetTableName) {
+        withRowTrackingEnabled(enabled = false) {
+          spark.range(end = 1).write.format("delta").saveAsTable(sourceTableName)
+          assert(getMaterializedColumnName(sourceTableName).isEmpty)
+
+          sql(s"CREATE OR REPLACE TABLE $targetTableName SHALLOW CLONE $sourceTableName " +
+            s"TBLPROPERTIES ('${DeltaConfigs.ROW_TRACKING_ENABLED.key}' = 'true')")
+
+          assert(getMaterializedColumnName(targetTableName).isDefined)
+        }
+      }
+    }
+
+    test(s"clone does not assign a materialized $name column when table property is not set") {
+      val sourceTableName = "source"
+      val targetTableName = "target"
+
+      withTable(sourceTableName, targetTableName) {
+        withRowTrackingEnabled(enabled = true) {
+          spark.range(end = 1).toDF("col1").write.format("delta").saveAsTable(sourceTableName)
+
+          sql(s"CREATE TABLE $targetTableName SHALLOW CLONE $sourceTableName")
+
+          val sourceTableColumnName = getMaterializedColumnName(sourceTableName)
+          val targetTableColumnName = getMaterializedColumnName(targetTableName)
+
+          assert(sourceTableColumnName.isDefined)
+          assert(targetTableColumnName.isEmpty)
+        }
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
## Description
This change is part of implementing row tracking as specified in https://github.com/delta-io/delta/pull/1610 and https://github.com/delta-io/delta/commit/7272b04db76507a98e07e96dc88e2c1a54283693.
It covers assigning a column name for the materialized Row ID and Row commit version columns by setting them in the table metadata when creating or cloning a table.

## How was this patch tested?
- Add test suite `rowtracking.MaterializedColumnSuite` to cover assigning materialized column names in various table creation and clone scenarios.
