### PR TITLE
Refactor merge & DML test helpers to allow reusability

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
@@ -27,7 +27,8 @@ import org.apache.spark.sql.types.StructType
 
 abstract class DeleteSuiteBase extends QueryTest
   with SharedSparkSession
-  with DeltaDMLTestUtils  with DeltaTestUtilsForTempViews {
+  with DeltaDMLTestUtils
+  with DeltaTestUtilsForTempViews {
 
   import testImplicits._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
@@ -17,60 +17,21 @@
 package org.apache.spark.sql.delta
 
 // scalastyle:off import.ordering.noEmptyLine
-import java.io.File
-
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.hadoop.fs.Path
-import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.functions.struct
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
-import org.apache.spark.util.Utils
+import org.apache.spark.sql.types.StructType
 
 abstract class DeleteSuiteBase extends QueryTest
   with SharedSparkSession
-  with BeforeAndAfterEach  with DeltaTestUtilsForTempViews {
+  with DeltaDMLTestUtils  with DeltaTestUtilsForTempViews {
 
   import testImplicits._
 
-  var tempDir: File = _
-
-  var deltaLog: DeltaLog = _
-
-  protected def tempPath: String = tempDir.getCanonicalPath
-
-  protected def readDeltaTable(path: String): DataFrame = {
-    spark.read.format("delta").load(path)
-  }
-
-  override def beforeEach() {
-    super.beforeEach()
-    // Using a space in path to provide coverage for special characters.
-    tempDir = Utils.createTempDir(namePrefix = "spark test")
-    deltaLog = DeltaLog.forTable(spark, new Path(tempPath))
-  }
-
-  override def afterEach() {
-    try {
-      Utils.deleteRecursively(tempDir)
-      DeltaLog.clearCache()
-    } finally {
-      super.afterEach()
-    }
-  }
-
   protected def executeDelete(target: String, where: String = null): Unit
-
-  protected def append(df: DataFrame, partitionBy: Seq[String] = Nil): Unit = {
-    val writer = df.write.format("delta").mode("append")
-    if (partitionBy.nonEmpty) {
-      writer.partitionBy(partitionBy: _*)
-    }
-    writer.save(deltaLog.dataPath.toString)
-  }
 
   protected def checkDelete(
       condition: Option[String],

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -369,7 +369,8 @@ trait DeltaTestUtilsForTempViews
  * cleaning it up after each test.
  */
 trait DeltaDMLTestUtils
-  extends DeltaTestUtilsBase  with BeforeAndAfterEach {
+  extends DeltaTestUtilsBase
+  with BeforeAndAfterEach {
   self: SharedSparkSession =>
 
   protected var tempDir: File = _

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -378,14 +378,14 @@ trait DeltaDMLTestUtils
 
   protected def tempPath: String = tempDir.getCanonicalPath
 
-  override def beforeEach(): Unit = {
+  override protected def beforeEach(): Unit = {
     super.beforeEach()
     // Using a space in path to provide coverage for special characters.
     tempDir = Utils.createTempDir(namePrefix = "spark test")
     deltaLog = DeltaLog.forTable(spark, new Path(tempPath))
   }
 
-  override def afterEach(): Unit = {
+  override protected def afterEach(): Unit = {
     try {
       Utils.deleteRecursively(tempDir)
       DeltaLog.clearCache()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -16,9 +16,9 @@
 
 package org.apache.spark.sql.delta
 
+import java.io.File
 import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.JavaConverters._
 import scala.collection.concurrent
@@ -27,16 +27,19 @@ import scala.util.matching.Regex
 import org.apache.spark.sql.delta.DeltaTestUtils.Plans
 import org.apache.spark.sql.delta.actions.{AddFile, Protocol}
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.hadoop.fs.Path
+import org.scalatest.BeforeAndAfterEach
 
 import org.apache.spark.SparkContext
 import org.apache.spark.scheduler.{JobFailed, SparkListener, SparkListenerJobEnd, SparkListenerJobStart}
-import org.apache.spark.sql.{AnalysisException, SparkSession}
+import org.apache.spark.sql.{AnalysisException, DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.{FileSourceScanExec, QueryExecution, RDDScanExec, SparkPlan, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.aggregate.HashAggregateExec
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.util.QueryExecutionListener
+import org.apache.spark.util.Utils
 
 trait DeltaTestUtilsBase {
   import DeltaTestUtils.TableIdentifierOrPath
@@ -198,6 +201,11 @@ trait DeltaTestUtilsBase {
         TableIdentifierOrPath.Identifier(TableIdentifier(tableName), Option(alias))
     }
   }
+
+  @deprecated("Use checkError() instead")
+  protected def errorContains(errMsg: String, str: String): Unit = {
+    assert(errMsg.toLowerCase(Locale.ROOT).contains(str.toLowerCase(Locale.ROOT)))
+  }
 }
 
 object DeltaTestUtils extends DeltaTestUtilsBase {
@@ -288,7 +296,8 @@ object DeltaTestUtils extends DeltaTestUtilsBase {
 
 trait DeltaTestUtilsForTempViews
   extends SharedSparkSession
-{
+  with DeltaTestUtilsBase {
+
   def testWithTempView(testName: String)(testFun: Boolean => Any): Unit = {
     Seq(true, false).foreach { isSQLTempView =>
       val tempViewUsed = if (isSQLTempView) "SQL TempView" else "Dataset TempView"
@@ -330,10 +339,6 @@ trait DeltaTestUtilsForTempViews
     }
   }
 
-  protected def errorContains(errMsg: String, str: String): Unit = {
-    assert(errMsg.toLowerCase(Locale.ROOT).contains(str.toLowerCase(Locale.ROOT)))
-  }
-
   def testErrorMessageAndClass(
       isSQLTempView: Boolean,
       ex: AnalysisException,
@@ -357,4 +362,49 @@ trait DeltaTestUtilsForTempViews
       }
     }
   }
+}
+
+/**
+ * Trait collecting helper methods for DML tests e.p. creating a test table for each test and
+ * cleaning it up after each test.
+ */
+trait DeltaDMLTestUtils
+  extends DeltaTestUtilsBase  with BeforeAndAfterEach {
+  self: SharedSparkSession =>
+
+  protected var tempDir: File = _
+
+  protected var deltaLog: DeltaLog = _
+
+  protected def tempPath: String = tempDir.getCanonicalPath
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    // Using a space in path to provide coverage for special characters.
+    tempDir = Utils.createTempDir(namePrefix = "spark test")
+    deltaLog = DeltaLog.forTable(spark, new Path(tempPath))
+  }
+
+  override def afterEach(): Unit = {
+    try {
+      Utils.deleteRecursively(tempDir)
+      DeltaLog.clearCache()
+    } finally {
+      super.afterEach()
+    }
+  }
+
+  protected def append(df: DataFrame, partitionBy: Seq[String] = Nil): Unit = {
+    val dfw = df.write.format("delta").mode("append")
+    if (partitionBy.nonEmpty) {
+      dfw.partitionBy(partitionBy: _*)
+    }
+    dfw.save(tempPath)
+  }
+
+  protected def readDeltaTable(path: String): DataFrame = {
+    spark.read.format("delta").load(path)
+  }
+
+  protected def getDeltaFileStmt(path: String): String = s"SELECT * FROM delta.`$path`"
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
@@ -30,45 +30,12 @@ import org.apache.spark.sql.functions.udf
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
-class MergeIntoSQLSuite extends MergeIntoSuiteBase  with MergeIntoNotMatchedBySourceSuite
+class MergeIntoSQLSuite extends MergeIntoSuiteBase
+  with MergeIntoSQLTestUtils  with MergeIntoNotMatchedBySourceSuite
   with DeltaSQLCommandTest
   with DeltaTestUtilsForTempViews {
 
   import testImplicits._
-
-  private def basicMergeStmt(
-      target: String,
-      source: String,
-      condition: String,
-      update: String,
-      insert: String): String = {
-    s"""
-       |MERGE INTO $target
-       |USING $source
-       |ON $condition
-       |WHEN MATCHED THEN UPDATE SET $update
-       |WHEN NOT MATCHED THEN INSERT $insert
-      """.stripMargin
-  }
-
-  override def executeMerge(
-      target: String,
-      source: String,
-      condition: String,
-      update: String,
-      insert: String): Unit = {
-    sql(basicMergeStmt(target, source, condition, update, insert))
-  }
-
-  override def executeMerge(
-      tgt: String,
-      src: String,
-      cond: String,
-      clauses: MergeClause*): Unit = {
-
-    val merge = s"MERGE INTO $tgt USING $src ON $cond\n" + clauses.map(_.sql).mkString("\n")
-    sql(merge)
-  }
 
   test("CTE as a source in MERGE") {
     withTable("source") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
@@ -31,7 +31,8 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
 class MergeIntoSQLSuite extends MergeIntoSuiteBase
-  with MergeIntoSQLTestUtils  with MergeIntoNotMatchedBySourceSuite
+  with MergeIntoSQLTestUtils
+  with MergeIntoNotMatchedBySourceSuite
   with DeltaSQLCommandTest
   with DeltaTestUtilsForTempViews {
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
@@ -29,7 +29,8 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.StructType
 
 class MergeIntoScalaSuite extends MergeIntoSuiteBase
-  with MergeIntoScalaTestUtils  with MergeIntoNotMatchedBySourceSuite
+  with MergeIntoScalaTestUtils
+  with MergeIntoNotMatchedBySourceSuite
   with DeltaSQLCommandTest
   with DeltaTestUtilsForTempViews {
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
@@ -21,7 +21,6 @@ import java.util.Locale
 import org.apache.spark.sql.delta.actions.SetTransaction
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
-import io.delta.tables._
 
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.plans.Inner
@@ -29,7 +28,8 @@ import org.apache.spark.sql.catalyst.plans.logical.{Assignment, DeltaMergeIntoCl
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.StructType
 
-class MergeIntoScalaSuite extends MergeIntoSuiteBase  with MergeIntoNotMatchedBySourceSuite
+class MergeIntoScalaSuite extends MergeIntoSuiteBase
+  with MergeIntoScalaTestUtils  with MergeIntoNotMatchedBySourceSuite
   with DeltaSQLCommandTest
   with DeltaTestUtilsForTempViews {
 
@@ -585,99 +585,6 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase  with MergeIntoNotMatchedBy
     }
   }
 
-  override protected def executeMerge(
-      target: String,
-      source: String,
-      condition: String,
-      update: String,
-      insert: String): Unit = {
-
-    executeMerge(
-      tgt = target,
-      src = source,
-      cond = condition,
-      this.update(set = update),
-      this.insert(values = insert))
-  }
-
-  override protected def executeMerge(
-      tgt: String,
-      src: String,
-      cond: String,
-      clauses: MergeClause*): Unit = {
-
-    def buildClause(clause: MergeClause, mergeBuilder: DeltaMergeBuilder)
-      : DeltaMergeBuilder = clause match {
-      case _: MatchedClause =>
-        val actionBuilder: DeltaMergeMatchedActionBuilder =
-          if (clause.condition != null) mergeBuilder.whenMatched(clause.condition)
-          else mergeBuilder.whenMatched()
-        if (clause.action.startsWith("DELETE")) {   // DELETE clause
-          actionBuilder.delete()
-        } else {                                    // UPDATE clause
-          val setColExprStr = clause.action.trim.stripPrefix("UPDATE SET")
-          if (setColExprStr.trim == "*") {          // UPDATE SET *
-            actionBuilder.updateAll()
-          } else if (setColExprStr.contains("array_")) { // UPDATE SET x = array_union(..)
-            val setColExprPairs = parseUpdate(setColExprStr)
-            actionBuilder.updateExpr(setColExprPairs)
-          } else {                                 // UPDATE SET x = a, y = b, z = c
-            val setColExprPairs = parseUpdate(setColExprStr.split(","))
-            actionBuilder.updateExpr(setColExprPairs)
-          }
-        }
-      case _: NotMatchedClause =>                     // INSERT clause
-        val actionBuilder: DeltaMergeNotMatchedActionBuilder =
-          if (clause.condition != null) mergeBuilder.whenNotMatched(clause.condition)
-          else mergeBuilder.whenNotMatched()
-        val valueStr = clause.action.trim.stripPrefix("INSERT")
-        if (valueStr.trim == "*") {                   // INSERT *
-          actionBuilder.insertAll()
-        } else {                                      // INSERT (x, y, z) VALUES (a, b, c)
-          val valueColExprsPairs = parseInsert(valueStr, Some(clause))
-          actionBuilder.insertExpr(valueColExprsPairs)
-        }
-      case _: NotMatchedBySourceClause =>
-        val actionBuilder: DeltaMergeNotMatchedBySourceActionBuilder =
-          if (clause.condition != null) mergeBuilder.whenNotMatchedBySource(clause.condition)
-          else mergeBuilder.whenNotMatchedBySource()
-        if (clause.action.startsWith("DELETE")) { // DELETE clause
-          actionBuilder.delete()
-        } else { // UPDATE clause
-          val setColExprStr = clause.action.trim.stripPrefix("UPDATE SET")
-          if (setColExprStr.contains("array_")) { // UPDATE SET x = array_union(..)
-            val setColExprPairs = parseUpdate(setColExprStr)
-            actionBuilder.updateExpr(setColExprPairs)
-          } else { // UPDATE SET x = a, y = b, z = c
-            val setColExprPairs = parseUpdate(setColExprStr.split(","))
-            actionBuilder.updateExpr(setColExprPairs)
-          }
-        }
-      }
-
-    val deltaTable = {
-      val (tableNameOrPath, optionalAlias) = DeltaTestUtils.parseTableAndAlias(tgt)
-      var table = makeDeltaTable(tableNameOrPath)
-      optionalAlias.foreach { alias => table = table.as(alias) }
-      table
-    }
-
-    val sourceDataFrame: DataFrame = {
-      val (tableOrQuery, optionalAlias) = DeltaTestUtils.parseTableAndAlias(src)
-      var df =
-        if (tableOrQuery.startsWith("(")) spark.sql(tableOrQuery) else spark.table(tableOrQuery)
-      optionalAlias.foreach { alias => df = df.as(alias) }
-      df
-    }
-
-    var mergeBuilder = deltaTable.merge(sourceDataFrame, cond)
-    clauses.foreach { clause =>
-      mergeBuilder = buildClause(clause, mergeBuilder)
-    }
-    mergeBuilder.execute()
-    deltaTable.toDF
-  }
-
   // scalastyle:off argcount
   override def testNestedDataSupport(name: String, namePrefix: String = "nested data support")(
       source: String,
@@ -742,46 +649,6 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase  with MergeIntoNotMatchedBy
         }
       }
     }
-  }
-
-  private def makeDeltaTable(nameOrPath: String): DeltaTable = {
-    val isPath: Boolean = nameOrPath.startsWith("delta.")
-    if (isPath) {
-      val path = nameOrPath.stripPrefix("delta.`").stripSuffix("`")
-      io.delta.tables.DeltaTable.forPath(spark, path)
-    } else {
-      DeltaTableTestUtils.createTable(spark.table(nameOrPath), DeltaLog.forTable(spark, nameOrPath))
-    }
-  }
-
-  private def parseUpdate(update: Seq[String]): Map[String, String] = {
-    update.map { _.split("=").toList }.map {
-      case setCol :: setExpr :: Nil => setCol.trim -> setExpr.trim
-      case _ => fail("error parsing update actions " + update)
-    }.toMap
-  }
-
-  private def parseInsert(valueStr: String, clause: Option[MergeClause]): Map[String, String] = {
-    valueStr.split("VALUES").toList match {
-      case colsStr :: exprsStr :: Nil =>
-        def parse(str: String): Seq[String] = {
-          str.trim.stripPrefix("(").stripSuffix(")").split(",").map(_.trim)
-        }
-        val cols = parse(colsStr)
-        val exprs = parse(exprsStr)
-        require(cols.size == exprs.size,
-          s"Invalid insert action ${clause.get.action}: cols = $cols, exprs = $exprs")
-        cols.zip(exprs).toMap
-
-      case list =>
-        fail(s"Invalid insert action ${clause.get.action} split into $list")
-    }
-  }
-
-  private def parsePath(nameOrPath: String): String = {
-    if (nameOrPath.startsWith("delta.`")) {
-      nameOrPath.stripPrefix("delta.`").stripSuffix("`")
-    } else nameOrPath
   }
 
   // Scala API won't hit the resolution exception.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
@@ -23,10 +23,8 @@ import java.util.Locale
 import scala.language.implicitConversions
 
 import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions, UsageRecord}
-import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
 import org.apache.spark.sql.delta.commands.merge.MergeStats
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.test.ScanReportHelper
 import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.hadoop.fs.Path
@@ -47,61 +45,12 @@ import org.apache.spark.util.Utils
 abstract class MergeIntoSuiteBase
     extends QueryTest
     with SharedSparkSession
-    with BeforeAndAfterEach    with SQLTestUtils
+    with SQLTestUtils
     with ScanReportHelper
     with DeltaTestUtilsForTempViews
-    with MergeHelpers {
+    with MergeIntoTestUtils {
 
   import testImplicits._
-
-  protected var tempDir: File = _
-
-  protected def tempPath: String = tempDir.getCanonicalPath
-
-  override def beforeEach() {
-    super.beforeEach()
-    // Using a space in path to provide coverage for special characters.
-    tempDir = Utils.createTempDir(namePrefix = "spark test")
-  }
-
-  override def afterEach() {
-    try {
-      Utils.deleteRecursively(tempDir)
-    } finally {
-      super.afterEach()
-    }
-  }
-
-  protected def executeMerge(
-      target: String,
-      source: String,
-      condition: String,
-      update: String,
-      insert: String): Unit
-
-  protected def executeMerge(
-      tgt: String,
-      src: String,
-      cond: String,
-      clauses: MergeClause*): Unit
-
-  protected def append(df: DataFrame, partitions: Seq[String] = Nil): Unit = {
-    val dfw = df.write.format("delta").mode("append")
-    if (partitions.nonEmpty) {
-      dfw.partitionBy(partitions: _*)
-    }
-    dfw.save(tempPath)
-  }
-
-  protected def readDeltaTable(path: String): DataFrame = {
-    spark.read.format("delta").load(path)
-  }
-
-  protected def getDeltaFileStmt(path: String): String = s"SELECT * FROM delta.`$path`"
-
-  protected def withCrossJoinEnabled(body: => Unit): Unit = {
-    withSQLConf(SQLConf.CROSS_JOINS_ENABLED.key -> "true") { body }
-  }
 
   Seq(true, false).foreach { isPartitioned =>
     test(s"basic case - merge to Delta table by path, isPartitioned: $isPartitioned") {
@@ -2707,24 +2656,6 @@ abstract class MergeIntoSuiteBase
     isMatchedOnly = true,
     update(condition = "t.key == 1 AND t.value == 5", set = "*"))(
     result = Seq((1, 10), (2, 20), (3, 30)))
-
-
-  /**
-   * Parse the input JSON data into a dataframe, one row per input element.
-   * Throws an exception on malformed inputs or records that don't comply with the provided schema.
-   */
-  protected def readFromJSON(data: Seq[String], schema: StructType = null): DataFrame = {
-    if (schema != null) {
-      spark.read
-        .schema(schema)
-        .option("mode", FailFastMode.name)
-        .json(data.toDS)
-    } else {
-      spark.read
-        .option("mode", FailFastMode.name)
-        .json(data.toDS)
-    }
-  }
 
   // scalastyle:off argcount
   protected def testNestedStructsEvolution(name: String)(
@@ -5993,51 +5924,4 @@ class ComplexTestUDT extends UserDefinedType[ComplexTest] {
   }
 
   override def userClass: Class[ComplexTest] = classOf[ComplexTest]
-}
-
-trait MergeHelpers {
-  /** A simple representative of a any WHEN clause in a MERGE statement */
-  protected sealed trait MergeClause {
-    def condition: String
-    def action: String
-    def clause: String
-    def sql: String = {
-      assert(action != null, "action not specified yet")
-      val cond = if (condition != null) s"AND $condition" else ""
-      s"WHEN $clause $cond THEN $action"
-    }
-  }
-
-  protected case class MatchedClause(condition: String, action: String) extends MergeClause {
-    override def clause: String = "MATCHED"
-  }
-
-  protected case class NotMatchedClause(condition: String, action: String) extends MergeClause {
-    override def clause: String = "NOT MATCHED"
-  }
-
-  protected case class NotMatchedBySourceClause(condition: String, action: String)
-    extends MergeClause {
-    override def clause: String = "NOT MATCHED BY SOURCE"
-  }
-
-  protected def update(set: String = null, condition: String = null): MergeClause = {
-    MatchedClause(condition, s"UPDATE SET $set")
-  }
-
-  protected def delete(condition: String = null): MergeClause = {
-    MatchedClause(condition, s"DELETE")
-  }
-
-  protected def insert(values: String = null, condition: String = null): MergeClause = {
-    NotMatchedClause(condition, s"INSERT $values")
-  }
-
-  protected def updateNotMatched(set: String = null, condition: String = null): MergeClause = {
-    NotMatchedBySourceClause(condition, s"UPDATE SET $set")
-  }
-
-  protected def deleteNotMatched(condition: String = null): MergeClause = {
-    NotMatchedBySourceClause(condition, s"DELETE")
-  }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoTestUtils.scala
@@ -87,7 +87,7 @@ trait MergeIntoSQLTestUtils extends SQLTestUtils with MergeIntoTestUtils {
       """.stripMargin
   }
 
-  override def executeMerge(
+  override protected def executeMerge(
       target: String,
       source: String,
       condition: String,
@@ -95,7 +95,7 @@ trait MergeIntoSQLTestUtils extends SQLTestUtils with MergeIntoTestUtils {
       insert: String): Unit =
     sql(basicMergeStmt(target, source, condition, update, insert))
 
-  override def executeMerge(
+  override protected def executeMerge(
       tgt: String,
       src: String,
       cond: String,
@@ -106,7 +106,7 @@ trait MergeIntoSQLTestUtils extends SQLTestUtils with MergeIntoTestUtils {
 trait MergeIntoScalaTestUtils extends MergeIntoTestUtils {
   self: SharedSparkSession =>
 
-  override def executeMerge(
+  override protected def executeMerge(
       target: String,
       source: String,
       condition: String,
@@ -120,7 +120,7 @@ trait MergeIntoScalaTestUtils extends MergeIntoTestUtils {
       this.insert(values = insert))
   }
 
-  override def executeMerge(
+  override protected def executeMerge(
       tgt: String,
       src: String,
       cond: String,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoTestUtils.scala
@@ -1,0 +1,287 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import io.delta.tables._
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.catalyst.util.FailFastMode
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
+import org.apache.spark.sql.types.StructType
+
+/**
+ * Base trait collecting helper methods to run MERGE tests. Merge test suite will want to mix in
+ * either [[MergeIntoSQLTestUtils]] or [[MergeIntoScalaTestUtils]] to run merge tests using the SQL
+ * or Scala API resp.
+ */
+trait MergeIntoTestUtils extends DeltaDMLTestUtils with MergeHelpers {
+  self: SharedSparkSession =>
+
+  import testImplicits._
+
+  protected def executeMerge(
+      target: String,
+      source: String,
+      condition: String,
+      update: String,
+      insert: String): Unit
+
+  protected def executeMerge(
+      tgt: String,
+      src: String,
+      cond: String,
+      clauses: MergeClause*): Unit
+
+  protected def withCrossJoinEnabled(body: => Unit): Unit = {
+    withSQLConf(SQLConf.CROSS_JOINS_ENABLED.key -> "true") { body }
+  }
+
+  /**
+   * Parse the input JSON data into a dataframe, one row per input element.
+   * Throws an exception on malformed inputs or records that don't comply with the provided schema.
+   */
+  protected def readFromJSON(data: Seq[String], schema: StructType = null): DataFrame = {
+    if (schema != null) {
+      spark.read
+        .schema(schema)
+        .option("mode", FailFastMode.name)
+        .json(data.toDS)
+    } else {
+      spark.read
+        .option("mode", FailFastMode.name)
+        .json(data.toDS)
+    }
+  }
+}
+
+trait MergeIntoSQLTestUtils extends SQLTestUtils with MergeIntoTestUtils {
+  self: SharedSparkSession =>
+
+  protected def basicMergeStmt(
+      target: String,
+      source: String,
+      condition: String,
+      update: String,
+      insert: String): String = {
+    s"""
+       |MERGE INTO $target
+       |USING $source
+       |ON $condition
+       |WHEN MATCHED THEN UPDATE SET $update
+       |WHEN NOT MATCHED THEN INSERT $insert
+      """.stripMargin
+  }
+
+  override def executeMerge(
+      target: String,
+      source: String,
+      condition: String,
+      update: String,
+      insert: String): Unit =
+    sql(basicMergeStmt(target, source, condition, update, insert))
+
+  override def executeMerge(
+      tgt: String,
+      src: String,
+      cond: String,
+      clauses: MergeClause*): Unit =
+    sql(s"MERGE INTO $tgt USING $src ON $cond\n" + clauses.map(_.sql).mkString("\n"))
+}
+
+trait MergeIntoScalaTestUtils extends MergeIntoTestUtils {
+  self: SharedSparkSession =>
+
+  override def executeMerge(
+      target: String,
+      source: String,
+      condition: String,
+      update: String,
+      insert: String): Unit = {
+    executeMerge(
+      tgt = target,
+      src = source,
+      cond = condition,
+      this.update(set = update),
+      this.insert(values = insert))
+  }
+
+  override def executeMerge(
+      tgt: String,
+      src: String,
+      cond: String,
+      clauses: MergeClause*): Unit = {
+
+    def buildClause(clause: MergeClause, mergeBuilder: DeltaMergeBuilder)
+      : DeltaMergeBuilder = clause match {
+      case _: MatchedClause =>
+        val actionBuilder: DeltaMergeMatchedActionBuilder =
+          if (clause.condition != null) mergeBuilder.whenMatched(clause.condition)
+          else mergeBuilder.whenMatched()
+        if (clause.action.startsWith("DELETE")) {   // DELETE clause
+          actionBuilder.delete()
+        } else {                                    // UPDATE clause
+          val setColExprStr = clause.action.trim.stripPrefix("UPDATE SET")
+          if (setColExprStr.trim == "*") {          // UPDATE SET *
+            actionBuilder.updateAll()
+          } else if (setColExprStr.contains("array_")) { // UPDATE SET x = array_union(..)
+            val setColExprPairs = parseUpdate(Seq(setColExprStr))
+            actionBuilder.updateExpr(setColExprPairs)
+          } else {                                 // UPDATE SET x = a, y = b, z = c
+            val setColExprPairs = parseUpdate(setColExprStr.split(","))
+            actionBuilder.updateExpr(setColExprPairs)
+          }
+        }
+      case _: NotMatchedClause =>                     // INSERT clause
+        val actionBuilder: DeltaMergeNotMatchedActionBuilder =
+          if (clause.condition != null) mergeBuilder.whenNotMatched(clause.condition)
+          else mergeBuilder.whenNotMatched()
+        val valueStr = clause.action.trim.stripPrefix("INSERT")
+        if (valueStr.trim == "*") {                   // INSERT *
+          actionBuilder.insertAll()
+        } else {                                      // INSERT (x, y, z) VALUES (a, b, c)
+          val valueColExprsPairs = parseInsert(valueStr, Some(clause))
+          actionBuilder.insertExpr(valueColExprsPairs)
+        }
+      case _: NotMatchedBySourceClause =>
+        val actionBuilder: DeltaMergeNotMatchedBySourceActionBuilder =
+          if (clause.condition != null) mergeBuilder.whenNotMatchedBySource(clause.condition)
+          else mergeBuilder.whenNotMatchedBySource()
+        if (clause.action.startsWith("DELETE")) { // DELETE clause
+          actionBuilder.delete()
+        } else { // UPDATE clause
+          val setColExprStr = clause.action.trim.stripPrefix("UPDATE SET")
+          if (setColExprStr.contains("array_")) { // UPDATE SET x = array_union(..)
+            val setColExprPairs = parseUpdate(Seq(setColExprStr))
+            actionBuilder.updateExpr(setColExprPairs)
+          } else { // UPDATE SET x = a, y = b, z = c
+            val setColExprPairs = parseUpdate(setColExprStr.split(","))
+            actionBuilder.updateExpr(setColExprPairs)
+          }
+        }
+      }
+
+    val deltaTable = {
+      val (tableNameOrPath, optionalAlias) = DeltaTestUtils.parseTableAndAlias(tgt)
+      var table = makeDeltaTable(tableNameOrPath)
+      optionalAlias.foreach { alias => table = table.as(alias) }
+      table
+    }
+
+    val sourceDataFrame: DataFrame = {
+      val (tableOrQuery, optionalAlias) = DeltaTestUtils.parseTableAndAlias(src)
+      var df =
+        if (tableOrQuery.startsWith("(")) spark.sql(tableOrQuery) else spark.table(tableOrQuery)
+      optionalAlias.foreach { alias => df = df.as(alias) }
+      df
+    }
+
+    var mergeBuilder = deltaTable.merge(sourceDataFrame, cond)
+    clauses.foreach { clause =>
+      mergeBuilder = buildClause(clause, mergeBuilder)
+    }
+    mergeBuilder.execute()
+    deltaTable.toDF
+  }
+
+  protected def makeDeltaTable(nameOrPath: String): DeltaTable = {
+    val isPath: Boolean = nameOrPath.startsWith("delta.")
+    if (isPath) {
+      val path = nameOrPath.stripPrefix("delta.`").stripSuffix("`")
+      io.delta.tables.DeltaTable.forPath(spark, path)
+    } else {
+      DeltaTableTestUtils.createTable(spark.table(nameOrPath), DeltaLog.forTable(spark, nameOrPath))
+    }
+  }
+
+  protected def parseUpdate(update: Seq[String]): Map[String, String] = {
+    update.map { _.split("=").toList }.map {
+      case setCol :: setExpr :: Nil => setCol.trim -> setExpr.trim
+      case _ => fail("error parsing update actions " + update)
+    }.toMap
+  }
+
+  protected def parseInsert(valueStr: String, clause: Option[MergeClause]): Map[String, String] = {
+    valueStr.split("VALUES").toList match {
+      case colsStr :: exprsStr :: Nil =>
+        def parse(str: String): Seq[String] = {
+          str.trim.stripPrefix("(").stripSuffix(")").split(",").map(_.trim)
+        }
+        val cols = parse(colsStr)
+        val exprs = parse(exprsStr)
+        require(cols.size == exprs.size,
+          s"Invalid insert action ${clause.get.action}: cols = $cols, exprs = $exprs")
+        cols.zip(exprs).toMap
+
+      case list =>
+        fail(s"Invalid insert action ${clause.get.action} split into $list")
+    }
+  }
+
+  protected def parsePath(nameOrPath: String): String = {
+    if (nameOrPath.startsWith("delta.`")) {
+      nameOrPath.stripPrefix("delta.`").stripSuffix("`")
+    } else nameOrPath
+  }
+}
+
+trait MergeHelpers {
+  /** A simple representative of a any WHEN clause in a MERGE statement */
+  protected sealed trait MergeClause {
+    def condition: String
+    def action: String
+    def clause: String
+    def sql: String = {
+      assert(action != null, "action not specified yet")
+      val cond = if (condition != null) s"AND $condition" else ""
+      s"WHEN $clause $cond THEN $action"
+    }
+  }
+
+  protected case class MatchedClause(condition: String, action: String) extends MergeClause {
+    override def clause: String = "MATCHED"
+  }
+
+  protected case class NotMatchedClause(condition: String, action: String) extends MergeClause {
+    override def clause: String = "NOT MATCHED"
+  }
+
+  protected case class NotMatchedBySourceClause(condition: String, action: String)
+    extends MergeClause {
+    override def clause: String = "NOT MATCHED BY SOURCE"
+  }
+
+  protected def update(set: String = null, condition: String = null): MergeClause = {
+    MatchedClause(condition, s"UPDATE SET $set")
+  }
+
+  protected def delete(condition: String = null): MergeClause = {
+    MatchedClause(condition, s"DELETE")
+  }
+
+  protected def insert(values: String = null, condition: String = null): MergeClause = {
+    NotMatchedClause(condition, s"INSERT $values")
+  }
+
+  protected def updateNotMatched(set: String = null, condition: String = null): MergeClause = {
+    NotMatchedBySourceClause(condition, s"UPDATE SET $set")
+  }
+
+  protected def deleteNotMatched(condition: String = null): MergeClause = {
+    NotMatchedBySourceClause(condition, s"DELETE")
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSQLSuite.scala
@@ -32,7 +32,7 @@ class UpdateSQLSuite extends UpdateSuiteBase  with DeltaSQLCommandTest {
     assert(outputs.contains("Delta"))
     assert(!outputs.contains("index") && !outputs.contains("ActionLog"))
     // no change should be made by explain
-    checkAnswer(readDeltaTableByPath(tempPath), Row(2, 2))
+    checkAnswer(readDeltaTable(tempPath), Row(2, 2))
   }
 
   test("SC-11376: Update command should check target columns during analysis, same key") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateScalaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateScalaSuite.scala
@@ -31,7 +31,7 @@ class UpdateScalaSuite extends UpdateSuiteBase  with DeltaSQLCommandTest {
     append(Seq((1, 10), (2, 20), (3, 30), (4, 40)).toDF("key", "value"))
     val table = io.delta.tables.DeltaTable.forPath(tempPath)
     table.updateExpr(Map("key" -> "100"))
-    checkAnswer(readDeltaTableByPath(tempPath),
+    checkAnswer(readDeltaTable(tempPath),
       Row(100, 10) :: Row(100, 20) :: Row(100, 30) :: Row(100, 40) :: Nil)
   }
 
@@ -39,7 +39,7 @@ class UpdateScalaSuite extends UpdateSuiteBase  with DeltaSQLCommandTest {
     append(Seq((1, 10), (2, 20), (3, 30), (4, 40)).toDF("key", "value"))
     val table = io.delta.tables.DeltaTable.forPath(tempPath)
     table.update(Map("key" -> functions.expr("100")))
-    checkAnswer(readDeltaTableByPath(tempPath),
+    checkAnswer(readDeltaTable(tempPath),
       Row(100, 10) :: Row(100, 20) :: Row(100, 30) :: Row(100, 40) :: Nil)
   }
 
@@ -47,7 +47,7 @@ class UpdateScalaSuite extends UpdateSuiteBase  with DeltaSQLCommandTest {
     append(Seq((1, 10), (2, 20), (3, 30), (4, 40)).toDF("key", "value"))
     val table = io.delta.tables.DeltaTable.forPath(tempPath)
     table.updateExpr("key = 1 or key = 2", Map("key" -> "100"))
-    checkAnswer(readDeltaTableByPath(tempPath),
+    checkAnswer(readDeltaTable(tempPath),
       Row(100, 10) :: Row(100, 20) :: Row(3, 30) :: Row(4, 40) :: Nil)
   }
 
@@ -56,7 +56,7 @@ class UpdateScalaSuite extends UpdateSuiteBase  with DeltaSQLCommandTest {
     val table = io.delta.tables.DeltaTable.forPath(tempPath)
     table.update(functions.expr("key = 1 or key = 2"),
       Map("key" -> functions.expr("100"), "value" -> functions.expr("101")))
-    checkAnswer(readDeltaTableByPath(tempPath),
+    checkAnswer(readDeltaTable(tempPath),
       Row(100, 101) :: Row(100, 101) :: Row(3, 30) :: Row(4, 40) :: Nil)
   }
 


### PR DESCRIPTION

#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This change is a plain refactor of our test helpers, gathering merge and DML test helpers outside of the existing test suites into traits that can be reused in separate suites.

## How was this patch tested?
N/A
