### PR TITLE
#1478 Add support for syncing Delta table schema and properties to HMS

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -81,6 +81,11 @@ case class DeltaConfig[T](
  */
 trait DeltaConfigsBase extends DeltaLogging {
 
+  // Special properties stored in the Hive MetaStore that specifies which version last updated
+  // the entry in the MetaStore with the latest schema and table property information
+  val METASTORE_LAST_UPDATE_VERSION = "delta.lastUpdateVersion"
+  val METASTORE_LAST_COMMIT_TIMESTAMP = "delta.lastCommitTimestamp"
+
   /**
    * Convert a string to [[CalendarInterval]]. This method is case-insensitive and will throw
    * [[IllegalArgumentException]] when the input string is not a valid interval.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTableIdentifier.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTableIdentifier.scala
@@ -89,10 +89,10 @@ object DeltaTableIdentifier extends DeltaLogging {
     }
 
     spark.sessionState.conf.runSQLonFile &&
+      new Path(identifier.table).isAbsolute &&
       DeltaSourceUtils.isDeltaTable(identifier.database) &&
       !tableIsTemporaryTable &&
-      !tableExists &&
-      new Path(identifier.table).isAbsolute
+      !tableExists
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.DeletionVectorUtils
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.files._
-import org.apache.spark.sql.delta.hooks.{CheckpointHook, GenerateSymlinkManifest, IcebergConverterHook, PostCommitHook}
+import org.apache.spark.sql.delta.hooks.{CheckpointHook, GenerateSymlinkManifest, IcebergConverterHook, PostCommitHook, UpdateCatalogFactory}
 import org.apache.spark.sql.delta.implicits.addFileEncoder
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.{SchemaMergingUtils, SchemaUtils}
@@ -321,6 +321,9 @@ trait OptimisticTransactionImpl extends TransactionalWrite
   }
 
   protected val postCommitHooks = new ArrayBuffer[PostCommitHook]()
+  catalogTable.foreach { ct =>
+    registerPostCommitHook(UpdateCatalogFactory.getUpdateCatalogHook(ct, spark))
+  }
   // The CheckpointHook will only checkpoint if necessary, so always register it to run.
   registerPostCommitHook(CheckpointHook)
   registerPostCommitHook(IcebergConverterHook)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.DeltaColumnMapping.{dropColumnMappingMetadata, filterColumnMappingProperties}
 import org.apache.spark.sql.delta.actions.{Action, Metadata, Protocol}
 import org.apache.spark.sql.delta.actions.DomainMetadata
+import org.apache.spark.sql.delta.hooks.{UpdateCatalog, UpdateCatalogFactory}
 import org.apache.spark.sql.delta.hooks.IcebergConverterHook
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.SchemaUtils
@@ -534,7 +535,7 @@ case class CreateDeltaTableCommand(
           validateLocation = false)
       case TableCreationModes.Replace | TableCreationModes.CreateOrReplace
           if existingTableOpt.isDefined =>
-        spark.sessionState.catalog.alterTable(table)
+        UpdateCatalogFactory.getUpdateCatalogHook(table, spark).updateSchema(spark, snapshot)
       case TableCreationModes.Replace =>
         val ident = Identifier.of(table.identifier.database.toArray, table.identifier.table)
         throw DeltaErrors.cannotReplaceMissingTableException(ident)
@@ -558,13 +559,37 @@ case class CreateDeltaTableCommand(
       table.storage.copy(properties = Map.empty)
     }
 
-    table.copy(
-      schema = new StructType(),
-      properties = Map.empty,
-      partitionColumnNames = Nil,
-      // Remove write specific options when updating the catalog
-      storage = storageProps,
-      tracksPartitionsInCatalog = true)
+    // If we have to update the catalog, use the correct schema and table properties, otherwise
+    // empty out the schema and property information
+    if (conf.getConf(DeltaSQLConf.DELTA_UPDATE_CATALOG_ENABLED)) {
+      // In the case we're creating a Delta table on an existing path and adopting the schema
+      val schema = if (table.schema.isEmpty) snapshot.schema else table.schema
+      val truncatedSchema = UpdateCatalog.truncateSchemaIfNecessary(schema)
+      val additionalProperties = if (truncatedSchema.isEmpty) {
+        Map(UpdateCatalog.ERROR_KEY -> UpdateCatalog.LONG_SCHEMA_ERROR)
+      } else {
+        Map.empty
+      }
+
+      table.copy(
+        schema = truncatedSchema,
+        // Hive does not allow for the removal of partition columns once stored.
+        // To avoid returning the incorrect schema when the partition columns change,
+        // we store the partition columns as regular data columns.
+        partitionColumnNames = Nil,
+        properties = UpdateCatalog.updatedProperties(snapshot)
+          ++ additionalProperties,
+        storage = storageProps,
+        tracksPartitionsInCatalog = true)
+    } else {
+      table.copy(
+        schema = new StructType(),
+        properties = Map.empty,
+        partitionColumnNames = Nil,
+        // Remove write specific options when updating the catalog
+        storage = storageProps,
+        tracksPartitionsInCatalog = true)
+    }
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/UpdateCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/UpdateCatalog.scala
@@ -1,0 +1,367 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.hooks
+
+import java.nio.charset.Charset
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.collection.JavaConverters._
+import scala.concurrent.{ExecutionContext, Future, TimeoutException}
+import scala.util.Try
+import scala.util.control.NonFatal
+
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaTableIdentifier, OptimisticTransactionImpl, Snapshot}
+import org.apache.spark.sql.delta.actions.{Action, Metadata}
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.util.threads.DeltaThreadPool
+import org.apache.commons.lang3.exception.ExceptionUtils
+
+import org.apache.spark.internal.config.ConfigEntry
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAME
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{StructField, StructType}
+import org.apache.spark.util.ThreadUtils
+
+/**
+ * Factory object to create an UpdateCatalog post commit hook. This should always be used
+ * instead of directly creating a specific hook.
+ */
+object UpdateCatalogFactory {
+  def getUpdateCatalogHook(table: CatalogTable, spark: SparkSession): UpdateCatalogBase = {
+    UpdateCatalog(table)
+  }
+}
+
+/**
+ * Base trait for post commit hooks that want to update the catalog with the
+ * latest table schema and properties.
+ */
+trait UpdateCatalogBase extends PostCommitHook with DeltaLogging {
+
+  protected val table: CatalogTable
+
+  override def run(
+      spark: SparkSession,
+      txn: OptimisticTransactionImpl,
+      committedVersion: Long,
+      postCommitSnapshot: Snapshot,
+      actions: Seq[Action]): Unit = {
+    // There's a potential race condition here, where a newer commit has already triggered
+    // this to run. That's fine.
+    executeOnWrite(spark, postCommitSnapshot)
+  }
+
+  /**
+   * Used to manually execute an UpdateCatalog hook during a write.
+   */
+  def executeOnWrite(
+    spark: SparkSession,
+    snapshot: Snapshot
+    ): Unit
+
+
+  /**
+   * Update the schema in the catalog based on the provided snapshot.
+   */
+  def updateSchema(spark: SparkSession, snapshot: Snapshot): Unit
+
+  /**
+   * Update the properties in the catalog based on the provided snapshot.
+   */
+  protected def updateProperties(spark: SparkSession, snapshot: Snapshot): Unit
+
+  /**
+   * Checks if the table schema has changed in the Snapshot with respect to what's stored in
+   * the catalog.
+   */
+  protected def schemaHasChanged(snapshot: Snapshot, spark: SparkSession): Boolean
+
+  /**
+   * Checks if the table properties have changed in the Snapshot with respect to what's stored in
+   * the catalog.
+   *
+   * Visible for testing.
+   */
+  protected[sql] def propertiesHaveChanged(
+    properties: Map[String, String],
+    metadata: Metadata,
+    spark: SparkSession): Boolean
+
+  protected def shouldRun(
+      spark: SparkSession,
+      snapshot: Snapshot
+      ): Boolean = {
+    // Do not execute for path based tables, because they don't exist in the MetaStore
+    if (isPathBasedDeltaTable(table, spark)) return false
+    // Only execute if this is a Delta table
+    if (snapshot.version < 0) return false
+    true
+  }
+
+  private def isPathBasedDeltaTable(table: CatalogTable, spark: SparkSession): Boolean = {
+    return DeltaTableIdentifier.isDeltaPath(spark, table.identifier)
+  }
+
+
+  /** Update the entry in the Catalog to reflect the latest schema and table properties. */
+  protected def execute(
+      spark: SparkSession,
+      snapshot: Snapshot): Unit = {
+    recordDeltaOperation(snapshot.deltaLog, "delta.catalog.update") {
+      val properties = snapshot.getProperties.toMap
+      val v = table.properties.get(DeltaConfigs.METASTORE_LAST_UPDATE_VERSION)
+        .flatMap(v => Try(v.toLong).toOption)
+        .getOrElse(-1L)
+      val lastCommitTimestamp = table.properties.get(DeltaConfigs.METASTORE_LAST_COMMIT_TIMESTAMP)
+        .flatMap(v => Try(v.toLong).toOption)
+        .getOrElse(-1L)
+      // If the metastore entry is at an older version and not the timestamp of that version, e.g.
+      // a table can be rm -rf'd and get the same version number with a different timestamp
+      if (v <= snapshot.version || lastCommitTimestamp < snapshot.timestamp) {
+        try {
+          val loggingData = Map(
+            "identifier" -> table.identifier,
+            "snapshotVersion" -> snapshot.version,
+            "snapshotTimestamp" -> snapshot.timestamp,
+            "catalogVersion" -> v,
+            "catalogTimestamp" -> lastCommitTimestamp
+          )
+          if (schemaHasChanged(snapshot, spark)) {
+            updateSchema(spark, snapshot)
+            recordDeltaEvent(
+              snapshot.deltaLog,
+              "delta.catalog.update.schema",
+              data = loggingData
+            )
+          } else if (propertiesHaveChanged(properties, snapshot.metadata, spark)) {
+            updateProperties(spark, snapshot)
+            recordDeltaEvent(
+              snapshot.deltaLog,
+              "delta.catalog.update.properties",
+              data = loggingData
+            )
+          }
+        } catch {
+          case NonFatal(e) =>
+            recordDeltaEvent(
+              snapshot.deltaLog,
+              "delta.catalog.update.error",
+              data = Map(
+                "exceptionMsg" -> ExceptionUtils.getMessage(e),
+                "stackTrace" -> ExceptionUtils.getStackTrace(e))
+            )
+            logWarning(s"Failed to update the catalog for ${table.identifier} with the latest " +
+              s"table information.", e)
+        }
+      }
+    }
+  }
+}
+
+/**
+ * A post-commit hook that allows us to cache the most recent schema and table properties of a Delta
+ * table in an External Catalog. In addition to the schema and table properties, we also store the
+ * last commit timestamp and version for which we updated the catalog. This prevents us from
+ * updating the MetaStore with potentially stale information.
+ */
+case class UpdateCatalog(table: CatalogTable) extends UpdateCatalogBase {
+
+  override val name: String = "Update Catalog"
+
+  override def executeOnWrite(
+      spark: SparkSession,
+      snapshot: Snapshot
+     ): Unit = {
+    executeAsync(spark, snapshot)
+  }
+
+
+  override protected def schemaHasChanged(snapshot: Snapshot, spark: SparkSession): Boolean = {
+    // We need to check whether the schema in the catalog matches the current schema. If a
+    // field in the schema is very long, we cannot store the schema in the catalog, therefore
+    // here we have to compare what's in the catalog with what we actually can store in the
+    // catalog
+    val schemaChanged = UpdateCatalog.truncateSchemaIfNecessary(snapshot.schema) != table.schema
+    // The table may have been dropped as we're just about to update the information. There is
+    // unfortunately no great way to avoid a race condition, but we do one last check here as
+    // updates may have been queued for some time.
+    schemaChanged && spark.sessionState.catalog.tableExists(table.identifier)
+  }
+
+  /**
+   * Checks if the table properties have changed in the Snapshot with respect to what's stored in
+   * the catalog. We check to see if our table properties are a subset of what is in the MetaStore
+   * to avoid flip-flopping the information between older and newer versions of Delta. The
+   * assumption here is that newer Delta releases will only add newer table properties and not
+   * remove them.
+   */
+  override protected[sql] def propertiesHaveChanged(
+      properties: Map[String, String],
+      metadata: Metadata,
+      spark: SparkSession): Boolean = {
+    val propertiesChanged = !properties.forall { case (k, v) =>
+      table.properties.get(k) == Some(v)
+    }
+    // The table may have been dropped as we're just about to update the information. There is
+    // unfortunately no great way to avoid a race condition, but we do one last check here as
+    // updates may have been queued for some time.
+    propertiesChanged && spark.sessionState.catalog.tableExists(table.identifier)
+  }
+
+  override def updateSchema(spark: SparkSession, snapshot: Snapshot): Unit = {
+    UpdateCatalog.replaceTable(spark, snapshot, table)
+  }
+
+  override protected def updateProperties(spark: SparkSession, snapshot: Snapshot): Unit = {
+    spark.sessionState.catalog.alterTable(
+      table.copy(properties = UpdateCatalog.updatedProperties(snapshot)))
+  }
+
+  /**
+   * Update the entry in the Catalog to reflect the latest schema and table properties
+   * asynchronously.
+   */
+  private def executeAsync(
+      spark: SparkSession,
+      snapshot: Snapshot): Unit = {
+    if (!shouldRun(spark, snapshot)) return
+    Future[Unit] {
+      UpdateCatalog.activeAsyncRequests.incrementAndGet()
+      execute(spark, snapshot)
+    }(UpdateCatalog.getOrCreateExecutionContext(spark.sessionState.conf)).onComplete { _ =>
+      UpdateCatalog.activeAsyncRequests.decrementAndGet()
+    }(UpdateCatalog.getOrCreateExecutionContext(spark.sessionState.conf))
+  }
+}
+
+object UpdateCatalog {
+  private var tp: ExecutionContext = _
+
+  // This is the encoding of the database for the Hive MetaStore
+  private val latin1 = Charset.forName("ISO-8859-1")
+
+  // Maximum number of characters that a catalog can store.
+  val MAX_CATALOG_TYPE_DDL_LENGTH = 4000
+  val ERROR_KEY = "delta.catalogUpdateError"
+  val LONG_SCHEMA_ERROR: String = "The schema contains a very long nested field and cannot be " +
+    "stored in the catalog."
+  val HIVE_METASTORE_NAME = "hive_metastore"
+
+  private def getOrCreateExecutionContext(conf: SQLConf): ExecutionContext = synchronized {
+    if (tp == null) {
+      tp = ExecutionContext.fromExecutorService(DeltaThreadPool.newDaemonCachedThreadPool(
+        "delta-catalog-update",
+        conf.getConf(DeltaSQLConf.DELTA_UPDATE_CATALOG_THREAD_POOL_SIZE)
+        )
+      )
+    }
+    tp
+  }
+
+  /** Keeps track of active or queued async requests. */
+  private val activeAsyncRequests = new AtomicInteger(0)
+
+  /**
+   * Waits for all active and queued updates to finish until the given timeout. Will return true
+   * if all async threads have completed execution. Will return false if not. Exposed for tests.
+   */
+  def awaitCompletion(timeoutMillis: Long): Boolean = {
+    try {
+      ThreadUtils.runInNewThread("UpdateCatalog-awaitCompletion") {
+        val startTime = System.currentTimeMillis()
+        while (activeAsyncRequests.get() > 0) {
+          Thread.sleep(100)
+          val currentTime = System.currentTimeMillis()
+          if (currentTime - startTime > timeoutMillis) {
+            throw new TimeoutException(
+              s"Timed out waiting for catalog updates to complete after $currentTime ms")
+          }
+        }
+      }
+      true
+    } catch {
+      case _: TimeoutException =>
+        false
+    }
+  }
+
+  /** Replace the table definition in the MetaStore. */
+  private def replaceTable(spark: SparkSession, snapshot: Snapshot, table: CatalogTable): Unit = {
+    val catalog = spark.sessionState.catalog
+    val qualifiedIdentifier =
+      catalog.qualifyIdentifier(TableIdentifier(table.identifier.table, Some(table.database)))
+    val db = qualifiedIdentifier.database.get
+    val tblName = qualifiedIdentifier.table
+    val schema = truncateSchemaIfNecessary(snapshot.schema)
+    val additionalProperties = if (schema.isEmpty) {
+      Map(ERROR_KEY -> LONG_SCHEMA_ERROR)
+    } else {
+      Map.empty
+    }
+
+    // We call the lower level API so that we can actually drop columns. We also assume that
+    // all columns are data columns so that we don't have to deal with partition columns
+    // having to be at the end of the schema, which Hive follows.
+    val catalogName = table.identifier.catalog.getOrElse(
+      spark.sessionState.catalogManager.currentCatalog.name())
+    if (
+      (catalogName == UpdateCatalog.HIVE_METASTORE_NAME
+        || catalogName == SESSION_CATALOG_NAME) &&
+      catalog.externalCatalog.tableExists(db, tblName)) {
+      catalog.externalCatalog.alterTableDataSchema(db, tblName, schema)
+    }
+
+    // We have to update the properties anyway with the latest version/timestamp information
+    catalog.alterTable(table.copy(properties = updatedProperties(snapshot) ++ additionalProperties))
+  }
+
+  /** Updates our properties map with the version and timestamp information of the snapshot. */
+  def updatedProperties(snapshot: Snapshot): Map[String, String] = {
+    var newProperties =
+      snapshot.getProperties.toMap ++ Map(
+        DeltaConfigs.METASTORE_LAST_UPDATE_VERSION -> snapshot.version.toString,
+        DeltaConfigs.METASTORE_LAST_COMMIT_TIMESTAMP -> snapshot.timestamp.toString)
+    newProperties
+  }
+
+  /**
+   * If a field in the schema has a very long string representation, then the schema will be
+   * truncated to an empty schema to avoid corruption.
+   * Also, if the schema contains non-latin encoding characters, the schema will be garbled. In
+   * this case we also truncate the schema.
+   */
+  def truncateSchemaIfNecessary(schema: StructType): StructType = {
+    // Encoders are not threadsafe
+    val encoder = latin1.newEncoder()
+    def isColumnValid(f: StructField): Boolean = {
+      val typeString = f.dataType.catalogString
+        encoder.canEncode(f.name) &&
+        typeString.length <= MAX_CATALOG_TYPE_DDL_LENGTH &&
+        encoder.canEncode(typeString)
+    }
+
+    if (schema.exists(f => !isColumnValid(f))) {
+      new StructType()
+    } else {
+      schema
+    }
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/UpdateCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/UpdateCatalog.scala
@@ -109,6 +109,9 @@ trait UpdateCatalogBase extends PostCommitHook with DeltaLogging {
       spark: SparkSession,
       snapshot: Snapshot
       ): Boolean = {
+    if (!spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_UPDATE_CATALOG_ENABLED)) {
+      return false
+    }
     // Do not execute for path based tables, because they don't exist in the MetaStore
     if (isPathBasedDeltaTable(table, spark)) return false
     // Only execute if this is a Delta table

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -357,6 +357,22 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
+  val DELTA_UPDATE_CATALOG_ENABLED =
+    buildConf("catalog.update.enabled")
+      .internal()
+      .doc("When enabled, we will cache the schema of the Delta table and the table properties " +
+        "in the external catalog, e.g. the Hive MetaStore.")
+      .booleanConf
+      .createWithDefault(false)
+
+  val DELTA_UPDATE_CATALOG_THREAD_POOL_SIZE =
+    buildStaticConf("catalog.update.threadPoolSize")
+      .internal()
+      .doc("The size of the thread pool for updating the external catalog.")
+      .intConf
+      .checkValue(_ > 0, "threadPoolSize must be positive")
+      .createWithDefault(20)
+
   val DELTA_ASSUMES_DROP_CONSTRAINT_IF_EXISTS =
     buildConf("constraints.assumesDropIfExists.enabled")
       .doc("""If true, DROP CONSTRAINT quietly drops nonexistent constraints even without

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaUpdateCatalogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaUpdateCatalogSuite.scala
@@ -1,0 +1,608 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.io.File
+
+import scala.util.control.NonFatal
+
+import com.databricks.spark.util.Log4jUsageLogger
+import org.apache.spark.sql.delta.hooks.UpdateCatalog
+import org.apache.spark.sql.delta.hooks.UpdateCatalog.MAX_CATALOG_TYPE_DDL_LENGTH
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaHiveTest
+import com.fasterxml.jackson.core.JsonParseException
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, SparkSession}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.ExternalCatalogWithListener
+import org.apache.spark.sql.execution.streaming.MemoryStream
+import org.apache.spark.sql.functions.{lit, struct}
+import org.apache.spark.sql.hive.HiveExternalCatalog
+import org.apache.spark.sql.types.{ArrayType, DoubleType, IntegerType, LongType, MapType, StringType, StructField, StructType}
+import org.apache.spark.util.{ThreadUtils, Utils}
+
+class DeltaUpdateCatalogSuite
+  extends DeltaUpdateCatalogSuiteBase
+    with DeltaHiveTest {
+
+  import testImplicits._
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    spark.conf.set(DeltaSQLConf.DELTA_UPDATE_CATALOG_ENABLED.key, "true")
+  }
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    cleanupDefaultTable()
+  }
+
+  override def afterEach(): Unit = {
+    if (!UpdateCatalog.awaitCompletion(10000)) {
+      logWarning(s"There are active catalog udpate requests after 10 seconds")
+    }
+    cleanupDefaultTable()
+    super.afterEach()
+  }
+
+  /** Remove Hive specific table properties. */
+  override protected def filterProperties(properties: Map[String, String]): Map[String, String] = {
+    properties.filterKeys(_ != "transient_lastDdlTime").toMap
+  }
+
+
+  test("streaming") {
+    withTable(tbl) {
+      implicit val _sqlContext = spark.sqlContext
+      val stream = MemoryStream[Long]
+      val df1 = stream.toDF().toDF("id")
+
+      withTempDir { dir =>
+        try {
+          val q = df1.writeStream
+            .option("checkpointLocation", dir.getCanonicalPath)
+            .format("delta")
+            .toTable(tbl)
+
+          verifyTableMetadata(expectedSchema = df1.schema.asNullable)
+
+          stream.addData(1, 2, 3)
+          q.processAllAvailable()
+          q.stop()
+
+          val q2 = df1.withColumn("id2", 'id)
+            .writeStream
+            .format("delta")
+            .option("mergeSchema", "true")
+            .option("checkpointLocation", dir.getCanonicalPath)
+            .toTable(tbl)
+
+          stream.addData(4, 5, 6)
+          q2.processAllAvailable()
+
+          verifyTableMetadataAsync(expectedSchema = df1.schema.asNullable.add("id2", LongType))
+        } finally {
+          spark.streams.active.foreach(_.stop())
+        }
+      }
+    }
+  }
+
+  test("streaming - external location") {
+    withTempDir { dir =>
+      withTable(tbl) {
+        implicit val _sqlContext = spark.sqlContext
+        val stream = MemoryStream[Long]
+        val df1 = stream.toDF().toDF("id")
+
+        val chk = new File(dir, "chkpoint").getCanonicalPath
+        val data = new File(dir, "data").getCanonicalPath
+        try {
+          val q = df1.writeStream
+            .option("checkpointLocation", chk)
+            .format("delta")
+            .option("path", data)
+            .toTable(tbl)
+
+          verifyTableMetadata(expectedSchema = df1.schema.asNullable)
+
+          stream.addData(1, 2, 3)
+          q.processAllAvailable()
+          q.stop()
+
+          val q2 = df1.withColumn("id2", 'id)
+            .writeStream
+            .format("delta")
+            .option("mergeSchema", "true")
+            .option("checkpointLocation", chk)
+            .toTable(tbl)
+
+          stream.addData(4, 5, 6)
+          q2.processAllAvailable()
+
+          verifyTableMetadataAsync(expectedSchema = df1.schema.add("id2", LongType).asNullable)
+        } finally {
+          spark.streams.active.foreach(_.stop())
+        }
+      }
+    }
+  }
+
+  test("streaming - external table that already exists") {
+    withTable(tbl) {
+      implicit val _sqlContext = spark.sqlContext
+      val stream = MemoryStream[Long]
+      val df1 = stream.toDF().toDF("id")
+
+      withTempDir { dir =>
+        val chk = new File(dir, "chkpoint").getCanonicalPath
+        val data = new File(dir, "data").getCanonicalPath
+
+        spark.range(10).write.format("delta").save(data)
+        try {
+          val q = df1.writeStream
+            .option("checkpointLocation", chk)
+            .format("delta")
+            .option("path", data)
+            .toTable(tbl)
+
+          verifyTableMetadataAsync(expectedSchema = df1.schema.asNullable)
+
+          stream.addData(1, 2, 3)
+          q.processAllAvailable()
+          q.stop()
+
+          val q2 = df1.withColumn("id2", 'id)
+            .writeStream
+            .format("delta")
+            .option("mergeSchema", "true")
+            .option("checkpointLocation", chk)
+            .toTable(tbl)
+
+          stream.addData(4, 5, 6)
+          q2.processAllAvailable()
+
+          verifyTableMetadataAsync(expectedSchema = df1.schema.add("id2", LongType).asNullable)
+        } finally {
+          spark.streams.active.foreach(_.stop())
+        }
+      }
+    }
+  }
+
+
+  test("convert to delta with partitioning change") {
+    withTable(tbl) {
+      val df = spark.range(10).withColumn("part", 'id / 2).withColumn("id2", 'id)
+      df.writeTo(tbl)
+        .partitionedBy('part)
+        .using("parquet")
+        .create()
+
+      // Partitioning columns go to the end for parquet tables
+      val tableSchema =
+        new StructType().add("id", LongType).add("id2", LongType).add("part", DoubleType)
+      verifyTableMetadata(
+        expectedSchema = tableSchema,
+        expectedProperties = Map.empty,
+        partitioningCols = Seq("part")
+      )
+
+      sql(s"CONVERT TO DELTA $tbl PARTITIONED BY (part double)")
+      // Information is duplicated for now
+      verifyTableMetadata(
+        expectedSchema = tableSchema,
+        expectedProperties = Map.empty,
+        partitioningCols = Seq("part")
+      )
+
+      // Remove partitioning of table
+      df.writeTo(tbl).using("delta").replace()
+
+      assert(snapshot.metadata.partitionColumns === Nil, "Table is unpartitioned")
+
+      // Hive does not allow for the removal of the partition column once it has
+      // been added. Spark keeps the partition columns towards the end if it
+      // finds them in Hive. So, for converted tables with partitions,
+      // Hive schema != df.schema
+      val expectedSchema = tableSchema
+
+      // Schema converts to Delta's format
+      verifyTableMetadata(
+        expectedSchema = expectedSchema,
+        expectedProperties = getBaseProperties(snapshot),
+        partitioningCols = Seq("part") // The partitioning information cannot be removed...
+      )
+
+      // table is still usable
+      checkAnswer(spark.table(tbl), df)
+
+      val df2 = spark.range(10).withColumn("id2", 'id)
+      // Gets rid of partition column "part" from the schema
+      df2.writeTo(tbl).using("delta").replace()
+
+      val expectedSchema2 = new StructType()
+        .add("id", LongType).add("id2", LongType).add("part", DoubleType)
+      verifyTableMetadataAsync(
+        expectedSchema = expectedSchema2,
+        expectedProperties = getBaseProperties(snapshot),
+        partitioningCols = Seq("part") // The partitioning information cannot be removed...
+      )
+
+      // table is still usable
+      checkAnswer(spark.table(tbl), df2)
+    }
+  }
+
+  test("partitioned table + add column") {
+    withTable(tbl) {
+      val df = spark.range(10).withColumn("part", 'id / 2).withColumn("id2", 'id)
+      df.writeTo(tbl)
+        .partitionedBy('part)
+        .using("delta")
+        .create()
+
+      val tableSchema =
+        new StructType().add("id", LongType).add("part", DoubleType).add("id2", LongType)
+      verifyTableMetadata(
+        expectedSchema = tableSchema,
+        expectedProperties = getBaseProperties(snapshot),
+        partitioningCols = Seq())
+
+      sql(s"ALTER TABLE $tbl ADD COLUMNS (id3 bigint)")
+      verifyTableMetadataAsync(
+        expectedSchema = tableSchema.add("id3", LongType),
+        expectedProperties = getBaseProperties(snapshot),
+        partitioningCols = Seq())
+    }
+  }
+
+  test("partitioned convert to delta with schema change") {
+    withTable(tbl) {
+      val df = spark.range(10).withColumn("part", 'id / 2).withColumn("id2", 'id)
+      df.writeTo(tbl)
+        .partitionedBy('part)
+        .using("parquet")
+        .create()
+
+      // Partitioning columns go to the end
+      val tableSchema =
+        new StructType().add("id", LongType).add("id2", LongType).add("part", DoubleType)
+      verifyTableMetadata(
+        expectedSchema = tableSchema,
+        expectedProperties = Map.empty,
+        partitioningCols = Seq("part")
+      )
+
+      sql(s"CONVERT TO DELTA $tbl PARTITIONED BY (part double)")
+      // Information is duplicated for now
+      verifyTableMetadata(
+        expectedSchema = tableSchema,
+        expectedProperties = Map.empty,
+        partitioningCols = Seq("part")
+      )
+
+      sql(s"ALTER TABLE $tbl ADD COLUMNS (id3 bigint)")
+
+      // Hive does not allow for the removal of the partition column once it has
+      // been added. Spark keeps the partition columns towards the end if it
+      // finds them in Hive. So, for converted tables with partitions,
+      // Hive schema != df.schema
+      val expectedSchema = new StructType()
+        .add("id", LongType)
+        .add("id2", LongType)
+        .add("id3", LongType)
+        .add("part", DoubleType)
+
+      verifyTableMetadataAsync(
+        expectedSchema = expectedSchema,
+        partitioningCols = Seq("part")
+      )
+
+      // Table is still queryable
+      checkAnswer(
+        spark.table(tbl),
+        // Ordering of columns are different than df due to Hive semantics
+        spark.range(10).withColumn("id2", 'id)
+          .withColumn("part", 'id / 2)
+          .withColumn("id3", lit(null)))
+    }
+  }
+
+
+  import UpdateCatalog.MAX_CATALOG_TYPE_DDL_LENGTH
+
+  test("Very long schemas can be stored in the catalog") {
+    withTable(tbl) {
+      val schema = StructType(Seq.tabulate(1000)(i => StructField(s"col$i", StringType)))
+      require(schema.toDDL.length >= MAX_CATALOG_TYPE_DDL_LENGTH,
+        s"The length of the schema should be over $MAX_CATALOG_TYPE_DDL_LENGTH " +
+          "characters for this test")
+
+      sql(s"CREATE TABLE $tbl (${schema.toDDL}) USING delta")
+      verifyTableMetadata(expectedSchema = schema)
+    }
+  }
+
+  test("Schemas that contain very long fields cannot be stored in the catalog") {
+    withTable(tbl) {
+      val schema = new StructType()
+        .add("i", StringType)
+        .add("struct", StructType(Seq.tabulate(1000)(i => StructField(s"col$i", StringType))))
+      require(schema.toDDL.length >= MAX_CATALOG_TYPE_DDL_LENGTH,
+        s"The length of the schema should be over $MAX_CATALOG_TYPE_DDL_LENGTH " +
+          s"characters for this test")
+
+      sql(s"CREATE TABLE $tbl (${schema.toDDL}) USING delta")
+      verifySchemaInCatalog()
+    }
+  }
+
+  test("Schemas that contain very long fields cannot be stored in the catalog - array") {
+    withTable(tbl) {
+      val struct = StructType(Seq.tabulate(1000)(i => StructField(s"col$i", StringType)))
+      val schema = new StructType()
+        .add("i", StringType)
+        .add("array", ArrayType(struct))
+      require(schema.toDDL.length >= MAX_CATALOG_TYPE_DDL_LENGTH,
+        s"The length of the schema should be over $MAX_CATALOG_TYPE_DDL_LENGTH " +
+          s"characters for this test")
+
+      sql(s"CREATE TABLE $tbl (${schema.toDDL}) USING delta")
+      verifySchemaInCatalog()
+    }
+  }
+
+  test("Schemas that contain very long fields cannot be stored in the catalog - map") {
+    withTable(tbl) {
+      val struct = StructType(Seq.tabulate(1000)(i => StructField(s"col$i", StringType)))
+      val schema = new StructType()
+        .add("i", StringType)
+        .add("map", MapType(StringType, struct))
+      require(schema.toDDL.length >= MAX_CATALOG_TYPE_DDL_LENGTH,
+        s"The length of the schema should be over $MAX_CATALOG_TYPE_DDL_LENGTH " +
+          s"characters for this test")
+
+      sql(s"CREATE TABLE $tbl (${schema.toDDL}) USING delta")
+      verifySchemaInCatalog()
+    }
+  }
+
+  test("Very long schemas can be stored in the catalog - partitioned") {
+    withTable(tbl) {
+      val schema = StructType(Seq.tabulate(1000)(i => StructField(s"col$i", StringType)))
+        .add("part", StringType)
+      require(schema.toDDL.length >= MAX_CATALOG_TYPE_DDL_LENGTH,
+        "The length of the schema should be over 4000 characters for this test")
+
+      sql(s"CREATE TABLE $tbl (${schema.toDDL}) USING delta PARTITIONED BY (part)")
+      verifyTableMetadata(expectedSchema = schema)
+    }
+  }
+
+  test("Very long nested fields cannot be stored in the catalog - partitioned") {
+    withTable(tbl) {
+      val schema = new StructType()
+        .add("i", StringType)
+        .add("part", StringType)
+        .add("struct", StructType(Seq.tabulate(1000)(i => StructField(s"col$i", StringType))))
+      require(schema.toDDL.length >= MAX_CATALOG_TYPE_DDL_LENGTH,
+        "The length of the schema should be over 4000 characters for this test")
+
+      sql(s"CREATE TABLE $tbl (${schema.toDDL}) USING delta PARTITIONED BY (part)")
+      verifySchemaInCatalog()
+    }
+  }
+
+  test("Very long schemas can be stored in the catalog - " +
+    "converted and partitioned") {
+    withTable(tbl) {
+      val exprs = Seq.tabulate(1000)(i => $"id".as(s"col$i"))
+      val df = spark.range(10).select(exprs :+ ($"id" % 2).as("part"): _*)
+      require(df.schema.toDDL.length >= MAX_CATALOG_TYPE_DDL_LENGTH,
+        "The length of the schema should be over 4000 characters for this test")
+      withTempView("tmp_view") {
+        df.createOrReplaceTempView("tmp_view")
+        sql(s"CREATE TABLE $tbl USING parquet PARTITIONED BY (part) AS SELECT * FROM tmp_view")
+        verifyTableMetadata(
+          expectedSchema = df.schema.asNullable,
+          expectedProperties = Map.empty,
+          partitioningCols = Seq("part"))
+      }
+      sql(s"CONVERT TO DELTA $tbl PARTITIONED BY (part bigint)")
+      // Cause an update to trigger
+      sql(s"DELETE FROM $tbl")
+      UpdateCatalog.awaitCompletion(10000)
+
+      verifyTableMetadata(expectedSchema = df.schema.asNullable, partitioningCols = Seq("part"))
+    }
+  }
+
+  test("Very long nested fields cannot be stored in the catalog - " +
+    "converted and partitioned") {
+    withTable(tbl) {
+      val exprs = Seq.tabulate(1000)(i => $"id".as(s"col$i"))
+      val df = spark.range(10).select(struct(exprs: _*).as("struct"), ($"id" % 2).as("part"))
+      require(df.schema.toDDL.length >= MAX_CATALOG_TYPE_DDL_LENGTH,
+        "The length of the schema should be over 4000 characters for this test")
+      withTempView("tmp_view") {
+        df.createOrReplaceTempView("tmp_view")
+        sql(s"CREATE TABLE $tbl USING parquet PARTITIONED BY (part) AS SELECT * FROM tmp_view")
+        verifyTableMetadata(
+          expectedSchema = df.schema.asNullable,
+          expectedProperties = Map.empty,
+          partitioningCols = Seq("part"))
+      }
+      sql(s"CONVERT TO DELTA $tbl PARTITIONED BY (part bigint)")
+      // Cause an update to trigger
+      sql(s"DELETE FROM $tbl")
+      UpdateCatalog.awaitCompletion(10000)
+
+      // There's a subtle race condition here, where the information in the catalog can be updated
+      // by either the first commit or after the DELETE with the second commit, therefore, we
+      // don't check the exact match of properties in the catalog.
+      val cat = spark.sessionState.catalog.externalCatalog.getTable("default", tbl)
+      // If a partitioned table is converted into Delta, the partition columns
+      // will always show up in the schema.
+      val expectedSchema = new StructType().add("part", LongType)
+      assert(cat.schema == expectedSchema, s"Schema didn't match for table: $tbl")
+      assert(cat.partitionColumnNames === Seq("part"))
+      assert(cat.properties.nonEmpty, s"Properties not uploaded for table: $tbl")
+
+      // Still get the schema properly even though it's not stored in the catalog
+      val tables = spark.sessionState.catalog.getTablesByName(Seq(TableIdentifier(tbl)))
+      assert(tables.head.schema.nonEmpty)
+
+      // Make sure table is readable
+      checkAnswer(spark.table(tbl), Nil)
+    }
+  }
+
+  // scalastyle:off nonascii
+  test("Schema containing non-latin characters cannot be stored - top-level") {
+    withTable(tbl) {
+      val schema = new StructType().add("今天", "string")
+      sql(s"CREATE TABLE $tbl (${schema.toDDL}) USING delta")
+      verifySchemaInCatalog()
+    }
+  }
+
+  test("Schema containing non-latin characters cannot be stored - struct") {
+    withTable(tbl) {
+      val schema = new StructType().add("struct", new StructType().add("今天", "string"))
+      sql(s"CREATE TABLE $tbl (${schema.toDDL}) USING delta")
+      verifySchemaInCatalog()
+    }
+  }
+
+  test("Schema containing non-latin characters cannot be stored - array") {
+    withTable(tbl) {
+      val schema = new StructType()
+        .add("i", StringType)
+        .add("array", ArrayType(new StructType().add("今天", "string")))
+
+      sql(s"CREATE TABLE $tbl (${schema.toDDL}) USING delta")
+      verifySchemaInCatalog()
+    }
+  }
+
+  test("Schema containing non-latin characters cannot be stored - map") {
+    withTable(tbl) {
+      val schema = new StructType()
+        .add("i", StringType)
+        .add("map", MapType(StringType, new StructType().add("今天", "string")))
+
+      sql(s"CREATE TABLE $tbl (${schema.toDDL}) USING delta")
+      verifySchemaInCatalog()
+    }
+  }
+  // scalastyle:on nonascii
+
+  /**
+   * Verifies that the schema stored in the catalog explicitly is empty, however the getTablesByName
+   * method still correctly returns the actual schema.
+   */
+  private def verifySchemaInCatalog(
+      table: String = tbl,
+      catalogPartitionCols: Seq[String] = Nil): Unit = {
+    val cat = spark.sessionState.catalog.externalCatalog.getTable("default", table)
+    assert(cat.schema.isEmpty, s"Schema wasn't empty")
+    assert(cat.partitionColumnNames === catalogPartitionCols)
+    getBaseProperties(snapshot).foreach { case (k, v) =>
+      assert(cat.properties.get(k) === Some(v),
+        s"Properties didn't match for table: $table. Expected: ${getBaseProperties(snapshot)}, " +
+        s"Got: ${cat.properties}")
+    }
+    assert(cat.properties(UpdateCatalog.ERROR_KEY) === UpdateCatalog.LONG_SCHEMA_ERROR)
+
+    // Make sure table is readable
+    checkAnswer(spark.table(table), Nil)
+  }
+
+  def testAddRemoveProperties(): Unit = {
+    withTable(tbl) {
+      val df = spark.range(10).toDF("id")
+      df.writeTo(tbl)
+        .using("delta")
+        .create()
+
+      var initialProperties: Map[String, String] = Map.empty
+      val logs = Log4jUsageLogger.track {
+        sql(s"ALTER TABLE $tbl SET TBLPROPERTIES(some.key = 1, another.key = 2)")
+
+        initialProperties = getBaseProperties(snapshot)
+        verifyTableMetadataAsync(
+          expectedSchema = df.schema.asNullable,
+          expectedProperties = Map("some.key" -> "1", "another.key" -> "2") ++
+            initialProperties
+        )
+      }
+      val updateLogged = logs.filter(_.metric == "tahoeEvent")
+        .filter(_.tags.get("opType").exists(_.startsWith("delta.catalog.update.properties")))
+      assert(updateLogged.nonEmpty, "Ensure that the schema update in the MetaStore is logged")
+
+      // The UpdateCatalog hook only checks if new properties have been
+      // added. If properties have been removed only, no metadata update will be triggered.
+      val logs2 = Log4jUsageLogger.track {
+        sql(s"ALTER TABLE $tbl UNSET TBLPROPERTIES(another.key)")
+        verifyTableMetadataAsync(
+          expectedSchema = df.schema.asNullable,
+          expectedProperties = Map("some.key" -> "1", "another.key" -> "2") ++
+            initialProperties
+        )
+      }
+      val updateLogged2 = logs2.filter(_.metric == "tahoeEvent")
+        .filter(_.tags.get("opType").exists(_.startsWith("delta.catalog.update.properties")))
+      assert(updateLogged2.size == 0, "Ensure that the schema update in the MetaStore is logged")
+
+      // Adding a new property will trigger an update
+      val logs3 = Log4jUsageLogger.track {
+        sql(s"ALTER TABLE $tbl SET TBLPROPERTIES(a.third.key = 3)")
+        verifyTableMetadataAsync(
+          expectedSchema = df.schema.asNullable,
+          expectedProperties = Map("some.key" -> "1", "a.third.key" -> "3") ++
+            getBaseProperties(snapshot)
+        )
+      }
+      val updateLogged3 = logs3.filter(_.metric == "tahoeEvent")
+        .filter(_.tags.get("opType").exists(_.startsWith("delta.catalog.update.properties")))
+      assert(updateLogged3.nonEmpty, "Ensure that the schema update in the MetaStore is logged")
+    }
+  }
+
+  test("add and remove properties") {
+    testAddRemoveProperties()
+  }
+
+  test("alter table commands update the catalog") {
+    runAlterTableTests { (tableName, expectedSchema) =>
+      verifyTableMetadataAsync(
+        expectedSchema = expectedSchema,
+        // The ALTER TABLE statements in runAlterTableTests create table version 7.
+        // However, version 7 is created by dropping a CHECK constraint, which currently
+        // *does not* trigger a catalog update. For Hive tables, only *adding* properties
+        // causes a catalog update, not *removing*. Hence, the metadata in the catalog should
+        // still be at version 6.
+        expectedProperties = getBaseProperties(snapshotAt(6)) ++
+          Map("some" -> "thing", "delta.constraints.id_3" -> "id3 > 10"),
+        table = tableName
+      )
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaUpdateCatalogSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaUpdateCatalogSuiteBase.scala
@@ -1,0 +1,313 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.io.File
+
+import scala.util.control.NonFatal
+
+import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils
+import org.apache.spark.sql.delta.hooks.UpdateCatalog
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
+import org.scalatest.time.SpanSugar
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.functions.{lit, struct}
+import org.apache.spark.sql.test.SQLTestUtils
+import org.apache.spark.sql.types.{BooleanType, DoubleType, IntegerType, LongType, StringType, StructField, StructType}
+import org.apache.spark.util.{ThreadUtils, Utils}
+
+abstract class DeltaUpdateCatalogSuiteBase
+  extends QueryTest
+    with SQLTestUtils
+    with SpanSugar {
+
+  protected val tbl = "delta_table"
+
+  import testImplicits._
+
+  protected def cleanupDefaultTable(): Unit = disableUpdates {
+    spark.sql(s"DROP TABLE IF EXISTS $tbl")
+    val path = spark.sessionState.catalog.defaultTablePath(TableIdentifier(tbl))
+    try Utils.deleteRecursively(new File(path)) catch {
+      case NonFatal(e) => // do nothing
+    }
+  }
+
+  /** Turns off the storing of metadata (schema + properties) in the catalog. */
+  protected def disableUpdates(f: => Unit): Unit = {
+    withSQLConf(DeltaSQLConf.DELTA_UPDATE_CATALOG_ENABLED.key -> "false") {
+      f
+    }
+  }
+
+  protected def deltaLog: DeltaLog = DeltaLog.forTable(spark, TableIdentifier(tbl))
+  protected def snapshot: Snapshot = deltaLog.unsafeVolatileSnapshot
+  protected def snapshotAt(v: Long): Snapshot = deltaLog.getSnapshotAt(v)
+
+  protected def getBaseProperties(snapshot: Snapshot): Map[String, String] = {
+    Map(
+      DeltaConfigs.METASTORE_LAST_UPDATE_VERSION -> snapshot.version.toString,
+      DeltaConfigs.METASTORE_LAST_COMMIT_TIMESTAMP -> snapshot.timestamp.toString,
+      DeltaConfigs.MIN_READER_VERSION.key -> snapshot.protocol.minReaderVersion.toString,
+      DeltaConfigs.MIN_WRITER_VERSION.key -> snapshot.protocol.minWriterVersion.toString) ++
+      snapshot.protocol.readerAndWriterFeatureNames.map { name =>
+        s"${TableFeatureProtocolUtils.FEATURE_PROP_PREFIX}$name" ->
+          TableFeatureProtocolUtils.FEATURE_PROP_SUPPORTED
+      } ++ snapshot.metadata.configuration.get("delta.enableDeletionVectors")
+        .map("delta.enableDeletionVectors" -> _).toMap
+  }
+
+  /**
+   * Verifies that the table metadata in the catalog are eventually up-to-date. Updates to the
+   * catalog are generally asynchronous, except explicit DDL operations, e.g. CREATE/REPLACE.
+   */
+  protected def verifyTableMetadataAsync(
+      expectedSchema: StructType,
+      expectedProperties: Map[String, String] = getBaseProperties(snapshot),
+      table: String = tbl,
+      partitioningCols: Seq[String] = Nil): Unit = {
+    // We unfortunately need an eventually, because the updates can be async
+    eventually(timeout(10.seconds)) {
+      verifyTableMetadata(expectedSchema, expectedProperties, table, partitioningCols)
+    }
+    // Ensure that no other threads will later revert us back to the state we just checked
+    if (!UpdateCatalog.awaitCompletion(10000)) {
+      logWarning(s"There are active catalog udpate requests after 10 seconds")
+    }
+  }
+
+  protected def filterProperties(properties: Map[String, String]): Map[String, String]
+
+  /** Verifies that the table metadata in the catalog are up-to-date. */
+  protected def verifyTableMetadata(
+      expectedSchema: StructType,
+      expectedProperties: Map[String, String] = getBaseProperties(snapshot),
+      table: String = tbl,
+      partitioningCols: Seq[String] = Nil): Unit = {
+    DeltaLog.clearCache()
+    val cat = spark.sessionState.catalog.externalCatalog.getTable("default", table)
+    assert(cat.schema === expectedSchema, s"Schema didn't match for table: $table")
+    assert(cat.partitionColumnNames === partitioningCols)
+    assert(filterProperties(cat.properties) === expectedProperties,
+      s"Properties didn't match for table: $table")
+
+    val tables = spark.sessionState.catalog.getTablesByName(Seq(TableIdentifier(table)))
+
+    assert(tables.head.schema === expectedSchema)
+    assert(tables.head.partitionColumnNames === partitioningCols)
+    assert(filterProperties(tables.head.properties) === expectedProperties)
+  }
+
+
+  test("mergeSchema") {
+    withTable(tbl) {
+      val df = spark.range(10).withColumn("part", 'id / 2)
+      df.writeTo(tbl).using("delta").create()
+
+      verifyTableMetadata(expectedSchema = df.schema.asNullable)
+
+      val df2 = spark.range(10).withColumn("part", 'id / 2).withColumn("id2", 'id)
+      df2.writeTo(tbl)
+        .option("mergeSchema", "true")
+        .append()
+
+      verifyTableMetadataAsync(expectedSchema = df2.schema.asNullable)
+    }
+  }
+
+  test("mergeSchema - nested data types") {
+    withTable(tbl) {
+      val df = spark.range(10).withColumn("part", 'id / 2)
+        .withColumn("str", struct('id.cast("int") as "int"))
+      df.writeTo(tbl).using("delta").create()
+
+      verifyTableMetadata(expectedSchema = df.schema.asNullable)
+
+      val df2 = spark.range(10).withColumn("part", 'id / 2)
+        .withColumn("str", struct('id as "id2", 'id.cast("int") as "int"))
+      df2.writeTo(tbl)
+        .option("mergeSchema", "true")
+        .append()
+
+      val schema = new StructType()
+        .add("id", LongType)
+        .add("part", DoubleType)
+        .add("str", new StructType()
+          .add("int", IntegerType)
+          .add("id2", LongType)) // New columns go to the end
+      verifyTableMetadataAsync(expectedSchema = schema)
+    }
+  }
+
+
+  test("merge") {
+    val tmp = "tmpView"
+    withDeltaTable { df =>
+      withTempView(tmp) {
+        withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true") {
+          df.withColumn("id2", 'id).createOrReplaceTempView(tmp)
+          sql(
+            s"""MERGE INTO $tbl t
+               |USING $tmp s
+               |ON t.id = s.id
+               |WHEN NOT MATCHED THEN INSERT *
+             """.stripMargin)
+
+          verifyTableMetadataAsync(df.withColumn("id2", 'id).schema.asNullable)
+        }
+      }
+    }
+  }
+
+  test("creating and replacing a table puts the schema and table properties in the metastore") {
+    withTable(tbl) {
+      val df = spark.range(10).withColumn("part", 'id / 2).withColumn("id2", 'id)
+      df.writeTo(tbl)
+        .tableProperty("delta.checkpointInterval", "5")
+        .tableProperty("some", "thing")
+        .partitionedBy('part)
+        .using("delta")
+        .create()
+
+      verifyTableMetadata(
+        expectedSchema = df.schema.asNullable,
+        expectedProperties = getBaseProperties(snapshot) ++ Map(
+          "delta.checkpointInterval" -> "5",
+          "some" -> "thing")
+      )
+
+      val df2 = spark.range(10).withColumn("part", 'id / 2)
+      df2.writeTo(tbl)
+        .tableProperty("other", "thing")
+        .using("delta")
+        .replace()
+
+      verifyTableMetadata(
+        expectedSchema = df2.schema.asNullable,
+        expectedProperties = getBaseProperties(snapshot) ++ Map("other" -> "thing")
+      )
+    }
+  }
+
+  test("creating table in metastore over existing path") {
+    withTempDir { dir =>
+      withTable(tbl) {
+        val df = spark.range(10).withColumn("part", 'id % 2).withColumn("id2", 'id)
+        df.write.format("delta").partitionBy("part").save(dir.getCanonicalPath)
+
+        sql(s"CREATE TABLE $tbl USING delta LOCATION '${dir.getCanonicalPath}'")
+        verifyTableMetadata(df.schema.asNullable)
+      }
+    }
+  }
+
+  test("replacing non-Delta table") {
+    withTable(tbl) {
+      val df = spark.range(10).withColumn("part", 'id / 2).withColumn("id2", 'id)
+      df.writeTo(tbl)
+        .tableProperty("delta.checkpointInterval", "5")
+        .tableProperty("some", "thing")
+        .partitionedBy('part)
+        .using("parquet")
+        .create()
+
+      val e = intercept[AnalysisException] {
+        df.writeTo(tbl).using("delta").replace()
+      }
+
+      assert(e.getMessage.contains("not a Delta table"))
+    }
+  }
+
+  test("alter table add columns") {
+    withDeltaTable { df =>
+      sql(s"ALTER TABLE $tbl ADD COLUMNS (id2 bigint)")
+      verifyTableMetadataAsync(df.withColumn("id2", 'id).schema.asNullable)
+    }
+  }
+
+  protected def runAlterTableTests(f: (String, StructType) => Unit): Unit = {
+    // We set the default minWriterVersion to the version required to ADD/DROP CHECK constraints
+    // to prevent an automatic protocol  upgrade  (i.e. an implicit property change) when adding
+    // the CHECK constraint below.
+    withSQLConf(
+      "spark.databricks.delta.properties.defaults.minReaderVersion" -> "1",
+      "spark.databricks.delta.properties.defaults.minWriterVersion" -> "3") {
+      withDeltaTable { _ =>
+        sql(s"ALTER TABLE $tbl SET TBLPROPERTIES ('some' = 'thing', 'other' = 'thing')")
+        sql(s"ALTER TABLE $tbl UNSET TBLPROPERTIES ('other')")
+        sql(s"ALTER TABLE $tbl ADD COLUMNS (id2 bigint, id3 bigint)")
+        sql(s"ALTER TABLE $tbl CHANGE COLUMN id2 id2 bigint FIRST")
+        sql(s"ALTER TABLE $tbl REPLACE COLUMNS (id3 bigint, id2 bigint, id bigint)")
+        sql(s"ALTER TABLE $tbl ADD CONSTRAINT id_3 CHECK (id3 > 10)")
+        sql(s"ALTER TABLE $tbl DROP CONSTRAINT id_3")
+
+        val expectedSchema = StructType(Seq(
+          StructField("id3", LongType, true),
+          StructField("id2", LongType, true),
+          StructField("id", LongType, true))
+        )
+
+        f(tbl, expectedSchema)
+      }
+    }
+  }
+
+  /**
+   * Creates a table with the name `tbl` and executes a function that takes a representative
+   * DataFrame with the schema of the table. Performs cleanup of the table afterwards.
+   */
+  protected def withDeltaTable(f: DataFrame => Unit): Unit = {
+    // Turn off async updates so that we don't update the catalog during table cleanup
+    disableUpdates {
+      withTable(tbl) {
+        withSQLConf(DeltaSQLConf.DELTA_UPDATE_CATALOG_ENABLED.key -> "true") {
+          sql(s"CREATE TABLE $tbl (id bigint) USING delta")
+          val df = spark.range(10)
+          verifyTableMetadata(df.schema.asNullable)
+
+          f(df.toDF())
+        }
+      }
+    }
+  }
+
+  test("skip update when flag is not set") {
+    withDeltaTable(df => {
+      withSQLConf(DeltaSQLConf.DELTA_UPDATE_CATALOG_ENABLED.key -> "false") {
+        val propertiesAtV1 = getBaseProperties(snapshot)
+        sql(s"ALTER TABLE $tbl SET TBLPROPERTIES(some.key = 1)")
+        verifyTableMetadataAsync(
+          expectedSchema = df.schema.asNullable,
+          expectedProperties = propertiesAtV1)
+      }
+    })
+  }
+
+
+  test(s"REORG TABLE does not perform catalog update") {
+    val tableName = "myTargetTable"
+    withDeltaTable { df =>
+      sql(s"REORG TABLE $tbl APPLY (PURGE)")
+      verifyTableMetadataAsync(df.schema.asNullable)
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Follow up for #1478.

This PR adds the class `UpdateCatalog` which is used as a post commit hook and during table creation for syncing table schema and properties to HMS. The new behaviour in Delta Lake is that when `catalog.update.enabled` = `true`, the schema and properties of the Delta table will be synced to HMS during creation/replacement and whenever an update to the table updates either of the schema or properties (asynchronously, in a post-commit hook).

Some new additions are:

1. New Config: `catalog.update.enabled` -> Setting this to true will enable schema sync.
2. New OSS Config: `catalog.update.threadPoolSize` -> Controls the size of the thread pool which is used to asynchronously update the catalog.
3. HMS-specific Quirk: Hive does not allow for the removal of the partition columns once it has been added. When sending the table schema to HMS in `UpdateCatalog`, we always send the partition columns as regular data columns to ensure that we can remove these columns on schema update. However, for tables that have been converted from parquet to Delta, the partition columns would have already been set in HMS. Since OSS Spark always appends the partition columns to the end of the schema when it finds them in Hive, for converted tables with partitions, the column order returned by Hive will be incorrect.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Adds multiple tests in a new suite `DeltaUpdateCatalogSuite`.

Co-authored-by: dhruvarya-db <dhruv.arya@databricks.com>
Co-authored-by: schatterjee6 <Sirsha_Chatterjee@intuit.com>
