### PR TITLE
[Standalone] Use GoldenTableUtils in ShadedJarSuite (to test delta standalone jar)

### DIFF
--- a/connectors/testStandaloneCosmetic/src/test/scala/io/delta/standalone/internal/ShadedJarSuite.scala
+++ b/connectors/testStandaloneCosmetic/src/test/scala/io/delta/standalone/internal/ShadedJarSuite.scala
@@ -70,8 +70,7 @@ class ShadedJarSuite extends FunSuite {
   test("basic read and write to verify the final delta-standalone jar is working") {
     val dir = Files.createTempDirectory(UUID.randomUUID().toString).toFile
     try {
-      val tablePath = new File("../golden-tables/src/test/resources/golden/data-reader-primitives")
-        .getCanonicalFile
+      val tablePath = io.delta.golden.GoldenTableUtils.goldenTableFile("data-reader-primitives")
       FileUtils.copyDirectory(tablePath, dir)
       val log = DeltaLog.forTable(new Configuration(), dir.getCanonicalPath)
       log.asInstanceOf[DeltaLogImpl].checkpoint()


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [X] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Minor refactor to use GoldenTableUtils in ShadedJarSuite.

## How was this patch tested?

Trivial.

## Does this PR introduce _any_ user-facing changes?

No.
