### PR TITLE
[Spark] Update build pipeline to use Python 3.9. (3.7 is deprecated)

### DIFF
--- a/.github/workflows/spark_test.yaml
+++ b/.github/workflows/spark_test.yaml
@@ -56,7 +56,7 @@ jobs:
           pipenv run pip install cryptography==37.0.4
           pipenv run pip install twine==4.0.1
           pipenv run pip install wheel==0.33.4
-          pipenv run pip install setuptools==41.0.1
+          pipenv run pip install setuptools==41.1.0
           pipenv run pip install pydocstyle==3.0.0
           pipenv run pip install pandas==1.0.5
           pipenv run pip install pyarrow==8.0.0

--- a/.github/workflows/spark_test.yaml
+++ b/.github/workflows/spark_test.yaml
@@ -46,9 +46,9 @@ jobs:
           export PATH="~/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
           eval "$(pyenv virtualenv-init -)"
-          pyenv install 3.8.18
-          pyenv global system 3.8.18
-          pipenv --python 3.8 install
+          pyenv install 3.9.17
+          pyenv global system 3.9.17
+          pipenv --python 3.9 install
           pipenv run pip install pyspark==3.5.0
           pipenv run pip install flake8==3.5.0 pypandoc==1.3.3
           pipenv run pip install importlib_metadata==3.10.0


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Python 3.7 is deprecated. This PR changes the build pipeline to use v3.9, matching Spark: https://github.com/apache/spark/blob/6ca45c52b7416e7b3520dc902cb24f060c7c72dd/.github/workflows/build_and_test.yml#L414

Also updated setuptools to v41.1.0 for Python 3.9 compatibility:

<img width="730" alt="image" src="https://github.com/delta-io/delta/assets/1336227/a25ea4a2-f95c-4cba-a59d-c1b7a94c8f39">

## How was this patch tested?
I temporarily commented the `if: steps.git-diff.outputs.diff` to run the tests: https://github.com/delta-io/delta/actions/runs/5665363510/job/15350071847?pr=1940

## Does this PR introduce _any_ user-facing changes?
No
