### PR TITLE
[Spark] Code cleanup

### DIFF
--- a/spark/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
+++ b/spark/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
@@ -487,7 +487,6 @@ object DeltaMergeMatchedActionBuilder {
  *
  * @since 0.3.0
  */
-@DeveloperApi
 class DeltaMergeNotMatchedActionBuilder private(
     private val mergeBuilder: DeltaMergeBuilder,
     private val notMatchCondition: Option[Column]) {

--- a/spark/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
+++ b/spark/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
@@ -487,6 +487,7 @@ object DeltaMergeMatchedActionBuilder {
  *
  * @since 0.3.0
  */
+@DeveloperApi
 class DeltaMergeNotMatchedActionBuilder private(
     private val mergeBuilder: DeltaMergeBuilder,
     private val notMatchCondition: Option[Column]) {

--- a/spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/deltaMerge.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/deltaMerge.scala
@@ -150,7 +150,7 @@ object DeltaMergeIntoClause {
       isEmptySeqEqualToStar: Boolean = true): Seq[Expression] = {
     assert(colNames.size == exprs.size)
     if (colNames.isEmpty && isEmptySeqEqualToStar) {
-      Seq[Expression](UnresolvedStar(None))
+      Seq(UnresolvedStar(None))
     } else {
       (colNames, exprs).zipped.map { (col, expr) => DeltaMergeAction(col.nameParts, expr) }
     }
@@ -608,8 +608,8 @@ object DeltaMergeInto {
           field.dataType match {
             // Specifically assigned to in one clause: always keep, including all nested attributes
             case _ if assignments.contains(fieldPath) => Some(field)
-            // If this is a struct and one of the child is being assigned to in a merge clause, keep
-            // it and continue filtering children.
+            // If this is a struct and one of the children is being assigned to in a merge clause,
+            // keep it and continue filtering children.
             case struct: StructType if childAssignedInMergeClause =>
               Some(field.copy(dataType = filterSchema(struct, fieldPath)))
             // The field isn't assigned to directly or indirectly (i.e. its children) in any non-*

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
@@ -64,7 +64,8 @@ case class MergeIntoCommand(
     matchedClauses: Seq[DeltaMergeIntoMatchedClause],
     notMatchedClauses: Seq[DeltaMergeIntoNotMatchedClause],
     notMatchedBySourceClauses: Seq[DeltaMergeIntoNotMatchedBySourceClause],
-    migratedSchema: Option[StructType]) extends MergeIntoCommandBase
+    migratedSchema: Option[StructType])
+  extends MergeIntoCommandBase
   with InsertOnlyMergeExecutor
   with ClassicMergeExecutor {
 
@@ -137,9 +138,15 @@ case class MergeIntoCommand(
       spark.sharedState.cacheManager.recacheByPlan(spark, target)
     }
     sendDriverMetrics(spark, metrics)
-    Seq(Row(metrics("numTargetRowsUpdated").value + metrics("numTargetRowsDeleted").value +
-            metrics("numTargetRowsInserted").value, metrics("numTargetRowsUpdated").value,
-            metrics("numTargetRowsDeleted").value, metrics("numTargetRowsInserted").value))
+    val num_affected_rows =
+      metrics("numTargetRowsUpdated").value +
+        metrics("numTargetRowsDeleted").value +
+        metrics("numTargetRowsInserted").value
+    Seq(Row(
+      num_affected_rows,
+      metrics("numTargetRowsUpdated").value,
+      metrics("numTargetRowsDeleted").value,
+      metrics("numTargetRowsInserted").value))
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
@@ -347,7 +347,7 @@ abstract class MergeIntoCommandBase extends LeafRunnableCommand
       names: Seq[String],
       valueToReturn: Boolean): Expression = {
     val incExpr = incrementMetricAndReturnBool(names.head, valueToReturn)
-    names.foldLeft(incExpr) { case (expr, name) =>
+    names.tail.foldLeft(incExpr) { case (expr, name) =>
       IncrementMetric(expr, metrics(name))
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
@@ -34,20 +34,20 @@ import org.apache.spark.sql.functions.{coalesce, col, count, input_file_name, li
  *
  * Phase 1: Find the input files in target that are touched by the rows that satisfy
  *    the condition and verify that no two source rows match with the same target row.
- *    This is implemented as an inner-join using the given condition. See [[findTouchedFiles]]
- *    for more details. In the special case that there is no update clause we write all the non-
- *    matching source data as new files and skip phase 2.
+ *    This is implemented as an inner-join using the given condition (see [[findTouchedFiles]]).
+ *    In the special case that there is no update clause we write all the non-matching
+ *    source data as new files and skip phase 2.
  *    Issues an error message when the ON search_condition of the MERGE statement can match
  *    a single row from the target table with multiple rows of the source table-reference.
  *
  * Phase 2: Read the touched files again and write new files with updated and/or inserted rows.
- *    If there are updates, then use a outer join using the given condition to write the
+ *    If there are updates, then use an outer join using the given condition to write the
  *    updates and inserts (see [[writeAllChanges()]]. If there are no matches for updates,
- *    only inserts, then write them directy (see [[writeInsertsOnlyWhenNoMatches()]].
+ *    only inserts, then write them directly (see [[writeInsertsOnlyWhenNoMatches()]].
  *
  * See [[InsertOnlyMergeExecutor]] for the optimized executor used in case there are only inserts.
  */
-trait ClassicMergeExecutor extends MergeIntoMaterializeSource with MergeOutputGeneration {
+trait ClassicMergeExecutor extends MergeOutputGeneration {
   self: MergeIntoCommandBase =>
   import MergeIntoCommandBase._
 
@@ -69,15 +69,6 @@ trait ClassicMergeExecutor extends MergeIntoMaterializeSource with MergeOutputGe
     // Accumulator to collect all the distinct touched files
     val touchedFilesAccum = new SetAccumulator[String]()
     spark.sparkContext.register(touchedFilesAccum, TOUCHED_FILES_ACCUM_NAME)
-
-    // UDFs to records touched files names and add them to the accumulator
-    val recordTouchedFileName =
-      DeltaUDF.intFromStringBoolean { (fileName, shouldRecord) => {
-        if (shouldRecord) {
-          touchedFilesAccum.add(fileName)
-        }
-        1
-      }}.asNondeterministic()
 
     // Prune non-matching files if we don't need to collect them for NOT MATCHED BY SOURCE clauses.
     val dataSkippedFiles =
@@ -119,8 +110,8 @@ trait ClassicMergeExecutor extends MergeIntoMaterializeSource with MergeOutputGe
     val incrSourceRowCountExpr = incrementMetricAndReturnBool("numSourceRows", true)
     // We can't use filter() directly on the expression because that will prevent
     // column pruning. We don't need the SOURCE_ROW_PRESENT_COL so we immediately drop it.
-    val sourceDF = getSourceDF()
-      .withColumn(SOURCE_ROW_PRESENT_COL, new Column(incrSourceRowCountExpr))
+    val sourceDF = getSourceDF
+      .withColumn(SOURCE_ROW_PRESENT_COL, Column(incrSourceRowCountExpr))
       .filter(SOURCE_ROW_PRESENT_COL)
       .drop(SOURCE_ROW_PRESENT_COL)
     val targetPlan =
@@ -134,12 +125,21 @@ trait ClassicMergeExecutor extends MergeIntoMaterializeSource with MergeOutputGe
       .withColumn(FILE_NAME_COL, input_file_name())
 
     val joinToFindTouchedFiles =
-      sourceDF.join(targetDF, new Column(condition), joinType)
+      sourceDF.join(targetDF, Column(condition), joinType)
+
+    // UDFs to records touched files names and add them to the accumulator
+    val recordTouchedFileName =
+      DeltaUDF.intFromStringBoolean { (fileName, shouldRecord) =>
+        if (shouldRecord) {
+          touchedFilesAccum.add(fileName)
+        }
+        1
+      }.asNondeterministic()
 
     // Process the matches from the inner join to record touched files and find multiple matches
     val collectTouchedFiles = joinToFindTouchedFiles
       .select(col(ROW_ID_COL),
-        recordTouchedFileName(col(FILE_NAME_COL), new Column(matchedPredicate)).as("one"))
+        recordTouchedFileName(col(FILE_NAME_COL), Column(matchedPredicate)).as("one"))
 
     // Calculate frequency of matches per source row
     val matchedRowCounts = collectTouchedFiles.groupBy(ROW_ID_COL).agg(sum("one").as("count"))
@@ -148,7 +148,7 @@ trait ClassicMergeExecutor extends MergeIntoMaterializeSource with MergeOutputGe
     import org.apache.spark.sql.delta.implicits._
     val (multipleMatchCount, multipleMatchSum) = matchedRowCounts
       .filter("count > 1")
-      .select(coalesce(count(new Column("*")), lit(0)), coalesce(sum("count"), lit(0)))
+      .select(coalesce(count(Column("*")), lit(0)), coalesce(sum("count"), lit(0)))
       .as[(Long, Long)]
       .collect()
       .head
@@ -210,16 +210,19 @@ trait ClassicMergeExecutor extends MergeIntoMaterializeSource with MergeOutputGe
       spark: SparkSession,
       deltaTxn: OptimisticTransaction,
       filesToRewrite: Seq[AddFile],
-      deduplicateCDFDeletes: DeduplicateCDFDeletes)
-    : Seq[FileAction] = recordMergeOperation(
+      deduplicateCDFDeletes: DeduplicateCDFDeletes): Seq[FileAction] =
+    recordMergeOperation(
       extraOpType =
         if (shouldOptimizeMatchedOnlyMerge(spark)) "writeAllUpdatesAndDeletes"
         else "writeAllChanges",
       status = s"MERGE operation - Rewriting ${filesToRewrite.size} files",
       sqlMetricName = "rewriteTimeMs") {
 
-    require(!deduplicateCDFDeletes.enabled || isCdcEnabled(deltaTxn),
-      "CDF delete duplication is enabled but overall the CDF generation is disabled")
+      val cdcEnabled = isCdcEnabled(deltaTxn)
+
+      require(
+        !deduplicateCDFDeletes.enabled || cdcEnabled,
+        "CDF delete duplication is enabled but overall the CDF generation is disabled")
 
     // Generate a new target dataframe that has same output attributes exprIds as the target plan.
     // This allows us to apply the existing resolved update/insert expressions.
@@ -229,6 +232,7 @@ trait ClassicMergeExecutor extends MergeIntoMaterializeSource with MergeOutputGe
       filesToRewrite,
       columnsToDrop = Nil)
     val baseTargetDF = Dataset.ofRows(spark, targetPlan)
+
     val joinType = if (shouldOptimizeMatchedOnlyMerge(spark)) {
       "rightOuter"
     } else {
@@ -248,26 +252,25 @@ trait ClassicMergeExecutor extends MergeIntoMaterializeSource with MergeOutputGe
 
     // Apply an outer join to find both, matches and non-matches. We are adding two boolean fields
     // with value `true`, one to each side of the join. Whether this field is null or not after
-    // the outer join, will allow us to identify whether the resultant joined row was a
+    // the outer join, will allow us to identify whether the joined row was a
     // matched inner result or an unmatched result with null on one side.
     val joinedDF = {
       val sourceDF = if (deduplicateCDFDeletes.enabled && deduplicateCDFDeletes.includesInserts) {
         // Add row index for the source rows to identify inserted rows during the cdf deleted rows
         // deduplication. See [[deduplicateCDFDeletes()]]
-        getSourceDF()
+        getSourceDF
           .withColumn(SOURCE_ROW_INDEX_COL, monotonically_increasing_id())
       } else {
-        getSourceDF()
+        getSourceDF
       }
+      val left = sourceDF
+        .withColumn(SOURCE_ROW_PRESENT_COL, Column(incrSourceRowCountExpr))
       val targetDF = baseTargetDF
         .withColumn(TARGET_ROW_PRESENT_COL, lit(true))
-      sourceDF
-        .withColumn(SOURCE_ROW_PRESENT_COL, new Column(incrSourceRowCountExpr))
-        .join(
-        if (deduplicateCDFDeletes.enabled) {
-          targetDF.withColumn(TARGET_ROW_INDEX_COL, monotonically_increasing_id())
-        } else targetDF,
-        new Column(condition), joinType)
+      val right = if (deduplicateCDFDeletes.enabled) {
+        targetDF.withColumn(TARGET_ROW_INDEX_COL, monotonically_increasing_id())
+      } else targetDF
+      left.join(right, Column(condition), joinType)
     }
 
     // Precompute conditions in matched and not matched clauses and generate
@@ -277,19 +280,16 @@ trait ClassicMergeExecutor extends MergeIntoMaterializeSource with MergeOutputGe
           joinedDF,
           clauses = matchedClauses ++ notMatchedClauses ++ notMatchedBySourceClauses)
 
-    val cdcEnabled = DeltaConfigs.CHANGE_DATA_FEED.fromMetaData(deltaTxn.metadata)
-
-
     // The target output columns need to be marked as nullable here, as they are going to be used
     // to reference the output of an outer join.
     val targetOutputCols = getTargetOutputCols(deltaTxn, makeNullable = true)
 
     // If there are N columns in the target table, the full outer join output will have:
     // - N columns for target table
-    // - ROW_DROPPED_COL to define whether the generated row should dropped or written
-    // - if CDC is enabled, also CDC_TYPE_COLUMN_NAME containing the type of change being performed
+    // - ROW_DROPPED_COL to define whether the generated row should be dropped or written
+    // - if CDC is enabled, also CDC_TYPE_COLUMN_NAME with the type of change being performed
     //   in a particular row
-    // (N+1 or N+2 or N+3 columns depending on CDC disabled / enabled and if Row IDs are preserved)
+    // (N+1 or N+2 columns depending on CDC disabled / enabled)
     val outputColNames =
       targetOutputCols.map(_.name) ++
         Seq(ROW_DROPPED_COL) ++
@@ -298,10 +298,8 @@ trait ClassicMergeExecutor extends MergeIntoMaterializeSource with MergeOutputGe
     // Copy expressions to copy the existing target row and not drop it (ROW_DROPPED_COL=false),
     // and in case CDC is enabled, set it to CDC_TYPE_NOT_CDC.
     // (N+1 or N+2 or N+3 columns depending on CDC disabled / enabled and if Row IDs are preserved)
-    val noopCopyExprs =
-      targetOutputCols ++
-        Seq(incrNoopCountExpr) ++
-        (if (cdcEnabled) Seq(CDC_TYPE_NOT_CDC) else Seq())
+    val noopCopyExprs = (targetOutputCols :+ incrNoopCountExpr) ++
+      (if (cdcEnabled) Seq(CDC_TYPE_NOT_CDC) else Nil)
 
     // Generate output columns.
     val outputCols = generateWriteAllChangesOutputCols(
@@ -312,24 +310,23 @@ trait ClassicMergeExecutor extends MergeIntoMaterializeSource with MergeOutputGe
       cdcEnabled
     )
 
-    val outputDF = if (cdcEnabled) {
+    val preOutputDF = if (cdcEnabled) {
       generateCdcAndOutputRows(
           joinedAndPrecomputedConditionsDF,
           outputCols,
           outputColNames,
           noopCopyExprs,
           deduplicateCDFDeletes)
-        .filter(s"$ROW_DROPPED_COL = false")
-        .drop(ROW_DROPPED_COL)
-    } else { // change data capture is off, just output the normal data
-      // Apply the expressions on the join output. The filter ensures we only consider rows
-      // that are not dropped. And the drop ensures that the dropped flag does not leak out
-      // to the output.
+    } else {
+      // change data capture is off, just output the normal data
       joinedAndPrecomputedConditionsDF
         .select(outputCols: _*)
-        .filter(s"$ROW_DROPPED_COL = false")
-        .drop(ROW_DROPPED_COL)
     }
+    // The filter ensures we only consider rows that are not dropped.
+    // The drop ensures that the dropped flag does not leak out to the output.
+    val outputDF = preOutputDF
+      .filter(s"$ROW_DROPPED_COL = false")
+      .drop(ROW_DROPPED_COL)
 
     logDebug("writeAllChanges: join output plan:\n" + outputDF.queryExecution)
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
@@ -107,7 +107,7 @@ trait ClassicMergeExecutor extends MergeOutputGeneration {
       .filterNot { field =>
         targetColsNeeded.exists { name => columnComparator(name, field) }
       }
-    val incrSourceRowCountExpr = incrementMetricAndReturnBool("numSourceRows", true)
+    val incrSourceRowCountExpr = incrementMetricAndReturnBool("numSourceRows", valueToReturn = true)
     // We can't use filter() directly on the expression because that will prevent
     // column pruning. We don't need the SOURCE_ROW_PRESENT_COL so we immediately drop it.
     val sourceDF = getSourceDF
@@ -170,8 +170,8 @@ trait ClassicMergeExecutor extends MergeOutputGeneration {
     logTrace(s"findTouchedFiles: matched files:\n\t${touchedFileNames.mkString("\n\t")}")
 
     val nameToAddFileMap = generateCandidateFileMap(targetDeltaLog.dataPath, dataSkippedFiles)
-    val touchedAddFiles = touchedFileNames.map(f =>
-      getTouchedFile(targetDeltaLog.dataPath, f, nameToAddFileMap))
+    val touchedAddFiles = touchedFileNames.map(
+      getTouchedFile(targetDeltaLog.dataPath, _, nameToAddFileMap))
 
     if (metrics("numSourceRows").value == 0 && (dataSkippedFiles.isEmpty ||
       dataSkippedFiles.forall(_.numLogicalRecords.getOrElse(0) == 0))) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/InsertOnlyMergeExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/InsertOnlyMergeExecutor.scala
@@ -63,7 +63,7 @@ trait InsertOnlyMergeExecutor extends MergeOutputGeneration {
       sqlMetricName = "rewriteTimeMs") {
 
       // If nothing to do when not matched, then nothing to insert, that is, no new files to write
-      if (notMatchedClauses.isEmpty && !filterMatchedRows) {
+      if (!includesInserts && !filterMatchedRows) {
         metrics("numSourceRowsInSecondScan").set(-1)
         return Seq.empty
       }
@@ -71,16 +71,12 @@ trait InsertOnlyMergeExecutor extends MergeOutputGeneration {
       // Expression to update metrics
       val incrSourceRowCountExpr = incrementMetricAndReturnBool(numSourceRowsMetric, true)
       // source DataFrame
-      var sourceDF = getSourceDF().filter(new Column(incrSourceRowCountExpr))
+      var sourceDF = getSourceDF.filter(Column(incrSourceRowCountExpr))
       // If there is only one insert clause, then filter out the source rows that do not
       // satisfy the clause condition because those rows will not be written out.
-      if (notMatchedClauses.size == 1) {
-        notMatchedClauses
-          .head
-          .condition
-          .foreach { conditionCol =>
-            sourceDF = sourceDF.filter(new Column(conditionCol))
-          }
+      if (notMatchedClauses.size == 1 && notMatchedClauses.head.condition.isDefined) {
+        sourceDF =
+          sourceDF.filter(Column(notMatchedClauses.head.condition.get))
       }
 
       var dataSkippedFiles: Option[Seq[AddFile]] = None
@@ -100,7 +96,7 @@ trait InsertOnlyMergeExecutor extends MergeOutputGeneration {
           dataSkippedFiles.get,
           columnsToDrop = Nil)
         val targetDF = Dataset.ofRows(spark, targetPlan)
-        sourceDF.join(targetDF, new Column(condition), "leftanti")
+        sourceDF.join(targetDF, Column(condition), "leftanti")
       } else {
         sourceDF
       }
@@ -161,7 +157,8 @@ trait InsertOnlyMergeExecutor extends MergeOutputGeneration {
     // Generate output cols.
     val outputCols = generateInsertsOnlyOutputCols(
       targetOutputColNames,
-      insertClausesWithPrecompConditions.collect{case c: DeltaMergeIntoNotMatchedInsertClause => c})
+      insertClausesWithPrecompConditions
+        .collect { case c: DeltaMergeIntoNotMatchedInsertClause => c })
 
     sourceWithPrecompConditions
       .select(outputCols: _*)
@@ -216,7 +213,7 @@ trait InsertOnlyMergeExecutor extends MergeOutputGeneration {
     // ==== Generate the expressions to generate the target rows from the source rows ====
     // If there are N columns in the target table, there will be N + 1 columns generated
     // - N columns for target table
-    // - ROW_DROPPED_COL to define whether the generated row should dropped or written out
+    // - ROW_DROPPED_COL to define whether the generated row should be dropped or written out
     // To generate these N + 1 columns, we will generate N + 1 expressions
 
     val outputColNames = targetOutputColNames :+ ROW_DROPPED_COL
@@ -232,14 +229,14 @@ trait InsertOnlyMergeExecutor extends MergeOutputGeneration {
     // Expressions to drop the source row when it does not match any of the insert clause
     // conditions. Note that it sets the N+1-th column ROW_DROPPED_COL to true.
     val dropSourceRowExprs =
-      targetOutputColNames.map { _ => Literal(null)} :+ Literal(true)
+      targetOutputColNames.map { _ => Literal(null)} :+ Literal.TrueLiteral
 
     // Generate the final N + 1 expressions to generate the final target output rows.
     // There are multiple not match clauses. Use `CaseWhen` to conditionally evaluate the right
     // action expressions to output columns.
     val outputExprs: Seq[Expression] = {
       val allInsertConditions =
-        insertClausesWithPrecompConditions.map(_.condition.getOrElse(Literal(true)))
+        insertClausesWithPrecompConditions.map(_.condition.getOrElse(Literal.TrueLiteral))
 
       (0 until numOutputCols).map { i =>
         // For the i-th output column, generate

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
@@ -338,10 +338,10 @@ object MergeIntoMaterializeSource {
    * @return The columns of the source plan that are used in this MERGE
    */
   private def getReferencedSourceColumns(
-    source: LogicalPlan,
-    condition: Expression,
-    matchedClauses: Seq[DeltaMergeIntoMatchedClause],
-    notMatchedClauses: Seq[DeltaMergeIntoNotMatchedClause]) = {
+      source: LogicalPlan,
+      condition: Expression,
+      matchedClauses: Seq[DeltaMergeIntoMatchedClause],
+      notMatchedClauses: Seq[DeltaMergeIntoNotMatchedClause]) = {
     val conditionCols = condition.references
     val matchedCondCols = matchedClauses.flatMap(_.condition).flatMap(_.references)
     val notMatchedCondCols = notMatchedClauses.flatMap(_.condition).flatMap(_.references)
@@ -352,8 +352,11 @@ object MergeIntoMaterializeSource {
       .flatMap(_.resolvedActions)
       .flatMap(_.expr.references)
     val allCols = AttributeSet(
-      conditionCols ++ matchedCondCols ++ notMatchedCondCols ++
-        matchedActionsCols ++ notMatchedActionsCols)
+      conditionCols ++
+        matchedCondCols ++
+        notMatchedCondCols ++
+        matchedActionsCols ++
+        notMatchedActionsCols)
 
     source.output.filter(allCols.contains)
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
@@ -18,18 +18,20 @@ package org.apache.spark.sql.delta.commands.merge
 
 import scala.annotation.tailrec
 import scala.util.control.NonFatal
+
 import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.DeltaSparkPlanUtils
+
 import org.apache.spark.SparkException
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{AttributeSet, Expression, Literal}
+import org.apache.spark.sql.catalyst.expressions.{AttributeSet, Expression}
 import org.apache.spark.sql.catalyst.optimizer.EliminateResolvedHint
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.execution.{LogicalRDD, SQLExecution}
+import org.apache.spark.sql.execution.LogicalRDD
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.storage.StorageLevel
 
@@ -44,7 +46,7 @@ import org.apache.spark.storage.StorageLevel
  * materialized RDD[InternalRow] on the executor local disks.
  *
  * 1st concern is that if an executor is lost, this data can be lost.
- * When Spark executor decomissioning API is used, it should attempt to move this
+ * When Spark executor decommissioning API is used, it should attempt to move this
  * materialized data safely out before removing the executor.
  *
  * 2nd concern is that if an executor is lost for another reason (e.g. spot kill), we will

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
@@ -306,7 +306,7 @@ trait MergeIntoMaterializeSource extends DeltaLogging with DeltaSparkPlanUtils {
     materializeReason
   }
 
-  protected def getSourceDF: DataFrame = {
+  protected def getSourceDF(): DataFrame = {
     if (sourceDF.isEmpty) {
       throw new IllegalStateException(
         "sourceDF was not initialized! Call prepareSourceDFAndReturnMaterializeReason before.")

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeOutputGeneration.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeOutputGeneration.scala
@@ -48,8 +48,7 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
    */
   protected def generatePrecomputedConditionsAndDF(
       sourceDF: DataFrame,
-      clauses: Seq[DeltaMergeIntoClause])
-  : (DataFrame, Seq[DeltaMergeIntoClause]) = {
+      clauses: Seq[DeltaMergeIntoClause]): (DataFrame, Seq[DeltaMergeIntoClause]) = {
     //
     // ==== Precompute conditions in MATCHED and NOT MATCHED clauses ====
     // If there are conditions in the clauses, each condition will be computed once for every

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeOutputGeneration.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeOutputGeneration.scala
@@ -18,7 +18,6 @@ package org.apache.spark.sql.delta.commands.merge
 
 import scala.collection.mutable
 
-import org.apache.spark.sql.delta.metric.IncrementMetric
 import org.apache.spark.sql.delta.commands.MergeIntoCommandBase
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeOutputGeneration.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeOutputGeneration.scala
@@ -64,27 +64,28 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
     // Rewrite clause condition into a simple lookup of precomputed column
     def rewriteCondition[T <: DeltaMergeIntoClause](clause: T): T = {
       clause.condition match {
-        case Some(clauseCondition) =>
+        case Some(conditionExpr) =>
           val colName =
             s"""_${clause.clauseType}${PRECOMPUTED_CONDITION_COL}
             |${preComputedClauseConditions.length}_
             |""".stripMargin.replaceAll("\n", "") // ex: _update_condition_0_
-          preComputedClauseConditions += ((colName, clauseCondition))
+          preComputedClauseConditions += ((colName, conditionExpr))
           clause.makeCopy(Array(Some(UnresolvedAttribute(colName)), clause.actions)).asInstanceOf[T]
         case None => clause
       }
     }
 
-    // Get the clauses with possible rewritten clause conditions.
+    // Get the clauses with possibly rewritten clause conditions.
     // This will automatically populate the `preComputedClauseConditions`
+    // (as part of `rewriteCondition`)
     val clausesWithPrecompConditions = clauses.map(rewriteCondition)
 
-    // Add the columns to precompute clause conditions
+    // Add the columns to the given `sourceDF` to precompute clause conditions
     val sourceWithPrecompConditions = {
       val newCols = preComputedClauseConditions.map { case (colName, conditionExpr) =>
-        new Column(conditionExpr).as(colName)
-      }
-      sourceDF.select(Seq(col("*"))  ++ newCols : _*)
+        Column(conditionExpr).as(colName)
+      }.toSeq
+      sourceDF.select(col("*") +: newCols: _*)
     }
     (sourceWithPrecompConditions, clausesWithPrecompConditions)
   }
@@ -92,7 +93,7 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
   /**
    * Generate the expressions to process full-outer join output and generate target rows.
    *
-   * To generate these N + 2 columns, we will be generate N + 2 expressions and apply them
+   * To generate these N + 2 columns, we generate N + 2 expressions and apply them
    * on the joinedDF. The CDC column will be either used for CDC generation or dropped before
    * performing the final write, and the other column will always be dropped after executing the
    * increment metric expression and filtering on ROW_DROPPED_COL.
@@ -103,15 +104,14 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
       noopCopyExprs: Seq[Expression],
       clausesWithPrecompConditions: Seq[DeltaMergeIntoClause],
       cdcEnabled: Boolean,
-      shouldCountDeletedRows: Boolean = true)
-    : IndexedSeq[Column] = {
+      shouldCountDeletedRows: Boolean = true): IndexedSeq[Column] = {
 
     val numOutputCols = outputColNames.size
 
     // ==== Generate N + 2 (N + 4 preserving Row Tracking) expressions for MATCHED clauses ====
     val processedMatchClauses: Seq[ProcessedClause] = generateAllActionExprs(
       targetOutputCols,
-      clausesWithPrecompConditions.collect{ case c: DeltaMergeIntoMatchedClause => c },
+      clausesWithPrecompConditions.collect { case c: DeltaMergeIntoMatchedClause => c },
       cdcEnabled,
       shouldCountDeletedRows)
     val matchedExprs: Seq[Expression] = generateClauseOutputExprs(
@@ -122,15 +122,13 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
     // N + 1 (or N + 2 with CDC, N + 4 preserving Row Tracking and CDC) expressions to delete the
     // unmatched source row when it should not be inserted. `target.output` will produce NULLs
     // which will get deleted eventually.
-    val deleteSourceRowExprs =
-      (targetOutputCols ++
-        Seq(Literal(true))) ++
-        (if (cdcEnabled) Seq(CDC_TYPE_NOT_CDC) else Seq())
+    val deleteSourceRowExprs = (targetOutputCols :+ Literal.TrueLiteral) ++
+      (if (cdcEnabled) Seq(CDC_TYPE_NOT_CDC) else Nil)
 
     // ==== Generate N + 2 (N + 4 preserving Row Tracking) expressions for NOT MATCHED clause ====
     val processedNotMatchClauses: Seq[ProcessedClause] = generateAllActionExprs(
       targetOutputCols,
-      clausesWithPrecompConditions.collect{ case c: DeltaMergeIntoNotMatchedClause => c },
+      clausesWithPrecompConditions.collect { case c: DeltaMergeIntoNotMatchedClause => c },
       cdcEnabled,
       shouldCountDeletedRows)
     val notMatchedExprs: Seq[Expression] = generateClauseOutputExprs(
@@ -141,7 +139,7 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
     // === Generate N + 2 (N + 4 with Row Tracking) expressions for NOT MATCHED BY SOURCE clause ===
     val processedNotMatchBySourceClauses: Seq[ProcessedClause] = generateAllActionExprs(
       targetOutputCols,
-      clausesWithPrecompConditions.collect{ case c: DeltaMergeIntoNotMatchedBySourceClause => c },
+      clausesWithPrecompConditions.collect { case c: DeltaMergeIntoNotMatchedBySourceClause => c },
       cdcEnabled,
       shouldCountDeletedRows)
     val notMatchedBySourceExprs: Seq[Expression] = generateClauseOutputExprs(
@@ -157,7 +155,7 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
     val ifSourceRowNull = col(SOURCE_ROW_PRESENT_COL).isNull.expr
     val ifTargetRowNull = col(TARGET_ROW_PRESENT_COL).isNull.expr
 
-    val outputCols = (0 until numOutputCols).map { i =>
+    val outputCols = outputColNames.zipWithIndex.map { case (name, i) =>
       // Coupled with the clause conditions, the resultant possibly-nested CaseWhens can
       // be the following for every i-th column. (In the case with single matched/not-matched
       // clauses, instead of nested CaseWhens, there will be If/Else.)
@@ -191,8 +189,8 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
         ifSourceRowNull -> notMatchedBySourceExprs(i),
         ifTargetRowNull -> notMatchedExprs(i)),
         /*  otherwise  */ matchedExprs(i))
-      new Column(Alias(caseWhen, outputColNames(i))())
-    }
+      Column(Alias(caseWhen, name)())
+    }.toIndexedSeq
     logDebug("writeAllChanges: join output expressions\n\t" + seqToString(outputCols.map(_.expr)))
     outputCols
   }
@@ -215,7 +213,7 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
    * @param cdcEnabled Whether the generated expressions should include CDC information.
    * @param shouldCountDeletedRows Whether metrics for number of deleted rows should be incremented
    *                               here.
-   * @return For each merge clause, a list of [[ProcessedClause] each with a precomputed
+   * @return For each merge clause, a list of [[ProcessedClause]] each with a precomputed
    *         condition and N+2 action expressions (N output columns + [[ROW_DROPPED_COL]] +
    *         [[CDC_TYPE_COLUMN_NAME]]) to apply on a row when that clause matches.
    */
@@ -223,61 +221,68 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
       targetOutputCols: Seq[Expression],
       clausesWithPrecompConditions: Seq[DeltaMergeIntoClause],
       cdcEnabled: Boolean,
-      shouldCountDeletedRows: Boolean)
-    : Seq[ProcessedClause] = clausesWithPrecompConditions.map (clause => {
-    val incrUpdatedCountExpr =
-      incrementMetricAndReturnBool(name = "numTargetRowsUpdated", valueToReturn = false)
-    val incrDeletedCountExpr =
-      incrementMetricAndReturnBool(name = "numTargetRowsDeleted", valueToReturn = true)
-
-    val actions = clause match {
-      // Seq of up to N+3 expressions to generate output rows based on the UPDATE, DELETE and/or
-      // INSERT action(s)
-      case u: DeltaMergeIntoMatchedUpdateClause =>
-        val incrCountExpr =
-          IncrementMetric(incrUpdatedCountExpr, metrics("numTargetRowsMatchedUpdated"))
-        // Generate update expressions and set ROW_DROPPED_COL = false
-        u.resolvedActions.map(_.expr) ++
-          Seq(incrCountExpr) ++
-          (if (cdcEnabled) Seq(Literal(CDC_TYPE_UPDATE_POSTIMAGE)) else Seq())
-      case u: DeltaMergeIntoNotMatchedBySourceUpdateClause =>
-        val incrCountExpr =
-          IncrementMetric(incrUpdatedCountExpr, metrics("numTargetRowsNotMatchedBySourceUpdated"))
-        // Generate update expressions and set ROW_DROPPED_COL = false
-        u.resolvedActions.map(_.expr) ++
-          Seq(incrCountExpr) ++
-          (if (cdcEnabled) Seq(Literal(CDC_TYPE_UPDATE_POSTIMAGE)) else Seq())
-      case _: DeltaMergeIntoMatchedDeleteClause =>
-        val incrCountExpr =
-          if (shouldCountDeletedRows) {
-            IncrementMetric(incrDeletedCountExpr, metrics("numTargetRowsMatchedDeleted"))
-          } else {
-            lit(true).expr
+      shouldCountDeletedRows: Boolean): Seq[ProcessedClause] = {
+    clausesWithPrecompConditions.map { clause =>
+      val actions = clause match {
+        // Seq of up to N+3 expressions to generate output rows based on the UPDATE, DELETE and/or
+        // INSERT action(s)
+        case u: DeltaMergeIntoMatchedUpdateClause =>
+          val incrCountExpr = incrementMetricsAndReturnBool(
+            names = Seq("numTargetRowsUpdated", "numTargetRowsMatchedUpdated"),
+            valueToReturn = false)
+          // Generate update expressions and set ROW_DROPPED_COL = false
+          u.resolvedActions.map(_.expr) ++
+            Seq(incrCountExpr) ++
+            (if (cdcEnabled) Some(Literal(CDC_TYPE_UPDATE_POSTIMAGE)) else None)
+        case u: DeltaMergeIntoNotMatchedBySourceUpdateClause =>
+          val incrCountExpr = incrementMetricsAndReturnBool(
+            names = Seq("numTargetRowsUpdated", "numTargetRowsNotMatchedBySourceUpdated"),
+            valueToReturn = false)
+          // Generate update expressions and set ROW_DROPPED_COL = false
+          u.resolvedActions.map(_.expr) ++
+            Seq(incrCountExpr) ++
+            (if (cdcEnabled) Some(Literal(CDC_TYPE_UPDATE_POSTIMAGE)) else None)
+        case _: DeltaMergeIntoMatchedDeleteClause =>
+          val incrCountExpr = {
+            if (shouldCountDeletedRows) {
+              incrementMetricsAndReturnBool(
+                names = Seq("numTargetRowsDeleted", "numTargetRowsMatchedDeleted"),
+                valueToReturn = true)
+            } else {
+              Literal.TrueLiteral
+            }
           }
-        // Generate expressions to set the ROW_DROPPED_COL = true and mark as a DELETE
-        targetOutputCols ++
-          Seq(incrCountExpr) ++
-          (if (cdcEnabled) Seq(CDC_TYPE_DELETE) else Seq())
-      case _: DeltaMergeIntoNotMatchedBySourceDeleteClause =>
-        val incrCountExpr =
-          if (shouldCountDeletedRows) {
-            IncrementMetric(incrDeletedCountExpr, metrics("numTargetRowsNotMatchedBySourceDeleted"))
-          } else {
-            lit(true).expr
+          // Generate expressions to set the ROW_DROPPED_COL = true and mark as a DELETE
+          targetOutputCols ++
+            Seq(incrCountExpr) ++
+            (if (cdcEnabled) Some(CDC_TYPE_DELETE) else None)
+        case _: DeltaMergeIntoNotMatchedBySourceDeleteClause =>
+          val incrCountExpr = {
+            if (shouldCountDeletedRows) {
+              incrementMetricsAndReturnBool(
+                names = Seq("numTargetRowsDeleted", "numTargetRowsNotMatchedBySourceDeleted"),
+                valueToReturn = true)
+            } else {
+              Literal.TrueLiteral
+            }
           }
-        // Generate expressions to set the ROW_DROPPED_COL = true and mark as a DELETE
-        targetOutputCols ++
-          Seq(incrCountExpr) ++
-          (if (cdcEnabled) Seq(CDC_TYPE_DELETE) else Seq())
-      case i: DeltaMergeIntoNotMatchedInsertClause =>
-        val incrInsertedCountExpr =
-          incrementMetricAndReturnBool("numTargetRowsInserted", valueToReturn = false)
-        i.resolvedActions.map(_.expr) ++
-          Seq(incrInsertedCountExpr) ++
-          (if (cdcEnabled) Seq(Literal(CDC_TYPE_INSERT)) else Seq())
+          // Generate expressions to set the ROW_DROPPED_COL = true and mark as a DELETE
+          targetOutputCols ++
+            Seq(incrCountExpr) ++
+            (if (cdcEnabled) Some(CDC_TYPE_DELETE) else None)
+        case i: DeltaMergeIntoNotMatchedInsertClause =>
+          val incrInsertedCountExpr = {
+            incrementMetricsAndReturnBool(
+              names = Seq("numTargetRowsInserted"),
+              valueToReturn = false)
+          }
+          i.resolvedActions.map(_.expr) ++
+            Seq(incrInsertedCountExpr) ++
+            (if (cdcEnabled) Some(Literal(CDC_TYPE_INSERT)) else None)
+      }
+      ProcessedClause(clause.condition, actions)
     }
-    ProcessedClause(clause.condition, actions)
-  })
+  }
 
   /**
    * Generate the output expression for each output column to apply the correct action for a type of
@@ -289,10 +294,9 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
    * @return A list of one expression per output column to apply for a type of merge clause.
    */
   protected def generateClauseOutputExprs(
-      numOutputCols: Integer,
+      numOutputCols: Int,
       clauses: Seq[ProcessedClause],
-      noopExprs: Seq[Expression])
-  : Seq[Expression] = {
+      noopExprs: Seq[Expression]): Seq[Expression] = {
     val clauseExprs = if (clauses.isEmpty) {
       // Nothing to update or delete
       noopExprs
@@ -316,7 +320,7 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
       } else {
         // There are multiple clauses. Use `CaseWhen` to conditionally evaluate the right
         // action expressions to output columns
-        (0 until numOutputCols).map { i =>
+        Seq.range(0, numOutputCols).map { i =>
           // For the i-th output column, generate
           // CASE
           //     WHEN <condition 1> THEN <execute i-th expression of action 1>
@@ -324,9 +328,9 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
           //                        ...
           //                        ELSE <execute i-th expression to noop-copy>
           //
-          val conditionalBranches = clauses.map(precomp => {
-            precomp.condition.getOrElse(Literal(true)) -> precomp.actions(i)
-          })
+          val conditionalBranches = clauses.map { precomp =>
+            precomp.condition.getOrElse(Literal.TrueLiteral) -> precomp.actions(i)
+          }
           CaseWhen(conditionalBranches, Some(noopExprs(i)))
         }
       }
@@ -353,7 +357,7 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
     import org.apache.spark.sql.delta.commands.cdc.CDCReader._
     // The main partition just needs to swap in the CDC_TYPE_NOT_CDC value.
     val mainDataOutput =
-      outputCols.dropRight(1) :+ new Column(CDC_TYPE_NOT_CDC).as(CDC_TYPE_COLUMN_NAME)
+      outputCols.dropRight(1) :+ Column(CDC_TYPE_NOT_CDC).as(CDC_TYPE_COLUMN_NAME)
 
     // Deleted rows are sent to the CDC partition instead of the main partition. These rows are
     // marked as dropped, we need to retain them while incrementing the original metric column
@@ -366,9 +370,9 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
     // transformation for cdcOutputCols, but we have to transform the noop exprs to columns
     // ourselves because it hasn't already been done.
     val cdcNoopExprs = noopCopyExprs.dropRight(2) :+
-      Literal(false) :+ Literal(CDC_TYPE_UPDATE_PREIMAGE)
+      Literal.FalseLiteral :+ Literal(CDC_TYPE_UPDATE_PREIMAGE)
     val updatePreimageCdcOutput = cdcNoopExprs.zipWithIndex.map {
-      case (e, i) => new Column(Alias(e, outputColNames(i))())
+      case (e, i) => Column(Alias(e, outputColNames(i))())
     }
 
     // To avoid duplicate evaluation of nondeterministic column values such as
@@ -380,7 +384,7 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
     // main data rows stay the same.
 
     val cdcTypeCol = outputCols.last
-    val cdcArray = new Column(CaseWhen(Seq(
+    val cdcArray = Column(CaseWhen(Seq(
       EqualNullSafe(cdcTypeCol.expr, Literal(CDC_TYPE_INSERT)) -> array(
         struct(outputCols: _*)).expr,
 
@@ -396,7 +400,7 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
       array(struct(mainDataOutput: _*)).expr
     ))
 
-    val cdcToMainDataArray = new Column(If(
+    val cdcToMainDataArray = Column(If(
       Or(
         EqualNullSafe(col(s"packedCdc.$CDC_TYPE_COLUMN_NAME").expr,
           Literal(CDC_TYPE_INSERT)),
@@ -404,9 +408,9 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
           Literal(CDC_TYPE_UPDATE_POSTIMAGE))),
       array(
         col("packedCdc"),
-        struct(outputColNames.dropRight(1).map { n => col(s"packedCdc.`$n`") } :+
-          new Column(CDC_TYPE_NOT_CDC).as(CDC_TYPE_COLUMN_NAME)
-          : _*)
+        struct(
+          outputColNames.dropRight(1).map { n => col(s"packedCdc.`$n`") } :+
+          Column(CDC_TYPE_NOT_CDC).as(CDC_TYPE_COLUMN_NAME): _*)
       ).expr,
       array(col("packedCdc")).expr
     ))
@@ -460,7 +464,7 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
       .select(cdcArray.as("projectedCDC") +: dedupColumns: _*)
       .select(explode(col("projectedCDC")).as("packedCdc") +: dedupColumns: _*)
       .select(explode(cdcToMainDataArray).as("packedData") +: dedupColumns: _*)
-      .select(unpackedCols++ dedupColumns: _*)
+      .select(unpackedCols ++ dedupColumns: _*)
   }
 
   /**
@@ -482,11 +486,11 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
       cdcArray: Column,
       cdcToMainDataArray: Column,
       outputColNames: Seq[String]): DataFrame = {
-    val dedupColumns = (if (deduplicateDeletes.includesInserts) {
+    val dedupColumns = if (deduplicateDeletes.includesInserts) {
       Seq(col(TARGET_ROW_INDEX_COL), col(SOURCE_ROW_INDEX_COL))
     } else {
       Seq(col(TARGET_ROW_INDEX_COL))
-    })
+    }
 
     val cdcDf = packAndExplodeCDCOutput(
       df,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeOutputGeneration.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeOutputGeneration.scala
@@ -271,11 +271,9 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
             Seq(incrCountExpr) ++
             (if (cdcEnabled) Some(CDC_TYPE_DELETE) else None)
         case i: DeltaMergeIntoNotMatchedInsertClause =>
-          val incrInsertedCountExpr = {
-            incrementMetricsAndReturnBool(
-              names = Seq("numTargetRowsInserted"),
-              valueToReturn = false)
-          }
+          val incrInsertedCountExpr = incrementMetricsAndReturnBool(
+            names = Seq("numTargetRowsInserted"),
+            valueToReturn = false)
           i.resolvedActions.map(_.expr) ++
             Seq(incrInsertedCountExpr) ++
             (if (cdcEnabled) Some(Literal(CDC_TYPE_INSERT)) else None)
@@ -301,12 +299,10 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
       // Nothing to update or delete
       noopExprs
     } else {
-
       if (clauses.head.condition.isEmpty) {
         // Only one clause without any condition, so the corresponding action expressions
         // can be evaluated directly to generate the output columns.
         clauses.head.actions
-
       } else if (clauses.length == 1) {
         // Only one clause _with_ a condition, so generate IF/THEN instead of CASE WHEN.
         //
@@ -316,7 +312,6 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
         //
         val condition = clauses.head.condition.get
         clauses.head.actions.zip(noopExprs).map { case (a, noop) => If(condition, a, noop) }
-
       } else {
         // There are multiple clauses. Use `CaseWhen` to conditionally evaluate the right
         // action expressions to output columns
@@ -409,8 +404,10 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
       array(
         col("packedCdc"),
         struct(
-          outputColNames.dropRight(1).map { n => col(s"packedCdc.`$n`") } :+
-          Column(CDC_TYPE_NOT_CDC).as(CDC_TYPE_COLUMN_NAME): _*)
+          outputColNames
+            .dropRight(1)
+            .map { n => col(s"packedCdc.`$n`") }
+            :+ Column(CDC_TYPE_NOT_CDC).as(CDC_TYPE_COLUMN_NAME): _*)
       ).expr,
       array(col("packedCdc")).expr
     ))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -467,7 +467,7 @@ trait DeltaSQLConfBase {
   val MERGE_MATERIALIZE_SOURCE =
     buildConf("merge.materializeSource")
       .internal()
-      .doc("When to materializes source plan during MERGE execution. " +
+      .doc("When to materialize the source plan during MERGE execution. " +
         "The value 'none' means source will never be materialized. " +
         "The value 'all' means source will always be materialized. " +
         "The value 'auto' means sources will not be materialized when they are certain to be " +
@@ -513,7 +513,7 @@ trait DeltaSQLConfBase {
 
   val MERGE_MATERIALIZE_SOURCE_MAX_ATTEMPTS =
     buildStaticConf("merge.materializeSource.maxAttempts")
-      .doc("How many times to try MERGE with in case of lost RDD materialized source data")
+      .doc("How many times to try MERGE in case of lost RDD materialized source data")
       .intConf
       .createWithDefault(4)
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- Spark

## Description

There are various code cleanups to make reading the code easier:

1. Remove unnecessary type annotations
2. Typo fixes
3. Code formatting
4. Replacing `Literal(true)` with `Literal.TrueLiteral`
5. Replacing `new Column` with `Column` (object)

## How was this patch tested?

Local build. Expecting more to come from the official checks on github

## Does this PR introduce _any_ user-facing changes?

No
