### PR TITLE
Use storageAssighmentPolicy for casts in Delta DML commands

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -272,6 +272,14 @@
     ],
     "sqlState" : "0A000"
   },
+  "DELTA_CAST_OVERFLOW_IN_TABLE_WRITE" : {
+    "message" : [
+      "Failed to write a value of <sourceType> type into the <targetType> type column <columnName> due to an overflow.",
+      "Use `try_cast` on the input value to tolerate overflow and return NULL instead.",
+      "If necessary, set <storeAssignmentPolicyFlag> to \"LEGACY\" to bypass this error or set <updateAndMergeCastingFollowsAnsiEnabledFlag> to true to revert to the old behaviour and follow <ansiEnabledFlag> in UPDATE and MERGE."
+    ],
+    "sqlState" : "22003"
+  },
   "DELTA_CDC_NOT_ALLOWED_IN_THIS_VERSION" : {
     "message" : [
       "Configuration delta.enableChangeDataFeed cannot be set. Change data feed from Delta is not yet available."

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -44,6 +44,7 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference,
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.errors.QueryErrorsBase
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DataType, StructField, StructType}
 
@@ -118,7 +119,8 @@ trait DocsPath {
  */
 trait DeltaErrorsBase
     extends DocsPath
-    with DeltaLogging {
+    with DeltaLogging
+    with QueryErrorsBase {
 
   def baseDocsPath(spark: SparkSession): String = baseDocsPath(spark.sparkContext.getConf)
 
@@ -612,6 +614,22 @@ trait DeltaErrorsBase
       errorClass = "DELTA_CANNOT_WRITE_INTO_VIEW",
       messageParameters = Array(s"$table")
     )
+  }
+
+  def castingCauseOverflowErrorInTableWrite(
+      from: DataType,
+      to: DataType,
+      columnName: String): ArithmeticException = {
+    new DeltaArithmeticException(
+      errorClass = "DELTA_CAST_OVERFLOW_IN_TABLE_WRITE",
+      messageParameters = Map(
+        "sourceType" -> toSQLType(from),
+        "targetType" -> toSQLType(to),
+        "columnName" -> toSQLId(columnName),
+        "storeAssignmentPolicyFlag" -> SQLConf.STORE_ASSIGNMENT_POLICY.key,
+        "updateAndMergeCastingFollowsAnsiEnabledFlag" ->
+          DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key,
+        "ansiEnabledFlag" -> SQLConf.ANSI_ENABLED.key))
   }
 
   def notADeltaTable(table: String): Throwable = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaSharedExceptions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaSharedExceptions.scala
@@ -81,3 +81,11 @@ class DeltaParseException(
       ParserUtils.position(ctx.getStop)
     ) with DeltaThrowable
 
+class DeltaArithmeticException(
+    errorClass: String,
+    messageParameters: Map[String, String]) extends ArithmeticException with DeltaThrowable {
+  override def getErrorClass: String = errorClass
+
+  override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
+}
+

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableMerge.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableMerge.scala
@@ -175,7 +175,8 @@ case class PreprocessTableMerge(override val conf: SQLConf)
             castIfNeeded(
               a.expr,
               targetAttrib.dataType,
-              allowStructEvolution = migrateSchema),
+              allowStructEvolution = migrateSchema,
+              targetAttrib.name),
             targetColNameResolved = true)
         }.getOrElse {
           // If a target table column was not found in the INSERT columns and expressions,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -23,7 +23,6 @@ import org.apache.spark.internal.config.ConfigBuilder
 import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.storage.StorageLevel
-import org.apache.spark.util.Utils
 
 /**
  * [[SQLConf]] entries for Delta features.
@@ -1253,6 +1252,15 @@ trait DeltaSQLConfBase {
         |""".stripMargin)
     .intConf
     .createWithDefault(100 * 1000)
+
+  val UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG =
+    buildConf("updateAndMergeCastingFollowsAnsiEnabledFlag")
+      .internal()
+      .doc("""If false, casting behaviour in implicit casts in UPDATE and MERGE follows
+             |'spark.sql.storeAssignmentPolicy'. If true, these casts follow 'ansi.enabled'. This
+             |was the default before Delta 3.5.""".stripMargin)
+      .booleanConf
+      .createWithDefault(false)
 
 }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -300,6 +300,11 @@ trait DeltaErrorsSuiteBase
       assert(e.getMessageParameters.get("sourceType") == toSQLType(sourceType))
       assert(e.getMessageParameters.get("targetType") == toSQLType(targetType))
       assert(e.getMessageParameters.get("columnName") == toSQLId(columnName))
+      assert(e.getMessageParameters.get("storeAssignmentPolicyFlag")
+        == SQLConf.STORE_ASSIGNMENT_POLICY.key)
+      assert(e.getMessageParameters.get("updateAndMergeCastingFollowsAnsiEnabledFlag")
+        == DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key)
+      assert(e.getMessageParameters.get("ansiEnabledFlag") == SQLConf.ANSI_ENABLED.key)
     }
     {
       val e = intercept[DeltaAnalysisException] {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ImplicitDMLCastingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ImplicitDMLCastingSuite.scala
@@ -1,0 +1,279 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+
+// scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+import org.apache.spark.{SparkConf, SparkThrowable}
+import org.apache.spark.sql.{DataFrame, QueryTest}
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Tests for casts that are implicitly added in DML commands modifying Delta tables.
+ * These casts are added to convert values to the schema of a table.
+ * INSERT operations are excluded as they are covered by InsertSuite and InsertSuiteEdge.
+ */
+class ImplicitDMLCastingSuite extends QueryTest
+  with DeltaSQLCommandTest {
+
+  private case class TestConfiguration(
+      sourceType: String,
+      sourceTypeInErrorMessage: String,
+      targetType: String,
+      targetTypeInErrorMessage: String,
+      validValue: String,
+      overflowValue: String)
+
+  private case class SqlConfiguration(
+      followAnsiEnabled: Boolean,
+      ansiEnabled: Boolean,
+      storeAssignmentPolicy: String) {
+
+    def withSqlSettings(f: => Unit): Unit =
+      withSQLConf(
+        DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key
+          -> followAnsiEnabled.toString,
+        SQLConf.STORE_ASSIGNMENT_POLICY.key -> storeAssignmentPolicy,
+        SQLConf.ANSI_ENABLED.key -> ansiEnabled.toString)(f)
+
+    override def toString: String =
+      s"followAnsiEnabled: $followAnsiEnabled, ansiEnabled: $ansiEnabled," +
+        s" storeAssignmentPolicy: $storeAssignmentPolicy"
+  }
+
+  private val testConfigurations = Seq(
+    TestConfiguration(sourceType = "INT", sourceTypeInErrorMessage = "INT",
+      targetType = "TINYINT", targetTypeInErrorMessage = "TINYINT",
+      validValue = "1", overflowValue = Int.MaxValue.toString),
+    TestConfiguration(sourceType = "INT", sourceTypeInErrorMessage = "INT",
+      targetType = "SMALLINT", targetTypeInErrorMessage = "SMALLINT",
+      validValue = "1", overflowValue = Int.MaxValue.toString),
+    TestConfiguration(sourceType = "BIGINT", sourceTypeInErrorMessage = "BIGINT",
+      targetType = "INT", targetTypeInErrorMessage = "INT",
+      validValue = "1", overflowValue = Long.MaxValue.toString),
+    TestConfiguration(sourceType = "DOUBLE", sourceTypeInErrorMessage = "DOUBLE",
+      targetType = "BIGINT", targetTypeInErrorMessage = "BIGINT",
+      validValue = "1", overflowValue = "12345678901234567890D"),
+    TestConfiguration(sourceType = "BIGINT", sourceTypeInErrorMessage = "BIGINT",
+      targetType = "DECIMAL(7,2)", targetTypeInErrorMessage = "DECIMAL(7,2)",
+      validValue = "1", overflowValue = Long.MaxValue.toString),
+    TestConfiguration(sourceType = "Struct<value:BIGINT>", sourceTypeInErrorMessage = "BIGINT",
+      targetType = "Struct<value:INT>", targetTypeInErrorMessage = "INT",
+      validValue = "named_struct('value', 1)",
+      overflowValue = s"named_struct('value', ${Long.MaxValue.toString})"),
+    TestConfiguration(sourceType = "ARRAY<BIGINT>", sourceTypeInErrorMessage = "ARRAY<BIGINT>",
+      targetType = "ARRAY<INT>", targetTypeInErrorMessage = "ARRAY<INT>",
+      validValue = "ARRAY(1)", overflowValue = s"ARRAY(${Long.MaxValue.toString})")
+  )
+
+  @tailrec
+  private def arithmeticCause(exception: Throwable): Option[ArithmeticException] = {
+    exception match {
+      case arithmeticException: ArithmeticException => Some(arithmeticException)
+      case _ if exception.getCause != null => arithmeticCause(exception.getCause)
+      case _ => None
+    }
+  }
+
+  /** Validate that a custom error is throws in case ansi.enabled is false, or a different
+   * overflow error is case ansi.enabled is true. */
+  private def validateException(
+      exception: Throwable, sqlConfig: SqlConfiguration, testConfig: TestConfiguration): Unit = {
+    arithmeticCause(exception) match {
+      case Some(exception: DeltaArithmeticException) =>
+        assert(exception.getErrorClass == "DELTA_CAST_OVERFLOW_IN_TABLE_WRITE")
+        assert(exception.getMessageParameters ==
+          Map("sourceType" -> ("\"" + testConfig.sourceTypeInErrorMessage + "\""),
+              "targetType" -> ("\"" + testConfig.targetTypeInErrorMessage + "\""),
+              "columnName" -> "`value`",
+              "storeAssignmentPolicyFlag" -> "spark.sql.storeAssignmentPolicy",
+              "updateAndMergeCastingFollowsAnsiEnabledFlag" ->
+                "spark.databricks.delta.updateAndMergeCastingFollowsAnsiEnabledFlag",
+              "ansiEnabledFlag" -> "spark.sql.ansi.enabled").asJava)
+      case Some(exception: SparkThrowable) if sqlConfig.ansiEnabled =>
+        // With ANSI enabled the overflows are caught before the write operation.
+        assert(Seq("CAST_OVERFLOW", "NUMERIC_VALUE_OUT_OF_RANGE")
+          .contains(exception.getErrorClass))
+      case None => assert(false, "No arithmetic exception thrown.")
+      case Some(exception) =>
+        assert(false, s"Unexpected exception type: $exception")
+    }
+  }
+
+  Seq(true, false).foreach { followAnsiEnabled =>
+    Seq(true, false).foreach { ansiEnabled =>
+      Seq("ANSI", "LEGACY").foreach { storeAssignmentPolicy =>
+        val sqlConfiguration =
+          SqlConfiguration(followAnsiEnabled, ansiEnabled, storeAssignmentPolicy)
+        testConfigurations.foreach { testConfiguration =>
+          updateTest(sqlConfiguration, testConfiguration)
+          mergeTests(sqlConfiguration, testConfiguration)
+          streamingMergeTest(sqlConfiguration, testConfiguration)
+        }
+      }
+    }
+  }
+
+  /** Test an UPDATE that requires to cast the update value that is part of the SET clause. */
+  private def updateTest(
+      sqlConfig: SqlConfiguration, testConfig: TestConfiguration): Unit = {
+    val testName = s"UPDATE overflow targetType: ${testConfig.targetType} $sqlConfig"
+    test(testName) {
+      sqlConfig.withSqlSettings {
+        val tableName = "overflowTable"
+        withTable(tableName) {
+          sql(s"""CREATE TABLE $tableName USING DELTA
+                 |AS SELECT cast(${testConfig.validValue} AS ${testConfig.targetType}) AS value
+                 |""".stripMargin)
+          val updateCommand = s"UPDATE $tableName SET value = ${testConfig.overflowValue}"
+
+          val legacyCasts = (sqlConfig.followAnsiEnabled && !sqlConfig.ansiEnabled) ||
+            (!sqlConfig.followAnsiEnabled && sqlConfig.storeAssignmentPolicy == "LEGACY")
+
+          if (legacyCasts) {
+            sql(updateCommand)
+          } else {
+            val exception = intercept[Throwable] {
+              sql(updateCommand)
+            }
+
+            validateException(exception, sqlConfig, testConfig)
+          }
+        }
+      }
+    }
+  }
+
+
+  /** Tests for MERGE with overflows cause by the different conditions. */
+  private def mergeTests(
+      sqlConfig: SqlConfiguration, testConfig: TestConfiguration): Unit = {
+    mergeTest(matchedCondition = s"WHEN MATCHED THEN UPDATE SET t.value = s.value",
+      sqlConfig, testConfig)
+
+    mergeTest(matchedCondition = s"WHEN NOT MATCHED THEN INSERT *", sqlConfig, testConfig)
+
+    mergeTest(matchedCondition =
+      s"WHEN NOT MATCHED BY SOURCE THEN UPDATE SET t.value = ${testConfig.overflowValue}",
+      sqlConfig, testConfig)
+  }
+
+  private def mergeTest(
+      matchedCondition: String,
+      sqlConfig: SqlConfiguration,
+      testConfig: TestConfiguration
+  ): Unit = {
+    val testName =
+      s"MERGE overflow in $matchedCondition targetType: ${testConfig.targetType} $sqlConfig"
+    test(testName) {
+      sqlConfig.withSqlSettings {
+        val targetTableName = "target_table"
+        val sourceViewName = "source_vice"
+        withTable(targetTableName) {
+          withTempView(sourceViewName) {
+            val numRows = 10
+            sql(s"""CREATE TABLE $targetTableName USING DELTA
+                   |AS SELECT col as key,
+                   |  cast(${testConfig.validValue} AS ${testConfig.targetType}) AS value
+                   |FROM explode(sequence(0, $numRows))""".stripMargin)
+            // The view maps the key space such that we get matched, not matched by source, and
+            // not match by target rows.
+            sql(s"""CREATE TEMPORARY VIEW $sourceViewName
+                   |AS SELECT key + ($numRows / 2) AS key,
+                   |  cast(${testConfig.overflowValue} AS ${testConfig.sourceType}) AS value
+                   |FROM $targetTableName""".stripMargin)
+            val mergeCommand = s"""MERGE INTO $targetTableName t
+                                  |USING $sourceViewName s
+                                  |ON s.key = t.key
+                                  |$matchedCondition
+                                  |""".stripMargin
+            val legacyCasts = (sqlConfig.followAnsiEnabled && !sqlConfig.ansiEnabled) ||
+              (!sqlConfig.followAnsiEnabled && sqlConfig.storeAssignmentPolicy == "LEGACY")
+
+            if (legacyCasts) {
+              sql(mergeCommand)
+            } else {
+              val exception = intercept[Throwable] {
+                sql(mergeCommand)
+              }
+
+              validateException(exception, sqlConfig, testConfig)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /** A merge that is executed for each batch of a stream and has to cast values before insert. */
+  private def streamingMergeTest(
+      sqlConfig: SqlConfiguration, testConfig: TestConfiguration): Unit = {
+    val testName = s"Streaming MERGE overflow targetType: ${testConfig.targetType} $sqlConfig"
+    test(testName) {
+      sqlConfig.withSqlSettings {
+        val targetTableName = "target_table"
+        val sourceTableName = "source_table"
+        withTable(sourceTableName, targetTableName) {
+          sql(s"CREATE TABLE $targetTableName (key INT, value ${testConfig.targetType})" +
+            " USING DELTA")
+          sql(s"CREATE TABLE $sourceTableName (key INT, value ${testConfig.sourceType})" +
+            " USING DELTA")
+
+          def upsertToDelta(microBatchOutputDF: DataFrame, batchId: Long): Unit = {
+            microBatchOutputDF.createOrReplaceTempView("micro_batch_output")
+
+            microBatchOutputDF.sparkSession.sql(s"""MERGE INTO $targetTableName t
+                                                   |USING micro_batch_output s
+                                                   |ON s.key = t.key
+                                                   |WHEN NOT MATCHED THEN INSERT *
+                                                   |""".stripMargin)
+          }
+
+          val sourceStream = spark.readStream.table(sourceTableName)
+          val streamWriter =
+            sourceStream
+              .writeStream
+              .format("delta")
+              .foreachBatch(upsertToDelta _)
+              .outputMode("update")
+              .start()
+
+          sql(s"INSERT INTO $sourceTableName(key, value) VALUES(0, ${testConfig.overflowValue})")
+
+          val legacyCasts = (sqlConfig.followAnsiEnabled && !sqlConfig.ansiEnabled) ||
+            (!sqlConfig.followAnsiEnabled && sqlConfig.storeAssignmentPolicy == "LEGACY")
+
+          if (legacyCasts) {
+            streamWriter.processAllAvailable()
+          } else {
+            val exception = intercept[Throwable] {
+              streamWriter.processAllAvailable()
+            }
+
+            validateException(exception, sqlConfig, testConfig)
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
@@ -3871,7 +3871,7 @@ abstract class MergeIntoSuiteBase
       ((0, 0) +: (1, 10) +: (2, 2) +: (3, 30) +: (5, null) +: Nil)
         .asInstanceOf[List[(Integer, Integer)]].toDF("key", "value"),
     // Disable ANSI as this test needs to cast string "notANumber" to int
-    confs = Seq(SQLConf.ANSI_ENABLED.key -> "false")
+    confs = Seq(SQLConf.STORE_ASSIGNMENT_POLICY.key -> "LEGACY")
   )
 
   // This is kinda bug-for-bug compatibility. It doesn't really make sense that infinity is casted
@@ -3887,7 +3887,7 @@ abstract class MergeIntoSuiteBase
       ((0, 0) +: (1, 10) +: (2, 2) +: (3, 30) +: (5, Int.MaxValue) +: Nil)
         .asInstanceOf[List[(Integer, Integer)]].toDF("key", "value"),
     // Disable ANSI as this test needs to cast Double.PositiveInfinity to int
-    confs = Seq(SQLConf.ANSI_ENABLED.key -> "false")
+    confs = Seq(SQLConf.STORE_ASSIGNMENT_POLICY.key -> "LEGACY")
   )
 
   testEvolution("extra nested column in source - insert")(


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Follow spark.sql.storeAssignmentPolicy instead of spark.sql.ansi.enabled for casting behaviour in Delta UPDATE and MERGE. This will by default error out at runtime when an overflow happens because the default for storeAssignmentPolicy ins ANSI while ANSI is not enabled by default.

## How was this patch tested?

Tests for casting behavior added

## Does this PR introduce _any_ user-facing changes?

The UPDATE and MERGE command will error out by default if a cast that is on the write path overflows. The spark.databricks.delta.updateMergeLegacyCasting.enabled can be used to revert to the old behaviour.
