### PR TITLE
[Spark] Use IcebergCompatV2

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3000,7 +3000,7 @@ trait DeltaErrorsBase
   def icebergCompatVersionMutualExclusive(version: Int): Throwable = {
     new DeltaUnsupportedOperationException(
       errorClass = "DELTA_ICEBERG_COMPAT_VIOLATION.VERSION_MUTUAL_EXCLUSIVE",
-      messageParameters = Array(version.toString, version.toString)
+      messageParameters = Array(version.toString)
     )
   }
 
@@ -3008,7 +3008,7 @@ trait DeltaErrorsBase
     val newVersionString = newVersion.toString
     new DeltaUnsupportedOperationException(
       errorClass = "DELTA_ICEBERG_COMPAT_VIOLATION.CHANGE_VERSION_NEED_REWRITE",
-      messageParameters = Array(version.toString, newVersionString, newVersionString,
+      messageParameters = Array(newVersionString, newVersionString, newVersionString,
         newVersionString)
     )
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/IcebergCompatV1.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/IcebergCompatV1.scala
@@ -41,6 +41,7 @@ object IcebergCompatV1 extends IcebergCompat(
   requiredTableFeatures = Seq(ColumnMappingTableFeature),
   requiredTableProperties = Seq(RequireColumnMapping),
   checks = Seq(
+    CheckOnlySingleVersionEnabled,
     CheckAddFileHasStats,
     CheckNoPartitionEvolution,
     CheckNoListMapNullType,
@@ -54,6 +55,7 @@ object IcebergCompatV2 extends IcebergCompat(
   requiredTableFeatures = Seq(ColumnMappingTableFeature),
   requiredTableProperties = Seq(RequireColumnMapping),
   checks = Seq(
+    CheckOnlySingleVersionEnabled,
     CheckAddFileHasStats,
     CheckTypeInV2AllowList,
     CheckNoPartitionEvolution,
@@ -102,7 +104,7 @@ case class IcebergCompat(
       prevSnapshot: Snapshot,
       newestProtocol: Protocol,
       newestMetadata: Metadata,
-      isCreatingNewTable: Boolean,
+      isCreatingOrReorgTable: Boolean,
       actions: Seq[Action]): (Option[Protocol], Option[Metadata]) = {
     val prevProtocol = prevSnapshot.protocol
     val prevMetadata = prevSnapshot.metadata
@@ -111,12 +113,7 @@ case class IcebergCompat(
     val tableId = newestMetadata.id
 
     (wasEnabled, isEnabled) match {
-      case (false, false) => (None, None) // Ignore
-      case (true, false) => // Disabling
-        // UniversalFormat.validateIceberg should detect that IcebergCompatV1 is being disabled,
-        // and automatically disable Universal Format (Iceberg)
-        assert(!UniversalFormat.icebergEnabled(newestMetadata))
-        (None, None)
+      case (_, false) => (None, None) // not enable or disabling, Ignore
       case (_, true) => // Enabling now or already-enabled
         val tblFeatureUpdates = scala.collection.mutable.Set.empty[TableFeature]
         val tblPropertyUpdates = scala.collection.mutable.Map.empty[String, String]
@@ -126,11 +123,11 @@ case class IcebergCompat(
           (prevProtocol.isFeatureSupported(f), newestProtocol.isFeatureSupported(f)) match {
             case (_, true) => // all good
             case (false, false) => // txn has not supported it!
-              // Note: this code path should be impossible, since the IcebergCompatV1TableFeature
+              // Note: this code path should be impossible, since the IcebergCompatVxTableFeature
               //       specifies ColumnMappingTableFeature as a required table feature. Thus,
               //       it should already have been added during
               //       OptimisticTransaction::updateMetadataInternal
-              if (isCreatingNewTable) {
+              if (isCreatingOrReorgTable) {
                 tblFeatureUpdates += f
               } else {
                 throw DeltaErrors.icebergCompatMissingRequiredTableFeatureException(version, f)
@@ -151,7 +148,7 @@ case class IcebergCompat(
               version, deltaConfig.key, newestValue.toString, autoSetValue)
 
             if (!newestValueOkay) {
-              if (!newestValueExplicitlySet && isCreatingNewTable) {
+              if (!newestValueExplicitlySet && isCreatingOrReorgTable) {
                 // This case covers both CREATE and REPLACE TABLE commands that
                 // did not explicitly specify the required deltaConfig. In these
                 // cases, we set the property automatically.
@@ -178,7 +175,7 @@ case class IcebergCompat(
           var tmpNewMetadata = newestMetadata.copy(configuration = newConfiguration)
 
           requiredTableProperties.foreach { tp =>
-            tmpNewMetadata = tp.postProcess(prevMetadata, tmpNewMetadata, isCreatingNewTable)
+            tmpNewMetadata = tp.postProcess(prevMetadata, tmpNewMetadata, isCreatingOrReorgTable)
           }
 
           Some(tmpNewMetadata)
@@ -188,7 +185,7 @@ case class IcebergCompat(
         val context = IcebergCompatContext(prevSnapshot,
           protocolResult.getOrElse(newestProtocol),
           metadataResult.getOrElse(newestMetadata),
-          isCreatingNewTable, actions, tableId, version)
+          isCreatingOrReorgTable, actions, tableId, version)
         checks.foreach(_.apply(context))
 
         (protocolResult, metadataResult)
@@ -199,9 +196,9 @@ case class IcebergCompat(
 /**
  * Util methods to manage between IcebergCompat versions
  */
-object IcebergCompat {
+object IcebergCompat extends DeltaLogging {
 
-  private val knownVersions = Seq(
+  val knownVersions = Seq(
     DeltaConfigs.ICEBERG_COMPAT_V1_ENABLED -> 1,
     DeltaConfigs.ICEBERG_COMPAT_V2_ENABLED -> 2)
 
@@ -214,6 +211,18 @@ object IcebergCompat {
     knownVersions
       .find{ case (config, _) => config.fromMetaData(metadata).getOrElse(false) }
       .map{ case (_, version) => version }
+
+  /**
+   * @return true if any version of IcebergCompat is enabled
+   */
+  def isAnyEnabled(metadata: Metadata): Boolean =
+    knownVersions.exists{ case (config, _) => config.fromMetaData(metadata).getOrElse(false) }
+
+  /**
+   * @return true if the target version is enabled on the table.
+   */
+  def isVersionEnabled(metadata: Metadata, version: Integer): Boolean =
+    knownVersions.exists{ case (_, v) => v == version }
 }
 
 /**
@@ -265,7 +274,7 @@ case class IcebergCompatContext(
     prevSnapshot: Snapshot,
     newestProtocol: Protocol,
     newestMetadata: Metadata,
-    isCreatingNewTable: Boolean,
+    isCreatingOrReorgTable: Boolean,
     actions: Seq[Action],
     tableId: String,
     version: Integer) {
@@ -275,6 +284,21 @@ case class IcebergCompatContext(
 }
 
 trait IcebergCompatCheck extends (IcebergCompatContext => Unit)
+
+/**
+ * Checks that ensures no more than one IcebergCompatVx is enabled.
+ */
+object CheckOnlySingleVersionEnabled extends IcebergCompatCheck {
+  override def apply(context: IcebergCompatContext): Unit = {
+    val numEnabled = IcebergCompat.knownVersions
+      .map{ case (config, _) =>
+        if (config.fromMetaData(context.newestMetadata).getOrElse(false)) 1 else 0 }
+      .sum
+    if (numEnabled > 1) {
+      throw DeltaErrors.icebergCompatVersionMutualExclusive(context.version)
+    }
+  }
+}
 
 object CheckAddFileHasStats extends IcebergCompatCheck {
   override def apply(context: IcebergCompatContext): Unit = {
@@ -368,7 +392,7 @@ object CheckVersionChangeNeedsRewrite extends IcebergCompatCheck {
   private val versionChangesWithoutRewrite: Map[Int, Set[Int]] =
     Map(0 -> Set(0, 1), 1 -> Set(0, 1), 2 -> Set(0, 1, 2))
   override def apply(context: IcebergCompatContext): Unit = {
-    if (!context.isCreatingNewTable) {
+    if (!context.isCreatingOrReorgTable) {
       val oldVersion = IcebergCompat.getEnabledVersion(context.prevMetadata).getOrElse(0)
       val allowedChanges = versionChangesWithoutRewrite.getOrElse(oldVersion, Set.empty[Int])
       if (!allowedChanges.contains(context.version)) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1357,26 +1357,16 @@ trait OptimisticTransactionImpl extends TransactionalWrite
     // Protocol change (stored in newProtocol)
 
     val (protocolUpdate1, metadataUpdate1) =
-      UniversalFormat.enforceIcebergInvariantsAndDependencies(
+      UniversalFormat.enforceInvariantsAndDependencies(
         // Note: if this txn has no protocol or metadata updates, then `prev` will equal `newest`.
-        prevProtocol = snapshot.protocol,
-        prevMetadata = snapshot.metadata,
+        snapshot,
         newestProtocol = protocol, // Note: this will try to use `newProtocol`
         newestMetadata = metadata, // Note: this will try to use `newMetadata`
-        isCreatingNewTable
+        isCreatingNewTable,
+        otherActions
       )
     newProtocol = protocolUpdate1.orElse(newProtocol)
     newMetadata = metadataUpdate1.orElse(newMetadata)
-
-    val (protocolUpdate2, metadataUpdate2) = IcebergCompatV1.enforceInvariantsAndDependencies(
-      snapshot,
-      newestProtocol = protocol, // Note: this will try to use `newProtocol`
-      newestMetadata = metadata, // Note: this will try to use `newMetadata`
-      isCreatingNewTable,
-      otherActions
-    )
-    newProtocol = protocolUpdate2.orElse(newProtocol)
-    newMetadata = metadataUpdate2.orElse(newMetadata)
 
     var finalActions = newMetadata.toSeq ++ newProtocol.toSeq ++ otherActions
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
@@ -32,15 +32,17 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTable
  * Currently, UniForm only supports Iceberg. When `delta.universalFormat.enabledFormats` contains
  * "iceberg", we say that Universal Format (Iceberg) is enabled.
  *
- * [[enforceIcebergInvariantsAndDependencies]] ensures that all of UniForm (Iceberg)'s requirements
- * are met (i.e. that IcebergCompatV1 is enabled). It doesn't verify that its nested requirements
- * are met (i.e. IcebergCompatV1's requirements, like Column Mapping). That is the responsibility of
- * [[IcebergCompatV1.enforceInvariantsAndDependencies]].
+ * [[enforceInvariantsAndDependencies]] ensures that all of UniForm's requirements for the
+ * specified format are met (e.g. for 'iceberg' that IcebergCompatV1 or V2 is enabled).
+ * It doesn't verify that its nested requirements are met (e.g. IcebergCompat's requirements,
+ * like Column Mapping). That is the responsibility of format-specific validations such as
+ * [[IcebergCompatV1.enforceInvariantsAndDependencies]]
+ * and [[IcebergCompatV2.enforceInvariantsAndDependencies]].
  *
  *
- * Note that UniForm (Iceberg) depends on IcebergCompatV1, but IcebergCompatV1 does not depend on or
- * require UniForm (Iceberg). It is perfectly valid for a Delta table to have IcebergCompatV1
- * enabled but UniForm (Iceberg) not enabled.
+ * Note that UniForm (Iceberg) depends on IcebergCompat, but IcebergCompat does not
+ * depend on or require UniForm (Iceberg). It is perfectly valid for a Delta table to have
+ * IcebergCompatV1 or V2 enabled but UniForm (Iceberg) not enabled.
  */
 object UniversalFormat extends DeltaLogging {
 
@@ -59,90 +61,103 @@ object UniversalFormat extends DeltaLogging {
   /**
    * Expected to be called after the newest metadata and protocol have been ~ finalized.
    *
-   * Furthermore, this should be called *before*
-   * [[IcebergCompatV1.enforceInvariantsAndDependencies]].
-   *
-   * If you are enabling Universal Format (Iceberg), this method ensures that IcebergCompatV1 is
-   * supported and enabled. If this is a new table, IcebergCompatV1 will be automatically enabled.
-   *
-   * If you are disabling Universal Format (Iceberg), this method ensures that IcebergCompatV1 is
-   * disabled. It may still be supported, however.
+   * @return tuple of options of (updatedProtocol, updatedMetadata). For either action, if no
+   *         updates need to be applied, will return None.
+   */
+  def enforceInvariantsAndDependencies(
+      snapshot: Snapshot,
+      newestProtocol: Protocol,
+      newestMetadata: Metadata,
+      isCreatingOrReorgTable: Boolean,
+      actions: Seq[Action]): (Option[Protocol], Option[Metadata]) = {
+    enforceIcebergInvariantsAndDependencies(
+      snapshot, newestProtocol, newestMetadata, isCreatingOrReorgTable, actions)
+  }
+
+  /**
+   * If you are enabling Universal Format (Iceberg), this method ensures that at least one of
+   * IcebergCompat is enabled. If you are disabling Universal Format (Iceberg), this method
+   * will leave the current IcebergCompat version untouched.
    *
    * @return tuple of options of (updatedProtocol, updatedMetadata). For either action, if no
    *         updates need to be applied, will return None.
    */
   def enforceIcebergInvariantsAndDependencies(
-      prevProtocol: Protocol,
-      prevMetadata: Metadata,
+      snapshot: Snapshot,
       newestProtocol: Protocol,
       newestMetadata: Metadata,
-      isCreatingNewTable: Boolean): (Option[Protocol], Option[Metadata]) = {
+      isCreatingOrReorg: Boolean,
+      actions: Seq[Action]): (Option[Protocol], Option[Metadata]) = {
+
+    val prevMetadata = snapshot.metadata
     val uniformIcebergWasEnabled = UniversalFormat.icebergEnabled(prevMetadata)
     val uniformIcebergIsEnabled = UniversalFormat.icebergEnabled(newestMetadata)
     val tableId = newestMetadata.id
+    var changed = false
 
-    (uniformIcebergWasEnabled, uniformIcebergIsEnabled) match {
-      case (false, false) => (None, None) // Ignore
-      case (true, false) => // Disabling!
-        if (!IcebergCompatV1.isEnabled(newestMetadata)) {
-          (None, None)
-        } else {
-          logInfo(s"[tableId=$tableId] Universal Format (Iceberg): This feature is being " +
-            "disabled. Auto-disabling IcebergCompatV1, too.")
+    val (uniformProtocol, uniformMetadata) =
+      (uniformIcebergWasEnabled, uniformIcebergIsEnabled) match {
+        case (_, false) => (None, None) // Ignore
+        case (_, true) => // Enabling now or already-enabled
+          val icebergCompatWasEnabled = IcebergCompat.isAnyEnabled(prevMetadata)
+          val icebergCompatIsEnabled = IcebergCompat.isAnyEnabled(newestMetadata)
 
-          val newConfiguration = newestMetadata.configuration ++
-            Map(DeltaConfigs.ICEBERG_COMPAT_V1_ENABLED.key -> "false")
+          if (icebergCompatIsEnabled) {
+            (None, None)
+          } else if (icebergCompatWasEnabled) {
+            // IcebergCompat is being disabled. We need to also disable Universal Format (Iceberg)
+            val remainingSupportedFormats = DeltaConfigs.UNIVERSAL_FORMAT_ENABLED_FORMATS
+              .fromMetaData(newestMetadata)
+              .filterNot(_ == UniversalFormat.ICEBERG_FORMAT)
 
-          (None, Some(newestMetadata.copy(configuration = newConfiguration)))
-        }
-      case (_, true) => // Enabling now or already-enabled
-        val icebergCompatV1WasEnabled = IcebergCompatV1.isEnabled(prevMetadata)
-        val icebergCompatV1IsEnabled = IcebergCompatV1.isEnabled(newestMetadata)
+            val newConfiguration = if (remainingSupportedFormats.isEmpty) {
+              newestMetadata.configuration - DeltaConfigs.UNIVERSAL_FORMAT_ENABLED_FORMATS.key
+            } else {
+              newestMetadata.configuration ++
+                Map(DeltaConfigs.UNIVERSAL_FORMAT_ENABLED_FORMATS.key ->
+                  remainingSupportedFormats.mkString(","))
+            }
 
-        if (icebergCompatV1IsEnabled) {
-          (None, None)
-        } else if (isCreatingNewTable) {
-          // We need to handle the isCreatingNewTable case first because in the the case of
-          // a REPLACE TABLE, it could be that icebergCompatV1IsEnabled is false, if it
-          // is not explicitly specified as part of the REPLACE command, but
-          // icebergCompatV1WasEnabled is true, if it was set on the previous table. In this
-          // case, we do not want to auto disable Uniform but rather set its dependencies
-          // automatically, the same way as is done for CREATE.
-          logInfo(s"[tableId=$tableId] Universal Format (Iceberg): Creating a new table " +
-            s"with Universal Format (Iceberg) enabled, but IcebergCompatV1 is not yet enabled. " +
-            s"Auto-supporting and enabling IcebergCompatV1 now.")
-          val protocolResult = Some(
-            newestProtocol.merge(Protocol.forTableFeature(IcebergCompatV1TableFeature))
-          )
-          val metadataResult = Some(
-            newestMetadata.copy(
-              configuration = newestMetadata.configuration ++
-                Map(DeltaConfigs.ICEBERG_COMPAT_V1_ENABLED.key -> "true")
-            )
-          )
+            logInfo(s"[tableId=$tableId] IcebergCompat is being disabled. Auto-disabling " +
+              "Universal Format (Iceberg), too.")
 
-          (protocolResult, metadataResult)
-        } else if (icebergCompatV1WasEnabled) {
-          // IcebergCompatV1 is being disabled. We need to also disable Universal Format (Iceberg)
-          val remainingSupportedFormats = DeltaConfigs.UNIVERSAL_FORMAT_ENABLED_FORMATS
-            .fromMetaData(newestMetadata)
-            .filterNot(_ == UniversalFormat.ICEBERG_FORMAT)
-
-          val newConfiguration = if (remainingSupportedFormats.isEmpty) {
-            newestMetadata.configuration - DeltaConfigs.UNIVERSAL_FORMAT_ENABLED_FORMATS.key
+            (None, Some(newestMetadata.copy(configuration = newConfiguration)))
           } else {
-            newestMetadata.configuration ++
-              Map(DeltaConfigs.UNIVERSAL_FORMAT_ENABLED_FORMATS.key ->
-                remainingSupportedFormats.mkString(","))
+            throw DeltaErrors.uniFormIcebergRequiresIcebergCompat()
           }
+      }
 
-          logInfo(s"[tableId=$tableId] IcebergCompatV1 is being disabled. Auto-disabling " +
-            "Universal Format (Iceberg), too.")
+    var protocolToCheck = uniformProtocol.getOrElse(newestProtocol)
+    var metadataToCheck = uniformMetadata.getOrElse(newestMetadata)
+    changed = uniformProtocol.nonEmpty || uniformMetadata.nonEmpty
 
-          (None, Some(newestMetadata.copy(configuration = newConfiguration)))
-        } else {
-          throw DeltaErrors.uniFormIcebergRequiresIcebergCompat()
-        }
+    val (v1protocolUpdate, v1metadataUpdate) = IcebergCompatV1.enforceInvariantsAndDependencies(
+      snapshot,
+      newestProtocol = protocolToCheck,
+      newestMetadata = metadataToCheck,
+      isCreatingOrReorg,
+      actions
+    )
+    protocolToCheck = v1protocolUpdate.getOrElse(protocolToCheck)
+    metadataToCheck = v1metadataUpdate.getOrElse(metadataToCheck)
+    changed ||= v1protocolUpdate.nonEmpty || v1metadataUpdate.nonEmpty
+
+    val (v2protocolUpdate, v2metadataUpdate) = IcebergCompatV2.enforceInvariantsAndDependencies(
+      snapshot,
+      newestProtocol = protocolToCheck,
+      newestMetadata = metadataToCheck,
+      isCreatingOrReorg,
+      actions
+    )
+    changed ||= v2protocolUpdate.nonEmpty || v2metadataUpdate.nonEmpty
+
+    if (changed) {
+      (
+        v2protocolUpdate.orElse(Some(protocolToCheck)),
+        v2metadataUpdate.orElse(Some(metadataToCheck))
+      )
+    } else {
+      (None, None)
     }
   }
 
@@ -159,28 +174,18 @@ object UniversalFormat extends DeltaLogging {
     var metadata = Metadata(configuration = configuration)
 
     // Check UniversalFormat related property dependencies
-    val (_, universalMetadata) = UniversalFormat.enforceIcebergInvariantsAndDependencies(
-      prevProtocol = Protocol(),
-      prevMetadata = Metadata(),
+    val (_, universalMetadata) = UniversalFormat.enforceInvariantsAndDependencies(
+      snapshot,
       newestProtocol = Protocol(),
       newestMetadata = metadata,
-      isCreatingNewTable = true
-    )
-
-    metadata = universalMetadata.getOrElse(metadata)
-
-    // UniversalFormat relies on IcebergV1, check its dependencies
-    val (_, icebergMetadata) = IcebergCompatV1.enforceInvariantsAndDependencies(
-      prevSnapshot = snapshot,
-      newestProtocol = Protocol(),
-      newestMetadata = metadata,
-      isCreatingNewTable = true,
+      isCreatingOrReorgTable = true,
       actions = Seq()
     )
 
-    icebergMetadata
-      .orElse(universalMetadata).map(_.configuration)
-      .getOrElse(configuration)
+    universalMetadata match {
+      case Some(valid) => valid.configuration
+      case _ => configuration
+    }
   }
 
   val ICEBERG_TABLE_TYPE_KEY = "table_type"

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2ESuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2ESuite.scala
@@ -29,6 +29,7 @@ abstract class UniFormE2EIcebergSuiteBase extends UniFormE2ETest {
         s"""CREATE TABLE $testTableName (col1 INT) USING DELTA
            |TBLPROPERTIES (
            |  'delta.columnMapping.mode' = 'name',
+           |  'delta.enableIcebergCompatV1' = 'true',
            |  'delta.universalFormat.enabledFormats' = 'iceberg'
            |)""".stripMargin)
       write(s"INSERT INTO $testTableName VALUES (123)")
@@ -42,6 +43,7 @@ abstract class UniFormE2EIcebergSuiteBase extends UniFormE2ETest {
         s"""CREATE TABLE `$testTableName` (col1 INT) USING DELTA
            |TBLPROPERTIES (
            |  'delta.columnMapping.mode' = 'name',
+           |  'delta.enableIcebergCompatV1' = 'true',
            |  'delta.universalFormat.enabledFormats' = 'iceberg'
            |)""".stripMargin)
       write(s"INSERT INTO `$testTableName` VALUES (123),(456),(567),(331)")
@@ -59,6 +61,7 @@ abstract class UniFormE2EIcebergSuiteBase extends UniFormE2ETest {
            | , f6: INT>, f7: INT>) USING DELTA
            |TBLPROPERTIES (
            |  'delta.columnMapping.mode' = 'name',
+           |  'delta.enableIcebergCompatV1' = 'true',
            |  'delta.universalFormat.enabledFormats' = 'iceberg'
            |)""".stripMargin)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR enables IcebergCompatV2 to be used by UniForm
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Unit tests
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
