### PR TITLE
Add docs for default column values

### DIFF
--- a/docs/source/delta-batch.md
+++ b/docs/source/delta-batch.md
@@ -407,6 +407,10 @@ You can use an [EXPLAIN](https://spark.apache.org/docs/latest/sql-ref-syntax-qry
 
 <a id="special-chars-in-col-name"></a>
 
+### Specify default values for columns
+
+Delta enables the specification of [default expressions](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#default-columns) for columns in Delta tables. When users write to these tables without explicitly providing values for certain columns, or when they explicitly use the DEFAULT SQL keyword for a column, Delta automatically generates default values for those columns. For more information, please refer to the [dedicated documentation page](#delta-default-columns).
+
 ### Use special characters in column names
 
 

--- a/docs/source/delta-default-columns.md
+++ b/docs/source/delta-default-columns.md
@@ -4,7 +4,7 @@ description: Learn about default column values in Delta.
 
 # Delta default column values
 
-.. note:: This feature is available in <Delta> 2.3.0 and above and is enabled using the `allowColumnDefaults` writer [table feature](#versioning).
+.. note:: This feature is available in <Delta> 3.1.0 and above and is enabled using the `allowColumnDefaults` writer [table feature](#versioning).
 
 Delta enables the specification of [default expressions](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#default-columns) for columns in Delta tables. When users write to these tables without explicitly providing values for certain columns, or when they explicitly use the DEFAULT SQL keyword for a column, Delta automatically generates default values for those columns.
 
@@ -12,7 +12,7 @@ This information is stored in the [StructField](https://github.com/delta-io/delt
 
 ## How to enable <Delta> default column values
 
-.. important:: Enabling default column values for a table upgrades the Delta [table version](versioning.md) as a byproduct of enabling [table features](#versioning). This protocol upgrade is irreversible. Tables with default column values enabled can only be read in <Delta> 2.3 and above.
+.. important:: Enabling default column values for a table upgrades the Delta [table version](versioning.md) as a byproduct of enabling [table features](#versioning). This protocol upgrade is irreversible. Tables with default column values enabled can only be read in <Delta> 3.1 and above.
 
 You can enable default column values for a table by setting `delta.feature.allowColumnDefaults` to `enabled`:
 

--- a/docs/source/delta-default-columns.md
+++ b/docs/source/delta-default-columns.md
@@ -1,0 +1,41 @@
+---
+description: Learn about default column values in Delta.
+---
+
+# Delta default column values
+
+.. note:: This feature is available in <Delta> 2.3.0 and above and is enabled using the `allowColumnDefaults` writer [table feature](#versioning).
+
+Delta enables the specification of [default expressions](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#default-columns) for columns in Delta tables. When users write to these tables without explicitly providing values for certain columns, or when they explicitly use the DEFAULT SQL keyword for a column, Delta automatically generates default values for those columns.
+
+This information is stored in the [StructField](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#struct-field) corresponding to the column of interest.
+
+## How to enable <Delta> default column values
+
+.. important:: Enabling default column values for a table upgrades the Delta [table version](versioning.md) as a byproduct of enabling [table features](#versioning). This protocol upgrade is irreversible. Tables with default column values enabled can only be read in <Delta> 2.3 and above.
+
+You can enable default column values for a table by setting `delta.feature.allowColumnDefaults` to `enabled`:
+
+  ```sql
+  ALTER TABLE <table_name> SET TBLPROPERTIES (
+    'delta.feature.allowColumnDefaults' = 'enabled'
+  )
+  ```
+
+## How to use default columns in SQL commands
+
+- For SQL commands that perform table writes, such as `INSERT`, `UPDATE`, and `MERGE` commands, the `DEFAULT` keyword resolves to the most recently assigne default value for the corresponding column (or NULL if no default value exists). For instance, the following SQL command will use the default value for the second column in the table: `INSERT INTO t VALUES (16, DEFAULT);`
+
+- It is also possible for INSERT commands to specify lists of fewer column than the target table, in which case the engine will assign default values for the remaining columns (or NULL for any columns where no defaults yet exist).
+
+.. important:: The metadata discussed here apply solely to write operations, not read operations.
+
+-  The `ALTER TABLE ... ADD COLUMN` command that introduces a new column to an existing table may not to specify a default value for the new column. For instance, the following SQL command is not supported in Delta Lake: `ALTER TABLE t ADD COLUMN c INT DEFAULT 16;`
+
+- It is permissible, however, to assign or update default values for columns that were created in previous commands. For example, the following SQL command is valid: `ALTER TABLE t ALTER COLUMN c SET DEFAULT 16;`
+
+
+
+
+
+

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -21,6 +21,7 @@ This is the documentation site for <Delta>.
     delta-utility
     delta-constraints
     versioning
+    delta-column-defaults
     delta-column-mapping
     delta-deletion-vectors
     delta-apidoc


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [X] Other (Docs)

## Description

This PR adds documentation for default column values for Delta lake added in https://github.com/delta-io/delta/pull/2210. 

## How was this patch tested?

Docs-only changes.

## Does this PR introduce _any_ user-facing changes?

No.