### PR TITLE
[Spark] Adds and Sets catalogTable Member on DML Commands

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -451,7 +451,7 @@ class DeltaAnalysis(session: SparkSession)
       // rewrites Delta from V2 to V1
       val newTarget = stripTempViewWrapper(table).transformUp { case DeltaRelation(lr) => lr }
       val indices = newTarget.collect {
-        case DeltaFullTable(index) => index
+        case DeltaFullTable(_, index) => index
       }
       if (indices.isEmpty) {
         // Not a Delta table at all, do not transform
@@ -469,7 +469,7 @@ class DeltaAnalysis(session: SparkSession)
       // rewrites Delta from V2 to V1
       val newTable = stripTempViewWrapper(table).transformUp { case DeltaRelation(lr) => lr }
         newTable.collectLeaves().headOption match {
-          case Some(DeltaFullTable(index)) =>
+          case Some(DeltaFullTable(_, index)) =>
             DeltaUpdateTable(newTable, cols, expressions, condition)
           case o =>
             // not a Delta table

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableUpdate.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableUpdate.scala
@@ -49,9 +49,8 @@ case class PreprocessTableUpdate(sqlConf: SQLConf)
 
   def toCommand(update: DeltaUpdateTable): UpdateCommand = {
     val deltaLogicalNode = EliminateSubqueryAliases(update.child)
-    val index = deltaLogicalNode match {
-      case DeltaFullTable(tahoeFileIndex) =>
-        tahoeFileIndex
+    val (relation, index) = deltaLogicalNode match {
+      case DeltaFullTable(rel, tahoeFileIndex) => rel -> tahoeFileIndex
       case o =>
         throw DeltaErrors.notADeltaSourceException("UPDATE", Some(o))
     }
@@ -83,6 +82,7 @@ case class PreprocessTableUpdate(sqlConf: SQLConf)
       }
     UpdateCommand(
       index,
+      relation.catalogTable,
       update.child,
       alignedUpdateExprsAfterAddingGenerationExprs,
       update.condition)


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR adds a catalogTable member to UPDATE, DELETE, and MERGE commands. This catalogTable member is then passed to the transaction these commands create so that it is later accessible in the Iceberg conversion that Uniform performs. This is necessary so Uniform can correctly retrieve and update a table from HMS.

This PR is part of https://github.com/delta-io/delta/issues/2105.

## How was this patch tested?

Adapted existing unit tests. This is mainly a refactoring change so existing unit test coverage is sufficient.

## Does this PR introduce _any_ user-facing changes?

No
