### PR TITLE
Factor logic to collect files to REORG out of OPTIMIZE

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaReorgTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaReorgTableCommand.scala
@@ -16,13 +16,10 @@
 
 package org.apache.spark.sql.delta.commands
 
-import org.apache.spark.sql.delta.catalog.DeltaTableV2
-import org.apache.spark.sql.delta.sources.DeltaSourceUtils
+import org.apache.spark.sql.delta.actions.AddFile
 
 import org.apache.spark.sql.{Row, SparkSession}
-import org.apache.spark.sql.catalyst.analysis.ResolvedTable
 import org.apache.spark.sql.catalyst.plans.logical.{IgnoreCachedData, LeafCommand, LogicalPlan, UnaryCommand}
-import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
 
 object DeltaReorgTableMode extends Enumeration {
   val PURGE, UNIFORM_ICEBERG = Value
@@ -47,7 +44,7 @@ case class DeltaReorgTable(
 }
 
 /**
- * The PURGE command.
+ * The REORG TABLE command.
  */
 case class DeltaReorgTableCommand(
     target: LogicalPlan,
@@ -60,30 +57,66 @@ case class DeltaReorgTableCommand(
 
   override val otherCopyArgs: Seq[AnyRef] = predicates :: Nil
 
-  override def optimizeByReorg(
-    sparkSession: SparkSession,
-    isPurge: Boolean,
-    icebergCompatVersion: Option[Int]): Seq[Row] = {
+  override def optimizeByReorg(sparkSession: SparkSession): Seq[Row] = {
     val command = OptimizeTableCommand(
       target,
       predicates,
       optimizeContext = DeltaOptimizeContext(
-        isPurge = isPurge,
+        reorg = Some(reorgOperation),
         minFileSize = Some(0L),
-        maxDeletedRowsRatio = Some(0d),
-        icebergCompatVersion = icebergCompatVersion
-      )
+        maxDeletedRowsRatio = Some(0d))
     )(zOrderBy = Nil)
     command.run(sparkSession)
   }
 
-  override def run(sparkSession: SparkSession): Seq[Row] = {
-    reorgTableSpec match {
-      case DeltaReorgTableSpec(DeltaReorgTableMode.PURGE, None) =>
-        optimizeByReorg(sparkSession, isPurge = true, icebergCompatVersion = None)
-      case DeltaReorgTableSpec(DeltaReorgTableMode.UNIFORM_ICEBERG, Some(icebergCompatVersion)) =>
-        val table = getDeltaTable(target, "REORG")
-        upgradeUniformIcebergCompatVersion(table, sparkSession, icebergCompatVersion)
+  override def run(sparkSession: SparkSession): Seq[Row] = reorgTableSpec match {
+    case DeltaReorgTableSpec(DeltaReorgTableMode.PURGE, None) =>
+      optimizeByReorg(sparkSession)
+    case DeltaReorgTableSpec(DeltaReorgTableMode.UNIFORM_ICEBERG, Some(icebergCompatVersion)) =>
+      val table = getDeltaTable(target, "REORG")
+      upgradeUniformIcebergCompatVersion(table, sparkSession, icebergCompatVersion)
+  }
+
+  protected def reorgOperation: DeltaReorgOperation = reorgTableSpec match {
+    case DeltaReorgTableSpec(DeltaReorgTableMode.PURGE, None) =>
+      new DeltaPurgeOperation()
+    case DeltaReorgTableSpec(DeltaReorgTableMode.UNIFORM_ICEBERG, Some(icebergCompatVersion)) =>
+      new DeltaUpgradeUniformOperation(icebergCompatVersion)
+  }
+}
+
+/**
+ * Defines a Reorg operation to be applied during optimize.
+ */
+sealed trait DeltaReorgOperation {
+  /**
+   * Collects files that need to be processed by the reorg operation from the list of candidate
+   * files.
+   */
+  def filterFilesToReorg(files: Seq[AddFile]): Seq[AddFile]
+}
+
+/**
+ * Reorg operation to purge files with soft deleted rows.
+ */
+class DeltaPurgeOperation extends DeltaReorgOperation {
+  override def filterFilesToReorg(files: Seq[AddFile]): Seq[AddFile] =
+    files.filter { file =>
+      (file.deletionVector != null && file.numPhysicalRecords.isEmpty) ||
+        file.numDeletedRecords > 0L
     }
+}
+
+/**
+ * Reorg operation to upgrade the iceberg compatibility version of a table.
+ */
+class DeltaUpgradeUniformOperation(icebergCompatVersion: Int) extends DeltaReorgOperation {
+  override def filterFilesToReorg(files: Seq[AddFile]): Seq[AddFile] = {
+    def shouldRewriteToBeIcebergCompatible(file: AddFile): Boolean = {
+      if (file.tags == null) return true
+      val icebergCompatVersion = file.tags.getOrElse(AddFile.Tags.ICEBERG_COMPAT_VERSION.name, "0")
+      !icebergCompatVersion.exists(_.toString == icebergCompatVersion)
+    }
+    files.filter(shouldRewriteToBeIcebergCompatible)
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -265,7 +265,7 @@ class OptimizeExecutor(
 
       val filesToProcess = optimizeContext.reorg match {
         case Some(reorgOperation) => reorgOperation.filterFilesToReorg(candidateFiles)
-        case None => pruneCandidateFileList(minFileSize, maxDeletedRowsRatio, candidateFiles)
+        case None => filterCandidateFileList(minFileSize, maxDeletedRowsRatio, candidateFiles)
       }
       val partitionsToCompact = filesToProcess.groupBy(_.partitionValues).toSeq
 
@@ -341,7 +341,7 @@ class OptimizeExecutor(
    * Helper method to prune the list of selected files based on fileSize and ratio of
    * deleted rows according to the deletion vector in [[AddFile]].
    */
-  private def pruneCandidateFileList(
+  private def filterCandidateFileList(
       minFileSize: Long, maxDeletedRowsRatio: Double, files: Seq[AddFile]): Seq[AddFile] = {
 
     // Select all files in case of multi-dimensional clustering

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ReorgTableForUpgradeUniformHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ReorgTableForUpgradeUniformHelper.scala
@@ -49,10 +49,7 @@ trait ReorgTableForUpgradeUniformHelper extends DeltaLogging {
   /**
    * Helper function to rewrite the table. Implemented by Reorg Table Command.
    */
-  def optimizeByReorg(
-     sparkSession: SparkSession,
-     isPurge: Boolean,
-     icebergCompatVersion: Option[Int]): Seq[Row]
+  def optimizeByReorg(sparkSession: SparkSession): Seq[Row]
 
   /**
    * Helper function to update the table icebergCompat properties.
@@ -172,11 +169,7 @@ trait ReorgTableForUpgradeUniformHelper extends DeltaLogging {
       logInfo(s"Reorg Table ${target.tableIdentifier} to iceberg compat version = " +
         s"$targetIcebergCompatVersion need rewrite data files.")
       val metrics = try {
-        optimizeByReorg(
-          sparkSession,
-          isPurge = false,
-          icebergCompatVersion = Some(targetIcebergCompatVersion)
-        )
+        optimizeByReorg(sparkSession)
       } catch {
         case NonFatal(e) =>
           throw DeltaErrors.icebergCompatDataFileRewriteFailedException(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AutoCompact.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AutoCompact.scala
@@ -197,7 +197,7 @@ trait AutoCompactBase extends PostCommitHook with DeltaLogging {
     recordDeltaOperation(deltaLog, s"$opType.execute") {
       val txn = deltaLog.startTransaction(catalogTable)
       val optimizeContext = DeltaOptimizeContext(
-        isPurge = false,
+        reorg = None,
         minFileSizeOpt,
         maxFileSizeOpt,
         maxDeletedRowsRatio = maxDeletedRowsRatio


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)


## Description

This is a plain refactor of REORG TABLE / OPTIMIZE to allow for better extendability and adding new types of REORG TABLE operations in the future.

The REORG operation currently supports:
- PURGE: remove soft deleted rows (DVs) and dropped columns.
- UPGRADE UNIFORM: rewrite files to be iceberg compatible.

More operations can be used in the future to allow dropping table features, in particular for column mapping: rewrite files to have the physical column names match the logical column name.

## How was this patch tested?

This a plain refactor without functional changes.
