### PR TITLE
[Kernel][Data skipping] Generate data skipping filters when possible for IS_NOT_NULL

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
@@ -138,11 +138,32 @@ public class StatsSchemaHelper {
         return getStatsColumn(column, MIN);
     }
 
-    /** Given a logical column returns corresponding the MAX column in the statistic schema */
+    /**
+     * Given a logical column in the data schema provided when creating {@code this}, return
+     * the corresponding MAX column in the statistic schema that stores the MAX values for the
+     * provided logical column.
+     */
     public Column getMaxColumn(Column column) {
         checkArgument(isSkippingEligibleMinMaxColumn(column),
             String.format("%s is not a valid min column for data schema %s", column, dataSchema));
         return getStatsColumn(column, MAX);
+    }
+
+    /**
+     * Given a logical column in the data schema provided when creating {@code this}, return
+     * the corresponding NULL_COUNT column in the statistic schema that stores the null count values
+     * for the provided logical column.
+     */
+    public Column getNullCountColumn(Column column) {
+        checkArgument(isSkippingEligibleNullCountColumn(column),
+            String.format(
+                "%s is not a valid null_count column for data schema %s", column, dataSchema));
+        return getStatsColumn(column, NULL_COUNT);
+    }
+
+    /** Returns the NUM_RECORDS column in the statistic schema */
+    public Column getNumRecordsColumn() {
+        return new Column(NUM_RECORDS);
     }
 
     /**


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Generate skipping filters for IS_NOT_NULL and NOT(IS_NOT_NULL). Note NOT(IS_NOT_NULL) won't skip until IS_NULL is supported.

## How was this patch tested?

Adds tests.
