### PR TITLE
[Spark][TEST-ONLY] Add more test coverage for TRUNCATE HISTORY

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.{AlterTableSetPropertiesDeltaCommand, AlterTableUnsetPropertiesDeltaCommand}
 import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.util.{Utils => DeltaUtils}
 
 /**
  * A base class for implementing a preparation command for removing table features.
@@ -45,7 +46,10 @@ case class TestWriterFeaturePreDowngradeCommand(table: DeltaTableV2)
     // Make sure feature data/metadata exist before proceeding.
     if (TestRemovableWriterFeature.validateRemoval(table.initialSnapshot)) return false
 
-    recordDeltaEvent(table.deltaLog, "delta.test.TestWriterFeaturePreDowngradeCommand")
+    if (DeltaUtils.isTesting) {
+      recordDeltaEvent(table.deltaLog, "delta.test.TestWriterFeaturePreDowngradeCommand")
+    }
+
     val properties = Seq(TestRemovableWriterFeature.TABLE_PROP_KEY)
     AlterTableUnsetPropertiesDeltaCommand(table, properties, ifExists = true).run(table.spark)
     true
@@ -60,7 +64,10 @@ case class TestReaderWriterFeaturePreDowngradeCommand(table: DeltaTableV2)
     // Make sure feature data/metadata exist before proceeding.
     if (TestRemovableReaderWriterFeature.validateRemoval(table.initialSnapshot)) return false
 
-    recordDeltaEvent(table.deltaLog, "delta.test.TestReaderWriterFeaturePreDowngradeCommand")
+    if (DeltaUtils.isTesting) {
+      recordDeltaEvent(table.deltaLog, "delta.test.TestReaderWriterFeaturePreDowngradeCommand")
+    }
+
     val properties = Seq(TestRemovableReaderWriterFeature.TABLE_PROP_KEY)
     AlterTableUnsetPropertiesDeltaCommand(table, properties, ifExists = true).run(table.spark)
     true

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
@@ -53,12 +53,14 @@ case class TestWriterFeaturePreDowngradeCommand(table: DeltaTableV2)
 }
 
 case class TestReaderWriterFeaturePreDowngradeCommand(table: DeltaTableV2)
-  extends PreDowngradeTableFeatureCommand {
+  extends PreDowngradeTableFeatureCommand
+  with DeltaLogging {
   // To remove the feature we only need to remove the table property.
   override def removeFeatureTracesIfNeeded(): Boolean = {
     // Make sure feature data/metadata exist before proceeding.
     if (TestRemovableReaderWriterFeature.validateRemoval(table.initialSnapshot)) return false
 
+    recordDeltaEvent(table.deltaLog, "delta.test.TestReaderWriterFeaturePreDowngradeCommand")
     val properties = Seq(TestRemovableReaderWriterFeature.TABLE_PROP_KEY)
     AlterTableUnsetPropertiesDeltaCommand(table, properties, ifExists = true).run(table.spark)
     true

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -3193,6 +3193,77 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     }
   }
 
+  for {
+    withCatalog <- BOOLEAN_DOMAIN
+    quoteWith <- if (withCatalog) Seq("none", "single", "backtick") else Seq("none")
+  } test(s"Drop feature DDL TRUNCATE HISTORY - withCatalog=$withCatalog, quoteWith=$quoteWith") {
+    withTempDir { dir =>
+      val table = if (withCatalog) {
+        s"${spark.sessionState.catalog.getCurrentDatabase}.table"
+      } else {
+        s"delta.`${dir.getCanonicalPath}`"
+      }
+      if (withCatalog) sql(s"DROP TABLE IF EXISTS $table")
+      sql(
+        s"""CREATE TABLE $table (id bigint) USING delta
+           |TBLPROPERTIES (
+           |delta.feature.${TestRemovableReaderWriterFeature.name} = 'supported',
+           |${TestRemovableReaderWriterFeature.TABLE_PROP_KEY} = "true",
+           |${DeltaConfigs.TABLE_FEATURE_DROP_TRUNCATE_HISTORY_LOG_RETENTION.key} = "0 hours"
+           |)""".stripMargin)
+
+      // We need to use a Delta log object with the ManualClock created in this test instead of
+      // the default SystemClock. However, we can't pass the Delta log to use directly in the SQL
+      // command. Instead, we will
+      //  1. Clear the Delta log cache to remove the log associated with table creation.
+      //  2. Populate the Delta log cache with the Delta log object that has the ManualClock we
+      //  want to use
+      // TODO(c27kwan): Refactor this and provide a better way to control clocks in Delta tests.
+      val clock = new ManualClock(System.currentTimeMillis())
+      val deltaLog = if (withCatalog) {
+        val tableIdentifier =
+          TableIdentifier("table", Some(spark.sessionState.catalog.getCurrentDatabase))
+        // We need to hack the Delta log cache with path based access to setup the right key.
+        val path = DeltaLog.forTable(spark, tableIdentifier, clock).dataPath
+        DeltaLog.clearCache()
+        DeltaLog.forTable(spark, path, clock)
+      } else {
+        DeltaLog.clearCache()
+        DeltaLog.forTable(spark, dir, clock)
+      }
+
+      val protocol = deltaLog.update().protocol
+      assert(protocol === protocolWithReaderFeature(TestRemovableReaderWriterFeature))
+
+      val logs = Log4jUsageLogger.track {
+        val featureName = quoteWith match {
+          case "none" => s"${TestRemovableReaderWriterFeature.name}"
+          case "single" => s"'${TestRemovableReaderWriterFeature.name}'"
+          case "backtick" => s"`${TestRemovableReaderWriterFeature.name}`"
+        }
+
+        // Expect an exception when dropping a reader writer feature that has traces of the feature.
+        intercept[DeltaTableFeatureException] {
+          sql(s"ALTER TABLE $table DROP FEATURE $featureName")
+        }
+
+        // Move past retention period.
+        clock.advance(TimeUnit.HOURS.toMillis( 1))
+
+        sql(s"ALTER TABLE $table DROP FEATURE $featureName TRUNCATE HISTORY")
+        assert(deltaLog.update().protocol === Protocol(1, 1))
+      }
+
+      // Validate the correct downgrade command was invoked.
+      val expectedOpType = "delta.test.TestReaderWriterFeaturePreDowngradeCommand"
+      val blob = logs.collectFirst {
+        case r if r.metric == MetricDefinitions.EVENT_TAHOE.name &&
+          r.tags.get("opType").contains(expectedOpType) => r.blob
+      }
+      assert(blob.nonEmpty, s"Expecting an '$expectedOpType' event but didn't see any.")
+    }
+  }
+
   protected def testProtocolVersionDowngrade(
       initialMinReaderVersion: Int,
       initialMinWriterVersion: Int,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -3198,69 +3198,71 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     quoteWith <- if (withCatalog) Seq("none", "single", "backtick") else Seq("none")
   } test(s"Drop feature DDL TRUNCATE HISTORY - withCatalog=$withCatalog, quoteWith=$quoteWith") {
     withTempDir { dir =>
-      val table = if (withCatalog) {
+      val table: String = if (withCatalog) {
         s"${spark.sessionState.catalog.getCurrentDatabase}.table"
       } else {
         s"delta.`${dir.getCanonicalPath}`"
       }
-      if (withCatalog) sql(s"DROP TABLE IF EXISTS $table")
-      sql(
-        s"""CREATE TABLE $table (id bigint) USING delta
-           |TBLPROPERTIES (
-           |delta.feature.${TestRemovableReaderWriterFeature.name} = 'supported',
-           |${TestRemovableReaderWriterFeature.TABLE_PROP_KEY} = "true",
-           |${DeltaConfigs.TABLE_FEATURE_DROP_TRUNCATE_HISTORY_LOG_RETENTION.key} = "0 hours"
-           |)""".stripMargin)
+      withTable(table) {
+        sql(
+          s"""CREATE TABLE $table (id bigint) USING delta
+             |TBLPROPERTIES (
+             |delta.feature.${TestRemovableReaderWriterFeature.name} = 'supported',
+             |${TestRemovableReaderWriterFeature.TABLE_PROP_KEY} = "true",
+             |${DeltaConfigs.TABLE_FEATURE_DROP_TRUNCATE_HISTORY_LOG_RETENTION.key} = "0 hours"
+             |)""".stripMargin)
 
-      // We need to use a Delta log object with the ManualClock created in this test instead of
-      // the default SystemClock. However, we can't pass the Delta log to use directly in the SQL
-      // command. Instead, we will
-      //  1. Clear the Delta log cache to remove the log associated with table creation.
-      //  2. Populate the Delta log cache with the Delta log object that has the ManualClock we
-      //  want to use
-      // TODO(c27kwan): Refactor this and provide a better way to control clocks in Delta tests.
-      val clock = new ManualClock(System.currentTimeMillis())
-      val deltaLog = if (withCatalog) {
-        val tableIdentifier =
-          TableIdentifier("table", Some(spark.sessionState.catalog.getCurrentDatabase))
-        // We need to hack the Delta log cache with path based access to setup the right key.
-        val path = DeltaLog.forTable(spark, tableIdentifier, clock).dataPath
-        DeltaLog.clearCache()
-        DeltaLog.forTable(spark, path, clock)
-      } else {
-        DeltaLog.clearCache()
-        DeltaLog.forTable(spark, dir, clock)
-      }
-
-      val protocol = deltaLog.update().protocol
-      assert(protocol === protocolWithReaderFeature(TestRemovableReaderWriterFeature))
-
-      val logs = Log4jUsageLogger.track {
-        val featureName = quoteWith match {
-          case "none" => s"${TestRemovableReaderWriterFeature.name}"
-          case "single" => s"'${TestRemovableReaderWriterFeature.name}'"
-          case "backtick" => s"`${TestRemovableReaderWriterFeature.name}`"
+        // We need to use a Delta log object with the ManualClock created in this test instead of
+        // the default SystemClock. However, we can't pass the Delta log to use directly in the SQL
+        // command. Instead, we will
+        //  1. Clear the Delta log cache to remove the log associated with table creation.
+        //  2. Populate the Delta log cache with the Delta log object that has the ManualClock we
+        //  want to use
+        // TODO(c27kwan): Refactor this and provide a better way to control clocks in Delta tests.
+        val clock = new ManualClock(System.currentTimeMillis())
+        val deltaLog = if (withCatalog) {
+          val tableIdentifier =
+            TableIdentifier("table", Some(spark.sessionState.catalog.getCurrentDatabase))
+          // We need to hack the Delta log cache with path based access to setup the right key.
+          val path = DeltaLog.forTable(spark, tableIdentifier, clock).dataPath
+          DeltaLog.clearCache()
+          DeltaLog.forTable(spark, path, clock)
+        } else {
+          DeltaLog.clearCache()
+          DeltaLog.forTable(spark, dir, clock)
         }
 
-        // Expect an exception when dropping a reader writer feature that has traces of the feature.
-        intercept[DeltaTableFeatureException] {
-          sql(s"ALTER TABLE $table DROP FEATURE $featureName")
+        val protocol = deltaLog.update().protocol
+        assert(protocol === protocolWithReaderFeature(TestRemovableReaderWriterFeature))
+
+        val logs = Log4jUsageLogger.track {
+          val featureName = quoteWith match {
+            case "none" => s"${TestRemovableReaderWriterFeature.name}"
+            case "single" => s"'${TestRemovableReaderWriterFeature.name}'"
+            case "backtick" => s"`${TestRemovableReaderWriterFeature.name}`"
+          }
+
+          // Expect an exception when dropping a reader writer feature on a table that
+          // still has traces of the feature.
+          intercept[DeltaTableFeatureException] {
+            sql(s"ALTER TABLE $table DROP FEATURE $featureName")
+          }
+
+          // Move past retention period.
+          clock.advance(TimeUnit.HOURS.toMillis(1))
+
+          sql(s"ALTER TABLE $table DROP FEATURE $featureName TRUNCATE HISTORY")
+          assert(deltaLog.update().protocol === Protocol(1, 1))
         }
 
-        // Move past retention period.
-        clock.advance(TimeUnit.HOURS.toMillis(1))
-
-        sql(s"ALTER TABLE $table DROP FEATURE $featureName TRUNCATE HISTORY")
-        assert(deltaLog.update().protocol === Protocol(1, 1))
+        // Validate the correct downgrade command was invoked.
+        val expectedOpType = "delta.test.TestReaderWriterFeaturePreDowngradeCommand"
+        val blob = logs.collectFirst {
+          case r if r.metric == MetricDefinitions.EVENT_TAHOE.name &&
+            r.tags.get("opType").contains(expectedOpType) => r.blob
+        }
+        assert(blob.nonEmpty, s"Expecting an '$expectedOpType' event but didn't see any.")
       }
-
-      // Validate the correct downgrade command was invoked.
-      val expectedOpType = "delta.test.TestReaderWriterFeaturePreDowngradeCommand"
-      val blob = logs.collectFirst {
-        case r if r.metric == MetricDefinitions.EVENT_TAHOE.name &&
-          r.tags.get("opType").contains(expectedOpType) => r.blob
-      }
-      assert(blob.nonEmpty, s"Expecting an '$expectedOpType' event but didn't see any.")
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -3203,66 +3203,65 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       } else {
         s"delta.`${dir.getCanonicalPath}`"
       }
-      withTable(table) {
-        sql(
-          s"""CREATE TABLE $table (id bigint) USING delta
-             |TBLPROPERTIES (
-             |delta.feature.${TestRemovableReaderWriterFeature.name} = 'supported',
-             |${TestRemovableReaderWriterFeature.TABLE_PROP_KEY} = "true",
-             |${DeltaConfigs.TABLE_FEATURE_DROP_TRUNCATE_HISTORY_LOG_RETENTION.key} = "0 hours"
-             |)""".stripMargin)
+      if (withCatalog) sql(s"DROP TABLE IF EXISTS $table")
+      sql(
+        s"""CREATE TABLE $table (id bigint) USING delta
+           |TBLPROPERTIES (
+           |delta.feature.${TestRemovableReaderWriterFeature.name} = 'supported',
+           |${TestRemovableReaderWriterFeature.TABLE_PROP_KEY} = "true",
+           |${DeltaConfigs.TABLE_FEATURE_DROP_TRUNCATE_HISTORY_LOG_RETENTION.key} = "0 hours"
+           |)""".stripMargin)
 
-        // We need to use a Delta log object with the ManualClock created in this test instead of
-        // the default SystemClock. However, we can't pass the Delta log to use directly in the SQL
-        // command. Instead, we will
-        //  1. Clear the Delta log cache to remove the log associated with table creation.
-        //  2. Populate the Delta log cache with the Delta log object that has the ManualClock we
-        //  want to use
-        // TODO(c27kwan): Refactor this and provide a better way to control clocks in Delta tests.
-        val clock = new ManualClock(System.currentTimeMillis())
-        val deltaLog = if (withCatalog) {
-          val tableIdentifier =
-            TableIdentifier("table", Some(spark.sessionState.catalog.getCurrentDatabase))
-          // We need to hack the Delta log cache with path based access to setup the right key.
-          val path = DeltaLog.forTable(spark, tableIdentifier, clock).dataPath
-          DeltaLog.clearCache()
-          DeltaLog.forTable(spark, path, clock)
-        } else {
-          DeltaLog.clearCache()
-          DeltaLog.forTable(spark, dir, clock)
-        }
-
-        val protocol = deltaLog.update().protocol
-        assert(protocol === protocolWithReaderFeature(TestRemovableReaderWriterFeature))
-
-        val logs = Log4jUsageLogger.track {
-          val featureName = quoteWith match {
-            case "none" => s"${TestRemovableReaderWriterFeature.name}"
-            case "single" => s"'${TestRemovableReaderWriterFeature.name}'"
-            case "backtick" => s"`${TestRemovableReaderWriterFeature.name}`"
-          }
-
-          // Expect an exception when dropping a reader writer feature on a table that
-          // still has traces of the feature.
-          intercept[DeltaTableFeatureException] {
-            sql(s"ALTER TABLE $table DROP FEATURE $featureName")
-          }
-
-          // Move past retention period.
-          clock.advance(TimeUnit.HOURS.toMillis(1))
-
-          sql(s"ALTER TABLE $table DROP FEATURE $featureName TRUNCATE HISTORY")
-          assert(deltaLog.update().protocol === Protocol(1, 1))
-        }
-
-        // Validate the correct downgrade command was invoked.
-        val expectedOpType = "delta.test.TestReaderWriterFeaturePreDowngradeCommand"
-        val blob = logs.collectFirst {
-          case r if r.metric == MetricDefinitions.EVENT_TAHOE.name &&
-            r.tags.get("opType").contains(expectedOpType) => r.blob
-        }
-        assert(blob.nonEmpty, s"Expecting an '$expectedOpType' event but didn't see any.")
+      // We need to use a Delta log object with the ManualClock created in this test instead of
+      // the default SystemClock. However, we can't pass the Delta log to use directly in the SQL
+      // command. Instead, we will
+      //  1. Clear the Delta log cache to remove the log associated with table creation.
+      //  2. Populate the Delta log cache with the Delta log object that has the ManualClock we
+      //  want to use
+      // TODO(c27kwan): Refactor this and provide a better way to control clocks in Delta tests.
+      val clock = new ManualClock(System.currentTimeMillis())
+      val deltaLog = if (withCatalog) {
+        val tableIdentifier =
+          TableIdentifier("table", Some(spark.sessionState.catalog.getCurrentDatabase))
+        // We need to hack the Delta log cache with path based access to setup the right key.
+        val path = DeltaLog.forTable(spark, tableIdentifier, clock).dataPath
+        DeltaLog.clearCache()
+        DeltaLog.forTable(spark, path, clock)
+      } else {
+        DeltaLog.clearCache()
+        DeltaLog.forTable(spark, dir, clock)
       }
+
+      val protocol = deltaLog.update().protocol
+      assert(protocol === protocolWithReaderFeature(TestRemovableReaderWriterFeature))
+
+      val logs = Log4jUsageLogger.track {
+        val featureName = quoteWith match {
+          case "none" => s"${TestRemovableReaderWriterFeature.name}"
+          case "single" => s"'${TestRemovableReaderWriterFeature.name}'"
+          case "backtick" => s"`${TestRemovableReaderWriterFeature.name}`"
+        }
+
+        // Expect an exception when dropping a reader writer feature on a table that
+        // still has traces of the feature.
+        intercept[DeltaTableFeatureException] {
+          sql(s"ALTER TABLE $table DROP FEATURE $featureName")
+        }
+
+        // Move past retention period.
+        clock.advance(TimeUnit.HOURS.toMillis(1))
+
+        sql(s"ALTER TABLE $table DROP FEATURE $featureName TRUNCATE HISTORY")
+        assert(deltaLog.update().protocol === Protocol(1, 1))
+      }
+
+      // Validate the correct downgrade command was invoked.
+      val expectedOpType = "delta.test.TestReaderWriterFeaturePreDowngradeCommand"
+      val blob = logs.collectFirst {
+        case r if r.metric == MetricDefinitions.EVENT_TAHOE.name &&
+          r.tags.get("opType").contains(expectedOpType) => r.blob
+      }
+      assert(blob.nonEmpty, s"Expecting an '$expectedOpType' event but didn't see any.")
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -3248,7 +3248,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         }
 
         // Move past retention period.
-        clock.advance(TimeUnit.HOURS.toMillis( 1))
+        clock.advance(TimeUnit.HOURS.toMillis(1))
 
         sql(s"ALTER TABLE $table DROP FEATURE $featureName TRUNCATE HISTORY")
         assert(deltaLog.update().protocol === Protocol(1, 1))


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
We are currently missing SQL tests for ALTER TABLE DROP FEATURE TRUNCATE HISTORY with non-path based table. We have tests for writer feature, but not for readerwriter feature that require the TRUNCATE HISTORY syntax. This PR addresses that gap. 

## How was this patch tested?
This is a test-only PR.

## Does this PR introduce _any_ user-facing changes?
No.
