### PR TITLE
[Spark] Show clusteringColumns in DESCRIBE DETAIL for clustered tables

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
@@ -284,15 +284,15 @@ trait DescribeDeltaDetailSuiteBase extends QueryTest
     }
   }
 
-  private def withTempTableOrDir(useTable: Boolean = true)(table: String => Unit): Unit = {
+  private def withTempTableOrDir(useTable: Boolean = true)(f: String => Unit): Unit = {
     if (useTable) {
       val testTable = "test_table"
       withTable(testTable) {
-        table(testTable)
+        f(testTable)
       }
     } else {
       withTempDir { dir =>
-        table(s"delta.`$dir`")
+        f(s"delta.`$dir`")
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
@@ -284,6 +284,69 @@ trait DescribeDeltaDetailSuiteBase extends QueryTest
     }
   }
 
+  private def withTempTableOrDir(useTable: Boolean = true)(table: String => Unit): Unit = {
+    if (useTable) {
+      val testTable = "test_table"
+      withTable(testTable) {
+        table(testTable)
+      }
+    } else {
+      withTempDir { dir =>
+        table(s"delta.`$dir`")
+      }
+    }
+  }
+
+  private def checkResultForClusteredTable(
+      table: String,
+      clusteringColumns: Array[String]): Unit = {
+    // Check SQL details
+    checkResult(
+      sql(s"DESCRIBE DETAIL $table"),
+      Seq("delta", Array.empty, clusteringColumns, 0),
+      Seq("format", "partitionColumns", "clusteringColumns", "numFiles"))
+
+    // Check Scala details
+    val isPathBased = table.startsWith("delta.")
+    val deltaTable = if (isPathBased) {
+      val path = table.replace("delta.`", "").dropRight(1)
+      io.delta.tables.DeltaTable.forPath(path)
+    } else {
+      io.delta.tables.DeltaTable.forName(table)
+    }
+    checkResult(
+      deltaTable.detail(),
+      Seq("delta", Array.empty, clusteringColumns, 0),
+      Seq("format", "partitionColumns", "clusteringColumns", "numFiles"))
+  }
+
+  Seq(true -> "", false -> " - path based").foreach { case (useTable, testSuffix) =>
+    test(s"describe liquid table$testSuffix") {
+      withTempTableOrDir(useTable) { testTable =>
+        sql(s"CREATE TABLE $testTable(a STRUCT<b INT, c STRING>, d INT) USING DELTA " +
+          "CLUSTER BY (a.b, d)")
+
+        checkResultForClusteredTable(testTable, Array("a.b", "d"))
+
+        sql(s"ALTER TABLE $testTable CLUSTER BY NONE")
+
+        checkResultForClusteredTable(testTable, Array.empty)
+      }
+    }
+
+    test(s"describe liquid table - column mapping$testSuffix") {
+      withTempTableOrDir(useTable) { testTable =>
+        sql(s"CREATE TABLE $testTable (col1 STRING, col2 INT) USING delta CLUSTER BY (col1, col2)")
+        sql(s"ALTER TABLE $testTable SET TBLPROPERTIES ('delta.columnMapping.mode' = 'name'," +
+          "'delta.minReaderVersion' = '3'," +
+          "'delta.minWriterVersion'= '7')")
+        sql(s"ALTER TABLE $testTable RENAME COLUMN col2 TO new_col_name")
+
+        checkResultForClusteredTable(testTable, Array("col1", "new_col_name"))
+      }
+    }
+  }
+
   // TODO: run it with OSS Delta after it's supported
 }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaDetailSuite.scala
@@ -300,13 +300,13 @@ trait DescribeDeltaDetailSuiteBase extends QueryTest
   private def checkResultForClusteredTable(
       table: String,
       clusteringColumns: Array[String]): Unit = {
-    // Check SQL details
+    // Check SQL API.
     checkResult(
       sql(s"DESCRIBE DETAIL $table"),
       Seq("delta", Array.empty, clusteringColumns, 0),
       Seq("format", "partitionColumns", "clusteringColumns", "numFiles"))
 
-    // Check Scala details
+    // Check DeltaTable APIs.
     val isPathBased = table.startsWith("delta.")
     val deltaTable = if (isPathBased) {
       val path = table.replace("delta.`", "").dropRight(1)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Resolves #2469 

Support showing `clusteringColumns` in DESCRIBE DETAIL for clustered tables.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
New unit tests.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, it adds `clusteringColumns` to DESCRIBE DETAIL's output.