### PR TITLE
[ISSUE-2323] Replace hour truncation with minute truncation in DROP FEATURE command

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
@@ -21,7 +21,7 @@ import java.util.{Calendar, TimeZone}
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.delta.DeltaHistoryManager.BufferingLogDeletionIterator
-import org.apache.spark.sql.delta.TruncationGranularity.{DAY, HOUR, TruncationGranularity}
+import org.apache.spark.sql.delta.TruncationGranularity.{DAY, HOUR, MINUTE, TruncationGranularity}
 import org.apache.spark.sql.delta.actions.{Action, Metadata}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.util.FileNames
@@ -31,7 +31,7 @@ import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
 
 private[delta] object TruncationGranularity extends Enumeration {
   type TruncationGranularity = Value
-  val DAY, HOUR = Value
+  val DAY, HOUR, MINUTE = Value
 }
 
 /** Cleans up expired Delta table metadata. */
@@ -133,9 +133,10 @@ trait MetadataCleanup extends DeltaLogging {
   }
 
   /**
-   * Truncates a timestamp down to a given unit. The unit can be either DAY or HOUR.
+   * Truncates a timestamp down to a given unit. The unit can be either DAY, HOUR or MINUTE.
    * - DAY: The timestamp it truncated to the previous midnight.
    * - HOUR: The timestamp it truncated to the last hour.
+   * - MINUTE: The timestamp it truncated to the last minute.
    */
   private[delta] def truncateDate(timeMillis: Long, unit: TruncationGranularity): Calendar = {
     val date = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
@@ -144,6 +145,7 @@ trait MetadataCleanup extends DeltaLogging {
     val calendarUnit = unit match {
       case DAY => Calendar.DAY_OF_MONTH
       case HOUR => Calendar.HOUR_OF_DAY
+      case MINUTE => Calendar.MINUTE
     }
 
     DateUtils.truncate(date, calendarUnit)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -311,11 +311,11 @@ case class AlterTableDropFeatureDeltaCommand(
       if (isReaderWriterFeature) {
         // Clean up expired logs before checking history. This also makes sure there is no
         // concurrent metadataCleanup during findEarliestReliableCheckpoint. Note, this
-        // cleanUpExpiredLogs call truncates the cutoff at an hour granularity.
+        // cleanUpExpiredLogs call truncates the cutoff at a minute granularity.
         deltaLog.cleanUpExpiredLogs(
           snapshot,
           truncateHistoryLogRetentionMillis(txn),
-          TruncationGranularity.HOUR)
+          TruncationGranularity.MINUTE)
 
         val historyContainsFeature = removableFeature.historyContainsFeature(
           spark = sparkSession,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -2387,7 +2387,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         } else {
           deltaLog.deltaRetentionMillis(deltaLog.update().metadata)
         }
-        clock.advance(clockAdvanceMillis + TimeUnit.HOURS.toMillis(1))
+        clock.advance(clockAdvanceMillis + TimeUnit.MINUTES.toMillis(5))
       }
 
       val dropCommand = AlterTableDropFeatureDeltaCommand(
@@ -2715,7 +2715,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
 
       // The retention period has passed since the disablement.
       clock.advance(
-        deltaRetentionMillis - TimeUnit.DAYS.toMillis(10) + TimeUnit.HOURS.toMillis(1))
+        deltaRetentionMillis - TimeUnit.DAYS.toMillis(10) + TimeUnit.MINUTES.toMillis(5))
 
       // Cleanup logs.
       deltaLog.cleanUpExpiredLogs(deltaLog.update())
@@ -2802,7 +2802,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       // Pretend retention period has passed.
       clock.advance(
         deltaLog.deltaRetentionMillis(deltaLog.update().metadata) +
-        TimeUnit.HOURS.toMillis(1))
+        TimeUnit.MINUTES.toMillis(5))
 
       // History is now clean. We should be able to remove the feature.
       AlterTableDropFeatureDeltaCommand(
@@ -2906,7 +2906,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
 
       // Pretend retention period has passed.
       clock.advance(deltaLog.deltaRetentionMillis(deltaLog.update().metadata) +
-        TimeUnit.HOURS.toMillis(1))
+        TimeUnit.MINUTES.toMillis(5))
 
       // Perform an unrelated metadata change.
       sql(s"ALTER TABLE delta.`${deltaLog.dataPath}` ADD COLUMN (value INT)")
@@ -3241,7 +3241,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         // Pretend retention period has passed.
         clock.advance(
           targetLog.deltaRetentionMillis(targetLog.update().metadata) +
-            TimeUnit.HOURS.toMillis(1))
+            TimeUnit.MINUTES.toMillis(5))
 
         // History is now clean. We should be able to remove the feature.
         dropV2CheckpointsTableFeature(spark, targetLog)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
In DROP FEATURE command, we truncate history when removing reader+writer features. The cutoff time is calculated by subtracting the logRetentionPeriod/historyTruncationPeriod and then truncating the result at an hour granularity. This PR changes the hour truncation to minute truncation to simplify error messaging.

## How was this patch tested?
Modified existing tests.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.
