### PR TITLE
[Kernel] Resolve path given to `Table.forPath` using `TableClient` APIs

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Table.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Table.java
@@ -30,13 +30,15 @@ public interface Table {
     /**
      * Instantiate a table object for the Delta Lake table at the given path.
      *
-     * @param path location where the Delta table is present. Path needs to be fully qualified.
+     * @param tableClient {@link TableClient} instance to use in Delta Kernel.
+     * @param path        location where the Delta table is present. Path is resolved to fully
+     *                    qualified path using the given {@code tableClient}.
      * @return an instance of {@link Table} representing the Delta table at given path
      * @throws TableNotFoundException when there is no Delta table at the given path.
      */
-    static Table forPath(String path)
+    static Table forPath(TableClient tableClient, String path)
         throws TableNotFoundException {
-        return TableImpl.forPath(path);
+        return TableImpl.forPath(tableClient, path);
     }
 
     /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/TableNotFoundException.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/TableNotFoundException.java
@@ -26,4 +26,20 @@ import io.delta.kernel.annotation.Evolving;
 @Evolving
 public class TableNotFoundException
     extends Exception {
+
+    private final String tablePath;
+
+    public TableNotFoundException(String tablePath) {
+        this.tablePath = tablePath;
+    }
+
+    public TableNotFoundException(String tablePath, Throwable cause) {
+        super(cause);
+        this.tablePath = tablePath;
+    }
+
+    @Override
+    public String getMessage() {
+        return String.format("Table at path `%s` is not found", tablePath);
+    }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/client/FileSystemClient.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/client/FileSystemClient.java
@@ -43,9 +43,18 @@ public interface FileSystemClient {
      * @return Closeable iterator of files. It is the responsibility of the caller to close the
      * iterator.
      * @throws FileNotFoundException if the file at the given path is not found
+     * @throws IOException for any other IO error.
      */
-    CloseableIterator<FileStatus> listFrom(String filePath)
-        throws FileNotFoundException;
+    CloseableIterator<FileStatus> listFrom(String filePath) throws IOException;
+
+    /**
+     * Resolve the given path to a fully qualified path.
+     * @param path Input path
+     * @return Fully qualified path.
+     * @throws FileNotFoundException If the given path doesn't exist.
+     * @throws IOException for any other IO error.
+     */
+    String resolvePath(String path) throws IOException;
 
     // TODO: solidify input type; need some combination of path, offset, size
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -17,6 +17,7 @@
 package io.delta.kernel.internal.snapshot;
 
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -104,7 +105,7 @@ public class SnapshotManager
         Path logPath,
         TableClient tableClient,
         long startVersion)
-        throws FileNotFoundException {
+        throws IOException {
         logDebug(String.format("startVersion: %s", startVersion));
         return tableClient
             .getFileSystemClient()
@@ -144,6 +145,8 @@ public class SnapshotManager
             }
         } catch (FileNotFoundException e) {
             return Optional.empty();
+        } catch (IOException io) {
+            throw new RuntimeException("Failed to list the files in delta log", io);
         }
     }
 
@@ -220,7 +223,7 @@ public class SnapshotManager
                 logPath,
                 dataPath,
                 tableClient))
-            .orElseThrow(TableNotFoundException::new);
+            .orElseThrow(() -> new TableNotFoundException(dataPath.toString()));
     }
 
     private SnapshotImpl createSnapshot(

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileSystemClient.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileSystemClient.java
@@ -45,35 +45,38 @@ public class DefaultFileSystemClient
     }
 
     @Override
-    public CloseableIterator<FileStatus> listFrom(String filePath) {
-        try {
-            Iterator<org.apache.hadoop.fs.FileStatus> iter;
+    public CloseableIterator<FileStatus> listFrom(String filePath) throws IOException {
+        Iterator<org.apache.hadoop.fs.FileStatus> iter;
 
-            Path path = new Path(filePath);
-            FileSystem fs = path.getFileSystem(hadoopConf);
-            if (!fs.exists(path.getParent())) {
-                throw new FileNotFoundException(
-                    String.format("No such file or directory: %s", path.getParent())
-                );
-            }
-            org.apache.hadoop.fs.FileStatus[] files = fs.listStatus(path.getParent());
-            iter = Arrays.stream(files)
-                .filter(f -> f.getPath().getName().compareTo(path.getName()) >= 0)
-                .sorted(Comparator.comparing(o -> o.getPath().getName()))
-                .iterator();
-
-            return Utils.toCloseableIterator(iter)
-                .map(hadoopFileStatus ->
-                    FileStatus.of(
-                        hadoopFileStatus.getPath().toString(),
-                        hadoopFileStatus.getLen(),
-                        hadoopFileStatus.getModificationTime())
-                );
-        } catch (Exception ex) {
-            throw new RuntimeException("Could not resolve the FileSystem", ex);
+        Path path = new Path(filePath);
+        FileSystem fs = path.getFileSystem(hadoopConf);
+        if (!fs.exists(path.getParent())) {
+            throw new FileNotFoundException(
+                String.format("No such file or directory: %s", path.getParent())
+            );
         }
+        org.apache.hadoop.fs.FileStatus[] files = fs.listStatus(path.getParent());
+        iter = Arrays.stream(files)
+            .filter(f -> f.getPath().getName().compareTo(path.getName()) >= 0)
+            .sorted(Comparator.comparing(o -> o.getPath().getName()))
+            .iterator();
+
+        return Utils.toCloseableIterator(iter)
+            .map(hadoopFileStatus ->
+                FileStatus.of(
+                    hadoopFileStatus.getPath().toString(),
+                    hadoopFileStatus.getLen(),
+                    hadoopFileStatus.getModificationTime())
+            );
     }
 
+    @Override
+    public String resolvePath(String path) throws IOException {
+        Path pathObject = new Path(path);
+        FileSystem fs = pathObject.getFileSystem(hadoopConf);
+        Path resolvedPath = fs.resolvePath(pathObject);
+        return fs.makeQualified(resolvedPath).toString();
+    }
     @Override
     public CloseableIterator<ByteArrayInputStream> readFiles(
         CloseableIterator<Tuple2<String, Tuple2<Integer, Integer>>> iter) {

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileSystemClient.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileSystemClient.java
@@ -77,6 +77,7 @@ public class DefaultFileSystemClient
         Path resolvedPath = fs.resolvePath(pathObject);
         return fs.makeQualified(resolvedPath).toString();
     }
+
     @Override
     public CloseableIterator<ByteArrayInputStream> readFiles(
         CloseableIterator<Tuple2<String, Tuple2<Integer, Integer>>> iter) {

--- a/kernel/kernel-defaults/src/test/java/io/delta/kernel/defaults/client/TestDefaultFileSystemClient.java
+++ b/kernel/kernel-defaults/src/test/java/io/delta/kernel/defaults/client/TestDefaultFileSystemClient.java
@@ -15,6 +15,7 @@
  */
 package io.delta.kernel.defaults.client;
 
+import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -31,8 +32,9 @@ import static io.delta.kernel.defaults.utils.DefaultKernelTestUtils.getTestResou
 public class TestDefaultFileSystemClient {
     @Test
     public void listFrom() throws Exception {
-        String basePath = getTestResourceFilePath("json-files");
-        String listFrom = getTestResourceFilePath("json-files/2.json");
+        DefaultFileSystemClient fsClient = fsClient();
+        String basePath = fsClient.resolvePath(getTestResourceFilePath("json-files"));
+        String listFrom = fsClient.resolvePath(getTestResourceFilePath("json-files/2.json"));
 
         List<String> actListOutput = new ArrayList<>();
         try (CloseableIterator<FileStatus> files = fsClient().listFrom(listFrom)) {
@@ -44,6 +46,23 @@ public class TestDefaultFileSystemClient {
         List<String> expListOutput = Arrays.asList(basePath + "/2.json", basePath + "/3.json");
 
         assertEquals(expListOutput, actListOutput);
+    }
+
+    @Test(expected = FileNotFoundException.class)
+    public void listFromOnNonExistentFile() throws Exception {
+        fsClient().listFrom("file:/non-existentfileTable/01.json");
+    }
+
+    @Test
+    public void resolvePath() throws Exception {
+        String inputPath = getTestResourceFilePath("json-files");
+        String resolvedPath = fsClient().resolvePath(inputPath);
+        assertEquals("file:" + inputPath, resolvedPath);
+    }
+
+    @Test(expected = FileNotFoundException.class)
+    public void resolvePathOnNonExistentFile() throws Exception {
+        fsClient().resolvePath("/non-existentfileTable/01.json");
     }
 
     private static DefaultFileSystemClient fsClient() {

--- a/kernel/kernel-defaults/src/test/java/io/delta/kernel/defaults/integration/BaseIntegration.java
+++ b/kernel/kernel-defaults/src/test/java/io/delta/kernel/defaults/integration/BaseIntegration.java
@@ -53,7 +53,7 @@ public abstract class BaseIntegration {
         });
 
     protected Table table(String path) throws Exception {
-        return Table.forPath(path);
+        return Table.forPath(tableClient, path);
     }
 
     protected Snapshot snapshot(String path) throws Exception {

--- a/kernel/kernel-defaults/src/test/java/io/delta/kernel/defaults/utils/DefaultKernelTestUtils.java
+++ b/kernel/kernel-defaults/src/test/java/io/delta/kernel/defaults/utils/DefaultKernelTestUtils.java
@@ -28,8 +28,7 @@ public class DefaultKernelTestUtils {
      * @return
      */
     public static String getTestResourceFilePath(String resourcePath) {
-        return "file:" +
-            DefaultKernelTestUtils.class.getClassLoader().getResource(resourcePath).getFile();
+        return DefaultKernelTestUtils.class.getClassLoader().getResource(resourcePath).getFile();
     }
 
     public static Object getValueAsObject(Row row, int columnOrdinal) {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeletionVectorSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeletionVectorSuite.scala
@@ -51,7 +51,7 @@ class DeletionVectorSuite extends AnyFunSuite with TestUtils {
       }
 
     checkTable(
-      path = "file:" + goldenTablePath("dv-partitioned-with-checkpoint"),
+      path = goldenTablePath("dv-partitioned-with-checkpoint"),
       expectedAnswer = expectedResult.map(TestRow.fromTuple(_)),
       tableClient = tableClient
     )

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LogReplaySuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LogReplaySuite.scala
@@ -68,7 +68,7 @@ class LogReplaySuite extends AnyFunSuite {
 
   test("simple end to end with inserts and deletes and checkpoint") {
     val unresolvedPath = GoldenTableUtils.goldenTablePath("basic-with-inserts-deletes-checkpoint")
-    val table = io.delta.kernel.Table.forPath(s"file:$unresolvedPath")
+    val table = io.delta.kernel.Table.forPath(tableClient, unresolvedPath)
     val conf = new Configuration()
     val client = DefaultTableClient.create(conf)
     val snapshot = table.getLatestSnapshot(client)

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -15,7 +15,9 @@
  */
 package io.delta.kernel.defaults.utils
 
-import java.util.{Optional, TimeZone}
+import java.io.File
+import java.nio.file.Files
+import java.util.{Optional, TimeZone, UUID}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
@@ -27,6 +29,7 @@ import io.delta.kernel.defaults.client.DefaultTableClient
 import io.delta.kernel.types._
 import io.delta.kernel.utils.CloseableIterator
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.shaded.org.apache.commons.io.FileUtils
 import org.scalatest.Assertions
 
 trait TestUtils extends Assertions {
@@ -285,5 +288,16 @@ trait TestUtils extends Assertions {
        |${prepareAnswer(result).map(_.toString()).mkString("(", ",", ")")}
        |
        |""".stripMargin
+  }
+
+  /**
+   * Creates a temporary directory, which is then passed to `f` and will be deleted after `f`
+   * returns.
+   */
+  protected def withTempDir(f: File => Unit): Unit = {
+    val tempDir = Files.createTempDirectory(UUID.randomUUID().toString).toFile
+    try f(tempDir) finally {
+      FileUtils.deleteDirectory(tempDir)
+    }
   }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -68,6 +68,11 @@ trait TestUtils extends Assertions {
     }
   }
 
+  def latestSnapshot(path: String): Snapshot = {
+    Table.forPath(defaultTableClient, path)
+      .getLatestSnapshot(defaultTableClient)
+  }
+
   def readSnapshot(
     snapshot: Snapshot,
     readSchema: StructType = null,
@@ -178,7 +183,7 @@ trait TestUtils extends Assertions {
     // version
   ): Unit = {
 
-    val snapshot = Table.forPath(path).getLatestSnapshot(tableClient)
+    val snapshot = Table.forPath(tableClient, path).getLatestSnapshot(tableClient)
 
     val readSchema = if (readCols == null) {
       null

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -183,7 +183,7 @@ trait TestUtils extends Assertions {
     // version
   ): Unit = {
 
-    val snapshot = Table.forPath(tableClient, path).getLatestSnapshot(tableClient)
+    val snapshot = latestSnapshot(path)
 
     val readSchema = if (readCols == null) {
       null


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description
Currently, we expect the path given to `Table.forPath()` to be fully qualified. This enforces an unnecessary burden on the connector to add the necessary schema or authority etc. Instead, add a `FileSystemClient.resolvePath` API and use it to resolve the path to a fully qualified path from `Table.forPath()`.

## How was this patch tested?
Existing tests (deleted the `file:` prefix added to tests tables in the path) and a couple of new tests around missing table paths.
