### PR TITLE
[Spark] Use fieldId instead of index to lookup partition values during Iceberg to Delta Conversion

### DIFF
--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/ConvertIcebergToDeltaPartitionSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/ConvertIcebergToDeltaPartitionSuite.scala
@@ -542,7 +542,7 @@ class ConvertIcebergToDeltaPartitioningFiveDigitYearSuite
           case e: Throwable if e.isInstanceOf[org.apache.spark.SparkThrowable] &&
             e.getMessage.contains("spark.sql.legacy.timeParserPolicy") =>
             thrownError = true
-          case other => throw other
+          case other: Throwable => throw other
         }
         assert(thrownError, s"Error message $msg is incorrect.")
       } else {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Use fieldId instead of index to lookup partition values during Iceberg to Delta Conversion; This removes the dependency/assumption on the ordering of partition fields returned from Iceberg APIs. 

## How was this patch tested?

Existing Unit test

