### PR TITLE
[SPARK] Add a test case for implicit decimal conversion casts in DML commands

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/ImplicitDMLCastingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ImplicitDMLCastingSuite.scala
@@ -110,6 +110,11 @@ class ImplicitDMLCastingSuite extends QueryTest
       sourceTypeInErrorMessage = "MAP<STRING, BIGINT>", targetType = "MAP<STRING, INT>",
       targetTypeInErrorMessage = "MAP<STRING, INT>", validValue = "map('abc', 1)",
       overflowValue = s"map('abc', ${Long.MaxValue.toString})",
+      exceptionAnsiCast = "SparkArithmeticException"),
+    TestConfiguration(sourceType = "DECIMAL(3,1)",
+      sourceTypeInErrorMessage = "DECIMAL(3,1)", targetType = "DECIMAL(3,2)",
+      targetTypeInErrorMessage = "DECIMAL(3,2)", validValue = "CAST(1 AS DECIMAL(3,1))",
+      overflowValue = s"CAST(12.3 AS DECIMAL(3,1))",
       exceptionAnsiCast = "SparkArithmeticException")
   )
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Add a test case that validates that the implicit conversion between decimal types in DML commands works correctly

## How was this patch tested?

Only adding a new test

## Does this PR introduce _any_ user-facing changes?

No
