### PR TITLE
[Kernel] Clean up `ParquetBatchReader` move to next row logic

### DIFF
--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/DecimalConverters.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/DecimalConverters.java
@@ -33,6 +33,7 @@ import io.delta.kernel.types.DataType;
 import io.delta.kernel.types.DecimalType;
 
 import io.delta.kernel.defaults.internal.data.vector.DefaultDecimalVector;
+import io.delta.kernel.defaults.internal.parquet.ParquetConverters.BasePrimitiveColumnConverter;
 import static io.delta.kernel.defaults.internal.DefaultKernelUtils.checkArgument;
 
 public class DecimalConverters {
@@ -59,7 +60,6 @@ public class DecimalConverters {
                 return new IntDictionaryAwareDecimalConverter(typeFromClient,
                     10, 0, initialBatchSize);
             }
-
         } else if (primType.getPrimitiveTypeName() == INT64) {
             // For INT64 backed decimals
             if (typeAnnotation instanceof LogicalTypeAnnotation.DecimalLogicalTypeAnnotation) {
@@ -73,7 +73,6 @@ public class DecimalConverters {
                 return new LongDictionaryAwareDecimalConverter(typeFromClient,
                     20, 0, initialBatchSize);
             }
-
         } else if (primType.getPrimitiveTypeName() == FIXED_LEN_BYTE_ARRAY ||
             primType.getPrimitiveTypeName() == BINARY) {
             // For BINARY and FIXED_LEN_BYTE_ARRAY backed decimals
@@ -88,7 +87,6 @@ public class DecimalConverters {
                         "type is %s without decimal metadata.",
                     typeFromFile));
             }
-
         } else {
             throw new RuntimeException(String.format(
                 "Unable to create Parquet converter for DecimalType whose Parquet type " +
@@ -98,9 +96,7 @@ public class DecimalConverters {
         }
     }
 
-    public abstract static class BaseDecimalConverter extends
-        ParquetConverters.BasePrimitiveColumnConverter {
-
+    public abstract static class BaseDecimalConverter extends BasePrimitiveColumnConverter {
         // working state
         private BigDecimal[] values;
 
@@ -132,7 +128,6 @@ public class DecimalConverters {
         }
 
         protected void addDecimal(BigDecimal value) {
-            resizeIfNeeded();
             this.nullability[currentRowIndex] = false;
             this.values[currentRowIndex] = value;
         }
@@ -171,9 +166,7 @@ public class DecimalConverters {
         }
     }
 
-    public static class IntDictionaryAwareDecimalConverter extends
-        BaseDecimalConverter {
-
+    public static class IntDictionaryAwareDecimalConverter extends BaseDecimalConverter {
         IntDictionaryAwareDecimalConverter(
             DataType dataType, int precision, int scale, int initialBatchSize) {
             super(dataType, precision, scale, initialBatchSize);
@@ -194,9 +187,7 @@ public class DecimalConverters {
         }
     }
 
-    public static class LongDictionaryAwareDecimalConverter extends
-        BaseDecimalConverter {
-
+    public static class LongDictionaryAwareDecimalConverter extends BaseDecimalConverter {
         LongDictionaryAwareDecimalConverter(
             DataType dataType, int precision, int scale, int initialBatchSize) {
             super(dataType, precision, scale, initialBatchSize);
@@ -217,9 +208,7 @@ public class DecimalConverters {
         }
     }
 
-    public static class BinaryDictionaryAwareDecimalConverter extends
-        BaseDecimalConverter {
-
+    public static class BinaryDictionaryAwareDecimalConverter extends BaseDecimalConverter {
         BinaryDictionaryAwareDecimalConverter(
             DataType dataType, int precision, int scale, int initialBatchSize) {
             super(dataType, precision, scale, initialBatchSize);

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/DecimalConverters.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/DecimalConverters.java
@@ -128,6 +128,7 @@ public class DecimalConverters {
         }
 
         protected void addDecimal(BigDecimal value) {
+            resizeIfNeeded();
             this.nullability[currentRowIndex] = false;
             this.values[currentRowIndex] = value;
         }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetBatchReader.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetBatchReader.java
@@ -60,11 +60,8 @@ public class ParquetBatchReader {
         try {
             FileSystem fs = filePath.getFileSystem(configuration);
             FileStatus fileStatus = fs.getFileStatus(filePath);
-            reader.initialize(
-                new FileSplit(filePath, 0, fileStatus.getLen(), new String[0]),
-                configuration,
-                Reporter.NULL
-            );
+            FileSplit fileSplit = new FileSplit(filePath, 0, fileStatus.getLen(), new String[0]);
+            reader.initialize(fileSplit, configuration, Reporter.NULL);
         } catch (IOException | InterruptedException e) {
             throw new RuntimeException(e);
         }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetBatchReader.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetBatchReader.java
@@ -98,7 +98,7 @@ public class ParquetBatchReader {
                     hasNotConsumedNextElement = false;
                     // hasNext reads to row to confirm there is a next element.
                     try {
-                        batchReadSupport.moveToNextRow(reader.getCurrentRowIndex());
+                        batchReadSupport.finalizeCurrentRow(reader.getCurrentRowIndex());
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }
@@ -149,8 +149,8 @@ public class ParquetBatchReader {
         /**
          * @param fileRowIndex the file row index of the row just processed
          */
-        public void moveToNextRow(long fileRowIndex) {
-            rowRecordCollector.moveToNextRow(fileRowIndex);
+        public void finalizeCurrentRow(long fileRowIndex) {
+            rowRecordCollector.finalizeCurrentRow(fileRowIndex);
         }
     }
 
@@ -198,10 +198,11 @@ public class ParquetBatchReader {
         }
 
         /**
+         * Finalize the current row.
          * @param fileRowIndex the file row index of the row just processed
          */
-        public void moveToNextRow(long fileRowIndex) {
-            rowRecordGroupConverter.moveToNextRow(fileRowIndex);
+        public void finalizeCurrentRow(long fileRowIndex) {
+            rowRecordGroupConverter.finalizeCurrentRow(fileRowIndex);
         }
     }
 }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetConverters.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetConverters.java
@@ -99,11 +99,9 @@ class ParquetConverters {
 
         /**
          * Move the converter to accept the next row value.
-         *
-         * @return True if the last converted value is null, false otherwise
-         * TODO: Remove the return value. It is no longer relevant.
+         * @param prevRowIndex Row index of the previous row in the Parquet file.
          */
-        boolean moveToNextRow();
+        void moveToNextRow(long prevRowIndex);
 
         default void resizeIfNeeded() {}
 
@@ -125,9 +123,7 @@ class ParquetConverters {
         }
 
         @Override
-        public boolean moveToNextRow() {
-            return true;
-        }
+        public void moveToNextRow(long prevRowIndex) {}
     }
 
     public abstract static class BasePrimitiveColumnConverter
@@ -145,10 +141,9 @@ class ParquetConverters {
         }
 
         @Override
-        public boolean moveToNextRow() {
-            resizeIfNeeded();
+        public void moveToNextRow(long prevRowIndex) {
             currentRowIndex++;
-            return this.nullability[currentRowIndex - 1];
+            resizeIfNeeded();
         }
     }
 
@@ -481,14 +476,12 @@ class ParquetConverters {
             throw new UnsupportedOperationException("cannot add long to metadata column");
         }
 
-        /**
-         * @param fileRowIndex the file row index of the row processed
-         */
-        // If moveToNextRow() is called instead the value will be null
-        public boolean moveToNextRow(long fileRowIndex) {
-            super.values[currentRowIndex] = fileRowIndex;
+        @Override
+        public void moveToNextRow(long prevRowIndex) {
+            // Set the previous row index value as the value
+            super.values[currentRowIndex] = prevRowIndex;
             this.nullability[currentRowIndex] = false;
-            return moveToNextRow();
+            super.moveToNextRow(prevRowIndex);
         }
     }
 }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/RepeatedValueConverter.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/RepeatedValueConverter.java
@@ -71,15 +71,13 @@ abstract class RepeatedValueConverter extends GroupConverter implements BaseConv
     public void end() {}
 
     @Override
-    public boolean moveToNextRow() {
+    public void moveToNextRow(long prevRowIndex) {
         this.offsets[currentRowIndex + 1] = collector.currentEntryIndex;
         this.nullability[currentRowIndex] = isCurrentValueNull;
         this.isCurrentValueNull = true;
 
         currentRowIndex++;
         resizeIfNeeded();
-
-        return nullability[currentRowIndex - 1];
     }
 
     @Override
@@ -147,7 +145,9 @@ abstract class RepeatedValueConverter extends GroupConverter implements BaseConv
         @Override
         public void end() {
             for (Converter converter : elementConverters) {
-                ((ParquetConverters.BaseConverter) converter).moveToNextRow();
+                // Row indexes are not needed for nested columns
+                long prevRowIndex = -1;
+                ((ParquetConverters.BaseConverter) converter).moveToNextRow(prevRowIndex);
             }
             currentEntryIndex++;
         }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/RowConverter.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/RowConverter.java
@@ -125,8 +125,8 @@ class RowConverter
 
     @Override
     public void finalizeCurrentRow(long currentRowIndex) {
-        moveConvertersToNextRow(currentRowIndex);
         resizeIfNeeded();
+        finalizeLastRowInConverters(currentRowIndex);
         nullability[this.currentRowIndex] = isCurrentValueNull;
         isCurrentValueNull = true;
 
@@ -161,7 +161,7 @@ class RowConverter
         this.nullability = ParquetConverters.initNullabilityVector(this.nullability.length);
     }
 
-    private void moveConvertersToNextRow(long prevRowIndex) {
+    private void finalizeLastRowInConverters(long prevRowIndex) {
         for (int i = 0; i < converters.length; i++) {
             ((ParquetConverters.BaseConverter) converters[i]).finalizeCurrentRow(prevRowIndex);
         }


### PR DESCRIPTION
## Description
Minor cleanups.

* Currently, the `Converter` implementations have a method called `boolean moveToNextRow()`, which returns whether the previous row is `null` after moving the converter state to consume the next row. The return value is unnecessary now after delta-io/delta#1974. This PR removes the return type.

* There is an extra method on `RowConverter` called `boolean moveToNextRow(int rowIndex)`. This method is called to pass the row index of the record that was read. Also, there is an `if..and..else` to call this method or other method depending upon the `Converter`. Remove this extra method and just add one method `boolean finalizeCurrentRow(long currentRowIndex)`. This method sets the row index of the current row depending on the converter type and also finalizes the state of the column read from the current row.

## How was this patch tested?
Existing tests.