### PR TITLE
Make a Delta SQL conf for DeltaLog cache size 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,6 +79,7 @@ lazy val commonSettings = Seq(
     "-Dspark.databricks.delta.snapshotPartitions=2",
     "-Dspark.sql.shuffle.partitions=5",
     "-Ddelta.log.cacheSize=3",
+    "-Dspark.databricks.delta.delta.log.cacheSize=3",
     "-Dspark.sql.sources.parallelPartitionDiscovery.parallelism=5",
     "-Xmx1024m"
   ),
@@ -144,6 +145,7 @@ lazy val spark = (project in file("spark"))
       "-Dspark.databricks.delta.snapshotPartitions=2",
       "-Dspark.sql.shuffle.partitions=5",
       "-Ddelta.log.cacheSize=3",
+      "-Dspark.databricks.delta.delta.log.cacheSize=3",
       "-Dspark.sql.sources.parallelPartitionDiscovery.parallelism=5",
       "-Xmx1024m"
     ),
@@ -201,6 +203,7 @@ lazy val contribs = (project in file("contribs"))
       "-Dspark.databricks.delta.snapshotPartitions=2",
       "-Dspark.sql.shuffle.partitions=5",
       "-Ddelta.log.cacheSize=3",
+      "-Dspark.databricks.delta.delta.log.cacheSize=3",
       "-Dspark.sql.sources.parallelPartitionDiscovery.parallelism=5",
       "-Xmx1024m"
     ),

--- a/python/delta/testing/utils.py
+++ b/python/delta/testing/utils.py
@@ -37,6 +37,7 @@ class DeltaTestCase(ReusedSQLTestCase):
         _conf.set("spark.databricks.delta.snapshotPartitions", "2")
         _conf.set("spark.sql.shuffle.partitions", "5")
         _conf.set("delta.log.cacheSize", "3")
+        _conf.set("spark.databricks.delta.delta.log.cacheSize", "3")
         _conf.set("spark.sql.sources.parallelPartitionDiscovery.parallelism", "5")
         _conf.set("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
         _conf.set("spark.sql.catalog.spark_catalog",

--- a/run-tests.py
+++ b/run-tests.py
@@ -80,7 +80,7 @@ def run_sbt_tests(root_dir, test_group, coverage, scala_version=None):
     # a GC that is optimized for larger multiprocessor machines with large memory
     cmd += ["-J-XX:+UseG1GC"]
     # 6x the default heap size (set in delta/built.sbt)
-    cmd += ["-J-Xmx12G"]
+    cmd += ["-J-Xmx6G"]
     run_cmd(cmd, stream_output=True)
 
 def run_python_tests(root_dir):

--- a/run-tests.py
+++ b/run-tests.py
@@ -80,7 +80,7 @@ def run_sbt_tests(root_dir, test_group, coverage, scala_version=None):
     # a GC that is optimized for larger multiprocessor machines with large memory
     cmd += ["-J-XX:+UseG1GC"]
     # 6x the default heap size (set in delta/built.sbt)
-    cmd += ["-J-Xmx6G"]
+    cmd += ["-J-Xmx12G"]
     run_cmd(cmd, stream_output=True)
 
 def run_python_tests(root_dir):

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -641,7 +641,7 @@ object DeltaLog extends DeltaLogging {
   /**
    * Helper to create delta log caches
    */
-  private[delta] def createCacheBuilder(conf: SQLConf): CacheBuilder[AnyRef, AnyRef] = {
+  private def createCacheBuilder(conf: SQLConf): CacheBuilder[AnyRef, AnyRef] = {
     val cacheRetention = conf.getConf(DeltaSQLConf.DELTA_LOG_CACHE_RETENTION_MINUTES)
     val cacheSize = conf
       .getConf(DeltaSQLConf.DELTA_LOG_CACHE_SIZE)
@@ -808,8 +808,8 @@ object DeltaLog extends DeltaLogging {
       // - Different `authority` (e.g., different user tokens in the path)
       // - Different mount point.
       try {
-        getOrCreateCache(spark.sessionState.conf).get(
-            path -> fileSystemOptions, () => {
+        getOrCreateCache(spark.sessionState.conf)
+          .get(path -> fileSystemOptions, () => {
             createDeltaLog()
           }
         )
@@ -864,9 +864,7 @@ object DeltaLog extends DeltaLogging {
   }
 
   def clearCache(): Unit = {
-    deltaLogCache.foreach { cache =>
-      cache.invalidateAll()
-    }
+    deltaLogCache.foreach(_.invalidateAll())
   }
 
   /** Unset the caches. Exposing for testing */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.delta.schema.{SchemaMergingUtils, SchemaUtils}
 import org.apache.spark.sql.delta.sources._
 import org.apache.spark.sql.delta.storage.LogStoreProvider
 import org.apache.spark.sql.delta.util.FileNames
-import com.google.common.cache.{CacheBuilder, RemovalNotification}
+import com.google.common.cache.{Cache, CacheBuilder, RemovalNotification}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
 
@@ -615,21 +615,42 @@ object DeltaLog extends DeltaLogging {
    * We create only a single [[DeltaLog]] for any given `DeltaLogCacheKey` to avoid wasted work
    * in reconstructing the log.
    */
-  private val deltaLogCache = {
-    val builder = CacheBuilder.newBuilder()
-      .expireAfterAccess(60, TimeUnit.MINUTES)
-      .removalListener((removalNotification: RemovalNotification[DeltaLogCacheKey, DeltaLog]) => {
-          val log = removalNotification.getValue
-          // TODO: We should use ref-counting to uncache snapshots instead of a manual timed op
-          try log.unsafeVolatileSnapshot.uncache() catch {
-            case _: java.lang.NullPointerException =>
-            // Various layers will throw null pointer if the RDD is already gone.
-          }
-      })
-    sys.props.get("delta.log.cacheSize")
-      .flatMap(v => Try(v.toLong).toOption)
-      .foreach(builder.maximumSize)
-    builder.build[DeltaLogCacheKey, DeltaLog]()
+  type CacheKey = (Path, Map[String, String])
+  private[delta] def getOrCreateCache(conf: SQLConf):
+      Cache[CacheKey, DeltaLog] = synchronized {
+    deltaLogCache match {
+      case Some(c) => c
+      case None =>
+        val builder = createCacheBuilder(conf)
+          .removalListener(
+              (removalNotification: RemovalNotification[DeltaLogCacheKey, DeltaLog]) => {
+            val log = removalNotification.getValue
+            // TODO: We should use ref-counting to uncache snapshots instead of a manual timed op
+            try log.unsafeVolatileSnapshot.uncache() catch {
+              case _: java.lang.NullPointerException =>
+              // Various layers will throw null pointer if the RDD is already gone.
+            }
+          })
+        deltaLogCache = Some(builder.build[CacheKey, DeltaLog]())
+        deltaLogCache.get
+    }
+  }
+
+  private var deltaLogCache: Option[Cache[CacheKey, DeltaLog]] = None
+
+  /**
+   * Helper to create delta log caches
+   */
+  private[delta] def createCacheBuilder(conf: SQLConf): CacheBuilder[AnyRef, AnyRef] = {
+    val cacheRetention = conf.getConf(DeltaSQLConf.DELTA_LOG_CACHE_RETENTION_MINUTES)
+    val cacheSize = conf
+      .getConf(DeltaSQLConf.DELTA_LOG_CACHE_SIZE)
+      .max(sys.props.get("delta.log.cacheSize").map(_.toLong).getOrElse(0L))
+
+    CacheBuilder
+      .newBuilder()
+      .expireAfterAccess(cacheRetention, TimeUnit.MINUTES)
+      .maximumSize(cacheSize)
   }
 
 
@@ -787,7 +808,8 @@ object DeltaLog extends DeltaLogging {
       // - Different `authority` (e.g., different user tokens in the path)
       // - Different mount point.
       try {
-        deltaLogCache.get(path -> fileSystemOptions, () => {
+        getOrCreateCache(spark.sessionState.conf).get(
+            path -> fileSystemOptions, () => {
             createDeltaLog()
           }
         )
@@ -801,7 +823,7 @@ object DeltaLog extends DeltaLogging {
     if (Option(deltaLog.sparkContext.get).map(_.isStopped).getOrElse(true)) {
       // Invalid the cached `DeltaLog` and create a new one because the `SparkContext` of the cached
       // `DeltaLog` has been stopped.
-      deltaLogCache.invalidate(path -> fileSystemOptions)
+      getOrCreateCache(spark.sessionState.conf).invalidate(path -> fileSystemOptions)
       getDeltaLogFromCache()
     } else {
       deltaLog
@@ -819,6 +841,7 @@ object DeltaLog extends DeltaLogging {
       // scalastyle:on deltahadoopconfiguration
       val path = fs.makeQualified(rawPath)
 
+      val deltaLogCache = getOrCreateCache(spark.sessionState.conf)
       if (spark.sessionState.conf.getConf(
           DeltaSQLConf.LOAD_FILE_SYSTEM_CONFIGS_FROM_DATAFRAME_OPTIONS)) {
         // We rely on the fact that accessing the key set doesn't modify the entry access time. See
@@ -841,12 +864,21 @@ object DeltaLog extends DeltaLogging {
   }
 
   def clearCache(): Unit = {
-    deltaLogCache.invalidateAll()
+    deltaLogCache.foreach { cache =>
+      cache.invalidateAll()
+    }
+  }
+
+  /** Unset the caches. Exposing for testing */
+  private[delta] def unsetCache(): Unit = {
+    synchronized {
+      deltaLogCache = None
+    }
   }
 
   /** Return the number of cached `DeltaLog`s. Exposing for testing */
   private[delta] def cacheSize: Long = {
-    deltaLogCache.size()
+    deltaLogCache.map(_.size()).getOrElse(0L)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1607,6 +1607,18 @@ trait DeltaSQLConfBase {
       )
     .createWithDefault(4)
 
+  val DELTA_LOG_CACHE_SIZE = buildConf("delta.log.cacheSize")
+    .internal()
+    .doc("The maximum number of DeltaLog instances to cache in memory.")
+    .longConf
+    .createWithDefault(10000)
+
+  val DELTA_LOG_CACHE_RETENTION_MINUTES = buildConf("delta.log.cacheRetentionMinutes")
+    .internal()
+    .doc("The rentention duration of DeltaLog instances in the cache")
+    .timeConf(TimeUnit.MINUTES)
+    .createWithDefault(60)
+
   //////////////////
   // Delta Sharing
   //////////////////

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -656,12 +656,12 @@ class DeltaLogSuite extends QueryTest
     }
     DeltaLog.unsetCache()
     withSQLConf(DeltaSQLConf.DELTA_LOG_CACHE_SIZE.key -> "4") {
-      assertCacheSize(2)
+      assertCacheSize(4)
       DeltaLog.unsetCache()
       // the larger of SQLConf and env var is adopted
       try {
         System.getProperties.setProperty("delta.log.cacheSize", "5")
-        assertCacheSize(3)
+        assertCacheSize(5)
       } finally {
         System.getProperties.remove("delta.log.cacheSize")
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -646,7 +646,7 @@ class DeltaLogSuite extends QueryTest
 
   test("DeltaLog cache size should honor config limit") {
     def assertCacheSize(expected: Long): Unit = {
-      for (_ <- 1 to 5) {
+      for (_ <- 1 to 6) {
         withTempDir(dir => {
           val path = dir.getCanonicalPath
           spark.range(10).write.format("delta").mode("append").save(path)
@@ -655,12 +655,12 @@ class DeltaLogSuite extends QueryTest
       assert(DeltaLog.cacheSize === expected)
     }
     DeltaLog.unsetCache()
-    withSQLConf(DeltaSQLConf.DELTA_LOG_CACHE_SIZE.key -> "2") {
+    withSQLConf(DeltaSQLConf.DELTA_LOG_CACHE_SIZE.key -> "4") {
       assertCacheSize(2)
       DeltaLog.unsetCache()
       // the larger of SQLConf and env var is adopted
       try {
-        System.getProperties.setProperty("delta.log.cacheSize", "3")
+        System.getProperties.setProperty("delta.log.cacheSize", "5")
         assertCacheSize(3)
       } finally {
         System.getProperties.remove("delta.log.cacheSize")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Make a Delta SQL conf for DeltaLog cache size as the current impl can go unbounded and costs lots of driver memory. 

## How was this patch tested?

UT

