### PR TITLE
[Kernel] Run Kernel integration tests as part of the CI job

### DIFF
--- a/.github/workflows/kernel_test.yaml
+++ b/.github/workflows/kernel_test.yaml
@@ -15,3 +15,6 @@ jobs:
       - name: Run tests
         run: |
           python run-tests.py --group kernel --coverage
+      - name: Run integration tests
+        run: |
+          cd kernel/examples && python run-kernel-examples.py --use-local

--- a/kernel/examples/run-kernel-examples.py
+++ b/kernel/examples/run-kernel-examples.py
@@ -129,8 +129,9 @@ if __name__ == "__main__":
     """
 
     # get the version of the package
-    examples_root_dir = path.dirname(__file__)
-    with open(path.join(examples_root_dir, "../../version.sbt")) as fd:
+    examples_root_dir = path.abspath(path.dirname(__file__))
+    project_root_dir = path.join(examples_root_dir, "../../")
+    with open(path.join(project_root_dir, "version.sbt")) as fd:
         default_version = fd.readline().split('"')[1]
 
         parser = argparse.ArgumentParser()
@@ -161,13 +162,12 @@ if __name__ == "__main__":
     clear_artifact_cache()
 
     if args.use_local:
-        project_root = path.join(examples_root_dir, "../../")
-        with WorkingDirectory(project_root):
-            run_cmd([f"{project_root}/build/sbt", "kernelGroup/publishM2"], stream_output=True)
+        with WorkingDirectory(project_root_dir):
+            run_cmd(["build/sbt", "kernelGroup/publishM2"], stream_output=True)
 
     golden_file_dir = path.join(
         examples_root_dir,
-        "../../connectors//golden-tables/src/main/resources/golden/")
+        "../../connectors/golden-tables/src/main/resources/golden/")
 
     run_single_threaded_examples(args.version, args.maven_repo, examples_root_dir, golden_file_dir)
     run_multi_threaded_examples(args.version, args.maven_repo, examples_root_dir, golden_file_dir)

--- a/kernel/examples/table-reader/src/main/java/io/delta/kernel/examples/SingleThreadedTableReader.java
+++ b/kernel/examples/table-reader/src/main/java/io/delta/kernel/examples/SingleThreadedTableReader.java
@@ -95,9 +95,6 @@ public class SingleThreadedTableReader
     private int readData(StructType readSchema, Scan scan, int maxRowCount) throws IOException {
         printSchema(readSchema);
 
-        Row row;
-        row.getLong(2);
-
         Row scanState = scan.getScanState(tableClient);
         CloseableIterator<FilteredColumnarBatch> scanFileIter = scan.getScanFiles(tableClient);
 

--- a/kernel/examples/table-reader/src/main/java/io/delta/kernel/examples/SingleThreadedTableReader.java
+++ b/kernel/examples/table-reader/src/main/java/io/delta/kernel/examples/SingleThreadedTableReader.java
@@ -95,6 +95,9 @@ public class SingleThreadedTableReader
     private int readData(StructType readSchema, Scan scan, int maxRowCount) throws IOException {
         printSchema(readSchema);
 
+        Row row;
+        row.getLong(2);
+
         Row scanState = scan.getScanState(tableClient);
         CloseableIterator<FilteredColumnarBatch> scanFileIter = scan.getScanFiles(tableClient);
 

--- a/kernel/examples/table-reader/src/main/java/io/delta/kernel/examples/SingleThreadedTableReader.java
+++ b/kernel/examples/table-reader/src/main/java/io/delta/kernel/examples/SingleThreadedTableReader.java
@@ -95,7 +95,7 @@ public class SingleThreadedTableReader
     private int readData(StructType readSchema, Scan scan, int maxRowCount) throws IOException {
         printSchema(readSchema);
 
-        Row row = null;
+        Row row;
         row.getLong(2);
 
         Row scanState = scan.getScanState(tableClient);

--- a/kernel/examples/table-reader/src/main/java/io/delta/kernel/examples/SingleThreadedTableReader.java
+++ b/kernel/examples/table-reader/src/main/java/io/delta/kernel/examples/SingleThreadedTableReader.java
@@ -95,7 +95,7 @@ public class SingleThreadedTableReader
     private int readData(StructType readSchema, Scan scan, int maxRowCount) throws IOException {
         printSchema(readSchema);
 
-        Row row;
+        Row row = null;
         row.getLong(2);
 
         Row scanState = scan.getScanState(tableClient);


### PR DESCRIPTION
## Description
We have been changing the Kernel APIs which may cause the examples to fail. Currently, examples/integration can only be run manually. This PR runs the integration as part of the PR CI job so that we can cause any failure during the PR time.

Also fixes an issue with the integration test run script when using the local version of Kernel code.

## How was this patch tested?
CI job
