### PR TITLE
Add truncate history support for DROP FEATURE command

### DIFF
--- a/spark/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
+++ b/spark/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
@@ -87,7 +87,7 @@ statement
     | ALTER TABLE table=qualifiedName
         DROP CONSTRAINT (IF EXISTS)? name=identifier                    #dropTableConstraint
     | ALTER TABLE table=qualifiedName
-        DROP FEATURE featureName=featureNameValue                       #alterTableDropFeature
+        DROP FEATURE featureName=featureNameValue (TRUNCATE HISTORY)?   #alterTableDropFeature
     | OPTIMIZE (path=STRING | table=qualifiedName)
         (WHERE partitionPredicate=predicateToken)?
         (zorderSpec)?                                                   #optimizeTable
@@ -225,7 +225,7 @@ nonReserved
     | ZORDER | LEFT_PAREN | RIGHT_PAREN
     | SHOW | COLUMNS | IN | FROM | NO | STATISTICS
     | CLONE | SHALLOW
-    | FEATURE
+    | FEATURE | TRUNCATE
     ;
 
 // Define how the keywords above should appear in a user's SQL statement.
@@ -284,6 +284,7 @@ SYSTEM_VERSION: 'SYSTEM_VERSION';
 TABLE: 'TABLE';
 TBLPROPERTIES: 'TBLPROPERTIES';
 TIMESTAMP: 'TIMESTAMP';
+TRUNCATE: 'TRUNCATE';
 TO: 'TO';
 TRUE: 'TRUE';
 VACUUM: 'VACUUM';

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -763,7 +763,17 @@
     "message" : [
       "Cannot drop <feature> because the Delta log contains historical versions that use the feature.",
       "Please wait until the history retention period (<logRetentionPeriodKey>=<logRetentionPeriod>) ",
-      "has passed since the feature was last active."
+      "has passed since the feature was last active.",
+      "",
+      "Alternatively, please wait for the TRUNCATE HISTORY retention period to expire (<truncateHistoryLogRetentionPeriod>)",
+      "and then run:",
+      "    ALTER TABLE table_name DROP FEATURE feature_name TRUNCATE HISTORY"
+    ],
+    "sqlState" : "0AKDE"
+  },
+  "DELTA_FEATURE_DROP_HISTORY_TRUNCATION_NOT_ALLOWED" : {
+    "message" : [
+      "History truncation is only relevant for reader features."
     ],
     "sqlState" : "0AKDE"
   },
@@ -790,7 +800,11 @@
       "",
       "To drop the table feature from the protocol, please wait for the historical versions to",
       "expire, and then repeat this command. The retention period for historical versions is",
-      "currently configured as <logRetentionPeriodKey>=<logRetentionPeriod>."
+      "currently configured as <logRetentionPeriodKey>=<logRetentionPeriod>.",
+      "",
+      "Alternatively, please wait for the TRUNCATE HISTORY retention period to expire (<truncateHistoryLogRetentionPeriod>)",
+      "and then run:",
+      "    ALTER TABLE table_name DROP FEATURE feature_name TRUNCATE HISTORY"
     ],
     "sqlState" : "0AKDE"
   },

--- a/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
+++ b/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
@@ -513,10 +513,12 @@ class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
    * Parse an ALTER TABLE DROP FEATURE command.
    */
   override def visitAlterTableDropFeature(ctx: AlterTableDropFeatureContext): LogicalPlan = {
+    val truncateHistory = ctx.TRUNCATE != null && ctx.HISTORY != null
     AlterTableDropFeature(
       createUnresolvedTable(ctx.table.identifier.asScala.map(_.getText).toSeq,
         "ALTER TABLE ... DROP FEATURE"),
-      visitFeatureNameValue(ctx.featureName))
+      visitFeatureNameValue(ctx.featureName),
+      truncateHistory)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/deltaTableFeatures.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/deltaTableFeatures.scala
@@ -24,8 +24,9 @@ import org.apache.spark.sql.connector.catalog.TableChange
  * The logical plan of the ALTER TABLE ... DROP FEATURE command.
  */
 case class AlterTableDropFeature(
-    table: LogicalPlan, featureName: String) extends AlterTableCommand {
-  override def changes: Seq[TableChange] = Seq(DropFeature(featureName))
-
+    table: LogicalPlan,
+    featureName: String,
+    truncateHistory: Boolean) extends AlterTableCommand {
+  override def changes: Seq[TableChange] = Seq(DropFeature(featureName, truncateHistory))
   protected def withNewChildInternal(newChild: LogicalPlan): LogicalPlan = copy(table = newChild)
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -411,6 +411,19 @@ trait DeltaConfigsBase extends DeltaLogging {
   )
 
   /**
+   * The logRetention period to be used in DROP FEATURE ... TRUNCATE HISTORY command.
+   * The value should represent the expected duration of the longest running transaction. Setting
+   * this to a lower value than the longest running transaction may corrupt the table.
+   */
+  val TABLE_FEATURE_DROP_TRUNCATE_HISTORY_LOG_RETENTION = buildConfig[CalendarInterval](
+    "dropFeatureTruncateHistory.retentionDuration",
+    "interval 24 hours",
+    parseCalendarInterval,
+    isValidIntervalConfigValue,
+    "needs to be provided as a calendar interval such as '2 weeks'. Months " +
+    "and years are not accepted. You may specify '365 days' for a year instead.")
+
+  /**
    * The shortest duration we have to keep logically deleted data files around before deleting them
    * physically. This is to prevent failures in stale readers after compactions or partition
    * overwrites.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -337,8 +337,12 @@ object DeltaOperations {
       "ifExists" -> ifExists)
   }
   /** Recorded when dropping a table feature. */
-  case class DropTableFeature(featureName: String) extends Operation("DROP FEATURE") {
-    override val parameters: Map[String, Any] = Map("featureName" -> featureName)
+  case class DropTableFeature(
+      featureName: String,
+      truncateHistory: Boolean) extends Operation("DROP FEATURE") {
+    override val parameters: Map[String, Any] = Map(
+      "featureName" -> featureName,
+      "truncateHistory" -> truncateHistory)
   }
   /** Recorded when columns are added. */
   case class AddColumns(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
@@ -698,8 +698,10 @@ class DeltaCatalog extends DelegatingCatalogExtension
 
       case (t, dropFeature) if t == classOf[DropFeature] =>
         // Only single feature removal is supported.
-        val featureName = dropFeature.head.asInstanceOf[DropFeature].featureName
-        AlterTableDropFeatureDeltaCommand(table, featureName).run(spark)
+        val dropFeatureTableChange = dropFeature.head.asInstanceOf[DropFeature]
+        val featureName = dropFeatureTableChange.featureName
+        val truncateHistory = dropFeatureTableChange.truncateHistory
+        AlterTableDropFeatureDeltaCommand(table, featureName, truncateHistory).run(spark)
 
     }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/tablefeatures/tableChanges.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/tablefeatures/tableChanges.scala
@@ -20,6 +20,7 @@ import org.apache.spark.sql.connector.catalog.TableChange
 
 /**
  * Change to remove a feature from a table.
-  * @param featureName The name of the feature
+ * @param featureName The name of the feature
+ * @param truncateHistory When true we set the minimum log retention period and clean up metadata.
  */
-case class DropFeature(featureName: String) extends TableChange {}
+case class DropFeature(featureName: String, truncateHistory: Boolean) extends TableChange {}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -26,7 +26,7 @@ import scala.sys.process.Process
 
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.DeltaErrors.generateDocsLink
-import org.apache.spark.sql.delta.actions.{Action, Protocol}
+import org.apache.spark.sql.delta.actions.{Action, Metadata, Protocol}
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.{TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION}
 import org.apache.spark.sql.delta.catalog.DeltaCatalog
 import org.apache.spark.sql.delta.constraints.CharVarcharConstraint
@@ -1535,6 +1535,40 @@ trait DeltaErrorsSuiteBase
       assert(e.getSqlState == "0AKDC")
       assert(e.getMessage == "Creating a bloom filter index on a column with type date is " +
         "unsupported: col1")
+    }
+    {
+      val e = intercept[DeltaTableFeatureException] {
+        throw DeltaErrors.tableFeatureDropHistoryTruncationNotAllowed()
+      }
+      assert(e.getErrorClass == "DELTA_FEATURE_DROP_HISTORY_TRUNCATION_NOT_ALLOWED")
+      assert(e.getSqlState == "0AKDE")
+      assert(e.getMessage == "History truncation is only relevant for reader features.")
+    }
+    {
+      val logRetention = DeltaConfigs.LOG_RETENTION
+      val e = intercept[DeltaTableFeatureException] {
+        throw DeltaErrors.dropTableFeatureWaitForRetentionPeriod(
+          "test_feature",
+          Metadata(configuration = Map(logRetention.key -> "30 days")))
+      }
+      assert(e.getErrorClass == "DELTA_FEATURE_DROP_WAIT_FOR_RETENTION_PERIOD")
+      assert(e.getSqlState == "0AKDE")
+
+      val expectedMessage =
+        """Dropping test_feature was partially successful.
+          |
+          |The feature is now no longer used in the current version of the table. However, the feature
+          |is still present in historical versions of the table. The table feature cannot be dropped
+          |from the table protocol until these historical versions have expired.
+          |
+          |To drop the table feature from the protocol, please wait for the historical versions to
+          |expire, and then repeat this command. The retention period for historical versions is
+          |currently configured as delta.logRetentionDuration=30 days.
+          |
+          |Alternatively, please wait for the TRUNCATE HISTORY retention period to expire (24 hours)
+          |and then run:
+          |    ALTER TABLE table_name DROP FEATURE feature_name TRUNCATE HISTORY""".stripMargin
+      assert(e.getMessage == expectedMessage)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

The `DROP FEATURE` command allows to drop table features from Delta Tables. Dropping a reader+writer feature is performed in two steps:

1. We clean all traces of the feature in the latest version and inform the user they need to wait until the retention period is over.
2. After the retention period is over, the user executes the command again and the protocol is downgraded.

This PR adds the `TRUNCATE HISTORY` option in `DROP FEATURE` command. The new option is automatically sets the history retention period to minimum and cleans up metadata. This operation occurs at the second time the user invokes the operation.

## How was this patch tested?
Added tests in DeltaProtocolVersionSuite and DeltaErrorsSuite.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
Introduces the TRUNCATE HISTORY option in ALTER TABLE ... DROP FEATURE command. This can be used as follows:

`ALTER TABLE table_name DROP FEATURE feature_name [TRUNCATE HISTORY] `

The new option allows to truncate history older than the minimum retention period when dropping a reader+writer feature.

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
