### PR TITLE
[Spark] Normalize column names in the nested fields when writing

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -1460,12 +1460,6 @@
     ],
     "sqlState" : "21506"
   },
-  "DELTA_NESTED_FIELDS_NEED_RENAME" : {
-    "message" : [
-      "Nested fields need renaming to avoid data loss. Fields:\n<fields>.\nOriginal schema:\n<schema>"
-    ],
-    "sqlState" : "42K05"
-  },
   "DELTA_NESTED_NOT_NULL_CONSTRAINT" : {
     "message" : [
       "The <nestType> type of the field <parent> contains a NOT NULL constraint. Delta does not support NOT NULL constraints nested within arrays or maps. To suppress this error and silently ignore the specified constraints, set <configKey> = true.",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1175,13 +1175,6 @@ trait DeltaErrorsBase
     )
   }
 
-  def nestedFieldsNeedRename(columns : Set[String], baseSchema : StructType): Throwable = {
-    new DeltaAnalysisException(
-      errorClass = "DELTA_NESTED_FIELDS_NEED_RENAME",
-      messageParameters = Array(columns.mkString("[", ", ", "]"), formatSchema(baseSchema))
-    )
-  }
-
   def inSubqueryNotSupportedException(operation: String): Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_UNSUPPORTED_IN_SUBQUERY",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
@@ -103,7 +103,9 @@ trait TransactionalWrite extends DeltaLogging { self: OptimisticTransactionImpl 
       deltaLog: DeltaLog,
       options: Option[DeltaOptions],
       data: Dataset[_]): (QueryExecution, Seq[Attribute], Seq[Constraint], Set[String]) = {
-    val normalizedData = SchemaUtils.normalizeColumnNames(metadata.schema, data)
+    val normalizedData = SchemaUtils.normalizeColumnNames(
+      deltaLog, metadata.schema, data
+    )
     val nullAsDefault = options.isDefined &&
       options.get.options.contains(ColumnWithDefaultExprUtils.USE_NULL_AS_DEFAULT_DELTA_OPTION)
     val enforcesDefaultExprs = ColumnWithDefaultExprUtils.tableHasDefaultExpr(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.SchemaMergingUtils._
 import org.apache.spark.sql.delta.sources.DeltaSourceUtils.GENERATION_EXPRESSION_METADATA_KEY
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.util.ScalaExtensions._
 
 import org.apache.spark.sql._
 import org.apache.spark.sql.AnalysisException
@@ -36,6 +37,7 @@ import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.functions.{col, struct}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
+import org.apache.spark.util.Utils
 
 object SchemaUtils extends DeltaLogging {
   // We use case insensitive resolution while writing into Delta
@@ -194,11 +196,96 @@ object SchemaUtils extends DeltaLogging {
   }
 
   /**
+   * Recursively rewrite the query field names according to the table schema within nested
+   * data types.
+   *
+   * The same assumptions as in [[normalizeColumnNames]] are made.
+   *
+   * @param sourceDataType The data type that needs normalizing.
+   * @param tableDataType The normalization template from the table's schema.
+   * @param sourceParentFields The path (starting from the top level) to the nested field
+   *                           with `sourceDataType`.
+   * @param tableSchema The entire schema of the table.
+   *
+   * @return A normalized version of `sourceDataType`.
+   */
+def normalizeColumnNamesInDataType(
+      deltaLog: DeltaLog,
+      sourceDataType: DataType,
+      tableDataType: DataType,
+      sourceParentFields: Seq[String],
+      tableSchema: StructType
+    ): DataType = {
+
+    def getMatchingTableField(
+        sourceField: StructField,
+        tableFields: Map[String, StructField]): StructField = {
+      tableFields.get(sourceField.name) match {
+        case Some(tableField) => tableField
+        case None =>
+          val columnPath = (sourceParentFields ++ Seq(sourceField.name)).mkString(".")
+          throw DeltaErrors.cannotResolveColumn(columnPath, tableSchema)
+      }
+    }
+
+    (sourceDataType, tableDataType) match {
+      case (sourceStruct: StructType, tableStruct: StructType) =>
+        val tableFields = toFieldMap(tableStruct.fields, caseSensitive = false)
+        val normalizedFields = sourceStruct.fields.map { sourceField =>
+          val tableField = getMatchingTableField(sourceField, tableFields)
+          val normalizedDataType =
+            normalizeColumnNamesInDataType(deltaLog, sourceField.dataType, tableField.dataType,
+              sourceParentFields :+ sourceField.name, tableSchema)
+          val normalizedName = tableField.name
+          sourceField.copy(
+            name = normalizedName,
+            dataType = normalizedDataType
+          )
+        }
+        sourceStruct.copy(fields = normalizedFields)
+      case (sourceArray: ArrayType, tableArray: ArrayType) =>
+        val normalizedElementType = normalizeColumnNamesInDataType(deltaLog,
+          sourceArray.elementType, tableArray.elementType, sourceParentFields, tableSchema)
+        sourceArray.copy(elementType = normalizedElementType)
+      case (sourceMap: MapType, tableMap: MapType) =>
+        val normalizedKeyType = normalizeColumnNamesInDataType(deltaLog, sourceMap.keyType,
+          tableMap.keyType, sourceParentFields, tableSchema)
+        val normalizedValueType = normalizeColumnNamesInDataType(deltaLog, sourceMap.valueType,
+          tableMap.valueType, sourceParentFields, tableSchema)
+        sourceMap.copy(
+          keyType = normalizedKeyType,
+          valueType = normalizedValueType
+        )
+      case _ =>
+        if (Utils.isTesting) {
+          assert(sourceDataType == tableDataType,
+            s"Types without nesting should match but $sourceDataType != $tableDataType")
+        } else if (sourceDataType != tableDataType) {
+          recordDeltaEvent(
+            deltaLog = deltaLog,
+            opType = "delta.assertions.schemaNormalization.nonNestedTypeMismatch",
+            tags = Map.empty,
+            data = Map(
+              "sourceDataType" -> sourceDataType.json,
+              "tableDataType" -> tableDataType.json
+            ),
+            path = None)
+        }
+        // The data types are compatible.
+        sourceDataType
+    }
+  }
+
+  /**
    * Rewrite the query field names according to the table schema. This method assumes that all
    * schema validation checks have been made and this is the last operation before writing into
    * Delta.
    */
-  def normalizeColumnNames(baseSchema: StructType, data: Dataset[_]): DataFrame = {
+  def normalizeColumnNames(
+      deltaLog: DeltaLog,
+      baseSchema: StructType,
+      data: Dataset[_]
+    ): DataFrame = {
     val dataSchema = data.schema
     val dataFields = explodeNestedFieldNames(dataSchema).toSet
     val tableFields = explodeNestedFieldNames(baseSchema).toSet
@@ -213,29 +300,30 @@ object SchemaUtils extends DeltaLogging {
       if (nonCdcFields.subsetOf(tableFields)) {
         return data.toDF()
       }
-      // Check that nested columns don't need renaming. We can't handle that right now
-      val topLevelDataFields = dataFields.map(UnresolvedAttribute.parseAttributeName(_).head)
-      if (topLevelDataFields.subsetOf(tableFields)) {
-        val columnsThatNeedRenaming = dataFields -- tableFields
-        throw DeltaErrors.nestedFieldsNeedRename(columnsThatNeedRenaming, baseSchema)
-      }
 
-      val baseFields = toFieldMap(baseSchema)
+      val baseFields = toFieldMap(baseSchema, caseSensitive = false)
       val aliasExpressions = dataSchema.map { field =>
-        val originalCase: String = baseFields.get(field.name) match {
-          case Some(original) => original.name
-          // This is a virtual partition column used for doing CDC writes. It's not actually
-          // in the table schema.
-          case None if field.name == CDCReader.CDC_TYPE_COLUMN_NAME ||
-            field.name == CDCReader.CDC_PARTITION_COL => field.name
-          case None =>
-            throw DeltaErrors.cannotResolveColumn(field.name, baseSchema)
+        val (originalCase, castDataType): (String, Option[DataType]) =
+          baseFields.get(field.name) match {
+            case Some(original) =>
+              val normalizedDataType = normalizeColumnNamesInDataType(deltaLog,
+                field.dataType, original.dataType, Seq(field.name), baseSchema)
+              (original.name, Option.when(field.dataType != normalizedDataType)(normalizedDataType))
+            // This is a virtual partition column used for doing CDC writes. It's not actually
+            // in the table schema.
+            case None if field.name == CDCReader.CDC_TYPE_COLUMN_NAME ||
+              field.name == CDCReader.CDC_PARTITION_COL => (field.name, None)
+            case None =>
+              throw DeltaErrors.cannotResolveColumn(field.name, baseSchema)
+          }
+        var expression = fieldToColumn(field)
+        castDataType.foreach { castType =>
+          expression = expression.cast(castType)
         }
         if (originalCase != field.name) {
-          fieldToColumn(field).as(originalCase)
-        } else {
-          fieldToColumn(field)
+          expression = expression.as(originalCase)
         }
+        expression
       }
       data.select(aliasExpressions: _*)
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2602,16 +2602,6 @@ trait DeltaErrorsSuiteBase
         Some(s"Can only drop nested columns from StructType. Found $StringType"))
     }
     {
-      val columnsThatNeedRename = Set("c0", "c1")
-      val schema = StructType(Seq(StructField("schema1", StringType)))
-      val e = intercept[DeltaAnalysisException] {
-        throw DeltaErrors.nestedFieldsNeedRename(columnsThatNeedRename, schema)
-      }
-      checkErrorMessage(e, Some("DELTA_NESTED_FIELDS_NEED_RENAME"), Some("42K05"),
-        Some("Nested fields need renaming to avoid data loss. Fields:\n[c0, c1].\n" +
-          s"Original schema:\n${schema.treeString}"))
-    }
-    {
       val locations = Seq("location1", "location2")
       val e = intercept[DeltaIllegalArgumentException] {
         throw DeltaErrors.cannotSetLocationMultipleTimes(locations)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
@@ -1931,7 +1931,6 @@ class SchemaUtilsSuite extends QueryTest
     )
     verifyColumnsWithCasts(normalized, Seq("s"))
     assert(normalized.schema === tableSchema)
-
   }
 
   test("normalize column names - can normalize CDC type column") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
@@ -20,6 +20,9 @@ package org.apache.spark.sql.delta.schema
 import java.util.Locale
 import java.util.regex.Pattern
 
+import scala.annotation.tailrec
+
+import org.apache.spark.sql.delta.{DeltaAnalysisException, DeltaLog, DeltaTestUtils}
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.schema.SchemaMergingUtils._
 import org.apache.spark.sql.delta.sources.DeltaSourceUtils.GENERATION_EXPRESSION_METADATA_KEY
@@ -28,9 +31,12 @@ import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import io.delta.tables.DeltaTable
 import org.scalatest.GivenWhenThen
 
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
-import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.{AnalysisException, Column, DataFrame, QueryTest, Row}
+import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.expressions.{Alias, Cast, Expression}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project}
+import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
 import org.apache.spark.sql.types._
@@ -259,7 +265,7 @@ class SchemaUtilsSuite extends QueryTest
    * Tests change of nullability within a schema (making a field nullable is not allowed,
    * but making a nullable field non-nullable is ok).
    *  - the make() function is a "factory" function to create schemas that vary only by the
-   *    nullability (of a field, array elemnt, or map values) in a specific position in the schema.
+   *    nullability (of a field, array element, or map values) in a specific position in the schema.
    *  - other tests will call this method with different make() functions to test nullability
    *    incompatibility in all the different places within a schema (in a top-level struct,
    *    in a nested struct, for the element type of an array, etc.)
@@ -1434,64 +1440,608 @@ class SchemaUtilsSuite extends QueryTest
     }
   }
 
+  /////////////////////////////////
+  // normalizeColumnNamesInDataType
+  /////////////////////////////////
+
+  private def checkNormalizedColumnNamesInDataType(
+      sourceDataType: DataType,
+      tableDataType: DataType,
+      expectedDataType: DataType): Unit = {
+    assert(normalizeColumnNamesInDataType(
+      deltaLog = null,
+      sourceDataType,
+      tableDataType,
+      sourceParentFields = Seq.empty,
+      tableSchema = new StructType()) == expectedDataType)
+  }
+
+  test("normalize column names in data type - atomic types") {
+    val source = new StructType()
+      .add("a", IntegerType)
+      .add("b", StringType)
+    val table = new StructType()
+      .add("B", StringType)
+      .add("A", IntegerType)
+    val expected = new StructType()
+      .add("A", IntegerType)
+      .add("B", StringType)
+    checkNormalizedColumnNamesInDataType(source, table, expected)
+  }
+
+  test("normalize column names in data type - incompatible atomic types") {
+    val source = new StructType()
+      .add("a", IntegerType)
+      .add("b", StringType)
+    val table = new StructType()
+      .add("B", StringType)
+      .add("A", LongType) // LongType != IntType
+    val exception = intercept[AssertionError] {
+      normalizeColumnNamesInDataType(
+        deltaLog = null,
+        source,
+        table,
+        sourceParentFields = Seq.empty,
+        tableSchema = new StructType())
+    }
+    assert(exception.getMessage.contains("Types without nesting should match"))
+  }
+
+  test("normalize column names in data type - nested structs") {
+    val source = new StructType()
+      .add("a1", IntegerType)
+      .add("a2", new StructType()
+        .add("b1", IntegerType)
+        .add("b2", new StructType()
+          .add("c1", IntegerType)
+          .add("c2", LongType)
+        )
+        .add("b3", LongType)
+      )
+      .add("a3", new StructType()
+        .add("d1", IntegerType)
+        .add("d2", LongType)
+      )
+    val table = new StructType()
+      .add("A3", new StructType()
+        .add("D2", LongType)
+        .add("D3x", StringType)
+        .add("D1", IntegerType)
+      )
+      .add("A2", new StructType()
+        .add("B3", LongType)
+        .add("B4x", IntegerType)
+        .add("B1", IntegerType)
+        .add("B2", new StructType()
+          .add("C3", LongType)
+          .add("C2", LongType)
+          .add("C1", IntegerType)
+        )
+      )
+      .add("A4x", StringType)
+      .add("A1", IntegerType)
+    val expected = new StructType()
+      .add("A1", IntegerType)
+      .add("A2", new StructType()
+        .add("B1", IntegerType)
+        .add("B2", new StructType()
+          .add("C1", IntegerType)
+          .add("C2", LongType))
+        .add("B3", LongType)
+      )
+      .add("A3", new StructType()
+        .add("D1", IntegerType)
+        .add("D2", LongType)
+      )
+    checkNormalizedColumnNamesInDataType(source, table, expected)
+  }
+
+  test("normalize column names in data type - incompatible types in a struct") {
+    val source = new StructType()
+      .add("a", new StructType()
+      .add("b", new StructType()
+      .add("c", MapType(StringType, IntegerType))))
+    val table = new StructType()
+      .add("A", new StructType()
+      .add("B", new StructType()
+      .add("C", MapType(IntegerType, StringType))))
+    val expected = new StructType()
+      .add("A", new StructType()
+      .add("B", new StructType()
+      .add("C", MapType(StringType, IntegerType))))
+    assertThrows[AssertionError] {
+      checkNormalizedColumnNamesInDataType(source, table, expected)
+    }
+  }
+
+  test("normalize column names in data type - arrays, maps, structs") {
+    val source = MapType(
+      new StructType()
+        .add("aa", IntegerType)
+        .add("bb", StringType),
+      ArrayType(new StructType()
+        .add("aa", IntegerType)
+        .add("bb", StringType)))
+    val table = MapType(
+      new StructType()
+        .add("aA", IntegerType)
+        .add("bB", StringType),
+      ArrayType(new StructType()
+        .add("Cc", IntegerType)
+        .add("Aa", IntegerType)
+        .add("Bb", StringType)))
+    val expected = MapType(
+      new StructType()
+        .add("aA", IntegerType)
+        .add("bB", StringType),
+      ArrayType(new StructType()
+        .add("Aa", IntegerType)
+        .add("Bb", StringType)))
+    checkNormalizedColumnNamesInDataType(source, table, expected)
+  }
+
+  test("normalize column names in data type - missing column") {
+    val source = ArrayType(
+      new StructType()
+        .add("aa", IntegerType)
+        .add("bb", StringType)
+    )
+    val target = ArrayType(
+      new StructType()
+        .add("AA", IntegerType)
+        .add("CC", StringType) // "bb" != "CC"
+    )
+    val exception = intercept[DeltaAnalysisException] {
+      normalizeColumnNamesInDataType(deltaLog = null, source, target,
+        Seq("x", "Y"), new StructType())
+    }
+    checkError(
+      exception = exception,
+      errorClass = "DELTA_CANNOT_RESOLVE_COLUMN",
+      sqlState = "42703",
+      parameters = Map("columnName" -> "x.Y.bb", "schema" -> "root\n")
+    )
+  }
+
+  test("normalize column names in data type - preserve nullability and comments") {
+    val source = new StructType()
+      .add("a1", IntegerType, nullable = true)
+      .add("a2", new StructType()
+        .add("b1", IntegerType, nullable = false)
+        .add("b2", ArrayType(IntegerType, containsNull = true),
+          nullable = true, comment = "comment for b2")
+        .add("b3", MapType(IntegerType, StringType, valueContainsNull = false),
+          nullable = true, comment = "comment for b3"),
+        nullable = false, comment = "comment for a2"
+      )
+    val table = new StructType()
+      .add("A1", IntegerType, nullable = false, "comment for A1")
+      .add("A2", new StructType()
+        .add("B1", IntegerType, nullable = true)
+        .add("B2", ArrayType(IntegerType, containsNull = false),
+          nullable = false, comment = "comment for B2")
+        .add("B3", MapType(IntegerType, StringType, valueContainsNull = true),
+          nullable = false, comment = "comment for B3"),
+        nullable = true
+      )
+    val expected = new StructType()
+      .add("A1", IntegerType, nullable = true)
+      .add("A2", new StructType()
+        .add("B1", IntegerType, nullable = false)
+        .add("B2", ArrayType(IntegerType, containsNull = true),
+          nullable = true, comment = "comment for b2")
+        .add("B3", MapType(IntegerType, StringType, valueContainsNull = false),
+          nullable = true, comment = "comment for b3"),
+        nullable = false, comment = "comment for a2"
+      )
+    checkNormalizedColumnNamesInDataType(source, table, expected)
+  }
+
+  test("normalize column names in data type - empty source struct") {
+    val source = new StructType()
+    val table = new StructType().add("a", IntegerType)
+    val expected = new StructType()
+    checkNormalizedColumnNamesInDataType(source, table, expected)
+  }
+
   ////////////////////////////
   // normalizeColumnNames
   ////////////////////////////
 
-  test("normalize column names") {
-    val df = Seq((1, 2, 3)).toDF("Abc", "def", "gHi")
-    val schema = new StructType()
-      .add("abc", IntegerType)
-      .add("Def", IntegerType)
-      .add("ghi", IntegerType)
-    assert(normalizeColumnNames(schema, df).schema.fieldNames === schema.fieldNames)
-  }
+  /**
+   * SchemaUtils.normalizeColumnNames() introduces a Project operator where for each of the
+   * top-level columns:
+   * - If a top-level field name differs from the table schema, we correct it using an Alias.
+   * - If a nested field name differs from the table schema, we correct it using a Cast.
+   * This function verifies that the Casts are only introduced for the correct subset of top-level
+   * columns.
+   */
+  private def verifyColumnsWithCasts(df: DataFrame, columnsWithCasts: Seq[String]): Unit = {
+    @tailrec def isCast(expression: Expression): Boolean = expression match {
+      case _: Cast => true
+      case Alias(child, _) => isCast(child)
+      case _ => false
+    }
 
-  test("normalize column names - different ordering") {
-    val df = Seq((1, 2, 3)).toDF("def", "gHi", "abC")
-    val schema = new StructType()
-      .add("abc", IntegerType)
-      .add("Def", IntegerType)
-      .add("ghi", IntegerType)
-    assert(normalizeColumnNames(schema, df).schema.fieldNames === Seq("Def", "ghi", "abc"))
-  }
-
-  test("normalize column names - dots in the name") {
-    val df = Seq((1, 2)).toDF("a.b", "c.D")
-    val schema = new StructType().add("a.b", IntegerType).add("c.d", IntegerType)
-    assert(normalizeColumnNames(schema, df).schema.fieldNames === Seq("a.b", "c.d"))
-  }
-
-  test("throw error if nested column cases don't match") {
-    val df = spark.read.json(Seq("""{"a":1,"b":{"X":1,"y":2}}""").toDS())
-    val schema = new StructType()
-      .add("a", IntegerType)
-      .add("b", new StructType()
-        .add("x", IntegerType)
-        .add("y", IntegerType))
-    expectFailure("[b.X]", "b.x") {
-      normalizeColumnNames(schema, df)
+    val plan = df.queryExecution.analyzed
+    val projections = plan.asInstanceOf[Project].projectList
+    for (projection <- projections) {
+      val expectedIsCast = columnsWithCasts.contains(projection.name)
+      val actualIsCast = isCast(projection)
+      assert(expectedIsCast === actualIsCast, s"Verifying cast for ${projection.name}")
     }
   }
 
-  test("can rename top level nested column") {
-    val df = spark.read.json(Seq("""{"a":1,"B":{"x":1,"y":2}}""").toDS()).select('a, 'b)
-    val schema = new StructType()
-      .add("a", IntegerType)
-      .add("b", new StructType()
-        .add("x", IntegerType)
-        .add("y", IntegerType))
-    assert(normalizeColumnNames(schema, df).schema.fieldNames === Seq("a", "b"))
-  }
-
-  test("can normalize CDC type column") {
-    val df = Seq((1, 2, 3, 4)).toDF("Abc", "def", "gHi", CDCReader.CDC_TYPE_COLUMN_NAME)
-    val schema = new StructType()
+  test("normalize column names - different top-level ordering") {
+    val df = Seq((1, 2, 3)).toDF("def", "gHi", "abC")
+    val tableSchema = new StructType()
       .add("abc", IntegerType)
       .add("Def", IntegerType)
       .add("ghi", IntegerType)
-    assert(normalizeColumnNames(schema, df).schema.fieldNames ===
-      schema.fieldNames :+ CDCReader.CDC_TYPE_COLUMN_NAME)
+      // Add an extra column to the table schema to make sure it is not added, and does not cause
+      // an error.
+      .add("jkl", StringType)
+    val expectedSchema = new StructType()
+      .add("Def", IntegerType, false)
+      .add("ghi", IntegerType, false)
+      .add("abc", IntegerType, false)
+    val normalized = normalizeColumnNames(
+      deltaLog = null,
+      tableSchema,
+      df
+    )
+    verifyColumnsWithCasts(normalized, Seq.empty)
+    assert(normalized.schema == expectedSchema)
+  }
+
+  test("normalize column names - dots in the name") {
+    val df = spark.read.json(Seq("""{"a.b":1,"c.d":{"x.y":2, "y.z":1}}""").toDS())
+    val tableSchema = new StructType()
+      .add("c.D", new StructType()
+        .add("y.z", LongType)
+        .add("x.Y", LongType)
+      )
+      .add("a.B", LongType)
+    val expectedSchema = new StructType()
+      .add("a.B", LongType, nullable = true)
+      .add("c.D", new StructType()
+        .add("x.Y", LongType, nullable = true)
+        .add("y.z", LongType, nullable = true),
+        nullable = true
+      )
+    val normalized = normalizeColumnNames(
+      deltaLog = null,
+      tableSchema,
+      df
+    )
+    verifyColumnsWithCasts(normalized, Seq("c.D"))
+    assert(normalized.schema === expectedSchema)
+  }
+
+  test("normalize column names - different case in struct") {
+    // JSON schema inference does not preserve the order of columns, so we need an explicit schema.
+    val jsonSchema = new StructType()
+      .add("b", new StructType()
+        .add("x", LongType)
+        .add("y", new StructType()
+          .add("T", LongType)
+          .add("s", LongType)
+        )
+      )
+      .add("a", LongType)
+    val df = spark.read.schema(jsonSchema)
+      .json(Seq("""{"b":{"x":1,"y":{"T":2, "s":1}}, "a":1}""").toDS())
+    val tableSchema = new StructType()
+      .add("a", LongType)
+      .add("b", new StructType()
+        .add("x", LongType)
+        .add("y", new StructType()
+          .add("s", LongType)
+          .add("t", LongType)
+        )
+      )
+    val expectedSchema = new StructType()
+      .add("b", new StructType()
+        .add("x", LongType)
+        .add("y", new StructType()
+          .add("t", LongType)
+          .add("s", LongType)
+        )
+      )
+      .add("a", LongType)
+    val normalized = normalizeColumnNames(
+      deltaLog = null,
+      tableSchema,
+      df
+    )
+    verifyColumnsWithCasts(normalized, Seq("b"))
+    assert(normalized.schema === expectedSchema)
+  }
+
+  test("normalize column names - different case in array") {
+    val df = spark.read.json(Seq("""{"X":1,"y":[{"Z": "alpha"},{"Z":"beta"}]}""").toDS())
+    val tableSchema = new StructType()
+      .add("x", LongType)
+      .add("y", ArrayType(new StructType().add("z", StringType)))
+    val normalized = normalizeColumnNames(
+      deltaLog = null,
+      tableSchema,
+      df
+    )
+    verifyColumnsWithCasts(normalized, Seq("y"))
+    assert(normalized.schema == tableSchema)
+  }
+
+  test("normalize column names - different case in map") {
+    val sourceMapType = MapType(StringType, new StructType().add("Z", StringType))
+    val df = spark.range(1).toDF("X")
+      .withColumn("y", lit(null).cast(sourceMapType))
+      .select(col("y"), col("X"))
+    val tableSchema = new StructType()
+      .add("x", LongType)
+      .add("y", MapType(StringType, new StructType()
+        .add("z", StringType)
+        // Add an extra nested column to the table schema to make sure it is not added.
+        .add("v", IntegerType)))
+    val expectedSchema = new StructType()
+      .add("y", MapType(StringType, new StructType().add("z", StringType)))
+      .add("x", LongType, nullable = false)
+    val normalized = normalizeColumnNames(
+      deltaLog = null,
+      tableSchema,
+      df
+    )
+    verifyColumnsWithCasts(normalized, Seq("y"))
+    assert(normalized.schema === expectedSchema)
+  }
+
+  test("normalize column names - maintain nested column order") {
+    val sourceStructColumnNames =
+      Seq("the", "quick", "brown", "fox", "jumps", "over", "them", "lazy", "dog")
+    val sourceStructType = new StructType(
+      sourceStructColumnNames.map(StructField(_, IntegerType)).toArray)
+
+    // Nested columns in the table are all name in upper case, and listed in reverse order.
+    val tableStructColumnNames = Seq("LOOK") ++
+      sourceStructColumnNames.reverse.map(_.toUpperCase(Locale.ROOT))
+    val tableSchema = new StructType()
+      .add("s", new StructType(
+        tableStructColumnNames.map(StructField(_, IntegerType)).toArray))
+
+    // We expect the columns to maintain the same order as the source.
+    val expectedStructColumnNames = sourceStructColumnNames.map(_.toUpperCase(Locale.ROOT))
+    val expectedSchema = new StructType()
+      .add("s", new StructType(
+        expectedStructColumnNames.map(StructField(_, IntegerType)).toArray))
+
+    val df = spark.range(1).toDF("id")
+      .select(lit(null).cast(sourceStructType).as("s"))
+    val normalized = normalizeColumnNames(
+      deltaLog = null,
+      tableSchema,
+      df
+    )
+    verifyColumnsWithCasts(normalized, Seq("s"))
+    assert(normalized.schema === expectedSchema)
+  }
+
+  test("normalize column names - only top-level names of complex columns differ") {
+    val structType = new StructType()
+      .add("a", IntegerType)
+      .add("b", IntegerType)
+    val mapType = MapType(structType, structType)
+    val arrayType = ArrayType(structType)
+
+    val df = spark.range(1).toDF("id")
+      .select(lit(null).cast(structType).as("x"),
+        lit(null).cast(mapType).as("y"),
+        lit(null).cast(arrayType).as("z"))
+    val tableSchema = new StructType()
+      .add("X", structType)
+      .add("Y", mapType)
+      .add("Z", arrayType)
+    val normalized = normalizeColumnNames(
+      deltaLog = null,
+      tableSchema,
+      df
+    )
+    // If only top-level names differ, there is no need to cast complex types.
+    verifyColumnsWithCasts(normalized, Seq.empty)
+    assert(normalized.schema === tableSchema)
+  }
+
+  test("normalize column names - unmatched top-level column") {
+    val df = spark.range(1).toDF("id")
+      .select(lit(1L).as("one"), lit(2L).as("two"))
+    val tableSchema = new StructType()
+      .add("ONE", LongType)
+      .add("THREE", LongType)
+    val exception = intercept[DeltaAnalysisException] {
+      normalizeColumnNames(
+        deltaLog = null,
+        tableSchema,
+        df
+      )
+    }
+    checkError(
+      exception = exception,
+      errorClass = "DELTA_CANNOT_RESOLVE_COLUMN",
+      sqlState = "42703",
+      parameters = Map("columnName" -> "two", "schema" -> tableSchema.treeString)
+    )
+  }
+
+  test("normalize column names - unmatched nested column") {
+    val sourceStructType = new StructType()
+      .add("one", LongType)
+      .add("two", LongType)
+    val df = spark.range(1).toDF("id")
+      .select(lit(null).cast(sourceStructType).as("s"))
+    val tableSchema = new StructType()
+      .add("S", new StructType()
+        .add("ONE", LongType)
+        .add("THREE", LongType)
+      )
+    val exception = intercept[DeltaAnalysisException] {
+      normalizeColumnNames(
+        deltaLog = null,
+        tableSchema,
+        df
+      )
+    }
+    checkError(
+      exception = exception,
+      errorClass = "DELTA_CANNOT_RESOLVE_COLUMN",
+      sqlState = "42703",
+      parameters = Map("columnName" -> "s.two", "schema" -> tableSchema.treeString)
+    )
+  }
+
+  test("normalize column names - deeply nested schema") {
+    // The only difference is the case of the most deeply nested column.
+    val structTypes = Seq("z", "Z").map { finalColumnName =>
+      new StructType()
+        .add("a", IntegerType)
+        .add("b", MapType(StringType, new StructType()
+          .add("c", IntegerType)
+          .add("d", new StructType()
+            .add("e", IntegerType)
+            .add("f", IntegerType)
+            .add("g", ArrayType(new StructType()
+              .add("h", IntegerType)
+              .add("i", IntegerType)
+              .add("j", new StructType()
+                .add("k", MapType(StringType, new StructType()
+                  .add("l", ArrayType(new StructType()
+                    .add("m", IntegerType)
+                    .add(finalColumnName, IntegerType)
+      ))))))))))
+    }.toArray
+
+    val sourceStructType = structTypes(0)
+    val df = spark.range(1).toDF("id")
+      .select(lit(null).cast(sourceStructType).as("s"))
+    val tableStructType = structTypes(1)
+    val tableSchema = new StructType()
+      .add("s", tableStructType)
+    val normalized = normalizeColumnNames(
+      deltaLog = null,
+      tableSchema,
+      df
+    )
+    verifyColumnsWithCasts(normalized, Seq("s"))
+    assert(normalized.schema === tableSchema)
+
+  }
+
+  test("normalize column names - can normalize CDC type column") {
+    val df = Seq((1, 2, 3, 4)).toDF("Abc", "def", "gHi", CDCReader.CDC_TYPE_COLUMN_NAME)
+    val tableSchema = new StructType()
+      .add("abc", IntegerType)
+      .add("Def", IntegerType)
+      .add("ghi", IntegerType)
+    val normalized = normalizeColumnNames(
+      deltaLog = null,
+      tableSchema,
+      df
+    )
+    verifyColumnsWithCasts(normalized, Seq.empty)
+    assert(normalized.schema.fieldNames ===
+      tableSchema.fieldNames :+ CDCReader.CDC_TYPE_COLUMN_NAME)
+  }
+
+  private def checkLatestStatsForOneRowFile(
+      tableName: String,
+      expectedStats: Map[String, Option[Any]]): Unit = {
+    val snapshot = DeltaLog.forTable(spark, TableIdentifier(tableName)).update()
+    val fileStats = snapshot.allFiles
+      .orderBy(desc("modificationTime"))
+      .limit(1)
+      .withColumn("stats", from_json(col("stats"), snapshot.statsSchema))
+      .select("stats.*")
+
+    val assertions = Seq(assert_true(col("numRecords") === lit(1L))) ++
+        expectedStats.flatMap { case (columnName, columnValue) =>
+      columnValue match {
+        case Some(value) => Seq(
+          assert_true(col("minValues." + columnName) === lit(value)),
+          assert_true(col("maxValues." + columnName) === lit(value)),
+          assert_true(col("nullCount." + columnName) === lit(0L)))
+        case None => Seq(
+          assert_true(col("minValues." + columnName).isNull),
+          assert_true(col("maxValues." + columnName).isNull),
+          assert_true(col("nullCount." + columnName) === lit(1L)))
+      }
+    }
+    fileStats.select(assertions: _*).collect()
+  }
+
+  for (caseSensitive <- DeltaTestUtils.BOOLEAN_DOMAIN) {
+    test(s"normalize column names - e2e nested struct (caseSensitive=$caseSensitive)") {
+      withSQLConf(SQLConf.CASE_SENSITIVE.key -> caseSensitive.toString) {
+        val sourceData = Seq((105L, "foo", 205L, "bar",
+            Struct1("James", 11, "Smith", 3000, "Correct")))
+        val sourceDf = sourceData.toDF("long1", "str1", "long2", "str2", "struct1")
+        val sourceSchema = new StructType()
+          .add("long1", LongType, nullable = false)
+          .add("str1", StringType, nullable = true)
+          .add("long2", LongType, nullable = false)
+          .add("str2", StringType, nullable = true)
+          .add("struct1", new StructType()
+            .add("firstname", StringType, nullable = true)
+            .add("numberone", LongType, nullable = false)
+            .add("lastname", StringType, nullable = true)
+            .add("numbertwo", LongType, nullable = false)
+            .add("CorrectCase", StringType, nullable = true),
+            nullable = true
+          )
+        assert(sourceDf.schema === sourceSchema)
+        val createTableCommand =
+          """ CREATE TABLE t (
+            |  Long2 LONG, Str2 STRING, Long1 LONG, Str1 STRING, Int1 INT,
+            |  Struct1 STRUCT<LastName: STRING, NumberTwo: LONG, FirstName: STRING,
+            |    NumberOne: LONG, MissingNested: INT, CorrectCase: STRING>
+            | ) USING delta
+            |""".stripMargin
+
+        withTable("t") {
+          sql(createTableCommand)
+          sourceDf.write.format("delta").mode("append").saveAsTable("t")
+
+          // Make sure all the values were inserted into the right columns, and columns missing in
+          // the source were set to null.
+          spark.table("t")
+            .select(
+              assert_true(col("Long2") === 205L),
+              assert_true(col("Str2") === "bar"),
+              assert_true(col("Long1") === 105L),
+              assert_true(col("Str1") === "foo"),
+              assert_true(col("Int1").isNull),
+              assert_true(col("Struct1.LastName") === "Smith"),
+              assert_true(col("Struct1.NumberTwo") === 3000L),
+              assert_true(col("Struct1.FirstName") === "James"),
+              assert_true(col("Struct1.NumberOne") === 11L),
+              assert_true(col("Struct1.MissingNested").isNull),
+              assert_true(col("Struct1.CorrectCase") === "Correct")
+            ).collect()
+
+          // Make sure each of the columns stats was computed correctly.
+          checkLatestStatsForOneRowFile("t", Map(
+            "Long2" -> Some(205L),
+            "Str2" -> Some("bar"),
+            "Long1" -> Some(105L),
+            "Str1" -> Some("foo"),
+            "Int1" -> None,
+            "Struct1.LastName" -> Some("Smith"),
+            "Struct1.NumberTwo" -> Some(3000L),
+            "Struct1.FirstName" -> Some("James"),
+            "Struct1.NumberOne" -> Some(11L),
+            "Struct1.MissingNested" -> None,
+            "Struct1.CorrectCase" -> Some("Correct")
+          ))
+        }
+      }
+    }
   }
 
   ////////////////////////////
@@ -2176,3 +2726,9 @@ class PointUDT extends UserDefinedType[Point] {
 class UnsupportedUDT extends PointUDT {
   override def sqlType: DataType = UnsupportedDataType
 }
+case class Struct1(
+    firstname: String,
+    numberone: Long,
+    lastname: String,
+    numbertwo: Long,
+    CorrectCase: String)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Function `SchemaUtils.normalizeSchemaNames()` is used during a Delta write. It was intended to correct the case of names of any top level-fields that differed between the input schema and the table. If the case of any nested field differed, the function was supposed to raise an exception.

However, due to a long-standing bug, the function could instead ignore the difference in the nested fields. This results in a data corruption. While the column values are written into the Delta table, the stats for these column are not gathered correctly. Instead, the stats are recorded as-if the column was missing in the input, that is: `minValue = null`, `maxValue = null`, `nullCount = rowCount`.

This PR implements the full normalization of nested field names to fix this.

## How was this patch tested?

New tests in `SchemaUtilsSuite.scala`.

## Does this PR introduce _any_ user-facing changes?

No.
