### PR TITLE
[Spark] Introduce InCommitTimestamp feature and write monotonically increasing timestamps in CommitInfo

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -1388,6 +1388,18 @@
     ],
     "sqlState" : "42703"
   },
+  "DELTA_MISSING_COMMIT_INFO" : {
+    "message" : [
+      "This table has the feature <featureName> enabled which requires the presence of the CommitInfo action in every commit. However, the CommitInfo action is missing from commit version <version>."
+    ],
+    "sqlState" : "KD004"
+  },
+  "DELTA_MISSING_COMMIT_TIMESTAMP" : {
+    "message" : [
+      "This table has the feature <featureName> enabled which requires the presence of commitTimestamp in the CommitInfo action. However, this field has not been set in commit version <version>."
+    ],
+    "sqlState" : "KD004"
+  },
   "DELTA_MISSING_DELTA_TABLE" : {
     "message" : [
       "<tableName> is not a Delta table."

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -165,6 +165,7 @@ private[delta] class ConflictChecker(
     checkForAddedFilesThatShouldHaveBeenReadByCurrentTxn()
     checkForDeletedFilesAgainstCurrentTxnReadFiles()
     checkForDeletedFilesAgainstCurrentTxnDeletedFiles()
+    resolveTimestampOrderingConflicts()
 
     logMetrics()
     currentTransactionInfo
@@ -552,6 +553,53 @@ private[delta] class ConflictChecker(
     }
 
     currentTransactionInfo = currentTransactionInfo.copy(actions = newActions)
+  }
+
+  /**
+   * Adjust the current transaction's commit timestamp to account for the winning
+   * transaction's commit timestamp. If this transaction newly enabled ICT, also update
+   * the table properties to reflect the adjusted enablement version and timestamp.
+   */
+  private def resolveTimestampOrderingConflicts(): Unit = {
+    if (!DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(currentTransactionInfo.metadata)) {
+      return
+    }
+
+    val winningCommitTimestamp =
+      if (InCommitTimestampUtils.didCurrentTransactionEnableICT(
+              currentTransactionInfo.metadata, currentTransactionInfo.readSnapshot)) {
+        // Since the current transaction enabled inCommitTimestamps, we should use the file
+        // timestamp from the winning transaction as its commit timestamp.
+        winningCommitFileStatus.getModificationTime
+    } else {
+      // Get the inCommitTimestamp from the winning transaction.
+      CommitInfo.getRequiredInCommitTimestamp(
+        winningCommitSummary.commitInfo, winningCommitVersion.toString)
+    }
+    val currentTransactionTimestamp = CommitInfo.getRequiredInCommitTimestamp(
+      currentTransactionInfo.commitInfo, "NEW_COMMIT")
+    // getRequiredInCommitTimestamp will throw an exception if commitInfo is None.
+    val currentTransactionCommitInfo = currentTransactionInfo.commitInfo.get
+    val updatedCommitTimestamp = Math.max(currentTransactionTimestamp, winningCommitTimestamp + 1)
+    val updatedCommitInfo =
+      currentTransactionCommitInfo.copy(inCommitTimestamp = Some(updatedCommitTimestamp))
+    currentTransactionInfo = currentTransactionInfo.copy(commitInfo = Some(updatedCommitInfo))
+    val nextAvailableVersion = winningCommitVersion + 1L
+    val updatedMetadata =
+      InCommitTimestampUtils.getUpdatedMetadataWithICTEnablementInfo(
+        updatedCommitTimestamp,
+        currentTransactionInfo.readSnapshot,
+        currentTransactionInfo.metadata,
+        nextAvailableVersion)
+    updatedMetadata.foreach { updatedMetadata =>
+      currentTransactionInfo = currentTransactionInfo.copy(
+        metadata = updatedMetadata,
+        actions = currentTransactionInfo.actions.map {
+          case _: Metadata => updatedMetadata
+          case other => other
+        }
+      )
+    }
   }
 
   /** A helper function for pretty printing a specific partition directory. */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -754,6 +754,37 @@ trait DeltaConfigsBase extends DeltaLogging {
     _ => true,
     "A string-to-string map of configuration properties for the managed commit owner.")
 
+  val IN_COMMIT_TIMESTAMPS_ENABLED = buildConfig[Boolean](
+    "enableInCommitTimestamps-dev",
+    false.toString,
+    _.toBoolean,
+    validationFunction = _ => true,
+    "needs to be a boolean."
+  )
+
+  /**
+   * This table property is used to track the version of the table at which
+   * inCommitTimestamps were enabled.
+   */
+  val IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION = buildConfig[Option[Long]](
+    "inCommitTimestampEnablementVersion-dev",
+    null,
+    v => Option(v).map(_.toLong),
+    validationFunction = _ => true,
+    "needs to be a long."
+  )
+
+  /**
+   * This table property is used to track the timestamp at which inCommitTimestamps
+   * were enabled. More specifically, it is the inCommitTimestamp of the commit with
+   * the version specified in [[IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION]].
+   */
+  val IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP = buildConfig[Option[Long]](
+    "inCommitTimestampEnablementTimestamp-dev",
+    null,
+    v => Option(v).map(_.toLong),
+    validationFunction = _ => true,
+    "needs to be a long.")
 }
 
 object DeltaConfigs extends DeltaConfigsBase

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -186,6 +186,18 @@ trait DeltaErrorsBase
       cause = cause)
   }
 
+  def missingCommitInfo(featureName: String, commitVersion: String): DeltaIllegalStateException = {
+    new DeltaIllegalStateException(
+      errorClass = "DELTA_MISSING_COMMIT_INFO",
+      messageParameters = Array(featureName, commitVersion))
+  }
+
+  def missingCommitTimestamp(commitVersion: String): DeltaIllegalStateException = {
+    new DeltaIllegalStateException(
+      errorClass = "DELTA_MISSING_COMMIT_TIMESTAMP",
+      messageParameters = Array(InCommitTimestampTableFeature.name, commitVersion))
+  }
+
   def failOnCheckpointRename(src: Path, dest: Path): DeltaIllegalStateException = {
     new DeltaIllegalStateException(
       errorClass = "DELTA_CANNOT_RENAME_PATH",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -566,7 +566,7 @@ trait SnapshotManagement { self: DeltaLog =>
         version = segment.version,
         logSegment = segment,
         deltaLog = this,
-        timestamp = segment.lastCommitTimestamp,
+        inCommitTimestampOpt = None,
         checksumOpt = checksumOpt.orElse(
           readChecksum(segment.version, lastSeenChecksumFileStatusOpt))
       )
@@ -1154,9 +1154,9 @@ object SerializableFileStatus {
  * @param version The Snapshot version to generate
  * @param deltas The delta commit files (.json) to read
  * @param checkpointProvider provider to give information about Checkpoint files.
- * @param lastCommitTimestamp The "unadjusted" timestamp of the last commit within this segment. By
- *                            unadjusted, we mean that the commit timestamps may not necessarily be
- *                            monotonically increasing for the commits within this segment.
+ * @param lastCommitTimestamp The "unadjusted" file modification timestamp of the
+ *          last commit within this segment. By unadjusted, we mean that the commit timestamps may
+ *          not necessarily be monotonically increasing for the commits within this segment.
  */
 case class LogSegment(
     logPath: Path,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -356,6 +356,7 @@ object TableFeature {
         ManagedCommitTableFeature,
         // Row IDs are still under development and only available in testing.
         RowTrackingFeature,
+        InCommitTimestampTableFeature,
         TypeWideningTableFeature)
     }
     val featureMap = features.map(f => f.name.toLowerCase(Locale.ROOT) -> f).toMap
@@ -636,6 +637,23 @@ object TypeWideningTableFeature extends ReaderWriterFeature(name = "typeWidening
   override def metadataRequiresFeatureToBeEnabled(
       metadata: Metadata,
       spark: SparkSession): Boolean = isTypeWideningSupportNeededByMetadata(metadata)
+}
+
+/**
+ * inCommitTimestamp table feature is a writer feature that makes
+ * every writer write a monotonically increasing timestamp inside the commit file.
+ */
+object InCommitTimestampTableFeature
+  extends WriterFeature(name = "inCommitTimestamp-dev")
+  with FeatureAutomaticallyEnabledByMetadata {
+
+  override def automaticallyUpdateProtocolOfExistingTables: Boolean = true
+
+  override def metadataRequiresFeatureToBeEnabled(
+      metadata: Metadata,
+      spark: SparkSession): Boolean = {
+    DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(metadata)
+  }
 }
 
 /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/InCommitTimestampUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/InCommitTimestampUtils.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.actions.{Action, CommitInfo, Metadata}
+import org.apache.spark.sql.util.ScalaExtensions._
+
+object InCommitTimestampUtils {
+
+  /** Returns true if the current transaction implicitly/explicitly enables ICT. */
+  def didCurrentTransactionEnableICT(
+      currentTransactionMetadata: Metadata,
+      readSnapshot: Snapshot): Boolean = {
+    // If ICT is currently enabled, and the read snapshot did not have ICT enabled,
+    // then the current transaction must have enabled it.
+    // In case of a conflict, any winning transaction that enabled it after
+    // our read snapshot would have caused a metadata conflict abort
+    // (see [[ConflictChecker.checkNoMetadataUpdates]]), so we know that
+    // all winning transactions' ICT enablement status must match the read snapshot.
+    //
+    // WARNING: The Metadata() of InitialSnapshot can enable ICT by default. To ensure that
+    // this function returns true if ICT is enabled during the first commit, we explicitly handle
+    // the case where the readSnapshot.version is -1.
+    val isICTCurrentlyEnabled =
+      DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(currentTransactionMetadata)
+    val wasICTEnabledInReadSnapshot = readSnapshot.version != -1 &&
+      DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(readSnapshot.metadata)
+    isICTCurrentlyEnabled && !wasICTEnabledInReadSnapshot
+  }
+
+  /**
+   * Returns the updated [[Metadata]] with inCommitTimestamp enablement related info
+   * (version and timestamp) correctly set.
+   * This is done only
+   * 1. If this transaction enables inCommitTimestamp.
+   * 2. If the commit version is not 0. This is because we only need to persist
+   *  the enablement info if there are non-ICT commits in the Delta log.
+   * Note: This function must only be called after transaction conflicts have been resolved.
+   */
+  def getUpdatedMetadataWithICTEnablementInfo(
+      inCommitTimestamp: Long,
+      readSnapshot: Snapshot,
+      metadata: Metadata,
+      commitVersion: Long): Option[Metadata] = {
+    Option.when(didCurrentTransactionEnableICT(metadata, readSnapshot) && commitVersion != 0) {
+      val enablementTrackingProperties = Map(
+        DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.key -> commitVersion.toString,
+        DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.key -> inCommitTimestamp.toString)
+      metadata.copy(configuration = metadata.configuration ++ enablementTrackingProperties)
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2788,6 +2788,34 @@ trait DeltaErrorsSuiteBase
              |value first, then run a second ALTER TABLE ALTER COLUMN SET DEFAULT command to apply
              |for future inserted rows instead.""".stripMargin))
     }
+    {
+      val e = intercept[DeltaIllegalStateException] {
+        throw DeltaErrors.missingCommitInfo("featureName", "1225")
+      }
+      checkErrorMessage(
+        e,
+        Some("DELTA_MISSING_COMMIT_INFO"),
+        Some("KD004"),
+        Some(
+          "This table has the feature featureName enabled which requires the presence of the " +
+           "CommitInfo action in every commit. However, the CommitInfo action is missing from commit " +
+           "version 1225.")
+      )
+    }
+    {
+      val e = intercept[DeltaIllegalStateException] {
+        throw DeltaErrors.missingCommitTimestamp("1225")
+      }
+      checkErrorMessage(
+        e,
+        Some("DELTA_MISSING_COMMIT_TIMESTAMP"),
+        Some("KD004"),
+        Some(
+          s"This table has the feature ${InCommitTimestampTableFeature.name} enabled which requires " +
+            "the presence of commitTimestamp in the CommitInfo action. However, this field has not " +
+            "been set in commit version 1225.")
+      )
+    }
   }
 }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
@@ -1,0 +1,343 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import com.databricks.spark.util.{Log4jUsageLogger, UsageRecord}
+import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
+import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
+import org.apache.spark.sql.delta.actions.{Action, CommitInfo}
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.util.FileNames
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.util.ManualClock
+
+class InCommitTimestampSuite
+  extends QueryTest
+    with SharedSparkSession
+    with DeltaSQLCommandTest {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    spark.conf.set(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey, "true")
+  }
+
+  private def getInCommitTimestamp(deltaLog: DeltaLog, version: Long): Long = {
+    val commitInfo = DeltaHistoryManager.getCommitInfoOpt(
+      deltaLog.store, deltaLog.logPath, version, deltaLog.newDeltaHadoopConf())
+    commitInfo.get.inCommitTimestamp.get
+  }
+
+  def filterUsageRecords(usageRecords: Seq[UsageRecord], opType: String): Seq[UsageRecord] = {
+    usageRecords.filter { r =>
+      r.tags.get("opType").contains(opType) || r.opType.map(_.typeName).contains(opType)
+    }
+  }
+
+  test("Enable ICT on commit 0") {
+    withTempDir { tempDir =>
+      spark.range(10).write.format("delta").save(tempDir.getAbsolutePath)
+      val deltaLog =
+        DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
+      val ver0Snapshot = deltaLog.snapshot
+      assert(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(ver0Snapshot.metadata))
+      assert(ver0Snapshot.timestamp == getInCommitTimestamp(deltaLog, 0))
+    }
+  }
+
+  test("Create a non-inCommitTimestamp table and then enable timestamp") {
+    withSQLConf(
+      DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> false.toString
+    ) {
+      withTempDir { tempDir =>
+        spark.range(10).write.format("delta").save(tempDir.getAbsolutePath)
+        spark.sql(s"INSERT INTO delta.`$tempDir` VALUES 10")
+        val ver1Snapshot = DeltaLog.forTable(spark, tempDir.getAbsolutePath).snapshot
+        // File timestamp should be the same as snapshot.getTimestamp when inCommitTimestamp is not
+        // enabled
+        assert(
+          ver1Snapshot.logSegment.lastCommitTimestamp == ver1Snapshot.timestamp)
+
+        spark.sql(s"ALTER TABLE delta.`${tempDir.getAbsolutePath}`" +
+          s"SET TBLPROPERTIES ('${DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key}' = 'true')")
+
+        val ver2Snapshot = DeltaLog.forTable(spark, tempDir.getAbsolutePath).snapshot
+        // File timestamp should be different from snapshot.getTimestamp when inCommitTimestamp is
+        // enabled
+        assert(ver2Snapshot.timestamp == getInCommitTimestamp(ver2Snapshot.deltaLog, version = 2))
+
+        assert(ver2Snapshot.timestamp > ver1Snapshot.timestamp)
+
+        spark.sql(s"INSERT INTO delta.`$tempDir` VALUES 11")
+
+        val ver3Snapshot = DeltaLog.forTable(spark, tempDir.getAbsolutePath).snapshot
+
+        assert(ver3Snapshot.timestamp > ver2Snapshot.timestamp)
+      }
+    }
+  }
+
+  test("InCommitTimestamps are monotonic even when the clock is skewed") {
+    withTempDir { tempDir =>
+      spark.range(10).write.format("delta").save(tempDir.getAbsolutePath)
+      val startTime = System.currentTimeMillis()
+      val clock = new ManualClock(startTime)
+      // Clear the cache to ensure that a new DeltaLog is created with the new clock.
+      DeltaLog.clearCache()
+      val deltaLog =
+        DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath), clock)
+      // Move backwards in time.
+      deltaLog.startTransaction().commit(Seq(createTestAddFile("1")), ManualUpdate)
+      val ver1Timestamp = deltaLog.snapshot.timestamp
+      clock.setTime(startTime - 10000)
+      deltaLog.startTransaction().commit(Seq(createTestAddFile("2")), ManualUpdate)
+      val ver2Timestamp = deltaLog.snapshot.timestamp
+      assert(ver2Timestamp > ver1Timestamp)
+    }
+  }
+
+  test("Conflict resolution of timestamps") {
+    withTempDir { tempDir =>
+      spark.range(10).write.format("delta").save(tempDir.getAbsolutePath)
+      val startTime = System.currentTimeMillis()
+      val clock = new ManualClock(startTime)
+      // Clear the cache to ensure that a new DeltaLog is created with the new clock.
+      DeltaLog.clearCache()
+      val deltaLog =
+        DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath), clock)
+      val txn1 = deltaLog.startTransaction()
+      clock.setTime(startTime)
+      deltaLog.startTransaction().commit(Seq(createTestAddFile("1")), ManualUpdate)
+      // Move time backwards for the conflicting commit.
+      clock.setTime(startTime - 10000)
+      val usageRecords = Log4jUsageLogger.track {
+        txn1.commit(Seq(createTestAddFile("2")), ManualUpdate)
+      }
+      // Make sure that this transaction resulted in a conflict.
+      assert(filterUsageRecords(usageRecords, "delta.commit.retry").length == 1)
+      assert(getInCommitTimestamp(deltaLog, 2) > getInCommitTimestamp(deltaLog, 1))
+    }
+  }
+
+  test("Missing CommitInfo should result in a DELTA_MISSING_COMMIT_INFO exception") {
+    withTempDir { tempDir =>
+      spark.range(10).write.format("delta").save(tempDir.getAbsolutePath)
+      val deltaLog =
+        DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
+      deltaLog.startTransaction().commit(Seq(createTestAddFile("1")), ManualUpdate)
+      // Remove CommitInfo from the commit.
+      val actions = deltaLog.store.readAsIterator(
+        FileNames.deltaFile(deltaLog.logPath, 1), deltaLog.newDeltaHadoopConf())
+      val actionsWithoutCommitInfo = actions.filterNot(Action.fromJson(_).isInstanceOf[CommitInfo])
+      deltaLog.store.write(
+        FileNames.deltaFile(deltaLog.logPath, 1),
+        actionsWithoutCommitInfo,
+        overwrite = true,
+        deltaLog.newDeltaHadoopConf())
+      val latestSnapshot = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath)).snapshot
+      val e = intercept[DeltaIllegalStateException] {
+        latestSnapshot.timestamp
+      }
+      checkError(
+        exception = e,
+        errorClass = "DELTA_MISSING_COMMIT_INFO",
+        parameters = Map(
+          "featureName" -> InCommitTimestampTableFeature.name,
+          "version" -> "1"))
+    }
+  }
+
+  test("Missing CommitInfo.commitTimestamp should result in a " +
+    "DELTA_MISSING_COMMIT_TIMESTAMP exception") {
+    withTempDir { tempDir =>
+      spark.range(10).write.format("delta").save(tempDir.getAbsolutePath)
+      val deltaLog =
+        DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
+      deltaLog.startTransaction().commit(Seq(createTestAddFile("1")), ManualUpdate)
+      // Remove CommitInfo.commitTimestamp from the commit.
+      val actions = deltaLog.store.readAsIterator(
+        FileNames.deltaFile(deltaLog.logPath, 1),
+        deltaLog.newDeltaHadoopConf()).toList
+      val actionsWithoutCommitInfoCommitTimestamp =
+        actions.map(Action.fromJson).map {
+          case ci: CommitInfo =>
+            ci.copy(inCommitTimestamp = None).json
+          case other =>
+            other.json
+        }.toIterator
+      deltaLog.store.write(
+        FileNames.deltaFile(deltaLog.logPath, 1),
+        actionsWithoutCommitInfoCommitTimestamp,
+        overwrite = true,
+        deltaLog.newDeltaHadoopConf())
+
+      val latestSnapshot = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath)).snapshot
+      val e = intercept[DeltaIllegalStateException] {
+        latestSnapshot.timestamp
+      }
+      checkError(
+        exception = e,
+        errorClass = "DELTA_MISSING_COMMIT_TIMESTAMP",
+        parameters = Map("featureName" -> InCommitTimestampTableFeature.name, "version" -> "1"))
+    }
+  }
+
+  test("InCommitTimestamp is equal to snapshot.timestamp") {
+    withTempDir { tempDir =>
+      spark.range(10).write.format("delta").save(tempDir.getAbsolutePath)
+      val deltaLog =
+        DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
+      val ver0Snapshot = deltaLog.snapshot
+
+      assert(ver0Snapshot.timestamp == getInCommitTimestamp(deltaLog, 0))
+    }
+  }
+
+  test("CREATE OR REPLACE should not disable ICT") {
+    withSQLConf(
+      DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> false.toString
+    ) {
+      withTempDir { tempDir =>
+        spark.range(10).write.format("delta").save(tempDir.getAbsolutePath)
+        spark.sql(
+          s"ALTER TABLE delta.`${tempDir.getAbsolutePath}`" +
+            s"SET TBLPROPERTIES ('${DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key}' = 'true')")
+
+        spark.sql(
+          s"CREATE OR REPLACE TABLE delta.`${tempDir.getAbsolutePath}` (id long) USING delta")
+
+        val deltaLogAfterCreateOrReplace =
+          DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
+        val snapshot = deltaLogAfterCreateOrReplace.snapshot
+        assert(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(snapshot.metadata))
+        assert(snapshot.timestamp ==
+          getInCommitTimestamp(deltaLogAfterCreateOrReplace, snapshot.version))
+      }
+    }
+  }
+
+  test("Enablement tracking properties should not be added if ICT is enabled on commit 0") {
+    withTempDir { tempDir =>
+      spark.range(10).write.format("delta").save(tempDir.getAbsolutePath)
+      val deltaLog =
+        DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
+      val ver0Snapshot = deltaLog.snapshot
+
+      val observedEnablementTimestamp =
+        DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.fromMetaData(ver0Snapshot.metadata)
+      val observedEnablementVersion =
+        DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.fromMetaData(ver0Snapshot.metadata)
+      assert(observedEnablementTimestamp.isEmpty)
+      assert(observedEnablementVersion.isEmpty)
+    }
+  }
+
+  test("Enablement tracking works when ICT is enabled post commit 0") {
+    withSQLConf(
+      DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> false.toString
+    ) {
+      withTempDir { tempDir =>
+        spark.range(10).write.format("delta").save(tempDir.getAbsolutePath)
+        spark.sql(s"INSERT INTO delta.`$tempDir` VALUES 10")
+
+        spark.sql(
+          s"ALTER TABLE delta.`${tempDir.getAbsolutePath}`" +
+            s"SET TBLPROPERTIES ('${DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key}' = 'true')")
+
+        val deltaLog = DeltaLog.forTable(spark, tempDir.getAbsolutePath)
+        val ver2Snapshot = deltaLog.snapshot
+        val observedEnablementTimestamp =
+          DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.fromMetaData(ver2Snapshot.metadata)
+        val observedEnablementVersion =
+          DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.fromMetaData(ver2Snapshot.metadata)
+        assert(observedEnablementTimestamp.isDefined)
+        assert(observedEnablementVersion.isDefined)
+        assert(observedEnablementTimestamp.get == getInCommitTimestamp(deltaLog, version = 2))
+        assert(observedEnablementVersion.get == 2)
+      }
+    }
+  }
+
+  test("Conflict resolution of enablement version") {
+    withSQLConf(
+      DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> false.toString
+    ) {
+      withTempDir { tempDir =>
+        spark.range(10).write.format("delta").save(tempDir.getAbsolutePath)
+        spark.sql(s"INSERT INTO delta.`$tempDir` VALUES 10")
+        val startTime = System.currentTimeMillis()
+        val clock = new ManualClock(startTime)
+        val deltaLog =
+          DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath), clock)
+        val snapshot = deltaLog.snapshot
+        val txn1 = deltaLog.startTransaction()
+        clock.setTime(startTime)
+        deltaLog.startTransaction().commit(Seq(createTestAddFile("1")), ManualUpdate)
+        val ictEnablementMetadataConfig = snapshot.metadata.configuration ++ Map(
+          DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key -> "true")
+        val ictEnablementMetadata =
+          snapshot.metadata.copy(configuration = ictEnablementMetadataConfig)
+        val usageRecords = Log4jUsageLogger.track {
+          txn1.commit(Seq(ictEnablementMetadata), ManualUpdate)
+        }
+        val ver3Snapshot = deltaLog.update()
+        val observedEnablementTimestamp =
+          DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.fromMetaData(ver3Snapshot.metadata)
+        val observedEnablementVersion =
+          DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.fromMetaData(ver3Snapshot.metadata)
+        // Make sure that this transaction resulted in a conflict.
+        assert(filterUsageRecords(usageRecords, "delta.commit.retry").length == 1)
+        assert(observedEnablementTimestamp.get == getInCommitTimestamp(deltaLog, version = 3))
+        assert(observedEnablementVersion.get == 3)
+      }
+    }
+  }
+
+  test("commitLarge should correctly set the enablement tracking properties") {
+    withTempDir { tempDir =>
+      spark.range(2).write.format("delta").save(tempDir.getAbsolutePath)
+      val deltaLog = DeltaLog.forTable(spark, tempDir.getAbsolutePath)
+      val ver0Snapshot = deltaLog.snapshot
+      assert(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(ver0Snapshot.metadata))
+      // Disable ICT in version 1.
+      spark.sql(s"ALTER TABLE delta.`${tempDir.getAbsolutePath}`" +
+          s"SET TBLPROPERTIES ('${DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key}' = 'false')")
+      assert(!DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(deltaLog.update().metadata))
+
+      // Use a restore command to return the table state to version 0.
+      // This should internally invoke commitLarge and the enablement tracking properties should be
+      // updated correctly.
+      val usageRecords = Log4jUsageLogger.track {
+        spark.sql(s"RESTORE TABLE delta.`${tempDir.getAbsolutePath}` TO VERSION AS OF 0")
+      }
+      val ver2Snapshot = deltaLog.update()
+      assert(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(ver2Snapshot.metadata))
+      val observedEnablementTimestamp =
+        DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.fromMetaData(ver2Snapshot.metadata)
+      val observedEnablementVersion =
+        DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.fromMetaData(ver2Snapshot.metadata)
+      assert(filterUsageRecords(usageRecords, "delta.commit.large").length == 1)
+      assert(observedEnablementTimestamp.isDefined)
+      assert(observedEnablementVersion.isDefined)
+      assert(observedEnablementTimestamp.get == getInCommitTimestamp(deltaLog, version = 2))
+      assert(observedEnablementVersion.get == 2)
+    }
+  }
+}
+


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Follow-up for https://github.com/delta-io/delta/issues/2532.

Adds a new writer feature called `inCommitTimestamp`. When this feature is enabled, the writer will make sure that it writes `commitTimestamp` in CommitInfo which contains a monotonically increasing timestamp.

This PR is an initial implementation, it does not handle timestamp retrieval efficiently. It does not try to populate the inCommitTimestamp in Snapshot even in places where it is already available, instead Snapshot has to perform an IO to read the timestamp.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Added a new suite called `InCommitTimestampSuite`.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No