### PR TITLE
[Spark] Emphasize paths should (or should not) be escaped in DV helper

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DMLWithDeletionVectorsHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DMLWithDeletionVectorsHelper.scala
@@ -549,14 +549,14 @@ object DeletionVectorWriter extends DeltaLogging {
     val broadcastHadoopConf = sparkSession.sparkContext.broadcast(
       new SerializableConfiguration(hadoopConf))
     // hadoop.fs.Path is not Serializable, so close over the String representation instead
-    val tablePathString = DeletionVectorStore.pathToString(table)
+    val tablePathString = DeletionVectorStore.pathToEscapedString(table)
     val packingTargetSize =
       sparkSession.conf.get(DeltaSQLConf.DELETION_VECTOR_PACKING_TARGET_SIZE)
 
     // This is the (partition) mapper function we are returning
     (rowIterator: Iterator[InputT]) => {
       val dvStore = DeletionVectorStore.createInstance(broadcastHadoopConf.value.value)
-      val tablePath = DeletionVectorStore.stringToPath(tablePathString)
+      val tablePath = DeletionVectorStore.escapedStringToPath(tablePathString)
       val tablePathWithFS = dvStore.pathWithFileSystem(tablePath)
 
       val perBinFunction: Seq[InputT] => Seq[OutputT] = (rows: Seq[InputT]) => {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorStore.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorStore.scala
@@ -97,6 +97,9 @@ trait DeletionVectorStoreUtils {
     DATA_SIZE_LEN + bitmapDataSize + CHECKSUM_LEN
   }
 
+  /** Convert the given String path to a Hadoop Path. Please make sure the path is not escaped. */
+  def unescapedStringToPath(path: String): Path = SparkPath.fromPathString(path).toPath
+
   /** Convert the given String path to a Hadoop Path, Please make sure the path is escaped. */
   def escapedStringToPath(path: String): Path = SparkPath.fromUrlString(path).toPath
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorStore.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorStore.scala
@@ -30,6 +30,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, FSDataOutputStream, Path}
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.paths.SparkPath
 import org.apache.spark.util.Utils
 
 trait DeletionVectorStore extends Logging {
@@ -96,13 +97,11 @@ trait DeletionVectorStoreUtils {
     DATA_SIZE_LEN + bitmapDataSize + CHECKSUM_LEN
   }
 
-  // scalastyle:off pathfromuri
-  /** Convert the given String path to a Hadoop Path, handing special characters properly. */
-  def stringToPath(path: String): Path = new Path(new URI(path))
-  // scalastyle:on pathfromuri
+  /** Convert the given String path to a Hadoop Path, Please make sure the path is escaped. */
+  def escapedStringToPath(path: String): Path = SparkPath.fromUrlString(path).toPath
 
   /** Convert the given Hadoop path to a String Path, handing special characters properly. */
-  def pathToString(path: Path): String = path.toUri.toString
+  def pathToEscapedString(path: Path): String = SparkPath.fromPath(path).urlEncoded
 
   /**
    * Calculate checksum of a serialized deletion vector. We are using CRC32 which has 4bytes size,
@@ -223,7 +222,7 @@ class HadoopFileSystemDVStore(hadoopConf: Configuration)
       }
 
       override val serializedPath: Array[Byte] =
-        DeletionVectorStore.pathToString(path.path).getBytes(UTF_8)
+        DeletionVectorStore.pathToEscapedString(path.path).getBytes(UTF_8)
 
       override def close(): Unit = {
         if (outputStream != null) {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
@@ -128,7 +128,7 @@ trait DeletionVectorsTestUtils extends QueryTest with SharedSparkSession {
 
       // Check that DV exists.
       val dvPath = dv.absolutePath(tablePath)
-      val dvPathStr = DeletionVectorStore.pathToString(dvPath)
+      val dvPathStr = DeletionVectorStore.pathToEscapedString(dvPath)
       assert(new File(dvPathStr).exists(), s"DV not found $dvPath")
 
       // Check that cardinality is correct.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
 import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor
 import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
 import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
-import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore.pathToString
+import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore.pathToEscapedString
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.PathWithFileSystem
@@ -199,7 +199,7 @@ class DeltaParquetFileFormatSuite extends QueryTest
       writer.write(serializedBitmap)
     }
     DeletionVectorDescriptor.onDiskWithAbsolutePath(
-      pathToString(dvPath.makeQualified().path),
+      pathToEscapedString(dvPath.makeQualified().path),
       dvRange.length,
       rowIndexes.size,
       Some(dvRange.offset))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/RowIndexMarkingFiltersSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/RowIndexMarkingFiltersSuite.scala
@@ -65,7 +65,7 @@ class RowIndexMarkingFiltersSuite extends QueryTest with SharedSparkSession {
   } {
     test(s"deletion vector single row marked (isInline=$isInline) ($filterName filter)") {
       withTempDir { tableDir =>
-        val tablePath = escapedStringToPath(tableDir.toString)
+        val tablePath = unescapedStringToPath(tableDir.toString)
         val dv = createDV(isInline, tablePath, 25)
 
         val rowIndexFilter = filterType.createInstance(dv, newHadoopConf, Some(tablePath))
@@ -91,7 +91,7 @@ class RowIndexMarkingFiltersSuite extends QueryTest with SharedSparkSession {
   } {
     test(s"deletion vector with multiple rows marked (isInline=$isInline) ($filterName filter)") {
       withTempDir { tableDir =>
-        val tablePath = escapedStringToPath(tableDir.toString)
+        val tablePath = unescapedStringToPath(tableDir.toString)
         val markedRows = Seq[Long](0, 25, 35, 2000, 50000)
         val dv = createDV(isInline, tablePath, markedRows: _*)
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/RowIndexMarkingFiltersSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/RowIndexMarkingFiltersSuite.scala
@@ -65,7 +65,7 @@ class RowIndexMarkingFiltersSuite extends QueryTest with SharedSparkSession {
   } {
     test(s"deletion vector single row marked (isInline=$isInline) ($filterName filter)") {
       withTempDir { tableDir =>
-        val tablePath = stringToPath(tableDir.toString)
+        val tablePath = escapedStringToPath(tableDir.toString)
         val dv = createDV(isInline, tablePath, 25)
 
         val rowIndexFilter = filterType.createInstance(dv, newHadoopConf, Some(tablePath))
@@ -91,7 +91,7 @@ class RowIndexMarkingFiltersSuite extends QueryTest with SharedSparkSession {
   } {
     test(s"deletion vector with multiple rows marked (isInline=$isInline) ($filterName filter)") {
       withTempDir { tableDir =>
-        val tablePath = stringToPath(tableDir.toString)
+        val tablePath = escapedStringToPath(tableDir.toString)
         val markedRows = Seq[Long](0, 25, 35, 2000, 50000)
         val dv = createDV(isInline, tablePath, markedRows: _*)
 
@@ -140,7 +140,7 @@ class RowIndexMarkingFiltersSuite extends QueryTest with SharedSparkSession {
         writer.write(serializedBitmap)
       }
       onDiskWithAbsolutePath(
-        pathToString(dvPath.path), dvRange.length, cardinality, Some(dvRange.offset))
+        pathToEscapedString(dvPath.path), dvRange.length, cardinality, Some(dvRange.offset))
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorStoreSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorStoreSuite.scala
@@ -61,7 +61,7 @@ trait DeletionVectorStoreSuiteBase
   def withTempHadoopFileSystemPath[T](f: Path => T): T = {
     val dir: File = Utils.createTempDir()
     dir.delete()
-    val tempPath = DeletionVectorStore.stringToPath(dir.toString)
+    val tempPath = DeletionVectorStore.escapedStringToPath(dir.toString)
     try f(tempPath) finally Utils.deleteRecursively(dir)
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorStoreSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorStoreSuite.scala
@@ -61,7 +61,7 @@ trait DeletionVectorStoreSuiteBase
   def withTempHadoopFileSystemPath[T](f: Path => T): T = {
     val dir: File = Utils.createTempDir()
     dir.delete()
-    val tempPath = DeletionVectorStore.escapedStringToPath(dir.toString)
+    val tempPath = DeletionVectorStore.unescapedStringToPath(dir.toString)
     try f(tempPath) finally Utils.deleteRecursively(dir)
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR renames `stringToPath` and `pathToString` methods, this will emphasize the input/output string should/will be escaped.

We also added a third new method `unescapedStringToPath`. which is used by almost all calls from tests.

## How was this patch tested?

Refactoring PR.