### PR TITLE
[Spark] Discard scoverage from delta-iceberg JAR. Fix #2355

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -402,6 +402,9 @@ lazy val iceberg = (project in file("iceberg"))
           s"org/apache/spark/${xs.mkString("/")}".startsWith(prefix) } =>
         println(s"Discarding class: org/apache/spark/${xs.mkString("/")}")
         MergeStrategy.discard
+      case PathList("scoverage", xs @ _*) =>
+        println(s"Discarding class: scoverage/${xs.mkString("/")}")
+        MergeStrategy.discard
       case x =>
         println(s"Including class: $x")
         (assembly / assemblyMergeStrategy).value(x)


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Fix #2355

## How was this patch tested?
Unit tests

## Does this PR introduce _any_ user-facing changes?
No
