### PR TITLE
[Spark] Store CLUSTER BY columns as DomainMetadata

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -342,6 +342,32 @@
     ],
     "sqlState" : "0AKDC"
   },
+  "DELTA_CLUSTERING_COLUMNS_MISMATCH" : {
+    "message" : [
+      "The provided clustering columns do not match the existing table's.",
+      "- provided: <providedClusteringColumns>",
+      "- existing: <existingClusteringColumns>"
+    ],
+    "sqlState" : "42P10"
+  },
+  "DELTA_CLUSTERING_COLUMN_MISSING_STATS" : {
+    "message" : [
+      "Clustering requires clustering columns to have stats. Couldn't find clustering column(s) '<columns>' in stats schema:\n<schema>"
+    ],
+    "sqlState" : "22000"
+  },
+  "DELTA_CLUSTERING_REPLACE_TABLE_WITH_PARTITIONED_TABLE" : {
+    "message" : [
+      "Replacing a clustered Delta table with a partitioned table is not allowed."
+    ],
+    "sqlState" : "42000"
+  },
+  "DELTA_CLUSTER_BY_INVALID_NUM_COLUMNS" : {
+    "message" : [
+      "CLUSTER BY supports up to <numColumnsLimit> clustering columns, but the table has <actualNumColumns> clustering columns. Please remove the extra clustering columns."
+    ],
+    "sqlState" : "54000"
+  },
   "DELTA_COLUMN_DATA_SKIPPING_NOT_SUPPORTED_PARTITIONED_COLUMN" : {
     "message" : [
       "Data skipping is not supported for partition column '<column>'."
@@ -2250,6 +2276,12 @@
       "<view> is a view. DESCRIBE DETAIL is only supported for tables."
     ],
     "sqlState" : "42809"
+  },
+  "DELTA_UNSUPPORTED_DROP_CLUSTERING_COLUMN" : {
+    "message" : [
+      "Dropping clustering columns (<columnList>) is not allowed."
+    ],
+    "sqlState" : "0AKDC"
   },
   "DELTA_UNSUPPORTED_DROP_COLUMN" : {
     "message" : [

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3085,6 +3085,55 @@ trait DeltaErrorsBase
       messageParameters = Array(version.toString, version.toString, key, requiredValue, actualValue)
     )
   }
+
+  def clusterByInvalidNumColumnsException(
+      numColumnsLimit: Int,
+      actualNumColumns: Int): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_CLUSTER_BY_INVALID_NUM_COLUMNS",
+      messageParameters = Array(numColumnsLimit.toString, actualNumColumns.toString)
+    )
+  }
+
+  def clusteringColumnMissingStats(
+      clusteringColumnWithoutStats: String,
+      statsSchema: String): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_CLUSTERING_COLUMN_MISSING_STATS",
+      messageParameters = Array(clusteringColumnWithoutStats, statsSchema)
+    )
+  }
+
+  def clusteringColumnsMismatchException(
+      providedClusteringColumns: String,
+      existingClusteringColumns: String): Throwable = {
+    new DeltaAnalysisException(
+      "DELTA_CLUSTERING_COLUMNS_MISMATCH",
+      Array(providedClusteringColumns, existingClusteringColumns)
+    )
+  }
+
+  def dropClusteringColumnNotSupported(droppingClusteringCols: Seq[String]): Throwable = {
+    new DeltaAnalysisException(
+      "DELTA_UNSUPPORTED_DROP_CLUSTERING_COLUMN",
+      Array(droppingClusteringCols.mkString(",")))
+  }
+
+  def replacingClusteredTableWithPartitionedTableNotAllowed(): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_CLUSTERING_REPLACE_TABLE_WITH_PARTITIONED_TABLE",
+      messageParameters = Array.empty)
+  }
+
+  def clusteringTablePreviewDisabledException(): Throwable = {
+    val msg = s"""
+      |A clustered table is currently in preview and is disabled by default. Please set
+      |${DeltaSQLConf.DELTA_CLUSTERING_TABLE_PREVIEW_ENABLED.key} to true to enable it.
+      |Note that a clustered table is not recommended for production use (e.g., unsupported
+      |incremental clustering).
+      |""".stripMargin.replace("\n", " ")
+    new UnsupportedOperationException(msg)
+  }
 }
 
 object DeltaErrors extends DeltaErrorsBase

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
@@ -24,17 +24,23 @@ import java.util.Locale
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
+import org.apache.spark.sql.delta.skipping.clustering.ClusteredTableUtils
+import org.apache.spark.sql.delta.skipping.clustering.temp.ClusterBySpec
+import org.apache.spark.sql.delta.skipping.clustering.temp.{ClusterByTransform => TempClusterByTransform}
 import org.apache.spark.sql.delta.{DeltaConfigs, DeltaErrors, DeltaTableUtils}
 import org.apache.spark.sql.delta.{DeltaLog, DeltaOptions}
 import org.apache.spark.sql.delta.DeltaTableIdentifier.gluePermissionError
 import org.apache.spark.sql.delta.commands._
 import org.apache.spark.sql.delta.constraints.{AddConstraint, DropConstraint}
 import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.{DeltaDataSource, DeltaSourceUtils, DeltaSQLConf}
 import org.apache.spark.sql.delta.stats.StatisticsCollection
 import org.apache.spark.sql.delta.tablefeatures.DropFeature
+import org.apache.spark.sql.delta.util.PartitionUtils
 import org.apache.hadoop.fs.Path
 
+import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{AnalysisException, DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -99,9 +105,8 @@ class DeltaCatalog extends DelegatingCatalogExtension
       case "option.path" => false
       case _ => true
     }.toMap
-    val (
-      partitionColumns, maybeBucketSpec
-      ) = convertTransforms(partitions)
+    val (partitionColumns, maybeBucketSpec, maybeClusterBySpec) = convertTransforms(partitions)
+    validateClusterBySpec(maybeClusterBySpec, schema)
     var newSchema = schema
     var newPartitionColumns = partitionColumns
     var newBucketSpec = maybeBucketSpec
@@ -154,7 +159,8 @@ class DeltaCatalog extends DelegatingCatalogExtension
     val withDb =
       verifyTableAndSolidify(
         tableDesc,
-        None
+        None,
+        maybeClusterBySpec
       )
 
     val writer = sourceQuery.map { df =>
@@ -248,6 +254,26 @@ class DeltaCatalog extends DelegatingCatalogExtension
     }
   }
 
+  // Perform checks on ClusterBySpec.
+  def validateClusterBySpec(
+      maybeClusterBySpec: Option[ClusterBySpec], schema: StructType): Unit = {
+    // Validate that the preview is enabled if we are creating a clustered table.
+    ClusteredTableUtils.validatePreviewEnabled(maybeClusterBySpec)
+    maybeClusterBySpec.foreach { clusterBy =>
+      // Check if the specified cluster by columns exists in the table.
+      val resolver = spark.sessionState.conf.resolver
+      clusterBy.columnNames.foreach { column =>
+        // This is the same check as in rules.scala, to keep the behaviour consistent.
+        SchemaUtils.findColumnPosition(column.fieldNames(), schema, resolver)
+      }
+      // Check that columns are not duplicated in the cluster by statement.
+      PartitionUtils.checkColumnNameDuplication(
+        clusterBy.columnNames.map(_.toString), "in CLUSTER BY", resolver)
+      // Check number of clustering columns is within allowed range.
+      ClusteredTableUtils.validateNumClusteringColumns(
+        clusterBy.columnNames.map(_.fieldNames.toSeq))
+    }
+  }
 
   protected def newDeltaPathTable(ident: Identifier): DeltaTableV2 = {
     DeltaTableV2(spark, new Path(ident.name()))
@@ -372,11 +398,11 @@ class DeltaCatalog extends DelegatingCatalogExtension
     }
 
   // Copy of V2SessionCatalog.convertTransforms, which is private.
-  private def convertTransforms(partitions: Seq[Transform]): (
-    Seq[String], Option[BucketSpec]
-    ) = {
+  private def convertTransforms(
+      partitions: Seq[Transform]): (Seq[String], Option[BucketSpec], Option[ClusterBySpec]) = {
     val identityCols = new mutable.ArrayBuffer[String]
     var bucketSpec = Option.empty[BucketSpec]
+    var clusterBySpec = Option.empty[ClusterBySpec]
 
     partitions.map {
       case IdentityTransform(FieldReference(Seq(col))) =>
@@ -385,22 +411,29 @@ class DeltaCatalog extends DelegatingCatalogExtension
       case BucketTransform(numBuckets, bucketCols, sortCols) =>
         bucketSpec = Some(BucketSpec(
           numBuckets, bucketCols.map(_.fieldNames.head), sortCols.map(_.fieldNames.head)))
+      case TempClusterByTransform(columnNames) =>
+        if (clusterBySpec.nonEmpty) {
+          // Parser guarantees that it only passes down one TempClusterByTransform.
+          throw SparkException.internalError("Cannot have multiple cluster by transforms.")
+        }
+        clusterBySpec = Some(ClusterBySpec(columnNames))
 
       case transform =>
         throw DeltaErrors.operationNotSupportedException(s"Partitioning by expressions")
     }
+    // Parser guarantees that partition and cluster by can't both exist.
+    assert(!(identityCols.toSeq.nonEmpty && clusterBySpec.nonEmpty))
+    // Parser guarantees that bucketing and cluster by can't both exist.
+    assert(!(bucketSpec.nonEmpty && clusterBySpec.nonEmpty))
 
-    (
-      identityCols.toSeq, bucketSpec
-    )
+    (identityCols.toSeq, bucketSpec, clusterBySpec)
   }
 
   /** Performs checks on the parameters provided for table creation for a Delta table. */
   def verifyTableAndSolidify(
       tableDesc: CatalogTable,
-      query: Option[LogicalPlan]
-      ): CatalogTable = {
-
+      query: Option[LogicalPlan],
+      maybeClusterBySpec: Option[ClusterBySpec] = None): CatalogTable = {
     if (tableDesc.bucketSpec.isDefined) {
       throw DeltaErrors.operationNotSupportedException("Bucketing", tableDesc.identifier)
     }
@@ -415,8 +448,15 @@ class DeltaCatalog extends DelegatingCatalogExtension
       tableDesc.partitionColumnNames,
       caseSensitive = false) // Delta is case insensitive
 
-    val validatedConfigurations =
+    var validatedConfigurations =
       DeltaConfigs.validateConfigurations(tableDesc.properties)
+    // Add needed configs for Clustered table.
+    if (maybeClusterBySpec.nonEmpty) {
+      validatedConfigurations =
+        validatedConfigurations ++
+          ClusteredTableUtils.getClusteringColumnsAsProperty(maybeClusterBySpec) ++
+          ClusteredTableUtils.getTableFeatureProperties(validatedConfigurations)
+    }
 
     val db = tableDesc.identifier.database.getOrElse(catalog.getCurrentDatabase)
     val tableIdentWithDB = tableDesc.identifier.copy(database = Some(db))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/clustering/ClusteringMetadataDomain.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/clustering/ClusteringMetadataDomain.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.clustering
+
+import org.apache.spark.sql.delta.skipping.clustering.ClusteringColumn
+import org.apache.spark.sql.delta.{JsonMetadataDomain, JsonMetadataDomainUtils}
+
+/**
+ * Metadata domain for Clustered table which tracks clustering columns.
+ */
+case class ClusteringMetadataDomain(clusteringColumns: Seq[Seq[String]])
+  extends JsonMetadataDomain[ClusteringMetadataDomain] {
+  override val domainName: String = ClusteringMetadataDomain.domainName
+}
+
+object ClusteringMetadataDomain extends JsonMetadataDomainUtils[ClusteringMetadataDomain] {
+  override val domainName = "delta.clustering"
+
+  def fromClusteringColumns(clusteringColumns: Seq[ClusteringColumn]): ClusteringMetadataDomain = {
+    ClusteringMetadataDomain(clusteringColumns.map(_.physicalName))
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -316,7 +316,7 @@ case class CreateDeltaTableCommand(
         protocol.foreach { protocol =>
           txn.updateProtocol(protocol)
         }
-        Nil ++ ClusteredTableUtils.getDomainMetadataOptional(table, txn)
+        ClusteredTableUtils.getDomainMetadataOptional(table, txn).toSeq
       } else {
         verifyTableMetadata(txn, tableWithLocation)
         Nil

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.delta.commands
 // scalastyle:off import.ordering.noEmptyLine
 import java.util.concurrent.TimeUnit
 
+import org.apache.spark.sql.delta.skipping.clustering.ClusteredTableUtils
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.DeltaColumnMapping.{dropColumnMappingMetadata, filterColumnMappingProperties}
 import org.apache.spark.sql.delta.actions.{Action, Metadata, Protocol}
@@ -232,14 +233,16 @@ case class CreateDeltaTableCommand(
       }
       var actions = deltaWriter.write(
         txn,
-        sparkSession
+        sparkSession,
+        ClusteredTableUtils.getClusterBySpecOptional(table)
       )
       // Metadata updates for creating table (with any writer) and replacing table
       // (only with V1 writer) will be handled inside WriteIntoDelta.
       // For createOrReplace operation, metadata updates are handled here if the table already
       // exists (replacing table), otherwise it is handled inside WriteIntoDelta (creating table).
       if (!isV1Writer && isReplace && txn.readVersion > -1L) {
-        val newDomainMetadata = Seq.empty[DomainMetadata]
+        val newDomainMetadata = Seq.empty[DomainMetadata] ++
+          ClusteredTableUtils.getDomainMetadataOptional(table, txn)
         // Ensure to remove any domain metadata for REPLACE TABLE.
         actions = actions ++ DomainMetadataUtils.handleDomainMetadataForReplaceTable(
           txn.snapshot.domainMetadata, newDomainMetadata)
@@ -313,7 +316,7 @@ case class CreateDeltaTableCommand(
         protocol.foreach { protocol =>
           txn.updateProtocol(protocol)
         }
-        Nil
+        Nil ++ ClusteredTableUtils.getDomainMetadataOptional(table, txn)
       } else {
         verifyTableMetadata(txn, tableWithLocation)
         Nil
@@ -348,7 +351,10 @@ case class CreateDeltaTableCommand(
         val operationTimestamp = System.currentTimeMillis()
         var actionsToCommit = Seq.empty[Action]
         val removes = txn.filterFiles().map(_.removeWithTimestamp(operationTimestamp))
-        actionsToCommit = removes
+        actionsToCommit = removes ++
+          DomainMetadataUtils.handleDomainMetadataForReplaceTable(
+            txn.snapshot.domainMetadata,
+            ClusteredTableUtils.getDomainMetadataOptional(table, txn).toSeq)
         actionsToCommit
     }
 
@@ -366,7 +372,9 @@ case class CreateDeltaTableCommand(
       description = table.comment.orNull,
       schemaString = schemaString,
       partitionColumns = table.partitionColumnNames,
-      configuration = table.properties,
+      // Filter out ephemeral clustering columns config because we don't want to persist
+      // it in delta log. This will be persisted in CatalogTable's table properties instead.
+      configuration = ClusteredTableUtils.removeClusteringColumnsProperty(table.properties),
       createdTime = Some(System.currentTimeMillis()))
   }
 
@@ -618,12 +626,29 @@ case class CreateDeltaTableCommand(
       tableWithLocation: CatalogTable,
       snapshotOpt: Option[Snapshot] = None): OptimisticTransaction = {
     val txn = deltaLog.startTransaction(None, snapshotOpt)
+    validatePrerequisitesForClusteredTable(txn.snapshot.protocol, txn.deltaLog)
 
     // During CREATE/REPLACE, we synchronously run conversion (if Uniform is enabled) so
     // we always remove the post commit hook here.
     txn.unregisterPostCommitHooksWhere(hook => hook.name == IcebergConverterHook.name)
 
     txn
+  }
+
+  /**
+   * Validate pre-requisites for clustered tables for CREATE/REPLACE operations.
+   * @param protocol Protocol used for validations. This protocol should
+   *                 be used during the CREATE/REPLACE commit.
+   * @param deltaLog Delta log used for logging purposes.
+   */
+  private def validatePrerequisitesForClusteredTable(
+      protocol: Protocol,
+      deltaLog: DeltaLog): Unit = {
+    // Validate a clustered table is not replaced by a partitioned table.
+    if (table.partitionColumnNames.nonEmpty &&
+      ClusteredTableUtils.isSupported(protocol)) {
+      throw DeltaErrors.replacingClusteredTableWithPartitionedTableNotAllowed()
+    }
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -17,8 +17,6 @@
 package org.apache.spark.sql.delta.commands
 
 // scalastyle:off import.ordering.noEmptyLine
-import org.apache.spark.sql.delta.skipping.clustering.ClusteredTableUtils
-import org.apache.spark.sql.delta.skipping.clustering.temp.ClusterBySpec
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
@@ -26,6 +24,8 @@ import org.apache.spark.sql.delta.constraints.Constraint
 import org.apache.spark.sql.delta.constraints.Constraints.Check
 import org.apache.spark.sql.delta.constraints.Invariants.ArbitraryExpression
 import org.apache.spark.sql.delta.schema.{ImplicitMetadataOperation, InvariantViolationException, SchemaUtils}
+import org.apache.spark.sql.delta.skipping.clustering.ClusteredTableUtils
+import org.apache.spark.sql.delta.skipping.clustering.temp.ClusterBySpec
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.sql._

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDeltaLike.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDeltaLike.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.delta.commands
 
 // scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.sql.delta.skipping.clustering.temp.ClusterBySpec
 import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.OptimisticTransaction
 import org.apache.spark.sql.delta.actions.Action
@@ -59,8 +60,8 @@ trait WriteIntoDeltaLike {
    */
   def write(
       txn: OptimisticTransaction,
-      sparkSession: SparkSession
-  ): Seq[Action]
+      sparkSession: SparkSession,
+      clusterBySpecOpt: Option[ClusterBySpec] = None): Seq[Action]
 
   val deltaLog: DeltaLog
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/ImplicitMetadataOperation.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/ImplicitMetadataOperation.scala
@@ -16,6 +16,8 @@
 
 package org.apache.spark.sql.delta.schema
 
+import org.apache.spark.sql.delta.skipping.clustering.ClusteredTableUtils
+import org.apache.spark.sql.delta.skipping.clustering.temp.ClusterBySpec
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.DomainMetadata
 import org.apache.spark.sql.delta.actions.Metadata
@@ -154,10 +156,11 @@ trait ImplicitMetadataOperation extends DeltaLogging {
   protected final def getNewDomainMetadata(
       txn: OptimisticTransaction,
       canUpdateMetadata: Boolean,
-      isReplacingTable: Boolean
-      ): Seq[DomainMetadata] = {
+      isReplacingTable: Boolean,
+      clusterBySpecOpt: Option[ClusterBySpec] = None): Seq[DomainMetadata] = {
     if (canUpdateMetadata && (!txn.deltaLog.tableExists || isReplacingTable)) {
-      val newDomainMetadata = Seq.empty[DomainMetadata]
+      val newDomainMetadata = Seq.empty[DomainMetadata] ++
+        ClusteredTableUtils.getDomainMetadataOptional(clusterBySpecOpt, txn)
       if (!txn.deltaLog.tableExists) {
         newDomainMetadata
       } else {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableUtils.scala
@@ -16,12 +16,20 @@
 
 package org.apache.spark.sql.delta.skipping.clustering
 
-import org.apache.spark.sql.delta.ClusteringTableFeature
-import org.apache.spark.sql.delta.actions.Protocol
+import org.apache.spark.sql.delta.skipping.clustering.temp.ClusterBySpec
+import org.apache.spark.sql.delta.{ClusteringTableFeature, DeltaColumnMappingMode, DeltaErrors, DeltaLog, OptimisticTransaction, Snapshot}
+import org.apache.spark.sql.delta.actions.{DomainMetadata, Metadata, Protocol, TableFeatureProtocolUtils}
+import org.apache.spark.sql.delta.clustering.ClusteringMetadataDomain
 import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.stats.{DeltaStatistics, StatisticsCollection}
+import org.apache.spark.sql.delta.util.{Utils => DeltaUtils}
 
+import org.apache.spark.sql.{AnalysisException, SparkSession}
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{StructField, StructType}
 
 /**
  * Clustered table utility functions.
@@ -37,15 +45,289 @@ trait ClusteredTableUtilsBase extends DeltaLogging {
   */
   def isSupported(protocol: Protocol): Boolean = protocol.isFeatureSupported(ClusteringTableFeature)
 
-  /** Returns true to enable clustering table and currently it is only enabled for testing.
-   *
-   * Note this function is going to be removed when clustering table is fully developed.
-   */
-  def clusteringTableFeatureEnabled: Boolean =
-    SQLConf.get.getConf(DeltaSQLConf.DELTA_ENABLE_CLUSTERING_TABLE_FEATURE)
-
   /** The clustering implementation name for [[AddFile.clusteringProvider]] */
   def clusteringProvider: String = "liquid"
+
+  /**
+   * Validate the clustering table preview is enabled. If not, throw an exception.
+   * This version is used when checking existing tables with updated metadata / protocol.
+   */
+  def validatePreviewEnabled(protocol: Protocol): Unit = {
+    if (isSupported(protocol) &&
+      !SQLConf.get.getConf(DeltaSQLConf.DELTA_CLUSTERING_TABLE_PREVIEW_ENABLED) &&
+      !DeltaUtils.isTesting) {
+      throw DeltaErrors.clusteringTablePreviewDisabledException()
+    }
+  }
+
+  /**
+   * Validate the clustering table preview is enabled. If not, throw an exception.
+   * This version is used for `CREATE TABLE...` where the initial snapshot doesn't have
+   * updated metadata / protocol yet.
+   */
+  def validatePreviewEnabled(maybeClusterBySpec: Option[ClusterBySpec]): Unit = {
+    maybeClusterBySpec.foreach { _ =>
+      if (!SQLConf.get.getConf(DeltaSQLConf.DELTA_CLUSTERING_TABLE_PREVIEW_ENABLED) &&
+        !DeltaUtils.isTesting) {
+        throw DeltaErrors.clusteringTablePreviewDisabledException()
+      }
+    }
+  }
+
+  /**
+   * Returns an optional [[ClusterBySpec]] from the given CatalogTable.
+   */
+  def getClusterBySpecOptional(table: CatalogTable): Option[ClusterBySpec] = {
+    table.properties.get(PROP_CLUSTERING_COLUMNS).map(ClusterBySpec.fromProperty)
+  }
+
+  /**
+   * Extract clustering columns from ClusterBySpec.
+   *
+   * @param maybeClusterBySpec optional ClusterBySpec. If it's empty, will return the
+   *                             original properties.
+   * @return an optional pair with clustering columns.
+   */
+  def getClusteringColumnsAsProperty(
+      maybeClusterBySpec: Option[ClusterBySpec]): Option[(String, String)] = {
+    maybeClusterBySpec.map(ClusterBySpec.toProperty)
+  }
+
+  /**
+   * Returns table feature properties that's required to create a clustered table.
+   *
+   * @param existingProperties Table properties set by the user when creating a clustered table.
+   */
+  def getTableFeatureProperties(existingProperties: Map[String, String]): Map[String, String] = {
+    val properties = collection.mutable.Map.empty[String, String]
+    properties += TableFeatureProtocolUtils.propertyKey(ClusteringTableFeature) ->
+      TableFeatureProtocolUtils.FEATURE_PROP_SUPPORTED
+
+    properties.toMap
+  }
+
+  /**
+   * Validate the number of clustering columns doesn't exceed the limit.
+   *
+   * @param clusteringColumns clustering columns for the table.
+   * @param deltaLogOpt optional delta log. If present, will be used to record a delta event.
+   */
+  def validateNumClusteringColumns(
+      clusteringColumns: Seq[Seq[String]],
+      deltaLogOpt: Option[DeltaLog] = None): Unit = {
+    val numColumnsLimit =
+      SQLConf.get.getConf(DeltaSQLConf.DELTA_NUM_CLUSTERING_COLUMNS_LIMIT)
+    val actualNumColumns = clusteringColumns.size
+    if (actualNumColumns > numColumnsLimit) {
+      deltaLogOpt.foreach { deltaLog =>
+        recordDeltaEvent(
+          deltaLog,
+          opType = "delta.clusteredTable.invalidNumClusteringColumns",
+          data = Map(
+            "numCols" -> clusteringColumns.size,
+            "numColsLimit" -> numColumnsLimit))
+      }
+      throw DeltaErrors.clusterByInvalidNumColumnsException(numColumnsLimit, actualNumColumns)
+    }
+  }
+
+  /**
+   * Remove PROP_CLUSTERING_COLUMNS from metadata action.
+   * Clustering columns should only exist in:
+   * 1. CatalogTable.properties(PROP_CLUSTERING_COLUMNS)
+   * 2. Clustering metadata domain.
+   * @param configuration original configuration.
+   * @return new configuration without clustering columns property
+   */
+  def removeClusteringColumnsProperty(configuration: Map[String, String]): Map[String, String] = {
+    configuration - PROP_CLUSTERING_COLUMNS
+  }
+
+  /**
+   * Create an optional [[DomainMetadata]] action to store clustering columns.
+   */
+  def getDomainMetadataOptional(
+      clusterBySpecOpt: Option[ClusterBySpec],
+      txn: OptimisticTransaction): Option[DomainMetadata] = {
+    clusterBySpecOpt.map { clusterBy =>
+      ClusteredTableUtils.validateClusteringColumnsInStatsSchema(
+        txn.protocol, txn.metadata, clusterBy)
+      val clusteringColumns =
+        clusterBy.columnNames.map(_.toString).map(ClusteringColumn(txn.metadata.schema, _))
+      createDomainMetadata(clusteringColumns)
+    }
+  }
+
+  /**
+   * Create a [[DomainMetadata]] action to store clustering columns.
+   */
+  def createDomainMetadata(clusteringColumns: Seq[ClusteringColumn]): DomainMetadata = {
+    ClusteringMetadataDomain.fromClusteringColumns(clusteringColumns).toDomainMetadata
+  }
+
+  /**
+   * Create a [[ClusteringMetadataDomain]] with the given CatalogTable's clustering column property.
+   */
+  def getDomainMetadataOptional(
+      table: CatalogTable,
+      txn: OptimisticTransaction): Option[DomainMetadata] = {
+    getDomainMetadataOptional(getClusterBySpecOptional(table), txn)
+  }
+
+  /**
+   * Extract [[ClusteringColumn]]s from a given snapshot. Return None if the clustering domain
+   * metadata is missing.
+   */
+  def getClusteringColumnsOptional(snapshot: Snapshot): Option[Seq[ClusteringColumn]] = {
+    ClusteringMetadataDomain
+      .fromSnapshot(snapshot)
+      .map(_.clusteringColumns.map(ClusteringColumn.apply))
+  }
+
+  /**
+   * Extract [[DomainMetadata]] for storing clustering columns from a given snapshot.
+   * It returns clustering domain metadata if exists.
+   * Return empty if the clustering domain metadata is missing.
+   */
+  def getClusteringDomainMetadata(snapshot: Snapshot): Seq[DomainMetadata] = {
+    ClusteringMetadataDomain.fromSnapshot(snapshot).map(_.toDomainMetadata).toSeq
+  }
+
+  /**
+   * Validate stats will be collected for all clustering columns.
+   */
+  def validateClusteringColumnsInStatsSchema(
+      snapshot: Snapshot,
+      logicalClusteringColumns: Seq[String]): Unit = {
+    validateClusteringColumnsInStatsSchema(
+      snapshot,
+      logicalClusteringColumns.map { name =>
+        ClusteringColumnInfo(snapshot.schema, ClusteringColumn(snapshot.schema, name))
+      })
+  }
+
+  /**
+   * Returns true if stats will be collected for all clustering columns.
+   */
+  def areClusteringColumnsInStatsSchema(
+      snapshot: Snapshot,
+      logicalClusteringColumns: Seq[String]): Boolean = {
+    getClusteringColumnsNotInStatsSchema(
+      snapshot,
+      logicalClusteringColumns.map { name =>
+        ClusteringColumnInfo(snapshot.schema, ClusteringColumn(snapshot.schema, name))
+      }).isEmpty
+  }
+
+  /**
+   * Validate stats will be collected for all clustering columns.
+   *
+   * This version is used when [[Snapshot]] doesn't have latest stats column information such as
+   * `CREATE TABLE...` where the initial snapshot doesn't have updated metadata / protocol yet.
+   */
+  def validateClusteringColumnsInStatsSchema(
+      protocol: Protocol,
+      metadata: Metadata,
+      clusterBy: ClusterBySpec): Unit = {
+    validateClusteringColumnsInStatsSchema(
+      statisticsCollectionFromMetadata(protocol, metadata),
+      clusterBy.columnNames.map { column =>
+        ClusteringColumnInfo(metadata.schema, ClusteringColumn(metadata.schema, column.toString))
+      })
+  }
+
+  /**
+   * Build a [[StatisticsCollection]] with minimal requirements that can be used to find stats
+   * columns.
+   *
+   * We can not use [[Snapshot]] as in a normal case during table creation such as `CREATE TABLE`
+   * because the initial snapshot doesn't have the updated metadata / protocol to find latest stats
+   * columns.
+   */
+  private def statisticsCollectionFromMetadata(
+      p: Protocol,
+      metadata: Metadata): StatisticsCollection = {
+    new StatisticsCollection {
+      override val tableSchema: StructType = metadata.schema
+      override val outputAttributeSchema: StructType = tableSchema
+      // [[outputTableStatsSchema]] is the candidate schema to find statistics columns.
+      override val outputTableStatsSchema: StructType = tableSchema
+      override val statsColumnSpec = StatisticsCollection.configuredDeltaStatsColumnSpec(metadata)
+      override val columnMappingMode: DeltaColumnMappingMode = metadata.columnMappingMode
+      override val protocol: Protocol = p
+
+      override def spark: SparkSession = {
+        throw new Exception("Method not used in statisticsCollectionFromMetadata")
+      }
+    }
+  }
+
+  /**
+   * Validate physical clustering columns can be found in the latest stats columns.
+   *
+   * @param statsCollection Provides latest stats columns.
+   * @param clusteringColumnInfos Clustering columns in physical names.
+   *
+   * A [[AnalysisException]] is thrown if the clustering column can not be found in the latest
+   * stats columns. The error message contains logical names only for better user experience.
+   */
+  private def validateClusteringColumnsInStatsSchema(
+      statsCollection: StatisticsCollection,
+      clusteringColumnInfos: Seq[ClusteringColumnInfo]): Unit = {
+    val missingColumn = getClusteringColumnsNotInStatsSchema(statsCollection, clusteringColumnInfos)
+    if (missingColumn.nonEmpty) {
+      // Convert back to logical names.
+      throw DeltaErrors.clusteringColumnMissingStats(
+        missingColumn.mkString(", "),
+        statsCollection.statCollectionLogicalSchema.treeString)
+    }
+  }
+
+  /**
+   * Validate that the given clusterBySpec matches the existing table's in the given snapshot.
+   * This is used for append mode and replaceWhere.
+   */
+  def validateClusteringColumnsInSnapshot(
+      snapshot: Snapshot,
+      clusterBySpec: ClusterBySpec): Unit = {
+    // This uses physical column names to compare.
+    val providedClusteringColumns =
+      Some(clusterBySpec.columnNames.map(col => ClusteringColumn(snapshot.schema, col.toString)))
+    val existingClusteringColumns = ClusteredTableUtils.getClusteringColumnsOptional(snapshot)
+    if (providedClusteringColumns != existingClusteringColumns) {
+      throw DeltaErrors.clusteringColumnsMismatchException(
+        clusterBySpec.columnNames.map(_.toString).mkString(","),
+        existingClusteringColumns.map(_.map(
+          ClusteringColumnInfo(snapshot.schema, _).logicalName).mkString(",")).getOrElse("")
+      )
+    }
+  }
+
+  /**
+   * Returns empty if all physical clustering columns can be found in the latest stats columns.
+   * Otherwise, returns the logical names of the all clustering columns that are not found.
+   *
+   * [[StatisticsCollection.statsSchema]] has converted field's name to physical name and also it
+   * filters out any columns that are NOT qualified as a stats data type
+   * through [[SkippingEligibleDataType]].
+   *
+   * @param statsCollection       Provides latest stats columns.
+   * @param clusteringColumnInfos Clustering columns in physical names.
+   */
+  private def getClusteringColumnsNotInStatsSchema(
+      statsCollection: StatisticsCollection,
+      clusteringColumnInfos: Seq[ClusteringColumnInfo]): Seq[String] = {
+    clusteringColumnInfos.flatMap { info =>
+      val path = DeltaStatistics.MIN +: info.physicalName
+      SchemaUtils.findNestedFieldIgnoreCase(statsCollection.statsSchema, path) match {
+        // Validate that the column exists in the stats schema and is not a struct
+        // in the stats schema (to catch CLUSTER BY an entire struct).
+        case None | Some(StructField(_, _: StructType, _, _)) =>
+          Some(info.logicalName)
+        case _ => None
+      }
+    }
+  }
 }
 
 object ClusteredTableUtils extends ClusteredTableUtilsBase

--- a/spark/src/main/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteringColumn.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteringColumn.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.skipping.clustering
+
+import org.apache.spark.sql.delta.{DeltaColumnMapping, Snapshot}
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.schema.SchemaUtils
+
+import org.apache.spark.sql.connector.expressions.FieldReference
+import org.apache.spark.sql.types.{DataType, StructType}
+
+/**
+ * A wrapper class that stores a clustering column's physical name parts.
+ */
+case class ClusteringColumn(physicalName: Seq[String])
+
+object ClusteringColumn {
+  /**
+   * Note: `logicalName` must be validated to exist in the given `schema`.
+   */
+  def apply(schema: StructType, logicalName: String): ClusteringColumn = {
+    val resolver = SchemaUtils.DELTA_COL_RESOLVER
+    // Note that we use AttributeNameParser instead of CatalystSqlParser to account for the case
+    // where the column name is a backquoted string with spaces.
+    val logicalNameParts = FieldReference(logicalName).fieldNames
+    val physicalNameParts = logicalNameParts.foldLeft[(DataType, Seq[String])]((schema, Nil)) {
+      (partial, namePart) =>
+        val (currStructType, currPhysicalNameSeq) = partial
+        val field =
+          currStructType.asInstanceOf[StructType].find(field => resolver(field.name, namePart)).get
+        (field.dataType, currPhysicalNameSeq :+ DeltaColumnMapping.getPhysicalName(field))
+    }._2
+    ClusteringColumn(physicalNameParts)
+  }
+}
+
+/**
+ * A wrapper class that stores a clustering column's physical name parts and data type.
+ */
+case class ClusteringColumnInfo(
+    physicalName: Seq[String], dataType: DataType, schema: StructType) {
+  lazy val logicalName: String = {
+    val reversePhysicalNameParts = physicalName.reverse
+    val resolver = SchemaUtils.DELTA_COL_RESOLVER
+    val logicalNameParts =
+      reversePhysicalNameParts
+        .foldRight[(Seq[String], DataType)]((Nil, schema)) {
+          (namePart, state) =>
+            val (logicalNameParts, parentRawDataType) = state
+            val parentDataType = parentRawDataType.asInstanceOf[StructType]
+            val nextField =
+              parentDataType
+                .find(field => resolver(DeltaColumnMapping.getPhysicalName(field), namePart))
+                .get
+            (nextField.name +: logicalNameParts, nextField.dataType)
+        }._1.reverse
+    FieldReference(logicalNameParts).toString
+  }
+}
+
+object ClusteringColumnInfo extends DeltaLogging {
+  def apply(schema: StructType, clusteringColumn: ClusteringColumn): ClusteringColumnInfo =
+    apply(schema, clusteringColumn.physicalName)
+
+  def apply(schema: StructType, physicalName: Seq[String]): ClusteringColumnInfo = {
+    val resolver = SchemaUtils.DELTA_COL_RESOLVER
+    val dataType = physicalName.foldLeft[DataType](schema) {
+      (currStructType, namePart) =>
+        currStructType.asInstanceOf[StructType].find { field =>
+          resolver(DeltaColumnMapping.getPhysicalName(field), namePart)
+        }.get.dataType
+    }
+    ClusteringColumnInfo(physicalName, dataType, schema)
+  }
+
+  def extractLogicalNames(snapshot: Snapshot): Seq[String] = {
+    ClusteredTableUtils.getClusteringColumnsOptional(snapshot).map { clusteringColumns =>
+      clusteringColumns.map(ClusteringColumnInfo(snapshot.schema, _).logicalName)
+    }.getOrElse(Seq.empty)
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/skipping/clustering/temp/ClusterBySpec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/skipping/clustering/temp/ClusterBySpec.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.delta.skipping.clustering.temp
 
 import scala.reflect.ClassTag
 
+import org.apache.spark.sql.delta.skipping.clustering.ClusteredTableUtils
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
 import com.fasterxml.jackson.module.scala.{ClassTagExtensions, DefaultScalaModule}
@@ -60,6 +61,10 @@ object ClusterBySpec {
   // Convert from table property back to ClusterBySpec.
   def fromProperty(columns: String): ClusterBySpec = {
     ClusterBySpec(mapper.readValue[Seq[Seq[String]]](columns).map(FieldReference(_)))
+  }
+
+  def toProperty(clusterBySpec: ClusterBySpec): (String, String) = {
+    ClusteredTableUtils.PROP_CLUSTERING_COLUMNS -> clusterBySpec.toJson
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1417,12 +1417,24 @@ trait DeltaSQLConfBase {
   // Clustered Table
   //////////////////
 
-  val DELTA_ENABLE_CLUSTERING_TABLE_FEATURE =
-    buildConf("clusteringTable.enableClusteringTableFeature")
+  val DELTA_CLUSTERING_TABLE_PREVIEW_ENABLED =
+    buildConf("clusteredTable.enableClusteringTablePreview")
       .internal()
-      .doc("If true, enable ClusteringTableFeature when the table is a clustered table.")
-    .booleanConf
-    .createWithDefault(false)
+      .doc("Whether to enable the clustering table preview.")
+      .booleanConf
+      .createWithDefault(false)
+
+  val DELTA_NUM_CLUSTERING_COLUMNS_LIMIT =
+    buildStaticConf("clusteredTable.numClusteringColumnsLimit")
+      .internal()
+      .doc("""The maximum number of clustering columns allowed for a clustered table.
+        """.stripMargin)
+      .intConf
+      .checkValue(
+        _ > 0,
+        "'clusteredTable.numClusteringColumnsLimit' must be positive."
+      )
+    .createWithDefault(4)
 }
 
 object DeltaSQLConf extends DeltaSQLConfBase

--- a/spark/src/test/scala/org/apache/spark/sql/delta/clustering/ClusteringMetadataDomainSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/clustering/ClusteringMetadataDomainSuite.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.clustering
+
+import org.apache.spark.sql.delta.skipping.clustering.ClusteringColumn
+
+import org.apache.spark.SparkFunSuite
+
+class ClusteringMetadataDomainSuite extends SparkFunSuite {
+  test("serialized string follows the spec") {
+    val clusteringColumns = Seq(ClusteringColumn(Seq("col1", "`col2,col3`", "`col4.col5`,col6")))
+    val clusteringMetadataDomain = ClusteringMetadataDomain.fromClusteringColumns(clusteringColumns)
+    val serializedString = clusteringMetadataDomain.toDomainMetadata.json
+    assert(serializedString ===
+      """|{"domainMetadata":{"domain":"delta.clustering","configuration":
+         |"{\"clusteringColumns\":[[\"col1\",\"`col2,col3`\",\"`col4.col5`,col6\"]],
+         |\"domainName\":\"delta.clustering\"}","removed":false}}""".stripMargin.replace("\n", ""))
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/skipping/ClusteredTableTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/skipping/ClusteredTableTestUtils.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.skipping
+
+import org.apache.spark.sql.delta.skipping.clustering.{ClusteredTableUtils, ClusteringColumn}
+import org.apache.spark.sql.delta.{DeltaLog, Snapshot}
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.util.Utils
+
+trait ClusteredTableTestUtilsBase extends SparkFunSuite with SharedSparkSession {
+  def verifyClusteringColumnsInDomainMetadata(
+      snapshot: Snapshot,
+      expectedLogicalClusteringColumns: String): Unit = {
+    val logicalColumnNames = if (expectedLogicalClusteringColumns.trim.isEmpty) {
+      Seq.empty[String]
+    } else {
+      expectedLogicalClusteringColumns.split(",").map(_.trim).toSeq
+    }
+    val expectedClusteringColumns = logicalColumnNames.map(ClusteringColumn(snapshot.schema, _))
+    val actualClusteringColumns =
+      ClusteredTableUtils.getClusteringColumnsOptional(snapshot).getOrElse(Seq.empty)
+    assert(expectedClusteringColumns == actualClusteringColumns)
+  }
+
+  def withClusteredTable[T](
+      table: String,
+      schema: String,
+      clusterBy: String,
+      tableProperties: Map[String, String] = Map.empty,
+      location: Option[String] = None)(f: => T): T = {
+    createOrReplaceClusteredTable("CREATE", table, schema, clusterBy, tableProperties, location)
+
+    Utils.tryWithSafeFinally(f) {
+      spark.sql(s"DROP TABLE IF EXISTS $table")
+    }
+  }
+
+  /**
+   * Helper for creating or replacing table with different APIs.
+   * @param clause clause for SQL API ('CREATE', 'REPLACE', 'CREATE OR REPLACE')
+   * @param table the name of table
+   * @param schema comma separated list of "colName dataType"
+   * @param clusterBy comma separated list of clustering columns
+   */
+  def createOrReplaceClusteredTable(
+      clause: String,
+      table: String,
+      schema: String,
+      clusterBy: String,
+      tableProperties: Map[String, String] = Map.empty,
+      location: Option[String] = None): Unit = {
+    val locationClause = if (location.isEmpty) "" else s"LOCATION '${location.get}'"
+    val tablePropertiesClause = if (!tableProperties.isEmpty) {
+      val tablePropertiesString = tableProperties.map {
+        case (key, value) => s"'$key' = '$value'"
+      }.mkString(",")
+      s"TBLPROPERTIES($tablePropertiesString)"
+    } else {
+      ""
+    }
+    spark.sql(s"$clause TABLE $table ($schema) USING delta CLUSTER BY ($clusterBy) " +
+      s"$tablePropertiesClause $locationClause")
+  }
+
+  protected def createOrReplaceAsSelectClusteredTable(
+      clause: String,
+      table: String,
+      srcTable: String,
+      clusterBy: String,
+      location: Option[String] = None): Unit = {
+    val locationClause = if (location.isEmpty) "" else s"LOCATION '${location.get}'"
+    spark.sql(s"$clause TABLE $table USING delta CLUSTER BY ($clusterBy) " +
+      s"$locationClause AS SELECT * FROM $srcTable")
+  }
+
+  def verifyClusteringColumns(
+      tableIdentifier: TableIdentifier,
+      expectedLogicalClusteringColumns: String
+    ): Unit = {
+    val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, tableIdentifier)
+    verifyClusteringColumnsInternal(
+      snapshot,
+      tableIdentifier.table,
+      expectedLogicalClusteringColumns
+    )
+  }
+
+  def verifyClusteringColumns(
+      dataPath: String,
+      expectedLogicalClusteringColumns: String
+    ): Unit = {
+    val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, dataPath)
+    verifyClusteringColumnsInternal(
+      snapshot,
+      s"delta.`$dataPath`",
+      expectedLogicalClusteringColumns
+    )
+  }
+
+  def verifyClusteringColumnsInternal(
+      snapshot: Snapshot,
+      tableNameOrPath: String,
+      expectedLogicalClusteringColumns: String
+    ): Unit = {
+    assert(ClusteredTableUtils.isSupported(snapshot.protocol) === true)
+    verifyClusteringColumnsInDomainMetadata(snapshot, expectedLogicalClusteringColumns)
+  }
+}
+
+trait ClusteredTableTestUtils extends ClusteredTableTestUtilsBase

--- a/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
@@ -1,0 +1,588 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.skipping.clustering
+
+import java.io.File
+
+import org.apache.spark.sql.delta.skipping.ClusteredTableTestUtils
+import org.apache.spark.sql.delta.{DeltaAnalysisException, DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode, DeltaConfigs, DeltaLog}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.stats.SkippingEligibleDataType
+import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest}
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{ArrayType, IntegerType, StructField, StructType}
+
+trait ClusteredTableCreateOrReplaceDDLSuiteBase
+  extends QueryTest with SharedSparkSession with ClusteredTableTestUtils {
+
+  protected val testTable: String = "test_ddl_table"
+  protected val sourceTable: String = "test_ddl_source"
+  protected val targetTable: String = "test_ddl_target"
+
+  protected def isPathBased: Boolean = false
+
+  protected def supportedClauses: Seq[String]
+
+  testCtasRtasHelper(supportedClauses)
+  testClusteringColumnsPartOfStatsColumn(supportedClauses)
+  testColTypeValidation("CREATE")
+
+  def testCtasRtasHelper(clauses: Seq[String]): Unit = {
+    Seq(
+      ("",
+        "a INT, b STRING, ts TIMESTAMP",
+        "a, b"),
+      (" multipart name",
+        "a STRUCT<b INT, c STRING>, ts TIMESTAMP",
+        "a.b, ts")
+    ).foreach { case (testSuffix, columns, clusteringColumns) =>
+      test(s"create/replace table$testSuffix") {
+        withTable(testTable) {
+          clauses.foreach { clause =>
+            createOrReplaceClusteredTable(clause, testTable, columns, clusteringColumns)
+            verifyClusteringColumns(TableIdentifier(testTable), clusteringColumns)
+          }
+        }
+      }
+
+      test(s"ctas/rtas$testSuffix") {
+        withTable(sourceTable, targetTable) {
+          sql(s"CREATE TABLE $sourceTable($columns) USING delta")
+          withTempDirIfNecessary { location =>
+            clauses.foreach { clause =>
+              createOrReplaceAsSelectClusteredTable(
+                clause, targetTable, sourceTable, clusteringColumns, location = location)
+              verifyClusteringColumns(targetTable, clusteringColumns, location)
+            }
+          }
+        }
+      }
+
+      if (clauses.contains("REPLACE")) {
+        test(s"Replace from non clustered table$testSuffix") {
+          withTable(targetTable) {
+            sql(s"CREATE TABLE $targetTable($columns) USING delta")
+            createOrReplaceClusteredTable("REPLACE", targetTable, columns, clusteringColumns)
+            verifyClusteringColumns(TableIdentifier(targetTable), clusteringColumns)
+          }
+        }
+      }
+    }
+  }
+
+  protected def createTableWithStatsColumns(
+      clause: String,
+      table: String,
+      clusterColumns: Seq[String],
+      numIndexedColumns: Int,
+      tableSchema: Option[String],
+      statsColumns: Seq[String] = Seq.empty,
+      location: Option[String] = None): Unit = {
+    val clusterSpec = clusterColumns.mkString(",")
+    val updatedTableProperties =
+      collection.mutable.Map("delta.dataSkippingNumIndexedCols" -> s"$numIndexedColumns")
+    if (statsColumns.nonEmpty) {
+      updatedTableProperties(DeltaConfigs.DATA_SKIPPING_STATS_COLUMNS.key) =
+        statsColumns.mkString(",")
+    }
+    val tablePropertiesString = updatedTableProperties.map {
+      case (key, value) => s"'$key' = '$value'"
+    }.mkString(",")
+    val locationClause = if (location.isEmpty) "" else s"LOCATION '${location.get}'"
+    if (clause == "REPLACE") {
+      // Create the default before it can be replaced.
+      sql(s"CREATE TABLE IF NOT EXISTS $table USING DELTA $locationClause")
+    }
+    if (tableSchema.isEmpty) {
+      sql(
+        s"""
+           |$clause TABLE $table USING DELTA CLUSTER BY ($clusterSpec)
+           |TBLPROPERTIES($tablePropertiesString)
+           |$locationClause
+           |AS SELECT * FROM $sourceTable
+           |""".stripMargin)
+    } else {
+      createOrReplaceClusteredTable(
+        clause, table, tableSchema.get, clusterSpec, updatedTableProperties.toMap, location)
+    }
+  }
+
+  protected def testStatsCollectionHelper(
+      tableSchema: String,
+      numberOfIndexedCols: Int)(cb: => Unit): Unit = {
+    withTable(sourceTable) {
+      // Create a source table for CTAS.
+      sql(
+        s"""
+           | CREATE TABLE $sourceTable($tableSchema) USING DELTA
+           | TBLPROPERTIES('delta.dataSkippingNumIndexedCols' = '$numberOfIndexedCols')
+           |""".stripMargin)
+      // Run additional steps.
+      cb
+    }
+  }
+
+  protected def testColTypeValidation(clause: String): Unit = {
+    test(s"validate column datatype checking on $clause table") {
+      withTable("srcTbl", "dstTbl") {
+        // Create reference table for CTAS/RTAS.
+        sql(s"CREATE table srcTbl (a STRUCT<b INT, c INT>, d BOOLEAN, e MAP<INT, INT>) USING delta")
+
+        val data = (0 to 1000).map(i => Row(Row(i + 1, i * 10), i % 2 == 0, Map(i -> i)))
+        val schema = StructType(List(
+          StructField("a", StructType(
+            Array(
+              StructField("b", IntegerType),
+              StructField("c", IntegerType)
+            )
+          ))))
+        spark.createDataFrame(spark.sparkContext.parallelize(data), StructType(schema))
+          .write.mode("append").format("delta").saveAsTable("srcTbl")
+
+        val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, new TableIdentifier("srcTbl"))
+        val schemaStr = snapshot.statCollectionLogicalSchema.treeString
+        // Test multiple data types.
+        Seq("a", "d", "e").foreach { colName =>
+          withTempDir { tmpDir =>
+            // Since validation happens both on create and replace, validate for both cases to
+            // ensure that datatype validation behaves consistently between the two.
+            if (clause == "REPLACE") {
+              sql("DROP TABLE IF EXISTS dstTbl")
+              sql(s"CREATE TABLE dstTbl LIKE srcTbl LOCATION '${tmpDir.getAbsolutePath}'")
+            }
+
+            Seq(
+              // Scenario 1: Standard CREATE/REPLACE TABLE.
+              () => {
+                val schema = "a STRUCT<b INT, c INT>, d BOOLEAN, e MAP<INT, INT>"
+                createOrReplaceClusteredTable(
+                  clause, "dstTbl", schema, colName, location = Some(tmpDir.getAbsolutePath))
+              },
+              // Scenario 2: CTAS/RTAS.
+              () =>
+                createOrReplaceAsSelectClusteredTable(
+                clause, "dstTbl", "srcTbl", colName, location = Some(tmpDir.getAbsolutePath)))
+              .foreach { f =>
+                val e = intercept[DeltaAnalysisException] {
+                  f()
+                }
+                checkError(
+                  e,
+                  "DELTA_CLUSTERING_COLUMN_MISSING_STATS"
+                )
+              }
+          }
+        }
+      }
+    }
+  }
+
+  test("cluster by with more than 4 columns - create table") {
+    val testTable = "test_table"
+    withTable(testTable) {
+      val e = intercept[DeltaAnalysisException] {
+        createOrReplaceClusteredTable(
+          "CREATE", testTable, "a INT, b INT, c INT, d INT, e INT", "a, b, c, d, e")
+      }
+      checkError(
+        e,
+        errorClass = "DELTA_CLUSTER_BY_INVALID_NUM_COLUMNS"
+      )
+    }
+  }
+
+  test("cluster by with more than 4 columns - ctas") {
+    val testTable = "test_table"
+    val schema = "a INT, b INT, c INT, d INT, e INT"
+    withTempDirIfNecessary { location =>
+      withTable(sourceTable, testTable) {
+        sql(s"CREATE TABLE $sourceTable($schema) USING delta")
+        val e = intercept[DeltaAnalysisException] {
+          createOrReplaceAsSelectClusteredTable(
+            "CREATE", testTable, sourceTable, "a, b, c, d, e", location = location)
+        }
+        checkError(
+          e,
+          errorClass = "DELTA_CLUSTER_BY_INVALID_NUM_COLUMNS"
+        )
+      }
+    }
+  }
+
+  protected def verifyPartitionColumns(
+      tableIdentifier: TableIdentifier,
+      expectedPartitionColumns: Seq[String]): Unit = {
+    val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, tableIdentifier)
+    assert(snapshot.metadata.partitionColumns === expectedPartitionColumns)
+  }
+
+  protected def verifyClusteringColumns(
+      table: String,
+      expectedLogicalClusteringColumns: String,
+      locationOpt: Option[String]): Unit = {
+    locationOpt.map { location =>
+      verifyClusteringColumns(
+        location, expectedLogicalClusteringColumns
+      )
+    }.getOrElse {
+      verifyClusteringColumns(TableIdentifier(table), expectedLogicalClusteringColumns)
+    }
+  }
+
+  def testClusteringColumnsPartOfStatsColumn(clauses: Seq[String]): Unit = {
+    clauses.foreach { clause =>
+      val mode = if (clause == "CREATE") "create table" else "replace table"
+      test(s"Validate clustering columns part of stats columns - $mode") {
+        val tableSchema = "col0 int, col1 STRUCT<col11: int, col12: string>, col2 int"
+        val indexedColumns = 2
+        testStatsCollectionHelper(
+          tableSchema = tableSchema,
+          numberOfIndexedCols = indexedColumns) {
+          withTable(targetTable) {
+            val deltaLogSrc = DeltaLog.forTable(spark, TableIdentifier(sourceTable))
+            // Validate the 3rd column `col1.col12` and 4th column `col2` can not be
+            // clustering columns.
+            val e = intercept[DeltaAnalysisException](
+              createTableWithStatsColumns(
+                clause,
+                targetTable,
+                "col0" :: "col1.col11" :: "col1.col12" :: "col2" :: Nil,
+                indexedColumns,
+                Some(tableSchema)))
+            checkError(
+              e,
+              "DELTA_CLUSTERING_COLUMN_MISSING_STATS"
+            )
+            // Validate the first two columns can be clustering columns.
+            createTableWithStatsColumns(
+              clause,
+              targetTable,
+              "col0" :: "col1.col11" :: Nil,
+              indexedColumns,
+              Some(tableSchema))
+          }
+        }
+      }
+    }
+
+    clauses.foreach { clause =>
+      val mode = if (clause == "CREATE") "ctas" else "rtas"
+      test(s"Validate clustering columns part of stats columns - $mode") {
+        // Add a suffix for the target table name to work around the issue that delta table's
+        // location isn't removed by the DROP TABLE from ctas/rtas test cases.
+        val table = targetTable + "_" + clause
+
+        val tableSchema = "col0 int, col1 STRUCT<col11: int, col12: string>, col2 int"
+        val indexedColumns = 2
+        testStatsCollectionHelper(
+          tableSchema = tableSchema,
+          numberOfIndexedCols = indexedColumns) {
+          withTable(table) {
+            withTempDir { dir =>
+              val deltaLogSrc = DeltaLog.forTable(spark, TableIdentifier(sourceTable))
+              val targetLog = DeltaLog.forTable(spark, s"${dir.getPath}")
+              val dataPath = new File(targetLog.dataPath.toString.replace("file:", ""))
+              val initialNumFiles =
+                if (dataPath.listFiles() != null) { // Returns null if directory doesn't exist -> 0
+                  dataPath.listFiles().size
+                }
+                else {
+                  0
+                }
+              // Validate the 3rd column `col1.col12` and 4th column `col2` can not be
+              // clustering columns.
+              val e = intercept[DeltaAnalysisException](
+                createTableWithStatsColumns(
+                  clause,
+                  table,
+                  "col0" :: "col1.col11" :: "col1.col12" :: "col2" :: Nil,
+                  indexedColumns,
+                  None,
+                  location = Some(dir.getPath)))
+              checkError(
+                e,
+                "DELTA_CLUSTERING_COLUMN_MISSING_STATS"
+              )
+
+              // Validate the first two columns can be clustering columns.
+              createTableWithStatsColumns(
+                clause,
+                table,
+                "col0" :: "col1.col11" :: Nil,
+                indexedColumns,
+                None)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  test("Validate clustering columns cannot be non-eligible data types") {
+    val indexedColumns = 3
+    // Validate non-eligible column stat data type.
+    val nonEligibleType = ArrayType(IntegerType)
+    assert(!SkippingEligibleDataType(nonEligibleType))
+    val nonEligibleTableSchema = s"col0 int, col1 STRUCT<col11: array<int>, col12: string>"
+    testStatsCollectionHelper(
+      tableSchema = nonEligibleTableSchema,
+      numberOfIndexedCols = indexedColumns) {
+      withTable(targetTable) {
+        val deltaLogSrc = DeltaLog.forTable(spark, TableIdentifier(sourceTable))
+        // Validate the 2nd column `col1.col11` cannot be clustering column.
+        val e = intercept[DeltaAnalysisException](
+          createTableWithStatsColumns(
+            "CREATE",
+            targetTable,
+            "col0" :: "col1.col11" :: Nil,
+            indexedColumns,
+            Some(nonEligibleTableSchema)))
+        checkError(
+          e,
+          "DELTA_CLUSTERING_COLUMN_MISSING_STATS"
+        )
+      }
+    }
+  }
+
+  protected def withTempDirIfNecessary(f: Option[String] => Unit): Unit = {
+    if (isPathBased) {
+      withTempDir { dir =>
+        f(Some(dir.getAbsolutePath))
+      }
+    } else {
+      f(None)
+    }
+  }
+}
+
+trait ClusteredTableDDLWithColumnMapping
+  extends ClusteredTableCreateOrReplaceDDLSuite
+    with DeltaColumnMappingSelectedTestMixin {
+
+  override protected def runOnlyTests: Seq[String] = Seq(
+    "validate dropping clustering column is not allowed: single clustering column",
+    "validate dropping clustering column is not allowed: multiple clustering columns",
+    "validate dropping clustering column is not allowed: clustering column + " +
+      "non-clustering column"
+  )
+
+  test("validate dropping clustering column is not allowed: single clustering column") {
+    withClusteredTable(testTable, "col1 INT, col2 STRING, col3 LONG", "col1") {
+      val e = intercept[DeltaAnalysisException] {
+        sql(s"ALTER TABLE $testTable DROP COLUMNS (col1)")
+      }
+      checkError(
+        e,
+        "DELTA_UNSUPPORTED_DROP_CLUSTERING_COLUMN"
+      )
+      // Drop non-clustering columns are allowed.
+      sql(s"ALTER TABLE $testTable DROP COLUMNS (col2)")
+    }
+  }
+
+  test("validate dropping clustering column is not allowed: multiple clustering columns") {
+    withClusteredTable(testTable, "col1 INT, col2 STRING, col3 LONG", "col1, col2") {
+      val e = intercept[DeltaAnalysisException] {
+        sql(s"ALTER TABLE $testTable DROP COLUMNS (col1, col2)")
+      }
+      checkError(
+        e,
+        "DELTA_UNSUPPORTED_DROP_CLUSTERING_COLUMN"
+      )
+    }
+  }
+
+  test("validate dropping clustering column is not allowed: clustering column + " +
+    "non-clustering column") {
+    withClusteredTable(testTable, "col1 INT, col2 STRING, col3 LONG", "col1, col2") {
+      val e = intercept[DeltaAnalysisException] {
+        sql(s"ALTER TABLE $testTable DROP COLUMNS (col1, col3)")
+      }
+      checkError(
+        e,
+        "DELTA_UNSUPPORTED_DROP_CLUSTERING_COLUMN"
+      )
+    }
+  }
+}
+
+trait ClusteredTableDDLWithColumnMappingV2Base extends ClusteredTableDDLWithColumnMapping
+
+trait ClusteredTableDDLWithColumnMappingV2
+  extends ClusteredTableDDLWithColumnMappingV2Base
+
+trait ClusteredTableCreateOrReplaceDDLSuite
+  extends ClusteredTableCreateOrReplaceDDLSuiteBase
+
+trait ClusteredTableDDLSuiteBase
+  extends ClusteredTableCreateOrReplaceDDLSuite
+    with DeltaSQLCommandTest
+
+trait ClusteredTableDDLSuite extends ClusteredTableDDLSuiteBase
+trait ClusteredTableDDLWithNameColumnMapping
+  extends ClusteredTableCreateOrReplaceDDLSuite with DeltaColumnMappingEnableNameMode
+
+trait ClusteredTableDDLWithIdColumnMapping
+  extends ClusteredTableCreateOrReplaceDDLSuite with DeltaColumnMappingEnableIdMode
+
+trait ClusteredTableDDLWithV2Base
+  extends ClusteredTableCreateOrReplaceDDLSuite
+    with SharedSparkSession {
+  override protected def supportedClauses: Seq[String] = Seq("CREATE", "REPLACE")
+
+  testColTypeValidation("REPLACE")
+
+  test("replace with different clustering columns") {
+    withTable(sourceTable) {
+      sql(s"CREATE TABLE $sourceTable(i int, s string) USING delta")
+      // Validate REPLACE TABLE (AS SELECT).
+      Seq("REPLACE", "CREATE OR REPLACE").foreach { clause =>
+        Seq(true, false).foreach { isRTAS =>
+          withTempDirIfNecessary { location =>
+            withClusteredTable(testTable, "a int", "a", location = location) {
+              if (isRTAS) {
+                createOrReplaceAsSelectClusteredTable(
+                  clause, testTable, sourceTable, "i", location = location)
+              } else {
+                createOrReplaceClusteredTable(
+                  clause, testTable, "i int, b string", "i", location = location)
+              }
+              verifyClusteringColumns(testTable, "i", location)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  test("Validate replacing clustered tables with partitioned tables is not allowed") {
+    withTable(sourceTable) {
+      sql(s"CREATE TABLE $sourceTable(i int, s string) USING delta")
+
+      // Validate REPLACE TABLE (AS SELECT).
+      Seq("REPLACE", "CREATE OR REPLACE").foreach { clause =>
+        withClusteredTable(testTable, "a int", "a") {
+          verifyClusteringColumns(TableIdentifier(testTable), "a")
+
+          Seq(true, false).foreach { isRTAS =>
+            val e = intercept[DeltaAnalysisException] {
+              if (isRTAS) {
+                sql(s"$clause TABLE $testTable USING delta PARTITIONED BY (i) " +
+                  s"AS SELECT * FROM $sourceTable")
+              } else {
+                sql(s"$clause TABLE $testTable (i int, b string) USING delta PARTITIONED BY (i)")
+              }
+            }
+            checkError(
+              e,
+              "DELTA_CLUSTERING_REPLACE_TABLE_WITH_PARTITIONED_TABLE"
+            )
+          }
+        }
+      }
+    }
+  }
+
+  test("Validate replacing partitioned tables with clustered tables is allowed") {
+    withTable(sourceTable) {
+      sql(s"CREATE TABLE $sourceTable(i int, s string) USING delta")
+
+      // Validate REPLACE TABLE (AS SELECT).
+      Seq("REPLACE", "CREATE OR REPLACE").foreach { clause =>
+        Seq(true, false).foreach { isRTAS =>
+          withTable(testTable) {
+            withTempDirIfNecessary { location =>
+              val locationClause = if (location.isEmpty) "" else s"LOCATION '${location.get}'"
+              sql(s"CREATE TABLE $testTable USING delta PARTITIONED BY (i) $locationClause" +
+                s" SELECT 1 i, 'a' s")
+              verifyPartitionColumns(TableIdentifier(testTable), Seq("i"))
+              if (isRTAS) {
+                createOrReplaceAsSelectClusteredTable(
+                  clause, testTable, sourceTable, "i", location = location)
+              } else {
+                createOrReplaceClusteredTable(
+                  clause, testTable, "i int, b string", "i", location = location)
+              }
+              verifyClusteringColumns(testTable, "i", location)
+              verifyPartitionColumns(TableIdentifier(testTable), Seq())
+            }
+          }
+        }
+      }
+    }
+  }
+
+  Seq(
+    ("",
+      "a INT, b STRING, ts TIMESTAMP",
+      "a, b"),
+    (" multipart name",
+      "a STRUCT<b INT, c STRING>, ts TIMESTAMP",
+      "a.b, ts")
+  ).foreach { case (testSuffix, columns, clusteringColumns) =>
+    test(s"create/replace table createOrReplace$testSuffix") {
+      withTable(testTable) {
+        // Repeat two times to test both create and replace cases.
+        (1 to 2).foreach { _ =>
+          createOrReplaceClusteredTable("CREATE OR REPLACE", testTable, columns, clusteringColumns)
+          verifyClusteringColumns(TableIdentifier(testTable), clusteringColumns)
+        }
+      }
+    }
+
+    test(s"ctas/rtas createOrReplace$testSuffix") {
+      withTable(sourceTable, targetTable) {
+        sql(s"CREATE TABLE $sourceTable($columns) USING delta")
+        withTempDirIfNecessary { location =>
+          // Repeat two times to test both create and replace cases.
+          (1 to 2).foreach { _ =>
+            createOrReplaceAsSelectClusteredTable(
+              "CREATE OR REPLACE", targetTable, sourceTable, clusteringColumns, location = location)
+            verifyClusteringColumns(targetTable, clusteringColumns, location)
+          }
+        }
+      }
+    }
+  }
+}
+
+trait ClusteredTableDDLWithV2
+  extends ClusteredTableDDLWithV2Base
+
+trait ClusteredTableDDLDataSourceV2SuiteBase
+  extends ClusteredTableDDLWithV2
+    with ClusteredTableDDLSuite
+
+class ClusteredTableDDLDataSourceV2Suite
+  extends ClusteredTableDDLDataSourceV2SuiteBase
+
+class ClusteredTableDDLDataSourceV2IdColumnMappingSuite
+  extends ClusteredTableDDLWithIdColumnMapping
+    with ClusteredTableDDLWithV2
+    with ClusteredTableDDLWithColumnMappingV2
+    with ClusteredTableDDLSuite
+
+class ClusteredTableDDLDataSourceV2NameColumnMappingSuite
+  extends ClusteredTableDDLWithNameColumnMapping
+    with ClusteredTableDDLWithV2
+    with ClusteredTableDDLWithColumnMappingV2
+    with ClusteredTableDDLSuite


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Resolves https://github.com/delta-io/delta/issues/2447

According to the [protocol](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#writer-requirements-for-clustered-table), store the CLUSTER BY columns as DomainMetadata. This completes the table creation path for clustered tables.

Summary:
* Introduce a new DomainMetadata called `ClusteringMetadataDomain` that tracks clustering columns
* Extract the clustering columns passed down from the transform array and perform validations:
  * clustering column should have stats collected
  * number of clustering columns should not be greater than 4 (controlled by a config)
  * appending to a clustered table should have matching clustering columns
  * disallow replacing a clustered table with partitioned table
  * disallow dropping clustering columns
* Introduce a `ClusteringColumn` to hold physical names in order to support Column Mapping

Since clustered table support is still in preview, introduce a config to by default throw an exception when creating or writing to a clustered table.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Introduced DDL tests, and DDL tests with Id/Name column mapping enabled.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No