### PR TITLE
Rewrite DescribeDeltaDetailCommand to v1/v2 hybrid

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -402,8 +402,9 @@ class DeltaAnalysis(session: SparkSession)
       }
 
     // Resolve as a resolved table if the path is for delta table. For non delta table, we keep the
-    // path and pass it along.
-    case u: UnresolvedPath =>
+    // path and pass it along. This is needed as DESCRIBE DETAIL command currently supports both
+    // delta and non delta path.
+    case u: UnresolvedPathBasedTable =>
       val table = getPathBasedDeltaTable(u.path)
       val tableExists = try {
         table.tableExists

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -414,14 +414,7 @@ class DeltaAnalysis(session: SparkSession)
       if (!tableExists) {
         u
       } else {
-        val catalogName: Option[String] = table.catalogTable match {
-          case Some(ct) if ct.identifier.catalog.isDefined => Some(ct.identifier.catalog.get)
-          case _ => None
-        }
-        val catalog = catalogName match {
-          case Some(c) => session.sessionState.catalogManager.catalog(c).asTableCatalog
-          case None => session.sessionState.catalogManager.currentCatalog.asTableCatalog
-        }
+        val catalog = session.sessionState.catalogManager.currentCatalog.asTableCatalog
         ResolvedTable.create(
           catalog, Identifier.of(Array(DeltaSourceUtils.ALT_NAME), u.path), table)
       }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -400,17 +400,8 @@ class DeltaAnalysis(session: SparkSession)
           throw DeltaErrors.notADeltaTableException("RESTORE")
       }
 
-    // Resolve as a resolved table if the path is for delta table. For non delta table, we keep the
-    // path and pass it along.
-    case u: UnresolvedPath =>
-      val table = getPathBasedDeltaTable(u.path)
-      if (!table.tableExists) {
-        u
-      } else {
-        val catalog = session.sessionState.catalogManager.currentCatalog.asTableCatalog
-        val identifier = Identifier.of(Array(DeltaSourceUtils.ALT_NAME), u.path)
-        ResolvedTable.create(catalog, identifier, table)
-      }
+    // We keep the unresolved path and pass it along for DescribeDeltaDetail to process later.
+    case u: UnresolvedPath => u
 
     case u: UnresolvedPathBasedDeltaTable =>
       val table = getPathBasedDeltaTable(u.path)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -400,6 +400,17 @@ class DeltaAnalysis(session: SparkSession)
           throw DeltaErrors.notADeltaTableException("RESTORE")
       }
 
+    // Resolve as a resolved table if the path is for delta table. For non delta table, we keep the
+    // path and pass it along.
+    case u: UnresolvedPath =>
+      val table = getPathBasedDeltaTable(u.path)
+      if (!table.tableExists) {
+        u
+      } else {
+        val catalog = session.sessionState.catalogManager.currentCatalog.asTableCatalog
+        ResolvedTable.create(catalog, Identifier.of(Array(DeltaSourceUtils.ALT_NAME), u.path), table)
+      }
+
     case u: UnresolvedPathBasedDeltaTable =>
       val table = getPathBasedDeltaTable(u.path)
       if (!table.tableExists) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -413,7 +413,14 @@ class DeltaAnalysis(session: SparkSession)
       if (!tableExists) {
         u
       } else {
-        val catalog = session.sessionState.catalogManager.currentCatalog.asTableCatalog
+        val catalogName: Option[String] = table.catalogTable match {
+          case Some(ct) if ct.identifier.catalog.isDefined => Some(ct.identifier.catalog.get)
+          case _ => None
+        }
+        val catalog = catalogName match {
+          case Some(c) => session.sessionState.catalogManager.catalog(c).asTableCatalog
+          case None => session.sessionState.catalogManager.currentCatalog.asTableCatalog
+        }
         ResolvedTable.create(
           catalog, Identifier.of(Array(DeltaSourceUtils.ALT_NAME), u.path), table)
       }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -408,7 +408,8 @@ class DeltaAnalysis(session: SparkSession)
         u
       } else {
         val catalog = session.sessionState.catalogManager.currentCatalog.asTableCatalog
-        ResolvedTable.create(catalog, Identifier.of(Array(DeltaSourceUtils.ALT_NAME), u.path), table)
+        val identifier = Identifier.of(Array(DeltaSourceUtils.ALT_NAME), u.path)
+        ResolvedTable.create(catalog, identifier, table)
       }
 
     case u: UnresolvedPathBasedDeltaTable =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -565,8 +565,11 @@ case class UnresolvedPathBasedDeltaTableRelation(
     path: String,
     options: CaseInsensitiveStringMap) extends UnresolvedPathBasedDeltaTableBase(path)
 
-/** Resolves to a [[ResolvedTable]] if the path is for delta table, unchanged if non delta table */
-case class UnresolvedPath(
+/**
+ * This operator represents path-based tables in general including both Delta or non-Delta tables.
+ * It resolves to a [[ResolvedTable]] if the path is for delta table, unchanged if non delta table.
+ */
+case class UnresolvedPathBasedTable(
   path: String,
   commandName: String) extends LeafNode {
   override val output: Seq[Attribute] = Nil

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -610,7 +610,7 @@ object UnresolvedPathOrIdentifier {
     cmd: String): LogicalPlan = {
     (path, tableIdentifier) match {
       case (_, Some(t)) => UnresolvedTable(t.nameParts, cmd, None)
-      case (Some(p), None) => UnresolvedPath(p, cmd)
+      case (Some(p), None) => UnresolvedPathBasedTable(p, cmd)
       case _ => throw new IllegalArgumentException(
         s"At least one of path or tableIdentifier must be provided to $cmd")
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -28,7 +28,6 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{
   NoSuchTableException,
-  UnresolvedLeafNode,
   UnresolvedTable
 }
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, SessionCatalog}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -26,10 +26,7 @@ import org.apache.hadoop.fs.{FileSystem, Path}
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.catalyst.analysis.{
-  NoSuchTableException,
-  UnresolvedTable
-}
+import org.apache.spark.sql.catalyst.analysis.{NoSuchTableException, UnresolvedTable}
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, SessionCatalog}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -26,7 +26,11 @@ import org.apache.hadoop.fs.{FileSystem, Path}
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.catalyst.analysis.{NoSuchTableException, UnresolvedTable}
+import org.apache.spark.sql.catalyst.analysis.{
+  NoSuchTableException,
+  UnresolvedLeafNode,
+  UnresolvedTable
+}
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, SessionCatalog}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
@@ -565,6 +569,13 @@ case class UnresolvedPathBasedDeltaTableRelation(
     path: String,
     options: CaseInsensitiveStringMap) extends UnresolvedPathBasedDeltaTableBase(path)
 
+/** Resolves to a [[ResolvedTable]] if the path is for delta table, unchanged if non delta table */
+case class UnresolvedPath(
+  path: String,
+  commandName: String) extends LeafNode {
+  override val output: Seq[Attribute] = Nil
+}
+
 /**
  * A helper object with an apply method to transform a path or table identifier to a LogicalPlan.
  * If the path is set, it will be resolved to an [[UnresolvedPathBasedDeltaTable]] whereas if the
@@ -582,6 +593,28 @@ object UnresolvedDeltaPathOrIdentifier {
         UnresolvedTable(t.nameParts, cmd, None)
       case _ => throw new IllegalArgumentException(
         s"Exactly one of path or tableIdentifier must be provided to $cmd")
+    }
+  }
+}
+
+/**
+ * A helper object with an apply method to transform a path or table identifier to a LogicalPlan.
+ * If the tableIdentifier is set, the LogicalPlan will be an [[UnresolvedTable]] regardless of path
+ * set or not. If the tableIdentifier is not set but the path is set, it will be resolved to an
+ * [[UnresolvedPath]] since we can not tell if a path is for delta table or non delta table at this
+ * stage. If the path is for delta table, it will be resolved during analysis as resolved table.
+ * If neither of the two are set, throws an exception.
+ */
+object UnresolvedPathOrIdentifier {
+  def apply(
+    path: Option[String],
+    tableIdentifier: Option[TableIdentifier],
+    cmd: String): LogicalPlan = {
+    (path, tableIdentifier) match {
+      case (_, Some(t)) => UnresolvedTable(t.nameParts, cmd, None)
+      case (Some(p), None) => UnresolvedPath(p, cmd)
+      case _ => throw new IllegalArgumentException(
+        s"At least one of path or tableIdentifier must be provided to $cmd")
     }
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -598,8 +598,7 @@ object UnresolvedDeltaPathOrIdentifier {
  * If the tableIdentifier is set, the LogicalPlan will be an [[UnresolvedTable]] regardless of path
  * set or not. If the tableIdentifier is not set but the path is set, it will be resolved to an
  * [[UnresolvedPath]] since we can not tell if a path is for delta table or non delta table at this
- * stage. If the path is for delta table, it will be resolved during analysis as resolved table.
- * If neither of the two are set, throws an exception.
+ * stage. If neither of the two are set, throws an exception.
  */
 object UnresolvedPathOrIdentifier {
   def apply(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -512,8 +512,6 @@ object IcebergCompatV1TableFeature extends WriterFeature(name = "icebergCompatV1
   override def requiredFeatures: Set[TableFeature] = Set(ColumnMappingTableFeature)
 }
 
-}
-// END-EDGE
 
 /**
  * Features below are for testing only, and are being registered to the system only in the testing

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -512,6 +512,8 @@ object IcebergCompatV1TableFeature extends WriterFeature(name = "icebergCompatV1
   override def requiredFeatures: Set[TableFeature] = Set(ColumnMappingTableFeature)
 }
 
+}
+// END-EDGE
 
 /**
  * Features below are for testing only, and are being registered to the system only in the testing

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeUnit.NANOSECONDS
 
 import scala.util.control.NonFatal
 
-import com.databricks.sql.PathBasedDeltaTable
 import org.apache.spark.sql.delta.{
   DeltaErrors,
   DeltaLog,
@@ -327,8 +326,7 @@ trait DeltaCommand extends DeltaLogging {
     cmd: String): (Option[TableIdentifier], Option[String]) = {
     val table = getDeltaTable(target, cmd)
     table.catalogTable match {
-      case Some(catalogTable) if !catalogTable.isInstanceOf[PathBasedDeltaTable] =>
-        (Some(catalogTable.identifier), None)
+      case Some(catalogTable) => (Some(catalogTable.identifier), None)
       case _ => (None, Some(table.path.toString))
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.delta.{
   DeltaTableIdentifier,
   DeltaTableUtils,
   OptimisticTransaction,
-  UnresolvedPath
+  UnresolvedPathBasedTable
 }
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.catalog.{DeltaTableV2, IcebergTablePlaceHolder}
@@ -341,7 +341,7 @@ trait DeltaCommand extends DeltaLogging {
    * Helper method to extract the table id or path from a LogicalPlan representing a resolved table
    * or path. This calls getDeltaTablePathOrIdentifier if the resolved table is a delta table. For
    * non delta table with identifier, we extract its identifier. For non delta table with path, it
-   * will be represented as UnresolvedPath and pass along here, we extract its path.
+   * will be represented as UnresolvedPathBasedTable and pass along here, we extract its path.
    */
   def getTablePathOrIdentifier(
     target: LogicalPlan,
@@ -351,7 +351,7 @@ trait DeltaCommand extends DeltaLogging {
       case ResolvedTable(_, _, t: V1Table, _) if DeltaTableUtils.isDeltaTable(t.catalogTable) =>
         getDeltaTablePathOrIdentifier(target, cmd)
       case ResolvedTable(_, _, t: V1Table, _) => (Some(t.catalogTable.identifier), None)
-      case u: UnresolvedPathBasedDeltaTable => (None, Some(u.path))
+      case u: UnresolvedPathBasedTable => (None, Some(u.path))
       case _ => (None, None)
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
@@ -308,15 +308,10 @@ trait DeltaCommand extends DeltaLogging {
    * table can be a non delta table.
    */
   def getTableCatalogTable(target: LogicalPlan, cmd: String): Option[CatalogTable] = {
-    try {
-      val deltaTable = getDeltaTable(target, cmd)
-      deltaTable.catalogTable
-    } catch {
-      case e: DeltaAnalysisException =>
-        target match {
-          case ResolvedTable(_, _, t: V1Table, _) => Some(t.catalogTable)
-          case _ => None
-        }
+    target match {
+      case ResolvedTable(_, _, d: DeltaTableV2, _) => d.catalogTable
+      case ResolvedTable(_, _, t: V1Table, _) => Some(t.catalogTable)
+      case _ => None
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
@@ -21,7 +21,16 @@ import java.util.concurrent.TimeUnit.NANOSECONDS
 
 import scala.util.control.NonFatal
 
-import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaOptions, DeltaTableIdentifier, DeltaTableUtils, OptimisticTransaction}
+import com.databricks.sql.PathBasedDeltaTable
+import org.apache.spark.sql.delta.{
+  DeltaErrors,
+  DeltaLog,
+  DeltaOptions,
+  DeltaTableIdentifier,
+  DeltaTableUtils,
+  OptimisticTransaction,
+  UnresolvedPath
+}
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.catalog.{DeltaTableV2, IcebergTablePlaceHolder}
 import org.apache.spark.sql.delta.files.TahoeBatchFileIndex
@@ -33,7 +42,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{Analyzer, EliminateSubqueryAliases, NoSuchTableException, ResolvedTable, UnresolvedAttribute, UnresolvedRelation}
-import org.apache.spark.sql.catalyst.catalog.CatalogTableType
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType}
 import org.apache.spark.sql.catalyst.expressions.{Expression, SubqueryExpression}
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -291,6 +300,55 @@ trait DeltaCommand extends DeltaLogging {
       case ResolvedTable(_, _, t: V1Table, _) if DeltaTableUtils.isDeltaTable(t.catalogTable) =>
         DeltaTableV2(SparkSession.active, new Path(t.v1Table.location), Some(t.v1Table))
       case _ => throw DeltaErrors.notADeltaTableException(cmd)
+    }
+  }
+
+  /**
+   * Extracts [[CatalogTable]] metadata from a LogicalPlan if the plan is a [[ResolvedTable]].
+   */
+  def getTableCatalogTable(target: LogicalPlan): Option[CatalogTable] = {
+    target match {
+      case ResolvedTable(_, _, d: DeltaTableV2, _) => d.catalogTable
+      case ResolvedTable(_, _, t: V1Table, _) => Some(t.catalogTable)
+      case _ => None
+    }
+  }
+
+  /**
+   * Helper method to extract the table id or path from a LogicalPlan representing
+   * a Delta table. This uses [[DeltaCommand.getDeltaTable]] to convert the LogicalPlan
+   * to a [[DeltaTableV2]] and then extracts either the path or identifier from it. If
+   * the [[DeltaTableV2]] has a [[CatalogTable]], the table identifier will be returned.
+   * Otherwise, the table's path will be returned. Throws an exception if the LogicalPlan
+   * does not represent a Delta table.
+   */
+  def getDeltaTablePathOrIdentifier(
+    target: LogicalPlan,
+    cmd: String): (Option[TableIdentifier], Option[String]) = {
+    val table = getDeltaTable(target, cmd)
+    table.catalogTable match {
+      case Some(catalogTable) if !catalogTable.isInstanceOf[PathBasedDeltaTable] =>
+        (Some(catalogTable.identifier), None)
+      case _ => (None, Some(table.path.toString))
+    }
+  }
+
+  /**
+   * Helper method to extract the table id or path from a LogicalPlan representing a resolved table
+   * or path. This calls getDeltaTablePathOrIdentifier if the resolved table is a delta table. For
+   * non delta table with identifier, we extract its identifier. For non delta table with path, it
+   * will be represented as UnresolvedPath and pass along here, we extract its path.
+   */
+  def getTablePathOrIdentifier(
+    target: LogicalPlan,
+    cmd: String): (Option[TableIdentifier], Option[String]) = {
+    target match {
+      case ResolvedTable(_, _, t: DeltaTableV2, _) => getDeltaTablePathOrIdentifier(target, cmd)
+      case ResolvedTable(_, _, t: V1Table, _) if DeltaTableUtils.isDeltaTable(t.catalogTable) =>
+        getDeltaTablePathOrIdentifier(target, cmd)
+      case ResolvedTable(_, _, t: V1Table, _) => (Some(t.catalogTable.identifier), None)
+      case u: UnresolvedPath => (None, Some(u.path))
+      case _ => (None, None)
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit.NANOSECONDS
 import scala.util.control.NonFatal
 
 import org.apache.spark.sql.delta.{
+  DeltaAnalysisException,
   DeltaErrors,
   DeltaLog,
   DeltaOptions,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DescribeDeltaDetailsCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DescribeDeltaDetailsCommand.scala
@@ -86,7 +86,7 @@ case class DescribeDeltaDetailCommand(
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val tableMetadata = getTableCatalogTable(child, DescribeDeltaDetailCommand.CMD_NAME)
-    val path = getTablePathOrIdentifier(child, DescribeDeltaDetailCommand.CMD_NAME)._2
+    val (_, path) = getTablePathOrIdentifier(child, DescribeDeltaDetailCommand.CMD_NAME)
     val basePath = tableMetadata match {
       case Some(metadata) => new Path(metadata.location)
       case _ if path.isDefined => new Path(path.get)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DescribeDeltaDetailsCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DescribeDeltaDetailsCommand.scala
@@ -25,8 +25,7 @@ import org.apache.spark.sql.delta.{
   DeltaLog,
   DeltaTableIdentifier,
   Snapshot,
-  UnresolvedPathOrIdentifier,
-  UnresolvedPathBasedDeltaTable
+  UnresolvedPathOrIdentifier
 }
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.util.FileNames
@@ -86,7 +85,7 @@ case class DescribeDeltaDetailCommand(
     copy(child = newChild)
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    val tableMetadata = getTableCatalogTable(child)
+    val tableMetadata = getTableCatalogTable(child, DescribeDeltaDetailCommand.CMD_NAME)
     val path = getTablePathOrIdentifier(child, DescribeDeltaDetailCommand.CMD_NAME)._2
     val basePath = tableMetadata match {
       case Some(metadata) => new Path(metadata.location)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DescribeDeltaDetailsCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DescribeDeltaDetailsCommand.scala
@@ -38,7 +38,8 @@ import org.apache.spark.sql.catalyst.analysis.{NoSuchDatabaseException, NoSuchTa
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType, CatalogUtils}
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.execution.command.UnaryRunnableCommand
+import org.apache.spark.sql.catalyst.trees.UnaryLike
+import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.types.StructType
 
 /** The result returned by the `describe detail` command. */
@@ -77,7 +78,7 @@ object TableDetail {
 case class DescribeDeltaDetailCommand(
     override val child: LogicalPlan,
     hadoopConf: Map[String, String])
-  extends UnaryRunnableCommand with DeltaLogging with DeltaCommand {
+  extends RunnableCommand with UnaryLike[LogicalPlan] with DeltaLogging with DeltaCommand {
 
   override val output: Seq[Attribute] = TableDetail.schema.toAttributes
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
@@ -199,7 +199,7 @@ trait DescribeDeltaDetailSuiteBase extends QueryTest
         sql(s"DESCRIBE DETAIL $viewName")
       }
       assert(e.getMessage.contains(
-        s"`$viewName` is a view. DESCRIBE DETAIL is only supported for tables."))
+        s"$viewName is a temp view. 'DESCRIBE DETAIL' expects a table."))
     }
   }
 
@@ -209,7 +209,7 @@ trait DescribeDeltaDetailSuiteBase extends QueryTest
       sql(s"CREATE VIEW $view AS SELECT 1")
       val e = intercept[AnalysisException] { sql(s"DESCRIBE DETAIL $view") }
       assert(e.getMessage.contains(
-        "`detailTestView` is a view. DESCRIBE DETAIL is only supported for tables."))
+        "detailtestview is a view. 'DESCRIBE DETAIL' expects a table."))
     }
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR updates the Delta Lake DESCRIBE DETAIL command to work with V1 and V2 tables.

It rewrites the Delta DESCRIBE DETAIL command to use Spark's table resolution logic instead of resolving the target table manually at command execution time. For that, it changes `DescribeDeltaDetailCommand` from a `LeafRunnableCommand` to a `UnaryLike` command that takes an `UnresolvedTable` as a child plan node, which will be resolved by Spark. In addition, it also uses an `UnresolvedPath` LogicalPlan for the case that DESCRIBE DETAIL is run against a raw path. This logical plan is an indication that the target table is specified as a path so no table resolution is necessary.


<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
This PR is covered by the entire body of existing DESCRIBE DETAIL test coverage.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

N/A

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
