### PR TITLE
[Kernel] Add `@Evolving` and `@since` tags to all the Kernel API interfaces

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.client.FileReadContext;
 import io.delta.kernel.client.ParquetHandler;
 import io.delta.kernel.client.TableClient;
@@ -48,7 +49,10 @@ import io.delta.kernel.internal.util.PartitionUtils;
 
 /**
  * Represents a scan of a Delta table.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public interface Scan {
     /**
      * Get an iterator of data files to scan.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/ScanBuilder.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/ScanBuilder.java
@@ -16,13 +16,17 @@
 
 package io.delta.kernel;
 
+import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.client.TableClient;
 import io.delta.kernel.expressions.Expression;
 import io.delta.kernel.types.StructType;
 
 /**
  * Builder to construct {@link Scan} object.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public interface ScanBuilder {
 
     /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
@@ -16,12 +16,16 @@
 
 package io.delta.kernel;
 
+import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.client.TableClient;
 import io.delta.kernel.types.StructType;
 
 /**
  * Represents the snapshot of a Delta table.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public interface Snapshot {
 
     /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Table.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Table.java
@@ -15,13 +15,17 @@
  */
 package io.delta.kernel;
 
+import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.client.TableClient;
 
 import io.delta.kernel.internal.TableImpl;
 
 /**
  * Represents the Delta Lake table for a given path.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public interface Table {
     /**
      * Instantiate a table object for the Delta Lake table at the given path.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/TableNotFoundException.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/TableNotFoundException.java
@@ -16,9 +16,14 @@
 
 package io.delta.kernel;
 
+import io.delta.kernel.annotation.Evolving;
+
 /**
  * Thrown when there is no Delta table at the given location.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public class TableNotFoundException
     extends Exception {
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/annotation/Evolving.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/annotation/Evolving.java
@@ -13,20 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.delta.kernel.types;
+package io.delta.kernel.annotation;
 
-import io.delta.kernel.annotation.Evolving;
+import java.lang.annotation.*;
 
 /**
- * The data type representing {@code double} type values.
- *
- * @since 3.0.0
+ * APIs that are meant to evolve towards becoming stable APIs, but are not stable APIs yet.
+ * Evolving interfaces can change from one feature release to another release (i.e. 3.0 to 3.1).
  */
-@Evolving
-public class DoubleType extends BasePrimitiveType {
-    public static final DoubleType INSTANCE = new DoubleType();
-
-    private DoubleType() {
-        super("double");
-    }
-}
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER,
+    ElementType.CONSTRUCTOR, ElementType.LOCAL_VARIABLE, ElementType.PACKAGE})
+public @interface Evolving {}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/client/ExpressionHandler.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/client/ExpressionHandler.java
@@ -16,6 +16,7 @@
 
 package io.delta.kernel.client;
 
+import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.expressions.Expression;
 import io.delta.kernel.expressions.ExpressionEvaluator;
 import io.delta.kernel.types.StructType;
@@ -24,7 +25,10 @@ import io.delta.kernel.types.StructType;
  * Provides expression evaluation capability to Delta Kernel. Delta Kernel can use this client
  * to evaluate predicate on partition filters, fill up partition column values and any computation
  * on data using {@link Expression}s.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public interface ExpressionHandler {
     /**
      * Create an {@link ExpressionEvaluator} that can evaluate the given <i>expression</i> on

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/client/FileHandler.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/client/FileHandler.java
@@ -16,6 +16,7 @@
 
 package io.delta.kernel.client;
 
+import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.expressions.Expression;
 import io.delta.kernel.fs.FileStatus;
@@ -25,7 +26,10 @@ import io.delta.kernel.utils.CloseableIterator;
  * Provides file handling functionality to Delta Kernel. Connectors can implement this client to
  * provide Delta Kernel their own custom implementation of file splitting, additional predicate
  * pushdown or any other connector-specific capabilities.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public interface FileHandler {
     /**
      * Associates a connector specific {@link FileReadContext} for each scan file represented by a

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/client/FileReadContext.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/client/FileReadContext.java
@@ -16,13 +16,17 @@
 
 package io.delta.kernel.client;
 
+import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.data.Row;
 
 /**
  * Placeholder interface allowing connectors to attach their own custom implementation. Connectors
  * can use this to pass additional context about a scan file through Delta Kernel and back to the
  * connector for interpretation.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public interface FileReadContext {
     /**
      * Get the scan file info associated with the read context.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/client/FileSystemClient.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/client/FileSystemClient.java
@@ -20,6 +20,7 @@ import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
+import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.fs.FileStatus;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.Tuple2;
@@ -29,7 +30,10 @@ import io.delta.kernel.utils.Tuple2;
  * whenever it needs to access the underlying file system where the Delta table is present.
  * Connector implementation of this interface can hide filesystem specific details from Delta
  * Kernel.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public interface FileSystemClient {
     /**
      * List the paths in the same directory that are lexicographically greater or equal to

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/client/JsonHandler.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/client/JsonHandler.java
@@ -18,6 +18,7 @@ package io.delta.kernel.client;
 
 import java.io.IOException;
 
+import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.FileDataReadResult;
@@ -29,9 +30,11 @@ import io.delta.kernel.utils.CloseableIterator;
  * Provides JSON handling functionality to Delta Kernel. Delta Kernel can use this client to
  * parse JSON strings into {@link io.delta.kernel.data.Row} or read content from JSON files.
  * Connectors can leverage this interface to provide their best implementation of the JSON parsing
- * capability to
- * Delta Kernel.
+ * capability to Delta Kernel.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public interface JsonHandler
     extends FileHandler {
     /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/client/ParquetHandler.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/client/ParquetHandler.java
@@ -18,6 +18,7 @@ package io.delta.kernel.client;
 
 import java.io.IOException;
 
+import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.FileDataReadResult;
 import io.delta.kernel.types.StructField;
@@ -28,7 +29,10 @@ import io.delta.kernel.utils.CloseableIterator;
  * Provides Parquet file related functionalities to Delta Kernel. Connectors can leverage this
  * interface to provide their own custom implementation of Parquet data file functionalities to
  * Delta Kernel.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public interface ParquetHandler
     extends FileHandler {
     /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/client/TableClient.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/client/TableClient.java
@@ -16,11 +16,16 @@
 
 package io.delta.kernel.client;
 
+import io.delta.kernel.annotation.Evolving;
+
 /**
  * Interface encapsulating all clients needed by the Delta Kernel in order to read the
  * Delta table. Connectors are expected to pass an implementation of this interface when reading
  * a Delta table.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public interface TableClient {
 
     /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/data/ColumnVector.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/data/ColumnVector.java
@@ -20,11 +20,15 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 
+import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.types.DataType;
 
 /**
  * Represents zero or more values of a single column.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public interface ColumnVector extends AutoCloseable {
     /**
      * @return the data type of this column vector.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/data/ColumnarBatch.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/data/ColumnarBatch.java
@@ -16,6 +16,7 @@
 
 package io.delta.kernel.data;
 
+import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
@@ -24,7 +25,10 @@ import io.delta.kernel.internal.data.ColumnarBatchRow;
 
 /**
  * Represents zero or more rows of records with same schema type.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public interface ColumnarBatch {
     /**
      * @return the schema of the data in this batch.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/data/DataReadResult.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/data/DataReadResult.java
@@ -18,6 +18,8 @@ package io.delta.kernel.data;
 
 import java.util.Optional;
 
+import io.delta.kernel.annotation.Evolving;
+
 /**
  * Data read from Delta table file. Data is in {@link ColumnarBatch} format with an optional
  * selection vector to select only a subset of rows for this columnar batch.
@@ -26,7 +28,10 @@ import java.util.Optional;
  * {@link ColumnarBatch}. For each row index, a value of true in the selection vector indicates
  * the row at the same index in the data {@link ColumnarBatch} is valid; a value of false
  * indicates the row should be ignored. If there is no selection vector then all the rows are valid.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public class DataReadResult {
     private final ColumnarBatch data;
     private final Optional<ColumnVector> selectionVector;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/data/FileDataReadResult.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/data/FileDataReadResult.java
@@ -16,10 +16,14 @@
 
 package io.delta.kernel.data;
 
+import io.delta.kernel.annotation.Evolving;
 
 /**
  * Data read from a Delta table file and the corresponding scan file information.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public interface FileDataReadResult {
     /**
      * Get the data read from the file.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/data/Row.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/data/Row.java
@@ -20,11 +20,15 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 
+import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.types.StructType;
 
 /**
  * Represent a single record
+ *
+ * @since 3.0.0
  */
+@Evolving
 public interface Row {
 
     /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/ExpressionEvaluator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/ExpressionEvaluator.java
@@ -16,6 +16,7 @@
 
 package io.delta.kernel.expressions;
 
+import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.ColumnarBatch;
 
@@ -24,7 +25,10 @@ import io.delta.kernel.data.ColumnarBatch;
  * It contains one {@link Expression} which can be evaluated on multiple {@link ColumnarBatch}es
  * Connectors can implement this interface to optimize the evaluation using the
  * connector specific capabilities.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public interface ExpressionEvaluator extends AutoCloseable {
     /**
      * Evaluate the expression on given {@link ColumnarBatch} data.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/fs/FileStatus.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/fs/FileStatus.java
@@ -18,11 +18,15 @@ package io.delta.kernel.fs;
 
 import java.util.Objects;
 
+import io.delta.kernel.annotation.Evolving;
+
 /**
  * Class for encapsulating metadata about a file in Delta Lake table.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public class FileStatus {
-
     private final String path;
     private final long size;
     private final long modificationTime;
@@ -66,8 +70,8 @@ public class FileStatus {
     /**
      * Create a {@link FileStatus} with the given path, size and modification time.
      *
-     * @param path             Fully qualified file path.
-     * @param size             File size in bytes
+     * @param path Fully qualified file path.
+     * @param size File size in bytes
      * @param modificationTime Modification time of the file in epoch millis
      */
     public static FileStatus of(String path, long size, long modificationTime) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/ArrayType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/ArrayType.java
@@ -18,6 +18,14 @@ package io.delta.kernel.types;
 
 import java.util.Objects;
 
+import io.delta.kernel.annotation.Evolving;
+
+/**
+ * Represent {@code array} data type
+ *
+ * @since 3.0.0
+ */
+@Evolving
 public class ArrayType extends DataType {
     private final DataType elementType;
     private final boolean containsNull;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/BinaryType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/BinaryType.java
@@ -15,9 +15,14 @@
  */
 package io.delta.kernel.types;
 
+import io.delta.kernel.annotation.Evolving;
+
 /**
  * The data type representing {@code byte[]} values.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public class BinaryType extends BasePrimitiveType {
     public static final BinaryType INSTANCE = new BinaryType();
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/BooleanType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/BooleanType.java
@@ -15,9 +15,14 @@
  */
 package io.delta.kernel.types;
 
+import io.delta.kernel.annotation.Evolving;
+
 /**
  * Data type representing {@code boolean} type values.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public class BooleanType extends BasePrimitiveType {
     public static final BooleanType INSTANCE = new BooleanType();
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/ByteType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/ByteType.java
@@ -15,9 +15,14 @@
  */
 package io.delta.kernel.types;
 
+import io.delta.kernel.annotation.Evolving;
+
 /**
  * The data type representing {@code byte} type values.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public class ByteType extends BasePrimitiveType {
     public static final ByteType INSTANCE = new ByteType();
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/DataType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/DataType.java
@@ -16,6 +16,14 @@
 
 package io.delta.kernel.types;
 
+import io.delta.kernel.annotation.Evolving;
+
+/**
+ * Base class for all data types.
+ *
+ * @since 3.0.0
+ */
+@Evolving
 public abstract class DataType {
     /**
      * Convert the data type to Delta protocol specified serialization format.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/DateType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/DateType.java
@@ -15,10 +15,15 @@
  */
 package io.delta.kernel.types;
 
+import io.delta.kernel.annotation.Evolving;
+
 /**
  * A date type, supporting "0001-01-01" through "9999-12-31".
  * Internally, this is represented as the number of days from 1970-01-01.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public class DateType extends BasePrimitiveType {
     public static final DateType INSTANCE = new DateType();
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/DecimalType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/DecimalType.java
@@ -17,6 +17,8 @@ package io.delta.kernel.types;
 
 import java.util.Objects;
 
+import io.delta.kernel.annotation.Evolving;
+
 /**
  * The data type representing {@code java.math.BigDecimal} values.
  * A Decimal that must have fixed precision (the maximum number of digits) and scale (the number
@@ -25,7 +27,10 @@ import java.util.Objects;
  * The precision can be up to 38, scale can also be up to 38 (less or equal to precision).
  * <p>
  * The default precision and scale is (10, 0).
+ *
+ * @since 3.0.0
  */
+@Evolving
 public final class DecimalType extends DataType {
     public static final DecimalType USER_DEFAULT = new DecimalType(10, 0);
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/FloatType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/FloatType.java
@@ -15,9 +15,14 @@
  */
 package io.delta.kernel.types;
 
+import io.delta.kernel.annotation.Evolving;
+
 /**
  * The data type representing {@code float} type values.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public class FloatType extends BasePrimitiveType {
     public static final FloatType INSTANCE = new FloatType();
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/IntegerType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/IntegerType.java
@@ -15,9 +15,14 @@
  */
 package io.delta.kernel.types;
 
+import io.delta.kernel.annotation.Evolving;
+
 /**
  * The data type representing {@code integer} type values.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public class IntegerType extends BasePrimitiveType {
     public static final IntegerType INSTANCE = new IntegerType();
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/LongType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/LongType.java
@@ -15,9 +15,14 @@
  */
 package io.delta.kernel.types;
 
+import io.delta.kernel.annotation.Evolving;
+
 /**
  * The data type representing {@code long} type values.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public class LongType extends BasePrimitiveType {
     public static final LongType INSTANCE = new LongType();
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/MapType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/MapType.java
@@ -17,9 +17,14 @@ package io.delta.kernel.types;
 
 import java.util.Objects;
 
+import io.delta.kernel.annotation.Evolving;
+
 /**
- * Data type representing a map type.
+ * Data type representing a {@code map} type.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public class MapType extends DataType {
 
     private final DataType keyType;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/MixedDataType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/MixedDataType.java
@@ -15,6 +15,7 @@
  */
 package io.delta.kernel.types;
 
+import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.data.ColumnVector;
 
 /**
@@ -56,7 +57,10 @@ import io.delta.kernel.data.ColumnVector;
  * Whenever this type is specified, reader should expect either a `string` value or `struct` value.
  * The implementation of reader should convert the `string` or `struct` value to `string` type.
  * Reader implementations can expect this type only for JSON format data reading cases only.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public class MixedDataType extends DataType {
     public static final MixedDataType INSTANCE = new MixedDataType();
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/ShortType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/ShortType.java
@@ -15,9 +15,14 @@
  */
 package io.delta.kernel.types;
 
+import io.delta.kernel.annotation.Evolving;
+
 /**
  * The data type representing {@code short} type values.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public class ShortType extends BasePrimitiveType {
     public static final ShortType INSTANCE = new ShortType();
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/StringType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/StringType.java
@@ -15,9 +15,14 @@
  */
 package io.delta.kernel.types;
 
+import io.delta.kernel.annotation.Evolving;
+
 /**
  * The data type representing {@code string} type values.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public class StringType extends BasePrimitiveType {
     public static final StringType INSTANCE = new StringType();
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
@@ -21,6 +21,14 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import io.delta.kernel.annotation.Evolving;
+
+/**
+ * Represents a subfield of {@link StructType} with additional properties and metadata.
+ *
+ * @since 3.0.0
+ */
+@Evolving
 public class StructField {
 
     ////////////////////////////////////////////////////////////////////////////////

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructType.java
@@ -24,12 +24,16 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.expressions.Column;
 import io.delta.kernel.utils.Tuple2;
 
 /**
  * Struct type which contains one or more columns.
+ *
+ * @since 3.0.0
  */
+@Evolving
 public final class StructType extends DataType {
 
     private final Map<String, Tuple2<StructField, Integer>> nameToFieldAndOrdinal;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/TimestampType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/TimestampType.java
@@ -15,13 +15,18 @@
  */
 package io.delta.kernel.types;
 
+import io.delta.kernel.annotation.Evolving;
+
 /**
  * A timestamp type, supporting [0001-01-01T00:00:00.000000Z, 9999-12-31T23:59:59.999999Z]
  * where the left/right-bound is a date and time of the proleptic Gregorian
  * calendar in UTC+00:00.
  * Internally, this is represented as the number of microseconds since the Unix epoch,
  * 1970-01-01 00:00:00 UTC..
+ *
+ * @since 3.0.0
  */
+@Evolving
 public class TimestampType extends BasePrimitiveType {
     public static final TimestampType INSTANCE = new TimestampType();
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/utils/CloseableIterator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/utils/CloseableIterator.java
@@ -22,6 +22,15 @@ import java.util.Iterator;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import io.delta.kernel.annotation.Evolving;
+
+/**
+ * Closeable extension of {@link Iterator<T>}
+ *
+ * @param <T> the type of elements returned by this iterator
+ * @since 3.0.0
+ */
+@Evolving
 public interface CloseableIterator<T> extends Iterator<T>, Closeable {
     default <U> CloseableIterator<U> map(Function<T, U> mapper) {
         CloseableIterator<T> delegate = this;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/utils/Tuple2.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/utils/Tuple2.java
@@ -18,6 +18,16 @@ package io.delta.kernel.utils;
 
 import java.util.Objects;
 
+import io.delta.kernel.annotation.Evolving;
+
+/**
+ * Represents tuple of objects.
+ *
+ * @param <K> Type of the first element in the tuple
+ * @param <V> Type of the second element in the tuple
+ * @since 3.0.0
+ */
+@Evolving
 public class Tuple2<K, V> {
 
     public final K _1;
@@ -30,8 +40,12 @@ public class Tuple2<K, V> {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         Tuple2<?, ?> tuple2 = (Tuple2<?, ?>) o;
         return Objects.equals(_1, tuple2._1) && Objects.equals(_2, tuple2._2);
     }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/utils/Utils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/utils/Utils.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.delta.kernel.Scan;
+import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.client.TableClient;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.Row;
@@ -34,6 +35,12 @@ import io.delta.kernel.types.StructType;
 import io.delta.kernel.internal.data.ScanStateRow;
 import io.delta.kernel.internal.types.TableSchemaSerDe;
 
+/**
+ * Various utility methods to help the connectors work with data objects returned by Kernel
+ *
+ * @since 3.0.0
+ */
+@Evolving
 public class Utils {
     /**
      * Utility method to create a singleton {@link CloseableIterator}.

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultExpressionHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultExpressionHandler.java
@@ -36,13 +36,8 @@ import static io.delta.kernel.defaults.internal.DefaultKernelUtils.daysSinceEpoc
 
 /**
  * Default implementation of {@link ExpressionHandler}
- *
- * @see ExpressionHandler
  */
 public class DefaultExpressionHandler implements ExpressionHandler {
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public ExpressionEvaluator getEvaluator(StructType batchSchema, Expression expression) {
         return new DefaultExpressionEvaluator(expression);

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultExpressionHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultExpressionHandler.java
@@ -34,8 +34,15 @@ import io.delta.kernel.defaults.internal.data.vector.DefaultConstantVector;
 import static io.delta.kernel.defaults.internal.DefaultKernelUtils.checkArgument;
 import static io.delta.kernel.defaults.internal.DefaultKernelUtils.daysSinceEpoch;
 
-public class DefaultExpressionHandler
-    implements ExpressionHandler {
+/**
+ * Default implementation of {@link ExpressionHandler}
+ *
+ * @see ExpressionHandler
+ */
+public class DefaultExpressionHandler implements ExpressionHandler {
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public ExpressionEvaluator getEvaluator(StructType batchSchema, Expression expression) {
         return new DefaultExpressionEvaluator(expression);

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileHandler.java
@@ -25,9 +25,13 @@ import io.delta.kernel.utils.CloseableIterator;
 
 /**
  * Default client implementation of {@link FileHandler}. It splits file as one split.
+ *
+ * @see FileHandler
  */
-public class DefaultFileHandler
-    implements FileHandler {
+public class DefaultFileHandler implements FileHandler {
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public CloseableIterator<FileReadContext> contextualizeFileReads(
         CloseableIterator<Row> fileIter, Expression filter) {

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileHandler.java
@@ -25,13 +25,8 @@ import io.delta.kernel.utils.CloseableIterator;
 
 /**
  * Default client implementation of {@link FileHandler}. It splits file as one split.
- *
- * @see FileHandler
  */
 public class DefaultFileHandler implements FileHandler {
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public CloseableIterator<FileReadContext> contextualizeFileReads(
         CloseableIterator<Row> fileIter, Expression filter) {

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileReadContext.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileReadContext.java
@@ -20,6 +20,11 @@ import static java.util.Objects.requireNonNull;
 import io.delta.kernel.client.FileReadContext;
 import io.delta.kernel.data.Row;
 
+/**
+ * Default implementation of {@link FileReadContext}.
+ *
+ * @see FileReadContext
+ */
 public class DefaultFileReadContext
     implements FileReadContext {
     private final Row scanFileRow;

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileReadContext.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileReadContext.java
@@ -22,8 +22,6 @@ import io.delta.kernel.data.Row;
 
 /**
  * Default implementation of {@link FileReadContext}.
- *
- * @see FileReadContext
  */
 public class DefaultFileReadContext
     implements FileReadContext {

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileSystemClient.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileSystemClient.java
@@ -35,8 +35,6 @@ import io.delta.kernel.utils.Utils;
 
 /**
  * Default implementation of {@link FileSystemClient} based on Hadoop APIs.
- *
- * @see FileSystemClient
  */
 public class DefaultFileSystemClient
     implements FileSystemClient {
@@ -46,9 +44,6 @@ public class DefaultFileSystemClient
         this.hadoopConf = hadoopConf;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public CloseableIterator<FileStatus> listFrom(String filePath) {
         try {
@@ -79,9 +74,6 @@ public class DefaultFileSystemClient
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public CloseableIterator<ByteArrayInputStream> readFiles(
         CloseableIterator<Tuple2<String, Tuple2<Integer, Integer>>> iter) {

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileSystemClient.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileSystemClient.java
@@ -33,6 +33,11 @@ import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.Tuple2;
 import io.delta.kernel.utils.Utils;
 
+/**
+ * Default implementation of {@link FileSystemClient} based on Hadoop APIs.
+ *
+ * @see FileSystemClient
+ */
 public class DefaultFileSystemClient
     implements FileSystemClient {
     private final Configuration hadoopConf;
@@ -41,6 +46,9 @@ public class DefaultFileSystemClient
         this.hadoopConf = hadoopConf;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public CloseableIterator<FileStatus> listFrom(String filePath) {
         try {
@@ -71,6 +79,9 @@ public class DefaultFileSystemClient
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public CloseableIterator<ByteArrayInputStream> readFiles(
         CloseableIterator<Tuple2<String, Tuple2<Integer, Integer>>> iter) {

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultJsonHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultJsonHandler.java
@@ -49,8 +49,6 @@ import static io.delta.kernel.defaults.internal.DefaultKernelUtils.checkArgument
 
 /**
  * Default implementation of {@link JsonHandler} based on Hadoop APIs.
- *
- * @see JsonHandler
  */
 public class DefaultJsonHandler
     extends DefaultFileHandler
@@ -67,9 +65,6 @@ public class DefaultJsonHandler
         checkArgument(maxBatchSize > 0, "invalid JSON reader batch size: " + maxBatchSize);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public ColumnarBatch parseJson(ColumnVector jsonStringVector, StructType outputSchema) {
         List<Row> rows = new ArrayList<>();
@@ -79,9 +74,6 @@ public class DefaultJsonHandler
         return new DefaultRowBasedColumnarBatch(outputSchema, rows);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public CloseableIterator<FileDataReadResult> readJsonFiles(
         CloseableIterator<FileReadContext> fileIter,

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultJsonHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultJsonHandler.java
@@ -47,6 +47,11 @@ import io.delta.kernel.defaults.internal.data.DefaultJsonRow;
 import io.delta.kernel.defaults.internal.data.DefaultRowBasedColumnarBatch;
 import static io.delta.kernel.defaults.internal.DefaultKernelUtils.checkArgument;
 
+/**
+ * Default implementation of {@link JsonHandler} based on Hadoop APIs.
+ *
+ * @see JsonHandler
+ */
 public class DefaultJsonHandler
     extends DefaultFileHandler
     implements JsonHandler {
@@ -62,6 +67,9 @@ public class DefaultJsonHandler
         checkArgument(maxBatchSize > 0, "invalid JSON reader batch size: " + maxBatchSize);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public ColumnarBatch parseJson(ColumnVector jsonStringVector, StructType outputSchema) {
         List<Row> rows = new ArrayList<>();
@@ -71,6 +79,9 @@ public class DefaultJsonHandler
         return new DefaultRowBasedColumnarBatch(outputSchema, rows);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public CloseableIterator<FileDataReadResult> readJsonFiles(
         CloseableIterator<FileReadContext> fileIter,

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultParquetHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultParquetHandler.java
@@ -31,13 +31,26 @@ import io.delta.kernel.utils.Utils;
 
 import io.delta.kernel.defaults.internal.parquet.ParquetBatchReader;
 
+/**
+ * Default implementation of {@link ParquetHandler} based on Hadoop APIs.
+ *
+ * @see ParquetHandler
+ */
 public class DefaultParquetHandler extends DefaultFileHandler implements ParquetHandler {
     private final Configuration hadoopConf;
 
+    /**
+     * Create an instance of default {@link ParquetHandler} implementation.
+     *
+     * @param hadoopConf Hadoop configuration to use.
+     */
     public DefaultParquetHandler(Configuration hadoopConf) {
         this.hadoopConf = hadoopConf;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public CloseableIterator<FileDataReadResult> readParquetFiles(
         CloseableIterator<FileReadContext> fileIter, StructType physicalSchema) throws IOException {

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultParquetHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultParquetHandler.java
@@ -33,8 +33,6 @@ import io.delta.kernel.defaults.internal.parquet.ParquetBatchReader;
 
 /**
  * Default implementation of {@link ParquetHandler} based on Hadoop APIs.
- *
- * @see ParquetHandler
  */
 public class DefaultParquetHandler extends DefaultFileHandler implements ParquetHandler {
     private final Configuration hadoopConf;
@@ -48,9 +46,6 @@ public class DefaultParquetHandler extends DefaultFileHandler implements Parquet
         this.hadoopConf = hadoopConf;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public CloseableIterator<FileDataReadResult> readParquetFiles(
         CloseableIterator<FileReadContext> fileIter, StructType physicalSchema) throws IOException {

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultTableClient.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultTableClient.java
@@ -17,12 +17,13 @@ package io.delta.kernel.defaults.client;
 
 import org.apache.hadoop.conf.Configuration;
 
-import io.delta.kernel.client.ExpressionHandler;
-import io.delta.kernel.client.FileSystemClient;
-import io.delta.kernel.client.JsonHandler;
-import io.delta.kernel.client.ParquetHandler;
-import io.delta.kernel.client.TableClient;
+import io.delta.kernel.client.*;
 
+/**
+ * Default implementation of {@link TableClient} based on Hadoop APIs.
+ *
+ * @see TableClient
+ */
 public class DefaultTableClient
     implements TableClient {
     private final Configuration hadoopConf;
@@ -31,21 +32,33 @@ public class DefaultTableClient
         this.hadoopConf = hadoopConf;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public ExpressionHandler getExpressionHandler() {
         return new DefaultExpressionHandler();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public JsonHandler getJsonHandler() {
         return new DefaultJsonHandler(hadoopConf);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public FileSystemClient getFileSystemClient() {
         return new DefaultFileSystemClient(hadoopConf);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public ParquetHandler getParquetHandler() {
         return new DefaultParquetHandler(hadoopConf);

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultTableClient.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultTableClient.java
@@ -21,8 +21,6 @@ import io.delta.kernel.client.*;
 
 /**
  * Default implementation of {@link TableClient} based on Hadoop APIs.
- *
- * @see TableClient
  */
 public class DefaultTableClient
     implements TableClient {
@@ -32,33 +30,21 @@ public class DefaultTableClient
         this.hadoopConf = hadoopConf;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public ExpressionHandler getExpressionHandler() {
         return new DefaultExpressionHandler();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public JsonHandler getJsonHandler() {
         return new DefaultJsonHandler(hadoopConf);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public FileSystemClient getFileSystemClient() {
         return new DefaultFileSystemClient(hadoopConf);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public ParquetHandler getParquetHandler() {
         return new DefaultParquetHandler(hadoopConf);


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description
Kernel APIs are in the development phase. Add tags to indicate the APIs are evolving to set the expectations for API users.

Also, add a `@since` tag to indicate which version the API interface/method was introduced in. This is not done for the Kernel APIs in this PR. In the future, Kernel API docs can adopt the same.

The `Delta-Spark` module does extra labeling of evolving APIs by modifying the generated API
- example [javadoc](https://docs.delta.io/latest/api/java/io/delta/tables/DeltaTable.html#detail--), [scaladoc](https://docs.delta.io/latest/api/java/io/delta/tables/DeltaTable.html#detail--), [code](https://github.com/delta-io/delta/blob/master/spark/src/main/scala/io/delta/tables/DeltaTable.scala#L138)
- Evolving API label in Scala and Java docs. This is done by patching the generated HTML docs (code [here](https://github.com/delta-io/delta/blob/master/docs/api-javadocs.js#L44) and [here](https://github.com/delta-io/delta/blob/master/docs/generate_api_docs.py#L55))


## How was this patch tested?
NA