### PR TITLE
Implement UPGRADE UNIFORM (ICEBERG_COMPAT_VERSION) command

### DIFF
--- a/spark/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
+++ b/spark/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
@@ -92,8 +92,10 @@ statement
         (WHERE partitionPredicate=predicateToken)?
         (zorderSpec)?                                                   #optimizeTable
     | REORG TABLE table=qualifiedName
-        (WHERE partitionPredicate=predicateToken)?
-        APPLY LEFT_PAREN PURGE RIGHT_PAREN                              #reorgTable
+        (
+            (WHERE partitionPredicate=predicateToken)?APPLY LEFT_PAREN PURGE RIGHT_PAREN |
+            APPLY LEFT_PAREN UPGRADE UNIFORM LEFT_PAREN ICEBERG_COMPAT_VERSION EQ version=INTEGER_VALUE RIGHT_PAREN RIGHT_PAREN
+        )                                                               #reorgTable
     | cloneTableHeader SHALLOW CLONE source=qualifiedName clause=temporalClause?
        (TBLPROPERTIES tableProps=propertyList)?
        (LOCATION location=stringLit)?                                   #clone
@@ -223,7 +225,7 @@ nonReserved
     | CONVERT | TO | DELTA | PARTITIONED | BY
     | DESC | DESCRIBE | LIMIT | DETAIL
     | GENERATE | FOR | TABLE | CHECK | EXISTS | OPTIMIZE
-    | REORG | APPLY | PURGE
+    | REORG | APPLY | PURGE | UPGRADE | UNIFORM | ICEBERG_COMPAT_VERSION
     | RESTORE | AS | OF
     | ZORDER | LEFT_PAREN | RIGHT_PAREN
     | NO | STATISTICS
@@ -260,6 +262,7 @@ FOR: 'FOR';
 GENERATE: 'GENERATE';
 HISTORY: 'HISTORY';
 HOURS: 'HOURS';
+ICEBERG_COMPAT_VERSION: 'ICEBERG_COMPAT_VERSION';
 IF: 'IF';
 LEFT_PAREN: '(';
 LIMIT: 'LIMIT';
@@ -288,6 +291,8 @@ TIMESTAMP: 'TIMESTAMP';
 TRUNCATE: 'TRUNCATE';
 TO: 'TO';
 TRUE: 'TRUE';
+UNIFORM: 'UNIFORM';
+UPGRADE: 'UPGRADE';
 VACUUM: 'VACUUM';
 VERSION: 'VERSION';
 WHERE: 'WHERE';

--- a/spark/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
+++ b/spark/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
@@ -93,7 +93,7 @@ statement
         (zorderSpec)?                                                   #optimizeTable
     | REORG TABLE table=qualifiedName
         (
-            (WHERE partitionPredicate=predicateToken)?APPLY LEFT_PAREN PURGE RIGHT_PAREN |
+            (WHERE partitionPredicate=predicateToken)? APPLY LEFT_PAREN PURGE RIGHT_PAREN |
             APPLY LEFT_PAREN UPGRADE UNIFORM LEFT_PAREN ICEBERG_COMPAT_VERSION EQ version=INTEGER_VALUE RIGHT_PAREN RIGHT_PAREN
         )                                                               #reorgTable
     | cloneTableHeader SHALLOW CLONE source=qualifiedName clause=temporalClause?

--- a/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
+++ b/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
@@ -371,6 +371,10 @@ class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
    *   -- Physically delete dropped rows and columns of target table
    *   REORG TABLE (delta.`/path/to/table` | delta_table_name)
    *    [WHERE partition_predicate] APPLY (PURGE)
+   *
+   *   -- Rewrite the files in UNIFORM(ICEBERG) compliant way.
+   *   REORG TABLE table_name (delta.`/path/to/table` | catalog.db.table)
+   *    APPLY (UPGRADE UNIFORM(ICEBERG_COMPAT_VERSION=version))
    * }}}
    */
   override def visitReorgTable(ctx: ReorgTableContext): AnyRef = withOrigin(ctx) {
@@ -386,7 +390,17 @@ class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
     val tableNameParts = targetIdentifier.database.toSeq :+ targetIdentifier.table
     val targetTable = createUnresolvedTable(tableNameParts, "REORG")
 
-    DeltaReorgTable(targetTable)(Option(ctx.partitionPredicate).map(extractRawText(_)).toSeq)
+    val reorgTableSpec = if (ctx.PURGE != null) {
+      DeltaReorgTableSpec(DeltaReorgTableMode.PURGE, None)
+    } else if (ctx.ICEBERG_COMPAT_VERSION != null) {
+      DeltaReorgTableSpec(DeltaReorgTableMode.UNIFORM_ICEBERG, Option(ctx.version).map(_.getText.toInt))
+    } else {
+      throw new ParseException(
+        "Invalid syntax: REORG TABLE only support PURGE/UPGRADE UNIFORM.",
+        ctx)
+    }
+
+    DeltaReorgTable(targetTable, reorgTableSpec)(Option(ctx.partitionPredicate).map(extractRawText(_)).toSeq)
   }
 
   override def visitDescribeDeltaDetail(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -560,7 +560,7 @@ class DeltaAnalysis(session: SparkSession)
     case reorg @ DeltaReorgTable(resolved @ ResolvedTable(_, _, _: DeltaTableV2, _), spec) =>
       DeltaReorgTableCommand(resolved, spec)(reorg.predicates)
 
-    case DeltaReorgTable(ResolvedTable(_, _, t, _), spec) =>
+    case DeltaReorgTable(ResolvedTable(_, _, t, _), _) =>
       throw DeltaErrors.notADeltaTable(t.name())
 
     case cmd @ ShowColumns(child @ ResolvedTable(_, _, table: DeltaTableV2, _), namespace, _) =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -557,10 +557,10 @@ class DeltaAnalysis(session: SparkSession)
       }
       merge
 
-    case reorg @ DeltaReorgTable(resolved @ ResolvedTable(_, _, _: DeltaTableV2, _)) =>
-      DeltaReorgTableCommand(resolved)(reorg.predicates)
+    case reorg @ DeltaReorgTable(resolved @ ResolvedTable(_, _, _: DeltaTableV2, _), spec) =>
+      DeltaReorgTableCommand(resolved, spec)(reorg.predicates)
 
-    case DeltaReorgTable(ResolvedTable(_, _, t, _)) =>
+    case DeltaReorgTable(ResolvedTable(_, _, t, _), spec) =>
       throw DeltaErrors.notADeltaTable(t.name())
 
     case cmd @ ShowColumns(child @ ResolvedTable(_, _, table: DeltaTableV2, _), namespace, _) =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -580,6 +580,17 @@ object DeltaOperations {
     val maxToStringFields = SQLConf.get.maxToStringFields
     predicates.map(_.simpleString(maxToStringFields))
   }
+
+  /** Recorded when the table properties are set. */
+  private val OP_UPGRADE_UNIFORM_BY_REORG = "REORG TABLE UPGRADE UNIFORM"
+
+  /**
+   * recorded when upgrading a table set uniform properties by REORG TABLE ... UPGRADE UNIFORM
+   */
+  case class UpgradeUniformProperties(properties: Map[String, String]) extends Operation(
+      OP_UPGRADE_UNIFORM_BY_REORG) {
+    override val parameters: Map[String, Any] = Map("properties" -> JsonUtils.toJson(properties))
+  }
 }
 
 private[delta] object DeltaOperationMetrics {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/IcebergCompat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/IcebergCompat.scala
@@ -213,6 +213,21 @@ object IcebergCompat extends DeltaLogging {
       .map{ case (_, version) => version }
 
   /**
+   * Get the DeltaConfig for the given IcebergCompat version. If version is not valid,
+   * throw an exception.
+   * @return the DeltaConfig for the given version. E.g.,
+   *         [[DeltaConfigs.ICEBERG_COMPAT_V1_ENABLED]] for version 1.
+   */
+  def getIcebergCompatVersionConfigForValidVersion(version: Int): DeltaConfig[Option[Boolean]] = {
+    if (version <= 0 || version > knownVersions.length) {
+      throw DeltaErrors.icebergCompatVersionNotSupportedException(
+        version, knownVersions.length
+      )
+    }
+    knownVersions(version - 1)._1
+  }
+
+  /**
    * @return true if any version of IcebergCompat is enabled
    */
   def isAnyEnabled(metadata: Metadata): Boolean =

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1362,7 +1362,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
         snapshot,
         newestProtocol = protocol, // Note: this will try to use `newProtocol`
         newestMetadata = metadata, // Note: this will try to use `newMetadata`
-        isCreatingNewTable,
+        isCreatingNewTable || op.isInstanceOf[DeltaOperations.UpgradeUniformProperties],
         otherActions
       )
     newProtocol = protocolUpdate1.orElse(newProtocol)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -844,6 +844,9 @@ object AddFile {
     /** [[OPTIMIZE_TARGET_SIZE]]: target file size the file was optimized to. */
     object OPTIMIZE_TARGET_SIZE extends AddFile.Tags.KeyType("OPTIMIZE_TARGET_SIZE")
 
+
+    /** [[ICEBERG_COMPAT_VERSION]]: IcebergCompat version */
+    object ICEBERG_COMPAT_VERSION extends AddFile.Tags.KeyType("ICEBERG_COMPAT_VERSION")
   }
 
   /** Convert a [[Tags.KeyType]] to a string to be used in the AddMap.tags Map[String, String]. */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaReorgTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaReorgTableCommand.scala
@@ -24,7 +24,19 @@ import org.apache.spark.sql.catalyst.analysis.ResolvedTable
 import org.apache.spark.sql.catalyst.plans.logical.{IgnoreCachedData, LeafCommand, LogicalPlan, UnaryCommand}
 import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
 
-case class DeltaReorgTable(target: LogicalPlan)(val predicates: Seq[String]) extends UnaryCommand {
+object DeltaReorgTableMode extends Enumeration {
+  val PURGE, UNIFORM_ICEBERG = Value
+}
+
+case class DeltaReorgTableSpec(
+    reorgTableMode: DeltaReorgTableMode.Value,
+    icebergCompatVersionOpt: Option[Int]
+)
+
+case class DeltaReorgTable(
+    target: LogicalPlan,
+    reorgTableSpec: DeltaReorgTableSpec = DeltaReorgTableSpec(DeltaReorgTableMode.PURGE, None))(
+    val predicates: Seq[String]) extends UnaryCommand {
 
   def child: LogicalPlan = target
 
@@ -37,20 +49,41 @@ case class DeltaReorgTable(target: LogicalPlan)(val predicates: Seq[String]) ext
 /**
  * The PURGE command.
  */
-case class DeltaReorgTableCommand(target: LogicalPlan)(val predicates: Seq[String])
-  extends OptimizeTableCommandBase with LeafCommand with IgnoreCachedData {
+case class DeltaReorgTableCommand(
+    target: LogicalPlan,
+    reorgTableSpec: DeltaReorgTableSpec = DeltaReorgTableSpec(DeltaReorgTableMode.PURGE, None))(
+    val predicates: Seq[String])
+  extends OptimizeTableCommandBase
+  with ReorgTableForUpgradeUniformHelper
+  with LeafCommand
+  with IgnoreCachedData {
 
   override val otherCopyArgs: Seq[AnyRef] = predicates :: Nil
 
-  override def run(sparkSession: SparkSession): Seq[Row] = {
+  override def optimizeByReorg(
+    sparkSession: SparkSession,
+    isPurge: Boolean,
+    icebergCompatVersion: Option[Int]): Seq[Row] = {
     val command = OptimizeTableCommand(
       target,
       predicates,
       optimizeContext = DeltaOptimizeContext(
-        isPurge = true,
+        isPurge = isPurge,
         minFileSize = Some(0L),
-        maxDeletedRowsRatio = Some(0d))
+        maxDeletedRowsRatio = Some(0d),
+        icebergCompatVersion = icebergCompatVersion
+      )
     )(zOrderBy = Nil)
     command.run(sparkSession)
+  }
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    reorgTableSpec match {
+      case DeltaReorgTableSpec(DeltaReorgTableMode.PURGE, None) =>
+        optimizeByReorg(sparkSession, isPurge = true, icebergCompatVersion = None)
+      case DeltaReorgTableSpec(DeltaReorgTableMode.UNIFORM_ICEBERG, Some(icebergCompatVersion)) =>
+        val table = getDeltaTable(target, "REORG")
+        upgradeUniformIcebergCompatVersion(table, sparkSession, icebergCompatVersion)
+    }
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -319,17 +319,18 @@ class OptimizeExecutor(
           file.deletedToPhysicalRecordsRatio.getOrElse(0d) > maxDeletedRowsRatio
     }
 
-    def shouldRewriteToBeIcebergCompat(file: AddFile): Boolean = {
+    def shouldRewriteToBeIcebergCompatible(file: AddFile): Boolean = {
       if (optimizeContext.icebergCompatVersion.isEmpty) return false
       if (file.tags == null) return true
       val icebergCompatVersion = file.tags.getOrElse(AddFile.Tags.ICEBERG_COMPAT_VERSION.name, "0")
       !optimizeContext.icebergCompatVersion.exists(_.toString == icebergCompatVersion)
     }
 
-    // Select files that are small or have too many deleted rows
+    // Select files that are small, have too many deleted rows,
+    // or need to be made iceberg compatible
     files.filter(
       addFile => addFile.size < minFileSize || shouldCompactBecauseOfDeletedRows(addFile) ||
-        shouldRewriteToBeIcebergCompat(addFile))
+        shouldRewriteToBeIcebergCompatible(addFile))
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -320,9 +320,10 @@ class OptimizeExecutor(
     }
 
     def shouldRewriteToBeIcebergCompat(file: AddFile): Boolean = {
-      val icebergCompatVersion =
-        file.tags.getOrElse(AddFile.Tags.ICEBERG_COMPAT_VERSION.name, "0")
-      optimizeContext.icebergCompatVersion.exists(_.toString == icebergCompatVersion)
+      if (optimizeContext.icebergCompatVersion.isEmpty) return false
+      if (file.tags == null) return true
+      val icebergCompatVersion = file.tags.getOrElse(AddFile.Tags.ICEBERG_COMPAT_VERSION.name, "0")
+      !optimizeContext.icebergCompatVersion.exists(_.toString == icebergCompatVersion)
     }
 
     // Select files that are small or have too many deleted rows

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -182,12 +182,15 @@ case class OptimizeTableCommand(
  *                            specified, [[DeltaSQLConf.DELTA_OPTIMIZE_MAX_DELETED_ROWS_RATIO]]
  *                            will be used. This parameter must be set to `0` when [[isPurge]] is
  *                            true.
+ * @param icebergCompatVersion The iceberg compatibility version used to rewrite data for
+ *                             uniform tables.
  */
 case class DeltaOptimizeContext(
     isPurge: Boolean = false,
     minFileSize: Option[Long] = None,
-    maxDeletedRowsRatio: Option[Double] = None) {
-  if (isPurge) {
+    maxDeletedRowsRatio: Option[Double] = None,
+    icebergCompatVersion: Option[Int] = None) {
+  if (isPurge || icebergCompatVersion.isDefined) {
     require(
       minFileSize.contains(0L) && maxDeletedRowsRatio.contains(0d),
       "minFileSize and maxDeletedRowsRatio must be 0 when running PURGE.")
@@ -316,9 +319,16 @@ class OptimizeExecutor(
           file.deletedToPhysicalRecordsRatio.getOrElse(0d) > maxDeletedRowsRatio
     }
 
+    def shouldRewriteToBeIcebergCompat(file: AddFile): Boolean = {
+      val icebergCompatVersion =
+        file.tags.getOrElse(AddFile.Tags.ICEBERG_COMPAT_VERSION.name, "0")
+      optimizeContext.icebergCompatVersion.exists(_.toString == icebergCompatVersion)
+    }
+
     // Select files that are small or have too many deleted rows
     files.filter(
-      addFile => addFile.size < minFileSize || shouldCompactBecauseOfDeletedRows(addFile))
+      addFile => addFile.size < minFileSize || shouldCompactBecauseOfDeletedRows(addFile) ||
+        shouldRewriteToBeIcebergCompat(addFile))
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ReorgTableForUpgradeUniformHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ReorgTableForUpgradeUniformHelper.scala
@@ -1,0 +1,238 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands
+
+// scalastyle:off import.ordering.noEmptyLine
+import scala.util.control.NonFatal
+
+import org.apache.spark.sql.delta.{DeltaConfig, DeltaConfigs, DeltaErrors, DeltaOperations, Snapshot}
+import org.apache.spark.sql.delta.IcebergCompat.{getEnabledVersion, getIcebergCompatVersionConfigForValidVersion}
+import org.apache.spark.sql.delta.UniversalFormat.{icebergEnabled, ICEBERG_FORMAT}
+import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.util.Utils.try_element_at
+
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.functions.col
+
+/**
+ * Helper trait for ReorgTableCommand to rewrite the table to be Iceberg compatible.
+ */
+trait ReorgTableForUpgradeUniformHelper extends DeltaLogging {
+
+  private val versionChangesRequireRewrite: Map[Int, Set[Int]] =
+    Map(0 -> Set(2), 1 -> Set(2), 2 -> Set(2))
+
+  /**
+   * Helper function to check if the table data may need to be rewritten to be iceberg compatible.
+   * Only if not all addFiles has the tag, Rewriting would be performed.
+   */
+  private def reorgMayNeedRewrite(oldVersion: Int, newVersion: Int): Boolean = {
+    versionChangesRequireRewrite.getOrElse(oldVersion, Set.empty[Int]).contains(newVersion)
+  }
+
+  /**
+   * Helper function to rewrite the table. Implemented by Reorg Table Command.
+   */
+  def optimizeByReorg(
+     sparkSession: SparkSession,
+     isPurge: Boolean,
+     icebergCompatVersion: Option[Int]): Seq[Row]
+
+  /**
+   * Helper function to update the table icebergCompat properties.
+   * We can not use AlterTableSetPropertiesDeltaCommand here because we don't allow customer to
+   * change icebergCompatVersion by using Alter Table command.
+   */
+  private def enableIcebergCompat(
+      target: DeltaTableV2,
+      currIcebergCompatVersionOpt: Option[Int],
+      targetVersionDeltaConfig: DeltaConfig[Option[Boolean]]): Unit = {
+    var enableIcebergCompatConf = Map(
+      targetVersionDeltaConfig.key -> "true",
+      DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.key -> "false",
+      DeltaConfigs.COLUMN_MAPPING_MODE.key -> "name"
+    )
+    if (currIcebergCompatVersionOpt.nonEmpty) {
+      val currIcebergCompatVersionDeltaConfig = getIcebergCompatVersionConfigForValidVersion(
+        currIcebergCompatVersionOpt.get)
+      enableIcebergCompatConf ++= Map(currIcebergCompatVersionDeltaConfig.key -> "false")
+    }
+
+    val alterConfTxn = target.startTransaction()
+    val metadata = alterConfTxn.metadata
+    val newMetadata = metadata.copy(
+      description = metadata.description,
+      configuration = metadata.configuration ++ enableIcebergCompatConf)
+    alterConfTxn.updateMetadata(newMetadata)
+    alterConfTxn.commit(
+      Nil,
+      DeltaOperations.UpgradeUniformProperties(enableIcebergCompatConf)
+    )
+  }
+
+  /**
+   * Helper function to get the num of addFiles as well as
+   * num of addFiles with ICEBERG_COMPAT_VERSION tag.
+   * @param icebergCompatVersion target iceberg compat version
+   * @param snapshot current snapshot
+   * @return (NumOfAddFiles, NumOfAddFilesWithIcebergCompatTag)
+   */
+  private def getNumOfAddFiles(
+      icebergCompatVersion: Int,
+      table: DeltaTableV2,
+      snapshot: Snapshot): (Long, Long) = {
+    val numOfAddFilesWithTag = snapshot.allFiles
+      .select("tags")
+      .where(try_element_at(col("tags"), AddFile.Tags.ICEBERG_COMPAT_VERSION.name)
+        === icebergCompatVersion.toString)
+      .count()
+    val numOfAddFiles = snapshot.numOfFiles
+    logInfo(s"For table ${table.tableIdentifier} at version ${snapshot.version}, there are " +
+      s"$numOfAddFiles addFiles, and $numOfAddFilesWithTag addFiles with ICEBERG_COMPAT_VERSION=" +
+      s"$icebergCompatVersion tag.")
+    (numOfAddFiles, numOfAddFilesWithTag)
+  }
+
+  /**
+   * Helper function to rewrite the table data files in Iceberg compatible way.
+   * This method would do following things:
+   * 1. Update the table properties to enable the target iceberg compat version and disable the
+   *    existing iceberg compat version.
+   * 2. If target iceberg compat version require rewriting and not all addFiles has
+   *    ICEBERG_COMPAT_VERSION=version tag, rewrite the table data files to be iceberg compatible
+   *    and adding tag to all addFiles.
+   * 3. If universal format not enabled, alter the table properties to enable
+   *    universalFormat = Iceberg.
+   *
+   * * There are six possible write combinations:
+   * | CurrentIcebergCompatVersion | TargetIcebergCompatVersion | Required steps|
+   * | --------------- | --------------- | --------------- |
+   * |      None       |         1       |   1, 3          |
+   * |      None       |         2       |   1, 2, 3       |
+   * |      1          |         1       |   3             |
+   * |      1          |         2       |   1, 2, 3       |
+   * |      2          |         1       |   1, 3          |
+   * |      2          |         2       |   2, 3          |
+   */
+  private def doRewrite(
+      target: DeltaTableV2,
+      sparkSession: SparkSession,
+      targetIcebergCompatVersion: Int): Seq[Row] = {
+
+    val snapshot = target.deltaLog.update()
+    val currIcebergCompatVersionOpt = getEnabledVersion(snapshot.metadata)
+    val targetVersionDeltaConfig = getIcebergCompatVersionConfigForValidVersion(
+      targetIcebergCompatVersion)
+    val versionChangeMayNeedRewrite = reorgMayNeedRewrite(
+      currIcebergCompatVersionOpt.getOrElse(0), targetIcebergCompatVersion)
+
+    // Step 1: Update the table properties to enable the target iceberg compat version
+    val didUpdateIcebergCompatVersion =
+      if (!currIcebergCompatVersionOpt.contains(targetIcebergCompatVersion)) {
+        enableIcebergCompat(target, currIcebergCompatVersionOpt, targetVersionDeltaConfig)
+        logInfo(s"Update table ${target.tableIdentifier} to iceberg compat version = " +
+          s"$targetIcebergCompatVersion successfully.")
+        true
+      } else {
+        false
+      }
+
+    // Step 2: Rewrite the table data files to be Iceberg compatible.
+    val (numOfAddFilesBefore, numOfAddFilesWithTagBefore) = getNumOfAddFiles(
+      targetIcebergCompatVersion, target, snapshot)
+    val allAddFilesHaveTag = numOfAddFilesWithTagBefore == numOfAddFilesBefore
+    // The table needs to be rewritten if:
+    //   1. The target iceberg compat version requires rewrite.
+    //   2. Not all addFile have ICEBERG_COMPAT_VERSION=targetVersion tag
+    val (metricsOpt, didRewrite) = if (versionChangeMayNeedRewrite && !allAddFilesHaveTag) {
+      logInfo(s"Reorg Table ${target.tableIdentifier} to iceberg compat version = " +
+        s"$targetIcebergCompatVersion need rewrite data files.")
+      val metrics = try {
+        optimizeByReorg(
+          sparkSession,
+          isPurge = false,
+          icebergCompatVersion = Some(targetIcebergCompatVersion)
+        )
+      } catch {
+        case NonFatal(e) =>
+          throw DeltaErrors.icebergCompatDataFileRewriteFailedException(
+            targetIcebergCompatVersion, e)
+      }
+      logInfo(s"Rewrite table ${target.tableIdentifier} to iceberg compat version = " +
+        s"$targetIcebergCompatVersion successfully.")
+      (Some(metrics), true)
+    } else {
+      (None, false)
+    }
+    val updatedSnapshot = target.deltaLog.update()
+    val (numOfAddFiles, numOfAddFilesWithIcebergCompatTag) = getNumOfAddFiles(
+      targetIcebergCompatVersion, target, updatedSnapshot)
+    if (versionChangeMayNeedRewrite && numOfAddFilesWithIcebergCompatTag != numOfAddFiles) {
+      throw DeltaErrors.icebergCompatReorgAddFileTagsMissingException(
+        updatedSnapshot.version,
+        targetIcebergCompatVersion,
+        numOfAddFiles,
+        numOfAddFilesWithIcebergCompatTag
+      )
+    }
+
+    // Step 3: Update the table properties to enable the universalFormat = Iceberg.
+    if (!icebergEnabled(updatedSnapshot.metadata)) {
+      val enableUniformConf = Map(
+        DeltaConfigs.UNIVERSAL_FORMAT_ENABLED_FORMATS.key -> ICEBERG_FORMAT)
+      AlterTableSetPropertiesDeltaCommand(target, enableUniformConf).run(sparkSession)
+      logInfo(s"Enabling universal format with iceberg compat version = " +
+        s"$targetIcebergCompatVersion for table ${target.tableIdentifier} succeeded.")
+    }
+
+    recordDeltaEvent(updatedSnapshot.deltaLog, "delta.upgradeUniform.success", data = Map(
+      "currIcebergCompatVersion" -> currIcebergCompatVersionOpt.toString,
+      "targetIcebergCompatVersion" -> targetIcebergCompatVersion.toString,
+      "metrics" -> metricsOpt.toString,
+      "didUpdateIcebergCompatVersion" -> didUpdateIcebergCompatVersion.toString,
+      "needRewrite" -> versionChangeMayNeedRewrite.toString,
+      "didRewrite" -> didRewrite.toString,
+      "numOfAddFilesBefore" -> numOfAddFilesBefore.toString,
+      "numOfAddFilesWithIcebergCompatTagBefore" -> numOfAddFilesWithTagBefore.toString,
+      "numOfAddFilesAfter" -> numOfAddFiles.toString,
+      "numOfAddFilesWithIcebergCompatTagAfter" -> numOfAddFilesWithIcebergCompatTag.toString,
+      "universalFormatIcebergEnabled" -> icebergEnabled(target.deltaLog.update().metadata).toString
+    ))
+    metricsOpt.getOrElse(Seq.empty[Row])
+  }
+
+  /**
+   * Helper function to upgrade the table to uniform iceberg compat version.
+   */
+  protected def upgradeUniformIcebergCompatVersion(
+      target: DeltaTableV2,
+      sparkSession: SparkSession,
+      targetIcebergCompatVersion: Int): Seq[Row] = {
+    try {
+      doRewrite(target, sparkSession, targetIcebergCompatVersion)
+    } catch {
+      case NonFatal(e) =>
+        recordDeltaEvent(target.deltaLog, "delta.upgradeUniform.exception", data = Map(
+          "targetIcebergCompatVersion" -> targetIcebergCompatVersion.toString,
+          "exception" -> e.toString
+        ))
+        throw e
+    }
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
@@ -451,7 +451,7 @@ trait TransactionalWrite extends DeltaLogging { self: OptimisticTransactionImpl 
       }
     }
 
-    val resultFiles =
+    var resultFiles =
       (if (optionalStatsTracker.isDefined) {
         committer.addedStatuses.map { a =>
           a.copy(stats = optionalStatsTracker.map(
@@ -470,6 +470,14 @@ trait TransactionalWrite extends DeltaLogging { self: OptimisticTransactionImpl 
       // b) don't have any stats so we don't know the number of rows at all
       case a: AddFile => a.numLogicalRecords.forall(_ > 0)
       case _ => true
+    }
+
+    // add [[AddFile.Tags.ICEBERG_COMPAT_VERSION.name]] tags to addFiles
+    if (IcebergCompatV2.isEnabled(metadata)) {
+      resultFiles = resultFiles.map { addFile =>
+        addFile.copy(tags = addFile.tags + (AddFile.Tags.ICEBERG_COMPAT_VERSION.name ->
+          "2"))
+      }
     }
 
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/Utils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/Utils.scala
@@ -21,6 +21,9 @@ import scala.util.Random
 import org.apache.spark.sql.delta.DeltaConfigs
 import org.apache.spark.sql.delta.actions.Metadata
 
+import org.apache.spark.sql.{Column, Dataset}
+import org.apache.spark.sql.catalyst.expressions.ElementAt
+import org.apache.spark.sql.functions.lit
 
 /**
  * Various utility methods used by Delta.
@@ -56,4 +59,13 @@ object Utils {
     System.getenv("DELTA_TESTING") != null
   }
 
+  /**
+   * Returns value for the given key in value if column is a map and the key is present, NULL
+   * otherwise.
+   */
+  def try_element_at(mapColumn: Column, key: Any): Column = {
+    Column {
+      ElementAt(mapColumn.expr, lit(key).expr, failOnError = false)
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR is the implementation of REORG TABLE command for uniform tables to rewrite the parquet files in iceberg compatible way.
Previous sql syntax is REORG TABLE table_name [WHERE predicate] APPLY (PURGE). We added the UPGRADE UNIFORM option to this command, now REORG command also support syntax below
REORG TABLE table_name APPLY (UPGRADE UNIFORM (ICEBERG_COMPAT_VERSION = version)
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
