### PR TITLE
[Spark][3.1] Emphasize paths should (or should not) be escaped in DV helper

### DIFF
--- a/.github/workflows/kernel_test.yaml
+++ b/.github/workflows/kernel_test.yaml
@@ -15,3 +15,6 @@ jobs:
       - name: Run tests
         run: |
           python run-tests.py --group kernel --coverage
+      - name: Run integration tests
+        run: |
+          cd kernel/examples && python run-kernel-examples.py --use-local

--- a/build.sbt
+++ b/build.sbt
@@ -246,13 +246,13 @@ lazy val kernelApi = (project in file("kernel/kernel-api"))
     Test / javaOptions ++= Seq("-ea"),
     libraryDependencies ++= Seq(
       "org.roaringbitmap" % "RoaringBitmap" % "0.9.25",
-      "org.slf4j" % "slf4j-api" % "2.0.9",
+      "org.slf4j" % "slf4j-api" % "1.7.36",
 
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.5" % "test",
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
       "junit" % "junit" % "4.13" % "test",
       "com.novocode" % "junit-interface" % "0.11" % "test",
-      "org.slf4j" % "slf4j-log4j12" % "2.0.9" % "test"
+      "org.slf4j" % "slf4j-log4j12" % "1.7.36" % "test"
     ),
     javaCheckstyleSettings("kernel/dev/checkstyle.xml"),
     // Unidoc settings
@@ -278,7 +278,7 @@ lazy val kernelDefaults = (project in file("kernel/kernel-defaults"))
       "junit" % "junit" % "4.13" % "test",
       "commons-io" % "commons-io" % "2.8.0" % "test",
       "com.novocode" % "junit-interface" % "0.11" % "test",
-      "org.slf4j" % "slf4j-log4j12" % "2.0.9" % "test",
+      "org.slf4j" % "slf4j-log4j12" % "1.7.36" % "test",
 
       "org.apache.spark" %% "spark-hive" % sparkVersion % "test" classifier "tests",
       "org.apache.spark" %% "spark-sql" % sparkVersion % "test" classifier "tests",

--- a/build.sbt
+++ b/build.sbt
@@ -724,7 +724,7 @@ lazy val standaloneCosmetic = project
     Compile / packageSrc := (standalone / Compile / packageSrc).value,
     libraryDependencies ++= scalaCollectionPar(scalaVersion.value) ++ Seq(
       "org.apache.hadoop" % "hadoop-client" % hadoopVersion % "provided",
-      "org.apache.parquet" % "parquet-hadoop" % "1.12.0" % "provided",
+      "org.apache.parquet" % "parquet-hadoop" % "1.12.3" % "provided",
       // parquet4s-core dependencies that are not shaded are added with compile scope.
       "com.chuusai" %% "shapeless" % "2.3.4",
       "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.3"
@@ -756,7 +756,7 @@ lazy val testParquetUtilsWithStandaloneCosmetic = project.dependsOn(standaloneCo
     skipReleaseSettings,
     libraryDependencies ++= Seq(
       "org.apache.hadoop" % "hadoop-client" % hadoopVersion,
-      "org.apache.parquet" % "parquet-hadoop" % "1.12.0" % "provided",
+      "org.apache.parquet" % "parquet-hadoop" % "1.12.3" % "provided",
       "org.scalatest" %% "scalatest" % scalaTestVersionForConnectors % "test",
     )
   )
@@ -779,7 +779,7 @@ lazy val standaloneParquet = (project in file("connectors/standalone-parquet"))
     commonSettings,
     skipReleaseSettings,
     libraryDependencies ++= Seq(
-      "org.apache.parquet" % "parquet-hadoop" % "1.12.0" % "provided",
+      "org.apache.parquet" % "parquet-hadoop" % "1.12.3" % "provided",
       "org.scalatest" %% "scalatest" % scalaTestVersionForConnectors % "test"
     ),
     assemblyPackageScala / assembleArtifact := false
@@ -978,6 +978,8 @@ def flinkScalaVersion(scalaBinaryVersion: String): String = {
 
 lazy val flink = (project in file("connectors/flink"))
   .dependsOn(standaloneCosmetic % "provided")
+  .dependsOn(kernelApi)
+  .dependsOn(kernelDefaults)
   .settings (
     name := "delta-flink",
     commonSettings,

--- a/connectors/examples/flink-example/pom.xml
+++ b/connectors/examples/flink-example/pom.xml
@@ -29,7 +29,7 @@ limitations under the License.-->
         <staging.repo.url>""</staging.repo.url>
         <scala.main.version>2.12</scala.main.version>
         <connectors.version>0.6.0-SNAPSHOT</connectors.version>
-        <flink-version>1.16.1</flink-version>
+        <flink-version>1.16.2</flink-version>
         <hadoop-version>3.1.0</hadoop-version>
         <log4j.version>2.12.1</log4j.version>
     </properties>
@@ -51,6 +51,11 @@ limitations under the License.-->
             <groupId>io.delta</groupId>
             <artifactId>delta-standalone_${scala.main.version}</artifactId>
             <version>${connectors.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+          <version>2.13.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>

--- a/connectors/examples/flink-example/src/main/java/org/utils/ValueVisitor.java
+++ b/connectors/examples/flink-example/src/main/java/org/utils/ValueVisitor.java
@@ -1,5 +1,7 @@
 package org.utils;
 
+import java.time.LocalDate;
+
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.MapData;
@@ -110,8 +112,9 @@ public class ValueVisitor implements LogicalTypeVisitor<Object> {
     }
 
     @Override
-    public Object visit(DateType dateType) {
-        throw new UnsupportedOperationException("Not supported");
+    public LocalDate visit(DateType dateType) {
+        int sinceEpoch = row.getInt(index);
+        return LocalDate.ofEpochDay(sinceEpoch);
     }
 
     @Override

--- a/connectors/flink/src/main/java/io/delta/flink/internal/DeltaFlinkHadoopConf.java
+++ b/connectors/flink/src/main/java/io/delta/flink/internal/DeltaFlinkHadoopConf.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.flink.internal;
+
+public class DeltaFlinkHadoopConf {
+    /**
+     * If enabled, DeltaGlobalCommitter will use delta-kernel to get snapshots when committing. This
+     * can provide a signficate perfomance benefit in commit heavy workloads over the default
+     * delta-standalone implementation.
+     */
+    public static String DELTA_KERNEL_ENABLED = "io.delta.flink.kernel.enabled";
+}

--- a/connectors/flink/src/main/scala/io/delta/flink/internal/KernelDeltaLogDelegator.scala
+++ b/connectors/flink/src/main/scala/io/delta/flink/internal/KernelDeltaLogDelegator.scala
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.standalone.internal
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+
+import io.delta.kernel.{Table, TableNotFoundException}
+import io.delta.kernel.defaults.client.DefaultTableClient
+import io.delta.kernel.internal.{SnapshotImpl => SnapshotImplKernel, TableImpl}
+import io.delta.standalone.VersionLog
+import io.delta.standalone.actions.{CommitInfo => CommitInfoJ}
+import io.delta.standalone.internal.{SnapshotImpl => StandaloneSnapshotImpl, InitialSnapshotImpl => StandaloneInitialSnapshotImpl}
+import io.delta.standalone.internal.util.{Clock, SystemClock}
+
+class KernelOptTxn(kernelDeltaLog: KernelDeltaLogDelegator, kernelSnapshot: KernelSnapshotDelegator)
+    extends OptimisticTransactionImpl(kernelDeltaLog, kernelSnapshot) {
+  override def txnVersion(applicationId: String): Long = {
+    readTxn += applicationId
+    kernelSnapshot.getLatestTransactionVersion(applicationId).getOrElse(-1L)
+  }
+}
+
+/**
+ * We want to be able to construct an OptimisticTransactionImpl that uses a delta log and a snapshot
+ * provided by the Delta Kernel. OptimisticTransactionImpl takes a DeltaLogImpl and SnapshotImpl
+ * internally, so we need classes that extend those, and this is the one for DeltaLogImpl. It
+ * provides features used by flink+startTransaction.
+ */
+class KernelDeltaLogDelegator(
+    tableClient: DefaultTableClient,
+    table: TableImpl,
+    standaloneDeltaLog: DeltaLogImpl,
+    hadoopConf: Configuration,
+    logPath: Path,
+    dataPath: Path,
+    clock: Clock)
+  extends DeltaLogImpl(hadoopConf, logPath, dataPath, clock) {
+
+  // We override this so our super DeltaLogImpl constructor doesn't actually try and read the log
+  // none of the delegated methods require access to the current snapshot, so it's safe to just have
+  // this be null
+  override def getSnapshotAtInit(): SnapshotImpl = null
+
+  var currKernelSnapshot: Option[KernelSnapshotDelegator] = None
+
+  override def snapshot(): StandaloneSnapshotImpl = {
+    if (currKernelSnapshot.isEmpty) { return update() }
+    return currKernelSnapshot.get
+  }
+
+  override def update(): StandaloneSnapshotImpl = {
+    // get latest snapshot via kernel
+    val kernelSnapshot = try {
+      table.getLatestSnapshot(tableClient).asInstanceOf[SnapshotImplKernel]
+    } catch {
+      case e: TableNotFoundException =>
+        return new StandaloneInitialSnapshotImpl(hadoopConf, logPath, this)
+    }
+    currKernelSnapshot = Some(new KernelSnapshotDelegator(
+      kernelSnapshot,
+      hadoopConf,
+      logPath,
+      kernelSnapshot.getVersion(tableClient), // note: tableClient isn't used
+      this,
+      standaloneDeltaLog
+    ))
+    currKernelSnapshot.get
+  }
+
+  override def startTransaction(): io.delta.standalone.OptimisticTransaction = {
+    val snapshot = update()
+    if (snapshot.isInstanceOf[KernelSnapshotDelegator]) {
+      new KernelOptTxn(this, snapshot.asInstanceOf[KernelSnapshotDelegator])
+    } else {
+      new OptimisticTransactionImpl(this, snapshot)
+    }
+  }
+
+  override def tableExists: Boolean = snapshot.version >= 0
+
+  override def getChanges(startVersion: Long, failOnDataLoss: Boolean): java.util.Iterator[VersionLog] = {
+    logWarning("KernelDeltaLogDelegator falling back to DeltaLogImpl for getChanges")
+    standaloneDeltaLog.getChanges(startVersion, failOnDataLoss)
+  }
+
+  override def getSnapshotForVersionAsOf(version: Long): StandaloneSnapshotImpl = {
+    logWarning("KernelDeltaLogDelegator falling back to DeltaLogImpl for getSnapshotForVersionAsOf")
+    standaloneDeltaLog.getSnapshotForVersionAsOf(version)
+  }
+  override def getSnapshotForTimestampAsOf(timestamp: Long): StandaloneSnapshotImpl = {
+    throw new RuntimeException()
+  }
+  override def getCommitInfoAt(version: Long): CommitInfoJ = {
+    throw new RuntimeException()
+  }
+}
+
+object KernelDeltaLogDelegator {
+  def forTable(hadoopConf: Configuration, dataPath: String): KernelDeltaLogDelegator = {
+    val rawPath = new Path(dataPath, "_delta_log")
+    val fs = rawPath.getFileSystem(hadoopConf)
+    val logPath = fs.makeQualified(rawPath)
+    val dataPathFromLog = logPath.getParent
+    val clock = new SystemClock
+    // Create this first as we use it to it create the specified table if it doesn't exist, which
+    // the kernel does not
+    val standaloneDeltaLog = new DeltaLogImpl(hadoopConf, logPath, dataPathFromLog, clock)
+    standaloneDeltaLog.ensureLogDirectoryExist()
+    val tableClient = DefaultTableClient.create(hadoopConf)
+    val table = Table.forPath(tableClient, dataPath).asInstanceOf[TableImpl]
+    // Todo: Potentially we could get the resolved paths out of the table above
+    new KernelDeltaLogDelegator(tableClient, table, standaloneDeltaLog, hadoopConf, logPath, dataPathFromLog, clock)
+  }
+}

--- a/connectors/flink/src/main/scala/io/delta/flink/internal/KernelSnapshotDelegator.scala
+++ b/connectors/flink/src/main/scala/io/delta/flink/internal/KernelSnapshotDelegator.scala
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.standalone.internal
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+
+import io.delta.kernel.internal.{SnapshotImpl => SnapshotImplKernel}
+import io.delta.standalone.DeltaScan
+import io.delta.standalone.actions.{AddFile => AddFileJ, Metadata => MetadataJ}
+import io.delta.standalone.data.{CloseableIterator, RowRecord => RowParquetRecordJ}
+import io.delta.standalone.expressions.Expression
+import io.delta.standalone.internal.actions.{AddFile, Metadata, Protocol, SetTransaction}
+import io.delta.standalone.internal.scan.DeltaScanImpl
+import io.delta.standalone.internal.util.ConversionUtils
+
+
+/**
+ * This class is designed to be passed to OptimisticTransactionImpl, and provide exactly what that
+ * needs to operate, but on a Kernel Snapshot rather than a standalone Snapshot.
+ *
+ * The methods/variables used by OptimisticTransactionImpl that we implement are:
+ *  - protocolScala
+ *  - metadataScala
+ *  - version
+ *  - getMetadata
+ *
+ *  Other functions that are used, we do not implement, but fall back to standalone. These functions
+ *  are only called in "exceptional" cases, so should not overly impact performance.
+ *  They include:
+ *  - scanScala (only called in markFilesAsRead, not used by flink)
+ *  - transactions (only used in txnVersion, which is used only on first commit for a flink app)
+ *    - This is a val, but it calls setTransactionsScala, so we log for that
+ *  - numOfFiles (only used in verifySchemaCompatibility, which happens only when a metadata update occures)
+ *  - allFilesScala (only used in verifySchemaCompatibility)
+ */
+class KernelSnapshotDelegator(
+    kernelSnapshot: SnapshotImplKernel,
+    hadoopConf: Configuration,
+    path: Path,
+    override val version: Long,
+    kernelDeltaLog: KernelDeltaLogDelegator,
+    standaloneDeltaLog: DeltaLogImpl)
+  extends SnapshotImpl(hadoopConf, path, -1, LogSegment.empty(path), -1, standaloneDeltaLog, -1) {
+
+  // A KernelSnapshotWrapper holds a `SnapshotImplKernel` inside, and exposes the standalone
+  // snapshot interface. This allows us to return things (like metadata) as if they were being
+  // called on a standard standalone snapshot.
+  val kernelSnapshotWrapper = new KernelSnapshotWrapper(kernelSnapshot)
+  lazy val standaloneSnapshot: SnapshotImpl = standaloneDeltaLog.getSnapshotForVersionAsOf(getVersion())
+
+  /**
+   * Internal vals we need to override
+   */
+  override lazy val protocolScala: Protocol = {
+    val kernelProtocol = kernelSnapshot.getProtocol()
+    new Protocol(kernelProtocol.getMinReaderVersion(), kernelProtocol.getMinWriterVersion())
+  }
+
+  override lazy val metadataScala: Metadata = {
+    val metadata = kernelSnapshotWrapper.getMetadata()
+    ConversionUtils.convertMetadataJ(metadata)
+  }
+
+  // provide a path to use the faster txn lookup in kernel
+  def getLatestTransactionVersion(id: String): Option[Long] = {
+    val versionJOpt = kernelSnapshot.getLatestTransactionVersion(id)
+    if (versionJOpt.isPresent) {
+      Some(versionJOpt.get)
+    } else {
+      None
+    }
+  }
+
+  // Public APIS
+  override def getMetadata: MetadataJ = kernelSnapshotWrapper.getMetadata()
+  override def getVersion: Long = kernelSnapshotWrapper.getVersion()
+
+  // Internal apis that we need to verify don't get used often
+  override def scanScala(): DeltaScanImpl = {
+    logInfo("Calling scanScala on KernelSnapshotDelegator")
+    standaloneSnapshot.scanScala()
+  }
+  override def setTransactionsScala: Seq[SetTransaction] = {
+    logInfo("Calling setTransactionsScala on KernelSnapshotDelegator")
+    standaloneSnapshot.setTransactionsScala
+  }
+  override def numOfFiles: Long = {
+    logInfo("Calling numOfFiles on KernelSnapshotDelegator")
+    standaloneSnapshot.numOfFiles
+  }
+  override def allFilesScala: Seq[AddFile] = {
+    logInfo("Calling allFilesScala on KernelSnapshotDelegator")
+    standaloneSnapshot.allFilesScala
+  }
+
+
+  // throw for the following, as we don't expect flink to use them
+  override def scan(): DeltaScan = throw new RuntimeException()
+  override def scan(predicate: Expression): DeltaScan = throw new RuntimeException()
+  override def getAllFiles: java.util.List[AddFileJ] = throw new RuntimeException()
+  override def open(): CloseableIterator[RowParquetRecordJ] = throw new RuntimeException()
+}

--- a/connectors/flink/src/main/scala/io/delta/flink/internal/KernelSnapshotWrapper.java
+++ b/connectors/flink/src/main/scala/io/delta/flink/internal/KernelSnapshotWrapper.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.standalone.internal;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.delta.kernel.data.ColumnVector;
+
+import io.delta.standalone.DeltaScan;
+import io.delta.standalone.actions.AddFile;
+import io.delta.standalone.actions.Metadata;
+import io.delta.standalone.data.CloseableIterator;
+import io.delta.standalone.data.RowRecord;
+import io.delta.standalone.expressions.Expression;
+
+
+/**
+ * Wrap a {@link io.delta.kernel.Snapshot} such that it conforms to the the {@link
+ * io.delta.standalone.Snapshot} interface.
+ *
+ * NB: Currently only supports the getMetadata and getVersion methods. All others throw exceptions.
+ */
+
+public class KernelSnapshotWrapper implements io.delta.standalone.Snapshot {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KernelSnapshotWrapper.class);
+
+    // Converting from kernelMetadata to metadata could be expensive, so don't do it until asked,
+    // and cache the result.
+    private Optional<Metadata> metadata = Optional.empty();
+    private io.delta.kernel.internal.SnapshotImpl kernelSnapshot;
+
+    public KernelSnapshotWrapper(io.delta.kernel.internal.SnapshotImpl kernelSnapshot) {
+        this.kernelSnapshot = kernelSnapshot;
+    }
+
+    /**
+     * @return the table metadata for this snapshot.
+     *
+     */
+    @Override
+    public Metadata getMetadata() {
+        if (!metadata.isPresent()) {
+            metadata = Optional.of(convertMetadata());
+        }
+        return metadata.get();
+    }
+
+    /**
+     * @return the version for this snapshot
+     */
+    @Override
+    public long getVersion() {
+        // WARNING: getVersion in SnapshotImpl currently doesn't use the table client, so we can
+        // pass null, but if this changes this code could break
+        return kernelSnapshot.getVersion(null);
+    }
+
+    /**
+     * NOT SUPPORTED
+     * @return a {@link DeltaScan} of the files in this snapshot.
+     */
+    @Override
+    public DeltaScan scan() {
+        throw new UnsupportedOperationException("not supported");
+    }
+
+    /**
+     * NOT SUPPORTED
+     * @param predicate  the predicate to be used to filter the files in this snapshot.
+     * @return a {@link DeltaScan} of the files in this snapshot matching the pushed portion of
+     *         {@code predicate}
+     */
+    @Override
+    public DeltaScan scan(Expression predicate) {
+        throw new UnsupportedOperationException("not supported");
+    }
+
+    /**
+     * NOT SUPPORTED
+     * @return all of the files present in this snapshot
+     */
+    @Override
+    public List<AddFile> getAllFiles() {
+        throw new UnsupportedOperationException("not supported");
+    }
+
+    /**
+     * NOT SUPPORTED
+     * Creates a {@link CloseableIterator} which can iterate over data belonging to this snapshot.
+     * It provides no iteration ordering guarantee among data.
+     *
+     * @return a {@link CloseableIterator} to iterate over data
+     */
+    @Override
+    public CloseableIterator<RowRecord> open() {
+        throw new UnsupportedOperationException("not supported");
+    }
+
+    // Used for testing
+    protected io.delta.kernel.internal.SnapshotImpl getKernelSnapshot() {
+        return kernelSnapshot;
+    }
+
+    /**
+     * Converts the metadata in the kernel snapshot to a compatible Metadata type. The kernel
+     * uses more optional types, which are converted to `null` if they are `None` since that's what
+     * the standalone Metadata expects.
+     */
+    private Metadata convertMetadata() {
+        io.delta.kernel.internal.actions.Metadata kernelMetadata = kernelSnapshot.getMetadata();
+
+        // Convert the format type
+        io.delta.kernel.internal.actions.Format kernelFormat = kernelMetadata.getFormat();
+        io.delta.standalone.actions.Format format = new io.delta.standalone.actions.Format(
+            kernelFormat.getProvider(),
+            java.util.Collections.emptyMap() // TODO: Kernel doesn't currently support options
+        );
+
+        // Convert the partition columns from a ColumnVector to a List<String>
+        ColumnVector partitionsVec = kernelMetadata.getPartitionColumns().getElements();
+        ArrayList<String> partitionColumns = new ArrayList<String>(partitionsVec.getSize());
+        for(int i = 0; i < partitionsVec.getSize(); i++) {
+            partitionColumns.add(partitionsVec.getString(i));
+        }
+
+        // Convert over the schema StructType
+        List<io.delta.kernel.types.StructField> kernelFields = kernelMetadata.getSchema().fields();
+        io.delta.standalone.types.StructField[] fields =
+            new io.delta.standalone.types.StructField[kernelFields.size()];
+        int index = 0;
+        for (io.delta.kernel.types.StructField kernelField: kernelFields) {
+            // default to an empty set of metadata to use in case we get an exception while
+            // converting
+            io.delta.standalone.types.FieldMetadata fieldMetadata =
+                io.delta.standalone.types.FieldMetadata.builder().build();
+            try {
+                Constructor<io.delta.standalone.types.FieldMetadata> fieldMetadataContructor =
+                    io.delta.standalone.types.FieldMetadata.class.getDeclaredConstructor(
+                        java.util.Map.class
+                    );
+                fieldMetadataContructor.setAccessible(true);
+                fieldMetadata = fieldMetadataContructor.newInstance(
+                    kernelField.getMetadata().getEntries()
+                );
+            } catch (Exception e) {
+                LOG.warn(
+                    "Failed to convert field metadata via private constructor. " +
+                    "Using empty metadata", e
+                );
+            }
+            fields[index] = new io.delta.standalone.types.StructField(
+                kernelField.getName(),
+                io.delta.standalone.types.DataType.fromJson(
+                    kernelField.getDataType().toJson()
+                ),
+                kernelField.isNullable(),
+                fieldMetadata
+            );
+            index++;
+        }
+        io.delta.standalone.types.StructType schema =
+            new io.delta.standalone.types.StructType(fields);
+
+        return new Metadata(
+            kernelMetadata.getId(),
+            kernelMetadata.getName().orElse(null),
+            kernelMetadata.getDescription().orElse(null),
+            format,
+            partitionColumns,
+            kernelMetadata.getConfiguration(),
+            kernelMetadata.getCreatedTime(),
+            schema
+        );
+    }
+}

--- a/connectors/flink/src/test/java/io/delta/flink/internal/KernelDeltaLogDelegatorTest.java
+++ b/connectors/flink/src/test/java/io/delta/flink/internal/KernelDeltaLogDelegatorTest.java
@@ -1,0 +1,73 @@
+package io.delta.flink.internal;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+import io.delta.flink.utils.DeltaTestUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.delta.standalone.VersionLog;
+import io.delta.standalone.internal.KernelDeltaLogDelegator;
+import io.delta.standalone.internal.SnapshotImpl;
+
+@ExtendWith(MockitoExtension.class)
+class KernelDeltaLogDelegatorTest {
+    private static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+    private KernelDeltaLogDelegator kernelDeltaLog;
+
+    @BeforeAll
+    public static void beforeAll() throws IOException {
+        TEMPORARY_FOLDER.create();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        TEMPORARY_FOLDER.delete();
+    }
+
+    @Test
+    public void testKernelDetectsTable() throws Exception {
+        String sourceTablePath = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
+        DeltaTestUtils.initTestForTableApiTable(sourceTablePath);
+        KernelDeltaLogDelegator kernelDeltaLog = KernelDeltaLogDelegator.forTable(
+            new Configuration(),
+            sourceTablePath
+        );
+        assertThat(kernelDeltaLog.tableExists())
+            .withFailMessage(
+                "There should be Delta table files in test folder.")
+            .isTrue();
+    }
+
+    @Test
+    public void testSnapshot() throws Exception {
+        String sourceTablePath = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
+        DeltaTestUtils.initTestForTableApiTable(sourceTablePath);
+        KernelDeltaLogDelegator kernelDeltaLog = KernelDeltaLogDelegator.forTable(
+            new Configuration(),
+            sourceTablePath
+        );
+        SnapshotImpl snapshot = kernelDeltaLog.snapshot();
+        assertEquals(snapshot.getVersion(), 0L);
+    }
+
+    @Test
+    public void testGetChanges() throws Exception {
+        String sourceTablePath = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
+        DeltaTestUtils.initTestForTableApiTable(sourceTablePath);
+        KernelDeltaLogDelegator kernelDeltaLog = KernelDeltaLogDelegator.forTable(
+            new Configuration(),
+            sourceTablePath
+        );
+        Iterator<VersionLog> changes = kernelDeltaLog.getChanges(0, true);
+        assertThat(changes.hasNext());
+    }
+}

--- a/connectors/flink/src/test/java/io/delta/flink/internal/KernelSnapshotDelegatorTest.java
+++ b/connectors/flink/src/test/java/io/delta/flink/internal/KernelSnapshotDelegatorTest.java
@@ -1,0 +1,104 @@
+package io.delta.flink.internal;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import io.delta.flink.utils.DeltaTestUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.delta.standalone.actions.AddFile;
+import io.delta.standalone.actions.Metadata;
+import io.delta.standalone.actions.Protocol;
+import io.delta.standalone.data.CloseableIterator;
+import io.delta.standalone.internal.KernelDeltaLogDelegator;
+import io.delta.standalone.internal.SnapshotImpl;
+import io.delta.standalone.internal.scan.DeltaScanImpl;
+
+@ExtendWith(MockitoExtension.class)
+class KernelSnapshotDelegatorTest {
+    private static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+    private KernelDeltaLogDelegator kernelDeltaLog;
+
+    @BeforeAll
+    public static void beforeAll() throws IOException {
+        TEMPORARY_FOLDER.create();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        TEMPORARY_FOLDER.delete();
+    }
+
+    private KernelDeltaLogDelegator getLog() throws Exception {
+        String sourceTablePath = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
+        DeltaTestUtils.initTestForTableApiTable(sourceTablePath);
+        return KernelDeltaLogDelegator.forTable(
+            new Configuration(),
+            sourceTablePath
+            );
+    }
+
+    @Test
+    public void testSnapshotVersion() throws Exception {
+        KernelDeltaLogDelegator kernelDeltaLog = getLog();
+        SnapshotImpl snapshot = kernelDeltaLog.snapshot();
+        assertEquals(snapshot.getVersion(), 0L);
+    }
+
+    @Test
+    public void testMetadata() throws Exception {
+        KernelDeltaLogDelegator kernelDeltaLog = getLog();
+        SnapshotImpl snapshot = kernelDeltaLog.snapshot();
+        Metadata metadata = snapshot.getMetadata();
+        assertEquals(metadata.getId(), "eaf79abd-f74f-4618-a013-afd3a69c7ad2");
+        assertEquals(metadata.getName(), null);
+        Optional<Long> created = metadata.getCreatedTime();
+        assertThat(created.isPresent());
+        assertEquals(created.get(), 1641940596848L);
+    }
+
+    @Test
+    public void testProtocol() throws Exception {
+        KernelDeltaLogDelegator kernelDeltaLog = getLog();
+        SnapshotImpl snapshot = kernelDeltaLog.snapshot();
+        Protocol protocol = snapshot.protocol();
+        assertEquals(protocol.getMinReaderVersion(), 1);
+        assertEquals(protocol.getMinWriterVersion(), 2);
+    }
+
+    @Test
+    public void testNumOfFiles() throws Exception {
+        KernelDeltaLogDelegator kernelDeltaLog = getLog();
+        SnapshotImpl snapshot = kernelDeltaLog.snapshot();
+        Long n = snapshot.numOfFiles();
+        assertEquals(n, 1);
+    }
+
+    @Test
+    public void testScanScala() throws Exception {
+        KernelDeltaLogDelegator kernelDeltaLog = getLog();
+        SnapshotImpl snapshot = kernelDeltaLog.snapshot();
+        DeltaScanImpl scan = snapshot.scanScala();
+        CloseableIterator<AddFile> files = scan.getFiles();
+        assertThat(files.hasNext());
+        files.next();
+        assertThat(!files.hasNext());
+    }
+
+    // Just check these don't throw as the types get hairy
+    @Test
+    public void testCanCallScalaMethods() throws Exception {
+        KernelDeltaLogDelegator kernelDeltaLog = getLog();
+        SnapshotImpl snapshot = kernelDeltaLog.snapshot();
+        snapshot.setTransactionsScala();
+        snapshot.allFilesScala();
+    }
+}

--- a/connectors/flink/src/test/java/io/delta/flink/sink/internal/committer/DeltaGlobalCommitterTestKernel.java
+++ b/connectors/flink/src/test/java/io/delta/flink/sink/internal/committer/DeltaGlobalCommitterTestKernel.java
@@ -1,0 +1,628 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.flink.sink.internal.committer;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import io.delta.flink.internal.DeltaFlinkHadoopConf;
+import io.delta.flink.sink.internal.SchemaConverter;
+import io.delta.flink.sink.internal.committables.DeltaCommittable;
+import io.delta.flink.sink.internal.committables.DeltaGlobalCommittable;
+import io.delta.flink.sink.internal.committables.DeltaGlobalCommittableSerializer;
+import io.delta.flink.sink.utils.DeltaSinkTestUtils;
+import io.delta.flink.utils.DeltaTestUtils;
+import org.apache.flink.connector.file.sink.utils.FileSinkTestUtils;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.streaming.api.functions.sink.filesystem.DeltaPendingFile;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FileSystemTestHelper;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.rules.TemporaryFolder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.delta.standalone.DeltaLog;
+import io.delta.standalone.VersionLog;
+import io.delta.standalone.actions.AddFile;
+
+// TODO: This should be a parametrized version of GeltaGlobalCommitterTest
+
+/**
+ * Tests for {@link DeltaGlobalCommitter}.
+ */
+public class DeltaGlobalCommitterTestKernel {
+
+    private final String TEST_APP_ID = UUID.randomUUID().toString();
+
+    private final long TEST_CHECKPOINT_ID = new Random().nextInt(10);
+
+    public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+    private Path tablePath;
+
+    @BeforeAll
+    public static void beforeAll() throws IOException {
+        TEMPORARY_FOLDER.create();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        TEMPORARY_FOLDER.delete();
+    }
+
+    @BeforeEach
+    public void setup() throws IOException {
+        tablePath = new Path(TEMPORARY_FOLDER.newFolder().toURI());
+    }
+
+    @Test
+    public void testWrongPartitionOrderWillFail() throws IOException {
+        //GIVEN
+        DeltaTestUtils.initTestForPartitionedTable(tablePath.getPath());
+        Configuration hadoopConfig = DeltaTestUtils.getHadoopConf();
+        hadoopConfig.setBoolean(DeltaFlinkHadoopConf.DELTA_KERNEL_ENABLED, true);
+        DeltaGlobalCommitter globalCommitter = new DeltaGlobalCommitter(
+            hadoopConfig,
+            tablePath,
+            DeltaSinkTestUtils.TEST_ROW_TYPE,
+            false // mergeSchema
+        );
+        // the order of below partition spec is different from the one used when initializing test
+        // table
+        LinkedHashMap<String, String> partitionSpec = new LinkedHashMap<String, String>() {{
+                put("col2", "val2");
+                put("col1", "val1");
+            }};
+
+        List<DeltaGlobalCommittable> globalCommittables =
+            DeltaSinkTestUtils.getListOfDeltaGlobalCommittables(3, partitionSpec);
+
+        // WHEN
+        assertThrows(RuntimeException.class, () -> globalCommitter.commit(globalCommittables));
+    }
+
+    @Test
+    public void testCommitTwice() throws Exception {
+        //GIVEN
+        int numAddedFiles = 3;
+        DeltaTestUtils.initTestForPartitionedTable(tablePath.getPath());
+        DeltaLog deltaLog = DeltaLog.forTable(
+            DeltaTestUtils.getHadoopConf(), tablePath.getPath());
+        assertEquals(0, deltaLog.snapshot().getVersion());
+        int initialTableFilesCount = deltaLog.snapshot().getAllFiles().size();
+
+        List<DeltaGlobalCommittable> globalCommittables =
+            DeltaSinkTestUtils.getListOfDeltaGlobalCommittables(
+                numAddedFiles, DeltaSinkTestUtils.getTestPartitionSpec());
+        DeltaGlobalCommitter globalCommitter =
+            getTestGlobalCommitter(DeltaSinkTestUtils.TEST_PARTITIONED_ROW_TYPE);
+
+        // WHEN
+        getTestGlobalCommitter(DeltaSinkTestUtils.TEST_PARTITIONED_ROW_TYPE)
+            .commit(globalCommittables);
+        deltaLog.update();
+        assertEquals(1, deltaLog.snapshot().getVersion());
+
+        // create new GlobalCommitter as it would be during recovery
+        getTestGlobalCommitter(DeltaSinkTestUtils.TEST_PARTITIONED_ROW_TYPE)
+            .commit(globalCommittables);
+
+        // THEN
+        // after trying to commit same committables nothing should change in DeltaLog
+        deltaLog.update();
+        assertEquals(1, deltaLog.snapshot().getVersion());
+        assertEquals(
+            initialTableFilesCount + numAddedFiles,
+            deltaLog.snapshot().getAllFiles().size()
+        );
+    }
+
+    @Test
+    public void testMergeSchemaSetToTrue() throws IOException {
+        //GIVEN
+        DeltaTestUtils.initTestForPartitionedTable(tablePath.getPath());
+        DeltaLog deltaLog = DeltaLog.forTable(
+            DeltaTestUtils.getHadoopConf(), tablePath.getPath());
+        List<DeltaGlobalCommittable> globalCommittables =
+            DeltaSinkTestUtils.getListOfDeltaGlobalCommittables(
+                3, DeltaSinkTestUtils.getTestPartitionSpec());
+
+        // add new field to the schema
+        RowType updatedSchema =
+            DeltaSinkTestUtils.addNewColumnToSchema(DeltaSinkTestUtils.TEST_PARTITIONED_ROW_TYPE);
+
+        deltaLog.snapshot(); // force cache of current snapshot
+
+        Configuration hadoopConfig = DeltaTestUtils.getHadoopConf();
+        hadoopConfig.setBoolean(DeltaFlinkHadoopConf.DELTA_KERNEL_ENABLED, true);
+        DeltaGlobalCommitter globalCommitter = new DeltaGlobalCommitter(
+            hadoopConfig,
+            tablePath,
+            updatedSchema,
+            true // mergeSchema
+        );
+
+        // WHEN
+        globalCommitter.commit(globalCommittables);
+
+        // THEN
+        // schema before deltaLog.update() is in old format, but after update it equals to the new
+        // format
+        assertEquals(deltaLog.snapshot().getMetadata().getSchema().toJson(),
+            SchemaConverter.toDeltaDataType(DeltaSinkTestUtils.TEST_PARTITIONED_ROW_TYPE).toJson());
+        deltaLog.update();
+        assertEquals(deltaLog.snapshot().getMetadata().getSchema().toJson(),
+            SchemaConverter.toDeltaDataType(updatedSchema).toJson());
+    }
+
+    @Test
+    public void testMergeSchemaSetToFalse() throws Exception {
+        //GIVEN
+        DeltaTestUtils.initTestForPartitionedTable(tablePath.getPath());
+        List<DeltaGlobalCommittable> globalCommittables =
+            DeltaSinkTestUtils.getListOfDeltaGlobalCommittables(
+                3, DeltaSinkTestUtils.getTestPartitionSpec());
+
+        // new schema drops one of the previous columns
+        RowType updatedSchema =
+            DeltaSinkTestUtils.dropOneColumnFromSchema(DeltaSinkTestUtils.TEST_ROW_TYPE);
+        DeltaGlobalCommitter globalCommitter = getTestGlobalCommitter(updatedSchema);
+
+        // WHEN
+        assertThrows(RuntimeException.class, () -> globalCommitter.commit(globalCommittables));
+    }
+
+    @Test
+    public void testMergeIncompatibleSchema() throws Exception {
+        //GIVEN
+        DeltaTestUtils.initTestForNonPartitionedTable(tablePath.getPath());
+        List<DeltaGlobalCommittable> globalCommittables =
+            DeltaSinkTestUtils.getListOfDeltaGlobalCommittables(
+                3, new LinkedHashMap<>());
+
+
+        // new schema drops one of the previous columns
+        RowType updatedSchema1 = DeltaSinkTestUtils
+                .dropOneColumnFromSchema(DeltaSinkTestUtils.TEST_ROW_TYPE);
+        // new schema adds a non-null column
+        RowType updatedSchema2 = DeltaSinkTestUtils
+                .addNewColumnToSchema(DeltaSinkTestUtils.TEST_ROW_TYPE, false);
+        Configuration hadoopConfig = DeltaTestUtils.getHadoopConf();
+        hadoopConfig.setBoolean(DeltaFlinkHadoopConf.DELTA_KERNEL_ENABLED, true);
+        for (RowType newSchema: new RowType[]{updatedSchema1, updatedSchema2}) {
+            DeltaGlobalCommitter globalCommitter = new DeltaGlobalCommitter(
+                hadoopConfig,
+                tablePath,
+                newSchema,
+                true // mergeSchema
+            );
+            // WHEN
+            String errorMessage = assertThrows(
+                IllegalStateException.class,
+                () -> globalCommitter.commit(globalCommittables)
+            ).getMessage();
+            assert(errorMessage.contains("Detected incompatible schema change"));
+        }
+    }
+
+    @Test
+    public void testWrongStreamPartitionValues() throws Exception {
+        //GIVEN
+        DeltaTestUtils.initTestForPartitionedTable(tablePath.getPath());
+        List<DeltaGlobalCommittable> globalCommittables =
+            DeltaSinkTestUtils.getListOfDeltaGlobalCommittables(
+                1, getNonMatchingPartitionSpec());
+
+        DeltaGlobalCommitter globalCommitter =
+            getTestGlobalCommitter(DeltaSinkTestUtils.TEST_ROW_TYPE);
+
+        // WHEN
+        assertThrows(RuntimeException.class, () -> globalCommitter.commit(globalCommittables));
+    }
+
+    @Test
+    public void testCommittablesFromDifferentCheckpointInterval() {
+        //GIVEN
+        int numAddedFiles1 = 3;
+        int numAddedFiles2 = 5;
+        DeltaLog deltaLog = DeltaLog.forTable(
+            DeltaTestUtils.getHadoopConf(), tablePath.getPath());
+        int initialTableFilesCount = deltaLog.snapshot().getAllFiles().size();
+        assertEquals(-1, deltaLog.snapshot().getVersion());
+
+        // we are putting newer committables first in the collection on purpose - it will also test
+        // if global committer will commit them in correct order
+        List<DeltaCommittable> deltaCommittables = DeltaSinkTestUtils.getListOfDeltaCommittables(
+            numAddedFiles2, 2);
+        deltaCommittables.addAll(DeltaSinkTestUtils.getListOfDeltaCommittables(
+            numAddedFiles1, 1));
+        List<DeltaGlobalCommittable> globalCommittables =
+            DeltaSinkTestUtils.getListOfDeltaGlobalCommittables(deltaCommittables);
+
+        DeltaGlobalCommitter globalCommitter =
+            getTestGlobalCommitter(DeltaSinkTestUtils.TEST_ROW_TYPE);
+
+        // WHEN
+        globalCommitter.commit(globalCommittables);
+
+        // THEN
+        // we should have committed both checkpoints intervals so current snapshot version should
+        // be 1 and should contain files from both intervals.
+        deltaLog.update();
+        assertEquals(1, deltaLog.snapshot().getVersion());
+        assertEquals(
+            initialTableFilesCount + numAddedFiles1 + numAddedFiles2,
+            deltaLog.snapshot().getAllFiles().size());
+    }
+
+    @Test
+    public void testCommittablesFromDifferentCheckpointIntervalOneOutdated() {
+        // GIVEN
+        // although it does not make any sense for real world scenarios that the retried set of
+        // committables is different from the previous one however for this test it better to
+        // differentiate those by changing the number of files to commit which will make the final
+        // validation unambiguous
+        int numAddedFiles1FirstTrial = 3;
+        int numAddedFiles1SecondTrial = 4;
+        int numAddedFiles2 = 10;
+        DeltaLog deltaLog = DeltaLog.forTable(
+            DeltaTestUtils.getHadoopConf(), tablePath.getPath());
+        assertEquals(-1, deltaLog.snapshot().getVersion());
+
+        List<DeltaCommittable> deltaCommittables1FirstTrial =
+            DeltaSinkTestUtils.getListOfDeltaCommittables(numAddedFiles1FirstTrial, 1);
+        List<DeltaCommittable> deltaCommittables1SecondTrial =
+            DeltaSinkTestUtils.getListOfDeltaCommittables(numAddedFiles1SecondTrial, 1);
+        List<DeltaCommittable> deltaCommittables2 = DeltaSinkTestUtils.getListOfDeltaCommittables(
+            numAddedFiles2, 2);
+        List<DeltaCommittable> deltaCommittablesCombined = new ArrayList<>(Collections.emptyList());
+        deltaCommittablesCombined.addAll(deltaCommittables1FirstTrial);
+        deltaCommittablesCombined.addAll(deltaCommittables1SecondTrial);
+        deltaCommittablesCombined.addAll(deltaCommittables2);
+
+        List<DeltaGlobalCommittable> globalCommittables1FirstTrial =
+            DeltaSinkTestUtils.getListOfDeltaGlobalCommittables(deltaCommittables1FirstTrial);
+        List<DeltaGlobalCommittable> globalCommittablesCombined =
+            DeltaSinkTestUtils.getListOfDeltaGlobalCommittables(deltaCommittablesCombined);
+
+        // WHEN
+        // we first commit committables from the former checkpoint interval, and then combined
+        // committables from both checkpoint intervals
+        getTestGlobalCommitter(DeltaSinkTestUtils.TEST_ROW_TYPE)
+            .commit(globalCommittables1FirstTrial);
+
+        // create new GlobalCommitter as it would be during recovery
+        getTestGlobalCommitter(DeltaSinkTestUtils.TEST_ROW_TYPE)
+            .commit(globalCommittablesCombined);
+
+        // THEN
+        // we should've committed only files from the first try for checkpointId == 1 and files
+        // for checkpointId == 2
+        deltaLog.update();
+        assertEquals(2, deltaLog.snapshot().getVersion());
+        List<AddFile> filesInTable = deltaLog.snapshot().getAllFiles();
+        assertEquals(
+            numAddedFiles1FirstTrial + numAddedFiles1SecondTrial + numAddedFiles2,
+            filesInTable.size()
+        );
+
+        // we simply check if the table really contains all the files from all tries respective
+        // to the version.
+        List<VersionLog> changes = new ArrayList<>();
+        deltaLog.getChanges(0, true).forEachRemaining(changes::add);
+
+        assertEquals(3, changes.size());
+
+        List<String> filesFor1CommittableFirstTrial =
+            getCommittableFiles(deltaCommittables1FirstTrial);
+        List<String> filesFor1CommittableSecondTrial =
+            getCommittableFiles(deltaCommittables1SecondTrial);
+        List<String> filesFor2Committable = getCommittableFiles(deltaCommittables2);
+
+        List<String> filesFromVersionOne = getFromVersion(changes.get(0));
+        List<String> filesFromVersionTwo = getFromVersion(changes.get(1));
+        List<String> filesFromVersionThree =getFromVersion(changes.get(2));
+
+        assertThat(filesFromVersionOne)
+            .containsExactlyInAnyOrder(filesFor1CommittableFirstTrial.toArray(new String[0]));
+        assertThat(filesFromVersionTwo)
+            .containsExactlyInAnyOrder(filesFor1CommittableSecondTrial.toArray(new String[0]));
+        assertThat(filesFromVersionThree)
+            .containsExactlyInAnyOrder(filesFor2Committable.toArray(new String[0]));
+    }
+
+    @Test
+    public void testAddCommittableWithAbsolutePath() {
+
+        // GIVEN
+        DeltaLog deltaLog = DeltaLog.forTable(
+            DeltaTestUtils.getHadoopConf(), tablePath.getPath());
+        assertEquals(-1, deltaLog.snapshot().getVersion());
+
+        DeltaPendingFile pendingFileAbsolutePath =
+            DeltaSinkTestUtils.getTestDeltaPendingFileWithAbsolutePath(
+                deltaLog.getPath(),
+                new LinkedHashMap<>());
+
+        DeltaPendingFile pendingFileRelativePath =
+            DeltaSinkTestUtils.getTestDeltaPendingFileForFileName(
+                Paths.get(
+                    URI.create(pendingFileAbsolutePath.getFileName())).getFileName().toString(),
+                new LinkedHashMap<>()
+            );
+
+        // Make sure that second DeltaPendingFile has the same file name.
+        assertThat(
+            pendingFileAbsolutePath.getFileName().endsWith(pendingFileRelativePath.getFileName()))
+            .isEqualTo(true);
+
+        DeltaCommittable committableWithAbsolutePath = new DeltaCommittable(
+            pendingFileAbsolutePath,
+            TEST_APP_ID,
+            TEST_CHECKPOINT_ID
+        );
+
+        DeltaCommittable committableWithRelativePath = new DeltaCommittable(
+            DeltaSinkTestUtils.getTestDeltaPendingFileForFileName(
+                pendingFileRelativePath.getFileName(),
+                new LinkedHashMap<>()),
+            TEST_APP_ID,
+            TEST_CHECKPOINT_ID
+        );
+
+        // WHEN
+        // commit AddFile with relative path.
+        getTestGlobalCommitter(DeltaSinkTestUtils.TEST_PARTITIONED_ROW_TYPE)
+            .commit(Collections.singletonList(
+                new DeltaGlobalCommittable(
+                    DeltaSinkTestUtils.committablesToAbstractCommittables(Collections.singletonList(
+                        committableWithRelativePath
+                    ))
+                )
+            ));
+
+        // commit AddFile with absolute path.
+        getTestGlobalCommitter(DeltaSinkTestUtils.TEST_PARTITIONED_ROW_TYPE)
+            .commit(Collections.singletonList(
+                new DeltaGlobalCommittable(
+                    DeltaSinkTestUtils.committablesToAbstractCommittables(Collections.singletonList(
+                        committableWithAbsolutePath
+                    ))
+                )
+            ));
+
+        // THEN
+        assertThat(deltaLog.update().getVersion())
+            .describedAs(
+                "Target delta table should be at version 0 since second commit call should be "
+                    + "ignored since it is adding a duplicate data.")
+            .isEqualTo(0L);
+        assertThat(deltaLog.snapshot().getAllFiles().size()).isEqualTo(1);
+
+        VersionLog versionLog = deltaLog.getChanges(0, true).next();
+        assertThat(
+            versionLog.getActions().stream().filter(action -> action instanceof AddFile)
+                .count())
+            .describedAs("Target Delta Table should have only one AddFile action in its log. "
+                + "Probably duplicate data was added.")
+            .isEqualTo(1);
+    }
+
+    @Test
+    public void testCommittablesFromDifferentCheckpointIntervalOneWithIncompatiblePartitions()
+        throws Exception {
+        //GIVEN
+        DeltaTestUtils.initTestForPartitionedTable(tablePath.getPath());
+        int numAddedFiles1 = 3;
+        int numAddedFiles2 = 5;
+        DeltaLog deltaLog = DeltaLog.forTable(
+            DeltaTestUtils.getHadoopConf(), tablePath.getPath());
+        assertEquals(0, deltaLog.snapshot().getVersion());
+        int initialNumberOfFiles = deltaLog.snapshot().getAllFiles().size();
+
+        List<DeltaCommittable> deltaCommittables1 = DeltaSinkTestUtils.getListOfDeltaCommittables(
+            numAddedFiles1, DeltaSinkTestUtils.getTestPartitionSpec(), 1);
+        List<DeltaCommittable> deltaCommittables2 = DeltaSinkTestUtils.getListOfDeltaCommittables(
+            numAddedFiles2, getNonMatchingPartitionSpec(), 2);
+
+        List<DeltaGlobalCommittable> globalCommittables = Arrays.asList(
+            new DeltaGlobalCommittable(
+                DeltaSinkTestUtils.committablesToAbstractCommittables(deltaCommittables1)),
+            new DeltaGlobalCommittable(
+                DeltaSinkTestUtils.committablesToAbstractCommittables(deltaCommittables2))
+        );
+
+        DeltaGlobalCommitter globalCommitter =
+            getTestGlobalCommitter(DeltaSinkTestUtils.TEST_PARTITIONED_ROW_TYPE);
+
+        // WHEN
+        assertThrows(RuntimeException.class, () -> globalCommitter.commit(globalCommittables));
+
+        // the commit should raise an exception for incompatible committables for the second
+        // checkpoint interval but correct committables for the first checkpoint interval should
+        // have been committed
+        deltaLog.update();
+        assertEquals(1, deltaLog.snapshot().getVersion());
+        assertEquals(
+            initialNumberOfFiles + numAddedFiles1,
+            deltaLog.snapshot().getAllFiles().size()
+        );
+    }
+
+    @Test
+    public void testGlobalCommittableSerializerWithCommittables() throws IOException {
+        // GIVEN
+        LinkedHashMap<String, String> partitionSpec = new LinkedHashMap<>();
+        partitionSpec.put("col1", "val1");
+        partitionSpec.put("col2", "val2");
+
+        List<DeltaCommittable> deltaCommittables = Arrays.asList(
+            new DeltaCommittable(
+                DeltaSinkTestUtils.getTestDeltaPendingFile(partitionSpec),
+                TEST_APP_ID,
+                TEST_CHECKPOINT_ID),
+            new DeltaCommittable(
+                DeltaSinkTestUtils.getTestDeltaPendingFile(partitionSpec),
+                TEST_APP_ID,
+                TEST_CHECKPOINT_ID + 1)
+        );
+        DeltaGlobalCommittable globalCommittable = new DeltaGlobalCommittable(
+            DeltaSinkTestUtils.committablesToAbstractCommittables(deltaCommittables));
+
+        // WHEN
+        DeltaGlobalCommittable deserialized = serializeAndDeserialize(globalCommittable);
+
+        // THEN
+        for (int i = 0; i < deserialized.getDeltaCommittables().size(); i++) {
+            DeltaSinkTestUtils.validateDeltaCommittablesEquality(
+                globalCommittable.getDeltaCommittables().get(i),
+                deserialized.getDeltaCommittables().get(i),
+                partitionSpec
+            );
+        }
+    }
+
+    @Test
+    public void testGlobalCommittableSerializerWithEmptyCommittables() throws IOException {
+        // GIVEN
+        DeltaGlobalCommittable globalCommittable = new DeltaGlobalCommittable(new ArrayList<>());
+
+        // WHEN
+        DeltaGlobalCommittable deserialized = serializeAndDeserialize(globalCommittable);
+
+        // THEN
+        assertTrue(globalCommittable.getDeltaCommittables().isEmpty());
+        assertTrue(deserialized.getDeltaCommittables().isEmpty());
+    }
+
+    @Test
+    public void testUseFullPathForDeltaLog() throws Exception {
+        //GIVEN
+        int numAddedFiles = 3;
+
+        assertEquals(tablePath.toUri().getScheme(), "file");
+        DeltaTestUtils.initTestForPartitionedTable(tablePath.getPath());
+        DeltaLog deltaLog = DeltaLog.forTable(
+            DeltaTestUtils.getHadoopConf(), tablePath.getPath());
+        assertEquals(deltaLog.snapshot().getVersion(), 0);
+        int initialTableFilesCount = deltaLog.snapshot().getAllFiles().size();
+
+        List<DeltaGlobalCommittable> globalCommittables =
+                DeltaSinkTestUtils.getListOfDeltaGlobalCommittables(
+                        numAddedFiles, DeltaSinkTestUtils.getTestPartitionSpec());
+        Configuration hadoopConfig = DeltaTestUtils.getHadoopConf();
+
+        // set up a simple hdfs mock as default filesystem. This FS should not be
+        // used by the global committer below, as the path we are passing is from
+        // a local filesystem
+        hadoopConfig.set("fs.defaultFS", "mockfs:///");
+        hadoopConfig.setClass("fs.mockfs.impl",
+                FileSystemTestHelper.MockFileSystem.class, FileSystem.class);
+        hadoopConfig.setBoolean(DeltaFlinkHadoopConf.DELTA_KERNEL_ENABLED, true);
+
+        // create a globalCommitter that points to a local FS path (file:/// scheme). If
+        // the path were to use the default filesystem (mockfs:///), it would return
+        // a null DeltaLog to write to, which will make operations in the global committer
+        // to fail. If it uses the full path correctly, it will open the already prepared
+        // delta log
+        DeltaGlobalCommitter globalCommitter = new DeltaGlobalCommitter(
+                hadoopConfig,
+                tablePath,
+                DeltaSinkTestUtils.TEST_PARTITIONED_ROW_TYPE,
+                false // mergeSchema
+        );
+
+        // WHEN
+        globalCommitter.commit(globalCommittables);
+        deltaLog.update();
+
+        // THEN
+        // should have created the deltaLog files in the specified path regardless
+        // of the configured default filesystem
+        assertEquals(1, deltaLog.snapshot().getVersion());
+        assertEquals(
+                initialTableFilesCount + numAddedFiles,
+                deltaLog.snapshot().getAllFiles().size());
+    }
+
+    ///////////////////////////////////////////////////
+    // test method utils
+    ///////////////////////////////////////////////////
+
+    private DeltaGlobalCommitter getTestGlobalCommitter(RowType schema) {
+        Configuration hadoopConfig = DeltaTestUtils.getHadoopConf();
+        hadoopConfig.setBoolean(DeltaFlinkHadoopConf.DELTA_KERNEL_ENABLED, true);
+        return new DeltaGlobalCommitter(
+            hadoopConfig,
+            tablePath,
+            schema,
+            false // mergeSchema
+        );
+    }
+
+    private LinkedHashMap<String, String> getNonMatchingPartitionSpec() {
+        LinkedHashMap<String, String> nonMatchingPartitionSpec =
+            DeltaSinkTestUtils.getTestPartitionSpec();
+        nonMatchingPartitionSpec.remove(nonMatchingPartitionSpec.keySet().toArray()[0]);
+        return nonMatchingPartitionSpec;
+    }
+
+    ///////////////////////////////////////////////////
+    // serde test utils
+    ///////////////////////////////////////////////////
+
+    private DeltaGlobalCommittable serializeAndDeserialize(DeltaGlobalCommittable globalCommittable)
+        throws IOException {
+        DeltaGlobalCommittableSerializer serializer =
+            new DeltaGlobalCommittableSerializer(
+                new FileSinkTestUtils.SimpleVersionedWrapperSerializer<>(
+                    FileSinkTestUtils.TestPendingFileRecoverable::new)
+            );
+        byte[] data = serializer.serialize(globalCommittable);
+        return serializer.deserialize(serializer.getVersion(), data);
+    }
+
+    private List<String> getFromVersion(VersionLog versionLog) {
+        return versionLog.getActions().stream().filter(action -> action instanceof AddFile)
+            .map(action -> ((AddFile) action).getPath()).collect(Collectors.toList());
+    }
+
+    private List<String> getCommittableFiles(List<DeltaCommittable> deltaCommittables1FirstTrial) {
+        return deltaCommittables1FirstTrial.stream()
+            .map(committable -> committable.getDeltaPendingFile().toAddFile())
+            .map(AddFile::getPath).collect(Collectors.toList());
+    }
+}

--- a/connectors/flink/src/test/java/io/delta/flink/source/internal/KernelMetadataUtils.java
+++ b/connectors/flink/src/test/java/io/delta/flink/source/internal/KernelMetadataUtils.java
@@ -1,0 +1,115 @@
+package io.delta.flink.source.internal;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Optional;
+
+import io.delta.kernel.data.ArrayValue;
+import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.data.MapValue;
+import io.delta.kernel.defaults.internal.data.vector.DefaultGenericVector;
+import io.delta.kernel.internal.actions.Metadata;
+import io.delta.kernel.types.*;
+
+public class KernelMetadataUtils {
+    public static StructType getSchema() {
+        FieldMetadata.Builder builder = FieldMetadata.builder();
+        builder.putString("key1", "value1");
+        builder.putString("key2", "value2");
+        ArrayList<DataType> typesToTest = new ArrayList<DataType>();
+        ArrayType arrayType = new ArrayType(IntegerType.INTEGER, false);
+        typesToTest.add(arrayType);
+        typesToTest.add(BinaryType.BINARY);
+        typesToTest.add(BooleanType.BOOLEAN);
+        typesToTest.add(ByteType.BYTE);
+        typesToTest.add(DateType.DATE);
+        typesToTest.add(DecimalType.USER_DEFAULT);
+        typesToTest.add(DoubleType.DOUBLE);
+        typesToTest.add(FloatType.FLOAT);
+        typesToTest.add(IntegerType.INTEGER);
+        typesToTest.add(LongType.LONG);
+        typesToTest.add(new MapType(ShortType.SHORT, arrayType, false));
+        typesToTest.add(ShortType.SHORT);
+        typesToTest.add(StringType.STRING);
+        typesToTest.add(TimestampType.TIMESTAMP);
+        ArrayList<StructField> fields = new ArrayList<StructField>();
+        int fnum = 1;
+        for (DataType dt : typesToTest) {
+            fields.add(
+                new StructField(
+                    "Field " + fnum,
+                    dt,
+                    false,
+                    builder.build()
+                    )
+            );
+            fnum++;
+        }
+        return new StructType(fields);
+    }
+
+    public static Metadata getKernelMetadata() {
+        StructType schema = getSchema();
+        return new io.delta.kernel.internal.actions.Metadata(
+            "id",
+            Optional.ofNullable("name"),
+            Optional.ofNullable("description"),
+            new io.delta.kernel.internal.actions.Format("parquet", new HashMap<String, String>()),
+            "schemaString",
+            schema,
+            new ArrayValue() { // paritionColumns
+                @Override
+                public int getSize() {
+                    return 2;
+                }
+
+                @Override
+                public ColumnVector getElements() {
+                    return new ColumnVector() {
+                        @Override
+                        public DataType getDataType() {
+                            return null;
+                        }
+
+                        @Override
+                        public int getSize() {
+                            return 2;
+                        }
+
+                        @Override
+                        public void close() {}
+
+                        @Override
+                        public boolean isNullAt(int rowId) {
+                            return false;
+                        }
+
+                        @Override
+                        public String getString(int rowId) {
+                            return "Row " + rowId;
+                        }
+                    };
+                }
+            },
+            Optional.ofNullable(1234L),
+            new MapValue() { // conf
+                @Override
+                public int getSize() {
+                    return 1;
+                }
+                @Override
+                public ColumnVector getKeys() {
+                    return DefaultGenericVector.fromArray(
+                        IntegerType.INTEGER, new Integer[]{new Integer(1)}
+                    );
+                }
+                @Override
+                public ColumnVector getValues() {
+                    return DefaultGenericVector.fromArray(
+                        IntegerType.INTEGER, new Integer[]{new Integer(2)}
+                    );
+                }
+            }
+        );
+    }
+}

--- a/connectors/flink/uml/puml/KernelDeltaLogDelegator.puml
+++ b/connectors/flink/uml/puml/KernelDeltaLogDelegator.puml
@@ -1,0 +1,49 @@
+@startuml
+'https://plantuml.com/class-diagram
+
+scale 2
+skinparam defaultFontName Fira Sans
+set separator none
+
+package "io.delta.standalone.internal" {
+
+  class DeltaLogImpl
+  
+  class KernelDeltaLogDelegator extends DeltaLogImpl {
+    standaloneDeltaLog : DeltaLogImpl 
+    currentKernelSnapshot : KernelSnapshotDelegator
+
+    KernelSnapshotDelegator snapshot()
+    update() - only update the kernel snapshot
+    tableExists() - use kernel snapshot
+    
+    getChanges() - delegate to standaloneDeltaLog
+
+    getSnapshotForVersionAsOf() - throws
+    getSnapshotForTimestampAsOf() - throws
+    getCommitInfoAt() - throws
+  }
+
+  class SnapshotImpl
+
+  class KernelSnapshotDelegator extends SnapshotImpl {
+    kernelSnapshot : SnapshotImplKernel [SnapshotImpl from kernel package]
+    lazy standaloneSnapshot : SnapshotImpl [SnapshotImpl from standalone]
+
+    protocolScala() - use kernel snapshot
+    metadataScala() - use kernel snapshot
+    getMetadata() - use kernel snapshot
+    getVersion() - use kernel snapshot
+
+    scanScala() - Delegate to standaloneSnapshot
+    setTransactionsScala() - Delegate to standaloneSnapshot
+    numOfFiles() - Delegate to standaloneSnapshot
+    allFilesScala() - Delegate to standaloneSnapshot
+  }
+
+  KernelDeltaLogDelegator::currentKernelSnapshot --> KernelSnapshotDelegator
+  KernelDeltaLogDelegator::standaloneDeltaLog -left-> DeltaLogImpl
+  KernelSnapshotDelegator::standaloneSnapshot -left-> SnapshotImpl
+}
+
+@enduml

--- a/connectors/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
+++ b/connectors/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
@@ -39,7 +39,7 @@ import io.delta.standalone.internal.util.{Clock, ConversionUtils, FileNames, Sys
 /**
  * Scala implementation of Java interface [[DeltaLog]].
  */
-private[internal] class DeltaLogImpl private(
+private[internal] class DeltaLogImpl private[internal](
     val hadoopConf: Configuration,
     val logPath: Path,
     val dataPath: Path,

--- a/connectors/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
+++ b/connectors/standalone/src/main/scala/io/delta/standalone/internal/OptimisticTransactionImpl.scala
@@ -47,7 +47,7 @@ private[internal] class OptimisticTransactionImpl(
   private val txnId = UUID.randomUUID().toString
 
   /** Tracks the appIds that have been seen by this transaction. */
-  private val readTxn = new ArrayBuffer[String]
+  private[internal] val readTxn = new ArrayBuffer[String]
 
   /**
    * Tracks the data that could have been seen by recording the partition
@@ -525,7 +525,9 @@ private[internal] class OptimisticTransactionImpl(
    * Returns true if we should checkpoint the version that has just been committed.
    */
   private def shouldCheckpoint(committedVersion: Long): Boolean = {
-    committedVersion != 0 && committedVersion % deltaLog.checkpointInterval == 0
+    val checkpointingEnabled =
+      deltaLog.hadoopConf.getBoolean(StandaloneHadoopConf.CHECKPOINTING_ENABLED, true)
+    checkpointingEnabled && committedVersion != 0 && committedVersion % deltaLog.checkpointInterval == 0
   }
 
   /** Returns the next attempt version given the last attempted version */

--- a/connectors/standalone/src/main/scala/io/delta/standalone/internal/SnapshotManagement.scala
+++ b/connectors/standalone/src/main/scala/io/delta/standalone/internal/SnapshotManagement.scala
@@ -218,7 +218,7 @@ private[internal] trait SnapshotManagement { self: DeltaLogImpl =>
    * file as a hint on where to start listing the transaction log directory. If the _delta_log
    * directory doesn't exist, this method will return an `InitialSnapshot`.
    */
-  private def getSnapshotAtInit: SnapshotImpl = {
+  protected def getSnapshotAtInit: SnapshotImpl = {
     try {
       val logSegment = getLogSegmentForVersion(lastCheckpoint.map(_.version))
 

--- a/kernel/examples/table-reader/src/main/java/io/delta/kernel/integration/IntegrationTestSuite.java
+++ b/kernel/examples/table-reader/src/main/java/io/delta/kernel/integration/IntegrationTestSuite.java
@@ -100,16 +100,29 @@ public class IntegrationTestSuite {
                     Literal.ofDecimal(new BigDecimal("2342222.23454"), 12, 5)))),
             1 /* expected row count */);
 
-        // Partition pruning: filter on data and metadata columns
+        // Partition pruning: filter on data and metadata columns where
+        // data filter doesn't prune anything
         runAndVerifyRowCount(
-            "partition_pruning_filter_on_data_and_metadata_columns",
+            "partition_pruning_filter_on_data_and_metadata_columns_1",
             "dv-partitioned-with-checkpoint",
             Optional.of(asList("part", "col2")), /* read schema */
             Optional.of(
                 new And(
                     new Predicate(">=", asList(new Column("part"), Literal.ofInt(7))),
-                    new Predicate("=", asList(new Column("col1"), Literal.ofInt(0))))),
+                    new Predicate(">=", asList(new Column("col1"), Literal.ofInt(0))))),
             12 /* expected row count */);
+
+        // Partition pruning: filter on data and metadata columns where
+        // data filter also prunes few files based on the stats based skipping
+        runAndVerifyRowCount(
+            "partition_pruning_filter_on_data_and_metadata_columns_2",
+            "dv-partitioned-with-checkpoint",
+            Optional.of(asList("part", "col2")), /* read schema */
+            Optional.of(
+                new And(
+                    new Predicate(">=", asList(new Column("part"), Literal.ofInt(7))),
+                    new Predicate("=", asList(new Column("col1"), Literal.ofInt(28))))),
+            5 /* expected row count */);
     }
 
     private void runAndVerifyRowCount(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -19,9 +19,6 @@ import java.io.IOException;
 import java.util.*;
 import static java.util.stream.Collectors.toMap;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.delta.kernel.Scan;
 import io.delta.kernel.client.TableClient;
 import io.delta.kernel.data.*;
@@ -46,8 +43,6 @@ import static io.delta.kernel.internal.util.Preconditions.checkArgument;
  * Implementation of {@link Scan}
  */
 public class ScanImpl implements Scan {
-    private static final Logger logger = LoggerFactory.getLogger(ScanImpl.class);
-
     /**
      * Schema of the snapshot from the Delta log being scanned in this scan. It is a logical schema
      * with metadata properties to derive the physical schema.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -17,13 +17,13 @@ package io.delta.kernel.internal;
 
 import java.io.IOException;
 import java.util.*;
+import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 
 import io.delta.kernel.Scan;
 import io.delta.kernel.client.TableClient;
 import io.delta.kernel.data.*;
 import io.delta.kernel.expressions.*;
-import io.delta.kernel.types.DataType;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
@@ -178,15 +178,16 @@ public class ScanImpl implements Scan {
         }
 
         Set<String> partitionColNames = metadata.getPartitionColNames();
-        Map<String, DataType> partitionColNameToTypeMap = metadata.getSchema().fields().stream()
-            .filter(field -> partitionColNames.contains(field.getName()))
-            .collect(toMap(
-                field -> field.getName().toLowerCase(Locale.ENGLISH),
-                field -> field.getDataType()));
+        Map<String, StructField> partitionColNameToStructFieldMap =
+            metadata.getSchema().fields().stream()
+                .filter(field -> partitionColNames.contains(field.getName()))
+                .collect(toMap(
+                    field -> field.getName().toLowerCase(Locale.ENGLISH),
+                    identity()));
 
         Predicate predicateOnScanFileBatch = rewritePartitionPredicateOnScanFileSchema(
             partitionPredicate.get(),
-            partitionColNameToTypeMap);
+            partitionColNameToStructFieldMap);
 
         return new CloseableIterator<FilteredColumnarBatch>() {
             PredicateEvaluator predicateEvaluator = null;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -33,11 +33,11 @@ import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.data.ScanStateRow;
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.replay.LogReplay;
+import io.delta.kernel.internal.skipping.DataSkippingPredicate;
 import io.delta.kernel.internal.skipping.DataSkippingUtils;
 import io.delta.kernel.internal.util.*;
 import static io.delta.kernel.internal.skipping.StatsSchemaHelper.getStatsSchema;
 import static io.delta.kernel.internal.util.PartitionUtils.rewritePartitionPredicateOnScanFileSchema;
-import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 
 /**
  * Implementation of {@link Scan}
@@ -56,8 +56,6 @@ public class ScanImpl implements Scan {
     private final LogReplay logReplay;
     private final Path dataPath;
     private final Optional<Tuple2<Predicate, Predicate>> partitionAndDataFilters;
-    // Partition column names in lower case.
-    private final Set<String> partitionColumnNames;
     private boolean accessedScanFiles;
 
     public ScanImpl(
@@ -73,7 +71,6 @@ public class ScanImpl implements Scan {
         this.protocol = protocol;
         this.metadata = metadata;
         this.logReplay = logReplay;
-        this.partitionColumnNames = loadPartitionColNames(); // must be called before `splitFilters`
         this.partitionAndDataFilters = splitFilters(filter);
         this.dataPath = dataPath;
     }
@@ -91,7 +88,7 @@ public class ScanImpl implements Scan {
         accessedScanFiles = true;
 
         // Generate data skipping filter and decide if we should read the stats column
-        Optional<Predicate> dataSkippingFilter = getDataSkippingFilter();
+        Optional<DataSkippingPredicate> dataSkippingFilter = getDataSkippingFilter();
         boolean shouldReadStats = dataSkippingFilter.isPresent();
 
         // Get active AddFiles via log replay
@@ -151,7 +148,8 @@ public class ScanImpl implements Scan {
 
     private Optional<Tuple2<Predicate, Predicate>> splitFilters(Optional<Predicate> filter) {
         return filter.map(predicate ->
-            PartitionUtils.splitMetadataAndDataPredicates(predicate, partitionColumnNames));
+            PartitionUtils.splitMetadataAndDataPredicates(
+                predicate, metadata.getPartitionColNames()));
     }
 
     private Optional<Predicate> getDataFilters() {
@@ -179,7 +177,7 @@ public class ScanImpl implements Scan {
             return scanFileIter;
         }
 
-        Set<String> partitionColNames = partitionColumnNames;
+        Set<String> partitionColNames = metadata.getPartitionColNames();
         Map<String, DataType> partitionColNameToTypeMap = metadata.getSchema().fields().stream()
             .filter(field -> partitionColNames.contains(field.getName()))
             .collect(toMap(
@@ -222,19 +220,22 @@ public class ScanImpl implements Scan {
         };
     }
 
-    private Optional<Predicate> getDataSkippingFilter() {
+    private Optional<DataSkippingPredicate> getDataSkippingFilter() {
         return getDataFilters().flatMap(dataFilters ->
-            DataSkippingUtils.constructDataSkippingFilter(dataFilters, metadata.getSchema())
+            DataSkippingUtils.constructDataSkippingFilter(dataFilters, metadata.getDataSchema())
         );
     }
 
     private CloseableIterator<FilteredColumnarBatch> applyDataSkipping(
             TableClient tableClient,
             CloseableIterator<FilteredColumnarBatch> scanFileIter,
-            Predicate dataSkippingFilter) {
+            DataSkippingPredicate dataSkippingFilter) {
         // Get the stats schema
-        // TODO prune stats schema according to the data skipping filter delta-io/delta#2458
-        StructType statsSchema = getStatsSchema(metadata.getSchema());
+        // It's possible to instead provide the referenced columns when building the schema but
+        // pruning it after is much simpler
+        StructType prunedStatsSchema = DataSkippingUtils.pruneStatsSchema(
+            getStatsSchema(metadata.getDataSchema()),
+            dataSkippingFilter.getReferencedCols());
 
         // Skipping happens in two steps:
         // 1. The predicate produces false for any file whose stats prove we can safely skip it. A
@@ -250,7 +251,7 @@ public class ScanImpl implements Scan {
 
         PredicateEvaluator predicateEvaluator = tableClient
             .getExpressionHandler()
-            .getPredicateEvaluator(statsSchema, filterToEval);
+            .getPredicateEvaluator(prunedStatsSchema, filterToEval);
 
         return scanFileIter.map(filteredScanFileBatch -> {
 
@@ -258,7 +259,7 @@ public class ScanImpl implements Scan {
                 DataSkippingUtils.parseJsonStats(
                     tableClient,
                     filteredScanFileBatch,
-                    statsSchema
+                    prunedStatsSchema
                 ),
                 filteredScanFileBatch.getSelectionVector());
 
@@ -267,23 +268,5 @@ public class ScanImpl implements Scan {
                 Optional.of(newSelectionVector));
             }
         );
-    }
-
-    /**
-     * Helper method to load the partition column names from the metadata.
-     */
-    private Set<String> loadPartitionColNames() {
-        ArrayValue partitionColValue = metadata.getPartitionColumns();
-        ColumnVector partitionColNameVector = partitionColValue.getElements();
-        Set<String> partitionColumnNames = new HashSet<>();
-        for (int i = 0; i < partitionColValue.getSize(); i++) {
-            checkArgument(!partitionColNameVector.isNullAt(i),
-                "Expected a non-null partition column name");
-            String partitionColName = partitionColNameVector.getString(i);
-            checkArgument(partitionColName != null && !partitionColName.isEmpty(),
-                "Expected non-null and non-empty partition column name");
-            partitionColumnNames.add(partitionColName.toLowerCase(Locale.ENGLISH));
-        }
-        return Collections.unmodifiableSet(partitionColumnNames);
     }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingPredicate.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.skipping;
+
+import java.util.*;
+
+import io.delta.kernel.expressions.Column;
+import io.delta.kernel.expressions.Expression;
+import io.delta.kernel.expressions.Predicate;
+
+/**
+ * A {@link Predicate} with a set of {@link Set<Column>} of columns referenced by the expression.
+ */
+public class DataSkippingPredicate extends Predicate {
+
+    /** Set of {@link Column}s referenced by the predicate or any of its child expressions */
+    private final Set<Column> referencedCols;
+
+    /**
+     * @param name the predicate name
+     * @param children list of expressions that are input to this predicate.
+     * @param referencedCols set of columns referenced by this predicate or any of its child
+     *                       expressions
+     */
+    DataSkippingPredicate(String name, List<Expression> children, Set<Column> referencedCols) {
+        super(name, children);
+        this.referencedCols = Collections.unmodifiableSet(referencedCols);
+    }
+
+    /**
+     * Constructor for a binary {@link DataSkippingPredicate} where both children are instances of
+     * {@link DataSkippingPredicate}.
+     * @param name the predicate name
+     * @param left left input to this predicate
+     * @param right right input to this predicate
+     */
+    DataSkippingPredicate(String name, DataSkippingPredicate left, DataSkippingPredicate right) {
+        this(
+            name,
+            Arrays.asList(left, right),
+            new HashSet<Column>(){
+                {
+                    addAll(left.getReferencedCols());
+                    addAll(right.getReferencedCols());
+                }
+            });
+    }
+
+    public Set<Column> getReferencedCols() {
+        return referencedCols;
+    }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingPredicate.java
@@ -22,7 +22,7 @@ import io.delta.kernel.expressions.Expression;
 import io.delta.kernel.expressions.Predicate;
 
 /**
- * A {@link Predicate} with a set of {@link Set<Column>} of columns referenced by the expression.
+ * A {@link Predicate} with a set of columns referenced by the expression.
  */
 public class DataSkippingPredicate extends Predicate {
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
@@ -138,11 +138,32 @@ public class StatsSchemaHelper {
         return getStatsColumn(column, MIN);
     }
 
-    /** Given a logical column returns corresponding the MAX column in the statistic schema */
+    /**
+     * Given a logical column in the data schema provided when creating {@code this}, return
+     * the corresponding MAX column in the statistic schema that stores the MAX values for the
+     * provided logical column.
+     */
     public Column getMaxColumn(Column column) {
         checkArgument(isSkippingEligibleMinMaxColumn(column),
             String.format("%s is not a valid min column for data schema %s", column, dataSchema));
         return getStatsColumn(column, MAX);
+    }
+
+    /**
+     * Given a logical column in the data schema provided when creating {@code this}, return
+     * the corresponding NULL_COUNT column in the statistic schema that stores the null count values
+     * for the provided logical column.
+     */
+    public Column getNullCountColumn(Column column) {
+        checkArgument(isSkippingEligibleNullCountColumn(column),
+            String.format(
+                "%s is not a valid null_count column for data schema %s", column, dataSchema));
+        return getStatsColumn(column, NULL_COUNT);
+    }
+
+    /** Returns the NUM_RECORDS column in the statistic schema */
+    public Column getNumRecordsColumn() {
+        return new Column(NUM_RECORDS);
     }
 
     /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
@@ -149,34 +149,37 @@ public class PartitionUtils {
      * `partition_value` deserializes the string value into the given partition column type value.
      * String type partition values don't need any deserialization.
      *
-     * @param predicate             Predicate containing filters only on partition columns.
-     * @param partitionColNameTypes Map of partition column name (in lower case) to its type.
+     * @param predicate            Predicate containing filters only on partition columns.
+     * @param partitionColMetadata Map of partition column name (in lower case) to its type.
      * @return
      */
     public static Predicate rewritePartitionPredicateOnScanFileSchema(
-        Predicate predicate, Map<String, DataType> partitionColNameTypes) {
+        Predicate predicate, Map<String, StructField> partitionColMetadata) {
         return new Predicate(
             predicate.getName(),
             predicate.getChildren().stream()
-                .map(child -> rewritePartitionColumnRef(child, partitionColNameTypes))
+                .map(child -> rewritePartitionColumnRef(child, partitionColMetadata))
                 .collect(Collectors.toList()));
     }
 
     private static Expression rewritePartitionColumnRef(
-        Expression expression, Map<String, DataType> partitionColNameTypes) {
+        Expression expression, Map<String, StructField> partitionColMetadata) {
         Column scanFilePartitionValuesRef = InternalScanFileUtils.ADD_FILE_PARTITION_COL_REF;
         if (expression instanceof Column) {
             Column column = (Column) expression;
             String partColName = column.getNames()[0];
-            DataType partColType = partitionColNameTypes.get(partColName.toLowerCase(Locale.ROOT));
-            if (partColType == null) {
-                throw new IllegalArgumentException(partColName + " has no data type in metadata");
+            StructField partColField =
+                partitionColMetadata.get(partColName.toLowerCase(Locale.ROOT));
+            if (partColField == null) {
+                throw new IllegalArgumentException(partColName + " is not present in metadata");
             }
+            DataType partColType = partColField.getDataType();
+            String partColPhysicalName = ColumnMapping.getPhysicalName(partColField);
 
             Expression elementAt =
                 new ScalarExpression(
                     "element_at",
-                    asList(scanFilePartitionValuesRef, Literal.ofString(partColName)));
+                    asList(scanFilePartitionValuesRef, Literal.ofString(partColPhysicalName)));
 
             if (partColType instanceof StringType) {
                 return elementAt;
@@ -186,7 +189,7 @@ public class PartitionUtils {
             return new PartitionValueExpression(elementAt, partColType);
         } else if (expression instanceof Predicate) {
             return rewritePartitionPredicateOnScanFileSchema(
-                (Predicate) expression, partitionColNameTypes);
+                (Predicate) expression, partitionColMetadata);
         }
 
         return expression;

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/DataSkippingUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/DataSkippingUtilsSuite.scala
@@ -1,0 +1,170 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.util
+
+import scala.collection.JavaConverters._
+
+import io.delta.kernel.expressions.Column
+import io.delta.kernel.internal.skipping.DataSkippingUtils
+import io.delta.kernel.types.IntegerType.INTEGER
+import io.delta.kernel.types.{DataType, StructField, StructType}
+import org.scalatest.funsuite.AnyFunSuite
+
+class DataSkippingUtilsSuite extends AnyFunSuite {
+
+  def col(name: String): Column = new Column(name)
+
+  def nestedCol(name: String): Column = {
+    new Column(name.split("\\."))
+  }
+
+  /* For struct type checks for equality based on field names & data type only */
+  def compareDataTypeUnordered(type1: DataType, type2: DataType): Boolean = (type1, type2) match {
+    case (schema1: StructType, schema2: StructType) =>
+      val fields1 = schema1.fields().asScala.sortBy(_.getName)
+      val fields2 = schema2.fields().asScala.sortBy(_.getName)
+      if (fields1.length != fields2.length) {
+        false
+      } else {
+        fields1.zip(fields2).forall { case (field1: StructField, field2: StructField) =>
+          field1.getName == field2.getName &&
+            compareDataTypeUnordered(field1.getDataType, field2.getDataType)
+        }
+      }
+    case _ =>
+      type1 == type2
+  }
+
+  def checkPruneStatsSchema(
+    inputSchema: StructType, referencedCols: Set[Column], expectedSchema: StructType): Unit = {
+    val prunedSchema = DataSkippingUtils.pruneStatsSchema(inputSchema, referencedCols.asJava)
+    assert(compareDataTypeUnordered(expectedSchema, prunedSchema),
+      s"expected=$expectedSchema\nfound=$prunedSchema")
+  }
+
+  test("pruneStatsSchema - multiple basic cases one level of nesting") {
+    val nestedField = new StructField(
+      "nested",
+      new StructType()
+        .add("col1", INTEGER)
+        .add("col2", INTEGER),
+      true
+    )
+    val testSchema = new StructType()
+      .add(nestedField)
+      .add("top_level_col", INTEGER)
+    // no columns pruned
+    checkPruneStatsSchema(
+      testSchema,
+      Set(col("top_level_col"), nestedCol("nested.col1"), nestedCol("nested.col2")),
+      testSchema
+    )
+    // top level column pruned
+    checkPruneStatsSchema(
+      testSchema,
+      Set(nestedCol("nested.col1"), nestedCol("nested.col2")),
+      new StructType().add(nestedField)
+    )
+    // nested column only one field pruned
+    checkPruneStatsSchema(
+      testSchema,
+      Set(nestedCol("top_level_col"), nestedCol("nested.col1")),
+      new StructType()
+        .add("nested", new StructType().add("col1", INTEGER))
+        .add("top_level_col", INTEGER)
+    )
+    // nested column completely pruned
+    checkPruneStatsSchema(
+      testSchema,
+      Set(nestedCol("top_level_col")),
+      new StructType().add("top_level_col", INTEGER)
+    )
+    // prune all columns
+    checkPruneStatsSchema(
+      testSchema,
+      Set(),
+      new StructType()
+    )
+  }
+
+  test("pruneStatsSchema - 3 levels of nesting") {
+    /*
+    |--level1: struct
+    |   |--level2: struct
+    |       |--level3: struct
+    |           |--level_4_col: int
+    |       |--level_3_col: int
+    |   |--level_2_col: int
+     */
+    val testSchema = new StructType()
+      .add("level1",
+        new StructType()
+          .add(
+            "level2",
+            new StructType()
+              .add(
+                "level3",
+                new StructType().add("level_4_col", INTEGER))
+              .add("level_3_col", INTEGER)
+          )
+          .add("level_2_col", INTEGER)
+      )
+    // prune only 4th level col
+    checkPruneStatsSchema(
+      testSchema,
+      Set(nestedCol("level1.level2.level_3_col"), nestedCol("level1.level_2_col")),
+      new StructType()
+        .add(
+          "level1",
+          new StructType()
+            .add("level2", new StructType().add("level_3_col", INTEGER))
+            .add("level_2_col", INTEGER))
+    )
+    // prune only 3rd level column
+    checkPruneStatsSchema(
+      testSchema,
+      Set(nestedCol("level1.level2.level3.level_4_col"), nestedCol("level1.level_2_col")),
+      new StructType()
+        .add("level1",
+          new StructType()
+            .add(
+              "level2",
+              new StructType()
+                .add(
+                  "level3",
+                  new StructType().add("level_4_col", INTEGER))
+            )
+            .add("level_2_col", INTEGER)
+        )
+    )
+    // prune 4th and 3rd level column
+    checkPruneStatsSchema(
+      testSchema,
+      Set(nestedCol("level1.level_2_col")),
+      new StructType()
+        .add("level1",
+          new StructType()
+            .add("level_2_col", INTEGER)
+        )
+    )
+    // prune all columns
+    checkPruneStatsSchema(
+      testSchema,
+      Set(),
+      new StructType()
+    )
+  }
+}

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/PartitionUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/PartitionUtilsSuite.scala
@@ -29,15 +29,25 @@ class PartitionUtilsSuite extends AnyFunSuite {
   // Table schema
   // Data columns: data1: int, data2: string, date3: struct(data31: boolean, data32: long)
   // Partition columns: part1: int, part2: date, part3: string
-  private val partitionColsToType = new util.HashMap[String, DataType]() {
+  val tableSchema = new StructType()
+    .add("data1", IntegerType.INTEGER)
+    .add("data2", StringType.STRING)
+    .add("data3", new StructType()
+      .add("data31", BooleanType.BOOLEAN)
+      .add("data32", LongType.LONG))
+    .add("part1", IntegerType.INTEGER)
+    .add("part2", DateType.DATE)
+    .add("part3", StringType.STRING)
+
+  private val partitionColsMetadata = new util.HashMap[String, StructField]() {
     {
-      put("part1", IntegerType.INTEGER)
-      put("part2", DateType.DATE)
-      put("part3", StringType.STRING)
+      put("part1", tableSchema.get("part1"))
+      put("part2", tableSchema.get("part2"))
+      put("part3", tableSchema.get("part3"))
     }
   }
 
-  private val partitionCols: java.util.Set[String] = partitionColsToType.keySet()
+  private val partitionCols: java.util.Set[String] = partitionColsMetadata.keySet()
 
   // Test cases for verifying partition of predicate into data and partition predicates
   // Map entry format (predicate -> (partition predicate, data predicate)
@@ -169,7 +179,7 @@ class PartitionUtilsSuite extends AnyFunSuite {
     case (predicate, expRewrittenPredicate) =>
       test(s"rewrite partition predicate on scan file schema: $predicate") {
         val actRewrittenPredicate =
-          rewritePartitionPredicateOnScanFileSchema(predicate, partitionColsToType)
+          rewritePartitionPredicateOnScanFileSchema(predicate, partitionColsMetadata)
         assert(actRewrittenPredicate.toString === expRewrittenPredicate)
       }
   }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
@@ -213,7 +213,6 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
       greaterThanOrEqual(ofInt(0), col("a")), // 0 >= a
       not(equals(col("a"), ofInt(1))), // NOT a = 1
       not(equals(ofInt(1), col("a"))) // NOT 1 = a
-
     )
   )
 
@@ -372,10 +371,75 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
     )
   )
 
-  // Test: 'or statements - simple' Expression: OR
-  // Test: 'or statements - two fields' Expression: OR
-  // Test: 'or statements - one side supported' Expression: OR
-  // Test: 'NOT statements - or' Expression: NOT, OR
+  testSkipping(
+    "data skipping - or statements - simple",
+    """
+      {"a": 1}
+      {"a": 2}
+    """,
+    hits = Seq(
+      // a > 0 or a < -3
+      new Or(greaterThan(col("a"), ofInt(0)), lessThan(col("a"), ofInt(-3))),
+      // a >= 2 or a < -1
+      new Or(greaterThanOrEqual(col("a"), ofInt(2)), lessThan(col("a"), ofInt(-1)))
+    ),
+    misses = Seq(
+      // a > 5 or a < -2
+      new Or(greaterThan(col("a"), ofInt(5)), lessThan(col("a"), ofInt(-2)))
+    )
+  )
+
+  testSkipping(
+    "data skipping - or statements - two fields",
+    """
+      {"a": 1, "b": "2017-09-01"}
+      {"a": 2, "b": "2017-08-31"}
+    """,
+    hits = Seq(
+      new Or(
+        lessThan(col("a"), ofInt(0)),
+        equals(col("b"), ofString("2017-09-01"))
+      ),
+      new Or(
+        equals(col("a"), ofInt(2)),
+        lessThan(col("b"), ofString("2017-08-30"))
+      ),
+      // note startsWith is not supported yet but these should still be hits once supported
+      new Or( //  a < 2 or b like '2017-08-%'
+        lessThan(col("a"), ofInt(2)),
+        startsWith(col("b"), ofString("2017-08-"))
+      ),
+      new Or( //  a >= 2 or b like '2016-08-%'
+        greaterThanOrEqual(col("a"), ofInt(2)),
+        startsWith(col("b"), ofString("2016-08-"))
+      ),
+      // MOVE BELOW EXPRESSION TO MISSES ONCE SUPPORTED BY DATA SKIPPING
+      new Or( // a < 0 or b like '2016-%'
+        lessThan(col("a"), ofInt(0)),
+        startsWith(col("b"), ofString("2016-"))
+      )
+    ),
+    misses = Seq()
+  )
+
+  // One side of OR by itself isn't powerful enough to prune any files.
+  testSkipping(
+    "data skipping - or statements - one side unsupported",
+    """
+      {"a": 10, "b": 10}
+      {"a": 20: "b": 20}
+    """,
+    hits = Seq(
+      // a % 100 < 10 OR b > 20
+      new Or(lessThan(aRem100, ofInt(10)), greaterThan(col("b"), ofInt(20))),
+      // a < 10 OR b % 100 > 20
+      new Or(lessThan(col("a"), ofInt(10)), greaterThan(bRem100, ofInt(20)))
+    ),
+    misses = Seq(
+      // a < 10 OR b > 20
+      new Or(lessThan(col("a"), ofInt(10)), greaterThan(col("b"), ofInt(20)))
+    )
+  )
 
   testSkipping(
     "data skipping - not statements - simple",
@@ -421,16 +485,45 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
           greaterThanOrEqual(aRem100, ofInt(10)),
           lessThanOrEqual(col("b"), ofInt(20))
         )
-      ),
-      // MOVE BELOW EXPRESSION TO MISSES ONCE OR IS SUPPORTED BY DATA SKIPPING
+      )
+    ),
+    misses = Seq(
       not(
         new And(
           greaterThanOrEqual(col("a"), ofInt(10)),
           lessThanOrEqual(col("b"), ofInt(20))
         )
       )
+    )
+  )
+
+  // NOT(OR(a, b)) === AND(NOT(a), NOT(b)) => One side by itself is enough to prune.
+  testSkipping(
+    "data skipping - not statements - or",
+    """
+      {"a": 1, "b": 10}
+      {"a": 2, "b": 20}
+    """,
+    hits = Seq(
+      // NOT(a < 1 OR b > 20),
+      not(new Or(lessThan(col("a"), ofInt(1)), greaterThan(col("b"), ofInt(20)))),
+      // NOT(a % 100 >= 1 OR b % 100 <= 20)
+      not(new Or(greaterThanOrEqual(aRem100, ofInt(1)), lessThanOrEqual(bRem100, ofInt(20))))
     ),
-    misses = Seq()
+    misses = Seq(
+      // NOT(a >= 1 OR b <= 20)
+      not(
+        new Or(greaterThanOrEqual(col("a"), ofInt(1)), lessThanOrEqual(col("b"), ofInt(20)))
+      ),
+      // NOT(a % 100 >= 1 OR b <= 20),
+      not(
+        new Or(greaterThanOrEqual(aRem100, ofInt(1)), lessThanOrEqual(col("b"), ofInt(20)))
+      ),
+      // NOT(a >= 1 OR b % 100 <= 20)
+      not(
+        new Or(greaterThanOrEqual(col("a"), ofInt(1)), lessThanOrEqual(bRem100, ofInt(20)))
+      )
+    )
   )
 
   // If a column does not have stats, it does not participate in data skipping, which disqualifies
@@ -450,16 +543,15 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
       new Or( // a < 1 OR (a >= 1 AND b < 10): ==> a < 1 OR a >=1 ==> TRUE
         lessThan(col("a"), ofInt(1)),
         new And(greaterThanOrEqual(col("a"), ofInt(1)), lessThan(col("b"), ofInt(10)))
-      ),
-      // MOVE BELOW EXPRESSION TO MISSES ONCE SUPPORTED BY DATA SKIPPING
-      new Or( // a < 1 OR (a > 10 AND b < 10): ==> a < 1 OR a > 10 ==> FALSE
-        lessThan(col("a"), ofInt(1)),
-        new And(greaterThan(col("a"), ofInt(10)), lessThan(col("b"), ofInt(10)))
       )
     ),
     misses = Seq(
       new And( // a < 1 AND b < 10: ==> a < 1 ==> FALSE
-        lessThan(col("a"), ofInt(1)), lessThan(col("b"), ofInt(10)))
+        lessThan(col("a"), ofInt(1)), lessThan(col("b"), ofInt(10))),
+      new Or( // a < 1 OR (a > 10 AND b < 10): ==> a < 1 OR a > 10 ==> FALSE
+        lessThan(col("a"), ofInt(1)),
+        new And(greaterThan(col("a"), ofInt(10)), lessThan(col("b"), ofInt(10)))
+      )
     )
   )
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
@@ -49,13 +49,6 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
 
   import io.delta.kernel.defaults.ScanSuite._
 
-  private val spark = SparkSession
-    .builder()
-    .appName("Spark Test Writer for Delta Kernel")
-    .config("spark.master", "local")
-    .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
-    .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
-    .getOrCreate()
   // scalastyle:off sparkimplicits
   import spark.implicits._
   // scalastyle:on sparkimplicits

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
@@ -768,12 +768,12 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
       nullSafeEquals(col("a"), ofInt(1)),
 
       // MOVE BELOW EXPRESSIONS TO MISSES ONCE SUPPORTED BY DATA SKIPPING
-      isNotNull(col("a")),
       // This can be optimized to `IsNotNull(a)` (done by NullPropagation in Spark)
       not(nullSafeEquals(col("a"), ofNull(INTEGER)))
     ),
     misses = Seq(
-      AlwaysFalse.ALWAYS_FALSE
+      AlwaysFalse.ALWAYS_FALSE,
+      isNotNull(col("a"))
     )
   )
 
@@ -1082,8 +1082,8 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
 
       checkResults(
         predicate = isNotNull(col("value")),
-        expNumPartitions = 3, // should be 2 once IS_NOT_NULL is supported for data skipping
-        expNumFiles = 5) // should be 5 once IS_NOT_NULL is supported for skipping
+        expNumPartitions = 2, // one of the partitions has no files left after data skipping
+        expNumFiles = 3) // files with all NULL values get skipped
 
       checkResults(
         predicate = nullSafeEquals(col("value"), ofNull(STRING)),
@@ -1131,8 +1131,8 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
 
       checkResults(
         predicate = new And(isNotNull(col("key")), isNotNull(col("value"))),
-        expNumPartitions = 2, // should be 1 once we do data skipping for IS_NOT_NULL
-        expNumFiles = 2) // should be 2 once we do data skipping for IS_NUT_NULL
+        expNumPartitions = 1,
+        expNumFiles = 1) // 1 file with (*, a)
 
       checkResults(
         predicate = new Or(
@@ -1295,20 +1295,168 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
     }
   }
 
-  test("data skipping - non-eligible data skipping types") {
+  test("data skipping - non-eligible min/max data skipping types") {
     withTempDir { tempDir =>
       val schema = SparkStructType.fromDDL("`id` INT, `arr_col` ARRAY<INT>, " +
         "`map_col` MAP<STRING, INT>, `struct_col` STRUCT<`field1`: INT>")
       val data = SparkRow(0, Array(1, 2), Map("foo" -> 1), SparkRow(5)) :: Nil
       spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
         .write.format("delta").save(tempDir.getCanonicalPath)
-      // For now just filter on the one eligible column to ensure we can read stats from tables with
-      // these types. In the future we should be able to skip with null predicates on these columns
       checkSkipping(
         tempDir.getCanonicalPath,
-        hits = Seq(equals(col("id"), ofInt(0))),
+        hits = Seq(
+          equals(col("id"), ofInt(0)), // filter on the one eligible column
+          isNotNull(col("id")),
+          isNotNull(col("arr_col")),
+          isNotNull(col("map_col")),
+          isNotNull(col("struct_col")),
+          isNotNull(nestedCol("struct_col.field1")),
+          not(isNotNull(col("struct_col"))), // we don't skip on non-leaf columns
+            // MOVE BELOW EXPRESSIONS TO MISSES ONCE IS_NULL IS SUPPORTED BY DATA SKIPPING
+          // [not(is_not_null) is converted to is_null]
+          not(isNotNull(col("id"))),
+          not(isNotNull(col("arr_col"))),
+          not(isNotNull(col("map_col"))),
+          not(isNotNull(nestedCol("struct_col.field1")))
+        ),
         misses = Seq(equals(col("id"), ofInt(1)))
       )
+    }
+  }
+
+  test("data skipping - non-eligible min/max data skipping types all nulls in file") {
+    withTempDir { tempDir =>
+      val schema = SparkStructType.fromDDL("`id` INT, `arr_col` ARRAY<INT>, " +
+        "`map_col` MAP<STRING, INT>, `struct_col` STRUCT<`field1`: INT>")
+      val data = SparkRow(null, null, null, null) :: Nil
+      spark.createDataFrame(spark.sparkContext.parallelize(data), schema).coalesce(1)
+        .write.format("delta").save(tempDir.getCanonicalPath)
+      checkSkipping(
+        tempDir.getCanonicalPath,
+        hits = Seq(
+          // note "is_null" is not supported yet [not(is_not_null) is converted to is_null] but
+          // these should still be hits once supported
+          not(isNotNull(col("id"))),
+          not(isNotNull(col("arr_col"))),
+          not(isNotNull(col("map_col"))),
+          not(isNotNull(col("struct_col"))),
+          not(isNotNull(nestedCol("struct_col.field1"))),
+          isNotNull(col("struct_col")) // we don't skip on non-leaf columns
+        ),
+        misses = Seq(
+          isNotNull(col("id")),
+          isNotNull(col("arr_col")),
+          isNotNull(col("map_col")),
+          isNotNull(nestedCol("struct_col.field1"))
+        )
+      )
+    }
+  }
+
+  test("data skipping - non-eligible min/max data skipping types null +" +
+    "non-null in same file") {
+    withTempDir { tempDir =>
+      val schema = SparkStructType.fromDDL("`id` INT, `arr_col` ARRAY<INT>, " +
+        "`map_col` MAP<STRING, INT>, `struct_col` STRUCT<`field1`: INT>")
+      val data = SparkRow(0, Array(1, 2), Map("foo" -> 1), SparkRow(5)) ::
+        SparkRow(null, null, null, null) :: Nil
+      spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+        .write.format("delta").save(tempDir.getCanonicalPath)
+      checkSkipping(
+        tempDir.getCanonicalPath,
+        hits = Seq(
+          // note "is_null" is not supported yet [not(is_not_null) is converted to is_null] but
+          // these should still be hits once supported
+          not(isNotNull(col("id"))),
+          not(isNotNull(col("arr_col"))),
+          not(isNotNull(col("map_col"))),
+          not(isNotNull(col("struct_col"))),
+          not(isNotNull(nestedCol("struct_col.field1"))),
+          isNotNull(col("id")),
+          isNotNull(col("arr_col")),
+          isNotNull(col("map_col")),
+          isNotNull(col("struct_col")),
+          isNotNull(nestedCol("struct_col.field1"))
+        ),
+        misses = Seq()
+      )
+    }
+  }
+
+  test("data skipping - is not null with DVs in file with non-nulls") {
+    withSQLConf(("spark.databricks.delta.properties.defaults.enableDeletionVectors", "true")) {
+      withTempDir { tempDir =>
+        def overwriteTableAndPerformDelete(deleteCondition: String): Unit = {
+          val data = SparkRow(0, 0) :: SparkRow(1, 1) :: SparkRow(2, null) ::
+            SparkRow(3, null) :: Nil
+          val schema = new SparkStructType()
+            .add("col1", SparkIntegerType)
+            .add("col2", SparkIntegerType)
+
+          spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+            .repartition(1)
+            .write
+            .format("delta")
+            .mode("overwrite")
+            .save(tempDir.getCanonicalPath)
+          spark.sql(s"DELETE FROM delta.`${tempDir.getCanonicalPath}` WHERE $deleteCondition")
+        }
+        def checkNoSkipping(): Unit = {
+          checkSkipping(
+            tempDir.getCanonicalPath,
+            hits = Seq(
+              isNotNull(col("col2")),
+              isNotNull(col("col1"))
+            ),
+            misses = Seq()
+          )
+        }
+
+        // remove no rows
+        overwriteTableAndPerformDelete("false")
+        checkNoSkipping()
+        // remove all null rows
+        overwriteTableAndPerformDelete("col2 IS NULL")
+        checkNoSkipping()
+        // remove all non-null rows
+        overwriteTableAndPerformDelete("col2 IS NOT NULL")
+        checkNoSkipping()
+        // remove one null row
+        overwriteTableAndPerformDelete("col1 = 2")
+        checkNoSkipping()
+      }
+    }
+  }
+
+  test("data skipping - is not null with DVs in file with all nulls") {
+    withSQLConf(("spark.databricks.delta.properties.defaults.enableDeletionVectors", "true")) {
+      withTempDir { tempDir =>
+        def checkDoesSkipping(): Unit = {
+          checkSkipping(
+            tempDir.getCanonicalPath,
+            hits = Seq(
+              isNotNull(col("col1"))
+            ),
+            misses = Seq(
+              isNotNull(col("col2"))
+            )
+          )
+        }
+        // write initial table with all nulls for col2
+        val data = SparkRow(0, null) :: SparkRow(1, null) :: Nil
+        val schema = new SparkStructType()
+          .add("col1", SparkIntegerType)
+          .add("col2", SparkIntegerType)
+        spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+          .repartition(1)
+          .write
+          .format("delta")
+          .save(tempDir.getCanonicalPath)
+        checkDoesSkipping()
+        // delete one of the nulls
+        spark.sql(s"DELETE FROM delta.`${tempDir.getCanonicalPath}` WHERE col1 = 0")
+        checkDoesSkipping()
+      }
     }
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/ExpressionTestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/ExpressionTestUtils.scala
@@ -15,7 +15,7 @@
  */
 package io.delta.kernel.defaults.utils
 
-import io.delta.kernel.expressions.{Column, Expression, Literal, Predicate}
+import io.delta.kernel.expressions.{Column, Expression, Predicate}
 
 /** Useful helper functions for creating expressions in tests */
 trait ExpressionTestUtils {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -34,12 +34,22 @@ import io.delta.kernel.types._
 import io.delta.kernel.utils.CloseableIterator
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.shaded.org.apache.commons.io.FileUtils
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.scalatest.Assertions
 
-trait TestUtils extends Assertions {
+trait TestUtils extends Assertions with SQLHelper {
 
   lazy val configuration = new Configuration()
   lazy val defaultTableClient = DefaultTableClient.create(configuration)
+
+  lazy val spark = SparkSession
+    .builder()
+    .appName("Spark Test Writer for Delta Kernel")
+    .config("spark.master", "local")
+    .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+    .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+    .getOrCreate()
 
   implicit class CloseableIteratorOps[T](private val iter: CloseableIterator[T]) {
 

--- a/project/FlinkMimaExcludes.scala
+++ b/project/FlinkMimaExcludes.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright (2020-present) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.typesafe.tools.mima.core._
+
+/**
+ * The list of Mima errors to exclude in the Flink project.
+ */
+object FlinkMimaExcludes {
+  val ignoredABIProblems = Seq()
+}

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -105,6 +105,7 @@ object Mima {
     Test / test := ((Test / test) dependsOn mimaReportBinaryIssues).value,
     mimaPreviousArtifacts := {
       Set("io.delta" % "delta-flink" % getPrevConnectorVersion(version.value))
-    }
+    },
+    mimaBinaryIssueFilters ++= FlinkMimaExcludes.ignoredABIProblems
   )
 }

--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaFormatSharingSource.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaFormatSharingSource.scala
@@ -1,0 +1,532 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.spark
+
+import java.lang.ref.WeakReference
+import java.util.concurrent.TimeUnit
+
+import org.apache.spark.sql.delta.{
+  DeltaErrors,
+  DeltaLog,
+  DeltaOptions,
+  SnapshotDescriptor
+}
+import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
+import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.sources.{
+  DeltaDataSource,
+  DeltaSource,
+  DeltaSourceOffset
+}
+import io.delta.sharing.client.DeltaSharingClient
+import io.delta.sharing.client.model.{Table => DeltaSharingTable}
+
+import org.apache.spark.delta.sharing.CachedTableManager
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.connector.read.streaming
+import org.apache.spark.sql.connector.read.streaming.{ReadLimit, SupportsAdmissionControl}
+import org.apache.spark.sql.execution.streaming.{Offset, Source}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.StructType
+
+/**
+ * A streaming source for a Delta Sharing table.
+ *
+ * This class wraps a DeltaSource to read data out of locally constructed delta log.
+ * When a new stream is started, delta sharing starts by fetching delta log from the server side,
+ * constructing a local delta log, and call delta source apis to compute offset or read data.
+ *
+ * TODO: Support CDC Streaming, SupportsTriggerAvailableNow and SupportsConcurrentExecution.
+ */
+case class DeltaFormatSharingSource(
+    spark: SparkSession,
+    client: DeltaSharingClient,
+    table: DeltaSharingTable,
+    options: DeltaSharingOptions,
+    parameters: Map[String, String],
+    sqlConf: SQLConf,
+    metadataPath: String)
+    extends Source
+    with SupportsAdmissionControl
+    with DeltaLogging {
+
+  private var tableId: String = "unset_table_id"
+
+  private val tablePath = options.options.getOrElse(
+    "path",
+    throw DeltaSharingErrors.pathNotSpecifiedException
+  )
+
+  // A unique string composed of a formatted timestamp and an uuid.
+  // Used as a suffix for the table name and its delta log path of a delta sharing table in a
+  // streaming job, to avoid overwriting the delta log from multiple references of the same delta
+  // sharing table in one streaming job.
+  private val timestampWithUUID = DeltaSharingUtils.getFormattedTimestampWithUUID()
+  private val customTablePathWithUUIDSuffix = DeltaSharingUtils.getTablePathWithIdSuffix(
+    client.getProfileProvider.getCustomTablePath(tablePath),
+    timestampWithUUID
+  )
+  private val deltaLogPath =
+    s"${DeltaSharingLogFileSystem.encode(customTablePathWithUUIDSuffix).toString}/_delta_log"
+
+  // The latest metadata of the shared table, fetched at the initialization time of the
+  // DeltaFormatSharingSource, used to initialize the wrapped DeltaSource.
+  private lazy val deltaSharingTableMetadata =
+    DeltaSharingUtils.getDeltaSharingTableMetadata(client, table)
+
+  private lazy val deltaSource = initDeltaSource()
+
+  private def initDeltaSource(): DeltaSource = {
+    val (localDeltaLog, snapshotDescriptor) = DeltaSharingUtils.getDeltaLogAndSnapshotDescriptor(
+      spark,
+      deltaSharingTableMetadata,
+      customTablePathWithUUIDSuffix
+    )
+    val schemaTrackingLogOpt =
+      DeltaDataSource.getMetadataTrackingLogForDeltaSource(
+        spark,
+        snapshotDescriptor,
+        parameters,
+        // Pass in the metadata path opt so we can use it for validation
+        sourceMetadataPathOpt = Some(metadataPath)
+      )
+
+    val readSchema = schemaTrackingLogOpt
+      .flatMap(_.getCurrentTrackedMetadata.map(_.dataSchema))
+      .getOrElse(snapshotDescriptor.schema)
+
+    if (readSchema.isEmpty) {
+      throw DeltaErrors.schemaNotSetException
+    }
+
+    DeltaSource(
+      spark = spark,
+      deltaLog = localDeltaLog,
+      options = new DeltaOptions(parameters, sqlConf),
+      snapshotAtSourceInit = snapshotDescriptor,
+      metadataPath = metadataPath,
+      metadataTrackingLog = schemaTrackingLogOpt
+    )
+  }
+
+  // schema of the streaming source, based on the latest metadata of the shared table.
+  override val schema: StructType = {
+    val schemaWithoutCDC = deltaSharingTableMetadata.metadata.schema
+    tableId = deltaSharingTableMetadata.metadata.deltaMetadata.id
+    if (options.readChangeFeed) {
+      CDCReader.cdcReadSchema(schemaWithoutCDC)
+    } else {
+      schemaWithoutCDC
+    }
+  }
+
+  // Latest endOffset of the getBatch call, used to compute startingOffset which will then be used
+  // to compare with the the latest table version on server to decide whether to fetch new data.
+  private var latestProcessedEndOffsetOption: Option[DeltaSourceOffset] = None
+
+  // Latest table version for the data fetched from the delta sharing server, and stored in the
+  // local delta log. Used to check whether all fetched files are processed by the DeltaSource.
+  private var latestTableVersionInLocalDeltaLogOpt: Option[Long] = None
+
+  // This is needed because DeltaSource is not advancing the offset to the next version
+  // automatically when scanning through a snapshot, so DeltaFormatSharingSource needs to count the
+  // number of files in the min version and advance the offset to the next version when the offset
+  // is at the last index of the version.
+  private var numFileActionsInStartingSnapshotOpt: Option[Int] = None
+
+  // Latest timestamp for getTableVersion rpc from the server, used to compare with the current
+  // timestamp, to ensure the gap QUERY_TABLE_VERSION_INTERVAL_MILLIS between two rpcs, to avoid
+  // a high traffic load to the server.
+  private var lastTimestampForGetVersionFromServer: Long = -1
+
+  // The minimum gap between two getTableVersion rpcs, to avoid a high traffic load to the server.
+  private val QUERY_TABLE_VERSION_INTERVAL_MILLIS = TimeUnit.SECONDS.toMillis(30)
+
+  // Maximum number of versions of getFiles() rpc when fetching files from the server. Used to
+  // reduce the number of files returned to avoid timeout of the rpc on the server.
+  private val maxVersionsPerRpc: Int = options.maxVersionsPerRpc.getOrElse(
+    DeltaSharingOptions.MAX_VERSIONS_PER_RPC_DEFAULT
+  )
+
+  // A variable to store the latest table version on server, returned from the getTableVersion rpc.
+  // Used to store the latest table version for getOrUpdateLatestTableVersion when not getting
+  // updates from the server.
+  // For all other callers, please use getOrUpdateLatestTableVersion instead of this variable.
+  private var latestTableVersionOnServer: Long = -1
+
+  /**
+   * Check the latest table version from the delta sharing server through the client.getTableVersion
+   * RPC. Adding a minimum interval of QUERY_TABLE_VERSION_INTERVAL_MILLIS between two consecutive
+   * rpcs to avoid traffic jam on the delta sharing server.
+   *
+   * @return the latest table version on the server.
+   */
+  private def getOrUpdateLatestTableVersion: Long = {
+    val currentTimeMillis = System.currentTimeMillis()
+    if ((currentTimeMillis - lastTimestampForGetVersionFromServer) >=
+      QUERY_TABLE_VERSION_INTERVAL_MILLIS) {
+      latestTableVersionOnServer = client.getTableVersion(table)
+      lastTimestampForGetVersionFromServer = currentTimeMillis
+    }
+    latestTableVersionOnServer
+  }
+
+  /**
+   * NOTE: need to match with the logic in DeltaSource.extractStartingState().
+   *
+   * Get the starting offset used to send rpc to delta sharing server, to fetch needed files.
+   * Use input startOffset when it's defined, otherwise use user defined starting version, otherwise
+   * use input endOffset if it's defined, the least option is the latest table version returned from
+   * the delta sharing server (which is usually used when a streaming query starts from scratch).
+   *
+   * @param startOffsetOption optional start offset, return it if defined. It's empty when the
+   *                          streaming query starts from scratch. It's set for following calls.
+   * @param endOffsetOption   optional end offset. It's set when the function is called from
+   *                          getBatch and is empty when called from latestOffset.
+   * @return The starting offset.
+   */
+  private def getStartingOffset(
+      startOffsetOption: Option[DeltaSourceOffset],
+      endOffsetOption: Option[DeltaSourceOffset]): DeltaSourceOffset = {
+    if (startOffsetOption.isEmpty) {
+      val (version, isInitialSnapshot) = getStartingVersion match {
+        case Some(v) => (v, false)
+        case None =>
+          if (endOffsetOption.isDefined) {
+            if (endOffsetOption.get.isInitialSnapshot) {
+              (endOffsetOption.get.reservoirVersion, true)
+            } else {
+              assert(
+                endOffsetOption.get.reservoirVersion > 0,
+                s"invalid reservoirVersion in endOffset: ${endOffsetOption.get}"
+              )
+              // Load from snapshot `endOffset.reservoirVersion - 1L` so that `index` in `endOffset`
+              // is still valid.
+              // It's OK to use the previous version as the updated initial snapshot, even if the
+              // initial snapshot might have been different from the last time when this starting
+              // offset was computed.
+              (endOffsetOption.get.reservoirVersion - 1L, true)
+            }
+          } else {
+            (getOrUpdateLatestTableVersion, true)
+          }
+      }
+      // Constructed the same way as DeltaSource.buildOffsetFromIndexedFile
+      DeltaSourceOffset(
+        reservoirId = tableId,
+        reservoirVersion = version,
+        index = DeltaSourceOffset.BASE_INDEX,
+        isInitialSnapshot = isInitialSnapshot
+      )
+    } else {
+      startOffsetOption.get
+    }
+  }
+
+  /**
+   * The ending version used in rpc is restricted by both the latest table version and
+   * maxVersionsPerRpc, to avoid loading too many files from the server to cause a timeout.
+   * @param startingOffset The start offset used in the rpc.
+   * @param latestTableVersion The latest table version at the server.
+   * @return the ending version used in the rpc.
+   */
+  private def getEndingVersionForRpc(
+      startingOffset: DeltaSourceOffset,
+      latestTableVersion: Long): Long = {
+    if (startingOffset.isInitialSnapshot) {
+      // ending version is the same as starting version for snapshot query.
+      return startingOffset.reservoirVersion
+    }
+    // using "startVersion + maxVersionsPerRpc - 1" because the endingVersion is inclusive.
+    val endingVersionForQuery = latestTableVersion.min(
+      startingOffset.reservoirVersion + maxVersionsPerRpc - 1
+    )
+    if (endingVersionForQuery < latestTableVersion) {
+      logInfo(
+        s"Reducing ending version for delta sharing rpc from latestTableVersion(" +
+        s"$latestTableVersion) to endingVersionForQuery($endingVersionForQuery), " +
+        s"startVersion:${startingOffset.reservoirVersion}, maxVersionsPerRpc:$maxVersionsPerRpc, " +
+        s"for table(id:$tableId, name:${table.toString})."
+      )
+    }
+    endingVersionForQuery
+  }
+
+  override def getDefaultReadLimit: ReadLimit = {
+    deltaSource.getDefaultReadLimit
+  }
+
+  override def latestOffset(startOffset: streaming.Offset, limit: ReadLimit): streaming.Offset = {
+    val deltaSourceOffset = getStartingOffset(latestProcessedEndOffsetOption, None)
+
+    if (deltaSourceOffset.reservoirVersion < 0) {
+      return null
+    }
+
+    maybeGetLatestFileChangesFromServer(deltaSourceOffset)
+
+    maybeMoveToNextVersion(deltaSource.latestOffset(startOffset, limit))
+  }
+
+  // Advance the DeltaSourceOffset to the next version when the offset is at the last index of the
+  // version.
+  // This is because DeltaSource is not advancing the offset automatically when processing a
+  // snapshot (isStartingVersion = true), and advancing the offset is necessary for delta sharing
+  // streaming to fetch new files from the delta sharing server.
+  private def maybeMoveToNextVersion(
+      latestOffsetFromDeltaSource: streaming.Offset): DeltaSourceOffset = {
+    val deltaLatestOffset = deltaSource.toDeltaSourceOffset(latestOffsetFromDeltaSource)
+    if (deltaLatestOffset.isInitialSnapshot &&
+      (numFileActionsInStartingSnapshotOpt.exists(_ == deltaLatestOffset.index + 1))) {
+      DeltaSourceOffset(
+        reservoirId = deltaLatestOffset.reservoirId,
+        reservoirVersion = deltaLatestOffset.reservoirVersion + 1,
+        index = DeltaSourceOffset.BASE_INDEX,
+        isInitialSnapshot = false
+      )
+    } else {
+      deltaLatestOffset
+    }
+  }
+
+  /**
+   * Whether need to fetch new files from the delta sharing server.
+   * @param startingOffset  the startingOffset of the next batch asked by spark streaming engine.
+   * @param latestTableVersion  the latest table version on the delta sharing server.
+   * @return whether need to fetch new files from the delta sharing server, this is needed when all
+   *         files are processed in the local delta log, and there are new files on the delta
+   *         sharing server.
+   *         And we avoid fetching new files when files in the delta log are not fully processed.
+   */
+  private def needNewFilesFromServer(
+      startingOffset: DeltaSourceOffset,
+      latestTableVersion: Long): Boolean = {
+    if (latestTableVersionInLocalDeltaLogOpt.isEmpty) {
+      return true
+    }
+
+    val allLocalFilesProcessed = latestTableVersionInLocalDeltaLogOpt.exists(
+      _ < startingOffset.reservoirVersion
+    )
+    val newChangesOnServer = latestTableVersionInLocalDeltaLogOpt.exists(_ < latestTableVersion)
+    allLocalFilesProcessed && newChangesOnServer
+  }
+
+  /**
+   * Check whether we need to fetch new files from the server and calls getTableFileChanges if true.
+   *
+   * @param startingOffset the starting offset used to fetch files, the 3 parameters will be useful:
+   *                       - reservoirVersion: initially would be the startingVersion or the latest
+   *                         table version.
+   *                       - index: index of a file within the same version.
+   *                       - isInitialSnapshot: If true, will load fromVersion as a table snapshot(
+   *                         including files from previous versions). If false, will only load files
+   *                         since fromVersion.
+   *                       2 usages: 1) used to compare with latestTableVersionInLocalDeltaLogOpt to
+   *                       check whether new files are needed. 2) used for getTableFileChanges,
+   *                       check more details in the function header.
+   */
+  private def maybeGetLatestFileChangesFromServer(startingOffset: DeltaSourceOffset): Unit = {
+    // Use a local variable to avoid a difference in the two usages below.
+    val latestTableVersion = getOrUpdateLatestTableVersion
+
+    if (needNewFilesFromServer(startingOffset, latestTableVersion)) {
+      val endingVersionForQuery =
+        getEndingVersionForRpc(startingOffset, latestTableVersion)
+
+      if (startingOffset.isInitialSnapshot || !options.readChangeFeed) {
+        getTableFileChanges(startingOffset, endingVersionForQuery)
+      } else {
+        throw new UnsupportedOperationException("CDF Streaming is not supported yet.")
+      }
+    }
+  }
+
+  /**
+   * Fetch the table changes from delta sharing server starting from (version, index) of the
+   * startingOffset, and store them in locally constructed delta log.
+   *
+   * @param startingOffset  Includes a reservoirVersion, an index of a file within the same version,
+   *                        and an isInitialSnapshot.
+   *                        If isInitialSnapshot is true, will load startingOffset.reservoirVersion
+   *                        as a table snapshot (including files from previous versions). If false,
+   *                        it will only load files since startingOffset.reservoirVersion.
+   * @param endingVersionForQuery The ending version used for the query, always smaller than
+   *                              the latest table version on server.
+   */
+  private def getTableFileChanges(
+      startingOffset: DeltaSourceOffset,
+      endingVersionForQuery: Long): Unit = {
+    logInfo(
+      s"Fetching files with table version(${startingOffset.reservoirVersion}), " +
+      s"index(${startingOffset.index}), isInitialSnapshot(${startingOffset.isInitialSnapshot})," +
+      s" endingVersionForQuery($endingVersionForQuery), for table(id:$tableId, " +
+      s"name:${table.toString}) with latest version on server($latestTableVersionOnServer)."
+    )
+
+    val (tableFiles, refreshFunc) = if (startingOffset.isInitialSnapshot) {
+      // If isInitialSnapshot is true, it means to fetch the snapshot at the fromVersion, which may
+      // include table changes from previous versions.
+      val tableFiles = client.getFiles(
+        table = table,
+        predicates = Nil,
+        limit = None,
+        versionAsOf = Some(startingOffset.reservoirVersion),
+        timestampAsOf = None,
+        jsonPredicateHints = None,
+        refreshToken = None
+      )
+      val refreshFunc = DeltaSharingUtils.getRefresherForGetFiles(
+        client = client,
+        table = table,
+        predicates = Nil,
+        limit = None,
+        versionAsOf = Some(startingOffset.reservoirVersion),
+        timestampAsOf = None,
+        jsonPredicateHints = None,
+        refreshToken = None
+      )
+      logInfo(
+        s"Fetched ${tableFiles.lines.size} lines for table version ${tableFiles.version} from" +
+        " delta sharing server."
+      )
+      (tableFiles, refreshFunc)
+    } else {
+      // If isStartingVersion is false, it means to fetch files for data changes since fromVersion,
+      // not including files from previous versions.
+      val tableFiles = client.getFiles(
+        table = table,
+        startingVersion = startingOffset.reservoirVersion,
+        endingVersion = Some(endingVersionForQuery)
+      )
+      val refreshFunc = DeltaSharingUtils.getRefresherForGetFilesWithStartingVersion(
+        client = client,
+        table = table,
+        startingVersion = startingOffset.reservoirVersion,
+        endingVersion = Some(endingVersionForQuery)
+      )
+      logInfo(
+        s"Fetched ${tableFiles.lines.size} lines from startingVersion " +
+        s"${startingOffset.reservoirVersion} to enedingVersion ${endingVersionForQuery} from " +
+        "delta sharing server."
+      )
+      (tableFiles, refreshFunc)
+    }
+
+    val deltaLogMetadata = DeltaSharingLogFileSystem.constructLocalDeltaLogAcrossVersions(
+      lines = tableFiles.lines,
+      customTablePath = customTablePathWithUUIDSuffix,
+      startingVersionOpt = Some(startingOffset.reservoirVersion),
+      endingVersionOpt = Some(endingVersionForQuery)
+    )
+    assert(
+      deltaLogMetadata.maxVersion > 0,
+      s"Invalid table version in delta sharing response: ${tableFiles.lines}."
+    )
+    latestTableVersionInLocalDeltaLogOpt = Some(deltaLogMetadata.maxVersion)
+    assert(
+      deltaLogMetadata.numFileActionsInMinVersionOpt.isDefined,
+      "numFileActionsInMinVersionOpt missing after constructed delta log."
+    )
+    if (startingOffset.isInitialSnapshot) {
+      numFileActionsInStartingSnapshotOpt = deltaLogMetadata.numFileActionsInMinVersionOpt
+    }
+
+    CachedTableManager.INSTANCE.register(
+      tablePath = DeltaSharingUtils.getTablePathWithIdSuffix(tablePath, timestampWithUUID),
+      idToUrl = deltaLogMetadata.idToUrl,
+      refs = Seq(new WeakReference(this)),
+      profileProvider = client.getProfileProvider,
+      refresher = refreshFunc,
+      expirationTimestamp =
+        if (CachedTableManager.INSTANCE
+            .isValidUrlExpirationTime(deltaLogMetadata.minUrlExpirationTimestamp)) {
+          deltaLogMetadata.minUrlExpirationTimestamp.get
+        } else {
+          System.currentTimeMillis() + CachedTableManager.INSTANCE.preSignedUrlExpirationMs
+        },
+      refreshToken = tableFiles.refreshToken
+    )
+  }
+
+  override def getBatch(startOffsetOption: Option[Offset], end: Offset): DataFrame = {
+    val endOffset = deltaSource.toDeltaSourceOffset(end)
+    val startDeltaOffsetOption = startOffsetOption.map(deltaSource.toDeltaSourceOffset)
+    val startingOffset = getStartingOffset(startDeltaOffsetOption, Some(endOffset))
+
+    maybeGetLatestFileChangesFromServer(startingOffset = startingOffset)
+    // Reset latestProcessedEndOffsetOption only when endOffset is larger.
+    // Because with microbatch pipelining, we may get getBatch requests out of order.
+    if (latestProcessedEndOffsetOption.isEmpty ||
+      endOffset.reservoirVersion > latestProcessedEndOffsetOption.get.reservoirVersion ||
+      (endOffset.reservoirVersion == latestProcessedEndOffsetOption.get.reservoirVersion &&
+      endOffset.index > latestProcessedEndOffsetOption.get.index)) {
+      latestProcessedEndOffsetOption = Some(endOffset)
+    }
+
+    deltaSource.getBatch(startOffsetOption, end)
+  }
+
+  override def getOffset: Option[Offset] = {
+    throw new UnsupportedOperationException(
+      "latestOffset(Offset, ReadLimit) should be called instead of this method."
+    )
+  }
+
+  /**
+   * Extracts whether users provided the option to time travel a relation. If a query restarts from
+   * a checkpoint and the checkpoint has recorded the offset, this method should never been called.
+   */
+  private lazy val getStartingVersion: Option[Long] = {
+
+    /** DeltaOption validates input and ensures that only one is provided. */
+    if (options.startingVersion.isDefined) {
+      val v = options.startingVersion.get match {
+        case StartingVersionLatest =>
+          getOrUpdateLatestTableVersion + 1
+        case StartingVersion(version) =>
+          version
+      }
+      Some(v)
+    } else if (options.startingTimestamp.isDefined) {
+      Some(client.getTableVersion(table, options.startingTimestamp))
+    } else {
+      None
+    }
+  }
+
+  override def stop(): Unit = {
+    deltaSource.stop()
+
+    DeltaSharingLogFileSystem.tryToCleanUpDeltaLog(deltaLogPath)
+  }
+
+  // Calls deltaSource.commit for checks related to column mapping.
+  override def commit(end: Offset): Unit = {
+    deltaSource.commit(end)
+
+    // Clean up previous blocks after commit.
+    val endOffset = deltaSource.toDeltaSourceOffset(end)
+    DeltaSharingLogFileSystem.tryToCleanUpPreviousBlocks(
+      deltaLogPath,
+      endOffset.reservoirVersion - 1
+    )
+  }
+
+  override def toString(): String = s"DeltaFormatSharingSource[${table.toString}]"
+}

--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingFileIndex.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingFileIndex.scala
@@ -72,20 +72,25 @@ case class DeltaSharingFileIndex(
 
   override def partitionSchema: StructType = params.metadata.partitionSchema
 
+  // Returns the partition columns of the shared delta table based on the returned metadata.
+  def partitionColumns: Seq[String] = params.metadata.deltaMetadata.partitionColumns
+
   override def rootPaths: Seq[Path] = params.path :: Nil
 
   override def inputFiles: Array[String] = {
     throw new UnsupportedOperationException("DeltaSharingFileIndex.inputFiles")
   }
 
-  // A set that includes the queriedTableQueryId that we've issued delta sharing rpc.
-  // This is because listFiles will be called twice or more in a spark query, with this set, we
+  // A map that from queriedTableQueryId that we've issued delta sharing rpc, to the deltaLog
+  // constructed with the response.
+  // It is because this function will be called twice or more in a spark query, with this set, we
   // can avoid doing duplicated work of making expensive rpc and constructing the delta log.
-  private val queriedTableQueryIdSet = scala.collection.mutable.Set[String]()
+  private val queriedTableQueryIdToDeltaLog = scala.collection.mutable.Map[String, DeltaLog]()
 
-  override def listFiles(
+  def fetchFilesAndConstructDeltaLog(
       partitionFilters: Seq[Expression],
-      dataFilters: Seq[Expression]): Seq[PartitionDirectory] = {
+      dataFilters: Seq[Expression],
+      overrideLimit: Option[Long]): DeltaLog = {
     val jsonPredicateHints = convertToJsonPredicate(partitionFilters, dataFilters)
     val queryParamsHashId = DeltaSharingUtils.getQueryParamsHashId(
       params.options,
@@ -101,79 +106,109 @@ case class DeltaSharingFileIndex(
     )
     // listFiles will be called twice or more in a spark query, with this check we can avoid
     // duplicated work of making expensive rpc and constructing the delta log.
-    if (!queriedTableQueryIdSet.contains(tablePathWithHashIdSuffix)) {
-      //  1. Call client.getFiles.
-      val startTime = System.currentTimeMillis()
-      val deltaTableFiles = client.getFiles(
+    queriedTableQueryIdToDeltaLog.get(tablePathWithHashIdSuffix) match {
+      case Some(deltaLog) => deltaLog
+      case None =>
+        createDeltaLog(
+          jsonPredicateHints,
+          queryParamsHashId,
+          tablePathWithHashIdSuffix,
+          overrideLimit
+        )
+    }
+  }
+
+  private def createDeltaLog(
+      jsonPredicateHints: Option[String],
+      queryParamsHashId: String,
+      tablePathWithHashIdSuffix: String,
+      overrideLimit: Option[Long]): DeltaLog = {
+    //  1. Call client.getFiles.
+    val startTime = System.currentTimeMillis()
+    val deltaTableFiles = client.getFiles(
+      table = table,
+      predicates = Nil,
+      limit = overrideLimit.orElse(limitHint),
+      versionAsOf = params.options.versionAsOf,
+      timestampAsOf = params.options.timestampAsOf,
+      jsonPredicateHints = jsonPredicateHints,
+      refreshToken = None
+    )
+    logInfo(
+      s"Fetched ${deltaTableFiles.lines.size} lines for table $table with version " +
+      s"${deltaTableFiles.version} from delta sharing server, took " +
+      s"${(System.currentTimeMillis() - startTime) / 1000.0}s."
+    )
+
+    // 2. Prepare a DeltaLog.
+    val deltaLogMetadata =
+      DeltaSharingLogFileSystem.constructLocalDeltaLogAtVersionZero(
+        deltaTableFiles.lines,
+        tablePathWithHashIdSuffix
+      )
+
+    // 3. Register parquet file id to url mapping
+    CachedTableManager.INSTANCE.register(
+      // Using params.path instead of queryCustomTablePath because it will be customized
+      // within CachedTableManager.
+      tablePath = DeltaSharingUtils.getTablePathWithIdSuffix(
+        params.path.toString,
+        queryParamsHashId
+      ),
+      idToUrl = deltaLogMetadata.idToUrl,
+      refs = Seq(new WeakReference(this)),
+      profileProvider = client.getProfileProvider,
+      refresher = DeltaSharingUtils.getRefresherForGetFiles(
+        client = client,
         table = table,
         predicates = Nil,
-        limit = limitHint,
+        limit = overrideLimit.orElse(limitHint),
         versionAsOf = params.options.versionAsOf,
         timestampAsOf = params.options.timestampAsOf,
         jsonPredicateHints = jsonPredicateHints,
-        refreshToken = None
-      )
-      logInfo(
-        s"Fetched ${deltaTableFiles.lines.size} lines for table $table with version " +
-        s"${deltaTableFiles.version} from delta sharing server, took " +
-        s"${(System.currentTimeMillis() - startTime) / 1000.0}s."
-      )
-
-      // 2. Prepare a DeltaLog.
-      val deltaLogMetadata =
-        DeltaSharingLogFileSystem.constructLocalDeltaLogAtVersionZero(
-          deltaTableFiles.lines,
-          tablePathWithHashIdSuffix
-        )
-
-      // 3. Register parquet file id to url mapping
-      CachedTableManager.INSTANCE.register(
-        // Using params.path instead of queryCustomTablePath because it will be customized
-        // within CachedTableManager.
-        tablePath = DeltaSharingUtils.getTablePathWithIdSuffix(
-          params.path.toString,
-          queryParamsHashId
-        ),
-        idToUrl = deltaLogMetadata.idToUrl,
-        refs = Seq(new WeakReference(this)),
-        profileProvider = client.getProfileProvider,
-        refresher = DeltaSharingUtils.getRefresherForGetFiles(
-          client = client,
-          table = table,
-          predicates = Nil,
-          limit = limitHint,
-          versionAsOf = params.options.versionAsOf,
-          timestampAsOf = params.options.timestampAsOf,
-          jsonPredicateHints = jsonPredicateHints,
-          refreshToken = deltaTableFiles.refreshToken
-        ),
-        expirationTimestamp =
-          if (CachedTableManager.INSTANCE
-              .isValidUrlExpirationTime(deltaLogMetadata.minUrlExpirationTimestamp)) {
-            deltaLogMetadata.minUrlExpirationTimestamp.get
-          } else {
-            System.currentTimeMillis() + CachedTableManager.INSTANCE.preSignedUrlExpirationMs
-          },
         refreshToken = deltaTableFiles.refreshToken
-      )
-
-      // In theory there should only be one entry in this set since each query creates its own
-      // FileIndex class. This is purged together with the FileIndex class when the query finishes.
-      queriedTableQueryIdSet.add(tablePathWithHashIdSuffix)
-    }
+      ),
+      expirationTimestamp =
+        if (CachedTableManager.INSTANCE
+            .isValidUrlExpirationTime(deltaLogMetadata.minUrlExpirationTimestamp)) {
+          deltaLogMetadata.minUrlExpirationTimestamp.get
+        } else {
+          System.currentTimeMillis() + CachedTableManager.INSTANCE.preSignedUrlExpirationMs
+        },
+      refreshToken = deltaTableFiles.refreshToken
+    )
 
     // 4. Create a local file index and call listFiles of this class.
     val deltaLog = DeltaLog.forTable(
       params.spark,
       DeltaSharingLogFileSystem.encode(tablePathWithHashIdSuffix)
     )
-    val fileIndex = new TahoeLogFileIndex(
+
+    // In theory there should only be one entry in this set since each query creates its own
+    // FileIndex class. This is purged together with the FileIndex class when the query
+    // finishes.
+    queriedTableQueryIdToDeltaLog.put(tablePathWithHashIdSuffix, deltaLog)
+
+    deltaLog
+  }
+
+  def asTahoeFileIndex(
+      partitionFilters: Seq[Expression],
+      dataFilters: Seq[Expression]): TahoeLogFileIndex = {
+    val deltaLog = fetchFilesAndConstructDeltaLog(partitionFilters, dataFilters, None)
+    new TahoeLogFileIndex(
       params.spark,
       deltaLog,
       deltaLog.dataPath,
       deltaLog.unsafeVolatileSnapshot
     )
-    fileIndex.listFiles(partitionFilters, dataFilters)
+  }
+
+  override def listFiles(
+      partitionFilters: Seq[Expression],
+      dataFilters: Seq[Expression]): Seq[PartitionDirectory] = {
+    // NOTE: The server is not required to apply all filters, so we apply them client-side as well.
+    asTahoeFileIndex(partitionFilters, dataFilters).listFiles(partitionFilters, dataFilters)
   }
 
   // Converts the specified SQL expressions to a json predicate.

--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala
@@ -44,6 +44,8 @@ import org.apache.spark.storage.{BlockId, StorageLevel}
 
 object DeltaSharingUtils extends Logging {
 
+  val STREAMING_SUPPORTED_READER_FEATURES: Seq[String] =
+    Seq(DeletionVectorsTableFeature.name, ColumnMappingTableFeature.name)
   val SUPPORTED_READER_FEATURES: Seq[String] =
     Seq(DeletionVectorsTableFeature.name, ColumnMappingTableFeature.name)
 
@@ -60,6 +62,15 @@ object DeltaSharingUtils extends Logging {
       protocol: model.DeltaSharingProtocol,
       metadata: model.DeltaSharingMetadata
   )
+
+  // A wrapper function for streaming query to get the latest version/protocol/metadata of the
+  // shared table.
+  def getDeltaSharingTableMetadata(
+      client: DeltaSharingClient,
+      table: Table): DeltaSharingTableMetadata = {
+    val deltaTableMetadata = client.getMetadata(table)
+    getDeltaSharingTableMetadata(table, deltaTableMetadata)
+  }
 
   def queryDeltaTableMetadata(
       client: DeltaSharingClient,
@@ -228,6 +239,34 @@ object DeltaSharingUtils extends Logging {
     )
   }
 
+  // A helper function used by DeltaSharingSource and DeltaSharingDataSource to get
+  // SnapshotDescriptor used for delta sharing streaming.
+  def getDeltaLogAndSnapshotDescriptor(
+      spark: SparkSession,
+      deltaSharingTableMetadata: DeltaSharingTableMetadata,
+      customTablePathWithUUIDSuffix: String): (DeltaLog, SnapshotDescriptor) = {
+    // Create a delta log with metadata at version 0.
+    // Used by DeltaSharingSource to initialize a DeltaLog class, which is then used to initialize
+    // a DeltaSource class, also the metadata id will be used for schemaTrackingLocation.
+    DeltaSharingLogFileSystem.constructDeltaLogWithMetadataAtVersionZero(
+      customTablePathWithUUIDSuffix,
+      deltaSharingTableMetadata
+    )
+    val tablePath = DeltaSharingLogFileSystem.encode(customTablePathWithUUIDSuffix).toString
+    val localDeltaLog = DeltaLog.forTable(spark, tablePath)
+    (
+      localDeltaLog,
+      new SnapshotDescriptor {
+        val deltaLog: DeltaLog = localDeltaLog
+        val metadata: Metadata = deltaSharingTableMetadata.metadata.deltaMetadata
+        val protocol: Protocol = deltaSharingTableMetadata.protocol.deltaProtocol
+        val version = deltaSharingTableMetadata.version
+        val numOfFilesIfKnown = None
+        val sizeInBytesIfKnown = None
+      }
+    )
+  }
+
   // Get a query hash id based on the query parameters: time travel options and filters.
   // The id concatenated with table name and used in local DeltaLog and CachedTableManager.
   // This is to uniquely identify the delta sharing table used twice in the same query but with
@@ -256,6 +295,18 @@ object DeltaSharingUtils extends Logging {
   // its corresponding delta log in a query.
   private[sharing] def getTablePathWithIdSuffix(customTablePath: String, id: String): String = {
     s"${customTablePath}_${id}"
+  }
+
+  // Get a unique string composed of a formatted timestamp and an uuid.
+  // Used as a suffix for the table name and its delta log path of a delta sharing table in a
+  // streaming job, to avoid overwriting the delta log from multiple references of the same delta
+  // sharing table in one streaming job.
+  private[sharing] def getFormattedTimestampWithUUID(): String = {
+    val dateFormat = new SimpleDateFormat("yyyyMMdd_HHmmss")
+    dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"))
+    val formattedDateTime = dateFormat.format(System.currentTimeMillis())
+    val uuid = UUID.randomUUID().toString().split('-').head
+    s"${formattedDateTime}_${uuid}"
   }
 
   private def removeBlockForJsonLogIfExists(blockId: BlockId): Unit = {

--- a/sharing/src/main/scala/io/delta/sharing/spark/PrepareDeltaSharingScan.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/PrepareDeltaSharingScan.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.spark
+
+import org.apache.spark.sql.delta.{DeltaTableUtils => SqlDeltaTableUtils}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.stats.{PreparedDeltaFileIndex, PrepareDeltaScan}
+import io.delta.sharing.client.util.ConfUtils
+import io.delta.sharing.spark.DeltaSharingFileIndex
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans.logical._
+
+/**
+ * Before query planning, we prepare any scans over delta sharing tables by pushing
+ * any filters or limits to delta sharing server through RPC, allowing us to return only needed
+ * files and gather more accurate statistics for CBO and metering.
+ */
+class PrepareDeltaSharingScan(override val spark: SparkSession) extends PrepareDeltaScan(spark) {
+
+  /**
+   * Prepares delta sharing scans sequentially.
+   */
+  override protected def prepareDeltaScan(plan: LogicalPlan): LogicalPlan = {
+    transformWithSubqueries(plan) {
+      case scan @ DeltaSharingTableScan(_, filters, dsFileIndex, limit, _) =>
+        val partitionCols = dsFileIndex.partitionColumns
+        val (partitionFilters, dataFilters) = filters.partition { e =>
+          SqlDeltaTableUtils.isPredicatePartitionColumnsOnly(e, partitionCols, spark)
+        }
+        logInfo(s"Classified filters: partition: $partitionFilters, data: $dataFilters")
+        val deltaLog = dsFileIndex.fetchFilesAndConstructDeltaLog(
+          partitionFilters,
+          dataFilters,
+          limit.map(_.toLong)
+        )
+        val snapshot = deltaLog.snapshot
+        val deltaScan = limit match {
+          case Some(limit) => snapshot.filesForScan(limit, filters)
+          case _ => snapshot.filesForScan(filters)
+        }
+        val preparedIndex = PreparedDeltaFileIndex(
+          spark,
+          deltaLog,
+          deltaLog.dataPath,
+          preparedScan = deltaScan,
+          versionScanned = Some(snapshot.version)
+        )
+        SqlDeltaTableUtils.replaceFileIndex(scan, preparedIndex)
+    }
+  }
+
+  // Just return the plan if statistics based skipping is off.
+  // It will fall back to just partition pruning at planning time.
+  // When data skipping is disabled, just convert Delta sharing scans to normal tahoe scans.
+  // NOTE: File skipping is only disabled on the client, so we still pass filters to the server.
+  override protected def prepareDeltaScanWithoutFileSkipping(plan: LogicalPlan): LogicalPlan = {
+    plan.transformDown {
+      case scan@DeltaSharingTableScan(_, filters, sharingIndex, _, _) =>
+        val partitionCols = sharingIndex.partitionColumns
+        val (partitionFilters, dataFilters) = filters.partition { e =>
+          SqlDeltaTableUtils.isPredicatePartitionColumnsOnly(e, partitionCols, spark)
+        }
+        logInfo(s"Classified filters: partition: $partitionFilters, data: $dataFilters")
+        val fileIndex = sharingIndex.asTahoeFileIndex(partitionFilters, dataFilters)
+        SqlDeltaTableUtils.replaceFileIndex(scan, fileIndex)
+    }
+  }
+
+  // TODO: Support metadata-only query optimization!
+  override def optimizeQueryWithMetadata(plan: LogicalPlan): LogicalPlan = plan
+
+  /**
+   * This is an extractor object. See https://docs.scala-lang.org/tour/extractor-objects.html.
+   */
+  object DeltaSharingTableScan extends DeltaTableScan[DeltaSharingFileIndex] {
+    // Since delta library is used to read the data on constructed delta log, this should also
+    // consider the spark config for delta limit pushdown.
+    override def limitPushdownEnabled(plan: LogicalPlan): Boolean =
+      ConfUtils.limitPushdownEnabled(plan.conf) &&
+        (spark.conf.get(DeltaSQLConf.DELTA_LIMIT_PUSHDOWN_ENABLED.key) == "true")
+
+    override def getPartitionColumns(fileIndex: DeltaSharingFileIndex): Seq[String] =
+      fileIndex.partitionColumns
+
+    override def getPartitionFilters(fileIndex: DeltaSharingFileIndex): Seq[Expression] =
+      Seq.empty[Expression]
+
+  }
+}

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaFormatSharingSourceSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaFormatSharingSourceSuite.scala
@@ -1,0 +1,867 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.spark
+
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.DeltaOptions.{
+  IGNORE_CHANGES_OPTION,
+  IGNORE_DELETES_OPTION,
+  SKIP_CHANGE_COMMITS_OPTION
+}
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import io.delta.sharing.client.DeltaSharingRestClient
+import io.delta.sharing.client.model.{Table => DeltaSharingTable}
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.SparkEnv
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.delta.sharing.DeltaSharingTestSparkUtils
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.streaming.StreamTest
+import org.apache.spark.sql.types.{
+  DateType,
+  IntegerType,
+  LongType,
+  StringType,
+  StructType,
+  TimestampType
+}
+
+class DeltaFormatSharingSourceSuite
+    extends StreamTest
+    with DeltaSQLCommandTest
+    with DeltaSharingTestSparkUtils
+    with DeltaSharingDataSourceDeltaTestUtils {
+
+  import testImplicits._
+
+  private def getSource(parameters: Map[String, String]): DeltaFormatSharingSource = {
+    val options = new DeltaSharingOptions(parameters)
+    val path = options.options.getOrElse(
+      "path",
+      throw DeltaSharingErrors.pathNotSpecifiedException
+    )
+    val parsedPath = DeltaSharingRestClient.parsePath(path)
+    val client = DeltaSharingRestClient(
+      profileFile = parsedPath.profileFile,
+      forStreaming = true,
+      responseFormat = "delta",
+      readerFeatures = DeltaSharingUtils.STREAMING_SUPPORTED_READER_FEATURES.mkString(",")
+    )
+    val dsTable = DeltaSharingTable(
+      share = parsedPath.share,
+      schema = parsedPath.schema,
+      name = parsedPath.table
+    )
+    DeltaFormatSharingSource(
+      spark = spark,
+      client = client,
+      table = dsTable,
+      options = options,
+      parameters = parameters,
+      sqlConf = sqlContext.sparkSession.sessionState.conf,
+      metadataPath = ""
+    )
+  }
+
+  private def assertBlocksAreCleanedUp(): Unit = {
+    val blockManager = SparkEnv.get.blockManager
+    val matchingBlockIds = blockManager.getMatchingBlockIds(
+      _.name.startsWith(DeltaSharingLogFileSystem.DELTA_SHARING_LOG_BLOCK_ID_PREFIX)
+    )
+    assert(matchingBlockIds.isEmpty, "delta sharing blocks are not cleaned up.")
+  }
+
+  test("DeltaFormatSharingSource able to get schema") {
+    withTempDir { tempDir =>
+      val deltaTableName = "delta_table_schema"
+      withTable(deltaTableName) {
+        createTable(deltaTableName)
+        val sharedTableName = "shared_table_schema"
+        prepareMockedClientMetadata(deltaTableName, sharedTableName)
+        prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+
+        val profileFile = prepareProfileFile(tempDir)
+        withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
+          val deltaSharingSource = getSource(
+            Map("path" -> s"${profileFile.getCanonicalPath}#share1.default.$sharedTableName")
+          )
+          val expectedSchema: StructType = new StructType()
+            .add("c1", IntegerType)
+            .add("c2", StringType)
+            .add("c3", DateType)
+            .add("c4", TimestampType)
+          assert(deltaSharingSource.schema == expectedSchema)
+
+          // CDF schema
+          val cdfDeltaSharingSource = getSource(
+            Map(
+              "path" -> s"${profileFile.getCanonicalPath}#share1.default.$sharedTableName",
+              "readChangeFeed" -> "true"
+            )
+          )
+          val expectedCdfSchema: StructType = expectedSchema
+            .copy()
+            .add("_change_type", StringType)
+            .add("_commit_version", LongType)
+            .add("_commit_timestamp", TimestampType)
+          assert(cdfDeltaSharingSource.schema == expectedCdfSchema)
+        }
+      }
+    }
+  }
+
+  test("DeltaFormatSharingSource do not support cdc") {
+    withTempDir { tempDir =>
+      val sharedTableName = "shared_streaming_table_nocdc"
+      val profileFile = prepareProfileFile(tempDir)
+      withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
+        val tablePath = profileFile.getCanonicalPath + s"#share1.default.$sharedTableName"
+        val e = intercept[Exception] {
+          val df = spark.readStream
+            .format("deltaSharing")
+            .option("responseFormat", "delta")
+            .option("readChangeFeed", "true")
+            .load(tablePath)
+          testStream(df)(
+            AssertOnQuery { q =>
+              q.processAllAvailable(); true
+            }
+          )
+        }
+        assert(e.getMessage.contains("Delta sharing cdc streaming is not supported"))
+      }
+    }
+  }
+
+  test("DeltaFormatSharingSource simple query works") {
+    withTempDir { tempDir =>
+      val deltaTableName = "delta_table_simple"
+      withTable(deltaTableName) {
+        sql(s"""
+               |CREATE TABLE $deltaTableName (value STRING)
+               |USING DELTA
+               |""".stripMargin)
+
+        val sharedTableName = "shared_streaming_table_simple"
+        prepareMockedClientMetadata(deltaTableName, sharedTableName)
+
+        val profileFile = prepareProfileFile(tempDir)
+        withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
+          val tablePath = profileFile.getCanonicalPath + s"#share1.default.$sharedTableName"
+
+          def InsertToDeltaTable(values: String): Unit = {
+            sql(s"INSERT INTO $deltaTableName VALUES $values")
+          }
+
+          InsertToDeltaTable("""("keep1"), ("keep2"), ("drop3")""")
+          prepareMockedClientAndFileSystemResult(deltaTableName, sharedTableName, Some(1L))
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+
+          val df = spark.readStream
+            .format("deltaSharing")
+            .option("responseFormat", "delta")
+            .load(tablePath)
+            .filter($"value" contains "keep")
+
+          testStream(df)(
+            AssertOnQuery { q =>
+              q.processAllAvailable(); true
+            },
+            CheckAnswer("keep1", "keep2"),
+            StopStream
+          )
+        }
+      }
+    }
+  }
+
+  test("restart works sharing") {
+    withTempDirs { (inputDir, outputDir, checkpointDir) =>
+      val deltaTableName = "delta_table_restart"
+      withTable(deltaTableName) {
+        createTableForStreaming(deltaTableName)
+        val sharedTableName = "shared_streaming_table_restart"
+        prepareMockedClientMetadata(deltaTableName, sharedTableName)
+        val profileFile = prepareProfileFile(inputDir)
+        val tablePath = profileFile.getCanonicalPath + s"#share1.default.$sharedTableName"
+
+        withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
+          def InsertToDeltaTable(values: String): Unit = {
+            sql(s"INSERT INTO $deltaTableName VALUES $values")
+          }
+
+          // TODO: check testStream() function helper
+          def processAllAvailableInStream(): Unit = {
+            val q = spark.readStream
+              .format("deltaSharing")
+              .option("responseFormat", "delta")
+              .load(tablePath)
+              .filter($"value" contains "keep")
+              .writeStream
+              .format("delta")
+              .option("checkpointLocation", checkpointDir.toString)
+              .start(outputDir.toString)
+
+            try {
+              q.processAllAvailable()
+            } finally {
+              q.stop()
+            }
+          }
+
+          // Able to stream snapshot at version 1.
+          InsertToDeltaTable("""("keep1"), ("keep2"), ("drop1")""")
+          prepareMockedClientAndFileSystemResult(
+            deltaTable = deltaTableName,
+            sharedTable = sharedTableName,
+            versionAsOf = Some(1L)
+          )
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+          processAllAvailableInStream()
+          checkAnswer(
+            spark.read.format("delta").load(outputDir.getCanonicalPath),
+            Seq("keep1", "keep2").toDF()
+          )
+
+          // No new data, so restart will not process any new data.
+          processAllAvailableInStream()
+          checkAnswer(
+            spark.read.format("delta").load(outputDir.getCanonicalPath),
+            Seq("keep1", "keep2").toDF()
+          )
+
+          // Able to stream new data at version 2.
+          InsertToDeltaTable("""("keep3"), ("keep4"), ("drop2")""")
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName,
+            sharedTableName,
+            2,
+            2
+          )
+          processAllAvailableInStream()
+          checkAnswer(
+            spark.read.format("delta").load(outputDir.getCanonicalPath),
+            Seq("keep1", "keep2", "keep3", "keep4").toDF()
+          )
+
+          sql(s"""OPTIMIZE $deltaTableName""")
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName,
+            sharedTableName,
+            2,
+            3
+          )
+          // Optimize doesn't produce new data, so restart will not process any new data.
+          processAllAvailableInStream()
+          checkAnswer(
+            spark.read.format("delta").load(outputDir.getCanonicalPath),
+            Seq("keep1", "keep2", "keep3", "keep4").toDF()
+          )
+
+          // Able to stream new data at version 3.
+          InsertToDeltaTable("""("keep5"), ("keep6"), ("drop3")""")
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName,
+            sharedTableName,
+            3,
+            4
+          )
+
+          processAllAvailableInStream()
+          checkAnswer(
+            spark.read.format("delta").load(outputDir.getCanonicalPath),
+            Seq("keep1", "keep2", "keep3", "keep4", "keep5", "keep6").toDF()
+          )
+          assertBlocksAreCleanedUp()
+        }
+      }
+    }
+  }
+
+  test("streaming works with deletes on basic table") {
+    withTempDir { inputDir =>
+      val deltaTableName = "delta_table_deletes"
+      withTable(deltaTableName) {
+        createTableForStreaming(deltaTableName)
+        val sharedTableName = "shared_streaming_table_deletes"
+        prepareMockedClientMetadata(deltaTableName, sharedTableName)
+        val profileFile = prepareProfileFile(inputDir)
+        val tablePath = profileFile.getCanonicalPath + s"#share1.default.$sharedTableName"
+
+        withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
+          def InsertToDeltaTable(values: String): Unit = {
+            sql(s"INSERT INTO $deltaTableName VALUES $values")
+          }
+
+          def processAllAvailableInStream(
+              sourceOptions: Map[String, String],
+              expectations: StreamAction*): Unit = {
+            val df = spark.readStream
+              .format("deltaSharing")
+              .options(sourceOptions)
+              .load(tablePath)
+
+            val base = Seq(StartStream(), ProcessAllAvailable())
+            testStream(df)((base ++ expectations): _*)
+          }
+
+          // Insert at version 1 and 2.
+          InsertToDeltaTable("""("keep1")""")
+          InsertToDeltaTable("""("keep2")""")
+          // delete at version 3.
+          sql(s"""DELETE FROM $deltaTableName WHERE value = "keep1" """)
+          // update at version 4.
+          sql(s"""UPDATE $deltaTableName SET value = "keep3" WHERE value = "keep2" """)
+
+          prepareMockedClientAndFileSystemResult(
+            deltaTable = deltaTableName,
+            sharedTable = sharedTableName,
+            versionAsOf = Some(4L)
+          )
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+          processAllAvailableInStream(
+            Map("responseFormat" -> "delta"),
+            CheckAnswer("keep3")
+          )
+
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName,
+            sharedTableName,
+            0,
+            4
+          )
+
+          // The streaming query will fail because changes detected in version 4.
+          // This is the original delta behavior.
+          val e = intercept[Exception] {
+            processAllAvailableInStream(
+              Map("responseFormat" -> "delta", "startingVersion" -> "0")
+            )
+          }
+          for (msg <- Seq(
+              "Detected",
+              "not supported",
+              "true"
+            )) {
+            assert(e.getMessage.contains(msg))
+          }
+
+          // The streaming query will fail because changes detected in version 4.
+          // This is the original delta behavior.
+          val e2 = intercept[Exception] {
+            processAllAvailableInStream(
+              Map(
+                "responseFormat" -> "delta",
+                "startingVersion" -> "0",
+                IGNORE_DELETES_OPTION -> "true"
+              )
+            )
+          }
+          for (msg <- Seq(
+              "Detected",
+              "not supported",
+              "true"
+            )) {
+            assert(e2.getMessage.contains(msg))
+          }
+
+          // The streaming query will succeed because ignoreChanges helps to ignore the updates, but
+          // added updated data "keep3".
+          processAllAvailableInStream(
+            Map(
+              "responseFormat" -> "delta",
+              "startingVersion" -> "0",
+              IGNORE_CHANGES_OPTION -> "true"
+            ),
+            CheckAnswer("keep1", "keep2", "keep3")
+          )
+
+          // The streaming query will succeed because skipChangeCommits helps to ignore the whole
+          // commit with data update, so updated data is not produced either.
+          processAllAvailableInStream(
+            Map(
+              "responseFormat" -> "delta",
+              "startingVersion" -> "0",
+              SKIP_CHANGE_COMMITS_OPTION -> "true"
+            ),
+            CheckAnswer("keep1", "keep2")
+          )
+          assertBlocksAreCleanedUp()
+        }
+      }
+    }
+  }
+
+  test("streaming works with DV") {
+    withTempDir { inputDir =>
+      val deltaTableName = "delta_table_dv"
+      withTable(deltaTableName) {
+        createSimpleTable(deltaTableName, enableCdf = false)
+        spark.sql(
+          s"ALTER TABLE $deltaTableName SET TBLPROPERTIES('delta.enableDeletionVectors' = true)"
+        )
+        val sharedTableName = "shared_streaming_table_dv"
+        prepareMockedClientMetadata(deltaTableName, sharedTableName)
+        val profileFile = prepareProfileFile(inputDir)
+        val tablePath = profileFile.getCanonicalPath + s"#share1.default.$sharedTableName"
+
+        withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
+          def InsertToDeltaTable(values: String): Unit = {
+            sql(s"INSERT INTO $deltaTableName VALUES $values")
+          }
+
+          def processAllAvailableInStream(
+              sourceOptions: Map[String, String],
+              expectations: StreamAction*): Unit = {
+            val df = spark.readStream
+              .format("deltaSharing")
+              .options(sourceOptions)
+              .load(tablePath)
+              .filter($"c2" contains "keep")
+              .select("c1")
+
+            val base = Seq(StartStream(), ProcessAllAvailable())
+            testStream(df)((base ++ expectations): _*)
+          }
+
+          // Insert at version 2.
+          InsertToDeltaTable("""(1, "keep1"),(2, "keep1"),(3, "keep1"),(1,"drop1")""")
+          // delete at version 3.
+          sql(s"""DELETE FROM $deltaTableName WHERE c1 >= 2 """)
+
+          prepareMockedClientAndFileSystemResult(
+            deltaTable = deltaTableName,
+            sharedTable = sharedTableName,
+            versionAsOf = Some(3L)
+          )
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+          processAllAvailableInStream(
+            Map("responseFormat" -> "delta"),
+            CheckAnswer(1)
+          )
+
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName,
+            sharedTableName,
+            startingVersion = 0,
+            endingVersion = 3,
+            assertDVExists = true
+          )
+
+          // The streaming query will fail because deletes detected in version 3. And there are no
+          // options provided to ignore the deletion.
+          val e = intercept[Exception] {
+            processAllAvailableInStream(
+              Map("responseFormat" -> "delta", "startingVersion" -> "0")
+            )
+          }
+          for (msg <- Seq(
+              "Detected a data update",
+              "not supported",
+              SKIP_CHANGE_COMMITS_OPTION,
+              "true"
+            )) {
+            assert(e.getMessage.contains(msg))
+          }
+
+          // The streaming query will fail because deletes detected in version 3, and it's
+          // recognized as updates and ignoreDeletes doesn't help. This is the original delta
+          // behavior.
+          val e2 = intercept[Exception] {
+            processAllAvailableInStream(
+              Map(
+                "responseFormat" -> "delta",
+                "startingVersion" -> "0",
+                IGNORE_DELETES_OPTION -> "true"
+              )
+            )
+          }
+          for (msg <- Seq(
+              "Detected a data update",
+              "not supported",
+              SKIP_CHANGE_COMMITS_OPTION,
+              "true"
+            )) {
+            assert(e2.getMessage.contains(msg))
+          }
+
+          // The streaming query will succeed because ignoreChanges helps to ignore the delete, but
+          // added duplicated data 1.
+          processAllAvailableInStream(
+            Map(
+              "responseFormat" -> "delta",
+              "startingVersion" -> "0",
+              IGNORE_CHANGES_OPTION -> "true"
+            ),
+            CheckAnswer(1, 2, 3, 1)
+          )
+
+          // The streaming query will succeed because skipChangeCommits helps to ignore the whole
+          // commit with data update, so no duplicated data is produced either.
+          processAllAvailableInStream(
+            Map(
+              "responseFormat" -> "delta",
+              "startingVersion" -> "0",
+              SKIP_CHANGE_COMMITS_OPTION -> "true"
+            ),
+            CheckAnswer(1, 2, 3)
+          )
+          assertBlocksAreCleanedUp()
+        }
+      }
+    }
+  }
+
+  test("startingVersion works") {
+    withTempDirs { (inputDir, outputDir, checkpointDir) =>
+      val deltaTableName = "delta_table_startVersion"
+      withTable(deltaTableName) {
+        createTableForStreaming(deltaTableName)
+        val sharedTableName = "shared_streaming_table_startVersion"
+        prepareMockedClientMetadata(deltaTableName, sharedTableName)
+        val profileFile = prepareProfileFile(inputDir)
+        val tablePath = profileFile.getCanonicalPath + s"#share1.default.$sharedTableName"
+
+        withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
+          def InsertToDeltaTable(values: String): Unit = {
+            sql(s"INSERT INTO $deltaTableName VALUES $values")
+          }
+
+          def processAllAvailableInStream(): Unit = {
+            val q = spark.readStream
+              .format("deltaSharing")
+              .option("responseFormat", "delta")
+              .option("startingVersion", 0)
+              .load(tablePath)
+              .filter($"value" contains "keep")
+              .writeStream
+              .format("delta")
+              .option("checkpointLocation", checkpointDir.toString)
+              .start(outputDir.toString)
+
+            try {
+              q.processAllAvailable()
+            } finally {
+              q.stop()
+            }
+          }
+
+          // Able to stream snapshot at version 1.
+          InsertToDeltaTable("""("keep1"), ("keep2"), ("drop1")""")
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTable = deltaTableName,
+            sharedTable = sharedTableName,
+            startingVersion = 0L,
+            endingVersion = 1L
+          )
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+          processAllAvailableInStream()
+          checkAnswer(
+            spark.read.format("delta").load(outputDir.getCanonicalPath),
+            Seq("keep1", "keep2").toDF()
+          )
+
+          // No new data, so restart will not process any new data.
+          processAllAvailableInStream()
+          checkAnswer(
+            spark.read.format("delta").load(outputDir.getCanonicalPath),
+            Seq("keep1", "keep2").toDF()
+          )
+
+          // Able to stream new data at version 2.
+          InsertToDeltaTable("""("keep3"), ("keep4"), ("drop2")""")
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName,
+            sharedTableName,
+            0,
+            2
+          )
+          processAllAvailableInStream()
+          checkAnswer(
+            spark.read.format("delta").load(outputDir.getCanonicalPath),
+            Seq("keep1", "keep2", "keep3", "keep4").toDF()
+          )
+
+          sql(s"""OPTIMIZE $deltaTableName""")
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName,
+            sharedTableName,
+            2,
+            3
+          )
+          // Optimize doesn't produce new data, so restart will not process any new data.
+          processAllAvailableInStream()
+          checkAnswer(
+            spark.read.format("delta").load(outputDir.getCanonicalPath),
+            Seq("keep1", "keep2", "keep3", "keep4").toDF()
+          )
+
+          // No new data, so restart will not process any new data. It will ask for the last commit
+          // so that it can figure out that there's nothing to do.
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName,
+            sharedTableName,
+            3,
+            3
+          )
+          processAllAvailableInStream()
+          checkAnswer(
+            spark.read.format("delta").load(outputDir.getCanonicalPath),
+            Seq("keep1", "keep2", "keep3", "keep4").toDF()
+          )
+
+          // Able to stream new data at version 3.
+          InsertToDeltaTable("""("keep5"), ("keep6"), ("drop3")""")
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName,
+            sharedTableName,
+            3,
+            4
+          )
+          processAllAvailableInStream()
+          checkAnswer(
+            spark.read.format("delta").load(outputDir.getCanonicalPath),
+            Seq("keep1", "keep2", "keep3", "keep4", "keep5", "keep6").toDF()
+          )
+
+          // No new data, so restart will not process any new data. It will ask for the last commit
+          // so that it can figure out that there's nothing to do.
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName,
+            sharedTableName,
+            4,
+            4
+          )
+          processAllAvailableInStream()
+          checkAnswer(
+            spark.read.format("delta").load(outputDir.getCanonicalPath),
+            Seq("keep1", "keep2", "keep3", "keep4", "keep5", "keep6").toDF()
+          )
+          assertBlocksAreCleanedUp()
+        }
+      }
+    }
+  }
+
+  test("files are in a stable order for streaming") {
+    // This test function is to check that DeltaSharingLogFileSystem puts the files in the delta log
+    // in a stable order for each commit, regardless of the returning order from the server, so that
+    // the DeltaSource can produce a stable file index.
+    // We are using maxBytesPerTrigger which causes the streaming to stop in the middle of a commit
+    // to be able to test this behavior.
+    withTempDirs { (inputDir, outputDir, checkpointDir) =>
+      withTempDirs { (_, outputDir2, checkpointDir2) =>
+        val deltaTableName = "delta_table_order"
+        withTable(deltaTableName) {
+          createSimpleTable(deltaTableName, enableCdf = false)
+          val sharedTableName = "shared_streaming_table_order"
+          prepareMockedClientMetadata(deltaTableName, sharedTableName)
+          val profileFile = prepareProfileFile(inputDir)
+          val tablePath = profileFile.getCanonicalPath + s"#share1.default.$sharedTableName"
+
+          def InsertToDeltaTable(values: String): Unit = {
+            sql(s"INSERT INTO $deltaTableName VALUES $values")
+          }
+
+          // Able to stream snapshot at version 1.
+          InsertToDeltaTable("""(1, "one"), (2, "two"), (3, "three")""")
+
+          withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
+            def processAllAvailableInStream(
+                outputDirStr: String,
+                checkpointDirStr: String): Unit = {
+              val q = spark.readStream
+                .format("deltaSharing")
+                .option("responseFormat", "delta")
+                .option("maxBytesPerTrigger", "1b")
+                .load(tablePath)
+                .writeStream
+                .format("delta")
+                .option("checkpointLocation", checkpointDirStr)
+                .start(outputDirStr)
+
+              try {
+                q.processAllAvailable()
+                val progress = q.recentProgress.filter(_.numInputRows != 0)
+                assert(progress.length === 3)
+                progress.foreach { p =>
+                  assert(p.numInputRows === 1)
+                }
+              } finally {
+                q.stop()
+              }
+            }
+
+            // First output, without reverseFileOrder
+            prepareMockedClientAndFileSystemResult(
+              deltaTable = deltaTableName,
+              sharedTable = sharedTableName,
+              versionAsOf = Some(1L)
+            )
+            prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+            processAllAvailableInStream(outputDir.toString, checkpointDir.toString)
+            checkAnswer(
+              spark.read.format("delta").load(outputDir.getCanonicalPath),
+              Seq((1, "one"), (2, "two"), (3, "three")).toDF()
+            )
+
+            // Second output, with reverseFileOrder = true
+            prepareMockedClientAndFileSystemResult(
+              deltaTable = deltaTableName,
+              sharedTable = sharedTableName,
+              versionAsOf = Some(1L),
+              reverseFileOrder = true
+            )
+            prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+            processAllAvailableInStream(outputDir2.toString, checkpointDir2.toString)
+            checkAnswer(
+              spark.read.format("delta").load(outputDir2.getCanonicalPath),
+              Seq((1, "one"), (2, "two"), (3, "three")).toDF()
+            )
+
+            // Check each version of the two output are the same, which means the files are sorted
+            // by DeltaSharingLogFileSystem, and are processed in a deterministic order by the
+            // DeltaSource.
+            val deltaLog = DeltaLog.forTable(spark, new Path(outputDir.toString))
+            Seq(0, 1, 2).foreach { v =>
+              val version = deltaLog.snapshot.version - v
+              val df1 = spark.read
+                .format("delta")
+                .option("versionAsOf", version)
+                .load(outputDir.getCanonicalPath)
+              val df2 = spark.read
+                .format("delta")
+                .option("versionAsOf", version)
+                .load(outputDir2.getCanonicalPath)
+              checkAnswer(df1, df2)
+              assert(df1.count() == (3 - v))
+            }
+            assertBlocksAreCleanedUp()
+          }
+        }
+      }
+    }
+  }
+
+  test("DeltaFormatSharingSource query with two delta sharing tables works") {
+    withTempDirs { (inputDir, outputDir, checkpointDir) =>
+      val deltaTableName = "delta_table_two"
+
+      def InsertToDeltaTable(values: String): Unit = {
+        sql(s"INSERT INTO $deltaTableName VALUES $values")
+      }
+
+      withTable(deltaTableName) {
+        createSimpleTable(deltaTableName, enableCdf = false)
+        val sharedTableName = "shared_streaming_table_two"
+        prepareMockedClientMetadata(deltaTableName, sharedTableName)
+
+        val profileFile = prepareProfileFile(inputDir)
+        val tablePath = profileFile.getCanonicalPath + s"#share1.default.$sharedTableName"
+        withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
+          InsertToDeltaTable("""(1, "one"), (2, "one")""")
+          InsertToDeltaTable("""(1, "two"), (2, "two")""")
+          InsertToDeltaTable("""(1, "three"), (2, "three")""")
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+          prepareMockedClientAndFileSystemResult(
+            deltaTableName,
+            sharedTableName,
+            Some(3L)
+          )
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName,
+            sharedTableName,
+            startingVersion = 1,
+            endingVersion = 3
+          )
+
+          def processAllAvailableInStream(): Unit = {
+            val dfLatest = spark.readStream
+              .format("deltaSharing")
+              .option("responseFormat", "delta")
+              .load(tablePath)
+            val dfV1 = spark.readStream
+              .format("deltaSharing")
+              .option("responseFormat", "delta")
+              .option("startingVersion", 1)
+              .load(tablePath)
+              .select(col("c2"), col("c1").as("v1c1"))
+              .filter(col("v1c1") === 1)
+
+            val q = dfLatest
+              .join(dfV1, "c2")
+              .writeStream
+              .format("delta")
+              .option("checkpointLocation", checkpointDir.toString)
+              .start(outputDir.toString)
+
+            try {
+              q.processAllAvailable()
+            } finally {
+              q.stop()
+            }
+          }
+
+          // c1 from dfLatest, c2 from dfLatest, c1 from dfV1
+          var expected = Seq(
+            Row("one", 1, 1),
+            Row("one", 2, 1),
+            Row("two", 1, 1),
+            Row("two", 2, 1),
+            Row("three", 1, 1),
+            Row("three", 2, 1)
+          )
+          processAllAvailableInStream()
+          checkAnswer(
+            spark.read.format("delta").load(outputDir.getCanonicalPath),
+            expected
+          )
+
+          InsertToDeltaTable("""(1, "four"), (2, "four")""")
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName,
+            sharedTableName,
+            startingVersion = 4,
+            endingVersion = 4
+          )
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName,
+            sharedTableName,
+            startingVersion = 1,
+            endingVersion = 4
+          )
+
+          expected = expected ++ Seq(Row("four", 1, 1), Row("four", 2, 1))
+          processAllAvailableInStream()
+          checkAnswer(
+            spark.read.format("delta").load(outputDir.getCanonicalPath),
+            expected
+          )
+          assertBlocksAreCleanedUp()
+        }
+      }
+    }
+  }
+}

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingCDFUtilsSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingCDFUtilsSuite.scala
@@ -212,8 +212,8 @@ class DeltaSharingCDFUtilsSuite
           fileStr1Id,
           1000
         )
-        // sleep for expirationTimeMs to ensure that the urls are refreshed.
-        Thread.sleep(expirationTimeMs)
+        // sleep for 25000ms to ensure that the urls are refreshed.
+        Thread.sleep(25000)
 
         // Verify that the url is refreshed as paths(1), not paths(0) anymore.
         assert(fetcher.getUrl == paths(1))

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceCMSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceCMSuite.scala
@@ -1,0 +1,984 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.sharing.spark
+
+import java.io.File
+
+import org.apache.spark.sql.delta.{
+  BatchCDFSchemaEndVersion,
+  BatchCDFSchemaLatest,
+  BatchCDFSchemaLegacy,
+  DeltaUnsupportedOperationException
+}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+import org.apache.spark.sql.delta.sharing.DeltaSharingTestSparkUtils
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.streaming.{StreamingQueryException, StreamTest, Trigger}
+import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
+
+// Unit tests to verify that delta format sharing support column mapping (CM).
+class DeltaSharingDataSourceCMSuite
+    extends StreamTest
+    with DeltaSQLCommandTest
+    with DeltaSharingTestSparkUtils
+    with DeltaSharingDataSourceDeltaTestUtils {
+
+  import testImplicits._
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    spark.conf.set("spark.databricks.delta.streaming.allowSourceColumnRenameAndDrop", "false")
+  }
+
+
+  private def testReadCMTable(
+      deltaTableName: String,
+      sharedTablePath: String,
+      dropC1: Boolean = false): Unit = {
+    val expectedSchema: StructType = if (deltaTableName == "cm_id_table") {
+      spark.read.format("delta").table(deltaTableName).schema
+    } else {
+      if (dropC1) {
+        new StructType()
+          .add("c2rename", StringType)
+      } else {
+        new StructType()
+          .add("c1", IntegerType)
+          .add("c2rename", StringType)
+      }
+    }
+    assert(
+      expectedSchema == spark.read
+        .format("deltaSharing")
+        .option("responseFormat", "delta")
+        .load(sharedTablePath)
+        .schema
+    )
+
+    val sharingDf =
+      spark.read.format("deltaSharing").option("responseFormat", "delta").load(sharedTablePath)
+    val deltaDf = spark.read.format("delta").table(deltaTableName)
+    checkAnswer(sharingDf, deltaDf)
+    assert(sharingDf.count() > 0)
+
+    val filteredSharingDf =
+      spark.read
+        .format("deltaSharing")
+        .option("responseFormat", "delta")
+        .load(sharedTablePath)
+        .filter(col("c2rename") === "one")
+    val filteredDeltaDf =
+      spark.read
+        .format("delta")
+        .table(deltaTableName)
+        .filter(col("c2rename") === "one")
+    checkAnswer(filteredSharingDf, filteredDeltaDf)
+    assert(filteredSharingDf.count() > 0)
+  }
+
+  private def testReadCMCdf(
+      deltaTableName: String,
+      sharedTablePath: String,
+      startingVersion: Int): Unit = {
+    val schema = spark.read
+      .format("deltaSharing")
+      .option("responseFormat", "delta")
+      .option("readChangeFeed", "true")
+      .option("startingVersion", startingVersion)
+      .load(sharedTablePath)
+      .schema
+    val expectedSchema = spark.read
+      .format("delta")
+      .option("readChangeFeed", "true")
+      .option("startingVersion", startingVersion)
+      .table(deltaTableName)
+      .schema
+    assert(expectedSchema == schema)
+
+    val deltaDf = spark.read
+      .format("delta")
+      .option("readChangeFeed", "true")
+      .option("startingVersion", startingVersion)
+      .table(deltaTableName)
+    val sharingDf = spark.read
+      .format("deltaSharing")
+      .option("responseFormat", "delta")
+      .option("readChangeFeed", "true")
+      .option("startingVersion", startingVersion)
+      .load(sharedTablePath)
+    if (startingVersion <= 2) {
+      Seq(BatchCDFSchemaEndVersion, BatchCDFSchemaLatest, BatchCDFSchemaLegacy).foreach { m =>
+        withSQLConf(
+          DeltaSQLConf.DELTA_CDF_DEFAULT_SCHEMA_MODE_FOR_COLUMN_MAPPING_TABLE.key ->
+          m.name
+        ) {
+          val deltaException = intercept[DeltaUnsupportedOperationException] {
+            deltaDf.collect()
+          }
+          assert(
+            deltaException.getMessage.contains("Retrieving table changes between") &&
+            deltaException.getMessage.contains("failed because of an incompatible")
+          )
+          val sharingException = intercept[DeltaUnsupportedOperationException] {
+            sharingDf.collect()
+          }
+          assert(
+            sharingException.getMessage.contains("Retrieving table changes between") &&
+            sharingException.getMessage.contains("failed because of an incompatible")
+          )
+        }
+      }
+    } else {
+      checkAnswer(sharingDf, deltaDf)
+      assert(sharingDf.count() > 0)
+    }
+  }
+
+  private def testReadingSharedCMTable(
+      tempDir: File,
+      deltaTableName: String,
+      sharedTableNameBase: String): Unit = {
+    val sharedTableNameBasic = sharedTableNameBase + "_one"
+    prepareMockedClientAndFileSystemResult(
+      deltaTable = deltaTableName,
+      sharedTable = sharedTableNameBasic
+    )
+    prepareMockedClientGetTableVersion(deltaTableName, sharedTableNameBasic)
+
+    withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
+      val profileFile = prepareProfileFile(tempDir)
+      testReadCMTable(
+        deltaTableName = deltaTableName,
+        sharedTablePath = s"${profileFile.getCanonicalPath}#share1.default.$sharedTableNameBasic"
+      )
+    }
+
+    val sharedTableNameCdf = sharedTableNameBase + "_cdf"
+    // Test CM and CDF
+    // Error when reading cdf with startingVersion <= 2, matches delta behavior.
+    prepareMockedClientGetTableVersion(deltaTableName, sharedTableNameCdf)
+    prepareMockedClientAndFileSystemResultForCdf(
+      deltaTableName,
+      sharedTableNameCdf,
+      startingVersion = 0
+    )
+    prepareMockedClientAndFileSystemResultForCdf(
+      deltaTableName,
+      sharedTableNameCdf,
+      startingVersion = 2
+    )
+    prepareMockedClientAndFileSystemResultForCdf(
+      deltaTableName,
+      sharedTableNameCdf,
+      startingVersion = 3
+    )
+
+    withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
+      val profileFile = prepareProfileFile(tempDir)
+      testReadCMCdf(
+        deltaTableName,
+        s"${profileFile.getCanonicalPath}#share1.default.$sharedTableNameCdf",
+        0
+      )
+      testReadCMCdf(
+        deltaTableName,
+        s"${profileFile.getCanonicalPath}#share1.default.$sharedTableNameCdf",
+        2
+      )
+      testReadCMCdf(
+        deltaTableName,
+        s"${profileFile.getCanonicalPath}#share1.default.$sharedTableNameCdf",
+        3
+      )
+    }
+
+    val sharedTableNameDrop = sharedTableNameBase + "_drop"
+    // DROP COLUMN
+    sql(s"ALTER TABLE $deltaTableName DROP COLUMN c1")
+    prepareMockedClientGetTableVersion(deltaTableName, sharedTableNameDrop)
+    prepareMockedClientAndFileSystemResult(
+      deltaTable = deltaTableName,
+      sharedTable = sharedTableNameDrop
+    )
+    prepareMockedClientGetTableVersion(deltaTableName, sharedTableNameDrop)
+    withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
+      val profileFile = prepareProfileFile(tempDir)
+      testReadCMTable(
+        deltaTableName = deltaTableName,
+        sharedTablePath = s"${profileFile.getCanonicalPath}#share1.default.$sharedTableNameDrop",
+        dropC1 = true
+      )
+    }
+  }
+
+  /**
+   * column mapping tests
+   */
+  test(
+    "DeltaSharingDataSource able to read data for cm name mode"
+  ) {
+    withTempDir { tempDir =>
+      val deltaTableName = "delta_table_cm_name"
+      withTable(deltaTableName) {
+        createSimpleTable(deltaTableName, enableCdf = true)
+        sql(s"""INSERT INTO $deltaTableName VALUES (1, "one"), (2, "one")""")
+        spark.sql(
+          s"""ALTER TABLE $deltaTableName SET TBLPROPERTIES('delta.minReaderVersion' = '2',
+             |'delta.minWriterVersion' = '5',
+             |'delta.columnMapping.mode' = 'name')""".stripMargin
+        )
+        sql(s"""ALTER TABLE $deltaTableName RENAME COLUMN c2 TO c2rename""")
+        sql(s"""INSERT INTO $deltaTableName VALUES (1, "two"), (2, "two")""")
+
+        sql(s"""DELETE FROM $deltaTableName where c1=1""")
+        sql(s"""UPDATE $deltaTableName set c1="3" where c2rename="one"""")
+
+        val sharedTableName = "shared_table_cm_name"
+        testReadingSharedCMTable(tempDir, deltaTableName, sharedTableName)
+      }
+    }
+  }
+
+  test("DeltaSharingDataSource able to read data for cm id mode") {
+    withTempDir { tempDir =>
+      val deltaTableName = "delta_table_cm_id"
+      withTable(deltaTableName) {
+        createCMIdTableWithCdf(deltaTableName)
+        sql(s"""INSERT INTO $deltaTableName VALUES (1, "one"), (2, "one")""")
+        sql(s"""INSERT INTO $deltaTableName VALUES (1, "two"), (2, "two")""")
+
+        sql(s"""ALTER TABLE $deltaTableName RENAME COLUMN c2 TO c2rename""")
+        sql(s"""INSERT INTO $deltaTableName VALUES (1, "two"), (2, "two")""")
+
+        sql(s"""DELETE FROM $deltaTableName where c1=1""")
+        sql(s"""UPDATE $deltaTableName set c1="3" where c2rename="one"""")
+
+        val sharedTableName = "shared_table_cm_id"
+        testReadingSharedCMTable(tempDir, deltaTableName, sharedTableName)
+      }
+    }
+  }
+
+  /**
+   * Streaming Test
+   */
+  private def InsertToDeltaTable(tableName: String, values: String): Unit = {
+    sql(s"INSERT INTO $tableName VALUES $values")
+  }
+
+  private def processAllAvailableInStream(
+      tablePath: String,
+      checkpointDirStr: String,
+      outputDirStr: String): Unit = {
+    val q = spark.readStream
+      .format("deltaSharing")
+      .option("responseFormat", "delta")
+      .load(tablePath)
+      .writeStream
+      .format("delta")
+      .option("checkpointLocation", checkpointDirStr)
+      .option("mergeSchema", "true")
+      .start(outputDirStr)
+
+    try {
+      q.processAllAvailable()
+    } finally {
+      q.stop()
+    }
+  }
+
+  private def processStreamWithSchemaTracking(
+      tablePath: String,
+      checkpointDirStr: String,
+      outputDirStr: String,
+      trigger: Option[Trigger] = None,
+      maxFilesPerTrigger: Option[Int] = None): Unit = {
+    var dataStreamReader = spark.readStream
+      .format("deltaSharing")
+      .option("schemaTrackingLocation", checkpointDirStr)
+      .option("responseFormat", "delta")
+    if (maxFilesPerTrigger.isDefined || trigger.isDefined) {
+      // When trigger.Once is defined, maxFilesPerTrigger is ignored -- this is the
+      // behavior of the streaming engine. And AvailableNow is converted as Once for delta sharing.
+      dataStreamReader =
+        dataStreamReader.option("maxFilesPerTrigger", maxFilesPerTrigger.getOrElse(1))
+    }
+    var dataStreamWriter = dataStreamReader
+      .load(tablePath)
+      .writeStream
+      .format("delta")
+      .option("checkpointLocation", checkpointDirStr)
+      .option("mergeSchema", "true")
+    if (trigger.isDefined) {
+      dataStreamWriter = dataStreamWriter.trigger(trigger.get)
+    }
+
+    val q = dataStreamWriter.start(outputDirStr)
+
+    try {
+      q.processAllAvailable()
+      if (maxFilesPerTrigger.isDefined && trigger.isEmpty) {
+        val progress = q.recentProgress.filter(_.numInputRows != 0)
+        // 2 batches -- 2 files are processed, this is how the delta table is constructed.
+        assert(progress.length === 2)
+        progress.foreach { p =>
+          assert(p.numInputRows === 2) // 2 rows per batch -- 2 rows in each file.
+        }
+      }
+    } finally {
+      q.stop()
+    }
+  }
+
+  private def prepareProcessAndCheckInitSnapshot(
+      deltaTableName: String,
+      sharedTableName: String,
+      sharedTablePath: String,
+      checkpointDirStr: String,
+      outputDir: File,
+      useSchemaTracking: Boolean,
+      trigger: Option[Trigger] = None
+  ): Unit = {
+    InsertToDeltaTable(deltaTableName, """(1, "one"), (2, "one"), (1, "two")""")
+    prepareMockedClientAndFileSystemResult(
+      deltaTable = deltaTableName,
+      sharedTable = sharedTableName,
+      versionAsOf = Some(1L)
+    )
+    prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+    prepareMockedClientMetadata(deltaTableName, sharedTableName)
+    if (useSchemaTracking) {
+      processStreamWithSchemaTracking(
+        sharedTablePath,
+        checkpointDirStr,
+        outputDir.toString,
+        trigger
+      )
+    } else {
+      processAllAvailableInStream(
+        sharedTablePath,
+        checkpointDirStr,
+        outputDir.toString
+      )
+    }
+
+    checkAnswer(
+      spark.read.format("delta").load(outputDir.getCanonicalPath),
+      Seq((1, "one"), (2, "one"), (1, "two")).toDF()
+    )
+  }
+
+  def prepareNewInsert(
+      deltaTableName: String,
+      sharedTableName: String,
+      values: String,
+      startingVersion: Long,
+      endingVersion: Long): Unit = {
+    InsertToDeltaTable(deltaTableName, values)
+    prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+    prepareMockedClientAndFileSystemResultForStreaming(
+      deltaTableName,
+      sharedTableName,
+      startingVersion,
+      endingVersion
+    )
+  }
+
+  private def renameColumnAndPrepareRpcResponse(
+      deltaTableName: String,
+      sharedTableName: String,
+      startingVersion: Long,
+      endingVersion: Long,
+      insertAfterRename: Boolean): Unit = {
+    // Rename on the original delta table.
+    sql(s"""ALTER TABLE $deltaTableName RENAME COLUMN c2 TO c2rename""")
+    if (insertAfterRename) {
+      InsertToDeltaTable(deltaTableName, """(1, "three")""")
+      InsertToDeltaTable(deltaTableName, """(2, "three")""")
+    }
+    // Prepare all the delta sharing rpcs.
+    prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+    prepareMockedClientMetadata(deltaTableName, sharedTableName)
+    prepareMockedClientAndFileSystemResultForStreaming(
+      deltaTableName,
+      sharedTableName,
+      startingVersion,
+      endingVersion
+    )
+  }
+
+  private def expectUseSchemaLogException(
+      tablePath: String,
+      checkpointDirStr: String,
+      outputDirStr: String): Unit = {
+    val error = intercept[StreamingQueryException] {
+      processAllAvailableInStream(
+        tablePath,
+        checkpointDirStr,
+        outputDirStr
+      )
+    }.toString
+    assert(error.contains("DELTA_STREAMING_INCOMPATIBLE_SCHEMA_CHANGE_USE_SCHEMA_LOG"))
+    assert(error.contains("Please provide a 'schemaTrackingLocation'"))
+  }
+
+  private def expectMetadataEvolutionException(
+      tablePath: String,
+      checkpointDirStr: String,
+      outputDirStr: String,
+      trigger: Option[Trigger] = None,
+      maxFilesPerTrigger: Option[Int] = None): Unit = {
+    val error = intercept[StreamingQueryException] {
+      processStreamWithSchemaTracking(
+        tablePath,
+        checkpointDirStr,
+        outputDirStr,
+        trigger,
+        maxFilesPerTrigger
+      )
+    }.toString
+    assert(error.contains("DELTA_STREAMING_METADATA_EVOLUTION"))
+    assert(error.contains("Please restart the stream to continue"))
+  }
+
+  private def expectSqlConfException(
+      tablePath: String,
+      checkpointDirStr: String,
+      outputDirStr: String,
+      trigger: Option[Trigger] = None,
+      maxFilesPerTrigger: Option[Int] = None): Unit = {
+    val error = intercept[StreamingQueryException] {
+      processStreamWithSchemaTracking(
+        tablePath,
+        checkpointDirStr,
+        outputDirStr,
+        trigger,
+        maxFilesPerTrigger
+      )
+    }.toString
+    assert(error.contains("DELTA_STREAMING_CANNOT_CONTINUE_PROCESSING_POST_SCHEMA_EVOLUTION"))
+    assert(error.contains("delta.streaming.allowSourceColumnRenameAndDrop"))
+  }
+
+  private def processWithSqlConf(
+      tablePath: String,
+      checkpointDirStr: String,
+      outputDirStr: String,
+      trigger: Option[Trigger] = None,
+      maxFilesPerTrigger: Option[Int] = None): Unit = {
+    // Using allowSourceColumnRenameAndDrop instead of
+    // allowSourceColumnRenameAndDrop.[checkpoint_hash] because the checkpointDir changes
+    // every test.
+    spark.conf
+      .set("spark.databricks.delta.streaming.allowSourceColumnRenameAndDrop", "always")
+    processStreamWithSchemaTracking(
+      tablePath,
+      checkpointDirStr,
+      outputDirStr,
+      trigger,
+      maxFilesPerTrigger
+    )
+  }
+
+  private def testRestartStreamingFourTimes(
+      tablePath: String,
+      checkpointDir: java.io.File,
+      outputDirStr: String): Unit = {
+    val checkpointDirStr = checkpointDir.toString
+
+    // 1. Followed the previous error message to use schemaTrackingLocation, but received
+    // error suggesting restart.
+    expectMetadataEvolutionException(tablePath, checkpointDirStr, outputDirStr)
+
+    // 2. Followed the previous error message to restart, but need to restart again for
+    // DeltaSource to handle offset movement, this is the SAME behavior as stream reading from
+    // the delta table directly.
+    expectMetadataEvolutionException(tablePath, checkpointDirStr, outputDirStr)
+
+    // 3. Followed the previous error message to restart, but cannot write to the dest table.
+    expectSqlConfException(tablePath, checkpointDirStr, outputDirStr)
+
+    // 4. Restart with new sqlConf, able to process new data and writing to a new column.
+    // Not using allowSourceColumnRenameAndDrop.[checkpoint_hash] because the checkpointDir
+    // changes every test, using allowSourceColumnRenameAndDrop=always instead.
+    processWithSqlConf(tablePath, checkpointDirStr, outputDirStr)
+  }
+
+  test("cm streaming works with newly added schemaTrackingLocation") {
+    withTempDirs { (inputDir, outputDir, checkpointDir) =>
+      val deltaTableName = "delta_table_cm_streaming_basic"
+      withTable(deltaTableName) {
+        createCMIdTableWithCdf(deltaTableName)
+        val sharedTableName = "shared_table_cm_streaming_basic"
+        val profileFile = prepareProfileFile(inputDir)
+        val tablePath = profileFile.getCanonicalPath + s"#share1.default.$sharedTableName"
+
+        withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
+          // 1. Able to stream snapshot at version 1.
+          // The streaming is started without schemaTrackingLocation.
+          prepareProcessAndCheckInitSnapshot(
+            deltaTableName = deltaTableName,
+            sharedTableName = sharedTableName,
+            sharedTablePath = tablePath,
+            checkpointDirStr = checkpointDir.toString,
+            outputDir = outputDir,
+            useSchemaTracking = false
+          )
+
+          // 2. Able to stream new data at version 2.
+          // The streaming is continued without schemaTrackingLocation.
+          prepareNewInsert(
+            deltaTableName = deltaTableName,
+            sharedTableName = sharedTableName,
+            values = """(2, "two")""",
+            startingVersion = 2,
+            endingVersion = 2
+          )
+          processAllAvailableInStream(
+            tablePath,
+            checkpointDir.toString,
+            outputDir.toString
+          )
+          checkAnswer(
+            spark.read.format("delta").load(outputDir.getCanonicalPath),
+            Seq((1, "one"), (2, "one"), (1, "two"), (2, "two")).toDF()
+          )
+
+          // 3. column renaming at version 3, and expect exception.
+          renameColumnAndPrepareRpcResponse(
+            deltaTableName = deltaTableName,
+            sharedTableName = sharedTableName,
+            startingVersion = 2,
+            endingVersion = 3,
+            insertAfterRename = false
+          )
+          expectUseSchemaLogException(tablePath, checkpointDir.toString, outputDir.toString)
+
+          // 4. insert new data at version 4.
+          prepareNewInsert(
+            deltaTableName = deltaTableName,
+            sharedTableName = sharedTableName,
+            values = """(1, "three"), (2, "three")""",
+            startingVersion = 2,
+            endingVersion = 4
+          )
+          // Additional preparation for rpc because deltaSource moved the offset to (3, -20) and
+          // (3, -19) after restart.
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName,
+            sharedTableName,
+            3,
+            4
+          )
+
+          // 5. with 4 restarts, able to continue the streaming
+          // The streaming is re-started WITH schemaTrackingLocation, and it's able to capture the
+          // schema used in previous version, based on the initial call of getBatch for the latest
+          // offset, which pulls the metadata from the server.
+          testRestartStreamingFourTimes(tablePath, checkpointDir, outputDir.toString)
+
+          // An additional column is added to the output table.
+          checkAnswer(
+            spark.read.format("delta").load(outputDir.getCanonicalPath),
+            Seq(
+              (1, "one", null),
+              (2, "one", null),
+              (1, "two", null),
+              (2, "two", null),
+              (1, null, "three"),
+              (2, null, "three")
+            ).toDF()
+          )
+        }
+      }
+    }
+  }
+
+  test("cm streaming works with restart on snapshot query") {
+    // The main difference in this test is the rename happens after processing the initial snapshot,
+    // (instead of after making continuous progress), to test that the restart could fetch the
+    // latest metadata and the metadata from lastest offset.
+    withTempDirs { (inputDir, outputDir, checkpointDir) =>
+      val deltaTableName = "delta_table_streaming_restart"
+      withTable(deltaTableName) {
+        createCMIdTableWithCdf(deltaTableName)
+        val sharedTableName = "shared_table_streaming_restart"
+        val profileFile = prepareProfileFile(inputDir)
+        val tablePath = profileFile.getCanonicalPath + s"#share1.default.$sharedTableName"
+
+        withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
+          // 1. Able to stream snapshot at version 1.
+          prepareProcessAndCheckInitSnapshot(
+            deltaTableName = deltaTableName,
+            sharedTableName = sharedTableName,
+            sharedTablePath = tablePath,
+            checkpointDirStr = checkpointDir.toString,
+            outputDir = outputDir,
+            useSchemaTracking = false
+          )
+
+          // 2. column renaming at version 2, and expect exception.
+          renameColumnAndPrepareRpcResponse(
+            deltaTableName = deltaTableName,
+            sharedTableName = sharedTableName,
+            startingVersion = 2,
+            endingVersion = 2,
+            insertAfterRename = false
+          )
+          expectUseSchemaLogException(tablePath, checkpointDir.toString, outputDir.toString)
+
+          // 3. insert new data at version 3.
+          prepareNewInsert(
+            deltaTableName = deltaTableName,
+            sharedTableName = sharedTableName,
+            values = """(1, "three"), (2, "three")""",
+            startingVersion = 2,
+            endingVersion = 3
+          )
+
+          // 4. with 4 restarts, able to continue the streaming
+          testRestartStreamingFourTimes(tablePath, checkpointDir, outputDir.toString)
+
+          // An additional column is added to the output table.
+          checkAnswer(
+            spark.read.format("delta").load(outputDir.getCanonicalPath),
+            Seq(
+              (1, "one", null),
+              (2, "one", null),
+              (1, "two", null),
+              (1, null, "three"),
+              (2, null, "three")
+            ).toDF()
+          )
+        }
+      }
+    }
+  }
+
+  test("cm streaming works with schemaTracking used at start") {
+    withTempDirs { (inputDir, outputDir, checkpointDir) =>
+      val deltaTableName = "delta_table_streaming_schematracking"
+      withTable(deltaTableName) {
+        createCMIdTableWithCdf(deltaTableName)
+        val sharedTableName = "shared_table_streaming_schematracking"
+        val profileFile = prepareProfileFile(inputDir)
+        val tablePath = profileFile.getCanonicalPath + s"#share1.default.$sharedTableName"
+
+        withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
+          // 1. Able to stream snapshot at version 1.
+          prepareProcessAndCheckInitSnapshot(
+            deltaTableName = deltaTableName,
+            sharedTableName = sharedTableName,
+            sharedTablePath = tablePath,
+            checkpointDirStr = checkpointDir.toString,
+            outputDir = outputDir,
+            useSchemaTracking = true
+          )
+
+          // 2. Able to stream new data at version 2.
+          prepareNewInsert(
+            deltaTableName = deltaTableName,
+            sharedTableName = sharedTableName,
+            values = """(2, "two")""",
+            startingVersion = 2,
+            endingVersion = 2
+          )
+          processStreamWithSchemaTracking(
+            tablePath,
+            checkpointDir.toString,
+            outputDir.toString
+          )
+          checkAnswer(
+            spark.read.format("delta").load(outputDir.getCanonicalPath),
+            Seq((1, "one"), (2, "one"), (1, "two"), (2, "two")).toDF()
+          )
+
+          // 3. column renaming at version 3, and expect exception.
+          renameColumnAndPrepareRpcResponse(
+            deltaTableName = deltaTableName,
+            sharedTableName = sharedTableName,
+            startingVersion = 2,
+            endingVersion = 3,
+            insertAfterRename = false
+          )
+          expectMetadataEvolutionException(tablePath, checkpointDir.toString, outputDir.toString)
+
+          // 4. First see exception, then with sql conf, able to stream new data at version 4.
+          prepareNewInsert(
+            deltaTableName = deltaTableName,
+            sharedTableName = sharedTableName,
+            values = """(1, "three"), (2, "three")""",
+            startingVersion = 3,
+            endingVersion = 4
+          )
+          expectSqlConfException(tablePath, checkpointDir.toString, outputDir.toString)
+          processWithSqlConf(tablePath, checkpointDir.toString, outputDir.toString)
+
+          checkAnswer(
+            spark.read.format("delta").load(outputDir.getCanonicalPath),
+            Seq(
+              (1, "one", null),
+              (2, "one", null),
+              (1, "two", null),
+              (2, "two", null),
+              (1, null, "three"),
+              (2, null, "three")
+            ).toDF()
+          )
+        }
+      }
+    }
+  }
+
+  test("cm streaming works with restart with accumulated inserts after rename") {
+    withTempDirs { (inputDir, outputDir, checkpointDir) =>
+      val deltaTableName = "delta_table_streaming_accumulate"
+      withTable(deltaTableName) {
+        createCMIdTableWithCdf(deltaTableName)
+        val sharedTableName = "shared_table_streaming_accumulate"
+        val profileFile = prepareProfileFile(inputDir)
+        val tablePath = profileFile.getCanonicalPath + s"#share1.default.$sharedTableName"
+
+        withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
+          // 1. Able to stream snapshot at version 1.
+          prepareProcessAndCheckInitSnapshot(
+            deltaTableName = deltaTableName,
+            sharedTableName = sharedTableName,
+            sharedTablePath = tablePath,
+            checkpointDirStr = checkpointDir.toString,
+            outputDir = outputDir,
+            useSchemaTracking = false
+          )
+
+          // 2. column renaming at version 2, and expect exception.
+          renameColumnAndPrepareRpcResponse(
+            deltaTableName = deltaTableName,
+            sharedTableName = sharedTableName,
+            startingVersion = 2,
+            endingVersion = 4,
+            insertAfterRename = true
+          )
+          expectUseSchemaLogException(tablePath, checkpointDir.toString, outputDir.toString)
+
+          // 4. with 4 restarts, able to continue the streaming
+          testRestartStreamingFourTimes(tablePath, checkpointDir, outputDir.toString)
+
+          // An additional column is added to the output table.
+          checkAnswer(
+            spark.read.format("delta").load(outputDir.getCanonicalPath),
+            Seq(
+              (1, "one", null),
+              (2, "one", null),
+              (1, "two", null),
+              (1, null, "three"),
+              (2, null, "three")
+            ).toDF()
+          )
+        }
+      }
+    }
+  }
+
+  test("cm streaming works with column drop and add") {
+    withTempDirs { (inputDir, outputDir, checkpointDir) =>
+      val deltaTableName = "delta_table_column_drop"
+      withTable(deltaTableName) {
+        createCMIdTableWithCdf(deltaTableName)
+        val sharedTableName = "shared_table_column_drop"
+        val profileFile = prepareProfileFile(inputDir)
+        val tablePath = profileFile.getCanonicalPath + s"#share1.default.$sharedTableName"
+
+        withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
+          // 1. Able to stream snapshot at version 1.
+          prepareProcessAndCheckInitSnapshot(
+            deltaTableName = deltaTableName,
+            sharedTableName = sharedTableName,
+            sharedTablePath = tablePath,
+            checkpointDirStr = checkpointDir.toString,
+            outputDir = outputDir,
+            useSchemaTracking = true
+          )
+
+          // 2. drop column c1 at version 2
+          sql(s"ALTER TABLE $deltaTableName DROP COLUMN c1")
+          // 3. add column c3 at version 3
+          sql(s"ALTER TABLE $deltaTableName ADD COLUMN (c3 int)")
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+          prepareMockedClientMetadata(deltaTableName, sharedTableName)
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName,
+            sharedTableName,
+            2,
+            3
+          )
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName,
+            sharedTableName,
+            3,
+            3
+          )
+
+          // Needs a 3 restarts for deltaSource to catch up.
+          expectMetadataEvolutionException(tablePath, checkpointDir.toString, outputDir.toString)
+          expectSqlConfException(tablePath, checkpointDir.toString, outputDir.toString)
+          spark.conf
+            .set("spark.databricks.delta.streaming.allowSourceColumnRenameAndDrop", "always")
+          expectMetadataEvolutionException(tablePath, checkpointDir.toString, outputDir.toString)
+          processWithSqlConf(tablePath, checkpointDir.toString, outputDir.toString)
+
+          // 4. insert at version 4
+          InsertToDeltaTable(deltaTableName, """("four", 4)""")
+          // 5. insert at version 5
+          InsertToDeltaTable(deltaTableName, """("five", 5)""")
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName,
+            sharedTableName,
+            3,
+            5
+          )
+
+          processStreamWithSchemaTracking(
+            tablePath,
+            checkpointDir.toString,
+            outputDir.toString
+          )
+          checkAnswer(
+            spark.read.format("delta").load(outputDir.getCanonicalPath),
+            Seq[(java.lang.Integer, String, java.lang.Integer)](
+              (1, "one", null),
+              (2, "one", null),
+              (1, "two", null),
+              (null, "four", 4),
+              (null, "five", 5)
+            ).toDF()
+          )
+        }
+      }
+    }
+  }
+
+
+  test("cm streaming works with MaxFilesPerTrigger") {
+    withTempDirs { (inputDir, outputDir, checkpointDir) =>
+      val deltaTableName = "delta_table_maxfiles"
+      withTable(deltaTableName) {
+        createCMIdTableWithCdf(deltaTableName)
+        val sharedTableName = "shared_table_maxfiles"
+        val profileFile = prepareProfileFile(inputDir)
+        val tablePath = profileFile.getCanonicalPath + s"#share1.default.$sharedTableName"
+
+        withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
+          // 1. Able to stream snapshot at version 1.
+          InsertToDeltaTable(deltaTableName, """(1, "one"), (2, "one"), (1, "two"), (2, "two")""")
+          prepareMockedClientAndFileSystemResult(
+            deltaTable = deltaTableName,
+            sharedTable = sharedTableName,
+            versionAsOf = Some(1L)
+          )
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+          prepareMockedClientMetadata(deltaTableName, sharedTableName)
+
+          // process with maxFilesPerTrigger.
+          processStreamWithSchemaTracking(
+            tablePath,
+            checkpointDir.toString,
+            outputDir.toString,
+            trigger = None,
+            maxFilesPerTrigger = Some(1)
+          )
+          checkAnswer(
+            spark.read.format("delta").load(outputDir.getCanonicalPath),
+            Seq((1, "one"), (2, "one"), (1, "two"), (2, "two")).toDF()
+          )
+
+          // 2. column renaming at version 2, no exception because of Trigger.Once.
+          sql(s"""ALTER TABLE $deltaTableName RENAME COLUMN c2 TO c2rename""")
+
+          // Prepare all the delta sharing rpcs.
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+          prepareMockedClientMetadata(deltaTableName, sharedTableName)
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName,
+            sharedTableName,
+            startingVersion = 1,
+            endingVersion = 2
+          )
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName,
+            sharedTableName,
+            startingVersion = 2,
+            endingVersion = 2
+          )
+
+          // maxFilesPerTrigger doesn't change whether exception is thrown or not.
+          expectMetadataEvolutionException(
+            tablePath,
+            checkpointDir.toString,
+            outputDir.toString,
+            trigger = None,
+            maxFilesPerTrigger = Some(1)
+          )
+
+          // 4. First see exception, then with sql conf, able to stream new data at version 4 and 5.
+          InsertToDeltaTable(
+            deltaTableName,
+            """(1, "three"), (2, "three"), (1, "four"), (2, "four")"""
+          )
+          prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+          prepareMockedClientAndFileSystemResultForStreaming(
+            deltaTableName,
+            sharedTableName,
+            2,
+            3
+          )
+
+          expectSqlConfException(
+            tablePath,
+            checkpointDir.toString,
+            outputDir.toString,
+            trigger = None,
+            maxFilesPerTrigger = Some(1)
+          )
+          processWithSqlConf(
+            tablePath,
+            checkpointDir.toString,
+            outputDir.toString,
+            trigger = None,
+            maxFilesPerTrigger = Some(1)
+          )
+
+          checkAnswer(
+            spark.read.format("delta").load(outputDir.getCanonicalPath),
+            Seq(
+              (1, "one", null),
+              (2, "one", null),
+              (1, "two", null),
+              (2, "two", null),
+              (1, null, "three"),
+              (2, null, "three"),
+              (1, null, "four"),
+              (2, null, "four")
+            ).toDF()
+          )
+        }
+      }
+    }
+  }
+}

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaTestUtils.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaTestUtils.scala
@@ -48,7 +48,7 @@ import io.delta.sharing.spark.model.{
   DeltaSharingProtocol
 }
 import org.apache.commons.io.FileUtils
-import org.apache.hadoop.fs.Path
+import org.apache.hadoop.fs.{FileSystem, Path}
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -56,12 +56,18 @@ import org.apache.spark.sql.test.SharedSparkSession
 
 trait DeltaSharingDataSourceDeltaTestUtils extends SharedSparkSession {
 
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    // close DeltaSharingFileSystem to avoid impact from other unit tests.
+    FileSystem.closeAll()
+  }
+
   override protected def sparkConf: SparkConf = {
     super.sparkConf
-      .set("spark.delta.sharing.preSignedUrl.expirationMs", "15000")
-      .set("spark.delta.sharing.driver.refreshCheckIntervalMs", "5000")
+      .set("spark.delta.sharing.preSignedUrl.expirationMs", "30000")
+      .set("spark.delta.sharing.driver.refreshCheckIntervalMs", "3000")
       .set("spark.delta.sharing.driver.refreshThresholdMs", "10000")
-      .set("spark.delta.sharing.driver.accessThresholdToExpireMs", "120000")
+      .set("spark.delta.sharing.driver.accessThresholdToExpireMs", "300000")
   }
 
   private[spark] def removePartitionPrefix(filePath: String): String = {

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingFileIndexSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingFileIndexSuite.scala
@@ -323,8 +323,8 @@ class DeltaSharingFileIndexSuite
                 decodedPath.fileId,
                 1000
               )
-              // sleep for expirationTimeMs to ensure that the urls are refreshed.
-              Thread.sleep(15000)
+              // sleep for 25000ms to ensure that the urls are refreshed.
+              Thread.sleep(25000)
 
               // Verify that the url is refreshed as paths(1), not paths(0) anymore.
               assert(fetcher.getUrl == paths(1))

--- a/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
@@ -123,10 +123,12 @@ private[spark] class TestClientForDeltaFormatSharing(
       jsonPredicateHints: Option[String],
       refreshToken: Option[String]
   ): DeltaTableFiles = {
-    limit.foreach(lim => TestClientForDeltaFormatSharing.limits.put(
-      s"${table.share}.${table.schema}.${table.name}", lim))
-    TestClientForDeltaFormatSharing.requestedFormat.put(
-      s"${table.share}.${table.schema}.${table.name}", responseFormat)
+    val tableFullName = s"${table.share}.${table.schema}.${table.name}"
+    limit.foreach(lim => TestClientForDeltaFormatSharing.limits.put(tableFullName, lim))
+    TestClientForDeltaFormatSharing.requestedFormat.put(tableFullName, responseFormat)
+    jsonPredicateHints.foreach(p =>
+      TestClientForDeltaFormatSharing.jsonPredicateHints.put(tableFullName, p))
+
     val iterator = SparkEnv.get.blockManager
       .get[String](getBlockId(table.name, "getFiles", versionAsOf, timestampAsOf))
       .map(_.data.asInstanceOf[Iterator[String]])
@@ -267,4 +269,5 @@ object TestClientForDeltaFormatSharing {
 
   val limits = scala.collection.mutable.Map[String, Long]()
   val requestedFormat = scala.collection.mutable.Map[String, String]()
+  val jsonPredicateHints = scala.collection.mutable.Map[String, String]()
 }

--- a/spark/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
+++ b/spark/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
@@ -16,12 +16,17 @@
 
 package io.delta.sql
 
+import scala.util.control.NonFatal
+
 import org.apache.spark.sql.delta.optimizer.RangePartitionIdRewrite
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.PrepareDeltaScan
 import io.delta.sql.parser.DeltaSqlParser
 
 import org.apache.spark.sql.SparkSessionExtensions
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.delta.PreprocessTimeTravel
 import org.apache.spark.sql.internal.SQLConf
 
@@ -127,9 +132,47 @@ class DeltaSparkSessionExtension extends (SparkSessionExtensions => Unit) {
       new PrepareDeltaScan(session)
     }
 
+    // Tries to load PrepareDeltaSharingScan class with class reflection, when delta-sharing-spark
+    // 3.1+ package is installed, this will be loaded and delta sharing batch queries with
+    // DeltaSharingFileIndex will be handled by the rule.
+    // When the package is not installed or upon any other issues, it should do nothing and not
+    // affect all the existing rules.
+    try {
+      // scalastyle:off classforname
+      val constructor = Class.forName("io.delta.sharing.spark.PrepareDeltaSharingScan")
+        .getConstructor(classOf[org.apache.spark.sql.SparkSession])
+      // scalastyle:on classforname
+      extensions.injectPreCBORule { session =>
+        try {
+          // Inject the PrepareDeltaSharingScan rule if enabled, otherwise, inject the no op
+          // rule. It can be disabled if there are any issues so all existing rules are not blocked.
+          if (
+            session.conf.get(DeltaSQLConf.DELTA_SHARING_ENABLE_DELTA_FORMAT_BATCH.key) == "true"
+          ) {
+            constructor.newInstance(session).asInstanceOf[Rule[LogicalPlan]]
+          } else {
+            new NoOpRule
+          }
+        } catch {
+          // Inject a no op rule which doesn't apply any changes to the logical plan.
+          case NonFatal(_) => new NoOpRule
+        }
+      }
+    } catch {
+      case NonFatal(_) => // Do nothing
+    }
+
     DeltaTableValueFunctions.supportedFnNames.foreach { fnName =>
       extensions.injectTableFunction(
         DeltaTableValueFunctions.getTableValueFunctionInjection(fnName))
     }
+  }
+
+  /**
+   * An no op rule which doesn't apply any changes to the LogicalPlan. Used to be injected upon
+   * exceptions.
+   */
+  class NoOpRule extends Rule[LogicalPlan] {
+    override def apply(plan: LogicalPlan): LogicalPlan = plan
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -42,15 +42,23 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
+ * Extractor Object for pulling out the file index of a logical relation.
+ */
+object RelationFileIndex {
+  def unapply(a: LogicalRelation): Option[FileIndex] = a match {
+    case LogicalRelation(hrel: HadoopFsRelation, _, _, _) => Some(hrel.location)
+    case _ => None
+  }
+}
+
+/**
  * Extractor Object for pulling out the table scan of a Delta table. It could be a full scan
  * or a partial scan.
  */
 object DeltaTable {
   def unapply(a: LogicalRelation): Option[TahoeFileIndex] = a match {
-    case LogicalRelation(HadoopFsRelation(index: TahoeFileIndex, _, _, _, _, _), _, _, _) =>
-      Some(index)
-    case _ =>
-      None
+    case RelationFileIndex(fileIndex: TahoeFileIndex) => Some(fileIndex)
+    case _ => None
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DMLWithDeletionVectorsHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DMLWithDeletionVectorsHelper.scala
@@ -549,14 +549,14 @@ object DeletionVectorWriter extends DeltaLogging {
     val broadcastHadoopConf = sparkSession.sparkContext.broadcast(
       new SerializableConfiguration(hadoopConf))
     // hadoop.fs.Path is not Serializable, so close over the String representation instead
-    val tablePathString = DeletionVectorStore.pathToString(table)
+    val tablePathString = DeletionVectorStore.pathToEscapedString(table)
     val packingTargetSize =
       sparkSession.conf.get(DeltaSQLConf.DELETION_VECTOR_PACKING_TARGET_SIZE)
 
     // This is the (partition) mapper function we are returning
     (rowIterator: Iterator[InputT]) => {
       val dvStore = DeletionVectorStore.createInstance(broadcastHadoopConf.value.value)
-      val tablePath = DeletionVectorStore.stringToPath(tablePathString)
+      val tablePath = DeletionVectorStore.escapedStringToPath(tablePathString)
       val tablePathWithFS = dvStore.pathWithFileSystem(tablePath)
 
       val perBinFunction: Seq[InputT] => Seq[OutputT] = (rows: Seq[InputT]) => {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -415,6 +415,7 @@ class OptimizeExecutor(
         bins.filter { bin =>
           bin.size > 1 || // bin has more than one file or
           (bin.size == 1 && bin(0).deletionVector != null) || // single file in the bin has a DV or
+          (bin.size == 1 && optimizeContext.icebergCompatVersion.isDefined) || // uniform reorg
           isMultiDimClustering // multi-clustering
         }.map(b => (partition, b))
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
@@ -476,8 +476,8 @@ trait TransactionalWrite extends DeltaLogging { self: OptimisticTransactionImpl 
     // add [[AddFile.Tags.ICEBERG_COMPAT_VERSION.name]] tags to addFiles
     if (IcebergCompatV2.isEnabled(metadata)) {
       resultFiles = resultFiles.map { addFile =>
-        addFile.copy(tags = addFile.tags + (AddFile.Tags.ICEBERG_COMPAT_VERSION.name ->
-          "2"))
+        val tags = if (addFile.tags != null) addFile.tags else Map.empty[String, String]
+        addFile.copy(tags = tags + (AddFile.Tags.ICEBERG_COMPAT_VERSION.name -> "2"))
       }
     }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1582,6 +1582,17 @@ trait DeltaSQLConfBase {
         "'clusteredTable.numClusteringColumnsLimit' must be positive."
       )
     .createWithDefault(4)
+
+  //////////////////
+  // Delta Sharing
+  //////////////////
+
+  val DELTA_SHARING_ENABLE_DELTA_FORMAT_BATCH =
+    buildConf("spark.sql.delta.sharing.enableDeltaFormatBatch")
+      .doc("Enable delta format sharing in case of issues.")
+      .internal()
+      .booleanConf
+      .createWithDefault(true)
 }
 
 object DeltaSQLConf extends DeltaSQLConfBase

--- a/spark/src/main/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorStore.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorStore.scala
@@ -97,6 +97,9 @@ trait DeletionVectorStoreUtils {
     DATA_SIZE_LEN + bitmapDataSize + CHECKSUM_LEN
   }
 
+  /** Convert the given String path to a Hadoop Path. Please make sure the path is not escaped. */
+  def unescapedStringToPath(path: String): Path = SparkPath.fromPathString(path).toPath
+
   /** Convert the given String path to a Hadoop Path, Please make sure the path is escaped. */
   def escapedStringToPath(path: String): Path = SparkPath.fromUrlString(path).toPath
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorStore.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorStore.scala
@@ -30,6 +30,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, FSDataOutputStream, Path}
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.paths.SparkPath
 import org.apache.spark.util.Utils
 
 trait DeletionVectorStore extends Logging {
@@ -96,13 +97,11 @@ trait DeletionVectorStoreUtils {
     DATA_SIZE_LEN + bitmapDataSize + CHECKSUM_LEN
   }
 
-  // scalastyle:off pathfromuri
-  /** Convert the given String path to a Hadoop Path, handing special characters properly. */
-  def stringToPath(path: String): Path = new Path(new URI(path))
-  // scalastyle:on pathfromuri
+  /** Convert the given String path to a Hadoop Path, Please make sure the path is escaped. */
+  def escapedStringToPath(path: String): Path = SparkPath.fromUrlString(path).toPath
 
   /** Convert the given Hadoop path to a String Path, handing special characters properly. */
-  def pathToString(path: Path): String = path.toUri.toString
+  def pathToEscapedString(path: Path): String = SparkPath.fromPath(path).urlEncoded
 
   /**
    * Calculate checksum of a serialized deletion vector. We are using CRC32 which has 4bytes size,
@@ -223,7 +222,7 @@ class HadoopFileSystemDVStore(hadoopConf: Configuration)
       }
 
       override val serializedPath: Array[Byte] =
-        DeletionVectorStore.pathToString(path.path).getBytes(UTF_8)
+        DeletionVectorStore.pathToEscapedString(path.path).getBytes(UTF_8)
 
       override def close(): Unit = {
         if (outputStream != null) {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
@@ -128,7 +128,7 @@ trait DeletionVectorsTestUtils extends QueryTest with SharedSparkSession {
 
       // Check that DV exists.
       val dvPath = dv.absolutePath(tablePath)
-      val dvPathStr = DeletionVectorStore.pathToString(dvPath)
+      val dvPathStr = DeletionVectorStore.pathToEscapedString(dvPath)
       assert(new File(dvPathStr).exists(), s"DV not found $dvPath")
 
       // Check that cardinality is correct.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
 import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor
 import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
 import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
-import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore.pathToString
+import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore.pathToEscapedString
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.PathWithFileSystem
@@ -199,7 +199,7 @@ class DeltaParquetFileFormatSuite extends QueryTest
       writer.write(serializedBitmap)
     }
     DeletionVectorDescriptor.onDiskWithAbsolutePath(
-      pathToString(dvPath.makeQualified().path),
+      pathToEscapedString(dvPath.makeQualified().path),
       dvRange.length,
       rowIndexes.size,
       Some(dvRange.offset))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/RowIndexMarkingFiltersSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/RowIndexMarkingFiltersSuite.scala
@@ -65,7 +65,7 @@ class RowIndexMarkingFiltersSuite extends QueryTest with SharedSparkSession {
   } {
     test(s"deletion vector single row marked (isInline=$isInline) ($filterName filter)") {
       withTempDir { tableDir =>
-        val tablePath = escapedStringToPath(tableDir.toString)
+        val tablePath = unescapedStringToPath(tableDir.toString)
         val dv = createDV(isInline, tablePath, 25)
 
         val rowIndexFilter = filterType.createInstance(dv, newHadoopConf, Some(tablePath))
@@ -91,7 +91,7 @@ class RowIndexMarkingFiltersSuite extends QueryTest with SharedSparkSession {
   } {
     test(s"deletion vector with multiple rows marked (isInline=$isInline) ($filterName filter)") {
       withTempDir { tableDir =>
-        val tablePath = escapedStringToPath(tableDir.toString)
+        val tablePath = unescapedStringToPath(tableDir.toString)
         val markedRows = Seq[Long](0, 25, 35, 2000, 50000)
         val dv = createDV(isInline, tablePath, markedRows: _*)
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/RowIndexMarkingFiltersSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/deletionvectors/RowIndexMarkingFiltersSuite.scala
@@ -65,7 +65,7 @@ class RowIndexMarkingFiltersSuite extends QueryTest with SharedSparkSession {
   } {
     test(s"deletion vector single row marked (isInline=$isInline) ($filterName filter)") {
       withTempDir { tableDir =>
-        val tablePath = stringToPath(tableDir.toString)
+        val tablePath = escapedStringToPath(tableDir.toString)
         val dv = createDV(isInline, tablePath, 25)
 
         val rowIndexFilter = filterType.createInstance(dv, newHadoopConf, Some(tablePath))
@@ -91,7 +91,7 @@ class RowIndexMarkingFiltersSuite extends QueryTest with SharedSparkSession {
   } {
     test(s"deletion vector with multiple rows marked (isInline=$isInline) ($filterName filter)") {
       withTempDir { tableDir =>
-        val tablePath = stringToPath(tableDir.toString)
+        val tablePath = escapedStringToPath(tableDir.toString)
         val markedRows = Seq[Long](0, 25, 35, 2000, 50000)
         val dv = createDV(isInline, tablePath, markedRows: _*)
 
@@ -140,7 +140,7 @@ class RowIndexMarkingFiltersSuite extends QueryTest with SharedSparkSession {
         writer.write(serializedBitmap)
       }
       onDiskWithAbsolutePath(
-        pathToString(dvPath.path), dvRange.length, cardinality, Some(dvRange.offset))
+        pathToEscapedString(dvPath.path), dvRange.length, cardinality, Some(dvRange.offset))
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorStoreSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorStoreSuite.scala
@@ -61,7 +61,7 @@ trait DeletionVectorStoreSuiteBase
   def withTempHadoopFileSystemPath[T](f: Path => T): T = {
     val dir: File = Utils.createTempDir()
     dir.delete()
-    val tempPath = DeletionVectorStore.stringToPath(dir.toString)
+    val tempPath = DeletionVectorStore.escapedStringToPath(dir.toString)
     try f(tempPath) finally Utils.deleteRecursively(dir)
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorStoreSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorStoreSuite.scala
@@ -61,7 +61,7 @@ trait DeletionVectorStoreSuiteBase
   def withTempHadoopFileSystemPath[T](f: Path => T): T = {
     val dir: File = Utils.createTempDir()
     dir.delete()
-    val tempPath = DeletionVectorStore.escapedStringToPath(dir.toString)
+    val tempPath = DeletionVectorStore.unescapedStringToPath(dir.toString)
     try f(tempPath) finally Utils.deleteRecursively(dir)
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR is a backport of https://github.com/delta-io/delta/pull/2510 to the 3.1 branch.

This PR renames `stringToPath` and `pathToString` methods, this will emphasize the input/output string should/will be escaped.

We also added a third new method `unescapedStringToPath`. which is used by almost all calls from tests.

## How was this patch tested?

Refactoring PR.