### PR TITLE
[Spark][Uniform]support timestamp as partition value for uniform

### DIFF
--- a/icebergShaded/iceberg_src_patches/0004-uniform-support-timestamp-as-partition-value.patch
+++ b/icebergShaded/iceberg_src_patches/0004-uniform-support-timestamp-as-partition-value.patch
@@ -1,0 +1,57 @@
+Uniform support timestamp as partition value
+---
+Index: api/src/main/java/org/apache/iceberg/types/Conversions.java
+===================================================================
+diff --git a/api/src/main/java/org/apache/iceberg/types/Conversions.java b/api/src/main/java/org/apache/iceberg/types/Conversions.java
+--- a/api/src/main/java/org/apache/iceberg/types/Conversions.java
++++ b/api/src/main/java/org/apache/iceberg/types/Conversions.java
+@@ -27,6 +27,7 @@
+ import java.nio.charset.CharsetDecoder;
+ import java.nio.charset.CharsetEncoder;
+ import java.nio.charset.StandardCharsets;
++import java.sql.Timestamp;
+ import java.util.Arrays;
+ import java.util.UUID;
+ import org.apache.iceberg.exceptions.RuntimeIOException;
+@@ -68,6 +69,8 @@
+         return new BigDecimal(asString);
+       case DATE:
+         return Literal.of(asString).to(Types.DateType.get()).value();
++      case TIMESTAMP:
++        return Timestamp.valueOf(asString);
+       default:
+         throw new UnsupportedOperationException(
+             "Unsupported type for fromPartitionString: " + type);
+diff --git a/api/src/test/java/org/apache/iceberg/types/TestConversions.java b/api/src/test/java/org/apache/iceberg/types/TestConversions.java
+--- a/api/src/test/java/org/apache/iceberg/types/TestConversions.java
++++ b/api/src/test/java/org/apache/iceberg/types/TestConversions.java
+@@ -22,7 +22,9 @@
+ import java.nio.ByteBuffer;
+ import java.nio.CharBuffer;
+ import java.nio.charset.StandardCharsets;
++import java.sql.Timestamp;
+ import java.util.UUID;
++
+ import org.apache.iceberg.expressions.Literal;
+ import org.apache.iceberg.types.Types.BinaryType;
+ import org.apache.iceberg.types.Types.BooleanType;
+@@ -182,4 +184,19 @@
+     Assert.assertArrayEquals(expectedBinary, byteBuffer.array());
+     Assert.assertEquals(value, Conversions.fromByteBuffer(type, byteBuffer));
+   }
++
++  @Test
++  public void testPartitionString() {
++    // timestamps are stored as {year}-{month}-{day} {hour}:{minute}:{second} or
++    // {year}-{month}-{day} {hour}:{minute}:{second}.{microsecond}
++    assertPartitionConversion("1970-01-01 00:00:00.001", TimestampType.withoutZone(), new Timestamp(1L));
++    assertPartitionConversion("1970-01-01 00:00:00.001", TimestampType.withZone(), new Timestamp(1L));
++    assertPartitionConversion("1970-01-01 00:00:01", TimestampType.withoutZone(), new Timestamp(1000L));
++    assertPartitionConversion("1970-01-01 00:00:01", TimestampType.withZone(), new Timestamp(1000L));
++  }
++
++  private void assertPartitionConversion(String asString, Type type, Object expectedObject) {
++    Object resultObject = Conversions.fromPartitionString(type, asString);
++    Assert.assertEquals(expectedObject, resultObject);
++  }
+ }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Support timestamp as partition value for UniForm. Now UniForm could work if a Delta table is partitioned by a timestamp field. 

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Unit test.
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Previously, the UniForm throws an exception when a Delta table is partitioned by a timestamp column and show `Error in SQL statement: UnsupportedOperationException: Unsupported type for fromPartitionString: timestamptz`. Now it could work.