### PR TITLE
Allow ClusteringTableFeature to be removed

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
@@ -117,3 +117,14 @@ case class V2CheckpointPreDowngradeCommand(table: DeltaTableV2)
     true
   }
 }
+
+case class ClusteringPreDowngradeCommand(table: DeltaTableV2)
+  extends PreDowngradeTableFeatureCommand
+    with DeltaLogging {
+  /**
+   * It returns false as no cleaning action is required.
+   */
+  override def removeFeatureTracesIfNeeded(): Boolean = {
+    false
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -538,8 +538,16 @@ object IcebergCompatV2TableFeature extends WriterFeature(name = "icebergCompatV2
 /**
  * Clustering table feature is enabled when a table is created with CLUSTER BY clause.
  */
-object ClusteringTableFeature extends WriterFeature("clustering") {
+object ClusteringTableFeature extends WriterFeature("clustering") with RemovableFeature {
   override val requiredFeatures: Set[TableFeature] = Set(DomainMetadataTableFeature)
+  override def preDowngradeCommand(table: DeltaTableV2): PreDowngradeTableFeatureCommand =
+    ClusteringPreDowngradeCommand(table)
+
+  // Dropping ClusteringTableFeature is always allowed without any action.
+  override def validateRemoval(snapshot: Snapshot): Boolean = true
+
+  // Writer features should directly return false, as it is only used for reader+writer features.
+  override def actionUsesFeature(action: Action): Boolean = false
 }
 
 /**


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This sets ClusteringTableFeature to be RemovableFeature. This allows dropping it through `ALTER TABLE DROP FEATURE`.

## How was this patch tested?
Unit tests in DeltaProtocolVersionSuite.scala