### PR TITLE
[Kernel] Add support for nested column reference expression

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/data/ColumnVector.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/data/ColumnVector.java
@@ -196,4 +196,15 @@ public interface ColumnVector extends AutoCloseable {
     default <T> List<T> getArray(int rowId) {
         throw new UnsupportedOperationException("Invalid value request for data type");
     }
+
+    /**
+     * Get the child vector associated with the given ordinal. This method is applicable only to the
+     * {@code struct} type columns.
+     *
+     * @param ordinal Ordinal of the child vector to return.
+     * @return
+     */
+    default ColumnVector getChild(int ordinal) {
+        throw new UnsupportedOperationException("Child vectors are not available.");
+    }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/Column.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/Column.java
@@ -66,7 +66,7 @@ public final class Column implements Expression {
         return "column(" + quoteColumnPath(names)  + ")";
     }
 
-    private static String quoteColumnPath(String names[]) {
+    private static String quoteColumnPath(String[] names) {
         return Arrays.stream(names)
             .map(s -> format("`%s`", s.replace("`", "``")))
             .collect(Collectors.joining("."));

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/Column.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/Column.java
@@ -20,6 +20,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static java.lang.String.format;
+
 import io.delta.kernel.annotation.Evolving;
 
 /**
@@ -60,6 +62,13 @@ public final class Column implements Expression {
 
     @Override
     public String toString() {
-        return "column(" + Arrays.stream(names).collect(Collectors.joining(".")) + ")";
+
+        return "column(" + quoteColumnPath(names)  + ")";
+    }
+
+    private static String quoteColumnPath(String names[]) {
+        return Arrays.stream(names)
+            .map(s -> format("`%s`", s.replace("`", "``")))
+            .collect(Collectors.joining("."));
     }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/Column.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/Column.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import static java.lang.String.format;
 
 import io.delta.kernel.annotation.Evolving;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/Column.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/Column.java
@@ -15,29 +15,42 @@
  */
 package io.delta.kernel.expressions;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import io.delta.kernel.annotation.Evolving;
 
 /**
- * An expression type that refers to a column by name (case-sensitive) in the input.
+ * An expression type that refers to a column (case-sensitive) in the input. The column name is
+ * either a single name or array of names (when referring to a nested column).
  *
  * @since 3.0.0
  */
 @Evolving
 public final class Column implements Expression {
-    private final String name;
+    private final String[] names;
 
+    /**
+     * Create a column expression for referring to a column.
+     */
     public Column(String name) {
-        this.name = name;
+        this.names = new String[] {name};
     }
 
     /**
-     * @return the column name.
+     * Create a column expression to refer to a nested column.
      */
-    public String getName() {
-        return name;
+    public Column(String[] names) {
+        this.names = names;
+    }
+
+    /**
+     * @return the column names. Each part in the name correspond to one level of nested reference.
+     */
+    public String[] getNames() {
+        return names;
     }
 
     @Override
@@ -47,6 +60,6 @@ public final class Column implements Expression {
 
     @Override
     public String toString() {
-        return "column(" + name + ")";
+        return "column(" + Arrays.stream(names).collect(Collectors.joining(".")) + ")";
     }
 }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultStructVector.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultStructVector.java
@@ -68,6 +68,13 @@ public class DefaultStructVector
         return new StructRow(this, rowId);
     }
 
+    @Override
+    public ColumnVector getChild(int ordinal) {
+        checkArgument(
+            ordinal >= 0 && ordinal < memberVectors.length, "Invalid ordinal " + ordinal);
+        return memberVectors[ordinal];
+    }
+
     /**
      * Wrapper class to expose one member as a {@link Row}
      */

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
@@ -386,10 +386,8 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
 
     private static void assertColumnExists(boolean condition, StructType schema, Column column) {
         if (!condition) {
-            throw new IllegalArgumentException(format(
-                "Column `%s` doesn't exist in input data schema: %s",
-                Arrays.stream(column.getNames()).collect(joining(".")),
-                schema));
+            throw new IllegalArgumentException(
+                format("%s doesn't exist in input data schema: %s", column, schema));
         }
     }
 }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 import java.util.Optional;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.joining;
 
 import io.delta.kernel.client.ExpressionHandler;
 import io.delta.kernel.data.ColumnVector;

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Optional;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
 
 import io.delta.kernel.client.ExpressionHandler;
 import io.delta.kernel.data.ColumnVector;
@@ -155,13 +156,17 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
 
         @Override
         ExpressionTransformResult visitColumn(Column column) {
-            int ordinal = inputDataSchema.indexOf(column.getName());
-            if (ordinal == -1) {
-                throw new IllegalArgumentException(
-                    format("Column `%s` doesn't exist in input data schema: %s",
-                        column.getName(), inputDataSchema));
+            String[] names = column.getNames();
+            DataType currentType = inputDataSchema;
+            for(int level = 0; level < names.length; level++) {
+                assertColumnExists(currentType instanceof StructType, inputDataSchema, column);
+                StructType structSchema = ((StructType) currentType);
+                int ordinal = structSchema.indexOf(names[level]);
+                assertColumnExists(ordinal != -1, inputDataSchema, column);
+                currentType = structSchema.at(ordinal).getDataType();
             }
-            return new ExpressionTransformResult(column, inputDataSchema.at(ordinal).getDataType());
+            assertColumnExists(currentType != null, inputDataSchema, column);
+            return new ExpressionTransformResult(column, currentType);
         }
 
         @Override
@@ -317,13 +322,24 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
 
         @Override
         ColumnVector visitColumn(Column column) {
-            int ordinal = input.getSchema().indexOf(column.getName());
-            if (ordinal == -1) {
-                throw new IllegalArgumentException(
-                    format("Column `%s` doesn't exist in input data schema: %s",
-                        column.getName(), input.getSchema()));
+            String[] names = column.getNames();
+            DataType currentType = input.getSchema();
+            ColumnVector columnVector = null;
+            for(int level = 0; level < names.length; level++) {
+                assertColumnExists(currentType instanceof StructType, input.getSchema(), column);
+                StructType structSchema = ((StructType) currentType);
+                int ordinal = structSchema.indexOf(names[level]);
+                assertColumnExists(ordinal != -1, input.getSchema(), column);
+                currentType = structSchema.at(ordinal).getDataType();
+
+                if (level == 0) {
+                    columnVector = input.getColumnVector(ordinal);
+                } else {
+                    columnVector = columnVector.getChild(ordinal);
+                }
             }
-            return input.getColumnVector(ordinal);
+            assertColumnExists(columnVector != null, input.getSchema(), column);
+            return columnVector;
         }
 
         @Override
@@ -365,6 +381,15 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
             this.rowCount = rowCount;
             this.leftResult = leftResult;
             this.rightResult = rightResult;
+        }
+    }
+
+    private static void assertColumnExists(boolean condition, StructType schema, Column column) {
+        if (!condition) {
+            throw new IllegalArgumentException(format(
+                "Column `%s` doesn't exist in input data schema: %s",
+                Arrays.stream(column.getNames()).collect(joining(".")),
+                schema));
         }
     }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
@@ -162,6 +162,13 @@ class DefaultExpressionEvaluatorSuite extends AnyFunSuite with TestUtils {
     val col1Ref = new Column(Array("col1"))
     val col1RefResult = evaluator(batchSchema, col1Ref, col1Type).eval(batch)
     assertTypeAndNullability(col1RefResult, col1Type, col1Nullability)
+
+    // try to reference non-existent nested column
+    val colNotValid = new Column(Array("col1", "colX`X"))
+    val ex = intercept[IllegalArgumentException] {
+      evaluator(batchSchema, colNotValid, col1Type).eval(batch)
+    }
+    assert(ex.getMessage.contains("column(`col1`.`colX``X`) doesn't exist in input data schema"))
   }
 
   test("evaluate expression: always true, always false") {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description
Part of delta-io/delta#2071 (Partition Pruning in Kernel). We need a way to reference the `partitionValues` nested column in scan file `ColumnarBatch`.

Currently, the `Column` expression can only be used to refer to a top-level column. There is no way to refer to a nested column. This PR updates the `Column` expression to be a multi-part identifier. This is similar to the Spark's [`NamedReference`](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/java/org/apache/spark/sql/connector/expressions/NamedReference.java) DSv2 expression. 

Fixes delta-io/delta#2040 (also contains different approaches to refer to a nested column).

## How was this patch tested?
Added a UT
