### PR TITLE
[Spark] Always materialize the merge source if it contains a UDF

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
@@ -260,6 +260,11 @@ trait MergeIntoMaterializeSource extends DeltaLogging with DeltaSparkPlanUtils {
         } else if (forceMaterializationWithUnreadableFiles &&
             ignoreUnreadableFilesConfigsAreSet(source, spark)) {
           (true, MergeIntoMaterializeSourceReason.IGNORE_UNREADABLE_FILES_CONFIGS_ARE_SET)
+        } else if (planContainsUdf(source)) {
+          // Force source materialization if the source contains a User Defined Function, even if
+          // the user defined function is marked as deterministic, as it is often incorrectly marked
+          // as such.
+          (true, MergeIntoMaterializeSourceReason.NON_DETERMINISTIC_SOURCE_WITH_DETERMINISTIC_UDF)
         } else {
           (false, MergeIntoMaterializeSourceReason.NOT_MATERIALIZED_AUTO)
         }
@@ -442,6 +447,9 @@ object MergeIntoMaterializeSourceReason extends Enumeration {
   // with ignore unreadable files options.
   val IGNORE_UNREADABLE_FILES_CONFIGS_ARE_SET =
     Value("materializeIgnoreUnreadableFilesConfigsAreSet")
+  // The source query is considered non-determistic because it contains a User Defined Function.
+  val NON_DETERMINISTIC_SOURCE_WITH_DETERMINISTIC_UDF =
+    Value("materializeNonDeterministicSourceWithDeterministicUdf")
   // Materialize when the configuration is invalid
   val INVALID_CONFIG = Value("invalidConfigurationFailsafe")
   // Catch-all case.
@@ -453,6 +461,7 @@ object MergeIntoMaterializeSourceReason extends Enumeration {
     NON_DETERMINISTIC_SOURCE_NON_DELTA,
     NON_DETERMINISTIC_SOURCE_OPERATORS,
     IGNORE_UNREADABLE_FILES_CONFIGS_ARE_SET,
+    NON_DETERMINISTIC_SOURCE_WITH_DETERMINISTIC_UDF,
     INVALID_CONFIG
   )
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaSparkPlanUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaSparkPlanUtils.scala
@@ -84,6 +84,12 @@ trait DeltaSparkPlanUtils {
     }
   }
 
+  protected def planContainsUdf(plan: LogicalPlan): Boolean = {
+    plan.collectWithSubqueries {
+      case node if node.expressions.exists(_.exists(_.isInstanceOf[UserDefinedExpression])) => ()
+    }.nonEmpty
+  }
+
   protected def findFirstNonDeterministicChildNode(
       children: Seq[Expression],
       checkDeterministicOptions: CheckDeterministicOptions): Option[PlanOrExpression] =

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoMaterializeSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoMaterializeSourceSuite.scala
@@ -570,6 +570,45 @@ trait MergeIntoMaterializeSourceTests
     }
   }
 
+  test("materialize source for non-deterministic source queries - udf") {
+    {
+      val targetSchema = StructType(Array(
+        StructField("id", IntegerType, nullable = false),
+        StructField("value", IntegerType, nullable = true)))
+      val targetData = Seq(
+        Row(1, 0),
+        Row(2, 0),
+        Row(3, 0))
+      val sourceData = Seq(1, 3).toDF("id")
+      withSQLConf(DeltaSQLConf.MERGE_MATERIALIZE_SOURCE.key -> "auto") {
+        withTable("target", "source") {
+          val targetRdd = spark.sparkContext.parallelize(targetData)
+          val targetDf = spark.createDataFrame(targetRdd, targetSchema)
+          targetDf.write.format("delta").mode("overwrite").saveAsTable("target")
+          val targetTable = io.delta.tables.DeltaTable.forName("target")
+
+          sourceData.write.format("delta").mode("overwrite").saveAsTable("source")
+          val f = udf { () => 1L }
+          val sourceDf = spark.table("source").withColumn("value", f())
+
+          val events: Seq[UsageRecord] = Log4jUsageLogger.track {
+            targetTable
+              .merge(sourceDf, col("target.id") === sourceDf("id"))
+              .whenMatched(col("target.value") > sourceDf("value")).delete()
+              .whenMatched().updateAll()
+              .whenNotMatched().insertAll()
+              .execute()
+          }
+
+          val materializeReason = mergeSourceMaterializeReason(events)
+          assert(materializeReason == MergeIntoMaterializeSourceReason.
+            NON_DETERMINISTIC_SOURCE_WITH_DETERMINISTIC_UDF.toString,
+            "Source has a udf and merge should have materialized the source.")
+        }
+      }
+    }
+  }
+
   test("materialize source for non-deterministic source queries - rand expr") {
     val targetSchema = StructType(Array(
       StructField("id", IntegerType, nullable = false),


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR fixes a correctness issue in merge due the source query returning different results in job 1 and job 2. This issue is present when the source contains a non-deterministic UDF that has been marked as deterministic. UDFs are often incorrectly marked as deterministic, and therefore we should not trust this information and instead always materialize the source if it contains a UDF

## How was this patch tested?

Added a test to `MergeIntoMaterializeSourceSuite`.

## Does this PR introduce _any_ user-facing changes?

No
