### PR TITLE
[Spark] CI - Publish Spark Group only during Python tests

### DIFF
--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -59,7 +59,7 @@ def prepare(root_dir):
     sbt_path = path.join(root_dir, path.join("build", "sbt"))
     delete_if_exists(os.path.expanduser("~/.ivy2/cache/io.delta"))
     delete_if_exists(os.path.expanduser("~/.m2/repository/io/delta/"))
-    run_cmd([sbt_path, "clean", "publishM2"], stream_output=True)
+    run_cmd([sbt_path, "clean", "sparkGroup/publishM2"], stream_output=True)
 
     # Get current release which is required to be loaded
     version = '0.0.0'


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Python tests are specific to Spark Delta, so there is no need to publish everything.

```
        # Python tests are run only when spark group of projects are being tested.
        is_testing_spark_group = args.group is None or args.group == "spark"
        # Python tests are skipped when using Scala 2.13 as PySpark doesn't support it.
        is_testing_scala_212 = scala_version is None or scala_version.startswith("2.12")
        if is_testing_spark_group and is_testing_scala_212:
            run_python_tests(root_dir)
```

## How was this patch tested?
Unit Tests

## Does this PR introduce _any_ user-facing changes?
No
