### PR TITLE
[Standalone] Include sources in delta-standalone JAR

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -625,6 +625,7 @@ lazy val standaloneCosmetic = project
     releaseSettings,
     exportJars := true,
     Compile / packageBin := (standaloneParquet / assembly).value,
+    Compile / packageSrc := (standalone / Compile / packageSrc).value,
     libraryDependencies ++= scalaCollectionPar(scalaVersion.value) ++ Seq(
       "org.apache.hadoop" % "hadoop-client" % hadoopVersion % "provided",
       "org.apache.parquet" % "parquet-hadoop" % "1.12.0" % "provided",


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [X] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Include the proper sources in the delta-standalone JAR. Note: these sources are from the delta-standalone-original project, and so currently excludes `<delta>/connectors/standalone-parquet/src/main/java/io/delta/standalone/util/ParquetSchemaConverter.java`. I couldn't figure out how to include that one file. But this at least is a substantial improvement for now.

Resolves delta-io/delta#1922

## How was this patch tested?

```
build/sbt standaloneCosmetic/publishM2

jar tvf /Users/scott.sandre/.m2/repository/io/delta/delta-standalone_2.12/3.0.0-SNAPSHOT/delta-standalone_2.12-3.0.0-SNAPSHOT-sources.jar

~/.m2/repository/io/delta jar tvf /Users/scott.sandre/.m2/repository/io/delta/delta-standalone_2.12/3.0.0-SNAPSHOT/delta-standalone_2.12-3.0.0-SNAPSHOT-sources.jar
   144 Fri Jan 01 00:00:00 PST 2010 META-INF/MANIFEST.MF
     0 Fri Jan 01 00:00:00 PST 2010 io/
     0 Fri Jan 01 00:00:00 PST 2010 io/delta/
     0 Fri Jan 01 00:00:00 PST 2010 io/delta/standalone/
     0 Fri Jan 01 00:00:00 PST 2010 io/delta/standalone/actions/
     0 Fri Jan 01 00:00:00 PST 2010 io/delta/standalone/data/
     0 Fri Jan 01 00:00:00 PST 2010 io/delta/standalone/exceptions/
     0 Fri Jan 01 00:00:00 PST 2010 io/delta/standalone/expressions/
     0 Fri Jan 01 00:00:00 PST 2010 io/delta/standalone/internal/
     0 Fri Jan 01 00:00:00 PST 2010 io/delta/standalone/internal/actions/
     0 Fri Jan 01 00:00:00 PST 2010 io/delta/standalone/internal/data/
     0 Fri Jan 01 00:00:00 PST 2010 io/delta/standalone/internal/exception/
     0 Fri Jan 01 00:00:00 PST 2010 io/delta/standalone/internal/expressions/
     0 Fri Jan 01 00:00:00 PST 2010 io/delta/standalone/internal/logging/
     0 Fri Jan 01 00:00:00 PST 2010 io/delta/standalone/internal/scan/
     ........
```

## Does this PR introduce _any_ user-facing changes?

Yes! Correctly includes the sources in the delta-standalone jar on maven.