### PR TITLE
CreateOrReplace table command should not follow DPO option

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDeltaLike.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDeltaLike.scala
@@ -61,7 +61,8 @@ trait WriteIntoDeltaLike {
   def write(
       txn: OptimisticTransaction,
       sparkSession: SparkSession,
-      clusterBySpecOpt: Option[ClusterBySpec] = None): Seq[Action]
+      clusterBySpecOpt: Option[ClusterBySpec] = None,
+      isTableReplace: Boolean = false): Seq[Action]
 
   val deltaLog: DeltaLog
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
@@ -29,6 +29,7 @@ import org.apache.commons.io.FileUtils
 import org.apache.parquet.format.CompressionCodec
 
 import org.apache.spark.sql.{AnalysisException, QueryTest}
+import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.internal.SQLConf.PARTITION_OVERWRITE_MODE
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.util.Utils
@@ -306,6 +307,26 @@ class DeltaOptionSuite extends QueryTest
     }
   }
 
+  test("overwriteSchema=true should be invalid with partitionOverwriteMode=dynamic, " +
+      "saveAsTable") {
+    withTable("temp") {
+      val e = intercept[DeltaIllegalArgumentException] {
+        withSQLConf(DeltaSQLConf.DYNAMIC_PARTITION_OVERWRITE_ENABLED.key -> "true") {
+          Seq(1, 2, 3).toDF
+            .withColumn("part", $"value" % 2)
+            .write
+            .mode("overwrite")
+            .format("delta")
+            .partitionBy("part")
+            .option(OVERWRITE_SCHEMA_OPTION, "true")
+            .option(PARTITION_OVERWRITE_MODE_OPTION, "dynamic")
+            .saveAsTable("temp")
+        }
+      }
+      assert(e.getErrorClass == "DELTA_OVERWRITE_SCHEMA_WITH_DYNAMIC_PARTITION_OVERWRITE")
+    }
+  }
+
   test("Prohibit spark.databricks.delta.dynamicPartitionOverwrite.enabled=false in " +
     "dynamic partition overwrite mode") {
     withTempDir { tempDir =>
@@ -332,6 +353,80 @@ class DeltaOptionSuite extends QueryTest
         }
         assert(e.getErrorClass == "DELTA_DYNAMIC_PARTITION_OVERWRITE_DISABLED")
       }
+    }
+  }
+
+  for (createOrReplace <- Seq("CREATE OR REPLACE", "REPLACE")) {
+    test(s"$createOrReplace table command should not respect " +
+      "dynamic partition overwrite mode") {
+      withTempDir { tempDir =>
+        Seq(0, 1).toDF
+          .withColumn("key", $"value" % 2)
+          .withColumn("stringColumn", lit("string"))
+          .withColumn("part", $"value" % 2)
+          .write
+          .format("delta")
+          .partitionBy("part")
+          .save(tempDir.getAbsolutePath)
+        withSQLConf(PARTITION_OVERWRITE_MODE.key -> "dynamic") {
+          // Write only to one partition with a different schema type of stringColumn.
+          sql(
+            s"""
+               |$createOrReplace TABLE delta.`${tempDir.getAbsolutePath}`
+               |USING delta
+               |PARTITIONED BY (part)
+               |LOCATION '${tempDir.getAbsolutePath}'
+               |AS SELECT -1 as value, 0 as part, 0 as stringColumn
+               |""".stripMargin)
+          assert(spark.read.format("delta").load(tempDir.getAbsolutePath).count() == 1,
+            "Table should be fully replaced even with DPO mode enabled")
+        }
+      }
+    }
+  }
+
+  // Same test as above but using DeltaWriter V2.
+  test("create or replace table V2 should not respect dynamic partition overwrite mode") {
+    withTable("temp") {
+      Seq(0, 1).toDF
+        .withColumn("part", $"value" % 2)
+        .write
+        .format("delta")
+        .partitionBy("part")
+        .saveAsTable("temp")
+      withSQLConf(PARTITION_OVERWRITE_MODE.key -> "dynamic") {
+        // Write to one partition only.
+        Seq(0).toDF
+          .withColumn("part", $"value" % 2)
+          .writeTo("temp")
+          .using("delta")
+          .createOrReplace()
+        assert(spark.read.format("delta").table("temp").count() == 1,
+          "Table should be fully replaced even with DPO mode enabled")
+      }
+    }
+  }
+
+  // Same test as above but using saveAsTable.
+  test("saveAsTable with overwrite should respect dynamic partition overwrite mode") {
+    withTable("temp") {
+      Seq(0, 1).toDF
+        .withColumn("part", $"value" % 2)
+        .write
+        .format("delta")
+        .partitionBy("part")
+        .saveAsTable("temp")
+      // Write to one partition only.
+      Seq(0).toDF
+        .withColumn("part", $"value" % 2)
+        .write
+        .mode("overwrite")
+        .option(PARTITION_OVERWRITE_MODE_OPTION, "dynamic")
+        .partitionBy("part")
+        .format("delta")
+        .saveAsTable("temp")
+      assert(spark.read.format("delta").table("temp").count() == 2,
+        "Table should keep the original partition with DPO mode enabled.")
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
CreateOrReplace table command accidentally followed DPO semantics when replacing an existing table.
This PR adds writeOptions to the write command to differenciate a replace command from other inserts.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
new UTs

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No