### PR TITLE
Re-enable iceberg module and clone iceberg github repo using shallow clone

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -273,10 +273,6 @@ lazy val storageS3DynamoDB = (project in file("storage-s3-dynamodb"))
     )
   )
 
-/*
-// TODO: Investigate a smarter way to pull the Iceberg github.
-//       Make sure to add `iceberg` back to `sparkGroup` below.
-
 val icebergSparkRuntimeArtifactName = {
  val (expMaj, expMin, _) = getMajorMinorPatch(sparkVersion)
  s"iceberg-spark-runtime-$expMaj.$expMin"
@@ -338,7 +334,6 @@ lazy val icebergShaded = (project in file("icebergShaded"))
     assemblyPackageScala / assembleArtifact := false,
     // Make the 'compile' invoke the 'assembly' task to generate the uber jar.
   )
-*/
 
 lazy val hive = (project in file("connectors/hive"))
   .dependsOn(standaloneCosmetic)
@@ -964,7 +959,7 @@ val createTargetClassesDir = taskKey[Unit]("create target classes dir")
 
 // Don't use these groups for any other projects
 lazy val sparkGroup = project
-  .aggregate(spark, contribs, storage, storageS3DynamoDB) /* iceberg */
+  .aggregate(spark, contribs, storage, storageS3DynamoDB, iceberg)
   .settings(
     // crossScalaVersions must be set to Nil on the aggregating project
     crossScalaVersions := Nil,

--- a/icebergShaded/generate_iceberg_jars.py
+++ b/icebergShaded/generate_iceberg_jars.py
@@ -29,13 +29,17 @@ iceberg_src_dir_name = "iceberg_src"
 iceberg_patches_dir_name = "iceberg_src_patches"
 
 iceberg_src_commit_hash = "ede085d0f7529f24acd0c81dd0a43f7bb969b763"
-iceberg_src_branch_with_commit_hash = "master"   # only this branch will be downloaded
-iceberg_src_compiled_jar_rel_paths = [ # related to `iceberg_src_dir_name`
-    "bundled-guava/build/libs/iceberg-bundled-guava-1.2.0-SNAPSHOT.jar",
-    "common/build/libs/iceberg-common-1.2.0-SNAPSHOT.jar",
-    "api/build/libs/iceberg-api-1.2.0-SNAPSHOT.jar",
-    "core/build/libs/iceberg-core-1.2.0-SNAPSHOT.jar",
-    "parquet/build/libs/iceberg-parquet-1.2.0-SNAPSHOT.jar",
+iceberg_src_branch = "master"  # only this branch will be downloaded
+
+# Relative to iceberg_src directory.
+# We use * because after applying the patches, a random git hash will be appended to each jar name.
+# This, for all usages below, we must search for these jar files using `glob.glob(pattern)`
+iceberg_src_compiled_jar_rel_glob_patterns = [
+    "bundled-guava/build/libs/iceberg-bundled-guava-*.jar",
+    "common/build/libs/iceberg-common-*.jar",
+    "api/build/libs/iceberg-api-*.jar",
+    "core/build/libs/iceberg-core-*.jar",
+    "parquet/build/libs/iceberg-parquet-*.jar",
 ]
 
 iceberg_root_dir = path.abspath(path.dirname(__file__))
@@ -44,32 +48,50 @@ iceberg_patches_dir = path.join(iceberg_root_dir, iceberg_patches_dir_name)
 iceberg_lib_dir = path.join(iceberg_root_dir, iceberg_lib_dir_name)
 
 
-def compile_jar_rel_path_to_lib_jar_path(jar_rel_path):
-    jar_file_name = path.basename(path.normpath(jar_rel_path))
-    jar_file_name_splits = path.splitext(jar_file_name)
-    new_jar_file_name = "%s_%s%s" % (jar_file_name_splits[0], iceberg_src_commit_hash, jar_file_name_splits[1])
-    return path.join(iceberg_lib_dir, new_jar_file_name)
-
-
 def iceberg_jars_exists():
-    for jar_rel_path in iceberg_src_compiled_jar_rel_paths:
-        if not path.exists(compile_jar_rel_path_to_lib_jar_path(jar_rel_path)):
+    for compiled_jar_rel_glob_pattern in iceberg_src_compiled_jar_rel_glob_patterns:
+        jar_file_name_pattern = path.basename(path.normpath(compiled_jar_rel_glob_pattern))
+        lib_jar_abs_pattern = path.join(iceberg_lib_dir, jar_file_name_pattern)
+        results = glob.glob(lib_jar_abs_pattern)
+
+        if len(results) > 1:
+            raise Exception("More jars than expected: " + str(results))
+        
+        if len(results) == 0:
             return False
+
     return True
+
+
+def set_git_config_if_empty(config_key, default_value):
+    curr_val = None
+    try:
+        (_, curr_val, _) = run_cmd("git config --get user.%s" % config_key)
+        curr_val = curr_val.decode("utf-8")
+    except:
+        print("Error getting user.%s" & config_key)
+    if not curr_val:
+        run_cmd("git config user.%s \"%s\"" % (config_key, default_value))
 
 
 def prepare_iceberg_source():
     with WorkingDirectory(iceberg_root_dir):
         print(">>> Cloning Iceberg repo")
         shutil.rmtree(iceberg_src_dir_name, ignore_errors=True)
-        run_cmd("git config user.email \"<>\"")
-        run_cmd("git config user.name \"Anonymous\"")
-        run_cmd("git clone --branch %s https://github.com/apache/iceberg.git %s" %
-                (iceberg_src_branch_with_commit_hash, iceberg_src_dir_name))
+
+        set_git_config_if_empty("email", "<>")
+        set_git_config_if_empty("name", "Anonymous")
+
+        # We just want the shallowest, smallest iceberg clone. We will check out the commit later.
+        run_cmd("git clone --depth 1 --branch %s https://github.com/apache/iceberg.git %s" %
+                (iceberg_src_branch, iceberg_src_dir_name))
 
     with WorkingDirectory(iceberg_src_dir):
         run_cmd("git config user.email \"<>\"")
         run_cmd("git config user.name \"Anonymous\"")
+
+        # Fetch just the single commit (shallow)
+        run_cmd("git fetch origin %s --depth 1" % iceberg_src_commit_hash)
         run_cmd("git checkout %s" % iceberg_src_commit_hash)
 
         print(">>> Applying patch files")
@@ -95,12 +117,25 @@ def generate_iceberg_jars():
     shutil.rmtree(iceberg_lib_dir, ignore_errors=True)
     os.mkdir(iceberg_lib_dir)
 
-    for compiled_jar_rel_path in iceberg_src_compiled_jar_rel_paths:
-        compiled_jar_full_path = path.join(iceberg_src_dir, compiled_jar_rel_path)
-        if not path.exists(compiled_jar_full_path):
-            raise Exception("Could not find the jar " + compiled_jar_full_path)
-        lib_jar_full_path = compile_jar_rel_path_to_lib_jar_path(compiled_jar_rel_path)
-        shutil.copyfile(compiled_jar_full_path, lib_jar_full_path)
+    # For each relative pattern p ...
+    for compiled_jar_rel_glob_pattern in iceberg_src_compiled_jar_rel_glob_patterns:
+        # Get the absolute pattern
+        compiled_jar_abs_pattern = path.join(iceberg_src_dir, compiled_jar_rel_glob_pattern)
+        # Search for all glob results
+        results = glob.glob(compiled_jar_abs_pattern)
+        # Compiled jars will include tests, sources, javadocs; exclude them
+        results = list(filter(lambda result: all(x not in result for x in ["test", "source", "javadoc"]), results))
+
+        if len(results) == 0:
+            raise Exception("Could not find the jar: " + compled_jar_rel_glob_pattern)
+        if len(results) > 1:
+            raise Exception("More jars created than expected: " + str(results))
+
+        # Copy the one jar result into the <iceberg root>/lib directory
+        compiled_jar_abs_path = results[0]
+        compiled_jar_name = path.basename(path.normpath(compiled_jar_abs_path))
+        lib_jar_abs_path = path.join(iceberg_lib_dir, compiled_jar_name)
+        shutil.copyfile(compiled_jar_abs_path, lib_jar_abs_path)
 
     if not iceberg_jars_exists():
         raise Exception("JAR copying failed")

--- a/icebergShaded/generate_iceberg_jars.py
+++ b/icebergShaded/generate_iceberg_jars.py
@@ -69,7 +69,7 @@ def set_git_config_if_empty(config_key, default_value):
         (_, curr_val, _) = run_cmd("git config --get user.%s" % config_key)
         curr_val = curr_val.decode("utf-8")
     except:
-        print("Error getting user.%s" & config_key)
+        print("Error getting user.%s" % config_key)
     if not curr_val:
         run_cmd("git config user.%s \"%s\"" % (config_key, default_value))
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR uncomments the iceberg module (it was commented out previously to prevent compilation).

This PR also changes how we clone the iceberg src code (in order to be able to apply patch files). Instead of using a deep clone, we use a shallow clone. This had some ramifications in how the JAR files were named ... so needed to update the python generation script, too.