### PR TITLE
[Kernel] Move Parquet utility methods into a separate utils file

### DIFF
--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/DefaultKernelUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/DefaultKernelUtils.java
@@ -16,86 +16,11 @@
 package io.delta.kernel.defaults.internal;
 
 import java.time.LocalDate;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
-import org.apache.parquet.schema.GroupType;
-import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.Type;
-
-import io.delta.kernel.types.DataType;
-import io.delta.kernel.types.StructField;
-import io.delta.kernel.types.StructType;
 
 public class DefaultKernelUtils {
     private static final LocalDate EPOCH = LocalDate.ofEpochDay(0);
 
     private DefaultKernelUtils() {}
-
-    /**
-     * Given the file schema in Parquet file and selected columns by Delta, return
-     * a subschema of the file schema.
-     *
-     * @param fileSchema
-     * @param deltaType
-     * @return
-     */
-    public static final MessageType pruneSchema(
-        GroupType fileSchema /* parquet */,
-        StructType deltaType /* delta-kernel */) {
-        return new MessageType("fileSchema", pruneFields(fileSchema, deltaType));
-    }
-
-    /**
-     * Search for the Parquet type in {@code groupType} of subfield which is equivalent to
-     * given {@code field}.
-     *
-     * @param groupType Parquet group type coming from the file schema.
-     * @param field     Sub field given as Delta Kernel's {@link StructField}
-     * @return {@link Type} of the Parquet field. Returns {@code null}, if not found.
-     */
-    public static Type findSubFieldType(GroupType groupType, StructField field) {
-        // TODO: Need a way to search by id once we start supporting column mapping `id` mode.
-        final String columnName = field.getName();
-        if (groupType.containsField(columnName)) {
-            return groupType.getType(columnName);
-        }
-        // Parquet is case-sensitive, but the engine that generated the parquet file may not be.
-        // Check for direct match above but if no match found, try case-insensitive match.
-        for (org.apache.parquet.schema.Type type : groupType.getFields()) {
-            if (type.getName().equalsIgnoreCase(columnName)) {
-                return type;
-            }
-        }
-
-        return null;
-    }
-
-    private static List<Type> pruneFields(GroupType type, StructType deltaDataType) {
-        // prune fields including nested pruning like in pruneSchema
-        return deltaDataType.fields().stream()
-            .map(column -> {
-                Type subType = findSubFieldType(type, column);
-                if (subType != null) {
-                    return prunedType(subType, column.getDataType());
-                } else {
-                    return null;
-                }
-            })
-            .filter(Objects::nonNull)
-            .collect(Collectors.toList());
-    }
-
-    private static Type prunedType(Type type, DataType deltaType) {
-        if (type instanceof GroupType && deltaType instanceof StructType) {
-            GroupType groupType = (GroupType) type;
-            StructType structType = (StructType) deltaType;
-            return groupType.withNewFields(pruneFields(groupType, structType));
-        } else {
-            return type;
-        }
-    }
 
     //////////////////////////////////////////////////////////////////////////////////
     // Below utils are adapted from org.apache.spark.sql.catalyst.util.DateTimeUtils

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetBatchReader.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetBatchReader.java
@@ -39,8 +39,6 @@ import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 
-import io.delta.kernel.defaults.internal.DefaultKernelUtils;
-
 public class ParquetBatchReader {
     private final Configuration configuration;
     private final int maxBatchSize;
@@ -129,7 +127,7 @@ public class ParquetBatchReader {
         @Override
         public ReadContext init(InitContext context) {
             return new ReadContext(
-                DefaultKernelUtils.pruneSchema(context.getFileSchema(), readSchema));
+                ParquetSchemaUtils.pruneSchema(context.getFileSchema(), readSchema));
         }
 
         @Override

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetSchemaUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetSchemaUtils.java
@@ -30,7 +30,7 @@ import io.delta.kernel.types.StructType;
 /**
  * Utility methods for Delta schema to Parquet schema conversion.
  */
-public class ParquetSchemaUtils {
+class ParquetSchemaUtils {
     private ParquetSchemaUtils() {}
 
     /**
@@ -41,7 +41,7 @@ public class ParquetSchemaUtils {
      * @param deltaType
      * @return
      */
-    public static final MessageType pruneSchema(
+    static MessageType pruneSchema(
         GroupType fileSchema /* parquet */,
         StructType deltaType /* delta-kernel */) {
         return new MessageType("fileSchema", pruneFields(fileSchema, deltaType));
@@ -55,7 +55,7 @@ public class ParquetSchemaUtils {
      * @param field     Sub field given as Delta Kernel's {@link StructField}
      * @return {@link Type} of the Parquet field. Returns {@code null}, if not found.
      */
-    public static Type findSubFieldType(GroupType groupType, StructField field) {
+    static Type findSubFieldType(GroupType groupType, StructField field) {
         // TODO: Need a way to search by id once we start supporting column mapping `id` mode.
         final String columnName = field.getName();
         if (groupType.containsField(columnName)) {

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetSchemaUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetSchemaUtils.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults.internal.parquet;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.Type;
+
+import io.delta.kernel.types.DataType;
+import io.delta.kernel.types.StructField;
+import io.delta.kernel.types.StructType;
+
+/**
+ * Utility methods for Delta schema to Parquet schema conversion.
+ */
+public class ParquetSchemaUtils {
+    private ParquetSchemaUtils() {}
+
+    /**
+     * Given the file schema in Parquet file and selected columns by Delta, return
+     * a subschema of the file schema.
+     *
+     * @param fileSchema
+     * @param deltaType
+     * @return
+     */
+    public static final MessageType pruneSchema(
+        GroupType fileSchema /* parquet */,
+        StructType deltaType /* delta-kernel */) {
+        return new MessageType("fileSchema", pruneFields(fileSchema, deltaType));
+    }
+
+    /**
+     * Search for the Parquet type in {@code groupType} of subfield which is equivalent to
+     * given {@code field}.
+     *
+     * @param groupType Parquet group type coming from the file schema.
+     * @param field     Sub field given as Delta Kernel's {@link StructField}
+     * @return {@link Type} of the Parquet field. Returns {@code null}, if not found.
+     */
+    public static Type findSubFieldType(GroupType groupType, StructField field) {
+        // TODO: Need a way to search by id once we start supporting column mapping `id` mode.
+        final String columnName = field.getName();
+        if (groupType.containsField(columnName)) {
+            return groupType.getType(columnName);
+        }
+        // Parquet is case-sensitive, but the engine that generated the parquet file may not be.
+        // Check for direct match above but if no match found, try case-insensitive match.
+        for (org.apache.parquet.schema.Type type : groupType.getFields()) {
+            if (type.getName().equalsIgnoreCase(columnName)) {
+                return type;
+            }
+        }
+
+        return null;
+    }
+
+    private static List<Type> pruneFields(GroupType type, StructType deltaDataType) {
+        // prune fields including nested pruning like in pruneSchema
+        return deltaDataType.fields().stream()
+            .map(column -> {
+                Type subType = findSubFieldType(type, column);
+                if (subType != null) {
+                    return prunedType(subType, column.getDataType());
+                } else {
+                    return null;
+                }
+            })
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList());
+    }
+
+    private static Type prunedType(Type type, DataType deltaType) {
+        if (type instanceof GroupType && deltaType instanceof StructType) {
+            GroupType groupType = (GroupType) type;
+            StructType structType = (StructType) deltaType;
+            return groupType.withNewFields(pruneFields(groupType, structType));
+        } else {
+            return type;
+        }
+    }
+}

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/RowConverter.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/RowConverter.java
@@ -33,7 +33,7 @@ import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 
 import io.delta.kernel.defaults.internal.data.DefaultColumnarBatch;
 import io.delta.kernel.defaults.internal.data.vector.DefaultStructVector;
-import static io.delta.kernel.defaults.internal.DefaultKernelUtils.findSubFieldType;
+import static io.delta.kernel.defaults.internal.parquet.ParquetSchemaUtils.findSubFieldType;
 
 class RowConverter
     extends GroupConverter


### PR DESCRIPTION
## Description
Just a refactoring. Currently, the Parquet related utility methods are in the generic utility file. Move them to a separate file as the utility methods are going to increase (with #2374).

## How was this patch tested?
Existing tests.
