### PR TITLE
[Spark][Sharing][3.1] Add deletion vector support in delta format sharing

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingFileIndex.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingFileIndex.scala
@@ -72,20 +72,25 @@ case class DeltaSharingFileIndex(
 
   override def partitionSchema: StructType = params.metadata.partitionSchema
 
+  // Returns the partition columns of the shared delta table based on the returned metadata.
+  def partitionColumns: Seq[String] = params.metadata.deltaMetadata.partitionColumns
+
   override def rootPaths: Seq[Path] = params.path :: Nil
 
   override def inputFiles: Array[String] = {
     throw new UnsupportedOperationException("DeltaSharingFileIndex.inputFiles")
   }
 
-  // A set that includes the queriedTableQueryId that we've issued delta sharing rpc.
-  // This is because listFiles will be called twice or more in a spark query, with this set, we
+  // A map that from queriedTableQueryId that we've issued delta sharing rpc, to the deltaLog
+  // constructed with the response.
+  // It is because this function will be called twice or more in a spark query, with this set, we
   // can avoid doing duplicated work of making expensive rpc and constructing the delta log.
-  private val queriedTableQueryIdSet = scala.collection.mutable.Set[String]()
+  private val queriedTableQueryIdToDeltaLog = scala.collection.mutable.Map[String, DeltaLog]()
 
-  override def listFiles(
+  def fetchFilesAndConstructDeltaLog(
       partitionFilters: Seq[Expression],
-      dataFilters: Seq[Expression]): Seq[PartitionDirectory] = {
+      dataFilters: Seq[Expression],
+      overrideLimit: Option[Long]): DeltaLog = {
     val jsonPredicateHints = convertToJsonPredicate(partitionFilters, dataFilters)
     val queryParamsHashId = DeltaSharingUtils.getQueryParamsHashId(
       params.options,
@@ -101,79 +106,109 @@ case class DeltaSharingFileIndex(
     )
     // listFiles will be called twice or more in a spark query, with this check we can avoid
     // duplicated work of making expensive rpc and constructing the delta log.
-    if (!queriedTableQueryIdSet.contains(tablePathWithHashIdSuffix)) {
-      //  1. Call client.getFiles.
-      val startTime = System.currentTimeMillis()
-      val deltaTableFiles = client.getFiles(
+    queriedTableQueryIdToDeltaLog.get(tablePathWithHashIdSuffix) match {
+      case Some(deltaLog) => deltaLog
+      case None =>
+        createDeltaLog(
+          jsonPredicateHints,
+          queryParamsHashId,
+          tablePathWithHashIdSuffix,
+          overrideLimit
+        )
+    }
+  }
+
+  private def createDeltaLog(
+      jsonPredicateHints: Option[String],
+      queryParamsHashId: String,
+      tablePathWithHashIdSuffix: String,
+      overrideLimit: Option[Long]): DeltaLog = {
+    //  1. Call client.getFiles.
+    val startTime = System.currentTimeMillis()
+    val deltaTableFiles = client.getFiles(
+      table = table,
+      predicates = Nil,
+      limit = overrideLimit.orElse(limitHint),
+      versionAsOf = params.options.versionAsOf,
+      timestampAsOf = params.options.timestampAsOf,
+      jsonPredicateHints = jsonPredicateHints,
+      refreshToken = None
+    )
+    logInfo(
+      s"Fetched ${deltaTableFiles.lines.size} lines for table $table with version " +
+      s"${deltaTableFiles.version} from delta sharing server, took " +
+      s"${(System.currentTimeMillis() - startTime) / 1000.0}s."
+    )
+
+    // 2. Prepare a DeltaLog.
+    val deltaLogMetadata =
+      DeltaSharingLogFileSystem.constructLocalDeltaLogAtVersionZero(
+        deltaTableFiles.lines,
+        tablePathWithHashIdSuffix
+      )
+
+    // 3. Register parquet file id to url mapping
+    CachedTableManager.INSTANCE.register(
+      // Using params.path instead of queryCustomTablePath because it will be customized
+      // within CachedTableManager.
+      tablePath = DeltaSharingUtils.getTablePathWithIdSuffix(
+        params.path.toString,
+        queryParamsHashId
+      ),
+      idToUrl = deltaLogMetadata.idToUrl,
+      refs = Seq(new WeakReference(this)),
+      profileProvider = client.getProfileProvider,
+      refresher = DeltaSharingUtils.getRefresherForGetFiles(
+        client = client,
         table = table,
         predicates = Nil,
-        limit = limitHint,
+        limit = overrideLimit.orElse(limitHint),
         versionAsOf = params.options.versionAsOf,
         timestampAsOf = params.options.timestampAsOf,
         jsonPredicateHints = jsonPredicateHints,
-        refreshToken = None
-      )
-      logInfo(
-        s"Fetched ${deltaTableFiles.lines.size} lines for table $table with version " +
-        s"${deltaTableFiles.version} from delta sharing server, took " +
-        s"${(System.currentTimeMillis() - startTime) / 1000.0}s."
-      )
-
-      // 2. Prepare a DeltaLog.
-      val deltaLogMetadata =
-        DeltaSharingLogFileSystem.constructLocalDeltaLogAtVersionZero(
-          deltaTableFiles.lines,
-          tablePathWithHashIdSuffix
-        )
-
-      // 3. Register parquet file id to url mapping
-      CachedTableManager.INSTANCE.register(
-        // Using params.path instead of queryCustomTablePath because it will be customized
-        // within CachedTableManager.
-        tablePath = DeltaSharingUtils.getTablePathWithIdSuffix(
-          params.path.toString,
-          queryParamsHashId
-        ),
-        idToUrl = deltaLogMetadata.idToUrl,
-        refs = Seq(new WeakReference(this)),
-        profileProvider = client.getProfileProvider,
-        refresher = DeltaSharingUtils.getRefresherForGetFiles(
-          client = client,
-          table = table,
-          predicates = Nil,
-          limit = limitHint,
-          versionAsOf = params.options.versionAsOf,
-          timestampAsOf = params.options.timestampAsOf,
-          jsonPredicateHints = jsonPredicateHints,
-          refreshToken = deltaTableFiles.refreshToken
-        ),
-        expirationTimestamp =
-          if (CachedTableManager.INSTANCE
-              .isValidUrlExpirationTime(deltaLogMetadata.minUrlExpirationTimestamp)) {
-            deltaLogMetadata.minUrlExpirationTimestamp.get
-          } else {
-            System.currentTimeMillis() + CachedTableManager.INSTANCE.preSignedUrlExpirationMs
-          },
         refreshToken = deltaTableFiles.refreshToken
-      )
-
-      // In theory there should only be one entry in this set since each query creates its own
-      // FileIndex class. This is purged together with the FileIndex class when the query finishes.
-      queriedTableQueryIdSet.add(tablePathWithHashIdSuffix)
-    }
+      ),
+      expirationTimestamp =
+        if (CachedTableManager.INSTANCE
+            .isValidUrlExpirationTime(deltaLogMetadata.minUrlExpirationTimestamp)) {
+          deltaLogMetadata.minUrlExpirationTimestamp.get
+        } else {
+          System.currentTimeMillis() + CachedTableManager.INSTANCE.preSignedUrlExpirationMs
+        },
+      refreshToken = deltaTableFiles.refreshToken
+    )
 
     // 4. Create a local file index and call listFiles of this class.
     val deltaLog = DeltaLog.forTable(
       params.spark,
       DeltaSharingLogFileSystem.encode(tablePathWithHashIdSuffix)
     )
-    val fileIndex = new TahoeLogFileIndex(
+
+    // In theory there should only be one entry in this set since each query creates its own
+    // FileIndex class. This is purged together with the FileIndex class when the query
+    // finishes.
+    queriedTableQueryIdToDeltaLog.put(tablePathWithHashIdSuffix, deltaLog)
+
+    deltaLog
+  }
+
+  def asTahoeFileIndex(
+      partitionFilters: Seq[Expression],
+      dataFilters: Seq[Expression]): TahoeLogFileIndex = {
+    val deltaLog = fetchFilesAndConstructDeltaLog(partitionFilters, dataFilters, None)
+    new TahoeLogFileIndex(
       params.spark,
       deltaLog,
       deltaLog.dataPath,
       deltaLog.unsafeVolatileSnapshot
     )
-    fileIndex.listFiles(partitionFilters, dataFilters)
+  }
+
+  override def listFiles(
+      partitionFilters: Seq[Expression],
+      dataFilters: Seq[Expression]): Seq[PartitionDirectory] = {
+    // NOTE: The server is not required to apply all filters, so we apply them client-side as well.
+    asTahoeFileIndex(partitionFilters, dataFilters).listFiles(partitionFilters, dataFilters)
   }
 
   // Converts the specified SQL expressions to a json predicate.

--- a/sharing/src/main/scala/io/delta/sharing/spark/PrepareDeltaSharingScan.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/PrepareDeltaSharingScan.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.spark
+
+import scala.util.control.NonFatal
+
+import org.apache.spark.sql.delta.{DeltaTableUtils => SqlDeltaTableUtils}
+import org.apache.spark.sql.delta.RelationFileIndex
+import org.apache.spark.sql.delta.files.TahoeLogFileIndex
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.stats.{PreparedDeltaFileIndex, PrepareDeltaScan}
+import io.delta.sharing.client.util.ConfUtils
+import io.delta.sharing.spark.DeltaSharingFileIndex
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans.logical._
+
+/**
+ * Before query planning, we prepare any scans over delta sharing tables by pushing
+ * any filters or limits to delta sharing server through RPC, allowing us to return only needed
+ * files and gather more accurate statistics for CBO and metering.
+ */
+class PrepareDeltaSharingScan(override val spark: SparkSession) extends PrepareDeltaScan(spark) {
+
+  /**
+   * Prepares delta sharing scans sequentially.
+   */
+  override protected def prepareDeltaScan(plan: LogicalPlan): LogicalPlan = {
+    transformWithSubqueries(plan) {
+      case scan @ DeltaSharingTableScan(_, filters, dsFileIndex, limit, _) =>
+        val partitionCols = dsFileIndex.partitionColumns
+        val (partitionFilters, dataFilters) = filters.partition { e =>
+          SqlDeltaTableUtils.isPredicatePartitionColumnsOnly(e, partitionCols, spark)
+        }
+        logInfo(s"Classified filters: partition: $partitionFilters, data: $dataFilters")
+        val deltaLog = dsFileIndex.fetchFilesAndConstructDeltaLog(
+          partitionFilters,
+          dataFilters,
+          limit.map(_.toLong)
+        )
+        val snapshot = deltaLog.snapshot
+        val deltaScan = limit match {
+          case Some(limit) => snapshot.filesForScan(limit, filters)
+          case _ => snapshot.filesForScan(filters)
+        }
+        val preparedIndex = PreparedDeltaFileIndex(
+          spark,
+          deltaLog,
+          deltaLog.dataPath,
+          preparedScan = deltaScan,
+          versionScanned = Some(snapshot.version)
+        )
+        SqlDeltaTableUtils.replaceFileIndex(scan, preparedIndex)
+    }
+  }
+
+  // Just return the plan if statistics based skipping is off.
+  // It will fall back to just partition pruning at planning time.
+  // When data skipping is disabled, just convert Delta sharing scans to normal tahoe scans.
+  // NOTE: File skipping is only disabled on the client, so we still pass filters to the server.
+  override protected def prepareDeltaScanWithoutFileSkipping(plan: LogicalPlan): LogicalPlan = {
+    plan.transformDown {
+      case scan@DeltaSharingTableScan(_, filters, sharingIndex, _, _) =>
+        val partitionCols = sharingIndex.partitionColumns
+        val (partitionFilters, dataFilters) = filters.partition { e =>
+          SqlDeltaTableUtils.isPredicatePartitionColumnsOnly(e, partitionCols, spark)
+        }
+        logInfo(s"Classified filters: partition: $partitionFilters, data: $dataFilters")
+        val fileIndex = sharingIndex.asTahoeFileIndex(partitionFilters, dataFilters)
+        SqlDeltaTableUtils.replaceFileIndex(scan, fileIndex)
+    }
+  }
+
+  // TODO: Support metadata-only query optimization!
+  override def optimizeQueryWithMetadata(plan: LogicalPlan): LogicalPlan = plan
+
+  /**
+   * This is an extractor object. See https://docs.scala-lang.org/tour/extractor-objects.html.
+   */
+  object DeltaSharingTableScan extends DeltaTableScan[DeltaSharingFileIndex] {
+    // Since delta library is used to read the data on constructed delta log, this should also
+    // consider the spark config for delta limit pushdown.
+    override def limitPushdownEnabled(plan: LogicalPlan): Boolean =
+      ConfUtils.limitPushdownEnabled(plan.conf) &&
+      spark.conf.get(DeltaSQLConf.DELTA_LIMIT_PUSHDOWN_ENABLED)
+
+    override def getPartitionColumns(fileIndex: DeltaSharingFileIndex): Seq[String] =
+      fileIndex.partitionColumns
+
+    override def getPartitionFilters(fileIndex: DeltaSharingFileIndex): Seq[Expression] =
+      Seq.empty[Expression]
+
+  }
+}

--- a/sharing/src/main/scala/io/delta/sharing/spark/PrepareDeltaSharingScan.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/PrepareDeltaSharingScan.scala
@@ -16,11 +16,7 @@
 
 package io.delta.sharing.spark
 
-import scala.util.control.NonFatal
-
 import org.apache.spark.sql.delta.{DeltaTableUtils => SqlDeltaTableUtils}
-import org.apache.spark.sql.delta.RelationFileIndex
-import org.apache.spark.sql.delta.files.TahoeLogFileIndex
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.{PreparedDeltaFileIndex, PrepareDeltaScan}
 import io.delta.sharing.client.util.ConfUtils
@@ -97,7 +93,7 @@ class PrepareDeltaSharingScan(override val spark: SparkSession) extends PrepareD
     // consider the spark config for delta limit pushdown.
     override def limitPushdownEnabled(plan: LogicalPlan): Boolean =
       ConfUtils.limitPushdownEnabled(plan.conf) &&
-      spark.conf.get(DeltaSQLConf.DELTA_LIMIT_PUSHDOWN_ENABLED)
+        (spark.conf.get(DeltaSQLConf.DELTA_LIMIT_PUSHDOWN_ENABLED.key) == "true")
 
     override def getPartitionColumns(fileIndex: DeltaSharingFileIndex): Seq[String] =
       fileIndex.partitionColumns

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaSuite.scala
@@ -978,7 +978,6 @@ trait DeltaSharingDataSourceDeltaSuiteBase
             val sharingDf =
               spark.read.format("deltaSharing").option("responseFormat", "delta").load(tablePath)
             val deltaDf = spark.read.format("delta").table(deltaTableName)
-
             val filteredSharingDf =
               spark.read
                 .format("deltaSharing")
@@ -990,6 +989,7 @@ trait DeltaSharingDataSourceDeltaSuiteBase
                 .format("delta")
                 .table(deltaTableName)
                 .filter(col("id").mod(10) > 5)
+
             if (!skippingEnabled) {
               def assertError(dataFrame: DataFrame): Unit = {
                 val ex = intercept[IllegalArgumentException] {

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaSuite.scala
@@ -16,6 +16,7 @@
 
 package io.delta.sharing.spark
 
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.{DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
@@ -35,6 +36,13 @@ trait DeltaSharingDataSourceDeltaSuiteBase
     with DeltaSQLCommandTest
     with DeltaSharingTestSparkUtils
     with DeltaSharingDataSourceDeltaTestUtils {
+
+  override def beforeEach(): Unit = {
+    spark.sessionState.conf.setConfString(
+      "spark.delta.sharing.jsonPredicateV2Hints.enabled",
+      "false"
+    )
+  }
 
   /**
    * metadata tests
@@ -100,14 +108,20 @@ trait DeltaSharingDataSourceDeltaSuiteBase
     }
   }
 
-  def assertLimit(tablePath: String, expectedLimit: Seq[Long]): Unit = {
+  def assertLimit(tableName: String, expectedLimit: Seq[Long]): Unit = {
     assert(expectedLimit ==
-      TestClientForDeltaFormatSharing.limits.filter(_._1.contains(tablePath)).map(_._2))
+      TestClientForDeltaFormatSharing.limits.filter(_._1.contains(tableName)).map(_._2))
   }
 
-  def assertRequestedFormat(tablePath: String, expectedFormat: Seq[String]): Unit = {
+  def assertRequestedFormat(tableName: String, expectedFormat: Seq[String]): Unit = {
     assert(expectedFormat ==
-      TestClientForDeltaFormatSharing.requestedFormat.filter(_._1.contains(tablePath)).map(_._2))
+      TestClientForDeltaFormatSharing.requestedFormat.filter(_._1.contains(tableName)).map(_._2))
+  }
+
+  def assertJsonPredicateHints(tableName: String, expectedHints: Seq[String]): Unit = {
+    assert(expectedHints ==
+      TestClientForDeltaFormatSharing.jsonPredicateHints.filter(_._1.contains(tableName)).map(_._2)
+    )
   }
   /**
    * snapshot queries
@@ -123,6 +137,10 @@ trait DeltaSharingDataSourceDeltaSuiteBase
               |(2, "two", "2023-02-02", "2023-02-02 00:00:00")""".stripMargin
         )
 
+        val sharedTableName = "shared_table_simple"
+        prepareMockedClientAndFileSystemResult(deltaTableName, sharedTableName)
+        prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+
         val expectedSchema: StructType = new StructType()
           .add("c1", IntegerType)
           .add("c2", StringType)
@@ -133,40 +151,47 @@ trait DeltaSharingDataSourceDeltaSuiteBase
           Row(2, "two", sqlDate("2023-02-02"), sqlTimestamp("2023-02-02 00:00:00"))
         )
 
-        Seq(true, false).foreach { enableLimitPushdown =>
-          val sharedTableName = s"shared_table_simple_$enableLimitPushdown"
-          prepareMockedClientAndFileSystemResult(deltaTableName, sharedTableName)
-          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+        Seq(true, false).foreach { skippingEnabled =>
+          Seq(true, false).foreach { sharingConfig =>
+            Seq(true, false).foreach { deltaConfig =>
+              val sharedTableName = s"shared_table_simple_" +
+                s"${skippingEnabled}_${sharingConfig}_$deltaConfig"
+              prepareMockedClientAndFileSystemResult(deltaTableName, sharedTableName)
+              prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
 
-          def test(tablePath: String, tableName: String): Unit = {
-            assert(
-              expectedSchema == spark.read
-                .format("deltaSharing")
-                .option("responseFormat", "delta")
-                .load(tablePath)
-                .schema
-            )
-            val df =
-              spark.read.format("deltaSharing").option("responseFormat", "delta").load(tablePath)
-            checkAnswer(df, expected)
-            assert(df.count() > 0)
-            assertLimit(tableName, Seq.empty[Long])
-            val limitDf = spark.read
-              .format("deltaSharing")
-              .option("responseFormat", "delta")
-              .load(tablePath)
-              .limit(1)
-            assert(limitDf.collect().size == 1)
-            assertLimit(tableName, Some(1L).filter(_ => enableLimitPushdown).toSeq)
-          }
+              def test(tablePath: String, tableName: String): Unit = {
+                assert(
+                  expectedSchema == spark.read
+                    .format("deltaSharing")
+                    .option("responseFormat", "delta")
+                    .load(tablePath)
+                    .schema
+                )
+                val df =
+                  spark.read.format("deltaSharing").option("responseFormat", "delta").load(tablePath)
+                  checkAnswer(df, expected)
+                assert(df.count() > 0)
+                assertLimit(tableName, Seq.empty[Long])
+                val limitDf = spark.read
+                  .format("deltaSharing")
+                  .option("responseFormat", "delta")
+                  .load(tablePath)
+                  .limit(1)
+                assert(limitDf.collect().size == 1)
+                assertLimit(tableName, Some(1L).filter(_ => skippingEnabled && sharingConfig && deltaConfig).toSeq)
+              }
 
-          val limitPushdownConfig = Map(
-            "spark.delta.sharing.limitPushdown.enabled" -> enableLimitPushdown.toString
-          )
-          withSQLConf((limitPushdownConfig ++ getDeltaSharingClassesSQLConf).toSeq: _*) {
-            val profileFile = prepareProfileFile(tempDir)
-            val tableName = s"share1.default.$sharedTableName"
-            test(s"${profileFile.getCanonicalPath}#$tableName", tableName)
+              val limitPushdownConfigs = Map(
+                "spark.delta.sharing.limitPushdown.enabled" -> sharingConfig.toString,
+                DeltaSQLConf.DELTA_LIMIT_PUSHDOWN_ENABLED.key -> deltaConfig.toString,
+                DeltaSQLConf.DELTA_STATS_SKIPPING.key -> skippingEnabled.toString
+              )
+              withSQLConf((limitPushdownConfigs ++ getDeltaSharingClassesSQLConf).toSeq: _*) {
+                val profileFile = prepareProfileFile(tempDir)
+                val tableName = s"share1.default.$sharedTableName"
+                test(s"${profileFile.getCanonicalPath}#$tableName", tableName)
+              }
+            }
           }
         }
       }
@@ -272,75 +297,124 @@ trait DeltaSharingDataSourceDeltaSuiteBase
         sql(s"""INSERT INTO $deltaTableName VALUES (1, "second"), (2, "second")""")
         sql(s"""INSERT INTO $deltaTableName VALUES (1, "third"), (2, "third")""")
 
-        val sharedTableName = "shared_table_filters"
-        prepareMockedClientAndFileSystemResult(deltaTableName, sharedTableName)
-        prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+        Seq("c1", "c2", "c1c2").foreach { filterColumn =>
+          val sharedTableName = s"shared_table_filters_$filterColumn"
+          prepareMockedClientAndFileSystemResult(deltaTableName, sharedTableName)
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
 
-        // The files returned from delta sharing client are the same for these queries.
-        // This is to test the filters are passed correctly to TahoeLogFileIndex for the local delta
-        // log.
-        def testFiltersAndSelect(tablePath: String): Unit = {
-          var expected = Seq(Row(1, "first"), Row(1, "second"), Row(1, "third"), Row(2, "second"))
-          var df = spark.read
-            .format("deltaSharing")
-            .option("responseFormat", "delta")
-            .load(tablePath)
-            .filter(col("c1") === 1 || col("c2") === "second")
-          checkAnswer(df, expected)
-
-          expected = Seq(Row(1, "first"), Row(1, "second"), Row(1, "third"))
-          df = spark.read
-            .format("deltaSharing")
-            .option("responseFormat", "delta")
-            .load(tablePath)
-            .filter(col("c1") === 1)
-          checkAnswer(df, expected)
-
-          expected = Seq(Row(1, "second"), Row(2, "second"))
-          df = spark.read
-            .format("deltaSharing")
-            .option("responseFormat", "delta")
-            .load(tablePath)
-            .filter(col("c2") === "second")
-          checkAnswer(df, expected)
-
-          // with select as well
-          expected = Seq(Row(1), Row(1), Row(1), Row(2), Row(2), Row(2))
-          df = spark.read
-            .format("deltaSharing")
-            .option("responseFormat", "delta")
-            .load(tablePath)
-            .select("c1")
-          checkAnswer(df, expected)
-
-          expected = Seq(
-            Row("first"),
-            Row("first"),
-            Row("second"),
-            Row("second"),
-            Row("third"),
-            Row("third")
+          spark.sessionState.conf.setConfString(
+            "spark.delta.sharing.jsonPredicateV2Hints.enabled",
+            "true"
           )
-          df = spark.read
-            .format("deltaSharing")
-            .option("responseFormat", "delta")
-            .load(tablePath)
-            .select("c2")
-          checkAnswer(df, expected)
 
-          expected = Seq(Row(1), Row(2))
-          df = spark.read
-            .format("deltaSharing")
-            .option("responseFormat", "delta")
-            .load(tablePath)
-            .filter(col("c2") === "second")
-            .select("c1")
-          checkAnswer(df, expected)
-        }
+          // The files returned from delta sharing client are the same for these queries.
+          // This is to test the filters are passed correctly to TahoeLogFileIndex for the local delta
+          // log.
+          def testFiltersAndSelect(tablePath: String, tableName: String): Unit = {
+            // select
+            var expected = Seq(Row(1), Row(1), Row(1), Row(2), Row(2), Row(2))
+            var df = spark.read
+              .format("deltaSharing")
+              .option("responseFormat", "delta")
+              .load(tablePath)
+              .select("c1")
+            checkAnswer(df, expected)
+            assertJsonPredicateHints(tableName, Seq.empty[String])
 
-        withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
-          val profileFile = prepareProfileFile(tempDir)
-          testFiltersAndSelect(s"${profileFile.getCanonicalPath}#share1.default.$sharedTableName")
+            expected = Seq(
+              Row("first"),
+              Row("first"),
+              Row("second"),
+              Row("second"),
+              Row("third"),
+              Row("third")
+            )
+            df = spark.read
+              .format("deltaSharing")
+              .option("responseFormat", "delta")
+              .load(tablePath)
+              .select("c2")
+            checkAnswer(df, expected)
+            assertJsonPredicateHints(tableName, Seq.empty[String])
+
+            // filter
+            var expectedJson = ""
+            if (filterColumn == "c1c2") {
+              expected = Seq(Row(1, "first"), Row(1, "second"), Row(1, "third"), Row(2, "second"))
+              df = spark.read
+                .format("deltaSharing")
+                .option("responseFormat", "delta")
+                .load(tablePath)
+                .filter(col("c1") === 1 || col("c2") === "second")
+              checkAnswer(df, expected)
+              expectedJson =
+                """{"op":"or","children":[
+                  |  {"op":"equal","children":[
+                  |    {"op":"column","name":"c1","valueType":"int"},
+                  |    {"op":"literal","value":"1","valueType":"int"}]},
+                  |  {"op":"equal","children":[
+                  |    {"op":"column","name":"c2","valueType":"string"},
+                  |    {"op":"literal","value":"second","valueType":"string"}]}
+                  |]}""".stripMargin.replaceAll("\n", "").replaceAll(" ", "")
+              assertJsonPredicateHints(tableName, Seq(expectedJson))
+            } else if (filterColumn == "c1") {
+              expected = Seq(Row(1, "first"), Row(1, "second"), Row(1, "third"))
+              df = spark.read
+                .format("deltaSharing")
+                .option("responseFormat", "delta")
+                .load(tablePath)
+                .filter(col("c1") === 1)
+              checkAnswer(df, expected)
+              expectedJson =
+                """{"op":"and","children":[
+                  |  {"op":"not","children":[
+                  |    {"op":"isNull","children":[
+                  |      {"op":"column","name":"c1","valueType":"int"}]}]},
+                  |  {"op":"equal","children":[
+                  |    {"op":"column","name":"c1","valueType":"int"},
+                  |    {"op":"literal","value":"1","valueType":"int"}]}
+                  |]}""".stripMargin.replaceAll("\n", "").replaceAll(" ", "")
+              assertJsonPredicateHints(tableName, Seq(expectedJson))
+            } else {
+              assert(filterColumn == "c2")
+              expected = Seq(Row(1, "second"), Row(2, "second"))
+              expectedJson =
+                """{"op":"and","children":[
+                  |  {"op":"not","children":[
+                  |    {"op":"isNull","children":[
+                  |      {"op":"column","name":"c2","valueType":"string"}]}]},
+                  |  {"op":"equal","children":[
+                  |    {"op":"column","name":"c2","valueType":"string"},
+                  |    {"op":"literal","value":"second","valueType":"string"}]}
+                  |]}""".stripMargin.replaceAll("\n", "").replaceAll(" ", "")
+              df = spark.read
+                .format("deltaSharing")
+                .option("responseFormat", "delta")
+                .load(tablePath)
+                .filter(col("c2") === "second")
+              checkAnswer(df, expected)
+              assertJsonPredicateHints(tableName, Seq(expectedJson))
+
+              // filters + select as well
+              expected = Seq(Row(1), Row(2))
+              df = spark.read
+                .format("deltaSharing")
+                .option("responseFormat", "delta")
+                .load(tablePath)
+                .filter(col("c2") === "second")
+                .select("c1")
+              checkAnswer(df, expected)
+              assertJsonPredicateHints(tableName, Seq(expectedJson))
+            }
+          }
+
+          withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
+            val profileFile = prepareProfileFile(tempDir)
+            testFiltersAndSelect(
+              s"${profileFile.getCanonicalPath}#share1.default.$sharedTableName",
+              s"share1.default.$sharedTableName"
+            )
+          }
         }
       }
     }
@@ -576,7 +650,6 @@ trait DeltaSharingDataSourceDeltaSuiteBase
         prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
 
         def testEmpty(tablePath: String): Unit = {
-          // linzhou
           val deltaDf = spark.read.format("delta").table(deltaTableName)
           val sharingDf =
             spark.read.format("deltaSharing").option("responseFormat", "delta").load(tablePath)
@@ -841,6 +914,260 @@ trait DeltaSharingDataSourceDeltaSuiteBase
           withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
             val profileFile = prepareProfileFile(tempDir)
             test(profileFile.getCanonicalPath + s"#share1.default.$sharedTableName")
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * deletion vector tests
+   */
+  test("DeltaSharingDataSource able to read data for dv table") {
+    withTempDir { tempDir =>
+      val deltaTableName = "delta_table_dv"
+      withTable(deltaTableName) {
+        spark
+          .range(start = 0, end = 100)
+          .withColumn("partition", col("id").divide(10).cast("int"))
+          .write
+          .partitionBy("partition")
+          .format("delta")
+          .saveAsTable(deltaTableName)
+        spark
+          .range(start = 100, end = 200)
+          .withColumn("partition", col("id").mod(100).divide(10).cast("int"))
+          .write
+          .mode("append")
+          .partitionBy("partition")
+          .format("delta")
+          .saveAsTable(deltaTableName)
+        spark.sql(
+          s"ALTER TABLE $deltaTableName SET TBLPROPERTIES('delta.enableDeletionVectors' = true)"
+        )
+
+        // Delete 2 rows per partition.
+        sql(s"""DELETE FROM $deltaTableName where mod(id, 10) < 2""")
+        // Delete 1 more row per partition.
+        sql(s"""DELETE FROM $deltaTableName where mod(id, 10) = 3""")
+        // Delete 1 more row per partition.
+        sql(s"""DELETE FROM $deltaTableName where mod(id, 10) = 6""")
+
+        Seq(true, false).foreach { skippingEnabled =>
+          val sharedTableName = s"shared_table_dv_$skippingEnabled"
+          prepareMockedClientAndFileSystemResult(
+            deltaTable = deltaTableName,
+            sharedTable = sharedTableName,
+            assertMultipleDvsInOneFile = true
+          )
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+
+          def testReadDVTable(tablePath: String): Unit = {
+            val expectedSchema: StructType = new StructType()
+              .add("id", LongType)
+              .add("partition", IntegerType)
+            assert(
+              expectedSchema == spark.read
+                .format("deltaSharing")
+                .option("responseFormat", "delta")
+                .load(tablePath)
+                .schema
+            )
+
+            val sharingDf =
+              spark.read.format("deltaSharing").option("responseFormat", "delta").load(tablePath)
+            val deltaDf = spark.read.format("delta").table(deltaTableName)
+            checkAnswer(sharingDf, deltaDf)
+            assert(sharingDf.count() > 0)
+
+            val filteredSharingDf =
+              spark.read
+                .format("deltaSharing")
+                .option("responseFormat", "delta")
+                .load(tablePath)
+                .filter(col("id").mod(10) > 5)
+            val filteredDeltaDf =
+              spark.read
+                .format("delta")
+                .table(deltaTableName)
+                .filter(col("id").mod(10) > 5)
+            checkAnswer(filteredSharingDf, filteredDeltaDf)
+            assert(filteredSharingDf.count() > 0)
+          }
+
+          val additionalConfigs = Map(
+            DeltaSQLConf.DELTA_STATS_SKIPPING.key -> skippingEnabled.toString
+          )
+          withSQLConf((additionalConfigs ++ getDeltaSharingClassesSQLConf).toSeq: _*) {
+            val profileFile = prepareProfileFile(tempDir)
+            testReadDVTable(s"${profileFile.getCanonicalPath}#share1.default.$sharedTableName")
+          }
+        }
+      }
+    }
+  }
+
+  test("DeltaSharingDataSource able to read data for dv and cdf") {
+    withTempDir { tempDir =>
+      val deltaTableName = "delta_table_dv_cdf"
+      withTable(deltaTableName) {
+        createDVTableWithCdf(deltaTableName)
+        // version 1: 20 inserts
+        spark
+          .range(start = 0, end = 20)
+          .select(col("id").cast("int").as("c1"))
+          .withColumn("partition", col("c1").divide(10).cast("int"))
+          .write
+          .mode("append")
+          .format("delta")
+          .saveAsTable(deltaTableName)
+        // version 2: 20 inserts
+        spark
+          .range(start = 100, end = 120)
+          .select(col("id").cast("int").as("c1"))
+          .withColumn("partition", col("c1").mod(100).divide(10).cast("int"))
+          .write
+          .mode("append")
+          .format("delta")
+          .saveAsTable(deltaTableName)
+        // version 3: 20 updates
+        sql(s"""UPDATE $deltaTableName SET c1=c1+5 where partition=0""")
+        // This deletes will create one DV file used by AddFile from both version 1 and version 2.
+        // version 4: 14 deletes
+        sql(s"""DELETE FROM $deltaTableName WHERE mod(c1, 100)<=10""")
+
+        val sharedTableName = "shard_table_dv_cdf"
+        prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+
+        Seq(0, 1, 2, 3, 4).foreach { startingVersion =>
+          prepareMockedClientAndFileSystemResultForCdf(
+            deltaTableName,
+            sharedTableName,
+            startingVersion,
+            assertMultipleDvsInOneFile = true
+          )
+
+          def testReadDVCdf(tablePath: String): Unit = {
+            val schema = spark.read
+              .format("deltaSharing")
+              .option("responseFormat", "delta")
+              .option("readChangeFeed", "true")
+              .option("startingVersion", startingVersion)
+              .load(tablePath)
+              .schema
+            val expectedSchema: StructType = new StructType()
+              .add("c1", IntegerType)
+              .add("partition", IntegerType)
+              .add("_change_type", StringType)
+              .add("_commit_version", LongType)
+              .add("_commit_timestamp", TimestampType)
+            assert(expectedSchema == schema)
+
+            val deltaDf = spark.read
+              .format("delta")
+              .option("readChangeFeed", "true")
+              .option("startingVersion", startingVersion)
+              .table(deltaTableName)
+            val sharingDf = spark.read
+              .format("deltaSharing")
+              .option("responseFormat", "delta")
+              .option("readChangeFeed", "true")
+              .option("startingVersion", startingVersion)
+              .load(tablePath)
+            checkAnswer(sharingDf, deltaDf)
+            assert(sharingDf.count() > 0)
+          }
+
+          withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
+            val profileFile = prepareProfileFile(tempDir)
+            testReadDVCdf(s"${profileFile.getCanonicalPath}#share1.default.$sharedTableName")
+          }
+        }
+      }
+    }
+  }
+
+  test("DeltaSharingDataSource able to read data for inline dv") {
+    import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArrayFormat
+    Seq(RoaringBitmapArrayFormat.Portable, RoaringBitmapArrayFormat.Native).foreach { format =>
+      withTempDir { tempDir =>
+        val deltaTableName = s"delta_table_inline_dv_$format"
+        withTable(deltaTableName) {
+          createDVTableWithCdf(deltaTableName)
+          // Use divide 10 to set partition column to 0 for all values, then use repartition to
+          // ensure the 5 values are written in one file.
+          spark
+            .range(start = 0, end = 5)
+            .select(col("id").cast("int").as("c1"))
+            .withColumn("partition", col("c1").divide(10).cast("int"))
+            .repartition(1)
+            .write
+            .mode("append")
+            .format("delta")
+            .saveAsTable(deltaTableName)
+
+          val sharedTableName = s"shared_table_inline_dv_$format"
+          prepareMockedClientAndFileSystemResult(
+            deltaTable = deltaTableName,
+            sharedTable = sharedTableName,
+            inlineDvFormat = Some(format)
+          )
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+          prepareMockedClientAndFileSystemResultForCdf(
+            deltaTableName,
+            sharedTableName,
+            startingVersion = 1,
+            inlineDvFormat = Some(format)
+          )
+
+          def testReadInlineDVCdf(tablePath: String): Unit = {
+            val deltaDf = spark.read
+              .format("delta")
+              .option("readChangeFeed", "true")
+              .option("startingVersion", 1)
+              .table(deltaTableName)
+              .filter(col("c1") > 1)
+            val sharingDf = spark.read
+              .format("deltaSharing")
+              .option("responseFormat", "delta")
+              .option("readChangeFeed", "true")
+              .option("startingVersion", 1)
+              .load(tablePath)
+            checkAnswer(sharingDf, deltaDf)
+            assert(sharingDf.count() > 0)
+          }
+
+          def testReadInlineDV(tablePath: String): Unit = {
+            val expectedSchema: StructType = new StructType()
+              .add("c1", IntegerType)
+              .add("partition", IntegerType)
+            assert(
+              expectedSchema == spark.read
+                .format("deltaSharing")
+                .option("responseFormat", "delta")
+                .load(tablePath)
+                .schema
+            )
+
+            val sharingDf =
+              spark.read.format("deltaSharing").option("responseFormat", "delta").load(tablePath)
+            val expectedDf = Seq(Row(1, 0), Row(3, 0), Row(4, 0))
+            checkAnswer(sharingDf, expectedDf)
+
+            val filteredSharingDf =
+              spark.read
+                .format("deltaSharing")
+                .option("responseFormat", "delta")
+                .load(tablePath)
+                .filter(col("c1") < 4)
+            val expectedFilteredDf = Seq(Row(1, 0), Row(3, 0))
+            checkAnswer(filteredSharingDf, expectedFilteredDf)
+          }
+
+          withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
+            val profileFile = prepareProfileFile(tempDir)
+            testReadInlineDV(s"${profileFile.getCanonicalPath}#share1.default.$sharedTableName")
+            testReadInlineDVCdf(s"${profileFile.getCanonicalPath}#share1.default.$sharedTableName")
           }
         }
       }

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaSuite.scala
@@ -18,6 +18,7 @@ package io.delta.sharing.spark
 
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
 import org.apache.spark.sql.{DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.delta.sharing.DeltaSharingTestSparkUtils

--- a/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
@@ -123,10 +123,12 @@ private[spark] class TestClientForDeltaFormatSharing(
       jsonPredicateHints: Option[String],
       refreshToken: Option[String]
   ): DeltaTableFiles = {
-    limit.foreach(lim => TestClientForDeltaFormatSharing.limits.put(
-      s"${table.share}.${table.schema}.${table.name}", lim))
-    TestClientForDeltaFormatSharing.requestedFormat.put(
-      s"${table.share}.${table.schema}.${table.name}", responseFormat)
+    val tableFullName = s"${table.share}.${table.schema}.${table.name}"
+    limit.foreach(lim => TestClientForDeltaFormatSharing.limits.put(tableFullName, lim))
+    TestClientForDeltaFormatSharing.requestedFormat.put(tableFullName, responseFormat)
+    jsonPredicateHints.foreach(p =>
+      TestClientForDeltaFormatSharing.jsonPredicateHints.put(tableFullName, p))
+
     val iterator = SparkEnv.get.blockManager
       .get[String](getBlockId(table.name, "getFiles", versionAsOf, timestampAsOf))
       .map(_.data.asInstanceOf[Iterator[String]])
@@ -267,4 +269,5 @@ object TestClientForDeltaFormatSharing {
 
   val limits = scala.collection.mutable.Map[String, Long]()
   val requestedFormat = scala.collection.mutable.Map[String, String]()
+  val jsonPredicateHints = scala.collection.mutable.Map[String, String]()
 }

--- a/spark/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
+++ b/spark/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.delta.PreprocessTimeTravel
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.internal.SQLConf
 
 /**
@@ -145,8 +146,9 @@ class DeltaSparkSessionExtension extends (SparkSessionExtensions => Unit) {
         try {
           // Inject the PrepareDeltaSharingScan rule if enabled, otherwise, inject the no op
           // rule. It can be disabled if there are any issues so all existing rules are not blocked.
-          if (session.conf.getOption("spark.sql.delta.sharing.enableDeltaFormatBatch")
-            .contains("true")) {
+          if (
+            session.conf.get(DeltaSQLConf.DELTA_SHARING_ENABLE_DELTA_FORMAT_BATCH.key) == "true"
+          ) {
             constructor.newInstance(session).asInstanceOf[Rule[LogicalPlan]]
           } else {
             new NoOpRule

--- a/spark/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
+++ b/spark/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
@@ -20,6 +20,7 @@ import scala.util.control.NonFatal
 
 import org.apache.spark.sql.delta.optimizer.RangePartitionIdRewrite
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.PrepareDeltaScan
 import io.delta.sql.parser.DeltaSqlParser
 
@@ -27,7 +28,6 @@ import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.delta.PreprocessTimeTravel
-import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.internal.SQLConf
 
 /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -42,15 +42,23 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
+ * Extractor Object for pulling out the file index of a logical relation.
+ */
+object RelationFileIndex {
+  def unapply(a: LogicalRelation): Option[FileIndex] = a match {
+    case LogicalRelation(hrel: HadoopFsRelation, _, _, _) => Some(hrel.location)
+    case _ => None
+  }
+}
+
+/**
  * Extractor Object for pulling out the table scan of a Delta table. It could be a full scan
  * or a partial scan.
  */
 object DeltaTable {
   def unapply(a: LogicalRelation): Option[TahoeFileIndex] = a match {
-    case LogicalRelation(HadoopFsRelation(index: TahoeFileIndex, _, _, _, _, _), _, _, _) =>
-      Some(index)
-    case _ =>
-      None
+    case RelationFileIndex(fileIndex: TahoeFileIndex) => Some(fileIndex)
+    case _ => None
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1582,6 +1582,17 @@ trait DeltaSQLConfBase {
         "'clusteredTable.numClusteringColumnsLimit' must be positive."
       )
     .createWithDefault(4)
+
+  //////////////////
+  // Delta Sharing
+  //////////////////
+
+  val DELTA_SHARING_ENABLE_DELTA_FORMAT_BATCH =
+    buildConf("spark.sql.delta.sharing.enableDeltaFormatBatch")
+      .doc("Enable delta format sharing in case of issues.")
+      .internal()
+      .booleanConf
+      .createWithDefault(true)
 }
 
 object DeltaSQLConf extends DeltaSQLConfBase


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (delta sharing)

## Description
(Cherry-pick of https://github.com/delta-io/delta/pull/2480 to branch-3.1)

Fifth PR of https://github.com/delta-io/delta/issues/2291: Adds deletion vector support for "delta format sharing"
- Extends PrepareDeltaScan to PrepareDeltaSharingScan, to convert DeltaSharingFileIndex to TahoeLogFileIndex.
- Update DeltaSparkSessionExtension to add the rule of PrepareDeltaSharingScan
- Added unit test in DeltaSharingDataSourceDeltaSuite

## How was this patch tested?
Unit Tests

## Does this PR introduce _any_ user-facing changes?
No
