### PR TITLE
[Kernel] Add mocked unit tests for log segment construction

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -299,7 +299,7 @@ public class SnapshotManager
      * Helper function for the getLogSegmentForVersion above. Called with a provided files list,
      * and will then try to construct a new LogSegment using that.
      */
-    private Optional<LogSegment> getLogSegmentForVersion(
+    protected Optional<LogSegment> getLogSegmentForVersion(
         Path logPath,
         TableClient tableClient,
         Optional<Long> startCheckpointOpt,

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/SnapshotManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/SnapshotManagerSuite.scala
@@ -15,12 +15,22 @@
  */
 package io.delta.kernel
 
+import java.io.ByteArrayInputStream
 import java.util.{Arrays, Collections, Optional}
 
-import io.delta.kernel.internal.snapshot.SnapshotManager
+import scala.collection.JavaConverters._
+import scala.reflect.ClassTag
+
 import org.scalatest.funsuite.AnyFunSuite
 
+import io.delta.kernel.client.{ExpressionHandler, FileReadRequest, FileSystemClient, JsonHandler, ParquetHandler, TableClient}
+import io.delta.kernel.utils.{CloseableIterator, FileStatus}
+import io.delta.kernel.internal.snapshot.{LogSegment, SnapshotManager}
+import io.delta.kernel.internal.fs.Path
+import io.delta.kernel.internal.util.FileNames
+
 class SnapshotManagerSuite extends AnyFunSuite {
+  import SnapshotManagerSuite._
 
   test("verifyDeltaVersions") {
     // empty array
@@ -93,4 +103,689 @@ class SnapshotManagerSuite extends AnyFunSuite {
         Optional.empty())
     }
   }
+
+  //////////////////////////////////////////////////////////////////////////////////
+  // getLogSegmentForVersion tests
+  //////////////////////////////////////////////////////////////////////////////////
+
+  /* ------------------HELPER METHODS------------------ */
+
+  private val logPath = new Path("/fake/path/to/table/_delta_log")
+
+  private def deltaFileStatuses(deltaVersions: Seq[Long]): Seq[FileStatus] = {
+    assert(deltaVersions.size == deltaVersions.toSet.size)
+    deltaVersions.map(v => FileStatus.of(FileNames.deltaFile(logPath, v), v, v))
+  }
+
+  private def singularCheckpointFileStatuses(checkpointVersions: Seq[Long]): Seq[FileStatus] = {
+    assert(checkpointVersions.size == checkpointVersions.toSet.size)
+    checkpointVersions.map(v =>
+      FileStatus.of(FileNames.checkpointFileSingular(logPath, v).toString, v, v))
+  }
+
+  private def multiCheckpointFileStatuses(
+      checkpointVersions: Seq[Long], numParts: Int): Seq[FileStatus] = {
+    assert(checkpointVersions.size == checkpointVersions.toSet.size)
+    checkpointVersions.flatMap { v =>
+      FileNames.checkpointFileWithParts(logPath, v, numParts).asScala
+        .map(p => FileStatus.of(p.toString, v, v))
+    }
+  }
+
+  private def checkLogSegment(
+      logSegment: LogSegment,
+      expectedVersion: Long,
+      expectedDeltas: Seq[FileStatus],
+      expectedCheckpoints: Seq[FileStatus],
+      expectedCheckpointVersion: Option[Long],
+      expectedLastCommitTimestamp: Long): Unit = {
+
+    assert(logSegment.logPath == logPath)
+    assert(logSegment.version == expectedVersion)
+    assert(expectedDeltas.map(f => (f.getPath, f.getSize, f.getModificationTime)) sameElements
+      logSegment.deltas.asScala.map(f => (f.getPath, f.getSize, f.getModificationTime)))
+
+    val expectedCheckpointStatuses = expectedCheckpoints
+      .map(f => (f.getPath, f.getSize, f.getModificationTime))
+    val actualCheckpointStatuses = logSegment.checkpoints.asScala
+      .map(f => (f.getPath, f.getSize, f.getModificationTime))
+    assert(expectedCheckpointStatuses sameElements actualCheckpointStatuses,
+      s"expected:\n$expectedCheckpointStatuses\nactual:\n$actualCheckpointStatuses")
+
+    expectedCheckpointVersion match {
+      case Some(v) =>
+        assert(logSegment.checkpointVersionOpt.isPresent() &&
+          logSegment.checkpointVersionOpt.get == v)
+      case None => assert(!logSegment.checkpointVersionOpt.isPresent())
+    }
+    assert(expectedLastCommitTimestamp == logSegment.lastCommitTimestamp)
+  }
+
+  /**
+   * Test `getLogSegmentForVersion` for a given set of delta versions, singular checkpoint versions,
+   * and multi-part checkpoint versions with a given _last_checkpoint starting checkpoint and
+   * a versionToLoad.
+   *
+   * @param deltaVersions versions of the delta JSON files in the delta log
+   * @param checkpointVersions version of the singular checkpoint parquet files in the delta log
+   * @param multiCheckpointVersions versions of the multi-part checkpoint files in the delta log
+   * @param numParts number of parts for the multi-part checkpoints if applicable
+   * @param startCheckpoint starting checkpoint to list from, in practice provided by the
+   *                        _last_checkpoint file; if not provided list from 0
+   * @param versionToLoad specific version to load; if not provided load the latest
+   */
+  def testWithCheckpoints(
+      deltaVersions: Seq[Long],
+      checkpointVersions: Seq[Long],
+      multiCheckpointVersions: Seq[Long],
+      numParts: Int = -1,
+      startCheckpoint: Optional[java.lang.Long] = Optional.empty(),
+      versionToLoad: Optional[java.lang.Long] = Optional.empty()): Unit = {
+    val deltas = deltaFileStatuses(deltaVersions)
+    val checkpoints = singularCheckpointFileStatuses(checkpointVersions)
+    val multiCheckpoints = multiCheckpointFileStatuses(multiCheckpointVersions, numParts)
+
+    val logSegmentOpt = new SnapshotManager().getLogSegmentForVersion(
+      logPath,
+      createMockTableClient(listFromFileList(deltas ++ checkpoints ++ multiCheckpoints)),
+      startCheckpoint,
+      versionToLoad
+    )
+    assert(logSegmentOpt.isPresent())
+
+    val expectedCheckpointVersion = (checkpointVersions ++ multiCheckpointVersions)
+      .filter(_ <= versionToLoad.orElse(Long.MaxValue))
+      .sorted
+      .lastOption
+
+    val expectedDeltas = deltaFileStatuses(
+      deltaVersions.filter { v =>
+        v > expectedCheckpointVersion.getOrElse(-1L) && v <= versionToLoad.orElse(Long.MaxValue)
+      }
+    )
+    val expectedCheckpoints = expectedCheckpointVersion.map { v =>
+      if (checkpointVersions.toSet.contains(v)) {
+        singularCheckpointFileStatuses(Seq(v))
+      } else {
+        multiCheckpointFileStatuses(Seq(v), numParts)
+      }
+    }.getOrElse(Seq.empty)
+
+    checkLogSegment(
+      logSegmentOpt.get(),
+      expectedVersion = versionToLoad.orElse(deltaVersions.max),
+      expectedDeltas = expectedDeltas,
+      expectedCheckpoints = expectedCheckpoints,
+      expectedCheckpointVersion = expectedCheckpointVersion,
+      expectedLastCommitTimestamp = versionToLoad.orElse(deltaVersions.max)
+    )
+  }
+
+  /** Simple test for a log with only JSON files and no checkpoints */
+  def testNoCheckpoint(
+      deltaVersions: Seq[Long],
+      versionToLoad: Optional[java.lang.Long] = Optional.empty()): Unit = {
+    testWithCheckpoints(
+      deltaVersions,
+      checkpointVersions = Seq.empty,
+      multiCheckpointVersions = Seq.empty,
+      versionToLoad = versionToLoad
+    )
+  }
+
+  /**
+   * Test `getLogSegmentForVersion` for a set of delta versions and checkpoint versions. Tests
+   * with (1) singular checkpoint (2) multi-part checkpoints with 5 parts
+   * (3) multi-part checkpoints with 1 part
+   */
+  def testWithSingularAndMultipartCheckpoint(
+      deltaVersions: Seq[Long],
+      checkpointVersions: Seq[Long],
+      startCheckpoint: Optional[java.lang.Long] = Optional.empty(),
+      versionToLoad: Optional[java.lang.Long] = Optional.empty()): Unit = {
+
+    // test with singular checkpoint
+    testWithCheckpoints(
+      deltaVersions = deltaVersions,
+      checkpointVersions = checkpointVersions,
+      multiCheckpointVersions = Seq.empty,
+      startCheckpoint = startCheckpoint,
+      versionToLoad = versionToLoad
+    )
+
+    // test with multi-part checkpoint  numParts=5
+    testWithCheckpoints(
+      deltaVersions = deltaVersions,
+      checkpointVersions = Seq.empty,
+      multiCheckpointVersions = checkpointVersions,
+      numParts = 5,
+      startCheckpoint = startCheckpoint,
+      versionToLoad = versionToLoad
+    )
+
+    // test with multi-part checkpoint numParts=1
+    testWithCheckpoints(
+      deltaVersions = deltaVersions,
+      checkpointVersions = Seq.empty,
+      multiCheckpointVersions = checkpointVersions,
+      numParts = 1,
+      startCheckpoint = startCheckpoint,
+      versionToLoad = versionToLoad
+    )
+  }
+
+  /**
+   * For a given set of _delta_log files check for error.
+   */
+  def testExpectedError[T <: Throwable](
+      files: Seq[FileStatus],
+      startCheckpoint: Optional[java.lang.Long] = Optional.empty(),
+      versionToLoad: Optional[java.lang.Long] = Optional.empty(),
+      expectedErrorMessageContains: String = "")(implicit classTag: ClassTag[T]): Unit = {
+    val e = intercept[T] {
+      new SnapshotManager().getLogSegmentForVersion(
+        logPath,
+        createMockTableClient(listFromFileList(files)),
+        startCheckpoint,
+        versionToLoad
+      )
+    }
+    assert(e.getMessage.contains(expectedErrorMessageContains))
+  }
+
+  /* ------------------- VALID DELTA LOG FILE LISTINGS ----------------------- */
+
+  test("getLogSegmentForVersion: 000.json only") {
+    testNoCheckpoint(Seq(0))
+    testNoCheckpoint(Seq(0), Optional.of(0))
+  }
+
+  test("getLogSegmentForVersion: 000.json .. 009.json") {
+    testNoCheckpoint(0L until 10L)
+    testNoCheckpoint(0L until 10L, Optional.of(9))
+    testNoCheckpoint(0L until 10L, Optional.of(5))
+  }
+
+  test("getLogSegmentForVersion: 000.json..010.json + checkpoint(10)") {
+    testWithSingularAndMultipartCheckpoint(
+      deltaVersions = (0L to 10L),
+      checkpointVersions = Seq(10)
+    )
+    testWithSingularAndMultipartCheckpoint(
+      deltaVersions = (0L to 10L),
+      checkpointVersions = Seq(10),
+      startCheckpoint = Optional.of(10)
+    )
+    testWithSingularAndMultipartCheckpoint(
+      deltaVersions = (0L to 10L),
+      checkpointVersions = Seq(10),
+      versionToLoad = Optional.of(10)
+    )
+    testWithSingularAndMultipartCheckpoint(
+      deltaVersions = (0L to 10L),
+      checkpointVersions = Seq(10),
+      startCheckpoint = Optional.of(10),
+      versionToLoad = Optional.of(10)
+    )
+    testWithSingularAndMultipartCheckpoint(
+      deltaVersions = (0L to 10L),
+      checkpointVersions = Seq(10),
+      versionToLoad = Optional.of(6)
+    )
+    testWithSingularAndMultipartCheckpoint(
+      deltaVersions = (0L to 10L),
+      checkpointVersions = Seq(10),
+      startCheckpoint = Optional.of(10),
+      versionToLoad = Optional.of(6)
+    )
+  }
+
+  test("getLogSegmentForVersion: 000.json...20.json + checkpoint(10) + checkpoint(20)") {
+    testWithSingularAndMultipartCheckpoint(
+      deltaVersions = (0L to 20L),
+      checkpointVersions = Seq(10, 20)
+    )
+    testWithSingularAndMultipartCheckpoint(
+      deltaVersions = (0L to 20L),
+      checkpointVersions = Seq(10, 20),
+      startCheckpoint = Optional.of(20),
+    )
+    // _last_checkpoint hasn't been updated yet
+    testWithSingularAndMultipartCheckpoint(
+      deltaVersions = (0L to 20L),
+      checkpointVersions = Seq(10, 20),
+      startCheckpoint = Optional.of(10),
+    )
+    testWithSingularAndMultipartCheckpoint(
+      deltaVersions = (0L to 20L),
+      checkpointVersions = Seq(10, 20),
+      versionToLoad = Optional.of(15)
+    )
+    testWithSingularAndMultipartCheckpoint(
+      deltaVersions = (0L to 20L),
+      checkpointVersions = Seq(10, 20),
+      startCheckpoint = Optional.of(20),
+      versionToLoad = Optional.of(15)
+    )
+  }
+
+  test("getLogSegmentForVersion: outdated _last_checkpoint that does not exist") {
+    testWithSingularAndMultipartCheckpoint(
+      deltaVersions = (20L until 25L),
+      checkpointVersions = Seq(20),
+      startCheckpoint = Optional.of(10)
+    )
+    testWithSingularAndMultipartCheckpoint(
+      deltaVersions = (20L until 25L),
+      checkpointVersions = Seq(20),
+      startCheckpoint = Optional.of(10),
+      versionToLoad = Optional.of(20)
+    )
+  }
+
+  test("getLogSegmentForVersion: 20.json...25.json + checkpoint(20)") {
+    testWithSingularAndMultipartCheckpoint(
+      deltaVersions = (20L to 25L),
+      checkpointVersions = Seq(20)
+    )
+    testWithSingularAndMultipartCheckpoint(
+      deltaVersions = (20L to 25L),
+      checkpointVersions = Seq(20),
+      startCheckpoint = Optional.of(20),
+    )
+    testWithSingularAndMultipartCheckpoint(
+      deltaVersions = (20L to 25L),
+      checkpointVersions = Seq(20),
+      versionToLoad = Optional.of(23)
+    )
+  }
+
+  test("getLogSegmentForVersion: empty delta log") {
+    // listDeltaAndCheckpointFiles = Optional.empty()
+    val logSegmentOpt = new SnapshotManager().getLogSegmentForVersion(
+      logPath,
+      createMockTableClient(listFromFileList(Seq.empty)),
+      Optional.empty(),
+      Optional.empty()
+    )
+    assert(!logSegmentOpt.isPresent())
+  }
+
+  test("getLogSegmentForVersion: no delta files in the delta log") {
+    // listDeltaAndCheckpointFiles = Optional.of(EmptyList)
+    val files = Seq("foo", "notdelta.parquet", "foo.json", "001.checkpoint.00foo0.parquet")
+      .map(FileStatus.of(_, 10, 10))
+    testExpectedError[RuntimeException](
+      files,
+      // TODO this message seems misleading
+      expectedErrorMessageContains = "Empty directory: /fake/path/to/table/_delta_log"
+    )
+  }
+
+  test("getLogSegmentForVersion: versionToLoad higher than possible") {
+    // TODO improve error message? not very clear
+    testExpectedError[IllegalArgumentException](
+      files = deltaFileStatuses(Seq(0)),
+      versionToLoad = Optional.of(15),
+      expectedErrorMessageContains =
+        "Did not get the last delta file version 15 to compute Snapshot"
+    )
+    testExpectedError[IllegalArgumentException](
+      files = deltaFileStatuses((10L until 13L)) ++ singularCheckpointFileStatuses(Seq(10)),
+      versionToLoad = Optional.of(15),
+      expectedErrorMessageContains =
+        "Did not get the last delta file version 15 to compute Snapshot"
+    )
+  }
+
+  test("getLogSegmentForVersion: start listing from _last_checkpoint when it is provided") {
+    val deltas = deltaFileStatuses(0L until 25)
+    val checkpoints = singularCheckpointFileStatuses(Seq(10, 20))
+    val files = deltas ++ checkpoints
+    def listFrom(minVersion: Long)(filePath: String): Seq[FileStatus] = {
+      if (filePath < FileNames.listingPrefix(logPath, minVersion)) {
+        throw new RuntimeException("Listing from before provided _last_checkpoint")
+      }
+      listFromFileList(files)(filePath)
+    }
+    for (checkpointV <- Seq(10, 20)) {
+      val logSegmentOpt = new SnapshotManager().getLogSegmentForVersion(
+        logPath,
+        createMockTableClient(listFrom(checkpointV)),
+        Optional.of(checkpointV),
+        Optional.empty()
+      )
+      assert(logSegmentOpt.isPresent())
+      checkLogSegment(
+        logSegmentOpt.get(),
+        expectedVersion = 24,
+        expectedDeltas = deltaFileStatuses(21L until 25L),
+        expectedCheckpoints = singularCheckpointFileStatuses(Seq(20)),
+        expectedCheckpointVersion = Some(20),
+        expectedLastCommitTimestamp = 24L
+      )
+    }
+  }
+
+  test("getLogSegmentForVersion: multi-part and single-part checkpoints in same log") {
+    testWithCheckpoints(
+      (0L to 50L),
+      Seq(10, 30, 50),
+      Seq(20, 40),
+      numParts = 5,
+    )
+    testWithCheckpoints(
+      (0L to 50L),
+      Seq(10, 30, 50),
+      Seq(20, 40),
+      numParts = 5,
+      startCheckpoint = Optional.of(40)
+    )
+  }
+
+  test("getLogSegmentForVersion: versionToLoad not constructable from history") {
+    val files = deltaFileStatuses(20L until 25L) ++ singularCheckpointFileStatuses(Seq(20))
+    // TODO this error message is not helpful
+    testExpectedError[RuntimeException](
+      files,
+      versionToLoad = Optional.of(15),
+      expectedErrorMessageContains = "Empty directory: /fake/path/to/table/_delta_log"
+    )
+    testExpectedError[RuntimeException](
+      files,
+      startCheckpoint = Optional.of(20),
+      versionToLoad = Optional.of(15),
+      expectedErrorMessageContains = "Empty directory: /fake/path/to/table/_delta_log"
+    )
+  }
+
+  /* ------------------- CORRUPT DELTA LOG FILE LISTINGS ------------------ */
+
+  test("getLogSegmentForVersion: corrupt listing with only checkpoint file") {
+    for (versionToLoad <-
+           Seq(Optional.empty(), Optional.of(10L)): Seq[Optional[java.lang.Long]]) {
+      for (startCheckpoint <-
+             Seq(Optional.empty(), Optional.of(10L)): Seq[Optional[java.lang.Long]]) {
+        testExpectedError[IllegalStateException](
+          files = singularCheckpointFileStatuses(Seq(10)),
+          startCheckpoint = startCheckpoint,
+          versionToLoad = versionToLoad,
+          expectedErrorMessageContains = "Could not find any delta files for version 10"
+        )
+      }
+    }
+  }
+
+  // TODO address the inconsistent behaviors? better error messages?
+  test("getLogSegmentForVersion: corrupt listing 000.json...009.json + checkpoint(10)") {
+    val fileList = deltaFileStatuses((0L until 10L)) ++ singularCheckpointFileStatuses(Seq(10))
+
+    /* ----------  version to load is 15 (greater than latest checkpoint/delta file) ---------- */
+    // (?) different error messages
+    testExpectedError[IllegalStateException](
+      fileList,
+      versionToLoad = Optional.of(15),
+      expectedErrorMessageContains = "Trying to load a non-existent version 15"
+    )
+    testExpectedError[IllegalStateException](
+      fileList,
+      startCheckpoint = Optional.of(10),
+      versionToLoad = Optional.of(15),
+      expectedErrorMessageContains = "Could not find any delta files for version 10"
+    )
+
+    /* ---------- versionToLoad is latest (10) ---------- */
+    // (?) fails when startCheckpoint is provided, passes when it's not
+    testExpectedError[IllegalStateException](
+      fileList,
+      startCheckpoint = Optional.of(10),
+      expectedErrorMessageContains = "Could not find any delta files for version 10"
+    )
+    val logSegment = new SnapshotManager().getLogSegmentForVersion(
+      logPath,
+      createMockTableClient(listFromFileList(fileList)),
+      Optional.empty(),
+      Optional.empty()
+    )
+    assert(logSegment.isPresent())
+    checkLogSegment(
+      logSegment.get(),
+      10,
+      Seq.empty,
+      singularCheckpointFileStatuses(Seq(10)),
+      Some(10),
+      9 // is the last available delta file
+    )
+  }
+
+  // it's weird that checkpoint(10) fails but 011.json...014.json + checkpoint(10) does not
+  test("getLogSegmentForVersion: corrupt listing 011.json...014.json + checkpoint(10)") {
+    val fileList = singularCheckpointFileStatuses(Seq(10)) ++ deltaFileStatuses((11L until 15L))
+    /* ---------- versionToLoad is latest (14) ---------- */
+    // no error
+    testWithSingularAndMultipartCheckpoint(
+      deltaVersions = (11L until 15L),
+      checkpointVersions = Seq(10)
+    )
+    testWithSingularAndMultipartCheckpoint(
+      deltaVersions = (11L until 15L),
+      checkpointVersions = Seq(10),
+      startCheckpoint = Optional.of(10)
+    )
+    /* ---------- versionToLoad is 10 ---------- */
+    // (?) throws an error
+    testExpectedError[IllegalStateException](
+      fileList,
+      versionToLoad = Optional.of(10),
+      expectedErrorMessageContains = "Could not find any delta files for version 10"
+    )
+    testExpectedError[IllegalStateException](
+      fileList,
+      startCheckpoint = Optional.of(10),
+      versionToLoad = Optional.of(10),
+      expectedErrorMessageContains = "Could not find any delta files for version 10"
+    )
+  }
+
+  test("getLogSegmentForVersion: corrupted log missing json files / no way to construct history") {
+    def expectedErrorMessage(v: Int): String = {
+      s"""|Log file not found.
+          |Expected: ${FileNames.deltaFile(logPath, 0)}
+          |Found: ${FileNames.deltaFile(logPath, v)}""".stripMargin
+    }
+    testExpectedError[RuntimeException](
+      deltaFileStatuses(1L until 10L),
+      expectedErrorMessageContains = expectedErrorMessage(1)
+    )
+    testExpectedError[RuntimeException](
+      deltaFileStatuses(15L until 25L) ++ singularCheckpointFileStatuses(Seq(20)),
+      versionToLoad = Optional.of(17),
+      expectedErrorMessageContains = expectedErrorMessage(15)
+    )
+    testExpectedError[RuntimeException](
+      deltaFileStatuses(15L until 25L) ++ singularCheckpointFileStatuses(Seq(20)),
+      startCheckpoint = Optional.of(20),
+      versionToLoad = Optional.of(17),
+      expectedErrorMessageContains = expectedErrorMessage(15)
+    )
+    testExpectedError[RuntimeException](
+      deltaFileStatuses((0L until 5L) ++ (6L until 9L)),
+      expectedErrorMessageContains = "are not continuous"
+    )
+    // corrupt incomplete multi-part checkpoint
+    val corruptedCheckpointStatuses = FileNames.checkpointFileWithParts(logPath, 10, 5).asScala
+      .map(p => FileStatus.of(p.toString, 10, 10))
+      .take(4)
+    val deltas = deltaFileStatuses(10L to 13L)
+    testExpectedError[RuntimeException](
+      corruptedCheckpointStatuses ++ deltas,
+      Optional.empty(),
+      Optional.empty(),
+      expectedErrorMessageContains = expectedErrorMessage(10)
+    )
+  }
+
+  test("getLogSegmentForVersion: corrupt log but reading outside corrupted range") {
+    testNoCheckpoint(
+      (0L until 5L) ++ (6L until 9L),
+      Optional.of(4)
+    )
+    testWithSingularAndMultipartCheckpoint(
+      15L until 25L,
+      Seq(20),
+      versionToLoad = Optional.of(22)
+    )
+    testWithSingularAndMultipartCheckpoint(
+      15L until 25L,
+      Seq(20),
+      startCheckpoint = Optional.of(20),
+      versionToLoad = Optional.of(22)
+    )
+  }
+
+  test("getLogSegmentForVersion: corrupt _last_checkpoint (is after existing versions)") {
+    // in the case of a corrupted _last_checkpoint we revert to listing from version 0
+    // (on first run newFiles.isEmpty() but since startingCheckpointOpt.isPresent() re-list from 0)
+    testWithSingularAndMultipartCheckpoint(
+      (0L until 25L),
+      Seq(10L, 20L),
+      startCheckpoint = Optional.of(30),
+    )
+  }
+
+  // TODO recover from missing checkpoint (getLogSegmentWithMaxExclusiveCheckpointVersion)
+  test("getLogSegmentForVersion: corrupt _last_checkpoint refers to in range version " +
+    "but no valid checkpoint") {
+    testExpectedError[RuntimeException](
+      deltaFileStatuses(0L until 25L) ++ singularCheckpointFileStatuses(Seq(10L)),
+      startCheckpoint = Optional.of(20),
+      expectedErrorMessageContains = "Checkpoint file to load version: 20 is missing."
+    )
+    // _last_checkpoint refers to incomplete multi-part checkpoint
+    val corruptedCheckpointStatuses = FileNames.checkpointFileWithParts(logPath, 20, 5).asScala
+      .map(p => FileStatus.of(p.toString, 10, 10))
+      .take(4)
+    testExpectedError[RuntimeException](
+      files = corruptedCheckpointStatuses ++ deltaFileStatuses(10L to 20L) ++
+        singularCheckpointFileStatuses(Seq(10)),
+      startCheckpoint = Optional.of(20),
+      expectedErrorMessageContains = "Checkpoint file to load version: 20 is missing."
+    )
+  }
+
+  test("getLogSegmentForVersion: corrupted incomplete multi-part checkpoint with no" +
+    "_last_checkpoint or a valid _last_checkpoint provided") {
+    val cases: Seq[(Long, Seq[Long], Seq[Long], Optional[java.lang.Long])] = Seq(
+      /* (corruptedCheckpointVersion, validCheckpointVersions, deltaVersions, startCheckpoint) */
+      (20, Seq(10), (10L to 20L), Optional.empty()),
+      (20, Seq(10), (10L to 20L), Optional.of(10)),
+      (10, Seq.empty, (0L to 10L), Optional.empty())
+    )
+    cases.foreach { case (corruptedVersion, validVersions, deltaVersions, startCheckpoint) =>
+      val corruptedCheckpoint = FileNames.checkpointFileWithParts(logPath, corruptedVersion, 5)
+        .asScala
+        .map(p => FileStatus.of(p.toString, 10, 10))
+        .take(4)
+      val checkpoints = singularCheckpointFileStatuses(validVersions)
+      val deltas = deltaFileStatuses(deltaVersions)
+      val logSegmentOpt = new SnapshotManager().getLogSegmentForVersion(
+        logPath,
+        createMockTableClient(listFromFileList(deltas ++ corruptedCheckpoint ++ checkpoints)),
+        Optional.empty(),
+        Optional.empty()
+      )
+      val checkpointVersion = validVersions.sorted.lastOption
+      assert(logSegmentOpt.isPresent())
+      checkLogSegment(
+        logSegment = logSegmentOpt.get(),
+        expectedVersion = deltaVersions.max,
+        expectedDeltas = deltaFileStatuses(
+          deltaVersions.filter(_ > checkpointVersion.getOrElse(-1L))),
+        expectedCheckpoints = checkpoints,
+        expectedCheckpointVersion = checkpointVersion,
+        expectedLastCommitTimestamp = deltaVersions.max
+      )
+    }
+  }
+
+  test("getLogSegmentForVersion: corrupt _last_checkpoint with empty delta log") {
+    // listDeltaAndCheckpointFiles = Optional.empty()
+    val logSegmentOpt = new SnapshotManager().getLogSegmentForVersion(
+      logPath,
+      createMockTableClient(listFromFileList(Seq.empty)),
+      Optional.of(1),
+      Optional.empty()
+    )
+    assert(!logSegmentOpt.isPresent())
+  }
 }
+
+object SnapshotManagerSuite {
+
+  /**
+   * Create input function for createMockTableClient to implement listFrom from a list of
+   * file statuses.
+   * */
+  private def listFromFileList(files: Seq[FileStatus])(filePath: String): Seq[FileStatus] = {
+    files.filter(_.getPath.compareTo(filePath) >= 0).sortBy(_.getPath)
+  }
+
+  /**
+   * Create a mock {@link TableClient} to test log segment generation.
+   */
+  def createMockTableClient(listFromPath: String => Seq[FileStatus]): TableClient = {
+    new TableClient {
+      override def getExpressionHandler: ExpressionHandler = {
+        throw new UnsupportedOperationException("not supported for SnapshotManagerSuite tests")
+      }
+
+      override def getJsonHandler: JsonHandler = {
+        throw new UnsupportedOperationException("not supported for SnapshotManagerSuite tests")
+      }
+
+      override def getFileSystemClient: FileSystemClient =
+        createMockFileSystemClient(listFromPath)
+
+      override def getParquetHandler: ParquetHandler = {
+        throw new UnsupportedOperationException("not supported for SnapshotManagerSuite tests")
+      }
+    }
+  }
+
+  private def createMockFileSystemClient(
+    listFromPath: String => Seq[FileStatus]): FileSystemClient = {
+
+    new FileSystemClient {
+
+      override def listFrom(filePath: String): CloseableIterator[FileStatus] = {
+        val fileStatuses = listFromPath(filePath)
+
+        new CloseableIterator[FileStatus] {
+          private var idx = -1
+
+          override def hasNext: Boolean = {
+            idx + 1 < fileStatuses.length
+          }
+
+          override def next(): FileStatus = {
+            idx += 1
+            fileStatuses(idx)
+          }
+
+          override def close(): Unit = {}
+        }
+      }
+
+      override def resolvePath(path: String): String = {
+        throw new UnsupportedOperationException("not supported for SnapshotManagerSuite tests")
+      }
+
+      override def readFiles(
+          readRequests: CloseableIterator[FileReadRequest]
+      ): CloseableIterator[ByteArrayInputStream] = {
+        throw new UnsupportedOperationException("not supported for SnapshotManagerSuite tests")
+      }
+    }
+  }
+}
+

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/SnapshotManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/SnapshotManagerSuite.scala
@@ -348,13 +348,13 @@ class SnapshotManagerSuite extends AnyFunSuite {
     testWithSingularAndMultipartCheckpoint(
       deltaVersions = (0L to 20L),
       checkpointVersions = Seq(10, 20),
-      startCheckpoint = Optional.of(20),
+      startCheckpoint = Optional.of(20)
     )
     // _last_checkpoint hasn't been updated yet
     testWithSingularAndMultipartCheckpoint(
       deltaVersions = (0L to 20L),
       checkpointVersions = Seq(10, 20),
-      startCheckpoint = Optional.of(10),
+      startCheckpoint = Optional.of(10)
     )
     testWithSingularAndMultipartCheckpoint(
       deltaVersions = (0L to 20L),
@@ -391,7 +391,7 @@ class SnapshotManagerSuite extends AnyFunSuite {
     testWithSingularAndMultipartCheckpoint(
       deltaVersions = (20L to 25L),
       checkpointVersions = Seq(20),
-      startCheckpoint = Optional.of(20),
+      startCheckpoint = Optional.of(20)
     )
     testWithSingularAndMultipartCheckpoint(
       deltaVersions = (20L to 25L),
@@ -472,7 +472,7 @@ class SnapshotManagerSuite extends AnyFunSuite {
       (0L to 50L),
       Seq(10, 30, 50),
       Seq(20, 40),
-      numParts = 5,
+      numParts = 5
     )
     testWithCheckpoints(
       (0L to 50L),
@@ -649,7 +649,7 @@ class SnapshotManagerSuite extends AnyFunSuite {
     testWithSingularAndMultipartCheckpoint(
       (0L until 25L),
       Seq(10L, 20L),
-      startCheckpoint = Optional.of(30),
+      startCheckpoint = Optional.of(30)
     )
   }
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
@@ -418,13 +418,13 @@ class SnapshotManagerSuite extends AnyFunSuite {
       .map(FileStatus.of(_, 10, 10))
     testExpectedError[RuntimeException](
       files,
-      // TODO this message seems misleading
+      // TODO error message is misleading (delta-io/delta#2283)
       expectedErrorMessageContains = "Empty directory: /fake/path/to/table/_delta_log"
     )
   }
 
   test("getLogSegmentForVersion: versionToLoad higher than possible") {
-    // TODO improve error message? not very clear
+    // TODO throw more informative error message (delta-io/delta#2283)
     testExpectedError[IllegalArgumentException](
       files = deltaFileStatuses(Seq(0)),
       versionToLoad = Optional.of(15),
@@ -486,7 +486,7 @@ class SnapshotManagerSuite extends AnyFunSuite {
 
   test("getLogSegmentForVersion: versionToLoad not constructable from history") {
     val files = deltaFileStatuses(20L until 25L) ++ singularCheckpointFileStatuses(Seq(20))
-    // TODO this error message is not helpful
+    // TODO this error message is misleading (delta-io/delta#2283)
     testExpectedError[RuntimeException](
       files,
       versionToLoad = Optional.of(15),
@@ -517,7 +517,8 @@ class SnapshotManagerSuite extends AnyFunSuite {
     }
   }
 
-  // TODO address the inconsistent behaviors? better error messages?
+  // TODO address the inconsistent behaviors and throw better error messages for corrupt listings?
+  //  (delta-io/delta#2283)
   test("getLogSegmentForVersion: corrupt listing 000.json...009.json + checkpoint(10)") {
     val fileList = deltaFileStatuses((0L until 10L)) ++ singularCheckpointFileStatuses(Seq(10))
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Adds mocked unit tests for the log segment construction code.

Items to address
1) [P0] For some of the _valid file listings_ the error messages are confusing / misleading. We should fix these.
2) [P2] Behavior for _corrupt file listings_ is sporadic and inconsistent and error messages are confusing. We should consider fixing these at some point.
3) [P2] The log segment building code is really confusing. I think completely re-doing this has been discussed (?) at some point but is low priority. I'm planning to revisit this PR and see what low-effort improvements I can make for readability (max 15-20 minutes.)


## How was this patch tested?

Test PR.