### PR TITLE
[Spark] Remove unused DeltaTableIdentifier overloads of DeltaLog.forTable

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -721,20 +721,6 @@ object DeltaLog extends DeltaLogging {
     apply(spark, logPathFor(new Path(table.location)), clock)
   }
 
-  /** Helper for creating a log for the table. */
-  def forTable(spark: SparkSession, deltaTable: DeltaTableIdentifier): DeltaLog = {
-    forTable(spark, deltaTable, new SystemClock)
-  }
-
-  /** Helper for creating a log for the table. */
-  def forTable(spark: SparkSession, deltaTable: DeltaTableIdentifier, clock: Clock): DeltaLog = {
-    if (deltaTable.path.isDefined) {
-      forTable(spark, new Path(deltaTable.path.get), clock)
-    } else {
-      forTable(spark, deltaTable.table.get, clock)
-    }
-  }
-
   private def apply(spark: SparkSession, rawPath: Path, clock: Clock = new SystemClock): DeltaLog =
     apply(spark, rawPath, Map.empty, clock)
 
@@ -751,12 +737,6 @@ object DeltaLog extends DeltaLogging {
   def forTableWithSnapshot(
       spark: SparkSession,
       tableName: TableIdentifier): (DeltaLog, Snapshot) =
-    withFreshSnapshot { forTable(spark, tableName, _) }
-
-  /** Helper for getting a log, as well as the latest snapshot, of the table */
-  def forTableWithSnapshot(
-      spark: SparkSession,
-      tableName: DeltaTableIdentifier): (DeltaLog, Snapshot) =
     withFreshSnapshot { forTable(spark, tableName, _) }
 
   /** Helper for getting a log, as well as the latest snapshot, of the table */


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

The `DeltaTableIdentifier` overloads of `DeltaLog.forTable` involve an internal catalog lookup, which interferes with https://github.com/delta-io/delta/issues/2052 because the resulting `CatalogTable` is lost. Fortunately, the overloads are not actually used, so we can simply delete them to prevent any future problems.

## How was this patch tested?

Dead code removal. Compilation suffices.

## Does this PR introduce _any_ user-facing changes?

No.