### PR TITLE
Minor fixes to make release smoother

### DIFF
--- a/examples/scala/build.sbt
+++ b/examples/scala/build.sbt
@@ -35,8 +35,10 @@ def getMajorMinor(version: String): (Int, Int) = {
   }
 }
 val lookupSparkVersion: PartialFunction[(Int, Int), String] = {
-  // versions 2.4.0 and above
-  case (major,  minor) if (major == 2 && minor >= 4) || major >= 3 => "3.4.0"
+  // versions 3.0.0 and above
+  case (major,  minor) if major >= 3 => "3.5.0"
+  // versions 2.4.x
+  case (major,  minor) if major == 2 && minor == 4 => "3.4.0"
   // versions 2.3.x
   case (major, minor) if major == 2  && minor == 3 => "3.3.2"
   // versions 2.2.x

--- a/run-integration-tests.py
+++ b/run-integration-tests.py
@@ -424,12 +424,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "--iceberg-spark-version",
         required=False,
-        default="3.3",
+        default="3.5",
         help="Spark version for the Iceberg library")
     parser.add_argument(
         "--iceberg-lib-version",
         required=False,
-        default="1.0.0",
+        default="1.4.0",
         help="Iceberg Spark Runtime library version")
 
     args = parser.parse_args()

--- a/run-integration-tests.py
+++ b/run-integration-tests.py
@@ -205,13 +205,13 @@ def run_s3_log_store_util_integration_tests():
         raise
 
 
-def run_iceberg_integration_tests(root_dir, version, spark_version, iceberg_version, use_local):
+def run_iceberg_integration_tests(root_dir, version, spark_version, iceberg_version, extra_maven_repo, use_local):
     print("\n\n##### Running Iceberg tests on version %s #####" % str(version))
     clear_artifact_cache()
     if use_local:
         run_cmd(["build/sbt", "publishM2"])
 
-    test_dir = path.join(root_dir, path.join("delta-iceberg", "integration_tests"))
+    test_dir = path.join(root_dir, path.join("iceberg", "integration_tests"))
 
     # Add more Iceberg tests here if needed ...
     test_files_names = ["iceberg_converter.py"]
@@ -224,7 +224,7 @@ def run_iceberg_integration_tests(root_dir, version, spark_version, iceberg_vers
         "io.delta:delta-iceberg_2.12:" + version,
         "org.apache.iceberg:iceberg-spark-runtime-{}_2.12:{}".format(spark_version, iceberg_version)])
 
-    repo = ""
+    repo = extra_maven_repo if extra_maven_repo else ""
 
     for test_file in test_files:
         try:
@@ -451,7 +451,7 @@ if __name__ == "__main__":
     if args.run_iceberg_integration_tests:
         run_iceberg_integration_tests(
             root_dir, args.version,
-            args.iceberg_spark_version, args.iceberg_lib_version, args.use_local)
+            args.iceberg_spark_version, args.iceberg_lib_version, args.maven_repo, args.use_local)
         quit()
 
     if args.run_storage_s3_dynamodb_integration_tests:


### PR DESCRIPTION
## Description
- Fix to scala version check in examples
- Fix to allow iceberg integration tests to use staged sonatype repo

## How was this patch tested?
Locally ran integration tests

```
python3 run-integration-tests.py --run-iceberg-integration-tests --version 3.0.0rc2 --maven-repo https://oss.sonatype.org/content/repositories/iodelta-1120
```
