### PR TITLE
[Kernel] Fix a bug around closing partially opened resources

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActionsIterator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActionsIterator.java
@@ -226,12 +226,9 @@ class ActionsIterator implements CloseableIterator<Tuple2<FileDataReadResult, Bo
                 );
             }
         } catch (IOException ex) {
+            // Close the opened iterators to avoid resource leak
+            Utils.closeCloseablesSilently(iteratorsToClose);
             throw new UncheckedIOException(ex);
-        } finally {
-            // We don't know if this is normal operation, or if `readJsonFiles` or
-            // `readParquetFiles` above have thrown an exception. Luckily, it doesn't matter:
-            // closing a closeable that is already closed is safe.
-            Utils.closeCloseables(iteratorsToClose);
         }
     }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description
Fix a bug in resource handling where we are always closing the resources which should be closed only when a failure occurs.

Currently, the code opens two resources, it maintains the opened resource list to close in case the function isn't successful in opening all the required resources. Resources in the maintained list should only be closed when an error occurs (it should be in the `catch` block not in `finally`)

## How was this patch tested?
Existing tests

## Does this PR introduce _any_ user-facing changes?
No
