### PR TITLE
Make DELTA_ICEBERG_COMPAT_V1_VIOLATION show proper feature names

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3091,7 +3091,7 @@ trait DeltaErrorsBase
       version: Int, tf: TableFeature): Throwable = {
     new DeltaUnsupportedOperationException(
       errorClass = "DELTA_ICEBERG_COMPAT_VIOLATION.MISSING_REQUIRED_TABLE_FEATURE",
-      messageParameters = Array(version.toString, version.toString, tf.toString)
+      messageParameters = Array(version.toString, version.toString, tf.name)
     )
   }
 
@@ -3099,7 +3099,7 @@ trait DeltaErrorsBase
       version: Int, tf: TableFeature): Throwable = {
     new DeltaUnsupportedOperationException(
       errorClass = "DELTA_ICEBERG_COMPAT_VIOLATION.DISABLING_REQUIRED_TABLE_FEATURE",
-      messageParameters = Array(version.toString, version.toString, tf.toString, version.toString)
+      messageParameters = Array(version.toString, version.toString, tf.name, version.toString)
     )
   }
 
@@ -3107,7 +3107,7 @@ trait DeltaErrorsBase
       version: Int, tf: TableFeature): Throwable = {
     new DeltaUnsupportedOperationException(
       errorClass = "DELTA_ICEBERG_COMPAT_VIOLATION.INCOMPATIBLE_TABLE_FEATURE",
-      messageParameters = Array(version.toString, version.toString, tf.toString)
+      messageParameters = Array(version.toString, version.toString, tf.name)
     )
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR fixes an unfriendly error message that shows the raw string form of a table feature object. Instead it should show the name of the table feature.

## How was this patch tested?

No because too trivial.

## Does this PR introduce _any_ user-facing changes?

No.
