### PR TITLE
[Kernel][Expressions] Support COALESCE expression for boolean type arguments

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/ScalarExpression.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/ScalarExpression.java
@@ -40,7 +40,7 @@ import io.delta.kernel.annotation.Evolving;
  *   </li>
  *  <li>Name: <code>COALESCE</code>
  *   <ul>
- *    <li>Semantic: <code>COALESCE(expr1, ..., exprN)</code> Return the first non-null argument</li>
+ *    <li>Semantic: <code>COALESCE(expr1, ..., exprN)</code> Return the first non-null argument. If all arguments are null returns null</li>
  *    <li>Since version: 3.1.0</li>
  *   </ul>
  *  </li>

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/ScalarExpression.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/ScalarExpression.java
@@ -40,7 +40,8 @@ import io.delta.kernel.annotation.Evolving;
  *   </li>
  *  <li>Name: <code>COALESCE</code>
  *   <ul>
- *    <li>Semantic: <code>COALESCE(expr1, ..., exprN)</code> Return the first non-null argument. If all arguments are null returns null</li>
+ *    <li>Semantic: <code>COALESCE(expr1, ..., exprN)</code> Return the first non-null argument.
+ *    If all arguments are null returns null</li>
  *    <li>Since version: 3.1.0</li>
  *   </ul>
  *  </li>

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/ScalarExpression.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/ScalarExpression.java
@@ -38,6 +38,12 @@ import io.delta.kernel.annotation.Evolving;
  *       <li>Since version: 3.0.0</li>
  *     </ul>
  *   </li>
+ *  <li>Name: <code>COALESCE</code>
+ *   <ul>
+ *    <li>Semantic: <code>COALESCE(expr1, ..., exprN)</code> Return the first non-null argument</li>
+ *    <li>Since version: 3.1.0</li>
+ *   </ul>
+ *  </li>
  * </ol>
  *
  * @since 3.0.0

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
@@ -522,10 +522,14 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
                 .collect(Collectors.toList());
             return ExpressionUtils.combinationVector(
                 childResults,
-                rowId -> IntStream.range(0, childResults.size())
-                    .filter(idx -> !childResults.get(idx).isNullAt(rowId))
-                    .findFirst()
-                    .orElse(0) // If all are null then any idx suffices
+                rowId -> {
+                    for (int idx = 0; idx < childResults.size(); idx++) {
+                        if (!childResults.get(idx).isNullAt(rowId)) {
+                            return idx;
+                        }
+                    }
+                    return 0; // If all are null then any idx suffices
+                }
             );
         }
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
@@ -18,7 +18,6 @@ package io.delta.kernel.defaults.internal.expressions;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionUtils.java
@@ -28,7 +28,6 @@ import io.delta.kernel.data.MapValue;
 import io.delta.kernel.expressions.Expression;
 import io.delta.kernel.types.*;
 import io.delta.kernel.internal.util.Utils;
-
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 
 /**

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionUtils.java
@@ -26,8 +26,8 @@ import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.MapValue;
 import io.delta.kernel.expressions.Expression;
-import io.delta.kernel.internal.util.Utils;
 import io.delta.kernel.types.*;
+import io.delta.kernel.internal.util.Utils;
 
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionUtils.java
@@ -19,9 +19,12 @@ import java.math.BigDecimal;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import static java.lang.String.format;
 
+import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.data.MapValue;
 import io.delta.kernel.expressions.Expression;
 import io.delta.kernel.types.*;
 
@@ -241,5 +244,111 @@ class ExpressionUtils {
 
     static Expression childAt(Expression expression, int index) {
         return expression.getChildren().get(index);
+    }
+
+    /**
+     * Combines a list of column vectors into one column vector based on the resolution of
+     * idxToReturn
+     * @param vectors List of ColumnVectors of the same data type with length >= 1
+     * @param idxToReturn Function that takes in a rowId and returns the index of the column vector
+     *                    to use as the return value
+     */
+    static ColumnVector combinationVector(
+        List<ColumnVector> vectors,
+        Function<Integer, Integer> idxToReturn) {
+        return new ColumnVector() {
+
+            @Override
+            public DataType getDataType() {
+                return vectors.get(0).getDataType();
+            }
+
+            @Override
+            public int getSize() {
+                return vectors.get(0).getSize();
+            }
+
+            @Override
+            public void close() {
+                vectors.forEach(ColumnVector::close);
+            }
+
+            @Override
+            public boolean isNullAt(int rowId) {
+                return getVector(rowId).isNullAt(rowId);
+            }
+
+            @Override
+            public boolean getBoolean(int rowId) {
+                return getVector(rowId).getBoolean(rowId);
+            }
+
+            @Override
+            public byte getByte(int rowId) {
+                return getVector(rowId).getByte(rowId);
+            }
+
+            @Override
+            public short getShort(int rowId) {
+                return getVector(rowId).getShort(rowId);
+            }
+
+            @Override
+            public int getInt(int rowId) {
+                return getVector(rowId).getInt(rowId);
+            }
+
+            @Override
+            public long getLong(int rowId) {
+                return getVector(rowId).getLong(rowId);
+            }
+
+            @Override
+            public float getFloat(int rowId) {
+                return getVector(rowId).getFloat(rowId);
+            }
+
+            @Override
+            public double getDouble(int rowId) {
+                return getVector(rowId).getDouble(rowId);
+            }
+
+            @Override
+            public byte[] getBinary(int rowId) {
+                return getVector(rowId).getBinary(rowId);
+            }
+
+            @Override
+            public String getString(int rowId) {
+                return getVector(rowId).getString(rowId);
+            }
+
+            @Override
+            public BigDecimal getDecimal(int rowId) {
+                return getVector(rowId).getDecimal(rowId);
+            }
+
+            @Override
+            public MapValue getMap(int rowId) {
+                return getVector(rowId).getMap(rowId);
+            }
+
+            @Override
+            public ArrayValue getArray(int rowId) {
+                return getVector(rowId).getArray(rowId);
+            }
+
+            @Override
+            public ColumnVector getChild(int ordinal) {
+                return combinationVector(
+                    vectors.stream().map(v -> v.getChild(ordinal)).collect(Collectors.toList()),
+                    idxToReturn
+                );
+            }
+
+            private ColumnVector getVector(int rowId) {
+                return vectors.get(idxToReturn.apply(rowId));
+            }
+        };
     }
 }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionVisitor.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionVisitor.java
@@ -55,6 +55,8 @@ abstract class ExpressionVisitor<R> {
 
     abstract R visitIsNotNull(Predicate predicate);
 
+    abstract R visitCoalesce(ScalarExpression ifNull);
+
     final R visit(Expression expression) {
         if (expression instanceof PartitionValueExpression) {
             return visitPartitionValue((PartitionValueExpression) expression);
@@ -97,6 +99,8 @@ abstract class ExpressionVisitor<R> {
                 return visitNot(new Predicate(name, children));
             case "IS_NOT_NULL":
                 return visitIsNotNull(new Predicate(name, children));
+            case "COALESCE":
+                return visitCoalesce(expression);
             default:
                 throw new UnsupportedOperationException(
                     String.format("Scalar expression `%s` is not supported.", name));


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

This PR introduces the `COALESCE` expression to the kernel-api expression framework. It also adds support for resolving _only boolean type_ `COALESCE` expressions to the `DefaultExpressionHandler`. This is needed for data skipping #2229. Further support for `COALESCE` in the `DefaultExpressionHandler` can come in follow-up PRs.

## How was this patch tested?

Adds unit tests for boolean type expressions.