### PR TITLE
Fix typo around log compactions in Delta Spec

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -264,36 +264,36 @@ These files reside in the `_delta_log/_sidecars` directory.
 ### Log Compaction Files
 
 Log compaction files reside in the `_delta_log` directory. A log compaction file from a start version `x` to an end version `y` will have the following name:
-`<x>.<y>.compact.json`. This contains the aggregated
+`<x>.<y>.compacted.json`. This contains the aggregated
 actions for commit range `[x, y]`. Similar to commits, each row in the log
 compaction file represents an [action](#actions).
 The commit files for a given range are created by doing [Action Reconciliation](#action-reconciliation)
 of the corresponding commits.
 Instead of reading the individual commit files in range `[x, y]`, an implementation could choose to read
-the log compaction file `<x>.<y>.compact.json` to speed up the snapshot construction.
+the log compaction file `<x>.<y>.compacted.json` to speed up the snapshot construction.
 
 Example:
-Suppose we have `4.json` as:
+Suppose we have `00000000000000000004.json` as:
 ```
 {"commitInfo":{...}}
 {"add":{"path":"f2",...}}
 {"remove":{"path":"f1",...}}
 ```
-`5.json` as:
+`00000000000000000005.json` as:
 ```
 {"commitInfo":{...}}
 {"add":{"path":"f3",...}}
 {"add":{"path":"f4",...}}
 {"txn":{"appId":"3ae45b72-24e1-865a-a211-34987ae02f2a","version":4389}}
 ```
-`6.json` as:
+`00000000000000000006.json` as:
 ```
 {"commitInfo":{...}}
 {"remove":{"path":"f3",...}}
 {"txn":{"appId":"3ae45b72-24e1-865a-a211-34987ae02f2a","version":4390}}
 ```
 
-Then `4.6.compact.json` will have the following content:
+Then `00000000000000000004.00000000000000000006.compacted.json` will have the following content:
 ```
 {"add":{"path":"f2",...}}
 {"add":{"path":"f4",...}}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other - Protocol

## Description

This PR fixes a small typo in Protocol around log compaction files.

## How was this patch tested?

NA

## Does this PR introduce _any_ user-facing changes?

NA