### PR TITLE
[Spark] Support external DSV2 catalog in RESTORE command

### DIFF
--- a/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
+++ b/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
@@ -402,7 +402,7 @@ class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
   }
 
   override def visitRestore(ctx: RestoreContext): LogicalPlan = withOrigin(ctx) {
-    val tableRelation = UnresolvedRelation(visitTableIdentifier(ctx.table))
+    val tableRelation = UnresolvedIdentifier(ctx.table.identifier.asScala.toSeq.map(_.getText))
     val timeTravelTableRelation = maybeTimeTravelChild(ctx.clause, tableRelation)
     RestoreTableStatement(timeTravelTableRelation.asInstanceOf[TimeTravel])
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -103,7 +103,8 @@ object DeltaTableUtils extends PredicateHelper
   }
 
   /**
-   * Check whether the provided table identifier is a Delta table based on information from the Catalog.
+   * Check whether the provided table identifier is a Delta table based on information
+   * from the Catalog.
    */
   def isDeltaTable(tableCatalog: TableCatalog, identifier: Identifier): Boolean = {
     val tableExists = tableCatalog.tableExists(identifier)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTimeTravel.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTimeTravel.scala
@@ -74,7 +74,12 @@ case class PreprocessTimeTravel(sparkSession: SparkSession) extends Rule[Logical
     val (catalog, identifier) =
       resolveCatalogAndIdentifier(sparkSession.sessionState.catalogManager,
         unresolvedIdentifier.nameParts)
-    val tableId = identifier.asTableIdentifier
+    // If the identifier is not a multipart identifier, we assume it is a table or view name.
+    val tableId = if (unresolvedIdentifier.nameParts.length == 1) {
+      TableIdentifier(unresolvedIdentifier.nameParts.head)
+    } else {
+      identifier.asTableIdentifier
+    }
     assert(catalog.isInstanceOf[TableCatalog], s"Catalog ${catalog.name()} must implement " +
       s"TableCatalog to support loading Delta table.")
     val tableCatalog = catalog.asInstanceOf[TableCatalog]

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DescribeDeltaDetailsCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DescribeDeltaDetailsCommand.scala
@@ -19,16 +19,17 @@ package org.apache.spark.sql.delta.commands
 // scalastyle:off import.ordering.noEmptyLine
 import java.io.FileNotFoundException
 import java.sql.Timestamp
+
 import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaTableIdentifier, Snapshot}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.util.FileNames
 import org.apache.hadoop.fs.Path
+
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, ScalaReflection, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.{NoSuchDatabaseException, NoSuchTableException}
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType, CatalogUtils}
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
 import org.apache.spark.sql.types.StructType
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DescribeDeltaDetailsCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DescribeDeltaDetailsCommand.scala
@@ -19,17 +19,16 @@ package org.apache.spark.sql.delta.commands
 // scalastyle:off import.ordering.noEmptyLine
 import java.io.FileNotFoundException
 import java.sql.Timestamp
-
 import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaTableIdentifier, Snapshot}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.util.FileNames
 import org.apache.hadoop.fs.Path
-
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, ScalaReflection, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.{NoSuchDatabaseException, NoSuchTableException}
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType, CatalogUtils}
 import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
 import org.apache.spark.sql.types.StructType
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CustomCatalogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CustomCatalogSuite.scala
@@ -49,7 +49,8 @@ class CustomCatalogSuite extends QueryTest with SharedSparkSession
     val tableName = "table1"
     withTable(tableName) {
       sql("SET CATALOG dummy")
-      val dummyCatalog = spark.sessionState.catalogManager.catalog("dummy").asInstanceOf[DummyCatalog]
+      val dummyCatalog =
+        spark.sessionState.catalogManager.catalog("dummy").asInstanceOf[DummyCatalog]
       val tablePath = dummyCatalog.getTablePath(tableName)
       sql(f"CREATE TABLE $tableName (id bigint) USING delta")
       sql(f"INSERT INTO delta.`$tablePath` VALUES (0)")
@@ -73,7 +74,10 @@ class CustomCatalogSuite extends QueryTest with SharedSparkSession
 class DummyCatalog extends TableCatalog {
   private val spark: SparkSession = SparkSession.active
   private val tempDir: Path = new Path(Utils.createTempDir().getAbsolutePath)
-  private val fs: FileSystem = tempDir.getFileSystem(spark.sessionState.newHadoopConf())
+  // scalastyle:off deltahadoopconfiguration
+  private val fs: FileSystem =
+    tempDir.getFileSystem(spark.sessionState.newHadoopConf())
+  // scalastyle:on deltahadoopconfiguration
 
   override def name: String = "dummy"
 
@@ -134,5 +138,3 @@ class DummyCatalog extends TableCatalog {
     }
   }
 }
-
-

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CustomCatalogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CustomCatalogSuite.scala
@@ -53,6 +53,8 @@ class CustomCatalogSuite extends QueryTest with SharedSparkSession
         spark.sessionState.catalogManager.catalog("dummy").asInstanceOf[DummyCatalog]
       val tablePath = dummyCatalog.getTablePath(tableName)
       sql(f"CREATE TABLE $tableName (id bigint) USING delta")
+      // Insert some data into the table in the dummy catalog.
+      // To make it simple, here we insert data directly into the table path.
       sql(f"INSERT INTO delta.`$tablePath` VALUES (0)")
       sql(f"INSERT INTO delta.`$tablePath` VALUES (1)")
       sql(f"RESTORE TABLE $tableName VERSION AS OF 0")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CustomCatalogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CustomCatalogSuite.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.delta
+
+import java.util
+import org.apache.spark.sql.connector.catalog._
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import io.delta.tables.DeltaTable
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+import java.nio.file.{Files, Paths}
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.{QueryTest, SparkSession}
+import org.apache.spark.sql.connector.catalog.{Identifier, Table, TableCatalog, TableChange}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.delta.catalog.{DeltaCatalog, DeltaTableV2}
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.util.Utils
+import org.apache.spark.SparkConf
+
+import java.io.{File, IOException}
+
+
+class CustomCatalogSuite extends QueryTest with SharedSparkSession
+  with DeltaSQLCommandTest {
+
+  override def sparkConf: SparkConf =
+    super.sparkConf.set("spark.sql.catalog.dummy", classOf[DummyCatalog].getName)
+
+  test("RESTORE a table from DummyCatalog") {
+    val tableName = "table1"
+    withTable(tableName) {
+      sql("SET CATALOG dummy")
+      val dummyCatalog = spark.sessionState.catalogManager.catalog("dummy").asInstanceOf[DummyCatalog]
+      val tablePath = dummyCatalog.getTablePath(tableName)
+      sql(f"CREATE TABLE $tableName (id bigint) USING delta")
+      sql(f"INSERT INTO delta.`$tablePath` VALUES (0)")
+      sql(f"INSERT INTO delta.`$tablePath` VALUES (1)")
+      sql(f"RESTORE TABLE $tableName VERSION AS OF 0")
+      checkAnswer(spark.table(tableName), Nil)
+      sql(f"RESTORE TABLE $tableName VERSION AS OF 1")
+      checkAnswer(spark.table(tableName), spark.range(1).toDF())
+      // Test 3-part identifier
+      sql(f"RESTORE TABLE dummy.default.$tableName VERSION AS OF 2")
+      checkAnswer(spark.table(tableName), spark.range(2).toDF())
+
+      sql("SET CATALOG spark_catalog")
+      // Test 3-part identifier when the current catalog is the default catalog
+      sql(f"RESTORE TABLE dummy.default.$tableName VERSION AS OF 1")
+      checkAnswer(spark.table(f"dummy.default.$tableName"), spark.range(1).toDF())
+    }
+  }
+}
+
+class DummyCatalog extends TableCatalog {
+  private val spark: SparkSession = SparkSession.active
+  private val tempDir: Path = new Path(Utils.createTempDir().getAbsolutePath)
+  private val fs: FileSystem = tempDir.getFileSystem(spark.sessionState.newHadoopConf())
+
+  override def name: String = "dummy"
+
+  def getTablePath(tableName: String): Path = {
+    new Path(tempDir, tableName)
+  }
+  override def defaultNamespace(): Array[String] = Array("default")
+
+  override def listTables(namespace: Array[String]): Array[Identifier] = {
+    val status = fs.listStatus(tempDir)
+    status.filter(_.isDirectory).map { dir =>
+      Identifier.of(namespace, dir.getPath.getName)
+    }
+  }
+
+  override def tableExists(ident: Identifier): Boolean = {
+    val tablePath = getTablePath(ident.name())
+    fs.exists(tablePath)
+  }
+  override def loadTable(ident: Identifier): Table = {
+    val tablePath = getTablePath(ident.name())
+    DeltaTableV2(spark, tablePath)
+  }
+
+  override def createTable(
+    ident: Identifier,
+    schema: StructType,
+    partitions: Array[Transform],
+    properties: java.util.Map[String, String]): Table = {
+    val tablePath = getTablePath(ident.name())
+    // Create an empty Delta table on the tablePath
+    spark.range(0).write.format("delta").save(tablePath.toString)
+    DeltaTableV2(spark, tablePath)
+  }
+
+  override def alterTable(ident: Identifier, changes: TableChange*): Table = {
+    throw new UnsupportedOperationException("Alter table operation is not supported.")
+  }
+
+  override def dropTable(ident: Identifier): Boolean = {
+    val tablePath = getTablePath(ident.name())
+    try {
+      fs.delete(tablePath, true)
+      true
+    } catch {
+      case _: Exception => false
+    }
+  }
+
+  override def renameTable(oldIdent: Identifier, newIdent: Identifier): Unit = {
+    throw new UnsupportedOperationException("Rename table operation is not supported.")
+  }
+
+  override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
+    // Initialize tempDir here
+    if (!fs.exists(tempDir)) {
+      fs.mkdirs(tempDir)
+    }
+  }
+}
+
+


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
Support external DSV2 catalog in RESTORE command. After the changes, the restore command supports tables from external DSV2 catalog.
For example, with
```
spark.sql.catalog.customer_catalog=org.apache.spark.sql.CustomerCatalog
```
We can query
```
SET CATALOG customer_catalog;
RESTORE TABLE t1 VERSION AS OF 0
```
Or simply
```
RESTORE TABLE customer_catalog.default.t1 VERSION AS OF 0
```
-->

## How was this patch tested?

1. A new end-to-end test
2. A parser test case

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, users can use RESTORE command on the tables of their external DSV2 catalogs.
