### PR TITLE
Support data skipping on TimestampNTZ columns

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.catalyst.util.TypeUtils
 import org.apache.spark.sql.execution.InSubqueryExec
 import org.apache.spark.sql.expressions.SparkUserDefinedFunction
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types.{AtomicType, BooleanType, CalendarIntervalType, DataType, DateType, LongType, NumericType, StringType, StructField, StructType, TimestampType}
+import org.apache.spark.sql.types.{AtomicType, BooleanType, CalendarIntervalType, DataType, DateType, LongType, NumericType, StringType, StructField, StructType, TimestampNTZType, TimestampType}
 import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
 
 /**
@@ -145,7 +145,7 @@ object SkippingEligibleLiteral {
 object SkippingEligibleDataType {
   // Call this directly, e.g. `SkippingEligibleDataType(dataType)`
   def apply(dataType: DataType): Boolean = dataType match {
-    case _: NumericType | DateType | TimestampType | StringType => true
+    case _: NumericType | DateType | TimestampType | TimestampNTZType | StringType => true
     case _ => false
   }
 
@@ -652,6 +652,10 @@ trait DataSkippingReaderBase
           // There is a longer term task SC-22825 to fix the serialization problem that caused this.
           // But we need the adjustment in any case to correctly read stats written by old versions.
           new Column(Cast(TimeAdd(statCol.expr, oneMillisecondLiteralExpr), TimestampType))
+        case (statCol, TimestampNTZType, _) if statType == MAX =>
+          // We also apply the same adjustment of max stats that was applied to Timestamp
+          // for TimestampNTZ because these 2 types have the same precision in terms of time.
+          new Column(Cast(TimeAdd(statCol.expr, oneMillisecondLiteralExpr), TimestampNTZType))
         case (statCol, _, _) =>
           statCol
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimestampNTZSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimestampNTZSuite.scala
@@ -119,12 +119,17 @@ class DeltaTimestampNTZSuite extends QueryTest
     }
   }
 
-  test("min/max stats collection should not apply on TIMESTAMP_NTZ") {
+  test("min/max stats collection should apply on TIMESTAMP_NTZ") {
     withTable("delta_test") {
-      sql("CREATE TABLE delta_test(c1 STRING, c2 TIMESTAMP, c3 TIMESTAMP_NTZ) USING delta")
-      val statsSchema = DeltaLog.forTable(spark, TableIdentifier("delta_test")).snapshot.statsSchema
-      assert(statsSchema("minValues").dataType == StructType.fromDDL("c1 STRING, c2 TIMESTAMP"))
-      assert(statsSchema("maxValues").dataType == StructType.fromDDL("c1 STRING, c2 TIMESTAMP"))
+      val schemaString = "c1 STRING, c2 TIMESTAMP, c3 TIMESTAMP_NTZ"
+      sql(s"CREATE TABLE delta_test($schemaString) USING delta")
+      val statsSchema = DeltaLog.forTable(spark, TableIdentifier("delta_test"))
+        .unsafeVolatileSnapshot.statsSchema
+      assert(statsSchema("minValues").dataType == StructType
+        .fromDDL(schemaString))
+      assert(statsSchema("maxValues").dataType == StructType
+        .fromDDL(schemaString))
     }
   }
+
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaTests.scala
@@ -1519,47 +1519,49 @@ trait DataSkippingDeltaTestsBase extends QueryTest
 
   // Note that we cannot use testSkipping here, because the JSON parsing bug we're working around
   // prevents specifying a microsecond timestamp as input data.
-  test("data skipping on timestamps") {
-    val data = "2019-09-09 01:02:03.456789"
-    val df = Seq(data).toDF("strTs")
-      .selectExpr(
-        "CAST(strTs AS TIMESTAMP) AS ts",
-        "STRUCT(CAST(strTs AS TIMESTAMP) AS ts) AS nested")
+  for (timestampType <- Seq("TIMESTAMP", "TIMESTAMP_NTZ")) {
+    test(s"data skipping on $timestampType") {
+      val data = "2019-09-09 01:02:03.456789"
+      val df = Seq(data).toDF("strTs")
+        .selectExpr(
+          s"CAST(strTs AS $timestampType) AS ts",
+          s"STRUCT(CAST(strTs AS $timestampType) AS ts) AS nested")
 
-    val tempDir = Utils.createTempDir()
-    val r = DeltaLog.forTable(spark, tempDir)
-    df.coalesce(1).write.format("delta").save(r.dataPath.toString)
+      val tempDir = Utils.createTempDir()
+      val r = DeltaLog.forTable(spark, tempDir)
+      df.coalesce(1).write.format("delta").save(r.dataPath.toString)
 
-    // Check to ensure that the value actually in the file is always in range queries.
-    val hits = Seq(
-      """ts >= cast("2019-09-09 01:02:03.456789" AS TIMESTAMP)""",
-      """ts <= cast("2019-09-09 01:02:03.456789" AS TIMESTAMP)""",
-      """nested.ts >= cast("2019-09-09 01:02:03.456789" AS TIMESTAMP)""",
-      """nested.ts <= cast("2019-09-09 01:02:03.456789" AS TIMESTAMP)""",
-      """TS >= cast("2019-09-09 01:02:03.456789" AS TIMESTAMP)""",
-      """nEstED.tS >= cast("2019-09-09 01:02:03.456789" AS TIMESTAMP)""")
+      // Check to ensure that the value actually in the file is always in range queries.
+      val hits = Seq(
+        s"""ts >= cast("2019-09-09 01:02:03.456789" AS $timestampType)""",
+        s"""ts <= cast("2019-09-09 01:02:03.456789" AS $timestampType)""",
+        s"""nested.ts >= cast("2019-09-09 01:02:03.456789" AS $timestampType)""",
+        s"""nested.ts <= cast("2019-09-09 01:02:03.456789" AS $timestampType)""",
+        s"""TS >= cast("2019-09-09 01:02:03.456789" AS $timestampType)""",
+        s"""nEstED.tS >= cast("2019-09-09 01:02:03.456789" AS $timestampType)""")
 
-    // Check the range of values that are far enough away to be data skipped. Note that the values
-    // are aligned with millisecond boundaries because of the JSON serialization truncation.
-    val misses = Seq(
-      """ts >= cast("2019-09-09 01:02:03.457001" AS TIMESTAMP)""",
-      """ts <= cast("2019-09-04 01:02:03.455999" AS TIMESTAMP)""",
-      """nested.ts >= cast("2019-09-09 01:02:03.457001" AS TIMESTAMP)""",
-      """nested.ts <= cast("2019-09-09 01:02:03.455999" AS TIMESTAMP)""",
-      """TS >= cast("2019-09-09 01:02:03.457001" AS TIMESTAMP)""",
-      """nEstED.tS >= cast("2019-09-09 01:02:03.457001" AS TIMESTAMP)""")
+      // Check the range of values that are far enough away to be data skipped. Note that the values
+      // are aligned with millisecond boundaries because of the JSON serialization truncation.
+      val misses = Seq(
+        s"""ts >= cast("2019-09-09 01:02:03.457001" AS $timestampType)""",
+        s"""ts <= cast("2019-09-04 01:02:03.455999" AS $timestampType)""",
+        s"""nested.ts >= cast("2019-09-09 01:02:03.457001" AS $timestampType)""",
+        s"""nested.ts <= cast("2019-09-09 01:02:03.455999" AS $timestampType)""",
+        s"""TS >= cast("2019-09-09 01:02:03.457001" AS $timestampType)""",
+        s"""nEstED.tS >= cast("2019-09-09 01:02:03.457001" AS $timestampType)""")
 
-    hits.foreach { predicate =>
-      Given(predicate)
-      if (filesRead(r, predicate) != 1) {
-        failPretty(s"Expected hit but got miss for $predicate", predicate, data)
+      hits.foreach { predicate =>
+        Given(predicate)
+        if (filesRead(r, predicate) != 1) {
+          failPretty(s"Expected hit but got miss for $predicate", predicate, data)
+        }
       }
-    }
 
-    misses.foreach { predicate =>
-      Given(predicate)
-      if (filesRead(r, predicate) != 0) {
-        failPretty(s"Expected miss but got hit for $predicate", predicate, data)
+      misses.foreach { predicate =>
+        Given(predicate)
+        if (filesRead(r, predicate) != 0) {
+          failPretty(s"Expected miss but got hit for $predicate", predicate, data)
+        }
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.delta.stats
 
 import java.math.BigDecimal
 import java.sql.Date
+import java.time.LocalDateTime
 
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta._
@@ -423,7 +424,6 @@ class StatsCollectionSuite
   Seq(
     ("BINARY", "BinaryType"),
     ("BOOLEAN", "BooleanType"),
-    ("TIMESTAMP_NTZ", "TimestampNTZType"),
     ("ARRAY<TINYINT>", "ArrayType(ByteType,true)"),
     ("MAP<DATE, INT>", "MapType(DateType,IntegerType,true)"),
     ("STRUCT<c60:INT, c61:ARRAY<INT>>", "ArrayType(IntegerType,true)")
@@ -500,7 +500,7 @@ class StatsCollectionSuite
 
   Seq(
     "BIGINT", "DATE", "DECIMAL(3, 2)", "DOUBLE", "FLOAT", "INT", "SMALLINT", "STRING",
-    "TIMESTAMP", "TINYINT"
+    "TIMESTAMP", "TIMESTAMP_NTZ", "TINYINT"
   ).foreach { validType =>
     val tableName1 = "delta_table_1"
     val tableName2 = "delta_table_2"
@@ -701,11 +701,10 @@ class StatsCollectionSuite
   test("Change Columns with delta statistics column") {
     Seq(
       "BIGINT", "DATE", "DECIMAL(3, 2)", "DOUBLE", "FLOAT", "INT", "SMALLINT", "STRING",
-      "TIMESTAMP", "TINYINT"
+      "TIMESTAMP", "TIMESTAMP_NTZ", "TINYINT"
     ).foreach { validType =>
       Seq(
-        "BINARY", "BOOLEAN", "ARRAY<TINYINT>", "MAP<DATE, INT>", "STRUCT<c60:INT, c61:ARRAY<INT>>",
-        "TIMESTAMP_NTZ"
+        "BINARY", "BOOLEAN", "ARRAY<TINYINT>", "MAP<DATE, INT>", "STRUCT<c60:INT, c61:ARRAY<INT>>"
       ).foreach { invalidType =>
         withTable("delta_table") {
           sql(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Support data skipping on `TimestampNTZ` columns.

Support data skipping on `TimestampNTZType` columns in `DataSkippingReader`.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Unit tests are added to the `DataSkippingDeltaTests` and `DeltaTimestampNTZSuite`.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
