### PR TITLE
[Spark] Exclude all temp view tests for Scala API DML suites

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
@@ -692,8 +692,9 @@ abstract class MergeIntoSuiteBase
           update = "key2 = 20 + key1, value = 20 + src.value",
           insert = "(key2, value) VALUES (key1 - 10, src.value + 10)")
       }.getMessage
-      // The MERGE Scala API is for Delta only and reports error differently.
       assert(e.contains("does not support MERGE") ||
+        // The MERGE Scala API is for Delta only and reports error differently.
+        e.contains("is not a Delta table") ||
         e.contains("MERGE destination only supports Delta sources"))
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoTestUtils.scala
@@ -175,12 +175,9 @@ trait MergeIntoScalaTestUtils extends MergeIntoTestUtils {
         }
       }
 
-    val deltaTable = {
-      val (tableNameOrPath, optionalAlias) = DeltaTestUtils.parseTableAndAlias(tgt)
-      var table = makeDeltaTable(tableNameOrPath)
-      optionalAlias.foreach { alias => table = table.as(alias) }
-      table
-    }
+    val deltaTable = DeltaTestUtils.getDeltaTableForIdentifierOrPath(
+      spark,
+      DeltaTestUtils.getTableIdentifierOrPath(tgt))
 
     val sourceDataFrame: DataFrame = {
       val (tableOrQuery, optionalAlias) = DeltaTestUtils.parseTableAndAlias(src)
@@ -196,16 +193,6 @@ trait MergeIntoScalaTestUtils extends MergeIntoTestUtils {
     }
     mergeBuilder.execute()
     deltaTable.toDF
-  }
-
-  protected def makeDeltaTable(nameOrPath: String): DeltaTable = {
-    val isPath: Boolean = nameOrPath.startsWith("delta.")
-    if (isPath) {
-      val path = nameOrPath.stripPrefix("delta.`").stripSuffix("`")
-      io.delta.tables.DeltaTable.forPath(spark, path)
-    } else {
-      DeltaTableTestUtils.createTable(spark.table(nameOrPath), DeltaLog.forTable(spark, nameOrPath))
-    }
   }
 
   protected def parseUpdate(update: Seq[String]): Map[String, String] = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Instead of trying to work around the issue that `DeltaTable.forName` cannot resolve temporary views, exclude these tests from the {Delete,Update,Merge}ScalaSuites, since there is no public API to use this anyway.

## How was this patch tested?

Test-only PR.

## Does this PR introduce _any_ user-facing changes?

No
