### PR TITLE
[Spark] Replaces startTransaction calls with catalogTable overload

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
@@ -96,7 +96,7 @@ abstract class ConvertToDeltaCommandBase(
     val targetTable = getTargetTable(spark, convertProperties)
     val deltaPathToUse = new Path(deltaPath.getOrElse(convertProperties.targetDir))
     val deltaLog = DeltaLog.forTable(spark, deltaPathToUse)
-    val txn = deltaLog.startTransaction()
+    val txn = deltaLog.startTransaction(convertProperties.catalogTable)
     if (txn.readVersion > -1) {
       handleExistingTransactionLog(spark, txn, convertProperties, targetTable.format)
       return Seq.empty[Row]

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
@@ -99,7 +99,7 @@ case class DeltaSink(
 
 
   private def addBatchWithStatusImpl(batchId: Long, data: DataFrame): Boolean = {
-    val txn = deltaLog.startTransaction()
+    val txn = deltaLog.startTransaction(catalogTable)
     assert(queryId != null)
 
     if (SchemaUtils.typeExistsRecursively(data.schema)(_.isInstanceOf[NullType])) {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR replaces all calls to DeltaLog.startTransaction() with calls to DeltaLog.startTransaction(Option[CatalogTable]). This PR is part of https://github.com/delta-io/delta/issues/2105 and ensures that transactions have a valid catalogTable attached to them so Uniform can correctly update the table in the catalog.

## How was this patch tested?

This is a small refactoring change so existing test coverage is sufficient.

## Does this PR introduce _any_ user-facing changes?

No
