### PR TITLE
[Docs] Fix documentation for default columns

### DIFF
--- a/docs/source/delta-default-columns.md
+++ b/docs/source/delta-default-columns.md
@@ -34,8 +34,4 @@ You can enable default column values for a table by setting `delta.feature.allow
 
 - It is permissible, however, to assign or update default values for columns that were created in previous commands. For example, the following SQL command is valid: `ALTER TABLE t ALTER COLUMN c SET DEFAULT 16;`
 
-
-
-
-
-
+ .. include:: /shared/replacements.md

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -21,7 +21,7 @@ This is the documentation site for <Delta>.
     delta-utility
     delta-constraints
     versioning
-    delta-column-defaults
+    delta-default-columns
     delta-column-mapping
     delta-clustering
     delta-deletion-vectors


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?


- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [X] Other (fill in here)

## Description

Fix index to contain correct reference to `delta-default-columns` instead of `delta-column-defaults` and include default replacements.

## How was this patch tested?

N/A

## Does this PR introduce _any_ user-facing changes?

No