### PR TITLE
[Spark][1.0] Fix a data loss bug in MergeIntoCommand

### DIFF
--- a/core/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
@@ -19,7 +19,7 @@ package io.delta.tables
 import scala.collection.JavaConverters._
 import scala.collection.Map
 
-import org.apache.spark.sql.delta.{DeltaErrors, PreprocessTableMerge}
+import org.apache.spark.sql.delta.{DeltaErrors, DeltaTableUtils, PreprocessTableMerge}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.util.AnalysisHelper
 
@@ -203,24 +203,26 @@ class DeltaMergeBuilder private(
    */
   def execute(): Unit = improveUnsupportedOpError {
     val sparkSession = targetTable.toDF.sparkSession
-    // Note: We are explicitly resolving DeltaMergeInto plan rather than going to through the
-    // Analyzer using `Dataset.ofRows()` because the Analyzer incorrectly resolves all
-    // references in the DeltaMergeInto using both source and target child plans, even before
-    // DeltaAnalysis rule kicks in. This is because the Analyzer  understands only MergeIntoTable,
-    // and handles that separately by skipping resolution (for Delta) and letting the
-    // DeltaAnalysis rule do the resolving correctly. This can be solved by generating
-    // MergeIntoTable instead, which blocked by the different issue with MergeIntoTable as explained
-    // in the function `mergePlan` and https://issues.apache.org/jira/browse/SPARK-34962.
-    val resolvedMergeInto =
-      DeltaMergeInto.resolveReferences(mergePlan, sparkSession.sessionState.conf)(
-        tryResolveReferences(sparkSession) _)
-    if (!resolvedMergeInto.resolved) {
-      throw DeltaErrors.analysisException("Failed to resolve\n", plan = Some(resolvedMergeInto))
+    DeltaTableUtils.withActiveSession(sparkSession) {
+      // Analyzer using `Dataset.ofRows()` because the Analyzer incorrectly resolves all
+      // references in the DeltaMergeInto using both source and target child plans, even before
+      // DeltaAnalysis rule kicks in. This is because the Analyzer  understands only MergeIntoTable,
+      // and handles that separately by skipping resolution (for Delta) and letting the
+      // DeltaAnalysis rule do the resolving correctly. This can be solved by generating
+      // MergeIntoTable instead, which blocked by the different issue with MergeIntoTable as
+      // explained in the function `mergePlan` and
+      // https://issues.apache.org/jira/browse/SPARK-34962.
+      val resolvedMergeInto =
+        DeltaMergeInto.resolveReferences(mergePlan, sparkSession.sessionState.conf)(
+          tryResolveReferences(sparkSession) _)
+      if (!resolvedMergeInto.resolved) {
+        throw DeltaErrors.analysisException("Failed to resolve\n", plan = Some(resolvedMergeInto))
+      }
+      // Preprocess the actions and verify
+      val mergeIntoCommand = PreprocessTableMerge(sparkSession.sessionState.conf)(resolvedMergeInto)
+      sparkSession.sessionState.analyzer.checkAnalysis(mergeIntoCommand)
+      mergeIntoCommand.run(sparkSession)
     }
-    // Preprocess the actions and verify
-    val mergeIntoCommand = PreprocessTableMerge(sparkSession.sessionState.conf)(resolvedMergeInto)
-    sparkSession.sessionState.analyzer.checkAnalysis(mergeIntoCommand)
-    mergeIntoCommand.run(sparkSession)
   }
 
   /**

--- a/core/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
@@ -19,7 +19,8 @@ package io.delta.tables
 import scala.collection.JavaConverters._
 import scala.collection.Map
 
-import org.apache.spark.sql.delta.{DeltaErrors, DeltaTableUtils, PreprocessTableMerge}
+import org.apache.spark.sql.delta.{DeltaErrors, PreprocessTableMerge}
+import org.apache.spark.sql.delta.DeltaTableUtils.withActiveSession
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.util.AnalysisHelper
 
@@ -203,7 +204,7 @@ class DeltaMergeBuilder private(
    */
   def execute(): Unit = improveUnsupportedOpError {
     val sparkSession = targetTable.toDF.sparkSession
-    DeltaTableUtils.withActiveSession(sparkSession) {
+    withActiveSession(sparkSession) {
       // Analyzer using `Dataset.ofRows()` because the Analyzer incorrectly resolves all
       // references in the DeltaMergeInto using both source and target child plans, even before
       // DeltaAnalysis rule kicks in. This is because the Analyzer  understands only MergeIntoTable,

--- a/core/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -19,6 +19,7 @@ package io.delta.tables
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.DeltaTableUtils.withActiveSession
 import org.apache.spark.sql.delta.actions.Protocol
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -806,10 +807,8 @@ object DeltaTable {
    * @since 1.0.0
    */
   @Evolving
-  def createOrReplace(spark: SparkSession): DeltaTableBuilder = {
-    DeltaTableUtils.withActiveSession(spark) {
-      new DeltaTableBuilder(spark, ReplaceTableOptions(orCreate = true))
-    }
+  def createOrReplace(spark: SparkSession): DeltaTableBuilder = withActiveSession(spark) {
+    new DeltaTableBuilder(spark, ReplaceTableOptions(orCreate = true))
   }
 
   /**

--- a/core/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -807,7 +807,9 @@ object DeltaTable {
    */
   @Evolving
   def createOrReplace(spark: SparkSession): DeltaTableBuilder = {
-    new DeltaTableBuilder(spark, ReplaceTableOptions(orCreate = true))
+    DeltaTableUtils.withActiveSession(spark) {
+      new DeltaTableBuilder(spark, ReplaceTableOptions(orCreate = true))
+    }
   }
 
   /**

--- a/core/src/main/scala/io/delta/tables/DeltaTableBuilder.scala
+++ b/core/src/main/scala/io/delta/tables/DeltaTableBuilder.scala
@@ -19,6 +19,7 @@ package io.delta.tables
 import scala.collection.mutable
 
 import org.apache.spark.sql.delta.{DeltaErrors, DeltaTableUtils}
+import org.apache.spark.sql.delta.DeltaTableUtils.withActiveSession
 import io.delta.tables.execution._
 
 import org.apache.spark.annotation._
@@ -295,73 +296,71 @@ class DeltaTableBuilder private[tables](
    * @since 1.0.0
    */
   @Evolving
-  def execute(): DeltaTable = {
-    DeltaTableUtils.withActiveSession(spark) {
-      if (identifier == null && location.isEmpty) {
-        throw DeltaErrors.analysisException("Table name or location has to be specified")
-      }
+  def execute(): DeltaTable = withActiveSession(spark) {
+    if (identifier == null && location.isEmpty) {
+      throw DeltaErrors.analysisException("Table name or location has to be specified")
+    }
 
-      if (this.identifier == null) {
-        identifier = s"delta.`${location.get}`"
-      }
+    if (this.identifier == null) {
+      identifier = s"delta.`${location.get}`"
+    }
 
-      // Return DeltaTable Object.
-      val tableId: TableIdentifier = spark.sessionState.sqlParser.parseTableIdentifier(identifier)
+    // Return DeltaTable Object.
+    val tableId: TableIdentifier = spark.sessionState.sqlParser.parseTableIdentifier(identifier)
 
-      if (DeltaTableUtils.isValidPath(tableId) && location.nonEmpty
-          && tableId.table != location.get) {
-        throw DeltaErrors.analysisException(
-          s"Creating path-based Delta table with a different location isn't supported. "
-            + s"Identifier: $identifier, Location: ${location.get}")
-      }
+    if (DeltaTableUtils.isValidPath(tableId) && location.nonEmpty
+        && tableId.table != location.get) {
+      throw DeltaErrors.analysisException(
+        s"Creating path-based Delta table with a different location isn't supported. "
+          + s"Identifier: $identifier, Location: ${location.get}")
+    }
 
-      val table = spark.sessionState.sqlParser.parseMultipartIdentifier(identifier)
+    val table = spark.sessionState.sqlParser.parseMultipartIdentifier(identifier)
 
-      val partitioning = partitioningColumns.map { colNames =>
-        colNames.map(name => DeltaTableUtils.parseColToTransform(name))
-      }.getOrElse(Seq.empty[Transform])
+    val partitioning = partitioningColumns.map { colNames =>
+      colNames.map(name => DeltaTableUtils.parseColToTransform(name))
+    }.getOrElse(Seq.empty[Transform])
 
-      val stmt = builderOption match {
-        case CreateTableOptions(ifNotExists) =>
-          CreateTableStatement(
-            table,
-            StructType(columns),
-            partitioning,
-            None,
-            this.properties,
-            Some(FORMAT_NAME),
-            Map.empty,
-            location,
-            tblComment,
-            None,
-            false,
-            ifNotExists
-          )
-        case ReplaceTableOptions(orCreate) =>
-          ReplaceTableStatement(
-            table,
-            StructType(columns),
-            partitioning,
-            None,
-            this.properties,
-            Some(FORMAT_NAME),
-            Map.empty,
-            location,
-            tblComment,
-            None,
-            orCreate
-          )
-      }
-      val qe = spark.sessionState.executePlan(stmt)
-      // call `QueryExecution.toRDD` to trigger the execution of commands.
-      SQLExecution.withNewExecutionId(qe, Some("create delta table"))(qe.toRdd)
+    val stmt = builderOption match {
+      case CreateTableOptions(ifNotExists) =>
+        CreateTableStatement(
+          table,
+          StructType(columns),
+          partitioning,
+          None,
+          this.properties,
+          Some(FORMAT_NAME),
+          Map.empty,
+          location,
+          tblComment,
+          None,
+          false,
+          ifNotExists
+        )
+      case ReplaceTableOptions(orCreate) =>
+        ReplaceTableStatement(
+          table,
+          StructType(columns),
+          partitioning,
+          None,
+          this.properties,
+          Some(FORMAT_NAME),
+          Map.empty,
+          location,
+          tblComment,
+          None,
+          orCreate
+        )
+    }
+    val qe = spark.sessionState.executePlan(stmt)
+    // call `QueryExecution.toRDD` to trigger the execution of commands.
+    SQLExecution.withNewExecutionId(qe, Some("create delta table"))(qe.toRdd)
 
-      // Return DeltaTable Object.
-      if (DeltaTableUtils.isValidPath(tableId)) {
-        DeltaTable.forPath(location.get)
-      } else {
-        DeltaTable.forName(this.identifier)
-      }
+    // Return DeltaTable Object.
+    if (DeltaTableUtils.isValidPath(tableId)) {
+      DeltaTable.forPath(location.get)
+    } else {
+      DeltaTable.forName(this.identifier)
     }
   }
 }

--- a/core/src/main/scala/io/delta/tables/execution/DeltaConvert.scala
+++ b/core/src/main/scala/io/delta/tables/execution/DeltaConvert.scala
@@ -16,6 +16,7 @@
 
 package io.delta.tables.execution
 
+import org.apache.spark.sql.delta.DeltaTableUtils
 import org.apache.spark.sql.delta.commands.ConvertToDeltaCommand
 import io.delta.tables.DeltaTable
 
@@ -29,12 +30,14 @@ trait DeltaConvertBase {
       tableIdentifier: TableIdentifier,
       partitionSchema: Option[StructType],
       deltaPath: Option[String]): DeltaTable = {
-    val cvt = ConvertToDeltaCommand(tableIdentifier, partitionSchema, deltaPath)
-    cvt.run(spark)
-    if (cvt.isCatalogTable(spark.sessionState.analyzer, tableIdentifier)) {
-      DeltaTable.forName(spark, tableIdentifier.toString)
-    } else {
-      DeltaTable.forPath(spark, tableIdentifier.table)
+    DeltaTableUtils.withActiveSession(spark) {
+      val cvt = ConvertToDeltaCommand(tableIdentifier, partitionSchema, deltaPath)
+      cvt.run(spark)
+      if (cvt.isCatalogTable(spark.sessionState.analyzer, tableIdentifier)) {
+        DeltaTable.forName(spark, tableIdentifier.toString)
+      } else {
+        DeltaTable.forPath(spark, tableIdentifier.table)
+      }
     }
   }
 }

--- a/core/src/main/scala/io/delta/tables/execution/DeltaConvert.scala
+++ b/core/src/main/scala/io/delta/tables/execution/DeltaConvert.scala
@@ -16,7 +16,7 @@
 
 package io.delta.tables.execution
 
-import org.apache.spark.sql.delta.DeltaTableUtils
+import org.apache.spark.sql.delta.DeltaTableUtils.withActiveSession
 import org.apache.spark.sql.delta.commands.ConvertToDeltaCommand
 import io.delta.tables.DeltaTable
 
@@ -29,15 +29,13 @@ trait DeltaConvertBase {
       spark: SparkSession,
       tableIdentifier: TableIdentifier,
       partitionSchema: Option[StructType],
-      deltaPath: Option[String]): DeltaTable = {
-    DeltaTableUtils.withActiveSession(spark) {
-      val cvt = ConvertToDeltaCommand(tableIdentifier, partitionSchema, deltaPath)
-      cvt.run(spark)
-      if (cvt.isCatalogTable(spark.sessionState.analyzer, tableIdentifier)) {
-        DeltaTable.forName(spark, tableIdentifier.toString)
-      } else {
-        DeltaTable.forPath(spark, tableIdentifier.table)
-      }
+      deltaPath: Option[String]): DeltaTable = withActiveSession(spark) {
+    val cvt = ConvertToDeltaCommand(tableIdentifier, partitionSchema, deltaPath)
+    cvt.run(spark)
+    if (cvt.isCatalogTable(spark.sessionState.analyzer, tableIdentifier)) {
+      DeltaTable.forName(spark, tableIdentifier.toString)
+    } else {
+      DeltaTable.forPath(spark, tableIdentifier.table)
     }
   }
 }

--- a/core/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
+++ b/core/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
@@ -51,12 +51,14 @@ trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
   }
 
   protected def executeGenerate(tblIdentifier: String, mode: String): Unit = {
-    val tableId: TableIdentifier = sparkSession
-      .sessionState
-      .sqlParser
-      .parseTableIdentifier(tblIdentifier)
-    val generate = DeltaGenerateCommand(mode, tableId)
-    toDataset(sparkSession, generate)
+    withActiveSession(sparkSession) {
+      val tableId: TableIdentifier = sparkSession
+        .sessionState
+        .sqlParser
+        .parseTableIdentifier(tblIdentifier)
+      val generate = DeltaGenerateCommand(mode, tableId)
+      toDataset(sparkSession, generate)
+    }
   }
 
   protected def executeUpdate(

--- a/core/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
+++ b/core/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
@@ -18,7 +18,7 @@ package io.delta.tables.execution
 
 import scala.collection.Map
 
-import org.apache.spark.sql.delta.{DeltaErrors, DeltaHistoryManager, DeltaLog, PreprocessTableUpdate}
+import org.apache.spark.sql.delta.{DeltaErrors, DeltaHistoryManager, DeltaLog, DeltaTableUtils, PreprocessTableUpdate}
 import org.apache.spark.sql.delta.commands.{DeleteCommand, DeltaGenerateCommand, VacuumCommand}
 import org.apache.spark.sql.delta.util.AnalysisHelper
 import io.delta.tables.DeltaTable
@@ -28,6 +28,7 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.expressions.{Expression, SubqueryExpression}
 import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.SparkSession
 
 /**
  * Interface to provide the actual implementations of DeltaTable operations.
@@ -35,17 +36,21 @@ import org.apache.spark.sql.catalyst.plans.logical._
 trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
 
   protected def executeDelete(condition: Option[Expression]): Unit = improveUnsupportedOpError {
-    val delete = DeleteFromTable(self.toDF.queryExecution.analyzed, condition)
-    toDataset(sparkSession, delete)
+    DeltaTableUtils.withActiveSession(sparkSession) {
+      val delete = DeleteFromTable(self.toDF.queryExecution.analyzed, condition)
+      toDataset(sparkSession, delete)
+    }
   }
 
   protected def executeHistory(
       deltaLog: DeltaLog,
       limit: Option[Int] = None,
       tableId: Option[TableIdentifier] = None): DataFrame = {
-    val history = deltaLog.history
-    val spark = self.toDF.sparkSession
-    spark.createDataFrame(history.getHistory(limit))
+    DeltaTableUtils.withActiveSession(sparkSession) {
+      val history = deltaLog.history
+      val spark = self.toDF.sparkSession
+      spark.createDataFrame(history.getHistory(limit))
+    }
   }
 
   protected def executeGenerate(tblIdentifier: String, mode: String): Unit = {
@@ -60,19 +65,24 @@ trait DeltaTableOperations extends AnalysisHelper { self: DeltaTable =>
   protected def executeUpdate(
       set: Map[String, Column],
       condition: Option[Column]): Unit = improveUnsupportedOpError {
-    val assignments = set.map { case (targetColName, column) =>
-      Assignment(UnresolvedAttribute.quotedString(targetColName), column.expr)
-    }.toSeq
-    val update = UpdateTable(self.toDF.queryExecution.analyzed, assignments, condition.map(_.expr))
-    toDataset(sparkSession, update)
+    DeltaTableUtils.withActiveSession(sparkSession) {
+      val assignments = set.map { case (targetColName, column) =>
+        Assignment(UnresolvedAttribute.quotedString(targetColName), column.expr)
+      }.toSeq
+      val update =
+        UpdateTable(self.toDF.queryExecution.analyzed, assignments, condition.map(_.expr))
+      toDataset(sparkSession, update)
+    }
   }
 
   protected def executeVacuum(
       deltaLog: DeltaLog,
       retentionHours: Option[Double],
       tableId: Option[TableIdentifier] = None): DataFrame = {
-    VacuumCommand.gc(sparkSession, deltaLog, false, retentionHours)
-    sparkSession.emptyDataFrame
+    DeltaTableUtils.withActiveSession(sparkSession) {
+      VacuumCommand.gc(sparkSession, deltaLog, false, retentionHours)
+      sparkSession.emptyDataFrame
+    }
   }
 
   protected def toStrColumnMap(map: Map[String, String]): Map[String, Column] = {

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -356,4 +356,14 @@ object DeltaTableUtils extends PredicateHelper
   def parseColToTransform(col: String): IdentityTransform = {
     IdentityTransform(FieldReference(Seq(col)))
   }
+
+  def withActiveSession[T](spark: SparkSession)(body: => T): T = {
+    val old = SparkSession.getActiveSession
+    SparkSession.setActiveSession(spark)
+    try {
+      body
+    } finally {
+      SparkSession.setActiveSession(old.getOrElse(null))
+    }
+  }
 }

--- a/core/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/core/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -357,13 +357,6 @@ object DeltaTableUtils extends PredicateHelper
     IdentityTransform(FieldReference(Seq(col)))
   }
 
-  def withActiveSession[T](spark: SparkSession)(body: => T): T = {
-    val old = SparkSession.getActiveSession
-    SparkSession.setActiveSession(spark)
-    try {
-      body
-    } finally {
-      SparkSession.setActiveSession(old.getOrElse(null))
-    }
-  }
+  // Workaround for withActive not being visible in io/delta.
+  def withActiveSession[T](spark: SparkSession)(body: => T): T = spark.withActive(body)
 }

--- a/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
@@ -2920,38 +2920,31 @@ abstract class MergeIntoSuiteBase
       Option("Aggregate functions are not supported in the .* condition of MERGE operation.*")
   )
 
-  Seq(true, false).foreach { differentActiveSession =>
-    test("merge should use the same SparkSession consistently, differentActiveSession: " +
-      s"$differentActiveSession") {
-      withTempDir { dir =>
-        withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "false") {
-          val r = dir.getCanonicalPath
-          val sourcePath = s"$r/source"
-          val targetPath = s"$r/target"
-          val numSourceRecords = 20
-          spark.range(numSourceRecords)
-            .withColumn("x", $"id")
-            .withColumn("y", $"id")
-            .write.mode("overwrite").format("delta").save(sourcePath)
-          spark.range(1)
-            .withColumn("x", $"id")
-            .write.mode("overwrite").format("delta").save(targetPath)
-          val spark2 = if (differentActiveSession) {
-            spark.newSession
-          } else {
-            spark
-          }
-          spark2.conf.set(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key, "true")
-          val target = io.delta.tables.DeltaTable.forPath(spark2, targetPath)
-          val source = spark.read.format("delta").load(sourcePath).alias("s")
-          val merge = target.alias("t")
-            .merge(source, "t.id = s.id")
-            .whenMatched.updateExpr(Map("t.x" -> "t.x + 1"))
-            .whenNotMatched.insertAll()
-            .execute()
-          // The target table should have the same number of rows as the source after the merge
-          assert(spark.read.format("delta").load(targetPath).count() == numSourceRecords)
-        }
+  test("Merge should use the same SparkSession consistently") {
+    withTempDir { dir =>
+      withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "false") {
+        val r = dir.getCanonicalPath
+        val sourcePath = s"$r/source"
+        val targetPath = s"$r/target"
+        val numSourceRecords = 20
+        spark.range(numSourceRecords)
+          .withColumn("x", $"id")
+          .withColumn("y", $"id")
+          .write.mode("overwrite").format("delta").save(sourcePath)
+        spark.range(1)
+          .withColumn("x", $"id")
+          .write.mode("overwrite").format("delta").save(targetPath)
+        val spark2 = spark.newSession
+        spark2.conf.set(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key, "true")
+        val target = io.delta.tables.DeltaTable.forPath(spark2, targetPath)
+        val source = spark.read.format("delta").load(sourcePath).alias("s")
+        val merge = target.alias("t")
+          .merge(source, "t.id = s.id")
+          .whenMatched.updateExpr(Map("t.x" -> "t.x + 1"))
+          .whenNotMatched.insertAll()
+          .execute()
+        // The target table should have the same number of rows as the source after the merge
+        assert(spark.read.format("delta").load(targetPath).count() == numSourceRecords)
       }
     }
   }

--- a/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
+++ b/core/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
@@ -2919,4 +2919,40 @@ abstract class MergeIntoSuiteBase
     customConditionErrorRegex =
       Option("Aggregate functions are not supported in the .* condition of MERGE operation.*")
   )
+
+  Seq(true, false).foreach { differentActiveSession =>
+    test("merge should use the same SparkSession consistently, differentActiveSession: " +
+      s"$differentActiveSession") {
+      withTempDir { dir =>
+        withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "false") {
+          val r = dir.getCanonicalPath
+          val sourcePath = s"$r/source"
+          val targetPath = s"$r/target"
+          val numSourceRecords = 20
+          spark.range(numSourceRecords)
+            .withColumn("x", $"id")
+            .withColumn("y", $"id")
+            .write.mode("overwrite").format("delta").save(sourcePath)
+          spark.range(1)
+            .withColumn("x", $"id")
+            .write.mode("overwrite").format("delta").save(targetPath)
+          val spark2 = if (differentActiveSession) {
+            spark.newSession
+          } else {
+            spark
+          }
+          spark2.conf.set(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key, "true")
+          val target = io.delta.tables.DeltaTable.forPath(spark2, targetPath)
+          val source = spark.read.format("delta").load(sourcePath).alias("s")
+          val merge = target.alias("t")
+            .merge(source, "t.id = s.id")
+            .whenMatched.updateExpr(Map("t.x" -> "t.x + 1"))
+            .whenNotMatched.insertAll()
+            .execute()
+          // The target table should have the same number of rows as the source after the merge
+          assert(spark.read.format("delta").load(targetPath).count() == numSourceRecords)
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Fix a data loss bug in MergeIntoCommand.
It's caused by using different spark session config object for PreprocessTableMerge and MergeIntoCommand. In PreprocessTableMerge, the config value is from the spark session which is given for DeltaTable. In MergeIntoSchema it refers SQLConf.get which is from the active session of the current thread. It can be different when user set another new spark session or active session just doesn't set properly before the execution.

If source dataframe has more columns than target table, auto schema merge feature adds additional nullable column to 
target table schema. The updated output projection built in PreprocessTableMerge, so `matchedClauses` and `notMatchedClauses` contains the addtional columns, but target table schema in MergeIntoCommand doesn't have it.

As a result, the following index doesn't indicate the delete flag column index, which is `numFields - 2`.
```
      def shouldDeleteRow(row: InternalRow): Boolean =
        row.getBoolean(outputRowEncoder.schema.fields.size)
```

row.getBoolean returns `getByte() != 0`, which causes dropping rows randomly.
- matched rows in target table loss

Also as autoMerge doesn't work
- newly added column data in source df loss.


The fix makes sure setting active session as the given spark session for target table. The PR applies the fix for other command to avoid any inconsistent config behavior.

Fixes #2104 

## How was this patch tested?

I confirmed that #2104 is fixed with the change.
I confirmed the following by debug log message without the change:

1. matchedClauses has more columns after processRow
2. row.getBoolean(outputRowEncoder.schema.fields.size) refers random column value (It's Unsafe read)
3. canMergeSchema in MergeIntoCommand is false, it was true in PreprocessTableMerge

## Does this PR introduce _any_ user-facing changes?
Yes, fixes the data loss issue