### PR TITLE
[Spark] Add config to make post-commit hooks throw on error

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1939,7 +1939,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
           "version" -> version,
           "exception" -> e.toString
         ))
-        hook.handleError(e, version)
+        hook.handleError(spark, e, version)
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
@@ -76,7 +76,7 @@ trait GenerateSymlinkManifestImpl extends PostCommitHook with DeltaLogging with 
       spark, txn.deltaLog, txn.snapshot, postCommitSnapshot, committedActions)
   }
 
-  override def handleError(error: Throwable, version: Long): Unit = {
+  override def handleError(spark: SparkSession, error: Throwable, version: Long): Unit = {
     error match {
       case e: ColumnMappingUnsupportedException => throw e
       case e: DeltaCommandUnsupportedWithDeletionVectorsException => throw e

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/PostCommitHook.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/PostCommitHook.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.delta.hooks
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.Action
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.sql.SparkSession
 
@@ -51,5 +52,9 @@ trait PostCommitHook {
    * Handle any error caused while running the hook. By default, all errors are ignored as
    * default policy should be to not let post-commit hooks to cause failures in the operation.
    */
-  def handleError(error: Throwable, version: Long): Unit = {}
+  def handleError(spark: SparkSession, error: Throwable, version: Long): Unit = {
+    if (spark.conf.get(DeltaSQLConf.DELTA_POST_COMMIT_HOOK_THROW_ON_ERROR)) {
+      throw DeltaErrors.postCommitHookFailedException(this, version, name, error)
+    }
+  }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1617,6 +1617,17 @@ trait DeltaSQLConfBase {
       .internal()
       .booleanConf
       .createWithDefault(true)
+
+
+  ///////////
+  // TESTING
+  ///////////
+  val DELTA_POST_COMMIT_HOOK_THROW_ON_ERROR =
+    buildConf("postCommitHook.throwOnError")
+      .internal()
+      .doc("If true, post-commit hooks will by default throw an exception when they fail.")
+      .booleanConf
+      .createWithDefault(Utils.isTesting)
 }
 
 object DeltaSQLConf extends DeltaSQLConfBase


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Currently most post-commit hooks, except manifest generation, suppress errors, i.e. they are logged but do not throw during the command that triggered them. Although this makes sense for production, it can hide issues in testing. This commit adds a config to make post-commit hooks always throw an exception.

## How was this patch tested?

Existing tests provide sufficient coverage.

## Does this PR introduce _any_ user-facing changes?

No