### PR TITLE
Fix Checksum.scala store.read callsite to use the new LogStore API

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.FileSizeHistogram
 import org.apache.spark.sql.delta.storage.LogStore
 import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
+import org.apache.hadoop.fs.FileStatus
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.SparkSession
@@ -117,12 +118,19 @@ trait ReadChecksum extends DeltaLogging { self: DeltaLog =>
   val logPath: Path
   private[delta] def store: LogStore
 
-  private[delta] def readChecksum(version: Long): Option[VersionChecksum] = {
+  private[delta] def readChecksum(
+      version: Long,
+      checksumFileStatusHintOpt: Option[FileStatus] = None): Option[VersionChecksum] = {
     recordDeltaOperation(self, "delta.readChecksum") {
-      val checksumFile = FileNames.checksumFile(logPath, version)
-
+      val checksumFilePath = FileNames.checksumFile(logPath, version)
+      val verifiedChecksumFileStatusOpt =
+        checksumFileStatusHintOpt.filter(_.getPath == checksumFilePath)
       var exception: Option[String] = None
-      val content = try Some(store.read(checksumFile, newDeltaHadoopConf())) catch {
+      val content = try Some(
+        verifiedChecksumFileStatusOpt
+          .map(store.read(_, newDeltaHadoopConf()))
+          .getOrElse(store.read(checksumFilePath, newDeltaHadoopConf()))
+      ) catch {
         case NonFatal(e) =>
           // We expect FileNotFoundException; if it's another kind of exception, we still catch them
           // here but we log them in the checksum error event below.


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Cache the fileStatus of the last-read checksum file in SnapshotManagement.scala. This cache can then be used to potentially invoke the new LogStore read API in Checksum.scala.

## How was this patch tested?

- Assert that `readAsIterator(fileStatus, hadoopConf)` is called > 0 times for .crc files in UTs
- Existing test suites

## Does this PR introduce _any_ user-facing changes?

No
