### PR TITLE
[Spark] Make sure files are writable in EvolvabilitySuiteBase

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/EvolvabilitySuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/EvolvabilitySuiteBase.scala
@@ -73,8 +73,23 @@ abstract class EvolvabilitySuiteBase extends QueryTest with SharedSparkSession
       // copy the existing dir to the temp data dir.
       FileUtils.copyDirectory(
         new File("src/test/resources/delta/transaction_log_schema_evolvability"), tempDir)
+      makeWritable(tempDir)
       DeltaLog.clearCache()
       operation(tempDir.getAbsolutePath)
+    }
+  }
+
+  /**
+   * Recursively make all files in a directory writable.
+   */
+  private def makeWritable(directory: File): Unit = {
+    if (!directory.isDirectory) return
+    directory.listFiles().foreach { file =>
+      if (file.isDirectory) {
+        makeWritable(file)
+      } else {
+        file.setWritable(true)
+      }
     }
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

When running tests with Bazel, in some circumstances the files might be read-only. We make sure to make all the files inside our temporary directory writable so the tests can write to tables.

## How was this patch tested?

Existing tests

## Does this PR introduce _any_ user-facing changes?

No
