### PR TITLE
[Spark] Reorder checks in ConflictChecker

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -135,14 +135,18 @@ private[delta] class ConflictChecker(
    * the transaction as if it had started while reading the `winningCommitVersion`.
    */
   def checkConflicts(): CurrentTransactionInfo = {
-    // Protocol and metadata checks.
+    // Check early the protocol and metadata compatibility that is required for subsequent
+    // file-level checks.
     checkProtocolCompatibility()
     checkNoMetadataUpdates()
     checkIfDomainMetadataConflict()
+
+    // Perform cheap check for transaction dependencies before we start checks files.
     checkForUpdatedApplicationTransactionIdsThatCurrentTxnDependsOn()
 
     // Row Tracking reconciliation. We perform this before the file checks to ensure that
-    // no files have duplicate row IDs.
+    // no files have duplicate row IDs and avoid interacting with files that don't comply with
+    // the protocol.
     reassignOverlappingRowIds()
     reassignRowCommitVersions()
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Reorder checks in Delta Conflict Checker:
- Move the check `checkIfDomainMetadataConflict` and `checkForUpdatedApplicationTransactionIdsThatCurrentTxnDependsOn` earlier to fail the transaction as early as possible.
- Move Row Tracking reconciliation before file-level checks to ensure that files do no have duplicate row IDs.


## How was this patch tested?

Existing tests.

## Does this PR introduce _any_ user-facing changes?

No