### PR TITLE
[Spark] Add messageParameters to DeltaAnalysisException

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaSharedExceptions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaSharedExceptions.scala
@@ -31,6 +31,10 @@ class DeltaAnalysisException(
     origin: Option[Origin] = None)
   extends AnalysisException(
     message = DeltaThrowableHelper.getMessage(errorClass, messageParameters),
+    messageParameters = DeltaThrowableHelper
+        .getParameterNames(errorClass, errorSubClass = null)
+        .zip(messageParameters)
+        .toMap,
     errorClass = Some(errorClass),
     line = origin.flatMap(_.line),
     startPosition = origin.flatMap(_.startPosition),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTableSuite.scala
@@ -555,7 +555,8 @@ class DeltaColumnDefaultsInsertSuite extends InsertIntoSQLOnlyTests with DeltaSQ
               s"i boolean, s bigint, q int default 42) using $v2Format " +
               "partitioned by (i)")
           },
-          errorClass = "WRONG_COLUMN_DEFAULTS_FOR_DELTA_FEATURE_NOT_ENABLED"
+          errorClass = "WRONG_COLUMN_DEFAULTS_FOR_DELTA_FEATURE_NOT_ENABLED",
+          parameters = Map("commandType" -> "CREATE TABLE")
         )
       }
       withTable("alterTableSetDefaultFeatureNotEnabled") {
@@ -564,7 +565,8 @@ class DeltaColumnDefaultsInsertSuite extends InsertIntoSQLOnlyTests with DeltaSQ
           exception = intercept[DeltaAnalysisException] {
             sql("alter table alterTableSetDefaultFeatureNotEnabled alter column a set default 42")
           },
-          errorClass = "WRONG_COLUMN_DEFAULTS_FOR_DELTA_FEATURE_NOT_ENABLED"
+          errorClass = "WRONG_COLUMN_DEFAULTS_FOR_DELTA_FEATURE_NOT_ENABLED",
+          parameters = Map("commandType" -> "ALTER TABLE")
         )
       }
       // Adding a new column with a default value to an existing table is not allowed.
@@ -575,7 +577,8 @@ class DeltaColumnDefaultsInsertSuite extends InsertIntoSQLOnlyTests with DeltaSQ
           exception = intercept[DeltaAnalysisException] {
             sql("alter table alterTableTest add column z int default 42")
           },
-          errorClass = "WRONG_COLUMN_DEFAULTS_FOR_DELTA_ALTER_TABLE_ADD_COLUMN_NOT_SUPPORTED")
+          errorClass = "WRONG_COLUMN_DEFAULTS_FOR_DELTA_ALTER_TABLE_ADD_COLUMN_NOT_SUPPORTED"
+        )
       }
       // The default value fails to analyze.
       checkError(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
@@ -158,7 +158,6 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase
           .write.mode("append").format("delta").saveAsTable("srcTbl")
 
         val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, new TableIdentifier("srcTbl"))
-        val schemaStr = snapshot.statCollectionLogicalSchema.treeString
         // Test multiple data types.
         Seq("a", "d", "e").foreach { colName =>
           withTempDir { tmpDir =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
@@ -185,8 +185,19 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase
                   f()
                 }
                 checkError(
-                  e,
-                  "DELTA_CLUSTERING_COLUMN_MISSING_STATS"
+                  exception = e,
+                  errorClass = "DELTA_CLUSTERING_COLUMN_MISSING_STATS",
+                  parameters = Map(
+                    "columns" -> colName,
+                    "schema" -> """root
+                      | |-- a: struct (nullable = true)
+                      | |    |-- b: integer (nullable = true)
+                      | |    |-- c: integer (nullable = true)
+                      | |-- d: boolean (nullable = true)
+                      | |-- e: map (nullable = true)
+                      | |    |-- key: integer
+                      | |    |-- value: integer (valueContainsNull = true)
+                      |""".stripMargin)
                 )
               }
           }
@@ -203,8 +214,9 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase
           "CREATE", testTable, "a INT, b INT, c INT, d INT, e INT", "a, b, c, d, e")
       }
       checkError(
-        e,
-        errorClass = "DELTA_CLUSTER_BY_INVALID_NUM_COLUMNS"
+        exception = e,
+        errorClass = "DELTA_CLUSTER_BY_INVALID_NUM_COLUMNS",
+        parameters = Map("numColumnsLimit" -> "4", "actualNumColumns" -> "5")
       )
     }
   }
@@ -220,8 +232,9 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase
             "CREATE", testTable, sourceTable, "a, b, c, d, e", location = location)
         }
         checkError(
-          e,
-          errorClass = "DELTA_CLUSTER_BY_INVALID_NUM_COLUMNS"
+          exception = e,
+          errorClass = "DELTA_CLUSTER_BY_INVALID_NUM_COLUMNS",
+          parameters = Map("numColumnsLimit" -> "4", "actualNumColumns" -> "5")
         )
       }
     }
@@ -268,8 +281,15 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase
                 indexedColumns,
                 Some(tableSchema)))
             checkError(
-              e,
-              "DELTA_CLUSTERING_COLUMN_MISSING_STATS"
+              exception = e,
+              errorClass = "DELTA_CLUSTERING_COLUMN_MISSING_STATS",
+              parameters = Map(
+                "columns" -> "col1.col12, col2",
+                "schema" -> """root
+                    | |-- col0: integer (nullable = true)
+                    | |-- col1: struct (nullable = true)
+                    | |    |-- col11: integer (nullable = true)
+                    |""".stripMargin)
             )
             // Validate the first two columns can be clustering columns.
             createTableWithStatsColumns(
@@ -318,8 +338,15 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase
                   None,
                   location = Some(dir.getPath)))
               checkError(
-                e,
-                "DELTA_CLUSTERING_COLUMN_MISSING_STATS"
+                exception = e,
+                errorClass = "DELTA_CLUSTERING_COLUMN_MISSING_STATS",
+                parameters = Map(
+                  "columns" -> "col1.col12, col2",
+                  "schema" -> """root
+                    | |-- col0: integer (nullable = true)
+                    | |-- col1: struct (nullable = true)
+                    | |    |-- col11: integer (nullable = true)
+                    |""".stripMargin)
               )
 
               // Validate the first two columns can be clustering columns.
@@ -356,8 +383,17 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase
             indexedColumns,
             Some(nonEligibleTableSchema)))
         checkError(
-          e,
-          "DELTA_CLUSTERING_COLUMN_MISSING_STATS"
+          exception = e,
+          errorClass = "DELTA_CLUSTERING_COLUMN_MISSING_STATS",
+          parameters = Map(
+            "columns" -> "col1.col11",
+            "schema" -> """root
+              | |-- col0: integer (nullable = true)
+              | |-- col1: struct (nullable = true)
+              | |    |-- col11: array (nullable = true)
+              | |    |    |-- element: integer (containsNull = true)
+              | |    |-- col12: string (nullable = true)
+              |""".stripMargin)
         )
       }
     }
@@ -391,8 +427,9 @@ trait ClusteredTableDDLWithColumnMapping
         sql(s"ALTER TABLE $testTable DROP COLUMNS (col1)")
       }
       checkError(
-        e,
-        "DELTA_UNSUPPORTED_DROP_CLUSTERING_COLUMN"
+        exception = e,
+        errorClass = "DELTA_UNSUPPORTED_DROP_CLUSTERING_COLUMN",
+        parameters = Map("columnList" -> "col1")
       )
       // Drop non-clustering columns are allowed.
       sql(s"ALTER TABLE $testTable DROP COLUMNS (col2)")
@@ -405,8 +442,9 @@ trait ClusteredTableDDLWithColumnMapping
         sql(s"ALTER TABLE $testTable DROP COLUMNS (col1, col2)")
       }
       checkError(
-        e,
-        "DELTA_UNSUPPORTED_DROP_CLUSTERING_COLUMN"
+        exception = e,
+        errorClass = "DELTA_UNSUPPORTED_DROP_CLUSTERING_COLUMN",
+        parameters = Map("columnList" -> "col1,col2")
       )
     }
   }
@@ -418,8 +456,9 @@ trait ClusteredTableDDLWithColumnMapping
         sql(s"ALTER TABLE $testTable DROP COLUMNS (col1, col3)")
       }
       checkError(
-        e,
-        "DELTA_UNSUPPORTED_DROP_CLUSTERING_COLUMN"
+        exception = e,
+        errorClass = "DELTA_UNSUPPORTED_DROP_CLUSTERING_COLUMN",
+        parameters = Map("columnList" -> "col1")
       )
     }
   }
@@ -454,8 +493,9 @@ trait ClusteredTableDDLSuiteBase
         sql(s"OPTIMIZE $testTable ZORDER BY (a)")
       }
       checkError(
-        e2,
-        "DELTA_CLUSTERING_WITH_ZORDER_BY"
+        exception = e2,
+        errorClass = "DELTA_CLUSTERING_WITH_ZORDER_BY",
+        parameters = Map("zOrderBy" -> "a")
       )
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Add the correct `messageParameters` mapping to `DeltaAnalysisException` (like we have for `DeltaIllegalArgumentException` for example), so that Spark's `checkError` actually tests them, rather than testing against an empty `Map`.

## How was this patch tested?

Test-only PR.

## Does this PR introduce _any_ user-facing changes?

No.
