### PR TITLE
[Infra] Set next Delta version to 3.1.0-SNAPSHOT

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "3.0.0-SNAPSHOT"
+ThisBuild / version := "3.1.0-SNAPSHOT"


### PR DESCRIPTION
Now that the Delta Lake 3.0.0 release has been finalized, set the next Delta version to 3.1.0-SNAPSHOT.