### PR TITLE
[Spark] Clean up OptimisticTransaction constructor code

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -88,8 +88,6 @@ class DeltaLog private(
   import org.apache.spark.sql.delta.util.FileNames._
 
 
-  private lazy implicit val _clock = clock
-
   protected def spark = SparkSession.active
 
   checkRequiredConfigurations()
@@ -197,7 +195,7 @@ class DeltaLog private(
   def startTransaction(): OptimisticTransaction = startTransaction(None)
 
   def startTransaction(snapshotOpt: Option[Snapshot]): OptimisticTransaction = {
-    new OptimisticTransaction(this, snapshotOpt)
+    new OptimisticTransaction(this, snapshotOpt.getOrElse(update()))
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -136,21 +136,11 @@ private[delta] case class DeltaTableReadPredicate(
  * @param deltaLog The Delta Log for the table this transaction is modifying.
  * @param snapshot The snapshot that this transaction is reading at.
  */
-class OptimisticTransaction
-    (override val deltaLog: DeltaLog, override val snapshot: Snapshot)
-    (implicit override val clock: Clock)
+class OptimisticTransaction(
+    override val deltaLog: DeltaLog,
+    override val snapshot: Snapshot)
   extends OptimisticTransactionImpl
   with DeltaLogging {
-
-  /** Creates a new OptimisticTransaction.
-   *
-   * @param deltaLog The Delta Log for the table this transaction is modifying.
-   * @param snapshotOpt The most recent snapshot of the table, if available.
-   */
-  // TODO: The deltaLog object already has a clock; an implicit clock shouldn't be needed
-  def this(deltaLog: DeltaLog, snapshotOpt: Option[Snapshot] = None)(implicit clock: Clock) {
-    this(deltaLog, snapshotOpt.getOrElse(deltaLog.update()))
-  }
 }
 
 object OptimisticTransaction {
@@ -217,7 +207,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
 
   val deltaLog: DeltaLog
   val snapshot: Snapshot
-  implicit val clock: Clock
+  def clock: Clock = deltaLog.clock
 
   protected def spark = SparkSession.active
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Get rid of an unnecessary alternate constructor, eliminate the implicit `clock` arg by referencing `DeltaLog.clock` instead, and update unit tests accordingly.

## How was this patch tested?

Unit tests cover this code

## Does this PR introduce _any_ user-facing changes?

No
