### PR TITLE
Widen non-deterministic predicates during partition-level conflict checking

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -24,10 +24,11 @@ import scala.collection.mutable
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.FileNames
 import org.apache.hadoop.fs.FileStatus
 
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionSet, Or}
 import org.apache.spark.sql.types.StructType
 
@@ -120,7 +121,7 @@ private[delta] class ConflictChecker(
     spark: SparkSession,
     initialCurrentTransactionInfo: CurrentTransactionInfo,
     winningCommitFileStatus: FileStatus,
-    isolationLevel: IsolationLevel) extends DeltaLogging {
+    isolationLevel: IsolationLevel) extends DeltaLogging with ConflictCheckerPredicateElimination {
 
   protected val winningCommitVersion = FileNames.deltaVersion(winningCommitFileStatus)
   protected val startTimeMs = System.currentTimeMillis()
@@ -240,21 +241,68 @@ private[delta] class ConflictChecker(
     import org.apache.spark.sql.delta.implicits._
     val filesDf = files.toDF(spark)
 
+    spark.conf.get(DeltaSQLConf.DELTA_CONFLICT_DETECTION_WIDEN_NONDETERMINISTIC_PREDICATES) match {
+      case DeltaSQLConf.NonDeterministicPredicateWidening.OFF =>
+        getFirstFileMatchingPartitionPredicatesInternal(
+          filesDf, shouldWidenNonDeterministicPredicates = false)
+      case wideningMode =>
+        val fileWithWidening = getFirstFileMatchingPartitionPredicatesInternal(
+          filesDf, shouldWidenNonDeterministicPredicates = true)
+
+        fileWithWidening.flatMap { fileWithWidening =>
+          val fileWithoutWidening =
+            getFirstFileMatchingPartitionPredicatesInternal(
+              filesDf, shouldWidenNonDeterministicPredicates = false)
+          if (fileWithoutWidening.isEmpty) {
+            // Conflict due to widening of non-deterministic predicate.
+            recordDeltaEvent(deltaLog,
+              opType = "delta.conflictDetection.partitionLevelConcurrency." +
+                "additionalConflictDueToWideningOfNonDeterministicPredicate",
+              data = Map(
+                "wideningMode" -> wideningMode,
+                "predicate" ->
+                  currentTransactionInfo.readPredicates.map(_.partitionPredicate.toString)))
+          }
+          if (wideningMode == DeltaSQLConf.NonDeterministicPredicateWidening.ON) {
+            Some(fileWithWidening)
+          } else {
+            fileWithoutWidening
+          }
+        }
+    }
+  }
+
+  private def getFirstFileMatchingPartitionPredicatesInternal(
+      filesDf: DataFrame,
+      shouldWidenNonDeterministicPredicates: Boolean): Option[AddFile] = {
+
+    def rewritePredicateFn(
+        predicate: Expression,
+        shouldRewriteFilter: Boolean): DeltaTableReadPredicate = {
+      val rewrittenPredicate = if (shouldWidenNonDeterministicPredicates) {
+        eliminateNonDeterministicPredicates(Seq(predicate)).newPredicates
+      } else {
+        Seq(predicate)
+      }
+      DeltaTableReadPredicate(
+        partitionPredicates = rewrittenPredicate,
+        shouldRewriteFilter = shouldRewriteFilter)
+    }
+
     // we need to canonicalize the partition predicates per each group of rewrites vs. nonRewrites
     val canonicalPredicates = currentTransactionInfo.readPredicates
       .partition(_.shouldRewriteFilter) match {
         case (rewrites, nonRewrites) =>
           val canonicalRewrites =
-            ExpressionSet(rewrites.map(_.partitionPredicate)).map { e =>
-              DeltaTableReadPredicate(partitionPredicates = Seq(e))
-            }
+            ExpressionSet(rewrites.map(_.partitionPredicate)).map(
+              predicate => rewritePredicateFn(predicate, shouldRewriteFilter = true))
           val canonicalNonRewrites =
-            ExpressionSet(nonRewrites.map(_.partitionPredicate)).map { e =>
-              DeltaTableReadPredicate(partitionPredicates = Seq(e), shouldRewriteFilter = false)
-            }
+            ExpressionSet(nonRewrites.map(_.partitionPredicate)).map(
+              predicate => rewritePredicateFn(predicate, shouldRewriteFilter = false))
           canonicalRewrites ++ canonicalNonRewrites
       }
 
+    import org.apache.spark.sql.delta.implicits._
     val filesMatchingPartitionPredicates = canonicalPredicates.iterator
       .flatMap { readPredicate =>
         DeltaLog.filterFileList(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictCheckerPredicateElimination.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictCheckerPredicateElimination.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.util.DeltaSparkPlanUtils
+
+import org.apache.spark.sql.catalyst.expressions.{And, EmptyRow, Expression, Literal, Or}
+import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+
+private[delta] trait ConflictCheckerPredicateElimination extends DeltaSparkPlanUtils {
+
+  /**
+   * This class represents the state of a expression tree transformation, whereby we try to
+   * eliminate predicates that are non-deterministic in a way that widens the set of rows to
+   * include any row that could be read by the original predicate.
+   *
+   * Example: `c1 = 5 AND c2 IN (SELECT c FROM <parquet table>)` would be widened to
+   * `c1 = 5 AND True` eliminating the non-deterministic parquet table read by assuming it would
+   * have matched all c2 values.
+   *
+   * `c1 = 5 OR NOT some_udf(c2)` would be widened to `c1 = 5 OR True`, eliminating the
+   * non-deterministic `some_udf` by assuming `NOT some_udf(c2)` would have selected all rows.
+   *
+   * @param newPredicates
+   *   The (potentially widened) list of predicates.
+   * @param eliminatedPredicates
+   *   The predicates that were eliminated as non-deterministic.
+   */
+  protected case class PredicateElimination(
+      newPredicates: Seq[Expression],
+      eliminatedPredicates: Seq[String])
+  protected object PredicateElimination {
+    final val EMPTY: PredicateElimination = PredicateElimination(Seq.empty, Seq.empty)
+
+    def eliminate(p: Expression, eliminated: Option[String] = None): PredicateElimination =
+      PredicateElimination(
+        // Always eliminate with a `TrueLiteral`, implying that the eliminated expression would
+        // have read the entire table.
+        newPredicates = Seq(TrueLiteral),
+        eliminatedPredicates = Seq(eliminated.getOrElse(p.prettyName)))
+
+    def keep(p: Expression): PredicateElimination =
+      PredicateElimination(newPredicates = Seq(p), eliminatedPredicates = Seq.empty)
+
+    def recurse(
+        p: Expression,
+        recFun: Seq[Expression] => PredicateElimination): PredicateElimination = {
+      val eliminatedChildren = recFun(p.children)
+      if (eliminatedChildren.eliminatedPredicates.isEmpty) {
+        // All children were ok, so keep the current expression.
+        keep(p)
+      } else {
+        // Fold the new predicates after sub-expression widening.
+        val newPredicate = p.withNewChildren(eliminatedChildren.newPredicates) match {
+          case p if p.foldable => Literal.create(p.eval(EmptyRow), p.dataType)
+          case Or(TrueLiteral, _) => TrueLiteral
+          case Or(_, TrueLiteral) => TrueLiteral
+          case And(left, TrueLiteral) => left
+          case And(TrueLiteral, right) => right
+          case p => p
+        }
+        PredicateElimination(
+          newPredicates = Seq(newPredicate),
+          eliminatedPredicates = eliminatedChildren.eliminatedPredicates)
+      }
+    }
+  }
+
+  /**
+   * Replace non-deterministic expressions in a way that can only increase the number of selected
+   * files when these predicates are used for file skipping.
+   */
+  protected def eliminateNonDeterministicPredicates(
+      predicates: Seq[Expression]): PredicateElimination = {
+    eliminateUnsupportedPredicates(predicates) {
+      case p @ SubqueryExpression(plan) =>
+        findFirstNonDeltaScan(plan) match {
+          case Some(plan) => PredicateElimination.eliminate(p, eliminated = Some(plan.nodeName))
+          case None =>
+            findFirstNonDeterministicNode(plan) match {
+              case Some(node) =>
+                PredicateElimination.eliminate(p, eliminated = Some(planOrExpressionName(node)))
+              case None => PredicateElimination.keep(p)
+            }
+        }
+      // And and Or can safely be recursed through. Replacing any non-deterministic sub-tree
+      // with `True` will lead us to at most select more files than necessary later.
+      case p: And => PredicateElimination.recurse(p, eliminateNonDeterministicPredicates)
+      case p: Or => PredicateElimination.recurse(p, eliminateNonDeterministicPredicates)
+      // All other expressions must either be completely deterministic,
+      // or must be replaced entirely, since replacing only their non-deterministic children
+      // may lead to files wrongly being deselected (e.g. `NOT True`).
+      case p =>
+        // We always look for non-deterministic child nodes, whether or not `p` is actually
+        // deterministic. This gives us better feedback on what caused the non-determinism in
+        // cases where `p` itself it deterministic but `p.deterministic = false` due to correctly
+        // detected non-deterministic child nodes.
+        findFirstNonDeterministicChildNode(p.children) match {
+          case Some(node) =>
+            PredicateElimination.eliminate(p, eliminated = Some(planOrExpressionName(node)))
+          case None => if (p.deterministic) {
+            PredicateElimination.keep(p)
+          } else {
+            PredicateElimination.eliminate(p)
+          }
+        }
+    }
+  }
+
+  private def eliminateUnsupportedPredicates(predicates: Seq[Expression])(
+     eliminatePredicates: Expression => PredicateElimination): PredicateElimination = {
+    predicates
+      .map(eliminatePredicates)
+      .foldLeft(PredicateElimination.EMPTY) { case (acc, predicates) =>
+        acc.copy(
+          newPredicates = acc.newPredicates ++ predicates.newPredicates,
+          eliminatedPredicates = acc.eliminatedPredicates ++ predicates.eliminatedPredicates)
+      }
+  }
+
+  private def planOrExpressionName(e: Either[LogicalPlan, Expression]): String = e match {
+    case scala.util.Left(plan) => plan.nodeName
+    case scala.util.Right(expression) => expression.prettyName
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1045,6 +1045,30 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(false)
 
+  final object NonDeterministicPredicateWidening {
+    final val OFF = "off"
+    final val LOGGING = "logging"
+    final val ON = "on"
+
+    final val list = Set(OFF, LOGGING, ON)
+  }
+
+  val DELTA_CONFLICT_DETECTION_WIDEN_NONDETERMINISTIC_PREDICATES =
+    buildConf("conflictDetection.partitionLevelConcurrency.widenNonDeterministicPredicates")
+      .doc("Whether to widen non-deterministic predicates during partition-level concurrency. " +
+        "Widening can lead to additional conflicts." +
+        "When the value is 'off', non-deterministic predicates are not widened during conflict " +
+        "resolution." +
+        "The value 'logging' will log whether the widening of non-deterministic predicates lead " +
+        "to additional conflicts. The conflict resolution is still done without widening. " +
+        "When the value is 'on', non-deterministic predicates are widened during conflict " +
+        "resolution.")
+      .internal()
+      .stringConf
+      .transform(_.toLowerCase(Locale.ROOT))
+      .checkValues(NonDeterministicPredicateWidening.list)
+      .createWithDefault(NonDeterministicPredicateWidening.ON)
+
   val DELTA_UNIFORM_ICEBERG_SYNC_CONVERT_ENABLED =
     buildConf("uniform.iceberg.sync.convert.enabled")
       .doc("If enabled, iceberg conversion will be done synchronously. " +

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ConflictCheckerPredicateEliminationUnitSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ConflictCheckerPredicateEliminationUnitSuite.scala
@@ -1,0 +1,170 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.dsl.expressions.DslExpression
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
+import org.apache.spark.sql.catalyst.expressions.ScalarSubquery
+import org.apache.spark.sql.functions.{col, rand, udf}
+import org.apache.spark.sql.test.SharedSparkSession
+
+/**
+ * A set cheaper unit tests, that behave the same no matter if DVs, CDF, etc. are enabled
+ * and do not need to be repeated in each conflict checker suite.
+ */
+class ConflictCheckerPredicateEliminationUnitSuite
+  extends QueryTest
+  with SharedSparkSession
+  with ConflictCheckerPredicateElimination {
+
+  val simpleExpressionA: Expression = (col("a") === 1).expr
+  val simpleExpressionB: Expression = (col("b") === "test").expr
+
+  val deterministicExpression: Expression = (col("c") > 5L).expr
+  val nonDeterministicExpression: Expression = (col("c") > rand()).expr
+  lazy val deterministicSubquery: Expression = {
+    val df = spark.sql("SELECT 5")
+    df.collect()
+    col("c").expr > ScalarSubquery(df.queryExecution.analyzed)
+  }
+  lazy val nonDeterministicSubquery: Expression = {
+    val df = spark.sql("SELECT rand()")
+    df.collect()
+    col("c").expr > ScalarSubquery(df.queryExecution.analyzed)
+  }
+
+  private def checkEliminationResult(
+      predicate: Expression,
+      expected: PredicateElimination,
+      eliminationFunction: Seq[Expression] => PredicateElimination =
+        eliminateNonDeterministicPredicates): Unit = {
+    require(expected.newPredicates.size === 1)
+    val actual = eliminationFunction(Seq(predicate))
+    assert(actual.newPredicates.size === 1)
+    assert(actual.newPredicates.head.canonicalized == expected.newPredicates.head.canonicalized,
+      s"actual=$actual\nexpected=$expected")
+    assert(actual.eliminatedPredicates === expected.eliminatedPredicates)
+  }
+
+  for {
+    deterministic <- BOOLEAN_DOMAIN
+    subquery <- BOOLEAN_DOMAIN
+  } {
+    lazy val exprUnderTest = if (deterministic) {
+      if (subquery) deterministicSubquery else deterministicExpression
+    } else {
+      if (subquery) nonDeterministicSubquery else nonDeterministicExpression
+    }
+
+    val testSuffix = s"deterministic $deterministic - subquery $subquery"
+
+    def newPredicates(exprF: Expression => Expression): PredicateElimination = PredicateElimination(
+      newPredicates = Seq(exprF(if (deterministic) exprUnderTest else Literal.TrueLiteral)),
+      eliminatedPredicates = if (deterministic) Seq.empty else Seq("rand"))
+
+    test(s"and expression - $testSuffix") {
+      checkEliminationResult(
+        predicate = simpleExpressionA && exprUnderTest,
+        expected = newPredicates { eliminatedExprUnderTest =>
+          if (deterministic) {
+            simpleExpressionA && eliminatedExprUnderTest
+          } else {
+            simpleExpressionA
+          }
+        }
+      )
+    }
+
+    test(s"or expression - $testSuffix") {
+      checkEliminationResult(
+        predicate = simpleExpressionA || exprUnderTest,
+        expected = newPredicates { _ =>
+          if (deterministic) {
+            simpleExpressionA || exprUnderTest
+          } else {
+            Literal.TrueLiteral
+          }
+        }
+      )
+    }
+
+    test(s"and or expression - $testSuffix") {
+      checkEliminationResult(
+        predicate = simpleExpressionA && (simpleExpressionB || exprUnderTest),
+        expected = newPredicates { _ =>
+          if (deterministic) {
+            simpleExpressionA && (simpleExpressionB || exprUnderTest)
+          } else {
+            simpleExpressionA
+          }
+        }
+      )
+    }
+
+    test(s"or and expression - $testSuffix") {
+      checkEliminationResult(
+        predicate = simpleExpressionA || (simpleExpressionB && exprUnderTest),
+        expected = newPredicates { _ =>
+          if (deterministic) {
+            simpleExpressionA || (simpleExpressionB && exprUnderTest)
+          } else {
+            simpleExpressionA || simpleExpressionB
+          }
+        }
+      )
+    }
+
+    test(s"or not and expression - $testSuffix") {
+      checkEliminationResult(
+        predicate = simpleExpressionA || !(simpleExpressionB && exprUnderTest),
+        expected = newPredicates { _ =>
+          if (deterministic) {
+            simpleExpressionA || !(simpleExpressionB && exprUnderTest)
+          } else {
+            Literal.TrueLiteral
+          }
+        }
+      )
+    }
+
+    test(s"and not or expression - $testSuffix") {
+      checkEliminationResult(
+        predicate = simpleExpressionA && !(simpleExpressionB || exprUnderTest),
+        expected = newPredicates { _ =>
+          if (deterministic) {
+            simpleExpressionA && !(simpleExpressionB || exprUnderTest)
+          } else {
+            simpleExpressionA
+          }
+        })
+    }
+  }
+
+  test("udf name is not exposed") {
+    val random = udf(() => Math.random())
+      .asNondeterministic()
+      .withName("sensitive_udf_name")
+    checkEliminationResult(
+      predicate = simpleExpressionA && (col("c") > random()).expr,
+      expected = PredicateElimination(
+        newPredicates = Seq(simpleExpressionA),
+        eliminatedPredicates = Seq("scalaudf")))
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

During conflict checking we use the partition predicates of the transaction to see if any newly added files of the winning transaction should have been read by the current transaction. This causes a re-evaluation of non-deterministic predicates. This can lead to not detecting conflicts, even though they should have been detected. To fix this, we widen non-deterministic predicates to `TrueLiteral`s, to always conflict with more files.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

* UT that checks that `PredicateElimination` eliminates non-deterministic predicates. It's hard to write an E2E test, as we don't have a way to write good concurrency tests.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
