### PR TITLE
[Spark] CI - Use Python packages compatible to Python 3.9 + Run CI when workflow files change

### DIFF
--- a/.github/workflows/spark_test.yaml
+++ b/.github/workflows/spark_test.yaml
@@ -16,6 +16,7 @@ jobs:
         with:
           PATTERNS: |
             **
+            .github/workflows/**
             !kernel/**
             !connectors/**
       - name: install java

--- a/.github/workflows/spark_test.yaml
+++ b/.github/workflows/spark_test.yaml
@@ -56,9 +56,9 @@ jobs:
           pipenv run pip install cryptography==37.0.4
           pipenv run pip install twine==4.0.1
           pipenv run pip install wheel==0.33.4
-          pipenv run pip install setuptools==41.0.1
+          pipenv run pip install setuptools==41.1.0
           pipenv run pip install pydocstyle==3.0.0
-          pipenv run pip install pandas==1.0.5
+          pipenv run pip install pandas==1.1.3
           pipenv run pip install pyarrow==8.0.0
           pipenv run pip install numpy==1.20.3
         if: steps.git-diff.outputs.diff


### PR DESCRIPTION
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Use Python packages compatible to both Python 3.8 and 3.9

https://setuptools.pypa.io/en/stable/history.html#v41-1-0
https://pypi.org/project/pandas/1.1.3/

## How was this patch tested?


## Does this PR introduce _any_ user-facing changes?

