### PR TITLE
[Kernel] Add class `FieldMetadata` for storing field metadata

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/InternalScanFileUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/InternalScanFileUtils.java
@@ -15,7 +15,6 @@
  */
 package io.delta.kernel.internal;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -53,8 +52,7 @@ public class InternalScanFileUtils {
     public static StructField TABLE_ROOT_STRUCT_FIELD = new StructField(
         TABLE_ROOT_COL_NAME,
         TABLE_ROOT_DATA_TYPE,
-        false, /* nullable */
-        Collections.emptyMap());
+        false /* nullable */);
 
     public static final StructType SCAN_FILE_SCHEMA = new StructType()
         .add("add", AddFile.SCHEMA)

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/InternalSchemaUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/InternalSchemaUtils.java
@@ -56,7 +56,7 @@ public class InternalSchemaUtils {
                     } else {
                         newType = oldType;
                     }
-                    String physicalName = fieldFromMetadata
+                    String physicalName = (String) fieldFromMetadata
                         .getMetadata()
                         .get("delta.columnMapping.physicalName");
                     newSchema = newSchema.add(physicalName, newType);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/FieldMetadata.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/FieldMetadata.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This file contains code from the Apache Spark project (original license below).
+ * It contains modifications which are licensed as specified above.
+ */
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.types;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * The metadata for a given {@link StructField}.
+ */
+public final class FieldMetadata {
+    private final Map<String, Object> metadata;
+
+    private FieldMetadata(Map<String, Object> metadata) {
+        this.metadata = metadata;
+    }
+
+    // TODO should we include typed getters like in Spark?
+
+    /**
+     * @return list of the key-value pairs in this {@link FieldMetadata}
+     */
+    public Map<String, Object> getEntries() {
+        return Collections.unmodifiableMap(metadata);
+    }
+
+    /**
+     * @param key  the key to check for
+     * @return True if {@code this} contains a mapping for the given key, False otherwise
+     */
+    public boolean contains(String key) {
+        return metadata.containsKey(key);
+    }
+
+    /**
+     * @param key  the key to check for
+     * @return the value to which the specified key is mapped, or null if there is no mapping for
+     * the given key
+     */
+    public Object get(String key) {
+        return metadata.get(key);
+    }
+
+    public String toJson() {
+        return metadata.entrySet().stream()
+            .map(e -> String.format("\"%s\" : %s", e.getKey(), valueToJson(e.getValue())))
+            .collect(Collectors.joining(",\n", "{", "}"));
+    }
+
+    // TODO this is a hack for now until we have real serialization as part of the JsonHandler
+    /** Wraps string objects in quotations, otherwise converts using toString() */
+    private String valueToJson(Object value) {
+        if (value == null) {
+            return "null";
+        } else if (value instanceof String) {
+            return String.format("\"%s\"", value);
+        } else {
+            return value.toString();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return toJson();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FieldMetadata that = (FieldMetadata) o;
+        if (this.metadata.size() != that.metadata.size()) return false;
+        return this.metadata.entrySet().stream().allMatch(e ->
+            Objects.equals(e.getValue(), that.metadata.get(e.getKey())) ||
+                (e.getValue() != null && e.getValue().getClass().isArray() &&
+                    that.metadata.get(e.getKey()).getClass().isArray() &&
+                    Arrays.equals(
+                        (Object[]) e.getValue(),
+                        (Object[]) that.metadata.get(e.getKey()))));
+    }
+
+    @Override
+    public int hashCode() {
+        return metadata.entrySet()
+            .stream()
+            .mapToInt( entry -> (entry.getValue().getClass().isArray() ?
+                (entry.getKey() == null ? 0 : entry.getKey().hashCode())^
+                    Arrays.hashCode((Object[]) entry.getValue()) :
+                entry.hashCode())
+            ).sum();
+    }
+
+    /**
+     * @return a new {@link FieldMetadata.Builder}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for {@link FieldMetadata}.
+     */
+    public static class Builder {
+        private Map<String, Object> metadata = new HashMap<String, Object>();
+
+        public Builder putNull(String key) {
+            metadata.put(key, null);
+            return this;
+        }
+
+        public Builder putLong(String key, long value) {
+            metadata.put(key, value);
+            return this;
+        }
+
+        public Builder putDouble(String key, double value) {
+            metadata.put(key, value);
+            return this;
+        }
+
+        public Builder putBoolean(String key, boolean value) {
+            metadata.put(key, value);
+            return this;
+        }
+
+        public Builder putString(String key, String value) {
+            metadata.put(key, value);
+            return this;
+        }
+
+        public Builder putMetadata(String key, FieldMetadata value) {
+            metadata.put(key, value);
+            return this;
+        }
+
+        public Builder putLongArray(String key, Long[] value) {
+            metadata.put(key, value);
+            return this;
+        }
+
+        public Builder putDoubleArray(String key, Double[] value) {
+            metadata.put(key, value);
+            return this;
+        }
+
+        public Builder putBooleanArray(String key, Boolean[] value) {
+            metadata.put(key, value);
+            return this;
+        }
+
+        public Builder putStringArray(String key, String[] value) {
+            metadata.put(key, value);
+            return this;
+        }
+
+        public Builder putMetadataArray(String key, FieldMetadata[] value) {
+            metadata.put(key, value);
+            return this;
+        }
+
+        /**
+         * @return a new {@link FieldMetadata} with the mappings added to the builder
+         */
+        public FieldMetadata build() {
+            return new FieldMetadata(this.metadata);
+        }
+    }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
@@ -16,10 +16,7 @@
 
 package io.delta.kernel.types;
 
-import java.util.Collections;
-import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import io.delta.kernel.annotation.Evolving;
 
@@ -49,7 +46,7 @@ public class StructField {
         METADATA_ROW_INDEX_COLUMN_NAME,
         LongType.LONG,
         false,
-        Collections.singletonMap(IS_METADATA_COLUMN_KEY, "true"));
+        FieldMetadata.builder().putBoolean(IS_METADATA_COLUMN_KEY, true).build());
 
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -59,20 +56,20 @@ public class StructField {
     private final String name;
     private final DataType dataType;
     private final boolean nullable;
-    private final Map<String, String> metadata;
+    private final FieldMetadata metadata;
 
     public StructField(
             String name,
             DataType dataType,
             boolean nullable) {
-        this(name, dataType, nullable, Collections.emptyMap());
+        this(name, dataType, nullable, FieldMetadata.builder().build());
     }
 
     public StructField(
             String name,
             DataType dataType,
             boolean nullable,
-            Map<String, String> metadata) {
+            FieldMetadata metadata) {
         this.name = name;
         this.dataType = dataType;
         this.nullable = nullable;
@@ -96,7 +93,7 @@ public class StructField {
     /**
      * @return the metadata for this field
      */
-    public Map<String, String> getMetadata() {
+    public FieldMetadata getMetadata() {
         return metadata;
     }
 
@@ -108,8 +105,8 @@ public class StructField {
     }
 
     public boolean isMetadataColumn() {
-        return metadata.containsKey(IS_METADATA_COLUMN_KEY) &&
-            Boolean.parseBoolean(metadata.get(IS_METADATA_COLUMN_KEY));
+        return metadata.contains(IS_METADATA_COLUMN_KEY) &&
+            (boolean) metadata.get(IS_METADATA_COLUMN_KEY);
     }
 
     public boolean isDataColumn() {
@@ -119,21 +116,17 @@ public class StructField {
     @Override
     public String toString() {
         return String.format("StructField(name=%s,type=%s,nullable=%s,metadata=%s)",
-            name, dataType, nullable, "empty(fix - this)");
+            name, dataType, nullable, metadata.toString());
     }
 
     public String toJson() {
-        String metadataAsJson = metadata.entrySet().stream()
-            .map(e -> String.format("\"%s\" : \"%s\"", e.getKey(), e.getValue()))
-            .collect(Collectors.joining(",\n"));
-
         return String.format(
             "{\n" +
                 "  \"name\" : \"%s\",\n" +
                 "  \"type\" : %s,\n" +
                 "  \"nullable\" : %s, \n" +
-                "  \"metadata\" : { %s }\n" +
-                "}", name, dataType.toJson(), nullable, metadataAsJson);
+                "  \"metadata\" : %s\n" +
+                "}", name, dataType.toJson(), nullable, metadata.toJson());
     }
 
     @Override

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructType.java
@@ -58,14 +58,14 @@ public final class StructType extends DataType {
     }
 
     public StructType add(String name, DataType dataType) {
-        return add(new StructField(name, dataType, true /* nullable */, new HashMap<>()));
+        return add(new StructField(name, dataType, true /* nullable */));
     }
 
     public StructType add(String name, DataType dataType, boolean nullable) {
-        return add(new StructField(name, dataType, nullable, new HashMap<>()));
+        return add(new StructField(name, dataType, nullable));
     }
 
-    public StructType add(String name, DataType dataType, Map<String, String> metadata) {
+    public StructType add(String name, DataType dataType, FieldMetadata metadata) {
         return add(new StructField(name, dataType, true /* nullable */, metadata));
     }
 
@@ -73,7 +73,7 @@ public final class StructType extends DataType {
             String name,
             DataType dataType,
             boolean nullable,
-            Map<String, String> metadata) {
+            FieldMetadata metadata) {
         return add(new StructField(name, dataType, nullable, metadata));
     }
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultPredicateEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultPredicateEvaluator.java
@@ -17,7 +17,6 @@ package io.delta.kernel.defaults.internal.expressions;
 
 import java.util.Arrays;
 import java.util.Optional;
-import static java.util.Collections.emptyMap;
 
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.ColumnarBatch;
@@ -40,7 +39,7 @@ public class DefaultPredicateEvaluator implements PredicateEvaluator {
     private static final String EXISTING_SEL_VECTOR_COL_NAME =
         "____existing_selection_vector_value____";
     private static final StructField EXISTING_SEL_VECTOR_FIELD =
-        new StructField(EXISTING_SEL_VECTOR_COL_NAME, BooleanType.BOOLEAN, false, emptyMap());
+        new StructField(EXISTING_SEL_VECTOR_COL_NAME, BooleanType.BOOLEAN, false);
 
     private final ExpressionEvaluator expressionEvaluator;
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/types/DataTypeParser.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/types/DataTypeParser.java
@@ -16,6 +16,7 @@
 package io.delta.kernel.defaults.internal.types;
 
 import java.util.*;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -149,7 +150,7 @@ public class DataTypeParser {
         String name = getStringField(json, "name");
         DataType type = parseDataType(getNonNullField(json, "type"));
         boolean nullable = getBooleanField(json, "nullable");
-        Map<String, String> metadata = parseFieldMetadata(json.get("metadata"));
+        FieldMetadata metadata = parseFieldMetadata(json.get("metadata"));
         return new StructField(
             name,
             type,
@@ -158,30 +159,93 @@ public class DataTypeParser {
         );
     }
 
-    // TODO for now we maintain the current behavior that parses field metadata as a
-    //  Map<String, String> for either string or numerical value types. A follow-up PR will refactor
-    //  this to support all the supported value types for field metadata and add a FieldMetadata
-    //  class in place of Map<String, String>
-    private static Map<String, String> parseFieldMetadata(JsonNode json) {
+    /**
+     * Parses an {@link FieldMetadata}.
+     */
+    private static FieldMetadata parseFieldMetadata(JsonNode json) {
         if (json == null || json.isNull()) {
-            return Collections.emptyMap();
+            return FieldMetadata.builder().build();
         }
 
         checkArgument(json.isObject(), "Expected JSON object for struct field metadata");
         final Iterator<Map.Entry<String,JsonNode>> iterator = json.fields();
-        final Map<String, String> metadata = new HashMap<>();
+        final FieldMetadata.Builder builder = FieldMetadata.builder();
         while (iterator.hasNext()) {
             Map.Entry<String, JsonNode> entry = iterator.next();
             JsonNode value = entry.getValue();
             String key = entry.getKey();
 
-            if (!(value.isTextual() || value.isIntegralNumber())) {
-                throw new UnsupportedOperationException(
-                    "Only numerical or string type field metadata values are supported");
+            if (value.isNull()) {
+                builder.putNull(key);
+            } else if (value.isInt()) {
+                builder.putLong(key, value.intValue());
+            } else if (value.isDouble()) {
+                builder.putDouble(key, value.doubleValue());
+            } else if (value.isBoolean()) {
+                builder.putBoolean(key, value.booleanValue());
+            } else if (value.isTextual()) {
+                builder.putString(key, value.textValue());
+            } else if (value.isObject()) {
+                builder.putMetadata(key, parseFieldMetadata(value));
+            } else if (value.isArray()) {
+                final Iterator<JsonNode> fields = value.elements();
+                if (!fields.hasNext()) {
+                    // If it is an empty array, we cannot infer its element type.
+                    // We put an empty Array[Long].
+                    builder.putLongArray(key, new Long[0]);
+                } else {
+                    final JsonNode head = fields.next();
+                    // TODO could these have null elements?
+                    if (head.isInt()) {
+                        builder.putLongArray(
+                            key,
+                            buildList(value, node -> (long) node.intValue()).toArray(new Long[0])
+                        );
+                    } else if (head.isDouble()) {
+                        builder.putDoubleArray(
+                            key,
+                            buildList(value, JsonNode::doubleValue).toArray(new Double[0])
+                        );
+                    } else if (head.isBoolean()) {
+                        builder.putBooleanArray(
+                            key,
+                            buildList(value, JsonNode::booleanValue).toArray(new Boolean[0])
+                        );
+                    } else if (head.isTextual()) {
+                        builder.putStringArray(
+                            key,
+                            buildList(value, JsonNode::textValue).toArray(new String[0])
+                        );
+                    } else if (head.isObject()) {
+                        builder.putMetadataArray(
+                            key,
+                            buildList(value, DataTypeParser::parseFieldMetadata)
+                                .toArray(new FieldMetadata[0])
+                        );
+                    } else {
+                        throw new IllegalArgumentException(String.format(
+                            "Unsupported type for Array as field metadata value: %s", value));
+                    }
+                }
+            } else {
+                throw new IllegalArgumentException(
+                    String.format("Unsupported type for field metadata value: %s", value));
             }
-            metadata.put(key, value.asText());
         }
-        return metadata;
+        return builder.build();
+    }
+
+    /**
+     * For an array JSON node builds a {@link List} using the provided {@code accessor} for each
+     * element.
+     */
+    private static <T> List<T> buildList(JsonNode json, Function<JsonNode, T> accessor) {
+        List<T> result = new ArrayList<>();
+        Iterator<JsonNode> elements = json.elements();
+        while (elements.hasNext()) {
+            result.add(accessor.apply(elements.next()));
+        }
+        return result;
     }
 
     private static String FIXED_DECIMAL_REGEX = "decimal\\(\\s*(\\d+)\\s*,\\s*(\\-?\\d+)\\s*\\)";

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/client/DefaultJsonHandlerSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/client/DefaultJsonHandlerSuite.scala
@@ -31,12 +31,13 @@ class DefaultJsonHandlerSuite extends AnyFunSuite {
   // END-TO-END TESTS FOR deserializeStructType (more tests in DataTypeParserSuite)
   //////////////////////////////////////////////////////////////////////////////////
 
-  // TODO once we add full support for field metadata update this to include other types
-  private def sampleMetadata: java.util.Map[String, String] =
-    Map(
-      "key1" -> "value1",
-      "key2" -> "value2"
-    ).asJava
+  private def sampleMetadata: FieldMetadata = FieldMetadata.builder()
+    .putNull("null")
+    .putLong("long", 1000L)
+    .putDouble("double", 2.222)
+    .putBoolean("boolean", true)
+    .putString("string", "value")
+    .build()
 
   test("deserializeStructType: primitive type round trip") {
     val fields = BasePrimitiveType.getAllPrimitiveTypes().asScala.flatMap { dataType =>


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Resolves #2315

Adds a class `FieldMetadata` for storing `StructField` metadata. Currently field metadata is stored as a `Map<String, String>`; this is not sufficient for column level metadata as values are stored in JSON as strings, numbers, lists, etc.

The `FieldMetadata` class allows us to restrict the possible value types through its builder class. This will be important in the future when we support writes.

Full `FieldMetadata` parsing support in the `DefaultJsonHandler` is also added in this PR.

## How was this patch tested?

Existing tests and adds tests for the JSON parsing.
