### PR TITLE
[Kernel] Add `PredicateEvaluator` interface and default implementation

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/client/ExpressionHandler.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/client/ExpressionHandler.java
@@ -20,6 +20,8 @@ import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.expressions.Expression;
 import io.delta.kernel.expressions.ExpressionEvaluator;
+import io.delta.kernel.expressions.Predicate;
+import io.delta.kernel.expressions.PredicateEvaluator;
 import io.delta.kernel.types.DataType;
 import io.delta.kernel.types.StructType;
 
@@ -46,6 +48,16 @@ public interface ExpressionHandler {
         StructType inputSchema,
         Expression expression,
         DataType outputType);
+
+    /**
+     * Create a {@link PredicateEvaluator} that can evaluate the given <i>predicate</i> expression
+     * and return a selection vector ({@link ColumnVector} of {@code boolean} type).
+     *
+     * @param inputSchema Schema of the data referred by the given predicate expression.
+     * @param predicate Predicate expression to evaluate.
+     * @return
+     */
+    PredicateEvaluator getPredicateEvaluator(StructType inputSchema, Predicate predicate);
 
     /**
      * Create a selection vector, a boolean type {@link ColumnVector}, on top of the range of values

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/PredicateEvaluator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/PredicateEvaluator.java
@@ -30,7 +30,10 @@ import io.delta.kernel.data.ColumnarBatch;
  * Result selection vector is combined with the given existing selection vector and a new selection
  * vector is returned. This mechanism allows running an input batch through several predicate
  * evaluations without rewriting the input batch to remove rows that do not pass the predicate
- * after each predicate evaluation.
+ * after each predicate evaluation. The new selection should be same or more selective as the
+ * existing selection vector. For example if a row is marked as unselected in existing selection
+ * vector, then it should remain unselected in the returned selection vector even when the given
+ * predicate returns true for the row.
  *
  * @since 3.0.0
  */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/PredicateEvaluator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/PredicateEvaluator.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.expressions;
+
+import java.util.Optional;
+
+import io.delta.kernel.annotation.Evolving;
+import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.data.ColumnarBatch;
+
+/**
+ * Special interface for evaluating {@link Predicate} on input batch and return a selection
+ * vector containing one value for each row in input batch indicating whether the row has passed
+ * the predicate or not.
+ *
+ * Optionally it takes an existing selection vector along with the input batch for evaluation.
+ * Result selection vector is combined with the given existing selection vector and a new selection
+ * vector is returned. This mechanism allows running an input batch through several predicate
+ * evaluations without rewriting the input batch to remove rows that do not pass the predicate
+ * after each predicate evaluation.
+ *
+ * @since 3.0.0
+ */
+@Evolving
+public interface PredicateEvaluator {
+    /**
+     * Evaluate the predicate on given inputData. Combine the existing selection vector with the
+     * output of the predicate result and return a new selection vector.
+     *
+     * @param inputData               {@link ColumnarBatch} of data to which the predicate
+     *                                expression refers for input.
+     * @param existingSelectionVector Optional existing selection vector. If not empty, it is
+     *                                combined with the predicate result. The caller is also
+     *                                releasing the ownership of `existingSelectionVector` to this
+     *                                callee, and the callee is responsible for closing it.
+     * @return A {@link ColumnVector} of boolean type that captures the predicate result for each
+     * row together with the existing selection vector.
+     */
+    ColumnVector eval(ColumnarBatch inputData, Optional<ColumnVector> existingSelectionVector);
+}

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultExpressionHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultExpressionHandler.java
@@ -24,11 +24,14 @@ import io.delta.kernel.client.ExpressionHandler;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.expressions.Expression;
 import io.delta.kernel.expressions.ExpressionEvaluator;
+import io.delta.kernel.expressions.Predicate;
+import io.delta.kernel.expressions.PredicateEvaluator;
 import io.delta.kernel.types.DataType;
 import io.delta.kernel.types.StructType;
 
 import io.delta.kernel.defaults.internal.data.vector.DefaultBooleanVector;
 import io.delta.kernel.defaults.internal.expressions.DefaultExpressionEvaluator;
+import io.delta.kernel.defaults.internal.expressions.DefaultPredicateEvaluator;
 import static io.delta.kernel.defaults.internal.DefaultKernelUtils.checkArgument;
 
 /**
@@ -41,6 +44,11 @@ public class DefaultExpressionHandler implements ExpressionHandler {
         Expression expression,
         DataType outputType) {
         return new DefaultExpressionEvaluator(inputSchema, expression, outputType);
+    }
+
+    @Override
+    public PredicateEvaluator getPredicateEvaluator(StructType inputSchema, Predicate predicate) {
+        return new DefaultPredicateEvaluator(inputSchema, predicate);
     }
 
     @Override

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultPredicateEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultPredicateEvaluator.java
@@ -44,6 +44,9 @@ public class DefaultPredicateEvaluator implements PredicateEvaluator {
     private final ExpressionEvaluator expressionEvaluator;
 
     public DefaultPredicateEvaluator(StructType inputSchema, Predicate predicate) {
+        // Create a predicate that takes into account of the selection value in existing selection
+        // vector in addition to the given predicate. This is needed to make a row remain
+        // unselected in the final vector when it is unselected in existing selection vector.
         Predicate rewrittenPredicate = new And(
             new Predicate(
                 "=",

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultPredicateEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultPredicateEvaluator.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults.internal.expressions;
+
+import java.util.Arrays;
+import java.util.Optional;
+import static java.util.Collections.emptyMap;
+
+import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.expressions.*;
+import io.delta.kernel.types.BooleanType;
+import io.delta.kernel.types.StructField;
+import io.delta.kernel.types.StructType;
+import io.delta.kernel.utils.Utils;
+
+import io.delta.kernel.defaults.internal.data.vector.DefaultConstantVector;
+
+/**
+ * Default implementation of {@link PredicateEvaluator}. It makes use of the
+ * {@link DefaultExpressionEvaluator} with some modification of the given predicate. Refer to
+ * {@link #DefaultPredicateEvaluator(StructType, Predicate)} and
+ * {@link #eval(ColumnarBatch, Optional)} for details.
+ */
+public class DefaultPredicateEvaluator implements PredicateEvaluator {
+    private static final String EXISTING_SEL_VECTOR_COL_NAME =
+        "____existing_selection_vector_value____";
+    private static final StructField EXISTING_SEL_VECTOR_FIELD =
+        new StructField(EXISTING_SEL_VECTOR_COL_NAME, BooleanType.INSTANCE, false, emptyMap());
+
+    private final ExpressionEvaluator expressionEvaluator;
+
+    public DefaultPredicateEvaluator(StructType inputSchema, Predicate predicate) {
+        Predicate rewrittenPredicate = new And(
+            new Predicate(
+                "=",
+                Arrays.asList(new Column(EXISTING_SEL_VECTOR_COL_NAME), Literal.ofBoolean(true))),
+            predicate);
+        StructType rewrittenInputSchema = inputSchema.add(EXISTING_SEL_VECTOR_FIELD);
+        this.expressionEvaluator = new DefaultExpressionEvaluator(
+            rewrittenInputSchema, rewrittenPredicate, BooleanType.INSTANCE);
+    }
+
+    @Override
+    public ColumnVector eval(
+        ColumnarBatch inputData,
+        Optional<ColumnVector> existingSelectionVector) {
+        try {
+            ColumnVector newVector = existingSelectionVector.orElse(
+                new DefaultConstantVector(BooleanType.INSTANCE, inputData.getSize(), true));
+            ColumnarBatch withExistingSelVector =
+                inputData.withNewColumn(
+                    inputData.getSchema().length(), EXISTING_SEL_VECTOR_FIELD, newVector);
+
+            return expressionEvaluator.eval(withExistingSelVector);
+        } finally {
+            // release the existing selection vector.
+            Utils.closeCloseables(existingSelectionVector.orElse(null));
+        }
+    }
+}

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultPredicateEvaluatorSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultPredicateEvaluatorSuite.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults.internal.expressions
+
+import java.lang.{Boolean => BooleanJ}
+import java.util.Optional
+import java.util.Optional.empty
+
+import io.delta.kernel.data.{ColumnarBatch, ColumnVector}
+import io.delta.kernel.defaults.internal.data.DefaultColumnarBatch
+import io.delta.kernel.expressions.{Column, Literal}
+import io.delta.kernel.types.{BooleanType, StructType}
+import org.scalatest.funsuite.AnyFunSuite
+
+/**
+ * [[DefaultPredicateEvaluator]] internally uses [[DefaultExpressionEvaluator]]. In this suite
+ * test the code specific to the [[DefaultPredicateEvaluator]] such as taking into consideration of
+ * existing selection vector.
+ */
+class DefaultPredicateEvaluatorSuite extends AnyFunSuite with ExpressionSuiteBase {
+  private val testLeftCol = booleanVector(
+    Seq[BooleanJ](true, true, false, true, true, false, null, true, null, false, null))
+  private val testRightCol = booleanVector(
+    Seq[BooleanJ](true, false, false, true, false, false, true, null, false, null, null))
+
+  private val testSchema = new StructType()
+    .add("left", BooleanType.INSTANCE)
+    .add("right", BooleanType.INSTANCE)
+
+  private val batch = new DefaultColumnarBatch(
+    testLeftCol.getSize, testSchema, Array(testLeftCol, testRightCol))
+
+  private val left = comparator("=", new Column("left"), Literal.ofBoolean(true))
+  private val right = comparator("=", new Column("right"), Literal.ofBoolean(true))
+
+  private val orPredicate = or(left, right)
+
+  private val expOrOutput = booleanVector(
+    Seq[BooleanJ](true, true, false, true, true, false, null, null, null, null, null))
+
+  test("evaluate predicate: with no starting selection vector") {
+    val batch = new DefaultColumnarBatch(
+      testLeftCol.getSize, testSchema, Array(testLeftCol, testRightCol))
+
+    val actOutputVector = evalOr(batch)
+    checkBooleanVectors(actOutputVector, expOrOutput)
+  }
+
+  test("evaluate predicate: with existing selection vector") {
+    val existingSelVector = booleanVector(
+      Seq[BooleanJ](false, true, true, true, false, false, null, null, null, null, null))
+    val outputWithSelVector = booleanVector(
+      Seq[BooleanJ](false, true, false, true, false, false, null, null, null, null, null))
+
+    val actOutputVector = evalOr(batch, Optional.of(existingSelVector))
+    checkBooleanVectors(actOutputVector, outputWithSelVector)
+  }
+
+  test("evaluate predicate: multiple rounds with selection vectors") {
+    val output0 = evalOr(batch)
+    checkBooleanVectors(output0, expOrOutput)
+
+    val selVec1 = booleanVector(
+      Seq[BooleanJ](false, true, false, true, false, false, null, null, null, null, null))
+    val expOutputWithSelVec1 = booleanVector(
+      Seq[BooleanJ](false, true, false, true, false, false, null, null, null, null, null))
+    checkBooleanVectors(evalOr(batch, Optional.of(selVec1)), expOutputWithSelVec1)
+
+    val selVec2 = booleanVector(
+      Seq[BooleanJ](false, false, false, true, false, false, null, null, null, null, null))
+    val expOutputWithSelVec2 = booleanVector(
+      Seq[BooleanJ](false, false, false, true, false, false, null, null, null, null, null))
+    checkBooleanVectors(evalOr(batch, Optional.of(selVec2)), expOutputWithSelVec2)
+  }
+
+  def evalOr(
+    batch: ColumnarBatch, existingSelVector: Optional[ColumnVector] = empty()): ColumnVector = {
+    val evaluator = new DefaultPredicateEvaluator(batch.getSchema, orPredicate)
+    evaluator.eval(batch, existingSelVector)
+  }
+}

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/ExpressionSuiteBase.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/ExpressionSuiteBase.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults.internal.expressions
+
+import java.lang.{Boolean => BooleanJ}
+import java.util
+
+import io.delta.kernel.data.{ColumnarBatch, ColumnVector}
+import io.delta.kernel.defaults.internal.data.DefaultColumnarBatch
+import io.delta.kernel.defaults.utils.TestUtils
+import io.delta.kernel.expressions._
+import io.delta.kernel.types._
+
+trait ExpressionSuiteBase extends TestUtils {
+  /** create a columnar batch of given `size` with zero columns in it. */
+  protected def zeroColumnBatch(rowCount: Int): ColumnarBatch = {
+    new DefaultColumnarBatch(rowCount, new StructType(), new Array[ColumnVector](0))
+  }
+
+  protected def and(left: Predicate, right: Predicate): And = {
+    new And(left, right)
+  }
+
+  protected def or(left: Predicate, right: Predicate): Or = {
+    new Or(left, right)
+  }
+
+  protected def comparator(symbol: String, left: Expression, right: Expression): Predicate = {
+    new Predicate(symbol, util.Arrays.asList(left, right))
+  }
+
+  protected def checkBooleanVectors(actual: ColumnVector, expected: ColumnVector): Unit = {
+    assert(actual.getDataType === expected.getDataType)
+    assert(actual.getSize === expected.getSize)
+    Seq.range(0, actual.getSize).foreach { rowId =>
+      assert(actual.isNullAt(rowId) === expected.isNullAt(rowId))
+      if (!actual.isNullAt(rowId)) {
+        assert(
+          actual.getBoolean(rowId) === expected.getBoolean(rowId),
+          s"unexpected value at $rowId"
+        )
+      }
+    }
+  }
+
+  protected def booleanVector(values: Seq[BooleanJ]): ColumnVector = {
+    new ColumnVector {
+      override def getDataType: DataType = BooleanType.INSTANCE
+
+      override def getSize: Int = values.length
+
+      override def close(): Unit = {}
+
+      override def isNullAt(rowId: Int): Boolean = values(rowId) == null
+
+      override def getBoolean(rowId: Int): Boolean = values(rowId)
+    }
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description
Part of delta-io/delta#2071 (Partition Pruning in Kernel). We need a way to evaluate the predicate on a `ColumnarBatch` using an existing optional selection vector.

Adds `PredicateEvaluator` interface.
```
public interface PredicateEvaluator {
    /**
     * Evaluate the predicate on given inputData. Combine the existing selection vector with the
     * output of the predicate result and return a new selection vector.
     *
     * @param inputData               {@link ColumnarBatch} of data to which the predicate
     *                                expression refers to input.
     * @param existingSelectionVector Optional existing selection vector. If not empty, it is
     *                                combined with the predicate result. The caller is also
     *                                releasing the ownership of `existingSelectionVector` to this
     *                                callee, and the callee is responsible for closing it.
     * @return A {@link ColumnVector} of boolean type that captures the predicate result for each
     * row together with the existing selection vector.
     */
    ColumnVector eval(ColumnarBatch inputData, Optional<ColumnVector> existingSelectionVector);
}
```

## How was this patch tested?
Unit tests
