### PR TITLE
[Spark] Delete duplicate DeltaErrorsSuite test

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -444,13 +444,6 @@ trait DeltaErrorsSuiteBase
         Some("Column c is not specified in INSERT"))
     }
     {
-      val e = intercept[DeltaAnalysisException] {
-        throw DeltaErrors.missingColumnsInInsertInto("c")
-      }
-      checkErrorMessage(e, None, None,
-        Some("Column c is not specified in INSERT"))
-    }
-    {
       val table = DeltaTableIdentifier(Some("path"))
       val e = intercept[DeltaAnalysisException] {
         throw DeltaErrors.nonExistentDeltaTable(table)


### PR DESCRIPTION
If you look closely, you'll see that the error test this PR deletes already exists - exactly just above it. This PR cleans this up and deletes the bottom duplicate test.