### PR TITLE
[DOCS] Updating markdown header formatting and language in PROTOCOL.md

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -151,7 +151,7 @@ This directory format is only used to follow existing conventions and is not req
 Actual partition values for a file must be read from the transaction log.
 
 ### Deletion Vector Files
-Deletion Vector (DV) files are stored root directory of the table alongside the data files. A DV file contains one or more serialised DV, each describing the set of *invalidated* (or "soft deleted") rows for a particular data file it is associated with.
+Deletion Vector (DV) files are stored in the root directory of the table alongside the data files. A DV file contains one or more serialised DV, each describing the set of *invalidated* (or "soft deleted") rows for a particular data file it is associated with.
 For data with partition values, DV files are *not* kept in the same directory hierarchy as data files, as each one can contain DVs for files from multiple partitions.
 DV files store DVs in a [binary format](#deletion-vector-format).
 
@@ -245,7 +245,7 @@ Because a multi-part checkpoint cannot be created atomically (e.g. vulnerable to
 
 Checkpoints for a given version must only be created after the associated delta file has been successfully written.
 
-#### Sidecar Files
+### Sidecar Files
 
 A sidecar file contains file actions. These files are in parquet format and they must have unique names.
 These are then [linked](#sidecar-file-information) to checkpoints. Refer to [V2 checkpoint spec](#v2-spec)


### PR DESCRIPTION
Correcting the header formatting level of "Sidecar Files" to align with its peer section headers. Also making a minor language correction to the "Deletion Vector Files" section to add "in the" where it was missing.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Documentation)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Minor markdown fix and grammar update.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

GitHub preview.

![image](https://github.com/delta-io/delta/assets/11821839/a5f82b14-0337-4752-831e-e7dd437dbcab)
![image](https://github.com/delta-io/delta/assets/11821839/ef4d5eab-bc67-4c69-b087-f2bb0c906304)

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.
