### PR TITLE
Fix Delta Sharing DataFrame not updated for Snapshot Query

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -224,7 +224,7 @@ lazy val sharing = (project in file("sharing"))
     libraryDependencies ++= Seq(
       "org.apache.spark" %% "spark-sql" % sparkVersion % "provided",
 
-      "io.delta" %% "delta-sharing-client" % "1.0.4",
+      "io.delta" %% "delta-sharing-client" % "1.0.3",
 
       // Test deps
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -224,7 +224,7 @@ lazy val sharing = (project in file("sharing"))
     libraryDependencies ++= Seq(
       "org.apache.spark" %% "spark-sql" % sparkVersion % "provided",
 
-      "io.delta" %% "delta-sharing-client" % "1.0.3",
+      "io.delta" %% "delta-sharing-client" % "1.0.4",
 
       // Test deps
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test",

--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingDataSource.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingDataSource.scala
@@ -391,7 +391,7 @@ private[sharing] class DeltaSharingDataSource
     val params = new DeltaSharingFileIndexParams(
       new Path(path),
       spark,
-      deltaSharingTableMetadata.metadata,
+      deltaSharingTableMetadata,
       options
     )
     if (ConfUtils.limitPushdownEnabled(spark.sessionState.conf)) {

--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala
@@ -276,9 +276,10 @@ object DeltaSharingUtils extends Logging {
       options: DeltaSharingOptions,
       partitionFiltersString: String,
       dataFiltersString: String,
-      jsonPredicateHints: String): String = {
+      jsonPredicateHints: String,
+      version: Long): String = {
     val fullQueryString = s"${options.versionAsOf}_${options.timestampAsOf}_" +
-      s"${partitionFiltersString}_${dataFiltersString}_${jsonPredicateHints}"
+      s"${partitionFiltersString}_${dataFiltersString}_${jsonPredicateHints}_${version}"
     Hashing.sha256().hashString(fullQueryString, UTF_8).toString
   }
 

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingFileIndexSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingFileIndexSuite.scala
@@ -59,7 +59,8 @@ private object TestUtils {
   }
 
   // scalastyle:off line.size.limit
-  val protocolStr = """{"protocol":{"deltaProtocol":{"minReaderVersion": 1, "minWriterVersion": 1}}}"""
+  val protocolStr =
+    """{"protocol":{"deltaProtocol":{"minReaderVersion": 1, "minWriterVersion": 1}}}"""
   val metaDataStr =
     """{"metaData":{"size":809,"deltaMetadata":{"id":"testId","format":{"provider":"parquet","options":{}},"schemaString":"{\"type\":\"struct\",\"fields\":[{\"name\":\"c1\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}},{\"name\":\"c2\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]}","partitionColumns":["c2"],"configuration":{},"createdTime":1691734718560}}}"""
   val metaDataWithoutSizeStr =

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingFileIndexSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingFileIndexSuite.scala
@@ -224,7 +224,7 @@ class DeltaSharingFileIndexSuite
       DeltaSharingUtils.DeltaSharingTableMetadata(
         version = 0,
         protocol = JsonUtils.fromJson[model.DeltaSharingSingleAction](protocolStr).protocol,
-        metadata = getMockedDeltaSharingMetadata(metaData),
+        metadata = getMockedDeltaSharingMetadata(metaData)
       ),
       new DeltaSharingOptions(Map("path" -> tablePath.toString))
     )


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Sharing)

## Description
Fix Delta Sharing DataFrame not updated for Snapshot Query:
When provider updated the table(insert or delete row), in delta-sharing-spark session, the dataframe on the same query for the same table is not updated, though a new rpc is made, the local delta log is updated, but it’s still at version 0.

## How was this patch tested?
Unit Test, Integration Test

```
scala> val df = spark.read.format("deltaSharing").load(dvcmtable2)
df: org.apache.spark.sql.DataFrame = [id2: int, name: string]

scala> df.show()
+---+----+                                                                      
|id2|name|
+---+----+
|  2| one|
|  3| one|
+---+----+

// Insert on provider table

scala> val df = spark.read.format("deltaSharing").load(dvcmtable2)
df: org.apache.spark.sql.DataFrame = [id2: int, name: string]

scala> df.show()
+---+----+                                                                      
|id2|name|
+---+----+
|  6| one|
|  3| one|
|  2| one|
+---+----+

```

## Does this PR introduce _any_ user-facing changes?
No
