### PR TITLE
Resolve UpCast expressions introduced in Delta DMLs

### DIFF
--- a/spark/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
+++ b/spark/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
@@ -107,6 +107,11 @@ class DeltaSparkSessionExtension extends (SparkSessionExtensions => Unit) {
     extensions.injectPostHocResolutionRule { session =>
       new PreprocessTableDelete(session.sessionState.conf)
     }
+    // Resolve new UpCast expressions that might have been introduced by [[PreprocessTableUpdate]]
+    // and [[PreprocessTableMerge]].
+    extensions.injectPostHocResolutionRule { session =>
+      PostHocResolveUpCast(session)
+    }
     // We don't use `injectOptimizerRule` here as we won't want to apply further optimizations after
     // `PrepareDeltaScan`.
     // For example, `ConstantFolding` will break unit tests in `OptimizeGeneratedColumnSuite`.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PostHocResolveUpCast.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PostHocResolveUpCast.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
+
+/**
+ * Post-hoc resolution rules [[PreprocessTableMerge]] and [[PreprocessTableUpdate]] may introduce
+ * new unresolved UpCast expressions that won't be resolved by [[ResolveUpCast]] that ran in the
+ * previous resolution phase. This rule ensures these UpCast expressions get resolved in the
+ * Post-hoc resolution phase.
+ */
+case class PostHocResolveUpCast(spark: SparkSession)
+  extends Rule[LogicalPlan] {
+
+  override def apply(plan: LogicalPlan): LogicalPlan =
+    spark.sessionState.analyzer.ResolveUpCast.apply(plan)
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PostHocResolveUpCast.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PostHocResolveUpCast.scala
@@ -25,6 +25,10 @@ import org.apache.spark.sql.catalyst.rules.Rule
  * new unresolved UpCast expressions that won't be resolved by [[ResolveUpCast]] that ran in the
  * previous resolution phase. This rule ensures these UpCast expressions get resolved in the
  * Post-hoc resolution phase.
+ *
+ * Note: we can't inject [[ResolveUpCast]] directly because we need an initialized analyzer instance
+ * for that which is not available at the time Delta rules are injected. [[PostHocResolveUpCast]] is
+ * just a mean to delay accessing the analyzer until after it's initialized.
  */
 case class PostHocResolveUpCast(spark: SparkSession)
   extends Rule[LogicalPlan] {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
@@ -3923,7 +3923,7 @@ abstract class MergeIntoSuiteBase
   )
 
   // Valid implicit casts that are not upcasts (e.g. string -> int) are allowed with
-  // storeAssignmentPolicy = LEGACY, ANSI and rejected with storeAssignmentPolicy = STRICT.
+  // storeAssignmentPolicy = LEGACY or ANSI.
   for (storeAssignmentPolicy <- StoreAssignmentPolicy.values - StoreAssignmentPolicy.STRICT)
   testEvolution("valid implicit cast string source type into int target, " +
    s"storeAssignmentPolicy = ${storeAssignmentPolicy}")(
@@ -3937,6 +3937,8 @@ abstract class MergeIntoSuiteBase
       DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false")
   )
 
+  // Valid implicit casts that are not upcasts (e.g. string -> int) are rejected with
+  // storeAssignmentPolicy = STRICT.
   testEvolution("valid implicit cast string source type into int target, " +
    s"storeAssignmentPolicy = ${StoreAssignmentPolicy.STRICT}")(
     targetData = Seq((0, 0), (1, 1), (3, 3)).toDF("key", "value"),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
@@ -40,6 +40,7 @@ import org.apache.spark.sql.catalyst.util.FailFastMode
 import org.apache.spark.sql.execution.adaptive.DisableAdaptiveExecution
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.SQLConf.StoreAssignmentPolicy
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
@@ -3872,6 +3873,80 @@ abstract class MergeIntoSuiteBase
         .asInstanceOf[List[(Integer, Integer)]].toDF("key", "value"),
     // Disable ANSI as this test needs to cast string "notANumber" to int
     confs = Seq(SQLConf.STORE_ASSIGNMENT_POLICY.key -> "LEGACY")
+  )
+
+  // Upcasting is always allowed.
+  for (storeAssignmentPolicy <- StoreAssignmentPolicy.values)
+  testEvolution("upcast int source type into long target, storeAssignmentPolicy = " +
+    s"$storeAssignmentPolicy")(
+    targetData = Seq((0, 0L), (1, 1L), (3, 3L)).toDF("key", "value"),
+    sourceData = Seq((1, 1), (2, 2)).toDF("key", "value"),
+    clauses = update("*") :: insert("*") :: Nil,
+    expected =
+      ((0, 0L) +: (1, 1L) +: (2, 2L) +: (3, 3L) +: Nil).toDF("key", "value"),
+    expectedWithoutEvolution =
+      ((0, 0L) +: (1, 1L) +: (2, 2L) +: (3, 3L) +: Nil).toDF("key", "value"),
+    confs = Seq(
+      SQLConf.STORE_ASSIGNMENT_POLICY.key -> storeAssignmentPolicy.toString,
+      DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false")
+  )
+
+  // Casts that are not valid implicit casts (e.g. string -> boolean) are never allowed with
+  // schema evolution enabled and allowed only when storeAssignmentPolicy is LEGACY or ANSI when
+  // schema evolution is disabled.
+  for (storeAssignmentPolicy <- StoreAssignmentPolicy.values - StoreAssignmentPolicy.STRICT)
+  testEvolution("invalid implicit cast string source type into boolean target, " +
+    s"storeAssignmentPolicy = $storeAssignmentPolicy")(
+    targetData = Seq((0, true), (1, false), (3, true)).toDF("key", "value"),
+    sourceData = Seq((1, "true"), (2, "false")).toDF("key", "value"),
+    clauses = update("*") :: insert("*") :: Nil,
+    expectErrorContains = "Failed to merge incompatible data types BooleanType and StringType",
+    expectedWithoutEvolution = ((0, true) +: (1, true) +: (2, false) +: (3, true) +: Nil)
+      .toDF("key", "value"),
+    confs = Seq(
+      SQLConf.STORE_ASSIGNMENT_POLICY.key -> storeAssignmentPolicy.toString,
+      DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false")
+  )
+
+  // Casts that are not valid implicit casts (e.g. string -> boolean) are not allowed with
+  // storeAssignmentPolicy = STRICT.
+  testEvolution("invalid implicit cast string source type into boolean target, " +
+   s"storeAssignmentPolicy = ${StoreAssignmentPolicy.STRICT}")(
+    targetData = Seq((0, true), (1, false), (3, true)).toDF("key", "value"),
+    sourceData = Seq((1, "true"), (2, "false")).toDF("key", "value"),
+    clauses = update("*") :: insert("*") :: Nil,
+    expectErrorContains = "Failed to merge incompatible data types BooleanType and StringType",
+    expectErrorWithoutEvolutionContains = "cannot up cast s.value from \"string\" to \"boolean\"",
+    confs = Seq(
+      SQLConf.STORE_ASSIGNMENT_POLICY.key -> StoreAssignmentPolicy.STRICT.toString,
+      DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false")
+  )
+
+  // Valid implicit casts that are not upcasts (e.g. string -> int) are allowed with
+  // storeAssignmentPolicy = LEGACY, ANSI and rejected with storeAssignmentPolicy = STRICT.
+  for (storeAssignmentPolicy <- StoreAssignmentPolicy.values - StoreAssignmentPolicy.STRICT)
+  testEvolution("valid implicit cast string source type into int target, " +
+   s"storeAssignmentPolicy = ${storeAssignmentPolicy}")(
+    targetData = Seq((0, 0), (1, 1), (3, 3)).toDF("key", "value"),
+    sourceData = Seq((1, "1"), (2, "2")).toDF("key", "value"),
+    clauses = update("*") :: insert("*") :: Nil,
+    expected = ((0, 0)+: (1, 1) +: (2, 2) +: (3, 3)  +: Nil).toDF("key", "value"),
+    expectedWithoutEvolution = ((0, 0) +: (1, 1) +: (2, 2) +: (3, 3) +: Nil).toDF("key", "value"),
+    confs = Seq(
+      SQLConf.STORE_ASSIGNMENT_POLICY.key -> storeAssignmentPolicy.toString,
+      DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false")
+  )
+
+  testEvolution("valid implicit cast string source type into int target, " +
+   s"storeAssignmentPolicy = ${StoreAssignmentPolicy.STRICT}")(
+    targetData = Seq((0, 0), (1, 1), (3, 3)).toDF("key", "value"),
+    sourceData = Seq((1, "1"), (2, "2")).toDF("key", "value"),
+    clauses = update("*") :: insert("*") :: Nil,
+    expectErrorContains = "cannot up cast s.value from \"string\" to \"int\"",
+    expectErrorWithoutEvolutionContains = "cannot up cast s.value from \"string\" to \"int\"",
+    confs = Seq(
+      SQLConf.STORE_ASSIGNMENT_POLICY.key -> StoreAssignmentPolicy.STRICT.toString,
+      DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false")
   )
 
   // This is kinda bug-for-bug compatibility. It doesn't really make sense that infinity is casted

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSQLSuite.scala
@@ -17,9 +17,13 @@
 package org.apache.spark.sql.delta
 
 // scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
-import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.errors.QueryExecutionErrors.toSQLType
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.SQLConf.StoreAssignmentPolicy
 
 class UpdateSQLSuite extends UpdateSuiteBase  with DeltaSQLCommandTest {
 
@@ -93,6 +97,55 @@ class UpdateSQLSuite extends UpdateSuiteBase  with DeltaSQLCommandTest {
             s"Invalid _change_type for id=${row.get(0)}")
         }
       }
+    }
+  }
+
+  // The following two tests are run only against the SQL API because using the Scala API
+  // incorrectly triggers the analyzer rule [[ResolveRowLevelCommandAssignments]] which allows
+  // the casts without respecting the value of `storeAssignmentPolicy`.
+
+  // Casts that are not valid upcasts (e.g. string -> boolean) are not allowed with
+  // storeAssignmentPolicy = STRICT.
+  test("invalid implicit cast string source type into boolean target, " +
+   s"storeAssignmentPolicy = ${StoreAssignmentPolicy.STRICT}") {
+    append(Seq((99, true), (100, false), (101, true)).toDF("key", "value"))
+    withSQLConf(
+      SQLConf.STORE_ASSIGNMENT_POLICY.key -> StoreAssignmentPolicy.STRICT.toString,
+      DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false") {
+    checkError(
+      exception = intercept[AnalysisException] {
+        executeUpdate(target = s"delta.`$tempPath`", set = "value = 'false'")
+      },
+      errorClass = "CANNOT_UP_CAST_DATATYPE",
+      parameters = Map(
+        "expression" -> "'false'",
+        "sourceType" -> toSQLType("STRING"),
+        "targetType" -> toSQLType("BOOLEAN"),
+        "details" -> ("The type path of the target object is:\n\nYou can either add an explicit " +
+          "cast to the input data or choose a higher precision type of the field in the target " +
+          "object")))
+    }
+  }
+
+  // Implicit casts that are not upcasts are not allowed with storeAssignmentPolicy = STRICT.
+  test("valid implicit cast string source type into int target, " +
+     s"storeAssignmentPolicy = ${StoreAssignmentPolicy.STRICT}") {
+    append(Seq((99, 2), (100, 4), (101, 3)).toDF("key", "value"))
+    withSQLConf(
+        SQLConf.STORE_ASSIGNMENT_POLICY.key -> StoreAssignmentPolicy.STRICT.toString,
+        DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false") {
+    checkError(
+      exception = intercept[AnalysisException] {
+        executeUpdate(target = s"delta.`$tempPath`", set = "value = '5'")
+      },
+      errorClass = "CANNOT_UP_CAST_DATATYPE",
+        parameters = Map(
+        "expression" -> "'5'",
+        "sourceType" -> toSQLType("STRING"),
+        "targetType" -> toSQLType("INT"),
+        "details" -> ("The type path of the target object is:\n\nYou can either add an explicit " +
+          "cast to the input data or choose a higher precision type of the field in the target " +
+          "object")))
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
@@ -317,7 +317,7 @@ abstract class UpdateSuiteBase
       DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false") {
       checkUpdate(
         condition = None,
-        setClauses = "value = 4::int",
+        setClauses = "value = 4",
         expectedResults = Row(100, 4) :: Row(101, 4) :: Row(99, 4) :: Nil)
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.datasources.FileFormat
 import org.apache.spark.sql.functions.struct
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.SQLConf.StoreAssignmentPolicy
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
 import org.apache.spark.sql.types._
 import org.apache.spark.util.Utils
@@ -304,6 +305,52 @@ abstract class UpdateSuiteBase
         condition = Some("cast(key as long) * cast('1.0' as decimal(38, 18)) > 100"),
         setClauses = "value = -3",
         expectedResults = Row(100, 4) :: Row(101, -3) :: Row(99, 2) :: Nil)
+    }
+  }
+
+  for (storeAssignmentPolicy <- StoreAssignmentPolicy.values)
+  test("upcast int source type into long target, storeAssignmentPolicy = " +
+    s"$storeAssignmentPolicy") {
+    append(Seq((99, 2L), (100, 4L), (101, 3L)).toDF("key", "value"))
+    withSQLConf(
+      SQLConf.STORE_ASSIGNMENT_POLICY.key -> storeAssignmentPolicy.toString,
+      DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false") {
+      checkUpdate(
+        condition = None,
+        setClauses = "value = 4::int",
+        expectedResults = Row(100, 4) :: Row(101, 4) :: Row(99, 4) :: Nil)
+    }
+  }
+
+  // Casts that are not valid implicit casts (e.g. string -> boolean) are allowed only when
+  // storeAssignmentPolicy is LEGACY or ANSI.
+  for (storeAssignmentPolicy <- StoreAssignmentPolicy.values - StoreAssignmentPolicy.STRICT)
+  test("invalid implicit cast string source type into boolean target, " +
+    s"storeAssignmentPolicy = $storeAssignmentPolicy") {
+    append(Seq((99, true), (100, false), (101, true)).toDF("key", "value"))
+    withSQLConf(
+      SQLConf.STORE_ASSIGNMENT_POLICY.key -> storeAssignmentPolicy.toString,
+      DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false") {
+      checkUpdate(
+        condition = None,
+        setClauses = "value = 'false'",
+        expectedResults = Row(100, false) :: Row(101, false) :: Row(99, false) :: Nil)
+    }
+  }
+
+  // Valid implicit casts that are not upcasts (e.g. string -> int) are allowed only when
+  // storeAssignmentPolicy is LEGACY or ANSI.
+  for (storeAssignmentPolicy <- StoreAssignmentPolicy.values - StoreAssignmentPolicy.STRICT)
+  test("valid implicit cast string source type into int target, " +
+     s"storeAssignmentPolicy = ${storeAssignmentPolicy}") {
+    append(Seq((99, 2), (100, 4), (101, 3)).toDF("key", "value"))
+    withSQLConf(
+        SQLConf.STORE_ASSIGNMENT_POLICY.key -> storeAssignmentPolicy.toString,
+        DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false") {
+      checkUpdate(
+        condition = None,
+        setClauses = "value = '5'",
+        expectedResults = Row(100, 5) :: Row(101, 5) :: Row(99, 5) :: Nil)
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
@@ -323,7 +323,8 @@ abstract class UpdateSuiteBase
   }
 
   // Casts that are not valid implicit casts (e.g. string -> boolean) are allowed only when
-  // storeAssignmentPolicy is LEGACY or ANSI.
+  // storeAssignmentPolicy is LEGACY or ANSI. STRICT is tested in [[UpdateSQLSuite]] only due to
+  // limitations when using the Scala API.
   for (storeAssignmentPolicy <- StoreAssignmentPolicy.values - StoreAssignmentPolicy.STRICT)
   test("invalid implicit cast string source type into boolean target, " +
     s"storeAssignmentPolicy = $storeAssignmentPolicy") {
@@ -339,7 +340,8 @@ abstract class UpdateSuiteBase
   }
 
   // Valid implicit casts that are not upcasts (e.g. string -> int) are allowed only when
-  // storeAssignmentPolicy is LEGACY or ANSI.
+  // storeAssignmentPolicy is LEGACY or ANSI. STRICT is tested in [[UpdateSQLSuite]] only due to
+  // limitations when using the Scala API.
   for (storeAssignmentPolicy <- StoreAssignmentPolicy.values - StoreAssignmentPolicy.STRICT)
   test("valid implicit cast string source type into int target, " +
      s"storeAssignmentPolicy = ${storeAssignmentPolicy}") {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

https://github.com/delta-io/delta/pull/1938 changed the casting behavior in MERGE and UPDATE to follow the value of the `storeAssignmentPolicy` config instead of the `ansiEnabled` one, making the behavior consistent with INSERT.

This change breaks MERGE and UPDATE operations that contain a cast when `storeAssignmentPolicy` is set to `STRICT`, throwing an internal error during analysis.

The cause is the `UpCast` expression added by `PreprocessTableMerge` and `PreprocessTableUpdate`  when processing assignments. `UpCast` is meant to be replaced by a regular cast after performing checks by the `ResolveUpCast` rule that runs during the resolution phase **before** `PreprocessTableMerge` and `PreprocessTableUpdate` introduce the expression, leaving the cast unresolved.

The fix is to run the `ResolveUpCast` rule once more after `PreprocessTableMerge` and `PreprocessTableUpdate`  have run.

## How was this patch tested?
Missing tests covering cast behavior for the different values of`storeAssignmentPolicy` for UPDATE and MERGE are added, covering:
- Invalid implicit cast (string -> boolean), valid implicit cast (string -> int), upcast (int -> long)
- UPDATE, MERGE
- storeAssignmentPolicy = LEGACY, ANSI, STRICT
