### PR TITLE
[Spark] Add tests to check the behaviour of CLONE with row IDs

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -609,9 +609,6 @@ trait OptimisticTransactionImpl extends TransactionalWrite
     newMetadataTmp = MaterializedRowCommitVersion.updateMaterializedColumnName(
       protocol, oldMetadata = snapshot.metadata, newMetadataTmp)
 
-    RowId.verifyMetadata(
-      snapshot.protocol, protocol, snapshot.metadata, newMetadataTmp, isCreatingNewTable)
-
     assertMetadata(newMetadataTmp)
     logInfo(s"Updated metadata from ${newMetadata.getOrElse("-")} to $newMetadataTmp")
     newMetadata = Some(newMetadataTmp)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowId.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowId.scala
@@ -67,25 +67,6 @@ object RowId {
   }
 
   /**
-   * Verifies that row IDs are only set as readable when a new table is created.
-   */
-  private[delta] def verifyMetadata(
-      oldProtocol: Protocol,
-      newProtocol: Protocol,
-      oldMetadata: Metadata,
-      newMetadata: Metadata,
-      isCreatingNewTable: Boolean): Unit = {
-
-    val rowIdsEnabledBefore = isEnabled(oldProtocol, oldMetadata)
-    val rowIdsEnabledAfter = isEnabled(newProtocol, newMetadata)
-
-    if (rowIdsEnabledAfter && !rowIdsEnabledBefore && !isCreatingNewTable) {
-      throw new UnsupportedOperationException(
-        "Cannot enable Row IDs on an existing table.")
-    }
-  }
-
-  /**
    * Assigns fresh row IDs to all AddFiles inside `actions` that do not have row IDs yet and emits
    * a [[RowIdHighWaterMark]] action with the new high-water mark.
    */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowTracking.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowTracking.scala
@@ -60,32 +60,4 @@ object RowTracking {
       throw DeltaErrors.convertToDeltaRowTrackingEnabledWithoutStatsCollection
     }
   }
-
-  /**
-   * Returns the sourceMetadata with the row tracking property coming from the targetMetadata.
-   */
-  private[delta] def takeRowTrackingPropertyFromTarget(
-      targetMetadata: Metadata,
-      sourceMetadata: Metadata): Metadata = {
-    var newConfig = sourceMetadata.configuration - DeltaConfigs.ROW_TRACKING_ENABLED.key
-    targetMetadata.configuration.get(DeltaConfigs.ROW_TRACKING_ENABLED.key).foreach { v =>
-      newConfig += DeltaConfigs.ROW_TRACKING_ENABLED.key -> v
-    }
-    sourceMetadata.copy(configuration = newConfig)
-  }
-
-  /**
-   * Removes the row tracking property from the metadata.
-   */
-  private[delta] def removeRowTrackingProperty(metadata: Metadata): Metadata = {
-    metadata.copy(configuration = metadata.configuration - DeltaConfigs.ROW_TRACKING_ENABLED.key)
-  }
-
-  /**
-   * Removes the row tracking table feature from the protocol.
-   */
-  private[delta] def removeRowTrackingTableFeature(protocol: Protocol): Protocol = {
-    val writerFeaturesWithoutRowTracking = protocol.writerFeatures.map(_ - RowTrackingFeature.name)
-    protocol.copy(writerFeatures = writerFeaturesWithoutRowTracking)
-  }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
@@ -280,16 +280,10 @@ abstract class CloneTableBase(
         id = UUID.randomUUID().toString,
         name = targetSnapshot.metadata.name,
         description = targetSnapshot.metadata.description)
-    // If it's a new table, we remove the row tracking table property to create a 1:1 CLONE of
-    // the source, just without row tracking. If it's an existing table, we take whatever
-    // setting is currently on the target, as the setting should be independent between
-    // target and source.
-    if (!tableExists(targetSnapshot)) {
-      clonedMetadata = RowTracking.removeRowTrackingProperty(clonedMetadata)
-    } else {
-      clonedMetadata = RowTracking.takeRowTrackingPropertyFromTarget(
-        targetMetadata = targetSnapshot.metadata,
-        sourceMetadata = clonedMetadata)
+    // Existing target table
+    if (tableExists(targetSnapshot)) {
+      // Set the ID equal to the target ID
+      clonedMetadata = clonedMetadata.copy(id = targetSnapshot.metadata.id)
     }
     clonedMetadata
   }
@@ -356,14 +350,12 @@ abstract class CloneTableBase(
     conf.getConf(DeltaSQLConf.RESTORE_TABLE_PROTOCOL_DOWNGRADE_ALLOWED) ||
       // It's not a real downgrade if the table doesn't exist before the CLONE.
       !tableExists(txn.snapshot)
-    val sourceProtocolWithoutRowTracking = RowTracking.removeRowTrackingTableFeature(sourceProtocol)
 
     if (protocolDowngradeAllowed) {
       minReaderVersion = minReaderVersion.max(sourceProtocol.minReaderVersion)
       minWriterVersion = minWriterVersion.max(sourceProtocol.minWriterVersion)
       val minProtocol = Protocol(minReaderVersion, minWriterVersion).withFeatures(enabledFeatures)
-      // Row tracking settings should be independent between target and source.
-      sourceProtocolWithoutRowTracking.merge(minProtocol)
+      sourceProtocol.merge(minProtocol)
     } else {
       // Take the maximum of all protocol versions being merged to ensure that table features
       // from table property overrides are correctly added to the table feature list or are only
@@ -373,8 +365,7 @@ abstract class CloneTableBase(
       minWriterVersion = Seq(
         targetProtocol.minWriterVersion, sourceProtocol.minWriterVersion, minWriterVersion).max
       val minProtocol = Protocol(minReaderVersion, minWriterVersion).withFeatures(enabledFeatures)
-      // Row tracking settings should be independent between target and source.
-      targetProtocol.merge(sourceProtocolWithoutRowTracking, minProtocol)
+      targetProtocol.merge(sourceProtocol, minProtocol)
     }
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -112,6 +112,15 @@ case class AlterTableSetPropertiesDeltaCommand(
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val deltaLog = table.deltaLog
+
+    val rowTrackingPropertyKey = DeltaConfigs.ROW_TRACKING_ENABLED.key
+    val enableRowTracking = configuration.keySet.contains(rowTrackingPropertyKey) &&
+      configuration(rowTrackingPropertyKey).toBoolean
+
+    if (enableRowTracking) {
+      // TODO(longvu-db): This will be removed once we support backfill.
+      throw new UnsupportedOperationException("Cannot enable Row IDs on an existing table.")
+    }
     val columnMappingPropertyKey = DeltaConfigs.COLUMN_MAPPING_MODE.key
     val disableColumnMapping = configuration.get(columnMappingPropertyKey).contains("none")
     val columnMappingRemovalAllowed = sparkSession.sessionState.conf.getConf(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdCloneSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdCloneSuite.scala
@@ -1,0 +1,248 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rowid
+
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaIllegalStateException, DeltaLog, RowId}
+import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.test.SharedSparkSession
+
+class RowIdCloneSuite
+  extends QueryTest
+  with SharedSparkSession
+  with RowIdTestUtils {
+
+
+  val numRows = 10
+
+  test("clone assigns fresh row IDs when explicitly adding row IDs support") {
+    withTables(
+      TableSetupInfo(tableName = "source",
+        rowIdsEnabled = false, tableState = TableState.NON_EMPTY),
+      TableSetupInfo(tableName = "target",
+        rowIdsEnabled = false, tableState = TableState.NON_EXISTING)) {
+      cloneTable(
+        targetTableName = "target",
+        sourceTableName = "source",
+        tblProperties = s"'$rowTrackingFeatureName' = 'supported'" :: Nil)
+
+      val (targetLog, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier("target"))
+      assertRowIdsAreValid(targetLog)
+      assert(RowId.isSupported(snapshot.protocol))
+      assert(!RowId.isEnabled(snapshot.protocol, snapshot.metadata))
+    }
+  }
+
+  test("clone a table with row tracking enabled into non-existing target " +
+    "enables row tracking even if disabled by default") {
+    withTables(
+      TableSetupInfo(tableName = "source",
+        rowIdsEnabled = true, tableState = TableState.NON_EMPTY),
+      TableSetupInfo(tableName = "target",
+        rowIdsEnabled = false, tableState = TableState.NON_EXISTING)) {
+      withRowTrackingEnabled(enabled = false) {
+        cloneTable(targetTableName = "target", sourceTableName = "source")
+
+        val (targetLog, snapshot) =
+          DeltaLog.forTableWithSnapshot(spark, TableIdentifier("target"))
+        assertRowIdsAreValid(targetLog)
+        assert(RowId.isSupported(targetLog.update().protocol))
+        assert(RowId.isEnabled(snapshot.protocol, snapshot.metadata))
+      }
+    }
+  }
+
+  test("clone that add row ID feature using table property override " +
+    "doesn't enable row IDs on target") {
+    withTables(
+      TableSetupInfo(tableName = "source",
+        rowIdsEnabled = false, tableState = TableState.NON_EMPTY),
+      TableSetupInfo(tableName = "target",
+        rowIdsEnabled = false, tableState = TableState.EMPTY)) {
+
+      cloneTable(
+        targetTableName = "target",
+        sourceTableName = "source",
+        tblProperties = s"'$rowTrackingFeatureName' = 'supported'" ::
+                        s"'delta.minWriterVersion' = $TABLE_FEATURES_MIN_WRITER_VERSION" :: Nil)
+
+      val (targetLog, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier("target"))
+      assertRowIdsAreValid(targetLog)
+      assert(RowId.isSupported(snapshot.protocol))
+      assert(!RowId.isEnabled(snapshot.protocol, snapshot.metadata))
+    }
+  }
+
+  test("clone can disable row IDs using property override") {
+    withTables(
+      TableSetupInfo(tableName = "source",
+        rowIdsEnabled = true, tableState = TableState.NON_EMPTY),
+      TableSetupInfo(tableName = "target",
+        rowIdsEnabled = true, tableState = TableState.EMPTY)) {
+
+      cloneTable(
+        targetTableName = "target",
+        sourceTableName = "source",
+        tblProperties = s"'${DeltaConfigs.ROW_TRACKING_ENABLED.key}' = false" :: Nil)
+
+      val (targetLog, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier("target"))
+      assertRowIdsAreValid(targetLog)
+      assert(RowId.isSupported(snapshot.protocol))
+      assert(!RowId.isEnabled(snapshot.protocol, snapshot.metadata))
+    }
+  }
+
+  test("clone throws error when assigning row IDs without stats") {
+    withSQLConf(
+      DeltaSQLConf.DELTA_COLLECT_STATS.key -> "false") {
+      withTable("source", "target") {
+        withRowTrackingEnabled(enabled = false) {
+          spark.range(end = 10)
+            .write.format("delta").saveAsTable("source")
+        }
+        withRowTrackingEnabled(enabled = true) {
+          // enable stats to create table with row IDs
+          withSQLConf(DeltaSQLConf.DELTA_COLLECT_STATS.key -> "true") {
+            spark.range(0).write.format("delta").saveAsTable("target")
+          }
+          val err = intercept[DeltaIllegalStateException] {
+            cloneTable(targetTableName = "target", sourceTableName = "source")
+          }
+          checkError(err, "DELTA_ROW_ID_ASSIGNMENT_WITHOUT_STATS")
+        }
+      }
+    }
+  }
+
+  test("clone can enable row tracking on empty target using property override") {
+    withTables(
+      TableSetupInfo(tableName = "source",
+        rowIdsEnabled = false, tableState = TableState.NON_EMPTY),
+      TableSetupInfo(tableName = "target",
+        rowIdsEnabled = false, tableState = TableState.EMPTY)) {
+
+      cloneTable(
+        targetTableName = "target",
+        sourceTableName = "source",
+        tblProperties = s"'${DeltaConfigs.ROW_TRACKING_ENABLED.key}' = true" :: Nil)
+
+      val (targetLog, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier("target"))
+      assertRowIdsAreValid(targetLog)
+      assert(RowId.isSupported(snapshot.protocol))
+      assert(RowId.isEnabled(snapshot.protocol, snapshot.metadata))
+    }
+  }
+
+  test("clone assigns fresh row IDs for empty target") {
+    withTables(
+      TableSetupInfo(tableName = "source",
+        rowIdsEnabled = false, tableState = TableState.NON_EMPTY),
+      TableSetupInfo(tableName = "target",
+        rowIdsEnabled = true, tableState = TableState.EMPTY)) {
+      cloneTable(targetTableName = "target", sourceTableName = "source")
+
+      val (targetLog, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier("target"))
+      assertRowIdsAreValid(targetLog)
+      assert(RowId.isSupported(snapshot.protocol))
+      assert(!RowId.isEnabled(snapshot.protocol, snapshot.metadata))
+    }
+  }
+
+  test("clone can't assign row IDs for non-empty target") {
+    withTables(
+      TableSetupInfo(tableName = "source",
+        rowIdsEnabled = false, tableState = TableState.NON_EMPTY),
+      TableSetupInfo(tableName = "target",
+        rowIdsEnabled = true, tableState = TableState.NON_EMPTY)) {
+      assert(intercept[DeltaIllegalStateException] {
+        cloneTable(targetTableName = "target", sourceTableName = "source")
+      }.getErrorClass === "DELTA_UNSUPPORTED_NON_EMPTY_CLONE")
+    }
+  }
+
+  test("clone from source with row tracking enabled into existing empty target " +
+    "without row tracking enables row tracking") {
+    withTables(
+      TableSetupInfo(tableName = "source",
+        rowIdsEnabled = true, tableState = TableState.NON_EMPTY),
+      TableSetupInfo(tableName = "target",
+        rowIdsEnabled = false, tableState = TableState.EMPTY)) {
+      cloneTable(targetTableName = "target", sourceTableName = "source")
+
+      val (targetLog, snapshot) =
+        DeltaLog.forTableWithSnapshot(spark, TableIdentifier("target"))
+      assertRowIdsAreValid(targetLog)
+      assert(RowId.isSupported(targetLog.update().protocol))
+      assert(RowId.isEnabled(snapshot.protocol, snapshot.metadata))
+    }
+  }
+
+  def cloneTable(
+      targetTableName: String,
+      sourceTableName: String,
+      tblProperties: Seq[String] = Seq.empty): Unit = {
+    val tblPropertiesStr = if (tblProperties.nonEmpty) {
+      s"TBLPROPERTIES ${tblProperties.mkString("(", ",", ")")}"
+    } else {
+      ""
+    }
+    sql(
+      s"""
+         |CREATE OR REPLACE TABLE $targetTableName
+         |SHALLOW CLONE $sourceTableName
+         |$tblPropertiesStr
+         |""".stripMargin)
+  }
+
+  final object TableState extends Enumeration {
+    type TableState = Value
+    val NON_EMPTY, EMPTY, NON_EXISTING = Value
+  }
+
+  case class TableSetupInfo(
+      tableName: String,
+      rowIdsEnabled: Boolean,
+      tableState: TableState.TableState)
+
+  private def withTables(tables: TableSetupInfo*)(f: => Unit): Unit = {
+    if (tables.isEmpty) {
+      f
+    } else {
+      val firstTable = tables.head
+      withTable(firstTable.tableName) {
+        firstTable.tableState match {
+          case TableState.NON_EMPTY | TableState.EMPTY =>
+            val rows = if (firstTable.tableState == TableState.NON_EMPTY) {
+              spark.range(start = 0, end = numRows, step = 1, numPartitions = 1)
+            } else {
+              spark.range(0)
+            }
+            withRowTrackingEnabled(enabled = firstTable.rowIdsEnabled) {
+              rows.write.format("delta").saveAsTable(firstTable.tableName)
+            }
+          case TableState.NON_EXISTING =>
+        }
+
+        withTables(tables.drop(1): _*)(f)
+      }
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/MaterializedColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/MaterializedColumnSuite.scala
@@ -164,7 +164,7 @@ class MaterializedColumnSuite extends RowIdTestUtils
       }
     }
 
-    test(s"clone does not assign a materialized $name column when table property is not set") {
+    test(s"clone assigns a materialized $name column when source enables row tracking") {
       val sourceTableName = "source"
       val targetTableName = "target"
 
@@ -178,10 +178,10 @@ class MaterializedColumnSuite extends RowIdTestUtils
           val targetTableColumnName = getMaterializedColumnName(targetTableName)
 
           assert(sourceTableColumnName.isDefined)
-          assert(targetTableColumnName.isEmpty)
+          assert(targetTableColumnName.isDefined)
+          assert(sourceTableColumnName !== targetTableColumnName)
         }
       }
     }
-
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Add tests to check the behaviour of CLONE with row IDs.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Add more UTs.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
