### PR TITLE
[Kernel] Add a FileReadRequest interface for reading deletion vectors

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/client/FileReadRequest.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/client/FileReadRequest.java
@@ -13,8 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.delta.kernel.fs;
-// TODO here or in io.delta.kernel.client?
+package io.delta.kernel.client;
 
 import io.delta.kernel.annotation.Evolving;
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/client/FileSystemClient.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/client/FileSystemClient.java
@@ -24,7 +24,6 @@ import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.fs.FileReadRequest;
 import io.delta.kernel.fs.FileStatus;
 import io.delta.kernel.utils.CloseableIterator;
-import io.delta.kernel.utils.Tuple2;
 
 /**
  * Provides file system related functionalities to Delta Kernel. Delta Kernel uses this client

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/client/FileSystemClient.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/client/FileSystemClient.java
@@ -21,6 +21,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import io.delta.kernel.annotation.Evolving;
+import io.delta.kernel.fs.FileReadRequest;
 import io.delta.kernel.fs.FileStatus;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.Tuple2;
@@ -56,17 +57,15 @@ public interface FileSystemClient {
      */
     String resolvePath(String path) throws IOException;
 
-    // TODO: solidify input type; need some combination of path, offset, size
-
     /**
-     * Read data specified by the start and end offset from the file. It is the responsibility
-     * of the caller close each returned stream.
+     * Return an iterator of byte streams one for each read request in {@code readRequests}.
+     * It is the responsibility of the caller to close each returned stream.
      *
-     * @param iter Iterator for tuples (file path, range (start offset, end offset)
-     * @return Data for each range requested as one {@link ByteArrayInputStream}.
+     * @param readRequests Iterator of read requests
+     * @return Data for each request as one {@link ByteArrayInputStream}.
      * @throws IOException
      */
     CloseableIterator<ByteArrayInputStream> readFiles(
-        CloseableIterator<Tuple2<String, Tuple2<Integer, Integer>>> iter)
+        CloseableIterator<FileReadRequest> readRequests)
         throws IOException;
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/client/FileSystemClient.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/client/FileSystemClient.java
@@ -21,7 +21,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import io.delta.kernel.annotation.Evolving;
-import io.delta.kernel.fs.FileReadRequest;
 import io.delta.kernel.fs.FileStatus;
 import io.delta.kernel.utils.CloseableIterator;
 
@@ -57,7 +56,8 @@ public interface FileSystemClient {
     String resolvePath(String path) throws IOException;
 
     /**
-     * Return an iterator of byte streams one for each read request in {@code readRequests}.
+     * Return an iterator of byte streams one for each read request in {@code readRequests}. The
+     * returned streams are in the same order as the given {@link FileReadRequest}s.
      * It is the responsibility of the caller to close each returned stream.
      *
      * @param readRequests Iterator of read requests

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/fs/FileReadRequest.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/fs/FileReadRequest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.fs;
+// TODO here or in io.delta.kernel.client?
+
+import io.delta.kernel.annotation.Evolving;
+
+/**
+ * Represents a request to read a range of bytes from a given file.
+ */
+@Evolving
+public interface FileReadRequest {
+    /**
+     * Get the fully qualified path of the file from which to read the data.
+     */
+    String getPath();
+
+    /**
+     * Get the start offset in the file from where to start reading the data.
+     */
+    int getStartOffset();
+
+    /**
+     * Get the length of the data to read from the file starting at the <i>startOffset</i>.
+     */
+    int getReadLength();
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/deletionvectors/DeletionVectorStoredBitmap.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/deletionvectors/DeletionVectorStoredBitmap.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 import java.util.zip.CRC32;
 
 import io.delta.kernel.client.FileSystemClient;
-import io.delta.kernel.fs.FileReadRequest;
+import io.delta.kernel.client.FileReadRequest;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.Utils;
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/deletionvectors/DeletionVectorStoredBitmap.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/deletionvectors/DeletionVectorStoredBitmap.java
@@ -25,7 +25,6 @@ import java.util.zip.CRC32;
 import io.delta.kernel.client.FileSystemClient;
 import io.delta.kernel.fs.FileReadRequest;
 import io.delta.kernel.utils.CloseableIterator;
-import io.delta.kernel.utils.Tuple2;
 import io.delta.kernel.utils.Utils;
 
 import io.delta.kernel.internal.actions.DeletionVectorDescriptor;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/deletionvectors/DeletionVectorStoredBitmap.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/deletionvectors/DeletionVectorStoredBitmap.java
@@ -22,8 +22,8 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.zip.CRC32;
 
-import io.delta.kernel.client.FileSystemClient;
 import io.delta.kernel.client.FileReadRequest;
+import io.delta.kernel.client.FileSystemClient;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.Utils;
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileSystemClient.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileSystemClient.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
 
+import io.delta.kernel.fs.FileReadRequest;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -80,11 +81,11 @@ public class DefaultFileSystemClient
 
     @Override
     public CloseableIterator<ByteArrayInputStream> readFiles(
-        CloseableIterator<Tuple2<String, Tuple2<Integer, Integer>>> iter) {
-        return iter.map(elem -> getStream(elem._1, elem._2._1, elem._2._2));
+        CloseableIterator<FileReadRequest> readRequests) {
+        return readRequests.map(elem -> getStream(elem.getPath(), elem.getStartOffset(), elem.getReadLength()));
     }
 
-    private ByteArrayInputStream getStream(String filePath, Integer offset, Integer size) {
+    private ByteArrayInputStream getStream(String filePath, int offset, int size) {
         Path path = new Path(filePath);
         try {
             FileSystem fs = path.getFileSystem(hadoopConf);

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileSystemClient.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileSystemClient.java
@@ -23,15 +23,14 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
 
-import io.delta.kernel.fs.FileReadRequest;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
 import io.delta.kernel.client.FileSystemClient;
+import io.delta.kernel.fs.FileReadRequest;
 import io.delta.kernel.fs.FileStatus;
 import io.delta.kernel.utils.CloseableIterator;
-import io.delta.kernel.utils.Tuple2;
 import io.delta.kernel.utils.Utils;
 
 /**
@@ -82,7 +81,8 @@ public class DefaultFileSystemClient
     @Override
     public CloseableIterator<ByteArrayInputStream> readFiles(
         CloseableIterator<FileReadRequest> readRequests) {
-        return readRequests.map(elem -> getStream(elem.getPath(), elem.getStartOffset(), elem.getReadLength()));
+        return readRequests.map(elem ->
+                getStream(elem.getPath(), elem.getStartOffset(), elem.getReadLength()));
     }
 
     private ByteArrayInputStream getStream(String filePath, int offset, int size) {

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileSystemClient.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileSystemClient.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
 import io.delta.kernel.client.FileSystemClient;
-import io.delta.kernel.fs.FileReadRequest;
+import io.delta.kernel.client.FileReadRequest;
 import io.delta.kernel.fs.FileStatus;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.Utils;

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileSystemClient.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileSystemClient.java
@@ -27,8 +27,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
-import io.delta.kernel.client.FileSystemClient;
 import io.delta.kernel.client.FileReadRequest;
+import io.delta.kernel.client.FileSystemClient;
 import io.delta.kernel.fs.FileStatus;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.Utils;


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Adds interface `FileReadRequest` which exposes the necessary information for reading a deletion vector.

## How was this patch tested?

Existing tests suffice.
