### PR TITLE
[Spark] Add support for V2 Checkpoint metadata cleanup

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
@@ -22,11 +22,12 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.delta.DeltaHistoryManager.BufferingLogDeletionIterator
 import org.apache.spark.sql.delta.TruncationGranularity.{DAY, HOUR, TruncationGranularity}
-import org.apache.spark.sql.delta.actions.Metadata
+import org.apache.spark.sql.delta.actions.{Action, Metadata}
 import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.util.FileNames
 import org.apache.spark.sql.delta.util.FileNames.{checkpointVersion, listingPrefix, CheckpointFile, DeltaFile}
 import org.apache.commons.lang3.time.DateUtils
-import org.apache.hadoop.fs.{FileStatus, Path}
+import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
 
 private[delta] object TruncationGranularity extends Enumeration {
   type TruncationGranularity = Value
@@ -71,9 +72,36 @@ trait MetadataCleanup extends DeltaLogging {
 
       val fs = logPath.getFileSystem(newDeltaHadoopConf())
       var numDeleted = 0
-      listExpiredDeltaLogs(fileCutOffTime.getTime).map(_.getPath).foreach { path =>
+      val expiredDeltaLogs = listExpiredDeltaLogs(fileCutOffTime.getTime)
+      if (expiredDeltaLogs.hasNext) {
+        // Trigger compatibility checkpoint creation logic only when this round of metadata cleanup
+        // is going to delete any deltas/checkpoint files.
+        // We need to create compat checkpoint before deleting delta/checkpoint files so that we
+        // don't have a window in b/w where the old checkpoint is deleted and there is no
+        // compat-checkpoint available.
+        val v2CompatCheckpointMetrics = new V2CompatCheckpointMetrics
+        createSinglePartCheckpointForBackwardCompat(snapshotToCleanup, v2CompatCheckpointMetrics)
+        logInfo(s"Compatibility checkpoint creation metrics: $v2CompatCheckpointMetrics")
+      }
+      var wasCheckpointDeleted = false
+      expiredDeltaLogs.map(_.getPath).foreach { path =>
         // recursive = false
-        if (fs.delete(path, false)) numDeleted += 1
+        if (fs.delete(path, false)) {
+          numDeleted += 1
+          if (FileNames.isCheckpointFile(path)) {
+            wasCheckpointDeleted = true
+          }
+        }
+      }
+      if (wasCheckpointDeleted) {
+        // Trigger sidecar deletion only when some checkpoints have been deleted as part of this
+        // round of Metadata cleanup.
+        val sidecarDeletionMetrics = new SidecarDeletionMetrics
+        identifyAndDeleteUnreferencedSidecarFiles(
+          snapshotToCleanup,
+          fileCutOffTime.getTime,
+          sidecarDeletionMetrics)
+        logInfo(s"Sidecar deletion metrics: $sidecarDeletionMetrics")
       }
       logInfo(s"Deleted $numDeleted log files older than $formattedDate")
     }
@@ -124,6 +152,172 @@ trait MetadataCleanup extends DeltaLogging {
   /** Truncates a timestamp down to the previous midnight and returns the time. */
   private[delta] def truncateDay(timeMillis: Long): Calendar = {
     truncateDate(timeMillis, TruncationGranularity.DAY)
+  }
+
+  /**
+   * Helper method to create a compatibility classic single file checkpoint file for this table.
+   * This is needed so that any legacy reader which do not understand [[V2CheckpointTableFeature]]
+   * could read the legacy classic checkpoint file and fail gracefully with Protocol requirement
+   * failure.
+   */
+  protected def createSinglePartCheckpointForBackwardCompat(
+      snapshotToCleanup: Snapshot,
+      metrics: V2CompatCheckpointMetrics): Unit = {
+    // Do nothing if this table does not use V2 Checkpoints, or has no checkpoints at all.
+    if (!CheckpointProvider.isV2CheckpointEnabled(snapshotToCleanup)) return
+    if (snapshotToCleanup.checkpointProvider.isEmpty) return
+
+    val startTimeMs = System.currentTimeMillis()
+    val hadoopConf = newDeltaHadoopConf()
+    val checkpointInstance =
+      CheckpointInstance(snapshotToCleanup.checkpointProvider.topLevelFiles.head.getPath)
+    // The current checkpoint provider is already using a checkpoint with the naming
+    // scheme of classic checkpoints. There is no need to create a compatibility checkpoint
+    // in this case.
+    if (checkpointInstance.format != CheckpointInstance.Format.V2) return
+
+    val checkpointVersion = snapshotToCleanup.checkpointProvider.version
+    val checkpoints = listFrom(checkpointVersion)
+      .takeWhile(file => FileNames.getFileVersionOpt(file.getPath).exists(_ <= checkpointVersion))
+      .collect {
+        case file if FileNames.isCheckpointFile(file) => CheckpointInstance(file.getPath)
+      }
+      .filter(_.format != CheckpointInstance.Format.V2)
+      .toArray
+    val availableNonV2Checkpoints =
+      getLatestCompleteCheckpointFromList(checkpoints, Some(checkpointVersion))
+    if (availableNonV2Checkpoints.nonEmpty) {
+      metrics.v2CheckpointCompatLogicTimeTakenMs = System.currentTimeMillis() - startTimeMs
+      return
+    }
+
+    // topLevelFileIndex must be non-empty when topLevelFiles are present
+    val shallowCopyDf =
+      loadIndex(snapshotToCleanup.checkpointProvider.topLevelFileIndex.get, Action.logSchema)
+    val finalPath =
+      FileNames.checkpointFileSingular(snapshotToCleanup.deltaLog.logPath, checkpointVersion)
+    Checkpoints.createCheckpointV2ParquetFile(
+      spark,
+      shallowCopyDf,
+      finalPath,
+      hadoopConf,
+      useRename = false)
+    metrics.v2CheckpointCompatLogicTimeTakenMs = System.currentTimeMillis() - startTimeMs
+    metrics.checkpointVersion = checkpointVersion
+  }
+
+  /** Deletes any unreferenced files from the sidecar directory `_delta_log/_sidecar` */
+  protected def identifyAndDeleteUnreferencedSidecarFiles(
+      snapshotToCleanup: Snapshot,
+      checkpointRetention: Long,
+      metrics: SidecarDeletionMetrics): Unit = {
+    val startTimeMs = System.currentTimeMillis()
+    // If v2 checkpoints are not enabled on the table, we don't need to attempt the sidecar cleanup.
+    if (!CheckpointProvider.isV2CheckpointEnabled(snapshotToCleanup)) return
+
+    val hadoopConf = newDeltaHadoopConf()
+    val fs = sidecarDirPath.getFileSystem(hadoopConf)
+    // This can happen when the V2 Checkpoint feature is present in the Protocol but
+    // only Classic checkpoints have been created for the table.
+    if (!fs.exists(sidecarDirPath)) return
+
+    val (parquetCheckpointFiles, otherFiles) = store
+      .listFrom(listingPrefix(logPath, 0), hadoopConf)
+      .collect { case CheckpointFile(status, _) => (status, CheckpointInstance(status.getPath)) }
+      .collect { case (fileStatus, ci) if ci.format.usesSidecars => fileStatus }
+      .toSeq
+      .partition(_.getPath.getName.endsWith("parquet"))
+    val (jsonCheckpointFiles, unknownFormatCheckpointFiles) =
+      otherFiles.partition(_.getPath.getName.endsWith("json"))
+    if (unknownFormatCheckpointFiles.nonEmpty) {
+      logWarning(
+        "Found checkpoint files other than parquet and json: " +
+          s"${unknownFormatCheckpointFiles.map(_.getPath.toString).mkString(",")}")
+    }
+    metrics.numActiveParquetCheckpointFiles = parquetCheckpointFiles.size
+    metrics.numActiveJsonCheckpointFiles = jsonCheckpointFiles.size
+    val parquetCheckpointsFileIndex =
+      DeltaLogFileIndex(DeltaLogFileIndex.CHECKPOINT_FILE_FORMAT_PARQUET, parquetCheckpointFiles)
+    val jsonCheckpointsFileIndex =
+      DeltaLogFileIndex(DeltaLogFileIndex.CHECKPOINT_FILE_FORMAT_JSON, jsonCheckpointFiles)
+    val identifyActiveSidecarsStartTimeMs = System.currentTimeMillis()
+    metrics.activeCheckpointsListingTimeTakenMs = identifyActiveSidecarsStartTimeMs - startTimeMs
+    import org.apache.spark.sql.delta.implicits._
+    val df = (parquetCheckpointsFileIndex ++ jsonCheckpointsFileIndex)
+      .map(loadIndex(_, Action.logSchema(Set("sidecar"))))
+      .reduceOption(_ union _)
+      .getOrElse { return }
+
+    val activeSidecarFiles = df
+      .select("sidecar.path")
+      .where("path is not null")
+      .as[String]
+      .collect()
+      .map(p => new Path(p).getName) // Get bare file names
+      .toSet
+
+    val identifyAndDeleteSidecarsStartTimeMs = System.currentTimeMillis()
+    metrics.identifyActiveSidecarsTimeTakenMs =
+      identifyAndDeleteSidecarsStartTimeMs - identifyActiveSidecarsStartTimeMs
+    // Retain all files created in the checkpoint retention window - irrespective of whether they
+    // are referenced in a checkpoint or not. This is to make sure that we don't end up deleting an
+    // in-progress checkpoint.
+    val retentionTimestamp: Long = checkpointRetention
+    val sidecarFilesIterator = new Iterator[FileStatus] {
+      // Hadoop's RemoteIterator is neither java nor scala Iterator, so have to wrap it
+      val remoteIterator = fs.listStatusIterator(sidecarDirPath)
+      override def hasNext(): Boolean = remoteIterator.hasNext()
+      override def next(): FileStatus = remoteIterator.next()
+    }
+    val sidecarFilesToDelete = sidecarFilesIterator
+      .collect { case file if file.getModificationTime < retentionTimestamp => file.getPath }
+      .filterNot(path => activeSidecarFiles.contains(path.getName))
+    val sidecarDeletionStartTimeMs = System.currentTimeMillis()
+    logInfo(s"Starting the deletion of unreferenced sidecar files")
+    val count = deleteMultiple(fs, sidecarFilesToDelete)
+
+    logInfo(s"Deleted $count sidecar files")
+    metrics.numSidecarFilesDeleted = count
+    val endTimeMs = System.currentTimeMillis()
+    metrics.identifyAndDeleteSidecarsTimeTakenMs =
+      sidecarDeletionStartTimeMs - identifyAndDeleteSidecarsStartTimeMs
+    metrics.overallSidecarProcessingTimeTakenMs = endTimeMs - startTimeMs
+  }
+
+  private def deleteMultiple(fs: FileSystem, paths: Iterator[Path]): Long = {
+      paths.map { path =>
+        if (fs.delete(path, false)) 1L else 0L
+      }.sum
+  }
+
+  /** Class to track metrics related to V2 Checkpoint Sidecars deletion. */
+  protected class SidecarDeletionMetrics {
+    // number of sidecar files deleted
+    var numSidecarFilesDeleted: Long = -1
+    // number of active parquet checkpoint files present in delta log directory
+    var numActiveParquetCheckpointFiles: Long = -1
+    // number of active json checkpoint files present in delta log directory
+    var numActiveJsonCheckpointFiles: Long = -1
+    // time taken (in ms) to list and identify active checkpoints
+    var activeCheckpointsListingTimeTakenMs: Long = -1
+    // time taken (in ms) to list the sidecar directory to get all sidecars and delete those which
+    // aren't referenced by any checkpoint anymore
+    var identifyAndDeleteSidecarsTimeTakenMs: Long = -1
+    // time taken (in ms) to read the active checkpoint json / parquet files and identify active
+    // sidecar files
+    var identifyActiveSidecarsTimeTakenMs: Long = -1
+    // time taken (in ms) for everything related to sidecar processing
+    var overallSidecarProcessingTimeTakenMs: Long = -1
+  }
+
+  /** Class to track metrics related to V2 Compatibility checkpoint creation. */
+  protected class V2CompatCheckpointMetrics {
+    // time taken (in ms) to run the v2 checkpoint compat logic
+    var v2CheckpointCompatLogicTimeTakenMs: Long = -1
+
+    // the version at which we have created a v2 compat checkpoint, -1 if no compat checkpoint was
+    // created.
+    var checkpointVersion: Long = -1
   }
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuiteBase.scala
@@ -18,10 +18,15 @@ package org.apache.spark.sql.delta
 
 import java.io.File
 
+import scala.collection.mutable
+
 import org.apache.spark.sql.delta.DeltaOperations.Truncate
-import org.apache.spark.sql.delta.actions.Metadata
+import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
+import org.apache.spark.sql.delta.actions.{CheckpointMetadata, Metadata, SidecarFile}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.FileNames
+import org.apache.spark.sql.delta.util.FileNames.{newV2CheckpointJsonFile, newV2CheckpointParquetFile}
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkConf
@@ -29,6 +34,7 @@ import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.util.IntervalUtils
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.util.ManualClock
 
 trait DeltaRetentionSuiteBase extends QueryTest
   with SharedSparkSession {
@@ -50,6 +56,128 @@ trait DeltaRetentionSuiteBase extends QueryTest
     dir.listFiles().filter(f => FileNames.isCheckpointFile(new Path(f.getCanonicalPath)))
 
   protected def getLogFiles(dir: File): Seq[File]
+
+  protected def getFileVersions(files: Seq[File]): Set[Long] = {
+    files.map(f => f.getName()).map(s => s.substring(0, s.indexOf(".")).toLong).toSet
+  }
+
+  protected def getDeltaVersions(dir: File): Set[Long] = {
+    getFileVersions(getDeltaFiles(dir))
+  }
+
+  protected def getSidecarFiles(log: DeltaLog): Set[String] = {
+    new java.io.File(log.sidecarDirPath.toUri)
+      .listFiles()
+      .filter(_.getName.endsWith(".parquet"))
+      .map(_.getName)
+      .toSet
+  }
+
+  protected def getCheckpointVersions(dir: File): Set[Long] = {
+    getFileVersions(getCheckpointFiles(dir))
+  }
+
+  /** Compares the given versions with expected and generates a nice error message. */
+  protected def compareVersions(
+      versions: Set[Long],
+      logType: String,
+      expected: Iterable[Int]): Unit = {
+    val expectedSet = expected.map(_.toLong).toSet
+    val deleted = expectedSet -- versions
+    val notDeleted = versions -- expectedSet
+    if (!(deleted.isEmpty && notDeleted.isEmpty)) {
+      fail(s"""Mismatch in log clean up for ${logType}s:
+           |Shouldn't be deleted but deleted: ${deleted.toArray.sorted.mkString("[", ", ", "]")}
+           |Should be deleted but not: ${notDeleted.toArray.sorted.mkString("[", ", ", "]")}
+         """.stripMargin)
+    }
+  }
+
+  // Set modification time of the new files in _delta_log directory and mark them as visited.
+  def setModificationTimeOfNewFiles(
+      log: DeltaLog,
+      clock: ManualClock,
+      visitedFiled: mutable.Set[String]): Unit = {
+    val fs = log.logPath.getFileSystem(log.newDeltaHadoopConf())
+    val allFiles = fs.listFiles(log.logPath, true)
+    while (allFiles.hasNext) {
+      val file = allFiles.next()
+      if (!visitedFiled.contains(file.getPath.toString)) {
+        visitedFiled += file.getPath.toString
+        fs.setTimes(file.getPath, clock.getTimeMillis(), 0)
+      }
+    }
+  }
+
+  protected def day(startTime: Long, day: Int): Long =
+    startTime + intervalStringToMillis(s"interval $day days")
+
+  // Create a sidecar file with given AddFiles inside it.
+  protected def createSidecarFile(log: DeltaLog, files: Seq[Int]): String = {
+    val sparkSession = spark
+    // scalastyle:off sparkimplicits
+    import sparkSession.implicits._
+    // scalastyle:on sparkimplicits
+    var sidecarFileName: String = ""
+    withTempDir { dir =>
+      val adds = files.map(i => createTestAddFile(i.toString))
+      adds.map(_.wrap).toDF.repartition(1).write.mode("overwrite").parquet(dir.getAbsolutePath)
+      val srcPath =
+        new Path(dir.listFiles().filter(_.getName.endsWith("parquet")).head.getAbsolutePath)
+      val dstPath = new Path(log.sidecarDirPath, srcPath.getName)
+      val fs = srcPath.getFileSystem(log.newDeltaHadoopConf())
+      fs.mkdirs(log.sidecarDirPath)
+      fs.rename(srcPath, dstPath)
+      sidecarFileName = fs.getFileStatus(dstPath).getPath.getName
+    }
+    sidecarFileName
+  }
+
+  // Create a V2 Checkpoint at given version with given sidecar files.
+  protected def createV2CheckpointWithSidecarFile(
+      log: DeltaLog,
+      version: Long,
+      sidecarFileNames: Seq[String]): Unit = {
+    val hadoopConf = log.newDeltaHadoopConf()
+    val fs = log.logPath.getFileSystem(hadoopConf)
+    val sidecarFiles = sidecarFileNames.map { fileName =>
+      val sidecarPath = new Path(log.sidecarDirPath, fileName)
+      val fileStatus = SerializableFileStatus.fromStatus(fs.getFileStatus(sidecarPath))
+      SidecarFile(fileStatus)
+    }
+    val snapshot = log.getSnapshotAt(version)
+    val actionsForCheckpoint =
+      snapshot.nonFileActions ++ sidecarFiles :+ CheckpointMetadata(version)
+    val v2CheckpointFormat =
+      spark.conf.getOption(DeltaSQLConf.CHECKPOINT_V2_TOP_LEVEL_FILE_FORMAT.key)
+    v2CheckpointFormat match {
+      case Some(V2Checkpoint.Format.JSON.name) | None =>
+        log.store.write(
+          newV2CheckpointJsonFile(log.logPath, version),
+          actionsForCheckpoint.map(_.json).toIterator,
+          overwrite = true,
+          hadoopConf = hadoopConf)
+      case Some(V2Checkpoint.Format.PARQUET.name) =>
+        val parquetFile = newV2CheckpointParquetFile(log.logPath, version)
+        val sparkSession = spark
+        // scalastyle:off sparkimplicits
+        import sparkSession.implicits._
+        // scalastyle:on sparkimplicits
+        val dfToWrite = actionsForCheckpoint.map(_.wrap).toDF
+        Checkpoints.createCheckpointV2ParquetFile(
+          spark,
+          dfToWrite,
+          parquetFile,
+          hadoopConf,
+          useRename = false)
+      case _ =>
+        assert(false, "Invalid v2 checkpoint format")
+    }
+    log.writeLastCheckpointFile(
+      log,
+      LastCheckpointInfo(version, -1, None, None, None, None),
+      false)
+  }
 
   /**
    * Start a txn that disables automatic log cleanup. Some tests may need to manually clean up logs


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Adds metadata cleanup logic for V2 Checkpoints (described in https://github.com/delta-io/delta/issues/1793). MetadataCleanup has been updated to make it aware of V2 Checkpoint sidecar files. Sidecar files are only deleted if 1. They are not being used by any non-expired checkpoints AND 2. They have expired as per the log retention period.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Added Unit Test that checks for sidecar cleanup.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No