### PR TITLE
[Kernel] Add support for column mapping `id` mode

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
@@ -39,6 +39,7 @@ import io.delta.kernel.internal.data.ScanStateRow;
 import io.delta.kernel.internal.data.SelectionColumnVector;
 import io.delta.kernel.internal.deletionvectors.DeletionVectorUtils;
 import io.delta.kernel.internal.deletionvectors.RoaringBitmapArray;
+import io.delta.kernel.internal.util.ColumnMapping;
 import io.delta.kernel.internal.util.PartitionUtils;
 import io.delta.kernel.internal.util.Tuple2;
 
@@ -221,10 +222,11 @@ public interface Scan {
                 // Change back to logical schema
                 String columnMappingMode = ScanStateRow.getColumnMappingMode(scanState);
                 switch (columnMappingMode) {
-                    case "name":
+                    case ColumnMapping.COLUMN_MAPPING_MODE_NAME:
+                    case ColumnMapping.COLUMN_MAPPING_MODE_ID:
                         updatedBatch = updatedBatch.withNewSchema(logicalSchema);
                         break;
-                    case "none":
+                    case ColumnMapping.COLUMN_MAPPING_MODE_NONE:
                         break;
                     default:
                         throw new UnsupportedOperationException(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/client/ParquetHandler.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/client/ParquetHandler.java
@@ -42,6 +42,12 @@ public interface ParquetHandler
      * If {@code physicalSchema} has a {@link StructField} with column name
      * {@link StructField#METADATA_ROW_INDEX_COLUMN_NAME} and the field is a metadata column
      * {@link StructField#isMetadataColumn()} the column must be populated with the file row index.
+     * <p>
+     * How does a column in {@code physicalSchema} match to the column in the Parquet file?
+     * If the {@link StructField} has a field id in the {@code metadata} with key `parquet.field.id`
+     * the column is attempted to match by id. If the column is not found by id, the column is
+     * matched by name. When trying to find the column in Parquet by name,
+     * first case-sensitive match is used. If not found then a case-insensitive match is attempted.
      *
      * @param fileIter       Iterator of {@link FileReadContext} objects to read data from.
      * @param physicalSchema Select list of columns to read from the Parquet file.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ColumnMapping.java
@@ -123,8 +123,8 @@ public class ColumnMapping {
                     .putLong(PARQUET_FIELD_ID_KEY, fieldId)
                     .build();
 
-                newSchema =
-                    newSchema.add(physicalName, physicalType, logicalField.isNullable(), fieldMetadata);
+                newSchema = newSchema
+                    .add(physicalName, physicalType, logicalField.isNullable(), fieldMetadata);
             } else {
                 newSchema = newSchema.add(physicalName, physicalType, logicalField.isNullable());
             }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetSchemaUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetSchemaUtils.java
@@ -16,6 +16,7 @@
 package io.delta.kernel.defaults.internal.parquet;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -23,16 +24,16 @@ import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Type;
 
-import io.delta.kernel.types.DataType;
-import io.delta.kernel.types.StructField;
-import io.delta.kernel.types.StructType;
+import io.delta.kernel.types.*;
+
+import io.delta.kernel.internal.util.ColumnMapping;
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 
 /**
  * Utility methods for Delta schema to Parquet schema conversion.
  */
 class ParquetSchemaUtils {
     private ParquetSchemaUtils() {}
-
     /**
      * Given the file schema in Parquet file and selected columns by Delta, return
      * a subschema of the file schema.
@@ -44,7 +45,8 @@ class ParquetSchemaUtils {
     static MessageType pruneSchema(
         GroupType fileSchema /* parquet */,
         StructType deltaType /* delta-kernel */) {
-        return new MessageType("fileSchema", pruneFields(fileSchema, deltaType));
+        boolean hasFieldIds = hasFieldIds(deltaType);
+        return new MessageType("fileSchema", pruneFields(fileSchema, deltaType, hasFieldIds));
     }
 
     /**
@@ -55,8 +57,21 @@ class ParquetSchemaUtils {
      * @param field     Sub field given as Delta Kernel's {@link StructField}
      * @return {@link Type} of the Parquet field. Returns {@code null}, if not found.
      */
-    static Type findSubFieldType(GroupType groupType, StructField field) {
-        // TODO: Need a way to search by id once we start supporting column mapping `id` mode.
+    static Type findSubFieldType(
+            GroupType groupType,
+            StructField field,
+            Map<Integer, Type> parquetFieldIdToTypeMap) {
+
+        // First search by the field id. If not found, search by case-sensitive name. Finally
+        // by the case-insensitive name.
+        if (hasFieldId(field.getMetadata())) {
+            int deltaFieldId = getFieldId(field.getMetadata());
+            Type subType = parquetFieldIdToTypeMap.get(deltaFieldId);
+            if (subType != null) {
+                return subType;
+            }
+        }
+
         final String columnName = field.getName();
         if (groupType.containsField(columnName)) {
             return groupType.getType(columnName);
@@ -72,13 +87,33 @@ class ParquetSchemaUtils {
         return null;
     }
 
-    private static List<Type> pruneFields(GroupType type, StructType deltaDataType) {
+    /**
+     * Returns a map from field id to Parquet type for fields that have the field id set.
+     */
+    static Map<Integer, Type> getParquetFieldToTypeMap(GroupType parquetGroupType) {
+        // Generate the field id to Parquet type map only if the read schema has field ids.
+        return parquetGroupType.getFields().stream()
+            .filter(subFieldType -> subFieldType.getId() != null)
+            .collect(
+                Collectors.toMap(
+                    subFieldType -> subFieldType.getId().intValue(),
+                    subFieldType -> subFieldType,
+                    (u, v) -> {
+                        throw new IllegalStateException(String.format("Parquet file contains " +
+                            "multiple columns (%s, %s) with the same field id", u, v));
+                    }));
+    }
+
+    private static List<Type> pruneFields(
+        GroupType type, StructType deltaDataType, boolean hasFieldIds) {
         // prune fields including nested pruning like in pruneSchema
+        final Map<Integer, Type> parquetFieldIdToTypeMap = getParquetFieldToTypeMap(type);
+
         return deltaDataType.fields().stream()
             .map(column -> {
-                Type subType = findSubFieldType(type, column);
+                Type subType = findSubFieldType(type, column, parquetFieldIdToTypeMap);
                 if (subType != null) {
-                    return prunedType(subType, column.getDataType());
+                    return prunedType(subType, column.getDataType(), hasFieldIds);
                 } else {
                     return null;
                 }
@@ -87,13 +122,54 @@ class ParquetSchemaUtils {
             .collect(Collectors.toList());
     }
 
-    private static Type prunedType(Type type, DataType deltaType) {
+    private static Type prunedType(Type type, DataType deltaType, boolean hasFieldIds) {
         if (type instanceof GroupType && deltaType instanceof StructType) {
             GroupType groupType = (GroupType) type;
             StructType structType = (StructType) deltaType;
-            return groupType.withNewFields(pruneFields(groupType, structType));
+            return groupType.withNewFields(pruneFields(groupType, structType, hasFieldIds));
         } else {
             return type;
         }
+    }
+
+    /**
+     * Recursively checks whether the given data type has any Parquet field ids in it.
+     */
+    private static boolean hasFieldIds(DataType dataType) {
+        if (dataType instanceof StructType) {
+            StructType structType = (StructType) dataType;
+            for (StructField field : structType.fields()) {
+                if (hasFieldId(field.getMetadata()) || hasFieldIds(field.getDataType())) {
+                    return true;
+                }
+            }
+            return false;
+        } else if (dataType instanceof ArrayType) {
+            return hasFieldIds(((ArrayType) dataType).getElementType());
+        } else if (dataType instanceof MapType) {
+            MapType mapType = (MapType) dataType;
+            return hasFieldIds(mapType.getKeyType()) || hasFieldIds(mapType.getValueType());
+        }
+
+        // Primitive types don't have metadata field. It will be checked as part of the
+        // StructType check this primitive type is part of.
+        return false;
+    }
+
+    private static Boolean hasFieldId(FieldMetadata fieldMetadata) {
+        return fieldMetadata.contains(ColumnMapping.PARQUET_FIELD_ID_KEY);
+    }
+
+    /** Assumes the field id exists */
+    private static int getFieldId(FieldMetadata fieldMetadata) {
+        // Field id delta schema metadata is deserialized as long, but the range should always
+        // be within integer range.
+        Long fieldId = (Long) fieldMetadata.get(ColumnMapping.PARQUET_FIELD_ID_KEY);
+        long fieldIdLong = fieldId.longValue();
+        int fieldIdInt = (int) fieldIdLong;
+        checkArgument(
+            (long) fieldIdInt == fieldIdLong,
+            "Field id out of range", fieldIdLong);
+        return fieldIdInt;
     }
 }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/RowConverter.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/RowConverter.java
@@ -34,6 +34,7 @@ import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 import io.delta.kernel.defaults.internal.data.DefaultColumnarBatch;
 import io.delta.kernel.defaults.internal.data.vector.DefaultStructVector;
 import static io.delta.kernel.defaults.internal.parquet.ParquetSchemaUtils.findSubFieldType;
+import static io.delta.kernel.defaults.internal.parquet.ParquetSchemaUtils.getParquetFieldToTypeMap;
 
 class RowConverter
     extends GroupConverter
@@ -76,8 +77,9 @@ class RowConverter
         for (int i = 0; i < converters.length; i++) {
             final StructField field = fields.get(i);
             final DataType typeFromClient = field.getDataType();
+            final Map<Integer, Type> paruqetFieldIdToTypeMap = getParquetFieldToTypeMap(fileSchema);
             final Type typeFromFile = field.isDataColumn() ?
-                findSubFieldType(fileSchema, field) : null;
+                findSubFieldType(fileSchema, field, paruqetFieldIdToTypeMap) : null;
             if (typeFromFile == null) {
                 if (StructField.METADATA_ROW_INDEX_COLUMN_NAME.equalsIgnoreCase(field.getName()) &&
                     field.isMetadataColumn()) {

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/RowConverter.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/RowConverter.java
@@ -77,9 +77,9 @@ class RowConverter
         for (int i = 0; i < converters.length; i++) {
             final StructField field = fields.get(i);
             final DataType typeFromClient = field.getDataType();
-            final Map<Integer, Type> paruqetFieldIdToTypeMap = getParquetFieldToTypeMap(fileSchema);
+            final Map<Integer, Type> parquetFieldIdToTypeMap = getParquetFieldToTypeMap(fileSchema);
             final Type typeFromFile = field.isDataColumn() ?
-                findSubFieldType(fileSchema, field, paruqetFieldIdToTypeMap) : null;
+                findSubFieldType(fileSchema, field, parquetFieldIdToTypeMap) : null;
             if (typeFromFile == null) {
                 if (StructField.METADATA_ROW_INDEX_COLUMN_NAME.equalsIgnoreCase(field.getName()) &&
                     field.isMetadataColumn()) {

--- a/kernel/kernel-defaults/src/test/java/io/delta/kernel/defaults/integration/TestDeltaTableReads.java
+++ b/kernel/kernel-defaults/src/test/java/io/delta/kernel/defaults/integration/TestDeltaTableReads.java
@@ -150,15 +150,4 @@ public class TestDeltaTableReads
         ColumnarBatch expData = builder.build();
         compareEqualUnorderd(expData, actualData);
     }
-
-    @Test
-    public void columnMappingIdModeThrowsError()
-        throws Exception {
-        expectedEx.expect(UnsupportedOperationException.class);
-        expectedEx.expectMessage("Unsupported column mapping mode: id");
-
-        String tablePath = getTestResourceFilePath("column-mapping-id");
-        Snapshot snapshot = snapshot(tablePath);
-        readSnapshot(snapshot.getSchema(tableClient), snapshot);
-    }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
@@ -293,68 +293,100 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
     )
   }
 
+  Seq("name", "id").foreach { columnMappingMode =>
+    test(s"table with `$columnMappingMode` column mapping mode") {
+      val path = goldenTablePath(s"table-with-columnmapping-mode-$columnMappingMode")
 
-  test("table with `name` column mapping mode") {
-    val path = goldenTablePath("table-with-columnmapping-mode-name")
-
-    val expectedAnswer = (0 until 5).map { i =>
-      TestRow(
-        i.byteValue(),
-        i.shortValue(),
-        i,
-        i.longValue(),
-        i.floatValue(),
-        i.doubleValue(),
-        new java.math.BigDecimal(i),
-        i % 2 == 0,
-        i.toString,
-        i.toString.getBytes,
-        daysSinceEpoch(Date.valueOf("2021-11-18")), // date in days
-        (i * 1000).longValue(), // timestamp in micros
-        TestRow(i.toString, TestRow(i)), // nested_struct
-        Seq(i, i + 1), // array_of_prims
-        Seq(Seq(i, i + 1), Seq(i + 2, i + 3)), // array_of_arrays
-        Seq(TestRow(i.longValue()), null), // array_of_structs
-        Map(
-          i -> (i + 1).longValue(),
-          (i + 2) -> (i + 3).longValue()
-        ), // map_of_prims
-        Map(i + 1 -> TestRow((i * 20).longValue())), // map_of_rows
-        {
-          val val1 = Seq(i, null, i + 1)
-          val val2 = Seq[Integer]()
+      val expectedAnswer = (0 until 5).map { i =>
+        TestRow(
+          i.byteValue(),
+          i.shortValue(),
+          i,
+          i.longValue(),
+          i.floatValue(),
+          i.doubleValue(),
+          new java.math.BigDecimal(i),
+          i % 2 == 0,
+          i.toString,
+          i.toString.getBytes,
+          daysSinceEpoch(Date.valueOf("2021-11-18")), // date in days
+          (i * 1000).longValue(), // timestamp in micros
+          TestRow(i.toString, TestRow(i)), // nested_struct
+          Seq(i, i + 1), // array_of_prims
+          Seq(Seq(i, i + 1), Seq(i + 2, i + 3)), // array_of_arrays
+          Seq(TestRow(i.longValue()), null), // array_of_structs
           Map(
-            i.longValue() -> val1,
-            (i + 1).longValue() -> val2
-          ) // map_of_arrays
-        }
-      )
-    } ++ (TestRow(
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null,
-      null
-    ) :: Nil)
+            i -> (i + 1).longValue(),
+            (i + 2) -> (i + 3).longValue()
+          ), // map_of_prims
+          Map(i + 1 -> TestRow((i * 20).longValue())), // map_of_rows
+          {
+            val val1 = Seq(i, null, i + 1)
+            val val2 = Seq[Integer]()
+            Map(
+              i.longValue() -> val1,
+              (i + 1).longValue() -> val2
+            ) // map_of_arrays
+          }
+        )
+      } ++ (TestRow(
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ) :: Nil)
 
-    checkTable(
-      path = path,
-      expectedAnswer = expectedAnswer
-    )
+      checkTable(
+        path = path,
+        expectedAnswer = expectedAnswer
+      )
+    }
+  }
+
+  Seq("name", "id").foreach { columnMappingMode =>
+    test(s"table with `$columnMappingMode` column mapping mode - read subset of columns") {
+      val path = goldenTablePath(s"table-with-columnmapping-mode-$columnMappingMode")
+
+      val expectedAnswer = (0 until 5).map { i =>
+        TestRow(
+          i.byteValue(),
+          new java.math.BigDecimal(i),
+          TestRow(i.toString, TestRow(i)), // nested_struct
+          Seq(i, i + 1), // array_of_prims
+          Map(
+            i -> (i + 1).longValue(),
+            (i + 2) -> (i + 3).longValue()
+          ) // map_of_prims
+        )
+      } ++ (TestRow(
+        null,
+        null,
+        null,
+        null,
+        null
+      ) :: Nil)
+
+      checkTable(
+        path = path,
+        expectedAnswer = expectedAnswer,
+        readCols = Seq("ByteType", "decimal", "nested_struct", "array_of_prims", "map_of_prims")
+      )
+    }
   }
 
   test("table with complex map types") {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetSchemaUtilsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetSchemaUtilsSuite.scala
@@ -138,7 +138,7 @@ class ParquetSchemaUtilsSuite extends AnyFunSuite with TestUtils {
         "f0",
         new StructType()
           .add("F00", IntegerType.INTEGER) // no field id and with case-insensitive column name
-          .add("f01", IntegerType.INTEGER, fieldMetadata(3)),
+          .add("f01", IntegerType.INTEGER, fieldMetadata(3))
         // no field id for struct f0
       )
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetSchemaUtilsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetSchemaUtilsSuite.scala
@@ -1,0 +1,239 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults.internal.parquet
+
+import io.delta.kernel.defaults.internal.parquet.ParquetSchemaUtils.pruneSchema
+import io.delta.kernel.defaults.utils.TestUtils
+import io.delta.kernel.internal.util.ColumnMapping
+import io.delta.kernel.types.{ArrayType, DoubleType, FieldMetadata, IntegerType, LongType, MapType, StructType}
+import org.apache.parquet.schema.MessageTypeParser
+import org.scalatest.funsuite.AnyFunSuite
+
+class ParquetSchemaUtilsSuite extends AnyFunSuite with TestUtils {
+  // Test parquet schema type containing different types of columns with field ids
+  private val testParquetFileSchema = MessageTypeParser.parseMessageType(
+    """message fileSchema {
+      |  required group f0 = 1 {
+      |    optional int32 f00 = 2;
+      |    optional int64 f01 = 3;
+      |  }
+      |  optional group f1 = 4 {
+      |    repeated group list = 5 {
+      |      optional int32 element = 6;
+      |    }
+      |  }
+      |  required group f2 (MAP) = 7 {
+      |    repeated group key_value = 8 {
+      |      required group key = 9 {
+      |        required int32 key_f0 = 10;
+      |        required int64 key_f1 = 11;
+      |      }
+      |      required int32 value = 12;
+      |    }
+      |  }
+      |  optional double f3 = 13;
+      |}
+      """.stripMargin)
+
+  // Delta schema corresponding to the above test [[parquetSchema]]
+  private val testParquetFileDeltaSchema = new StructType()
+    .add("f0",
+      new StructType()
+        .add("f00", IntegerType.INTEGER, fieldMetadata(2))
+        .add("f01", LongType.LONG, fieldMetadata(3)),
+      fieldMetadata(1))
+    .add("f1", new ArrayType(IntegerType.INTEGER, false), fieldMetadata(4))
+    .add(
+      "f2",
+      new MapType(
+        new StructType()
+          .add("key_f0", IntegerType.INTEGER, fieldMetadata(10))
+          .add("key_f1", IntegerType.INTEGER, fieldMetadata(11)),
+        IntegerType.INTEGER,
+        false
+      ),
+      fieldMetadata(7))
+    .add("f3", DoubleType.DOUBLE, fieldMetadata(13))
+
+
+  test("id mapping mode - delta reads all columns in the parquet file") {
+    val prunedParquetSchema = pruneSchema(testParquetFileSchema, testParquetFileDeltaSchema)
+    assert(prunedParquetSchema === testParquetFileSchema)
+  }
+
+  test("id mapping mode - delta selects a subset of columns in the parquet file") {
+    val readDeltaSchema = new StructType()
+      .add(testParquetFileDeltaSchema.get("f1"))
+      .add( // nested column pruning
+        "f0",
+        new StructType()
+          .add("f00", IntegerType.INTEGER, fieldMetadata(2)),
+        fieldMetadata(1)
+      )
+
+    val expectedParquetSchema = MessageTypeParser.parseMessageType(
+      """message fileSchema {
+        |  optional group f1 = 4 {
+        |    repeated group list = 5 {
+        |      optional int32 element = 6;
+        |    }
+        |  }
+        |  required group f0 = 1 {
+        |    optional int32 f00 = 2;
+        |  }
+        |}
+        """.stripMargin)
+
+    val prunedParquetSchema = pruneSchema(testParquetFileSchema, readDeltaSchema)
+    assert(prunedParquetSchema === expectedParquetSchema)
+  }
+
+  test("id mapping mode - delta tries to read a column not present in the parquet file") {
+    val readDeltaSchema = new StructType()
+      .add(testParquetFileDeltaSchema.get("f1"))
+      .add( // nested column has extra column that is not present in the file
+        "f0",
+        new StructType()
+          .add("f00", IntegerType.INTEGER, fieldMetadata(2))
+          .add("f02", IntegerType.INTEGER, fieldMetadata(15)),
+        fieldMetadata(1)
+      )
+      .add("f4", IntegerType.INTEGER, fieldMetadata(14))
+
+    // pruned parquet file schema shouldn't have the column "f4"
+    val expectedParquetSchema = MessageTypeParser.parseMessageType(
+      """message fileSchema {
+        |  optional group f1 = 4 {
+        |    repeated group list = 5 {
+        |      optional int32 element = 6;
+        |    }
+        |  }
+        |  required group f0 = 1 {
+        |    optional int32 f00 = 2;
+        |  }
+        |}
+        """.stripMargin)
+
+    val prunedParquetSchema = pruneSchema(testParquetFileSchema, readDeltaSchema)
+    assert(prunedParquetSchema === expectedParquetSchema)
+  }
+
+  test("id mapping mode - combination of columns with and w/o field ids in delta read schema") {
+    val readDeltaSchema = new StructType()
+      .add(testParquetFileDeltaSchema.get("f1")) // with field id
+      .add( // nested column has extra column that is not present in the file
+        "f0",
+        new StructType()
+          .add("F00", IntegerType.INTEGER) // no field id and with case-insensitive column name
+          .add("f01", IntegerType.INTEGER, fieldMetadata(3)),
+        // no field id for struct f0
+      )
+
+    val expectedParquetSchema = MessageTypeParser.parseMessageType(
+      """message fileSchema {
+        |  optional group f1 = 4 {
+        |    repeated group list = 5 {
+        |      optional int32 element = 6;
+        |    }
+        |  }
+        |  required group f0 = 1 {
+        |    optional int32 f00 = 2;
+        |    optional int64 f01 = 3;
+        |  }
+        |}
+        """.stripMargin)
+
+    val prunedParquetSchema = pruneSchema(testParquetFileSchema, readDeltaSchema)
+    assert(prunedParquetSchema === expectedParquetSchema)
+  }
+
+  test("id mapping mode - field id matches but not the column name") {
+    val readDeltaSchema = new StructType()
+       // physical name in the file is f3, but the same field id
+      .add("f3_new", DoubleType.DOUBLE, fieldMetadata(13))
+      .add(
+        "f0",
+        new StructType()
+          // physical name in the file is f00, but the same field id
+          .add("f00_new", IntegerType.INTEGER, fieldMetadata(2)),
+        fieldMetadata(1)
+      )
+
+    val expectedParquetSchema = MessageTypeParser.parseMessageType(
+      """message fileSchema {
+        |  optional double f3 = 13;
+        |  required group f0 = 1 {
+        |    optional int32 f00 = 2;
+        |  }
+        |}
+        """.stripMargin)
+
+    val prunedParquetSchema = pruneSchema(testParquetFileSchema, readDeltaSchema)
+    assert(prunedParquetSchema === expectedParquetSchema)
+  }
+
+  test("id mapping mode - duplicate id in file at the same level throws error") {
+    val readDeltaSchema = new StructType()
+      .add("f3", DoubleType.DOUBLE, fieldMetadata(13))
+
+    val testParquetFileSchema = MessageTypeParser.parseMessageType(
+      """message fileSchema {
+        |  optional double f3 = 13;
+        |  optional double f4 = 13;
+        |}
+        """.stripMargin)
+
+    val ex = intercept[Exception] {
+      pruneSchema(testParquetFileSchema, readDeltaSchema)
+    }
+    assert(ex.getMessage.contains(
+      "Parquet file contains multiple columns (optional double f3 = 13, " +
+        "optional double f4 = 13) with the same field id"))
+  }
+
+  test("id mapping mode - duplicate id in file at the same nested level throws error") {
+    val readDeltaSchema = new StructType()
+      .add(
+        "f0",
+        new StructType()
+          .add("f00", IntegerType.INTEGER, fieldMetadata(2)),
+        fieldMetadata(1)
+      )
+
+    val testParquetFileSchema = MessageTypeParser.parseMessageType(
+      """message fileSchema {
+        |  required group f0 = 1 {
+        |    optional int32 f00 = 2;
+        |    optional int64 f01 = 3;
+        |    optional int64 f02 = 2;
+        |  }
+        |}
+        """.stripMargin)
+
+    val ex = intercept[Exception] {
+      pruneSchema(testParquetFileSchema, readDeltaSchema)
+    }
+    assert(ex.getMessage.contains(
+      "Parquet file contains multiple columns (optional int32 f00 = 2, " +
+        "optional int64 f02 = 2) with the same field id"))
+  }
+
+  private def fieldMetadata(id: Int): FieldMetadata = {
+    FieldMetadata.builder()
+      .putLong(ColumnMapping.PARQUET_FIELD_ID_KEY, id)
+      .build()
+  }
+}


### PR DESCRIPTION
## Description
Adds support for column mapping id mode. The Parquet handler API contract is updated to look for the field id in `StructField`s of given read schema. When field IDs are present attempt is made to look up the column in the Parquet file by ID. If not found, an attempt is made to find the column in the Parquet file by column name.

## How was this patch tested?
Added integration tests and granular unittests (converting missing field ids etc.) for the Delta schema to Parquet schema conversion utilities.

