### PR TITLE
[Spark] Rewrite SHOW COLUMNS as v2 command

### DIFF
--- a/spark/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
+++ b/spark/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
@@ -94,8 +94,6 @@ statement
     | REORG TABLE table=qualifiedName
         (WHERE partitionPredicate=predicateToken)?
         APPLY LEFT_PAREN PURGE RIGHT_PAREN                              #reorgTable
-    | SHOW COLUMNS (IN | FROM) tableName=qualifiedName
-        ((IN | FROM) schemaName=identifier)?                            #showColumns
     | cloneTableHeader SHALLOW CLONE source=qualifiedName clause=temporalClause?
        (TBLPROPERTIES tableProps=propertyList)?
        (LOCATION location=stringLit)?                                   #clone
@@ -223,7 +221,7 @@ nonReserved
     | REORG | APPLY | PURGE
     | RESTORE | AS | OF
     | ZORDER | LEFT_PAREN | RIGHT_PAREN
-    | SHOW | COLUMNS | IN | FROM | NO | STATISTICS
+    | NO | STATISTICS
     | CLONE | SHALLOW
     | FEATURE | TRUNCATE
     ;
@@ -236,7 +234,6 @@ AS: 'AS';
 BY: 'BY';
 CHECK: 'CHECK';
 CLONE: 'CLONE';
-COLUMNS: 'COLUMNS';
 COMMA: ',';
 COMMENT: 'COMMENT';
 CONSTRAINT: 'CONSTRAINT';
@@ -253,12 +250,10 @@ EXISTS: 'EXISTS';
 FALSE: 'FALSE';
 FEATURE: 'FEATURE';
 FOR: 'FOR';
-FROM: 'FROM';
 GENERATE: 'GENERATE';
 HISTORY: 'HISTORY';
 HOURS: 'HOURS';
 IF: 'IF';
-IN: 'IN';
 LEFT_PAREN: '(';
 LIMIT: 'LIMIT';
 LOCATION: 'LOCATION';
@@ -278,7 +273,6 @@ RETAIN: 'RETAIN';
 RIGHT_PAREN: ')';
 RUN: 'RUN';
 SHALLOW: 'SHALLOW';
-SHOW: 'SHOW';
 SYSTEM_TIME: 'SYSTEM_TIME';
 SYSTEM_VERSION: 'SYSTEM_VERSION';
 TABLE: 'TABLE';

--- a/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
+++ b/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
@@ -521,42 +521,6 @@ class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
       truncateHistory)
   }
 
-  /**
- * Create a [[ShowTableColumnsCommand]] logical plan.
- *
- * Syntax:
- * {{{
- *   SHOW COLUMNS (FROM | IN) tableName [(FROM | IN) schemaName];
- * }}}
- * Examples:
- * {{{
- *   SHOW COLUMNS IN delta.`test_table`
- *   SHOW COLUMNS IN `test_table` IN `test_database`
- * }}}
- */
-  override def visitShowColumns(
-      ctx: ShowColumnsContext): LogicalPlan = withOrigin(ctx) {
-    val spark = SparkSession.active
-    val tableName = visitTableIdentifier(ctx.tableName)
-    val schemaName = Option(ctx.schemaName).map(db => db.getText)
-
-    val tableIdentifier = if (tableName.database.isEmpty) {
-      schemaName match {
-        case Some(db) =>
-          TableIdentifier(tableName.identifier, Some(db))
-        case None => tableName
-      }
-    } else tableName
-
-    DeltaTableIdentifier(spark, tableIdentifier).map { id =>
-      val resolver = spark.sessionState.analyzer.resolver
-      if (schemaName.nonEmpty && tableName.database.exists(!resolver(_, schemaName.get))) {
-        throw DeltaErrors.showColumnsWithConflictDatabasesError(schemaName.get, tableName)
-      }
-      ShowTableColumnsCommand(id)
-    }.orNull
-  }
-
   protected def typedVisit[T](ctx: ParseTree): T = {
     ctx.accept(this).asInstanceOf[T]
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2715,11 +2715,6 @@ trait DeltaErrorsBase
       cause = Some(cause))
   }
 
-  def showColumnsWithConflictDatabasesError(db: String, tableID: TableIdentifier): Throwable = {
-    new AnalysisException(
-      s"SHOW COLUMNS with conflicting databases: '$db' != '${tableID.database.get}'")
-  }
-
   def unsupportedDeltaTableForPathHadoopConf(unsupportedOptions: Map[String, String]): Throwable = {
     new DeltaIllegalArgumentException(
       errorClass = "DELTA_TABLE_FOR_PATH_UNSUPPORTED_HADOOP_CONF",

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
@@ -2060,6 +2060,7 @@ class DeltaTableCreationSuite
         // create table, alter tbl property, tbl comment
         assert(sql(s"DESCRIBE HISTORY $emptyTableName").collect().length == 3)
 
+        checkAnswer(sql(s"SHOW COLUMNS IN $emptyTableName"), Nil)
       }
 
       // schema evolution ddl should work

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ShowDeltaTableColumnsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ShowDeltaTableColumnsSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.Utils
 
-class ShowTableColumnsSuite extends QueryTest
+class ShowDeltaTableColumnsSuite extends QueryTest
   with SharedSparkSession
   with DeltaSQLCommandTest
   with DeltaTestUtilsForTempViews {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

The Delta verison of SHOW COLUMNS command used to rely on a hacky custom SQL parser rule, but it turns out this is unnecessary -- we can simply add a new DeltaAnalysis rule to intercept the v2 `ShowColumns` command, and replace it with the Delta-specific `ShowDeltaTableColumnsCommand` (which we rename and also upgrade to v2, so it doesn't trigger extra catalog lookups any more).

## How was this patch tested?

Existing unit tests updated.

## Does this PR introduce _any_ user-facing changes?

No.