### PR TITLE
[Kernel] Fix comparison bug in default Parquet reader

### DIFF
--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/RowConverter.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/RowConverter.java
@@ -79,7 +79,7 @@ class RowConverter
             final Type typeFromFile = field.isDataColumn() ?
                 findSubFieldType(fileSchema, field) : null;
             if (typeFromFile == null) {
-                if (field.getName() == StructField.METADATA_ROW_INDEX_COLUMN_NAME &&
+                if (StructField.METADATA_ROW_INDEX_COLUMN_NAME.equalsIgnoreCase(field.getName()) &&
                     field.isMetadataColumn()) {
                     checkArgument(field.getDataType() instanceof LongType,
                         "row index metadata column must be type long");


### PR DESCRIPTION
## Description
We are using `==` to compare strings. It worked because we used the same static variable everywhere.

## How was this patch tested?
Existing tests.
