### PR TITLE
Update PROTOCOL to replace incorrect Deletion Vector example

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -883,7 +883,7 @@ Assuming that this DV is stored relative to an `s3://mytable/` directory, the ab
 ```json
 {
   "storageType" : "i",
-  "pathOrInlineDv" : "^Bg9^0rr910000000000iXQKl0rr91000935c8X    g000621onSa",
+  "pathOrInlineDv" : "^Bg9^0rr910000000000iXQKl0rr91000935c8Xg000621onSa",
   "sizeInBytes" : 40,
   "cardinality" : 4
 }

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -883,12 +883,12 @@ Assuming that this DV is stored relative to an `s3://mytable/` directory, the ab
 ```json
 {
   "storageType" : "i",
-  "pathOrInlineDv" : "wi5b=000010000siXQKl0rr91000f55c8Xg0@@D72lkbi5=-{L",
+  "pathOrInlineDv" : "^Bg9^0rr910000000000iXQKl0rr91000935c8X    g000621onSa",
   "sizeInBytes" : 40,
-  "cardinality" : 6
+  "cardinality" : 4
 }
 ```
-The row indexes encoded in this DV are: 3, 4, 7, 11, 18, 29.
+The row indexes encoded in this DV are: 0, 2, 4, 6
 
 ## Reader Requirements for Deletion Vectors
 If a snapshot contains logical files with records that are invalidated by a DV, then these records *must not* be returned in the output.


### PR DESCRIPTION
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Spec Doc)

## Description

The current example inlined Deletion Vector in PROTOCOL.md does not work. When trying to read a table with this deletion vector in spark, this is the error:

24/02/12 09:34:59 WARN TaskSetManager: Lost task 2.0 in stage 11.0 (TID 159) (10.0.0.160 executor driver): TaskKilled (Stage cancelled: Job aborted due to stage failure: Task 0 in stage 11.0 failed 1 times, most recent failure: Lost task 0.0 in stage 11.0 (TID 157) (10.0.0.160 executor driver): java.io.IOException: Unexpected RoaringBitmapArray magic number -791463580

This PR replaces it with an inlined deletion vector that does work.


## How was this patch tested?

Tested loading the example DV in spark and in some rust code using the roaring crate.

## Does this PR introduce _any_ user-facing changes?

Documentation.