### PR TITLE
[Spark] Remove .internal from DELTA_UPDATE_CATALOG_ENABLED

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -483,7 +483,6 @@ trait DeltaSQLConfBase {
 
   val DELTA_UPDATE_CATALOG_ENABLED =
     buildConf("catalog.update.enabled")
-      .internal()
       .doc("When enabled, we will cache the schema of the Delta table and the table properties " +
         "in the external catalog, e.g. the Hive MetaStore.")
       .booleanConf


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Removes `.internal()` from `DELTA_UPDATE_CATALOG_ENABLED` conf as it is user facing.
 

## How was this patch tested?

NA

## Does this PR introduce _any_ user-facing changes?

No