### PR TITLE
[Spark] Remove two unused methods in DeltaErrors.scala

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2910,14 +2910,6 @@ trait DeltaErrorsBase
       pos = 0)
   }
 
-  def deletionVectorNonIncrementalUpdate(): Throwable = {
-    new DeltaIllegalStateException(errorClass = "DELTA_DELETION_VECTOR_NON_INCREMENTAL_UPDATE")
-  }
-
-  def deletionVectorOverlappingRows(): Throwable = {
-    new DeltaIllegalStateException(errorClass = "DELTA_DELETION_VECTOR_OVERLAPPING_ROWS")
-  }
-
   def statsRecomputeNotSupportedOnDvTables(): Throwable = {
     new DeltaCommandUnsupportedWithDeletionVectorsException(
       errorClass = "DELTA_UNSUPPORTED_STATS_RECOMPUTE_WITH_DELETION_VECTORS",


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Remove two unused methods in DeltaErrors.scala

## How was this patch tested?

N/A