### PR TITLE
[Spark] Limit number of retries for non-conflict retryable commit failures

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -375,6 +375,15 @@ trait DeltaSQLConfBase {
       .checkValue(_ >= 0, "maxCommitAttempts has to be positive")
       .createWithDefault(10000000)
 
+  val DELTA_MAX_NON_CONFLICT_RETRY_COMMIT_ATTEMPTS =
+    buildConf("maxNonConflictCommitAttempts")
+      .internal()
+      .doc("The maximum number of non-conflict commit attempts we will try for a single commit " +
+        "before failing")
+      .intConf
+      .checkValue(_ >= 0, "maxNonConflictCommitAttempts has to be positive")
+      .createWithDefault(10)
+
   val DELTA_PROTOCOL_DEFAULT_WRITER_VERSION =
     buildConf("properties.defaults.minWriterVersion")
       .doc("The default writer protocol version to create new tables with, unless a feature " +

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -17,12 +17,17 @@
 package org.apache.spark.sql.delta
 
 // scalastyle:off import.ordering.noEmptyLine
+import java.nio.file.FileAlreadyExistsException
+
 import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
 import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo, Metadata, Protocol, RemoveFile, SetTransaction}
+import org.apache.spark.sql.delta.managedcommit.{Commit, CommitFailedException, CommitResponse, CommitStore, CommitStoreBuilder, CommitStoreProvider, UpdatedActions}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.storage.LogStore
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.FileNames
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.Row
@@ -438,6 +443,106 @@ class OptimisticTransactionSuite
       assert(testTxn.preCommitLogSegment.lastCommitTimestamp < testTxnEndTs)
       assert(testTxn.preCommitLogSegment.deltas.size == 2)
       assert(testTxn.preCommitLogSegment.checkpointProvider.version == 10)
+    }
+  }
+
+  test("Limited retries for non-conflict retryable CommitFailedExceptions") {
+    val commitStoreName = "retryable-non-conflict-commit-store"
+    var commitAttempts = 0
+    val numRetries = "100"
+    val numNonConflictRetries = "10"
+    val initialNonConflictErrors = 5
+    val initialConflictErrors = 5
+
+    object RetryableNonConflictCommitStoreBuilder extends CommitStoreBuilder {
+
+      override def name: String = commitStoreName
+
+      override def build(conf: Map[String, String]): CommitStore = {
+        new CommitStore {
+          override def commit(
+              logStore: LogStore,
+              hadoopConf: Configuration,
+              tablePath: Path,
+              commitVersion: Long,
+              actions: Iterator[String],
+              updatedActions: UpdatedActions): CommitResponse = {
+            commitAttempts += 1
+            throw new CommitFailedException(
+              retryable = true,
+              conflict = commitAttempts > initialNonConflictErrors &&
+                commitAttempts <= (initialNonConflictErrors + initialConflictErrors),
+              message = "")
+          }
+          override def getCommits(
+              tablePath: Path,
+              startVersion: Long,
+              endVersion: Option[Long]): Seq[Commit] = Seq.empty
+        }
+      }
+    }
+
+    CommitStoreProvider.registerBuilder(RetryableNonConflictCommitStoreBuilder)
+
+    withSQLConf(
+        DeltaSQLConf.DELTA_MAX_RETRY_COMMIT_ATTEMPTS.key -> numRetries,
+        DeltaSQLConf.DELTA_MAX_NON_CONFLICT_RETRY_COMMIT_ATTEMPTS.key -> numNonConflictRetries) {
+      withTempDir { tempDir =>
+        val log = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
+        val conf = Map(DeltaConfigs.MANAGED_COMMIT_OWNER_NAME.key -> commitStoreName)
+        log.startTransaction().commit(Seq(Metadata(configuration = conf)), ManualUpdate)
+        val testTxn = log.startTransaction()
+        intercept[CommitFailedException] { testTxn.commit(Seq.empty, ManualUpdate) }
+        // num-attempts = 1 + num-retries
+        assert(commitAttempts ==
+          (initialNonConflictErrors + initialConflictErrors + numNonConflictRetries.toInt + 1))
+      }
+    }
+  }
+
+  test("No retries for FileAlreadyExistsException with Commit Store") {
+    val commitStoreName = "file-already-exists-commit-store"
+    var commitAttempts = 0
+
+    object FileAlreadyExistsCommitStoreBuilder extends CommitStoreBuilder {
+
+      override def name: String = commitStoreName
+
+      override def build(conf: Map[String, String]): CommitStore = {
+        new CommitStore {
+          override def commit(
+              logStore: LogStore,
+              hadoopConf: Configuration,
+              tablePath: Path,
+              commitVersion: Long,
+              actions: Iterator[String],
+              updatedActions: UpdatedActions): CommitResponse = {
+            commitAttempts += 1
+            throw new FileAlreadyExistsException("Commit-File Already Exists")
+          }
+          override def getCommits(
+              tablePath: Path,
+              startVersion: Long,
+              endVersion: Option[Long]): Seq[Commit] = Seq.empty
+        }
+      }
+    }
+
+    CommitStoreProvider.registerBuilder(FileAlreadyExistsCommitStoreBuilder)
+
+    withSQLConf(
+        DeltaSQLConf.DELTA_MAX_RETRY_COMMIT_ATTEMPTS.key -> "100",
+        DeltaSQLConf.DELTA_MAX_NON_CONFLICT_RETRY_COMMIT_ATTEMPTS.key -> "10") {
+      withTempDir { tempDir =>
+        val log = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
+        val conf = Map(DeltaConfigs.MANAGED_COMMIT_OWNER_NAME.key -> commitStoreName)
+        log.startTransaction().commit(Seq(Metadata(configuration = conf)), ManualUpdate)
+        val testTxn = log.startTransaction()
+        intercept[FileAlreadyExistsException] { testTxn.commit(Seq.empty, ManualUpdate) }
+        // Test that there are no retries for the FileAlreadyExistsException in CommitStore.commit()
+        // num-attempts(1) = 1 + num-retries(0)
+        assert(commitAttempts == 1)
+      }
     }
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

We add limited retries (default = 10) for retryable CommitFailedExceptions which are non-conflict. The number of default retries for retryable conflict CommitFailedExceptions is set to 10M right now.

## How was this patch tested?

UT to make sure the change is working as intended

## Does this PR introduce _any_ user-facing changes?

No
