### PR TITLE
[Spark] Fix integration tests (use `delta-spark` or `delta-core` artifact based on the version to test)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,5 +5,5 @@ In this folder there are examples taken from the delta.io quickstart guide and d
 * See [Set up Apache Spark with Delta Lake](https://docs.delta.io/latest/quick-start.html#set-up-apache-spark-with-delta-lake).
 
 ### Instructions
-* To run an example in Python run `spark-submit --packages io.delta:delta-core_2.12:{Delta Lake version} PATH/TO/EXAMPLE`
+* To run an example in Python run `spark-submit --packages io.delta:delta-spark_2.12:{Delta Lake version} PATH/TO/EXAMPLE`
 * To run the Scala examples, `cd examples/scala` and run `./build/sbt "runMain example.{Example class name}"` e.g. `./build/sbt "runMain example.Quickstart"`

--- a/examples/scala/build.sbt
+++ b/examples/scala/build.sbt
@@ -57,6 +57,9 @@ val getScalaVersion = settingKey[String](
 val getDeltaVersion = settingKey[String](
   s"get delta version from environment variable DELTA_VERSION. If it doesn't exist, use $deltaVersion"
 )
+val getDeltaArtifactName = settingKey[String](
+  s"get delta artifact name based on the delta version. either `delta-core` or `delta-spark`."
+)
 
 getScalaVersion := {
   sys.env.get("SCALA_VERSION") match {
@@ -87,6 +90,11 @@ getDeltaVersion := {
   }
 }
 
+getDeltaArtifactName := {
+  val deltaVersion = getDeltaVersion.value
+  if (deltaVersion.charAt(0).asDigit >= 3) "delta-spark" else "delta-core"
+}
+
 lazy val extraMavenRepo = sys.env.get("EXTRA_MAVEN_REPO").toSeq.map { repo =>
   resolvers += "Delta" at repo
 }
@@ -97,7 +105,7 @@ lazy val root = (project in file("."))
     name := "hello-world",
     crossScalaVersions := Seq(scala212, scala213),
     libraryDependencies ++= Seq(
-      "io.delta" %% "delta-core" % getDeltaVersion.value,
+      "io.delta" %% getDeltaArtifactName.value % getDeltaVersion.value,
       "org.apache.spark" %% "spark-sql" % lookupSparkVersion.apply(
         getMajorMinor(getDeltaVersion.value)
       )

--- a/run-integration-tests.py
+++ b/run-integration-tests.py
@@ -61,6 +61,14 @@ def run_scala_integration_tests(root_dir, version, test_name, extra_maven_repo, 
                 raise
 
 
+def get_artifact_name(version):
+    """
+    version: string representation, e.g. 2.3.0 or 3.0.0.rc1
+    return: either "core" or "spark"
+    """
+    return "spark" if int(version[0]) >= 3 else "core"
+
+
 def run_python_integration_tests(root_dir, version, test_name, extra_maven_repo, use_local):
     print("\n\n##### Running Python tests on version %s #####" % str(version))
     clear_artifact_cache()
@@ -77,7 +85,7 @@ def run_python_integration_tests(root_dir, version, test_name, extra_maven_repo,
 
     python_root_dir = path.join(root_dir, "python")
     extra_class_path = path.join(python_root_dir, path.join("delta", "testing"))
-    package = "io.delta:delta-core_2.12:" + version
+    package = "io.delta:delta-%s_2.12:%s" % (get_artifact_name(version), version)
 
     repo = extra_maven_repo if extra_maven_repo else ""
 
@@ -117,11 +125,12 @@ def test_missing_delta_storage_jar(root_dir, version, use_local):
     python_root_dir = path.join(root_dir, "python")
     extra_class_path = path.join(python_root_dir, path.join("delta", "testing"))
     test_file = path.join(root_dir, path.join("examples", "python", "missing_delta_storage_jar.py"))
+    artifact_name = get_artifact_name(version)
     jar = path.join(
         os.path.expanduser("~/.m2/repository/io/delta/"),
-        "delta-core_2.12",
+        "delta-%s_2.12" % artifact_name,
         version,
-        "delta-core_2.12-%s.jar" % str(version))
+        "delta-%s_2.12-%s.jar" % (artifact_name, str(version)))
 
     try:
         cmd = ["spark-submit",
@@ -151,7 +160,7 @@ def run_dynamodb_logstore_integration_tests(root_dir, version, test_name, extra_
 
     python_root_dir = path.join(root_dir, "python")
     extra_class_path = path.join(python_root_dir, path.join("delta", "testing"))
-    packages = "io.delta:delta-core_2.12:" + version
+    packages = "io.delta:delta-%s_2.12:%s" % (get_artifact_name(version), version)
     packages += "," + "io.delta:delta-storage-s3-dynamodb:" + version
     if extra_packages:
         packages += "," + extra_packages
@@ -211,7 +220,7 @@ def run_iceberg_integration_tests(root_dir, version, spark_version, iceberg_vers
     python_root_dir = path.join(root_dir, "python")
     extra_class_path = path.join(python_root_dir, path.join("delta", "testing"))
     package = ','.join([
-        "io.delta:delta-core_2.12:" + version,
+        "io.delta:delta-%s_2.12:%s" % (get_artifact_name(version), version),
         "io.delta:delta-iceberg_2.12:" + version,
         "org.apache.iceberg:iceberg-spark-runtime-{}_2.12:{}".format(spark_version, iceberg_version)])
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Update our integration tests (scala, python, with pip, without pip) to use the artifact `delta-spark` when the version is >= 3, else `delta-core`.

## How was this patch tested?

```
python3 run-integration-tests.py --version 3.0.0rc1 --no-pip
python3 run-integration-tests.py --version 2.4.0 --no-pip

python3 run-integration-tests.py --version 3.0.0rc1 --pip-only
python3 run-integration-tests.py --version 2.4.0 --pip-only
```

## Does this PR introduce _any_ user-facing changes?
No