### PR TITLE
[SPARK] Reliably pass options when resolving path-based tables

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -364,10 +364,6 @@ class DeltaAnalysis(session: SparkSession)
             if tt.expressions.forall(_.resolved) =>
           val ttSpec = DeltaTimeTravelSpec(tt.timestamp, tt.version, tt.creationSource)
           val traveledTable = tbl.copy(timeTravelOpt = Some(ttSpec))
-          val tblIdent = tbl.catalogTable match {
-            case Some(existingCatalog) => existingCatalog.identifier
-            case None => TableIdentifier(tbl.path.toString, Some("delta"))
-          }
           // restoring to same version as latest should be a no-op.
           val sourceSnapshot = try {
             traveledTable.initialSnapshot
@@ -391,7 +387,7 @@ class DeltaAnalysis(session: SparkSession)
             return LocalRelation(restoreStatement.output)
           }
 
-          RestoreTableCommand(traveledTable, tblIdent)
+          RestoreTableCommand(traveledTable)
 
         case u: UnresolvedRelation =>
           u.tableNotFound(u.multipartIdentifier)
@@ -407,20 +403,19 @@ class DeltaAnalysis(session: SparkSession)
     // path and pass it along in a ResolvedPathBasedNonDeltaTable. This is needed as DESCRIBE DETAIL
     // supports both delta and non delta paths.
     case u: UnresolvedPathBasedTable =>
-      val table = getPathBasedDeltaTable(u.path)
-      val tableExists = Try(table.tableExists).getOrElse(false)
-      if (tableExists) {
+      val table = getPathBasedDeltaTable(u.path, u.options)
+      if (Try(table.tableExists).getOrElse(false)) {
         // Resolve it as a path-based Delta table
         val catalog = session.sessionState.catalogManager.currentCatalog.asTableCatalog
         ResolvedTable.create(
           catalog, Identifier.of(Array(DeltaSourceUtils.ALT_NAME), u.path), table)
       } else {
         // Resolve it as a placeholder, to identify it as a non-Delta table.
-        ResolvedPathBasedNonDeltaTable(u.path, u.commandName)
+        ResolvedPathBasedNonDeltaTable(u.path, u.options, u.commandName)
       }
 
     case u: UnresolvedPathBasedDeltaTable =>
-      val table = getPathBasedDeltaTable(u.path)
+      val table = getPathBasedDeltaTable(u.path, u.options)
       if (!table.tableExists) {
         throw DeltaErrors.notADeltaTableException(u.commandName, u.deltaTableIdentifier)
       }
@@ -626,9 +621,7 @@ class DeltaAnalysis(session: SparkSession)
     )
   }
 
-  private def getPathBasedDeltaTable(
-      path: String,
-      options: Map[String, String] = Map.empty): DeltaTableV2 = {
+  private def getPathBasedDeltaTable(path: String, options: Map[String, String]): DeltaTableV2 = {
     DeltaTableV2(session, new Path(path), options = options)
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -558,6 +558,7 @@ sealed abstract class UnresolvedPathBasedDeltaTableBase(path: String) extends Le
 /** Resolves to a [[ResolvedTable]] if the DeltaTable exists */
 case class UnresolvedPathBasedDeltaTable(
     path: String,
+    options: Map[String, String],
     commandName: String) extends UnresolvedPathBasedDeltaTableBase(path)
 
 /** Resolves to a [[DataSourceV2Relation]] if the DeltaTable exists */
@@ -572,6 +573,7 @@ case class UnresolvedPathBasedDeltaTableRelation(
  */
 case class UnresolvedPathBasedTable(
     path: String,
+    options: Map[String, String],
     commandName: String) extends LeafNode {
   override lazy val resolved: Boolean = false
   override val output: Seq[Attribute] = Nil
@@ -585,6 +587,7 @@ case class UnresolvedPathBasedTable(
  */
 case class ResolvedPathBasedNonDeltaTable(
     path: String,
+    options: Map[String, String],
     commandName: String) extends LeafNode {
   override val output: Seq[Attribute] = Nil
 }
@@ -601,7 +604,7 @@ object UnresolvedDeltaPathOrIdentifier {
       tableIdentifier: Option[TableIdentifier],
       cmd: String): LogicalPlan = {
     (path, tableIdentifier) match {
-      case (Some(p), None) => UnresolvedPathBasedDeltaTable(p, cmd)
+      case (Some(p), None) => UnresolvedPathBasedDeltaTable(p, Map.empty, cmd)
       case (None, Some(t)) =>
         UnresolvedTable(t.nameParts, cmd, None)
       case _ => throw new IllegalArgumentException(
@@ -626,7 +629,7 @@ object UnresolvedPathOrIdentifier {
     (path, tableIdentifier) match {
       case (_, Some(t)) =>
         UnresolvedTable(t.nameParts, cmd, None)
-      case (Some(p), None) => UnresolvedPathBasedTable(p, cmd)
+      case (Some(p), None) => UnresolvedPathBasedTable(p, Map.empty, cmd)
       case _ => throw new IllegalArgumentException(
         s"At least one of path or tableIdentifier must be provided to $cmd")
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -317,8 +317,9 @@ case class DeltaTableV2(
 
 object DeltaTableV2 {
   /** Resolves a path into a DeltaTableV2, leveraging standard v2 table resolution. */
-  def apply(spark: SparkSession, tablePath: Path, cmd: String): DeltaTableV2 =
-    resolve(spark, UnresolvedPathBasedDeltaTable(tablePath.toString, cmd), cmd)
+  def apply(spark: SparkSession, tablePath: Path, options: Map[String, String], cmd: String)
+      : DeltaTableV2 =
+    resolve(spark, UnresolvedPathBasedDeltaTable(tablePath.toString, options, cmd), cmd)
 
   /** Resolves a table identifier into a DeltaTableV2, leveraging standard v2 table resolution. */
   def apply(spark: SparkSession, tableId: TableIdentifier, cmd: String): DeltaTableV2 = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.delta.util.DeltaFileOperations.absolutePath
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.{Column, DataFrame, Dataset, Row, SparkSession}
-import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Literal}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
@@ -86,9 +85,7 @@ trait RestoreTableCommandBase {
  * 7) If table was modified in parallel then ignore restore and raise exception.
  *
  */
-case class RestoreTableCommand(
-    sourceTable: DeltaTableV2,
-    targetIdent: TableIdentifier)
+case class RestoreTableCommand(sourceTable: DeltaTableV2)
   extends LeafRunnableCommand with DeltaCommand with RestoreTableCommandBase {
 
   override val output: Seq[Attribute] = outputSchema

--- a/spark/src/test/scala/io/delta/sql/parser/DeltaSqlParserSuite.scala
+++ b/spark/src/test/scala/io/delta/sql/parser/DeltaSqlParserSuite.scala
@@ -55,7 +55,8 @@ class DeltaSqlParserSuite extends SparkFunSuite with SQLHelper {
         None, false))
 
     assert(parser.parsePlan("vacuum \"/tmp/table\"") ===
-      VacuumTableCommand(UnresolvedPathBasedDeltaTable("/tmp/table", "VACUUM"), None, false))
+      VacuumTableCommand(
+        UnresolvedPathBasedDeltaTable("/tmp/table", Map.empty, "VACUUM"), None, false))
   }
 
   test("Restore command is parsed as expected") {
@@ -121,7 +122,7 @@ class DeltaSqlParserSuite extends SparkFunSuite with SQLHelper {
     assert(parsedCmd ===
       OptimizeTableCommand(Some("/path/to/tbl"), None, Nil)(Nil))
     assert(parsedCmd.asInstanceOf[OptimizeTableCommand].child ===
-      UnresolvedPathBasedDeltaTable("/path/to/tbl", "OPTIMIZE"))
+      UnresolvedPathBasedDeltaTable("/path/to/tbl", Map.empty, "OPTIMIZE"))
 
     parsedCmd = parser.parsePlan("OPTIMIZE delta.`/path/to/tbl`")
     assert(parsedCmd ===
@@ -179,7 +180,7 @@ class DeltaSqlParserSuite extends SparkFunSuite with SQLHelper {
     // Desc detail on a raw path
     assert(parser.parsePlan("DESCRIBE DETAIL \"/tmp/table\"") ===
       DescribeDeltaDetailCommand(
-        UnresolvedPathBasedTable("/tmp/table", DescribeDeltaDetailCommand.CMD_NAME),
+        UnresolvedPathBasedTable("/tmp/table", Map.empty, DescribeDeltaDetailCommand.CMD_NAME),
         Map.empty))
 
     // Desc detail on a delta raw path
@@ -199,7 +200,7 @@ class DeltaSqlParserSuite extends SparkFunSuite with SQLHelper {
       UnresolvedTable(Seq("delta", "/path/to/tbl"), DescribeDeltaHistory.COMMAND_NAME, None))
     parsedCmd = parser.parsePlan("DESCRIBE HISTORY '/path/to/tbl'")
     assert(parsedCmd.asInstanceOf[DescribeDeltaHistory].child ===
-      UnresolvedPathBasedDeltaTable("/path/to/tbl", DescribeDeltaHistory.COMMAND_NAME))
+      UnresolvedPathBasedDeltaTable("/path/to/tbl", Map.empty, DescribeDeltaHistory.COMMAND_NAME))
   }
 
   private def targetPlanForTable(tableParts: String*): UnresolvedTable =


### PR DESCRIPTION

#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Path-based table resolution in spark often relies on options passed by the user. The recently-added `UnresolvedPathBased[Delta]Table` node types do not currently support options, which prevents the user from passing them reliably. Fortunately the code is dead so far, but future changes will rely on this capability. Thus, we fix the shortcoming now so those future changes can rely on it.

## How was this patch tested?

Refactor only so far, unit tests verify that there are no unexpected behavior changes.

## Does this PR introduce _any_ user-facing changes?

No