### PR TITLE
[Spark][TEST-ONLY] Add tests to check the behaviour of the different combinations of CREATE and REPLACE with row IDs.

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdCreateReplaceTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdCreateReplaceTableSuite.scala
@@ -16,10 +16,13 @@
 
 package org.apache.spark.sql.delta.rowid
 
+import org.apache.spark.sql.delta.DeltaConfigs
 import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.RowId.extractHighWatermark
+import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION
 
 import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.test.SharedSparkSession
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdCreateReplaceTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdCreateReplaceTableSuite.scala
@@ -16,13 +16,11 @@
 
 package org.apache.spark.sql.delta.rowid
 
-import org.apache.spark.sql.delta.DeltaConfigs
-import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog}
 import org.apache.spark.sql.delta.RowId.extractHighWatermark
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION
 
 import org.apache.spark.sql.QueryTest
-import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.test.SharedSparkSession
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdCreateReplaceTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdCreateReplaceTableSuite.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rowid
+
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.RowId.extractHighWatermark
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.test.SharedSparkSession
+
+class RowIdCreateReplaceTableSuite extends QueryTest
+  with SharedSparkSession with RowIdTestUtils {
+
+  private val numSourceRows = 50
+
+  test("Create or replace table with values list") {
+    withRowTrackingEnabled(enabled = true) {
+      withTable("target") {
+        writeTargetTestData(withRowIds = true)
+        val (log, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier("target"))
+
+        val highWaterMarkBefore = extractHighWatermark(snapshot).get
+        createReplaceTargetTable(
+          commandName = "CREATE OR REPLACE",
+          query = "SELECT * FROM VALUES (0, 0), (1, 1)")
+
+        assertHighWatermarkIsCorrectAfterUpdate(
+          log, highWaterMarkBefore, expectedNumRecordsWritten = 2)
+        assertRowIdsAreLargerThanValue(log, highWaterMarkBefore)
+      }
+    }
+  }
+
+  test("Create or replace table with other delta table") {
+    withRowTrackingEnabled(enabled = true) {
+      withTable("source", "target") {
+        writeTargetTestData(withRowIds = true)
+
+        writeSourceTestData(withRowIds = true)
+        val (log, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier("target"))
+
+        val highWaterMarkBefore = extractHighWatermark(snapshot).get
+        createReplaceTargetTable(commandName = "CREATE OR REPLACE", query = "SELECT * FROM source")
+
+        assertHighWatermarkIsCorrectAfterUpdate(
+          log, highWaterMarkBefore, expectedNumRecordsWritten = numSourceRows)
+        assertRowIdsAreLargerThanValue(log, highWaterMarkBefore)
+      }
+    }
+  }
+
+  test("Replace table with values list") {
+    withRowTrackingEnabled(enabled = true) {
+      withTable("target") {
+        writeTargetTestData(withRowIds = true)
+        val (log, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier("target"))
+
+        val highWaterMarkBefore = extractHighWatermark(snapshot).get
+        createReplaceTargetTable(commandName = "REPLACE", query = "SELECT * FROM VALUES (0), (1)")
+
+        assertHighWatermarkIsCorrectAfterUpdate(
+          log, highWaterMarkBefore, expectedNumRecordsWritten = 2)
+        assertRowIdsAreLargerThanValue(log, highWaterMarkBefore)
+      }
+    }
+  }
+
+  test("Replace table with another delta table") {
+    withRowTrackingEnabled(enabled = true) {
+      withTable("source", "target") {
+        writeTargetTestData(withRowIds = true)
+        val log = DeltaLog.forTable(spark, TableIdentifier("target"))
+
+        writeSourceTestData(withRowIds = true)
+
+        val highWaterMarkBefore = extractHighWatermark(log.update()).get
+        createReplaceTargetTable(commandName = "REPLACE", query = "SELECT * FROM source")
+
+        assertHighWatermarkIsCorrectAfterUpdate(
+          log, highWaterMarkBefore, expectedNumRecordsWritten = numSourceRows)
+        assertRowIdsAreLargerThanValue(log, highWaterMarkBefore)
+      }
+    }
+  }
+
+  test("Replace table with row IDs with table without row IDs assigns new row IDs") {
+    withTable("source", "target") {
+      writeTargetTestData(withRowIds = true)
+      val log = DeltaLog.forTable(spark, TableIdentifier("target"))
+
+      writeSourceTestData(withRowIds = false)
+
+      val highWaterMarkBefore = extractHighWatermark(log.update()).get
+      withRowTrackingEnabled(enabled = false) {
+        createReplaceTargetTable(commandName = "REPLACE", query = "SELECT * FROM source")
+      }
+
+      assertHighWatermarkIsCorrectAfterUpdate(
+        log, highWaterMarkBefore, expectedNumRecordsWritten = numSourceRows)
+    }
+  }
+
+  def createReplaceTargetTable(
+      commandName: String, query: String, tblProperties: Seq[String] = Seq.empty): Unit = {
+    val tblPropertiesStr = if (tblProperties.nonEmpty) {
+      s"TBLPROPERTIES ${tblProperties.mkString("(", ",", ")")}"
+    } else {
+      ""
+    }
+    sql(
+      s"""
+         |$commandName TABLE target
+         |USING delta
+         |$tblPropertiesStr
+         |AS $query
+         |""".stripMargin)
+  }
+
+  def writeTargetTestData(withRowIds: Boolean): Unit = {
+    withRowTrackingEnabled(enabled = withRowIds) {
+      spark.range(start = 0, end = 100, step = 1, numPartitions = 10)
+        .write.format("delta").saveAsTable("target")
+    }
+  }
+
+  def writeSourceTestData(withRowIds: Boolean): Unit = {
+    withRowTrackingEnabled(enabled = withRowIds) {
+      spark.range(start = 0, end = numSourceRows, step = 1, numPartitions = 10)
+        .write.format("delta").saveAsTable("source")
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdCreateReplaceTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdCreateReplaceTableSuite.scala
@@ -123,8 +123,8 @@ class RowIdCreateReplaceTableSuite extends QueryTest
       writeTargetTestData(withRowIds = false)
       writeSourceTestData(withRowIds = true)
 
-      val beforeCommandLog = DeltaLog.forTable(spark, TableIdentifier("target"))
-      assertRowIdsAreNotSet(beforeCommandLog)
+      val log = DeltaLog.forTable(spark, TableIdentifier("target"))
+      assertRowIdsAreNotSet(log)
 
       withRowTrackingEnabled(enabled = true) {
         createReplaceTargetTable(
@@ -134,8 +134,7 @@ class RowIdCreateReplaceTableSuite extends QueryTest
             s"'delta.minWriterVersion' = $TABLE_FEATURES_MIN_WRITER_VERSION" :: Nil)
       }
 
-      val afterCommandLog = DeltaLog.forTable(spark, TableIdentifier("target"))
-      assertRowIdsAreValid(afterCommandLog)
+      assertRowIdsAreValid(log)
     }
   }
 
@@ -144,8 +143,8 @@ class RowIdCreateReplaceTableSuite extends QueryTest
     withTable("target") {
       writeTargetTestData(withRowIds = false)
 
-      val beforeCommandLog = DeltaLog.forTable(spark, TableIdentifier("target"))
-      assertRowIdsAreNotSet(beforeCommandLog)
+      val log = DeltaLog.forTable(spark, TableIdentifier("target"))
+      assertRowIdsAreNotSet(log)
 
       withRowTrackingEnabled(enabled = true) {
         createReplaceTargetTable(
@@ -154,8 +153,7 @@ class RowIdCreateReplaceTableSuite extends QueryTest
           tblProperties = s"${DeltaConfigs.ROW_TRACKING_ENABLED.key} = 'true'" :: Nil)
       }
 
-      val afterCommandLog = DeltaLog.forTable(spark, TableIdentifier("target"))
-      assertRowIdsAreValid(afterCommandLog)
+      assertRowIdsAreValid(log)
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdTestUtils.scala
@@ -78,4 +78,11 @@ trait RowIdTestUtils extends RowTrackingTestUtils with DeltaSQLCommandTest {
     val files = snapshot.allFiles.collect()
     assert(files.forall(_.baseRowId.isEmpty))
   }
+
+  def assertRowIdsAreLargerThanValue(log: DeltaLog, value: Long): Unit = {
+    log.update().allFiles.collect().foreach { f =>
+      val minRowId = getRowIdRangeInclusive(f)._1
+      assert(minRowId > value, s"${f.toString} has a row id smaller or equal than $value")
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Add tests to check the behaviour of the different combinations of CREATE and REPLACE with row IDs. We want to make sure Row Tracking is well tested before [Enabling Row Tracking outside of Testing](https://github.com/delta-io/delta/pull/2059).

## How was this patch tested?
New test suite added.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
