### PR TITLE
[Spark] Avoid superfluous always-true filter conditions in MERGE command

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
@@ -100,7 +100,7 @@ trait ClassicMergeExecutor extends MergeIntoMaterializeSource with MergeOutputGe
       if (isMatchedOnly) {
         matchedClauses
           .flatMap(_.condition)
-          .foldLeft[Expression](Literal.TrueLiteral)(Or.apply)
+          .foldLeft[Expression](Literal.FalseLiteral)(Or.apply)
       } else Literal.TrueLiteral
 
     // Compute the columns needed for the inner join.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
@@ -101,7 +101,7 @@ trait ClassicMergeExecutor extends MergeIntoMaterializeSource with MergeOutputGe
     val matchedPredicate =
       if (isMatchedOnly) {
         matchedClauses
-          .map(clause => clause.condition.getOrElse(Literal(true)))
+          .flatMap(_.condition)
           .reduce((a, b) => Or(a, b))
       } else Literal(true)
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
@@ -100,7 +100,7 @@ trait ClassicMergeExecutor extends MergeIntoMaterializeSource with MergeOutputGe
       if (isMatchedOnly) {
         matchedClauses
           .flatMap(_.condition)
-          .foldLeft[Expression](Literal.FalseLiteral)(Or.apply)
+          .foldLeft[Expression](Literal.TrueLiteral)(Or.apply)
       } else Literal.TrueLiteral
 
     // Compute the columns needed for the inner join.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
@@ -100,7 +100,8 @@ trait ClassicMergeExecutor extends MergeIntoMaterializeSource with MergeOutputGe
       if (isMatchedOnly) {
         matchedClauses
           .flatMap(_.condition)
-          .foldLeft[Expression](Literal.TrueLiteral)(Or.apply)
+          .reduceOption((a, b) => Or(a, b))
+          .getOrElse(Literal.TrueLiteral)
       } else Literal.TrueLiteral
 
     // Compute the columns needed for the inner join.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/InsertOnlyMergeExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/InsertOnlyMergeExecutor.scala
@@ -72,11 +72,10 @@ trait InsertOnlyMergeExecutor extends MergeOutputGeneration {
       val incrSourceRowCountExpr = incrementMetricAndReturnBool(numSourceRowsMetric, true)
       // source DataFrame
       var sourceDF = getSourceDF().filter(new Column(incrSourceRowCountExpr))
-      if (notMatchedClauses.size == 1) {
-        // If there is only one insert clause, then filter out the source rows that do not
-        // satisfy the clause condition because those rows will not be written out.
-        sourceDF =
-          sourceDF.filter(new Column(notMatchedClauses.head.condition.getOrElse(Literal(true))))
+      // If there is only one insert clause, then filter out the source rows that do not
+      // satisfy the clause condition because those rows will not be written out.
+      if (notMatchedClauses.size == 1 && notMatchedClauses.head.condition.isDefined) {
+        sourceDF = sourceDF.filter(Column(notMatchedClauses.head.condition.get))
       }
 
       var dataSkippedFiles: Option[Seq[AddFile]] = None

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/InsertOnlyMergeExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/InsertOnlyMergeExecutor.scala
@@ -74,8 +74,14 @@ trait InsertOnlyMergeExecutor extends MergeOutputGeneration {
       var sourceDF = getSourceDF().filter(new Column(incrSourceRowCountExpr))
       // If there is only one insert clause, then filter out the source rows that do not
       // satisfy the clause condition because those rows will not be written out.
-      if (notMatchedClauses.size == 1 && notMatchedClauses.head.condition.isDefined) {
-        sourceDF = sourceDF.filter(Column(notMatchedClauses.head.condition.get))
+      if (notMatchedClauses.size == 1) {
+        notMatchedClauses
+          .head
+          .condition
+          .map(Column.apply)
+          .foreach { conditionCol =>
+            sourceDF = sourceDF.filter(conditionCol)
+          }
       }
 
       var dataSkippedFiles: Option[Seq[AddFile]] = None


### PR DESCRIPTION
## Description

While building the output dataset to write to a delta table as part of MERGE command, Delta Lake builds conditions based on optional parts that lead to extra processing (possibly even slowing down MERGE execution = just guessing = no evidence = just gut feelings).

Although Spark SQL optimizer could likely remove such extra always-true filter conditions, so can we (making the codebase smaller and easier to comprehend, hopefully). Hence the PR.

## How was this patch tested?

Local builds

## Does this PR introduce _any_ user-facing changes?

No