### PR TITLE
Use the OSS metadata key for generated columns

### DIFF
--- a/spark/src/main/scala/io/delta/tables/DeltaColumnBuilder.scala
+++ b/spark/src/main/scala/io/delta/tables/DeltaColumnBuilder.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.delta.sources.DeltaSourceUtils.GENERATION_EXPRESSION
 
 import org.apache.spark.annotation._
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.util.GeneratedColumn
 import org.apache.spark.sql.types.{DataType, MetadataBuilder, StructField}
 
 /**
@@ -121,6 +122,11 @@ class DeltaColumnBuilder private[tables](
   def build(): StructField = {
     val metadataBuilder = new MetadataBuilder()
     if (generationExpr.nonEmpty) {
+      metadataBuilder.putString(
+        GeneratedColumn.GENERATION_EXPRESSION_METADATA_KEY,
+        generationExpr.get
+      )
+      // Still set the legacy Delta key for backward compatibility.
       metadataBuilder.putString(GENERATION_EXPRESSION_METADATA_KEY, generationExpr.get)
     }
     if (comment.nonEmpty) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ColumnWithDefaultExprUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ColumnWithDefaultExprUtils.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.delta.sources.{DeltaSourceUtils, DeltaSQLConf}
 import org.apache.spark.sql.{Column, DataFrame, Dataset, Encoder}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.expressions.EqualNullSafe
-import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
+import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, GeneratedColumn => SparkGeneratedColumn}
 import org.apache.spark.sql.catalyst.util.ResolveDefaultColumns._
 import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.execution.streaming.{IncrementalExecution, StreamExecution}
@@ -175,6 +175,8 @@ object ColumnWithDefaultExprUtils extends DeltaLogging {
         updated = true
         val newMetadata = new MetadataBuilder()
           .withMetadata(field.metadata)
+          .remove(SparkGeneratedColumn.GENERATION_EXPRESSION_METADATA_KEY)
+          // Also remove the legacy Delta key.
           .remove(DeltaSourceUtils.GENERATION_EXPRESSION_METADATA_KEY)
           .build()
         field.copy(metadata = newMetadata)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
@@ -47,7 +47,7 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{NoSuchDatabaseException, NoSuchNamespaceException, NoSuchTableException, UnresolvedAttribute, UnresolvedFieldName, UnresolvedFieldPosition}
 import org.apache.spark.sql.catalyst.catalog.{BucketSpec, CatalogTable, CatalogTableType, CatalogUtils, SessionCatalog}
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, QualifiedColType}
-import org.apache.spark.sql.connector.catalog.{DelegatingCatalogExtension, Identifier, StagedTable, StagingTableCatalog, SupportsWrite, Table, TableCapability, TableCatalog, TableChange, V1Table}
+import org.apache.spark.sql.connector.catalog.{DelegatingCatalogExtension, Identifier, StagedTable, StagingTableCatalog, SupportsWrite, Table, TableCapability, TableCatalog, TableCatalogCapability, TableChange, V1Table}
 import org.apache.spark.sql.connector.catalog.TableCapability._
 import org.apache.spark.sql.connector.catalog.TableChange._
 import org.apache.spark.sql.connector.expressions.{FieldReference, IdentityTransform, Literal, NamedReference, Transform}
@@ -67,6 +67,11 @@ class DeltaCatalog extends DelegatingCatalogExtension
   with SupportsPathIdentifier
   with DeltaLogging {
 
+  override def capabilities: java.util.Set[TableCatalogCapability] = {
+    (super.capabilities().asScala ++ Set(
+      TableCatalogCapability.SUPPORTS_CREATE_TABLE_WITH_GENERATED_COLUMNS
+    )).asJava
+  }
 
   val spark = SparkSession.active
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
@@ -1029,10 +1029,7 @@ trait GeneratedColumnSuiteBase extends GeneratedColumnTest {
       )
       // Verify schema
       val f1 = StructField("c1", IntegerType, nullable = true)
-      val fieldMetadata = new MetadataBuilder()
-        .putString(GENERATION_EXPRESSION_METADATA_KEY, "c1 + 10")
-        .putString("comment", "foo")
-        .build()
+      val fieldMetadata = withGenerationExpression(f1.withComment("foo"), "c1 + 10").metadata
       val f2 = StructField("c2", IntegerType, nullable = true, metadata = fieldMetadata)
       val f3 = StructField("c3", IntegerType, nullable = false, metadata = fieldMetadata)
       val expectedSchema = StructType(f1 :: f2 :: f3 :: Nil)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR is to prepare for the Spark 4.0 compatibility, by using the Spark metadata key for generated columns, which can be recognized by Spark.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
existing tests
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no