### PR TITLE
[Kernel] Add selection vector create API on `ExpressionHandler`

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/client/ExpressionHandler.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/client/ExpressionHandler.java
@@ -16,6 +16,7 @@
 package io.delta.kernel.client;
 
 import io.delta.kernel.annotation.Evolving;
+import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.expressions.Expression;
 import io.delta.kernel.expressions.ExpressionEvaluator;
@@ -45,4 +46,17 @@ public interface ExpressionHandler {
         StructType inputSchema,
         Expression expression,
         DataType outputType);
+
+    /**
+     * Create a selection vector, a boolean type {@link ColumnVector}, on top of the range of values
+     * given in <i>values</i> array.
+     *
+     * @param values Array of initial boolean values for the selection vector. The ownership of
+     *               this array is with the caller and this method shouldn't depend on it after the
+     *               call is complete.
+     * @param from   start index of the range, inclusive.
+     * @param to     end index of the range, exclusive.
+     * @return A {@link ColumnVector} of {@code boolean} type values.
+     */
+    ColumnVector createSelectionVector(boolean[] values, int from, int to);
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActiveAddFilesIterator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActiveAddFilesIterator.java
@@ -49,6 +49,10 @@ class ActiveAddFilesIterator implements CloseableIterator<FilteredColumnarBatch>
     private final Set<UniqueFileActionTuple> addFilesFromJson;
 
     private Optional<FilteredColumnarBatch> next;
+    /**
+     * This buffer is reused across batches to keep the memory allocations minimal. It is resized
+     * as required and the array entries are reset between batches.
+     */
     private boolean[] selectionVectorBuffer;
     private boolean closed;
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActiveAddFilesIterator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActiveAddFilesIterator.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.delta.kernel.internal.replay;
 
 import java.io.IOException;
@@ -21,16 +20,14 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
 
+import io.delta.kernel.client.TableClient;
 import io.delta.kernel.data.*;
-import io.delta.kernel.types.BooleanType;
-import io.delta.kernel.types.DataType;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.Tuple2;
 import static io.delta.kernel.utils.Utils.requireNonNull;
 
 import io.delta.kernel.internal.actions.AddFile;
 import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
-import static io.delta.kernel.internal.util.InternalUtils.checkArgument;
 
 /**
  * This class takes an iterator of ({@link FileDataReadResult}, isFromCheckpoint), where the
@@ -46,14 +43,19 @@ class ActiveAddFilesIterator implements CloseableIterator<FilteredColumnarBatch>
         }
     }
 
+    private final TableClient tableClient;
     private final CloseableIterator<Tuple2<FileDataReadResult, Boolean>> iter;
     private final Set<UniqueFileActionTuple> tombstonesFromJson;
     private final Set<UniqueFileActionTuple> addFilesFromJson;
 
     private Optional<FilteredColumnarBatch> next;
+    private boolean[] selectionVectorBuffer;
     private boolean closed;
 
-    ActiveAddFilesIterator(CloseableIterator<Tuple2<FileDataReadResult, Boolean>> iter) {
+    ActiveAddFilesIterator(
+        TableClient tableClient,
+        CloseableIterator<Tuple2<FileDataReadResult, Boolean>> iter) {
+        this.tableClient = tableClient;
         this.iter = iter;
         this.tombstonesFromJson = new HashSet<>();
         this.addFilesFromJson = new HashSet<>();
@@ -153,7 +155,7 @@ class ActiveAddFilesIterator implements CloseableIterator<FilteredColumnarBatch>
         // Step 2: Iterate over all the AddFiles in this columnar batch in order to build up the
         //         selection vector. We unselect an AddFile when it was removed by a RemoveFile
         final ColumnVector addsVector = addRemoveColumnarBatch.getColumnVector(0);
-        boolean[] selectionVector = new boolean[addsVector.getSize()];
+        prepareSelectionVectorBuffer(addsVector.getSize());
         boolean atLeastOneUnselected = false;
 
         for (int rowId = 0; rowId < addsVector.getSize(); rowId++) {
@@ -183,7 +185,7 @@ class ActiveAddFilesIterator implements CloseableIterator<FilteredColumnarBatch>
 
                 if (!alreadyDeleted) {
                     doSelect = true;
-                    selectionVector[rowId] = true;
+                    selectionVectorBuffer[rowId] = true;
                 }
             }
 
@@ -194,48 +196,23 @@ class ActiveAddFilesIterator implements CloseableIterator<FilteredColumnarBatch>
 
         // Step 3: Drop the RemoveFile column and use the selection vector to build a new
         //         DataReadResult
+        Optional<ColumnVector> selectionColumnVector = atLeastOneUnselected ?
+            Optional.of(tableClient.getExpressionHandler()
+                .createSelectionVector(selectionVectorBuffer, 0, addsVector.getSize())) :
+            Optional.empty();
         next = Optional.of(
             new FilteredColumnarBatch(
                 addRemoveColumnarBatch.withDeletedColumnAt(1),
-                atLeastOneUnselected ?
-                    Optional.of(boolArrayToColumnVector(selectionVector)) :
-                    Optional.empty()
-            )
-        );
+                selectionColumnVector));
     }
 
-    private ColumnVector boolArrayToColumnVector(boolean[] arr) {
-        return new ColumnVector() {
-            @Override
-            public DataType getDataType() {
-                return BooleanType.INSTANCE;
-            }
-
-            @Override
-            public int getSize() {
-                return arr.length;
-            }
-
-            @Override
-            public void close() { }
-
-            @Override
-            public boolean isNullAt(int rowId) {
-                assertValidRowId(rowId);
-                return false;
-            }
-
-            @Override
-            public boolean getBoolean(int rowId) {
-                assertValidRowId(rowId);
-                return arr[rowId];
-            }
-
-            private void assertValidRowId(int rowId) {
-                checkArgument(rowId < getSize(),
-                    "Invalid rowId: " + rowId + ", max allowed rowId is: " + (getSize() - 1));
-            }
-        };
+    private void prepareSelectionVectorBuffer(int size) {
+        if (selectionVectorBuffer == null || selectionVectorBuffer.length < size) {
+            selectionVectorBuffer = new boolean[size];
+        } else {
+            // reset the array - if we are reusing the same buffer.
+            Arrays.fill(selectionVectorBuffer, false);
+        }
     }
 
     private URI pathToUri(String path) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
@@ -112,7 +112,7 @@ public class LogReplay implements Logging {
                 logSegment.allLogFilesReversed(),
                 ADD_REMOVE_READ_SCHEMA);
 
-        return new ActiveAddFilesIterator(addRemoveIter);
+        return new ActiveAddFilesIterator(tableClient, addRemoveIter);
     }
 
     /**

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultExpressionHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultExpressionHandler.java
@@ -15,13 +15,21 @@
  */
 package io.delta.kernel.defaults.client;
 
+import java.util.Arrays;
+import java.util.Optional;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
 import io.delta.kernel.client.ExpressionHandler;
+import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.expressions.Expression;
 import io.delta.kernel.expressions.ExpressionEvaluator;
 import io.delta.kernel.types.DataType;
 import io.delta.kernel.types.StructType;
 
+import io.delta.kernel.defaults.internal.data.vector.DefaultBooleanVector;
 import io.delta.kernel.defaults.internal.expressions.DefaultExpressionEvaluator;
+import static io.delta.kernel.defaults.internal.DefaultKernelUtils.checkArgument;
 
 /**
  * Default implementation of {@link ExpressionHandler}
@@ -33,5 +41,17 @@ public class DefaultExpressionHandler implements ExpressionHandler {
         Expression expression,
         DataType outputType) {
         return new DefaultExpressionEvaluator(inputSchema, expression, outputType);
+    }
+
+    @Override
+    public ColumnVector createSelectionVector(boolean[] values, int from, int to) {
+        requireNonNull(values, "values is null");
+        int length = to - from;
+        checkArgument(length >= 0 && values.length > from && values.length >= to,
+            format("invalid range from=%s, to=%s, values length=%s", from, to, values.length));
+
+        // Make a copy of the `values` array.
+        boolean[] valuesCopy = Arrays.copyOfRange(values, from, to);
+        return new DefaultBooleanVector(length, Optional.empty(), valuesCopy);
     }
 }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/AbstractColumnVector.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/AbstractColumnVector.java
@@ -73,7 +73,10 @@ public abstract class AbstractColumnVector
     @Override
     public boolean isNullAt(int rowId) {
         checkValidRowId(rowId);
-        return !nullability.isPresent() || nullability.get()[rowId];
+        if (!nullability.isPresent()) {
+            return false; // if there is no-nullability vector, every value is a non-null value
+        }
+        return nullability.get()[rowId];
     }
 
     @Override

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/client/DefaultExpressionHandlerSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/client/DefaultExpressionHandlerSuite.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults.client
+
+import io.delta.kernel.types.BooleanType
+import org.scalatest.funsuite.AnyFunSuite
+
+class DefaultExpressionHandlerSuite extends AnyFunSuite {
+
+  test("create selection vector: single value") {
+    Seq(true, false).foreach { testValue =>
+      val outputVector = selectionVector(Seq(testValue).toArray, 0, 1)
+      assert(outputVector.getDataType === BooleanType.INSTANCE)
+      assert(outputVector.getSize == 1)
+      assert(outputVector.isNullAt(0) == false)
+      assert(outputVector.getBoolean(0) == testValue)
+    }
+  }
+
+  test("create selection vector: multiple values array, partial array") {
+    Seq((0, testValues.length), (0, 3), (2, 2), (2, 4), (3, testValues.length)).foreach { pair =>
+      val (from, to) = (pair._1, pair._2)
+      val outputVector = selectionVector(testValues, from, to)
+      assert(outputVector.getDataType === BooleanType.INSTANCE)
+      assert(outputVector.getSize == (to - from))
+      Seq.range(from, to).foreach { rowId =>
+        assert(outputVector.isNullAt(rowId - from) == false)
+        assert(outputVector.getBoolean(rowId - from) == testValues(rowId))
+      }
+    }
+  }
+
+  test("create selection vector: update values array and expect no changes in output") {
+    val outputVector = selectionVector(testValues, 0, testValues.length)
+    // update the input values array and assert the value is not changed in the returned vector
+    val oldValue = testValues(2)
+    assert(oldValue == false)
+    testValues(2) = true
+    assert(outputVector.isNullAt(2) == false)
+    assert(outputVector.getBoolean(2) == oldValue)
+  }
+
+  test("create selection vector: invalid to and/or from offset") {
+    Seq((3, 2), (2, testValues.length + 1), (testValues.length + 1, 100)).foreach { pair =>
+      val (from, to) = (pair._1, pair._2)
+      val ex = intercept[IllegalArgumentException] {
+        selectionVector(testValues, from, to)
+      }
+      assert(ex.getMessage.contains(
+        s"invalid range from=$from, to=$to, values length=${testValues.length}"))
+    }
+  }
+
+  test("create selection vector: null values array") {
+    val ex = intercept[NullPointerException] {
+      selectionVector(null, 0, 25)
+    }
+    assert(ex.getMessage.contains("values is null"))
+  }
+
+  private def selectionVector(values: Array[Boolean], from: Int, to: Int) = {
+    new DefaultExpressionHandler().createSelectionVector(values, from, to)
+  }
+
+  private val testValues = Seq(false, true, false, false, true, true).toArray
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description
Part of delta-io/delta#2071 (Partition Pruning in Kernel).

Delta `kernel-api` module creates a selection vector (a `ColumnVector` boolean data type) that goes along with `ColumnarBatch` of scan files read from the Delta checkpoint or commit files. It uses the `selection vector` to select only a subset of rows from the scan file `ColumnarBatch`. Also at the same time `kernel-api` module shouldn't be creating `ColumnVector`s. Instead should rely on the `TableClient` APIs to create the vectors.

It adds the below API on `ExpressionHandler`
```
    /**
     * Create a selection vector, a boolean type {@link ColumnVector}, on top of the range of values
     * given in <i>values</i> array.
     *
     * @param values Array of initial boolean values for the selection vector. The ownership of
     *               this array is with the caller and this method shouldn't depend on it after the
     *               call is complete.
     * @param from   start index of the range, inclusive.
     * @param to     end index of the range, exclusive.
     * @return A {@link ColumnVector} of {@code boolean} type values.
     */
    ColumnVector createSelectionVector(boolean[] values, int from, int to);
```

This also handles [this](https://github.com/delta-io/delta/pull/1939#discussion_r1293764014) code review comment.

## How was this patch tested?
Added tests.