### PR TITLE
[Kernel] Add `package-info` for `io.delta.kernel.defaults.client` package

### DIFF
--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/package-info.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Default implementation of {@link TableClient} interface and the sub-interfaces exposed by
+ * the {@link TableClient}.
+ */
+package io.delta.kernel.defaults.client;


### PR DESCRIPTION
## Description
Add missing `package-info` for `io.delta.kernel.defaults.client` package.