### PR TITLE
[Spark] Integrate domain metadata with OPTIMIZE

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -362,6 +362,18 @@
     ],
     "sqlState" : "42000"
   },
+  "DELTA_CLUSTERING_WITH_PARTITION_PREDICATE" : {
+    "message" : [
+      "OPTIMIZE command for Delta table with clustering doesn't support partition predicates. Please remove the predicates: <predicates>."
+    ],
+    "sqlState" : "0A000"
+  },
+  "DELTA_CLUSTERING_WITH_ZORDER_BY" : {
+    "message" : [
+      "OPTIMIZE command for Delta table with clustering cannot specify ZORDER BY. Please remove ZORDER BY (<zOrderBy>)."
+    ],
+    "sqlState" : "42613"
+  },
   "DELTA_CLUSTER_BY_INVALID_NUM_COLUMNS" : {
     "message" : [
       "CLUSTER BY supports up to <numColumnsLimit> clustering columns, but the table has <actualNumColumns> clustering columns. Please remove the extra clustering columns."

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3125,6 +3125,19 @@ trait DeltaErrorsBase
       messageParameters = Array.empty)
   }
 
+  def clusteringWithPartitionPredicatesException(predicates: Seq[String]): Throwable = {
+    new DeltaUnsupportedOperationException(
+      errorClass = "DELTA_CLUSTERING_WITH_PARTITION_PREDICATE",
+      messageParameters = Array(s"${predicates.mkString(" ")}")
+    )
+  }
+
+  def clusteringWithZOrderByException(zOrderBy: Seq[UnresolvedAttribute]): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_CLUSTERING_WITH_ZORDER_BY",
+      messageParameters = Array(s"${zOrderBy.map(_.name).mkString(", ")}"))
+  }
+
   def clusteringTablePreviewDisabledException(): Throwable = {
     val msg = s"""
       |A clustered table is currently in preview and is disabled by default. Please set

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3128,8 +3128,7 @@ trait DeltaErrorsBase
   def clusteringWithPartitionPredicatesException(predicates: Seq[String]): Throwable = {
     new DeltaUnsupportedOperationException(
       errorClass = "DELTA_CLUSTERING_WITH_PARTITION_PREDICATE",
-      messageParameters = Array(s"${predicates.mkString(" ")}")
-    )
+      messageParameters = Array(s"${predicates.mkString(" ")}"))
   }
 
   def clusteringWithZOrderByException(zOrderBy: Seq[UnresolvedAttribute]): Throwable = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -19,10 +19,9 @@ package org.apache.spark.sql.delta.commands
 import java.util.ConcurrentModificationException
 
 import scala.collection.mutable.ArrayBuffer
-import scala.collection.parallel.ForkJoinTaskSupport
-import scala.collection.parallel.immutable.ParVector
 
 import org.apache.spark.sql.delta.skipping.MultiDimClustering
+import org.apache.spark.sql.delta.skipping.clustering.{ClusteredTableUtils, ClusteringColumnInfo}
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.DeltaOperations.Operation
 import org.apache.spark.sql.delta.actions.{Action, AddFile, DeletionVectorDescriptor, FileAction, RemoveFile}
@@ -147,6 +146,17 @@ case class OptimizeTableCommand(
       throw DeltaErrors.notADeltaTableException(table.deltaLog.dataPath.toString)
     }
 
+    // Validate that the preview is enabled if we are optimizing a clustered table.
+    ClusteredTableUtils.validatePreviewEnabled(txn.snapshot.protocol)
+    if (ClusteredTableUtils.isSupported(txn.protocol)) {
+      if (userPartitionPredicates.nonEmpty) {
+        throw DeltaErrors.clusteringWithPartitionPredicatesException(userPartitionPredicates)
+      }
+      if (zOrderBy.nonEmpty) {
+        throw DeltaErrors.clusteringWithZOrderByException(zOrderBy)
+      }
+    }
+
     val partitionColumns = txn.snapshot.metadata.partitionColumns
     // Parse the predicate expression into Catalyst expression and verify only simple filters
     // on partition columns are present
@@ -213,7 +223,19 @@ class OptimizeExecutor(
   /** Timestamp to use in [[FileAction]] */
   private val operationTimestamp = new SystemClock().getTimeMillis()
 
-  private val isMultiDimClustering = zOrderByColumns.nonEmpty
+  private val isClusteredTable = ClusteredTableUtils.isSupported(txn.snapshot.protocol)
+
+  private val isZOrderBy = zOrderByColumns.nonEmpty
+
+  private val isMultiDimClustering = isClusteredTable || isZOrderBy
+
+  private val (clusteringColumns, curve): (Seq[String], String) = {
+    if (zOrderByColumns.nonEmpty) {
+      (zOrderByColumns, "zorder")
+    } else {
+      (ClusteringColumnInfo.extractLogicalNames(txn.snapshot), "hilbert")
+    }
+  }
 
   def optimize(): Seq[Row] = {
     recordDeltaOperation(txn.deltaLog, "delta.optimize") {
@@ -391,8 +413,8 @@ class OptimizeExecutor(
       MultiDimClustering.cluster(
         input,
         approxNumFiles,
-        zOrderByColumns,
-        "zorder")
+        clusteringColumns,
+        curve)
     } else {
       val useRepartition = sparkSession.sessionState.conf.getConf(
         DeltaSQLConf.DELTA_OPTIMIZE_REPARTITION_ENABLED)
@@ -413,7 +435,11 @@ class OptimizeExecutor(
 
     val addFiles = txn.writeFiles(repartitionDF, None, isOptimize = true, Nil).collect {
       case a: AddFile =>
-        a.copy(dataChange = false)
+        (if (isClusteredTable) {
+          a.copy(clusteringProvider = Some(ClusteredTableUtils.clusteringProvider))
+        } else {
+          a
+        }).copy(dataChange = false)
       case other =>
         throw new IllegalStateException(
           s"Unexpected action $other with type ${other.getClass}. File compaction job output" +
@@ -458,7 +484,7 @@ class OptimizeExecutor(
     if (optimizeContext.isPurge) {
       DeltaOperations.Reorg(partitionPredicate)
     } else {
-      DeltaOperations.Optimize(partitionPredicate, zOrderByColumns)
+      DeltaOperations.Optimize(partitionPredicate, clusteringColumns)
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -146,9 +146,9 @@ case class OptimizeTableCommand(
       throw DeltaErrors.notADeltaTableException(table.deltaLog.dataPath.toString)
     }
 
-    // Validate that the preview is enabled if we are optimizing a clustered table.
-    ClusteredTableUtils.validatePreviewEnabled(txn.snapshot.protocol)
     if (ClusteredTableUtils.isSupported(txn.protocol)) {
+      // Validate that the preview is enabled if we are optimizing a clustered table.
+      ClusteredTableUtils.validatePreviewEnabled(txn.snapshot.protocol)
       if (userPartitionPredicates.nonEmpty) {
         throw DeltaErrors.clusteringWithPartitionPredicatesException(userPartitionPredicates)
       }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -227,13 +227,22 @@ class OptimizeExecutor(
 
   private val isMultiDimClustering = isClusteredTable || zOrderByColumns.nonEmpty
 
-  private val (clusteringColumns, curve): (Seq[String], String) = {
+  private val clusteringColumns: Seq[String] = {
     if (zOrderByColumns.nonEmpty) {
-      (zOrderByColumns, "zorder")
+      zOrderByColumns
     } else if (isClusteredTable) {
-      (ClusteringColumnInfo.extractLogicalNames(txn.snapshot), "hilbert")
+      ClusteringColumnInfo.extractLogicalNames(txn.snapshot)
     } else {
-      Nil -> ""
+      Nil
+    }
+  }
+
+  private lazy val curve: String = {
+    if (zOrderByColumns.nonEmpty) {
+      "zorder"
+    } else {
+      assert(isClusteredTable)
+      "hilbert"
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -225,15 +225,15 @@ class OptimizeExecutor(
 
   private val isClusteredTable = ClusteredTableUtils.isSupported(txn.snapshot.protocol)
 
-  private val isZOrderBy = zOrderByColumns.nonEmpty
-
-  private val isMultiDimClustering = isClusteredTable || isZOrderBy
+  private val isMultiDimClustering = isClusteredTable || zOrderByColumns.nonEmpty
 
   private val (clusteringColumns, curve): (Seq[String], String) = {
     if (zOrderByColumns.nonEmpty) {
       (zOrderByColumns, "zorder")
-    } else {
+    } else if (isClusteredTable) {
       (ClusteringColumnInfo.extractLogicalNames(txn.snapshot), "hilbert")
+    } else {
+      Nil -> ""
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/clustering/ClusteredTableClusteringSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/clustering/ClusteredTableClusteringSuite.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.clustering
+
+import org.apache.spark.sql.delta.skipping.ClusteredTableTestUtils
+import org.apache.spark.sql.delta.skipping.clustering.ClusteredTableUtils
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+class ClusteredTableClusteringSuite extends SparkFunSuite
+  with SharedSparkSession
+  with ClusteredTableTestUtils
+  with DeltaSQLCommandTest {
+  import testImplicits._
+
+  private val table: String = "test_table"
+
+  // Ingest data to create numFiles files with one row in each file.
+  private def addFiles(table: String, numFiles: Int): Unit = {
+    val df = (1 to numFiles).map(i => (i, i)).toDF("col1", "col2")
+    withSQLConf(SQLConf.MAX_RECORDS_PER_FILE.key -> "1") {
+      df.write.format("delta").mode("append").saveAsTable(table)
+    }
+  }
+
+  private def getFiles(table: String): Set[AddFile] = {
+    val deltaLog = DeltaLog.forTable(spark, TableIdentifier(table))
+    deltaLog.update().allFiles.collect().toSet
+  }
+
+  private def assertClustered(files: Set[AddFile]): Unit = {
+    assert(files.forall(_.clusteringProvider.contains(ClusteredTableUtils.clusteringProvider)))
+  }
+
+  test("optimize clustered table") {
+    withSQLConf(SQLConf.MAX_RECORDS_PER_FILE.key -> "2") {
+      withClusteredTable(
+        table = table,
+        schema = "col1 int, col2 int",
+        clusterBy = "col1, col2") {
+        addFiles(table, numFiles = 4)
+        val files0 = getFiles(table)
+        assert(files0.size === 4)
+
+        // Optimize should cluster the data into two 2 files since MAX_RECORDS_PER_FILE is 2.
+        runOptimize(table) { metrics =>
+          assert(metrics.numFilesRemoved == 4)
+          assert(metrics.numFilesAdded == 2)
+        }
+
+        val files1 = getFiles(table)
+        assert(files1.size == 2)
+        assertClustered(files1)
+      }
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/clustering/ClusteredTableClusteringSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/clustering/ClusteredTableClusteringSuite.scala
@@ -52,6 +52,10 @@ class ClusteredTableClusteringSuite extends SparkFunSuite
     assert(files.forall(_.clusteringProvider.contains(ClusteredTableUtils.clusteringProvider)))
   }
 
+  private def assertNotClustered(files: Set[AddFile]): Unit = {
+    assert(files.forall(_.clusteringProvider.isEmpty))
+  }
+
   test("optimize clustered table") {
     withSQLConf(SQLConf.MAX_RECORDS_PER_FILE.key -> "2") {
       withClusteredTable(
@@ -61,6 +65,7 @@ class ClusteredTableClusteringSuite extends SparkFunSuite
         addFiles(table, numFiles = 4)
         val files0 = getFiles(table)
         assert(files0.size === 4)
+        assertNotClustered(files0)
 
         // Optimize should cluster the data into two 2 files since MAX_RECORDS_PER_FILE is 2.
         runOptimize(table) { metrics =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/skipping/ClusteredTableTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/skipping/ClusteredTableTestUtils.scala
@@ -18,13 +18,34 @@ package org.apache.spark.sql.delta.skipping
 
 import org.apache.spark.sql.delta.skipping.clustering.{ClusteredTableUtils, ClusteringColumn}
 import org.apache.spark.sql.delta.{DeltaLog, Snapshot}
+import org.apache.spark.sql.delta.commands.optimize.OptimizeMetrics
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.Utils
 
 trait ClusteredTableTestUtilsBase extends SparkFunSuite with SharedSparkSession {
+  import testImplicits._
+
+  /**
+   * Helper for running optimize on the table with different APIs.
+   * @param table the name of table
+   */
+  def optimizeTable(table: String): DataFrame = {
+    sql(s"OPTIMIZE $table")
+  }
+
+  /**
+   * Runs optimize on the table and calls postHook on the metrics
+   * @param table the name of table
+   * @param postHook callback triggered with OptimizeMetrics returned by the OPTIMIZE command
+   */
+  def runOptimize(table: String)(postHook: OptimizeMetrics => Unit): Unit = {
+    postHook(optimizeTable(table).select($"metrics.*").as[OptimizeMetrics].head())
+  }
+
   def verifyClusteringColumnsInDomainMetadata(
       snapshot: Snapshot,
       expectedLogicalClusteringColumns: String): Unit = {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/skipping/ClusteredTableTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/skipping/ClusteredTableTestUtils.scala
@@ -38,7 +38,7 @@ trait ClusteredTableTestUtilsBase extends SparkFunSuite with SharedSparkSession 
   }
 
   /**
-   * Runs optimize on the table and calls postHook on the metrics
+   * Runs optimize on the table and calls postHook on the metrics.
    * @param table the name of table
    * @param postHook callback triggered with OptimizeMetrics returned by the OPTIMIZE command
    */


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Resolves https://github.com/delta-io/delta/issues/2451

Integrates domain metadata with OPTIMIZE to get the clustering columns from DomainMetadata and perform clustering. Disallow specifying partition predicates and ZORDER BY for a clustered table.
## How was this patch tested?
Introduce a new test suite `ClusteredTableClusteringSuite` and add test for running optimize on a clustered table.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No