### PR TITLE
[Kernel] Replace `Arrays.stream` with `for` loops to improve replay performance ~3x

### DIFF
--- a/kernel/kernel-default/src/main/java/io/delta/kernel/parquet/MapConverter.java
+++ b/kernel/kernel-default/src/main/java/io/delta/kernel/parquet/MapConverter.java
@@ -158,21 +158,23 @@ class MapConverter
 
         @Override
         public void start() {
-            Arrays.stream(converters)
-                .filter(conv -> !conv.isPrimitive())
-                .forEach(conv -> ((GroupConverter) conv).start());
+            for (int i = 0; i < converters.length; i++) {
+                if (!converters[i].isPrimitive()) {
+                    ((GroupConverter) converters[i]).start();
+                }
+            }
         }
 
         @Override
         public void end() {
-            Arrays.stream(converters)
-                .filter(conv -> !conv.isPrimitive())
-                .forEach(conv -> ((GroupConverter) conv).end());
-
-            Arrays.stream(converters)
-                .map(converter -> (ParquetConverters.BaseConverter) converter)
-                .forEach(converter -> converter.moveToNextRow());
-
+            for (int i = 0; i < converters.length; i++) {
+                if (!converters[i].isPrimitive()) {
+                    ((GroupConverter) converters[i]).end();
+                }
+            }
+            for (int i = 0; i < converters.length; i++) {
+                ((ParquetConverters.BaseConverter) converters[i]).moveToNextRow();
+            }
             currentEntryIndex++;
         }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description
This PR replaces usages of `Arrays.stream` (slow, known performance issues) with simple `for` loops (faster) inside of the delta kernel hot path (parquet row conversion). This yielded a ~3x performance boost at replaying the delta log.

## How was this patch tested?
Created a table with 1M rows, 1M add files, and 1000 commits. Loaded the latest snapshot of this table (20 times, to be able to aggregate my results), and recorded the time spent performing `LogReplay::loadTableProtocolAndMetadata()`.

The results are

- master (98fe7797f681408036d08aefda8c6684d8b0e0a1): ~4100ms
- this PR: ~1400ms

