### PR TITLE
Updated error message for DELTA_SOURCE_TABLE_IGNORE_CHANGES

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -1877,7 +1877,7 @@
   },
   "DELTA_SOURCE_TABLE_IGNORE_CHANGES" : {
     "message" : [
-      "Detected a data update (for example <file>) in the source table at version <version>. This is currently not supported. If you'd like to ignore updates, set the option 'skipChangeCommits' to 'true'. If you would like the data update to be reflected, please restart this query with a fresh checkpoint directory. The source table can be found at path <dataPath>."
+      "Detected a data update (for example <file>) in the source table at version <version>. This is currently not supported. If this is going to happen regularly and you are okay to skip changes, set the option 'skipChangeCommits' to 'true'. If you would like the data update to be reflected, please restart this query with a fresh checkpoint directory. The source table can be found at path <dataPath>."
     ],
     "sqlState" : "0A000"
   },

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2541,7 +2541,7 @@ trait DeltaErrorsSuiteBase
           "10. This is currently not supported. If this is going to happen regularly and you are" +
           " okay to skip changes, set the option 'skipChangeCommits' to 'true'. If you would like" +
           " the data update to be reflected, please restart this query with a fresh checkpoint" +
-          " directory"
+          " directory" +
           ". The source table can be found at path tablePath."))
     }
     {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2538,10 +2538,11 @@ trait DeltaErrorsSuiteBase
       }
       checkErrorMessage(e, Some("DELTA_SOURCE_TABLE_IGNORE_CHANGES"), Some("0A000"),
         Some("Detected a data update (for example removedFile) in the source table at version " +
-          "10. This is currently not supported. If you'd like to ignore updates, set the " +
-          "option 'skipChangeCommits' to 'true'. If you would like the data update to be reflected, " +
-          "please restart this query with a fresh checkpoint directory. The source table can be " +
-          "found at path tablePath."))
+          "10. This is currently not supported. If this is going to happen regularly and you are" +
+          " okay to skip changes, set the option 'skipChangeCommits' to 'true'. If you would like" +
+          " the data update to be reflected, please restart this query with a fresh checkpoint" +
+          " directory"
+          ". The source table can be found at path tablePath."))
     }
     {
       val limit = "limit"

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -1910,8 +1910,9 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
 
       assert(e.getCause.isInstanceOf[UnsupportedOperationException])
       assert(e.getCause.getMessage.contains(
-        "This is currently not supported. If you'd like to ignore updates, set the option " +
-          "'skipChangeCommits' to 'true'."))
+        "This is currently not supported. If this is going to happen regularly and you are okay" +
+          " to skip changes, set the option 'skipChangeCommits' to 'true'."
+      ))
       assert(e.getCause.getMessage.contains("for example"))
       assert(e.getCause.getMessage.contains("version"))
       assert(e.getCause.getMessage.matches(s".*$inputDir.*"))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Updated error message for DELTA_SOURCE_TABLE_IGNORE_CHANGES to provide more information on offending commit and a clearer guide for using `skipChangeCommits` option.

## How was this patch tested?
Updated existing unit tests.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
Yes, this is a error message update.

existing message
```
[DELTA_SOURCE_TABLE_IGNORE_CHANGES] Detected a data update (for example part-00000-bea82363-32f9-4a0a-880b-b1bce04cb411-c000.snappy.parquet) in the source table at version 1. This is currently not supported. If you'd like to ignore updates, set the option 'skipChangeCommits' to 'true'. If you would like the data update to be reflected, please restart this query with a fresh checkpoint directory. The source table can be found at path file:/tmp/spark-c28782fa-9662-4b91-a524-ae7d177244da.
```
new message
```
[DELTA_SOURCE_TABLE_IGNORE_CHANGES] Detected a data update (for example WRITE (Map(mode -> Overwrite, statsOnLoad -> false, partitionBy -> []))) in the source table at version 1. This is currently not supported. If this is going to happen regularly and you are okay to skip changes, set the option 'skipChangeCommits' to 'true'. If you would like the data update to be reflected, please restart this query with a fresh checkpoint directory. The source table can be found at path file:/tmp/spark-a611e379-4376-4b96-921d-534b81550bde.
```
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
