### PR TITLE
[Spark] Add two error classes for Deletion Vector integrity checks

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2910,6 +2910,14 @@ trait DeltaErrorsBase
       pos = 0)
   }
 
+  def deletionVectorNonIncrementalUpdate(): Throwable = {
+    new DeltaIllegalStateException(errorClass = "DELTA_DELETION_VECTOR_NON_INCREMENTAL_UPDATE")
+  }
+
+  def deletionVectorOverlappingRows(): Throwable = {
+    new DeltaIllegalStateException(errorClass = "DELTA_DELETION_VECTOR_OVERLAPPING_ROWS")
+  }
+
   def statsRecomputeNotSupportedOnDvTables(): Throwable = {
     new DeltaCommandUnsupportedWithDeletionVectorsException(
       errorClass = "DELTA_UNSUPPORTED_STATS_RECOMPUTE_WITH_DELETION_VECTORS",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/deletionvectors/StoredBitmap.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/deletionvectors/StoredBitmap.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta.deletionvectors
 
 import java.io.{IOException, ObjectInputStream}
 
-import org.apache.spark.sql.delta.DeltaErrorsBase
+import org.apache.spark.sql.delta.DeltaErrors
 import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
@@ -63,7 +63,7 @@ trait StoredBitmap {
 case class DeletionVectorStoredBitmap(
     dvDescriptor: DeletionVectorDescriptor,
     tableDataPath: Option[Path] = None
-) extends StoredBitmap with DeltaLogging with DeltaErrorsBase {
+) extends StoredBitmap with DeltaLogging {
   require(tableDataPath.isDefined || !dvDescriptor.isOnDisk,
     "Table path is required for on-disk deletion vectors")
 
@@ -87,7 +87,7 @@ case class DeletionVectorStoredBitmap(
           "deletionVectorCardinality" -> bitmap.cardinality,
           "deletionVectorDescriptor" -> dvDescriptor),
         path = tableDataPath)
-      throw deletionVectorCardinalityMismatch()
+      throw DeltaErrors.deletionVectorCardinalityMismatch()
     }
 
     bitmap


### PR DESCRIPTION

#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Add the error classes for `DELTA_DELETION_VECTOR_NON_INCREMENTAL_UPDATE` and `DELTA_DELETION_VECTOR_OVERLAPPING_ROWS` integrity checks.


## How was this patch tested?

Existing tests.

## Does this PR introduce _any_ user-facing changes?

No
