### PR TITLE
[Spark] Add Feature Phaseout support for V2 Checkpoints

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -527,6 +527,7 @@ object IcebergCompatV1TableFeature extends WriterFeature(name = "icebergCompatV1
  */
 object V2CheckpointTableFeature
   extends ReaderWriterFeature(name = "v2Checkpoint")
+  with RemovableFeature
   with FeatureAutomaticallyEnabledByMetadata {
 
   override def automaticallyUpdateProtocolOfExistingTables: Boolean = true
@@ -537,6 +538,31 @@ object V2CheckpointTableFeature
   override def metadataRequiresFeatureToBeEnabled(
       metadata: Metadata,
       spark: SparkSession): Boolean = isV2CheckpointSupportNeededByMetadata(metadata)
+
+  override def validateRemoval(snapshot: Snapshot): Boolean = {
+    // Fail validation if v2 checkpoints are still enabled in the current snapshot
+    if (isV2CheckpointSupportNeededByMetadata(snapshot.metadata)) return false
+
+    // Validation also fails if the current snapshot might depend on a v2 checkpoint.
+    // NOTE: Empty and preloaded checkpoint providers never reference v2 checkpoints.
+    snapshot.checkpointProvider match {
+      case p if p.isEmpty => true
+      case _: PreloadedCheckpointProvider => true
+      case lazyProvider: LazyCompleteCheckpointProvider =>
+        lazyProvider.underlyingCheckpointProvider.isInstanceOf[PreloadedCheckpointProvider]
+      case _ => false
+    }
+  }
+
+  override def actionUsesFeature(action: Action): Boolean = action match {
+    case m: Metadata => isV2CheckpointSupportNeededByMetadata(m)
+    case _: CheckpointMetadata => true
+    case _: SidecarFile => true
+    case _ => false
+  }
+
+  override def preDowngradeCommand(table: DeltaTableV2): PreDowngradeTableFeatureCommand =
+    V2CheckpointPreDowngradeCommand(table)
 }
 
 /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -31,11 +31,13 @@ import org.apache.spark.sql.delta.commands.{AlterTableDropFeatureDeltaCommand, A
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
+import org.apache.spark.sql.delta.util.FileNames
 import org.apache.spark.sql.delta.util.FileNames.{deltaFile, DeltaFile}
 import org.apache.spark.sql.delta.util.JsonUtils
 
 import org.apache.spark.{SparkConf, SparkThrowable}
 import org.apache.spark.sql.{AnalysisException, QueryTest, SaveMode}
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.util.DateTimeConstants
 import org.apache.spark.sql.execution.streaming.MemoryStream
@@ -3137,6 +3139,139 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       featuresToAdd = Seq(TestRemovableReaderWriterFeature, TestRemovableWriterFeature),
       featuresToRemove = Seq(TestRemovableWriterFeature),
       expectedDowngradedProtocol = protocolWithReaderFeature(TestRemovableReaderWriterFeature))
+  }
+
+  private def dropV2CheckpointsTableFeature(spark: SparkSession, log: DeltaLog): Unit = {
+    spark.sql(s"ALTER TABLE delta.`${log.dataPath}` DROP FEATURE " +
+      s"`${V2CheckpointTableFeature.name}`")
+  }
+
+  private def testV2CheckpointTableFeatureDrop(
+      v2CheckpointFormat: V2Checkpoint.Format,
+      withInitialV2Checkpoint: Boolean,
+      forceMultiPartCheckpoint: Boolean = false): Unit = {
+    var confs = Seq(
+      DeltaConfigs.CHECKPOINT_POLICY.defaultTablePropertyKey -> CheckpointPolicy.V2.name,
+      DeltaSQLConf.CHECKPOINT_V2_TOP_LEVEL_FILE_FORMAT.key -> v2CheckpointFormat.name
+    )
+    val expectedClassicCheckpointType = if (forceMultiPartCheckpoint) {
+      confs :+= DeltaSQLConf.DELTA_CHECKPOINT_PART_SIZE.key -> "1"
+      CheckpointInstance.Format.WITH_PARTS
+    } else {
+      CheckpointInstance.Format.SINGLE
+    }
+    withSQLConf(confs: _*) {
+      withTempPath { dir =>
+        val clock = new ManualClock(System.currentTimeMillis())
+        val targetLog = DeltaLog.forTable(spark, dir, clock)
+        val defaultRetentionPeriod =
+          DeltaConfigs.LOG_RETENTION.fromMetaData(targetLog.update().metadata).toString
+
+        val targetDF = spark.range(start = 0, end = 100, step = 1, numPartitions = 2)
+        targetDF.write.format("delta").save(dir.toString)
+
+        val initialCheckpointCount = if (withInitialV2Checkpoint) 1 else 0
+
+        if (withInitialV2Checkpoint) {
+          // Create a v2 checkpoint.
+          targetLog.checkpoint()
+        }
+
+        // Assert that the current checkpointing policy requires v2 checkpoint support.
+        val preDowngradeSnapshot = targetLog.update()
+        assert(
+          DeltaConfigs.CHECKPOINT_POLICY
+            .fromMetaData(preDowngradeSnapshot.metadata)
+            .needsV2CheckpointSupport)
+        val checkpointFiles = targetLog.listFrom(0).filter(FileNames.isCheckpointFile)
+        assert(checkpointFiles.length == initialCheckpointCount)
+        checkpointFiles.foreach { f =>
+          assert(CheckpointInstance(f.getPath).format == CheckpointInstance.Format.V2)
+        }
+
+        // Dropping the feature should fail because
+        // 1. The checkpointing policy in metadata requires v2 checkpoint support.
+        // 2. Also, when initialCheckpointCount = true, there is a v2 checkpoint.
+        val e1 = intercept[DeltaTableFeatureException] {
+          dropV2CheckpointsTableFeature(spark, targetLog)
+        }
+        checkError(
+          exception = e1,
+          errorClass = "DELTA_FEATURE_DROP_WAIT_FOR_RETENTION_PERIOD",
+          parameters = Map(
+            "feature" -> V2CheckpointTableFeature.name,
+            "logRetentionPeriodKey" -> "delta.logRetentionDuration",
+            "logRetentionPeriod" -> defaultRetentionPeriod,
+            "truncateHistoryLogRetentionPeriod" -> truncateHistoryDefaultLogRetention.toString))
+
+        val postCleanupCheckpointFiles =
+          targetLog.listFrom(0).filter(FileNames.isCheckpointFile).toList
+
+        // Assert that a new classic checkpoint has been created.
+        val uniqueCheckpointCount = postCleanupCheckpointFiles
+          .drop(initialCheckpointCount)
+          .map { checkpointFile =>
+            val checkpointInstance = CheckpointInstance(checkpointFile.getPath)
+
+            assert(checkpointInstance.format == expectedClassicCheckpointType)
+
+            checkpointInstance.version
+          }
+          // Count a multi-part checkpoint as a single checkpoint.
+          .toSet.size
+        // Drop feature command generates one classic checkpoints after v2 checkpoint cleanup.
+        val expectedClassicCheckpointCount = 1
+        assert(uniqueCheckpointCount == expectedClassicCheckpointCount)
+
+        spark.range(100, 120).write.format("delta").mode("append").save(dir.getCanonicalPath)
+
+        // V2 Checkpoint related traces have not been cleaned up yet. Attempt should fail.
+        val e2 = intercept[DeltaTableFeatureException] {
+          dropV2CheckpointsTableFeature(spark, targetLog)
+        }
+        checkError(
+          exception = e2,
+          errorClass = "DELTA_FEATURE_DROP_HISTORICAL_VERSIONS_EXIST",
+          parameters = Map(
+            "feature" -> V2CheckpointTableFeature.name,
+            "logRetentionPeriodKey" -> "delta.logRetentionDuration",
+            "logRetentionPeriod" -> defaultRetentionPeriod,
+            "truncateHistoryLogRetentionPeriod" -> truncateHistoryDefaultLogRetention.toString))
+
+        // Pretend retention period has passed.
+        clock.advance(
+          targetLog.deltaRetentionMillis(targetLog.update().metadata) +
+            TimeUnit.HOURS.toMillis(1))
+
+        // History is now clean. We should be able to remove the feature.
+        dropV2CheckpointsTableFeature(spark, targetLog)
+
+        val postDowngradeSnapshot = targetLog.update()
+        val protocol = postDowngradeSnapshot.protocol
+        assert(!protocol.readerFeatureNames.contains(V2CheckpointTableFeature.name))
+        assert(
+          !DeltaConfigs.CHECKPOINT_POLICY
+            .fromMetaData(postDowngradeSnapshot.metadata)
+            .needsV2CheckpointSupport)
+        assert(targetLog.listFrom(0).filter(FileNames.isCheckpointFile).forall { f =>
+          CheckpointInstance(f.getPath).format == expectedClassicCheckpointType
+        })
+      }
+    }
+  }
+
+  for (
+    v2CheckpointFormat <- V2Checkpoint.Format.ALL;
+    withInitialV2Checkpoint <- BOOLEAN_DOMAIN)
+  test(s"Remove v2 Checkpoints Feature [v2CheckpointFormat: ${v2CheckpointFormat.name}; " +
+      s"withInitialV2Checkpoint: $withInitialV2Checkpoint; forceMultiPartCheckpoint: false]") {
+    testV2CheckpointTableFeatureDrop(v2CheckpointFormat, withInitialV2Checkpoint)
+  }
+
+  test(
+    s"Remove v2 Checkpoints Feature [v2CheckpointFormat: ${V2Checkpoint.Format.PARQUET.name}; " +
+      s"withInitialV2Checkpoint: true; forceMultiPartCheckpoint: true]") {
+    testV2CheckpointTableFeatureDrop(V2Checkpoint.Format.PARQUET, true, true)
   }
 
   private def assertPropertiesAndShowTblProperties(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Follow up for https://github.com/delta-io/delta/issues/2270. This PR adds table table feature phaseout support for V2 checkpoints. Users can now downgrade their tables from v2 checkpoints to classic checkpoints allowing older clients to interact with these tables.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Added new unit tests.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, users can now run `ALTER table_name DROP FEATURE v2Checkpoint` to drop the V2 Checkpoint feature.