### PR TITLE
[Spark] Throw exception when CREATE OR REPLACE is run on existing catalog tables with missing delta_log

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -1329,6 +1329,13 @@
     ],
     "sqlState" : "XXKDS"
   },
+  "DELTA_METADATA_ABSENT_EXISTING_CATALOG_TABLE" : {
+    "message" : [
+      "The table <tableName> already exists in the catalog but no metadata could be found for the table at the path <tablePath>.",
+      "Did you manually delete files from the _delta_log directory? If so, then you should be able to recreate it as follows. First, drop the table by running `DROP TABLE <tableNameForDropCmd>`. Then, recreate it by running the current command again."
+    ],
+    "sqlState" : "XXKDS"
+  },
   "DELTA_MISSING_CHANGE_DATA" : {
     "message" : [
       "Error getting change data for range [<startVersion> , <endVersion>] as change data was not",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1600,6 +1600,12 @@ trait DeltaErrorsBase
       messageParameters = Array(DeltaSQLConf.DELTA_COMMIT_VALIDATION_ENABLED.key))
   }
 
+  def metadataAbsentForExistingCatalogTable(tableName: String, tablePath: String): Throwable = {
+    new DeltaIllegalStateException(
+      errorClass = "DELTA_METADATA_ABSENT_EXISTING_CATALOG_TABLE",
+      messageParameters = Array(tableName, tablePath, tableName))
+  }
+
   def updateSchemaMismatchExpression(from: StructType, to: StructType): Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_UPDATE_SCHEMA_MISMATCH_EXPRESSION",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -354,6 +354,12 @@ case class CreateDeltaTableCommand(
         if (tableWithLocation.schema.isEmpty) {
           throw DeltaErrors.schemaNotProvidedException
         }
+        // This can happen if someone deleted files from the filesystem but
+        // the table still exists in the catalog.
+        if (txn.readVersion == -1 && tableExistsInCatalog) {
+          throw DeltaErrors.metadataAbsentForExistingCatalogTable(
+            tableWithLocation.identifier.toString, txn.deltaLog.logPath.toString)
+        }
         // We need to replace
         replaceMetadataIfNecessary(
           txn,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2620,6 +2620,20 @@ trait DeltaErrorsSuiteBase
         Some(s"Can't set location multiple times. Found ${locations}"))
     }
     {
+      val e = intercept[DeltaIllegalStateException] {
+        throw DeltaErrors.metadataAbsentForExistingCatalogTable("tblName", "file://path/to/table")
+      }
+      checkErrorMessage(
+        e,
+        Some("DELTA_METADATA_ABSENT_EXISTING_CATALOG_TABLE"),
+        Some("XXKDS"),
+        Some(
+          "The table tblName already exists in the catalog but no metadata could be found for the table at the path file://path/to/table.\n" +
+            "Did you manually delete files from the _delta_log directory? If so, then you should be able to recreate it as follows. First, drop the table by running `DROP TABLE tblName`. Then, recreate it by running the current command again."
+        )
+      )
+    }
+    {
       val e = intercept[DeltaStreamingColumnMappingSchemaIncompatibleException] {
         throw DeltaErrors.blockStreamingReadsWithIncompatibleColumnMappingSchemaChanges(
           spark,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest}
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
+import org.apache.commons.io.FileUtils
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.{SparkConf, SparkException}
@@ -2366,6 +2367,44 @@ class DeltaTableCreationSuite
     }
   }
 
+  test("CREATE OR REPLACE TABLE on a catalog table where the backing " +
+    "directory has been deleted") {
+    val tbl = "delta_tbl"
+    withTempDir { dir =>
+      withTable(tbl) {
+        val subdir = new File(dir, "subdir")
+        sql(s"CREATE OR REPLACE table $tbl (id String) USING delta " +
+          s"LOCATION '${subdir.getCanonicalPath}'")
+        val tableIdentifier =
+          spark.sessionState.catalog.getTableMetadata(TableIdentifier(tbl)).identifier
+        val tableName = tableIdentifier.copy(catalog = None).toString
+        val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tbl))
+        sql(s"INSERT INTO $tbl VALUES ('1')")
+        FileUtils.deleteDirectory(subdir)
+        val e = intercept[DeltaIllegalStateException] {
+          sql(
+            s"CREATE OR REPLACE table $tbl (id String) USING delta" +
+              s" LOCATION '${subdir.getCanonicalPath}'")
+        }
+        checkError(
+          exception = e,
+          errorClass = "DELTA_METADATA_ABSENT_EXISTING_CATALOG_TABLE",
+          parameters = Map(
+            "tableName" -> tableName,
+            "tablePath" -> deltaLog.logPath.toString,
+            "tableNameForDropCmd" -> tableName
+          ))
+
+        // Table creation should work after running DROP TABLE.
+        sql(s"DROP table ${e.getMessageParameters().get("tableNameForDropCmd")}")
+        sql(s"CREATE OR REPLACE table $tbl (id String) USING delta " +
+          s"LOCATION '${subdir.getCanonicalPath}'")
+        sql(s"INSERT INTO $tbl VALUES ('21')")
+        val data = sql(s"SELECT * FROM $tbl").collect()
+        assert(data.length == 1)
+      }
+    }
+  }
 }
 
 trait DeltaTableCreationColumnMappingSuiteBase extends DeltaColumnMappingSelectedTestMixin {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Currently, CREATE OR REPLACE does throw any exception when it is run on an existing table where the backing delta_log directory has been manually deleted. Even though we don't throw any exceptions during CREATE OR REPLACE, other queries don't work on these broken tables.

This PR handles this scenario explicitly and throws an exception with the message:

```
[DELTA_METADATA_ABSENT_EXISTING_CATALOG_TABLE] The table `spark_catalog`.`default`.`delta_tbl` already exists in the catalog but no metadata could be found
for the table at the path file:/tmp/spark-5103f24e-a80a-4cc0-b1a7-86926fe8ff4f/subdir/_delta_log.
Did you manually delete files from the _delta_log directory? If so, dropping the
table by running `DROP TABLE `spark_catalog`.`default`.`delta_tbl`` and then recreating it by running the current command again
should enable you to recreate it.
```

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
New unit test.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Introduces a new error message when a user runs CREATE OR REPLACE on a catalog table for which the backing delta_log is missing:

```
[DELTA_METADATA_ABSENT_EXISTING_CATALOG_TABLE] The table `spark_catalog`.`default`.`delta_tbl` already exists in the catalog but no metadata could be found
for the table at the path file:/tmp/spark-5103f24e-a80a-4cc0-b1a7-86926fe8ff4f/subdir/_delta_log.
Did you manually delete files from the _delta_log directory? If so, dropping the
table by running `DROP TABLE `spark_catalog`.`default`.`delta_tbl`` and then recreating it by running the current command again
should enable you to recreate it.
```