### PR TITLE
[Spark] Introduce tag delta.rowTracking.preserved tag

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaCommitTag.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaCommitTag.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.actions.CommitInfo
+
+/** Marker trait for a commit tag used by delta. */
+sealed trait DeltaCommitTag {
+
+  /** Key to be used in the commit tags `Map[String, String]`. */
+  def key: String
+
+  /**
+   * Combine tags coming from multiple sub-jobs into a single tag according to the tags'
+   * semantics.
+   */
+  def merge(left: String, right: String): String
+}
+
+object DeltaCommitTag {
+
+  trait TypedCommitTag[ValueT] extends DeltaCommitTag {
+
+    /**
+     * Combine tags coming from multiple sub-jobs into a single tag according to the tags'
+     * semantics.
+     */
+    def mergeTyped(left: ValueT, right: ValueT): ValueT
+
+    override def merge(left: String, right: String): String =
+      valueToString(mergeTyped(valueFromString(left), valueFromString(right)))
+
+    /**
+     * Combine tags coming from multiple sub-jobs into a single tag according to the tags'
+     * semantics.
+     *
+     * This variant is used when adding a new typed value to a potentially existing value from a
+     * `Map[<tagtype>, String]`.
+     */
+    def mergeWithNewTypedValue(existingOpt: Option[String], newValue: ValueT): String = {
+      existingOpt match {
+        case Some(existing) => valueToString(mergeTyped(valueFromString(existing), newValue))
+        case None => valueToString(newValue)
+      }
+    }
+
+    /** Deserialize a value for this tag from String. */
+    def valueFromString(s: String): ValueT
+
+    /** Serialize a value for this tag to String. */
+    def valueToString(value: ValueT): String = value.toString
+
+    def withValue(value: ValueT): TypedCommitTagPair[ValueT] = TypedCommitTagPair(this, value)
+  }
+
+  final case class TypedCommitTagPair[ValueT](tag: TypedCommitTag[ValueT], value: ValueT) {
+    /** Produce a tuple for inserting into `Map[DeltaCommitTag, String]` instances. */
+    def stringValue: (DeltaCommitTag, String) = tag -> tag.valueToString(value)
+
+    /** Produce a tuple for inserting into `Map[String, String]` instances. */
+    def stringPair: (String, String) = tag.key -> tag.valueToString(value)
+  }
+
+  /** Any [[DeltaCommitTag]] where `ValueT` is `Boolean`. */
+  trait BooleanCommitTag extends TypedCommitTag[Boolean] {
+    override def valueFromString(value: String): Boolean = value.toBoolean
+  }
+
+  /**
+   * Tag to indicate whether the operation preserved row tracking. If not set, it is assumed that
+   * the operation did not preserve row tracking.
+   */
+  case object PreservedRowTrackingTag extends BooleanCommitTag {
+    override val key = "delta.rowTracking.preserved"
+
+    override def mergeTyped(left: Boolean, right: Boolean): Boolean = left && right
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DMLUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DMLUtils.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands
+
+import org.apache.spark.sql.delta.DeltaCommitTag
+import org.apache.spark.sql.delta.actions.{Action, FileAction}
+
+object DMLUtils {
+
+  /** Holder for some of the parameters for a `OptimisticTransaction.commit` */
+  case class TaggedCommitData[A <: Action](
+      actions: Seq[A],
+      tags: Map[DeltaCommitTag, String] = Map.empty) {
+
+    def withTag[T](key: DeltaCommitTag.TypedCommitTag[T], value: T): TaggedCommitData[A] = {
+      val mergedValue = key.mergeWithNewTypedValue(tags.get(key), value)
+      this.copy(tags = this.tags + (key -> mergedValue))
+    }
+
+    def stringTags: Map[String, String] = tags.map { case (k, v) => k.key -> v }
+  }
+
+  object TaggedCommitData {
+    def empty[A <: Action]: TaggedCommitData[A] = TaggedCommitData(Seq.empty[A])
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDeltaLike.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDeltaLike.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.delta.OptimisticTransaction
 import org.apache.spark.sql.delta.actions.Action
 import org.apache.spark.sql.delta.actions.AddCDCFile
 import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.commands.DMLUtils.TaggedCommitData
 import org.apache.spark.sql.delta.constraints.Constraint
 import org.apache.spark.sql.delta.constraints.Constraints.Check
 import org.apache.spark.sql.delta.constraints.Invariants.ArbitraryExpression
@@ -58,11 +59,18 @@ trait WriteIntoDeltaLike {
   /**
    * Write [[data]] into Delta table as part of [[txn]] and @return the actions to be committed.
    */
+  def writeAndReturnCommitData(
+      txn: OptimisticTransaction,
+      sparkSession: SparkSession,
+      clusterBySpecOpt: Option[ClusterBySpec] = None,
+      isTableReplace: Boolean = false): TaggedCommitData[Action]
+
   def write(
       txn: OptimisticTransaction,
       sparkSession: SparkSession,
       clusterBySpecOpt: Option[ClusterBySpec] = None,
-      isTableReplace: Boolean = false): Seq[Action]
+      isTableReplace: Boolean = false): Seq[Action] = writeAndReturnCommitData(
+    txn, sparkSession, clusterBySpecOpt, isTableReplace).actions
 
   val deltaLog: DeltaLog
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Introduce `delta.rowTracking.preserved` commit tag that should be set by transactions that preserve Row Tracking. This commit adds only the tag definition and helper code for manipulating tags to prepare for subsequent commits that will actually use it.

## How was this patch tested?

Existing tests.

## Does this PR introduce _any_ user-facing changes?

N/A