### PR TITLE
[Spark] Refactor DeltaTable to derive its DataFrame from DeltaTableV2

### DIFF
--- a/spark/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/spark/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -41,27 +41,22 @@ import org.apache.spark.sql.types.StructType
  * @since 0.3.0
  */
 class DeltaTable private[tables](
-    @transient private val _df: Dataset[Row],
-    @transient private val table: DeltaTableV2)
+    @transient private val _table: DeltaTableV2,
+    private val alias: Option[String] = None)
   extends DeltaTableOperations with Serializable {
 
-  protected def deltaLog: DeltaLog = {
-    /** Assert the codes run in the driver. */
-    if (table == null) {
-      throw DeltaErrors.deltaTableFoundInExecutor()
-    }
+  // Ensure table's initial snapshot has been captured, for consistent behavior.
+  _table.initialSnapshot
 
-    table.deltaLog
+  /** Assert the codes run in the driver. */
+  private def table: DeltaTableV2 = Option(_table).getOrElse {
+    throw DeltaErrors.deltaTableFoundInExecutor()
   }
 
-  protected def df: Dataset[Row] = {
-    /** Assert the codes run in the driver. */
-    if (_df == null) {
-      throw DeltaErrors.deltaTableFoundInExecutor()
-    }
+  protected def deltaLog: DeltaLog = table.deltaLog
 
-    _df
-  }
+  @transient
+  protected lazy val df: Dataset[Row] = alias.foldLeft(table.toDf)(_ as _)
 
   /**
    * Apply an alias to the DeltaTable. This is similar to `Dataset.as(alias)` or
@@ -69,7 +64,7 @@ class DeltaTable private[tables](
    *
    * @since 0.3.0
    */
-  def as(alias: String): DeltaTable = new DeltaTable(df.as(alias), table)
+  def as(alias: String): DeltaTable = new DeltaTable(table, Some(alias))
 
   /**
    * Apply an alias to the DeltaTable. This is similar to `Dataset.as(alias)` or
@@ -84,7 +79,9 @@ class DeltaTable private[tables](
    *
    * @since 0.3.0
    */
-  def toDF: Dataset[Row] = df
+  def toDF: Dataset[Row] = Option(df).getOrElse {
+    throw DeltaErrors.deltaTableFoundInExecutor()
+  }
 
   /**
    * Recursively delete files and directories in the table that are not needed by the table for
@@ -712,11 +709,7 @@ object DeltaTable {
     val fileSystemOptions: Map[String, String] = hadoopConf.toMap
     val hdpPath = new Path(path)
     if (DeltaTableUtils.isDeltaTable(sparkSession, hdpPath, fileSystemOptions)) {
-      new DeltaTable(sparkSession.read.format("delta").options(fileSystemOptions).load(path),
-        DeltaTableV2(
-          spark = sparkSession,
-          path = hdpPath,
-          options = fileSystemOptions))
+      new DeltaTable(DeltaTableV2(sparkSession, hdpPath, options = fileSystemOptions))
     } else {
       throw DeltaErrors.notADeltaTableException(DeltaTableIdentifier(path = Some(path)))
     }
@@ -781,9 +774,8 @@ object DeltaTable {
     val tableId = sparkSession.sessionState.sqlParser.parseTableIdentifier(tableName)
     if (DeltaTableUtils.isDeltaTable(sparkSession, tableId)) {
       val tbl = sparkSession.sessionState.catalog.getTableMetadata(tableId)
-      new DeltaTable(
-        sparkSession.table(tableName),
-        DeltaTableV2(sparkSession, new Path(tbl.location), Some(tbl), Some(tableName)))
+      val newTable = DeltaTableV2(sparkSession, new Path(tbl.location), Some(tbl), Some(tableName))
+      new DeltaTable(newTable)
     } else if (DeltaTableUtils.isValidPath(tableId)) {
       forPath(sparkSession, tableId.table)
     } else {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -652,9 +652,12 @@ class DeltaAnalysis(session: SparkSession)
             Identifier.of(Array("delta"), path.toString))
         }
         // Trying to clone something on itself should be a no-op
-        if (sourceTbl == new CloneDeltaSource(targetTbl)) {
-          return LocalRelation()
+        sourceTbl match {
+          case deltaSourceTbl: CloneDeltaSource if deltaSourceTbl.sourceTable == targetTbl =>
+            return LocalRelation()
+          case _ => ()
         }
+
         // If this is a path based table and an external location is also defined throw an error
         if (statement.targetLocation.exists(loc => new Path(loc).toString != path.toString)) {
           throw DeltaErrors.cloneAmbiguousTarget(statement.targetLocation.get, tblIdent)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -143,6 +143,18 @@ case class DeltaTableV2(
     )
   }
 
+  /**
+   * Returns a fresh snapshot for this table. If time travel is in use, this is just the table's
+   * initial snapshot. Otherwise, obtain a fresh snapshot from the table's [[DeltaLog]].
+   */
+  def getFreshSnapshot(checkIfUpdatedSinceTs: Option[Long] = None): Snapshot = {
+    if (timeTravelSpec.isDefined) {
+      initialSnapshot
+    } else {
+      deltaLog.update(checkIfUpdatedSinceTs = checkIfUpdatedSinceTs)
+    }
+  }
+
   // We get the cdcRelation ahead of time if this is a CDC read to be able to return the correct
   // schema. The schema for CDC reads are currently convoluted due to column mapping behavior
   private lazy val cdcRelation: Option[BaseRelation] = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
@@ -146,10 +146,13 @@ object CloneTableCommand {
 
 /** A delta table source to be cloned from */
 class CloneDeltaSource(
-  sourceTable: DeltaTableV2) extends CloneSource {
+    val sourceTable: DeltaTableV2,
+    sourceSnapshot: Snapshot)
+  extends CloneSource {
 
-  private val deltaLog = sourceTable.deltaLog
-  private val sourceSnapshot = sourceTable.initialSnapshot
+  def this(sourceTable: DeltaTableV2) = this(sourceTable, sourceTable.getFreshSnapshot())
+
+  private def deltaLog = sourceSnapshot.deltaLog
 
   def format: String = CloneSourceFormat.DELTA
 

--- a/spark/src/test/scala/io/delta/tables/DeltaTableTestUtils.scala
+++ b/spark/src/test/scala/io/delta/tables/DeltaTableTestUtils.scala
@@ -25,6 +25,6 @@ object DeltaTableTestUtils {
 
   /** A utility method to access the private constructor of [[DeltaTable]] in tests. */
   def createTable(df: DataFrame, deltaLog: DeltaLog): DeltaTable = {
-    new DeltaTable(df, DeltaTableV2(df.sparkSession, deltaLog.dataPath))
+    new DeltaTable(DeltaTableV2(df.sparkSession, deltaLog.dataPath))
   }
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

The `DeltaTable` implementation is redundant, internally tracking both a `DeltaTableV2` and a `DataFrame`. Use `DeltaTableV2.toDf` method to replace the latter, simplifying the class implementation.

## How was this patch tested?

New unit tests.

## Does this PR introduce _any_ user-facing changes?

No.