### PR TITLE
[Kernel] Enforce header in java files with checksytle

### DIFF
--- a/kernel/dev/checkstyle.xml
+++ b/kernel/dev/checkstyle.xml
@@ -71,6 +71,10 @@
 
     <module name="NewlineAtEndOfFile"/>
 
+    <module name="RegexpHeader">
+        <property name="headerFile" value="kernel/dev/copyrightHeader"/>
+    </module>
+
     <module name="TreeWalker">
         <!--
         If you wish to turn off checking for a section of code, you can put a comment in the source

--- a/kernel/dev/copyrightHeader
+++ b/kernel/dev/copyrightHeader
@@ -1,0 +1,15 @@
+\/\*
+ \* Copyright \(\d\d\d\d\) The Delta Lake Project Authors\.
+ \*
+ \* Licensed under the Apache License, Version 2\.0 \(the "License"\);
+ \* you may not use this file except in compliance with the License\.
+ \* You may obtain a copy of the License at
+ \*
+ \* http:\/\/www\.apache\.org\/licenses\/LICENSE-2\.0
+ \*
+ \* Unless required by applicable law or agreed to in writing, software
+ \* distributed under the License is distributed on an "AS IS" BASIS,
+ \* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied\.
+ \* See the License for the specific language governing permissions and
+ \* limitations under the License\.
+ \*\/

--- a/kernel/kernel-api/src/test/java/io/delta/kernel/internal/types/JsonHandlerTestImpl.java
+++ b/kernel/kernel-api/src/test/java/io/delta/kernel/internal/types/JsonHandlerTestImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.delta.kernel.internal.types;
 
 import java.math.BigDecimal;

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/VectorUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/VectorUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.delta.kernel.defaults.internal.data.vector;
 
 import io.delta.kernel.data.ColumnVector;

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/DecimalConverters.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/DecimalConverters.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.delta.kernel.defaults.internal.parquet;
 
 import java.math.BigDecimal;

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/RowConverter.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/RowConverter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.delta.kernel.defaults.internal.parquet;
 
 import java.util.Arrays;


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

Adds header to the java checkstyle for Kernel. Fixes instances where missing.

## How was this patch tested?

Checkstyle passes