### PR TITLE
[Spark] Base merge schema evolution off set expressions, not source schema

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/deltaMerge.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/deltaMerge.scala
@@ -591,7 +591,7 @@ object DeltaMergeInto {
         case (schema, DeltaMergeAction(targetColNameParts, expr, _)) =>
           // Generate the schema for this target assignment
           var assignmentSchema =
-            StructType(StructField(targetColNameParts.last, expr.dataType.asNullable) :: Nil)
+            StructType(StructField(targetColNameParts.last, expr.dataType) :: Nil)
           assignmentSchema = targetColNameParts.init.foldRight(assignmentSchema) {
             case (part, schema) =>
               StructType(StructField(part, schema) :: Nil)

--- a/spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/deltaMerge.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/deltaMerge.scala
@@ -590,13 +590,11 @@ object DeltaMergeInto {
       actions.foldLeft(target.schema) {
         case (schema, DeltaMergeAction(targetColNameParts, expr, _)) =>
           // Generate the schema for this target assignment
-          var assignmentSchema = StructType(StructField(targetColNameParts.last, expr.dataType,
-            expr.nullable) :: Nil)
+          var assignmentSchema =
+            StructType(StructField(targetColNameParts.last, expr.dataType) :: Nil)
           assignmentSchema = targetColNameParts.init.foldRight(assignmentSchema) {
             case (part, schema) =>
-              // We will always write the outer structs when writing to an inner field, so we can
-              // set it to non-nullable
-              StructType(StructField(part, schema, false) :: Nil)
+              StructType(StructField(part, schema) :: Nil)
           }
           // The implicit conversions flag allows any type to be merged from source to target if
           // Spark SQL considers the source type implicitly castable to the target. Normally,

--- a/spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/deltaMerge.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/deltaMerge.scala
@@ -601,7 +601,7 @@ object DeltaMergeInto {
           SchemaMergingUtils.mergeSchemas(
             schema,
             assignmentSchema,
-            allowTypeCoersion = true
+            allowTypeCoercion = true
           )
       }
       // The implicit conversions flag allows any type to be merged from source to target if

--- a/spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/deltaMerge.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/deltaMerge.scala
@@ -591,7 +591,7 @@ object DeltaMergeInto {
         case (schema, DeltaMergeAction(targetColNameParts, expr, _)) =>
           // Generate the schema for this target assignment
           var assignmentSchema =
-            StructType(StructField(targetColNameParts.last, expr.dataType) :: Nil)
+            StructType(StructField(targetColNameParts.last, expr.dataType.asNullable) :: Nil)
           assignmentSchema = targetColNameParts.init.foldRight(assignmentSchema) {
             case (part, schema) =>
               StructType(StructField(part, schema) :: Nil)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaMergingUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaMergingUtils.scala
@@ -157,7 +157,7 @@ object SchemaMergingUtils {
    *                                 the same way in Parquet files. With this flag enabled, the
    *                                 merge will succeed, because once we get to write time Spark SQL
    *                                 will support implicitly converting the int to a string.
-   * @param allowTypeCoersion Whether to allow type coersion using Spark's AnsiTypeCoersion when
+   * @param allowTypeCoercion Whether to allow type coersion using Spark's AnsiTypeCoersion when
    *                          merging fields. This can be used to resolve different types for a new
    *                          field being added, such as in a merge, before combining the new type
    *                          with the existing table schema using implicit casting.
@@ -170,7 +170,7 @@ object SchemaMergingUtils {
       tableSchema: StructType,
       dataSchema: StructType,
       allowImplicitConversions: Boolean = false,
-      allowTypeCoersion: Boolean = false,
+      allowTypeCoercion: Boolean = false,
       keepExistingType: Boolean = false,
       fixedTypeColumns: Set[String] = Set.empty,
       caseSensitive: Boolean = false): StructType = {
@@ -233,7 +233,7 @@ object SchemaMergingUtils {
         // Simply keeps the existing type for primitive types
         case (current, update) if keepExistingType => current
 
-        case (current, update) if allowTypeCoersion &&
+        case (current, update) if allowTypeCoercion &&
             TypeCoercion.findWiderTypeForTwo(current, update).isDefined =>
           TypeCoercion.findWiderTypeForTwo(current, update).get
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaMergingUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaMergingUtils.scala
@@ -157,23 +157,23 @@ object SchemaMergingUtils {
    *                                 the same way in Parquet files. With this flag enabled, the
    *                                 merge will succeed, because once we get to write time Spark SQL
    *                                 will support implicitly converting the int to a string.
-   * @param allowTypeCoercion Whether to allow type coersion using Spark's AnsiTypeCoersion when
-   *                          merging fields. This can be used to resolve different types for a new
-   *                          field being added, such as in a merge, before combining the new type
-   *                          with the existing table schema using implicit casting.
    * @param keepExistingType Whether to keep existing types instead of trying to merge types.
    * @param fixedTypeColumns The set of columns whose type should not be changed in any case.
    * @param caseSensitive Whether we should keep field mapping case-sensitively.
    *                      This should default to false for Delta, which is case insensitive.
+   * @param allowTypeCoercion Whether to allow type coersion using Spark's TypeCoercion when
+   *                          merging fields. This can be used to resolve different types for a new
+   *                          field being added, such as in a merge, before combining the new type
+   *                          with the existing table schema using implicit casting.
    */
   def mergeSchemas(
       tableSchema: StructType,
       dataSchema: StructType,
       allowImplicitConversions: Boolean = false,
-      allowTypeCoercion: Boolean = false,
       keepExistingType: Boolean = false,
       fixedTypeColumns: Set[String] = Set.empty,
-      caseSensitive: Boolean = false): StructType = {
+      caseSensitive: Boolean = false,
+      allowTypeCoercion: Boolean = false): StructType = {
     checkColumnNameDuplication(dataSchema, "in the data to save", caseSensitive)
     def merge(
         current: DataType,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1409,7 +1409,7 @@ trait DeltaErrorsSuiteBase
       val e = intercept[DeltaAnalysisException] {
         val s1 = StructType(Seq(StructField("c0", IntegerType, true)))
         val s2 = StructType(Seq(StructField("c0", StringType, false)))
-        SchemaMergingUtils.mergeSchemas(s1, s2, fixedTypeColumns = Set("c0"))
+        SchemaMergingUtils.mergeSchemas(s1, s2, false, false, Set("c0"))
       }
       checkErrorMessage(e, Some("DELTA_GENERATED_COLUMNS_DATA_TYPE_MISMATCH"), Some("42K09"),
         Some("Column c0 is a generated column or a column used by a generated " +

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1409,7 +1409,7 @@ trait DeltaErrorsSuiteBase
       val e = intercept[DeltaAnalysisException] {
         val s1 = StructType(Seq(StructField("c0", IntegerType, true)))
         val s2 = StructType(Seq(StructField("c0", StringType, false)))
-        SchemaMergingUtils.mergeSchemas(s1, s2, false, false, Set("c0"))
+        SchemaMergingUtils.mergeSchemas(s1, s2, fixedTypeColumns = Set("c0"))
       }
       checkErrorMessage(e, Some("DELTA_GENERATED_COLUMNS_DATA_TYPE_MISMATCH"), Some("42K09"),
         Some("Column c0 is a generated column or a column used by a generated " +

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSchemaEvolutionSuite.scala
@@ -3048,6 +3048,7 @@ trait MergeIntoNestedStructEvolutionTests {
       SQLConf.STORE_ASSIGNMENT_POLICY.key -> StoreAssignmentPolicy.STRICT.toString,
       DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key -> "false"))
 
+  // scalastyle:off line.size.limit
   testNestedStructsEvolution("new column type reconciliation in array struct value")(
     target = """{ "key": "A", "value": [ { "a": 1 } ] }""",
     source = """{ "key": "A", "value1": [ { "a": 2, "b": 2 } ], "value2": [ { "a": 2, "b": "2" } ] }""",
@@ -3075,4 +3076,5 @@ trait MergeIntoNestedStructEvolutionTests {
     clauses = update(condition = "s.key = 'A'", set = "value = s.value1") :: update("value = s.value2") :: Nil,
     result = """{ "key": "A", "value": [ { "a": 2, "b": "2" } ] }""",
     expectErrorWithoutEvolutionContains = "cannot cast")
+  // scalastyle:on line.size.limit
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSchemaEvolutionSuite.scala
@@ -953,6 +953,71 @@ trait MergeIntoSchemaEvolutionBaseTests {
     expectErrorContains = "Cannot add column 'extra' with type 'void'",
     expectedWithoutEvolution = Seq((1, 100), (2, 200)).toDF("key", "value")
   )
+
+  // scalastyle:off line.size.limit
+  testEvolution("new column type reconciliation - int and string resolves to int")(
+    targetData = Seq((1)).toDF("key"),
+    sourceData = Seq((1, 2, "val")).toDF("key", "value1", "value2"),
+    clauses = update(condition = "s.key < 2", set = "value = s.value1"):: update(set = "value = s.value2") :: Nil,
+    expected = Seq((1, 2)).toDF("key", "value"),
+    expectErrorWithoutEvolutionContains = "cannot resolve value in UPDATE clause"
+  )
+
+  testEvolution("new column type reconciliation - string and int resolves to string")(
+    targetData = Seq((1)).toDF("key"),
+    sourceData = Seq((1, 2, "val")).toDF("key", "value1", "value2"),
+    clauses = update(condition = "s.key < 2", set = "value = s.value2") :: update(set = "value = s.value1") :: Nil,
+    expected = Seq((1, "val")).toDF("key", "value"),
+    expectErrorWithoutEvolutionContains = "cannot resolve value in UPDATE clause"
+  )
+
+  testEvolution("new column type reconciliation - int and long resolves to int")(
+    targetData = Seq((1)).toDF("key"),
+    sourceData = Seq((1, 2, 3L)).toDF("key", "value1", "value2"),
+    clauses = update(condition = "s.key < 2", set = "value = s.value1") :: update(set = "value = s.value2") :: Nil,
+    expected = Seq((1, 2)).toDF("key", "value"),
+    expectErrorWithoutEvolutionContains = "cannot resolve value in UPDATE clause"
+  )
+
+  testEvolution("new column type reconciliation - long and int resolves to long")(
+    targetData = Seq((1)).toDF("key"),
+    sourceData = Seq((1, 2, 3L)).toDF("key", "value1", "value2"),
+    clauses = update(condition = "s.key < 2", set = "value = s.value2") :: update(set = "value = s.value1") :: Nil,
+    expected = Seq((1, 3L)).toDF("key", "value"),
+    expectErrorWithoutEvolutionContains = "cannot resolve value in UPDATE clause"
+  )
+
+  testEvolution("new column type reconciliation - array and int fails")(
+    targetData = Seq((1)).toDF("key"),
+    sourceData = Seq((1, Seq(2), 3)).toDF("key", "value1", "value2"),
+    clauses = update(condition = "s.key < 2", set = "value = s.value1") :: update(set = "value = s.value2") :: Nil,
+    expectErrorContains = "Failed to merge incompatible data types",
+    expectErrorWithoutEvolutionContains = "cannot resolve value in UPDATE clause"
+  )
+
+  testEvolution("new column type reconciliation - timestamp and timestamp_ntz resolves to timestamp")(
+    targetData = Seq((1)).toDF("key"),
+    sourceData = Seq((1, "2000-01-01 00:00:00", "2000-01-02 00:00:00"))
+      .toDF("key", "value1", "value2")
+      .withColumns(Seq("value1", "value2"), Seq('value1.cast("timestamp"), 'value2.cast("timestamp_ntz"))),
+    clauses = update(condition = "s.key < 2", set = "value = s.value1") :: update(set = "value = s.value2") :: Nil,
+    expected = Seq((1, "2000-01-01 00:00:00")).toDF("key", "value").withColumn("value", 'value.cast("timestamp")),
+    expectErrorWithoutEvolutionContains = "cannot resolve value in UPDATE clause"
+  )
+
+  testEvolution("new column type reconciliation - timestamp_ntz and timestamp resolves to timestamp_ntz")(
+    // Include a timestamp_ntz column in original data to force timestamp_ntz table feature
+    targetData = Seq((1, "1999-01-01 00:00:00")).toDF("key", "unused").withColumn("unused", 'unused.cast("timestamp_ntz")),
+    sourceData = Seq((1, "2000-01-01 00:00:00", "2000-01-02 00:00:00"))
+      .toDF("key", "value1", "value2")
+      .withColumns(Seq("value1", "value2"), Seq('value1.cast("timestamp"), 'value2.cast("timestamp_ntz"))),
+    clauses = update(condition = "s.key < 2", set = "value = s.value2") :: update(set = "value = s.value1") :: Nil,
+    expected = Seq((1, "1999-01-01 00:00:00", "2000-01-02 00:00:00"))
+      .toDF("key", "unused", "value")
+      .withColumns(Seq("unused", "value"), Seq('unused.cast("timestamp_ntz"), 'value.cast("timestamp_ntz"))),
+    expectErrorWithoutEvolutionContains = "cannot resolve value in UPDATE clause"
+  )
+  // scalastyle:on line.size.limit
 }
 
 /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSchemaEvolutionSuite.scala
@@ -955,10 +955,18 @@ trait MergeIntoSchemaEvolutionBaseTests {
   )
 
   // scalastyle:off line.size.limit
+  testEvolution("existing columns use current type - string and bool")(
+    targetData = Seq((1, "false")).toDF("key", "value"),
+    sourceData = Seq((1, "true", false)).toDF("key", "value1", "value2"),
+    clauses = update(condition = "s.key < 2", set = "value = s.value1") :: update(set = "value = s.value2") :: Nil,
+    expected = Seq((1, "true")).toDF("key", "value"),
+    expectedWithoutEvolution = Seq((1, "true")).toDF("key", "value"),
+  )
+
   testEvolution("new column type reconciliation - int and string resolves to string")(
     targetData = Seq((1)).toDF("key"),
     sourceData = Seq((1, 2, "val")).toDF("key", "value1", "value2"),
-    clauses = update(condition = "s.key < 2", set = "value = s.value1"):: update(set = "value = s.value2") :: Nil,
+    clauses = update(condition = "s.key < 2", set = "value = s.value1") :: update(set = "value = s.value2") :: Nil,
     expected = Seq((1, "2")).toDF("key", "value"),
     expectErrorWithoutEvolutionContains = "cannot resolve value in UPDATE clause"
   )
@@ -974,7 +982,7 @@ trait MergeIntoSchemaEvolutionBaseTests {
   testEvolution("new column type reconciliation - double and string resolves to string")(
     targetData = Seq((1)).toDF("key"),
     sourceData = Seq((1, 2.0, "val")).toDF("key", "value1", "value2"),
-    clauses = update(condition = "s.key < 2", set = "value = s.value1"):: update(set = "value = s.value2") :: Nil,
+    clauses = update(condition = "s.key < 2", set = "value = s.value1") :: update(set = "value = s.value2") :: Nil,
     expected = Seq((1, "2.0")).toDF("key", "value"),
     expectErrorWithoutEvolutionContains = "cannot resolve value in UPDATE clause"
   )
@@ -1028,7 +1036,7 @@ trait MergeIntoSchemaEvolutionBaseTests {
   testEvolution("new column type reconciliation in array - int and string resolves to string")(
     targetData = Seq((1)).toDF("key"),
     sourceData = Seq((1, Seq(2), Seq("val"))).toDF("key", "value1", "value2"),
-    clauses = update(condition = "s.key < 2", set = "value = s.value1"):: update(set = "value = s.value2") :: Nil,
+    clauses = update(condition = "s.key < 2", set = "value = s.value1") :: update(set = "value = s.value2") :: Nil,
     expected = Seq((1, Seq("2"))).toDF("key", "value"),
     expectErrorWithoutEvolutionContains = "cannot resolve value in UPDATE clause"
   )
@@ -1036,7 +1044,7 @@ trait MergeIntoSchemaEvolutionBaseTests {
   testEvolution("new column type reconciliation in map - int and string resolves to string")(
     targetData = Seq((1)).toDF("key"),
     sourceData = Seq((1, Map(2 -> 2), Map("2" -> "2"))).toDF("key", "value1", "value2"),
-    clauses = update(condition = "s.key < 2", set = "value = s.value1"):: update(set = "value = s.value2") :: Nil,
+    clauses = update(condition = "s.key < 2", set = "value = s.value1") :: update(set = "value = s.value2") :: Nil,
     expected = Seq((1, Map("2" -> "2"))).toDF("key", "value"),
     expectErrorWithoutEvolutionContains = "cannot resolve value in UPDATE clause"
   )
@@ -1045,7 +1053,7 @@ trait MergeIntoSchemaEvolutionBaseTests {
     targetData = Seq((1)).toDF("key"),
     sourceData = Seq((1, 2, "val")).toDF("key", "value1", "value2")
       .select('key, struct('value1.alias("value")).alias("nested1"), struct('value2.alias("value")).alias("nested2")),
-    clauses = update(condition = "s.key < 2", set = "nested = s.nested1"):: update(set = "nested = s.nested2") :: Nil,
+    clauses = update(condition = "s.key < 2", set = "nested = s.nested1") :: update(set = "nested = s.nested2") :: Nil,
     expected = Seq((1, "2")).toDF("key", "value").select('key, struct("value").alias("nested")),
     expectErrorWithoutEvolutionContains = "cannot resolve nested in UPDATE clause"
   )

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSchemaEvolutionSuite.scala
@@ -362,7 +362,8 @@ trait MergeIntoSchemaEvolutionBaseTests {
     targetData = Seq((0, 0), (1, 10), (3, 30)).toDF("key", "value"),
     sourceData = Seq((1, 1, "extra1"), (2, 2, "extra2")).toDF("key", "value", "extra"),
     clauses = update(set = "nonexistent = s.extra") :: Nil,
-    expected = ((0, 0, null) +: (1, 10, "extra1") +: (3, 30, null) +: Nil).toDF("key", "value", "nonexistent"),
+    expected = ((0, 0, null) +: (1, 10, "extra1") +: (3, 30, null) +: Nil)
+      .toDF("key", "value", "nonexistent"),
     expectErrorWithoutEvolutionContains = "cannot resolve nonexistent in UPDATE clause")
 
   testEvolution("insert values nonexistent column")(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Resolves #2300 

This updates schema evolution in merging to use the target assignment columns and expression schema to determine the new target schema instead of the source schema. The current implementation seems to only support upserting use cases, where the source schema looks like the target schema. However when using custom set expressions, there's no requirement for this to be the case. 

When auto schema migration is enabled and the target assignment column doesn't exist in the table, the column parts and the data type of the expression are used for determining schema updates, regardless of what the source schema is. For upserting cases, this works the same way, since the data types and assignment columns will match the source table. But it also supports more use cases where the source schema doesn't match the target schema.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Updated two tests that were showing this use case didn't work, to show it now does work, and added one additional test for adding a new nested column in an update.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, supports more schema evolution use cases in merge