### PR TITLE
 Include column names in the DELTA_INVALID_CHARACTERS_IN_COLUMN_NAMES exception

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -1117,7 +1117,9 @@
   },
   "DELTA_INVALID_CHARACTERS_IN_COLUMN_NAMES" : {
     "message" : [
-      "Found invalid character(s) among ' ,;{}()\\n\\t=' in the column names of your schema. Please use other characters and try again."
+      "Found invalid character(s) among ' ,;{}()\\n\\t=' in the column names of your schema.",
+      "Invalid column names: <invalidColumnNames>.",
+      "Please use other characters and try again."
     ],
     "sqlState" : "42K05"
   },

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -1119,7 +1119,8 @@
     "message" : [
       "Found invalid character(s) among ' ,;{}()\\n\\t=' in the column names of your schema.",
       "Invalid column names: <invalidColumnNames>.",
-      "Please use other characters and try again."
+      "Please use other characters and try again.",
+      "Alternatively, enable Column Mapping to keep using these characters."
     ],
     "sqlState" : "42K05"
   },

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2025,11 +2025,10 @@ trait DeltaErrorsBase
         formatSchema(oldSchema),
         formatSchema(newSchema)))
 
-  def foundInvalidCharsInColumnNames(cause: Throwable): Throwable =
+  def foundInvalidCharsInColumnNames(invalidColumnNames: Seq[String]): Throwable =
     new DeltaAnalysisException(
       errorClass = "DELTA_INVALID_CHARACTERS_IN_COLUMN_NAMES",
-      messageParameters = Array.empty,
-      cause = Some(cause))
+      messageParameters = invalidColumnNames.toArray)
 
   def foundViolatingConstraintsForColumnChange(
       operation: String,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -1028,8 +1028,8 @@ object SchemaUtils extends DeltaLogging {
    * Finds columns with illegal names, i.e. names containing any of the ' ,;{}()\n\t=' characters.
    */
   private def findInvalidColumnNames(columnNames: Seq[String]): Seq[String] = {
-    val badChars = Seq(' ', ',', ';', '{', '}', '(', ')', '\n', '\t', '=').map(_.toString)
-    columnNames.filter(colName => badChars.exists(colName.contains))
+    val badChars = Seq(' ', ',', ';', '{', '}', '(', ')', '\n', '\t', '=')
+    columnNames.filter(colName => badChars.map(_.toString).exists(colName.contains))
   }
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
@@ -35,7 +35,6 @@ import org.apache.parquet.format.converter.ParquetMetadataConverter
 import org.apache.parquet.hadoop.ParquetFileReader
 import org.scalatest.GivenWhenThen
 
-import org.apache.spark.SparkThrowableHelper
 import org.apache.spark.sql.{DataFrame, QueryTest, Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.functions._
@@ -1935,8 +1934,8 @@ class DeltaColumnMappingSuite extends QueryTest
       checkError(
         exception = e,
         errorClass = errorClass,
-        parameters = SparkThrowableHelper
-          .getParameterNames(errorClass)
+        parameters = DeltaThrowableHelper
+          .getParameterNames(errorClass, errorSubClass = null)
           .zip(Array(illegalColName1, illegalColName2)).toMap
       )
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
@@ -1919,25 +1919,31 @@ class DeltaColumnMappingSuite extends QueryTest
   test("DELTA_INVALID_CHARACTERS_IN_COLUMN_NAMES exception should include column names") {
     val testTableName = "columnMappingTestTable"
     withTable(testTableName) {
-      val illegalColName1 = colName("col1")
-      val illegalColName2 = colName("col2")
-      val allColumns = Seq("a", illegalColName1, "b", illegalColName2)
-        .mkString("(`", "` int, `", "` int)")
-      val e = intercept[DeltaAnalysisException] {
-        sql(
-          s"""CREATE TABLE $testTableName $allColumns
-             |USING DELTA
-             |TBLPROPERTIES('${DeltaConfigs.COLUMN_MAPPING_MODE.key}'='none')
-             |""".stripMargin)
+      val invalidColName1 = colName("col1")
+      val invalidColName2 = colName("col2")
+      // Make sure the error class stays the same for a single and multiple columns.
+      testWithInvalidColumns(Seq(invalidColName1))
+      testWithInvalidColumns(Seq(invalidColName1, invalidColName2))
+
+      def testWithInvalidColumns(invalidColumns: Seq[String]): Unit = {
+        val allColumns = (Seq("a", "b") ++ invalidColumns)
+          .mkString("(`", "` int, `", "` int)")
+        val e = intercept[DeltaAnalysisException] {
+          sql(
+            s"""CREATE TABLE $testTableName $allColumns
+               |USING DELTA
+               |TBLPROPERTIES('${DeltaConfigs.COLUMN_MAPPING_MODE.key}'='none')
+               |""".stripMargin)
+        }
+        val errorClass = "DELTA_INVALID_CHARACTERS_IN_COLUMN_NAMES"
+        checkError(
+          exception = e,
+          errorClass = errorClass,
+          parameters = DeltaThrowableHelper
+            .getParameterNames(errorClass, errorSubClass = null)
+            .zip(invalidColumns).toMap
+        )
       }
-      val errorClass = "DELTA_INVALID_CHARACTERS_IN_COLUMN_NAMES"
-      checkError(
-        exception = e,
-        errorClass = errorClass,
-        parameters = DeltaThrowableHelper
-          .getParameterNames(errorClass, errorSubClass = null)
-          .zip(Array(illegalColName1, illegalColName2)).toMap
-      )
     }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
@@ -1907,8 +1907,8 @@ class SchemaUtilsSuite extends QueryTest
           exception = intercept[AnalysisException] {
             SchemaUtils.checkFieldNames(Seq(name))
           },
-          errorClass = "INVALID_COLUMN_NAME_AS_PATH",
-          parameters = Map("datasource" -> "delta", "columnName" -> s"`$name`")
+          errorClass = "DELTA_INVALID_CHARACTERS_IN_COLUMN_NAME",
+          parameters = Map("columnName" -> s"$name")
         )
       }
     }


### PR DESCRIPTION

#### Which Delta project/connector is this regarding?


- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Add column names to `DELTA_INVALID_CHARACTERS_IN_COLUMN_NAMES` exception.
It is thrown whenever an invalid character is found in column names.

Previously:
```
Found invalid character(s) among ' ,;{}()\n\t=' in the column names of your schema. Please use other characters and try again.
```
After this patch:
```
Found invalid character(s) among ' ,;{}()\n\t=' in the column names of your schema.
Invalid column names: <columnNames>.,
Please use other characters and try again.
```

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
