### PR TITLE
[Spark] Make DeltaSourceOffset versionless

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -1868,7 +1868,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
           assert(endOffsets.toList ==
             DeltaSourceOffset(id, 1, 0, isInitialSnapshot = false)
               // When we reach the end of version 1, we will jump to version 2 with index -1
-              :: DeltaSourceOffset(id, 2, -1, isInitialSnapshot = false)
+              :: DeltaSourceOffset(id, 2, DeltaSourceOffset.BASE_INDEX, isInitialSnapshot = false)
               :: Nil)
         } finally {
           q.stop()
@@ -2212,7 +2212,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
           index = 10,
           isInitialSnapshot = true)
       )
-    }.getMessage.contains("Found invalid offsets: 'isInitialSnapshot' fliped incorrectly."))
+    }.getMessage.contains("Found invalid offsets: 'isInitialSnapshot' flipped incorrectly."))
     assert(intercept[IllegalStateException] {
       DeltaSourceOffset.validateOffsets(
         previousOffset = DeltaSourceOffset(


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
The DeltaSourceOffset still has a version, but it's supposed to always be VERSION_3. This turned out to not always be the case. Furthermore, it was not guaranteed that all use cases would use the new BASE_INDEX, as some of them still used a hardcoded -1. This PR removes the concept of a version from DeltaSourceOffset and makes it entirely versionless. The versioning is retained in the serialized form where it belongs.

## How was this patch tested?

Existing unit tests.
## Does this PR introduce _any_ user-facing changes?

No