### PR TITLE
[SPARK-45383] Handle unresolved RelationTimeTravel gracefully

### DIFF
--- a/spark/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
+++ b/spark/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
@@ -92,6 +92,11 @@ class DeltaSparkSessionExtension extends (SparkSessionExtensions => Unit) {
       session.sessionState.conf.setConf(SQLConf.PARQUET_FIELD_ID_WRITE_ENABLED, true)
       new DeltaAnalysis(session)
     }
+    // [SPARK-45383] Spark CheckAnalysis rule misses a case for RelationTimeTravel, and so a
+    // non-existent table throws an internal spark error instead of the expected AnalysisException.
+    extensions.injectCheckRule { session =>
+      new CheckUnresolvedRelationTimeTravel(session)
+    }
     extensions.injectCheckRule { session =>
       new DeltaUnsupportedOperationsCheck(session)
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/CheckUnresolvedRelationTimeTravel.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/CheckUnresolvedRelationTimeTravel.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.analysis.RelationTimeTravel
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.trees.TreePattern.RELATION_TIME_TRAVEL
+
+/**
+ * Custom check rule that compensates for [SPARK-45383]. It checks the (unresolved) child relation
+ * of each [[RelationTimeTravel]] in the plan, in order to trigger a helpful table-not-found
+ * [[AnalysisException]] instead of the internal spark error that would otherwise result.
+ */
+class CheckUnresolvedRelationTimeTravel(spark: SparkSession) extends (LogicalPlan => Unit) {
+  override def apply(plan: LogicalPlan): Unit = {
+    // Short circuit: We only care about (unresolved) plans containing [[RelationTimeTravel]].
+    if (plan.containsPattern(RELATION_TIME_TRAVEL)) {
+      plan.foreachUp {
+        case tt: RelationTimeTravel => spark.sessionState.analyzer.checkAnalysis0(tt.relation)
+        case _ => ()
+      }
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
@@ -412,6 +412,12 @@ class DeltaTimeTravelSuite extends QueryTest
     )
   }
 
+  test("[SPARK-45383] Time travel on a non-existing table should throw AnalysisException") {
+    intercept[AnalysisException] {
+      spark.sql("SELECT * FROM not_existing VERSION AS OF 0")
+    }
+  }
+
   test("as of timestamp in between commits should use commit before timestamp") {
     withTempDir { dir =>
       val tblLoc = dir.getCanonicalPath


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Spark doesn't handle unresolved `RelationTimeTravel` very gracefully (throwing spark internal error instead of `AnalysisException`). It will eventually get fixed, but meanwhile Delta needs a workaround.

## How was this patch tested?

New unit test

## Does this PR introduce _any_ user-facing changes?

No