### PR TITLE
[Spark] Widen all UDFs during conflict checking

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.util.DeltaSparkPlanUtils.CheckDeterministicOptions
 import org.apache.spark.sql.delta.util.FileNames
 import org.apache.hadoop.fs.FileStatus
 
@@ -244,15 +245,15 @@ private[delta] class ConflictChecker(
     spark.conf.get(DeltaSQLConf.DELTA_CONFLICT_DETECTION_WIDEN_NONDETERMINISTIC_PREDICATES) match {
       case DeltaSQLConf.NonDeterministicPredicateWidening.OFF =>
         getFirstFileMatchingPartitionPredicatesInternal(
-          filesDf, shouldWidenNonDeterministicPredicates = false)
+          filesDf, shouldWidenNonDeterministicPredicates = false, shouldWidenAllUdf = false)
       case wideningMode =>
         val fileWithWidening = getFirstFileMatchingPartitionPredicatesInternal(
-          filesDf, shouldWidenNonDeterministicPredicates = true)
+          filesDf, shouldWidenNonDeterministicPredicates = true, shouldWidenAllUdf = true)
 
         fileWithWidening.flatMap { fileWithWidening =>
           val fileWithoutWidening =
             getFirstFileMatchingPartitionPredicatesInternal(
-              filesDf, shouldWidenNonDeterministicPredicates = false)
+              filesDf, shouldWidenNonDeterministicPredicates = false, shouldWidenAllUdf = false)
           if (fileWithoutWidening.isEmpty) {
             // Conflict due to widening of non-deterministic predicate.
             recordDeltaEvent(deltaLog,
@@ -261,7 +262,10 @@ private[delta] class ConflictChecker(
               data = Map(
                 "wideningMode" -> wideningMode,
                 "predicate" ->
-                  currentTransactionInfo.readPredicates.map(_.partitionPredicate.toString)))
+                  currentTransactionInfo.readPredicates.map(_.partitionPredicate.toString),
+                "deterministicUDFs" -> containsDeterministicUDF(
+                  currentTransactionInfo.readPredicates, partitionedOnly = true))
+            )
           }
           if (wideningMode == DeltaSQLConf.NonDeterministicPredicateWidening.ON) {
             Some(fileWithWidening)
@@ -274,13 +278,16 @@ private[delta] class ConflictChecker(
 
   private def getFirstFileMatchingPartitionPredicatesInternal(
       filesDf: DataFrame,
-      shouldWidenNonDeterministicPredicates: Boolean): Option[AddFile] = {
+      shouldWidenNonDeterministicPredicates: Boolean,
+      shouldWidenAllUdf: Boolean): Option[AddFile] = {
 
     def rewritePredicateFn(
         predicate: Expression,
         shouldRewriteFilter: Boolean): DeltaTableReadPredicate = {
       val rewrittenPredicate = if (shouldWidenNonDeterministicPredicates) {
-        eliminateNonDeterministicPredicates(Seq(predicate)).newPredicates
+        val checkDeterministicOptions =
+          CheckDeterministicOptions(allowDeterministicUdf = !shouldWidenAllUdf)
+        eliminateNonDeterministicPredicates(Seq(predicate), checkDeterministicOptions).newPredicates
       } else {
         Seq(predicate)
       }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
@@ -239,6 +239,8 @@ trait MergeIntoMaterializeSource extends DeltaLogging with DeltaSparkPlanUtils {
     val forceMaterializationWithUnreadableFiles =
       spark.conf.get(DeltaSQLConf.MERGE_FORCE_SOURCE_MATERIALIZATION_WITH_UNREADABLE_FILES)
     import DeltaSQLConf.MergeMaterializeSource._
+    val checkDeterministicOptions =
+      DeltaSparkPlanUtils.CheckDeterministicOptions(allowDeterministicUdf = true)
     materializeType match {
       case ALL =>
         (true, MergeIntoMaterializeSourceReason.MATERIALIZE_ALL)
@@ -249,7 +251,7 @@ trait MergeIntoMaterializeSource extends DeltaLogging with DeltaSparkPlanUtils {
           (false, MergeIntoMaterializeSourceReason.NOT_MATERIALIZED_AUTO_INSERT_ONLY)
         } else if (!planContainsOnlyDeltaScans(source)) {
           (true, MergeIntoMaterializeSourceReason.NON_DETERMINISTIC_SOURCE_NON_DELTA)
-        } else if (!planIsDeterministic(source)) {
+        } else if (!planIsDeterministic(source, checkDeterministicOptions)) {
           (true, MergeIntoMaterializeSourceReason.NON_DETERMINISTIC_SOURCE_OPERATORS)
           // Force source materialization if Spark configs IGNORE_CORRUPT_FILES,
           // IGNORE_MISSING_FILES or file source read options FileSourceOptions.IGNORE_CORRUPT_FILES


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Delta conflict detection widens non-deterministic expressions before applying them to the changes of the winning transaction. Unfortunately, user defined functions are marked as deterministic by default and customers need to mark them as deterministic. This can result in actually non-deterministic UDFs incorrectly being treated as deterministic. This commit makes conflict detection widen all UDFs to prevent customers from shooting themselves in the foot.

## How was this patch tested?

Existing tests.

## Does this PR introduce _any_ user-facing changes?

No