### PR TITLE
[Spark] Support List and Map columns in Uniform

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
@@ -32,13 +32,18 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{DataType, Metadata => SparkMetadata, MetadataBuilder, StructField, StructType}
+import org.apache.spark.sql.types.{ArrayType, DataType, MapType, Metadata => SparkMetadata, MetadataBuilder, StructField, StructType}
 
 trait DeltaColumnMappingBase extends DeltaLogging {
   val PARQUET_FIELD_ID_METADATA_KEY = "parquet.field.id"
+  val PARQUET_FIELD_NESTED_IDS_METADATA_KEY = "parquet.field.nested.ids"
   val COLUMN_MAPPING_METADATA_PREFIX = "delta.columnMapping."
   val COLUMN_MAPPING_METADATA_ID_KEY = COLUMN_MAPPING_METADATA_PREFIX + "id"
   val COLUMN_MAPPING_PHYSICAL_NAME_KEY = COLUMN_MAPPING_METADATA_PREFIX + "physicalName"
+  val COLUMN_MAPPING_METADATA_NESTED_IDS_KEY = COLUMN_MAPPING_METADATA_PREFIX + "nested.ids"
+  val PARQUET_LIST_ELEMENT_FIELD_NAME = "element"
+  val PARQUET_MAP_KEY_FIELD_NAME = "key"
+  val PARQUET_MAP_VALUE_FIELD_NAME = "value"
 
   /**
    * This list of internal columns (and only this list) is allowed to have missing
@@ -168,6 +173,12 @@ trait DeltaColumnMappingBase extends DeltaLogging {
   def getColumnId(field: StructField): Int =
     field.metadata.getLong(COLUMN_MAPPING_METADATA_ID_KEY).toInt
 
+  def hasNestedColumnIds(field: StructField): Boolean =
+    field.metadata.contains(COLUMN_MAPPING_METADATA_NESTED_IDS_KEY)
+
+  def getNestedColumnIds(field: StructField): SparkMetadata =
+    field.metadata.getMetadata(COLUMN_MAPPING_METADATA_NESTED_IDS_KEY)
+
   def hasPhysicalName(field: StructField): Boolean =
     field.metadata.contains(COLUMN_MAPPING_PHYSICAL_NAME_KEY)
 
@@ -181,7 +192,9 @@ trait DeltaColumnMappingBase extends DeltaLogging {
         new MetadataBuilder()
           .withMetadata(field.metadata)
           .remove(COLUMN_MAPPING_METADATA_ID_KEY)
+          .remove(COLUMN_MAPPING_METADATA_NESTED_IDS_KEY)
           .remove(PARQUET_FIELD_ID_METADATA_KEY)
+          .remove(PARQUET_FIELD_NESTED_IDS_METADATA_KEY)
           .remove(COLUMN_MAPPING_PHYSICAL_NAME_KEY)
           .build()
 
@@ -195,10 +208,17 @@ trait DeltaColumnMappingBase extends DeltaLogging {
         // Delta spec requires writer to always write field_id in parquet schema for column mapping
         // Reader strips PARQUET_FIELD_ID_METADATA_KEY in
         // DeltaParquetFileFormat:prepareSchemaForRead
-        new MetadataBuilder()
+        val builder = new MetadataBuilder()
           .withMetadata(field.metadata)
           .putLong(PARQUET_FIELD_ID_METADATA_KEY, getColumnId(field))
-          .build()
+
+        // Nested field IDs for the 'element' and 'key'/'value' fields of Arrays
+        // and Maps are written when Uniform with IcebergCompatV2 is enabled on a table.
+        if (hasNestedColumnIds(field)) {
+          builder.putMetadata(PARQUET_FIELD_NESTED_IDS_METADATA_KEY, getNestedColumnIds(field))
+        }
+
+        builder.build()
 
       case mode =>
         throw DeltaErrors.unsupportedColumnMappingMode(mode.name)
@@ -351,6 +371,7 @@ trait DeltaColumnMappingBase extends DeltaLogging {
     val rawSchema = newMetadata.schema
     var maxId = DeltaConfigs.COLUMN_MAPPING_MAX_ID.fromMetaData(newMetadata) max
                 findMaxColumnId(rawSchema)
+    val startId = maxId
     val newSchema =
       SchemaMergingUtils.transformColumns(rawSchema)((path, field, _) => {
         val builder = new MetadataBuilder().withMetadata(field.metadata)
@@ -418,10 +439,16 @@ trait DeltaColumnMappingBase extends DeltaLogging {
         field.copy(metadata = builder.build())
       })
 
+    val (finalSchema, newMaxId) = if (IcebergCompatV2.isEnabled(newMetadata)) {
+      rewriteFieldIdsForIceberg(newSchema, maxId)
+    } else {
+      (newSchema, maxId)
+    }
+
     newMetadata.copy(
-      schemaString = newSchema.json,
-      configuration =
-        newMetadata.configuration ++ Map(DeltaConfigs.COLUMN_MAPPING_MAX_ID.key -> maxId.toString)
+      schemaString = finalSchema.json,
+      configuration = newMetadata.configuration
+        ++ Map(DeltaConfigs.COLUMN_MAPPING_MAX_ID.key -> newMaxId.toString)
     )
   }
 
@@ -431,8 +458,10 @@ trait DeltaColumnMappingBase extends DeltaLogging {
         metadata = new MetadataBuilder()
           .withMetadata(field.metadata)
           .remove(COLUMN_MAPPING_METADATA_ID_KEY)
+          .remove(COLUMN_MAPPING_METADATA_NESTED_IDS_KEY)
           .remove(COLUMN_MAPPING_PHYSICAL_NAME_KEY)
           .remove(PARQUET_FIELD_ID_METADATA_KEY)
+          .remove(PARQUET_FIELD_NESTED_IDS_METADATA_KEY)
           .build()
       )
     }
@@ -636,6 +665,103 @@ trait DeltaColumnMappingBase extends DeltaLogging {
       // TODO: support column mapping downgrade check once that's rolled out.
       true
     }
+  }
+
+  /**
+   * Adds the nested field IDs required by Iceberg.
+   *
+   * In parquet, list-type columns have a nested, implicitly defined [[element]] field and
+   * map-type columns have implicitly defined [[key]] and [[value]] fields. By default,
+   * Spark does not write field IDs for these fields in the parquet files. However, Iceberg
+   * requires these *nested* field IDs to be present. This method rewrites the specified
+   * Spark schema to add those nested field IDs.
+   *
+   * As list and map types are not [[StructField]]s themselves, nested field IDs are stored in
+   * a map as part of the metadata of the *nearest* parent [[StructField]]. For example, consider
+   * the following schema:
+   *
+   * col1 ARRAY(INT)
+   * col2 MAP(INT, INT)
+   * col3 STRUCT(a INT, b ARRAY(STRUCT(c INT, d MAP(INT, INT))))
+   *
+   * col1 is a list and so requires one nested field ID for the [[element]] field in parquet.
+   * This nested field ID will be stored in a map that is part of col1's [[StructField.metadata]].
+   * The same applies to the nested field IDs for col2's implicit [[key]] and [[value]] fields.
+   * col3 itself is a Struct, consisting of an integer field and a list field named 'b'. The
+   * nested field ID for the list of 'b' is stored in b's StructField metadata. Finally, the
+   * list type itself is again a struct consisting of an integer field and a map field named 'd'.
+   * The nested field IDs for the map of 'd' are stored in d's StructField metadata.
+   *
+   * @param schema  The schema to which nested field IDs should be added
+   * @param startId The first field ID to use for the nested field IDs
+   */
+  def rewriteFieldIdsForIceberg(schema: StructType, startId: Long): (StructType, Long) = {
+    var currFieldId = startId
+
+    def initNestedIdsMetadata(field: StructField): MetadataBuilder = {
+      if (hasNestedColumnIds(field)) {
+        new MetadataBuilder().withMetadata(getNestedColumnIds(field))
+      } else {
+        new MetadataBuilder()
+      }
+    }
+
+    /*
+     * Helper to add the next field ID to the specified [[MetadataBuilder]] under
+     * the specified key. This method first checks whether this is an existing nested
+     * field or a newly added nested field. New field IDs are only assigned to newly
+     * added nested fields.
+     */
+    def updateFieldId(metadata: MetadataBuilder, key: String): Unit = {
+      if (!metadata.build().contains(key)) {
+        currFieldId += 1
+        metadata.putLong(key, currFieldId)
+      }
+    }
+
+    /*
+     * Recursively adds nested field IDs for the passed data type in pre-order,
+     * ensuring uniqueness of field IDs.
+     *
+     * @param dt The data type that should be transformed
+     * @param nestedIds A MetadataBuilder that keeps track of the nested field ID
+     *                  assignment. This metadata is added to the parent field.
+     * @param path The current field path relative to the parent field
+     */
+    def transform[E <: DataType](dt: E, nestedIds: MetadataBuilder, path: Seq[String]): E = {
+      val newDt = dt match {
+        case StructType(fields) =>
+          StructType(fields.map { field =>
+            val newNestedIds = initNestedIdsMetadata(field)
+            val newDt = transform(field.dataType, newNestedIds, Seq(getPhysicalName(field)))
+            val newFieldMetadata = new MetadataBuilder().withMetadata(field.metadata).putMetadata(
+              COLUMN_MAPPING_METADATA_NESTED_IDS_KEY, newNestedIds.build()).build()
+            field.copy(dataType = newDt, metadata = newFieldMetadata)
+          })
+        case ArrayType(elementType, containsNull) =>
+          // update element type metadata and recurse into element type
+          val elemPath = path :+ PARQUET_LIST_ELEMENT_FIELD_NAME
+          updateFieldId(nestedIds, elemPath.mkString("."))
+          val elementDt = transform(elementType, nestedIds, elemPath)
+          // return new array type with updated metadata
+          ArrayType(elementDt, containsNull)
+        case MapType(keyType, valType, valueContainsNull) =>
+          // update key type metadata and recurse into key type
+          val keyPath = path :+ PARQUET_MAP_KEY_FIELD_NAME
+          updateFieldId(nestedIds, keyPath.mkString("."))
+          val keyDt = transform(keyType, nestedIds, keyPath)
+          // update value type metadata and recurse into value type
+          val valPath = path :+ PARQUET_MAP_VALUE_FIELD_NAME
+          updateFieldId(nestedIds, valPath.mkString("."))
+          val valDt = transform(valType, nestedIds, valPath)
+          // return new map type with updated metadata
+          MapType(keyDt, valDt, valueContainsNull)
+        case other => other
+      }
+      newDt.asInstanceOf[E]
+    }
+
+    (transform(schema, new MetadataBuilder(), Seq.empty), currFieldId)
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.delta.schema.SchemaMergingUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapreduce.Job
+import org.apache.parquet.hadoop.ParquetOutputFormat
 import org.apache.parquet.hadoop.util.ContextUtil
 
 import org.apache.spark.broadcast.Broadcast
@@ -91,6 +92,7 @@ case class DeltaParquetFileFormat(
         field.copy(metadata = new MetadataBuilder()
           .withMetadata(field.metadata)
           .remove(DeltaColumnMapping.PARQUET_FIELD_ID_METADATA_KEY)
+          .remove(DeltaColumnMapping.PARQUET_FIELD_NESTED_IDS_METADATA_KEY)
           .build())
       }
     } else schema
@@ -212,6 +214,12 @@ case class DeltaParquetFileFormat(
     if (IcebergCompatV1.isEnabled(metadata) || IcebergCompatV2.isEnabled(metadata)) {
       conf.set(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key,
         SQLConf.ParquetOutputTimestampType.TIMESTAMP_MICROS.toString)
+    }
+    if (IcebergCompatV2.isEnabled(metadata)) {
+      // For Uniform with IcebergCompatV2, we need to write nested field IDs for list and map
+      // types to the parquet schema. Spark currently does not support it so we hook in our
+      // own write support class.
+      ParquetOutputFormat.setWriteSupportClass(job, classOf[DeltaParquetWriteSupport])
     }
     factory
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaParquetWriteSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaParquetWriteSupport.scala
@@ -1,0 +1,149 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import scala.util.Try
+
+import org.apache.spark.sql.delta.DeltaColumnMapping._
+import org.apache.hadoop.conf.Configuration
+import org.apache.parquet.hadoop.api.WriteSupport.WriteContext
+import org.apache.parquet.schema.{LogicalTypeAnnotation, Type, Types}
+import org.apache.parquet.schema.LogicalTypeAnnotation.{ListLogicalTypeAnnotation, MapLogicalTypeAnnotation}
+
+import org.apache.spark.SparkRuntimeException
+import org.apache.spark.sql.catalyst.parser.LegacyTypeStringParser
+import org.apache.spark.sql.catalyst.trees.Origin
+import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.execution.datasources.parquet.{ParquetSchemaConverter, ParquetWriteSupport}
+import org.apache.spark.sql.types.{DataType, StructField, StructType}
+
+class DeltaParquetWriteSupport extends ParquetWriteSupport {
+
+  private def getNestedFieldId(field: StructField, path: Seq[String]): Int = {
+    field.metadata
+      .getMetadata(PARQUET_FIELD_NESTED_IDS_METADATA_KEY)
+      .getLong(path.mkString("."))
+      .toInt
+  }
+
+  private def findFieldInSparkSchema(schema: StructType, path: Seq[String]): StructField = {
+    schema.findNestedField(path, true) match {
+      case Some((_, field)) => field
+      case None => throw QueryCompilationErrors.invalidFieldName(Seq(path.head), path, Origin())
+    }
+  }
+
+  override def init(configuration: Configuration): WriteContext = {
+    val writeContext = super.init(configuration)
+    // Parse the Spark schema. This is the same as is done in super.init, however, the
+    // parsed schema is stored in [[ParquetWriteSupport.schema]], which is private so
+    // we can't access it here and need to parse it again.
+    val schemaString = configuration.get(ParquetWriteSupport.SPARK_ROW_SCHEMA)
+    // This code is copied from Spark StructType.fromString because it is not accessible here
+    val parsedSchema = Try(DataType.fromJson(schemaString)).getOrElse(
+      LegacyTypeStringParser.parseString(schemaString)) match {
+        case t: StructType => t
+        case _ =>
+          // This code is copied from DataTypeErrors.failedParsingStructTypeError because
+          // it is not accessible here
+          throw new SparkRuntimeException(
+            errorClass = "FAILED_PARSE_STRUCT_TYPE",
+            messageParameters = Map("raw" -> s"'$schemaString'"))
+    }
+
+    val messageType = writeContext.getSchema
+    val newMessageTypeBuilder = Types.buildMessage()
+    messageType.getFields.forEach { field =>
+      val parentField = findFieldInSparkSchema(parsedSchema, Seq(field.getName))
+      newMessageTypeBuilder.addField(convert(
+        field, parentField, parsedSchema, Seq(field.getName), Seq(field.getName)))
+    }
+    val newMessageType = newMessageTypeBuilder.named(
+      ParquetSchemaConverter.SPARK_PARQUET_SCHEMA_NAME)
+    new WriteContext(newMessageType, writeContext.getExtraMetaData)
+  }
+
+  /**
+   * Recursively rewrites the parquet [[Type]] by adding the nested field
+   * IDs to list and map subtypes as defined in the schema. The
+   * recursion needs to keep track of the absolute field path in order
+   * to correctly identify the StructField in the spark schema for a
+   * corresponding parquet field. As nested field IDs are referenced
+   * by their relative path in a field's metadata, the recursion also needs
+   * to keep track of the relative path.
+   *
+   * For example, consider the following column type
+   * col1 STRUCT(a INT, b STRUCT(c INT, d ARRAY(INT)))
+   *
+   * The absolute path to the nested [[element]] field of the list is
+   * col1.b.d.element whereas the relative path is d.element, i.e. relative
+   * to the parent struct field.
+   */
+  private def convert(
+      field: Type,
+      parentField: StructField,
+      sparkSchema: StructType,
+      absolutePath: Seq[String],
+      relativePath: Seq[String]): Type = {
+    field.getLogicalTypeAnnotation match {
+      case _: ListLogicalTypeAnnotation =>
+        val relElemFieldPath = relativePath :+ PARQUET_LIST_ELEMENT_FIELD_NAME
+        val id = getNestedFieldId(parentField, relElemFieldPath)
+        val elementField =
+          field.asGroupType().getFields.get(0).asGroupType().getFields.get(0).withId(id)
+        Types
+          .buildGroup(field.getRepetition).as(LogicalTypeAnnotation.listType())
+          .addField(
+            Types.repeatedGroup()
+              .addField(convert(elementField, parentField, sparkSchema,
+                absolutePath :+ PARQUET_LIST_ELEMENT_FIELD_NAME, relElemFieldPath))
+              .named("list"))
+          .id(field.getId.intValue())
+          .named(field.getName)
+      case _: MapLogicalTypeAnnotation =>
+        val relKeyFieldPath = relativePath :+ PARQUET_MAP_KEY_FIELD_NAME
+        val relValFieldPath = relativePath :+ PARQUET_MAP_VALUE_FIELD_NAME
+        val keyId = getNestedFieldId(parentField, relKeyFieldPath)
+        val valId = getNestedFieldId(parentField, relValFieldPath)
+        val keyField =
+          field.asGroupType().getFields.get(0).asGroupType().getFields.get(0).withId(keyId)
+        val valueField =
+          field.asGroupType().getFields.get(0).asGroupType().getFields.get(1).withId(valId)
+        Types
+          .buildGroup(field.getRepetition).as(LogicalTypeAnnotation.mapType())
+          .addField(
+            Types
+              .repeatedGroup()
+              .addField(convert(keyField, parentField, sparkSchema,
+                absolutePath :+ PARQUET_MAP_KEY_FIELD_NAME, relKeyFieldPath))
+              .addField(convert(valueField, parentField, sparkSchema,
+                absolutePath :+ PARQUET_MAP_VALUE_FIELD_NAME, relValFieldPath))
+              .named("key_value"))
+          .id(field.getId.intValue())
+          .named(field.getName)
+      case _ if field.isPrimitive => field
+      case _ =>
+        val builder = Types.buildGroup(field.getRepetition)
+        field.asGroupType().getFields.forEach { field =>
+          val absPath = absolutePath :+ field.getName
+          val parentField = findFieldInSparkSchema(sparkSchema, absPath)
+          builder.addField(convert(field, parentField, sparkSchema, absPath, Seq(field.getName)))
+        }
+        builder.id(field.getId.intValue()).named(field.getName)
+    }
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR adds support for List and Map columns in Uniform. To support these types, Delta column mapping needs to write additional field IDs to the parquet schema. List columns require one additional field ID for the 'element' subfield and Map columns require two additional field IDs for the 'key' and 'value' subfields inside the parquet file. These nested field IDs are added to the table schema during the generation of the IDs and physical names for column mapping. They are added to the parquet schema through a new class, DeltaParquetWriteSupport, that hooks into Spark's parquet write path and rewrites the parquet schema based on the additional field IDs.

This PR is part of https://github.com/delta-io/delta/issues/2297.

## How was this patch tested?

Unit tests will be added soon in a separate PR.

## Does this PR introduce _any_ user-facing changes?

No
