### PR TITLE
[Spark] Make NonFateSharingFuture fully non fate sharing

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -18,9 +18,9 @@ package org.apache.spark.sql.delta
 
 import java.io.FileNotFoundException
 import java.util.Objects
+import java.util.concurrent.Future
 
 import scala.collection.mutable
-import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
 // scalastyle:off import.ordering.noEmptyLine
@@ -701,7 +701,7 @@ trait SnapshotManagement { self: DeltaLog =>
       }
     } else {
       // Kick off an async update, if one is not already obviously running. Intentionally racy.
-      if (Option(asyncUpdateTask).forall(_.isCompleted)) {
+      if (Option(asyncUpdateTask).forall(_.isDone)) {
         try {
           val jobGroup = spark.sparkContext.getLocalProperty(SparkContext.SPARK_JOB_GROUP_ID)
           asyncUpdateTask = SnapshotManagement.deltaLogAsyncUpdateThreadPool.submit(spark) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaThreadPool.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaThreadPool.scala
@@ -16,36 +16,36 @@
 
 package org.apache.spark.sql.delta.util
 
-import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent._
 
-import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.Duration
+import scala.util.control.NonFatal
 
 import org.apache.spark.sql.delta.DeltaErrors
 import org.apache.spark.sql.delta.metering.DeltaLogging
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.util.ThreadUtils
 
 /** A wrapper for [[ThreadPoolExecutor]] whose tasks run with the caller's [[SparkSession]]. */
 private[delta] class DeltaThreadPool(tpe: ThreadPoolExecutor) {
-  // WARNING: DO NOT use the EC directly. It exists here only to interface with scala Futures.
-  implicit protected val ec = ExecutionContext.fromExecutorService(tpe)
-
   /** Submits a task for execution and returns a [[Future]] representing that task. */
-  def submit[T](spark: SparkSession)(body: => T): Future[T] = Future[T](spark.withActive(body))
+  def submit[T](spark: SparkSession)(body: => T): Future[T] = {
+    tpe.submit { () => spark.withActive(body) }
+  }
 
   /**
    *  Executes `f` on each element of `items` as a task and returns the result.
-   *  Throws a [[SparkException]] if a timeout occurs.
+   *  Throws [[SparkException]] on error.
    */
   def parallelMap[T, R](
       spark: SparkSession,
-      items: Iterable[T],
-      timeout: Duration = Duration.Inf)(
+      items: Iterable[T])(
       f: T => R): Iterable[R] = {
-    val futures = items.map(i => submit(spark)(f(i)))
-    ThreadUtils.awaitResult(Future.sequence(futures), timeout)
+    // Materialize a list of futures, to ensure they all got submitted before we start waiting.
+    val futures = items.map(i => submit(spark)(f(i))).toList
+    futures.map(f => ThreadUtils.awaitResult(f, Duration.Inf)).toSeq
   }
 
   def submitNonFateSharing[T](f: SparkSession => T): NonFateSharingFuture[T] =
@@ -60,38 +60,72 @@ private[delta] object DeltaThreadPool {
 }
 
 /**
- * Helper class to run a function `f` immediately in a threadpool and avoid sharing [[SparkSession]]
- * on further retries if the the first attempt of function `f` (in the future) fails due to some
- * reason.
- * Everyone will use the future that prefetches f -- it succeeds -- but if the future fails,
- * everyone will call f themselves.
+ * A future invocation of `f` which avoids "fate sharing" of errors, in case multiple threads could
+ * wait on the future's result.
+ *
+ * The future is only launched if a [[SparkSession]] is available.
+ *
+ * If the future succeeds, any thread can consume the result.
+ *
+ * If the future fails, threads will just invoke `f` directly -- except that fatal errors will
+ * propagate (once) if the caller is from the same [[SparkSession]] that created the future.
  */
 class NonFateSharingFuture[T](pool: DeltaThreadPool)(f: SparkSession => T)
   extends DeltaLogging {
 
-  // We may not have a spark session yet, but that's ok (the future is best-effort)
-  // Submit a future if a spark session is available
-  private var futureOpt = SparkSession.getActiveSession.map { spark =>
-    pool.submit(spark) { f(spark) }
+  // Submit `f` as a future if a spark session is available
+  @volatile private var futureOpt = SparkSession.getActiveSession.map { spark =>
+    spark -> pool.submit(spark) { f(spark) }
   }
 
   def get(timeout: Duration): T = {
-    // Prefer to get a prefetched result from the future
-    futureOpt.foreach { future =>
+    // Prefer to get a prefetched result from the future, but never fail because of it.
+    val futureResult = futureOpt.flatMap { case (ownerSession, future) =>
       try {
-        return ThreadUtils.awaitResult(future, timeout)
+        Some(ThreadUtils.awaitResult(future, timeout))
       } catch {
+        // NOTE: ThreadUtils.awaitResult wraps all non-fatal exceptions other than TimeoutException
+        // with SparkException. Meanwhile, Java Future.get only throws four exceptions, all
+        // non-fatal: CancellationException, ExecutionException, InterruptedException,
+        // TimeoutException. Any Throwable from the task itself will surface as ExecutionException,
+        // so task failure usually means SparkException(ExecutionException(OriginalException)).
+        case e: TimeoutException =>
+          logWarning("Timed out waiting for future")
+          None
+        case outer: SparkException => outer.getCause match {
+          case e: InterruptedException =>
+            logWarning("Interrupted while waiting for future")
+            None
+          case e: CancellationException =>
+            logWarning("Future was cancelled")
+            futureOpt = None
+            None
+          case inner: ExecutionException => inner.getCause match {
+            case NonFatal(e) =>
+              logWarning("Future threw non-fatal exception", e)
+              futureOpt = None
+              None
+            case e: Throwable =>
+              logWarning("Future threw fatal error", e)
+              if (ownerSession eq SparkSession.active) {
+                futureOpt = None
+                throw e
+              }
+              None
+          }
+        }
         case e: Throwable =>
-          logError("Failed to get result from future", e)
-          futureOpt = None // avoid excessive log spam
-          throw e
+          logWarning("Unknown failure while waiting for future", e)
+          None
       }
     }
 
-    // Future missing or failed, so fall back to direct execution
-    SparkSession.getActiveSession match {
-      case Some(spark) => f(spark)
-      case _ => throw DeltaErrors.sparkSessionNotSetException()
+    futureResult.getOrElse {
+      // Future missing or failed, so fall back to direct execution.
+      SparkSession.getActiveSession match {
+        case Some(spark) => f(spark)
+        case _ => throw DeltaErrors.sparkSessionNotSetException()
+      }
     }
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaThreadPool.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaThreadPool.scala
@@ -95,7 +95,7 @@ class NonFateSharingFuture[T](pool: DeltaThreadPool)(f: SparkSession => T)
         case outer: SparkException => outer.getCause match {
           case e: InterruptedException =>
             logWarning("Interrupted while waiting for future")
-            None
+            throw e
           case e: CancellationException =>
             logWarning("Future was cancelled")
             futureOpt = None
@@ -114,7 +114,7 @@ class NonFateSharingFuture[T](pool: DeltaThreadPool)(f: SparkSession => T)
               None
           }
         }
-        case e: Throwable =>
+        case NonFatal(e) =>
           logWarning("Unknown failure while waiting for future", e)
           None
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/NonFateSharingFutureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/NonFateSharingFutureSuite.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.concurrent.duration._
+import scala.util.control.ControlThrowable
+
+import org.apache.spark.sql.delta.util.DeltaThreadPool
+
+import org.apache.spark.{SparkException, SparkFunSuite}
+import org.apache.spark.sql.test.SharedSparkSession
+
+class NonFateSharingFutureSuite extends SparkFunSuite with SharedSparkSession {
+  test("function only runs once on success") {
+    val count = new AtomicInteger
+    val future = DeltaThreadPool("test", 1).submitNonFateSharing { _ => count.incrementAndGet }
+    assert(future.get(10.seconds) === 1)
+    assert(future.get(10.seconds) === 1)
+    spark.cloneSession().withActive {
+      assert(future.get(10.seconds) === 1)
+    }
+  }
+
+  test("non-fatal exception in future is ignored") {
+    val count = new AtomicInteger
+    val future = DeltaThreadPool("test", 1).submitNonFateSharing { _ =>
+      count.incrementAndGet match {
+        case 1 => throw new Exception
+        case i => i
+      }
+    }
+    spark.cloneSession().withActive {
+      assert(future.get(10.seconds) === 2)
+    }
+    assert(future.get(10.seconds) === 3)
+
+    spark.cloneSession().withActive {
+      assert(future.get(10.seconds) === 4)
+    }
+    assert(future.get(10.seconds) === 5)
+  }
+
+  test("fatal exception in future only propagates once, and only to owning session") {
+    val count = new AtomicInteger
+    val future = DeltaThreadPool("test", 1).submitNonFateSharing { _ =>
+      count.incrementAndGet match {
+        case 1 => throw new InternalError
+        case i => i
+      }
+    }
+    spark.cloneSession().withActive {
+      assert(future.get(10.seconds) === 2)
+    }
+    intercept[InternalError] {
+      future.get(10.seconds)
+    }
+    spark.cloneSession().withActive {
+      assert(future.get(10.seconds) === 3)
+    }
+    assert(future.get(10.seconds) === 4)
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

It turns out `NonFateSharingFuture` can propagate the exception from a failed future between sessions, causing spurious failures in my session if it waits on a future launched by a job that got canceled.

The fix has several pieces:
* Non-fatal exceptions are completely ignored (other than being logged)
* Fatal exceptions only propagate (once) to a caller with the same session that created the future.
* Change `DeltaThreadPool` to use Java futures, because Scala futures do not handle fatal exceptions gracefully (they swallow the exception while leaving the future permanently unfinished).

## How was this patch tested?

A new unit test validates the expected behavior of `NonFateSharingFuture`. 
Existing unit tests validate other use sites of `DeltaThreadPool`.

## Does this PR introduce _any_ user-facing changes?

Yes -- spurious exceptions no longer thrown in my session, if a shared future launched by somebody else's session fails.
