### PR TITLE
[Kernel] Support filter pushdown in default parquet reader

### DIFF
--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultParquetHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultParquetHandler.java
@@ -56,7 +56,6 @@ public class DefaultParquetHandler implements ParquetHandler {
             Optional<Predicate> predicate) throws IOException {
         return new CloseableIterator<ColumnarBatch>() {
             private final ParquetFileReader batchReader = new ParquetFileReader(hadoopConf);
-            private FileStatus currentFile;
             private CloseableIterator<ColumnarBatch> currentFileReader;
 
             @Override
@@ -75,8 +74,8 @@ public class DefaultParquetHandler implements ParquetHandler {
                     Utils.closeCloseables(currentFileReader);
                     currentFileReader = null;
                     if (fileIter.hasNext()) {
-                        currentFile = fileIter.next();
-                        currentFileReader = batchReader.read(currentFile.getPath(), physicalSchema);
+                        String nextFile = fileIter.next().getPath();
+                        currentFileReader = batchReader.read(nextFile, physicalSchema, predicate);
                         return hasNext(); // recurse since it's possible the loaded file is empty
                     } else {
                         return false;

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFileReader.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFileReader.java
@@ -24,7 +24,6 @@ import static java.util.Objects.requireNonNull;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
-import org.apache.parquet.hadoop.ParquetInputFormat;
 import org.apache.parquet.hadoop.ParquetRecordReaderWrapper;
 import org.apache.parquet.hadoop.api.InitContext;
 import org.apache.parquet.hadoop.api.ReadSupport;
@@ -32,7 +31,7 @@ import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.io.api.GroupConverter;
 import org.apache.parquet.io.api.RecordMaterializer;
 import org.apache.parquet.schema.MessageType;
-import static org.apache.parquet.hadoop.ParquetInputFormat.setFilterPredicate;
+import static org.apache.parquet.hadoop.ParquetInputFormat.*;
 
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.expressions.Predicate;
@@ -138,9 +137,9 @@ public class ParquetFileReader {
                             // we use the predicate to prune the row groups which is more efficient.
                             // In the future, we can consider using the record level filtering if a
                             // native Parquet reader is implemented in Kernel default module.
-                            confCopy.set(ParquetInputFormat.RECORD_FILTERING_ENABLED, "false");
-                            confCopy.set(ParquetInputFormat.DICTIONARY_FILTERING_ENABLED, "false");
-                            confCopy.set(ParquetInputFormat.COLUMN_INDEX_FILTERING_ENABLED, "false");
+                            confCopy.set(RECORD_FILTERING_ENABLED, "false");
+                            confCopy.set(DICTIONARY_FILTERING_ENABLED, "false");
+                            confCopy.set(COLUMN_INDEX_FILTERING_ENABLED, "false");
                         }
 
                         // Pass the already read footer to the reader to avoid reading it again.

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFileReader.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFileReader.java
@@ -16,29 +16,34 @@
 package io.delta.kernel.defaults.internal.parquet;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URI;
-import java.util.Map;
-import java.util.NoSuchElementException;
+import java.util.*;
 import static java.util.Objects.requireNonNull;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.mapred.FileSplit;
-import org.apache.hadoop.mapred.Reporter;
-import org.apache.parquet.hadoop.ParquetRecordReader;
+import org.apache.parquet.filter2.predicate.FilterPredicate;
+import org.apache.parquet.hadoop.ParquetInputFormat;
+import org.apache.parquet.hadoop.ParquetRecordReaderWrapper;
 import org.apache.parquet.hadoop.api.InitContext;
 import org.apache.parquet.hadoop.api.ReadSupport;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.io.api.GroupConverter;
 import org.apache.parquet.io.api.RecordMaterializer;
 import org.apache.parquet.schema.MessageType;
+import static org.apache.parquet.hadoop.ParquetInputFormat.setFilterPredicate;
 
 import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
+
+import io.delta.kernel.internal.util.Utils;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+
+import static io.delta.kernel.defaults.internal.parquet.ParquetFilterUtils.toParquetFilter;
 
 public class ParquetFileReader {
     private final Configuration configuration;
@@ -47,46 +52,40 @@ public class ParquetFileReader {
     public ParquetFileReader(Configuration configuration) {
         this.configuration = requireNonNull(configuration, "configuration is null");
         this.maxBatchSize =
-            configuration.getInt("delta.kernel.default.parquet.reader.batch-size", 1024);
+                configuration.getInt("delta.kernel.default.parquet.reader.batch-size", 1024);
         checkArgument(maxBatchSize > 0, "invalid Parquet reader batch size: " + maxBatchSize);
     }
 
-    public CloseableIterator<ColumnarBatch> read(String path, StructType schema) {
-        BatchReadSupport batchReadSupport = new BatchReadSupport(maxBatchSize, schema);
-        ParquetRecordReader<Object> reader = new ParquetRecordReader<>(batchReadSupport);
-        final boolean hasRowIndexCol =
-            schema.indexOf(StructField.METADATA_ROW_INDEX_COLUMN_NAME) >= 0 &&
-            schema.get(StructField.METADATA_ROW_INDEX_COLUMN_NAME).isMetadataColumn();
+    public CloseableIterator<ColumnarBatch> read(
+            String path,
+            StructType schema,
+            Optional<Predicate> predicate) {
 
-        Path filePath = new Path(URI.create(path));
-        try {
-            FileSystem fs = filePath.getFileSystem(configuration);
-            FileStatus fileStatus = fs.getFileStatus(filePath);
-            FileSplit fileSplit = new FileSplit(filePath, 0, fileStatus.getLen(), new String[0]);
-            reader.initialize(fileSplit, configuration, Reporter.NULL);
-        } catch (IOException | InterruptedException e) {
-            throw new RuntimeException(e);
-        }
+        final boolean hasRowIndexCol =
+                schema.indexOf(StructField.METADATA_ROW_INDEX_COLUMN_NAME) >= 0 &&
+                        schema.get(StructField.METADATA_ROW_INDEX_COLUMN_NAME).isMetadataColumn();
 
         return new CloseableIterator<ColumnarBatch>() {
+            private final BatchReadSupport readSupport = new BatchReadSupport(maxBatchSize, schema);
+            private ParquetRecordReaderWrapper<Object> reader;
             private boolean hasNotConsumedNextElement;
 
             @Override
-            public void close()
-                throws IOException {
-                reader.close();
+            public void close() throws IOException {
+                Utils.closeCloseables(reader);
             }
 
             @Override
             public boolean hasNext() {
+                initParquetReaderIfRequired();
                 try {
                     if (hasNotConsumedNextElement) {
                         return true;
                     }
-                    hasNotConsumedNextElement = reader.nextKeyValue();
-                    return hasNotConsumedNextElement;
-                } catch (IOException | InterruptedException e) {
-                    throw new RuntimeException(e);
+                    return hasNotConsumedNextElement = reader.nextKeyValue() &&
+                            reader.getCurrentValue() != null;
+                } catch (IOException | InterruptedException ie) {
+                    throw new RuntimeException(ie);
                 }
             }
 
@@ -99,31 +98,67 @@ public class ParquetFileReader {
                 do {
                     hasNotConsumedNextElement = false;
                     // hasNext reads to row to confirm there is a next element.
-                    try {
-                        long rowIndex = 0;
-                        if (hasRowIndexCol) {
-                            // get the row index only if required by the read schema
-                            rowIndex = reader.getCurrentRowIndex();
-                        }
-                        batchReadSupport.finalizeCurrentRow(rowIndex);
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
+                    // get the row index only if required by the read schema
+                    long rowIndex = hasRowIndexCol ? reader.getCurrentRowIndex() : -1;
+                    readSupport.finalizeCurrentRow(rowIndex);
                     batchSize++;
                 }
                 while (batchSize < maxBatchSize && hasNext());
 
-                return batchReadSupport.getDataAsColumnarBatch(batchSize);
+                return readSupport.getDataAsColumnarBatch(batchSize);
+            }
+
+            void initParquetReaderIfRequired() {
+                if (reader == null) {
+                    org.apache.parquet.hadoop.ParquetFileReader fileReader = null;
+                    try {
+                        Configuration confCopy = configuration;
+                        Path filePath = new Path(URI.create(path));
+
+                        // We need physical schema in order to construct a filter that can be
+                        // pushed into the `parquet-mr` reader. For that reason read the footer
+                        // in advance.
+                        ParquetMetadata footer =
+                                org.apache.parquet.hadoop.ParquetFileReader.readFooter(
+                                        confCopy,
+                                        filePath);
+
+                        MessageType parquetSchema = footer.getFileMetaData().getSchema();
+                        Optional<FilterPredicate> parquetPredicate = predicate.flatMap(
+                                predicate -> toParquetFilter(parquetSchema, predicate));
+
+                        if (parquetPredicate.isPresent()) {
+                            // clone the configuration to avoid modifying the original one
+                            confCopy = new Configuration(confCopy);
+
+                            setFilterPredicate(confCopy, parquetPredicate.get());
+                            // Disable the record level filtering as the `parquet-mr` evaluates
+                            // the filter once the entire record has been materialized. Instead,
+                            // we use the predicate to prune the row groups which is more efficient.
+                            // In the future, we can consider using the record level filtering if a
+                            // native Parquet reader is implemented in Kernel default module.
+                            confCopy.set(ParquetInputFormat.RECORD_FILTERING_ENABLED, "false");
+                        }
+
+                        // Pass the already read footer to the reader to avoid reading it again.
+                        fileReader = new ParquetFileReaderWithFooter(filePath, confCopy, footer);
+                        reader = new ParquetRecordReaderWrapper<>(readSupport);
+                        reader.initialize(fileReader, confCopy);
+                    } catch (IOException e) {
+                        Utils.closeCloseablesSilently(fileReader, reader);
+                        throw new UncheckedIOException(e);
+                    }
+                }
             }
         };
     }
 
     /**
-     * Implement a {@link ReadSupport} that will collect the data for each row and return
-     * as a {@link ColumnarBatch}.
+     * Implement a {@link ReadSupport} that will collect the data for each row and return as a
+     * {@link ColumnarBatch}.
      */
     public static class BatchReadSupport
-        extends ReadSupport<Object> {
+            extends ReadSupport<Object> {
         private final int maxBatchSize;
         private final StructType readSchema;
         private RowRecordCollector rowRecordCollector;
@@ -136,15 +171,15 @@ public class ParquetFileReader {
         @Override
         public ReadContext init(InitContext context) {
             return new ReadContext(
-                ParquetSchemaUtils.pruneSchema(context.getFileSchema(), readSchema));
+                    ParquetSchemaUtils.pruneSchema(context.getFileSchema(), readSchema));
         }
 
         @Override
         public RecordMaterializer<Object> prepareForRead(
-            Configuration configuration,
-            Map<String, String> keyValueMetaData,
-            MessageType fileSchema,
-            ReadContext readContext) {
+                Configuration configuration,
+                Map<String, String> keyValueMetaData,
+                MessageType fileSchema,
+                ReadContext readContext) {
             rowRecordCollector = new RowRecordCollector(maxBatchSize, readSchema, fileSchema);
             return rowRecordCollector;
         }
@@ -163,14 +198,13 @@ public class ParquetFileReader {
 
     /**
      * Collects the records given by the Parquet reader as columnar data. Parquet reader allows
-     * reading data row by row, but {@link ParquetFileReader} wants to expose the data as a
-     * columnar batch. Parquet reader takes an implementation of {@link RecordMaterializer}
-     * to which it gives data for each column one row a time. This {@link RecordMaterializer}
-     * implementation collects the column values for multiple rows and returns a
-     * {@link ColumnarBatch} at the end.
+     * reading data row by row, but {@link ParquetFileReader} wants to expose the data as a columnar
+     * batch. Parquet reader takes an implementation of {@link RecordMaterializer} to which it gives
+     * data for each column one row at a time. This {@link RecordMaterializer} implementation
+     * collects the column values for multiple rows and returns a {@link ColumnarBatch} at the end.
      */
     public static class RowRecordCollector
-        extends RecordMaterializer<Object> {
+            extends RecordMaterializer<Object> {
         private static final Object FAKE_ROW_RECORD = new Object();
         private final RowColumnReader rowRecordGroupConverter;
 
@@ -207,10 +241,34 @@ public class ParquetFileReader {
 
         /**
          * Finalize the current row.
+         *
          * @param fileRowIndex the file row index of the row just processed
          */
         public void finalizeCurrentRow(long fileRowIndex) {
             rowRecordGroupConverter.finalizeCurrentRow(fileRowIndex);
+        }
+    }
+
+    /**
+     * Wrapper around {@link org.apache.parquet.hadoop.ParquetFileReader} to allow using the
+     * provided footer instead of reading it again. We read the footer in advance to construct a
+     * predicate for filtering rows.
+     */
+    private static class ParquetFileReaderWithFooter
+            extends org.apache.parquet.hadoop.ParquetFileReader {
+        private final ParquetMetadata footer;
+
+        ParquetFileReaderWithFooter(
+                Path filePath,
+                Configuration configuration,
+                ParquetMetadata footer) throws IOException {
+            super(configuration, filePath, footer);
+            this.footer = requireNonNull(footer, "footer is null");
+        }
+
+        @Override
+        public ParquetMetadata getFooter() {
+            return footer;  // return the footer passed in the constructor
         }
     }
 }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFilterUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFilterUtils.java
@@ -1,0 +1,428 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults.internal.parquet;
+
+import java.util.*;
+
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.filter2.compat.FilterCompat.Filter;
+import org.apache.parquet.filter2.predicate.FilterApi;
+import org.apache.parquet.filter2.predicate.FilterPredicate;
+import org.apache.parquet.filter2.predicate.Operators.*;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.*;
+import org.apache.parquet.schema.LogicalTypeAnnotation.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.delta.kernel.expressions.*;
+import io.delta.kernel.expressions.Column;
+import io.delta.kernel.types.*;
+
+import static io.delta.kernel.internal.util.ExpressionUtils.*;
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+
+/**
+ * Utilities to convert the Kernel {@link Predicate} into `parquet-mr` {@link FilterPredicate}.
+ */
+public class ParquetFilterUtils {
+    private static final Logger logger = LoggerFactory.getLogger(ParquetFilterUtils.class);
+
+    private ParquetFilterUtils() {
+    }
+
+    /**
+     * Convert the given Kernel predicate {@code kernelPredicate} into `parquet-mr` predicate.
+     *
+     * @param parquetFileSchema Schema of the Parquet file. We need it to find what columns exists
+     *                          in the Parquet file in order to remove predicates on columns that do
+     *                          not exist in the file. There is no clear way to handle the predicate
+     *                          on columns that don't exist in the Parquet file.
+     * @param kernelPredicate   Kernel predicate to convert.
+     * @return instance of {@link Filter} (`parquet-mr` filter)
+     */
+    public static Optional<FilterPredicate> toParquetFilter(
+            MessageType parquetFileSchema,
+            Predicate kernelPredicate) {
+        // Construct a map of field names to field metadata objects
+        Map<Column, ParquetField> parquetFieldMap = extractParquetFields(parquetFileSchema);
+        return convertToParquetFilter(parquetFieldMap, kernelPredicate);
+    }
+
+    private static class ParquetField {
+        final LogicalTypeAnnotation logicalType;
+        final PrimitiveType primitiveType;
+
+        private ParquetField(LogicalTypeAnnotation logicalType, PrimitiveType primitiveType) {
+            this.logicalType = logicalType;
+            this.primitiveType = primitiveType;
+        }
+
+        static ParquetField of(LogicalTypeAnnotation logicalType, PrimitiveType primitiveType) {
+            return new ParquetField(logicalType, primitiveType);
+        }
+    }
+
+    /**
+     * Create a mapping of column to ParquetField for each non-repeated leaf-level column in the
+     * given parquet schema.
+     *
+     * @param parquetSchema Schema of the Parquet file
+     * @return Mapping of column to ParquetField
+     */
+    private static Map<Column, ParquetField> extractParquetFields(MessageType parquetSchema) {
+        Map<Column, ParquetField> parquetFields = new HashMap<>();
+        for (ColumnDescriptor columnDescriptor : parquetSchema.getColumns()) {
+            String[] columnPath = columnDescriptor.getPath();
+            Type type = parquetSchema.getType(columnPath);
+            if (type.getRepetition() == Type.Repetition.REPEATED) {
+                // `parquet-mr` doesn't support applying filter on a repeated column
+                continue;
+            }
+            assert type.isPrimitive() : "Only primitive types are expected from .getColumns()";
+            PrimitiveType primitiveType = type.asPrimitiveType();
+            parquetFields.put(
+                    new Column(columnPath),
+                    ParquetField.of(type.getLogicalTypeAnnotation(), primitiveType));
+        }
+        return parquetFields;
+    }
+
+    private static boolean canUseLiteral(Literal literal, PrimitiveType parquetType) {
+        DataType litType = literal.getDataType();
+        LogicalTypeAnnotation logicalType = parquetType.getLogicalTypeAnnotation();
+        switch (parquetType.getPrimitiveTypeName()) {
+            case BOOLEAN:
+                return litType instanceof BooleanType;
+            case INT32:
+                if (!isInteger(literal)) {
+                    return false;
+                }
+                return logicalType == null || // no logical type when the type is int32 or int64
+                        (logicalType instanceof IntLogicalTypeAnnotation &&
+                                ((IntLogicalTypeAnnotation) logicalType).getBitWidth() <= 32) ||
+                        logicalType instanceof DateLogicalTypeAnnotation;
+            case INT64:
+                if (!isLong(literal)) {
+                    return false;
+                }
+                return logicalType == null || // no logical type when the type is int32 or int64
+                        (logicalType instanceof IntLogicalTypeAnnotation &&
+                                ((IntLogicalTypeAnnotation) logicalType).getBitWidth() <= 64);
+            case FLOAT:
+                return isFloat(literal);
+            case DOUBLE:
+                return isDouble(literal);
+            case BINARY: {
+                return isBinary(literal) &&
+                        // logical type should be binary (null) or string
+                        (logicalType == null || logicalType instanceof StringLogicalTypeAnnotation);
+            }
+            default:
+                return false;
+        }
+    }
+
+    private static Optional<FilterPredicate> convertToParquetFilter(
+            Map<Column, ParquetField> parquetFieldMap,
+            Predicate deltaPredicate) {
+        String name = deltaPredicate.getName().toLowerCase(Locale.ROOT);
+        switch (name) {
+            case "=":
+            case "<":
+            case "<=":
+            case ">":
+            case ">=":
+                return convertComparatorToParquetFilter(parquetFieldMap, deltaPredicate);
+            case "not":
+                return convertNotToParquetFilter(parquetFieldMap, deltaPredicate);
+            case "and":
+                return convertAndToParquetFilter(parquetFieldMap, deltaPredicate);
+            case "or":
+                return convertOrToParquetFilter(parquetFieldMap, deltaPredicate);
+            default:
+                return visitUnsupported(deltaPredicate, name + " is not a supported predicate.");
+        }
+    }
+
+    private static Optional<FilterPredicate> convertComparatorToParquetFilter(
+            Map<Column, ParquetField> parquetFieldMap,
+            Predicate deltaPredicate) {
+        Expression child0 = getLeft(deltaPredicate);
+        Expression child1 = getRight(deltaPredicate);
+
+        if (child0 instanceof Literal && child1 instanceof Column) {
+            Expression temp = child0;
+            child0 = child1;
+            child1 = temp;
+        }
+
+        if (!(child0 instanceof Column) || !(child1 instanceof Literal)) {
+            return visitUnsupported(
+                    deltaPredicate,
+                    "Comparison predicate must have a column and a literal.");
+        }
+
+        Column column = (Column) child0;
+        Literal literal = (Literal) child1;
+
+        ParquetField parquetField = parquetFieldMap.get(column);
+        if (parquetField == null) {
+            return visitUnsupported(
+                    deltaPredicate,
+                    "Column used in predicate does not exist in the parquet file.");
+        }
+
+        if (literal.getValue() == null) {
+            return visitUnsupported(deltaPredicate,
+                    "Literal value is null for a comparator operator. Comparator is not " +
+                            "supported for null values as the Parquet comparator is not null safe");
+        }
+
+        if (!canUseLiteral(literal, parquetField.primitiveType)) {
+            return visitUnsupported(
+                    deltaPredicate,
+                    "Literal type is not compatible with the column type: "
+                            + literal.getDataType());
+        }
+
+        PrimitiveType parquetType = parquetField.primitiveType;
+        String columnPath = ColumnPath.get(column.getNames()).toDotString();
+        String comparator = deltaPredicate.getName();
+
+        switch (parquetType.getPrimitiveTypeName()) {
+            case BOOLEAN:
+                BooleanColumn booleanColumn = FilterApi.booleanColumn(columnPath);
+                if ("=".equals(comparator)) { // Only = is supported for boolean
+                    return Optional.of(FilterApi.eq(booleanColumn, getBoolean(literal)));
+                }
+                break;
+            case INT32:
+                IntColumn intColumn = FilterApi.intColumn(columnPath);
+                switch (comparator) {
+                    case "=":
+                        return Optional.of(FilterApi.eq(intColumn, getInt(literal)));
+                    case "<":
+                        return Optional.of(FilterApi.lt(intColumn, getInt(literal)));
+                    case "<=":
+                        return Optional.of(FilterApi.ltEq(intColumn, getInt(literal)));
+                    case ">":
+                        return Optional.of(FilterApi.gt(intColumn, getInt(literal)));
+                    case ">=":
+                        return Optional.of(FilterApi.gtEq(intColumn, getInt(literal)));
+                }
+                break;
+            case INT64:
+                LongColumn longColumn = FilterApi.longColumn(columnPath);
+                switch (comparator) {
+                    case "=":
+                        return Optional.of(FilterApi.eq(longColumn, getLong(literal)));
+                    case "<":
+                        return Optional.of(FilterApi.lt(longColumn, getLong(literal)));
+                    case "<=":
+                        return Optional.of(FilterApi.ltEq(longColumn, getLong(literal)));
+                    case ">":
+                        return Optional.of(FilterApi.gt(longColumn, getLong(literal)));
+                    case ">=":
+                        return Optional.of(FilterApi.gtEq(longColumn, getLong(literal)));
+                }
+                break;
+            case FLOAT:
+                FloatColumn floatColumn = FilterApi.floatColumn(columnPath);
+                switch (comparator) {
+                    case "=":
+                        return Optional.of(FilterApi.eq(floatColumn, getFloat(literal)));
+                    case "<":
+                        return Optional.of(FilterApi.lt(floatColumn, getFloat(literal)));
+                    case "<=":
+                        return Optional.of(FilterApi.ltEq(floatColumn, getFloat(literal)));
+                    case ">":
+                        return Optional.of(FilterApi.gt(floatColumn, getFloat(literal)));
+                    case ">=":
+                        return Optional.of(FilterApi.gtEq(floatColumn, getFloat(literal)));
+                }
+                break;
+            case DOUBLE:
+                DoubleColumn doubleColumn = FilterApi.doubleColumn(columnPath);
+                switch (comparator) {
+                    case "=":
+                        return Optional.of(FilterApi.eq(doubleColumn, getDouble(literal)));
+                    case "<":
+                        return Optional.of(FilterApi.lt(doubleColumn, getDouble(literal)));
+                    case "<=":
+                        return Optional.of(FilterApi.ltEq(doubleColumn, getDouble(literal)));
+                    case ">":
+                        return Optional.of(FilterApi.gt(doubleColumn, getDouble(literal)));
+                    case ">=":
+                        return Optional.of(FilterApi.gtEq(doubleColumn, getDouble(literal)));
+                }
+                break;
+            case BINARY:
+                BinaryColumn binaryColumn = FilterApi.binaryColumn(columnPath);
+                Binary binary = getBinary(literal);
+                switch (comparator) {
+                    case "=":
+                        return Optional.of(FilterApi.eq(binaryColumn, binary));
+                    case "<":
+                        return Optional.of(FilterApi.lt(binaryColumn, binary));
+                    case "<=":
+                        return Optional.of(FilterApi.ltEq(binaryColumn, binary));
+                    case ">":
+                        return Optional.of(FilterApi.gt(binaryColumn, binary));
+                    case ">=":
+                        return Optional.of(FilterApi.gtEq(binaryColumn, binary));
+                }
+                break;
+        }
+        return visitUnsupported(
+                deltaPredicate,
+                String.format("Unsupported column type (%s) with comparator (%s): ",
+                        parquetType, comparator));
+    }
+
+    private static Optional<FilterPredicate> convertNotToParquetFilter(
+            Map<Column, ParquetField> parquetFieldMap,
+            Predicate deltaPredicate) {
+        Optional<FilterPredicate> childFilter =
+                convertToParquetFilter(parquetFieldMap, (Predicate) getUnaryChild(deltaPredicate));
+
+        return childFilter.map(FilterApi::not);
+    }
+
+    private static Optional<FilterPredicate> convertOrToParquetFilter(
+            Map<Column, ParquetField> parquetFieldMap,
+            Predicate deltaPredicate) {
+        Optional<FilterPredicate> leftFilter =
+                convertToParquetFilter(parquetFieldMap, asPredicate(getLeft(deltaPredicate)));
+        Optional<FilterPredicate> rightFilter =
+                convertToParquetFilter(parquetFieldMap, asPredicate(getRight(deltaPredicate)));
+
+        if (leftFilter.isPresent() && rightFilter.isPresent()) {
+            return Optional.of(FilterApi.or(leftFilter.get(), rightFilter.get()));
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<FilterPredicate> convertAndToParquetFilter(
+            Map<Column, ParquetField> parquetFieldMap,
+            Predicate deltaPredicate) {
+        Optional<FilterPredicate> leftFilter =
+                convertToParquetFilter(parquetFieldMap, asPredicate(getLeft(deltaPredicate)));
+        Optional<FilterPredicate> rightFilter =
+                convertToParquetFilter(parquetFieldMap, asPredicate(getRight(deltaPredicate)));
+
+        if (leftFilter.isPresent() && rightFilter.isPresent()) {
+            return Optional.of(FilterApi.and(leftFilter.get(), rightFilter.get()));
+        }
+        if (leftFilter.isPresent()) {
+            return leftFilter;
+        }
+        return rightFilter;
+    }
+
+    private static Optional<FilterPredicate> visitUnsupported(
+            Predicate predicate,
+            String message) {
+        logger.info("Unsupported predicate: {}. Reason: {}", predicate, message);
+        // Filtering is a best effort. If an unsupported predicate expression is received,
+        // do not consider it for filtering.
+        return Optional.empty();
+    }
+
+    private static boolean isBoolean(Literal literal) {
+        return literal.getDataType() instanceof BooleanType;
+    }
+
+    private static boolean getBoolean(Literal literal) {
+        checkArgument(isBoolean(literal), "Literal is not a boolean: " + literal);
+        return (boolean) literal.getValue();
+    }
+
+    private static boolean isInteger(Literal literal) {
+        DataType dataType = literal.getDataType();
+        if (dataType instanceof LongType) {
+            // Check if the long value can be represented as an integer
+            return ((Long) literal.getValue()).intValue() == (Long) literal.getValue();
+        }
+
+        return dataType instanceof ByteType ||
+                dataType instanceof ShortType ||
+                dataType instanceof IntegerType ||
+                dataType instanceof DateType;
+    }
+
+    private static int getInt(Literal literal) {
+        checkArgument(isInteger(literal), "Literal is not an integer: " + literal);
+        DataType dataType = literal.getDataType();
+        if (dataType instanceof LongType) {
+            return ((Long) literal.getValue()).intValue();
+        }
+
+        return ((Number) literal.getValue()).intValue();
+    }
+
+    private static boolean isLong(Literal literal) {
+        DataType dataType = literal.getDataType();
+        return dataType instanceof LongType ||
+                dataType instanceof ByteType ||
+                dataType instanceof ShortType ||
+                dataType instanceof IntegerType ||
+                dataType instanceof DateType;
+    }
+
+    private static long getLong(Literal literal) {
+        checkArgument(isLong(literal), "Literal is not a long: " + literal);
+        DataType dataType = literal.getDataType();
+        if (dataType instanceof LongType) {
+            return (long) literal.getValue();
+        }
+
+        return ((Number) literal.getValue()).longValue();
+    }
+
+    private static boolean isFloat(Literal literal) {
+        return literal.getDataType() instanceof FloatType;
+    }
+
+    private static float getFloat(Literal literal) {
+        checkArgument(isFloat(literal), "Literal is not a float: " + literal);
+        return ((Number) literal.getValue()).floatValue();
+    }
+
+    private static boolean isDouble(Literal literal) {
+        return literal.getDataType() instanceof DoubleType;
+    }
+
+    private static double getDouble(Literal literal) {
+        checkArgument(isDouble(literal), "Literal is not a double: " + literal);
+        return ((Number) literal.getValue()).doubleValue();
+    }
+
+    private static boolean isBinary(Literal literal) {
+        DataType type = literal.getDataType();
+        return type instanceof BinaryType || type instanceof StringType;
+    }
+
+    private static Binary getBinary(Literal literal) {
+        checkArgument(isBinary(literal), "Literal is not a binary: " + literal);
+        DataType type = literal.getDataType();
+        if (type instanceof BinaryType) {
+            return Binary.fromConstantByteArray((byte[]) literal.getValue());
+        }
+        return Binary.fromString((String) literal.getValue());
+    }
+}

--- a/kernel/kernel-defaults/src/main/java/org/apache/parquet/hadoop/ParquetRecordReaderWrapper.java
+++ b/kernel/kernel-defaults/src/main/java/org/apache/parquet/hadoop/ParquetRecordReaderWrapper.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.parquet.hadoop;
+
+import java.io.IOException;
+
+import org.apache.parquet.hadoop.api.ReadSupport;
+
+/**
+ * Wrapper around {@link InternalParquetRecordReader} to expose it as a public class. The package is
+ * kept same as the {@link InternalParquetRecordReader} to allow access to package-private methods.
+ *
+ * @param <T>
+ */
+public class ParquetRecordReaderWrapper<T>
+        extends InternalParquetRecordReader<T>
+        implements AutoCloseable {
+    public ParquetRecordReaderWrapper(ReadSupport<T> readSupport) {
+        super(readSupport);
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+    }
+}

--- a/kernel/kernel-defaults/src/test/java/io/delta/kernel/defaults/benchmarks/BenchmarkParallelCheckpointReading.java
+++ b/kernel/kernel-defaults/src/test/java/io/delta/kernel/defaults/benchmarks/BenchmarkParallelCheckpointReading.java
@@ -235,7 +235,8 @@ public class BenchmarkParallelCheckpointReading {
 
         List<ColumnarBatch> parquetFileReader(String filePath, StructType readSchema) {
             ParquetFileReader reader = new ParquetFileReader(hadoopConf);
-            try (CloseableIterator<ColumnarBatch> batchIter = reader.read(filePath, readSchema)) {
+            try (CloseableIterator<ColumnarBatch> batchIter =
+                         reader.read(filePath, readSchema, Optional.empty())) {
                 List<ColumnarBatch> batches = new ArrayList<>();
                 while (batchIter.hasNext()) {
                     batches.add(batchIter.next());

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetFileReaderSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetFileReaderSuite.scala
@@ -16,12 +16,10 @@
 package io.delta.kernel.defaults.internal.parquet
 
 import java.math.BigDecimal
-
 import io.delta.golden.GoldenTableUtils.goldenTableFile
 import io.delta.kernel.defaults.utils.{ExpressionTestUtils, TestRow, VectorTestUtils}
 import io.delta.kernel.types._
 import org.scalatest.funsuite.AnyFunSuite
-
 class ParquetFileReaderSuite extends AnyFunSuite
   with ParquetSuiteBase with VectorTestUtils with ExpressionTestUtils {
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetReaderPredicatePushdownSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetReaderPredicatePushdownSuite.scala
@@ -1,0 +1,324 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults.internal.parquet
+
+import io.delta.golden.GoldenTableUtils.goldenTablePath
+import io.delta.kernel.defaults.utils.{ExpressionTestUtils, TestRow, VectorTestUtils}
+import io.delta.kernel.expressions.Literal.{ofBinary, ofBoolean, ofDate, ofDouble, ofFloat, ofInt, ofLong, ofNull, ofString}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+import io.delta.kernel.expressions._
+import io.delta.kernel.internal.util.InternalUtils.daysSinceEpoch
+import io.delta.kernel.types.{IntegerType, StructType}
+import org.apache.spark.sql.{Row, types => sparktypes}
+
+import java.nio.file.Files
+import java.sql.Date
+import java.util.Optional
+
+class ParquetReaderPredicatePushdownSuite extends AnyFunSuite
+    with BeforeAndAfterAll with ParquetSuiteBase with VectorTestUtils with ExpressionTestUtils {
+
+  //////////////////////////////////////////////////////////////////////////////////
+  // Test data generation and helper methods
+  //////////////////////////////////////////////////////////////////////////////////
+
+  var testParquetTable: String = ""
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    testParquetTable = Files.createTempDirectory("tempDir").toString
+
+    // Generate a test Parquet file with 20 row groups. Each row group has 100 rows.
+    // Parquet-mr checks whether the current row group has reached the limit or for every 100 rows.
+    // We set the `parquet.block.size` to very low, so for every 100 rows, it will create a
+    // new row group.
+    val rows = Seq.range(0, 20).flatMap(i => generateRowsGroup(i))
+
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(rows), testTableSchema)
+    withSQLConf("parquet.block.size" -> 1.toString) {
+      df.repartition(1)
+        .orderBy("rowId")
+        .write
+        .format("delta")
+        .mode("append")
+        .save(testParquetTable)
+    }
+  }
+
+  // test table schema
+  val testTableSchema: sparktypes.StructType = {
+    // These are the only supported column types in Parquet filter push down
+    def allTypesSchema(): Array[sparktypes.StructField] = {
+      Seq(
+        sparktypes.StructField("byteCol", sparktypes.ByteType),
+        sparktypes.StructField("shortCol", sparktypes.ShortType),
+        sparktypes.StructField("intCol", sparktypes.IntegerType),
+        sparktypes.StructField("longCol", sparktypes.LongType),
+        sparktypes.StructField("floatCol", sparktypes.FloatType),
+        sparktypes.StructField("doubleCol", sparktypes.DoubleType),
+        sparktypes.StructField("stringCol", sparktypes.StringType),
+        // column with values that are truncated in stats
+        sparktypes.StructField("truncatedStringCol", sparktypes.StringType),
+        sparktypes.StructField("binaryCol", sparktypes.BinaryType),
+        sparktypes.StructField("truncatedBinaryCol", sparktypes.BinaryType),
+        sparktypes.StructField("booleanCol", sparktypes.BooleanType),
+        sparktypes.StructField("dateCol", sparktypes.DateType)
+      ).toArray
+    }
+
+    // supported data type columns as top level columns
+    new sparktypes.StructType(allTypesSchema())
+      // supported data type columns as nested columns
+      .add("nested", sparktypes.StructType(allTypesSchema()))
+      // row id to help with the test results verification
+      .add("rowId", sparktypes.IntegerType)
+  }
+
+  private def generateRowsGroup(rowGroupIdx: Int): Seq[Row] = {
+    def values(rowId: Int): Seq[Any] = {
+      Seq(
+        if (rowId % 72 != 0) rowId.byteValue() else null,
+        if (rowId % 56 != 0) rowId.shortValue() else null,
+        if (rowId % 23 != 0) rowId else null,
+        if (rowId % 25 != 0) (rowId + 1).longValue() else null,
+        if (rowId % 28 != 0) (rowId + 0.125).floatValue() else null,
+        if (rowId % 54 != 0) (rowId + 0.000001).doubleValue() else null,
+        if (rowId % 57 != 0) "%05d".format(rowId) else null,
+        if (rowId % 57 != 0) "%050d".format(rowId) else null, // truncated stats
+        if (rowId % 59 != 0) "%06d".format(rowId).getBytes else null,
+        if (rowId % 59 != 0) "%060d".format(rowId).getBytes else null, // truncated stats
+        // alternate between true and false for each row group
+        (rowId / 100) % 2 == 0,
+        if (rowId % 61 != 0) new Date(rowId * 86400000L /* millis in a day */) else null
+      )
+    }
+
+    Seq.range(rowGroupIdx * 100, (rowGroupIdx + 1) * 100).map { rowId =>
+      Row.fromSeq(
+        values(rowId) ++ // top-level column values
+          Seq(
+            Row.fromSeq(values(rowId)), // nested column values
+            rowId // row id to help with the test results verification
+          )
+      )
+    }
+  }
+
+  def generateExpData(rowGroupIndexes: Seq[Int]): Seq[TestRow] = {
+    spark.createDataFrame(
+      spark.sparkContext.parallelize(rowGroupIndexes.flatMap(i => generateRowsGroup(i))),
+      testTableSchema)
+      .collect
+      .map(TestRow(_))
+  }
+
+  private def readUsingKernel(tablePath: String, predicate: Predicate): Seq[TestRow] = {
+    val readSchema: StructType = tableSchema(testParquetTable)
+    readParquetFilesUsingKernel(tablePath, readSchema, Optional.of(predicate))
+  }
+
+  private def assertConvertedFilterIsEmpty(predicate: Predicate, tablePath: String): Unit = {
+    val parquetFileSchema = parquetFiles(tablePath).map(footer(_)).head.getFileMetaData.getSchema
+
+    assert(
+      !ParquetFilterUtils.toParquetFilter(parquetFileSchema, predicate).isPresent,
+      "Predicate should not be converted to Parquet filter")
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////
+  // End-2-end tests
+  //////////////////////////////////////////////////////////////////////////////////
+
+  Seq(
+    // filter on int type column
+    (
+      eq(col("intCol"), ofInt(20)), // top-level column
+      eq(col("nested", "intCol"), ofInt(20)), // nested column
+      Seq(0) // expected row groups
+    ),
+    // filter on long type column
+    (
+      gt(col("longCol"), ofLong(1600)),
+      gt(col("nested", "longCol"), ofLong(1600)),
+      Seq(16, 17, 18, 19) // expected row groups
+    ),
+    // filter on float type column
+    (
+      lt(col("floatCol"), ofFloat(1000.0f)),
+      lt(col("nested", "floatCol"), ofFloat(1000.0f)),
+      Seq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9) // expected row groups
+    ),
+    // filter on double type column
+    (
+      gt(col("doubleCol"), ofDouble(1000.0)),
+      gt(col("nested", "doubleCol"), ofDouble(1000.0)),
+      Seq(10, 11, 12, 13, 14, 15, 16, 17, 18, 19) // expected row groups
+    ),
+    // filter on boolean type column
+    (
+      eq(col("booleanCol"), ofBoolean(true)),
+      eq(col("nested", "booleanCol"), ofBoolean(true)),
+      Seq(0, 2, 4, 6, 8, 10, 12, 14, 16, 18) // expected row groups
+    ),
+    // filter on date type column
+    (
+      lte(col("dateCol"), ofDate(
+        daysSinceEpoch(new Date(500 * 86400000L /* millis in a day */)))),
+      lte(col("nested", "dateCol"), ofDate(
+        daysSinceEpoch(new Date(500 * 86400000L /* millis in a day */)))),
+      Seq(0, 1, 2, 3, 4, 5) // expected row groups
+    ),
+    // filter on string type column
+    (
+      eq(col("stringCol"), ofString("%05d".format(300))),
+      eq(col("nested", "stringCol"), ofString("%05d".format(300))),
+      Seq(3) // expected row groups
+    ),
+    // filter on binary type column
+    (
+      gte(col("binaryCol"), ofBinary("%06d".format(1700).getBytes)),
+      gte(col("nested", "binaryCol"), ofBinary("%06d".format(1700).getBytes)),
+      Seq(17, 18, 19) // expected row groups
+    ),
+    // filter on truncated stats string type column
+    (
+      gte(col("truncatedStringCol"), ofString("%050d".format(300))),
+      gte(col("nested", "truncatedStringCol"), ofString("%050d".format(300))),
+      Seq(3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19) // expected row groups
+    ),
+    // filter on truncated stats binary type column
+    (
+      lte(col("truncatedBinaryCol"), ofBinary("%060d".format(600).getBytes)),
+      lte(col("nested", "truncatedBinaryCol"), ofBinary("%060d".format(600).getBytes)),
+      Seq(0, 1, 2, 3, 4, 5, 6) // expected row groups
+    )
+  ).foreach {
+    // boolean, int32, data, int64, float, double, binary, string
+    // Test table has 20 row groups, each with 100 rows.
+    case (predicateTopLevelCol, predicateNestedCol, expRowGroups) =>
+      Seq(predicateTopLevelCol, predicateNestedCol).foreach { predicate =>
+        test(s"filter pushdown: $predicate") {
+          val actualData = readUsingKernel(testParquetTable, predicate)
+          val expOutputRowCount = expRowGroups.length * 100 // 100 rows per row group
+          assert(actualData.size === expOutputRowCount, s"predicate: $predicate")
+          checkAnswer(actualData, generateExpData(expRowGroups))
+        }
+      }
+  }
+
+  test("for a column that doesn't exist in the table") {
+    val testPredicate = predicate("=", col("nonExistentCol"), ofInt(20))
+    assertConvertedFilterIsEmpty(testPredicate, testParquetTable)
+
+    val actData = readUsingKernel(testParquetTable, testPredicate)
+    // contains all the data in the table as the predicate is not pushed down
+    checkAnswer(actData, generateExpData(Seq.range(0, 20)))
+  }
+
+  test("literal and column are swapped") {
+    val testPredicate = predicate("=", ofInt(20), col("intCol"))
+    val actData = readUsingKernel(testParquetTable, testPredicate)
+    checkAnswer(actData, generateExpData(Seq(0)))
+  }
+
+  test("comparator literal value is null") {
+    val testPredicate = predicate("=", col("intCol"), ofNull(IntegerType.INTEGER))
+    assertConvertedFilterIsEmpty(testPredicate, testParquetTable)
+
+    val actData = readUsingKernel(testParquetTable, testPredicate)
+    // contains all the data in the table as the predicate is not pushed down
+    checkAnswer(actData, generateExpData(Seq.range(0, 20)))
+  }
+
+  test("comparator that compare column and column") {
+    val testPredicate = predicate("=", col("intCol"), col("longCol"))
+    assertConvertedFilterIsEmpty(testPredicate, testParquetTable)
+
+    val actData = readUsingKernel(testParquetTable, testPredicate)
+    // contains all the data in the table as the predicate is not pushed down
+    checkAnswer(actData, generateExpData(Seq.range(0, 20)))
+  }
+
+  test("comparator that compare literal and literal") {
+    val testPredicate = predicate("=", ofInt(20), ofInt(20))
+    assertConvertedFilterIsEmpty(testPredicate, testParquetTable)
+
+    val actData = readUsingKernel(testParquetTable, testPredicate)
+    // contains all the data in the table as the predicate is not pushed down
+    checkAnswer(actData, generateExpData(Seq.range(0, 20)))
+  }
+
+  test("OR support") {
+    val predicate = or(
+      eq(col("intCol"), ofInt(20)),
+      eq(col("longCol"), ofLong(1600))
+    )
+    val actData = readUsingKernel(testParquetTable, predicate)
+    checkAnswer(actData, generateExpData(Seq(0, 15)))
+  }
+
+  test("one end of the OR is not convertible") {
+    val predicate = or(
+      eq(col("intCol"), ofInt(1599)),
+      eq(col("nonExistentCol"), ofInt(1600))
+    )
+    assertConvertedFilterIsEmpty(predicate, testParquetTable)
+
+    val actData = readUsingKernel(testParquetTable, predicate)
+    // contains all the data in the table as the predicate is not pushed down
+    checkAnswer(actData, generateExpData(Seq.range(0, 20)))
+  }
+
+  test("AND support") {
+    val predicate = and(
+      eq(col("intCol"), ofInt(1599)),
+      eq(col("longCol"), ofLong(1600))
+    )
+    val actData = readUsingKernel(testParquetTable, predicate)
+    checkAnswer(actData, generateExpData(Seq(15)))
+  }
+
+  test("one end of the AND is not convertible") {
+    val predicate = and(
+      eq(col("intCol"), ofInt(1599)),
+      eq(col("nonExistentCol"), ofInt(1600))
+    )
+    val actData = readUsingKernel(testParquetTable, predicate)
+    checkAnswer(actData, generateExpData(Seq(15)))
+  }
+
+  test("not support") {
+    val predicate = not(eq(col("booleanCol"), ofBoolean(true)))
+    val actData = readUsingKernel(testParquetTable, predicate)
+    // every odd rowgroup has true for booleanCol
+    checkAnswer(actData, generateExpData(Seq(1, 3, 5, 7, 9, 11, 13, 15, 17, 19)))
+  }
+
+  test("doesn't work on the repeated columns") {
+    val testTable = goldenTablePath("parquet-all-types")
+    val readSchema = tableSchema(testTable)
+
+    val predicate = eq(col("array_of_prims"), ofInt(20))
+    assertConvertedFilterIsEmpty(predicate, testTable)
+
+    val actResult = readParquetFilesUsingKernel(testTable, readSchema, Optional.of(predicate))
+    val expResult = readParquetFilesUsingSpark(testTable, readSchema)
+
+    checkAnswer(actResult, expResult)
+  }
+}


### PR DESCRIPTION
## Description
Pushing down the predicate helps read fewer records especially when getting the scan files and reading multi-part checkpoint files.

The current library we use parquet-mr already has support for pruning the records based on the stats in rowgroups and individual records as each record is read. This PR converts the given Kernel `Predicate` into `parquet-mr` predicate and gives as input to the `parquet-mr` reader.

The support is only to prune the row groups using the pushed-down predicate. Individual record level filter is disabled due to the following reasons:
*  the `parquet-mr` materializes the entire record first before evaluating the predicate. This causes implementation challenges around the current `ColumnarBatch` construction out of the rows returned by the `parquet-mr`
* We have additional partition pruning/data skipping that helps prune the records anyway.

Current support is on the following column types: BYTE, SHORT, INT, LONG, FLOAT, DOUBLE, DATA, BOOLEAN, STRING, BINARY. Timestamp is currently not supported as the most popular physical format is INT96 which can't be used for stats based rowgroup pruning.

Supported operators: eq, gt, lt, gte, lte, not, and, or

Resolves #2667 

## How was this patch tested?
Unit tests