### PR TITLE
[Spark] Use DeltaTable.forTableWithSnapshot more often in tests

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableSuiteBase.scala
@@ -547,7 +547,7 @@ trait CloneTableSuiteBase extends QueryTest
       spark.range(5).write.format("delta").mode("append").saveAsTable(tableName)
       spark.range(5).write.format("delta").mode("append").saveAsTable(tableName)
       spark.range(5).write.format("delta").mode("append").saveAsTable(tableName)
-      assert(DeltaLog.forTable(spark, TableIdentifier(tableName)).snapshot.version === 3)
+      assert(DeltaLog.forTableWithSnapshot(spark, TableIdentifier(tableName))._2.version === 3)
 
       runAndValidateClone(
         tableName,
@@ -613,8 +613,8 @@ trait CloneTableSuiteBase extends QueryTest
           isCreate = isCreate,
           isReplaceOperation = true)()
 
-        val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tbl))
-        val allFiles = deltaLog.snapshot.allFiles.collect()
+        val allFiles =
+          DeltaLog.forTableWithSnapshot(spark, TableIdentifier(tbl))._2.allFiles.collect()
         allFiles.foreach { file =>
           assert(!file.pathAsUri.isAbsolute, "File paths should not be absolute")
         }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ConvertToDeltaSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ConvertToDeltaSuiteBase.scala
@@ -215,11 +215,12 @@ trait ConvertToDeltaSuiteBase extends ConvertToDeltaSuiteBaseCommons
 
           convertToDelta(tableName)
 
-          val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName, Some("default")))
+          val tableId = TableIdentifier(tableName, Some("default"))
+          val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, tableId)
           val expectedSchema = StructType(
             StructField("id", IntegerType, true) :: StructField("part", StringType, true) :: Nil)
           // Schema is inferred from the data
-          assert(deltaLog.update().schema.equals(expectedSchema))
+          assert(snapshot.schema.equals(expectedSchema))
         }
       }
     }
@@ -1092,7 +1093,8 @@ trait ConvertToDeltaHiveTableTests extends ConvertToDeltaTestUtils with SQLTestU
 
             convertToDelta(tableName)
 
-            val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName, Some("default")))
+          val tableId = TableIdentifier(tableName, Some("default"))
+          val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, tableId)
             val catalog_columns = Seq[StructField](
               StructField("key1", LongType, true),
               StructField("key2", StringType, true)
@@ -1100,11 +1102,10 @@ trait ConvertToDeltaHiveTableTests extends ConvertToDeltaTestUtils with SQLTestU
 
             if (useCatalogSchema) {
               // Catalog schema is used, column id is excluded.
-              assert(deltaLog.snapshot.metadata.schema
-                .equals(StructType(catalog_columns)))
+              assert(snapshot.metadata.schema.equals(StructType(catalog_columns)))
             } else {
               // Schema is inferred from the data, all 3 columns are included.
-              assert(deltaLog.snapshot.metadata.schema
+              assert(snapshot.metadata.schema
                 .equals(StructType(StructField("id", LongType, true) +: catalog_columns)))
             }
           }
@@ -1258,12 +1259,12 @@ trait ConvertToDeltaHiveTableTests extends ConvertToDeltaTestUtils with SQLTestU
         TableIdentifier(tableName, Some("default"))).provider.contains("delta"))
 
       // Check the partition schema in the transaction log
-      assert(DeltaLog.forTable(spark, TableIdentifier(tableName, Some("default")))
-        .snapshot.metadata.partitionSchema.equals(
-            (new StructType())
-              .add(StructField("key1", LongType, true))
-              .add(StructField("key2", StringType, true))
-          ))
+      val tableId = TableIdentifier(tableName, Some("default"))
+      assert(DeltaLog.forTableWithSnapshot(spark, tableId)._2.metadata.partitionSchema.equals(
+        (new StructType())
+          .add(StructField("key1", LongType, true))
+          .add(StructField("key2", StringType, true))
+      ))
 
       // Check data in the converted delta table.
       checkAnswer(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeleteMetricsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeleteMetricsSuite.scala
@@ -122,7 +122,7 @@ class DeleteMetricsSuite extends QueryTest
           assert(!resultDf.isEmpty)
           numAffectedRows = resultDf.take(1).head(0).toString.toLong
 
-        val (deltaLog, snapshot) = DeltaLog.forTable(spark, TableIdentifier(tableName))
+        val (deltaLog, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(tableName))
         val changes = deltaLog.getChanges(snapshot.version).flatMap(_._2).toSeq
 
         // To get the expected Added and Removed Bytes we need to filter out files

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeleteMetricsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeleteMetricsSuite.scala
@@ -122,8 +122,8 @@ class DeleteMetricsSuite extends QueryTest
           assert(!resultDf.isEmpty)
           numAffectedRows = resultDf.take(1).head(0).toString.toLong
 
-        val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
-        val changes = deltaLog.getChanges(deltaLog.update().version).flatMap(_._2).toSeq
+        val (deltaLog, snapshot) = DeltaLog.forTable(spark, TableIdentifier(tableName))
+        val changes = deltaLog.getChanges(snapshot.version).flatMap(_._2).toSeq
 
         // To get the expected Added and Removed Bytes we need to filter out files
         // that have a dv associated with their path. Since we won't be physically deleting/adding

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
@@ -1452,8 +1452,8 @@ trait DeltaAlterTableByNameTests extends DeltaAlterTableTests {
 
         sql("ALTER TABLE delta_test ADD COLUMNS (v3 long, v4 double)")
 
-        val deltaLog = DeltaLog.forTable(spark, path)
-        assertEqual(deltaLog.snapshot.schema, new StructType()
+        val (deltaLog, snapshot) = DeltaLog.forTableWithSnapshot(spark, path)
+        assertEqual(snapshot.schema, new StructType()
           .add("v1", "integer").add("v2", "string")
           .add("v3", "long").add("v4", "double"))
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DomainMetadataSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DomainMetadataSuite.scala
@@ -142,10 +142,8 @@ class DomainMetadataSuite
 
         // force state reconstruction and validate it respects the DomainMetadata retention.
         DeltaLog.clearCache()
-        deltaLog = DeltaLog.forTable(spark, TableIdentifier(table))
-        assertEquals(
-          sortByDomain(domainMetadatasAfterDeletion),
-          deltaLog.update().domainMetadata)
+        val snapshot = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(table))._2
+        assertEquals(sortByDomain(domainMetadatasAfterDeletion), snapshot.domainMetadata)
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
@@ -873,10 +873,10 @@ trait GeneratedColumnSuiteBase extends GeneratedColumnTest {
    * write correct table metadata into the transaction logs.
    */
   protected def verifyDefaultTestTableMetadata(table: String): Unit = {
-    val deltaLog = if (table.startsWith("delta.")) {
-      DeltaLog.forTable(spark, table.stripPrefix("delta.`").stripSuffix("`"))
+    val (deltaLog, snapshot) = if (table.startsWith("delta.")) {
+      DeltaLog.forTableWithSnapshot(spark, table.stripPrefix("delta.`").stripSuffix("`"))
     } else {
-      DeltaLog.forTable(spark, TableIdentifier(table))
+      DeltaLog.forTableWithSnapshot(spark, TableIdentifier(table))
     }
     val schema = StructType.fromDDL(defaultTestTableSchema)
     val expectedSchema = StructType(schema.map { field =>
@@ -885,7 +885,7 @@ trait GeneratedColumnSuiteBase extends GeneratedColumnTest {
       }.getOrElse(field)
     })
     val partitionColumns = defaultTestTablePartitionColumns
-    val metadata = deltaLog.snapshot.metadata
+    val metadata = snapshot.metadata
     assert(metadata.schema == expectedSchema)
     assert(metadata.partitionColumns == partitionColumns)
   }
@@ -1124,8 +1124,8 @@ trait GeneratedColumnSuiteBase extends GeneratedColumnTest {
       val f2 = StructField("c2", IntegerType, nullable = true, metadata = fieldMetadata)
       val f3 = StructField("c3", IntegerType, nullable = false, metadata = fieldMetadata)
       val expectedSchema = StructType(f1 :: f2 :: f3 :: Nil)
-      val deltaLog = DeltaLog.forTable(spark, TableIdentifier(table))
-      assert(deltaLog.snapshot.metadata.schema == expectedSchema)
+      val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(table))
+      assert(snapshot.metadata.schema == expectedSchema)
       // Verify column comment
       val comments = sql(s"DESC $table")
         .where("col_name = 'c2'")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeGeneratedColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeGeneratedColumnSuite.scala
@@ -90,7 +90,7 @@ class OptimizeGeneratedColumnSuite extends GeneratedColumnTest {
           generatedColumns.keys.toSeq
         )
 
-        val metadata = DeltaLog.forTable(spark, TableIdentifier(table)).snapshot.metadata
+        val metadata = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(table))._2.metadata
         assert(metadata.optimizablePartitionExpressions(expressionKey.getOrElse(
           normalCol).toLowerCase(Locale.ROOT)) == expectedPartitionExpr :: Nil)
         filterTestCases.foreach { filterTestCase =>
@@ -117,7 +117,7 @@ class OptimizeGeneratedColumnSuite extends GeneratedColumnTest {
             updatedGeneratedColumns.keys.toSeq
           )
 
-          val metadata = DeltaLog.forTable(spark, TableIdentifier(table)).snapshot.metadata
+          val metadata = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(table))._2.metadata
           val nestedColPath =
             s"nested.${expressionKey.getOrElse(normalCol).toLowerCase(Locale.ROOT)}"
           assert(metadata.optimizablePartitionExpressions(nestedColPath)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/DefaultRowCommitVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/DefaultRowCommitVersionSuite.scala
@@ -126,8 +126,8 @@ class DefaultRowCommitVersionSuite extends QueryTest
           spark.sql(s"CREATE TABLE target SHALLOW CLONE delta.`${sourceDir.getAbsolutePath}` " +
               s"TBLPROPERTIES ('${DeltaConfigs.ROW_TRACKING_ENABLED.key}' = 'true')")
 
-          val targetLog = DeltaLog.forTable(spark, TableIdentifier("target"))
-          targetLog.update().allFiles.collect().foreach { f =>
+          val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier("target"))
+          snapshot.allFiles.collect().foreach { f =>
             assert(f.defaultRowCommitVersion.contains(0L))
           }
         }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/MaterializedColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/MaterializedColumnSuite.scala
@@ -37,13 +37,13 @@ class MaterializedColumnSuite extends RowIdTestUtils
   }
 
   private def getMaterializedRowIdColumnName(tableName: String): Option[String] = {
-    val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
-    deltaLog.update().metadata.configuration.get(MaterializedRowId.MATERIALIZED_COLUMN_NAME_PROP)
+    val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(tableName))
+    snapshot.metadata.configuration.get(MaterializedRowId.MATERIALIZED_COLUMN_NAME_PROP)
   }
 
   private def getMaterializedRowCommitVersionColumnName(tableName: String): Option[String] = {
-    val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
-    deltaLog.update().metadata.configuration.get(
+    val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(tableName))
+    snapshot.metadata.configuration.get(
       MaterializedRowCommitVersion.MATERIALIZED_COLUMN_NAME_PROP)
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Many unit tests do not currently take advantage of `DeltaLog.forTableWithSnapshot` and can be simplified.

## How was this patch tested?

Test-only change.

## Does this PR introduce _any_ user-facing changes?

No.