### PR TITLE
Extend RemoveFile actions with stats field

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -441,9 +441,9 @@ object Checkpoints extends DeltaLogging {
         }
         action
       }
-      // commitInfo, cdc and remove.tags are not included in the checkpoint
+      // commitInfo, cdc, remove.tags and remove.stats are not included in the checkpoint
       .drop("commitInfo", "cdc")
-      .withColumn("remove", col("remove").dropFields("tags"))
+      .withColumn("remove", col("remove").dropFields("tags", "stats"))
 
     val chk = buildCheckpoint(base, snapshot)
     val schema = chk.schema.asNullable

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -207,25 +207,35 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
   testActionSerDe(
     "AddFile (without tags) - json serialization/deserialization",
     AddFile("x=2/f1", partitionValues = Map("x" -> "2"),
-      size = 10, modificationTime = 1, dataChange = true, stats = "{\"rowCount\": 2}"),
+      size = 10, modificationTime = 1, dataChange = true, stats = "{\"numRecords\": 2}"),
     expectedJson = """{"add":{"path":"x=2/f1","partitionValues":{"x":"2"},"size":10,""" +
-      """"modificationTime":1,"dataChange":true,"stats":"{\"rowCount\": 2}"}}""".stripMargin)
+      """"modificationTime":1,"dataChange":true,"stats":"{\"numRecords\": 2}"}}""".stripMargin)
 
   testActionSerDe(
     "AddFile (with tags) - json serialization/deserialization",
     AddFile("part=p1/f1", partitionValues = Map("x" -> "2"), size = 10, modificationTime = 1,
-      dataChange = true, stats = "{\"rowCount\": 2}", tags = Map("TAG1" -> "23")),
+      dataChange = true, stats = "{\"numRecords\": 2}", tags = Map("TAG1" -> "23")),
     expectedJson = """{"add":{"path":"part=p1/f1","partitionValues":{"x":"2"},"size":10""" +
-      ""","modificationTime":1,"dataChange":true,"stats":"{\"rowCount\": 2}",""" +
+      ""","modificationTime":1,"dataChange":true,"stats":"{\"numRecords\": 2}",""" +
       """"tags":{"TAG1":"23"}}}"""
   )
 
   testActionSerDe(
     "RemoveFile (without tags) - json serialization/deserialization",
     AddFile("part=p1/f1", partitionValues = Map("x" -> "2"), size = 10, modificationTime = 1,
-      dataChange = true, stats = "{\"rowCount\": 2}").removeWithTimestamp(timestamp = 11),
+      dataChange = true, stats = "{\"numRecords\": 2}").removeWithTimestamp(timestamp = 11),
     expectedJson = """{"remove":{"path":"part=p1/f1","deletionTimestamp":11,"dataChange":true,""" +
-      """"extendedFileMetadata":true,"partitionValues":{"x":"2"},"size":10}}""".stripMargin)
+      """"extendedFileMetadata":true,"partitionValues":{"x":"2"},"size":10,""" +
+      """"stats":"{\"numRecords\": 2}"}}""")
+
+  testActionSerDe(
+    "RemoveFile (without tags and stats) - json serialization/deserialization",
+    AddFile("part=p1/f1", partitionValues = Map("x" -> "2"), size = 10, modificationTime = 1,
+        dataChange = true, stats = "{\"numRecords\": 2}")
+      .removeWithTimestamp(timestamp = 11)
+      .copy(stats = null),
+    expectedJson = """{"remove":{"path":"part=p1/f1","deletionTimestamp":11,"dataChange":true,""" +
+      """"extendedFileMetadata":true,"partitionValues":{"x":"2"},"size":10}}""")
 
   private def deletionVectorWithRelativePath: DeletionVectorDescriptor =
     DeletionVectorDescriptor.onDiskWithRelativePath(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description

Extend the remove actions with statistics about the data in the file that is being removed from the table and that can be used to optimize queries that read the changes of older versions, e.g., Change Data Feed queries. These statistics are copied from the add action when a file is being removed.

File statistics can be large and increase the size of checkpoints. However, statistics of remove actions are not needed for tombstones but only for Delta JSON files, and so are dropped from checkpoints.

## How was this patch tested?

- Extended existing tests for JSON (de-)serialization
- Existing tests provide coverage regarding the fields that are stored in checkpoints.

## Does this PR introduce _any_ user-facing changes?

No
