### PR TITLE
[Spark] Fix Implicit definition should have explicit type

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.util.PartitionUtils
 import org.apache.hadoop.fs.Path
-import org.json4s.NoTypeHints
+import org.json4s.{Formats, NoTypeHints}
 import org.json4s.jackson.Serialization
 
 import org.apache.spark.sql._
@@ -259,7 +259,7 @@ class DeltaDataSource
 }
 
 object DeltaDataSource extends DatabricksLogging {
-  private implicit val formats = Serialization.formats(NoTypeHints)
+  private implicit val formats: Formats = Serialization.formats(NoTypeHints)
 
   final val TIME_TRAVEL_SOURCE_KEY = "__time_travel_source__"
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR fixes `Implicit definition should have explicit type` in Scala 2.13.

## How was this patch tested?

Manually tested with Spark build.

## Does this PR introduce _any_ user-facing changes?

No.
