### PR TITLE
[Spark] Fix typo in ROW_INDEX_STRUCT_FIELD

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
@@ -363,7 +363,7 @@ object DeltaParquetFileFormat {
 
   /** Row index for each column */
   val ROW_INDEX_COLUMN_NAME = "__delta_internal_row_index"
-  val ROW_INDEX_STRUCT_FILED = StructField(ROW_INDEX_COLUMN_NAME, LongType)
+  val ROW_INDEX_STRUCT_FIELD = StructField(ROW_INDEX_COLUMN_NAME, LongType)
 
   /** Utility method to create a new writable vector */
   private def newVector(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DMLWithDeletionVectorsHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DMLWithDeletionVectorsHelper.scala
@@ -77,7 +77,7 @@ object DMLWithDeletionVectorsHelper extends DeltaCommand {
    * @param fileIndex the new file index
    */
   private def replaceFileIndex(target: LogicalPlan, fileIndex: TahoeFileIndex): LogicalPlan = {
-    val rowIndexCol = AttributeReference(ROW_INDEX_COLUMN_NAME, ROW_INDEX_STRUCT_FILED.dataType)();
+    val rowIndexCol = AttributeReference(ROW_INDEX_COLUMN_NAME, ROW_INDEX_STRUCT_FIELD.dataType)();
     var fileMetadataCol: AttributeReference = null
 
     val newTarget = target.transformUp {
@@ -85,11 +85,11 @@ object DMLWithDeletionVectorsHelper extends DeltaCommand {
         hfsr @ HadoopFsRelation(_, _, _, _, format: DeltaParquetFileFormat, _), _, _, _) =>
         fileMetadataCol = format.createFileMetadataCol()
         // Take the existing schema and add additional metadata columns
-        val newDataSchema = StructType(hfsr.dataSchema).add(ROW_INDEX_STRUCT_FILED)
+        val newDataSchema =
+          StructType(hfsr.dataSchema).add(ROW_INDEX_STRUCT_FIELD)
         val finalOutput = l.output ++ Seq(rowIndexCol, fileMetadataCol)
         // Disable splitting and filter pushdown in order to generate the row-indexes
         val newFormat = format.copy(isSplittable = false, disablePushDowns = true)
-
         val newBaseRelation = hfsr.copy(
           location = fileIndex,
           dataSchema = newDataSchema,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
@@ -68,7 +68,7 @@ class DeltaParquetFileFormatSuite extends QueryTest
           readingSchema = readingSchema.add(DeltaParquetFileFormat.IS_ROW_DELETED_STRUCT_FIELD)
         }
         if (readRowIndexCol) {
-          readingSchema = readingSchema.add(DeltaParquetFileFormat.ROW_INDEX_STRUCT_FILED)
+          readingSchema = readingSchema.add(DeltaParquetFileFormat.ROW_INDEX_STRUCT_FIELD)
         }
 
         // Fetch the only file in the DeltaLog snapshot


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Correct a typo: `ROW_INDEX_STRUCT_FILED` -> `ROW_INDEX_STRUCT_FIELD`

## How was this patch tested?
N/A
