### PR TITLE
[Spark] Fix metadata cleanup by retaining a checkpoint before the cutoff window 

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
@@ -451,8 +451,7 @@ object DeltaHistoryManager extends DeltaLogging {
     private def queueItemsIfNeeded(): Unit = {
       if (bufferedOutput.isEmpty && bufferedUnderlying.hasNext) {
         val group = new mutable.ArrayBuffer[T]()
-        while (bufferedUnderlying.hasNext &&
-          (!isNewGroupStart(bufferedUnderlying.head) || group.isEmpty)) {
+        while (!bufferedUnderlying.headOption.forall(isNewGroupStart) || group.isEmpty) {
           group += transformItem(bufferedUnderlying.next())
         }
         bufferedOutput = Some(group)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -334,7 +334,8 @@ trait SnapshotManagement { self: DeltaLog =>
       val (deltas, compactedDeltas) = deltasAndCompactedDeltas.partition(isDeltaFile)
       // Find the latest checkpoint in the listing that is not older than the versionToLoad
       val checkpointFiles = checkpoints.map(f => CheckpointInstance(f.getPath))
-      val newCheckpoint = getLatestCompleteCheckpointFromList(checkpointFiles, versionToLoad)
+      val newCheckpoint = Checkpoints.getLatestCompleteCheckpointFromList(
+        checkpointFiles, versionToLoad)
       val newCheckpointVersion = newCheckpoint.map(_.version).getOrElse {
         // If we do not have any checkpoint, pass new checkpoint version as -1 so that first
         // delta version can be 0.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
@@ -615,6 +615,10 @@ class DeltaRetentionSuite extends QueryTest
            |'delta.enableExpiredLogCleanup' = 'false',
            |'delta.checkpointInterval' = '10')
         """.stripMargin)
+      // Set time for commit 0 to ensure that the commits don't need timestamp adjustment.
+      val commit0Time = clock.getTimeMillis()
+      new File(FileNames.deltaFile(log.logPath, 0).toUri).setLastModified(commit0Time)
+      new File(FileNames.checksumFile(log.logPath, 0).toUri).setLastModified(commit0Time)
 
       // Day 0: Add commits 1 to 15 --> creates 1 checkpoint at Day 0 for version 10
       (1 to 15).foreach { i =>
@@ -684,9 +688,9 @@ class DeltaRetentionSuite extends QueryTest
       deltaFiles.zipWithIndex.foreach { case (f, i) =>
         val version = i + 1 // From 0-based indexing to 1-based versioning
         if (version < 10) {
-          assert(!f.exists())
+          assert(!f.exists(), version)
         } else {
-          assert(f.exists())
+          assert(f.exists(), version)
         }
       }
     }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

We delete eligible delta files only if there's a checkpoint newer than them before the cutoff window begins.

Note: In rare cases where a checkpoint outside the cutoff window is already retained to account for timestamp-adjustments, we might end up retaining an extra checkpoint and some commit files with this change.


## How was this patch tested?

New UTs and update some of the existing UTs

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
