### PR TITLE
[Spark] Improves InvalidProtocolVersionException message

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -1127,7 +1127,7 @@
   },
   "DELTA_INVALID_PROTOCOL_VERSION" : {
     "message" : [
-      "Delta protocol version is not supported by this version of Delta Lake: table requires <required>, client supports <supported>. Please upgrade to a newer release."
+      "Delta protocol version is not supported by this version of Delta Lake: table \"<tableNameOrPath>\" requires reader version <readerRequired> and writer version <writerRequired>, client supports reader versions <supportedReaders> and writer versions <supportedWriters>. Please upgrade to a newer release."
     ],
     "sqlState" : "KD004"
   },

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -1127,7 +1127,7 @@
   },
   "DELTA_INVALID_PROTOCOL_VERSION" : {
     "message" : [
-      "Delta protocol version is not supported by this version of Delta Lake: table \"<tableNameOrPath>\" requires reader version <readerRequired> and writer version <writerRequired>, client supports reader versions <supportedReaders> and writer versions <supportedWriters>. Please upgrade to a newer release."
+      "Unsupported Delta protocol version: table \"<tableNameOrPath>\" requires reader version <readerRequired> and writer version <writerRequired>, but Delta Lake \"<deltaVersion>\" supports reader versions <supportedReaders> and writer versions <supportedWriters>. Please upgrade to a newer release."
     ],
     "sqlState" : "KD004"
   },

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3270,11 +3270,11 @@ class DeltaIndexOutOfBoundsException(
 
 /** Thrown when the protocol version of a table is greater than supported by this client. */
 class InvalidProtocolVersionException(
-  tableNameOrPath: String,
-  readerRequiredVersion: Int,
-  writerRequiredVersion: Int,
-  supportedReaderVersions: Seq[Int],
-  supportedWriterVersions: Seq[Int])
+    tableNameOrPath: String,
+    readerRequiredVersion: Int,
+    writerRequiredVersion: Int,
+    supportedReaderVersions: Seq[Int],
+    supportedWriterVersions: Seq[Int])
   extends RuntimeException(DeltaThrowableHelper.getMessage(
     errorClass = "DELTA_INVALID_PROTOCOL_VERSION",
     messageParameters = Array(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3269,10 +3269,20 @@ class DeltaIndexOutOfBoundsException(
 }
 
 /** Thrown when the protocol version of a table is greater than supported by this client. */
-class InvalidProtocolVersionException(requiredVersion: Int, supportedVersions: Seq[Int])
+class InvalidProtocolVersionException(
+  tableNameOrPath: String,
+  readerRequiredVersion: Int,
+  writerRequiredVersion: Int,
+  supportedReaderVersions: Seq[Int],
+  supportedWriterVersions: Seq[Int])
   extends RuntimeException(DeltaThrowableHelper.getMessage(
     errorClass = "DELTA_INVALID_PROTOCOL_VERSION",
-    messageParameters = Array(requiredVersion.toString, supportedVersions.sorted.mkString(", "))))
+    messageParameters = Array(
+      tableNameOrPath,
+      readerRequiredVersion.toString,
+      writerRequiredVersion.toString,
+      supportedReaderVersions.sorted.mkString(", "),
+      supportedWriterVersions.sorted.mkString(", "))))
   with DeltaThrowable {
   override def getErrorClass: String = "DELTA_INVALID_PROTOCOL_VERSION"
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3270,11 +3270,11 @@ class DeltaIndexOutOfBoundsException(
 
 /** Thrown when the protocol version of a table is greater than supported by this client. */
 class InvalidProtocolVersionException(
-    tableNameOrPath: String,
-    readerRequiredVersion: Int,
-    writerRequiredVersion: Int,
-    supportedReaderVersions: Seq[Int],
-    supportedWriterVersions: Seq[Int])
+    val tableNameOrPath: String,
+    val readerRequiredVersion: Int,
+    val writerRequiredVersion: Int,
+    val supportedReaderVersions: Seq[Int],
+    val supportedWriterVersions: Seq[Int])
   extends RuntimeException(DeltaThrowableHelper.getMessage(
     errorClass = "DELTA_INVALID_PROTOCOL_VERSION",
     messageParameters = Array(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3269,12 +3269,12 @@ class DeltaIndexOutOfBoundsException(
 }
 
 /** Thrown when the protocol version of a table is greater than supported by this client. */
-class InvalidProtocolVersionException(
-    val tableNameOrPath: String,
-    val readerRequiredVersion: Int,
-    val writerRequiredVersion: Int,
-    val supportedReaderVersions: Seq[Int],
-    val supportedWriterVersions: Seq[Int])
+case class InvalidProtocolVersionException(
+    tableNameOrPath: String,
+    readerRequiredVersion: Int,
+    writerRequiredVersion: Int,
+    supportedReaderVersions: Seq[Int],
+    supportedWriterVersions: Seq[Int])
   extends RuntimeException(DeltaThrowableHelper.getMessage(
     errorClass = "DELTA_INVALID_PROTOCOL_VERSION",
     messageParameters = Array(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3281,6 +3281,7 @@ case class InvalidProtocolVersionException(
       tableNameOrPath,
       readerRequiredVersion.toString,
       writerRequiredVersion.toString,
+      io.delta.VERSION,
       supportedReaderVersions.sorted.mkString(", "),
       supportedWriterVersions.sorted.mkString(", "))))
   with DeltaThrowable {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -436,11 +436,9 @@ class DeltaLog private(
   /**
    * Asserts that the client is up to date with the protocol and allowed to read the table that is
    * using the given `protocol`.
-   * @param tableProtocol: The protocol to be checked.
-   * @param catalogTable: optional catalog table of the Delta table protocol being checked.
    */
-  def protocolRead(protocol: Protocol, catalogTable: Option[CatalogTable] = None): Unit = {
-    protocolCheck(protocol, "read", catalogTable)
+  def protocolRead(protocol: Protocol): Unit = {
+    protocolCheck(protocol, "read", None)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -345,8 +345,7 @@ class DeltaLog private(
    */
   private def protocolCheck(
       tableProtocol: Protocol,
-      readOrWrite: String,
-      catalogTable: Option[CatalogTable]): Unit = {
+      readOrWrite: String): Unit = {
     val clientSupportedProtocol = Action.supportedProtocolVersion()
     // Depending on the operation, pull related protocol versions out of Protocol objects.
     // `getEnabledFeatures` is a pointer to pull reader/writer features out of a Protocol.
@@ -395,14 +394,9 @@ class DeltaLog private(
         "clientFeatures" -> clientSupportedFeatureNames.mkString(","),
         "clientUnsupportedFeatures" -> clientUnsupportedFeatureNames.mkString(",")))
 
-    val tableNameInException = catalogTable match {
-      case Some(ct) => ct.identifier.copy(catalog = None).unquotedString
-      case None => dataPath.toString()
-    }
-
     if (!clientSupportedVersions.contains(tableRequiredVersion)) {
       throw new InvalidProtocolVersionException(
-        tableNameInException,
+        dataPath.toString(),
         tableProtocol.minReaderVersion,
         tableProtocol.minWriterVersion,
         Action.supportedReaderVersionNumbers.toSeq,
@@ -438,7 +432,7 @@ class DeltaLog private(
    * using the given `protocol`.
    */
   def protocolRead(protocol: Protocol): Unit = {
-    protocolCheck(protocol, "read", None)
+    protocolCheck(protocol, "read")
   }
 
   /**
@@ -447,8 +441,8 @@ class DeltaLog private(
    * @param tableProtocol: The protocol to be checked.
    * @param catalogTable: optional catalog table of the Delta table protocol being checked.
    */
-  def protocolWrite(protocol: Protocol, catalogTable: Option[CatalogTable] = None): Unit = {
-    protocolCheck(protocol, "write", catalogTable)
+  def protocolWrite(protocol: Protocol): Unit = {
+    protocolCheck(protocol, "write")
   }
 
   /* ---------------------------------------- *

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -395,8 +395,10 @@ class DeltaLog private(
         "clientFeatures" -> clientSupportedFeatureNames.mkString(","),
         "clientUnsupportedFeatures" -> clientUnsupportedFeatureNames.mkString(",")))
 
-    val tableNameInException = catalogTable.map(_.identifier.copy(catalog = None).unquotedString)
-      .getOrElse(dataPath.toString())
+    val tableNameInException = catalogTable match {
+      case Some(ct) => ct.identifier.copy(catalog = None).unquotedString
+      case None => dataPath.toString()
+    }
 
     if (!clientSupportedVersions.contains(tableRequiredVersion)) {
       throw new InvalidProtocolVersionException(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -339,13 +339,8 @@ class DeltaLog private(
    *
    * The operation type to be checked is passed as a string in `readOrWrite`. Valid values are
    * `read` and `write`.
-   * @param tableProtocol: The protocol to be checked.
-   * @param readOrWrite: The operation type to be checked: `read` or `write`.
-   * @param catalogTable: optional catalog table of the Delta table protocol being checked.
    */
-  private def protocolCheck(
-      tableProtocol: Protocol,
-      readOrWrite: String): Unit = {
+  private def protocolCheck(tableProtocol: Protocol, readOrWrite: String): Unit = {
     val clientSupportedProtocol = Action.supportedProtocolVersion()
     // Depending on the operation, pull related protocol versions out of Protocol objects.
     // `getEnabledFeatures` is a pointer to pull reader/writer features out of a Protocol.
@@ -393,7 +388,6 @@ class DeltaLog private(
         versionKey -> tableRequiredVersion,
         "clientFeatures" -> clientSupportedFeatureNames.mkString(","),
         "clientUnsupportedFeatures" -> clientUnsupportedFeatureNames.mkString(",")))
-
     if (!clientSupportedVersions.contains(tableRequiredVersion)) {
       throw new InvalidProtocolVersionException(
         dataPath.toString(),
@@ -438,8 +432,6 @@ class DeltaLog private(
   /**
    * Asserts that the client is up to date with the protocol and allowed to write to the table
    * that is using the given `protocol`.
-   * @param tableProtocol: The protocol to be checked.
-   * @param catalogTable: optional catalog table of the Delta table protocol being checked.
    */
   def protocolWrite(protocol: Protocol): Unit = {
     protocolCheck(protocol, "write")

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1415,7 +1415,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       case other => other
     }
 
-    deltaLog.protocolWrite(snapshot.protocol)
+    deltaLog.protocolWrite(snapshot.protocol, catalogTable)
 
     finalActions = RowId.assignFreshRowIds(protocol, snapshot, finalActions.toIterator).toList
     finalActions = DefaultRowCommitVersion

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1416,7 +1416,10 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       case other => other
     }
 
-    deltaLog.protocolWrite(snapshot.protocol, catalogTable)
+    DeltaTableV2.withEnrichedInvalidProtocolVersionException(
+      catalogTable.map(_.identifier.copy(catalog = None).unquotedString)) {
+      deltaLog.protocolWrite(snapshot.protocol)
+    }
 
     finalActions = RowId.assignFreshRowIds(protocol, snapshot, finalActions.toIterator).toList
     finalActions = DefaultRowCommitVersion

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -29,6 +29,7 @@ import com.databricks.spark.util.TagDefinitions.TAG_LOG_STORE_CLASS
 import org.apache.spark.sql.delta.DeltaOperations.Operation
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.DeletionVectorUtils
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.files._
@@ -1737,38 +1738,42 @@ trait OptimisticTransactionImpl extends TransactionalWrite
         "delta.commit.retry.conflictCheck",
         tags = Map(TAG_LOG_STORE_CLASS -> deltaLog.store.getClass.getName)) {
 
-    val nextAttemptVersion = getNextAttemptVersion(checkVersion)
+    DeltaTableV2.withEnrichedInvalidProtocolVersionException(
+      catalogTable.map(_.identifier.copy(catalog = None).unquotedString)) {
 
-    val logPrefixStr = s"[attempt $attemptNumber]"
-    val txnDetailsLogStr = {
-      var adds = 0L
-      var removes = 0L
-      currentTransactionInfo.actions.foreach {
-        case _: AddFile => adds += 1
-        case _: RemoveFile => removes += 1
-        case _ =>
+      val nextAttemptVersion = getNextAttemptVersion(checkVersion)
+
+      val logPrefixStr = s"[attempt $attemptNumber]"
+      val txnDetailsLogStr = {
+        var adds = 0L
+        var removes = 0L
+        currentTransactionInfo.actions.foreach {
+          case _: AddFile => adds += 1
+          case _: RemoveFile => removes += 1
+          case _ =>
+        }
+        s"$adds adds, $removes removes, ${readPredicates.size} read predicates, " +
+          s"${readFiles.size} read files"
       }
-      s"$adds adds, $removes removes, ${readPredicates.size} read predicates, " +
-        s"${readFiles.size} read files"
-    }
 
-    logInfo(s"$logPrefixStr Checking for conflicts with versions " +
-      s"[$checkVersion, $nextAttemptVersion) with current txn having $txnDetailsLogStr")
+      logInfo(s"$logPrefixStr Checking for conflicts with versions " +
+        s"[$checkVersion, $nextAttemptVersion) with current txn having $txnDetailsLogStr")
 
-    var updatedCurrentTransactionInfo = currentTransactionInfo
-    (checkVersion until nextAttemptVersion).foreach { otherCommitVersion =>
-      updatedCurrentTransactionInfo = checkForConflictsAgainstVersion(
-        updatedCurrentTransactionInfo,
-        otherCommitVersion,
-        commitIsolationLevel)
-      logInfo(s"$logPrefixStr No conflicts in version $otherCommitVersion, " +
+      var updatedCurrentTransactionInfo = currentTransactionInfo
+      (checkVersion until nextAttemptVersion).foreach { otherCommitVersion =>
+        updatedCurrentTransactionInfo = checkForConflictsAgainstVersion(
+          updatedCurrentTransactionInfo,
+          otherCommitVersion,
+          commitIsolationLevel)
+        logInfo(s"$logPrefixStr No conflicts in version $otherCommitVersion, " +
+          s"${clock.getTimeMillis() - commitAttemptStartTime} ms since start")
+      }
+
+      logInfo(s"$logPrefixStr No conflicts with versions [$checkVersion, $nextAttemptVersion) " +
+        s"with current txn having $txnDetailsLogStr, " +
         s"${clock.getTimeMillis() - commitAttemptStartTime} ms since start")
+      (nextAttemptVersion, updatedCurrentTransactionInfo)
     }
-
-    logInfo(s"$logPrefixStr No conflicts with versions [$checkVersion, $nextAttemptVersion) " +
-      s"with current txn having $txnDetailsLogStr, " +
-      s"${clock.getTimeMillis() - commitAttemptStartTime} ms since start")
-    (nextAttemptVersion, updatedCurrentTransactionInfo)
   }
 
   protected def checkForConflictsAgainstVersion(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1416,8 +1416,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       case other => other
     }
 
-    DeltaTableV2.withEnrichedInvalidProtocolVersionException(
-      catalogTable.map(_.identifier.copy(catalog = None).unquotedString)) {
+    DeltaTableV2.withEnrichedInvalidProtocolVersionException(catalogTable) {
       deltaLog.protocolWrite(snapshot.protocol)
     }
 
@@ -1741,8 +1740,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
         "delta.commit.retry.conflictCheck",
         tags = Map(TAG_LOG_STORE_CLASS -> deltaLog.store.getClass.getName)) {
 
-    DeltaTableV2.withEnrichedInvalidProtocolVersionException(
-      catalogTable.map(_.identifier.copy(catalog = None).unquotedString)) {
+    DeltaTableV2.withEnrichedInvalidProtocolVersionException(catalogTable) {
 
       val nextAttemptVersion = getNextAttemptVersion(checkVersion)
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -92,7 +92,7 @@ case class DeltaTableV2(
         case None => tableIdentifier
       }
 
-      DeltaTableV2.withEnhancedInvalidProtocolVersionException(tableNameInException) {
+      DeltaTableV2.withEnrichedInvalidProtocolVersionException(tableNameInException) {
         DeltaLog.forTable(spark, rootPath, options)
       }
   }
@@ -125,7 +125,7 @@ case class DeltaTableV2(
    * WARNING: Because the snapshot is captured lazily, callers should explicitly access the snapshot
    * if they want to be certain it has been captured.
    */
-  lazy val initialSnapshot: Snapshot = DeltaTableV2.withEnhancedInvalidProtocolVersionException(
+  lazy val initialSnapshot: Snapshot = DeltaTableV2.withEnrichedInvalidProtocolVersionException(
     catalogTable.map(_.identifier.copy(catalog = None).unquotedString).orElse(tableIdentifier)) {
     timeTravelSpec.map { spec =>
       // By default, block using CDF + time-travel
@@ -355,7 +355,7 @@ object DeltaTableV2 {
    * When InvalidProtocolVersionException happens during the initialization (read)
    * it doesn't know the table name, so we need to update the message.
    */
-  def withEnhancedInvalidProtocolVersionException[T](tableName: Option[String])(thunk: => T): T = {
+  def withEnrichedInvalidProtocolVersionException[T](tableName: Option[String])(thunk: => T): T = {
     try thunk catch {
         case e: InvalidProtocolVersionException if tableName.isDefined =>
           throw e.copy(tableNameOrPath = tableName.get).initCause(e)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -347,12 +347,12 @@ object DeltaTableV2 {
   }
 
   /**
-   * When Delta Log throws InvalidProtocolVersionException it doesn't know the table name and uses 
-   * the data path in the message, this wrapper throw a new InvalidProtocolVersionException with 
+   * When Delta Log throws InvalidProtocolVersionException it doesn't know the table name and uses
+   * the data path in the message, this wrapper throw a new InvalidProtocolVersionException with
    * table name and sets its Cause to the original InvalidProtocolVersionException.
    */
   def withEnrichedInvalidProtocolVersionException[T](
-    catalogTable: Option[CatalogTable], 
+    catalogTable: Option[CatalogTable],
     tableName: Option[String] = None)(thunk: => T): T = {
 
     val tableNameToUse = catalogTable match {
@@ -361,7 +361,8 @@ object DeltaTableV2 {
     }
 
     try thunk catch {
-      case e: InvalidProtocolVersionException if tableNameToUse.isDefined =>
+      case e: InvalidProtocolVersionException if tableNameToUse.isDefined &&
+        tableNameToUse.get != e.tableNameOrPath =>
         throw e.copy(tableNameOrPath = tableNameToUse.get).initCause(e)
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -457,11 +457,13 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     }
   }
 
-  def testInvalidProtocolErrorMessageWithTableName(warm: Boolean) = {
+  def testInvalidProtocolErrorMessageWithTableName(warm: Boolean): Unit = {
     val protocolTableName = "mytableprotocoltoohigh"
     withTable(protocolTableName) {
       spark.range(1).write.format("delta").saveAsTable(protocolTableName)
-      val (deltaLog, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(protocolTableName))
+      val (deltaLog, snapshot) = DeltaLog.forTableWithSnapshot(
+        spark,
+        TableIdentifier(protocolTableName))
 
       var tableReaderVersion = 4
       var tableWriterVersion = 7
@@ -526,7 +528,8 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     testInvalidProtocolErrorMessageWithTableName(false)
   }
 
-  test("InvalidProtocolVersionException - incompatible protocol change during the transaction - table name") {
+  test("InvalidProtocolVersionException - " +
+    "incompatible protocol change during the transaction - table name") {
     for (incompatibleProtocol <- Seq(
       Protocol(minReaderVersion = Int.MaxValue),
       Protocol(minWriterVersion = Int.MaxValue),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -518,7 +518,8 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         spark.range(0).write.format("delta").saveAsTable(tableName)
         val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
         val hadoopConf = deltaLog.newDeltaHadoopConf()
-        val txn = deltaLog.startTransaction(DeltaTableV2(spark, TableIdentifier(tableName)).catalogTable)
+        val catalogTable = DeltaTableV2(spark, TableIdentifier(tableName)).catalogTable
+        val txn = deltaLog.startTransaction(catalogTable)
         val currentVersion = txn.snapshot.version
         deltaLog.store.write(
           deltaFile(deltaLog.logPath, currentVersion + 1),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -581,10 +581,10 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       requiredWriterVersion: Int): String = {
     // When testing flag is enabled Action.supportedReaderVersionNumbers includes 0.
     "[DELTA_INVALID_PROTOCOL_VERSION] " +
-      "Unsupported Delta protocol version: table \"" + tableNameOrPath + "\" requires " +
+      s"""Unsupported Delta protocol version: table "$tableNameOrPath" requires """ +
       s"reader version $requiredReaderVersion and " +
       s"writer version $requiredWriterVersion, " +
-      "but Delta Lake \"" + io.delta.VERSION + "\" supports reader versions 0, 1, 2, 3 " +
+      s"""but Delta Lake "${io.delta.VERSION}" supports reader versions 0, 1, 2, 3 """ +
       "and writer versions 0, 1, 2, 3, 4, 5, 7. Please upgrade to a newer release."
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -3210,7 +3210,6 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     require(blob.nonEmpty, "Expecting a delta.protocol.change event but didn't see any.")
     blob.map(JsonUtils.fromJson[Map[String, Any]]).head
   }
-  */
 }
 
 class DeltaProtocolVersionSuite extends DeltaProtocolVersionSuiteBase

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -68,7 +68,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     log.update()
     log
   }
-/*
+
   test("protocol for empty folder") {
     def testEmptyFolder(
         readerVersion: Int,
@@ -2090,7 +2090,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         tableWriterVersion))
     }
   }
-*/
+
   test("error message with protocol too high - table name") {
     val protocolTableName = "mytableprotocoltoohigh"
     withTable(protocolTableName) {
@@ -2107,7 +2107,10 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       }
 
       var pathInErrorMessage = "default." + protocolTableName
-      val readErrorMessage = getExpectedProtocolErrorMessage(pathInErrorMessage, tableReaderVersion, tableWriterVersion)
+      val readErrorMessage = getExpectedProtocolErrorMessage(
+        pathInErrorMessage,
+        tableReaderVersion,
+        tableWriterVersion)
 
       assert(exceptionRead.getMessage == readErrorMessage)
 
@@ -2116,7 +2119,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         deltaTable.merge(spark.range(1).as("src").toDF, s"src.id = $protocolTableName.id")
           .whenMatched()
           .updateAll()
-          .execute()      
+          .execute()
       }
 
       assert(exceptionMerge.getMessage == readErrorMessage)
@@ -2177,7 +2180,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       "client supports reader versions 0, 1, 2, 3 and writer versions 0, 1, 2, 3, 4, 5, 7. " +
       "Please upgrade to a newer release."
   }
-/*
+
   def protocolWithFeatures(
       readerFeatures: Seq[TableFeature] = Seq.empty,
       writerFeatures: Seq[TableFeature] = Seq.empty): Protocol = {
@@ -3165,7 +3168,6 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     require(blob.nonEmpty, "Expecting a delta.protocol.change event but didn't see any.")
     blob.map(JsonUtils.fromJson[Map[String, Any]]).head
   }
-  */
 }
 
 class DeltaProtocolVersionSuite extends DeltaProtocolVersionSuiteBase

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -485,16 +485,6 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
 
       assert(exceptionRead.getMessage == readErrorMessage)
 
-      val exceptionMerge = intercept[InvalidProtocolVersionException] {
-        val deltaTable = io.delta.tables.DeltaTable.forName(protocolTableName)
-        deltaTable.merge(spark.range(1).as("src").toDF, s"src.id = $protocolTableName.id")
-          .whenMatched()
-          .updateAll()
-          .execute()
-      }
-
-      assert(exceptionMerge.getMessage == readErrorMessage)
-
       tableReaderVersion = 3
       tableWriterVersion = 8
       version = version + 1

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -2123,7 +2123,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
           .saveAsTable(protocolTableName)
       }
 
-      pathInErrorMessage =  "default." + protocolTableName
+      pathInErrorMessage = "default." + protocolTableName
 
       assert(exceptionWrite.getMessage ==
         getExpectedProtocolErrorMessage(pathInErrorMessage, tableReaderVersion, tableWriterVersion))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -591,12 +591,11 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       requiredWriterVersion: Int): String = {
     // When testing flag is enabled Action.supportedReaderVersionNumbers includes 0.
     "[DELTA_INVALID_PROTOCOL_VERSION] " +
-      "Delta protocol version is not supported by this version of Delta Lake: " +
-      "table \"" + tableNameOrPath + "\" requires " +
+      "Unsupported Delta protocol version: table \"" + tableNameOrPath + "\" requires " +
       s"reader version $requiredReaderVersion and " +
       s"writer version $requiredWriterVersion, " +
-      "client supports reader versions 0, 1, 2, 3 and writer versions 0, 1, 2, 3, 4, 5, 7. " +
-      "Please upgrade to a newer release."
+      "but Delta Lake \"" + io.delta.VERSION + "\" supports reader versions 0, 1, 2, 3 " +
+      "and writer versions 0, 1, 2, 3, 4, 5, 7. Please upgrade to a newer release."
   }
 
   test("protocol downgrade is a no-op") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -2055,7 +2055,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       }.getMessage.contains(s"unsupported by this version of Delta Lake: $featureName"))
     }
   }
-  
+
   test("error message with protocol too high - table path") {
     withTempDir { path =>
       spark.range(1).write.format("delta").save(path.getCanonicalPath)
@@ -2069,8 +2069,10 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       val exceptionRead = intercept[InvalidProtocolVersionException] {
         spark.read.format("delta").load(path.getCanonicalPath)
       }
-      assert(exceptionRead.getMessage ==
-        getExpectedProtocolErrorMessage(log.dataPath.toString, tableReaderVersion, tableWriterVersion))
+      assert(exceptionRead.getMessage == getExpectedProtocolErrorMessage(
+        log.dataPath.toString,
+        tableReaderVersion,
+        tableWriterVersion))
 
       tableReaderVersion = 3
       tableWriterVersion = 8
@@ -2082,8 +2084,10 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
           .format("delta")
           .save(path.getCanonicalPath)
       }
-      assert(exceptionWrite.getMessage ==
-        getExpectedProtocolErrorMessage(log.dataPath.toString, tableReaderVersion, tableWriterVersion))
+      assert(exceptionWrite.getMessage == getExpectedProtocolErrorMessage(
+        log.dataPath.toString,
+        tableReaderVersion,
+        tableWriterVersion))
     }
   }
 
@@ -2134,7 +2138,9 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       tableProtocolReaderVersion: Int,
       tableProtocolWriterVersion: Int)
     {
-      overwriteDeltaLogWithVersion(log, Protocol(tableProtocolReaderVersion, tableProtocolWriterVersion))
+      overwriteDeltaLogWithVersion(
+        log,
+        Protocol(tableProtocolReaderVersion, tableProtocolWriterVersion))
     }
 
   private def overwriteDeltaLogWithVersion(
@@ -2156,7 +2162,8 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       requiredReaderVersion: Int,
       requiredWriterVersion: Int): String = {
     // When testing flag is enabled Action.supportedReaderVersionNumbers includes 0.
-    "[DELTA_INVALID_PROTOCOL_VERSION] Delta protocol version is not supported by this version of Delta Lake: " +
+    "[DELTA_INVALID_PROTOCOL_VERSION] " +
+      "Delta protocol version is not supported by this version of Delta Lake: " +
       "table \"" + tableNameOrPath + "\" requires " +
       s"reader version $requiredReaderVersion and " +
       s"writer version $requiredWriterVersion, " +

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -2106,8 +2106,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         spark.read.format("delta").table(protocolTableName)
       }
 
-      // During reads we can't get the table name, so we get the path instead
-      var pathInErrorMessage = log.dataPath.toString
+      var pathInErrorMessage = "default." + protocolTableName
 
       assert(exceptionRead.getMessage ==
         getExpectedProtocolErrorMessage(pathInErrorMessage, tableReaderVersion, tableWriterVersion))
@@ -2122,8 +2121,6 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
           .format("delta")
           .saveAsTable(protocolTableName)
       }
-
-      pathInErrorMessage = "default." + protocolTableName
 
       assert(exceptionWrite.getMessage ==
         getExpectedProtocolErrorMessage(pathInErrorMessage, tableReaderVersion, tableWriterVersion))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -68,7 +68,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     log.update()
     log
   }
-
+/*
   test("protocol for empty folder") {
     def testEmptyFolder(
         readerVersion: Int,
@@ -2090,7 +2090,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         tableWriterVersion))
     }
   }
-
+*/
   test("error message with protocol too high - table name") {
     val protocolTableName = "mytableprotocoltoohigh"
     withTable(protocolTableName) {
@@ -2107,9 +2107,19 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       }
 
       var pathInErrorMessage = "default." + protocolTableName
+      val readErrorMessage = getExpectedProtocolErrorMessage(pathInErrorMessage, tableReaderVersion, tableWriterVersion)
 
-      assert(exceptionRead.getMessage ==
-        getExpectedProtocolErrorMessage(pathInErrorMessage, tableReaderVersion, tableWriterVersion))
+      assert(exceptionRead.getMessage == readErrorMessage)
+
+      val exceptionMerge = intercept[InvalidProtocolVersionException] {
+        val deltaTable = io.delta.tables.DeltaTable.forName(protocolTableName)
+        deltaTable.merge(spark.range(1).as("src").toDF, s"src.id = $protocolTableName.id")
+          .whenMatched()
+          .updateAll()
+          .execute()      
+      }
+
+      assert(exceptionMerge.getMessage == readErrorMessage)
 
       tableReaderVersion = 3
       tableWriterVersion = 8
@@ -2167,7 +2177,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       "client supports reader versions 0, 1, 2, 3 and writer versions 0, 1, 2, 3, 4, 5, 7. " +
       "Please upgrade to a newer release."
   }
-
+/*
   def protocolWithFeatures(
       readerFeatures: Seq[TableFeature] = Seq.empty,
       writerFeatures: Seq[TableFeature] = Seq.empty): Protocol = {
@@ -3155,6 +3165,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     require(blob.nonEmpty, "Expecting a delta.protocol.change event but didn't see any.")
     blob.map(JsonUtils.fromJson[Map[String, Any]]).head
   }
+  */
 }
 
 class DeltaProtocolVersionSuite extends DeltaProtocolVersionSuiteBase


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Improve the InvalidProtocolVersionException error message. Fix #2082

## How was this patch tested?

Unit tests

## Does this PR introduce _any_ user-facing changes?

Yes, the error message changed to:

Delta protocol version is not supported by this version of Delta Lake: table "**tableNameOrPath**" requires reader version **readerRequired** and writer version **writerRequired**, client supports reader versions **supportedReaders** and writer versions **supportedWriters**. Please upgrade to a newer release.
