### PR TITLE
[Spark][Sharing] Log more info in DeltaFormatSharingSource

### DIFF
--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaFormatSharingSourceSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaFormatSharingSourceSuite.scala
@@ -174,7 +174,9 @@ class DeltaFormatSharingSourceSuite
               }
             )
           }
-          assert(e.getMessage.contains("Delta Sharing Server returning negative table version: -1."))
+          assert(
+            e.getMessage.contains("Delta Sharing Server returning negative table version: -1.")
+          )
         }
       }
     }

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaTestUtils.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaTestUtils.scala
@@ -153,11 +153,11 @@ trait DeltaSharingDataSourceDeltaTestUtils extends SharedSparkSession {
   // version of the deltaTable, use BlockManager to store the result.
   private[spark] def prepareMockedClientGetTableVersion(
       deltaTable: String,
-      sharedTable: String): Unit = {
-    val snapshotToUse = getSnapshotToUse(deltaTable, None)
+      sharedTable: String,
+      inputVersion: Option[Long] = None): Unit = {
     DeltaSharingUtils.overrideSingleBlock[Long](
       blockId = TestClientForDeltaFormatSharing.getBlockId(sharedTable, "getTableVersion"),
-      value = snapshotToUse.version
+      value = inputVersion.getOrElse(getSnapshotToUse(deltaTable, None).version)
     )
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [X] Other (Delta Sharing)

## Description
Log more info in DeltaFormatSharingSource and throw error when server returns bad version.

## How was this patch tested?
Unit Test

## Does this PR introduce _any_ user-facing changes?
No