### PR TITLE
[2.4] Re-enable iceberg module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -204,8 +204,6 @@ lazy val storageS3DynamoDB = (project in file("storage-s3-dynamodb"))
     )
   )
 
-// Requires iceberg release on 3.4
-/**
 lazy val deltaIceberg = (project in file("delta-iceberg"))
   .dependsOn(core % "compile->compile;test->test;provided->provided")
   .settings (
@@ -215,7 +213,7 @@ lazy val deltaIceberg = (project in file("delta-iceberg"))
     releaseSettings,
     libraryDependencies ++= Seq( {
         val (expMaj, expMin, _) = getMajorMinorPatch(sparkVersion)
-        ("org.apache.iceberg" % s"iceberg-spark-runtime-$expMaj.$expMin" % "1.1.0" % "provided")
+        ("org.apache.iceberg" % s"iceberg-spark-runtime-$expMaj.$expMin" % "1.3.0" % "provided")
           .cross(CrossVersion.binary)
       },
       // Fix Iceberg's legacy java.lang.NoClassDefFoundError: scala/jdk/CollectionConverters$ error
@@ -223,7 +221,6 @@ lazy val deltaIceberg = (project in file("delta-iceberg"))
       "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.1"
     )
   )
-*/
 
 /**
  * Get list of python files and return the mapping between source files and target paths


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

(Cherry-pick of d9a5f9f9c64b5066467801917de158650ae091cb to branch-2.4)

Reenable iceberg build that was previously disabled in #1720

## How was this patch tested?

N/A

## Does this PR introduce _any_ user-facing changes?

Yes, add delta-iceberg back to Delta 2.4
