### PR TITLE
[Spark] Increase test heap size

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -79,8 +79,8 @@ def run_sbt_tests(root_dir, test_group, coverage, scala_version=None):
     # https://docs.oracle.com/javase/7/docs/technotes/guides/vm/G1.html
     # a GC that is optimized for larger multiprocessor machines with large memory
     cmd += ["-J-XX:+UseG1GC"]
-    # 4x the default heap size (set in delta/built.sbt)
-    cmd += ["-J-Xmx4G"]
+    # 6x the default heap size (set in delta/built.sbt)
+    cmd += ["-J-Xmx6G"]
     run_cmd(cmd, stream_output=True)
 
 def run_python_tests(root_dir):


### PR DESCRIPTION
## Description

Increase spark test heap size from 4GB to 6GB to prevent `java.lang.OutOfMemoryError: GC overhead limit exceeded`

## How was this patch tested?

Trivial. Existing CI tests.