### PR TITLE
[Spark] fix Delta Uniform field id for nested types

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
@@ -304,7 +304,7 @@ class IcebergConversionTransaction(
     // hard code delta version as -1 for CREATE_TABLE and REPLACE_TABLE, which will be later set to
     // correct version during setSchema
     val deltaVersion = if (tableOp == CREATE_TABLE || tableOp == REPLACE_TABLE) -1
-      else postCommitSnapshot.version.toString
+      else postCommitSnapshot.version
 
     txn.updateProperties()
       .set(IcebergConverter.DELTA_VERSION_PROPERTY, deltaVersion.toString)

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
@@ -300,14 +300,32 @@ class IcebergConversionTransaction(
     assert(fileUpdates.forall(_.hasCommitted), "Cannot commit. You have uncommitted changes.")
 
     val nameMapping = NameMappingParser.toJson(MappingUtil.create(icebergSchema))
+
+    // hard code delta version as -1 for CREATE_TABLE and REPLACE_TABLE, which will be later set to
+    // correct version during setSchema
+    val deltaVersion = if (tableOp == CREATE_TABLE || tableOp == REPLACE_TABLE) -1
+      else postCommitSnapshot.version.toString
+
     txn.updateProperties()
-      .set(IcebergConverter.DELTA_VERSION_PROPERTY, postCommitSnapshot.version.toString)
+      .set(IcebergConverter.DELTA_VERSION_PROPERTY, deltaVersion.toString)
       .set(IcebergConverter.DELTA_TIMESTAMP_PROPERTY, postCommitSnapshot.timestamp.toString)
       .set(IcebergConverter.ICEBERG_NAME_MAPPING_PROPERTY, nameMapping)
       .commit()
 
     try {
       txn.commitTransaction()
+      if (tableOp == CREATE_TABLE || tableOp == REPLACE_TABLE) {
+        // Iceberg CREATE_TABLE and REPLACE_TABLE reassigns the field id in schema, which
+        // is overwritten by setting Delta schema with Delta generated field id to ensure
+        // consistency between field id in Iceberg schema after conversion and field id in
+        // parquet files written by Delta.
+        val setSchemaTxn = createIcebergTxn(Some(WRITE_TABLE))
+        setSchemaTxn.setSchema(icebergSchema).commit()
+        setSchemaTxn.updateProperties()
+          .set(IcebergConverter.DELTA_VERSION_PROPERTY, postCommitSnapshot.version.toString)
+          .commit()
+        setSchemaTxn.commitTransaction()
+      }
       recordIcebergCommit()
     } catch {
       case NonFatal(e) =>
@@ -322,7 +340,8 @@ class IcebergConversionTransaction(
   // Protected Methods //
   ///////////////////////
 
-  protected def createIcebergTxn(): IcebergTransaction = {
+  protected def createIcebergTxn(tableOpOpt: Option[IcebergTableOp] = None):
+      IcebergTransaction = {
     val hiveCatalog = IcebergTransactionUtils.createHiveCatalog(conf)
     val icebergTableId = IcebergTransactionUtils
       .convertSparkTableIdentifierToIcebergHive(catalogTable.identifier)
@@ -340,7 +359,7 @@ class IcebergConversionTransaction(
         .withProperties(properties.asJava)
     }
 
-    tableOp match {
+    tableOpOpt.getOrElse(tableOp) match {
       case WRITE_TABLE =>
         if (tableExists) {
           recordFrameProfile("IcebergConversionTransaction", "loadTable") {

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
@@ -301,8 +301,9 @@ class IcebergConversionTransaction(
 
     val nameMapping = NameMappingParser.toJson(MappingUtil.create(icebergSchema))
 
-    // hard code delta version as -1 for CREATE_TABLE and REPLACE_TABLE, which will be later set to
-    // correct version during setSchema
+    // hard code dummy delta version as -1 for CREATE_TABLE and REPLACE_TABLE, which will be later
+    // set to correct version in setSchemaTxn. -1 is chosen because it is less than the smallest
+    // possible legitimate Delta version which is 0.
     val deltaVersion = if (tableOp == CREATE_TABLE || tableOp == REPLACE_TABLE) -1
       else postCommitSnapshot.version
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2ESuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2ESuite.scala
@@ -87,7 +87,7 @@ abstract class UniFormE2EIcebergSuiteBase extends UniFormE2ETest {
 
       spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
         .write.format("delta").mode("append")
-        .saveAsTable(tableFullName)
+        .saveAsTable(testTableName)
 
       val result = read(s"SELECT * FROM $tableFullName")
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2ESuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2ESuite.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.delta.uniform
 
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.types._
 
 abstract class UniFormE2EIcebergSuiteBase extends UniFormE2ETest {
@@ -84,13 +83,13 @@ abstract class UniFormE2EIcebergSuiteBase extends UniFormE2ETest {
         StructField("col1", IntegerType) ::
           StructField("col2", innerStruct) :: Nil)
 
-      val rdd = spark.sparkContext.parallelize(data)
+      val tableFullName = tableNameForRead(testTableName)
 
-      spark.createDataFrame(rdd, schema).write.format("delta").mode("append")
-        .saveAsTable(TableIdentifier(testTableName))
+      spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+        .write.format("delta").mode("append")
+        .saveAsTable(tableFullName)
 
-      val table = tableNameForRead(testTableName)
-      val result = read(s"SELECT * FROM $table")
+      val result = read(s"SELECT * FROM $tableFullName")
 
       assert(result.head === data.head)
     }


### PR DESCRIPTION

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Iceberg CREATE_TABLE and REPLACE_TABLE reassigns the field id in schema, which made the field id in converted Iceberg schema different from whats in parquet file written by Delta. This fixes by setting Delta schema with Delta generated field id to ensure consistency between field id in Iceberg schema after conversion and field id in parquet files. 


## How was this patch tested?

UT
