### PR TITLE
[Spark] Don't commit empty transactions on Writes #1933

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -100,8 +100,7 @@ case class WriteIntoDelta(
         mode, Option(partitionColumns),
         options.replaceWhere, options.userMetadata
       )
-      txn.commit(actions, operation)
-
+      txn.commitIfNeeded(actions, operation)
     }
     Seq.empty
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -672,7 +672,7 @@ class OptimisticTransactionSuite
   Seq(true, false).foreach { skip =>
     test(s"Elide empty commits when requested - skipRecordingEmptyCommits=$skip") {
       withSQLConf(DeltaSQLConf.DELTA_SKIP_RECORDING_EMPTY_COMMITS.key -> skip.toString) {
-        withTempDir { tableDir => 
+        withTempDir { tableDir =>
           val df = Seq((1, 0), (2, 1)).toDF("key", "value")
           df.write.format("delta").mode("append").save(tableDir.getCanonicalPath)
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.FileNames
 import org.apache.hadoop.fs.Path
 
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions.{EqualTo, Literal}
@@ -34,6 +35,8 @@ import org.apache.spark.util.ManualClock
 class OptimisticTransactionSuite
   extends OptimisticTransactionLegacyTests
   with OptimisticTransactionSuiteBase {
+
+  import testImplicits._
 
   // scalastyle:off: removeFile
   private val addA = createTestAddFile(path = "a")
@@ -640,6 +643,60 @@ class OptimisticTransactionSuite
         txn.commit(addB :: Nil, DeltaOperations.Write(SaveMode.Append), tags = tags2)
       }
       checkLastCommitTags(expectedTags = Some(tags2))
+    }
+  }
+
+  test("empty commits are elided on write by default") {
+    withTempDir { tableDir =>
+      val df = Seq((1, 0), (2, 1)).toDF("key", "value")
+      df.write.format("delta").mode("append").save(tableDir.getCanonicalPath)
+
+      val deltaLog = DeltaLog.forTable(spark, tableDir)
+
+      val expectedSnapshot = deltaLog.update()
+      val expectedDeltaVersion = expectedSnapshot.version
+
+      val emptyDf = Seq.empty[(Integer, Integer)].toDF("key", "value")
+      emptyDf.write.format("delta").mode("append").save(tableDir.getCanonicalPath)
+
+      val actualSnapshot = deltaLog.update()
+      val actualDeltaVersion = actualSnapshot.version
+
+      checkAnswer(spark.read.format("delta").load(tableDir.getCanonicalPath),
+        Row(1, 0) :: Row(2, 1) :: Nil)
+
+      assert(expectedDeltaVersion === actualDeltaVersion)
+    }
+  }
+
+  Seq(true, false).foreach { skip =>
+    test(s"Elide empty commits when requested - skipRecordingEmptyCommits=$skip") {
+      withSQLConf(DeltaSQLConf.DELTA_SKIP_RECORDING_EMPTY_COMMITS.key -> skip.toString) {
+        withTempDir { tableDir => 
+          val df = Seq((1, 0), (2, 1)).toDF("key", "value")
+          df.write.format("delta").mode("append").save(tableDir.getCanonicalPath)
+
+          val deltaLog = DeltaLog.forTable(spark, tableDir)
+
+          val expectedSnapshot = deltaLog.update()
+          val expectedDeltaVersion = if (skip) {
+            expectedSnapshot.version
+          } else {
+            expectedSnapshot.version + 1
+          }
+
+          val emptyDf = Seq.empty[(Integer, Integer)].toDF("key", "value")
+          emptyDf.write.format("delta").mode("append").save(tableDir.getCanonicalPath)
+
+          val actualSnapshot = deltaLog.update()
+          val actualDeltaVersion = actualSnapshot.version
+
+          checkAnswer(spark.read.format("delta").load(tableDir.getCanonicalPath),
+            Row(1, 0) :: Row(2, 1) :: Nil)
+
+          assert(expectedDeltaVersion === actualDeltaVersion)
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR makes the write command behave similarly to delete, update, and merge, in that it will not write an empty commit to the transaction log.

Resolves #1933 

## How was this patch tested?

Working on testing this locally, `sbt test` hangs on the `hiveTez` suite currently.

## Does this PR introduce _any_ user-facing changes?

Yes, if the user consumes the delta transaction log and would expect an empty write transaction to include a record in the log.
