### PR TITLE
[Other] Clarify DV file format byte order

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1424,7 +1424,8 @@ Bytes | Name | Description
 ### Deletion Vector File Storage Format
 
 Deletion Vectors can be stored in files in cloud storage or inline in the Delta log.
-The format for storing DVs in file storage is one (or more) of DV, using the 64-bit RoaringBitmaps described in the previous section, per file, together with a checksum for each DV:
+The format for storing DVs in file storage is one (or more) DV, using the 64-bit RoaringBitmaps described in the previous section, per file, together with a checksum for each DV.
+The concrete format is as follows, with all numerical values written in big endian byte order:
 
 Bytes | Name | Description
 -|-|-


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Protocol Spec)

## Description

- Clarify in the spec that DV files are big endian, while serialized DVs are little endian.

Fixes #1979.

## How was this patch tested?

n/a

## Does this PR introduce _any_ user-facing changes?

No.
