### PR TITLE
[Kernel] Fix issue with column mapping and partition pruning

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
@@ -149,34 +149,37 @@ public class PartitionUtils {
      * `partition_value` deserializes the string value into the given partition column type value.
      * String type partition values don't need any deserialization.
      *
-     * @param predicate             Predicate containing filters only on partition columns.
-     * @param partitionColNameTypes Map of partition column name (in lower case) to its type.
+     * @param predicate            Predicate containing filters only on partition columns.
+     * @param partitionColMetadata Map of partition column name (in lower case) to its type.
      * @return
      */
     public static Predicate rewritePartitionPredicateOnScanFileSchema(
-        Predicate predicate, Map<String, DataType> partitionColNameTypes) {
+        Predicate predicate, Map<String, StructField> partitionColMetadata) {
         return new Predicate(
             predicate.getName(),
             predicate.getChildren().stream()
-                .map(child -> rewritePartitionColumnRef(child, partitionColNameTypes))
+                .map(child -> rewritePartitionColumnRef(child, partitionColMetadata))
                 .collect(Collectors.toList()));
     }
 
     private static Expression rewritePartitionColumnRef(
-        Expression expression, Map<String, DataType> partitionColNameTypes) {
+        Expression expression, Map<String, StructField> partitionColMetadata) {
         Column scanFilePartitionValuesRef = InternalScanFileUtils.ADD_FILE_PARTITION_COL_REF;
         if (expression instanceof Column) {
             Column column = (Column) expression;
             String partColName = column.getNames()[0];
-            DataType partColType = partitionColNameTypes.get(partColName.toLowerCase(Locale.ROOT));
-            if (partColType == null) {
-                throw new IllegalArgumentException(partColName + " has no data type in metadata");
+            StructField partColField =
+                partitionColMetadata.get(partColName.toLowerCase(Locale.ROOT));
+            if (partColField == null) {
+                throw new IllegalArgumentException(partColName + " is not present in metadata");
             }
+            DataType partColType = partColField.getDataType();
+            String partColPhysicalName = ColumnMapping.getPhysicalName(partColField);
 
             Expression elementAt =
                 new ScalarExpression(
                     "element_at",
-                    asList(scanFilePartitionValuesRef, Literal.ofString(partColName)));
+                    asList(scanFilePartitionValuesRef, Literal.ofString(partColPhysicalName)));
 
             if (partColType instanceof StringType) {
                 return elementAt;
@@ -186,7 +189,7 @@ public class PartitionUtils {
             return new PartitionValueExpression(elementAt, partColType);
         } else if (expression instanceof Predicate) {
             return rewritePartitionPredicateOnScanFileSchema(
-                (Predicate) expression, partitionColNameTypes);
+                (Predicate) expression, partitionColMetadata);
         }
 
         return expression;

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/PartitionUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/PartitionUtilsSuite.scala
@@ -29,15 +29,25 @@ class PartitionUtilsSuite extends AnyFunSuite {
   // Table schema
   // Data columns: data1: int, data2: string, date3: struct(data31: boolean, data32: long)
   // Partition columns: part1: int, part2: date, part3: string
-  private val partitionColsToType = new util.HashMap[String, DataType]() {
+  val tableSchema = new StructType()
+    .add("data1", IntegerType.INTEGER)
+    .add("data2", StringType.STRING)
+    .add("data3", new StructType()
+      .add("data31", BooleanType.BOOLEAN)
+      .add("data32", LongType.LONG))
+    .add("part1", IntegerType.INTEGER)
+    .add("part2", DateType.DATE)
+    .add("part3", StringType.STRING)
+
+  private val partitionColsMetadata = new util.HashMap[String, StructField]() {
     {
-      put("part1", IntegerType.INTEGER)
-      put("part2", DateType.DATE)
-      put("part3", StringType.STRING)
+      put("part1", tableSchema.get("part1"))
+      put("part2", tableSchema.get("part2"))
+      put("part3", tableSchema.get("part3"))
     }
   }
 
-  private val partitionCols: java.util.Set[String] = partitionColsToType.keySet()
+  private val partitionCols: java.util.Set[String] = partitionColsMetadata.keySet()
 
   // Test cases for verifying partition of predicate into data and partition predicates
   // Map entry format (predicate -> (partition predicate, data predicate)
@@ -169,7 +179,7 @@ class PartitionUtilsSuite extends AnyFunSuite {
     case (predicate, expRewrittenPredicate) =>
       test(s"rewrite partition predicate on scan file schema: $predicate") {
         val actRewrittenPredicate =
-          rewritePartitionPredicateOnScanFileSchema(predicate, partitionColsToType)
+          rewritePartitionPredicateOnScanFileSchema(predicate, partitionColsMetadata)
         assert(actRewrittenPredicate.toString === expRewrittenPredicate)
       }
   }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
@@ -49,13 +49,6 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
 
   import io.delta.kernel.defaults.ScanSuite._
 
-  private val spark = SparkSession
-    .builder()
-    .appName("Spark Test Writer for Delta Kernel")
-    .config("spark.master", "local")
-    .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
-    .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
-    .getOrCreate()
   // scalastyle:off sparkimplicits
   import spark.implicits._
   // scalastyle:on sparkimplicits

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -34,12 +34,22 @@ import io.delta.kernel.types._
 import io.delta.kernel.utils.CloseableIterator
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.shaded.org.apache.commons.io.FileUtils
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.scalatest.Assertions
 
-trait TestUtils extends Assertions {
+trait TestUtils extends Assertions with SQLHelper {
 
   lazy val configuration = new Configuration()
   lazy val defaultTableClient = DefaultTableClient.create(configuration)
+
+  lazy val spark = SparkSession
+    .builder()
+    .appName("Spark Test Writer for Delta Kernel")
+    .config("spark.master", "local")
+    .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+    .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+    .getOrCreate()
 
   implicit class CloseableIteratorOps[T](private val iter: CloseableIterator[T]) {
 


### PR DESCRIPTION
## Description
Currently, column name in the logical schema is used for lookup. For column mapping mode enabled tables, partition values are stored with physical name.

## How was this patch tested?
Added tests for pruning with `id` and `name` modes