### PR TITLE
Set time travel in Hive Metastore catalog for Delta Lake tables. 

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -69,7 +69,12 @@ case class DeltaTableV2(
   private lazy val (rootPath, partitionFilters, timeTravelByPath) = {
     if (catalogTable.isDefined) {
       // Fast path for reducing path munging overhead
-      (new Path(catalogTable.get.location), Nil, None)
+      if (timeTravelOpt.isDefined) { // time travel option overrides catalog settings
+        (new Path(catalogTable.get.location), Nil, None)
+      } else { // retrieve time travel from catalog table stricture serde properties
+        (new Path(catalogTable.get.location), Nil,
+          DeltaDataSource.getTimeTravelVersion(catalogTable.get.storage.properties))
+      }
     } else {
       DeltaDataSource.parsePathIdentifier(spark, path.toString, options)
     }


### PR DESCRIPTION
Ability to set time travel option in Hive Metastore catalog for HMS-managed Delta Lake tables. 
https://github.com/delta-io/delta/issues/2163


- [X ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Need to provide time travel options from the metadata catalog to deliver users a historical view of the table if the time travel option is not explicitly specified in Spark.
For example, Hive Metastore / Catalog will provide either versionAsOf or timestampAsOf SerDe parameters (similar to path, which is already stored in SerDe parameter in table’s Storage Descriptor to specify location of Delta table) to achieve this goal.
Time travel options from the Hive Metastore catalog will work the same as if it was set from Delta format options, only one versionAsOf or timestampAsOf is allowed.

## How was this patch tested?

This patch was tested with Hive metastore and covered with Delta test cases.

## Does this PR introduce any user-facing changes?

No changes, unless table serde parameters are specified via Catalog / Hive metastore