### PR TITLE
Support map and arrays in ALTER TABLE CHANGE COLUMN

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2260,6 +2260,12 @@
     ],
     "sqlState" : "0AKDC"
   },
+  "DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP" : {
+    "message" : [
+      "ALTER TABLE CHANGE COLUMN is not supported for changing column <oldColumns> to <newColumns>"
+    ],
+    "sqlState" : "0AKDC"
+  },
   "DELTA_UNSUPPORTED_ALTER_TABLE_REPLACE_COL_OP" : {
     "message" : [
       "Unsupported ALTER TABLE REPLACE COLUMNS operation. Reason: <details>",

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2262,7 +2262,7 @@
   },
   "DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP" : {
     "message" : [
-      "ALTER TABLE CHANGE COLUMN is not supported for changing column <oldColumns> to <newColumns>"
+      "ALTER TABLE CHANGE COLUMN is not supported for changing column <fieldPath> from <oldType> (nullable = <oldNullability>) to <newType> (nullable = <newNullability>)"
     ],
     "sqlState" : "0AKDC"
   },
@@ -2332,6 +2332,12 @@
   "DELTA_UNSUPPORTED_COLUMN_TYPE_IN_BLOOM_FILTER" : {
     "message" : [
       "Creating a bloom filter index on a column with type <dataType> is unsupported: <columnName>"
+    ],
+    "sqlState" : "0AKDC"
+  },
+  "DELTA_UNSUPPORTED_COMMENT_MAP_ARRAY" : {
+    "message" : [
+      "Can't add a comment to <fieldPath>. Adding a comment to a map key/value or array element is not supported."
     ],
     "sqlState" : "0AKDC"
   },

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2262,7 +2262,7 @@
   },
   "DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP" : {
     "message" : [
-      "ALTER TABLE CHANGE COLUMN is not supported for changing column <fieldPath> from <oldType> (nullable = <oldNullability>) to <newType> (nullable = <newNullability>)"
+      "ALTER TABLE CHANGE COLUMN is not supported for changing column <fieldPath> from <oldField> to <newField>"
     ],
     "sqlState" : "0AKDC"
   },

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -611,9 +611,20 @@ trait DeltaErrorsBase
   }
 
   def alterTableChangeColumnException(oldColumns: String, newColumns: String): Throwable = {
-    new AnalysisException(
-      "ALTER TABLE CHANGE COLUMN is not supported for changing column " + oldColumns + " to "
-      + newColumns)
+    new DeltaAnalysisException(
+      errorClass = "DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP",
+      messageParameters = Array(oldColumns, newColumns)
+    )
+  }
+
+  def alterTableReplaceColumnsException(
+      oldSchema: StructType,
+      newSchema: StructType,
+      reason: String): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_UNSUPPORTED_ALTER_TABLE_REPLACE_COL_OP",
+      messageParameters = Array(reason, formatSchema(oldSchema), formatSchema(newSchema))
+    )
   }
 
   def cannotWriteIntoView(table: TableIdentifier): Throwable = {
@@ -685,16 +696,6 @@ trait DeltaErrorsBase
     new DeltaAnalysisException(
       errorClass = "DELTA_COLUMN_STRUCT_TYPE_MISMATCH",
       messageParameters = Array(source, targetType, target, tableName))
-  }
-
-  def alterTableReplaceColumnsException(
-      oldSchema: StructType,
-      newSchema: StructType,
-      reason: String): Throwable = {
-    new DeltaAnalysisException(
-      errorClass = "DELTA_UNSUPPORTED_ALTER_TABLE_REPLACE_COL_OP",
-      messageParameters = Array(reason, formatSchema(oldSchema), formatSchema(newSchema))
-    )
   }
 
   def ambiguousPartitionColumnException(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -625,10 +625,8 @@ trait DeltaErrorsBase
       errorClass = "DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP",
       messageParameters = Array(
         fieldPath,
-        oldField.dataType.typeName,
-        oldField.nullable.toString,
-        newField.dataType.typeName,
-        newField.nullable.toString)
+        oldField.sql,
+        newField.sql)
     )
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -610,10 +610,25 @@ trait DeltaErrorsBase
     )
   }
 
-  def alterTableChangeColumnException(oldColumns: String, newColumns: String): Throwable = {
+  def addCommentToMapArrayException(fieldPath: String): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_UNSUPPORTED_COMMENT_MAP_ARRAY",
+      messageParameters = Array(fieldPath)
+    )
+  }
+
+  def alterTableChangeColumnException(
+      fieldPath: String,
+      oldField: StructField,
+      newField: StructField): Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP",
-      messageParameters = Array(oldColumns, newColumns)
+      messageParameters = Array(
+        fieldPath,
+        oldField.dataType.typeName,
+        oldField.nullable.toString,
+        newField.dataType.typeName,
+        newField.nullable.toString)
     )
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -621,12 +621,15 @@ trait DeltaErrorsBase
       fieldPath: String,
       oldField: StructField,
       newField: StructField): Throwable = {
+    def fieldToString(field: StructField): String =
+      field.dataType.sql + (if (!field.nullable) " NOT NULL" else "")
+
     new DeltaAnalysisException(
       errorClass = "DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP",
       messageParameters = Array(
         fieldPath,
-        oldField.sql,
-        newField.sql)
+        fieldToString(oldField),
+        fieldToString(newField))
     )
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.constraints.{CharVarcharConstraint, Constraints}
 import org.apache.spark.sql.delta.schema.{SchemaMergingUtils, SchemaUtils}
-import org.apache.spark.sql.delta.schema.SchemaUtils.transformColumnsStructs
+import org.apache.spark.sql.delta.schema.SchemaUtils.transformSchema
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.StatisticsCollection
 import org.apache.hadoop.fs.Path
@@ -529,7 +529,7 @@ case class AlterTableChangeColumnDeltaCommand(
       // Verify that the columnName provided actually exists in the schema
       SchemaUtils.findColumnPosition(columnPath :+ columnName, oldSchema, resolver)
 
-      val newSchema = transformColumnsStructs(oldSchema, Some(columnName)) {
+      val newSchema = transformSchema(oldSchema, Some(columnName)) {
         case (`columnPath`, struct @ StructType(fields), _) =>
           val oldColumn = struct(columnName)
           verifyColumnChange(sparkSession, struct(columnName), resolver, txn)
@@ -561,11 +561,27 @@ case class AlterTableChangeColumnDeltaCommand(
           }
 
           // Reorder new field to correct position if necessary
-          colPosition.map { position =>
+          StructType(colPosition.map { position =>
             reorderFieldList(struct, newFieldList, newField, position, resolver)
-          }.getOrElse(newFieldList.toSeq)
+          }.getOrElse(newFieldList.toSeq))
 
-        case (_, _ @ StructType(fields), _) => fields
+        case (`columnPath`, m: MapType, _) if columnName == "key" =>
+          val originalField = StructField(columnName, m.keyType, nullable = false)
+          verifyMapArrayChange(sparkSession, originalField, resolver, txn)
+          m.copy(keyType = SchemaUtils.changeDataType(m.keyType, newColumn.dataType, resolver))
+
+        case (`columnPath`, m: MapType, _) if columnName == "value" =>
+          val originalField = StructField(columnName, m.valueType, nullable = m.valueContainsNull)
+          verifyMapArrayChange(sparkSession, originalField, resolver, txn)
+          m.copy(valueType = SchemaUtils.changeDataType(m.valueType, newColumn.dataType, resolver))
+
+        case (`columnPath`, a: ArrayType, _) if columnName == "element" =>
+          val originalField = StructField(columnName, a.elementType, nullable = a.containsNull)
+          verifyMapArrayChange(sparkSession, originalField, resolver, txn)
+          a.copy(elementType =
+            SchemaUtils.changeDataType(a.elementType, newColumn.dataType, resolver))
+
+        case (_, other, _) => other
       }
 
       // update `partitionColumns` if the changed column is a partition column
@@ -685,8 +701,13 @@ case class AlterTableChangeColumnDeltaCommand(
     // first (original data type is already normalized as we store char/varchar as string type with
     // special metadata in the Delta log), then apply Delta-specific checks.
     val newType = CharVarcharUtils.replaceCharVarcharWithString(newColumn.dataType)
-    if (SchemaUtils.canChangeDataType(originalField.dataType, newType, resolver,
-        txn.metadata.columnMappingMode, columnPath :+ originalField.name).nonEmpty) {
+    if (SchemaUtils.canChangeDataType(
+        originalField.dataType,
+        newType,
+        resolver,
+        txn.metadata.columnMappingMode,
+        columnPath :+ originalField.name
+      ).nonEmpty) {
       throw DeltaErrors.alterTableChangeColumnException(
         s"'${UnresolvedAttribute(columnPath :+ originalField.name).name}' with type " +
           s"'${originalField.dataType}" +
@@ -711,6 +732,25 @@ case class AlterTableChangeColumnDeltaCommand(
           s"'${newColumn.dataType}" +
           s" (nullable = ${newColumn.nullable})'")
     }
+  }
+
+  /**
+   * Verify whether replacing the original map key/value or array element with a new data type is a
+   * valid operation.
+   *
+   * @param originalField the original map key/value or array element to update.
+   */
+  private def verifyMapArrayChange(spark: SparkSession, originalField: StructField,
+      resolver: Resolver, txn: OptimisticTransaction): Unit = {
+    // Map key/value and array element can't have metadata.
+    if (newColumn.metadata != Metadata.empty) {
+      throw DeltaErrors.alterTableChangeColumnException(
+        s"'${UnresolvedAttribute(columnPath :+ columnName).name}'",
+        s"'${UnresolvedAttribute(Seq(newColumn.name)).name}' with metadata " +
+          s"'${newColumn.metadata}'"
+      )
+    }
+    verifyColumnChange(spark, originalField, resolver, txn)
   }
 }
 
@@ -738,8 +778,13 @@ case class AlterTableReplaceColumnsDeltaCommand(
       val resolver = sparkSession.sessionState.conf.resolver
       val changingSchema = StructType(columns)
 
-      SchemaUtils.canChangeDataType(existingSchema, changingSchema, resolver,
-        txn.metadata.columnMappingMode, failOnAmbiguousChanges = true).foreach { operation =>
+      SchemaUtils.canChangeDataType(
+        existingSchema,
+        changingSchema,
+        resolver,
+        txn.metadata.columnMappingMode,
+        failOnAmbiguousChanges = true
+      ).foreach { operation =>
         throw DeltaErrors.alterTableReplaceColumnsException(
           existingSchema, changingSchema, operation)
       }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -928,8 +928,10 @@ object SchemaUtils extends DeltaLogging {
   /**
    * Runs the transform function `tf` on all nested StructTypes, MapTypes and ArrayTypes in the
    * schema.
-   * If `colName` is defined, the transform function is only applied to the fields with the given
-   * name.
+   * If `colName` is defined, the transform function is only applied to all the fields with the
+   * given name. There may be multiple matches if nested fields with the same name exist in the
+   * schema, it is the responsibility of the caller to check the full field path before transforming
+   * a field.
    * @param schema to transform.
    * @param colName Optional name to match for
    * @param tf function to apply on the StructType.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -697,7 +697,9 @@ object SchemaUtils extends DeltaLogging {
    */
   def addColumn(schema: StructType, column: StructField, position: Seq[Int]): StructType = {
     def addColumnInChild(parent: DataType, column: StructField, position: Seq[Int]): DataType = {
-      require(position.nonEmpty, s"Don't know where to add the column $column")
+      if (position.isEmpty) {
+          throw DeltaErrors.addColumnParentNotStructException(column, parent)
+      }
       parent match {
         case struct: StructType =>
           addColumn(struct, column, position)
@@ -765,7 +767,9 @@ object SchemaUtils extends DeltaLogging {
    */
   def dropColumn(schema: StructType, position: Seq[Int]): (StructType, StructField) = {
     def dropColumnInChild(parent: DataType, position: Seq[Int]): (DataType, StructField) = {
-      require(position.nonEmpty, s"Don't know where to drop the column")
+      if (position.isEmpty) {
+          throw DeltaErrors.dropNestedColumnsFromNonStructTypeException(parent)
+      }
       parent match {
         case struct: StructType =>
           dropColumn(struct, position)
@@ -922,38 +926,49 @@ object SchemaUtils extends DeltaLogging {
   }
 
   /**
-   * Transform (nested) columns in a schema. Runs the transform function on all nested StructTypes
-   *
-   * If `colName` is defined, we also check if the struct to process contains the column name.
-   *
+   * Runs the transform function `tf` on all nested StructTypes, MapTypes and ArrayTypes in the
+   * schema.
+   * If `colName` is defined, the transform function is only applied to the fields with the given
+   * name.
    * @param schema to transform.
    * @param colName Optional name to match for
    * @param tf function to apply on the StructType.
    * @return the transformed schema.
    */
-  def transformColumnsStructs(
+  def transformSchema(
       schema: StructType,
       colName: Option[String] = None)(
-      tf: (Seq[String], StructType, Resolver) => Seq[StructField]): StructType = {
+      tf: (Seq[String], DataType, Resolver) => DataType): StructType = {
     def transform[E <: DataType](path: Seq[String], dt: E): E = {
       val newDt = dt match {
         case struct @ StructType(fields) =>
-          val newFields = if (colName.isEmpty || fields.exists(f => colName.contains(f.name))) {
-            tf(path, struct, DELTA_COL_RESOLVER)
+          val newStruct = if (colName.isEmpty || fields.exists(f => colName.contains(f.name))) {
+            tf(path, struct, DELTA_COL_RESOLVER).asInstanceOf[StructType]
           } else {
-            fields.toSeq
+            struct
           }
 
-          StructType(newFields.map { field =>
+          StructType(newStruct.fields.map { field =>
             field.copy(dataType = transform(path :+ field.name, field.dataType))
           })
-        case ArrayType(elementType, containsNull) =>
-          ArrayType(transform(path :+ "element", elementType), containsNull)
-        case MapType(keyType, valueType, valueContainsNull) =>
-          MapType(
-            transform(path :+ "key", keyType),
-            transform(path :+ "value", valueType),
-            valueContainsNull)
+        case array: ArrayType =>
+          val newArray =
+            if (colName.isEmpty || colName.contains("element")) {
+              tf(path, array, DELTA_COL_RESOLVER).asInstanceOf[ArrayType]
+            } else {
+              array
+            }
+          newArray.copy(elementType = transform(path :+ "element", newArray.elementType))
+        case map: MapType =>
+          val newMap =
+            if (colName.isEmpty || colName.contains("key") || colName.contains("value")) {
+              tf(path, map, DELTA_COL_RESOLVER).asInstanceOf[MapType]
+            } else {
+              map
+            }
+          newMap.copy(
+            keyType = transform(path :+ "key", newMap.keyType),
+            valueType = transform(path :+ "value", newMap.valueType))
         case other => other
       }
       newDt.asInstanceOf[E]

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.delta.commands.DeletionVectorUtils
 import org.apache.spark.sql.delta.commands.DeltaCommand
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.{SchemaMergingUtils, SchemaUtils}
-import org.apache.spark.sql.delta.schema.SchemaUtils.transformColumnsStructs
+import org.apache.spark.sql.delta.schema.SchemaUtils.transformSchema
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.DeltaStatistics._
 import org.apache.spark.sql.delta.stats.StatisticsCollection.getIndexedColumns
@@ -490,12 +490,12 @@ object StatisticsCollection extends DeltaCommand {
         SchemaUtils.findColumnPosition(columnFullPath, schema)
         // Delta statistics columns must be data skipping type.
         val (prefixPath, columnName) = columnFullPath.splitAt(columnFullPath.size - 1)
-        transformColumnsStructs(schema, Some(columnName.head)) {
+        transformSchema(schema, Some(columnName.head)) {
           case (`prefixPath`, struct @ StructType(_), _) =>
             val columnField = struct(columnName.head)
             validateDataSkippingType(columnAttribute.name, columnField.dataType, visitedColumns)
             struct
-          case (_, s: StructType, _) => s
+          case (_, other, _) => other
         }
       }
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
@@ -1343,10 +1343,9 @@ trait DeltaAlterTableTests extends DeltaAlterTableTestBase {
       sql(s"ALTER TABLE $tableName CHANGE COLUMN a.element DROP NOT NULL")
 
       // Changing the nullability of map/array fields is not allowed.
+      var statement = s"ALTER TABLE $tableName CHANGE COLUMN m.key DROP NOT NULL"
       checkError(
-        exception = intercept[AnalysisException] {
-          sql(s"ALTER TABLE $tableName CHANGE COLUMN m.key DROP NOT NULL")
-        },
+        exception = intercept[AnalysisException] { sql(statement) },
         errorClass = "DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP",
         parameters = Map(
           "fieldPath" -> "m.key",
@@ -1356,23 +1355,25 @@ trait DeltaAlterTableTests extends DeltaAlterTableTestBase {
           "newNullability" -> "true"
         )
       )
+
+      statement = s"ALTER TABLE $tableName CHANGE COLUMN m.value SET NOT NULL"
       checkError(
-        exception = intercept[AnalysisException] {
-          sql(s"ALTER TABLE $tableName CHANGE COLUMN m.value SET NOT NULL")
-        },
+        exception = intercept[AnalysisException] { sql(statement) },
         errorClass = "_LEGACY_ERROR_TEMP_2330",
         parameters = Map(
           "fieldName" -> "m.value"
-        )
+        ),
+        context = ExpectedContext(statement, 0, statement.length - 1)
       )
+
+      statement = s"ALTER TABLE $tableName CHANGE COLUMN a.element SET NOT NULL"
       checkError(
-        exception = intercept[AnalysisException] {
-          sql(s"ALTER TABLE $tableName CHANGE COLUMN a.element SET NOT NULL")
-        },
+        exception = intercept[AnalysisException] { sql(statement) },
         errorClass = "_LEGACY_ERROR_TEMP_2330",
         parameters = Map(
           "fieldName" -> "a.element"
-        )
+        ),
+        context = ExpectedContext(statement, 0, statement.length - 1)
       )
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
@@ -1351,7 +1351,7 @@ trait DeltaAlterTableTests extends DeltaAlterTableTestBase {
           },
           errorClass = "_LEGACY_ERROR_TEMP_2330",
           parameters = Map(
-            "fieldName" -> fieldName,
+            "fieldName" -> fieldName
           )
         )
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
@@ -1049,8 +1049,10 @@ trait DeltaAlterTableTests extends DeltaAlterTableTestBase {
         errorClass = "DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP",
         parameters = Map(
           "fieldPath" -> "a.key",
-          "oldField" -> "key: INT NOT NULL",
-          "newField" -> "key: BIGINT NOT NULL"
+          // This should be `INT NOT NULL` and `BIGINT NOT NULL` but Spark 3.5 doesn't display
+          // nullability correctly. This is fixed in recent Spark by SPARK-46629.
+          "oldField" -> "key: INT",
+          "newField" -> "key: BIGINT"
         )
       )
     }
@@ -1386,7 +1388,9 @@ trait DeltaAlterTableTests extends DeltaAlterTableTestBase {
         errorClass = "DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP",
         parameters = Map(
           "fieldPath" -> "m.key",
-          "oldField" -> "key: INT NOT NULL",
+          // This should be `INT NOT NULL` but Spark 3.5 doesn't display
+          // nullability correctly. This is fixed in recent Spark by SPARK-46629.
+          "oldField" -> "key: INT",
           "newField" -> "key: INT"
         )
       )

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
@@ -1049,10 +1049,8 @@ trait DeltaAlterTableTests extends DeltaAlterTableTestBase {
         errorClass = "DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP",
         parameters = Map(
           "fieldPath" -> "a.key",
-          // This should be `INT NOT NULL` and `BIGINT NOT NULL` but Spark 3.5 doesn't display
-          // nullability correctly. This is fixed in recent Spark by SPARK-46629.
-          "oldField" -> "INT",
-          "newField" -> "BIGINT"
+          "oldField" -> "INT NOT NULL",
+          "newField" -> "BIGINT NOT NULL"
         )
       )
     }
@@ -1388,9 +1386,7 @@ trait DeltaAlterTableTests extends DeltaAlterTableTestBase {
         errorClass = "DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP",
         parameters = Map(
           "fieldPath" -> "m.key",
-          // This should be `INT NOT NULL` but Spark 3.5 doesn't display
-          // nullability correctly. This is fixed in recent Spark by SPARK-46629.
-          "oldField" -> "INT",
+          "oldField" -> "INT NOT NULL",
           "newField" -> "INT"
         )
       )

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
@@ -1013,8 +1013,8 @@ trait DeltaAlterTableTests extends DeltaAlterTableTestBase {
         errorClass = "DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP",
         parameters = Map(
           "fieldPath" -> "v1",
-          "oldField" -> "v1: INT",
-          "newField" -> "v1: BIGINT"
+          "oldField" -> "INT",
+          "newField" -> "BIGINT"
         )
       )
     }
@@ -1031,8 +1031,8 @@ trait DeltaAlterTableTests extends DeltaAlterTableTestBase {
         errorClass = "DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP",
         parameters = Map(
           "fieldPath" -> "struct.v1",
-          "oldField" -> "v1: INT",
-          "newField" -> "v1: BIGINT"
+          "oldField" -> "INT",
+          "newField" -> "BIGINT"
         )
       )
     }
@@ -1051,8 +1051,8 @@ trait DeltaAlterTableTests extends DeltaAlterTableTestBase {
           "fieldPath" -> "a.key",
           // This should be `INT NOT NULL` and `BIGINT NOT NULL` but Spark 3.5 doesn't display
           // nullability correctly. This is fixed in recent Spark by SPARK-46629.
-          "oldField" -> "key: INT",
-          "newField" -> "key: BIGINT"
+          "oldField" -> "INT",
+          "newField" -> "BIGINT"
         )
       )
     }
@@ -1069,8 +1069,8 @@ trait DeltaAlterTableTests extends DeltaAlterTableTestBase {
         errorClass = "DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP",
         parameters = Map(
           "fieldPath" -> "a.value",
-          "oldField" -> "value: INT",
-          "newField" -> "value: BIGINT"
+          "oldField" -> "INT",
+          "newField" -> "BIGINT"
         )
       )
     }
@@ -1087,8 +1087,8 @@ trait DeltaAlterTableTests extends DeltaAlterTableTestBase {
         errorClass = "DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP",
         parameters = Map(
           "fieldPath" -> "a.element",
-          "oldField" -> "element: INT",
-          "newField" -> "element: BIGINT"
+          "oldField" -> "INT",
+          "newField" -> "BIGINT"
         )
       )
     }
@@ -1390,8 +1390,8 @@ trait DeltaAlterTableTests extends DeltaAlterTableTestBase {
           "fieldPath" -> "m.key",
           // This should be `INT NOT NULL` but Spark 3.5 doesn't display
           // nullability correctly. This is fixed in recent Spark by SPARK-46629.
-          "oldField" -> "key: INT",
-          "newField" -> "key: INT"
+          "oldField" -> "INT",
+          "newField" -> "INT"
         )
       )
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
@@ -1351,9 +1351,9 @@ trait DeltaAlterTableTests extends DeltaAlterTableTestBase {
         parameters = Map(
           "fieldPath" -> "m.key",
           "oldType" -> "integer",
-          "oldNullability" -> "true",
+          "oldNullability" -> "false",
           "newType" -> "integer",
-          "newNullability" -> "false"
+          "newNullability" -> "true"
         )
       )
       checkError(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1017,8 +1017,8 @@ trait DeltaErrorsSuiteBase
         errorClass = "DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP",
         parameters = Map(
           "fieldPath" -> "a.b.c",
-          "oldField" -> "c: INT",
-          "newField" -> "c: BIGINT"
+          "oldField" -> "INT",
+          "newField" -> "BIGINT"
         )
       )
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1017,10 +1017,8 @@ trait DeltaErrorsSuiteBase
         errorClass = "DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP",
         parameters = Map(
           "fieldPath" -> "a.b.c",
-          "oldType" -> "integer",
-          "oldNullability" -> "true",
-          "newType" -> "long",
-          "newNullability" -> "true"
+          "oldField" -> "INT",
+          "newField" -> "LONG"
         )
       )
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1017,8 +1017,8 @@ trait DeltaErrorsSuiteBase
         errorClass = "DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP",
         parameters = Map(
           "fieldPath" -> "a.b.c",
-          "oldField" -> "INT",
-          "newField" -> "LONG"
+          "oldField" -> "c: INT",
+          "newField" -> "c: BIGINT"
         )
       )
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -56,7 +56,7 @@ import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.errors.QueryErrorsBase
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtils}
-import org.apache.spark.sql.types.{CalendarIntervalType, DataTypes, DateType, IntegerType, StringType, StructField, StructType, TimestampNTZType}
+import org.apache.spark.sql.types._
 
 trait DeltaErrorsSuiteBase
     extends QueryTest
@@ -1007,13 +1007,22 @@ trait DeltaErrorsSuiteBase
         ))
     }
     {
-      val e = intercept[DeltaAnalysisException] {
-        throw DeltaErrors.alterTableChangeColumnException("oldColumns", "newColumns")
-      }
-      checkErrorMessage(e, Some("DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP"), Some("0AKDC"),
-        Some("ALTER TABLE CHANGE COLUMN is not supported for changing column oldColumns to " +
-          "newColumns"
-      ))
+      checkError(
+        exception = intercept[DeltaAnalysisException] {
+          throw DeltaErrors.alterTableChangeColumnException(
+            fieldPath = "a.b.c",
+            oldField = StructField("c", IntegerType),
+            newField = StructField("c", LongType))
+        },
+        errorClass = "DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP",
+        parameters = Map(
+          "fieldPath" -> "a.b.c",
+          "oldType" -> "integer",
+          "oldNullability" -> "true",
+          "newType" -> "long",
+          "newNullability" -> "true"
+        )
+      )
     }
     {
       val s1 = StructType(Seq(StructField("c0", IntegerType)))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1007,6 +1007,15 @@ trait DeltaErrorsSuiteBase
         ))
     }
     {
+      val e = intercept[DeltaAnalysisException] {
+        throw DeltaErrors.alterTableChangeColumnException("oldColumns", "newColumns")
+      }
+      checkErrorMessage(e, Some("DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP"), Some("0AKDC"),
+        Some("ALTER TABLE CHANGE COLUMN is not supported for changing column oldColumns to " +
+          "newColumns"
+      ))
+    }
+    {
       val s1 = StructType(Seq(StructField("c0", IntegerType)))
       val s2 = StructType(Seq(StructField("c0", StringType)))
       val e = intercept[DeltaAnalysisException] {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
@@ -1089,6 +1089,14 @@ class SchemaUtilsSuite extends QueryTest
         keyType = new StructType().add(k),
         valueType = new StructType().add(v).add(x))))
 
+    // Adding to map key/value.
+    expectFailure("parent is not a structtype") {
+      SchemaUtils.addColumn(schema, x, Seq(0, MAP_KEY_INDEX))
+    }
+    expectFailure("parent is not a structtype") {
+      SchemaUtils.addColumn(schema, x, Seq(0, MAP_VALUE_INDEX))
+    }
+    // Invalid map access.
     expectFailure("parent is not a structtype") {
       SchemaUtils.addColumn(schema, x, Seq(0, MAP_KEY_INDEX - 1, 0))
     }
@@ -1137,6 +1145,13 @@ class SchemaUtilsSuite extends QueryTest
     assert(SchemaUtils.addColumn(schema(), x, Seq(0, MAP_VALUE_INDEX, MAP_VALUE_INDEX, 1)) ===
       schema(vv = new StructType().add("vv", IntegerType).add(x)))
 
+    // Adding to map key/value.
+    expectFailure("parent is not a structtype") {
+      SchemaUtils.addColumn(schema(), x, Seq(0, MAP_KEY_INDEX, MAP_KEY_INDEX))
+    }
+    expectFailure("parent is not a structtype") {
+      SchemaUtils.addColumn(schema(), x, Seq(0, MAP_KEY_INDEX, MAP_VALUE_INDEX))
+    }
     // Invalid map access.
     expectFailure("parent is not a structtype") {
       SchemaUtils.addColumn(schema(), x, Seq(0, MAP_KEY_INDEX, MAP_KEY_INDEX - 1, 0))
@@ -1166,6 +1181,10 @@ class SchemaUtilsSuite extends QueryTest
     assert(SchemaUtils.addColumn(schema, x, Seq(0, ARRAY_ELEMENT_INDEX, 1)) ===
       new StructType().add("a", ArrayType(new StructType().add(e).add(x))))
 
+    // Adding to array element.
+    expectFailure("parent is not a structtype") {
+      SchemaUtils.addColumn(schema, x, Seq(0, ARRAY_ELEMENT_INDEX))
+    }
     // Invalid array access.
     expectFailure("Incorrectly accessing an ArrayType") {
       SchemaUtils.addColumn(schema, x, Seq(0, ARRAY_ELEMENT_INDEX - 1, 0))
@@ -1189,6 +1208,10 @@ class SchemaUtilsSuite extends QueryTest
     assert(SchemaUtils.addColumn(schema, x, Seq(0, ARRAY_ELEMENT_INDEX, ARRAY_ELEMENT_INDEX, 1)) ===
       new StructType().add("a", ArrayType(ArrayType(new StructType().add(e).add(x)))))
 
+    // Adding to array element.
+    expectFailure("parent is not a structtype") {
+      SchemaUtils.addColumn(schema, x, Seq(0, ARRAY_ELEMENT_INDEX, ARRAY_ELEMENT_INDEX))
+    }
     // Invalid array access.
     expectFailure("Incorrectly accessing an ArrayType") {
       SchemaUtils.addColumn(schema, x, Seq(0, ARRAY_ELEMENT_INDEX, ARRAY_ELEMENT_INDEX - 1, 0))
@@ -1301,6 +1324,14 @@ class SchemaUtilsSuite extends QueryTest
         valueType = new StructType().add(c))),
       d))
 
+    // Dropping map key/value.
+    expectFailure("can only drop nested columns from structtype") {
+      SchemaUtils.dropColumn(schema, Seq(0, MAP_KEY_INDEX))
+    }
+    expectFailure("can only drop nested columns from structtype") {
+      SchemaUtils.dropColumn(schema, Seq(0, MAP_VALUE_INDEX))
+    }
+    // Invalid map access.
     expectFailure("can only drop nested columns from structtype") {
       SchemaUtils.dropColumn(schema, Seq(0, MAP_KEY_INDEX - 1, 0))
     }
@@ -1367,6 +1398,13 @@ class SchemaUtilsSuite extends QueryTest
       initialSchema = schema(vv = new StructType().add("vv", IntegerType).add(a)),
       position = Seq(0, MAP_VALUE_INDEX, MAP_VALUE_INDEX, 1))
 
+    // Dropping map key/value.
+    expectFailure("can only drop nested columns from structtype") {
+      SchemaUtils.dropColumn(schema(), Seq(0, MAP_KEY_INDEX, MAP_KEY_INDEX))
+    }
+    expectFailure("can only drop nested columns from structtype") {
+      SchemaUtils.dropColumn(schema(), Seq(0, MAP_KEY_INDEX, MAP_VALUE_INDEX))
+    }
     // Invalid map access.
     expectFailure("can only drop nested columns from structtype") {
       SchemaUtils.dropColumn(schema(), Seq(0, MAP_KEY_INDEX, MAP_KEY_INDEX - 1, 0))
@@ -1396,6 +1434,10 @@ class SchemaUtilsSuite extends QueryTest
     assert(SchemaUtils.dropColumn(schema, Seq(0, ARRAY_ELEMENT_INDEX, 1)) ===
       (new StructType().add("a", ArrayType(new StructType().add(e))), f))
 
+    // Dropping array element.
+    expectFailure("can only drop nested columns from structtype") {
+      SchemaUtils.dropColumn(schema, Seq(0, ARRAY_ELEMENT_INDEX))
+    }
     // Invalid array access.
     expectFailure("Incorrectly accessing an ArrayType") {
       SchemaUtils.dropColumn(schema, Seq(0, ARRAY_ELEMENT_INDEX - 1, 0))
@@ -1419,6 +1461,10 @@ class SchemaUtilsSuite extends QueryTest
     assert(SchemaUtils.dropColumn(schema, Seq(0, ARRAY_ELEMENT_INDEX, ARRAY_ELEMENT_INDEX, 1)) ===
       (new StructType().add("a", ArrayType(ArrayType(new StructType().add(e)))), f))
 
+    // Dropping array element.
+    expectFailure("can only drop nested columns from structtype") {
+      SchemaUtils.dropColumn(schema, Seq(0, ARRAY_ELEMENT_INDEX, ARRAY_ELEMENT_INDEX))
+    }
     // Invalid array access.
     expectFailure("Incorrectly accessing an ArrayType") {
       SchemaUtils.dropColumn(schema, Seq(0, ARRAY_ELEMENT_INDEX, ARRAY_ELEMENT_INDEX - 1, 0))


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This change addresses an issue where trying to change the key/value of a map or element of an array with ALTER TABLE CHANGE COLUMN would succeed while doing nothing.
 
In addition, a proper error is now thrown when trying to add or drop the key or value of a map or element of an array.

## How was this patch tested?

- Added tests to `DeltaAlterTableTests` to cover changing maps and arrays in ALTER TABLE CHANGE COLUMN.
- Added tests to `SchemaUtilsSuite` and `DeltaDropColumnSuite` to cover the updated error when trying to add/drop map key/value or array element.

## Does this PR introduce _any_ user-facing changes?

Changing the type of the key or value of a map or of the elements of an array now fails if the type change isn't supported (= anything except setting the same type or moving between char, varchar, string):
```
CREATE TABLE table (m map<int, int>) USING DELTA;
ALTER TABLE table CHANGE COLUMN m.key key long;
-- Fails with DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL, previously succeeded while applying no change.
```
Similarly, adding a comment now also fails.

The error when trying to add or drop a map key/value or array element field is updated:
```
CREATE TABLE table (m map<int, int>) USING DELTA;
ALTER TABLE table ADD COLUMN m.key long;
-- Now fails with DELTA_ADD_COLUMN_PARENT_NOT_STRUCT instead of IllegalArgumentException: Don't know where to add the column m.key"
```
