### PR TITLE
[Spark] Support subDirs parameter for VACUUM

### DIFF
--- a/python/delta/tables.py
+++ b/python/delta/tables.py
@@ -226,7 +226,7 @@ class DeltaTable(object):
     def vacuum(
             self,
             retentionHours: Optional[float] = None,
-            subDirs: Optional[list[str]] = None) -> DataFrame:
+            subDirs: Optional[List[str]] = None) -> DataFrame:
         """
         Recursively delete files and directories in the table that are not needed by the table for
         maintaining older versions up to the given retention threshold. This method will return an

--- a/python/delta/tables.py
+++ b/python/delta/tables.py
@@ -230,7 +230,7 @@ class DeltaTable(object):
         """
         Recursively delete files and directories in the table that are not needed by the table for
         maintaining older versions up to the given retention threshold. This method will return an
-        empty DataFrame on successful completion. If subDirs are given, delete only under the
+        empty DataFrame on successful completion. If subDirs are given, delete files only under the
         directories.
 
         Example::

--- a/spark/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/spark/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -113,6 +113,20 @@ class DeltaTable private[tables](
     executeVacuum(deltaLog, None, table.getTableIdentifierIfExists)
   }
 
+  def vacuum(retentionHours: Double, subDirs: Seq[String]): DataFrame = {
+    executeVacuum(
+      deltaLog,
+      Some(retentionHours),
+      subDirs)
+  }
+
+  def vacuum(subDirs: Seq[String]): DataFrame = {
+    executeVacuum(
+      deltaLog,
+      None,
+      subDirs)
+  }
+
   /**
    * Get the information of the latest `limit` commits on this table as a Spark DataFrame.
    * The information is in reverse chronological order.

--- a/spark/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
+++ b/spark/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
@@ -88,6 +88,14 @@ trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
     sparkSession.emptyDataFrame
   }
 
+  protected def executeVacuum(
+      deltaLog: DeltaLog,
+      retentionHours: Option[Double],
+      subDirs: Seq[String]): DataFrame = {
+    VacuumCommand.gc(sparkSession, deltaLog, false, retentionHours, subDirs = subDirs)
+    sparkSession.emptyDataFrame
+  }
+
   protected def executeRestore(
       table: DeltaTableV2,
       versionAsOf: Option[Long],


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Support subDirs parameter for VACUUM command. Currently VACUUM command builds a list of all files under the root table location and exclude valid files from the list. This operation could cause huge storage cost when >10M of valid files under the table and need to run VACUUM frequently for few files. For now there is no way to avoid listing all files for VACUUM operation. 

This PR adds `subDirs` parameter for VACUUM Scala/Python API to limit the candidate files. If subDirs parameter is given, only file paths under the directories will be considered for VACUUM.

It can be beneficial for the following scenario:
- A table maintains millions of files, keeps getting new data and needs to VACUUM frequently.
- If a table is partitioned by date type, it's clear which partitions need to be vacuumed.
- If there are many invalid files and a user want to run vacuum partially due to of lack of resources, etc.

For WHERE clause support in #1691, we usually use the clause to "filter" files. So we have to make the whole list first for filtering. Otherwise it needs to check the predicate before stepping into each subdirectory recursively, which requires a lot of code changes. This PR could be a workaround for #1691. There was the same request #220 

## How was this patch tested?

Unit tests, ran in production for months

## Does this PR introduce _any_ user-facing changes?

Yes, support new parameter for VACUUM.