### PR TITLE
[Kernel][Expressions] Update `AND` and `OR` expressions to follow SQL null semantics

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/And.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/And.java
@@ -28,7 +28,7 @@ import io.delta.kernel.annotation.Evolving;
  *     <li>Logical {@code expr1} AND {@code expr2} on two inputs.</li>
  *     <li>Requires both left and right input expressions of type {@link Predicate}.</li>
  *     <li>Result is null when both inputs are null, or when one input is null and the other
- *     is {@code false}.</li>
+ *     is {@code true}.</li>
  * </ul>
  *
  * @since 3.0.0

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/And.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/And.java
@@ -27,7 +27,8 @@ import io.delta.kernel.annotation.Evolving;
  * <ul>
  *     <li>Logical {@code expr1} AND {@code expr2} on two inputs.</li>
  *     <li>Requires both left and right input expressions of type {@link Predicate}.</li>
- *     <li>Result is null at least one of the inputs is null.</li>
+ *     <li>Result is null when both inputs are null, or when one input is null and the other
+ *     is {@code false}.</li>
  * </ul>
  *
  * @since 3.0.0

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/Or.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/Or.java
@@ -26,7 +26,8 @@ import io.delta.kernel.annotation.Evolving;
  * <p><ul>
  *     <li>Logical {@code expr1} OR {@code expr2} on two inputs.</li>
  *     <li>Requires both left and right input expressions of type {@link Predicate}.</li>
- *     <li>Result is null at least one of the inputs is null.</li>
+ *     <li>Result is null when both inputs are null, or when one input is null and the other
+ *     is {@code false}.</li>
  * </ul>
  *
  * @since 3.0.0

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
@@ -294,11 +294,11 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
                     // NULL || NULL --> NULL ; NULL || FALSE --> NULL ; NULL || TRUE --> TRUE
                     nullability[rowId] = argResults.rightResult.isNullAt(rowId) ||
                         !argResults.rightResult.getBoolean(rowId);
-                    result[rowId] = argResults.rightResult.getBoolean(rowId);
+                    result[rowId] = true;
                 } else if (argResults.rightResult.isNullAt(rowId)) {
                     // TRUE || NULL --> TRUE ; FALSE || NULL --> NULL
                     nullability[rowId] = !argResults.leftResult.getBoolean(rowId);
-                    result[rowId] = argResults.leftResult.getBoolean(rowId);
+                    result[rowId] = true;
                 } else {
                     nullability[rowId] = false;
                     result[rowId] = argResults.leftResult.getBoolean(rowId) ||

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
@@ -191,9 +191,9 @@ class DefaultExpressionEvaluatorSuite extends AnyFunSuite with ExpressionSuiteBa
     val rightColumn = booleanVector(
       Seq[BooleanJ](true, false, false, true, true, null, false, null, null))
     val expAndOutputVector = booleanVector(
-      Seq[BooleanJ](true, false, false, false, null, null, null, null, null))
+      Seq[BooleanJ](true, false, false, false, null, null, false, false, null))
     val expOrOutputVector = booleanVector(
-      Seq[BooleanJ](true, true, false, true, null, null, null, null, null))
+      Seq[BooleanJ](true, true, false, true, true, true, null, null, null))
 
     val schema = new StructType()
       .add("left", BooleanType.BOOLEAN)

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultPredicateEvaluatorSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultPredicateEvaluatorSuite.scala
@@ -49,7 +49,7 @@ class DefaultPredicateEvaluatorSuite extends AnyFunSuite with ExpressionSuiteBas
   private val orPredicate = or(left, right)
 
   private val expOrOutput = booleanVector(
-    Seq[BooleanJ](true, true, false, true, true, false, null, null, null, null, null))
+    Seq[BooleanJ](true, true, false, true, true, false, true, true, null, null, null))
 
   test("evaluate predicate: with no starting selection vector") {
     val batch = new DefaultColumnarBatch(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Updates the `DefaultExpressionEvaluator` to follow SQL null semantics for the logical operators `AND` and `OR`.
Also updates the docs for those expressions.

## How was this patch tested?

Existing unit tests are updated.