### PR TITLE
[#2441][Spark] Add Deletion Vectors Metrics in Merge 

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -250,6 +250,10 @@ object DeltaOperations {
         strMetrics += "numOutputRows" -> actualNumOutputRows.toString
       }
 
+      val dvMetrics = transformDeletionVectorMetrics(
+        metrics, dvMetrics = DeltaOperationMetrics.MERGE_DELETION_VECTORS)
+      strMetrics ++= dvMetrics
+
       strMetrics
     }
 
@@ -715,6 +719,16 @@ private[delta] object DeltaOperationMetrics {
       SumMetrics("numDeletionVectorsRemoved", "numDeletionVectorsUpdated")
   )
 
+  // The same as [[DELETION_VECTORS]] but with the "Target" prefix that is used by MERGE.
+  val MERGE_DELETION_VECTORS = Map(
+    // Adding "numDeletionVectorsUpdated" here makes the values line up with how
+    // "numFilesAdded"/"numFilesRemoved" behave.
+    "numTargetDeletionVectorsAdded" ->
+      SumMetrics("numTargetDeletionVectorsAdded", "numTargetDeletionVectorsUpdated"),
+    "numTargetDeletionVectorsRemoved" ->
+      SumMetrics("numTargetDeletionVectorsRemoved", "numTargetDeletionVectorsUpdated")
+  )
+
   val TRUNCATE = Set(
     "numRemovedFiles", // number of files removed
     "executionTimeMs" // time taken to execute the entire operation
@@ -744,7 +758,10 @@ private[delta] object DeltaOperationMetrics {
     "numTargetChangeFilesAdded", // number of CDC files
     "executionTimeMs",  // time taken to execute the entire operation
     "scanTimeMs", // time taken to scan the files for matches
-    "rewriteTimeMs" // time taken to rewrite the matched files
+    "rewriteTimeMs", // time taken to rewrite the matched files
+    "numTargetDeletionVectorsAdded", // number of deletion vectors added
+    "numTargetDeletionVectorsRemoved", // number of deletion vectors removed
+    "numTargetDeletionVectorsUpdated" // number of deletion vectors updated
   )
 
   val UPDATE = Set(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
@@ -180,7 +180,10 @@ trait MergeIntoCommandBase extends LeafRunnableCommand
     "scanTimeMs" ->
       createTimingMetric(sc, "time taken to scan the files for matches"),
     "rewriteTimeMs" ->
-      createTimingMetric(sc, "time taken to rewrite the matched files")
+      createTimingMetric(sc, "time taken to rewrite the matched files"),
+    "numTargetDeletionVectorsAdded" -> createMetric(sc, "number of deletion vectors added"),
+    "numTargetDeletionVectorsRemoved" -> createMetric(sc, "number of deletion vectors removed"),
+    "numTargetDeletionVectorsUpdated" -> createMetric(sc, "number of deletion vectors updated")
   )
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeStats.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeStats.scala
@@ -105,6 +105,9 @@ case class MergeStats(
     targetRowsDeleted: Long,
     targetRowsMatchedDeleted: Long,
     targetRowsNotMatchedBySourceDeleted: Long,
+    numTargetDeletionVectorsAdded: Long,
+    numTargetDeletionVectorsRemoved: Long,
+    numTargetDeletionVectorsUpdated: Long,
 
     // MergeMaterializeSource stats
     materializeSourceReason: Option[String] = None,
@@ -173,6 +176,11 @@ object MergeStats {
       targetRowsDeleted = metrics("numTargetRowsDeleted").value,
       targetRowsMatchedDeleted = metrics("numTargetRowsMatchedDeleted").value,
       targetRowsNotMatchedBySourceDeleted = metrics("numTargetRowsNotMatchedBySourceDeleted").value,
+
+      // Deletion Vector metrics.
+      numTargetDeletionVectorsAdded = metrics("numTargetDeletionVectorsAdded").value,
+      numTargetDeletionVectorsRemoved = metrics("numTargetDeletionVectorsRemoved").value,
+      numTargetDeletionVectorsUpdated = metrics("numTargetDeletionVectorsUpdated").value,
 
       // Deprecated fields
       updateConditionExpr = null,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
@@ -41,6 +41,7 @@ trait DeletionVectorsTestUtils extends QueryTest with SharedSparkSession {
       update: Boolean = false,
       merge: Boolean = false): Unit = {
     val global = delete || update || merge
+
     spark.conf
       .set(DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.defaultTablePropertyKey, global.toString)
     spark.conf.set(DeltaSQLConf.DELETE_USE_PERSISTENT_DELETION_VECTORS.key, delete.toString)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
@@ -41,7 +41,6 @@ trait DeletionVectorsTestUtils extends QueryTest with SharedSparkSession {
       update: Boolean = false,
       merge: Boolean = false): Unit = {
     val global = delete || update || merge
-
     spark.conf
       .set(DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.defaultTablePropertyKey, global.toString)
     spark.conf.set(DeltaSQLConf.DELETE_USE_PERSISTENT_DELETION_VECTORS.key, delete.toString)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoDVsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoDVsSuite.scala
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+<<<<<<< HEAD
 
+=======
+>>>>>>> c19d70ac (v1)
 package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.delta.cdc.MergeCDCTests

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoDVsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoDVsSuite.scala
@@ -13,10 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-<<<<<<< HEAD
 
-=======
->>>>>>> c19d70ac (v1)
 package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.delta.cdc.MergeCDCTests
@@ -58,7 +55,124 @@ trait MergeIntoDVsTests extends MergeIntoSQLSuite with DeletionVectorsTestUtils 
     "delta.dml.merge")
 }
 
-class MergeIntoDVsSuite extends MergeIntoDVsTests
+class MergeIntoDVsSuite extends MergeIntoDVsTests {
+  import testImplicits._
+
+  def assertOperationalDVMetrics(
+      tablePath: String,
+      numDeletedRows: Long,
+      numUpdatedRows: Long,
+      numCopiedRows: Long,
+      numTargetFilesRemoved: Long,
+      numDeletionVectorsAdded: Long,
+      numDeletionVectorsRemoved: Long,
+      numDeletionVectorsUpdated: Long): Unit = {
+    val table = io.delta.tables.DeltaTable.forPath(tablePath)
+    val mergeMetrics = DeltaMetricsUtils.getLastOperationMetrics(table)
+    assert(mergeMetrics.getOrElse("numTargetRowsDeleted", -1) === numDeletedRows)
+    assert(mergeMetrics.getOrElse("numTargetRowsUpdated", -1) === numUpdatedRows)
+    assert(mergeMetrics.getOrElse("numTargetRowsCopied", -1) === numCopiedRows)
+    assert(mergeMetrics.getOrElse("numTargetFilesRemoved", -1) === numTargetFilesRemoved)
+    assert(mergeMetrics.getOrElse("numTargetDeletionVectorsAdded", -1) === numDeletionVectorsAdded)
+    assert(
+      mergeMetrics.getOrElse("numTargetDeletionVectorsRemoved", -1) === numDeletionVectorsRemoved)
+    assert(
+      mergeMetrics.getOrElse("numTargetDeletionVectorsUpdated", -1) === numDeletionVectorsUpdated)
+  }
+
+  test(s"Merge with DVs metrics - Incremental Updates") {
+    withTempDir { dir =>
+      val sourcePath = s"$dir/source"
+      val targetPath = s"$dir/target"
+
+      spark.range(0, 10, 2).write.format("delta").save(sourcePath)
+      spark.range(10).write.format("delta").save(targetPath)
+
+      executeMerge(
+        tgt = s"delta.`$targetPath` t",
+        src = s"delta.`$sourcePath` s",
+        cond = "t.id = s.id",
+        clauses = updateNotMatched(set = "id = t.id * 10"))
+
+      checkAnswer(readDeltaTable(targetPath), Seq(0, 10, 2, 30, 4, 50, 6, 70, 8, 90).toDF("id"))
+
+      assertOperationalDVMetrics(
+        targetPath,
+        numDeletedRows = 0,
+        numUpdatedRows = 5,
+        numCopiedRows = 0,
+        numTargetFilesRemoved = 0, // No files were fully deleted.
+        numDeletionVectorsAdded = 2,
+        numDeletionVectorsRemoved = 0,
+        numDeletionVectorsUpdated = 0)
+
+      executeMerge(
+        tgt = s"delta.`$targetPath` t",
+        src = s"delta.`$sourcePath` s",
+        cond = "t.id = s.id",
+        clauses = delete(condition = "t.id = 2"))
+
+      checkAnswer(readDeltaTable(targetPath), Seq(0, 10, 30, 4, 50, 6, 70, 8, 90).toDF("id"))
+
+      assertOperationalDVMetrics(
+        targetPath,
+        numDeletedRows = 1,
+        numUpdatedRows = 0,
+        numCopiedRows = 0,
+        numTargetFilesRemoved = 0,
+        numDeletionVectorsAdded = 1, // Updating a DV equals removing and adding.
+        numDeletionVectorsRemoved = 1, // Updating a DV equals removing and adding.
+        numDeletionVectorsUpdated = 1)
+
+      // Delete all rows from a file.
+      executeMerge(
+        tgt = s"delta.`$targetPath` t",
+        src = s"delta.`$sourcePath` s",
+        cond = "t.id = s.id",
+        clauses = delete(condition = "t.id < 5"))
+
+      checkAnswer(readDeltaTable(targetPath), Seq(10, 30, 50, 6, 70, 8, 90).toDF("id"))
+
+      assertOperationalDVMetrics(
+        targetPath,
+        numDeletedRows = 2,
+        numUpdatedRows = 0,
+        numCopiedRows = 0,
+        numTargetFilesRemoved = 1,
+        numDeletionVectorsAdded = 0,
+        numDeletionVectorsRemoved = 1,
+        numDeletionVectorsUpdated = 0)
+    }
+  }
+
+  test(s"Merge with DVs metrics - delete entire file") {
+    withTempDir { dir =>
+      val sourcePath = s"$dir/source"
+      val targetPath = s"$dir/target"
+
+      spark.range(0, 7).write.format("delta").save(sourcePath)
+      spark.range(10).write.format("delta").save(targetPath)
+
+      executeMerge(
+        tgt = s"delta.`$targetPath` t",
+        src = s"delta.`$sourcePath` s",
+        cond = "t.id = s.id",
+        clauses = update(set = "id = t.id * 10"))
+
+      checkAnswer(readDeltaTable(targetPath), Seq(0, 10, 20, 30, 40, 50, 60, 7, 8, 9).toDF("id"))
+
+      assertOperationalDVMetrics(
+        targetPath,
+        numDeletedRows = 0,
+        numUpdatedRows = 7,
+        numCopiedRows = 0, // No rows were copied.
+        numTargetFilesRemoved = 1, // 1 file was removed entirely.
+        numDeletionVectorsAdded = 1, // 1 files was deleted partially.
+        numDeletionVectorsRemoved = 0,
+        numDeletionVectorsUpdated = 0)
+    }
+  }
+}
 
 trait MergeCDCWithDVsTests extends MergeCDCTests with DeletionVectorsTestUtils {
   override def beforeAll(): Unit = {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoDVsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoDVsSuite.scala
@@ -167,7 +167,7 @@ class MergeIntoDVsSuite extends MergeIntoDVsTests {
         numUpdatedRows = 7,
         numCopiedRows = 0, // No rows were copied.
         numTargetFilesRemoved = 1, // 1 file was removed entirely.
-        numDeletionVectorsAdded = 1, // 1 files was deleted partially.
+        numDeletionVectorsAdded = 1, // 1 file was deleted partially.
         numDeletionVectorsRemoved = 0,
         numDeletionVectorsUpdated = 0)
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoMetricsBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoMetricsBase.scala
@@ -1339,11 +1339,20 @@ object MergeIntoMetricsBase extends QueryTest with SharedSparkSession {
   val mergeTimeMetrics = Set("executionTimeMs", "scanTimeMs", "rewriteTimeMs")
   // Metrics related with CDF. Available only when CDF is available.
   val mergeCdfMetrics = Set("numTargetChangeFilesAdded")
+  // DV Metrics.
+  val mergeDVMetrics = Set(
+    "numTargetDeletionVectorsAdded",
+    "numTargetDeletionVectorsUpdated",
+    "numTargetDeletionVectorsRemoved")
 
   // Ensure that all metrics are properly copied here.
   assert(
     DeltaOperationMetrics.MERGE.size ==
-      mergeRowMetrics.size + mergeFileMetrics.size + mergeTimeMetrics.size + mergeCdfMetrics.size
+      mergeRowMetrics.size +
+      mergeFileMetrics.size +
+      mergeTimeMetrics.size +
+      mergeCdfMetrics.size +
+      mergeDVMetrics.size
   )
 
   ///////////////////


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This issue is a follow up of the recent implementation of Deletion Vectors in Merge (https://github.com/delta-io/delta/issues/2296). Merge needs to report deletion vector metrics similarly with UPDATE and DELETE commands.

Resolves #2441.
## How was this patch tested?

Added tests in `MergeIntoDVsSuite`.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Adds deletion vector metrics in Merge.
