### PR TITLE
[Spark] Add new checkpoint API which doesn't invoke metadata cleanup

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -305,6 +305,21 @@ trait Checkpoints extends DeltaLogging {
     }
   }
 
+  /**
+   * Creates a checkpoint at given version. Does not invoke metadata cleanup as part of it.
+   * @param version - version at which we want to create a checkpoint.
+   */
+  def createCheckpointAtVersion(version: Long): Unit =
+    recordDeltaOperation(this, "delta.createCheckpointAtVersion") {
+      val snapshot = getSnapshotAt(version)
+      withCheckpointExceptionHandling(this, "delta.checkpoint.sync.error") {
+        if (snapshot.version < 0) {
+          throw DeltaErrors.checkpointNonExistTable(dataPath)
+        }
+        writeCheckpointFiles(snapshot)
+      }
+    }
+
   def checkpointAndCleanUpDeltaLog(
       snapshotToCheckpoint: Snapshot): Unit = {
     val lastCheckpointInfo = writeCheckpointFiles(snapshotToCheckpoint)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR adds a new checkpoint API which doesn't invoke metadata cleanup.

## How was this patch tested?

Added UT

## Does this PR introduce _any_ user-facing changes?

Creates a new DeltaLog API to create checkpoints: `deltaLog.createCheckpointAtVersion`.