### PR TITLE
Add config to run MERGE source materialization eagerly

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
@@ -257,12 +257,11 @@ trait MergeIntoMaterializeSource extends DeltaLogging {
     val sourceWithSelectedColumns = Project(referencedSourceColumns, source)
     val baseSourcePlanDF = Dataset.ofRows(spark, sourceWithSelectedColumns)
 
-    // Caches the source in RDD cache using localCheckpopoint, which cuts away the RDD lineage,
+    // Caches the source in RDD cache using localCheckpoint, which cuts away the RDD lineage,
     // which shall ensure that the source cannot be recomputed and thus become inconsistent.
     val checkpointedSourcePlanDF = baseSourcePlanDF
-      // eager = false makes it be executed and materialized first time it's used.
-      // Doing it lazily inside the query lets it interleave this work better with other work.
-      // On the other hand, it makes it impossible to measure the time it took in a metric.
+      // Set eager=false for now, even if we should be doing eager, so that we can set the storage
+      // level before executing.
       .localCheckpoint(eager = false)
 
     // We have to reach through the crust and into the plan of the checkpointed DF
@@ -288,6 +287,20 @@ trait MergeIntoMaterializeSource extends DeltaLogging {
       }
     )
     rdd.persist(storageLevel)
+
+    // WARNING: if eager == false, the source used during the first Spark Job that uses this may
+    // still be inconsistent with source materialized afterwards.
+    // This is because doCheckpoint that finalizes the lazy checkpoint is called after the Job
+    // that triggered the lazy checkpointing finished.
+    // If blocks were lost during that job, they may still get recomputed and changed compared
+    // to how they were used during the execution of the job.
+    if (spark.conf.get(DeltaSQLConf.MERGE_MATERIALIZE_SOURCE_EAGER)) {
+      // Force the evaluation of the `rdd`, since we cannot access `doCheckpoint()` from here.
+      rdd
+        .mapPartitions(_ => Iterator.empty.asInstanceOf[Iterator[InternalRow]])
+        .foreach((_: InternalRow) => ())
+      assert(rdd.isCheckpointed)
+    }
 
     logDebug(s"Materializing MERGE with pruned columns $referencedSourceColumns. ")
     logDebug(s"Materialized MERGE source plan:\n${sourceDF.get.queryExecution}")

--- a/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -510,6 +510,13 @@ trait DeltaSQLConfBase {
       .intConf
       .createWithDefault(4)
 
+  val MERGE_MATERIALIZE_SOURCE_EAGER =
+    buildConf("merge.materializeSource.eager")
+      .internal()
+      .doc("Materialize the source eagerly before Job 1")
+      .booleanConf
+      .createWithDefault(true)
+
   val DELTA_LAST_COMMIT_VERSION_IN_SESSION =
     buildConf("lastCommitVersionInSession")
       .doc("The version of the last commit made in the SparkSession for any table.")


### PR DESCRIPTION
## Description

(Cherry-pick of 4932956ae52f7a1211999f5364b6f9e1875d183a to branch-2.4)

Add config to run MERGE source materialization eagerly.
Add a new config that that controls whether the MERGE source is materialized eagerly or lazily.
New config is set to eager by default to avoid suspected determinism issues with lazy materialization.

## How was this patch tested?
Run most sensitive tests with both eager and lazy settings, the rest only with the default to not blow up the CI time unnecessarily.