### PR TITLE
[Kernel] Add integration tests for staged/released maven artifact verification

### DIFF
--- a/kernel/examples/run-kernel-examples.py
+++ b/kernel/examples/run-kernel-examples.py
@@ -46,11 +46,22 @@ def run_multi_threaded_examples(version, maven_repo, examples_root_dir, golden_t
     run_example(version, maven_repo, project_dir, main_class, test_cases)
 
 
+def run_integration_tests(version, maven_repo, examples_root_dir, golden_tables_dir):
+    main_class = "io.delta.kernel.integration.IntegrationTestSuite"
+    project_dir = path.join(examples_root_dir, "table-reader")
+    with WorkingDirectory(project_dir):
+        cmd = ["mvn", "package", "exec:java", f"-Dexec.mainClass={main_class}",
+               f"-Dstaging.repo.url={maven_repo}",
+               f"-Ddelta-kernel.version={version}",
+               f"-Dexec.args={golden_tables_dir}"]
+        run_cmd(cmd, stream_output=True)
+
+
 def run_example(version, maven_repo, project_dir, main_class, test_cases):
     with WorkingDirectory(project_dir):
         for test in test_cases:
             cmd = ["mvn", "package", "exec:java", f"-Dexec.mainClass={main_class}",
-                   f"-Dstaging-repo={maven_repo}",
+                   f"-Dstaging.repo.url={maven_repo}",
                    f"-Ddelta-kernel.version={version}",
                    f"-Dexec.args={test}"]
             run_cmd(cmd, stream_output=True)
@@ -160,3 +171,4 @@ if __name__ == "__main__":
 
     run_single_threaded_examples(args.version, args.maven_repo, examples_root_dir, golden_file_dir)
     run_multi_threaded_examples(args.version, args.maven_repo, examples_root_dir, golden_file_dir)
+    run_integration_tests(args.version, args.maven_repo, examples_root_dir, golden_file_dir)

--- a/kernel/examples/table-reader/src/main/java/io/delta/kernel/examples/BaseTableReader.java
+++ b/kernel/examples/table-reader/src/main/java/io/delta/kernel/examples/BaseTableReader.java
@@ -40,6 +40,7 @@ import io.delta.kernel.TableNotFoundException;
 import io.delta.kernel.client.TableClient;
 import io.delta.kernel.data.FilteredColumnarBatch;
 import io.delta.kernel.data.Row;
+import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.types.*;
 import io.delta.kernel.utils.CloseableIterator;
 
@@ -60,15 +61,20 @@ public abstract class BaseTableReader {
     }
 
     /**
-     * Show the given {@code limit} rows containing the given columns from the table.
+     * Show the given {@code limit} rows containing the given columns with the predicate from the
+     * table.
      *
-     * @param limit      Max number of rows to show.
-     * @param columnsOpt If null, show all columns in the table.
+     * @param limit        Max number of rows to show.
+     * @param columnsOpt   If null, show all columns in the table.
+     * @param predicateOpt Optional predicate
+     * @return Number of rows returned by the query.
      * @throws TableNotFoundException
      * @throws IOException
      */
-    public abstract void show(int limit, Optional<List<String>> columnsOpt)
-        throws TableNotFoundException, IOException;
+    public abstract int show(
+        int limit,
+        Optional<List<String>> columnsOpt,
+        Optional<Predicate> predicateOpt) throws TableNotFoundException, IOException;
 
     /**
      * Utility method to return a pruned schema that contains the given {@code columns} from

--- a/kernel/examples/table-reader/src/main/java/io/delta/kernel/examples/SingleThreadedTableReader.java
+++ b/kernel/examples/table-reader/src/main/java/io/delta/kernel/examples/SingleThreadedTableReader.java
@@ -21,12 +21,10 @@ import java.util.Optional;
 
 import org.apache.commons.cli.CommandLine;
 
-import io.delta.kernel.Scan;
-import io.delta.kernel.Snapshot;
-import io.delta.kernel.Table;
-import io.delta.kernel.TableNotFoundException;
+import io.delta.kernel.*;
 import io.delta.kernel.data.FilteredColumnarBatch;
 import io.delta.kernel.data.Row;
+import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
 
@@ -50,13 +48,20 @@ public class SingleThreadedTableReader
     }
 
     @Override
-    public void show(int limit, Optional<List<String>> columnsOpt)
+    public int show(int limit, Optional<List<String>> columnsOpt, Optional<Predicate> predicate)
         throws TableNotFoundException, IOException {
         Table table = Table.forPath(tableClient, tablePath);
         Snapshot snapshot = table.getLatestSnapshot(tableClient);
         StructType readSchema = pruneSchema(snapshot.getSchema(tableClient), columnsOpt);
 
-        readData(readSchema, snapshot, limit);
+        ScanBuilder scanBuilder = snapshot.getScanBuilder(tableClient)
+            .withReadSchema(tableClient, readSchema);
+
+        if (predicate.isPresent()) {
+            scanBuilder = scanBuilder.withFilter(tableClient, predicate.get());
+        }
+
+        return readData(readSchema, scanBuilder.build(), limit);
     }
 
     public static void main(String[] args)
@@ -68,27 +73,20 @@ public class SingleThreadedTableReader
         Optional<List<String>> columns = parseColumnList(commandLine, "columns");
 
         new SingleThreadedTableReader(tablePath)
-            .show(limit, columns);
+            .show(limit, columns, Optional.empty());
     }
 
     /**
      * Utility method to read and print the data from the given {@code snapshot}.
      *
      * @param readSchema  Subset of columns to read from the snapshot.
-     * @param snapshot    Table snapshot object
+     * @param scan        Table scan object
      * @param maxRowCount Not a hard limit but use this limit to stop reading more columnar batches
      *                    once the already read columnar batches have at least these many rows.
-     * @return
+     * @return Number of rows read.
      * @throws Exception
      */
-    private void readData(
-        StructType readSchema,
-        Snapshot snapshot,
-        int maxRowCount) throws IOException {
-        Scan scan = snapshot.getScanBuilder(tableClient)
-            .withReadSchema(tableClient, readSchema)
-            .build();
-
+    private int readData(StructType readSchema, Scan scan, int maxRowCount) throws IOException {
         printSchema(readSchema);
 
         Row scanState = scan.getScanState(tableClient);
@@ -107,7 +105,7 @@ public class SingleThreadedTableReader
                         FilteredColumnarBatch dataReadResult = data.next();
                         readRecordCount += printData(dataReadResult, maxRowCount - readRecordCount);
                         if (readRecordCount >= maxRowCount) {
-                            return;
+                            return readRecordCount;
                         }
                     }
                 }
@@ -115,5 +113,7 @@ public class SingleThreadedTableReader
         } finally {
             scanFileIter.close();
         }
+
+        return readRecordCount;
     }
 }

--- a/kernel/examples/table-reader/src/main/java/io/delta/kernel/integration/IntegrationTestSuite.java
+++ b/kernel/examples/table-reader/src/main/java/io/delta/kernel/integration/IntegrationTestSuite.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.integration;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Arrays.asList;
+
+import io.delta.kernel.examples.SingleThreadedTableReader;
+import io.delta.kernel.expressions.And;
+import io.delta.kernel.expressions.Column;
+import io.delta.kernel.expressions.Literal;
+import io.delta.kernel.expressions.Predicate;
+
+/**
+ * Test suite that runs various integration tests for sanity testing the staged/released artifacts.
+ * It only verifies the number of rows in the results and not the specific values of rows.
+ * For full scale results verification we rely on unit tests which are run as part of the CI jobs.
+ */
+public class IntegrationTestSuite {
+    private final String goldenTableDir;
+
+    public static void main(String[] args) throws Exception {
+        new IntegrationTestSuite(args[0])
+            .runTests();
+    }
+
+    public IntegrationTestSuite(String goldenTableDir) {
+        this.goldenTableDir = goldenTableDir;
+    }
+
+    public void runTests() throws Exception {
+        // Definitions of golden tables is present in
+        // <root>/connectors/golden-tables/src/test/scala/io/delta/golden/GoldenTables.scala
+
+        // Basic reads: Simple table
+        runAndVerifyRowCount(
+            "basic_read_simple_table",
+            "data-reader-primitives",
+            Optional.empty(), /* read schema - read all columns */
+            Optional.empty(), /* predicate */
+            11 /* expected row count */);
+
+        // Basic reads: Partitioned table
+        runAndVerifyRowCount(
+            "basic_read_partitioned_table",
+            "data-reader-array-primitives",
+            Optional.empty(), /* read schema - read all columns */
+            Optional.empty(), /* predicate */
+            10 /* expected row count */);
+
+        // Basic reads: Table with DVs
+        runAndVerifyRowCount(
+            "basic_read_table_with_deletionvectors",
+            "dv-partitioned-with-checkpoint",
+            Optional.empty(), /* read schema - read all columns */
+            Optional.empty(), /* predicate */
+            35 /* expected row count */);
+
+        // Basic reads: select subset of columns
+        runAndVerifyRowCount(
+            "basic_read_subset_of_columns",
+            "dv-partitioned-with-checkpoint",
+            Optional.of(asList("part", "col2")), /* read schema */
+            Optional.empty(), /* predicate */
+            35 /* expected row count */);
+
+        // Partition pruning: simple expression
+        runAndVerifyRowCount(
+            "partition_pruning_simple_filter",
+            "basic-decimal-table",
+            Optional.empty(), /* read schema - read all columns */
+            Optional.of(new Predicate(
+                "=",
+                asList(
+                    new Column("part"),
+                    Literal.ofDecimal(new BigDecimal("2342222.23454"), 12, 5)))),
+            1 /* expected row count */);
+
+        // Partition pruning: filter on data and metadata columns
+        runAndVerifyRowCount(
+            "partition_pruning_filter_on_data_and_metadata_columns",
+            "dv-partitioned-with-checkpoint",
+            Optional.of(asList("part", "col2")), /* read schema */
+            Optional.of(
+                new And(
+                    new Predicate(">=", asList(new Column("part"), Literal.ofInt(7))),
+                    new Predicate("=", asList(new Column("col1"), Literal.ofInt(0))))),
+            12 /* expected row count */);
+    }
+
+    private void runAndVerifyRowCount(
+        String testName,
+        String goldenTable,
+        Optional<List<String>> readColumns,
+        Optional<Predicate> predicate,
+        int expectedRowCount) throws Exception {
+        System.out.println("\n========== TEST START: " + testName + " ==============");
+        try {
+            String path = goldenTableDir + "/" + goldenTable;
+            SingleThreadedTableReader reader = new SingleThreadedTableReader(path);
+            // Select a large number of rows (1M), so that everything in the table is read.
+            int actRowCount = reader.show(1_000_000, readColumns, predicate);
+            if (actRowCount != expectedRowCount) {
+                throw new RuntimeException(String.format(
+                    "Test (%s) failed: expected row count = %s, actual row count = %s",
+                    testName, expectedRowCount, actRowCount));
+            }
+        } finally {
+            System.out.println("========== TEST END: " + testName + " ==============\n");
+        }
+    }
+}

--- a/kernel/examples/table-reader/src/main/java/io/delta/kernel/integration/IntegrationTestSuite.java
+++ b/kernel/examples/table-reader/src/main/java/io/delta/kernel/integration/IntegrationTestSuite.java
@@ -80,6 +80,14 @@ public class IntegrationTestSuite {
             Optional.empty(), /* predicate */
             35 /* expected row count */);
 
+        // Basic reads: Table with DVs and column mapping
+        runAndVerifyRowCount(
+            "basic_read_table_with_columnmapping_deletionvectors",
+            "dv-with-columnmapping",
+            Optional.of(asList("col1", "col2")), /* read schema */
+            Optional.empty(), /* predicate */
+            35 /* expected row count */);
+
         // Partition pruning: simple expression
         runAndVerifyRowCount(
             "partition_pruning_simple_filter",


### PR DESCRIPTION
## Description
Add the following integration tests to verify the sanity of staged maven artifacts for Kernel release signoff.
* Reading a simple table w/o partitions
* Reading a simple table with partitions
* Reading only a subset of columns from a table
* Reading a table with deletion vectors
* Reading a table with deletion vectors and column mapping.
* Reading a table with partition pruning (simple filter)
* Reading a table with partition pruning (filter - combined with partition col filter and data col filter)

## How was this patch tested?
Here are the examples to run these tests
```
# To run with binaries built from the current repo
<repo-root>/kernel/examples/run-kernel-examples.py --use-local

# To run with staged artifacts at a particular location
 <repo-root>/kernel/examples/run-kernel-examples.py --maven-repo=https://oss.sonatype.org/content/repositories/iodelta-1120 --version=3.0.0rc2
```