### PR TITLE
[Spark] Inline non-correlated scalar subqueries in Merge

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoMaterializeSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoMaterializeSourceSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.delta.util.JsonUtils
 import org.scalactic.source.Position
 import org.scalatest.Tag
 
-import org.apache.spark.{SparkConf, SparkException}
+import org.apache.spark.{SparkConf, SparkException, TaskContext}
 import org.apache.spark.sql.{DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, Expression, Literal}
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -769,6 +769,47 @@ trait MergeIntoMaterializeSourceTests
     val stats = mergeStats(events)
     assert(stats.materializeSourceReason.isDefined)
     stats.materializeSourceReason.get
+  }
+
+  test("merge with non-deterministic scalar subquery in source") {
+    {
+      val numRows = 1000
+
+      val chooseOneRow = udf { i: Long =>
+        val stageId = TaskContext.get().stageId()
+        stageId % numRows == i
+      }
+      assert(chooseOneRow.deterministic)
+
+      // Create a subquery that returns a different row every time it is executed.
+      val subqueryViewName = "subquery_view"
+      spark.range(start = 0, end = numRows, step = 1, numPartitions = 1)
+        .filter(chooseOneRow(col("id")))
+        .createTempView(subqueryViewName)
+
+      val targetTableName = "target_table"
+      val sourceTableName = "source_table"
+      withTable(targetTableName, sourceTableName) {
+        spark.range(numRows).select(col("id").as("key"), col("id").as("value"))
+          .write.mode("overwrite").format("delta").saveAsTable(targetTableName)
+        spark.sql(s"SELECT key, value + $numRows AS value FROM $targetTableName")
+          .write.mode("overwrite").format("delta").saveAsTable(sourceTableName)
+
+        spark.sql(
+          s"""MERGE INTO $targetTableName t
+             |USING (SELECT * FROM $sourceTableName WHERE key = (SELECT * FROM $subqueryViewName)) s
+             |ON t.key = s.key
+             |WHEN MATCHED THEN UPDATE SET *
+             |WHEN NOT MATCHED THEN INSERT *""".stripMargin
+        )
+
+        // No new rows should have been inserted, as all keys in the source are already present in
+        // the target. If the subquery is evaluated multiple times, however, then the source may
+        // return different rows when finding the touched files and when writing the modified rows,
+        // in which case an update may be incorrectly treated as an insert.
+        assert(spark.table(targetTableName).count() === numRows)
+      }
+    }
   }
 }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
@@ -520,6 +520,113 @@ abstract class MergeIntoSuiteBase
     }
   }
 
+  test("non-correlated scalar subquery in source query") {
+    withTable("source") {
+      Seq((1, 6, "a"), (0, 3, "b")).toDF("key1", "value", "others")
+        .createOrReplaceTempView("source")
+      append(Seq((2, 2), (1, 4)).toDF("key2", "value"))
+
+      executeMerge(
+        target = s"delta.`$tempPath` as trg",
+        source = "(SELECT * FROM source WHERE value = (SELECT max(value) FROM source)) src",
+        condition = "src.key1 = trg.key2",
+        update = "trg.key2 = 20 + key1, value = 20 + src.value",
+        insert = "(trg.key2, value) VALUES (key1 - 10, src.value + 10)")
+
+      checkAnswer(readDeltaTable(tempPath),
+        Row(2, 2) :: // No change
+          Row(21, 26) :: // UPDATE
+          Nil)
+    }
+  }
+
+  test("correlated scalar subquery in source query") {
+    withTable("source") {
+      Seq((1, 6, "a"), (0, 3, "b")).toDF("key1", "value", "others")
+        .createOrReplaceTempView("source")
+      append(Seq((2, 2), (1, 4)).toDF("key2", "value"))
+
+      executeMerge(
+        target = s"delta.`$tempPath` as trg",
+        source = "(SELECT * FROM source WHERE " +
+          s"value = (SELECT MAX(value) FROM delta.`$tempPath` WHERE key1 = key2)) src",
+        condition = "src.key1 = trg.key2",
+        update = "trg.key2 = 20 + key1, value = 20 + src.value",
+        insert = "(trg.key2, value) VALUES (key1 - 10, src.value + 10)")
+
+      checkAnswer(readDeltaTable(tempPath),
+        Row(2, 2) :: // No change
+          Row(1, 4) :: // No change
+          Nil)
+    }
+  }
+
+  test("non-correlated exists subquery in source query") {
+    withTable("source") {
+      Seq((1, 6, "a"), (0, 3, "b")).toDF("key1", "value", "others")
+        .createOrReplaceTempView("source")
+      append(Seq((2, 2), (1, 4)).toDF("key2", "value"))
+
+      executeMerge(
+        target = s"delta.`$tempPath` as trg",
+        source = s"(SELECT * FROM source WHERE EXISTS (SELECT * FROM delta.`$tempPath`)) src",
+        condition = "src.key1 = trg.key2",
+        update = "trg.key2 = 20 + key1, value = 20 + src.value",
+        insert = "(trg.key2, value) VALUES (key1 - 10, src.value + 10)")
+
+      checkAnswer(
+        readDeltaTable(tempPath),
+        Row(2, 2) :: // No change
+          Row(21, 26) :: // Update
+          Row(-10, 13) :: // Insert
+          Nil)
+    }
+  }
+
+  test("correlated exists subquery in source query") {
+    withTable("source") {
+      Seq((1, 6, "a"), (0, 3, "b")).toDF("key1", "value", "others")
+        .createOrReplaceTempView("source")
+      append(Seq((2, 2), (1, 4)).toDF("key2", "value"))
+
+      executeMerge(
+        target = s"delta.`$tempPath` as trg",
+        source = s"(SELECT * FROM source WHERE " +
+          s"EXISTS (SELECT * FROM delta.`$tempPath` WHERE key1 = key2)) src",
+        condition = "src.key1 = trg.key2",
+        update = "trg.key2 = 20 + key1, value = 20 + src.value",
+        insert = "(trg.key2, value) VALUES (key1 - 10, src.value + 10)")
+
+      checkAnswer(
+        readDeltaTable(tempPath),
+        Row(2, 2) :: // No change
+          Row(21, 26) :: // Update
+          Nil)
+    }
+  }
+
+  test("in subquery in source query") {
+    withTable("source") {
+      Seq((1, 6, "a"), (0, 3, "b")).toDF("key1", "value", "others")
+        .createOrReplaceTempView("source")
+      append(Seq((2, 2), (1, 4)).toDF("key2", "value"))
+
+      executeMerge(
+        target = s"delta.`$tempPath` as trg",
+        source = s"(SELECT * FROM source WHERE " +
+          s"key1 IN (SELECT key2 FROM delta.`$tempPath`)) src",
+        condition = "src.key1 = trg.key2",
+        update = "trg.key2 = 20 + key1, value = 20 + src.value",
+        insert = "(trg.key2, value) VALUES (key1 - 10, src.value + 10)")
+
+      checkAnswer(
+        readDeltaTable(tempPath),
+        Row(2, 2) :: // No change
+          Row(21, 26) :: // Update
+          Nil)
+    }
+  }
+
   testQuietly("Negative case - more than one source rows match the same target row") {
     withTable("source") {
       Seq((1, 1), (0, 3), (1, 5)).toDF("key1", "value").createOrReplaceTempView("source")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR fixes a bug in MERGE that affects MERGE statements that contain a scalar subquery with non-deterministic results. Such a subquery can return different results during source materialization, while finding matches, and while writing modified rows. This can cause rows to be either dropped or duplicated.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Added a test with a non-deterministic subquery in the source in Merge. Also expanded test coverage of subqueries in Merge in general.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No