### PR TITLE
[Kernel] Return unsupported expression in partition pruning in remaining predicate

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
@@ -93,9 +93,10 @@ public interface Scan {
      * Get the remaining filter that is not guaranteed to be satisfied for the data Delta Kernel
      * returns. This filter is used by Delta Kernel to do data skipping when possible.
      *
+     * @param tableClient {@link TableClient} instance to use in Delta Kernel.
      * @return the remaining filter as a {@link Predicate}.
      */
-    Optional<Predicate> getRemainingFilter();
+    Optional<Predicate> getRemainingFilter(TableClient tableClient);
 
     /**
      * Get the scan state associated with the current scan. This state is common across all

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ExpressionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ExpressionUtils.java
@@ -18,8 +18,9 @@ package io.delta.kernel.internal.util;
 import java.util.List;
 import static java.lang.String.format;
 
-import io.delta.kernel.expressions.Expression;
-import io.delta.kernel.expressions.Predicate;
+import io.delta.kernel.expressions.*;
+import static io.delta.kernel.expressions.AlwaysFalse.ALWAYS_FALSE;
+
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 
 public class ExpressionUtils {
@@ -63,5 +64,23 @@ public class ExpressionUtils {
             children.size() == 1,
             format("%s: expected one inputs, but got %s", expression, children.size()));
         return children.get(0);
+    }
+
+    /*
+     * Utility method to combine the given predicates with AND
+     */
+    public static Predicate combineWithAndOp(Predicate left, Predicate right) {
+        String leftName = left.getName().toUpperCase();
+        String rightName = right.getName().toUpperCase();
+        if (leftName.equals("ALWAYS_FALSE") || rightName.equals("ALWAYS_FALSE")) {
+            return ALWAYS_FALSE;
+        }
+        if (leftName.equals("ALWAYS_TRUE")) {
+            return right;
+        }
+        if (rightName.equals("ALWAYS_TRUE")) {
+            return left;
+        }
+        return new And(left, right);
     }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/PartitionPruningSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/PartitionPruningSuite.scala
@@ -156,6 +156,58 @@ class PartitionPruningSuite extends AnyFunSuite with TestUtils {
     ) -> (
       predicate("=", col("as_value"), ofString("200")),
       Seq()
+    ),
+
+    (
+      "partition pruning: predicate with (unsupported expr OR data predicate)",
+      or(
+        predicate("=", col("as_value"), ofString("1")), // data col filter
+        predicate("unsupported") // unsupported expression
+      )
+    ) -> (
+      or(
+        predicate("=", col("as_value"), ofString("1")), // data col filter
+        predicate("unsupported") // unsupported expression
+      ),
+      Seq((18878, "0"), (18878, "1"), (null, "2"))
+    ),
+
+    (
+      "partition pruning: predicate with (unsupported expr OR partition predicate)",
+      or(
+        predicate("=", col("as_float"), ofFloat(1)), // partition col filter
+        predicate("unsupported") // unsupported expression
+      )
+    ) -> (
+      or(
+        predicate("=", col("as_float"), ofFloat(1)), // partition col filter
+        predicate("unsupported") // unsupported expression
+      ),
+      Seq((18878, "0"), (18878, "1"), (null, "2"))
+    ),
+    (
+      "partition pruning: predicate with (unsupported expr AND data predicate)",
+      and(
+        predicate("=", col("as_value"), ofString("1")), // data col filter
+        predicate("unsupported") // unsupported expression
+      )
+    ) -> (
+      and(
+        predicate("=", col("as_value"), ofString("1")), // data col filter
+        predicate("unsupported") // unsupported expression
+      ),
+      Seq((18878, "0"), (18878, "1"), (null, "2"))
+    ),
+
+    (
+      "partition pruning: predicate with (unsupported expr AND partition predicate)",
+      and(
+        predicate("=", col("as_float"), ofFloat(1)), // partition col filter
+        predicate("unsupported") // unsupported expression
+      )
+    ) -> (
+      predicate("unsupported"), // unsupported expression
+      Seq((18878, "1"))
     )
   )
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -183,7 +183,7 @@ trait TestUtils extends Assertions with SQLHelper {
     val scan = scanBuilder.build()
 
     if (filter != null) {
-      val actRemainingPredicate = scan.getRemainingFilter()
+      val actRemainingPredicate = scan.getRemainingFilter(defaultTableClient)
       assert(
         actRemainingPredicate.toString === Optional.ofNullable(expectedRemainingFilter).toString)
     }


### PR DESCRIPTION
## Description
Currently the `DefaultExpressionHandler` only supports a few expressions. If a user passes an unsupported expression, Kernel partition pruning fails with an unsupported operation exception. Instead, this PR changes it to return the unsupported part of the expression in the remaining filter of `Scan`. It makes use of `ExpressionHandler.getPredicateEvaluator` to decide whether an expression is supported or not.

## How was this patch tested?
Unit tests and integration tests.

