### PR TITLE
[Spark] Add Writer Protocol check in Vacuum Command

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
@@ -156,6 +156,8 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
       import org.apache.spark.sql.delta.implicits._
 
       val snapshot = deltaLog.update()
+      deltaLog.protocolWrite(snapshot.protocol)
+
       val snapshotTombstoneRetentionMillis = DeltaLog.tombstoneRetentionMillis(snapshot.metadata)
       val retentionMillis = retentionHours.map(h => TimeUnit.HOURS.toMillis(math.round(h)))
       val deleteBeforeTimestamp = retentionMillis match {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -445,7 +445,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         overwrite = false,
         log.newDeltaHadoopConf())
 
-      // Both vacuum and vacuum dry run works as expected
+      // Both vacuum and vacuum dry run fails as expected
       vacuumCommandsToTry.foreach { command =>
         intercept[DeltaUnsupportedTableFeatureException] {
           spark.sql(command).collect()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

(Cherry-pick of #2557 to branch-3.1)

This PR adds Write PROTOCOL check to the Vacuum Command since it makes changes to delta directory.




## How was this patch tested?

UTs

## Does this PR introduce _any_ user-facing changes?

No