### PR TITLE
[Kernel] Rename `DataReadResult` to `FilteredColumnarBatch`

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/data/ColumnarBatch.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/data/ColumnarBatch.java
@@ -16,6 +16,8 @@
 
 package io.delta.kernel.data;
 
+import java.util.NoSuchElementException;
+
 import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
@@ -118,6 +120,9 @@ public interface ColumnarBatch {
 
             @Override
             public Row next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
                 Row row = new ColumnarBatchRow(batch, rowId);
                 rowId += 1;
                 return row;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
@@ -102,11 +102,10 @@ public class LogReplay implements Logging {
     }
 
     /**
-     * Returns an iterator of {@link DataReadResult} with schema {@link #ADD_ONLY_DATA_SCHEMA}
-     * representing all the active AddFiles in the table (passing the DataReadResult's selection
-     * vector means it is active).
+     * Returns an iterator of {@link FilteredColumnarBatch} with schema
+     * {@link #ADD_ONLY_DATA_SCHEMA} representing all the active AddFiles in the table
      */
-    public CloseableIterator<DataReadResult> getAddFilesAsColumnarBatches() {
+    public CloseableIterator<FilteredColumnarBatch> getAddFilesAsColumnarBatches() {
         final CloseableIterator<Tuple2<FileDataReadResult, Boolean>> addRemoveIter =
             new ActionsIterator(
                 tableClient,
@@ -128,7 +127,7 @@ public class LogReplay implements Logging {
      */
     public CloseableIterator<AddFile> getAddFiles() {
         return new CloseableIterator<AddFile>() {
-            private final CloseableIterator<DataReadResult> batchesIter =
+            private final CloseableIterator<FilteredColumnarBatch> batchesIter =
                 getAddFilesAsColumnarBatches();
 
             // empty - not yet initialized
@@ -190,7 +189,7 @@ public class LogReplay implements Logging {
 
                         // even if this next `currBatchIter` doesn't have any rows, the while loop
                         // will check for it and keep searching
-                        final DataReadResult dataReadResult = batchesIter.next();
+                        final FilteredColumnarBatch dataReadResult = batchesIter.next();
                         assert(dataReadResult.getData().getSchema().equals(ADD_ONLY_DATA_SCHEMA));
                         currBatchIter = Optional.of(dataReadResult.getData().getRows());
                         currBatchSelectionVector = dataReadResult.getSelectionVector();

--- a/kernel/kernel-defaults/src/test/java/io/delta/kernel/defaults/integration/BaseIntegration.java
+++ b/kernel/kernel-defaults/src/test/java/io/delta/kernel/defaults/integration/BaseIntegration.java
@@ -29,7 +29,7 @@ import io.delta.kernel.Table;
 import io.delta.kernel.client.TableClient;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.ColumnarBatch;
-import io.delta.kernel.data.DataReadResult;
+import io.delta.kernel.data.FilteredColumnarBatch;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.types.*;
 import io.delta.kernel.utils.CloseableIterator;
@@ -79,14 +79,14 @@ public abstract class BaseIntegration {
         try {
             while (scanFilesBatchIter.hasNext()) {
                 // Read data
-                try (CloseableIterator<DataReadResult> data =
+                try (CloseableIterator<FilteredColumnarBatch> data =
                     Scan.readData(
                         tableClient,
                         scanState,
                         scanFilesBatchIter.next().getRows(),
                         Optional.empty())) {
                     while (data.hasNext()) {
-                        DataReadResult dataReadResult = data.next();
+                        FilteredColumnarBatch dataReadResult = data.next();
                         assertFalse(dataReadResult.getSelectionVector().isPresent());
                         dataBatches.add(dataReadResult.getData());
                     }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description
This is a preparatory change for supporting partition pruning in Delta Kernel.

Currently `DataReadResult` is used in representing a `ColumnarBatch` with a selection vector. It is used when reading the data from the scan files. The `ColumnarBatch` is the data read from Parquet data files and the selection vector is populated based on the deletion vector associated with the scan file. Having selection vector avoids the cost of rewriting the `ColumnarBatch`. We want to use the similar `DataReadResult` in metadata. Currently `Scan.getScanFiles` returns an iterator of `ColumnarBatch`. Instead, the plan is to return `DataReadResult` (which contains the `ColumnarBatch` of scan files, and a selection vector that tells whether a scan file is pruned or not based on the partition filter.).

Renaming `DataReadResult` to `FilteredColumnarBatch` to make it generic so that it is used both in the data and metadata path.

I am open to any other better names.

Also:
* Remove the API `public ColumnarBatch rewriteWithoutSelectionVector()` as `FilteredColumnarBatch` is `kernel-api` class and `kernel-api` shouldn't rewrite `ColumnarBatch`es.
* Add `getRows()` API on `FilteredColumnarBatch` to iterate through the rows that survived the selection vector. This API helps when the connectors have an easy way to access the survived rows (for example to iterate over the scan file rows that survived the selection vector).
* Fix a bug in `ColumnarBatch.getRows().hasNext()`
