### PR TITLE
[Spark] Override Jackson string length limits

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/JsonUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/JsonUtils.scala
@@ -30,6 +30,8 @@ object JsonUtils {
     _mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     _mapper.registerModule(DefaultScalaModule)
 
+    // We do not want to limit the length of JSON strings in the Delta log or table data. Also note
+    // that not having a limit was the default behavior before Jackson 2.15.
     val streamReadConstraints = StreamReadConstraints
       .builder()
       .maxStringLength(Int.MaxValue)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/JsonUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/JsonUtils.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.delta.util
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include
+import com.fasterxml.jackson.core.StreamReadConstraints
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
 import com.fasterxml.jackson.module.scala.{DefaultScalaModule, ScalaObjectMapper}
 
@@ -28,6 +29,13 @@ object JsonUtils {
     _mapper.setSerializationInclusion(Include.NON_ABSENT)
     _mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     _mapper.registerModule(DefaultScalaModule)
+
+    val streamReadConstraints = StreamReadConstraints
+      .builder()
+      .maxStringLength(Int.MaxValue)
+      .build()
+    _mapper.getFactory.setStreamReadConstraints(streamReadConstraints)
+
     _mapper
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/util/JsonUtilsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/util/JsonUtilsSuite.scala
@@ -47,7 +47,7 @@ class JsonUtilsSuite
   }
 
   test("Serialize and de-serialize commit info with large message") {
-    val operationStringSize = 200000000 // 200 MB, way above the 20MB default limit
+    val operationStringSize = StreamReadConstraints.DEFAULT_MAX_STRING_LEN * 10
     assert(operationStringSize > StreamReadConstraints.DEFAULT_MAX_STRING_LEN)
 
     val operation = Random.alphanumeric.take(operationStringSize).toString()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/util/JsonUtilsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/util/JsonUtilsSuite.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.util
+
+import scala.util.Random
+
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.actions.CommitInfo
+import org.apache.spark.sql.delta.stats.DataSize
+import com.fasterxml.jackson.core.StreamReadConstraints
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.test.SharedSparkSession
+
+class JsonUtilsSuite
+  extends QueryTest
+  with SharedSparkSession {
+
+  test("DataSize json serialization") {
+    val testCases = Seq(
+      DataSize() -> """{}""",
+      DataSize(bytesCompressed = Some(816L)) -> """{"bytesCompressed":816}""",
+      DataSize(rows = Some(111L)) -> """{"rows":111}""",
+      DataSize(logicalRows = Some(111L)) -> """{"logicalRows":111}""",
+      DataSize(bytesCompressed = Some(816L), rows = Some(111L), logicalRows = Some(111L)) ->
+        """{"bytesCompressed":816,"rows":111,"logicalRows":111}"""
+    )
+    for ((obj, json) <- testCases) {
+      assert(JsonUtils.toJson(obj) == json)
+      assert(JsonUtils.fromJson[DataSize](json) == obj)
+    }
+  }
+
+  test("Serialize and de-serialize commit info with large message") {
+    val operationStringSize = 200000000 // 200 MB, way above the 20MB default limit
+    assert(operationStringSize > StreamReadConstraints.DEFAULT_MAX_STRING_LEN)
+
+    val operation = Random.alphanumeric.take(operationStringSize).toString()
+    val commitInfo = CommitInfo(
+      time = System.currentTimeMillis(),
+      operation,
+      operationParameters = Map.empty,
+      commandContext = Map.empty,
+      readVersion = Some(1),
+      isolationLevel = None,
+      isBlindAppend = Some(false),
+      operationMetrics = None,
+      userMetadata = Some("I am a test and not a user"),
+      tags = None,
+      txnId = Some("Transaction with a veryyyyyyy large commit info")
+    )
+
+    val serialized = JsonUtils.toJson(commitInfo)
+    val deserialized = JsonUtils.fromJson[CommitInfo](serialized)
+
+    assert(commitInfo === deserialized)
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/util/JsonUtilsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/util/JsonUtilsSuite.scala
@@ -36,7 +36,9 @@ class JsonUtilsSuite
       DataSize() -> """{}""",
       DataSize(bytesCompressed = Some(816L)) -> """{"bytesCompressed":816}""",
       DataSize(rows = Some(111L)) -> """{"rows":111}""",
+      DataSize(rows = Some(0)) -> """{"rows":0}""",
       DataSize(logicalRows = Some(111L)) -> """{"logicalRows":111}""",
+      DataSize(logicalRows = Some(-1L)) -> """{"logicalRows":-1}""",
       DataSize(bytesCompressed = Some(816L), rows = Some(111L), logicalRows = Some(111L)) ->
         """{"bytesCompressed":816,"rows":111,"logicalRows":111}"""
     )


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Override the Jackson string length limit to allow reading and writing large json objects to and from the Delta Log.

## How was this patch tested?

Added a new test suite

## Does this PR introduce _any_ user-facing changes?

No
