### PR TITLE
[Kernel][Data skipping] Add selection vector for JsonHandler::parseJson and support remaining types in DefaultJsonHandler

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/client/JsonHandler.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/client/JsonHandler.java
@@ -63,7 +63,9 @@ public interface JsonHandler
      *                         for that
      *                         particular field in the returned {@link Row}. The type for each given
      *                         field is expected to match the type in the JSON.
-     * @param selectionVector  Optional selection vector indicating which rows to parse the JSON
+     * @param selectionVector  Optional selection vector indicating which rows to parse the JSON.
+     *                         If present, only the selected rows should be parsed. Unselected rows
+     *                         should be all null in the returned batch.
      * @return a {@link ColumnarBatch} of schema {@code outputSchema} with one row for each entry
      * in {@code jsonStringVector}
      */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/client/JsonHandler.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/client/JsonHandler.java
@@ -17,6 +17,7 @@
 package io.delta.kernel.client;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.data.ColumnVector;
@@ -40,6 +41,21 @@ public interface JsonHandler
     /**
      * Parse the given <i>json</i> strings and return the fields requested by {@code outputSchema}
      * as columns in a {@link ColumnarBatch}.
+     * <p>
+     * There are a couple special cases that should be handled for specific data types:
+     * <ul>
+     *    <li><b>FloatType and DoubleType:</b> handle non-numeric numbers encoded as strings
+     *    <ul>
+     *        <li>NaN: <code>"NaN"</code></li>
+     *        <li>Positive infinity: <code>"+INF", "Infinity", "+Infinity"</code></li>
+     *        <li>Negative infinity: <code>"-INF", "-Infinity""</code></li>
+     *    </ul>
+     *    </li>
+     *    <li><b>DateType:</b> handle dates encoded as strings in the format
+     *    <code>"yyyy-MM-dd"</code></li>
+     *    <li><b>TimestampType:</b> handle timestamps encoded as strings in the format
+     *    <code>"yyyy-MM-dd'T'HH:mm:ss.SSSXXX"</code></li>
+     * </ul>
      *
      * @param jsonStringVector String {@link ColumnVector} of valid JSON strings.
      * @param outputSchema     Schema of the data to return from the parsed JSON. If any requested
@@ -47,10 +63,12 @@ public interface JsonHandler
      *                         for that
      *                         particular field in the returned {@link Row}. The type for each given
      *                         field is expected to match the type in the JSON.
+     * @param selectionVector  Optional selection vector indicating which rows to parse the JSON
      * @return a {@link ColumnarBatch} of schema {@code outputSchema} with one row for each entry
      * in {@code jsonStringVector}
      */
-    ColumnarBatch parseJson(ColumnVector jsonStringVector, StructType outputSchema);
+    ColumnarBatch parseJson(ColumnVector jsonStringVector, StructType outputSchema,
+            Optional<ColumnVector> selectionVector);
 
     /**
      * Deserialize the Delta schema from {@code structTypeJson} according to the Delta Protocol

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultJsonHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultJsonHandler.java
@@ -22,10 +22,13 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -56,12 +59,17 @@ import io.delta.kernel.defaults.internal.types.DataTypeParser;
 public class DefaultJsonHandler
     extends DefaultFileHandler
     implements JsonHandler {
-    private final ObjectMapper objectMapper;
+    private final ObjectReader defaultObjectReader;
+    // by default BigDecimals are truncated and read as floats
+    private final ObjectReader objectReaderReadBigDecimals;
     private final Configuration hadoopConf;
     private final int maxBatchSize;
 
     public DefaultJsonHandler(Configuration hadoopConf) {
-        this.objectMapper = new ObjectMapper();
+        ObjectMapper mapper = new ObjectMapper();
+        this.defaultObjectReader = mapper.reader();
+        this.objectReaderReadBigDecimals = mapper
+            .reader(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
         this.hadoopConf = hadoopConf;
         this.maxBatchSize =
             hadoopConf.getInt("delta.kernel.default.json.reader.batch-size", 1024);
@@ -69,10 +77,18 @@ public class DefaultJsonHandler
     }
 
     @Override
-    public ColumnarBatch parseJson(ColumnVector jsonStringVector, StructType outputSchema) {
+    public ColumnarBatch parseJson(ColumnVector jsonStringVector, StructType outputSchema,
+            Optional<ColumnVector> selectionVector) {
         List<Row> rows = new ArrayList<>();
         for (int i = 0; i < jsonStringVector.getSize(); i++) {
-            rows.add(parseJson(jsonStringVector.getString(i), outputSchema));
+            boolean isSelected = !selectionVector.isPresent() ||
+                (!selectionVector.get().isNullAt(i) && selectionVector.get().getBoolean(i));
+            if (isSelected && !jsonStringVector.isNullAt(i)) {
+                rows.add(
+                    parseJson(jsonStringVector.getString(i), outputSchema));
+            } else {
+                rows.add(null);
+            }
         }
         return new DefaultRowBasedColumnarBatch(outputSchema, rows);
     }
@@ -80,7 +96,9 @@ public class DefaultJsonHandler
     @Override
     public StructType deserializeStructType(String structTypeJson) {
         try {
-            return DataTypeParser.parseSchema(objectMapper.readTree(structTypeJson));
+            // We don't expect Java BigDecimal anywhere in a Delta schema so we use the default
+            // JSON reader
+            return DataTypeParser.parseSchema(defaultObjectReader.readTree(structTypeJson));
         } catch (JsonProcessingException ex) {
             throw new RuntimeException(
                 String.format("Could not parse JSON: %s", structTypeJson), ex);
@@ -185,7 +203,7 @@ public class DefaultJsonHandler
 
     private Row parseJson(String json, StructType readSchema) {
         try {
-            final JsonNode jsonNode = objectMapper.readTree(json);
+            final JsonNode jsonNode = objectReaderReadBigDecimals.readTree(json);
             return new DefaultJsonRow((ObjectNode) jsonNode, readSchema);
         } catch (JsonProcessingException ex) {
             throw new RuntimeException(String.format("Could not parse JSON: %s", json), ex);

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultJsonHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultJsonHandler.java
@@ -59,17 +59,16 @@ import io.delta.kernel.defaults.internal.types.DataTypeParser;
 public class DefaultJsonHandler
     extends DefaultFileHandler
     implements JsonHandler {
-    private final ObjectReader defaultObjectReader;
+    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectReader defaultObjectReader = mapper.reader();
     // by default BigDecimals are truncated and read as floats
-    private final ObjectReader objectReaderReadBigDecimals;
+    private static final ObjectReader objectReaderReadBigDecimals = mapper
+        .reader(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
+
     private final Configuration hadoopConf;
     private final int maxBatchSize;
 
     public DefaultJsonHandler(Configuration hadoopConf) {
-        ObjectMapper mapper = new ObjectMapper();
-        this.defaultObjectReader = mapper.reader();
-        this.objectReaderReadBigDecimals = mapper
-            .reader(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
         this.hadoopConf = hadoopConf;
         this.maxBatchSize =
             hadoopConf.getInt("delta.kernel.default.json.reader.batch-size", 1024);

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/DefaultJsonRow.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/DefaultJsonRow.java
@@ -184,11 +184,11 @@ public class DefaultJsonRow implements Row {
                 case NUMBER:
                     throwIfTypeMismatch(
                         "float",
-                        // For BigDecimal values, floatValue() will be converted to +/-INF if it
-                        // cannot be represented by a float
-                        // TODO we can do this but it's still possible we lose precision;
-                        //   the jackson core parser (that spark uses) doesn't even bother with this
-                        !Double.isInfinite(jsonValue.decimalValue().floatValue()),
+                        // floatValue() will be converted to +/-INF if it cannot be represented
+                        // by a float
+                        // Note it is still possible to lose precision in this conversion but
+                        // checking for that requires converting to a float and back to BigDecimal
+                        !Float.isInfinite(jsonValue.floatValue()),
                         jsonValue
                     );
                     return jsonValue.floatValue();
@@ -211,11 +211,11 @@ public class DefaultJsonRow implements Row {
                 case NUMBER:
                     throwIfTypeMismatch(
                         "double",
-                        // For BigDecimal values, doubleValue() will be converted to +/-INF if it
-                        // cannot be represented by a double
-                        // TODO we can do this but it's still possible we lose precision;
-                        //   the jackson core parser (that spark uses) doesn't even bother with this
-                        !Double.isInfinite(jsonValue.decimalValue().doubleValue()),
+                        // doubleValue() will be converted to +/-INF if it cannot be represented by
+                        // a double
+                        // Note it is still possible to lose precision in this conversion but
+                        // checking for that requires converting to a double and back to BigDecimal
+                        !Double.isInfinite(jsonValue.doubleValue()),
                         jsonValue
                     );
                     return jsonValue.doubleValue();

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/DefaultJsonRow.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/DefaultJsonRow.java
@@ -16,6 +16,10 @@
 package io.delta.kernel.defaults.internal.data;
 
 import java.math.BigDecimal;
+import java.sql.Date;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -30,6 +34,7 @@ import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.MapValue;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.types.*;
+import io.delta.kernel.internal.util.InternalUtils;
 
 import io.delta.kernel.defaults.internal.data.vector.DefaultGenericVector;
 
@@ -65,12 +70,12 @@ public class DefaultJsonRow implements Row {
 
     @Override
     public byte getByte(int ordinal) {
-        throw new UnsupportedOperationException("not yet implemented");
+        return (byte) parsedValues[ordinal];
     }
 
     @Override
     public short getShort(int ordinal) {
-        throw new UnsupportedOperationException("not yet implemented");
+        return (short) parsedValues[ordinal];
     }
 
     @Override
@@ -85,12 +90,12 @@ public class DefaultJsonRow implements Row {
 
     @Override
     public float getFloat(int ordinal) {
-        throw new UnsupportedOperationException("not yet implemented");
+        return (float) parsedValues[ordinal];
     }
 
     @Override
     public double getDouble(int ordinal) {
-        throw new UnsupportedOperationException("not yet implemented");
+        return (double) parsedValues[ordinal];
     }
 
     @Override
@@ -100,7 +105,7 @@ public class DefaultJsonRow implements Row {
 
     @Override
     public BigDecimal getDecimal(int ordinal) {
-        throw new UnsupportedOperationException("not yet implemented");
+        return (BigDecimal) parsedValues[ordinal];
     }
 
     @Override
@@ -140,15 +145,82 @@ public class DefaultJsonRow implements Row {
             return jsonValue.booleanValue();
         }
 
+        if (dataType instanceof ByteType) {
+            throwIfTypeMismatch(
+                "byte",
+                jsonValue.canConvertToExactIntegral() && jsonValue.intValue() <= Byte.MAX_VALUE,
+                jsonValue
+            );
+            return jsonValue.numberValue().byteValue();
+        }
+
+        if (dataType instanceof ShortType) {
+            throwIfTypeMismatch(
+                "short",
+                jsonValue.canConvertToExactIntegral() && jsonValue.intValue() <= Short.MAX_VALUE,
+                jsonValue
+            );
+            return jsonValue.numberValue().shortValue();
+        }
+
         if (dataType instanceof IntegerType) {
             throwIfTypeMismatch(
-                "integer", jsonValue.isIntegralNumber() && !jsonValue.isLong(), jsonValue);
+                "integer",
+                jsonValue.isIntegralNumber() && jsonValue.canConvertToInt(),
+                jsonValue);
             return jsonValue.intValue();
         }
 
         if (dataType instanceof LongType) {
-            throwIfTypeMismatch("long", jsonValue.isIntegralNumber(), jsonValue);
+            throwIfTypeMismatch("long",
+                jsonValue.isIntegralNumber() && jsonValue.canConvertToLong(), jsonValue);
             return jsonValue.numberValue().longValue();
+        }
+
+        if (dataType instanceof FloatType) {
+            switch (jsonValue.getNodeType()) {
+                case NUMBER:
+                    throwIfTypeMismatch(
+                        "float",
+                        jsonValue.doubleValue() <= Float.MAX_VALUE,
+                        jsonValue
+                    );
+                    return jsonValue.floatValue();
+                case STRING:
+                    switch (jsonValue.asText()) {
+                        case "NaN":
+                            return Float.NaN;
+                        case "+INF": case "+Infinity": case "Infinity":
+                            return Float.POSITIVE_INFINITY;
+                        case "-INF": case "-Infinity":
+                            return Float.NEGATIVE_INFINITY;
+                    }
+                default:
+                    throwIfTypeMismatch("float", false, jsonValue);
+            }
+        }
+
+        if (dataType instanceof DoubleType) {
+            switch (jsonValue.getNodeType()) {
+                case NUMBER:
+                    throwIfTypeMismatch(
+                        "double",
+                        jsonValue.doubleValue() <= Double.MAX_VALUE,
+                        jsonValue
+                    );
+                    return jsonValue.doubleValue();
+                case STRING:
+                    switch (jsonValue.asText()) {
+                        case "NaN":
+                            return Double.NaN;
+                        case "+INF": case "+Infinity": case "Infinity":
+                            return Double.POSITIVE_INFINITY;
+                        case "-INF": case "-Infinity":
+                            return Double.NEGATIVE_INFINITY;
+                    }
+                default:
+                    throwIfTypeMismatch("double", false, jsonValue);
+            }
         }
 
         if (dataType instanceof StringType) {
@@ -157,6 +229,28 @@ public class DefaultJsonRow implements Row {
                 jsonValue.isTextual(),
                 jsonValue);
             return jsonValue.asText();
+        }
+
+        if (dataType instanceof DecimalType) {
+            throwIfTypeMismatch("decimal", jsonValue.isNumber(), jsonValue);
+            return jsonValue.decimalValue();
+        }
+
+        if (dataType instanceof DateType) {
+            throwIfTypeMismatch(
+                "date",
+                jsonValue.isTextual(),
+                jsonValue);
+            return InternalUtils.daysSinceEpoch(Date.valueOf(jsonValue.textValue()));
+        }
+
+        if (dataType instanceof TimestampType) {
+            throwIfTypeMismatch(
+                "timestamp",
+                jsonValue.isTextual(),
+                jsonValue);
+            Instant time = OffsetDateTime.parse(jsonValue.textValue()).toInstant();
+            return ChronoUnit.MICROS.between(Instant.EPOCH, time);
         }
 
         if (dataType instanceof StructType) {

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/DefaultJsonRow.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/DefaultJsonRow.java
@@ -149,7 +149,8 @@ public class DefaultJsonRow implements Row {
             throwIfTypeMismatch(
                 "byte",
                 jsonValue.canConvertToExactIntegral() &&
-                    jsonValue.canConvertToInt() && jsonValue.intValue() <= Byte.MAX_VALUE,
+                    jsonValue.canConvertToInt() && jsonValue.intValue() <= Byte.MAX_VALUE &&
+                    jsonValue.canConvertToInt() && jsonValue.intValue() >= Byte.MIN_VALUE,
                 jsonValue
             );
             return jsonValue.numberValue().byteValue();
@@ -159,7 +160,8 @@ public class DefaultJsonRow implements Row {
             throwIfTypeMismatch(
                 "short",
                 jsonValue.canConvertToExactIntegral() &&
-                    jsonValue.canConvertToInt() && jsonValue.intValue() <= Short.MAX_VALUE,
+                    jsonValue.canConvertToInt() && jsonValue.intValue() <= Short.MAX_VALUE &&
+                    jsonValue.canConvertToInt() && jsonValue.intValue() >= Short.MIN_VALUE,
                 jsonValue
             );
             return jsonValue.numberValue().shortValue();

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/DefaultJsonRow.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/DefaultJsonRow.java
@@ -148,7 +148,8 @@ public class DefaultJsonRow implements Row {
         if (dataType instanceof ByteType) {
             throwIfTypeMismatch(
                 "byte",
-                jsonValue.canConvertToExactIntegral() && jsonValue.intValue() <= Byte.MAX_VALUE,
+                jsonValue.canConvertToExactIntegral() &&
+                    jsonValue.canConvertToInt() && jsonValue.intValue() <= Byte.MAX_VALUE,
                 jsonValue
             );
             return jsonValue.numberValue().byteValue();
@@ -157,7 +158,8 @@ public class DefaultJsonRow implements Row {
         if (dataType instanceof ShortType) {
             throwIfTypeMismatch(
                 "short",
-                jsonValue.canConvertToExactIntegral() && jsonValue.intValue() <= Short.MAX_VALUE,
+                jsonValue.canConvertToExactIntegral() &&
+                    jsonValue.canConvertToInt() && jsonValue.intValue() <= Short.MAX_VALUE,
                 jsonValue
             );
             return jsonValue.numberValue().shortValue();
@@ -182,7 +184,11 @@ public class DefaultJsonRow implements Row {
                 case NUMBER:
                     throwIfTypeMismatch(
                         "float",
-                        jsonValue.doubleValue() <= Float.MAX_VALUE,
+                        // For BigDecimal values, floatValue() will be converted to +/-INF if it
+                        // cannot be represented by a float
+                        // TODO we can do this but it's still possible we lose precision;
+                        //   the jackson core parser (that spark uses) doesn't even bother with this
+                        !Double.isInfinite(jsonValue.decimalValue().floatValue()),
                         jsonValue
                     );
                     return jsonValue.floatValue();
@@ -205,7 +211,11 @@ public class DefaultJsonRow implements Row {
                 case NUMBER:
                     throwIfTypeMismatch(
                         "double",
-                        jsonValue.doubleValue() <= Double.MAX_VALUE,
+                        // For BigDecimal values, doubleValue() will be converted to +/-INF if it
+                        // cannot be represented by a double
+                        // TODO we can do this but it's still possible we lose precision;
+                        //   the jackson core parser (that spark uses) doesn't even bother with this
+                        !Double.isInfinite(jsonValue.decimalValue().doubleValue()),
                         jsonValue
                     );
                     return jsonValue.doubleValue();

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultSubFieldVector.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultSubFieldVector.java
@@ -160,10 +160,16 @@ public class DefaultSubFieldVector implements ColumnVector {
         StructType structType = (StructType) dataType;
         StructField childField = structType.at(childOrdinal);
         return new DefaultSubFieldVector(
-                size,
-                childField.getDataType(),
-                childOrdinal,
-                (rowId) -> (rowIdToRowAccessor.apply(rowId).getStruct(columnOrdinal)));
+            size,
+            childField.getDataType(),
+            childOrdinal,
+            (rowId) -> {
+                if (isNullAt(rowId)) {
+                    return null;
+                } else {
+                    return rowIdToRowAccessor.apply(rowId).getStruct(columnOrdinal);
+                }
+            });
     }
 
     private void assertValidRowId(int rowId) {

--- a/kernel/kernel-defaults/src/test/java/io/delta/kernel/defaults/client/TestDefaultJsonHandler.java
+++ b/kernel/kernel-defaults/src/test/java/io/delta/kernel/defaults/client/TestDefaultJsonHandler.java
@@ -129,8 +129,8 @@ public class TestDefaultJsonHandler {
             .add("size", LongType.LONG)
             .add("dataChange", BooleanType.BOOLEAN);
 
-        ColumnarBatch batch =
-            JSON_HANDLER.parseJson(singletonStringColumnVector(input), readSchema);
+        ColumnarBatch batch = JSON_HANDLER.parseJson(
+            singletonStringColumnVector(input), readSchema, Optional.empty());
         assertEquals(1, batch.getSize());
 
         try (CloseableIterator<Row> rows = batch.getRows()) {
@@ -185,7 +185,8 @@ public class TestDefaultJsonHandler {
                                 true
                         )
                 );
-        ColumnarBatch batch = JSON_HANDLER.parseJson(singletonStringColumnVector(json), schema);
+        ColumnarBatch batch = JSON_HANDLER.parseJson(
+            singletonStringColumnVector(json), schema, Optional.empty());
 
         try (CloseableIterator<Row> rows = batch.getRows()) {
             Row result = rows.next();

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/client/DefaultJsonHandlerSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/client/DefaultJsonHandlerSuite.scala
@@ -125,6 +125,7 @@ class DefaultJsonHandlerSuite extends AnyFunSuite with TestUtils {
       6,
       TestRow(-9223.33F, 0.4F, 120000000.0F, 0.000000123F, 0.004444444F, null)
     )
+    testOutOfRangeValue("3.4028235E+39", FloatType.FLOAT)
   }
 
   test("parse double type") {
@@ -137,6 +138,17 @@ class DefaultJsonHandlerSuite extends AnyFunSuite with TestUtils {
       6,
       TestRow(-922333333.33D, 0.4D, 120000000.0D, 0.0000001234444444D, 0.0444444444D, null)
     )
+    // For some reason out-of-range doubles are parsed initially as Double.INFINITY instead of
+    // a BigDecimal
+    val e = intercept[RuntimeException]{
+      testJsonParserForSingleType(
+        jsonString = s"""{"col1":1.7976931348623157E+309}""",
+        dataType = DoubleType.DOUBLE,
+        numColumns = 1,
+        expectedRow = TestRow()
+      )
+    }
+    assert(e.getMessage.contains(s"Couldn't decode"))
   }
 
   test("parse string type") {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/client/DefaultJsonHandlerSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/client/DefaultJsonHandlerSuite.scala
@@ -60,6 +60,18 @@ class DefaultJsonHandlerSuite extends AnyFunSuite with TestUtils {
     testJsonParserWithSchema(jsonString, schema, expectedRow)
   }
 
+  def testOutOfRangeValue(stringValue: String, dataType: DataType): Unit = {
+    val e = intercept[RuntimeException]{
+      testJsonParserForSingleType(
+        jsonString = s"""{"col1":$stringValue}""",
+        dataType = dataType,
+        numColumns = 1,
+        expectedRow = TestRow()
+      )
+    }
+    assert(e.getMessage.contains(s"Couldn't decode $stringValue"))
+  }
+
   test("parse byte type") {
     testJsonParserForSingleType(
       jsonString = """{"col1":0,"col2":-127,"col3":127, "col4":null}""",
@@ -67,6 +79,8 @@ class DefaultJsonHandlerSuite extends AnyFunSuite with TestUtils {
       4,
       TestRow(0.toByte, -127.toByte, 127.toByte, null)
     )
+    testOutOfRangeValue("128", ByteType.BYTE)
+    testOutOfRangeValue("2147483648", ByteType.BYTE)
   }
 
   test("parse short type") {
@@ -76,6 +90,8 @@ class DefaultJsonHandlerSuite extends AnyFunSuite with TestUtils {
       4,
       TestRow(-32767.toShort, 8.toShort, 32767.toShort, null)
     )
+    testOutOfRangeValue("32768", ShortType.SHORT)
+    testOutOfRangeValue("2147483648", ShortType.SHORT)
   }
 
   test("parse integer type") {
@@ -85,6 +101,7 @@ class DefaultJsonHandlerSuite extends AnyFunSuite with TestUtils {
       4,
       TestRow(-2147483648, 8, 2147483647, null)
     )
+    testOutOfRangeValue("2147483648", IntegerType.INTEGER)
   }
 
   test("parse long type") {
@@ -95,6 +112,7 @@ class DefaultJsonHandlerSuite extends AnyFunSuite with TestUtils {
       4,
       TestRow(-9223372036854775808L, 8L, 9223372036854775807L, null)
     )
+    testOutOfRangeValue("9223372036854775808", LongType.LONG)
   }
 
   test("parse float type") {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/client/DefaultJsonHandlerSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/client/DefaultJsonHandlerSuite.scala
@@ -62,47 +62,50 @@ class DefaultJsonHandlerSuite extends AnyFunSuite with TestUtils {
 
   test("parse byte type") {
     testJsonParserForSingleType(
-      jsonString = """{"col1":0,"col2":-127,"col3":127}""",
+      jsonString = """{"col1":0,"col2":-127,"col3":127, "col4":null}""",
       dataType = ByteType.BYTE,
-      3,
-      TestRow(0.toByte, -127.toByte, 127.toByte)
+      4,
+      TestRow(0.toByte, -127.toByte, 127.toByte, null)
     )
   }
 
   test("parse short type") {
     testJsonParserForSingleType(
-      jsonString = """{"col1":-32767,"col2":8,"col3":32767}""",
+      jsonString = """{"col1":-32767,"col2":8,"col3":32767, "col4":null}""",
       dataType = ShortType.SHORT,
-      3,
-      TestRow(-32767.toShort, 8.toShort, 32767.toShort)
+      4,
+      TestRow(-32767.toShort, 8.toShort, 32767.toShort, null)
     )
   }
 
   test("parse integer type") {
     testJsonParserForSingleType(
-      jsonString = """{"col1":-2147483648,"col2":8,"col3":2147483647}""",
+      jsonString = """{"col1":-2147483648,"col2":8,"col3":2147483647, "col4":null}""",
       dataType = IntegerType.INTEGER,
-      3,
-      TestRow(-2147483648, 8, 2147483647)
+      4,
+      TestRow(-2147483648, 8, 2147483647, null)
     )
   }
 
   test("parse long type") {
     testJsonParserForSingleType(
-      jsonString = """{"col1":-9223372036854775808,"col2":8,"col3":9223372036854775807}""",
+      jsonString =
+      """{"col1":-9223372036854775808,"col2":8,"col3":9223372036854775807, "col4":null}""",
       dataType = LongType.LONG,
-      3,
-      TestRow(-9223372036854775808L, 8L, 9223372036854775807L)
+      4,
+      TestRow(-9223372036854775808L, 8L, 9223372036854775807L, null)
     )
   }
 
   test("parse float type") {
     testJsonParserForSingleType(
       jsonString =
-      """{"col1":-9223.33,"col2":0.4,"col3":1.2E8,"col4":1.23E-7,"col5":0.004444444}""",
+        """
+          |{"col1":-9223.33,"col2":0.4,"col3":1.2E8,
+          |"col4":1.23E-7,"col5":0.004444444, "col6":null}""".stripMargin,
       dataType = FloatType.FLOAT,
-      5,
-      TestRow(-9223.33F, 0.4F, 120000000.0F, 0.000000123F, 0.004444444F)
+      6,
+      TestRow(-9223.33F, 0.4F, 120000000.0F, 0.000000123F, 0.004444444F, null)
     )
   }
 
@@ -111,10 +114,10 @@ class DefaultJsonHandlerSuite extends AnyFunSuite with TestUtils {
       jsonString =
         """
           |{"col1":-9.2233333333E8,"col2":0.4,"col3":1.2E8,
-          |"col4":1.234444444E-7,"col5":0.0444444444}""".stripMargin,
+          |"col4":1.234444444E-7,"col5":0.0444444444, "col6":null}""".stripMargin,
       dataType = DoubleType.DOUBLE,
-      5,
-      TestRow(-922333333.33D, 0.4D, 120000000.0D, 0.0000001234444444D, 0.0444444444D)
+      6,
+      TestRow(-922333333.33D, 0.4D, 120000000.0D, 0.0000001234444444D, 0.0444444444D, null)
     )
   }
 
@@ -135,7 +138,8 @@ class DefaultJsonHandlerSuite extends AnyFunSuite with TestUtils {
       |  "col2":0.01234567891234567891234567891234567890,
       |  "col3":123456789123456789123456789123456789,
       |  "col4":1234567891234567891234567891.2345678900,
-      |  "col5":1.23
+      |  "col5":1.23,
+      |  "col6":null
       |}
       |""".stripMargin,
       schema = new StructType()
@@ -143,23 +147,25 @@ class DefaultJsonHandlerSuite extends AnyFunSuite with TestUtils {
         .add("col2", new DecimalType(38, 38))
         .add("col3", new DecimalType(38, 0))
         .add("col4", new DecimalType(38, 10))
-        .add("col5", new DecimalType(5, 2)),
+        .add("col5", new DecimalType(5, 2))
+        .add("col6", new DecimalType(5, 2)),
       TestRow(
         new JBigDecimal(0),
         new JBigDecimal("0.01234567891234567891234567891234567890"),
         new JBigDecimal("123456789123456789123456789123456789"),
         new JBigDecimal("1234567891234567891234567891.2345678900"),
-        new JBigDecimal("1.23")
+        new JBigDecimal("1.23"),
+        null
       )
     )
   }
 
   test("parse date type") {
     testJsonParserForSingleType(
-      jsonString = """{"col1":"2020-12-31"}""",
+      jsonString = """{"col1":"2020-12-31", "col2":"1965-01-31", "col3": null}""",
       dataType = DateType.DATE,
-      1,
-      TestRow(18627)
+      3,
+      TestRow(18627, -1796, null)
     )
   }
 
@@ -169,12 +175,14 @@ class DefaultJsonHandlerSuite extends AnyFunSuite with TestUtils {
         """
           |{
           | "col1":"2050-01-01T00:00:00.000-08:00",
-          | "col2":"1970-01-01T06:30:23.523Z"
+          | "col2":"1970-01-01T06:30:23.523Z",
+          | "col3":"1960-01-01T10:00:00.000Z",
+          | "col4":null
           | }
           | """.stripMargin,
       dataType = TimestampType.TIMESTAMP,
-      numColumns = 2,
-      TestRow(2524636800000000L, 23423523000L)
+      numColumns = 4,
+      TestRow(2524636800000000L, 23423523000L, -315583200000000L, null)
     )
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/ExpressionSuiteBase.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/ExpressionSuiteBase.scala
@@ -15,16 +15,15 @@
  */
 package io.delta.kernel.defaults.internal.expressions
 
-import java.lang.{Boolean => BooleanJ}
 import java.util
 
 import io.delta.kernel.data.{ColumnarBatch, ColumnVector}
 import io.delta.kernel.defaults.internal.data.DefaultColumnarBatch
-import io.delta.kernel.defaults.utils.TestUtils
+import io.delta.kernel.defaults.utils.{TestUtils, VectorTestUtils}
 import io.delta.kernel.expressions._
 import io.delta.kernel.types._
 
-trait ExpressionSuiteBase extends TestUtils {
+trait ExpressionSuiteBase extends TestUtils with VectorTestUtils {
   /** create a columnar batch of given `size` with zero columns in it. */
   protected def zeroColumnBatch(rowCount: Int): ColumnarBatch = {
     new DefaultColumnarBatch(rowCount, new StructType(), new Array[ColumnVector](0))
@@ -53,20 +52,6 @@ trait ExpressionSuiteBase extends TestUtils {
           s"unexpected value at $rowId"
         )
       }
-    }
-  }
-
-  protected def booleanVector(values: Seq[BooleanJ]): ColumnVector = {
-    new ColumnVector {
-      override def getDataType: DataType = BooleanType.BOOLEAN
-
-      override def getSize: Int = values.length
-
-      override def close(): Unit = {}
-
-      override def isNullAt(rowId: Int): Boolean = values(rowId) == null
-
-      override def getBoolean(rowId: Int): Boolean = values(rowId)
     }
   }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/VectorTestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/VectorTestUtils.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults.utils
+
+import java.lang.{Boolean => BooleanJ}
+
+import io.delta.kernel.data.ColumnVector
+import io.delta.kernel.types.{BooleanType, DataType, StringType}
+
+trait VectorTestUtils {
+
+  protected def booleanVector(values: Seq[BooleanJ]): ColumnVector = {
+    new ColumnVector {
+      override def getDataType: DataType = BooleanType.BOOLEAN
+
+      override def getSize: Int = values.length
+
+      override def close(): Unit = {}
+
+      override def isNullAt(rowId: Int): Boolean = values(rowId) == null
+
+      override def getBoolean(rowId: Int): Boolean = values(rowId)
+    }
+  }
+
+  protected def stringVector(values: Seq[String]): ColumnVector = {
+    new ColumnVector {
+      override def getDataType: DataType = StringType.STRING
+
+      override def getSize: Int = values.length
+
+      override def close(): Unit = {}
+
+      override def isNullAt(rowId: Int): Boolean = values(rowId) == null
+
+      override def getString(rowId: Int): String = values(rowId)
+    }
+  }
+
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Part of #2229

1. Updates the JsonHandler::parseJson method to take an optional selection vector based on the design of #2229 
2. Updates DefaultJsonHandler to support remaining data types needed for data skipping using JSON statistics. Semantics of this are based on Design Decision 3 in the design of #2229.
3. Minor fix for `DefaultSubFieldVector` when top-level structs are null (test included in `DefaultJsonHandlerSuite`)

## How was this patch tested?

Adds unit tests.
