### PR TITLE
Use a Serializer and Deserializer for DeltaSourceOffset

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -1131,6 +1131,12 @@
     ],
     "sqlState" : "KD004"
   },
+  "DELTA_INVALID_SOURCE_OFFSET_FORMAT" : {
+    "message" : [
+      "The stored source offset format is invalid"
+    ],
+    "sqlState" : "XXKDS"
+  },
   "DELTA_INVALID_SOURCE_VERSION" : {
     "message" : [
       "sourceVersion(<version>) is invalid"

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2409,10 +2409,16 @@ trait DeltaErrorsBase
     new DeltaIllegalArgumentException(errorClass = "DELTA_UNRECOGNIZED_INVARIANT")
   }
 
-  def invalidSourceVersion(version: JValue): Throwable = {
+  def invalidSourceVersion(version: String): Throwable = {
     new DeltaIllegalStateException(
       errorClass = "DELTA_INVALID_SOURCE_VERSION",
-      messageParameters = Array(version.toString)
+      messageParameters = Array(version)
+    )
+  }
+
+  def invalidSourceOffsetFormat(): Throwable = {
+    new DeltaIllegalStateException(
+      errorClass = "DELTA_INVALID_SOURCE_OFFSET_FORMAT"
     )
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceOffset.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceOffset.scala
@@ -17,15 +17,19 @@
 package org.apache.spark.sql.delta.sources
 
 // scalastyle:off import.ordering.noEmptyLine
+import java.io.IOException
+
 import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog}
 import org.apache.spark.sql.delta.util.JsonUtils
-import com.fasterxml.jackson.annotation.JsonProperty
-import org.json4s._
-import org.json4s.jackson.JsonMethods.parse
+import com.fasterxml.jackson.core.{JsonGenerator, JsonParseException, JsonParser, JsonProcessingException}
+import com.fasterxml.jackson.databind.{DeserializationContext, SerializerProvider}
+import com.fasterxml.jackson.databind.annotation.{JsonDeserialize, JsonSerialize}
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
 
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.connector.read.streaming.{Offset => OffsetV2}
-import org.apache.spark.sql.execution.streaming.{Offset, SerializedOffset}
+import org.apache.spark.sql.execution.streaming.Offset
 
 /**
  * Tracks how far we processed in when reading changes from the [[DeltaLog]].
@@ -47,44 +51,20 @@ import org.apache.spark.sql.execution.streaming.{Offset, SerializedOffset}
  *                          table at the start and then move on to processing new data that has
  *                          arrived.
  */
+@JsonDeserialize(using = classOf[DeltaSourceOffset.Deserializer])
+@JsonSerialize(using = classOf[DeltaSourceOffset.Serializer])
 case class DeltaSourceOffset private(
     sourceVersion: Long,
     reservoirId: String,
     reservoirVersion: Long,
     index: Long,
-    // This was confusingly called "starting version" in earlier versions, even though enabling the
-    // option "starting version" actually causes this to be disabled. We still have to
-    // serialize it using the old name for backward compatibility.
-    @JsonProperty("isStartingVersion")
     isInitialSnapshot: Boolean
   ) extends Offset with Comparable[DeltaSourceOffset] {
 
   import DeltaSourceOffset._
 
   override def json: String = {
-    // We handle a few backward compatibility scenarios during Serialization here:
-    // 1. [Backward compatibility] If the source index is a schema changing base index, then replace
-    //    it with index = -1 and use VERSION_1.This allows older Delta to at least be able to read
-    //    the non-schema-changes stream offsets.
-    //    This needs to happen during serialization time so we won't be looking at a downgraded
-    //    index right away when we need to utilize this offset in memory.
-    // 2. [Backward safety] If the source index is a new schema changing index, then use
-    //    VERSION_3. Older Delta would explode upon seeing this, but that's the safe thing to do.
-    val minVersion = {
-      if (DeltaSourceOffset.isMetadataChangeIndex(index)) {
-        VERSION_3
-      }
-      else {
-        VERSION_1
-      }
-    }
-    val downgradedIndex = if (index == BASE_INDEX) {
-      BASE_INDEX_V1
-    } else {
-      index
-    }
-    val objectToSerialize = this.copy(sourceVersion = minVersion, index = downgradedIndex)
-    JsonUtils.toJson(objectToSerialize)
+    JsonUtils.toJson(this)
   }
 
   /**
@@ -165,57 +145,12 @@ object DeltaSourceOffset extends Logging {
     offset match {
       case o: DeltaSourceOffset => o
       case s =>
-        validateSourceVersion(s.json)
         val o = JsonUtils.mapper.readValue[DeltaSourceOffset](s.json)
         if (o.reservoirId != reservoirId) {
           throw DeltaErrors.differentDeltaTableReadByStreamingSource(
             newTableId = reservoirId, oldTableId = o.reservoirId)
         }
-        // Always upgrade to use the current latest INDEX_VERSION_BASE
-        val offsetIndex = if (o.sourceVersion < VERSION_3 && o.index == BASE_INDEX_V1) {
-          logDebug(s"upgrading offset to use latest version base index")
-          BASE_INDEX
-        } else {
-          o.index
-        }
-        // Leverage the only external facing constructor to initialize with latest sourceVersion
-        DeltaSourceOffset(
-          o.reservoirId,
-          o.reservoirVersion,
-          offsetIndex,
-          o.isInitialSnapshot
-        )
-    }
-  }
-
-  private def validateSourceVersion(json: String): Unit = {
-    val parsedJson = parse(json)
-    val versionJValueOpt = jsonOption(parsedJson \ "sourceVersion")
-    val versionOpt = versionJValueOpt.map {
-      case i: JInt => i.num.longValue
-      case other => throw DeltaErrors.invalidSourceVersion(other)
-    }
-    if (versionOpt.isEmpty) {
-      throw DeltaErrors.cannotFindSourceVersionException(json)
-    }
-
-    if (versionOpt.get == VERSION_2) {
-      // Version 2 is reserved.
-      throw DeltaErrors.invalidSourceVersion(versionJValueOpt.get)
-    }
-
-    val maxVersion = VERSION_3
-
-    if (versionOpt.get > maxVersion) {
-      throw DeltaErrors.invalidFormatFromSourceVersion(versionOpt.get, maxVersion)
-    }
-  }
-
-  /** Return an option that translates JNothing to None */
-  private def jsonOption(json: JValue): Option[JValue] = {
-    json match {
-      case JNothing => None
-      case value: JValue => Some(value)
+        o
     }
   }
 
@@ -244,4 +179,101 @@ object DeltaSourceOffset extends Logging {
 
   def isMetadataChangeIndex(index: Long): Boolean =
     index == METADATA_CHANGE_INDEX || index == POST_METADATA_CHANGE_INDEX
+
+  /**
+   * This is a 1:1 copy of [[DeltaSourceOffset]] used for JSON serialization. Our serializers only
+   * want to adjust some field values and then serialize in the normal way. But we cannot access the
+   * "default" serializers once we've overridden them. So instead, we use a separate case class that
+   * gets serialized "as-is".
+   */
+  private case class DeltaSourceOffsetForSerialization private(
+      sourceVersion: Long,
+      reservoirId: String,
+      reservoirVersion: Long,
+      index: Long,
+      // This stores isInitialSnapshot.
+      // This was confusingly called "starting version" in earlier versions, even though enabling
+      // the option "startingVersion" actually causes this to be disabled. We still have to
+      // serialize it using the old name for backward compatibility.
+      isStartingVersion: Boolean
+    )
+
+  class Deserializer
+    extends StdDeserializer[DeltaSourceOffset](classOf[DeltaSourceOffset]) {
+    @throws[IOException]
+    @throws[JsonProcessingException]
+    override def deserialize(p: JsonParser, ctxt: DeserializationContext): DeltaSourceOffset = {
+      val o = try {
+        p.readValueAs(classOf[DeltaSourceOffsetForSerialization])
+      } catch {
+        case _: JsonParseException =>
+          // The version may be there with a different format, or something else might be off.
+          throw DeltaErrors.invalidSourceOffsetFormat()
+      }
+
+      if (o.sourceVersion < VERSION_1) {
+        throw DeltaErrors.invalidSourceVersion(o.sourceVersion.toString)
+      }
+      if (o.sourceVersion > CURRENT_VERSION) {
+        throw DeltaErrors.invalidFormatFromSourceVersion(o.sourceVersion, CURRENT_VERSION)
+      }
+      if (o.sourceVersion == VERSION_2) {
+        // Version 2 is reserved.
+        throw DeltaErrors.invalidSourceVersion(o.sourceVersion.toString)
+      }
+      // Always upgrade to use the current latest INDEX_VERSION_BASE
+      val offsetIndex = if (o.sourceVersion < VERSION_3 && o.index == BASE_INDEX_V1) {
+        logDebug(s"upgrading offset to use latest version base index")
+        BASE_INDEX
+      } else {
+        o.index
+      }
+      // Leverage the only external facing constructor to initialize with latest sourceVersion
+      DeltaSourceOffset(
+        reservoirId = o.reservoirId,
+        reservoirVersion = o.reservoirVersion,
+        index = offsetIndex,
+        isInitialSnapshot = o.isStartingVersion
+      )
+    }
+  }
+
+  class Serializer
+    extends StdSerializer[DeltaSourceOffset](classOf[DeltaSourceOffset]) {
+
+    @throws[IOException]
+    override def serialize(
+        o: DeltaSourceOffset,
+        gen: JsonGenerator,
+        provider: SerializerProvider): Unit = {
+      // We handle a few backward compatibility scenarios during Serialization here:
+      // 1. [Backward compatibility] If the source index is a schema changing base index, then
+      //    replace it with index = -1 and use VERSION_1. This allows older Delta to at least be
+      //    able to read the non-schema-changes stream offsets.
+      //    This needs to happen during serialization time so we won't be looking at a downgraded
+      //    index right away when we need to utilize this offset in memory.
+      // 2. [Backward safety] If the source index is a new schema changing index, then use
+      //    VERSION_3. Older Delta would explode upon seeing this, but that's the safe thing to do.
+      val minVersion = {
+        if (DeltaSourceOffset.isMetadataChangeIndex(o.index)) {
+          VERSION_3
+        }
+        else {
+          VERSION_1
+        }
+      }
+      val downgradedIndex = if (o.index == BASE_INDEX) {
+        BASE_INDEX_V1
+      } else {
+        o.index
+      }
+      gen.writeObject(DeltaSourceOffsetForSerialization(
+        sourceVersion = minVersion,
+        reservoirId = o.reservoirId,
+        reservoirVersion = o.reservoirVersion,
+        index = downgradedIndex,
+        isStartingVersion = o.isInitialSnapshot
+      ))
+    }
+  }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceOffset.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceOffset.scala
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.core.{JsonGenerator, JsonParseException, JsonParser
 import com.fasterxml.jackson.databind.{DeserializationContext, SerializerProvider}
 import com.fasterxml.jackson.databind.annotation.{JsonDeserialize, JsonSerialize}
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import com.fasterxml.jackson.databind.exc.InvalidFormatException
 import com.fasterxml.jackson.databind.ser.std.StdSerializer
 
 import org.apache.spark.internal.Logging
@@ -206,7 +207,8 @@ object DeltaSourceOffset extends Logging {
       val o = try {
         p.readValueAs(classOf[DeltaSourceOffsetForSerialization])
       } catch {
-        case _: JsonParseException =>
+        case e: Throwable if e.isInstanceOf[JsonParseException] ||
+            e.isInstanceOf[InvalidFormatException] =>
           // The version may be there with a different format, or something else might be off.
           throw DeltaErrors.invalidSourceOffsetFormat()
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCStreamSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCStreamSuite.scala
@@ -485,7 +485,7 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
             query1.lastProgress.sources.head.endOffset
           )
           var expectedReservoirVersion = 1
-          var expectedIndex = 1
+          var expectedIndex = 1L
           assert(endOffset.reservoirVersion === expectedReservoirVersion)
           assert(endOffset.index === expectedIndex)
         }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1309,10 +1309,17 @@ trait DeltaErrorsSuiteBase
     }
     {
       val e = intercept[DeltaIllegalStateException] {
-        throw DeltaErrors.invalidSourceVersion(JString("xyz"))
+        throw DeltaErrors.invalidSourceVersion("xyz")
       }
       checkErrorMessage(e, Some("DELTA_INVALID_SOURCE_VERSION"), Some("XXKDS"),
-        Some("sourceVersion(JString(xyz)) is invalid"))
+        Some("sourceVersion(xyz) is invalid"))
+    }
+    {
+      val e = intercept[DeltaIllegalStateException] {
+        throw DeltaErrors.invalidSourceOffsetFormat()
+      }
+      checkErrorMessage(e, Some("DELTA_INVALID_SOURCE_OFFSET_FORMAT"), Some("XXKDS"),
+        Some("The stored source offset format is invalid"))
     }
     {
       val e = intercept[DeltaIllegalStateException] {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR changes `DeltaSourceOffset` to have a jackson `Serializer` and `Deserializer`. `DeltaSourceOffset` objects need extra adjustment of values at serialization and deserialization time, for backward compatibility. This was implemented using a hacky custom `.json` getter for serialization, and an `apply` constructor from `OffsetV2`. But some tests use a plain old `JsonUtils.mapper.readValue`, and they wouldn't get the special magic applied. With this change, the special magic is always applied. The PR also adds a specific error for arbitrary JSON parse errors.

## How was this patch tested?

Added new unit tests.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
