### PR TITLE
[Kernel] Fix splitting of partition & data predicates 

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
@@ -204,7 +204,9 @@ public class PartitionUtils {
                     return true;
                 }
             } else {
-                return hasNonPartitionColumns(child.getChildren(), partitionColNames);
+                if(hasNonPartitionColumns(child.getChildren(), partitionColNames)) {
+                    return true;
+                }
             }
         }
         return false;

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/PartitionUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/PartitionUtilsSuite.scala
@@ -128,7 +128,11 @@ class PartitionUtilsSuite extends AnyFunSuite {
       (
         "(column(`part3`) >= sss)",
         "(column(`data1`) = column(`part1`))"
-      )
+      ),
+
+    // predicate only on data column but reverse order of literal and column
+    predicate("=", ofInt(12), col("data1")) ->
+      ("ALWAYS_TRUE()", "(12 = column(`data1`))")
   )
 
   partitionTestCases.foreach {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Currently filters are incorrectly identified as partition vs metadata filters only by checking the first child when it is not a column and we don't progress through the for loop / rest of the children. Fix this.

## How was this patch tested?

Adds a unit test.
