### PR TITLE
[Kernel][Logging] Don't use the fluent logging API in SLF4J

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -20,9 +20,6 @@ import java.util.*;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.delta.kernel.Scan;
 import io.delta.kernel.client.TableClient;
 import io.delta.kernel.data.*;
@@ -46,8 +43,6 @@ import static io.delta.kernel.internal.util.PartitionUtils.rewritePartitionPredi
  * Implementation of {@link Scan}
  */
 public class ScanImpl implements Scan {
-    private static final Logger logger = LoggerFactory.getLogger(ScanImpl.class);
-
     /**
      * Schema of the snapshot from the Delta log being scanned in this scan. It is a logical schema
      * with metadata properties to derive the physical schema.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Not all connectors will support SLF4J 2.x so we should avoid using these newer APIs.

## How was this patch tested?

Ran unit tests and checked the output logs locally.