### PR TITLE
[Spark] Uncomment `assume`s in DeltaTableCreationTests

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
@@ -1464,7 +1464,7 @@ trait DeltaTableCreationTests
     test(s"data source table:partition column name containing $specialChars") {
       // On Windows, it looks colon in the file name is illegal by default. See
       // https://support.microsoft.com/en-us/help/289627
-      // assume(!Utils.isWindows || specialChars != "a:b")
+      assume(!Utils.isWindows || specialChars != "a:b")
 
       withTable("t") {
         withTempDir { dir =>
@@ -1492,7 +1492,7 @@ trait DeltaTableCreationTests
     test(s"location uri contains $specialChars for datasource table") {
       // On Windows, it looks colon in the file name is illegal by default. See
       // https://support.microsoft.com/en-us/help/289627
-      // assume(!Utils.isWindows || specialChars != "a:b")
+      assume(!Utils.isWindows || specialChars != "a:b")
 
       withTable("t", "t1") {
         withTempDir { dir =>


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR uncomment valid `assume`s in `DeltaTableCreationTests.scala`. The tests should be skipped on Windows.

## How was this patch tested?

Manually.

## Does this PR introduce _any_ user-facing changes?

No, test-only.