### PR TITLE
[Spark] Support populating iceberg default name mapping in Uniform Delta to Iceberg conversion

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
@@ -30,6 +30,8 @@ import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.hadoop.conf.Configuration
 import shadedForDelta.org.apache.iceberg.{AppendFiles, DeleteFiles, OverwriteFiles, PendingUpdate, RewriteFiles, Transaction => IcebergTransaction}
 import shadedForDelta.org.apache.iceberg.hadoop.HadoopTables
+import shadedForDelta.org.apache.iceberg.mapping.MappingUtil
+import shadedForDelta.org.apache.iceberg.mapping.NameMappingParser
 
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 
@@ -297,9 +299,11 @@ class IcebergConversionTransaction(
     }
     assert(fileUpdates.forall(_.hasCommitted), "Cannot commit. You have uncommitted changes.")
 
+    val nameMapping = NameMappingParser.toJson(MappingUtil.create(icebergSchema))
     txn.updateProperties()
       .set(IcebergConverter.DELTA_VERSION_PROPERTY, postCommitSnapshot.version.toString)
       .set(IcebergConverter.DELTA_TIMESTAMP_PROPERTY, postCommitSnapshot.timestamp.toString)
+      .set(IcebergConverter.ICEBERG_NAME_MAPPING_PROPERTY, nameMapping)
       .commit()
 
     try {

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
@@ -49,6 +49,8 @@ object IcebergConverter {
    * Indicates the timestamp (milliseconds) of the delta commit that it corresponds to.
    */
   val DELTA_TIMESTAMP_PROPERTY = "delta-timestamp"
+
+  val ICEBERG_NAME_MAPPING_PROPERTY = "schema.name-mapping.default"
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

When user enables Uniform on existing Delta table, the parquet files written before enabling may have missing "field id" if column mapping is not enabled from day 1. Missing field id is handled in following ways :

Iceberg uses "schema.name-mapping.default" (https://iceberg.apache.org/spec/#schemas-and-data-types ) table property to resolve column in parquet when field id is missing. This is documented in the iceberg spec.
Iceberg spark implemention uses "ParquetSchemaUtil.addFallbackIds" (org/apache/iceberg/parquet/ParquetSchemaUtil.java) to infer field ids. Note this is undocumented in spec.
This PR populates schema.name-mapping.default, so that compliant readers can use that to resolve columns in parquet when field id is missing.



## How was this patch tested?

tested with iceberg reader and verified name mapping is triggered. 