### PR TITLE
[Spark] Use ManualUpdate for manual transactions in tests

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -409,8 +409,14 @@ object DeltaOperations {
     )))
   }
 
+  case class ManualUpdate(
+      override val parameters: Map[String, Any] = Map.empty,
+      override val changesData: Boolean = true)
+    extends Operation("Manual Update")
+
   object ManualUpdate extends Operation("Manual Update") {
     override val parameters: Map[String, Any] = Map.empty
+    override val changesData = true
   }
 
   /** A commit without any actions. Could be used to force creation of new checkpoints. */

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta
 import java.io.File
 import java.util.UUID
 
-import org.apache.spark.sql.delta.DeltaOperations.Truncate
+import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.actions.{Action, AddFile, DeletionVectorDescriptor, RemoveFile}
 import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -178,7 +178,7 @@ trait DeletionVectorsTestUtils extends QueryTest with SharedSparkSession {
       log: DeltaLog, addFile: AddFile, rowIndexesToRemove: Seq[Long]): Unit = {
     val txn = log.startTransaction()
     val actions = removeRowsFromFileUsingDV(log, addFile, rowIndexesToRemove)
-    txn.commit(actions, Truncate())
+    txn.commit(actions, ManualUpdate)
   }
 
   protected def getFileActionsInLastVersion(log: DeltaLog): (Seq[AddFile], Seq[RemoveFile]) = {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -22,7 +22,7 @@ import java.util.Locale
 
 import scala.language.postfixOps
 
-import org.apache.spark.sql.delta.DeltaOperations.Truncate
+import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -50,7 +50,7 @@ class DeltaLogSuite extends QueryTest
   with SQLTestUtils {
 
 
-  protected val testOp = Truncate()
+  protected val testOp = ManualUpdate
 
   testDifferentCheckpoints("checkpoint", quiet = true) { (_, _) =>
     val tempDir = Utils.createTempDir()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuiteBase.scala
@@ -21,7 +21,7 @@ import java.util.{Calendar, TimeZone}
 
 import scala.collection.mutable
 
-import org.apache.spark.sql.delta.DeltaOperations.Truncate
+import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
 import org.apache.spark.sql.delta.actions.{CheckpointMetadata, Metadata, SidecarFile}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -40,7 +40,7 @@ import org.apache.spark.util.ManualClock
 
 trait DeltaRetentionSuiteBase extends QueryTest
   with SharedSparkSession {
-  protected val testOp = Truncate()
+  protected val testOp = ManualUpdate
 
   protected override def sparkConf: SparkConf = super.sparkConf
     // Disable the log cleanup because it runs asynchronously and causes test flakiness

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
@@ -549,7 +549,7 @@ trait DescribeDeltaHistorySuiteBase
     Seq(3).toDF().write.format("delta").mode("append").save(tempDir)  // readVersion = Some(2)
 
 
-    txn.commit(Seq.empty, DeltaOperations.Truncate())  // readVersion = Some(1)
+    txn.commit(Seq.empty, DeltaOperations.ManualUpdate)  // readVersion = Some(1)
 
     Seq(5).toDF().write.format("delta").mode("append").save(tempDir)   // readVersion = Some(4)
     val ans = sql(s"DESCRIBE HISTORY delta.`$tempDir`").as[DeltaHistory].collect()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionLegacyTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionLegacyTests.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.delta
 import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
 import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, AddFile, FileAction, Metadata, RemoveFile, SetTransaction}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.hadoop.fs.Path
@@ -615,7 +616,7 @@ trait OptimisticTransactionLegacyTests
       // tx1 rearranges files
       tx1.commit(
         setDataChangeFalse(addA_P1.remove :: addB_P1.remove :: addC_P1 :: Nil),
-        ManualUpdate)
+        ManualUpdate(changesData = false))
 
       checkAnswer(
         log.update().allFiles.select("path"),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -128,7 +128,7 @@ class OptimisticTransactionSuite
     actions = Seq(AddFile("b", Map("x" -> "1"), 1, 1, dataChange = true)),
     // commit info should show operation as truncate, because that's the operation used by the
     // harness
-    errorMessageHint = Some("[x=1]" :: "TRUNCATE" :: Nil))
+    errorMessageHint = Some("[x=1]" :: "Manual Update" :: Nil))
 
   check(
     "add / read + no write",  // no write = no real conflicting change even though data was added
@@ -192,7 +192,7 @@ class OptimisticTransactionSuite
     concurrentWrites = Seq(
       RemoveFile("a", Some(4))),
     actions = Seq(),
-    errorMessageHint = Some("a in partition [x=1]" :: "TRUNCATE" :: Nil))
+    errorMessageHint = Some("a in partition [x=1]" :: "Manual Update" :: Nil))
 
   check(
     "schema change",

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuiteBase.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta
 
 import java.util.ConcurrentModificationException
 
-import org.apache.spark.sql.delta.DeltaOperations.{ManualUpdate, Truncate}
+import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.actions.{Action, AddFile, FileAction, Metadata, RemoveFile}
 import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -65,7 +65,7 @@ trait OptimisticTransactionSuiteBase
       exceptionClass: Option[String] = None): Unit = {
 
     val concurrentTxn: OptimisticTransaction => Unit =
-      (opt: OptimisticTransaction) => opt.commit(concurrentWrites, Truncate())
+      (opt: OptimisticTransaction) => opt.commit(concurrentWrites, ManualUpdate)
 
     def initialSetup(log: DeltaLog): Unit = {
       // Setup the log
@@ -80,7 +80,7 @@ trait OptimisticTransactionSuiteBase
       reads,
       Seq(concurrentTxn),
       actions,
-      operation = Truncate(), // a data-changing operation
+      operation = ManualUpdate, // a data-changing operation
       errorMessageHint = errorMessageHint,
       exceptionClass = exceptionClass,
       additionalSQLConfs = Seq.empty


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

A lot of existing tests that perform manual transactions use the Truncate Delta operation instead of ManualUpdate, which makes it harder to write invariant checks per Delta operation. This commit fixes this issue.

## How was this patch tested?

Existing tests.