### PR TITLE
Allow specifying start snapshot in CDCReader

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
@@ -871,7 +871,7 @@ trait CDCReaderImpl extends DeltaLogging {
       spark: SparkSession,
       readSchemaSnapshot: Option[Snapshot] = None,
       useCoarseGrainedCDC: Boolean = false,
-      startVersionSnapshot: Option[Snapshot] = None): DataFrame = {
+      startVersionSnapshotOpt: Option[Snapshot] = None): DataFrame = {
 
     val changesWithinRange = deltaLog.getChanges(start).takeWhile { case (version, _) =>
       version <= end
@@ -884,7 +884,7 @@ trait CDCReaderImpl extends DeltaLogging {
       spark,
       isStreaming = false,
       useCoarseGrainedCDC = useCoarseGrainedCDC,
-      startVersionSnapshotOpt = startVersionSnapshot)
+      startVersionSnapshotOpt = startVersionSnapshotOpt)
       .fileChangeDf
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Extend `CDCReader.changesToBatchDF()` method with `startVersionSnapshotOpt` argument that allows specifying the `Snapshot` of the start version.

## How was this patch tested?

No change in existing behaviour. Existing tests are sufficient.

## Does this PR introduce _any_ user-facing changes?

No
