### PR TITLE
Implicit DML casts: Fix Delta version in error message and add more tests

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1257,8 +1257,8 @@ trait DeltaSQLConfBase {
     buildConf("updateAndMergeCastingFollowsAnsiEnabledFlag")
       .internal()
       .doc("""If false, casting behaviour in implicit casts in UPDATE and MERGE follows
-             |'spark.sql.storeAssignmentPolicy'. If true, these casts follow 'ansi.enabled'. This
-             |was the default before Delta 3.5.""".stripMargin)
+             |'spark.sql.storeAssignmentPolicy'. If true, these casts follow 'ansi.enabled'.
+             |""".stripMargin)
       .booleanConf
       .createWithDefault(false)
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This is a follow up to #1938 that fixes the Delta version mentioned in the error message and adds more tests for the implicit casting behaviour in MERGE and UPDATE

## How was this patch tested?

Only new tests added

## Does this PR introduce _any_ user-facing changes?

No
