### PR TITLE
[Spark] Test equivalency of compatibility V2 Checkpoints with normal V2 checkpoints

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
@@ -160,7 +160,7 @@ trait MetadataCleanup extends DeltaLogging {
    * could read the legacy classic checkpoint file and fail gracefully with Protocol requirement
    * failure.
    */
-  protected def createSinglePartCheckpointForBackwardCompat(
+  protected[delta] def createSinglePartCheckpointForBackwardCompat(
       snapshotToCleanup: Snapshot,
       metrics: V2CompatCheckpointMetrics): Unit = {
     // Do nothing if this table does not use V2 Checkpoints, or has no checkpoints at all.
@@ -311,7 +311,7 @@ trait MetadataCleanup extends DeltaLogging {
   }
 
   /** Class to track metrics related to V2 Compatibility checkpoint creation. */
-  protected class V2CompatCheckpointMetrics {
+  protected[delta] class V2CompatCheckpointMetrics {
     // time taken (in ms) to run the v2 checkpoint compat logic
     var v2CheckpointCompatLogicTimeTakenMs: Long = -1
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointProviderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointProviderSuite.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.actions.{Action}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.util.FileNames._
+
+import org.apache.spark.sql.test.SharedSparkSession
+
+class CheckpointProviderSuite
+  extends SharedSparkSession
+  with DeltaSQLCommandTest {
+
+  for (v2CheckpointFormat <- Seq("json", "parquet"))
+  test(s"V2 Checkpoint compat file equivalency to normal V2 Checkpoint" +
+      s" [v2CheckpointFormat: $v2CheckpointFormat]") {
+    withSQLConf(
+      DeltaConfigs.CHECKPOINT_POLICY.defaultTablePropertyKey -> CheckpointPolicy.V2.name,
+      DeltaSQLConf.CHECKPOINT_V2_TOP_LEVEL_FILE_FORMAT.key -> v2CheckpointFormat
+    ) {
+      withTempDir { tempDir =>
+        spark.range(10).write.format("delta").save(tempDir.getAbsolutePath)
+        val deltaLog = DeltaLog.forTable(spark, tempDir.getAbsolutePath)
+
+        spark.range(10).write.mode("append").format("delta").save(tempDir.getAbsolutePath)
+
+        deltaLog.checkpoint() // Checkpoint 1
+        val snapshot = deltaLog.update()
+
+        deltaLog.createSinglePartCheckpointForBackwardCompat(
+          snapshot, new deltaLog.V2CompatCheckpointMetrics) // Compatibility Checkpoint 1
+
+        val fs = deltaLog.logPath.getFileSystem(deltaLog.newDeltaHadoopConf())
+        val v2CompatCheckpoint = fs.getFileStatus(
+          checkpointFileSingular(deltaLog.logPath, snapshot.checkpointProvider.version))
+
+        val origCheckpoint = snapshot.checkpointProvider
+          .asInstanceOf[LazyCompleteCheckpointProvider]
+          .underlyingCheckpointProvider
+          .asInstanceOf[V2CheckpointProvider]
+        val compatCheckpoint = CheckpointProvider(
+          spark,
+          deltaLog.snapshot,
+          None,
+          UninitializedV2CheckpointProvider(
+            2L,
+            v2CompatCheckpoint,
+            deltaLog.logPath,
+            deltaLog.newDeltaHadoopConf(),
+            deltaLog.options,
+            deltaLog.store,
+            None))
+          .asInstanceOf[LazyCompleteCheckpointProvider]
+          .underlyingCheckpointProvider
+          .asInstanceOf[V2CheckpointProvider]
+
+        // Check whether these checkpoints are equivalent after being loaded
+        assert(compatCheckpoint.sidecarFiles.toSet === origCheckpoint.sidecarFiles.toSet)
+        assert(compatCheckpoint.checkpointMetadata === origCheckpoint.checkpointMetadata)
+
+        val compatDf =
+            deltaLog.loadIndex(compatCheckpoint.topLevelFileIndex.get, Action.logSchema)
+          // Check whether the manifest content is same or not
+        val originalDf =
+            deltaLog.loadIndex(origCheckpoint.topLevelFileIndex.get, Action.logSchema)
+            assert(originalDf.sort().collect() === compatDf.sort().collect())
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Adds a new suite with a test to check whether Compatibility V2 Checkpoints are equivalent to normal V2 Checkpoints after being loaded using the CheckpointProvider.


## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No