### PR TITLE
Replace IndexedFile.isLast by END_INDEX to reliably move to BASE_INDEX of next version

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCStreamSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCStreamSuite.scala
@@ -111,6 +111,37 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
     }
   }
 
+  testQuietly("CDC initial snapshot should end at base index of next version") {
+    withTempDir { inputDir =>
+      withSQLConf(DeltaConfigs.CHANGE_DATA_FEED.defaultTablePropertyKey -> "true") {
+        // version 0
+        Seq(5, 6).toDF("value").write.format("delta").save(inputDir.getAbsolutePath)
+
+        val deltaTable = io.delta.tables.DeltaTable.forPath(inputDir.getAbsolutePath)
+
+        val df = spark.readStream
+          .option(DeltaOptions.CDC_READ_OPTION, "true")
+          .format("delta")
+          .load(inputDir.getCanonicalPath)
+          .drop(CDCReader.CDC_COMMIT_TIMESTAMP)
+
+        testStream(df)(
+          ProcessAllAvailable(),
+          CheckAnswer((5, "insert", 0), (6, "insert", 0)),
+          AssertOnQuery { q =>
+            val offset = q.committedOffsets.iterator.next()._2.asInstanceOf[DeltaSourceOffset]
+            // The initial snapshot (version 0) was completely processed, so we should now be at
+            // the start of version 1.
+            assert(offset.reservoirVersion === 1)
+            assert(offset.index === DeltaSourceOffset.BASE_INDEX)
+            true
+          },
+          StopStream
+        )
+      }
+    }
+  }
+
   test("startingVersion = latest") {
     withTempDir { inputDir =>
       Seq(1, 2).toDF("value").write.format("delta").save(inputDir.getAbsolutePath)
@@ -419,8 +450,7 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
   }
 
   Seq(true, false).foreach { readChangeFeed =>
-    test(s"streams updating latest offset with " +
-        s"readChangeFeed=$readChangeFeed") {
+    test(s"streams updating latest offset with readChangeFeed=$readChangeFeed") {
       withTempDirs { (inputDir, checkpointDir, outputDir) =>
         withSQLConf(DeltaConfigs.CHANGE_DATA_FEED.defaultTablePropertyKey -> "true") {
 
@@ -430,64 +460,47 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
             .write.format("delta").mode("overwrite")
             .option("enableChangeDataFeed", "true").save(inputDir.getAbsolutePath)
 
-          // process the input table in a CDC manner
-          val df = spark.readStream
-            .option(DeltaOptions.CDC_READ_OPTION, readChangeFeed)
-            .format("delta")
-            .load(inputDir.getAbsolutePath)
+          def runStreamingQuery(): StreamingQuery = {
+            // process the input table in a CDC manner
+            val df = spark.readStream
+              .option(DeltaOptions.CDC_READ_OPTION, readChangeFeed)
+              .format("delta")
+              .load(inputDir.getAbsolutePath)
+            val query = df
+              .select("id")
+              .writeStream
+              .format("delta")
+              .outputMode("append")
+              .option("checkpointLocation", checkpointDir.toString)
+              .start(outputDir.getAbsolutePath)
 
-          val query = df
-            .select("id")
-            .writeStream
-            .format("delta")
-            .outputMode("append")
-            .option("checkpointLocation", checkpointDir.toString)
-            .start(outputDir.getAbsolutePath)
+            query.processAllAvailable()
+            query.stop()
+            query.awaitTermination()
+            query
+          }
 
-          query.processAllAvailable()
-          query.stop()
-          query.awaitTermination()
+          var query = runStreamingQuery()
 
-          // Create a temp view and write to input table as a no-op merge
-          spark.range(20, 30).withColumn("value", lit("b"))
-            .createOrReplaceTempView("source_table")
-
-          for (i <- 0 to 10) {
-            sql(s"MERGE INTO delta.`${inputDir.getAbsolutePath}` AS tgt " +
-              s"USING source_table src ON tgt.id = src.id " +
-              s"WHEN MATCHED THEN UPDATE SET * " +
-              s"WHEN NOT MATCHED AND src.id < 10 THEN INSERT *")
+          val deltaLog = DeltaLog.forTable(spark, inputDir.toString)
+          // Do three no-op updates to the table. These are tricky because the commits have no
+          // changes, but the stream should still pick up the new versions and progress past them.
+          for (i <- 0 to 2) {
+            deltaLog.startTransaction().commit(Seq(), DeltaOperations.ManualUpdate)
           }
 
           // Read again from input table and no new data should be generated
-          val df1 = spark.readStream
-            .option("readChangeFeed", readChangeFeed)
-            .format("delta")
-            .load(inputDir.getAbsolutePath)
-
-          val query1 = df1
-            .select("id")
-            .writeStream
-            .format("delta")
-            .outputMode("append")
-            .option("checkpointLocation", checkpointDir.toString)
-            .start(outputDir.getAbsolutePath)
-
-          query1.processAllAvailable()
-          query1.stop()
-          query1.awaitTermination()
+          query = runStreamingQuery()
 
           // check that the last batch was committed and that the
           // reservoirVersion for the table was updated to latest
           // in both cdf and non-cdf cases.
-          assert(query1.lastProgress.batchId === 1)
-          val endOffset = JsonUtils.mapper.readValue[DeltaSourceOffset](
-            query1.lastProgress.sources.head.endOffset
-          )
-          var expectedReservoirVersion = 1
-          var expectedIndex = 1L
-          assert(endOffset.reservoirVersion === expectedReservoirVersion)
-          assert(endOffset.index === expectedIndex)
+          assert(query.lastProgress.batchId === 1)
+          val endOffset =
+            JsonUtils.fromJson[DeltaSourceOffset](query.lastProgress.sources.head.endOffset)
+          assert(endOffset.reservoirVersion === 5,
+            s"endOffset = $endOffset")
+          assert(endOffset.index === DeltaSourceOffset.BASE_INDEX, s"endOffset = $endOffset")
         }
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Remove `IndexedFile.isLast` and replace it by a `DeltaSourceOffset.END_INDEX` that is always included after the last entry.

There were several problems with `isLast`. For one thing, we were not setting it for the last file in initial snapshots, so when a streaming query starts and processes the initial snapshot, it would stop at the last file in the snapshot. Then on the next trigger we would reconstruct the initial snapshot only to find out that we'd already processed all of it.

Another problem with `isLast` is that it doesn't exist for empty commits or snapshots. As a result, the stream would not be able to move forward if it started at the `BASE_INDEX` of an empty commit.

With this change, I added `END_INDEX` to the end of every snapshot (CDC and non-CDC), and also a BASE_INDEX to the start (even if it's technically not used, but it's good to be consistent).

I also updated some tests in `DeltaCDCStreamSuite` that were incorrect. They restarted a query without a checkpoint, and then did checks assuming that the query had restarted from a checkpoint. I also changed some tests to be very specific about the offsets that they expect the batches in the stream to end at.  

## How was this patch tested?

New tests added for regular and CDC snapshots.

## Does this PR introduce _any_ user-facing changes?

No. 