### PR TITLE
[Spark] Support enable Delta Uniform on tables with DV supported but not present - part1 refactor

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -923,6 +923,16 @@
         "message" : [
           "IcebergCompatV1 requires table property '<key>' to be set to '<requiredValue>'. Current value: '<actualValue>'."
         ]
+      },
+      "ICEBERG_DELETION_VECTORS_SHOULD_BE_DISABLED" : {
+        "message" : [
+          "IcebergCompatV1 requires Deletion Vectors to be disabled on the table. Please use the ALTER TABLE DROP FEATURE command to disable Deletion Vectors and to remove the existing Deletion Vectors from the table."
+        ]
+      },
+      "ICEBERG_DELETION_VECTORS_NOT_PURGED" : {
+        "message" : [
+          "IcebergCompatV1 requires Deletion Vectors to be completely purged from the table. Please run the REORG TABLE APPLY (PURGE) command."
+        ]
       }
     },
     "sqlState" : "KD00E"

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -891,6 +891,16 @@
       "The validation of IcebergCompatV1 has failed."
     ],
     "subClass" : {
+      "DELETION_VECTORS_NOT_PURGED" : {
+        "message" : [
+          "IcebergCompatV1 requires Deletion Vectors to be completely purged from the table. Please run the REORG TABLE APPLY (PURGE) command."
+        ]
+      },
+      "DELETION_VECTORS_SHOULD_BE_DISABLED" : {
+        "message" : [
+          "IcebergCompatV1 requires Deletion Vectors to be disabled on the table. Please use the ALTER TABLE DROP FEATURE command to disable Deletion Vectors and to remove the existing Deletion Vectors from the table."
+        ]
+      },
       "DISABLING_REQUIRED_TABLE_FEATURE" : {
         "message" : [
           "IcebergCompatV1 requires feature <feature> to be supported and enabled. You cannot drop it from the table. Instead, please disable IcebergCompatV1 first."
@@ -922,16 +932,6 @@
       "WRONG_REQUIRED_TABLE_PROPERTY" : {
         "message" : [
           "IcebergCompatV1 requires table property '<key>' to be set to '<requiredValue>'. Current value: '<actualValue>'."
-        ]
-      },
-      "ICEBERG_DELETION_VECTORS_SHOULD_BE_DISABLED" : {
-        "message" : [
-          "IcebergCompatV1 requires Deletion Vectors to be disabled on the table. Please use the ALTER TABLE DROP FEATURE command to disable Deletion Vectors and to remove the existing Deletion Vectors from the table."
-        ]
-      },
-      "ICEBERG_DELETION_VECTORS_NOT_PURGED" : {
-        "message" : [
-          "IcebergCompatV1 requires Deletion Vectors to be completely purged from the table. Please run the REORG TABLE APPLY (PURGE) command."
         ]
       }
     },

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3033,6 +3033,18 @@ trait DeltaErrorsBase
     )
   }
 
+  def icebergCompatV1DeletionVectorsShouldBeDisabledException(): Throwable = {
+    new DeltaUnsupportedOperationException(
+      errorClass = "DELTA_ICEBERG_COMPAT_V1_VIOLATION.ICEBERG_DELETION_VECTORS_SHOULD_BE_DISABLED"
+    )
+  }
+
+  def icebergCompatV1DeletionVectorsNotPurgedException(): Throwable = {
+    new DeltaUnsupportedOperationException(
+      errorClass = "DELTA_ICEBERG_COMPAT_V1_VIOLATION.ICEBERG_DELETION_VECTORS_NOT_PURGED"
+    )
+  }
+
   def icebergCompatV1WrongRequiredTablePropertyException(
       key: String,
       actualValue: String,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3035,13 +3035,13 @@ trait DeltaErrorsBase
 
   def icebergCompatV1DeletionVectorsShouldBeDisabledException(): Throwable = {
     new DeltaUnsupportedOperationException(
-      errorClass = "DELTA_ICEBERG_COMPAT_V1_VIOLATION.ICEBERG_DELETION_VECTORS_SHOULD_BE_DISABLED"
+      errorClass = "DELTA_ICEBERG_COMPAT_V1_VIOLATION.DELETION_VECTORS_SHOULD_BE_DISABLED"
     )
   }
 
   def icebergCompatV1DeletionVectorsNotPurgedException(): Throwable = {
     new DeltaUnsupportedOperationException(
-      errorClass = "DELTA_ICEBERG_COMPAT_V1_VIOLATION.ICEBERG_DELETION_VECTORS_NOT_PURGED"
+      errorClass = "DELTA_ICEBERG_COMPAT_V1_VIOLATION.DELETION_VECTORS_NOT_PURGED"
     )
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/IcebergCompatV1.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/IcebergCompatV1.scala
@@ -144,14 +144,8 @@ object IcebergCompatV1 extends DeltaLogging {
         // Deletion Vectors cannot be writeable; Note concurrent txns are also convered
         // to NOT write deletion vectors as that txn would need to make DVs writable, which
         // would conflict with current txn because of metadata change.
-        // If Deletion Vector is not writable but supported, check if Deletion Vectors are
-        // completely purged from the table.
         if (DeletionVectorUtils.deletionVectorsWritable(newestProtocol, newestMetadata)) {
           throw DeltaErrors.icebergCompatV1DeletionVectorsShouldBeDisabledException()
-        }
-        if (newestProtocol.isFeatureSupported(DeletionVectorsTableFeature) &&
-          !DeletionVectorsTableFeature.validateRemoval(prevSnapshot)) {
-          throw DeltaErrors.icebergCompatV1DeletionVectorsNotPurgedException()
         }
 
         // Check we have all required delta table properties

--- a/spark/src/main/scala/org/apache/spark/sql/delta/IcebergCompatV1.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/IcebergCompatV1.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.delta.actions.{Action, AddFile, Metadata, Protocol}
+import org.apache.spark.sql.delta.commands.DeletionVectorUtils
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.SchemaUtils
 
@@ -36,8 +37,6 @@ import org.apache.spark.sql.types.{ArrayType, MapType, NullType}
 object IcebergCompatV1 extends DeltaLogging {
 
   val REQUIRED_TABLE_FEATURES = Seq(ColumnMappingTableFeature)
-
-  val INCOMPATIBLE_TABLE_FEATURES = Seq(DeletionVectorsTableFeature)
 
   val REQUIRED_DELTA_TABLE_PROPERTIES = Seq(
     RequiredDeltaTableProperty(
@@ -70,12 +69,13 @@ object IcebergCompatV1 extends DeltaLogging {
    *         updates need to be applied, will return None.
    */
   def enforceInvariantsAndDependencies(
-      prevProtocol: Protocol,
-      prevMetadata: Metadata,
+      prevSnapshot: Snapshot,
       newestProtocol: Protocol,
       newestMetadata: Metadata,
       isCreatingNewTable: Boolean,
       actions: Seq[Action]): (Option[Protocol], Option[Metadata]) = {
+    val prevProtocol = prevSnapshot.protocol
+    val prevMetadata = prevSnapshot.metadata
     val wasEnabled = IcebergCompatV1.isEnabled(prevMetadata)
     val isEnabled = IcebergCompatV1.isEnabled(newestMetadata)
     val tableId = newestMetadata.id
@@ -140,11 +140,18 @@ object IcebergCompatV1 extends DeltaLogging {
           }
         }
 
-        // Check we haven't added any incompatible table features
-        INCOMPATIBLE_TABLE_FEATURES.foreach { f =>
-          if (newestProtocol.isFeatureSupported(f)) {
-            throw DeltaErrors.icebergCompatV1IncompatibleTableFeatureException(f)
-          }
+        // Check for incompatible table features;
+        // Deletion Vectors cannot be writeable; Note concurrent txns are also convered
+        // to NOT write deletion vectors as that txn would need to make DVs writable, which
+        // would conflict with current txn because of metadata change.
+        // If Deletion Vector is not writable but supported, check if Deletion Vectors are
+        // completely purged from the table.
+        if (DeletionVectorUtils.deletionVectorsWritable(newestProtocol, newestMetadata)) {
+          throw DeltaErrors.icebergCompatV1DeletionVectorsShouldBeDisabledException()
+        }
+        if (newestProtocol.isFeatureSupported(DeletionVectorsTableFeature) &&
+          !DeletionVectorsTableFeature.validateRemoval(prevSnapshot)) {
+          throw DeltaErrors.icebergCompatV1DeletionVectorsNotPurgedException()
         }
 
         // Check we have all required delta table properties

--- a/spark/src/main/scala/org/apache/spark/sql/delta/IcebergCompatV1.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/IcebergCompatV1.scala
@@ -141,7 +141,7 @@ object IcebergCompatV1 extends DeltaLogging {
         }
 
         // Check for incompatible table features;
-        // Deletion Vectors cannot be writeable; Note concurrent txns are also convered
+        // Deletion Vectors cannot be writeable; Note that concurrent txns are also covered
         // to NOT write deletion vectors as that txn would need to make DVs writable, which
         // would conflict with current txn because of metadata change.
         if (DeletionVectorUtils.deletionVectorsWritable(newestProtocol, newestMetadata)) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1345,8 +1345,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
     newMetadata = metadataUpdate1.orElse(newMetadata)
 
     val (protocolUpdate2, metadataUpdate2) = IcebergCompatV1.enforceInvariantsAndDependencies(
-      prevProtocol = snapshot.protocol,
-      prevMetadata = snapshot.metadata,
+      snapshot,
       newestProtocol = protocol, // Note: this will try to use `newProtocol`
       newestMetadata = metadata, // Note: this will try to use `newMetadata`
       isCreatingNewTable,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
@@ -152,7 +152,8 @@ object UniversalFormat extends DeltaLogging {
    * @param writer delta writer used to write CTAS data.
    * @return updated writer
    */
-  def enforceInvariantsAndDependenciesForCTAS(writer: WriteIntoDelta): WriteIntoDelta = {
+  def enforceInvariantsAndDependenciesForCTAS(
+      writer: WriteIntoDelta, snapshot: Snapshot): WriteIntoDelta = {
     var metadata = Metadata(configuration = writer.configuration)
 
     // Check UniversalFormat related property dependencies
@@ -168,8 +169,7 @@ object UniversalFormat extends DeltaLogging {
 
     // UniversalFormat relies on IcebergV1, check its dependencies
     val (_, icebergMetadata) = IcebergCompatV1.enforceInvariantsAndDependencies(
-      prevProtocol = Protocol(),
-      prevMetadata = Metadata(),
+      prevSnapshot = snapshot,
       newestProtocol = Protocol(),
       newestMetadata = metadata,
       isCreatingNewTable = true,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -247,7 +247,8 @@ case class CreateDeltaTableCommand(
       (actions, op)
     }
 
-    val updatedWriter = UniversalFormat.enforceInvariantsAndDependenciesForCTAS(deltaWriter)
+    val updatedWriter =
+      UniversalFormat.enforceInvariantsAndDependenciesForCTAS(deltaWriter, txn.snapshot)
 
     // We are either appending/overwriting with saveAsTable or creating a new table with CTAS
     if (!hasBeenExecuted(txn, sparkSession, Some(options))) {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaThrowableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaThrowableSuite.scala
@@ -82,7 +82,7 @@ class DeltaThrowableSuite extends SparkFunSuite {
     checkCondition(errorClasses ++ errorMsgs, s => !s.toLowerCase().contains("databricks"))
   }
 
-  test("Delta error classes are correctly formatted") {
+  test("Delta error classes are correctly formatted with keys in alphabetical order") {
     lazy val ossDeltaErrorFile = new File(getWorkspaceFilePath(
       "delta", "core", "src", "main", "resources", "error").toFile,
       "delta-error-classes.json")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Support enable Delta Uniform on tables with DV enabled but not present. Note this is mainly a refactor and the actual logic change will come later. 

## How was this patch tested?

Unit test

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No