### PR TITLE
[Spark] Print error details in user facing stack trace for implicit casts

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -628,14 +628,16 @@ trait DeltaErrorsBase
       columnName: String): ArithmeticException = {
     new DeltaArithmeticException(
       errorClass = "DELTA_CAST_OVERFLOW_IN_TABLE_WRITE",
-      messageParameters = Map(
-        "sourceType" -> toSQLType(from),
-        "targetType" -> toSQLType(to),
-        "columnName" -> toSQLId(columnName),
-        "storeAssignmentPolicyFlag" -> SQLConf.STORE_ASSIGNMENT_POLICY.key,
-        "updateAndMergeCastingFollowsAnsiEnabledFlag" ->
-          DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key,
-        "ansiEnabledFlag" -> SQLConf.ANSI_ENABLED.key))
+      messageParameters = Array(
+        toSQLType(from), // sourceType
+        toSQLType(to), // targetType
+        toSQLId(columnName), // columnName
+        SQLConf.STORE_ASSIGNMENT_POLICY.key, // storeAssignmentPolicyFlag
+        // updateAndMergeCastingFollowsAnsiEnabledFlag
+        DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key,
+        SQLConf.ANSI_ENABLED.key // ansiEnabledFlag
+      )
+    )
   }
 
   def notADeltaTable(table: String): Throwable = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaSharedExceptions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaSharedExceptions.scala
@@ -83,9 +83,15 @@ class DeltaParseException(
 
 class DeltaArithmeticException(
     errorClass: String,
-    messageParameters: Map[String, String]) extends ArithmeticException with DeltaThrowable {
+    messageParameters: Array[String])
+  extends ArithmeticException(
+      DeltaThrowableHelper.getMessage(errorClass, messageParameters))
+    with DeltaThrowable {
   override def getErrorClass: String = errorClass
 
-  override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
+  override def getMessageParameters: java.util.Map[String, String] = {
+    DeltaThrowableHelper.getParameterNames(errorClass, errorSubClass = null)
+      .zip(messageParameters).toMap.asJava
+  }
 }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ImplicitDMLCastingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ImplicitDMLCastingSuite.scala
@@ -22,7 +22,7 @@ import scala.collection.JavaConverters._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
-import org.apache.spark.{SparkConf, SparkThrowable}
+import org.apache.spark.{SparkConf, SparkException, SparkThrowable}
 import org.apache.spark.sql.{DataFrame, QueryTest}
 import org.apache.spark.sql.internal.SQLConf
 
@@ -307,6 +307,34 @@ class ImplicitDMLCastingSuite extends QueryTest
             validateException(exception, sqlConfig, testConfig)
           }
         }
+      }
+    }
+  }
+
+  test("Details are part of the error message") {
+    val sourceTableName = "source_table_name"
+    val sourceValueType = "INT"
+    val targetTableName = "target_table_name"
+    val targetValueType = "LONG"
+    val valueColumnName = "value"
+
+    withTable(sourceTableName, targetTableName) {
+      sql(s"CREATE OR REPLACE TABLE $targetTableName(id LONG, $valueColumnName $sourceValueType) " +
+        "USING DELTA")
+      sql(s"CREATE OR REPLACE TABLE $sourceTableName(id LONG, $valueColumnName $targetValueType) " +
+        "USING DELTA")
+      sql(s"INSERT INTO $sourceTableName VALUES(0, 9223372036854775807)")
+
+      val userFacingError = intercept[SparkException] {
+        sql(s"""MERGE INTO $targetTableName t
+               |USING $sourceTableName s
+               |ON s.id = t.id
+               |WHEN NOT MATCHED THEN INSERT *""".stripMargin)
+      }
+      val expectedDetails =
+        Seq("DELTA_CAST_OVERFLOW_IN_TABLE_WRITE", sourceValueType, targetValueType, valueColumnName)
+      for (detail <- expectedDetails) {
+        assert(userFacingError.toString.contains(detail))
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ImplicitDMLCastingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ImplicitDMLCastingSuite.scala
@@ -332,7 +332,7 @@ class ImplicitDMLCastingSuite extends QueryTest
                |WHEN NOT MATCHED THEN INSERT *""".stripMargin)
       }
       val expectedDetails =
-        Seq("DELTA_CAST_OVERFLOW_IN_TABLE_WRITE", sourceValueType, targetValueType, valueColumnName)
+        Seq("DELTA_CAST_OVERFLOW_IN_TABLE_WRITE", sourceValueType, valueColumnName)
       for (detail <- expectedDetails) {
         assert(userFacingError.toString.contains(detail))
       }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

For DeltaArithmeticException, print the error details in the message. This will for example make the column for which an implicit DML cast failed user visible.

## How was this patch tested?

Added a new test to validate message details

## Does this PR introduce _any_ user-facing changes?

No
