### PR TITLE
[Spark] Remove String+Clock overload of DeltaLog.forTable

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -580,7 +580,8 @@ object DeltaLog extends DeltaLogging {
   private[delta] def logPathFor(dataPath: String): Path = logPathFor(new Path(dataPath))
   private[delta] def logPathFor(dataPath: Path): Path =
     DeltaTableUtils.safeConcatPaths(dataPath, LOG_DIR_NAME)
-  private[delta] def logPathFor(dataPath: File): Path = logPathFor(dataPath.getAbsolutePath)
+  private[delta] def logPathFor(dataPath: File): Path =
+    logPathFor(new Path(dataPath.getCanonicalPath))
 
   /**
    * We create only a single [[DeltaLog]] for any given `DeltaLogCacheKey` to avoid wasted work
@@ -659,11 +660,6 @@ object DeltaLog extends DeltaLogging {
   }
 
   /** Helper for creating a log when it stored at the root of the data. */
-  def forTable(spark: SparkSession, dataPath: String, clock: Clock): DeltaLog = {
-    apply(spark, logPathFor(dataPath), clock)
-  }
-
-  /** Helper for creating a log when it stored at the root of the data. */
   def forTable(spark: SparkSession, dataPath: File, clock: Clock): DeltaLog = {
     apply(spark, logPathFor(dataPath), clock)
   }
@@ -705,7 +701,7 @@ object DeltaLog extends DeltaLogging {
   /** Helper for creating a log for the table. */
   def forTable(spark: SparkSession, deltaTable: DeltaTableIdentifier, clock: Clock): DeltaLog = {
     if (deltaTable.path.isDefined) {
-      forTable(spark, deltaTable.path.get, clock)
+      forTable(spark, new Path(deltaTable.path.get), clock)
     } else {
       forTable(spark, deltaTable.table.get, clock)
     }
@@ -717,7 +713,7 @@ object DeltaLog extends DeltaLogging {
 
   /** Helper for getting a log, as well as the latest snapshot, of the table */
   def forTableWithSnapshot(spark: SparkSession, dataPath: String): (DeltaLog, Snapshot) =
-    withFreshSnapshot { forTable(spark, dataPath, _) }
+    withFreshSnapshot { forTable(spark, new Path(dataPath), _) }
 
   /** Helper for getting a log, as well as the latest snapshot, of the table */
   def forTableWithSnapshot(spark: SparkSession, dataPath: Path): (DeltaLog, Snapshot) =

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaConfigSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaConfigSuite.scala
@@ -84,7 +84,7 @@ class DeltaConfigSuite extends SparkFunSuite
     withTempDir { dir =>
       sql(s"CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta")
 
-      val retentionTimestampOpt = DeltaLog.forTable(spark, dir.getCanonicalPath, clock)
+      val retentionTimestampOpt = DeltaLog.forTable(spark, dir, clock)
         .snapshot.minSetTransactionRetentionTimestamp
 
       assert(retentionTimestampOpt.isEmpty)
@@ -99,7 +99,7 @@ class DeltaConfigSuite extends SparkFunSuite
 
       DeltaLog.clearCache() // we want to ensure we can use the ManualClock we pass in
 
-      val log = DeltaLog.forTable(spark, dir.getCanonicalPath, clock)
+      val log = DeltaLog.forTable(spark, dir, clock)
       val retentionTimestampOpt = log.snapshot.minSetTransactionRetentionTimestamp
       assert(log.clock.getTimeMillis() == clock.getTimeMillis())
       val expectedRetentionTimestamp =

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
@@ -530,7 +530,7 @@ class DeltaVacuumSuite
 
   test("don't delete data in a non-reservoir") {
     withEnvironment { (tempDir, clock) =>
-      val deltaLog = DeltaLog.forTable(spark, tempDir.getAbsolutePath, clock)
+      val deltaLog = DeltaLog.forTable(spark, tempDir, clock)
       gcTest(deltaLog, clock)(
         CreateFile("file1.txt", commitToActionLog = false),
         CreateDirectory("abc"),
@@ -542,7 +542,7 @@ class DeltaVacuumSuite
 
   test("invisible files and dirs") {
     withEnvironment { (tempDir, clock) =>
-      val deltaLog = DeltaLog.forTable(spark, tempDir.getAbsolutePath, clock)
+      val deltaLog = DeltaLog.forTable(spark, tempDir, clock)
       gcTest(deltaLog, clock)(
         CreateFile("file1.txt", commitToActionLog = true),
         CreateFile("_hidden_dir/000001.text", commitToActionLog = false),
@@ -580,7 +580,7 @@ class DeltaVacuumSuite
 
   test("multiple levels of empty directory deletion") {
     withEnvironment { (tempDir, clock) =>
-      val deltaLog = DeltaLog.forTable(spark, tempDir.getAbsolutePath, clock)
+      val deltaLog = DeltaLog.forTable(spark, tempDir, clock)
       gcTest(deltaLog, clock)(
         CreateFile("file1.txt", commitToActionLog = true),
         CreateFile("abc/def/file2.txt", commitToActionLog = false),
@@ -599,7 +599,7 @@ class DeltaVacuumSuite
 
   test("gc doesn't delete base path") {
     withEnvironment { (tempDir, clock) =>
-      val deltaLog = DeltaLog.forTable(spark, tempDir.getAbsolutePath, clock)
+      val deltaLog = DeltaLog.forTable(spark, tempDir, clock)
       gcTest(deltaLog, clock)(
         CreateFile("file1.txt", commitToActionLog = true),
         AdvanceClock(100),
@@ -679,7 +679,7 @@ class DeltaVacuumSuite
 
   test("parallel file delete") {
     withEnvironment { (tempDir, clock) =>
-      val deltaLog = DeltaLog.forTable(spark, tempDir.getAbsolutePath, clock)
+      val deltaLog = DeltaLog.forTable(spark, tempDir, clock)
       withSQLConf("spark.databricks.delta.vacuum.parallelDelete.enabled" -> "true") {
         gcTest(deltaLog, clock)(
           CreateFile("file1.txt", commitToActionLog = true),
@@ -699,7 +699,7 @@ class DeltaVacuumSuite
 
   test("retention duration must be greater than 0") {
     withEnvironment { (tempDir, clock) =>
-      val deltaLog = DeltaLog.forTable(spark, tempDir.getAbsolutePath, clock)
+      val deltaLog = DeltaLog.forTable(spark, tempDir, clock)
       gcTest(deltaLog, clock)(
         CreateFile("file1.txt", commitToActionLog = true),
         CheckFiles(Seq("file1.txt")),
@@ -722,7 +722,7 @@ class DeltaVacuumSuite
 
   test("deleting directories") {
     withEnvironment { (tempDir, clock) =>
-      val deltaLog = DeltaLog.forTable(spark, tempDir.getAbsolutePath, clock)
+      val deltaLog = DeltaLog.forTable(spark, tempDir, clock)
       gcTest(deltaLog, clock)(
         CreateFile("abc/def/file1.txt", commitToActionLog = true),
         CreateFile("abc/def/file2.txt", commitToActionLog = true),
@@ -738,7 +738,7 @@ class DeltaVacuumSuite
 
   test("deleting files with special characters in path") {
     withEnvironment { (tempDir, clock) =>
-      val deltaLog = DeltaLog.forTable(spark, tempDir.getAbsolutePath, clock)
+      val deltaLog = DeltaLog.forTable(spark, tempDir, clock)
       gcTest(deltaLog, clock)(
         CreateFile("abc def/#1/file1.txt", commitToActionLog = true),
         CreateFile("abc def/#1/file2.txt", commitToActionLog = false),
@@ -754,7 +754,7 @@ class DeltaVacuumSuite
 
   testQuietly("additional retention duration check with vacuum command") {
     withEnvironment { (tempDir, clock) =>
-      val deltaLog = DeltaLog.forTable(spark, tempDir.getAbsolutePath, clock)
+      val deltaLog = DeltaLog.forTable(spark, tempDir, clock)
       withSQLConf("spark.databricks.delta.retentionDurationCheck.enabled" -> "true") {
         gcTest(deltaLog, clock)(
           CreateFile("file1.txt", commitToActionLog = true),
@@ -1037,7 +1037,7 @@ class DeltaVacuumSuite
 
         withEnvironment { (dir, clock) =>
           spark.range(2).write.format("delta").save(dir.getAbsolutePath)
-          val deltaLog = DeltaLog.forTable(spark, dir.getAbsolutePath, clock)
+          val deltaLog = DeltaLog.forTable(spark, dir, clock)
           val expectedReturn = if (isDryRun) {
             // dry run returns files that will be deleted
             Seq(new Path(dir.getAbsolutePath, "file1.txt").toString)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

The `DeltaLog.forTable` overloads that accept a `Clock` only exist for testing purposes, and have no place in prod code. Furthermore, even the unit tests that do use these overloads are better-served by calling more specific overloads instead of passing a string.

## How was this patch tested?

Test-only change.

## Does this PR introduce _any_ user-facing changes?

No
