### PR TITLE
[Spark] Fix UppdateSuiteBase nested data test

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
@@ -674,8 +674,8 @@ abstract class UpdateSuiteBase
 
     testAnalysisException(
       targetDF,
-      set =
-        Seq("a = named_struct('c', named_struct('d', 'rand', 'e', 'str'))", "a.c.d = 'RANDOM2'"),
+      set = Seq("a = named_struct('c', named_struct('d', 'rand', 'e', 'str'), 'g', 3)",
+        "a.c.d = 'RANDOM2'"),
       errMsgs = "There is a conflict from these SET columns" :: Nil)
 
     val schema = new StructType().add("a", MapType(StringType, IntegerType))


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR fixes a test case about nested data updates. The test case mean to test conflicting updates, but even the first update would fail without the fix.

## How was this patch tested?
Existing Ut.

## Does this PR introduce _any_ user-facing changes?
No.
