### PR TITLE
[BUILD] targetJvm and default_scala_version settable

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,15 +47,18 @@ scalaVersion := default_scala_version
 // crossScalaVersions must be set to Nil on the root project
 crossScalaVersions := Nil
 
+// Uncomment the following line for Java 11
+// val targetJvm = "11"
+val targetJvm = "1.8"
 lazy val commonSettings = Seq(
   organization := "io.delta",
   scalaVersion := default_scala_version,
   crossScalaVersions := all_scala_versions,
   fork := true,
-  scalacOptions ++= Seq("-target:jvm-1.8", "-Ywarn-unused:imports"),
-  javacOptions ++= Seq("-source", "1.8"),
+  scalacOptions ++= Seq(s"-target:jvm-$targetJvm", "-Ywarn-unused:imports"),
+  javacOptions ++= Seq("-source", targetJvm),
   // -target cannot be passed as a parameter to javadoc. See https://github.com/sbt/sbt/issues/355
-  Compile / compile / javacOptions ++= Seq("-target", "1.8"),
+  Compile / compile / javacOptions ++= Seq("-target", targetJvm),
 
   // Make sure any tests in any project that uses Spark is configured for running well locally
   Test / javaOptions ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -21,8 +21,16 @@ import java.nio.file.Files
 // Scala versions
 val scala212 = "2.12.15"
 val scala213 = "2.13.5"
-val default_scala_version = scala212
 val all_scala_versions = Seq(scala212, scala213)
+
+// Due to how publishArtifact is determined for javaOnlyReleaseSettings, incl. storage
+// It was necessary to change default_scala_version to scala213
+// to build the project with Scala 2.13 only
+// As a setting, it's possible to set it on command line easily
+// sbt 'set default_scala_version := 2.13.5' [commands]
+// FIXME Why not use scalaVersion?!
+val default_scala_version = settingKey[String]("Default Scala version")
+Global / default_scala_version := scala212
 
 // Dependent library versions
 val sparkVersion = "3.4.0"
@@ -42,7 +50,7 @@ val hadoopVersionForHive2 = "2.7.2"
 val hive2Version = "2.3.3"
 val tezVersionForHive2 = "0.8.4"
 
-scalaVersion := default_scala_version
+scalaVersion := default_scala_version.value
 
 // crossScalaVersions must be set to Nil on the root project
 crossScalaVersions := Nil
@@ -52,7 +60,7 @@ crossScalaVersions := Nil
 val targetJvm = "1.8"
 lazy val commonSettings = Seq(
   organization := "io.delta",
-  scalaVersion := default_scala_version,
+  scalaVersion := default_scala_version.value,
   crossScalaVersions := all_scala_versions,
   fork := true,
   scalacOptions ++= Seq(s"-target:jvm-$targetJvm", "-Ywarn-unused:imports"),
@@ -1131,7 +1139,7 @@ lazy val javaOnlyReleaseSettings = releaseSettings ++ Seq(
   // we publish jars for each scalaVersion in crossScalaVersions. however, we only need to publish
   // one java jar. thus, only do so when the current scala version == default scala version
   publishArtifact := {
-    val (expMaj, expMin, _) = getMajorMinorPatch(default_scala_version)
+    val (expMaj, expMin, _) = getMajorMinorPatch(default_scala_version.value)
     s"$expMaj.$expMin" == scalaBinaryVersion.value
   },
 

--- a/build.sbt
+++ b/build.sbt
@@ -24,11 +24,11 @@ val scala213 = "2.13.5"
 val all_scala_versions = Seq(scala212, scala213)
 
 // Due to how publishArtifact is determined for javaOnlyReleaseSettings, incl. storage
-// It was necessary to change default_scala_version to scala213
+// It was necessary to change default_scala_version to scala213 in build.sbt
 // to build the project with Scala 2.13 only
 // As a setting, it's possible to set it on command line easily
 // sbt 'set default_scala_version := 2.13.5' [commands]
-// FIXME Why not use scalaVersion?!
+// FIXME Why not use scalaVersion?
 val default_scala_version = settingKey[String]("Default Scala version")
 Global / default_scala_version := scala212
 
@@ -55,18 +55,20 @@ scalaVersion := default_scala_version.value
 // crossScalaVersions must be set to Nil on the root project
 crossScalaVersions := Nil
 
-// Uncomment the following line for Java 11
-// val targetJvm = "11"
-val targetJvm = "1.8"
+// For Java 11 use the following on command line
+// sbt 'set targetJvm := "11"' [commands]
+val targetJvm = settingKey[String]("Target JVM version")
+Global / targetJvm := "1.8"
+
 lazy val commonSettings = Seq(
   organization := "io.delta",
   scalaVersion := default_scala_version.value,
   crossScalaVersions := all_scala_versions,
   fork := true,
-  scalacOptions ++= Seq(s"-target:jvm-$targetJvm", "-Ywarn-unused:imports"),
-  javacOptions ++= Seq("-source", targetJvm),
+  scalacOptions ++= Seq(s"-target:jvm-${targetJvm.value}", "-Ywarn-unused:imports"),
+  javacOptions ++= Seq("-source", targetJvm.value),
   // -target cannot be passed as a parameter to javadoc. See https://github.com/sbt/sbt/issues/355
-  Compile / compile / javacOptions ++= Seq("-target", targetJvm),
+  Compile / compile / javacOptions ++= Seq("-target", targetJvm.value),
 
   // Make sure any tests in any project that uses Spark is configured for running well locally
   Test / javaOptions ++= Seq(


### PR DESCRIPTION
## Description

It is currently not possible to build the sources with Java 11 and Scala 2.13 with no changes to `build.sbt`. In order to make Java and Scala versions "settable" (e.g. on command line) this PR introduces two sbt settings:

* `default_scala_version`
* `targetJvm`

With the settings, it's possible to build the sources with Java 11 and just a single Scala 2.13 (no cross-compiling that would take longer).

```shell
sbt 'set Global / default_scala_version := "2.13.5"' \
    'set Global / targetJvm := "11"' \
    spark/publishLocal storage/publishLocal
```

Together with https://github.com/delta-io/delta/pull/1882 should make migrating to Java 11 easy (if not done already 😎).

## How was this patch tested?

Various build configurations (valid and invalid, e.g. `targetJvm := "123"`)

Once built, checked the ivy directories and ran `spark-shell`.

```
ls -l /Users/jacek/.ivy2/local/io.delta/delta-storage/3.0.0-SNAPSHOT/jars
ls -l /Users/jacek/.ivy2/local/io.delta/delta-spark_2.12/3.0.0-SNAPSHOT/jars
ls -l /Users/jacek/.ivy2/local/io.delta/delta-spark_2.13/3.0.0-SNAPSHOT/jars
```

```
./bin/spark-shell --packages io.delta:delta-spark_2.13:3.0.0-SNAPSHOT \
--conf spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension \
--conf spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog
```

```
sql("DROP TABLE IF EXISTS demo_001")
spark.range(0, 5, 1, numPartitions = 1).write.format("delta").saveAsTable("demo_001")
sql("DESC EXTENDED demo_001").where($"col_name" === "Provider").select("data_type").show
+---------+
|data_type|
+---------+
|    delta|
+---------+
assert(spark.table("demo_001").collect.length == 5)
```

## Does this PR introduce _any_ user-facing changes?

No
