### PR TITLE
[WIP] Fix a bug where the _metadata column was not available in streaming data frames

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/QueryMetadataSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/QueryMetadataSuite.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.QueryTest

--- a/spark/src/test/scala/org/apache/spark/sql/delta/QueryMetadataSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/QueryMetadataSuite.scala
@@ -1,0 +1,34 @@
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+class QueryMetadataSuite extends QueryTest
+  with SharedSparkSession
+  with DeltaDMLTestUtils
+  with DeltaSQLCommandTest {
+
+  import testImplicits._
+
+  test("batch _metadata query") {
+    withTable("source") {
+      append(Seq((1, 10), (2, 20)).toDF("key1", "value1"), Nil) // test table
+
+      val metadata = spark.read.format("delta").load(tempPath).select("_metadata").collect()
+
+      // TODO verify the metadata response
+    }
+  }
+
+  test("streaming _metadata query") {
+    withTable("source") {
+      append(Seq((1, 10), (2, 20)).toDF("key1", "value1"), Nil) // test table
+
+      // TODO breaks
+      val metadata = spark.readStream.format("delta").load(tempPath).select("_metadata").collect()
+
+      // TODO verify the metadata response
+    }
+  }
+}


### PR DESCRIPTION
**NOTE: This is WIP and currently simply reproduces the bug**

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Resolves #2014

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
