### PR TITLE
Count DVs that are updated as both "added" and "removed"

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
@@ -338,10 +338,15 @@ class DeletionVectorsSuite extends QueryTest
           val numDVUpdated = 1
           // An "updated" DV is "deleted" then "added" again.
           // We increment the count for "updated", "added", and "deleted".
-          val numDVAddedOrRemoved = initialNumDVs + numDVUpdated
-          assert(opMetrics.getOrElse("numDeletionVectorsAdded", -1) === numDVAddedOrRemoved)
-          assert(opMetrics.getOrElse("numDeletionVectorsRemoved", -1) === numDVAddedOrRemoved)
-          assert(opMetrics.getOrElse("numDeletionVectorsUpdated", -1) === numDVUpdated)
+          assert(
+            opMetrics.getOrElse("numDeletionVectorsAdded", -1) ===
+              initialNumDVs + numDVUpdated)
+          assert(
+            opMetrics.getOrElse("numDeletionVectorsRemoved", -1) ===
+              initialNumDVs + numDVUpdated)
+          assert(
+            opMetrics.getOrElse("numDeletionVectorsUpdated", -1) ===
+              numDVUpdated)
         }
 
         {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
@@ -334,9 +334,14 @@ class DeletionVectorsSuite extends QueryTest
           val opMetrics = DeltaMetricsUtils.getLastOperationMetrics(tableName)
           assert(opMetrics.getOrElse("numDeletedRows", -1) === 1)
           assert(opMetrics.getOrElse("numRemovedFiles", -1) === 0)
-          assert(opMetrics.getOrElse("numDeletionVectorsAdded", -1) === 0)
-          assert(opMetrics.getOrElse("numDeletionVectorsRemoved", -1) === 0)
-          assert(opMetrics.getOrElse("numDeletionVectorsUpdated", -1) === 1)
+          val initialNumDVs = 0
+          val numDVUpdated = 1
+          // An "updated" DV is "deleted" then "added" again.
+          // We increment the count for "updated", "added", and "deleted".
+          val numDVAddedOrRemoved = initialNumDVs + numDVUpdated
+          assert(opMetrics.getOrElse("numDeletionVectorsAdded", -1) === numDVAddedOrRemoved)
+          assert(opMetrics.getOrElse("numDeletionVectorsRemoved", -1) === numDVAddedOrRemoved)
+          assert(opMetrics.getOrElse("numDeletionVectorsUpdated", -1) === numDVUpdated)
         }
 
         {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Increase DV metrics "added" and "removed" for all DVs that have been "updated" because, from Delta Log's perspective, an "update" action is equivalent to a "remove" followed by an "add". Updating the counting rule will ensure that the metric reflects more accurately what happened at a lower level.

## How was this patch tested?

Updating existing tests.

## Does this PR introduce _any_ user-facing changes?

Yes, they'll see the change in DV metrics.