### PR TITLE
[Spark] Define and use DeltaTableV2.toLogicalRelation

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -1065,12 +1065,7 @@ object DeltaRelation extends DeltaLogging {
       } else {
         v2Relation.output
       }
-      val catalogTable = if (d.catalogTable.isDefined) {
-        Some(d.v1Table)
-      } else {
-        None
-      }
-      LogicalRelation(relation, output, catalogTable, isStreaming = false)
+      LogicalRelation(relation, output, d.ttSafeCatalogTable, isStreaming = false)
     }
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTableValueFunctions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTableValueFunctions.scala
@@ -191,13 +191,7 @@ case class TableChanges(
   def toReadQuery: LogicalPlan = child.transformUp {
     case DataSourceV2Relation(d: DeltaTableV2, _, _, _, options) =>
       // withOptions empties the catalog table stats
-      val deltaTable = d.withOptions(options.asScala.toMap)
-      val relation = deltaTable.toBaseRelation
-      LogicalRelation(
-        relation,
-        relation.schema.toAttributes,
-        deltaTable.catalogTable,
-        isStreaming = false)
+      d.withOptions(options.asScala.toMap).toLogicalRelation
     case r: NamedRelation =>
       throw DeltaErrors.notADeltaTableException(fnName, r.name)
     case l: LogicalRelation =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -30,9 +30,10 @@ import org.apache.spark.sql.delta.sources.{DeltaDataSource, DeltaSourceUtils}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
+import org.apache.spark.sql.{DataFrame, Dataset, SaveMode, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.{CatalogTable, CatalogTableType, CatalogUtils}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, SubqueryAlias}
 import org.apache.spark.sql.connector.catalog.{SupportsWrite, Table, TableCapability, TableCatalog, V2TableWithV1Fallback}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 import org.apache.spark.sql.connector.catalog.TableCapability._
@@ -184,7 +185,7 @@ case class DeltaTableV2(
 
   override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {
     new WriteIntoDeltaBuilder(
-      deltaLog, info.options, spark.sessionState.conf.useNullsForMissingDefaultColumnValues)
+      this, info.options, spark.sessionState.conf.useNullsForMissingDefaultColumnValues)
   }
 
   /**
@@ -213,6 +214,25 @@ case class DeltaTableV2(
         partitionPredicates, Some(snapshot), timeTravelSpec.isDefined)
     }
   }
+
+  /** Creates a [[LogicalRelation]] that represents this table */
+  lazy val toLogicalRelation: LogicalRelation = {
+    val relation = this.toBaseRelation
+    LogicalRelation(relation, relation.schema.toAttributes, ttSafeCatalogTable, isStreaming = false)
+  }
+
+  /** Creates a [[DataFrame]] that uses the requested spark session to read from this table */
+  def toDf(sparkSession: SparkSession): DataFrame = {
+    val plan = catalogTable.foldLeft[LogicalPlan](toLogicalRelation) { (child, ct) =>
+      // Catalog based tables need a SubqueryAlias that carries their fully-qualified name
+      val TableIdentifier(table, database, catalog) = ct.identifier
+      SubqueryAlias(catalog.toSeq ++ database :+ table, child)
+    }
+    Dataset.ofRows(sparkSession, plan)
+  }
+
+  /** Creates a [[DataFrame]] that reads from this table */
+  lazy val toDf: DataFrame = toDf(spark)
 
   /**
    * Check the passed in options and existing timeTravelOpt, set new time travel by options.
@@ -252,20 +272,19 @@ case class DeltaTableV2(
     }
   }
 
-  override def v1Table: CatalogTable = {
-    if (catalogTable.isEmpty) {
-      throw DeltaErrors.invalidV1TableCall("v1Table", "DeltaTableV2")
-    }
-    if (timeTravelSpec.isDefined) {
-      catalogTable.get.copy(stats = None)
-    } else {
-      catalogTable.get
-    }
+  /** A "clean" version of the catalog table, safe for use with or without time travel. */
+  def ttSafeCatalogTable: Option[CatalogTable] = catalogTable match {
+    case Some(ct) if timeTravelOpt.isDefined => Some(ct.copy(stats = None))
+    case other => other
+  }
+
+  override def v1Table: CatalogTable = ttSafeCatalogTable.getOrElse {
+    throw DeltaErrors.invalidV1TableCall("v1Table", "DeltaTableV2")
   }
 }
 
 private class WriteIntoDeltaBuilder(
-    log: DeltaLog,
+    table: DeltaTableV2,
     writeOptions: CaseInsensitiveStringMap,
     nullAsDefault: Boolean)
   extends WriteBuilder with SupportsOverwrite with SupportsTruncate with SupportsDynamicOverwrite {
@@ -313,18 +332,17 @@ private class WriteIntoDeltaBuilder(
           }
           // TODO: Get the config from WriteIntoDelta's txn.
           WriteIntoDelta(
-            log,
+            table.deltaLog,
             if (forceOverwrite) SaveMode.Overwrite else SaveMode.Append,
             new DeltaOptions(options.toMap, session.sessionState.conf),
             Nil,
-            log.unsafeVolatileSnapshot.metadata.configuration,
+            table.snapshot.metadata.configuration,
             data).run(session)
 
           // TODO: Push this to Apache Spark
           // Re-cache all cached plans(including this relation itself, if it's cached) that refer
           // to this data source relation. This is the behavior for InsertInto
-          session.sharedState.cacheManager.recacheByPlan(
-            session, LogicalRelation(log.createRelation()))
+          session.sharedState.cacheManager.recacheByPlan(session, table.toLogicalRelation)
         }
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Most call sites of `DeltaTableV2.toBaseRelation` immediately use the result to create a `LogicalRelation`, using other fields of `DeltaTableV2` as additional input. The duplicated code is not always consistent, either. Create helper methods `toLogicalRelation` and `toDf` which encapsulate the common-case logic for these operations.

## How was this patch tested?

Unit tests

## Does this PR introduce _any_ user-facing changes?

No