### PR TITLE
Add a config flag for partition change check in DeltaSource

### DIFF
--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaFormatSharingSourceSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaFormatSharingSourceSuite.scala
@@ -974,7 +974,6 @@ class DeltaFormatSharingSourceSuite
             var e = intercept[StreamingQueryException] {
               processAllAvailableInStream(0)
             }
-
             assert(e.getCause.asInstanceOf[DeltaIllegalStateException].getErrorClass
               == "DELTA_SCHEMA_CHANGED_WITH_STARTING_OPTIONS")
             assert(e.getMessage.contains("Detected schema change in version 3"))

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaFormatSharingSourceSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaFormatSharingSourceSuite.scala
@@ -16,12 +16,14 @@
 
 package io.delta.sharing.spark
 
+import org.apache.spark.sql.delta.DeltaIllegalStateException
 import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.DeltaOptions.{
   IGNORE_CHANGES_OPTION,
   IGNORE_DELETES_OPTION,
   SKIP_CHANGE_COMMITS_OPTION
 }
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import io.delta.sharing.client.DeltaSharingRestClient
 import io.delta.sharing.client.model.{Table => DeltaSharingTable}
@@ -30,7 +32,8 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkEnv
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.delta.sharing.DeltaSharingTestSparkUtils
-import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.functions.{col, lit}
+import org.apache.spark.sql.streaming.StreamingQueryExceptions
 import org.apache.spark.sql.streaming.StreamTest
 import org.apache.spark.sql.types.{
   DateType,
@@ -894,6 +897,108 @@ class DeltaFormatSharingSourceSuite
             expected
           )
           assertBlocksAreCleanedUp()
+        }
+      }
+    }
+  }
+
+  Seq(
+    ("add a partition column", Seq("part"), Seq("is_even", "part")),
+    ("change partition order", Seq("part", "is_even"), Seq("is_even", "part")),
+    ("different partition column", Seq("part"), Seq("is_even"))
+  ).foreach { case (repartitionTestCase, initPartitionCols, overwritePartitionCols) =>
+    test("deltaSharing - repartition delta source should fail by default " +
+      s"unless unsafe flag is set - $repartitionTestCase") {
+      withTempDirs { (inputDir, outputDir, checkpointDir) =>
+
+        val deltaTableName = "basic_delta_table_partition_check"
+        withTable(deltaTableName) {
+          spark.sql(
+            s"""CREATE TABLE $deltaTableName (id LONG, part INT, is_even BOOLEAN)
+               |USING DELTA PARTITIONED BY (${initPartitionCols.mkString(", ")})
+               |""".stripMargin
+          )
+          val sharedTableName = "shared_streaming_table_partition_check_" +
+            s"${repartitionTestCase.replace(' ', '_')}"
+          prepareMockedClientMetadata(deltaTableName, sharedTableName)
+          val profileFile = prepareProfileFile(inputDir)
+          val tablePath = profileFile.getCanonicalPath + s"#share1.default.$sharedTableName"
+
+          withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
+
+            def processAllAvailableInStream(startingVersion: Int): Unit = {
+              val q = spark.readStream
+                .format("deltaSharing")
+                .option("responseFormat", "delta")
+                .option("skipChangeCommits", "true")
+                .option("startingVersion", startingVersion)
+                .load(tablePath)
+                .writeStream
+                .format("delta")
+                .option("checkpointLocation", checkpointDir.toString)
+                .start(outputDir.toString)
+
+              try {
+                q.processAllAvailable()
+              } finally {
+                q.stop()
+              }
+            }
+
+            spark.range(10).withColumn("part", lit(1))
+              .withColumn("is_even", $"id" % 2 === 0).write
+              .format("delta").partitionBy(initPartitionCols: _*)
+              .mode("append")
+              .saveAsTable(deltaTableName)
+            spark.range(2).withColumn("part", lit(2))
+              .withColumn("is_even", $"id" % 2 === 0).write
+              .format("delta").partitionBy(initPartitionCols: _*)
+              .mode("append").saveAsTable(deltaTableName)
+            spark.range(10).withColumn("part", lit(1))
+              .withColumn("is_even", $"id" % 2 === 0).write
+              .format("delta").partitionBy(overwritePartitionCols: _*)
+              .option("overwriteSchema", "true").mode("overwrite")
+              .saveAsTable(deltaTableName)
+            spark.range(2).withColumn("part", lit(2))
+              .withColumn("is_even", $"id" % 2 === 0).write
+              .format("delta").partitionBy(overwritePartitionCols: _*)
+              .mode("append").saveAsTable(deltaTableName)
+
+            prepareMockedClientAndFileSystemResultForStreaming(
+              deltaTable = deltaTableName,
+              sharedTable = sharedTableName,
+              startingVersion = 0L,
+              endingVersion = 4L
+            )
+            prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+            var e = intercept[StreamingQueryException] {
+              processAllAvailableInStream(0)
+            }
+            assert(e.getCause.asInstanceOf[DeltaIllegalStateException].getErrorClass
+              == "DELTA_SCHEMA_CHANGED_WITH_STARTING_OPTIONS")
+            assert(e.getMessage.contains("Detected schema change in version 3"))
+
+            // delta table created using sql with specified partition col
+            // will construct their initial snapshot on the initial definition
+            prepareMockedClientAndFileSystemResultForStreaming(
+              deltaTable = deltaTableName,
+              sharedTable = sharedTableName,
+              startingVersion = 4L,
+              endingVersion = 4L
+            )
+            prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+            e = intercept[StreamingQueryException] {
+              processAllAvailableInStream(4)
+            }
+            assert(e.getMessage.contains("Detected schema change in version 4"))
+
+            // Streaming query made progress without throwing error when
+            // unsafe flag is set to true
+            withSQLConf(
+              DeltaSQLConf.DELTA_STREAMING_UNSAFE_READ_ON_PARTITION_COLUMN_CHANGE.key -> "true") {
+              processAllAvailableInStream(0)
+            }
+          }
         }
       }
     }

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaFormatSharingSourceSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaFormatSharingSourceSuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.SparkEnv
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.delta.sharing.DeltaSharingTestSparkUtils
 import org.apache.spark.sql.functions.{col, lit}
-import org.apache.spark.sql.streaming.StreamingQueryExceptions
+import org.apache.spark.sql.streaming.StreamingQueryException
 import org.apache.spark.sql.streaming.StreamTest
 import org.apache.spark.sql.types.{
   DateType,
@@ -974,6 +974,7 @@ class DeltaFormatSharingSourceSuite
             var e = intercept[StreamingQueryException] {
               processAllAvailableInStream(0)
             }
+
             assert(e.getCause.asInstanceOf[DeltaIllegalStateException].getErrorClass
               == "DELTA_SCHEMA_CHANGED_WITH_STARTING_OPTIONS")
             assert(e.getMessage.contains("Detected schema change in version 3"))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
@@ -629,10 +629,10 @@ trait DeltaColumnMappingBase extends DeltaLogging {
    * no rename column or drop column has happened in-between.
    */
   def hasNoColumnMappingSchemaChanges(newMetadata: Metadata, oldMetadata: Metadata,
-    allowUnsafeReadOnPartitionChanges: Boolean = false): Boolean = {
+      allowUnsafeReadOnPartitionChanges: Boolean = false): Boolean = {
     // Helper function to check no column mapping schema change and no repartition
     def hasNoColMappingAndRepartitionSchemaChange(
-        newMetadata: Metadata, oldMetadata: Metadata): Boolean = {
+       newMetadata: Metadata, oldMetadata: Metadata): Boolean = {
       isRenameColumnOperation(newMetadata, oldMetadata) ||
         isDropColumnOperation(newMetadata, oldMetadata) ||
         !SchemaUtils.isPartitionCompatible(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
@@ -632,15 +632,13 @@ trait DeltaColumnMappingBase extends DeltaLogging {
     allowUnsafeReadOnPartitionChanges: Boolean = false): Boolean = {
     // Helper function to check no column mapping schema change and no repartition
     def hasNoColMappingAndRepartitionSchemaChange(
-       newMetadata: Metadata, oldMetadata: Metadata): Boolean = {
+        newMetadata: Metadata, oldMetadata: Metadata): Boolean = {
       isRenameColumnOperation(newMetadata, oldMetadata) ||
         isDropColumnOperation(newMetadata, oldMetadata) ||
         !SchemaUtils.isPartitionCompatible(
           // if allow unsafe row read for partition change, ignore the check
-          if (allowUnsafeReadOnPartitionChanges) Seq.empty
-            else newMetadata.partitionColumns,
-          if (allowUnsafeReadOnPartitionChanges) Seq.empty
-            else oldMetadata.partitionColumns)
+          if (allowUnsafeReadOnPartitionChanges) Seq.empty else newMetadata.partitionColumns,
+          if (allowUnsafeReadOnPartitionChanges) Seq.empty else oldMetadata.partitionColumns)
     }
 
     val (oldMode, newMode) = (oldMetadata.columnMappingMode, newMetadata.columnMappingMode)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
@@ -628,7 +628,7 @@ trait DeltaColumnMappingBase extends DeltaLogging {
    * As of now, `newMetadata` is column mapping read compatible with `oldMetadata` if
    * no rename column or drop column has happened in-between.
    */
-  def hasNoColumnMappingSchemaChanges(newMetadata: Metadata, oldMetadata: Metadata
+  def hasNoColumnMappingSchemaChanges(newMetadata: Metadata, oldMetadata: Metadata,
     allowUnsafeReadOnPartitionChanges: Boolean = false): Boolean = {
     // Helper function to check no column mapping schema change and no repartition
     def hasNoColMappingAndRepartitionSchemaChange(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
@@ -628,14 +628,19 @@ trait DeltaColumnMappingBase extends DeltaLogging {
    * As of now, `newMetadata` is column mapping read compatible with `oldMetadata` if
    * no rename column or drop column has happened in-between.
    */
-  def hasNoColumnMappingSchemaChanges(newMetadata: Metadata, oldMetadata: Metadata): Boolean = {
+  def hasNoColumnMappingSchemaChanges(newMetadata: Metadata, oldMetadata: Metadata
+    allowUnsafeReadOnPartitionChanges: Boolean = false): Boolean = {
     // Helper function to check no column mapping schema change and no repartition
     def hasNoColMappingAndRepartitionSchemaChange(
        newMetadata: Metadata, oldMetadata: Metadata): Boolean = {
       isRenameColumnOperation(newMetadata, oldMetadata) ||
         isDropColumnOperation(newMetadata, oldMetadata) ||
         !SchemaUtils.isPartitionCompatible(
-          newMetadata.partitionColumns, oldMetadata.partitionColumns)
+          // if allow unsafe row read for partition change, ignore the check
+          if (allowUnsafeReadOnPartitionChanges) Seq.empty
+            else newMetadata.partitionColumns,
+          if (allowUnsafeReadOnPartitionChanges) Seq.empty
+            else oldMetadata.partitionColumns)
     }
 
     val (oldMode, newMode) = (oldMetadata.columnMappingMode, newMetadata.columnMappingMode)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -249,8 +249,7 @@ object SchemaUtils extends DeltaLogging {
   def isPartitionCompatible(
       newPartitionColumns: Seq[String] = Seq.empty,
       oldPartitionColumns: Seq[String] = Seq.empty): Boolean = {
-    (newPartitionColumns.isEmpty && oldPartitionColumns.isEmpty) ||
-      (newPartitionColumns == oldPartitionColumns)
+    newPartitionColumns == oldPartitionColumns
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1183,9 +1183,9 @@ trait DeltaSQLConfBase {
     buildConf("streaming.unsafeReadOnPartitionColumnChanges.enabled")
       .doc(
         "Streaming read on Delta table with partition column overwrite " +
-        "(e.g. changing partition column) is currently blocked due to potential data loss. " +
-        "However, existing users may use this flag to force unblock " +
-        "if they'd like to take the risk.")
+          "(e.g. changing partition column) is currently blocked due to potential data loss. " +
+          "However, existing users may use this flag to force unblock " +
+          "if they'd like to take the risk.")
       .internal()
       .booleanConf
       .createWithDefault(false)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1179,6 +1179,17 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(false)
 
+  val DELTA_STREAMING_UNSAFE_READ_ON_PARTITION_COLUMN_CHANGE =
+    buildConf("streaming.unsafeReadOnPartitionColumnChanges.enabled")
+      .doc(
+        "Streaming read on Delta table with partition column overwrite " +
+        "(e.g. changing partition column) is currently blocked due to potential data loss. " +
+        "However, existing users may use this flag to force unblock " +
+        "if they'd like to take the risk.")
+      .internal()
+      .booleanConf
+      .createWithDefault(false)
+
   val DELTA_STREAMING_ENABLE_SCHEMA_TRACKING =
     buildConf("streaming.schemaTracking.enabled")
       .doc(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -649,10 +649,10 @@ trait DeltaSourceBase extends Source
               allowUnsafeStreamingReadOnColumnMappingSchemaChanges &&
               backfilling,
             // Partition column change will be ignored if user enable the unsafe flag
-            newPartitionColumns = if (allowUnsafeStreamingReadOnPartitionColumnChanges) Seq.empty
-              else newMetadata.partitionColumns,
-            oldPartitionColumns = if (allowUnsafeStreamingReadOnPartitionColumnChanges) Seq.empty
-              else oldMetadata.partitionColumns
+          newPartitionColumns = if (allowUnsafeStreamingReadOnPartitionColumnChanges) Seq.empty
+            else newMetadata.partitionColumns,
+          oldPartitionColumns = if (allowUnsafeStreamingReadOnPartitionColumnChanges) Seq.empty
+            else oldMetadata.partitionColumns
         )) {
         // Only schema change later than the current read snapshot/schema can be retried, in other
         // words, backfills could never be retryable, because we have no way to refresh

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -124,6 +124,11 @@ trait DeltaSourceBase extends Source
     unsafeFlagEnabled
   }
 
+  protected lazy val allowUnsafeStreamingReadOnPartitionColumnChanges: Boolean =
+    spark.sessionState.conf.getConf(
+      DeltaSQLConf.DELTA_STREAMING_UNSAFE_READ_ON_PARTITION_COLUMN_CHANGE
+    )
+
   /**
    * Flag that allows user to disable the read-compatibility check during stream start which
    * protects against an corner case in which verifyStreamHygiene could not detect.
@@ -601,7 +606,8 @@ trait DeltaSourceBase extends Source
     if (!allowUnsafeStreamingReadOnColumnMappingSchemaChanges) {
       assert(!trackingMetadataChange, "should not check schema change while tracking it")
 
-      if (!DeltaColumnMapping.hasNoColumnMappingSchemaChanges(newMetadata, oldMetadata)) {
+      if (!DeltaColumnMapping.hasNoColumnMappingSchemaChanges(newMetadata, oldMetadata,
+        allowUnsafeStreamingReadOnPartitionColumnChanges)) {
         throw DeltaErrors.blockStreamingReadsWithIncompatibleColumnMappingSchemaChanges(
           spark,
           oldMetadata.schema,
@@ -642,8 +648,11 @@ trait DeltaSourceBase extends Source
             isStreamingFromColumnMappingTable &&
               allowUnsafeStreamingReadOnColumnMappingSchemaChanges &&
               backfilling,
-          newPartitionColumns = newMetadata.partitionColumns,
-          oldPartitionColumns = oldMetadata.partitionColumns
+            // Partition column change will be ignored if user enable the unsafe flag
+            newPartitionColumns = if (allowUnsafeStreamingReadOnPartitionColumnChanges) Seq.empty
+              else newMetadata.partitionColumns,
+            oldPartitionColumns = if (allowUnsafeStreamingReadOnPartitionColumnChanges) Seq.empty
+              else oldMetadata.partitionColumns
         )) {
         // Only schema change later than the current read snapshot/schema can be retried, in other
         // words, backfills could never be retryable, because we have no way to refresh

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -648,7 +648,7 @@ trait DeltaSourceBase extends Source
             isStreamingFromColumnMappingTable &&
               allowUnsafeStreamingReadOnColumnMappingSchemaChanges &&
               backfilling,
-            // Partition column change will be ignored if user enable the unsafe flag
+          // Partition column change will be ignored if user enable the unsafe flag
           newPartitionColumns = if (allowUnsafeStreamingReadOnPartitionColumnChanges) Seq.empty
             else newMetadata.partitionColumns,
           oldPartitionColumns = if (allowUnsafeStreamingReadOnPartitionColumnChanges) Seq.empty


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Add a config for partition change check in Delta Source. Users can turn on or turn off the check by changing the config.
## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No