### PR TITLE
[Kernel] Add `ExpressionHandler.isSupported` to check for expression support

### DIFF
--- a/connectors/golden-tables/src/test/scala/io/delta/golden/GoldenTables.scala
+++ b/connectors/golden-tables/src/test/scala/io/delta/golden/GoldenTables.scala
@@ -378,6 +378,7 @@ class GoldenTables extends QueryTest with SharedSparkSession {
 
     val commitInfoFile = CommitInfo(
       version = Some(0L),
+      None,
       timestamp = new Timestamp(1540415658000L),
       userId = Some("user_0"),
       userName = Some("username_0"),

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/client/ExpressionHandler.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/client/ExpressionHandler.java
@@ -35,6 +35,16 @@ import io.delta.kernel.types.StructType;
 @Evolving
 public interface ExpressionHandler {
     /**
+     * Is the given expression evaluation supported on the data with given schema?
+     *
+     * @param inputSchema Schema of input data on which the expression is evaluated.
+     * @param expression Expression to check whether it is supported for evaluation.
+     * @param outputType Expected result data type.
+     * @return true if supported and false otherwise.
+     */
+    boolean isSupported(StructType inputSchema, Expression expression, DataType outputType);
+
+    /**
      * Create an {@link ExpressionEvaluator} that can evaluate the given <i>expression</i> on
      * {@link ColumnarBatch}s with the given <i>batchSchema</i>. The <i>expression</i> is
      * expected to be a scalar expression where for each one input row there

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -86,8 +86,8 @@ public final class DeltaErrors {
         return new RuntimeException(message);
     }
 
-     // TODO: Change the exception to proper type as part of the exception framework
-     // (see delta-io/delta#2231)
+    // TODO: Change the exception to proper type as part of the exception framework
+    // (see delta-io/delta#2231)
     /**
      * Exception thrown when the expression evaluator doesn't support the given expression.
      * @param expression

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -16,6 +16,9 @@
 package io.delta.kernel.internal;
 
 import java.sql.Timestamp;
+import java.util.Optional;
+
+import io.delta.kernel.expressions.Expression;
 
 public final class DeltaErrors {
     private DeltaErrors() {}
@@ -81,6 +84,24 @@ public final class DeltaErrors {
             commitTimestamp,
             commitTimestampStr);
         return new RuntimeException(message);
+    }
+
+     // TODO: Change the exception to proper type as part of the exception framework
+     // (see delta-io/delta#2231)
+    /**
+     * Exception thrown when the expression evaluator doesn't support the given expression.
+     * @param expression
+     * @param reason Optional additional reason for why the expression is not supported.
+     * @return
+     */
+    public static UnsupportedOperationException unsupportedExpression(
+            Expression expression,
+            Optional<String> reason) {
+        String message = String.format(
+            "Expression evaluator doesn't support the expression: %s.%s",
+                expression,
+                reason.map(r -> " Reason: " + r).orElse(""));
+        return new UnsupportedOperationException(message);
     }
 
     private static String formatTimestamp(long millisSinceEpochUTC) {

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultExpressionHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultExpressionHandler.java
@@ -39,6 +39,18 @@ import io.delta.kernel.defaults.internal.expressions.DefaultPredicateEvaluator;
  */
 public class DefaultExpressionHandler implements ExpressionHandler {
     @Override
+    public boolean isSupported(StructType inputSchema, Expression expression, DataType outputType) {
+        // There is no extra cost to create an expression handler in default implementation in
+        // addition to checking the expression support. So we can just use `getEvaluator`.
+        try {
+            getEvaluator(inputSchema, expression, outputType);
+            return true;
+        } catch (UnsupportedOperationException e) {
+            return false;
+        }
+    }
+
+    @Override
     public ExpressionEvaluator getEvaluator(
         StructType inputSchema,
         Expression expression,

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
@@ -27,6 +27,7 @@ import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.expressions.*;
 import io.delta.kernel.types.*;
 
+import io.delta.kernel.internal.DeltaErrors;
 import static io.delta.kernel.internal.util.ExpressionUtils.getLeft;
 import static io.delta.kernel.internal.util.ExpressionUtils.getRight;
 import static io.delta.kernel.internal.util.ExpressionUtils.getUnaryChild;
@@ -63,8 +64,9 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
         ExpressionTransformResult transformResult =
             new ExpressionTransformer(inputSchema).visit(expression);
         if (!transformResult.outputType.equivalent(outputType)) {
-            throw new UnsupportedOperationException(format("Can not create an expression handler " +
-                "for expression `%s` returns result of type %s", expression, outputType));
+            String reason = format(
+                    "Can not create an expression handler returns result of type %s", outputType);
+            throw DeltaErrors.unsupportedExpression(expression, Optional.of(reason));
         }
         this.expression = transformResult.expression;
     }
@@ -149,8 +151,8 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
                         transformBinaryComparator(predicate),
                         BooleanType.BOOLEAN);
                 default:
-                    throw new UnsupportedOperationException(
-                        "unsupported expression encountered: " + predicate);
+                    throw DeltaErrors.unsupportedExpression(
+                            predicate, Optional.of("unsupported expression encountered"));
             }
         }
 
@@ -191,8 +193,9 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
             if (partitionColType instanceof StructType ||
                 partitionColType instanceof ArrayType ||
                 partitionColType instanceof MapType) {
-                throw new UnsupportedOperationException(
-                    "unsupported partition data type: " + partitionColType);
+                throw DeltaErrors.unsupportedExpression(
+                        partitionValue,
+                        Optional.of("unsupported partition data type: " + partitionColType));
             }
             return new ExpressionTransformResult(
                 new PartitionValueExpression(serializedPartValueInput.expression, partitionColType),
@@ -248,16 +251,17 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
                 .map(this::visit)
                 .collect(Collectors.toList());
             if (children.size() == 0) {
-                throw new UnsupportedOperationException(
-                    "Coalesce requires at least one expression");
+                throw DeltaErrors.unsupportedExpression(
+                    coalesce, Optional.of("Coalesce requires at least one expression"));
             }
             // TODO support least-common-type resolution
             long numDistinctTypes = children.stream().map(e -> e.outputType)
                 .distinct()
                 .count();
             if (numDistinctTypes > 1) {
-                throw new UnsupportedOperationException(
-                    "Coalesce is only supported for arguments of the same type");
+                throw DeltaErrors.unsupportedExpression(
+                        coalesce,
+                        Optional.of("Coalesce is only supported for arguments of the same type"));
             }
             // TODO support other data types besides boolean (just needs tests)
             if (!(children.get(0).outputType instanceof BooleanType)) {
@@ -298,10 +302,10 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
                 } else if (canCastTo(rightResult.outputType, leftResult.outputType)) {
                     right = new ImplicitCastExpression(right, leftResult.outputType);
                 } else {
-                    String msg = format("%s: operands are of different types which are not " +
+                    String msg = format("operands are of different types which are not " +
                             "comparable: left type=%s, right type=%s",
-                        predicate, leftResult.outputType, rightResult.outputType);
-                    throw new UnsupportedOperationException(msg);
+                            leftResult.outputType, rightResult.outputType);
+                    throw DeltaErrors.unsupportedExpression(predicate, Optional.of(msg));
                 }
             }
             return new Predicate(predicate.getName(), left, right);
@@ -433,8 +437,9 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
                     }
                     break;
                 default:
-                    throw new UnsupportedOperationException(
-                        "unsupported expression encountered: " + predicate);
+                    throw DeltaErrors.unsupportedExpression(
+                            predicate,
+                            Optional.of("unsupported expression encountered"));
             }
 
             return new DefaultBooleanVector(numRows, Optional.of(nullability), result);

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ElementAtEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ElementAtEvaluator.java
@@ -16,6 +16,7 @@
 package io.delta.kernel.defaults.internal.expressions;
 
 import java.util.Arrays;
+import java.util.Optional;
 import static java.lang.String.format;
 
 import io.delta.kernel.data.ColumnVector;
@@ -26,6 +27,7 @@ import io.delta.kernel.types.DataType;
 import io.delta.kernel.types.MapType;
 import io.delta.kernel.types.StringType;
 
+import io.delta.kernel.internal.DeltaErrors;
 import io.delta.kernel.internal.util.Utils;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 
@@ -55,9 +57,10 @@ class ElementAtEvaluator {
             if (canCastTo(lookupKeyType, keyTypeFromMapInput)) {
                 lookupKey = new ImplicitCastExpression(lookupKey, keyTypeFromMapInput);
             } else {
-                throw new UnsupportedOperationException(format(
-                    "%s: lookup key type (%s) is different from the map key type (%s)",
-                    elementAt, lookupKeyType, asMapType.getKeyType()));
+                String reason = format(
+                        "lookup key type (%s) is different from the map key type (%s)",
+                        lookupKeyType, asMapType.getKeyType());
+                throw DeltaErrors.unsupportedExpression(elementAt, Optional.of(reason));
             }
         }
         return new ScalarExpression(elementAt.getName(), Arrays.asList(mapInput, lookupKey));

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
@@ -554,7 +554,7 @@ class DefaultExpressionEvaluatorSuite extends AnyFunSuite with ExpressionSuiteBa
     val ex = intercept[UnsupportedOperationException] {
       evaluator(inputSchema, elementAtExpr, StringType.STRING)
     }
-    assert(ex.getMessage.contains("ELEMENT_AT(column(`as_map`), 24): " +
+    assert(ex.getMessage.contains(
       "lookup key type (short) is different from the map key type (string)"))
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/ExpressionTestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/ExpressionTestUtils.scala
@@ -15,52 +15,51 @@
  */
 package io.delta.kernel.defaults.utils
 
+import scala.collection.JavaConverters._
+
 import io.delta.kernel.expressions._
 
 /** Useful helper functions for creating expressions in tests */
 trait ExpressionTestUtils {
 
-  def equals(e1: Expression, e2: Expression): Predicate = {
-    new Predicate("=", e1, e2)
-  }
+  def eq(left: Expression, right: Expression): Predicate = predicate("=", left, right)
+  def equals(e1: Expression, e2: Expression): Predicate = eq(e1, e2)
 
-  def lessThan(e1: Expression, e2: Expression): Predicate = {
-    new Predicate("<", e1, e2)
-  }
+  def lt(e1: Expression, e2: Expression): Predicate = new Predicate("<", e1, e2)
+  def lessThan(e1: Expression, e2: Expression): Predicate = lt(e1, e2)
 
-  def greaterThan(e1: Expression, e2: Expression): Predicate = {
-    new Predicate(">", e1, e2)
-  }
+  def gt(e1: Expression, e2: Expression): Predicate = new Predicate(">", e1, e2)
+  def greaterThan(e1: Expression, e2: Expression): Predicate = gt(e1, e2)
 
-  def greaterThanOrEqual(e1: Expression, e2: Expression): Predicate = {
-    new Predicate(">=", e1, e2)
-  }
+  def gte(e1: Expression, e2: Expression): Predicate = predicate(">=", e1, e2)
+  def greaterThanOrEqual(e1: Expression, e2: Expression): Predicate = gte(e1, e2)
 
-  def lessThanOrEqual(e1: Expression, e2: Expression): Predicate = {
-    new Predicate("<=", e1, e2)
-  }
+  def lessThanOrEqual(e1: Expression, e2: Expression): Predicate = new Predicate("<=", e1, e2)
+  def lte(column: Column, literal: Literal): Predicate = predicate("<=", column, literal)
 
-  def not(pred: Predicate): Predicate = {
-    new Predicate("NOT", pred)
-  }
+  def not(pred: Predicate): Predicate = new Predicate("NOT", pred)
 
-  def isNotNull(e1: Expression): Predicate = {
-    new Predicate("IS_NOT_NULL", e1)
-  }
+  def isNotNull(e1: Expression): Predicate = new Predicate("IS_NOT_NULL", e1)
 
-  def col(name: String): Column = new Column(name)
+  def col(names: String*): Column = new Column(names.toArray)
 
   def nestedCol(name: String): Column = {
     new Column(name.split("\\."))
   }
 
-  protected def and(left: Predicate, right: Predicate): And = {
-    new And(left, right)
+  def predicate(name: String, children: Expression*): Predicate = {
+    new Predicate(name, children.asJava)
   }
 
-  protected def or(left: Predicate, right: Predicate): Or = {
-    new Or(left, right)
-  }
+  def and(left: Predicate, right: Predicate): Predicate = predicate("AND", left, right)
+
+  def or(left: Predicate, right: Predicate): Predicate = predicate("OR", left, right)
+
+  def int(value: Int): Literal = Literal.ofInt(value)
+
+  def str(value: String): Literal = Literal.ofString(value)
+
+  def unsupported(colName: String): Predicate = predicate("UNSUPPORTED", col(colName));
 
   /* ---------- NOT-YET SUPPORTED EXPRESSIONS ----------- */
 
@@ -71,19 +70,11 @@ trait ExpressionTestUtils {
   them to expect skipped files. If they are ever actually evaluated they will throw an exception.
    */
 
-  def nullSafeEquals(e1: Expression, e2: Expression): Predicate = {
-    new Predicate("<=>", e1, e2)
-  }
+  def nullSafeEquals(e1: Expression, e2: Expression): Predicate = new Predicate("<=>", e1, e2)
 
-  def notEquals(e1: Expression, e2: Expression): Predicate = {
-    new Predicate("<>", e1, e2)
-  }
+  def notEquals(e1: Expression, e2: Expression): Predicate = new Predicate("<>", e1, e2)
 
-  def startsWith(e1: Expression, e2: Expression): Predicate = {
-    new Predicate("STARTS_WITH", e1, e2)
-  }
+  def startsWith(e1: Expression, e2: Expression): Predicate = new Predicate("STARTS_WITH", e1, e2)
 
-  def isNull(e1: Expression): Predicate = {
-    new Predicate("IS_NULL", e1)
-  }
+  def isNull(e1: Expression): Predicate = new Predicate("IS_NULL", e1)
 }


### PR DESCRIPTION
## Description
Having the API to tell if an expression is supported on a given input schema and expected data type, can make the Kernel make better decisions in splitting the given query predicate to a guaranteed predicate and a best-effort predicate. The proposed API is:

```
    /**
     * Is the given expression evaluation supported on the data with given schema?
     *
     * @param inputSchema Schema of input data on which the expression is evaluated.
     * @param expression Expression to evaluate.
     * @param outputType Expected result data type.
     * @return true if supported and false otherwise.
     */
    boolean isSupported(StructType inputSchema, Expression expression, DataType outputType);
```

## How was this patch tested?
Unittests
