### PR TITLE
[Spark] Abbreviate long strings in DML stats

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeStats.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeStats.scala
@@ -16,8 +16,11 @@
 
 package org.apache.spark.sql.delta.commands.merge
 
+import scala.collection.mutable.ArrayBuffer
+
 import org.apache.spark.sql.util.ScalaExtensions._
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import org.apache.commons.lang3.StringUtils
 
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.{DeltaMergeIntoClause, DeltaMergeIntoMatchedClause, DeltaMergeIntoNotMatchedBySourceClause, DeltaMergeIntoNotMatchedClause}
@@ -47,9 +50,30 @@ case class MergeClauseStats(
 object MergeClauseStats {
   def apply(mergeClause: DeltaMergeIntoClause): MergeClauseStats = {
     MergeClauseStats(
-      condition = mergeClause.condition.map(_.sql),
+      condition = mergeClause.condition.map(c => StringUtils.abbreviate(c.sql, 256)),
       mergeClause.clauseType.toLowerCase(),
-      actionExpr = mergeClause.actions.map(_.sql))
+      actionExpr = truncateSeq(
+        mergeClause.actions.map(a => StringUtils.abbreviate(a.sql, 256)),
+        maxLength = 512)
+    )
+  }
+
+  /**
+   * Truncate a list of items to be serialized to around 'maxLength' characters.
+   * Always include at least on item.
+   */
+  private def truncateSeq(seq: Seq[String], maxLength: Long): Seq[String] = {
+    val buffer = ArrayBuffer.empty[String]
+    var length = 0L
+    for (x <- seq if length + x.length <= maxLength || buffer.isEmpty) {
+      length += x.length + 3 // quotes and comma
+      buffer.append(x)
+    }
+    val numTruncatedItems = seq.length - buffer.length
+    if (numTruncatedItems > 0) {
+      buffer.append("... " + numTruncatedItems + " more fields")
+    }
+    buffer.toSeq
   }
 }
 
@@ -132,7 +156,7 @@ object MergeStats {
 
     MergeStats(
       // Merge condition expression
-      conditionExpr = condition.sql,
+      conditionExpr = StringUtils.abbreviate(condition.sql, 2048),
 
       // Newer expressions used in MERGE with any number of MATCHED/NOT MATCHED/
       // NOT MATCHED BY SOURCE


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

The stats of DML commands contain the raw expression strings that can be arbitrarily long. The result is that the JSON blob is truncated at 16K and is not parseable. This commit fixes this issue by truncating the long string fields.

## How was this patch tested?

Existing tests.

## Does this PR introduce _any_ user-facing changes?

No
