### PR TITLE
[Kernel] Support reading timestamp partition columns

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanBuilderImpl.java
@@ -16,7 +16,6 @@
 
 package io.delta.kernel.internal;
 
-import java.util.List;
 import java.util.Optional;
 
 import io.delta.kernel.Scan;
@@ -24,13 +23,11 @@ import io.delta.kernel.ScanBuilder;
 import io.delta.kernel.client.TableClient;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.types.StructType;
-import io.delta.kernel.types.TimestampType;
 
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.replay.LogReplay;
-import io.delta.kernel.internal.util.VectorUtils;
 
 /**
  * Implementation of {@link ScanBuilder}.
@@ -83,23 +80,6 @@ public class ScanBuilderImpl
 
     @Override
     public Scan build() {
-        // TODO: support timestamp type partition columns
-        // Timestamp partition columns have complicated semantics related to timezones so block this
-        // for now
-        List<String> partitionCols = VectorUtils.toJavaList(
-            metadata.getPartitionColumns());
-        for (String colName : partitionCols) {
-            if (readSchema.indexOf(colName) >= 0 &&
-                readSchema.get(colName).getDataType() instanceof TimestampType) {
-                throw new UnsupportedOperationException(String.format(
-                    "Reading partition columns of TimestampType is unsupported.\n" +
-                        "readSchema: %s\npartitionColumns: %s",
-                    readSchema,
-                    partitionCols
-                ));
-            }
-        }
-
         return new ScanImpl(
             snapshotSchema,
             readSchema,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/InternalUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/InternalUtils.java
@@ -17,7 +17,10 @@ package io.delta.kernel.internal.util;
 
 import java.io.IOException;
 import java.sql.Date;
+import java.sql.Timestamp;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 
@@ -29,7 +32,9 @@ import io.delta.kernel.types.StringType;
 import io.delta.kernel.utils.CloseableIterator;
 
 public class InternalUtils {
-    private static final LocalDate EPOCH = LocalDate.ofEpochDay(0);
+    private static final LocalDate EPOCH_DAY = LocalDate.ofEpochDay(0);
+    private static final LocalDateTime EPOCH_DATETIME =
+        LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.UTC);
 
     private InternalUtils() {}
 
@@ -83,7 +88,16 @@ public class InternalUtils {
      */
     public static int daysSinceEpoch(Date date) {
         LocalDate localDate = date.toLocalDate();
-        return (int) ChronoUnit.DAYS.between(EPOCH, localDate);
+        return (int) ChronoUnit.DAYS.between(EPOCH_DAY, localDate);
+    }
+
+    /**
+     * Utility method to get the number of microseconds since the unix epoch for the given timestamp
+     * interpreted in UTC.
+     */
+    public static long microsSinceEpoch(Timestamp timestamp) {
+        LocalDateTime localTimestamp = timestamp.toLocalDateTime();
+        return ChronoUnit.MICROS.between(EPOCH_DATETIME, localTimestamp);
     }
 
     /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
@@ -17,6 +17,7 @@ package io.delta.kernel.internal.util;
 
 import java.math.BigDecimal;
 import java.sql.Date;
+import java.sql.Timestamp;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -268,6 +269,10 @@ public class PartitionUtils {
             DecimalType decimalType = (DecimalType) dataType;
             return Literal.ofDecimal(
                 new BigDecimal(partitionValue), decimalType.getPrecision(), decimalType.getScale());
+        }
+        if (dataType instanceof TimestampType) {
+            return Literal.ofTimestamp(
+                InternalUtils.microsSinceEpoch(Timestamp.valueOf(partitionValue)));
         }
 
         throw new UnsupportedOperationException("Unsupported partition column: " + dataType);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/TimestampType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/TimestampType.java
@@ -22,7 +22,10 @@ import io.delta.kernel.annotation.Evolving;
  * where the left/right-bound is a date and time of the proleptic Gregorian
  * calendar in UTC+00:00.
  * Internally, this is represented as the number of microseconds since the Unix epoch,
- * 1970-01-01 00:00:00 UTC..
+ * 1970-01-01 00:00:00 UTC.
+ * <p>
+ * Due to historical reasons timestamp partition columns do not store timezone information. Kernel
+ * interprets all timestamp partition columns in UTC.
  *
  * @since 3.0.0
  */

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/PartitionValueEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/PartitionValueEvaluator.java
@@ -17,12 +17,10 @@ package io.delta.kernel.defaults.internal.expressions;
 
 import java.math.BigDecimal;
 import java.sql.Date;
+import java.sql.Timestamp;
 
 import io.delta.kernel.data.ColumnVector;
-import io.delta.kernel.types.DataType;
-import io.delta.kernel.types.DateType;
-import io.delta.kernel.types.IntegerType;
-import io.delta.kernel.types.LongType;
+import io.delta.kernel.types.*;
 
 import io.delta.kernel.internal.util.InternalUtils;
 
@@ -85,8 +83,10 @@ class PartitionValueEvaluator {
             public long getLong(int rowId) {
                 if (partitionType.equivalent(LongType.LONG)) {
                     return Long.parseLong(input.getString(rowId));
+                } else if (partitionType.equivalent(TimestampType.TIMESTAMP)) {
+                    return InternalUtils.microsSinceEpoch(
+                        Timestamp.valueOf(input.getString(rowId)));
                 }
-                // TODO: partition value of timestamp type are not yet supported
                 throw new UnsupportedOperationException("Invalid value request for data type");
             }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
@@ -35,18 +35,8 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
   // Timestamp type tests
   //////////////////////////////////////////////////////////////////////////////////
 
-  // For now we do not support timestamp partition columns, make sure it's blocked
-  test("cannot read partition column of timestamp type") {
-    val path = goldenTablePath("kernel-timestamp-TIMESTAMP_MICROS")
-    val snapshot = latestSnapshot(path)
-
-    val e = intercept[UnsupportedOperationException] {
-      readSnapshot(snapshot) // request entire schema
-    }
-    assert(e.getMessage.contains("Reading partition columns of TimestampType is unsupported"))
-  }
-
   // Below table is written in either UTC or PDT for the golden tables
+  // Kernel always interprets partition timestamp columns in UTC
   /*
   id: int  | Part (TZ agnostic): timestamp     | time : timestamp
   ------------------------------------------------------------------------
@@ -59,26 +49,31 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
 
   def row0: TestRow = TestRow(
     0,
+    1577866150001000L, // 2020-01-01 08:09:10.001 UTC to micros since the epoch
     1580544550000000L // 2020-02-01 08:09:10 UTC to micros since the epoch
   )
 
   def row1: TestRow = TestRow(
     1,
+    1633075760000000L, // 2021-10-01 08:09:20 UTC to micros since the epoch
     915181200000000L // 1999-01-01 09:00:00 UTC to micros since the epoch
   )
 
   def row2: TestRow = TestRow(
     2,
+    1633075760000000L, // 2021-10-01 08:09:20 UTC to micros since the epoch
     946717200000000L // 2000-01-01 09:00:00 UTC to micros since the epoch
   )
 
   def row3: TestRow = TestRow(
     3,
+    -31536000000000L, // 1969-01-01 00:00:00  UTC to micros since the epoch
     -31536000000000L // 1969-01-01 00:00:00 UTC to micros since the epoch
   )
 
   def row4: TestRow = TestRow(
     4,
+    null,
     null
   )
 
@@ -91,9 +86,7 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
     withTimeZone(timeZone) {
       checkTable(
         path = goldenTablePath(goldenTableName),
-        expectedAnswer = expectedResult,
-        // for now omit "part" column since we don't support reading timestamp partition values
-        readCols = Seq("id", "time")
+        expectedAnswer = expectedResult
       )
     }
   }
@@ -112,10 +105,14 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
     val values = testRow.toSeq
     TestRow(
       values(0),
-      if (values(1) == null) {
+      // Partition columns are written as the local date time without timezone information and then
+      // interpreted by Kernel in UTC --> so the written partition value (& the read value) is the
+      // same as the UTC table
+      values(1),
+      if (values(2) == null) {
         null
       } else {
-        values(1).asInstanceOf[Long] + DefaultKernelUtils.DateTimeConstants.MICROS_PER_HOUR * 8
+        values(2).asInstanceOf[Long] + DefaultKernelUtils.DateTimeConstants.MICROS_PER_HOUR * 8
       }
     )
   }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/PartitionPruningSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/PartitionPruningSuite.scala
@@ -47,8 +47,8 @@ class PartitionPruningSuite extends AnyFunSuite with TestUtils {
     // 2021-09-08 in days since epoch 18878
     col("as_date") -> (ofDate(18878 /* daysSinceEpochUTC */), ofNull(DateType.DATE)),
     col("as_string") -> (ofString("1"), ofNull(StringType.STRING)),
-    // TODO: timestamp partition column is not yet supported
-    // col("as_timestamp") -> (ofTimestamp(1), ofNull(TimestampType.TIMESTAMP)),
+    // 2021-09-08 11:11:11 in micros since epoch UTC
+    col("as_timestamp") -> (ofTimestamp(1631099471000000L), ofNull(TimestampType.TIMESTAMP)),
     col("as_big_decimal") -> (
       ofDecimal(new BigDecimalJ(1), 1, 0),
       ofNull(new DecimalType(1, 0))))
@@ -62,22 +62,23 @@ class PartitionPruningSuite extends AnyFunSuite with TestUtils {
           test(s"partition pruning: simple filter `$partitionCol = $literal`, " +
             s"select partition predicate column = $selectPredicatePartitionCol") {
 
-            val isPartitionColDateType = literal.getDataType.isInstanceOf[DateType]
+            val isPartitionColDateOrTimestampType = literal.getDataType.isInstanceOf[DateType] ||
+              literal.getDataType.isInstanceOf[TimestampType]
 
             val filter = predicate("=", partitionCol, literal)
             val expectedResult = if (literal.getValue == null) {
               Seq.empty // part1 == null should always return false - that means no results
             } else {
               if (selectPredicatePartitionCol) {
-                if (isPartitionColDateType) {
-                  // Date type has two partitions with the same value in golden table
+                if (isPartitionColDateOrTimestampType) {
+                  // Date and timestamp type has two partitions with the same value in golden table
                   Seq((literal.getValue, 0L, "0"), (literal.getValue, 1L, "1"))
                 } else {
                   Seq((literal.getValue, 1L, "1"))
                 }
               } else {
-                if (isPartitionColDateType) {
-                  // Date type has two partitions with the same value in golden table
+                if (isPartitionColDateOrTimestampType) {
+                  // Date and timestamp type has two partitions with the same value in golden table
                   Seq((0L, "0"), (1L, "1"))
                 } else {
                   Seq((1L, "1"))

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
@@ -17,7 +17,7 @@ package io.delta.kernel.defaults.internal.expressions
 
 import java.lang.{Boolean => BooleanJ}
 import java.math.{BigDecimal => BigDecimalJ}
-import java.sql.Date
+import java.sql.{Date, Timestamp}
 import java.util
 import java.util.Optional
 
@@ -572,9 +572,11 @@ class DefaultExpressionEvaluatorSuite extends AnyFunSuite with ExpressionSuiteBa
       ("null", BinaryType.BINARY, null),
       ("2021-11-18", DateType.DATE, InternalUtils.daysSinceEpoch(Date.valueOf("2021-11-18"))),
       ("null", DateType.DATE, null),
-      ("2021-11-18", DateType.DATE, InternalUtils.daysSinceEpoch(Date.valueOf("2021-11-18"))),
-      ("null", DateType.DATE, null)
-      // TODO: timestamp partition value types are not yet supported in reading
+      ("2020-02-18 22:00:10", TimestampType.TIMESTAMP,
+        InternalUtils.microsSinceEpoch(Timestamp.valueOf("2020-02-18 22:00:10"))),
+      ("2020-02-18 00:00:10.023", TimestampType.TIMESTAMP,
+        InternalUtils.microsSinceEpoch(Timestamp.valueOf("2020-02-18 00:00:10.023"))),
+      ("null", TimestampType.TIMESTAMP, null)
     )
 
     val inputBatch = zeroColumnBatch(rowCount = 1)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Resolves #2278.

Adds support for reading timestamp partition columns (previously intentionally unsupported) according to the decisions in this doc https://docs.google.com/document/d/15chiWn7QwUzAxy6t2inIoTCKTBQMnv4UWRWtrZvfULQ/edit?usp=sharing.

Also adds support for partition pruning on timestamp columns.

## How was this patch tested?

Updates existing tests to test for timestamp partition columns