### PR TITLE
[Spark] Define and use DeltaTableV2.startTransaction helper method

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
@@ -286,12 +286,8 @@ trait DeltaCommand extends DeltaLogging {
    * other cases this method will throw a "Table not found" exception.
    */
   def getDeltaTable(target: LogicalPlan, cmd: String): DeltaTableV2 = {
-    target match {
-      case ResolvedTable(_, _, d: DeltaTableV2, _) => d
-      case ResolvedTable(_, _, t: V1Table, _) if DeltaTableUtils.isDeltaTable(t.catalogTable) =>
-        DeltaTableV2(SparkSession.active, new Path(t.v1Table.location), Some(t.v1Table))
-      case _ => throw DeltaErrors.notADeltaTableException(cmd)
-    }
+    // TODO: Remove this wrapper and let former callers invoke DeltaTableV2.extractFrom directly.
+    DeltaTableV2.extractFrom(target, cmd)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -49,14 +49,15 @@ trait AlterDeltaTableCommand extends DeltaCommand {
 
   def table: DeltaTableV2
 
-  protected def startTransaction(spark: SparkSession): OptimisticTransaction = {
-    val txn = table.deltaLog.startTransaction()
+  protected def startTransaction(): OptimisticTransaction = {
+    // WARNING: It's not safe to use startTransactionWithInitialSnapshot here. Some commands call
+    // this method more than once, and some commands can be created with a stale table.
+    val txn = table.startTransaction()
     if (txn.readVersion == -1) {
       throw DeltaErrors.notADeltaTableException(table.name())
     }
     txn
   }
-
 
   /**
    * Check if the column to change has any dependent expressions:
@@ -106,7 +107,7 @@ case class AlterTableSetPropertiesDeltaCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val deltaLog = table.deltaLog
     recordDeltaOperation(deltaLog, "delta.ddl.alter.setProperties") {
-      val txn = startTransaction(sparkSession)
+      val txn = startTransaction()
 
       val metadata = txn.metadata
       val filteredConfs = configuration.filterKeys {
@@ -154,7 +155,7 @@ case class AlterTableUnsetPropertiesDeltaCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val deltaLog = table.deltaLog
     recordDeltaOperation(deltaLog, "delta.ddl.alter.unsetProperties") {
-      val txn = startTransaction(sparkSession)
+      val txn = startTransaction()
       val metadata = txn.metadata
 
       val normalizedKeys = DeltaConfigs.normalizeConfigKeys(propKeys)
@@ -292,7 +293,7 @@ case class AlterTableDropFeatureDeltaCommand(
           featureName, table.snapshot.metadata)
       }
 
-      val txn = startTransaction(sparkSession)
+      val txn = table.startTransaction()
       val snapshot = txn.snapshot
 
       // Verify whether all requirements hold before performing the protocol downgrade.
@@ -348,7 +349,7 @@ case class AlterTableAddColumnsDeltaCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val deltaLog = table.deltaLog
     recordDeltaOperation(deltaLog, "delta.ddl.alter.addColumns") {
-      val txn = startTransaction(sparkSession)
+      val txn = startTransaction()
 
       if (SchemaUtils.filterRecursively(
             StructType(colsToAddWithPosition.map {
@@ -444,7 +445,7 @@ case class AlterTableDropColumnsDeltaCommand(
     }
     val deltaLog = table.deltaLog
     recordDeltaOperation(deltaLog, "delta.ddl.alter.dropColumns") {
-      val txn = startTransaction(sparkSession)
+      val txn = startTransaction()
       val metadata = txn.metadata
       if (txn.metadata.columnMappingMode == NoMapping) {
         throw DeltaErrors.dropColumnNotSupported(suggestUpgrade = true)
@@ -504,7 +505,7 @@ case class AlterTableChangeColumnDeltaCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val deltaLog = table.deltaLog
     recordDeltaOperation(deltaLog, "delta.ddl.alter.changeColumns") {
-      val txn = startTransaction(sparkSession)
+      val txn = startTransaction()
       val metadata = txn.metadata
       val oldSchema = metadata.schema
       val resolver = sparkSession.sessionState.conf.resolver
@@ -708,7 +709,7 @@ case class AlterTableReplaceColumnsDeltaCommand(
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     recordDeltaOperation(table.deltaLog, "delta.ddl.alter.replaceColumns") {
-      val txn = startTransaction(sparkSession)
+      val txn = startTransaction()
 
       val metadata = txn.metadata
       val existingSchema = metadata.schema
@@ -837,7 +838,7 @@ case class AlterTableAddConstraintDeltaCommand(
       throw DeltaErrors.invalidConstraintName(name)
     }
     recordDeltaOperation(deltaLog, "delta.ddl.alter.addConstraint") {
-      val txn = startTransaction(sparkSession)
+      val txn = startTransaction()
 
       getConstraintWithName(table, name, txn.metadata, sparkSession).foreach { oldExpr =>
         throw DeltaErrors.constraintAlreadyExists(name, oldExpr)
@@ -889,7 +890,7 @@ case class AlterTableDropConstraintDeltaCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val deltaLog = table.deltaLog
     recordDeltaOperation(deltaLog, "delta.ddl.alter.dropConstraint") {
-      val txn = startTransaction(sparkSession)
+      val txn = startTransaction()
 
       val oldExprText = Constraints.getExprTextByName(name, txn.metadata, sparkSession)
       if (oldExprText.isEmpty && !ifExists && !sparkSession.sessionState.conf.getConf(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/schema/InvariantEnforcementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/schema/InvariantEnforcementSuite.scala
@@ -24,6 +24,7 @@ import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.delta.{CheckConstraintsTableFeature, DeltaLog, DeltaOperations}
 import org.apache.spark.sql.delta.actions.{Metadata, TableFeatureProtocolUtils}
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.constraints.{Constraint, Constraints, Invariants}
 import org.apache.spark.sql.delta.constraints.Constraints.NotNull
 import org.apache.spark.sql.delta.constraints.Invariants.PersistedExpression
@@ -400,8 +401,8 @@ class InvariantEnforcementSuite extends QueryTest
       withTable("constraint") {
         spark.range(10).selectExpr("id AS valueA", "id AS valueB", "id AS valueC")
           .write.format("delta").saveAsTable("constraint")
-        val log = DeltaLog.forTable(spark, TableIdentifier("constraint", None))
-        val txn = log.startTransaction()
+        val table = DeltaTableV2(spark, TableIdentifier("constraint", None))
+        val txn = table.startTransactionWithInitialSnapshot()
         val newMetadata = txn.metadata.copy(
           configuration = txn.metadata.configuration +
             ("delta.constraints.mychk" -> "valueA < valueB"))
@@ -412,7 +413,7 @@ class InvariantEnforcementSuite extends QueryTest
         } else {
           CheckConstraintsTableFeature.minWriterVersion
         }
-        assert(log.snapshot.protocol.minWriterVersion === upVersion)
+        assert(table.deltaLog.unsafeVolatileSnapshot.protocol.minWriterVersion === upVersion)
         spark.sql("INSERT INTO constraint VALUES (50, 100, null)")
         val e = intercept[InvariantViolationException] {
           spark.sql("INSERT INTO constraint VALUES (100, 50, null)")
@@ -438,8 +439,8 @@ class InvariantEnforcementSuite extends QueryTest
       withTable("constraint") {
         spark.range(10).selectExpr("id AS valueA", "id AS valueB")
           .write.format("delta").saveAsTable("constraint")
-        val log = DeltaLog.forTable(spark, TableIdentifier("constraint", None))
-        val txn = log.startTransaction()
+        val table = DeltaTableV2(spark, TableIdentifier("constraint", None))
+        val txn = table.startTransactionWithInitialSnapshot()
         val newMetadata = txn.metadata.copy(
           configuration = txn.metadata.configuration +
             ("delta.constraints.mychk" -> "valueA < valueB"))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/test/DeltaTestImplicits.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/test/DeltaTestImplicits.scala
@@ -19,8 +19,10 @@ package org.apache.spark.sql.delta.test
 import org.apache.spark.sql.delta.{DeltaLog, OptimisticTransaction, Snapshot}
 import org.apache.spark.sql.delta.DeltaOperations.{ManualUpdate, Operation, Write}
 import org.apache.spark.sql.delta.actions.{Action, Metadata, Protocol}
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
 
 import org.apache.spark.sql.{SaveMode, SparkSession}
+import org.apache.spark.sql.catalyst.TableIdentifier
 
 /**
  * Additional method definitions for Delta classes that are intended for use only in testing.
@@ -87,5 +89,11 @@ object DeltaTestImplicits {
     def enableExpiredLogCleanup(): Boolean = {
       deltaLog.enableExpiredLogCleanup(snapshot.metadata)
     }
+  }
+
+  implicit class DeltaTableV2ObjectTestHelper(dt: DeltaTableV2.type) {
+    /** Convenience overload that omits the cmd arg (which is not helpful in tests). */
+    def apply(spark: SparkSession, id: TableIdentifier): DeltaTableV2 =
+      dt.apply(spark, id, "test")
   }
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

As part of making Delta more catalog-aware (see https://github.com/delta-io/delta/issues/2052), we need to solve two basic problems:
1. When code calls the `TableIdentifier` overload of `DeltaLog.forTable`, the catalog lookup is performed internally and immediately discarded after extracting the table's storage location from it. If the caller needed the catalog info, they are out of luck. Caller can avoid the problem by creating a `DeltaTableV2` instead, which already provides both `DeltaLog` and `CatalogTable`. To support this use case, we define new helper methods that make this easy to do (especially for unit tests).
2. Even if we have a `DeltaTableV2`, there's no convenient way to start a transaction from it, in order to pass along the catalog info. To make it easy for callers to do the right thing, we define new helper methods for starting transactions directly from the `DeltaTableV2` itself. When transactions eventually become aware of catalog info, these new helper methods will make a narrow waist that can be enhanced to pass along their catalog info.

## How was this patch tested?

Existing unit tests (most changes are anyway in test code).

## Does this PR introduce _any_ user-facing changes?

Internal APIs only.