### PR TITLE
Fix Delta benchmarks: unaccessible Utils.median

### DIFF
--- a/benchmarks/build.sbt
+++ b/benchmarks/build.sbt
@@ -20,7 +20,7 @@ scalaVersion := "2.12.17"
 lazy val root = (project in file("."))
   .settings(
     name := "benchmarks",
-    libraryDependencies += "org.apache.spark" %% "spark-sql" % "3.1.2" % "provided",
+    libraryDependencies += "org.apache.spark" %% "spark-sql" % "3.5.0" % "provided",
     libraryDependencies += "com.github.scopt" %% "scopt" % "4.0.1",
     libraryDependencies += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.13.1",
 

--- a/benchmarks/src/main/scala/benchmark/MergeBenchmark.scala
+++ b/benchmarks/src/main/scala/benchmark/MergeBenchmark.scala
@@ -18,8 +18,8 @@ package benchmark
 
 import java.util.UUID
 
+import org.apache.spark.SparkUtils
 import org.apache.spark.sql.Row
-import org.apache.spark.util.Utils
 
 trait MergeConf extends BenchmarkConf {
   def scaleInGB: Int
@@ -84,7 +84,7 @@ class MergeBenchmark(conf: MergeBenchmarkConf) extends Benchmark(conf) {
     if (results.forall(x => x.errorMsg.isEmpty && x.durationMs.nonEmpty) ) {
       val medianDurationSecPerQuery = results.groupBy(_.name).map { case (q, results) =>
         assert(results.length == conf.iterations)
-        val medianMs = Utils.median(results.map(_.durationMs.get), alreadySorted = false)
+        val medianMs = SparkUtils.median(results.map(_.durationMs.get), alreadySorted = false)
         (q, medianMs / 1000.0)
       }
       val sumOfMedians = medianDurationSecPerQuery.values.sum

--- a/benchmarks/src/main/scala/org/apache/spark/SparkUtils.scala
+++ b/benchmarks/src/main/scala/org/apache/spark/SparkUtils.scala
@@ -52,4 +52,6 @@ object SparkUtils {
       valueOption.map(value => f.getName -> value)
     }.toMap
   }
+
+  def median(sizes: Array[Long], alreadySorted: Boolean): Long = Utils.median(sizes, alreadySorted)
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
New Delta benchmarks for MERGE added in https://github.com/delta-io/delta/pull/1835 broke the benchmark build due to Spark helper `Utils.median` method being inaccessible for two reasons:
- Spark `Utils` object is package private to `spark`
- Delta benchmarks use an ancient Spark version that doesn't even define `Utils.median`.

This change upgrades the Spark version used in benchmarks to 3.5.0. and exposes `Utils.median` to the benchmark package.

## How was this patch tested?
Compiled the benchmarks locally.