### PR TITLE
[2108] pass catalogTable to WriteIntoDelta

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -1220,7 +1220,8 @@ case class DeltaDynamicPartitionOverwriteCommand(
       deltaOptions,
       partitionColumns = Nil,
       deltaTable.deltaLog.unsafeVolatileSnapshot.metadata.configuration,
-      Dataset.ofRows(sparkSession, query)
+      Dataset.ofRows(sparkSession, query),
+      deltaTable.catalogTable
     ).run(sparkSession)
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -484,6 +484,7 @@ class DeltaLog private(
   def createRelation(
       partitionFilters: Seq[Expression] = Nil,
       snapshotToUseOpt: Option[Snapshot] = None,
+      catalogTableOpt: Option[CatalogTable] = None,
       isTimeTravelQuery: Boolean = false): BaseRelation = {
 
     /** Used to link the files present in the table into the query planner. */
@@ -516,7 +517,8 @@ class DeltaLog private(
           new DeltaOptions(Map.empty[String, String], spark.sessionState.conf),
           partitionColumns = Seq.empty,
           configuration = Map.empty,
-          data = data).run(spark)
+          data = data,
+          catalogTableOpt = catalogTableOpt).run(spark)
       }
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
@@ -165,6 +165,7 @@ class DeltaCatalog extends DelegatingCatalogExtension
         withDb.partitionColumnNames,
         withDb.properties ++ commentOpt.map("comment" -> _),
         df,
+        Some(tableDesc),
         schemaInCatalog = if (newSchema != schema) Some(newSchema) else None)
     }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -244,7 +244,7 @@ case class DeltaTableV2(
 
     cdcRelation.getOrElse {
       deltaLog.createRelation(
-        partitionPredicates, Some(initialSnapshot), timeTravelSpec.isDefined)
+        partitionPredicates, Some(initialSnapshot), catalogTable, timeTravelSpec.isDefined)
     }
   }
 
@@ -395,7 +395,8 @@ private class WriteIntoDeltaBuilder(
             new DeltaOptions(options.toMap, session.sessionState.conf),
             Nil,
             table.deltaLog.unsafeVolatileSnapshot.metadata.configuration,
-            data).run(session)
+            data,
+            table.catalogTable).run(session)
 
           // TODO: Push this to Apache Spark
           // Re-cache all cached plans(including this relation itself, if it's cached) that refer

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -160,7 +160,8 @@ case class CreateDeltaTableCommand(
           options,
           partitionColumns = table.partitionColumnNames,
           configuration = tableWithLocation.properties + ("comment" -> table.comment.orNull),
-          data = data)
+          data = data,
+          Some(tableWithLocation))
         handleCreateTableAsSelect(sparkSession, txn, deltaLog, deltaWriter, tableWithLocation)
         Nil
       case _ =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
@@ -192,7 +192,10 @@ class DeltaDataSource
       partitionColumns = partitionColumns,
       configuration = DeltaConfigs.validateConfigurations(
         parameters.filterKeys(_.startsWith("delta.")).toMap),
-      data = data).run(sqlContext.sparkSession)
+      data = data,
+      // empty catalogTable is acceptable as the code path is only for path based writes
+      // (df.write.save("path")) which does not need to use/update catalog
+      catalogTableOpt = None).run(sqlContext.sparkSession)
 
     deltaLog.createRelation()
   }


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

As a part of the whole Delta uniform HMS support effort, this PR passes catalogTable to WriteIntoDelta which can then pass catalogTable to IcebergConversionTransactions so Iceberg can commit to HMS. 

## How was this patch tested?

refactor; existing unit test. 

## Does this PR introduce _any_ user-facing changes?

No
