### PR TITLE
[Delta-Iceberg] Fix delta iceberg clone script

### DIFF
--- a/icebergShaded/generate_iceberg_jars.py
+++ b/icebergShaded/generate_iceberg_jars.py
@@ -29,7 +29,7 @@ iceberg_src_dir_name = "iceberg_src"
 iceberg_patches_dir_name = "iceberg_src_patches"
 
 iceberg_src_commit_hash = "ede085d0f7529f24acd0c81dd0a43f7bb969b763"
-iceberg_src_branch = "master"  # only this branch will be downloaded
+iceberg_src_branch = "main"  # only this branch will be downloaded
 
 # Relative to iceberg_src directory.
 # We use * because after applying the patches, a random git hash will be appended to each jar name.


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [X] Other (Delta-Iceberg)

## Description
Building UniForm depends on cloning and then building iceberg at a particular commit, in order to apply patch files. It starts this by cloning iceberg `master` branch. This has been renamed to `main`, and so we need to update our script to use `main` accordingly, else it fails to build and tests fail.

## How was this patch tested?
Local build.

## Does this PR introduce _any_ user-facing changes?
No
