### PR TITLE
[Spark]Throw deletionVectorSizeMismatch for non-incremental DV updates.

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -737,7 +737,9 @@ case class AddFile(
     val removeFileWithOldDv = this.removeWithTimestamp(dataChange = dataChange)
 
     // Sanity check for incremental DV updates.
-    require(addFileWithNewDv.numDeletedRecords >= removeFileWithOldDv.numDeletedRecords)
+    if (addFileWithNewDv.numDeletedRecords < removeFileWithOldDv.numDeletedRecords) {
+      throw DeltaErrors.deletionVectorSizeMismatch()
+    }
 
     (addFileWithNewDv, removeFileWithOldDv)
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/DeletionVectorsSuite.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta.deletionvectors
 
 import java.io.File
 
-import org.apache.spark.sql.delta.{DeletionVectorsTableFeature, DeletionVectorsTestUtils, DeltaConfigs, DeltaLog, DeltaMetricsUtils, DeltaTestUtilsForTempViews}
+import org.apache.spark.sql.delta.{DeletionVectorsTableFeature, DeletionVectorsTestUtils, DeltaChecksumException, DeltaConfigs, DeltaLog, DeltaMetricsUtils, DeltaTestUtilsForTempViews}
 import org.apache.spark.sql.delta.DeltaTestUtils.{createTestAddFile, BOOLEAN_DOMAIN}
 import org.apache.spark.sql.delta.actions.{AddFile, DeletionVectorDescriptor, RemoveFile}
 import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor.{inlineInLog, EMPTY}
@@ -656,7 +656,7 @@ class DeletionVectorsSuite extends QueryTest
 
     // Updating with a DV with lower cardinality should throw.
     for (dv <- Seq(dv0, dv3)) {
-      assertThrows[IllegalArgumentException] {
+      assertThrows[DeltaChecksumException] {
         removeRows(addFileWithDV1, dv)
       }
     }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Update the sanity check for non-incremental updates to throw a deletionVectorSizeMismatch instead of using `require()`.

## How was this patch tested?

Update existing test.

## Does this PR introduce _any_ user-facing changes?

Changes an exception from `IllegalArgumentException` to `DeltaChecksumException`.
