### PR TITLE
[Spark] Refactor: Move lockInterruptibly to SnapshotManagement class

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.delta
 import java.lang.ref.WeakReference
 import java.net.URI
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.locks.ReentrantLock
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -120,9 +119,6 @@ class DeltaLog private(
   /** Used to read and write physical log files and checkpoints. */
   lazy val store = createLogStore(spark)
 
-  /** Use ReentrantLock to allow us to call `lockInterruptibly` */
-  protected val deltaLogLock = new ReentrantLock()
-
   /** Delta History Manager containing version and commit history. */
   lazy val history = new DeltaHistoryManager(
     this, spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_HISTORY_PAR_SEARCH_THRESHOLD))
@@ -154,19 +150,6 @@ class DeltaLog private(
    * composite id.
    */
   private[delta] def compositeId: (String, Path) = tableId -> dataPath
-
-  /**
-   * Run `body` inside `deltaLogLock` lock using `lockInterruptibly` so that the thread can be
-   * interrupted when waiting for the lock.
-   */
-  def lockInterruptibly[T](body: => T): T = {
-    deltaLogLock.lockInterruptibly()
-    try {
-      body
-    } finally {
-      deltaLogLock.unlock()
-    }
-  }
 
   /**
    * Creates a [[LogicalRelation]] for a given [[DeltaLogFileIndex]], with all necessary file source
@@ -454,11 +437,14 @@ class DeltaLog private(
   /** Creates the log directory if it does not exist. */
   def ensureLogDirectoryExist(): Unit = {
     val fs = logPath.getFileSystem(newDeltaHadoopConf())
-    if (!fs.exists(logPath)) {
-      if (!fs.mkdirs(logPath)) {
-        throw DeltaErrors.cannotCreateLogPathException(logPath.toString)
+    def createDirIfNotExists(path: Path): Unit = {
+      if (!fs.exists(path)) {
+        if (!fs.mkdirs(path)) {
+          throw DeltaErrors.cannotCreateLogPathException(logPath.toString)
+        }
       }
     }
+    createDirIfNotExists(logPath)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1572,9 +1572,9 @@ trait OptimisticTransactionImpl extends TransactionalWrite
 
   private def lockCommitIfEnabled[T](body: => T): T = {
     if (isCommitLockEnabled) {
-      // We are borrowing the `snapshotLock` even for commits because multiple threads fighting over
-      // a commit shouldn't interfere with normal snapshot updates by readers. Ideally we should be
-      // using a separate lock for this purpose.
+      // We are borrowing the `snapshotLock` even for commits. Ideally we should be
+      // using a separate lock for this purpose, because multiple threads fighting over
+      // a commit shouldn't interfere with normal snapshot updates by readers.
       deltaLog.withSnapshotLockInterruptibly(body)
     } else {
       body

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1575,7 +1575,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       // We are borrowing the `snapshotLock` even for commits because multiple threads fighting over
       // a commit shouldn't interfere with normal snapshot updates by readers. Ideally we should be
       // using a separate lock for this purpose.
-      deltaLog.lockInterruptibly(body)
+      deltaLog.withSnapshotLockInterruptibly(body)
     } else {
       body
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1572,6 +1572,9 @@ trait OptimisticTransactionImpl extends TransactionalWrite
 
   private def lockCommitIfEnabled[T](body: => T): T = {
     if (isCommitLockEnabled) {
+      // We are borrowing the `snapshotLock` even for commits because multiple threads fighting over
+      // a commit shouldn't interfere with normal snapshot updates by readers. Ideally we should be
+      // using a separate lock for this purpose.
       deltaLog.lockInterruptibly(body)
     } else {
       body

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -63,8 +63,8 @@ trait SnapshotManagement { self: DeltaLog =>
   protected val snapshotLock = new ReentrantLock()
 
   /**
-   * Run `body` inside `snapshotLock` lock using `withSnapshotLockInterruptibly` so that the thread can be
-   * interrupted when waiting for the lock.
+   * Run `body` inside `snapshotLock` lock using `withSnapshotLockInterruptibly` so that the thread
+   * can be interrupted when waiting for the lock.
    */
   def withSnapshotLockInterruptibly[T](body: => T): T = {
     snapshotLock.lockInterruptibly()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -59,11 +59,11 @@ trait SnapshotManagement { self: DeltaLog =>
 
   @volatile protected var currentSnapshot: CapturedSnapshot = getSnapshotAtInit
 
-  /** Use ReentrantLock to allow us to call `withSnapshotLockInterruptibly` */
+  /** Use ReentrantLock to allow us to call `lockInterruptibly` */
   protected val snapshotLock = new ReentrantLock()
 
   /**
-   * Run `body` inside `snapshotLock` lock using `withSnapshotLockInterruptibly` so that the thread
+   * Run `body` inside `snapshotLock` lock using `lockInterruptibly` so that the thread
    * can be interrupted when waiting for the lock.
    */
   def withSnapshotLockInterruptibly[T](body: => T): T = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Move `def lockInterruptibly` to SnapshotManagement class as this is where is it used.

## How was this patch tested?

Existing UTs

## Does this PR introduce _any_ user-facing changes?

No