### PR TITLE
[Kernel] Run Kernel integration test/examples as part of the CI

### DIFF
--- a/.github/workflows/kernel_test.yaml
+++ b/.github/workflows/kernel_test.yaml
@@ -15,3 +15,6 @@ jobs:
       - name: Run tests
         run: |
           python run-tests.py --group kernel --coverage
+      - name: Run integration tests
+        run: |
+          cd kernel/examples && python run-kernel-examples.py --use-local


### PR DESCRIPTION
Currently, integration tests/examples can only be run manually which doesn't capture any API updates. Make it run as part of the PR CI jobs so that we catch the failures early.

