### PR TITLE
[Spark] Refactor OptimisticTransaction commitLarge API

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
@@ -223,7 +223,7 @@ abstract class CloneTableBase(
     val newProtocol = determineTargetProtocol(spark, txn, deltaOperation.name)
 
     try {
-      var actions = Iterator.single(newProtocol) ++
+      var actions: Iterator[Action] =
         addedFileList.iterator.asScala.map { fileToCopy =>
           val copiedFile = fileToCopy.copy(dataChange = dataChangeInFileAction)
           // CLONE does not preserve Row IDs and Commit Versions
@@ -246,6 +246,7 @@ abstract class CloneTableBase(
           txn.commitLarge(
             spark,
             actions,
+            Some(newProtocol),
             deltaOperation,
             context,
             commitOpMetrics.mapValues(_.toString()).toMap)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
@@ -382,7 +382,8 @@ abstract class ConvertToDeltaCommandBase(
       )
       val (committedVersion, postCommitSnapshot) = txn.commitLarge(
         spark,
-        Iterator.single(txn.protocol) ++ addFilesIter,
+        addFilesIter,
+        Some(txn.protocol),
         getOperation(numFiles, convertProperties, targetTable.format),
         getContext,
         metrics)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
@@ -207,7 +207,8 @@ case class RestoreTableCommand(sourceTable: DeltaTableV2)
 
         txn.commitLarge(
           spark,
-          Iterator.single(newProtocol) ++ addActions ++ removeActions,
+          addActions ++ removeActions,
+          Some(newProtocol),
           DeltaOperations.Restore(version, timestamp),
           Map.empty,
           metrics.mapValues(_.toString).toMap)


### PR DESCRIPTION

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

 This PR refactors the OptimisticTransaction.commitlarge API. Currently the API is confusing as it expects metadata to be not passed from outside but protocol could be passed from outside.

## How was this patch tested?

Existing UTs

## Does this PR introduce _any_ user-facing changes?

No