### PR TITLE
[Spark] Replaces startTransaction in StatisticsCollection.recompute with catalogTable overload

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
@@ -40,6 +40,7 @@ import org.apache.spark.sql.util.ScalaExtensions._
 
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.parser.{AbstractSqlParser, AstBuilder, ParseException, ParserUtils}
 import org.apache.spark.sql.catalyst.parser.SqlBaseParser.MultipartIdentifierListContext
@@ -741,9 +742,10 @@ object StatisticsCollection extends DeltaCommand {
   def recompute(
       spark: SparkSession,
       deltaLog: DeltaLog,
+      catalogTable: Option[CatalogTable],
       predicates: Seq[Expression] = Seq(Literal(true)),
       fileFilter: AddFile => Boolean = af => true): Unit = {
-    val txn = deltaLog.startTransaction()
+    val txn = deltaLog.startTransaction(catalogTable)
     verifyPartitionPredicates(spark, txn.metadata.partitionColumns, predicates)
     // Save the current AddFiles that match the predicates so we can update their stats
     val files = txn.filterFiles(predicates).filter(fileFilter)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
@@ -308,7 +308,8 @@ class StatsCollectionSuite
         val biggest = deltaLog.snapshot.allFiles.agg(max('size)).first().getLong(0)
 
         {
-          StatisticsCollection.recompute(spark, deltaLog, fileFilter = _.size == biggest)
+          StatisticsCollection.recompute(
+            spark, deltaLog, catalogTable = None, fileFilter = _.size == biggest)
         }
 
         checkAnswer(


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR replaces the call to DeltaLog.startTransaction() in StatisticsCollection.recompute with calls to DeltaLog.startTransaction(Option[CatalogTable], Snapshot). This PR is part of https://github.com/delta-io/delta/issues/2105 and a follow-up to https://github.com/delta-io/delta/pull/2125, to ensure that all transactions have a valid catalogTable attached to them so Uniform can correctly update the table in the catalog.

This PR also introduces a new helper in DeltaTestImplicits, which allows unit test call sites to still call the old version of StatisticsCollection.recompute and passes None as the catalogTable. This implicit should only be used if the test really only runs against a path-based Delta table and so no catalogTable is present.

## How was this patch tested?

This is a small refactoring change so existing test coverage is sufficient.

## Does this PR introduce _any_ user-facing changes?

No
