### PR TITLE
[branch-3.0] Fix mima logic for delta-spark

### DIFF
--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -42,9 +42,11 @@ object Mima {
   }
 
   def getPrevSparkName(currentVersion: String): String = {
-    val (major, minor, patch) = getMajorMinorPatch(currentVersion)
-    // name change in version 3.0.0, so versions > 3.0.0 should have delta-spark are prev version.
-    if (major >= 3 && (minor > 0 || patch > 0)) "delta-spark" else "delta-core"
+    val prevSparkVersion = getPrevSparkVersion(currentVersion)
+
+    val (major, minor, patch) = getMajorMinorPatch(prevSparkVersion)
+
+    if (major >= 3) "delta-spark" else "delta-core"
   }
 
   def getPrevSparkVersion(currentVersion: String): String = {


### PR DESCRIPTION
## Description

Previously, the command `build/sbt spark/mimaPreviousClassfiles` was failing with:

```
[info] Resolved  dependencies
[error] sbt.librarymanagement.ResolveException: Error downloading io.delta:delta-spark_2.12:2.4.0
[error]   Not found
[error]   not found: /Users/scott.sandre/.ivy2/localio.delta/delta-spark_2.12/2.4.0/ivys/ivy.xml
[error]   not found: https://repo1.maven.org/maven2/io/delta/delta-spark_2.12/2.4.0/delta-spark_2.12-2.4.0.pom
```

due to our previous logic in `Mima.scala`:
- `getPrevSparkVersion(3.0.1-SNAPSHOT)` --> correctly returned `2.4.0`
- `getPrevSparkName(3.0.1-SNAPSHOT)` --> incorrectly returned `delta-spark` (instead of `delta-core`)

We need to better couple our logic of "prev version" and "prev spark name" so that there is no mismatch here. This PR does just that.

## How was this patch tested?

`build/sbt spark/mimaPreviousClassfiles` passes now.