### PR TITLE
[Spark] Fix an issue when reading a wide table with deletion vectors

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
@@ -17,10 +17,8 @@
 package org.apache.spark.sql.delta
 
 import java.net.URI
-
 import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
-
 import org.apache.spark.sql.delta.RowIndexFilterType
 import org.apache.spark.sql.delta.DeltaParquetFileFormat._
 import org.apache.spark.sql.delta.actions.{DeletionVectorDescriptor, Metadata, Protocol}
@@ -28,7 +26,6 @@ import org.apache.spark.sql.delta.deletionvectors.{DropMarkedRowsFilter, KeepAll
 import org.apache.spark.sql.delta.schema.SchemaMergingUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
@@ -38,7 +35,7 @@ import org.apache.spark.sql.execution.vectorized.{OffHeapColumnVector, OnHeapCol
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.{ByteType, LongType, MetadataBuilder, StructField, StructType}
-import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
+import org.apache.spark.sql.vectorized.{ColumnVector, ColumnarBatch, ColumnarBatchRow}
 import org.apache.spark.util.SerializableConfiguration
 
 /**
@@ -289,16 +286,30 @@ case class DeltaParquetFileFormat(
             newBatch
           }
 
+        case columnarRow: ColumnarBatchRow =>
+          // When vectorized reader is enabled by returns rows instead of columnar batches
+          // [[ColumnarBatchRow]] doesn't allow editing the contents. So we have to create a new
+          // [[InternalRow]] and set the row index and is deleted columns.
+          // This is not efficient. It should affect only the wide tables.
+          // https://github.com/delta-io/delta/issues/2246
+          val newRow = columnarRow.copy();
+          isRowDeletedColumn.foreach { columnMetadata =>
+            rowIndexFilter.get.materializeIntoVector(rowIndex, rowIndex + 1, tempVector)
+            newRow.setByte(columnMetadata.index, tempVector.getByte(0))
+          }
+
+          rowIndexColumn.foreach(columnMetadata => newRow.setLong(columnMetadata.index, rowIndex))
+          rowIndex += 1
+          newRow
+
         case rest: InternalRow => // When vectorized Parquet reader is disabled
           // Temporary vector variable used to get DV values from RowIndexFilter
           // Currently the RowIndexFilter only supports writing into a columnar vector
           // and doesn't have methods to get DV value for a specific row index.
           // TODO: This is not efficient, but it is ok given the default reader is vectorized
-          // reader and this will be temporary until Delta upgrades to Spark with Parquet
-          // reader that automatically generates the row index column.
           isRowDeletedColumn.foreach { columnMetadata =>
             rowIndexFilter.get.materializeIntoVector(rowIndex, rowIndex + 1, tempVector)
-            rest.setLong(columnMetadata.index, tempVector.getByte(0))
+            rest.setByte(columnMetadata.index, tempVector.getByte(0))
           }
 
           rowIndexColumn.foreach(columnMetadata => rest.setLong(columnMetadata.index, rowIndex))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.execution.vectorized.{OffHeapColumnVector, OnHeapCol
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.{ByteType, LongType, MetadataBuilder, StructField, StructType}
-import org.apache.spark.sql.vectorized.{ColumnVector, ColumnarBatch, ColumnarBatchRow}
+import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnarBatchRow, ColumnVector}
 import org.apache.spark.util.SerializableConfiguration
 
 /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
@@ -17,8 +17,10 @@
 package org.apache.spark.sql.delta
 
 import java.net.URI
+
 import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
+
 import org.apache.spark.sql.delta.RowIndexFilterType
 import org.apache.spark.sql.delta.DeltaParquetFileFormat._
 import org.apache.spark.sql.delta.actions.{DeletionVectorDescriptor, Metadata, Protocol}
@@ -26,6 +28,7 @@ import org.apache.spark.sql.delta.deletionvectors.{DropMarkedRowsFilter, KeepAll
 import org.apache.spark.sql.delta.schema.SchemaMergingUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
+
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
@@ -287,11 +287,11 @@ case class DeltaParquetFileFormat(
           }
 
         case columnarRow: ColumnarBatchRow =>
-          // When vectorized reader is enabled by returns rows instead of columnar batches
-          // [[ColumnarBatchRow]] doesn't allow editing the contents. So we have to create a new
-          // [[InternalRow]] and set the row index and is deleted columns.
-          // This is not efficient. It should affect only the wide tables.
-          // https://github.com/delta-io/delta/issues/2246
+          // When vectorized reader is enabled but returns immutable rows instead of
+          // columnar batches [[ColumnarBatchRow]]. So we have to copy the row as a
+          // mutable [[InternalRow]] and set the `row_index` and `is_row_deleted`
+          // column values. This is not efficient. It should affect only the wide
+          // tables. https://github.com/delta-io/delta/issues/2246
           val newRow = columnarRow.copy();
           isRowDeletedColumn.foreach { columnMetadata =>
             rowIndexFilter.get.materializeIntoVector(rowIndex, rowIndex + 1, tempVector)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
@@ -16,7 +16,6 @@
 
 package org.apache.spark.sql.delta
 
-import org.apache.spark.sql.delta.RowIndexFilterType
 import org.apache.spark.sql.delta.DeltaParquetFileFormat.DeletionVectorDescriptorWithFilterType
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
 import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor
@@ -152,10 +151,23 @@ class DeltaParquetFileFormatSuite extends QueryTest
 
   /** Helper method to run the test with vectorized and non-vectorized Parquet readers */
   private def testWithBothParquetReaders(name: String)(f: => Any): Unit = {
-    for (enableVectorizedParquetReader <- BOOLEAN_DOMAIN) {
-      test(s"$name, with vectorized Parquet reader=$enableVectorizedParquetReader)") {
+    for {
+      enableVectorizedParquetReader <- BOOLEAN_DOMAIN
+      readColumnarBatchAsRows <- BOOLEAN_DOMAIN
+      // don't run for the combination (vectorizedReader=false, readColumnarBathAsRows = false)
+      // as the non-vectorized reader always generates and returns rows, unlike the vectorized
+      // reader which internally generates columnar batches but can returns either columnar batches
+      // or rows from the columnar batch depending upon the config.
+      if enableVectorizedParquetReader || readColumnarBatchAsRows
+    } {
+      test(s"$name, with vectorized Parquet reader=$enableVectorizedParquetReader, " +
+        s"with readColumnarBatchAsRows=$readColumnarBatchAsRows") {
+        // Set the max code gen fields to 0 to force the vectorized Parquet reader generates rows
+        // from columnar batches.
+        val codeGenMaxFields = if (readColumnarBatchAsRows) "0" else "100"
         withSQLConf(
-          "spark.sql.parquet.enableVectorizedReader" -> enableVectorizedParquetReader.toString) {
+          "spark.sql.parquet.enableVectorizedReader" -> enableVectorizedParquetReader.toString,
+          "spark.sql.codegen.maxFields" -> codeGenMaxFields) {
           f
         }
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
@@ -162,7 +162,7 @@ class DeltaParquetFileFormatSuite extends QueryTest
     } {
       test(s"$name, with vectorized Parquet reader=$enableVectorizedParquetReader, " +
         s"with readColumnarBatchAsRows=$readColumnarBatchAsRows") {
-        // Set the max code gen fields to 0 to force the vectorized Parquet reader generates rows
+        // Set the max code gen fields to 0 to force the vectorized Parquet reader generate rows
         // from columnar batches.
         val codeGenMaxFields = if (readColumnarBatchAsRows) "0" else "100"
         withSQLConf(


### PR DESCRIPTION
## Description
Querying a wide table (containing more than 100 leaf-level columns) with deletion vectors throws unsupported operation exceptions

This is happening for wide tables which have more than 100 columns. When we are reading more than 100 columns, Sparks code generator makes a decision ([1](https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala#L560), [2](https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala#L541)) to not use the codegen. When not using codegen, Spark sets options to get rows instead of columnar batches from the Parquet reader. This causes the [vectorized Parquet reader]((https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala#L189)) to return row abstraction over each column in the columnar batch. This row abstraction doesn't allow modification of the contents.

Fix the issue by handling the `ColumnarBatchRow` by copying and making the updates. This is not efficient, but it affects only the wide tables.

More details at delta-io/delta#2246

Fixes delta-io/delta#2246

## How was this patch tested?
Added a unit test