### PR TITLE
[REFACTOR] Fix double spacing indentation in Delta classes

### DIFF
--- a/spark/src/test/scala/io/delta/tables/DeltaTableSuite.scala
+++ b/spark/src/test/scala/io/delta/tables/DeltaTableSuite.scala
@@ -203,7 +203,8 @@ class DeltaTableSuite extends QueryTest
 }
 
 class DeltaTableHadoopOptionsSuite extends QueryTest
-  with SharedSparkSession  with DeltaSQLCommandTest {
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
 
   import testImplicits._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
@@ -39,7 +39,8 @@ import org.apache.spark.sql.types.StructType
 
 
 class CheckpointsSuite extends QueryTest
-  with SharedSparkSession  with DeltaSQLCommandTest {
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
 
   protected override def sparkConf = {
     // Set the gs LogStore impl to `LocalLogStore` so that it will work with `FakeGCSFileSystem`.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ConvertToDeltaSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ConvertToDeltaSQLSuite.scala
@@ -62,3 +62,4 @@ trait ConvertToDeltaSQLSuiteBase extends ConvertToDeltaSuiteBaseCommons
 
 class ConvertToDeltaSQLSuite extends ConvertToDeltaSQLSuiteBase
   with ConvertToDeltaSuiteBase
+

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ConvertToDeltaSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ConvertToDeltaSQLSuite.scala
@@ -62,4 +62,3 @@ trait ConvertToDeltaSQLSuiteBase extends ConvertToDeltaSuiteBaseCommons
 
 class ConvertToDeltaSQLSuite extends ConvertToDeltaSQLSuiteBase
   with ConvertToDeltaSuiteBase
-

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ConvertToDeltaSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ConvertToDeltaSuiteBase.scala
@@ -80,8 +80,10 @@ trait ConvertToDeltaTestUtils extends QueryTest { self: SQLTestUtils =>
 }
 
 trait ConvertToDeltaSuiteBaseCommons extends ConvertToDeltaTestUtils
-  with SharedSparkSession  with SQLTestUtils
-  with DeltaSQLCommandTest  with DeltaTestUtilsForTempViews
+  with SharedSparkSession
+  with SQLTestUtils
+  with DeltaSQLCommandTest
+  with DeltaTestUtilsForTempViews
 
 /** Tests for CONVERT TO DELTA that can be leveraged across SQL and Scala APIs. */
 trait ConvertToDeltaSuiteBase extends ConvertToDeltaSuiteBaseCommons

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeleteMetricsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeleteMetricsSuite.scala
@@ -34,7 +34,8 @@ import org.apache.spark.sql.test.SharedSparkSession
  */
 class DeleteMetricsSuite extends QueryTest
   with SharedSparkSession
-  with DatabricksLogging  with DeltaSQLCommandTest {
+  with DatabricksLogging
+  with DeltaSQLCommandTest {
 
 
   /*

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSQLSuite.scala
@@ -20,7 +20,8 @@ import org.apache.spark.sql.delta.test.{DeltaExcludedTestMixin, DeltaSQLCommandT
 
 import org.apache.spark.sql.Row
 
-class DeleteSQLSuite extends DeleteSuiteBase  with DeltaSQLCommandTest {
+class DeleteSQLSuite extends DeleteSuiteBase
+  with DeltaSQLCommandTest {
 
   import testImplicits._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeleteSuiteBase.scala
@@ -32,7 +32,8 @@ import org.apache.spark.util.Utils
 
 abstract class DeleteSuiteBase extends QueryTest
   with SharedSparkSession
-  with BeforeAndAfterEach  with DeltaTestUtilsForTempViews {
+  with BeforeAndAfterEach
+  with DeltaTestUtilsForTempViews {
 
   import testImplicits._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
@@ -38,7 +38,9 @@ import org.apache.spark.util.Utils
 
 trait DeltaAlterTableTestBase
   extends QueryTest
-  with SharedSparkSession  with DeltaColumnMappingTestUtils  with DeltaTestUtilsForTempViews {
+  with SharedSparkSession
+  with DeltaColumnMappingTestUtils
+  with DeltaTestUtilsForTempViews {
 
   protected def createTable(schema: String, tblProperties: Map[String, String]): String
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSuite.scala
@@ -41,7 +41,8 @@ import org.apache.spark.sql.types.{LongType, StringType, StructType}
 
 abstract class DeltaCDCSuiteBase
   extends QueryTest
-  with SharedSparkSession  with CheckCDCAnswer
+  with SharedSparkSession
+  with CheckCDCAnswer
   with DeltaSQLCommandTest {
 
   import testImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCheckpointWithStructColsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCheckpointWithStructColsSuite.scala
@@ -29,7 +29,8 @@ import org.apache.spark.sql.types._
 
 class DeltaCheckpointWithStructColsSuite
   extends QueryTest
-  with SharedSparkSession  with DeltaColumnMappingTestUtils
+  with SharedSparkSession
+  with DeltaColumnMappingTestUtils
   with DeltaSQLCommandTest {
 
   import testImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
@@ -95,7 +95,8 @@ trait DeltaColumnMappingSuiteUtils extends SharedSparkSession with DeltaSQLComma
 }
 
 class DeltaColumnMappingSuite extends QueryTest
-  with GivenWhenThen  with DeltaColumnMappingSuiteUtils {
+  with GivenWhenThen
+  with DeltaColumnMappingSuiteUtils {
 
   import testImplicits._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaConfigSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaConfigSuite.scala
@@ -30,7 +30,8 @@ import org.apache.spark.unsafe.types.CalendarInterval
 import org.apache.spark.util.ManualClock
 
 class DeltaConfigSuite extends SparkFunSuite
-  with SharedSparkSession  with DeltaSQLCommandTest {
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
 
   test("parseCalendarInterval") {
     for (input <- Seq("5 MINUTES", "5 minutes", "5 Minutes", "inTERval 5 minutes")) {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDDLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDDLSuite.scala
@@ -33,7 +33,8 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
 import org.apache.spark.sql.types.{IntegerType, LongType, StringType, StructType}
 
-class DeltaDDLSuite extends DeltaDDLTestBase with SharedSparkSession  with DeltaSQLCommandTest {
+class DeltaDDLSuite extends DeltaDDLTestBase with SharedSparkSession
+  with DeltaSQLCommandTest {
 
   override protected def verifyNullabilityFailure(exception: AnalysisException): Unit = {
     exception.getMessage.contains("Cannot change nullable column to non-nullable")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -59,7 +59,8 @@ import org.apache.spark.sql.types.{CalendarIntervalType, DataTypes, DateType, In
 
 trait DeltaErrorsSuiteBase
     extends QueryTest
-    with SharedSparkSession    with GivenWhenThen
+    with SharedSparkSession
+    with GivenWhenThen
     with DeltaSQLCommandTest
     with SQLTestUtils
     with QueryErrorsBase {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaGenerateSymlinkManifestSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaGenerateSymlinkManifestSuite.scala
@@ -43,7 +43,8 @@ class DeltaGenerateSymlinkManifestSuite
   with DeltaSQLCommandTest
 
 trait DeltaGenerateSymlinkManifestSuiteBase extends QueryTest
-  with SharedSparkSession  with DeletionVectorsTestUtils
+  with SharedSparkSession
+  with DeletionVectorsTestUtils
   with DeltaTestUtilsForTempViews {
 
   import testImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
@@ -46,7 +46,8 @@ import org.apache.spark.util.Utils
 
 /** A set of tests which we can open source after Spark 3.0 is released. */
 trait DeltaTimeTravelTests extends QueryTest
-    with SharedSparkSession    with GivenWhenThen
+    with SharedSparkSession
+    with GivenWhenThen
     with DeltaSQLCommandTest
     with StatsUtils {
   protected implicit def durationToLong(duration: FiniteDuration): Long = {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTableSuite.scala
@@ -874,7 +874,8 @@ abstract class DeltaInsertIntoTests(
 
 trait InsertIntoSQLOnlyTests
     extends QueryTest
-    with SharedSparkSession    with BeforeAndAfter {
+    with SharedSparkSession
+    with BeforeAndAfter {
 
   import testImplicits._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -42,7 +42,9 @@ import org.apache.spark.util.Utils
 
 // scalastyle:off: removeFile
 class DeltaLogSuite extends QueryTest
-  with SharedSparkSession  with DeltaSQLCommandTest  with SQLTestUtils {
+  with SharedSparkSession
+  with DeltaSQLCommandTest
+  with SQLTestUtils {
 
   protected val testOp = Truncate()
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
@@ -33,7 +33,8 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.Utils
 
 class DeltaOptionSuite extends QueryTest
-  with SharedSparkSession  with DeltaSQLCommandTest {
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
 
   import testImplicits._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -42,7 +42,8 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.ManualClock
 
 trait DeltaProtocolVersionSuiteBase extends QueryTest
-  with SharedSparkSession  with DeltaSQLCommandTest {
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
 
   // `.schema` generates NOT NULL columns which requires writer protocol 2. We convert all to
   // NULLable to avoid silent writer protocol version bump.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
@@ -38,7 +38,8 @@ import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 
 class DeltaSinkSuite
-  extends StreamTest  with DeltaColumnMappingTestUtils
+  extends StreamTest
+  with DeltaColumnMappingTestUtils
   with DeltaSQLCommandTest {
 
   override val streamingTimeout = 60.seconds

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -48,7 +48,9 @@ import org.apache.spark.sql.types.{StringType, StructType}
 import org.apache.spark.util.Utils
 
 class DeltaSuite extends QueryTest
-  with SharedSparkSession  with DeltaColumnMappingTestUtils  with SQLTestUtils
+  with SharedSparkSession
+  with DeltaColumnMappingTestUtils
+  with SQLTestUtils
   with DeltaSQLCommandTest {
 
   import testImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
@@ -45,7 +45,8 @@ import org.apache.spark.util.Utils
 
 trait DeltaTableCreationTests
   extends QueryTest
-  with SharedSparkSession  with DeltaColumnMappingTestUtils {
+  with SharedSparkSession
+  with DeltaColumnMappingTestUtils {
 
   import testImplicits._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
@@ -34,7 +34,8 @@ import org.apache.spark.sql.types.StructType
 
 class DeltaTableFeatureSuite
   extends QueryTest
-  with SharedSparkSession  with DeltaSQLCommandTest {
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
 
   private lazy val testTableSchema = spark.range(1).schema
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
@@ -36,7 +36,8 @@ import org.apache.spark.sql.{functions, AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
 
 class DeltaTimeTravelSuite extends QueryTest
-  with SharedSparkSession  with SQLTestUtils
+  with SharedSparkSession
+  with SQLTestUtils
   with DeltaSQLCommandTest {
 
   import testImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimestampNTZSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimestampNTZSuite.scala
@@ -29,7 +29,8 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
 
 class DeltaTimestampNTZSuite extends QueryTest
-  with SharedSparkSession  with DeltaSQLCommandTest {
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
 
   private def getProtocolForTable(table: String): Protocol = {
     val deltaLog = DeltaLog.forTable(spark, TableIdentifier(table))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaWithNewTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaWithNewTransactionSuite.scala
@@ -25,7 +25,8 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.{ThreadUtils, Utils}
 
 trait DeltaWithNewTransactionSuiteBase extends QueryTest
-  with SharedSparkSession  with DeltaColumnMappingTestUtils
+  with SharedSparkSession
+  with DeltaColumnMappingTestUtils
   with DeltaSQLCommandTest {
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaWriteConfigsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaWriteConfigsSuite.scala
@@ -45,7 +45,8 @@ import org.apache.spark.sql.types.StringType
  * At the end of the test suite, it prints out summary tables all of the cases above.
  */
 class DeltaWriteConfigsSuite extends QueryTest
-  with SharedSparkSession  with DeltaSQLCommandTest {
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
 
   val config_no_prefix = "dataSkippingNumIndexedCols"
   val config_no_prefix_value = "33"

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
@@ -32,7 +32,8 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.Utils
 
 trait DescribeDeltaDetailSuiteBase extends QueryTest
-  with SharedSparkSession  with DeltaTestUtilsForTempViews {
+  with SharedSparkSession
+  with DeltaTestUtilsForTempViews {
 
   import testImplicits._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
@@ -38,7 +38,9 @@ import org.apache.spark.util.Utils
 
 trait DescribeDeltaHistorySuiteBase
   extends QueryTest
-  with SharedSparkSession  with DeltaSQLCommandTest  with DeltaTestUtilsForTempViews
+  with SharedSparkSession
+  with DeltaSQLCommandTest
+  with DeltaTestUtilsForTempViews
   with MergeIntoMetricsBase {
 
   import testImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
@@ -44,7 +44,8 @@ import org.apache.spark.util.Utils
 
 abstract class LogStoreSuiteBase extends QueryTest
   with LogStoreProvider
-  with SharedSparkSession  with DeltaSQLCommandTest {
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
 
   def logStoreClassName: String
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
@@ -30,7 +30,8 @@ import org.apache.spark.sql.functions.udf
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{IntegerType, StructField, StructType}
 
-class MergeIntoSQLSuite extends MergeIntoSuiteBase  with MergeIntoNotMatchedBySourceSuite
+class MergeIntoSQLSuite extends MergeIntoSuiteBase
+  with MergeIntoNotMatchedBySourceSuite
   with DeltaSQLCommandTest
   with DeltaTestUtilsForTempViews {
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
@@ -29,7 +29,8 @@ import org.apache.spark.sql.catalyst.plans.logical.{Assignment, DeltaMergeIntoCl
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.StructType
 
-class MergeIntoScalaSuite extends MergeIntoSuiteBase  with MergeIntoNotMatchedBySourceSuite
+class MergeIntoScalaSuite extends MergeIntoSuiteBase
+  with MergeIntoNotMatchedBySourceSuite
   with DeltaSQLCommandTest
   with DeltaTestUtilsForTempViews {
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
@@ -47,7 +47,8 @@ import org.apache.spark.util.Utils
 abstract class MergeIntoSuiteBase
     extends QueryTest
     with SharedSparkSession
-    with BeforeAndAfterEach    with SQLTestUtils
+    with BeforeAndAfterEach
+    with SQLTestUtils
     with ScanReportHelper
     with DeltaTestUtilsForTempViews
     with MergeHelpers {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionLegacyTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionLegacyTests.scala
@@ -32,7 +32,8 @@ import org.apache.spark.sql.types.{StringType, StructField, StructType}
 // truly a subset of the tests in OptimisticTransactionSuite.
 trait OptimisticTransactionLegacyTests
   extends QueryTest
-  with SharedSparkSession  with DeltaSQLCommandTest {
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
 
   private val addA = createTestAddFile(path = "a")
   private val addB = createTestAddFile(path = "b")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuiteBase.scala
@@ -30,7 +30,8 @@ import org.apache.spark.util.Utils
 
 trait OptimisticTransactionSuiteBase
   extends QueryTest
-    with SharedSparkSession    with DeletionVectorsTestUtils {
+    with SharedSparkSession
+    with DeletionVectorsTestUtils {
 
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/RestoreTableSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/RestoreTableSuiteBase.scala
@@ -32,7 +32,8 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
 /** Base suite containing the restore tests. */
-trait RestoreTableSuiteBase extends QueryTest with SharedSparkSession  with DeltaSQLCommandTest {
+trait RestoreTableSuiteBase extends QueryTest with SharedSparkSession
+  with DeltaSQLCommandTest {
 
   import testImplicits._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateMetricsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateMetricsSuite.scala
@@ -31,7 +31,8 @@ import org.apache.spark.sql.test.SharedSparkSession
  */
 class UpdateMetricsSuite extends QueryTest
   with SharedSparkSession
-  with DatabricksLogging  with DeltaSQLCommandTest {
+  with DatabricksLogging
+  with DeltaSQLCommandTest {
 
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSQLSuite.scala
@@ -21,7 +21,8 @@ import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 import org.apache.spark.sql.{QueryTest, Row}
 
-class UpdateSQLSuite extends UpdateSuiteBase  with DeltaSQLCommandTest {
+class UpdateSQLSuite extends UpdateSuiteBase
+  with DeltaSQLCommandTest {
 
   import testImplicits._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateScalaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateScalaSuite.scala
@@ -23,7 +23,8 @@ import io.delta.tables.DeltaTableTestUtils
 
 import org.apache.spark.sql.{functions, Row}
 
-class UpdateScalaSuite extends UpdateSuiteBase  with DeltaSQLCommandTest {
+class UpdateScalaSuite extends UpdateSuiteBase
+  with DeltaSQLCommandTest {
 
   import testImplicits._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
@@ -38,7 +38,8 @@ import org.apache.spark.util.Utils
 abstract class UpdateSuiteBase
   extends QueryTest
   with SharedSparkSession
-  with BeforeAndAfterEach  with SQLTestUtils
+  with BeforeAndAfterEach
+  with SQLTestUtils
   with DeltaTestUtilsForTempViews {
   import testImplicits._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/cdc/CDCReaderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/cdc/CDCReaderSuite.scala
@@ -39,7 +39,8 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSparkSession
 
 class CDCReaderSuite
-  extends QueryTest  with CheckCDCAnswer
+  extends QueryTest
+  with CheckCDCAnswer
   with SharedSparkSession
   with DeltaSQLCommandTest
   with DeltaColumnMappingTestUtils {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/cdc/CDCWorkloadSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/cdc/CDCWorkloadSuite.scala
@@ -25,7 +25,8 @@ import org.apache.spark.sql.test.SharedSparkSession
 /**
  * Small end to end tests of workloads using CDC from Delta.
  */
-class CDCWorkloadSuite extends QueryTest with SharedSparkSession  with DeltaSQLCommandTest {
+class CDCWorkloadSuite extends QueryTest with SharedSparkSession
+  with DeltaSQLCommandTest {
 
   test("replication workload") {
     withSQLConf((DeltaConfigs.CHANGE_DATA_FEED.defaultTablePropertyKey, "true")) {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/MaterializedColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/MaterializedColumnSuite.scala
@@ -22,7 +22,8 @@ import org.apache.spark.sql.delta.rowid.RowIdTestUtils
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.execution.datasources.parquet.ParquetTest
 
-class MaterializedColumnSuite extends RowIdTestUtils  with ParquetTest {
+class MaterializedColumnSuite extends RowIdTestUtils
+  with ParquetTest {
 
   private val testTableName = "target"
   private val testDataColumnName = "test_data"

--- a/spark/src/test/scala/org/apache/spark/sql/delta/schema/CaseSensitivitySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/schema/CaseSensitivitySuite.scala
@@ -32,7 +32,8 @@ import org.apache.spark.sql.streaming.{StreamingQuery, StreamingQueryException}
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
 
 class CaseSensitivitySuite extends QueryTest
-  with SharedSparkSession  with SQLTestUtils
+  with SharedSparkSession
+  with SQLTestUtils
   with DeltaSQLCommandTest {
 
   import testImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/schema/CheckConstraintsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/schema/CheckConstraintsSuite.scala
@@ -31,7 +31,8 @@ import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
 import org.apache.spark.sql.types.{ArrayType, IntegerType, MapType, StringType, StructField, StructType}
 
 class CheckConstraintsSuite extends QueryTest
-    with SharedSparkSession    with DeltaSQLCommandTest
+    with SharedSparkSession
+    with DeltaSQLCommandTest
     with SQLTestUtils {
 
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/schema/InvariantEnforcementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/schema/InvariantEnforcementSuite.scala
@@ -39,7 +39,8 @@ import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
 import org.apache.spark.sql.types._
 
 class InvariantEnforcementSuite extends QueryTest
-    with SharedSparkSession    with DeltaSQLCommandTest
+    with SharedSparkSession
+    with DeltaSQLCommandTest
     with SQLTestUtils {
 
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaTests.scala
@@ -42,7 +42,8 @@ import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
 
 trait DataSkippingDeltaTestsBase extends QueryTest
-    with SharedSparkSession    with DeltaSQLCommandTest
+    with SharedSparkSession
+    with DeltaSQLCommandTest
     with PredicateHelper
     with GivenWhenThen
     with ScanReportHelper {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
@@ -35,7 +35,8 @@ import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 
 class StatsCollectionSuite
     extends QueryTest
-    with SharedSparkSession    with DeltaColumnMappingTestUtils
+    with SharedSparkSession
+    with DeltaColumnMappingTestUtils
     with TestsStatistics
     with DeltaSQLCommandTest
     with DeletionVectorsTestUtils {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
* Fix double space indentation in some Delta classes. This is inconsistent and makes the code less readable.
## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
* Refactor-only

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
