### PR TITLE
[MINOR][Standalone] Rename the checkForConflicts

### DIFF
--- a/connectors/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
+++ b/connectors/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
@@ -411,7 +411,7 @@ private[internal] class OptimisticTransactionImpl(
    * next.
    *
    * @throws DeltaConcurrentModificationException if the next commit version cannot be resolved
-   *                                              due to the concurrent modifications in the
+   *                                              due to the concurrent modification in the
    *                                              commit log.
    */
   private def getNextCommitVersionOrFailIfConflictsDetected(

--- a/connectors/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
+++ b/connectors/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
@@ -411,7 +411,7 @@ private[internal] class OptimisticTransactionImpl(
    * next.
    *
    * @throws DeltaConcurrentModificationException if the next commit version cannot be resolved
-   *                                              due to the concurrent modification in the
+   *                                              due to the concurrent modifications to the
    *                                              commit log.
    */
   private def getNextCommitVersionOrFailIfConflictsDetected(

--- a/connectors/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
+++ b/connectors/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
@@ -336,7 +336,8 @@ private[internal] class OptimisticTransactionImpl(
             actions.length,
             totalCommitAttemptTime)
         } else {
-          commitVersion = checkForConflicts(commitVersion, actions, attemptNumber, isolationLevel)
+          commitVersion = getNextCommitVersionOrFailIfConflictsDetected(
+            checkVersion = commitVersion, actions, attemptNumber, isolationLevel)
           doCommit(commitVersion, actions, isolationLevel)
         }
         tryCommit = false
@@ -408,8 +409,12 @@ private[internal] class OptimisticTransactionImpl(
    * Looks at actions that have happened since the txn started and checks for logical
    * conflicts with the read/writes. If no conflicts are found return the commit version to attempt
    * next.
+   *
+   * @throws DeltaConcurrentModificationException if the next commit version cannot be resolved
+   *                                              due to the concurrent modifications in the
+   *                                              commit log.
    */
-  private def checkForConflicts(
+  private def getNextCommitVersionOrFailIfConflictsDetected(
       checkVersion: Long,
       actions: Seq[Action],
       attemptNumber: Int,


### PR DESCRIPTION
## Which Delta project/connector is this regarding?
- [ ] Spark
- [x] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)
 
## Description

While analyzing how does the commit work I found the `checkForConflicts` name a bit misleading. It does verify the conflicts but from my understanding, its main purpose is to return the next commit version if there are no conflicts with the last written transaction. Hence the renaming. I also added the `@throws` annotation to expose the possible errors returned. There is no inherent issue with the code itself. 

## How was this patch tested?
Compilation and existing tests should pass. It's just a renaming, no new features added.

## Does this PR introduce _any_ user-facing changes?
No

Signed-off-by: Bartosz Konieczny <[work@waitingforcode.com](mailto:work@waitingforcode.com)> 