### PR TITLE
[Spark] UniForm supports using Hive Metastore

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -364,7 +364,8 @@ lazy val iceberg = (project in file("iceberg"))
       // due to legacy scala.
       "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.1",
       "org.apache.iceberg" %% icebergSparkRuntimeArtifactName % "1.3.0" % "provided",
-      "com.github.ben-manes.caffeine" % "caffeine" % "2.9.3"
+      "com.github.ben-manes.caffeine" % "caffeine" % "2.9.3",
+      "org.apache.drill.contrib.storage-hive" % "drill-storage-hive-core" % "1.21.1" % "test" classifier "tests"
     ),
     Compile / unmanagedJars += (icebergShaded / assembly).value,
     // Generate the assembly JAR as the package JAR

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
@@ -31,6 +31,8 @@ import org.apache.hadoop.conf.Configuration
 import shadedForDelta.org.apache.iceberg.{AppendFiles, DeleteFiles, OverwriteFiles, PendingUpdate, RewriteFiles, Transaction => IcebergTransaction}
 import shadedForDelta.org.apache.iceberg.hadoop.HadoopTables
 
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+
 sealed trait IcebergTableOp
 case object CREATE_TABLE extends IcebergTableOp
 case object WRITE_TABLE extends IcebergTableOp
@@ -46,6 +48,7 @@ case object REPLACE_TABLE extends IcebergTableOp
  * @param tableOp How to instantiate the underlying Iceberg table. Defaults to WRITE_TABLE.
  */
 class IcebergConversionTransaction(
+    protected val catalogTable: CatalogTable,
     protected val conf: Configuration,
     protected val postCommitSnapshot: Snapshot,
     protected val tableOp: IcebergTableOp = WRITE_TABLE,
@@ -316,16 +319,19 @@ class IcebergConversionTransaction(
   ///////////////////////
 
   protected def createIcebergTxn(): IcebergTransaction = {
-    val hadoopTables = new HadoopTables(conf)
-    val tableExists = hadoopTables.exists(tablePath.toString)
+    val hiveCatalog = IcebergTransactionUtils.createHiveCatalog(conf)
+    val icebergTableId = IcebergTransactionUtils
+      .convertSparkTableIdentifierToIcebergHive(catalogTable.identifier)
+
+    val tableExists = hiveCatalog.tableExists(icebergTableId)
 
     def tableBuilder = {
       val properties = getIcebergPropertiesFromDeltaProperties(
         postCommitSnapshot.metadata.configuration
       )
 
-      hadoopTables
-        .buildTable(tablePath.toString, icebergSchema)
+      hiveCatalog
+        .buildTable(icebergTableId, icebergSchema)
         .withPartitionSpec(partitionSpec)
         .withProperties(properties.asJava)
     }
@@ -334,7 +340,7 @@ class IcebergConversionTransaction(
       case WRITE_TABLE =>
         if (tableExists) {
           recordFrameProfile("IcebergConversionTransaction", "loadTable") {
-            hadoopTables.load(tablePath.toString).newTransaction()
+            hiveCatalog.loadTable(icebergTableId).newTransaction()
           }
         } else {
           throw new IllegalStateException(s"Cannot write to table $tablePath. Table doesn't exist.")

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
@@ -23,16 +23,17 @@ import scala.collection.JavaConverters._
 import scala.util.control.Breaks._
 import scala.util.control.NonFatal
 
-import org.apache.spark.sql.delta.{DeltaFileNotFoundException, DeltaFileProviderUtils, OptimisticTransactionImpl, Snapshot, UniversalFormatConverter}
+import org.apache.spark.sql.delta.{DeltaFileNotFoundException, DeltaFileProviderUtils, OptimisticTransactionImpl, Snapshot, UniversalFormat, UniversalFormatConverter}
 import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo, RemoveFile}
 import org.apache.spark.sql.delta.hooks.IcebergConverterHook
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.hadoop.fs.Path
-import shadedForDelta.org.apache.iceberg.hadoop.HadoopTables
+import shadedForDelta.org.apache.iceberg.hive.{HiveCatalog, HiveTableOperations}
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 
 object IcebergConverter {
 
@@ -60,9 +61,9 @@ class IcebergConverter(spark: SparkSession)
   // Save an atomic reference of the snapshot being converted, and the txn that triggered
   // resulted in the specified snapshot
   protected val currentConversion =
-    new AtomicReference[(Snapshot, Option[OptimisticTransactionImpl])]()
+    new AtomicReference[(Snapshot, OptimisticTransactionImpl)]()
   protected val standbyConversion =
-    new AtomicReference[(Snapshot, Option[OptimisticTransactionImpl])]()
+    new AtomicReference[(Snapshot, OptimisticTransactionImpl)]()
 
   // Whether our async converter thread is active. We may already have an alive thread that is
   // about to shutdown, but in such cases this value should return false.
@@ -81,7 +82,10 @@ class IcebergConverter(spark: SparkSession)
    */
   override def enqueueSnapshotForConversion(
       snapshotToConvert: Snapshot,
-      txn: Option[OptimisticTransactionImpl]): Unit = {
+      txn: OptimisticTransactionImpl): Unit = {
+    if (!UniversalFormat.icebergEnabled(snapshotToConvert.metadata)) {
+      return
+    }
     val log = snapshotToConvert.deltaLog
     // Replace any previously queued snapshot
     val previouslyQueued = standbyConversion.getAndSet((snapshotToConvert, txn))
@@ -126,7 +130,7 @@ class IcebergConverter(spark: SparkSession)
               }
 
           // Get a snapshot to convert from the icebergQueue. Sets the queue to null after.
-          private def getNextSnapshot: (Snapshot, Option[OptimisticTransactionImpl]) =
+          private def getNextSnapshot: (Snapshot, OptimisticTransactionImpl) =
             asyncThreadLock.synchronized {
               val potentialSnapshotAndTxn = standbyConversion.get()
               currentConversion.set(potentialSnapshotAndTxn)
@@ -156,20 +160,65 @@ class IcebergConverter(spark: SparkSession)
   }
 
   /**
+   * Convert the specified snapshot into Iceberg for the given catalogTable
+   * @param snapshotToConvert the snapshot that needs to be converted to Iceberg
+   * @param catalogTable the catalogTable this conversion targets.
+   * @return Converted Delta version and commit timestamp
+   */
+  override def convertSnapshot(
+      snapshotToConvert: Snapshot, catalogTable: CatalogTable): Option[(Long, Long)] = {
+    if (!UniversalFormat.icebergEnabled(snapshotToConvert.metadata)) {
+      return None
+    }
+    convertSnapshot(snapshotToConvert, None, catalogTable)
+  }
+
+  /**
+   * Convert the specified snapshot into Iceberg when performing an OptimisticTransaction
+   * on a delta table.
+   * @param snapshotToConvert the snapshot that needs to be converted to Iceberg
+   * @param txn               the transaction that triggers the conversion. It must
+   *                          contain the catalogTable this conversion targets.
+   * @return Converted Delta version and commit timestamp
+   */
+  override def convertSnapshot(
+      snapshotToConvert: Snapshot, txn: OptimisticTransactionImpl): Option[(Long, Long)] = {
+    if (!UniversalFormat.icebergEnabled(snapshotToConvert.metadata)) {
+      return None
+    }
+    txn.catalogTable match {
+      case Some(table) => convertSnapshot(snapshotToConvert, Some(txn), table)
+      case _ =>
+        logWarning(s"CatalogTable for table ${snapshotToConvert.deltaLog.tableId} " +
+          s"is empty in txn. Skip iceberg conversion.")
+        recordDeltaEvent(
+          snapshotToConvert.deltaLog,
+          "delta.iceberg.conversion.skipped.emptyCatalogTable",
+          data = Map(
+            "version" -> snapshotToConvert.version
+          )
+        )
+      None
+    }
+  }
+
+  /**
    * Convert the specified snapshot into Iceberg. NOTE: This operation is blocking. Call
    * enqueueSnapshotForConversion to run the operation asynchronously.
    * @param snapshotToConvert the snapshot that needs to be converted to Iceberg
    * @param txnOpt the OptimisticTransaction that created snapshotToConvert.
    *            Used as a hint to avoid recomputing old metadata.
+   * @param catalogTable the catalogTable this conversion targets
    * @return Converted Delta version and commit timestamp
    */
-  override def convertSnapshot(
+  private def convertSnapshot(
       snapshotToConvert: Snapshot,
-      txnOpt: Option[OptimisticTransactionImpl]): Option[(Long, Long)] =
+      txnOpt: Option[OptimisticTransactionImpl],
+      catalogTable: CatalogTable): Option[(Long, Long)] =
       recordFrameProfile("Delta", "IcebergConverter.convertSnapshot") {
     val log = snapshotToConvert.deltaLog
     val lastDeltaVersionConverted: Option[Long] =
-      loadLastDeltaVersionConverted(snapshotToConvert)
+      loadLastDeltaVersionConverted(snapshotToConvert, catalogTable)
     val maxCommitsToConvert =
       spark.sessionState.conf.getConf(DeltaSQLConf.ICEBERG_MAX_COMMITS_TO_CONVERT)
 
@@ -202,8 +251,14 @@ class IcebergConverter(spark: SparkSession)
       case (Some(_), None) => REPLACE_TABLE
       case (None, None) => CREATE_TABLE
     }
+
+    UniversalFormat.enforceSupportInCatalog(catalogTable, snapshotToConvert.metadata) match {
+      case Some(updatedTable) => spark.sessionState.catalog.alterTable(updatedTable)
+      case _ =>
+    }
+
     val icebergTxn = new IcebergConversionTransaction(
-      log.newDeltaHadoopConf(), snapshotToConvert, tableOp, lastDeltaVersionConverted)
+      catalogTable, log.newDeltaHadoopConf(), snapshotToConvert, tableOp, lastDeltaVersionConverted)
 
     // Write out the actions taken since the last conversion (or since table creation).
     // This is done in batches, with each batch corresponding either to one delta file,
@@ -268,18 +323,10 @@ class IcebergConverter(spark: SparkSession)
     Some(snapshotToConvert.version, snapshotToConvert.timestamp)
   }
 
-  override def loadLastDeltaVersionConverted(snapshot: Snapshot): Option[Long] =
+  override def loadLastDeltaVersionConverted(
+      snapshot: Snapshot, catalogTable: CatalogTable): Option[Long] =
     recordFrameProfile("Delta", "IcebergConverter.loadLastDeltaVersionConverted") {
-      val deltaLog = snapshot.deltaLog
-      val hadoopTables = new HadoopTables(deltaLog.newDeltaHadoopConf())
-      if (hadoopTables.exists(deltaLog.dataPath.toString)) {
-        hadoopTables
-          .load(deltaLog.dataPath.toString)
-          .properties()
-          .asScala
-          .get(IcebergConverter.DELTA_VERSION_PROPERTY)
-          .map(_.toLong)
-      } else None
+        catalogTable.properties.get(IcebergConverter.DELTA_VERSION_PROPERTY).map(_.toLong)
     }
 
   /**

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergTransactionUtils.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergTransactionUtils.scala
@@ -22,11 +22,16 @@ import scala.util.control.NonFatal
 import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaConfigs, DeltaLog}
 import org.apache.spark.sql.delta.actions.{AddFile, FileAction, RemoveFile}
 import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import shadedForDelta.org.apache.iceberg.{DataFile, DataFiles, FileFormat, PartitionSpec, Schema => IcebergSchema}
+// scalastyle:off import.ordering.noEmptyLine
+import shadedForDelta.org.apache.iceberg.catalog.{Namespace, TableIdentifier => IcebergTableIdentifier}
+// scalastyle:on import.ordering.noEmptyLine
+import shadedForDelta.org.apache.iceberg.hive.HiveCatalog
 
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier => SparkTableIdentifier}
+import org.apache.spark.sql.types.StructType
 
 object IcebergTransactionUtils
     extends DeltaLogging
@@ -171,5 +176,31 @@ object IcebergTransactionUtils
     }
 
     builder
+  }
+
+  /**
+   * Create an Iceberg HiveCatalog
+   * @param conf: Hadoop Configuration
+   * @return
+   */
+  def createHiveCatalog(conf : Configuration) : HiveCatalog = {
+    val catalog = new HiveCatalog()
+    catalog.setConf(conf)
+    catalog.initialize("spark_catalog", Map.empty[String, String].asJava)
+    catalog
+  }
+
+  /**
+   * Encode Spark table identifier to Iceberg table identifier by putting
+   * only "database" to the "namespace" in Iceberg table identifier.
+   * See [[HiveCatalog.isValidateNamespace]]
+   */
+  def convertSparkTableIdentifierToIcebergHive(
+      identifier: SparkTableIdentifier): IcebergTableIdentifier = {
+    val namespace = (identifier.database) match {
+      case Some(database) => Namespace.of(database)
+      case _ => Namespace.empty()
+    }
+    IcebergTableIdentifier.of(namespace, identifier.table)
   }
 }

--- a/icebergShaded/generate_iceberg_jars.py
+++ b/icebergShaded/generate_iceberg_jars.py
@@ -40,6 +40,8 @@ iceberg_src_compiled_jar_rel_glob_patterns = [
     "api/build/libs/iceberg-api-*.jar",
     "core/build/libs/iceberg-core-*.jar",
     "parquet/build/libs/iceberg-parquet-*.jar",
+    "hive-metastore/build/libs/iceberg-hive-*.jar",
+    "data/build/libs/iceberg-data-*.jar"
 ]
 
 iceberg_root_dir = path.abspath(path.dirname(__file__))
@@ -112,6 +114,8 @@ def generate_iceberg_jars():
         build_args = "-x spotlessCheck -x checkstyleMain -x test -x integrationTest"
         run_cmd("./gradlew :iceberg-core:build %s" % build_args)
         run_cmd("./gradlew :iceberg-parquet:build %s" % build_args)
+        run_cmd("./gradlew :iceberg-hive-metastore:build %s" % build_args)
+        run_cmd("./gradlew :iceberg-data:build %s" % build_args)
 
     print(">>> Copying JARs to lib directory")
     shutil.rmtree(iceberg_lib_dir, ignore_errors=True)

--- a/icebergShaded/iceberg_src_patches/0003-iceberg-hive-metastore-must-not-remove-unknown-table-data.patch
+++ b/icebergShaded/iceberg_src_patches/0003-iceberg-hive-metastore-must-not-remove-unknown-table-data.patch
@@ -1,0 +1,45 @@
+HiveTableOperations should have its catalog operations compatible with Delta
+
+This patch prevent Iceberg HiveTableOperations to overwrite catalog table properties used by Delta. It also writes a dummy schema to metastore to be aligned with Delta's behavior.
+---
+Index: hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+===================================================================
+diff --git a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java	(revision ede085d0f7529f24acd0c81dd0a43f7bb969b763)
++++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java	(revision 4470b919dd6a97b0f6d6b7d57d1d57348a40c025)
+@@ -43,6 +43,7 @@
+ import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+ import org.apache.hadoop.hive.metastore.TableType;
+ import org.apache.hadoop.hive.metastore.api.InvalidObjectException;
++import org.apache.hadoop.hive.metastore.api.FieldSchema;
+ import org.apache.hadoop.hive.metastore.api.LockComponent;
+ import org.apache.hadoop.hive.metastore.api.LockLevel;
+ import org.apache.hadoop.hive.metastore.api.LockRequest;
+@@ -286,7 +287,9 @@
+         LOG.debug("Committing new table: {}", fullName);
+       }
+
+-      tbl.setSd(storageDescriptor(metadata, hiveEngineEnabled)); // set to pickup any schema changes
++      StorageDescriptor newsd = storageDescriptor(metadata, hiveEngineEnabled);
++      newsd.getSerdeInfo().setParameters(tbl.getSd().getSerdeInfo().getParameters());
++      tbl.setSd(newsd); // set to pickup any schema changes
+
+       String metadataLocation = tbl.getParameters().get(METADATA_LOCATION_PROP);
+       String baseMetadataLocation = base != null ? base.metadataFileLocation() : null;
+@@ -393,6 +396,7 @@
+   @VisibleForTesting
+   void persistTable(Table hmsTable, boolean updateHiveTable)
+       throws TException, InterruptedException {
++    hmsTable.getSd().setCols(Collections.singletonList(new FieldSchema("col", "array<string>", "")));
+     if (updateHiveTable) {
+       metaClients.run(
+           client -> {
+@@ -468,7 +472,7 @@
+     }
+
+     // remove any props from HMS that are no longer present in Iceberg table props
+-    obsoleteProps.forEach(parameters::remove);
++    // obsoleteProps.forEach(parameters::remove);
+
+     parameters.put(TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE.toUpperCase(Locale.ENGLISH));
+     parameters.put(METADATA_LOCATION_PROP, newMetadataLocation);

--- a/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
@@ -20,6 +20,7 @@ import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 
 /**
  * Utils to validate the Universal Format (UniForm) Delta feature (NOT a table feature).
@@ -144,8 +145,35 @@ object UniversalFormat extends DeltaLogging {
     }
   }
 
-}
+  val ICEBERG_TABLE_TYPE_KEY = "table_type"
 
+  /**
+   * Update CatalogTable to mark it readable by other table readers (iceberg for now).
+   * This method ensures 'table_type' = 'ICEBERG' when uniform is enabled,
+   * and ensure table_type is not 'ICEBERG' when uniform is not enabled
+   * If the key has other values than 'ICEBERG', this method will not touch it for compatibility
+   *
+   * @param table    catalogTable before change
+   * @param metadata snapshot metadata
+   * @return the converted catalog, or None if no change is made
+   */
+  def enforceSupportInCatalog(table: CatalogTable, metadata: Metadata): Option[CatalogTable] = {
+    val icebergInCatalog = table.properties.get(ICEBERG_TABLE_TYPE_KEY) match {
+      case Some(value) => value.equalsIgnoreCase(ICEBERG_FORMAT)
+      case _ => false
+    }
+
+    (icebergEnabled(metadata), icebergInCatalog) match {
+      case (true, false) =>
+        Some(table.copy(properties = table.properties
+          + (ICEBERG_TABLE_TYPE_KEY -> ICEBERG_FORMAT)))
+      case (false, true) =>
+        Some(table.copy(properties =
+          table.properties - ICEBERG_TABLE_TYPE_KEY))
+      case _ => None
+    }
+  }
+}
 /** Class to facilitate the conversion of Delta into other table formats. */
 abstract class UniversalFormatConverter(spark: SparkSession) {
   /**
@@ -157,12 +185,36 @@ abstract class UniversalFormatConverter(spark: SparkSession) {
    */
   def enqueueSnapshotForConversion(
     snapshotToConvert: Snapshot,
-    txn: Option[OptimisticTransactionImpl]): Unit
+    txn: OptimisticTransactionImpl): Unit
 
-  /** Perform a blocking conversion. */
+  /**
+   * Perform a blocking conversion when performing an OptimisticTransaction
+   * on a delta table.
+   *
+   * @param snapshotToConvert the snapshot that needs to be converted to Iceberg
+   * @param txn the transaction that triggers the conversion. Used as a hint to
+   *            avoid recomputing old metadata. It must contain the catalogTable
+   *            this conversion targets.
+   * @return Converted Delta version and commit timestamp
+   */
   def convertSnapshot(
-    snapshotToConvert: Snapshot,
-    txnOpt: Option[OptimisticTransactionImpl]): Option[(Long, Long)]
+    snapshotToConvert: Snapshot, txn: OptimisticTransactionImpl): Option[(Long, Long)]
 
-  def loadLastDeltaVersionConverted(snapshot: Snapshot): Option[Long]
+  /**
+   * Perform a blocking conversion for the given catalogTable
+   *
+   * @param snapshotToConvert the snapshot that needs to be converted to Iceberg
+   * @param catalogTable the catalogTable this conversion targets.
+   * @return Converted Delta version and commit timestamp
+   */
+  def convertSnapshot(
+      snapshotToConvert: Snapshot, catalogTable: CatalogTable): Option[(Long, Long)]
+
+  /**
+   * Fetch the delta version corresponding to the latest conversion.
+   * @param snapshot the snapshot to be converted
+   * @param table the catalogTable with info of previous conversions
+   * @return None if no previous conversion found
+   */
+  def loadLastDeltaVersionConverted(snapshot: Snapshot, table: CatalogTable): Option[Long]
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -193,7 +193,7 @@ case class CreateDeltaTableCommand(
 
 
     if (UniversalFormat.icebergEnabled(postCommitSnapshot.metadata)) {
-      deltaLog.icebergConverter.convertSnapshot(postCommitSnapshot, None)
+      deltaLog.icebergConverter.convertSnapshot(postCommitSnapshot, tableWithLocation)
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/IcebergConverterHook.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/IcebergConverterHook.scala
@@ -46,6 +46,6 @@ object IcebergConverterHook extends PostCommitHook with DeltaLogging {
     postCommitSnapshot
       .deltaLog
       .icebergConverter
-      .enqueueSnapshotForConversion(postCommitSnapshot, Some(txn))
+      .enqueueSnapshotForConversion(postCommitSnapshot, txn)
   }
 }


### PR DESCRIPTION
UniForm will use HMS as catalog instead of using file system by Hao Jiang <hao.jiang@databricks.com>

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR allows UniForm to use Hive Metastore when supporting reading Delta table as an iceberg table.
## How was this patch tested?
Update existing test cases to cover the change.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
