### PR TITLE
[Spark] Support external DSV2 catalog in RESTORE & Vacuum command

### DIFF
--- a/spark/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
+++ b/spark/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
@@ -79,6 +79,9 @@ class DeltaSparkSessionExtension extends (SparkSessionExtensions => Unit) {
       new DeltaSqlParser(parser)
     }
     extensions.injectResolutionRule { session =>
+      ResolveDeltaIdentifier(session)
+    }
+    extensions.injectResolutionRule { session =>
       new PreprocessTimeTravel(session)
     }
     extensions.injectResolutionRule { session =>

--- a/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
+++ b/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
@@ -402,7 +402,7 @@ class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
   }
 
   override def visitRestore(ctx: RestoreContext): LogicalPlan = withOrigin(ctx) {
-    val tableRelation = UnresolvedRelation(visitTableIdentifier(ctx.table))
+    val tableRelation = UnresolvedIdentifier(ctx.table.identifier.asScala.toSeq.map(_.getText))
     val timeTravelTableRelation = maybeTimeTravelChild(ctx.clause, tableRelation)
     RestoreTableStatement(timeTravelTableRelation.asInstanceOf[TimeTravel])
   }

--- a/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
+++ b/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
@@ -311,7 +311,7 @@ class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
       VacuumTableCommand(new Path(string(ctx.path)), horizonHours, dryRun)
     } else if (ctx.table != null) {
       VacuumTableStatement(
-        UnresolvedIdentifier(ctx.table.identifier.asScala.toSeq.map(_.getText)),
+        UnresolvedDeltaIdentifier(ctx.table.identifier.asScala.toSeq.map(_.getText)),
         horizonHours,
         dryRun)
     } else {
@@ -407,7 +407,8 @@ class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
   }
 
   override def visitRestore(ctx: RestoreContext): LogicalPlan = withOrigin(ctx) {
-    val tableRelation = UnresolvedIdentifier(ctx.table.identifier.asScala.toSeq.map(_.getText))
+    val tableRelation =
+      UnresolvedDeltaIdentifier(ctx.table.identifier.asScala.toSeq.map(_.getText))
     val timeTravelTableRelation = maybeTimeTravelChild(ctx.clause, tableRelation)
     RestoreTableStatement(timeTravelTableRelation.asInstanceOf[TimeTravel])
   }

--- a/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
+++ b/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
@@ -311,7 +311,7 @@ class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
       VacuumTableCommand(new Path(string(ctx.path)), horizonHours, dryRun)
     } else if (ctx.table != null) {
       VacuumTableStatement(
-        UnresolvedDeltaIdentifier(ctx.table.identifier.asScala.toSeq.map(_.getText)),
+        UnresolvedDeltaIdentifier(ctx.table.identifier.asScala.toSeq.map(_.getText), "VACUUM"),
         horizonHours,
         dryRun)
     } else {
@@ -408,7 +408,7 @@ class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
 
   override def visitRestore(ctx: RestoreContext): LogicalPlan = withOrigin(ctx) {
     val tableRelation =
-      UnresolvedDeltaIdentifier(ctx.table.identifier.asScala.toSeq.map(_.getText))
+      UnresolvedDeltaIdentifier(ctx.table.identifier.asScala.toSeq.map(_.getText), "RESTORE")
     val timeTravelTableRelation = maybeTimeTravelChild(ctx.clause, tableRelation)
     RestoreTableStatement(timeTravelTableRelation.asInstanceOf[TimeTravel])
   }

--- a/spark/src/main/scala/io/delta/tables/execution/VacuumTableCommand.scala
+++ b/spark/src/main/scala/io/delta/tables/execution/VacuumTableCommand.scala
@@ -32,8 +32,8 @@ import org.apache.spark.sql.types.StringType
  * }}}
  */
 case class VacuumTableCommand(
-    path: Option[String],
-    table: Option[TableIdentifier],
+    pathToVacuum: Path,
+    // table: Option[TableIdentifier],
     horizonHours: Option[Double],
     dryRun: Boolean) extends LeafRunnableCommand {
 
@@ -41,6 +41,7 @@ case class VacuumTableCommand(
     Seq(AttributeReference("path", StringType, nullable = true)())
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
+    /*
     val pathToVacuum =
       if (path.nonEmpty) {
         new Path(path.get)
@@ -54,6 +55,7 @@ case class VacuumTableCommand(
       } else {
         throw DeltaErrors.missingTableIdentifierException("VACUUM")
       }
+     */
     val baseDeltaPath = DeltaTableUtils.findDeltaTableRoot(sparkSession, pathToVacuum)
     if (baseDeltaPath.isDefined) {
       if (baseDeltaPath.get != pathToVacuum) {

--- a/spark/src/main/scala/io/delta/tables/execution/VacuumTableCommand.scala
+++ b/spark/src/main/scala/io/delta/tables/execution/VacuumTableCommand.scala
@@ -33,7 +33,6 @@ import org.apache.spark.sql.types.StringType
  */
 case class VacuumTableCommand(
     pathToVacuum: Path,
-    // table: Option[TableIdentifier],
     horizonHours: Option[Double],
     dryRun: Boolean) extends LeafRunnableCommand {
 
@@ -41,21 +40,6 @@ case class VacuumTableCommand(
     Seq(AttributeReference("path", StringType, nullable = true)())
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    /*
-    val pathToVacuum =
-      if (path.nonEmpty) {
-        new Path(path.get)
-      } else if (table.nonEmpty) {
-        DeltaTableIdentifier(sparkSession, table.get) match {
-          case Some(id) if id.path.nonEmpty =>
-            new Path(id.path.get)
-          case _ =>
-            new Path(sparkSession.sessionState.catalog.getTableMetadata(table.get).location)
-        }
-      } else {
-        throw DeltaErrors.missingTableIdentifierException("VACUUM")
-      }
-     */
     val baseDeltaPath = DeltaTableUtils.findDeltaTableRoot(sparkSession, pathToVacuum)
     if (baseDeltaPath.isDefined) {
       if (baseDeltaPath.get != pathToVacuum) {

--- a/spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/VacuumTableStatement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/VacuumTableStatement.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.plans.logical
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+/**
+ * VACUUM TABLE statement as parsed from SQL
+ *
+ * @param table - logical node of the table that will be vacuumed
+ */
+case class VacuumTableStatement(
+    table: LogicalPlan,
+    horizonHours: Option[Double],
+    dryRun: Boolean) extends UnaryNode {
+  override def output: Seq[Attribute] = Seq.empty
+
+  override def child: LogicalPlan = table
+
+  override protected def withNewChildInternal(newChild: LogicalPlan): LogicalPlan =
+    copy(table = newChild)
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.delta
 
 import io.delta.tables.execution.VacuumTableCommand
-import org.apache.spark.sql.delta.DeltaTableUtils.resolveDeltaIdentifier
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -405,9 +404,6 @@ class DeltaAnalysis(session: SparkSession)
 
     case v @ VacuumTableStatement(DataSourceV2Relation(d: DeltaTableV2, _, _, _, _), _, _) =>
       VacuumTableCommand(d.path, v.horizonHours, v.dryRun)
-
-    case u: UnresolvedDeltaIdentifier =>
-      resolveDeltaIdentifier(session, u).getOrElse(u.tableNotFound(u.nameParts))
 
     case u: UnresolvedPathBasedDeltaTable =>
       val table = getPathBasedDeltaTable(u.path)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -400,6 +400,15 @@ class DeltaAnalysis(session: SparkSession)
           throw DeltaErrors.notADeltaTableException("RESTORE")
       }
 
+    case v @ VacuumTableStatement(r: ResolvedIdentifier, _, _) =>
+      val pathToVacuum =
+          DeltaTableIdentifier(sparkSession, table.get) match {
+            case Some(id) if id.path.nonEmpty =>
+              new Path(id.path.get)
+            case _ =>
+              new Path(sparkSession.sessionState.catalog.getTableMetadata(table.get).location)
+        }
+
     case u: UnresolvedPathBasedDeltaTable =>
       val table = getPathBasedDeltaTable(u.path)
       if (!table.tableExists) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -407,7 +407,7 @@ class DeltaAnalysis(session: SparkSession)
       VacuumTableCommand(d.path, v.horizonHours, v.dryRun)
 
     case u: UnresolvedDeltaIdentifier =>
-      resolveDeltaIdentifier(session, u).getOrElse(u)
+      resolveDeltaIdentifier(session, u).getOrElse(u.tableNotFound(u.nameParts))
 
     case u: UnresolvedPathBasedDeltaTable =>
       val table = getPathBasedDeltaTable(u.path)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.catalyst.planning.NodeWithOnlyDeterministicProjectAndFilter
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LeafNode, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.util.CharVarcharCodegenUtils
+import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.{IdentifierHelper, MultipartIdentifierHelper}
 import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.connector.expressions.{FieldReference, IdentityTransform}
 import org.apache.spark.sql.execution.datasources.{FileFormat, FileIndex, HadoopFsRelation, LogicalRelation}
@@ -565,10 +566,16 @@ case class UnresolvedPathBasedDeltaTableRelation(
     path: String,
     options: CaseInsensitiveStringMap) extends UnresolvedPathBasedDeltaTableBase(path)
 
-case class UnresolvedDeltaIdentifier(nameParts: Seq[String]) extends LeafNode {
+case class UnresolvedDeltaIdentifier(
+    nameParts: Seq[String],
+    commandName: String) extends LeafNode {
   override def output: Seq[Attribute] = Nil
 
   override lazy val resolved: Boolean = false
+
+  def asTableIdentifier: TableIdentifier = nameParts.asTableIdentifier
+
+  def asIdentifier: Identifier = nameParts.asIdentifier
 }
 
 /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -30,9 +30,8 @@ import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.catalyst.planning.NodeWithOnlyDeterministicProjectAndFilter
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LeafNode, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.util.CharVarcharCodegenUtils
-import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
+import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.connector.expressions.{FieldReference, IdentityTransform}
-import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.execution.datasources.{FileFormat, FileIndex, HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.internal.SQLConf
@@ -100,15 +99,6 @@ object DeltaTableUtils extends PredicateHelper
         catalog.tableExists(tableName)
     }
     tableIsNotTemporaryTable && tableExists && isDeltaTable(catalog.getTableMetadata(tableName))
-  }
-
-  /**
-   * Check whether the provided table identifier is a Delta table based on information
-   * from the Catalog.
-   */
-  def isDeltaTable(tableCatalog: TableCatalog, identifier: Identifier): Boolean = {
-    val tableExists = tableCatalog.tableExists(identifier)
-    tableExists && tableCatalog.loadTable(identifier).isInstanceOf[DeltaTableV2]
   }
 
   /** Check if the provided path is the root or the children of a Delta table. */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -17,11 +17,10 @@
 package org.apache.spark.sql.delta
 
 // scalastyle:off import.ordering.noEmptyLine
-import scala.util.{Failure, Success, Try}
+import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.sql.delta.files.{TahoeFileIndex, TahoeLogFileIndex}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.{DeltaSourceUtils, DeltaSQLConf}
-import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{NoSuchTableException, UnresolvedTable}
@@ -31,15 +30,16 @@ import org.apache.spark.sql.catalyst.expressions.objects.StaticInvoke
 import org.apache.spark.sql.catalyst.planning.NodeWithOnlyDeterministicProjectAndFilter
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LeafNode, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.util.CharVarcharCodegenUtils
-import org.apache.spark.sql.connector.catalog.{CatalogManager, CatalogNotFoundException, CatalogPlugin, Identifier, TableCatalog}
-import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.IdentifierHelper
+import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
 import org.apache.spark.sql.connector.expressions.{FieldReference, IdentityTransform}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.execution.datasources.{FileFormat, FileIndex, HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
-import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+import scala.util.{Failure, Success, Try}
 
 /**
  * Extractor Object for pulling out the table scan of a Delta table. It could be a full scan
@@ -84,8 +84,6 @@ object DeltaTableUtils extends PredicateHelper
 
   // The valid hadoop prefixes passed through `DeltaTable.forPath` or DataFrame APIs.
   val validDeltaTableHadoopPrefixes: List[String] = List("fs.", "dfs.")
-
-  private val globalTempDB = SQLConf.get.getConf(StaticSQLConf.GLOBAL_TEMP_DATABASE)
 
   /** Check whether this table is a Delta table based on information from the Catalog. */
   def isDeltaTable(table: CatalogTable): Boolean = DeltaSourceUtils.isDeltaTable(table.provider)
@@ -143,60 +141,6 @@ object DeltaTableUtils extends PredicateHelper
       false
     } else {
       throw new NoSuchTableException(tableIdent.database.getOrElse(""), tableIdent.table)
-    }
-  }
-
-  def resolveDeltaIdentifier(
-      sparkSession: SparkSession,
-      unresolvedIdentifier: UnresolvedDeltaIdentifier): Option[DataSourceV2Relation] = {
-    val (catalog, identifier) =
-      resolveCatalogAndIdentifier(sparkSession.sessionState.catalogManager,
-        unresolvedIdentifier.nameParts)
-    // If the identifier is not a multipart identifier, we assume it is a table or view name.
-    val tableId = if (unresolvedIdentifier.nameParts.length == 1) {
-      TableIdentifier(unresolvedIdentifier.nameParts.head)
-    } else {
-      identifier.asTableIdentifier
-    }
-    assert(catalog.isInstanceOf[TableCatalog], s"Catalog ${catalog.name()} must implement " +
-      s"TableCatalog to support loading Delta table.")
-    val tableCatalog = catalog.asInstanceOf[TableCatalog]
-    val deltaTableV2 = if (DeltaTableUtils.isDeltaTable(tableCatalog, identifier)) {
-      Some(tableCatalog.loadTable(identifier).asInstanceOf[DeltaTableV2])
-    } else if (DeltaTableUtils.isValidPath(tableId)) {
-      Some(DeltaTableV2(sparkSession, new Path(tableId.table)))
-    } else {
-      None
-    }
-    deltaTableV2.map(d => DataSourceV2Relation.create(d, None, Some(identifier)))
-  }
-
-  // Resolve the input name parts to a CatalogPlugin and Identifier.
-  // The code is from Apache Spark on org.apache.spark.sql.connector.catalog.CatalogAndIdentifier.
-  // We need to use this because the original one is private.
-  def resolveCatalogAndIdentifier(
-      catalogManager: CatalogManager,
-      nameParts: Seq[String]): (CatalogPlugin, Identifier) = {
-    import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.MultipartIdentifierHelper
-    assert(nameParts.nonEmpty)
-    if (nameParts.length == 1) {
-      (catalogManager.currentCatalog,
-        Identifier.of(catalogManager.currentNamespace, nameParts.head))
-    } else if (nameParts.head.equalsIgnoreCase(globalTempDB)) {
-      // Conceptually global temp views are in a special reserved catalog. However, the v2 catalog
-      // API does not support view yet, and we have to use v1 commands to deal with global temp
-      // views. To simplify the implementation, we put global temp views in a special namespace
-      // in the session catalog. The special namespace has higher priority during name resolution.
-      // For example, if the name of a custom catalog is the same with `GLOBAL_TEMP_DATABASE`,
-      // this custom catalog can't be accessed.
-      (catalogManager.v2SessionCatalog, nameParts.asIdentifier)
-    } else {
-      try {
-        (catalogManager.catalog(nameParts.head), nameParts.tail.asIdentifier)
-      } catch {
-        case _: CatalogNotFoundException =>
-          (catalogManager.currentCatalog, nameParts.asIdentifier)
-      }
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -103,7 +103,8 @@ object DeltaTableUtils extends PredicateHelper
   }
 
   /**
-   * Check whether the provided table identifier is a Delta table based on information from the Catalog.
+   * Check whether the provided table identifier is a Delta table based on information
+   * from the Catalog.
    */
   def isDeltaTable(tableCatalog: TableCatalog, identifier: Identifier): Boolean = {
     val tableExists = tableCatalog.tableExists(identifier)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTimeTravel.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTimeTravel.scala
@@ -74,7 +74,12 @@ case class PreprocessTimeTravel(sparkSession: SparkSession) extends Rule[Logical
     val (catalog, identifier) =
       resolveCatalogAndIdentifier(sparkSession.sessionState.catalogManager,
         unresolvedIdentifier.nameParts)
-    val tableId = identifier.asTableIdentifier
+    // If the identifier is not a multipart identifier, we assume it is a table or view name.
+    val tableId = if (unresolvedIdentifier.nameParts.length == 1) {
+      TableIdentifier(unresolvedIdentifier.nameParts.head)
+    } else {
+      identifier.asTableIdentifier
+    }
     assert(catalog.isInstanceOf[TableCatalog], s"Catalog ${catalog.name()} must implement " +
       s"TableCatalog to support loading Delta table.")
     val tableCatalog = catalog.asInstanceOf[TableCatalog]

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ResolveDeltaIdentifier.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ResolveDeltaIdentifier.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.delta
+
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan, RestoreTableStatement}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.{TableIdentifier, TimeTravel}
+import org.apache.spark.sql.catalyst.analysis.AnalysisErrorAt
+import org.apache.spark.sql.catalyst.catalog.{CatalogTableType, SessionCatalog}
+import org.apache.spark.sql.connector.catalog.{CatalogManager, CatalogNotFoundException, CatalogPlugin, Identifier, TableCatalog}
+import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.{IdentifierHelper, MultipartIdentifierHelper}
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
+
+case class ResolveDeltaIdentifier(sparkSession: SparkSession) extends Rule[LogicalPlan] {
+  private val globalTempDB =
+    sparkSession.sessionState.conf.getConf(StaticSQLConf.GLOBAL_TEMP_DATABASE)
+  override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperators {
+    case u: UnresolvedDeltaIdentifier =>
+      resolveDeltaIdentifier(sparkSession, u).getOrElse(u.tableNotFound(u.nameParts))
+
+    // Since the Delta's TimeTravel is a leaf node, we have to resolve the UnresolvedIdentifier.
+    case tt @ TimeTravel(udi: UnresolvedDeltaIdentifier, _, _, _) =>
+      val sourceRelation = resolveIdentifierInTimeTravel(sparkSession, udi)
+      tt.copy(relation = sourceRelation)
+  }
+
+  private def resolveDeltaIdentifier(
+    sparkSession: SparkSession,
+    unresolvedIdentifier: UnresolvedDeltaIdentifier): Option[DataSourceV2Relation] = {
+    val (catalog, identifier) =
+      resolveCatalogAndIdentifier(sparkSession.sessionState.catalogManager,
+        unresolvedIdentifier.nameParts)
+    // If the identifier is not a multipart identifier, we assume it is a table or view name.
+    val tableId = if (unresolvedIdentifier.nameParts.length == 1) {
+      TableIdentifier(unresolvedIdentifier.nameParts.head)
+    } else {
+      identifier.asTableIdentifier
+    }
+    assert(catalog.isInstanceOf[TableCatalog], s"Catalog ${catalog.name()} must implement " +
+      s"TableCatalog to support loading Delta table.")
+    val tableCatalog = catalog.asInstanceOf[TableCatalog]
+    val deltaTableV2 = if (DeltaTableUtils.isDeltaTable(tableCatalog, identifier)) {
+      Some(tableCatalog.loadTable(identifier).asInstanceOf[DeltaTableV2])
+    } else if (DeltaTableUtils.isValidPath(tableId)) {
+      Some(DeltaTableV2(sparkSession, new Path(tableId.table)))
+    } else {
+      None
+    }
+    deltaTableV2.map(d => DataSourceV2Relation.create(d, None, Some(identifier)))
+  }
+
+  // Resolve the input name parts to a CatalogPlugin and Identifier.
+  // The code is from Apache Spark on org.apache.spark.sql.connector.catalog.CatalogAndIdentifier.
+  // We need to use this because the original one is private.
+  private def resolveCatalogAndIdentifier(
+    catalogManager: CatalogManager,
+    nameParts: Seq[String]): (CatalogPlugin, Identifier) = {
+    import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.MultipartIdentifierHelper
+    assert(nameParts.nonEmpty)
+    if (nameParts.length == 1) {
+      (catalogManager.currentCatalog,
+        Identifier.of(catalogManager.currentNamespace, nameParts.head))
+    } else if (nameParts.head.equalsIgnoreCase(globalTempDB)) {
+      // Conceptually global temp views are in a special reserved catalog. However, the v2 catalog
+      // API does not support view yet, and we have to use v1 commands to deal with global temp
+      // views. To simplify the implementation, we put global temp views in a special namespace
+      // in the session catalog. The special namespace has higher priority during name resolution.
+      // For example, if the name of a custom catalog is the same with `GLOBAL_TEMP_DATABASE`,
+      // this custom catalog can't be accessed.
+      (catalogManager.v2SessionCatalog, nameParts.asIdentifier)
+    } else {
+      try {
+        (catalogManager.catalog(nameParts.head), nameParts.tail.asIdentifier)
+      } catch {
+        case _: CatalogNotFoundException =>
+          (catalogManager.currentCatalog, nameParts.asIdentifier)
+      }
+    }
+  }
+
+  private def resolveIdentifierInTimeTravel(
+    sparkSession: SparkSession,
+    unresolvedIdentifier: UnresolvedDeltaIdentifier): DataSourceV2Relation = {
+    val relation = resolveDeltaIdentifier(sparkSession, unresolvedIdentifier)
+    if (relation.isDefined) {
+      relation.get
+    } else {
+      val tableId = if (unresolvedIdentifier.nameParts.length == 1) {
+        TableIdentifier(unresolvedIdentifier.nameParts.head)
+      } else {
+        unresolvedIdentifier.nameParts.asTableIdentifier
+      }
+      ResolveDeltaIdentifier.handleTableNotFoundInTimeTravel(
+        sparkSession.sessionState.catalog, unresolvedIdentifier, tableId)
+    }
+  }
+}
+
+object ResolveDeltaIdentifier {
+  def handleTableNotFoundInTimeTravel(
+      catalog: SessionCatalog,
+      inputPlan: LeafNode,
+      tableIdentifier: TableIdentifier): Nothing = {
+    if (
+      (catalog.tableExists(tableIdentifier) &&
+        catalog.getTableMetadata(tableIdentifier).tableType == CatalogTableType.VIEW) ||
+        catalog.isTempView(tableIdentifier)) {
+      // If table exists and not found to be a view, throw not supported error
+      throw DeltaErrors.notADeltaTableException("RESTORE")
+    } else {
+      inputPlan.tableNotFound(tableIdentifier.nameParts)
+    }
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ResolveDeltaIdentifier.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ResolveDeltaIdentifier.scala
@@ -60,9 +60,8 @@ case class ResolveDeltaIdentifier(sparkSession: SparkSession) extends Rule[Logic
   private def resolveAsTable(unresolvedId: UnresolvedDeltaIdentifier): Option[DeltaTableV2] = {
     val unresolvedTable =
       UnresolvedTable(unresolvedId.nameParts, unresolvedId.commandName, None)
-    val analyzer = sparkSession.sessionState.analyzer
     try {
-      analyzer.ResolveRelations(unresolvedTable) match {
+      sparkSession.sessionState.analyzer.ResolveRelations(unresolvedTable) match {
         case r: ResolvedTable =>
           r.table match {
             case deltaTableV2: DeltaTableV2 => Some(deltaTableV2)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ResolveDeltaIdentifier.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ResolveDeltaIdentifier.scala
@@ -17,136 +17,47 @@ package org.apache.spark.sql.delta
 
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.plans.logical.{LeafNode, LogicalPlan, RestoreTableStatement}
+import org.apache.spark.sql.catalyst.TimeTravel
+import org.apache.spark.sql.catalyst.analysis.{AnalysisErrorAt, ResolvedTable, UnresolvedTable}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.catalyst.{TableIdentifier, TimeTravel}
-import org.apache.spark.sql.catalyst.analysis.AnalysisErrorAt
-import org.apache.spark.sql.catalyst.catalog.{CatalogTableType, SessionCatalog}
-import org.apache.spark.sql.connector.catalog.{CatalogManager, CatalogNotFoundException, CatalogPlugin, Identifier, TableCatalog}
-import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.{IdentifierHelper, MultipartIdentifierHelper}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
-import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 
 case class ResolveDeltaIdentifier(sparkSession: SparkSession) extends Rule[LogicalPlan] {
-  private val globalTempDB =
-    sparkSession.sessionState.conf.getConf(StaticSQLConf.GLOBAL_TEMP_DATABASE)
+
   override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperators {
     case u: UnresolvedDeltaIdentifier =>
-      resolveDeltaIdentifier(sparkSession, u).getOrElse(u.tableNotFound(u.nameParts))
+      resolveDeltaIdentifier(u)
 
     // Since the Delta's TimeTravel is a leaf node, we have to resolve the UnresolvedIdentifier.
-    case tt @ TimeTravel(udi: UnresolvedDeltaIdentifier, _, _, _) =>
-      val sourceRelation = resolveIdentifierInTimeTravel(sparkSession, udi)
+    case tt @ TimeTravel(unresolvedId: UnresolvedDeltaIdentifier, _, _, _) =>
+      val sourceRelation = resolveDeltaIdentifier(unresolvedId)
       tt.copy(relation = sourceRelation)
   }
 
   private def resolveDeltaIdentifier(
-    sparkSession: SparkSession,
-    unresolvedIdentifier: UnresolvedDeltaIdentifier): Option[DataSourceV2Relation] = {
-    val (catalog, identifier) =
-      resolveCatalogAndIdentifier(sparkSession.sessionState.catalogManager,
-        unresolvedIdentifier.nameParts)
-    // If the identifier is not a multipart identifier, we assume it is a table or view name.
-    val tableId = if (unresolvedIdentifier.nameParts.length == 1) {
-      TableIdentifier(unresolvedIdentifier.nameParts.head)
-    } else {
-      identifier.asTableIdentifier
+      unresolvedId: UnresolvedDeltaIdentifier): DataSourceV2Relation = {
+    val unresolvedTable =
+      UnresolvedTable(unresolvedId.nameParts, unresolvedId.commandName, None)
+    val analyzer = sparkSession.sessionState.analyzer
+    val optionalDeltaTableV2 = analyzer.ResolveRelations(unresolvedTable) match {
+      case r: ResolvedTable =>
+        r.table match {
+          case deltaTableV2: DeltaTableV2 => Some(deltaTableV2)
+          case _ => throw DeltaErrors.notADeltaTableException(unresolvedTable.commandName)
+        }
+      case _ => None
     }
-    assert(catalog.isInstanceOf[TableCatalog], s"Catalog ${catalog.name()} must implement " +
-      s"TableCatalog to support loading Delta table.")
-    val tableCatalog = catalog.asInstanceOf[TableCatalog]
-    val optionalDeltaTableV2 = loadDeltaTable(tableCatalog, identifier)
-    val deltaTableV2 = optionalDeltaTableV2.orElse {
+
+    val deltaTableV2 = optionalDeltaTableV2.getOrElse {
+      val tableId = unresolvedId.asTableIdentifier
       if (DeltaTableUtils.isValidPath(tableId)) {
-        Some(DeltaTableV2(sparkSession, new Path(tableId.table)))
+        DeltaTableV2(sparkSession, new Path(tableId.table))
       } else {
-        None
+        unresolvedId.tableNotFound(unresolvedId.nameParts)
       }
     }
-    deltaTableV2.map(d => DataSourceV2Relation.create(d, None, Some(identifier)))
-  }
-
-  // Resolve the input name parts to a CatalogPlugin and Identifier.
-  // The code is from Apache Spark on org.apache.spark.sql.connector.catalog.CatalogAndIdentifier.
-  // We need to use this because the original one is private.
-  private def resolveCatalogAndIdentifier(
-    catalogManager: CatalogManager,
-    nameParts: Seq[String]): (CatalogPlugin, Identifier) = {
-    import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.MultipartIdentifierHelper
-    assert(nameParts.nonEmpty)
-    if (nameParts.length == 1) {
-      (catalogManager.currentCatalog,
-        Identifier.of(catalogManager.currentNamespace, nameParts.head))
-    } else if (nameParts.head.equalsIgnoreCase(globalTempDB)) {
-      // Conceptually global temp views are in a special reserved catalog. However, the v2 catalog
-      // API does not support view yet, and we have to use v1 commands to deal with global temp
-      // views. To simplify the implementation, we put global temp views in a special namespace
-      // in the session catalog. The special namespace has higher priority during name resolution.
-      // For example, if the name of a custom catalog is the same with `GLOBAL_TEMP_DATABASE`,
-      // this custom catalog can't be accessed.
-      (catalogManager.v2SessionCatalog, nameParts.asIdentifier)
-    } else {
-      try {
-        (catalogManager.catalog(nameParts.head), nameParts.tail.asIdentifier)
-      } catch {
-        case _: CatalogNotFoundException =>
-          (catalogManager.currentCatalog, nameParts.asIdentifier)
-      }
-    }
-  }
-
-  private def resolveIdentifierInTimeTravel(
-    sparkSession: SparkSession,
-    unresolvedIdentifier: UnresolvedDeltaIdentifier): DataSourceV2Relation = {
-    val relation = resolveDeltaIdentifier(sparkSession, unresolvedIdentifier)
-    if (relation.isDefined) {
-      relation.get
-    } else {
-      val tableId = if (unresolvedIdentifier.nameParts.length == 1) {
-        TableIdentifier(unresolvedIdentifier.nameParts.head)
-      } else {
-        unresolvedIdentifier.nameParts.asTableIdentifier
-      }
-      ResolveDeltaIdentifier.handleTableNotFoundInTimeTravel(
-        sparkSession.sessionState.catalog, unresolvedIdentifier, tableId)
-    }
-  }
-
-  /**
-   * Return a DeltaTableV2 instance if the table exists and it is a Delta table,
-   * otherwise return None.
-   */
-  private def loadDeltaTable(
-      tableCatalog: TableCatalog,
-      identifier: Identifier): Option[DeltaTableV2] = {
-    val tableExists = tableCatalog.tableExists(identifier)
-    if (tableExists) {
-      tableCatalog.loadTable(identifier) match {
-        case v: DeltaTableV2 =>
-          Some(v)
-        case _ =>
-          None
-      }
-    } else {
-      None
-    }
-  }
-}
-
-object ResolveDeltaIdentifier {
-  def handleTableNotFoundInTimeTravel(
-      catalog: SessionCatalog,
-      inputPlan: LeafNode,
-      tableIdentifier: TableIdentifier): Nothing = {
-    if (
-      (catalog.tableExists(tableIdentifier) &&
-        catalog.getTableMetadata(tableIdentifier).tableType == CatalogTableType.VIEW) ||
-        catalog.isTempView(tableIdentifier)) {
-      // If table exists and not found to be a view, throw not supported error
-      throw DeltaErrors.notADeltaTableException("RESTORE")
-    } else {
-      inputPlan.tableNotFound(tableIdentifier.nameParts)
-    }
+    DataSourceV2Relation.create(deltaTableV2, None, Some(unresolvedId.asIdentifier))
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DescribeDeltaDetailsCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DescribeDeltaDetailsCommand.scala
@@ -19,16 +19,17 @@ package org.apache.spark.sql.delta.commands
 // scalastyle:off import.ordering.noEmptyLine
 import java.io.FileNotFoundException
 import java.sql.Timestamp
+
 import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaTableIdentifier, Snapshot}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.util.FileNames
 import org.apache.hadoop.fs.Path
+
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, ScalaReflection, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.{NoSuchDatabaseException, NoSuchTableException}
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType, CatalogUtils}
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
 import org.apache.spark.sql.types.StructType
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DescribeDeltaDetailsCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DescribeDeltaDetailsCommand.scala
@@ -19,17 +19,16 @@ package org.apache.spark.sql.delta.commands
 // scalastyle:off import.ordering.noEmptyLine
 import java.io.FileNotFoundException
 import java.sql.Timestamp
-
 import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaTableIdentifier, Snapshot}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.util.FileNames
 import org.apache.hadoop.fs.Path
-
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, ScalaReflection, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.{NoSuchDatabaseException, NoSuchTableException}
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType, CatalogUtils}
 import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
 import org.apache.spark.sql.types.StructType
 

--- a/spark/src/test/scala/io/delta/sql/parser/DeltaSqlParserSuite.scala
+++ b/spark/src/test/scala/io/delta/sql/parser/DeltaSqlParserSuite.scala
@@ -34,20 +34,24 @@ class DeltaSqlParserSuite extends SparkFunSuite with SQLHelper {
     // Setting `delegate` to `null` is fine. The following tests don't need to touch `delegate`.
     val parser = new DeltaSqlParser(null)
     assert(parser.parsePlan("vacuum 123_") ===
-      VacuumTableStatement(UnresolvedDeltaIdentifier(Seq("123_")), None, false))
+      VacuumTableStatement(UnresolvedDeltaIdentifier(Seq("123_"), "VACUUM"), None, false))
     assert(parser.parsePlan("vacuum 1a.123_") ===
-      VacuumTableStatement(UnresolvedDeltaIdentifier(Seq("1a", "123_")), None, false))
+      VacuumTableStatement(UnresolvedDeltaIdentifier(Seq("1a", "123_"), "VACUUM"), None, false))
     assert(parser.parsePlan("vacuum a.123A") ===
-      VacuumTableStatement(UnresolvedDeltaIdentifier(Seq("a", "123A")), None, false))
+      VacuumTableStatement(UnresolvedDeltaIdentifier(Seq("a", "123A"), "VACUUM"), None, false))
     assert(parser.parsePlan("vacuum a.123E3_column") ===
-      VacuumTableStatement(UnresolvedDeltaIdentifier(Seq("a", "123E3_column")), None, false))
+      VacuumTableStatement(UnresolvedDeltaIdentifier(Seq("a", "123E3_column"), "VACUUM"),
+        None, false))
     assert(parser.parsePlan("vacuum a.123D_column") ===
-      VacuumTableStatement(UnresolvedDeltaIdentifier(Seq("a", "123D_column")), None, false))
+      VacuumTableStatement(UnresolvedDeltaIdentifier(Seq("a", "123D_column"), "VACUUM"),
+        None, false))
     assert(parser.parsePlan("vacuum a.123BD_column") ===
-      VacuumTableStatement(UnresolvedDeltaIdentifier(Seq("a", "123BD_column")), None, false))
+      VacuumTableStatement(UnresolvedDeltaIdentifier(Seq("a", "123BD_column"), "VACUUM"),
+        None, false))
 
     assert(parser.parsePlan("vacuum delta.`/tmp/table`") ===
-      VacuumTableStatement(UnresolvedDeltaIdentifier(Seq("delta", "/tmp/table")), None, false))
+      VacuumTableStatement(UnresolvedDeltaIdentifier(Seq("delta", "/tmp/table"), "VACUUM"),
+        None, false))
 
     assert(parser.parsePlan("vacuum \"/tmp/table\"") ===
       VacuumTableCommand(new Path("/tmp/table"), None, false))
@@ -58,7 +62,7 @@ class DeltaSqlParserSuite extends SparkFunSuite with SQLHelper {
     val parsedCmd = parser.parsePlan("RESTORE catalog_foo.db.tbl TO VERSION AS OF 1;")
     assert(parsedCmd ===
       RestoreTableStatement(TimeTravel(
-        UnresolvedDeltaIdentifier(Seq("catalog_foo", "db", "tbl")),
+        UnresolvedDeltaIdentifier(Seq("catalog_foo", "db", "tbl"), "RESTORE"),
         None,
         Some(1),
         Some("sql"))))

--- a/spark/src/test/scala/io/delta/sql/parser/DeltaSqlParserSuite.scala
+++ b/spark/src/test/scala/io/delta/sql/parser/DeltaSqlParserSuite.scala
@@ -17,8 +17,7 @@
 package io.delta.sql.parser
 
 import io.delta.tables.execution.VacuumTableCommand
-import org.apache.spark.sql.delta.CloneTableSQLTestUtils
-import org.apache.spark.sql.delta.UnresolvedPathBasedDeltaTable
+import org.apache.spark.sql.delta.{CloneTableSQLTestUtils, UnresolvedDeltaIdentifier, UnresolvedPathBasedDeltaTable}
 import org.apache.spark.sql.delta.commands.{DeltaReorgTable, OptimizeTableCommand}
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.{TableIdentifier, TimeTravel}
@@ -26,7 +25,7 @@ import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedId
 import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.SQLHelper
-import org.apache.spark.sql.catalyst.plans.logical.{CloneTableStatement, RestoreTableStatement}
+import org.apache.spark.sql.catalyst.plans.logical.{CloneTableStatement, RestoreTableStatement, VacuumTableStatement}
 
 class DeltaSqlParserSuite extends SparkFunSuite with SQLHelper {
 
@@ -34,17 +33,17 @@ class DeltaSqlParserSuite extends SparkFunSuite with SQLHelper {
     // Setting `delegate` to `null` is fine. The following tests don't need to touch `delegate`.
     val parser = new DeltaSqlParser(null)
     assert(parser.parsePlan("vacuum 123_") ===
-      VacuumTableCommand(None, Some(TableIdentifier("123_")), None, false))
+      VacuumTableStatement(UnresolvedDeltaIdentifier(Seq("123_")), None, false))
     assert(parser.parsePlan("vacuum 1a.123_") ===
-      VacuumTableCommand(None, Some(TableIdentifier("123_", Some("1a"))), None, false))
+      VacuumTableStatement(UnresolvedDeltaIdentifier(Seq("1a", "123_")), None, false))
     assert(parser.parsePlan("vacuum a.123A") ===
-      VacuumTableCommand(None, Some(TableIdentifier("123A", Some("a"))), None, false))
+      VacuumTableStatement(UnresolvedDeltaIdentifier(Seq("a", "123A")), None, false))
     assert(parser.parsePlan("vacuum a.123E3_column") ===
-      VacuumTableCommand(None, Some(TableIdentifier("123E3_column", Some("a"))), None, false))
+      VacuumTableStatement(UnresolvedDeltaIdentifier(Seq("a", "123E3_column")), None, false))
     assert(parser.parsePlan("vacuum a.123D_column") ===
-      VacuumTableCommand(None, Some(TableIdentifier("123D_column", Some("a"))), None, false))
+      VacuumTableStatement(UnresolvedDeltaIdentifier(Seq("a", "123D_column")), None, false))
     assert(parser.parsePlan("vacuum a.123BD_column") ===
-      VacuumTableCommand(None, Some(TableIdentifier("123BD_column", Some("a"))), None, false))
+      VacuumTableStatement(UnresolvedDeltaIdentifier(Seq("a", "123BD_column")), None, false))
   }
 
   test("RESTORE command is parsed as expected") {

--- a/spark/src/test/scala/io/delta/sql/parser/DeltaSqlParserSuite.scala
+++ b/spark/src/test/scala/io/delta/sql/parser/DeltaSqlParserSuite.scala
@@ -17,6 +17,8 @@
 package io.delta.sql.parser
 
 import io.delta.tables.execution.VacuumTableCommand
+
+import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.delta.{CloneTableSQLTestUtils, UnresolvedDeltaIdentifier, UnresolvedPathBasedDeltaTable}
 import org.apache.spark.sql.delta.commands.{DeltaReorgTable, OptimizeTableCommand}
 import org.apache.spark.SparkFunSuite
@@ -44,6 +46,12 @@ class DeltaSqlParserSuite extends SparkFunSuite with SQLHelper {
       VacuumTableStatement(UnresolvedDeltaIdentifier(Seq("a", "123D_column")), None, false))
     assert(parser.parsePlan("vacuum a.123BD_column") ===
       VacuumTableStatement(UnresolvedDeltaIdentifier(Seq("a", "123BD_column")), None, false))
+
+    assert(parser.parsePlan("vacuum delta.`/tmp/table`") ===
+      VacuumTableStatement(UnresolvedDeltaIdentifier(Seq("delta", "/tmp/table")), None, false))
+
+    assert(parser.parsePlan("vacuum \"/tmp/table\"") ===
+      VacuumTableCommand(new Path("/tmp/table"), None, false))
   }
 
   test("RESTORE command is parsed as expected") {

--- a/spark/src/test/scala/io/delta/sql/parser/DeltaSqlParserSuite.scala
+++ b/spark/src/test/scala/io/delta/sql/parser/DeltaSqlParserSuite.scala
@@ -23,9 +23,8 @@ import org.apache.spark.sql.delta.{CloneTableSQLTestUtils, UnresolvedDeltaIdenti
 import org.apache.spark.sql.delta.commands.{DeltaReorgTable, OptimizeTableCommand}
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.{TableIdentifier, TimeTravel}
-import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedIdentifier, UnresolvedRelation, UnresolvedTable}
+import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedRelation, UnresolvedTable}
 import org.apache.spark.sql.catalyst.expressions.Literal
-import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.catalyst.plans.logical.{CloneTableStatement, RestoreTableStatement, VacuumTableStatement}
 
@@ -59,7 +58,7 @@ class DeltaSqlParserSuite extends SparkFunSuite with SQLHelper {
     val parsedCmd = parser.parsePlan("RESTORE catalog_foo.db.tbl TO VERSION AS OF 1;")
     assert(parsedCmd ===
       RestoreTableStatement(TimeTravel(
-        UnresolvedIdentifier(Seq("catalog_foo", "db", "tbl")),
+        UnresolvedDeltaIdentifier(Seq("catalog_foo", "db", "tbl")),
         None,
         Some(1),
         Some("sql"))))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CustomCatalogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CustomCatalogSuite.scala
@@ -49,7 +49,8 @@ class CustomCatalogSuite extends QueryTest with SharedSparkSession
     val tableName = "table1"
     withTable(tableName) {
       sql("SET CATALOG dummy")
-      val dummyCatalog = spark.sessionState.catalogManager.catalog("dummy").asInstanceOf[DummyCatalog]
+      val dummyCatalog =
+        spark.sessionState.catalogManager.catalog("dummy").asInstanceOf[DummyCatalog]
       val tablePath = dummyCatalog.getTablePath(tableName)
       sql(f"CREATE TABLE $tableName (id bigint) USING delta")
       sql(f"INSERT INTO delta.`$tablePath` VALUES (0)")
@@ -73,7 +74,10 @@ class CustomCatalogSuite extends QueryTest with SharedSparkSession
 class DummyCatalog extends TableCatalog {
   private val spark: SparkSession = SparkSession.active
   private val tempDir: Path = new Path(Utils.createTempDir().getAbsolutePath)
-  private val fs: FileSystem = tempDir.getFileSystem(spark.sessionState.newHadoopConf())
+  // scalastyle:off deltahadoopconfiguration
+  private val fs: FileSystem =
+    tempDir.getFileSystem(spark.sessionState.newHadoopConf())
+  // scalastyle:on deltahadoopconfiguration
 
   override def name: String = "dummy"
 
@@ -134,5 +138,3 @@ class DummyCatalog extends TableCatalog {
     }
   }
 }
-
-

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CustomCatalogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CustomCatalogSuite.scala
@@ -15,30 +15,19 @@
  */
 package org.apache.spark.sql.delta
 
-import java.util
-import org.apache.spark.sql.connector.catalog._
-import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.connector.expressions.Transform
-import org.apache.spark.sql.util.CaseInsensitiveStringMap
-import io.delta.tables.DeltaTable
 import io.delta.tables.execution.VacuumTableCommand
 import org.apache.hadoop.fs.{FileSystem, Path}
 
-import java.nio.file.{Files, Paths}
-import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.{QueryTest, SparkSession}
 import org.apache.spark.sql.connector.catalog.{Identifier, Table, TableCatalog, TableChange}
 import org.apache.spark.sql.connector.expressions.Transform
-import org.apache.spark.sql.delta.catalog.{DeltaCatalog, DeltaTableV2}
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.Utils
 import org.apache.spark.SparkConf
-
-import java.io.{File, IOException}
-
 
 class CustomCatalogSuite extends QueryTest with SharedSparkSession
   with DeltaSQLCommandTest {
@@ -47,7 +36,7 @@ class CustomCatalogSuite extends QueryTest with SharedSparkSession
     super.sparkConf.set("spark.sql.catalog.dummy", classOf[DummyCatalog].getName)
 
   test("RESTORE a table from DummyCatalog") {
-    val tableName = "table1"
+    val tableName = "restore_table"
     withTable(tableName) {
       sql("SET CATALOG dummy")
       val dummyCatalog =
@@ -74,7 +63,7 @@ class CustomCatalogSuite extends QueryTest with SharedSparkSession
   }
 
     test("Vacuum a table from DummyCatalog") {
-      val tableName = "table1"
+      val tableName = "vacuum_table"
       withTable(tableName) {
         sql("SET CATALOG dummy")
         val dummyCatalog =

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CustomCatalogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CustomCatalogSuite.scala
@@ -53,6 +53,8 @@ class CustomCatalogSuite extends QueryTest with SharedSparkSession
         spark.sessionState.catalogManager.catalog("dummy").asInstanceOf[DummyCatalog]
       val tablePath = dummyCatalog.getTablePath(tableName)
       sql(f"CREATE TABLE $tableName (id bigint) USING delta")
+      // Insert some data into the table in the dummy catalog.
+      // To make it simple, here we insert data directly into the table path.
       sql(f"INSERT INTO delta.`$tablePath` VALUES (0)")
       sql(f"INSERT INTO delta.`$tablePath` VALUES (1)")
       sql(f"RESTORE TABLE $tableName VERSION AS OF 0")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CustomCatalogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CustomCatalogSuite.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.delta
+
+import java.util
+import org.apache.spark.sql.connector.catalog._
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import io.delta.tables.DeltaTable
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+import java.nio.file.{Files, Paths}
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.{QueryTest, SparkSession}
+import org.apache.spark.sql.connector.catalog.{Identifier, Table, TableCatalog, TableChange}
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.delta.catalog.{DeltaCatalog, DeltaTableV2}
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.util.Utils
+import org.apache.spark.SparkConf
+
+import java.io.{File, IOException}
+
+
+class CustomCatalogSuite extends QueryTest with SharedSparkSession
+  with DeltaSQLCommandTest {
+
+  override def sparkConf: SparkConf =
+    super.sparkConf.set("spark.sql.catalog.dummy", classOf[DummyCatalog].getName)
+
+  test("RESTORE a table from DummyCatalog") {
+    val tableName = "table1"
+    withTable(tableName) {
+      sql("SET CATALOG dummy")
+      val dummyCatalog = spark.sessionState.catalogManager.catalog("dummy").asInstanceOf[DummyCatalog]
+      val tablePath = dummyCatalog.getTablePath(tableName)
+      sql(f"CREATE TABLE $tableName (id bigint) USING delta")
+      sql(f"INSERT INTO delta.`$tablePath` VALUES (0)")
+      sql(f"INSERT INTO delta.`$tablePath` VALUES (1)")
+      sql(f"RESTORE TABLE $tableName VERSION AS OF 0")
+      checkAnswer(spark.table(tableName), Nil)
+      sql(f"RESTORE TABLE $tableName VERSION AS OF 1")
+      checkAnswer(spark.table(tableName), spark.range(1).toDF())
+      // Test 3-part identifier
+      sql(f"RESTORE TABLE dummy.default.$tableName VERSION AS OF 2")
+      checkAnswer(spark.table(tableName), spark.range(2).toDF())
+
+      sql("SET CATALOG spark_catalog")
+      // Test 3-part identifier when the current catalog is the default catalog
+      sql(f"RESTORE TABLE dummy.default.$tableName VERSION AS OF 1")
+      checkAnswer(spark.table(f"dummy.default.$tableName"), spark.range(1).toDF())
+    }
+  }
+}
+
+class DummyCatalog extends TableCatalog {
+  private val spark: SparkSession = SparkSession.active
+  private val tempDir: Path = new Path(Utils.createTempDir().getAbsolutePath)
+  private val fs: FileSystem = tempDir.getFileSystem(spark.sessionState.newHadoopConf())
+
+  override def name: String = "dummy"
+
+  def getTablePath(tableName: String): Path = {
+    new Path(tempDir, tableName)
+  }
+  override def defaultNamespace(): Array[String] = Array("default")
+
+  override def listTables(namespace: Array[String]): Array[Identifier] = {
+    val status = fs.listStatus(tempDir)
+    status.filter(_.isDirectory).map { dir =>
+      Identifier.of(namespace, dir.getPath.getName)
+    }
+  }
+
+  override def tableExists(ident: Identifier): Boolean = {
+    val tablePath = getTablePath(ident.name())
+    fs.exists(tablePath)
+  }
+  override def loadTable(ident: Identifier): Table = {
+    val tablePath = getTablePath(ident.name())
+    DeltaTableV2(spark, tablePath)
+  }
+
+  override def createTable(
+    ident: Identifier,
+    schema: StructType,
+    partitions: Array[Transform],
+    properties: java.util.Map[String, String]): Table = {
+    val tablePath = getTablePath(ident.name())
+    // Create an empty Delta table on the tablePath
+    spark.range(0).write.format("delta").save(tablePath.toString)
+    DeltaTableV2(spark, tablePath)
+  }
+
+  override def alterTable(ident: Identifier, changes: TableChange*): Table = {
+    throw new UnsupportedOperationException("Alter table operation is not supported.")
+  }
+
+  override def dropTable(ident: Identifier): Boolean = {
+    val tablePath = getTablePath(ident.name())
+    try {
+      fs.delete(tablePath, true)
+      true
+    } catch {
+      case _: Exception => false
+    }
+  }
+
+  override def renameTable(oldIdent: Identifier, newIdent: Identifier): Unit = {
+    throw new UnsupportedOperationException("Rename table operation is not supported.")
+  }
+
+  override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
+    // Initialize tempDir here
+    if (!fs.exists(tempDir)) {
+      fs.mkdirs(tempDir)
+    }
+  }
+}
+
+

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
@@ -498,8 +498,8 @@ class DeltaVacuumSuite
         val e = intercept[AnalysisException] {
           vacuumSQLTest(tablePath, viewName)
         }
-        assert(e.getMessage.contains("not found") ||
-          e.getMessage.contains("TABLE_OR_VIEW_NOT_FOUND"))
+        assert(e.getMessage.contains("VACUUM is only supported for Delta tables.") ||
+          e.getMessage.contains("DELTA_ONLY_OPERATION"))
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description


 
Support external DSV2 catalog in RESTORE & Vacuum command. After the changes, the restore command supports tables from external DSV2 catalog.
For example, with
```
spark.sql.catalog.customer_catalog=org.apache.spark.sql.CustomerCatalog
```
We can query
```
SET CATALOG customer_catalog;
RESTORE TABLE t1 VERSION AS OF 0
VACUUM t1
```
Or simply
```
RESTORE TABLE customer_catalog.default.t1 VERSION AS OF 0
VACUUM customer_catalog.default.t1
```
-->

## How was this patch tested?

1. new end-to-end tests
2. new parser test cases

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, users can use RESTORE & Vacuum command on the tables of their external DSV2 catalogs.
