### PR TITLE
[Kernel] Add an internal API to fetch the latest txn identifier

### DIFF
--- a/connectors/golden-tables/src/main/resources/golden/deltalog-getChanges/_delta_log/00000000000000000000.json
+++ b/connectors/golden-tables/src/main/resources/golden/deltalog-getChanges/_delta_log/00000000000000000000.json
@@ -1,4 +1,4 @@
-{"commitInfo":{"timestamp":1626806331480,"operation":"Manual Update","operationParameters":{},"isBlindAppend":true,"operationMetrics":{}}}
+{"commitInfo":{"timestamp":1704392842074,"operation":"Manual Update","operationParameters":{},"isolationLevel":"Serializable","isBlindAppend":true,"operationMetrics":{},"engineInfo":"Apache-Spark/3.5.0 Delta-Lake/3.1.0-SNAPSHOT","txnId":"95ec924a-6859-4433-8008-6d6b4a0e3ba5"}}
 {"protocol":{"minReaderVersion":1,"minWriterVersion":2}}
-{"metaData":{"id":"testId","format":{"provider":"parquet","options":{}},"partitionColumns":[],"configuration":{},"createdTime":1626806331460}}
+{"metaData":{"id":"testId","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"part\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},{\"name\":\"id\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":[],"configuration":{}}}
 {"add":{"path":"fake/path/1","partitionValues":{},"size":1,"modificationTime":1,"dataChange":true}}

--- a/connectors/golden-tables/src/main/resources/golden/deltalog-getChanges/_delta_log/00000000000000000001.json
+++ b/connectors/golden-tables/src/main/resources/golden/deltalog-getChanges/_delta_log/00000000000000000001.json
@@ -1,3 +1,3 @@
-{"commitInfo":{"timestamp":1626806336805,"operation":"Manual Update","operationParameters":{},"readVersion":0,"isBlindAppend":false,"operationMetrics":{}}}
+{"commitInfo":{"timestamp":1704392846030,"operation":"Manual Update","operationParameters":{},"readVersion":0,"isolationLevel":"Serializable","isBlindAppend":false,"operationMetrics":{},"engineInfo":"Apache-Spark/3.5.0 Delta-Lake/3.1.0-SNAPSHOT","txnId":"01d40235-c8b4-4f8e-8f19-8c97872217fd"}}
 {"cdc":{"path":"fake/path/2","partitionValues":{"partition_foo":"partition_bar"},"size":1,"tags":{"tag_foo":"tag_bar"},"dataChange":false}}
-{"remove":{"path":"fake/path/1","deletionTimestamp":100,"dataChange":true,"extendedFileMetadata":false,"size":0}}
+{"remove":{"path":"fake/path/1","deletionTimestamp":100,"dataChange":true}}

--- a/connectors/golden-tables/src/main/resources/golden/deltalog-getChanges/_delta_log/00000000000000000002.json
+++ b/connectors/golden-tables/src/main/resources/golden/deltalog-getChanges/_delta_log/00000000000000000002.json
@@ -1,3 +1,3 @@
-{"commitInfo":{"timestamp":1626806337545,"operation":"Manual Update","operationParameters":{},"readVersion":1,"isBlindAppend":true,"operationMetrics":{}}}
-{"protocol":{"minReaderVersion":1,"minWriterVersion":3}}
+{"commitInfo":{"timestamp":1704392846603,"operation":"Manual Update","operationParameters":{},"readVersion":1,"isolationLevel":"Serializable","isBlindAppend":true,"operationMetrics":{},"engineInfo":"Apache-Spark/3.5.0 Delta-Lake/3.1.0-SNAPSHOT","txnId":"6cef7579-ca93-4427-988e-9269e8db50c7"}}
+{"protocol":{"minReaderVersion":1,"minWriterVersion":2}}
 {"txn":{"appId":"fakeAppId","version":3,"lastUpdated":200}}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -15,6 +15,8 @@
  */
 package io.delta.kernel.internal;
 
+import java.util.Optional;
+
 import io.delta.kernel.ScanBuilder;
 import io.delta.kernel.Snapshot;
 import io.delta.kernel.client.TableClient;
@@ -83,5 +85,19 @@ public class SnapshotImpl implements Snapshot {
 
     public Protocol getProtocol() {
         return protocol;
+    }
+
+    /**
+     * Get the latest transaction version for given <i>applicationId</i>. This information comes
+     * from the transactions identifiers stored in Delta transaction log. This API is not a public
+     * API. For now keep this internal to enable Flink upgrade to use Kernel.
+     *
+     * @param applicationId Identifier of the application that put transaction identifiers in
+     *                      Delta transaction log
+     * @return Last transaction version or {@link Optional#empty()} if no transaction identifier
+     * exists for this application.
+     */
+    public Optional<Long> getLatestTransactionVersion(String applicationId) {
+        return logReplay.getRecentTransactionIdentifier(applicationId);
     }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/SetTransaction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/SetTransaction.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.actions;
+
+import java.util.Optional;
+
+import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.types.LongType;
+import io.delta.kernel.types.StringType;
+import io.delta.kernel.types.StructType;
+
+/**
+ * Delta log action representing a transaction identifier action.
+ */
+public class SetTransaction {
+    public static final StructType READ_SCHEMA = new StructType()
+        .add("appId", StringType.STRING, false /* nullable */)
+        .add("version", LongType.LONG, false /* nullable*/)
+        .add("lastUpdated", LongType.LONG, true /* nullable*/);
+
+    public static SetTransaction fromColumnVector(ColumnVector vector, int rowId) {
+        if (vector.isNullAt(rowId)) {
+            return null;
+        }
+        return new SetTransaction(
+            vector.getChild(0).getString(rowId),
+            vector.getChild(1).getLong(rowId),
+            vector.getChild(2).isNullAt(rowId) ?
+                Optional.empty() : Optional.of(vector.getChild(2).getLong(rowId)));
+    }
+
+    private final String appId;
+    private final long version;
+    private final Optional<Long> lastUpdated;
+
+    public SetTransaction(
+        String appId,
+        Long version,
+        Optional<Long> lastUpdated) {
+        this.appId = appId;
+        this.version = version;
+        this.lastUpdated = lastUpdated;
+    }
+
+    public String getAppId() {
+        return appId;
+    }
+
+    public long getVersion() {
+        return version;
+    }
+
+    public Optional<Long> getLastUpdated() {
+        return lastUpdated;
+    }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description
This PR adds an internal API on `SnapshotImpl` to fetch the latest version of the transaction identifier for a given app id. For now, this API is internal to unblock the Flink upgrade to use Kernel.

## How was this patch tested?
Unittest