### PR TITLE
[Spark] Harmonize path-based Delta table resolution

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTimeTravel.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTimeTravel.scala
@@ -75,7 +75,7 @@ case class PreprocessTimeTravel(sparkSession: SparkSession) extends Rule[Logical
         throw DeltaErrors.notADeltaTableException(commandName)
       case tableRelation if tableRelation.resolved =>
         tableRelation
-      case _ =>
+      case _ if ResolveDeltaPathTable.maybeSQLFile(sparkSession, ur.multipartIdentifier) =>
         // If the identifier doesn't exist as a table, try resolving it as a path table.
         ResolveDeltaPathTable.resolveAsPathTableRelation(sparkSession, ur).getOrElse {
           ur.tableNotFound(ur.multipartIdentifier)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaCommand.scala
@@ -287,7 +287,7 @@ trait DeltaCommand extends DeltaLogging {
    */
   def getDeltaTable(target: LogicalPlan, cmd: String): DeltaTableV2 = {
     // TODO: Remove this wrapper and let former callers invoke DeltaTableV2.extractFrom directly.
-    DeltaTableV2.extractFrom(target, cmd)
+    DeltaTableV2.extractFromResolvedTable(target, cmd)
   }
 
   /**


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Historically, path-based table resolution logic has been scattered all over Delta's code base. We can build on recent code improvements to start harmonizing and centralizing that logic in `DeltaTableV2`, which already plays a central role in all table resolution. Future changes can continue building on this base.

## How was this patch tested?

Existing unit tests.

## Does this PR introduce _any_ user-facing changes?

No.