### PR TITLE
[UniForm] Enable Column mapping in metadata before Cluster table fetch column names

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
@@ -162,13 +162,14 @@ object UniversalFormat extends DeltaLogging {
   }
 
   /**
-   * This method should be called before CTAS writer writes the new table to disk.
+   * This method is used to build UniForm metadata dependencies closure.
+   * It checks configuration conflicts and adds missing properties.
    * It will call [[enforceIcebergInvariantsAndDependencies]] to perform the actual check.
-   * @param configuration of delta writer used to write CTAS data.
+   * @param configuration the original metadata configuration.
    * @return updated configuration if any changes are required,
    *         otherwise the original configuration.
    */
-  def enforceInvariantsAndDependenciesForCTAS(
+  def enforceDependenciesInConfiguration(
       configuration: Map[String, String],
       snapshot: Snapshot): Map[String, String] = {
     var metadata = Metadata(configuration = configuration)
@@ -176,7 +177,7 @@ object UniversalFormat extends DeltaLogging {
     // Check UniversalFormat related property dependencies
     val (_, universalMetadata) = UniversalFormat.enforceInvariantsAndDependencies(
       snapshot,
-      newestProtocol = Protocol(),
+      newestProtocol = snapshot.protocol,
       newestMetadata = metadata,
       isCreatingOrReorgTable = true,
       actions = Seq()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -261,7 +261,7 @@ case class CreateDeltaTableCommand(
       (actions, op)
     }
     val updatedConfiguration = UniversalFormat
-      .enforceInvariantsAndDependenciesForCTAS(deltaWriter.configuration, txn.snapshot)
+      .enforceDependenciesInConfiguration(deltaWriter.configuration, txn.snapshot)
     val updatedWriter = deltaWriter.withNewWriterConfiguration(updatedConfiguration)
     // We are either appending/overwriting with saveAsTable or creating a new table with CTAS
     if (!hasBeenExecuted(txn, sparkSession, Some(options))) {
@@ -319,8 +319,12 @@ case class CreateDeltaTableCommand(
         assertPathEmpty(hadoopConf, tableWithLocation)
         // This is a user provided schema.
         // Doesn't come from a query, Follow nullability invariants.
-        val newMetadata =
+        var newMetadata =
           getProvidedMetadata(tableWithLocation, table.schema.json)
+        newMetadata = newMetadata.copy(configuration =
+          UniversalFormat.enforceDependenciesInConfiguration(
+            newMetadata.configuration, txn.snapshot))
+
         txn.updateMetadataForNewTable(newMetadata)
         protocol.foreach { protocol =>
           txn.updateProtocol(protocol)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR allows UniForm to work together with Liquid table by enabling column mapping before Liquid table read the column names.

## How was this patch tested?
Unit tests
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
