### PR TITLE
[#2515][3.1][Spark] Avoid redudant jobs in buildRowIndexSetsForFilesMatchingCondition 

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DMLWithDeletionVectorsHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DMLWithDeletionVectorsHelper.scala
@@ -391,14 +391,12 @@ object DeletionVectorBitmapGenerator {
       val filePathToDVDf = sparkSession.createDataset(filePathToDV)
 
       val joinExpr = filePathToDVDf("path") === matchedRowsDf(FILE_NAME_COL)
-      val joinedDf = matchedRowsDf.join(filePathToDVDf, joinExpr)
-      assert(joinedDf.count() == matchedRowsDf.count(),
-        s"""
-           |The joined DataFrame should contain the same number of entries as the original
-           |DataFrame. It is likely that _metadata.file_path is not encoded by Spark as expected.
-           |Joined DataFrame count: ${joinedDf.count()}
-           |matchedRowsDf count: ${matchedRowsDf.count()}
-           |""".stripMargin)
+      // Perform leftOuter join to make sure we do not eliminate any rows because of path
+      // encoding issues. If there is such an issue we will detect it during the aggregation
+      // of the bitmaps.
+      val joinedDf = matchedRowsDf.join(filePathToDVDf, joinExpr, "leftOuter")
+        .drop(FILE_NAME_COL)
+        .withColumnRenamed("path", FILE_NAME_COL)
       joinedDf
     } else {
       // When the table has no DVs, just add a column to indicate that the existing dv is null
@@ -631,6 +629,14 @@ object DeletionVectorWriter extends DeltaLogging {
    */
   def storeBitmapAndGenerateResult(ctx: DeletionVectorMapperContext, row: DeletionVectorData)
     : DeletionVectorResult = {
+    // If a group with null path exists it means there was an issue while joining with the log to
+    // fetch the DeletionVectorDescriptors.
+    assert(row.filePath != null,
+      s"""
+         |Encountered a non matched file path.
+         |It is likely that _metadata.file_path is not encoded by Spark as expected.
+         |""".stripMargin)
+
     val fileDvDescriptor = row.deletionVectorId.map(DeletionVectorDescriptor.fromJson(_))
     val finalDvDescriptor = fileDvDescriptor match {
       case Some(existingDvDescriptor) if row.deletedRowIndexCount > 0 =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoDVsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoDVsSuite.scala
@@ -151,52 +151,6 @@ class MergeIntoDVsSuite extends MergeIntoDVsTests {
         numDeletionVectorsRemoved = 1,
         numDeletionVectorsUpdated = 0)
     }
-
-    test(s"Verify error is produced when paths are not joined correctly") {
-      withTempDir { dir =>
-        val sourcePath = s"$dir/source"
-        val targetPath = s"$dir/target"
-
-        spark.range(0, 10, 2).write.format("delta").save(sourcePath)
-        spark.range(10).write.format("delta").save(targetPath)
-
-        // Execute buildRowIndexSetsForFilesMatchingCondition with a corrupted touched files list.
-        val sourceDF = io.delta.tables.DeltaTable.forPath(sourcePath).toDF
-        val targetDF = io.delta.tables.DeltaTable.forPath(targetPath).toDF
-        val targetLog = DeltaLog.forTable(spark, targetPath)
-        val condition = col("s.id") === col("t.id")
-        val allFiles = targetLog.update().allFiles.collect().toSeq
-        assert(allFiles.size === 2)
-        val corruptedFiles = Seq(
-          allFiles.head,
-          allFiles.last.copy(path = "corruptedPath"))
-        val txn = targetLog.startTransaction(catalogTableOpt = None)
-
-        val fileIndex = new TahoeBatchFileIndex(
-          spark,
-          actionType = "merge",
-          addFiles = allFiles,
-          deltaLog = targetLog,
-          path = new Path("file:" + targetPath),
-          snapshot = txn.snapshot)
-
-        val targetDFWithMetadata = DMLWithDeletionVectorsHelper.createTargetDfForScanningForMatches(
-          spark,
-          targetDF.queryExecution.logical,
-          fileIndex)
-        val e = intercept[SparkException] {
-          DeletionVectorBitmapGenerator.buildRowIndexSetsForFilesMatchingCondition(
-            spark,
-            txn,
-            tableHasDVs = true,
-            targetDf = sourceDF.as("s").join(targetDFWithMetadata.as("t"), condition),
-            candidateFiles = corruptedFiles,
-            condition = condition.expr
-          )
-        }
-        assert(e.getCause.getMessage.contains("Encountered a non matched file path."))
-      }
-    }
   }
 
   test(s"Merge with DVs metrics - delete entire file") {
@@ -224,6 +178,52 @@ class MergeIntoDVsSuite extends MergeIntoDVsTests {
         numDeletionVectorsAdded = 1, // 1 file was deleted partially.
         numDeletionVectorsRemoved = 0,
         numDeletionVectorsUpdated = 0)
+    }
+  }
+
+  test(s"Verify error is produced when paths are not joined correctly") {
+    withTempDir { dir =>
+      val sourcePath = s"$dir/source"
+      val targetPath = s"$dir/target"
+
+      spark.range(0, 10, 2).write.format("delta").save(sourcePath)
+      spark.range(10).write.format("delta").save(targetPath)
+
+      // Execute buildRowIndexSetsForFilesMatchingCondition with a corrupted touched files list.
+      val sourceDF = io.delta.tables.DeltaTable.forPath(sourcePath).toDF
+      val targetDF = io.delta.tables.DeltaTable.forPath(targetPath).toDF
+      val targetLog = DeltaLog.forTable(spark, targetPath)
+      val condition = col("s.id") === col("t.id")
+      val allFiles = targetLog.update().allFiles.collect().toSeq
+      assert(allFiles.size === 2)
+      val corruptedFiles = Seq(
+        allFiles.head,
+        allFiles.last.copy(path = "corruptedPath"))
+      val txn = targetLog.startTransaction(catalogTableOpt = None)
+
+      val fileIndex = new TahoeBatchFileIndex(
+        spark,
+        actionType = "merge",
+        addFiles = allFiles,
+        deltaLog = targetLog,
+        path = targetLog.dataPath,
+        snapshot = txn.snapshot)
+
+      val targetDFWithMetadata = DMLWithDeletionVectorsHelper.createTargetDfForScanningForMatches(
+        spark,
+        targetDF.queryExecution.logical,
+        fileIndex)
+      val e = intercept[SparkException] {
+        DeletionVectorBitmapGenerator.buildRowIndexSetsForFilesMatchingCondition(
+          spark,
+          txn,
+          tableHasDVs = true,
+          targetDf = sourceDF.as("s").join(targetDFWithMetadata.as("t"), condition),
+          candidateFiles = corruptedFiles,
+          condition = condition.expr
+        )
+      }
+      assert(e.getCause.getMessage.contains("Encountered a non matched file path."))
     }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoDVsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoDVsSuite.scala
@@ -17,7 +17,15 @@
 package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.delta.cdc.MergeCDCTests
+import org.apache.spark.sql.delta.commands.{DeletionVectorBitmapGenerator, DMLWithDeletionVectorsHelper}
+import org.apache.spark.sql.delta.files.TahoeBatchFileIndex
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.SparkException
+import org.apache.spark.sql.execution.datasources.FileFormat.FILE_PATH
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.functions.col
 
 trait MergeIntoDVsTests extends MergeIntoSQLSuite with DeletionVectorsTestUtils {
 
@@ -142,6 +150,52 @@ class MergeIntoDVsSuite extends MergeIntoDVsTests {
         numDeletionVectorsAdded = 0,
         numDeletionVectorsRemoved = 1,
         numDeletionVectorsUpdated = 0)
+    }
+
+    test(s"Verify error is produced when paths are not joined correctly") {
+      withTempDir { dir =>
+        val sourcePath = s"$dir/source"
+        val targetPath = s"$dir/target"
+
+        spark.range(0, 10, 2).write.format("delta").save(sourcePath)
+        spark.range(10).write.format("delta").save(targetPath)
+
+        // Execute buildRowIndexSetsForFilesMatchingCondition with a corrupted touched files list.
+        val sourceDF = io.delta.tables.DeltaTable.forPath(sourcePath).toDF
+        val targetDF = io.delta.tables.DeltaTable.forPath(targetPath).toDF
+        val targetLog = DeltaLog.forTable(spark, targetPath)
+        val condition = col("s.id") === col("t.id")
+        val allFiles = targetLog.update().allFiles.collect().toSeq
+        assert(allFiles.size === 2)
+        val corruptedFiles = Seq(
+          allFiles.head,
+          allFiles.last.copy(path = "corruptedPath"))
+        val txn = targetLog.startTransaction(catalogTableOpt = None)
+
+        val fileIndex = new TahoeBatchFileIndex(
+          spark,
+          actionType = "merge",
+          addFiles = allFiles,
+          deltaLog = targetLog,
+          path = new Path("file:" + targetPath),
+          snapshot = txn.snapshot)
+
+        val targetDFWithMetadata = DMLWithDeletionVectorsHelper.createTargetDfForScanningForMatches(
+          spark,
+          targetDF.queryExecution.logical,
+          fileIndex)
+        val e = intercept[SparkException] {
+          DeletionVectorBitmapGenerator.buildRowIndexSetsForFilesMatchingCondition(
+            spark,
+            txn,
+            tableHasDVs = true,
+            targetDf = sourceDF.as("s").join(targetDFWithMetadata.as("t"), condition),
+            candidateFiles = corruptedFiles,
+            condition = condition.expr
+          )
+        }
+        assert(e.getCause.getMessage.contains("Encountered a non matched file path."))
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Avoid redudant jobs in buildRowIndexSetsForFilesMatchingCondition.
In buildRowIndexSetsForFilesMatchingCondition we join the results DataFrame with the candidate file list to fetch the Deletion Vector Descriptors. Currently, there is a sanity check there to verify we do not eliminate any rows due to path encoding issues. The sanity check compares before and after counts. The counts produce 2 extra jobs which can cause a significant performance overhead. For example, in the case of merge each job could be a full shuffle join between the source and the target. This PR eliminates the extra jobs while maintaining the sanity check.

This is a cherry pick of https://github.com/delta-io/delta/pull/2516.
## How was this patch tested?
Added a new test in MergeIntoDVsSuite.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.
