### PR TITLE
[Spark] Improves DELTA_UNSUPPORTED_FEATURES_FOR_[READ/WRITE] message

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2226,13 +2226,13 @@
   },
   "DELTA_UNSUPPORTED_FEATURES_FOR_READ" : {
     "message" : [
-      "Unsupported Delta read feature: table \"<tableNameOrPath>\" requires reader table feature(s) that are unsupported by Delta Lake \"<deltaVersion>\": \"<unsupported>\"."
+      "Unsupported Delta read feature: table \"<tableNameOrPath>\" requires reader table feature(s) that are unsupported by Delta Lake \"<deltaVersion>\": <unsupported>."
     ],
     "sqlState" : "56038"
   },
   "DELTA_UNSUPPORTED_FEATURES_FOR_WRITE" : {
     "message" : [
-      "Unsupported Delta write feature: table \"<tableNameOrPath>\" requires writer table feature(s) that are unsupported by Delta Lake \"<deltaVersion>\": \"<unsupported>\"."
+      "Unsupported Delta write feature: table \"<tableNameOrPath>\" requires writer table feature(s) that are unsupported by Delta Lake \"<deltaVersion>\": <unsupported>."
     ],
     "sqlState" : "56038"
   },

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2226,13 +2226,13 @@
   },
   "DELTA_UNSUPPORTED_FEATURES_FOR_READ" : {
     "message" : [
-      "Unable to read this table because it requires reader table feature(s) that are unsupported by this version of Delta Lake: <unsupported>."
+      "Unsupported Delta read feature: table \"<tableNameOrPath>\" requires reader table feature(s) that are unsupported by Delta Lake \"<deltaVersion>\": \"<unsupported>\"."
     ],
     "sqlState" : "56038"
   },
   "DELTA_UNSUPPORTED_FEATURES_FOR_WRITE" : {
     "message" : [
-      "Unable to write this table because it requires writer table feature(s) that are unsupported by this version of Delta Lake: <unsupported>."
+      "Unsupported Delta write feature: table \"<tableNameOrPath>\" requires writer table feature(s) that are unsupported by Delta Lake \"<deltaVersion>\": \"<unsupported>\"."
     ],
     "sqlState" : "56038"
   },

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2132,18 +2132,20 @@ trait DeltaErrorsBase
 
   def unsupportedReaderTableFeaturesInTableException(
     tableNameOrPath: String,
-    unsupported: Iterable[String]): DeltaTableFeatureException = {
-    new DeltaTableFeatureException(
+    unsupported: Iterable[String]): DeltaUnsupportedTableFeatureException = {
+    new DeltaUnsupportedTableFeatureException(
       errorClass = "DELTA_UNSUPPORTED_FEATURES_FOR_READ",
-      messageParameters = Array(tableNameOrPath, io.delta.VERSION, unsupported.mkString(", ")))
+      tableNameOrPath = tableNameOrPath,
+      unsupported = unsupported)
   }
 
   def unsupportedWriterTableFeaturesInTableException(
     tableNameOrPath: String,
-    unsupported: Iterable[String]): DeltaTableFeatureException = {
-    new DeltaTableFeatureException(
+    unsupported: Iterable[String]): DeltaUnsupportedTableFeatureException = {
+    new DeltaUnsupportedTableFeatureException(
       errorClass = "DELTA_UNSUPPORTED_FEATURES_FOR_WRITE",
-      messageParameters = Array(tableNameOrPath, io.delta.VERSION, unsupported.mkString(", ")))
+      tableNameOrPath = tableNameOrPath,
+      unsupported = unsupported)
   }
 
   def unsupportedTableFeatureConfigsException(
@@ -3310,6 +3312,14 @@ class DeltaTableFeatureException(
     errorClass: String,
     messageParameters: Array[String] = Array.empty)
   extends DeltaRuntimeException(errorClass, messageParameters)
+
+case class DeltaUnsupportedTableFeatureException(
+    errorClass: String,
+    tableNameOrPath: String,
+    unsupported: Iterable[String])
+extends DeltaTableFeatureException(
+  errorClass,
+  Array(tableNameOrPath, io.delta.VERSION, unsupported.mkString(", ")))
 
 class DeltaRuntimeException(
     errorClass: String,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2131,17 +2131,19 @@ trait DeltaErrorsBase
   }
 
   def unsupportedReaderTableFeaturesInTableException(
+    tableNameOrPath: String,
     unsupported: Iterable[String]): DeltaTableFeatureException = {
     new DeltaTableFeatureException(
       errorClass = "DELTA_UNSUPPORTED_FEATURES_FOR_READ",
-      messageParameters = Array(unsupported.mkString(", ")))
+      messageParameters = Array(tableNameOrPath, io.delta.VERSION, unsupported.mkString(", ")))
   }
 
   def unsupportedWriterTableFeaturesInTableException(
+    tableNameOrPath: String,
     unsupported: Iterable[String]): DeltaTableFeatureException = {
     new DeltaTableFeatureException(
       errorClass = "DELTA_UNSUPPORTED_FEATURES_FOR_WRITE",
-      messageParameters = Array(unsupported.mkString(", ")))
+      messageParameters = Array(tableNameOrPath, io.delta.VERSION, unsupported.mkString(", ")))
   }
 
   def unsupportedTableFeatureConfigsException(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3317,9 +3317,9 @@ case class DeltaUnsupportedTableFeatureException(
     errorClass: String,
     tableNameOrPath: String,
     unsupported: Iterable[String])
-extends DeltaTableFeatureException(
-  errorClass,
-  Array(tableNameOrPath, io.delta.VERSION, unsupported.mkString(", ")))
+  extends DeltaTableFeatureException(
+    errorClass,
+    Array(tableNameOrPath, io.delta.VERSION, unsupported.mkString(", ")))
 
 class DeltaRuntimeException(
     errorClass: String,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -396,7 +396,7 @@ class DeltaLog private(
         Action.supportedReaderVersionNumbers.toSeq,
         Action.supportedWriterVersionNumbers.toSeq)
     } else {
-      throw unsupportedFeaturesException(clientUnsupportedFeatureNames)
+      throw unsupportedFeaturesException(dataPath.toString(), clientUnsupportedFeatureNames)
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1417,7 +1417,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       case other => other
     }
 
-    DeltaTableV2.withEnrichedInvalidProtocolVersionException(catalogTable) {
+    DeltaTableV2.withEnrichedUnsupportedTableException(catalogTable) {
       deltaLog.protocolWrite(snapshot.protocol)
     }
 
@@ -1741,7 +1741,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
         "delta.commit.retry.conflictCheck",
         tags = Map(TAG_LOG_STORE_CLASS -> deltaLog.store.getClass.getName)) {
 
-    DeltaTableV2.withEnrichedInvalidProtocolVersionException(catalogTable) {
+    DeltaTableV2.withEnrichedUnsupportedTableException(catalogTable) {
 
       val nextAttemptVersion = getNextAttemptVersion(checkVersion)
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -364,16 +364,9 @@ object DeltaTableV2 {
     try thunk catch {
       case e: InvalidProtocolVersionException if tableNameToUse.exists(_ != e.tableNameOrPath) =>
         throw e.copy(tableNameOrPath = tableNameToUse.get).initCause(e)
-      case e: DeltaTableFeatureException if Seq(
-          "DELTA_UNSUPPORTED_FEATURES_FOR_READ",
-          "DELTA_UNSUPPORTED_FEATURES_FOR_WRITE").contains(e.getErrorClass) &&
-          e.messageParameters.size == 3 &&
-          tableNameToUse.exists(_ != e.messageParameters(0)) =>
-        throw new DeltaTableFeatureException(
-          errorClass = e.getErrorClass,
-          messageParameters =
-            Array(tableNameToUse.get, e.messageParameters(1), e.messageParameters(2)))
-          .initCause(e)
+      case e: DeltaUnsupportedTableFeatureException if
+          tableNameToUse.exists(_ != e.tableNameOrPath) =>
+        throw e.copy(tableNameOrPath = tableNameToUse.get).initCause(e)
     }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -588,7 +588,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       "and writer versions 0, 1, 2, 3, 4, 5, 7. Please upgrade to a newer release."
   }
 
-  test("DeltaTableFeatureException - error message - table path") {
+  test("DeltaUnsupportedTableFeatureException - error message - table path") {
     withTempDir { path =>
       spark.range(1).write.format("delta").save(path.getCanonicalPath)
       val (deltaLog, snapshot) = DeltaLog.forTableWithSnapshot(spark, path.getCanonicalPath)
@@ -600,7 +600,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         .withReaderFeatures(Seq("NonExistingReaderFeature1", "NonExistingReaderFeature2"))
       untrackedChangeProtocolVersion(deltaLog, version, protocolReaderFeatures)
 
-      val exceptionRead = intercept[DeltaTableFeatureException] {
+      val exceptionRead = intercept[DeltaUnsupportedTableFeatureException] {
         spark.read.format("delta").load(path.getCanonicalPath)
       }
       assert(exceptionRead.getMessage ==
@@ -615,7 +615,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         .withWriterFeatures(Seq("NonExistingWriterFeature1", "NonExistingWriterFeature2"))
       untrackedChangeProtocolVersion(deltaLog, version, protocolWriterFeatures)
 
-      val exceptionWrite = intercept[DeltaTableFeatureException] {
+      val exceptionWrite = intercept[DeltaUnsupportedTableFeatureException] {
         spark.range(1).write
           .mode("append")
           .option("mergeSchema", "true")
@@ -645,7 +645,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         DeltaLog.clearCache()
       }
 
-      val exceptionRead = intercept[DeltaTableFeatureException] {
+      val exceptionRead = intercept[DeltaUnsupportedTableFeatureException] {
         spark.read.format("delta").table(featureTable)
       }
       val pathInErrorMessage = "default." + featureTable
@@ -664,7 +664,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         DeltaLog.clearCache()
       }
 
-      val exceptionWrite = intercept[DeltaTableFeatureException] {
+      val exceptionWrite = intercept[DeltaUnsupportedTableFeatureException] {
         spark.range(1).write
           .mode("append")
           .option("mergeSchema", "true")
@@ -682,15 +682,15 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     }
   }
 
-  test("DeltaTableFeatureException - error message with table name - warm") {
+  test("DeltaUnsupportedTableFeatureException - error message with table name - warm") {
     testTableFeatureErrorMessageWithTableName(true)
   }
 
-  test("DeltaTableFeatureException - error message with table name - cold") {
+  test("DeltaUnsupportedTableFeatureException - error message with table name - cold") {
     testTableFeatureErrorMessageWithTableName(false)
   }
 
-  test("DeltaTableFeatureException - " +
+  test("DeltaUnsupportedTableFeatureException - " +
     "incompatible protocol change during the transaction - table name") {
     for ((incompatibleProtocol, read) <- Seq(
         (Protocol(
@@ -714,7 +714,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         untrackedChangeProtocolVersion(deltaLog, currentVersion + 1, incompatibleProtocol)
 
         // Should detect the above incompatible feature and fail
-        val exception = intercept[DeltaTableFeatureException] {
+        val exception = intercept[DeltaUnsupportedTableFeatureException] {
           txn.commit(AddFile("test", Map.empty, 1, 1, dataChange = true) :: Nil, ManualUpdate)
         }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -2381,7 +2381,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         spark.range(0).toDF)
       assert(intercept[DeltaTableFeatureException] {
         sql(s"INSERT INTO delta.`${dir.getCanonicalPath}` VALUES (9)")
-      }.getMessage.contains(s"""unsupported by Delta Lake "${io.delta.VERSION}": "$featureName""""))
+      }.getMessage.contains(s"""unsupported by Delta Lake "${io.delta.VERSION}": $featureName"""))
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -737,7 +737,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     "[DELTA_UNSUPPORTED_FEATURES_FOR_READ] " +
     s"""Unsupported Delta read feature: table "$tableNameOrPath" """ +
     "requires reader table feature(s) that are unsupported " +
-    s"""by Delta Lake "${io.delta.VERSION}": "$unsupportedFeatures"."""
+    s"""by Delta Lake "${io.delta.VERSION}": $unsupportedFeatures."""
   }
 
   def getExpectedWriterFeatureErrorMessage(
@@ -746,7 +746,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     "[DELTA_UNSUPPORTED_FEATURES_FOR_WRITE] " +
     s"""Unsupported Delta write feature: table "$tableNameOrPath" """ +
     "requires writer table feature(s) that are unsupported " +
-    s"""by Delta Lake "${io.delta.VERSION}": "$unsupportedFeatures"."""
+    s"""by Delta Lake "${io.delta.VERSION}": $unsupportedFeatures."""
   }
 
   test("protocol downgrade is a no-op") {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Improves DELTA_UNSUPPORTED_FEATURES_FOR_READ and DELTA_UNSUPPORTED_FEATURES_FOR_WRITE error message by adding the table path/name and Delta version. Follow up of #2118
 
Resolves #2215

@ryan-johnson-databricks

Example of error message:

> org.apache.spark.sql.delta.DeltaUnsupportedTableFeatureException: [DELTA_UNSUPPORTED_FEATURES_FOR_READ] Unsupported Delta read feature: table "file:/tmp/spark-4fd41aee" requires reader table feature(s) that are unsupported by Delta Lake "3.1.0-SNAPSHOT": NonExistingReaderFeature1, NonExistingReaderFeature2.

## How was this patch tested?

Unit Tests

## Does this PR introduce _any_ user-facing changes?

Yes, the error message is improved.