### PR TITLE
[Spark] Resolve inconsistencies between the V2 Checkpoint specification and implementation

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -648,20 +648,18 @@ The schema of `sidecar` action is as follows:
 
 Field Name | Data Type | Description | optional/required
 -|-|-|-
-fileName | String | Name of the sidecar file (not a path). The file must reside in the _delta_log/_sidecars directory. | required
+path | String | URI-encoded path to the sidecar file. Because sidecar files must always reside in the table's own _delta_log/_sidecars directory, implementations are encouraged to store only the file's name (without scheme or parent directories). | required
 sizeInBytes | Long | Size of the sidecar file. | required
 modificationTime | Long | The time this logical file was created, as milliseconds since the epoch. | required
-type | String | Type of sidecar. Valid values are: "fileaction". This could be extended in future to allow different kinds of sidecars. | required
 tags|`Map[String, String]`|Map containing any additional metadata about the checkpoint sidecar file. | optional
 
 The following is an example `sidecar` action:
 ```json
 {
   "sidecar":{
-    "fileName": "016ae953-37a9-438e-8683-9a9a4a79a395.parquet",
+    "path": "016ae953-37a9-438e-8683-9a9a4a79a395.parquet",
     "sizeInBytes": 2304522,
     "modificationTime": 1512909768000,
-    "type": "fileaction",
     "tags": {}
   }
 }
@@ -673,14 +671,14 @@ It describes the details about the checkpoint. It has the following schema:
 
 Field Name | Data Type | Description | optional/required
 -|-|-|-
-flavor|`String`|The flavor of the V2 checkpoint. Allowed values: "flat".| required
+version|`Long`|The checkpoint version.| required
 tags|`Map[String, String]`|Map containing any additional metadata about the v2 spec checkpoint.| optional
 
 E.g.
 ```json
 {
   "checkpointMetadata":{
-    "flavor":"flat",
+    "version":1,
     "tags":{}
   }
 }
@@ -1124,18 +1122,18 @@ the `_last_checkpoint` file, so that readers don't have to read the V2 Checkpoin
 
 E.g. showing the content of V2 spec checkpoint:
 ```
-{"checkpointMetadata":{"flavor":"flat","tags":{}}}
+{"checkpointMetadata":{"version":364475,"tags":{}}}
 {"metaData":{...}}
 {"protocol":{...}}
 {"txn":{"appId":"3ba13872-2d47-4e17-86a0-21afd2a22395","version":364475}}
 {"txn":{"appId":"3ae45b72-24e1-865a-a211-34987ae02f2a","version":4389}}
-{"sidecar":{"path":"3a0d65cd-4056-49b8-937b-95f9e3ee90e5.parquet","sizeInBytes":2341330,"modificationTime":1512909768000,"type":"fileaction","tags":{}}
-{"sidecar":{"path":"016ae953-37a9-438e-8683-9a9a4a79a395.parquet","sizeInBytes":8468120,"modificationTime":1512909848000,"type":"fileaction","tags":{}}
+{"sidecar":{"path":"3a0d65cd-4056-49b8-937b-95f9e3ee90e5.parquet","sizeInBytes":2341330,"modificationTime":1512909768000,"tags":{}}
+{"sidecar":{"path":"016ae953-37a9-438e-8683-9a9a4a79a395.parquet","sizeInBytes":8468120,"modificationTime":1512909848000,"tags":{}}
 ```
 
 Another example of a v2 spec checkpoint without sidecars:
 ```
-{"checkpointMetadata":{"flavor":"flat","tags":{}}}
+{"checkpointMetadata":{"version":364475,"tags":{}}}
 {"metaData":{...}}
 {"protocol":{...}}
 {"txn":{"appId":"3ba13872-2d47-4e17-86a0-21afd2a22395","version":364475}}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Follow-up for https://github.com/delta-io/delta/issues/2214.

The V2 Checkpoint implementation does not match with what is expected in the PROTOCOL in some places.
It does not write some fields in the V2 Checkpoint-related actions:
1. flavor in checkpointMetadata
2. type in sidecar
Also,
3. The implementation writes a field called `version` (checkpoint version) in checkpointMetadata and relies on it but the PROTOCOL does not specify any such fields.
4. The PROTOCOL requires that the sidecar’s relative file path should be specified under the field `fileName` in the sidecar action. But the implementation writes this under the field name `path`.

This PR updates the specification so that it correctly reflects the implementation.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No