### PR TITLE
[Spark] Minor refactor to Merge test utils

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoTestUtils.scala
@@ -95,12 +95,18 @@ trait MergeIntoSQLTestUtils extends SQLTestUtils with MergeIntoTestUtils {
       insert: String): Unit =
     sql(basicMergeStmt(target, source, condition, update, insert))
 
+  protected def mergeStmt(
+      target: String,
+      source: String,
+      condition: String,
+      clauses: MergeClause*): String =
+    s"MERGE INTO $target USING $source ON $condition\n" + clauses.map(_.sql).mkString("\n")
+
   override protected def executeMerge(
       tgt: String,
       src: String,
       cond: String,
-      clauses: MergeClause*): Unit =
-    sql(s"MERGE INTO $tgt USING $src ON $cond\n" + clauses.map(_.sql).mkString("\n"))
+      clauses: MergeClause*): Unit = sql(mergeStmt(tgt, src, cond, clauses: _*))
 }
 
 trait MergeIntoScalaTestUtils extends MergeIntoTestUtils {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Minor refactor in MergeIntoSQLTestUtils to allow using helpers in suites that want to generate SQL test for MERGE commands but don't use executeMerge helper.


## How was this patch tested?

Existing tests.