### PR TITLE
Update error check in DeltaOptionSuite to use Spark error classes

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
@@ -28,7 +28,6 @@ import org.apache.spark.sql.delta.util.FileNames
 import org.apache.commons.io.FileUtils
 import org.apache.parquet.format.CompressionCodec
 
-import org.apache.spark.SparkIllegalArgumentException
 import org.apache.spark.sql.{AnalysisException, QueryTest}
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.internal.SQLConf.PARTITION_OVERWRITE_MODE

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
@@ -235,19 +235,15 @@ class DeltaOptionSuite extends QueryTest
     withTempDir { tempDir =>
       val path = tempDir.getCanonicalPath
       withTable("compression") {
-        checkErrorMatchPVals(
-          exception = intercept[SparkIllegalArgumentException] {
+        assert(
+          intercept[java.lang.IllegalArgumentException] {
             spark.range(100)
               .writeTo("compression")
               .using("delta")
               .option("compression", "???")
               .tableProperty("location", path)
               .create()
-          },
-          errorClass = "CODEC_NOT_AVAILABLE.WITH_AVAILABLE_CODECS_SUGGESTION",
-          parameters = Map(
-            "availableCodecs" -> ".*",
-            "codecName" -> ".*"))
+          }.getMessage.nonEmpty)
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.delta.util.FileNames
 import org.apache.commons.io.FileUtils
 import org.apache.parquet.format.CompressionCodec
 
+import org.apache.spark.SparkIllegalArgumentException
 import org.apache.spark.sql.{AnalysisException, QueryTest}
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.internal.SQLConf.PARTITION_OVERWRITE_MODE

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
@@ -234,16 +234,19 @@ class DeltaOptionSuite extends QueryTest
     withTempDir { tempDir =>
       val path = tempDir.getCanonicalPath
       withTable("compression") {
-        val e = intercept[IllegalArgumentException] {
-          spark.range(100)
-            .writeTo("compression")
-            .using("delta")
-            .option("compression", "???")
-            .tableProperty("location", path)
-            .create()
-        }
-        val expectedMessage = "Codec [???] is not available. Available codecs are "
-        assert(e.getMessage.startsWith(expectedMessage))
+        checkErrorMatchPVals(
+          exception = intercept[SparkIllegalArgumentException] {
+            spark.range(100)
+              .writeTo("compression")
+              .using("delta")
+              .option("compression", "???")
+              .tableProperty("location", path)
+              .create()
+          },
+          errorClass = "CODEC_NOT_AVAILABLE.WITH_AVAILABLE_CODECS_SUGGESTION",
+          parameters = Map(
+            "availableCodecs" -> ".*",
+            "codecName" -> ".*"))
       }
     }
   }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR updates an error check in `DeltaOptionSuite` to use the error class framework from Apache Spark. This makes the test less brittle and fits into the framework that Spark is using.

## How was this patch tested?

This PR only modifies test coverage.

## Does this PR introduce _any_ user-facing changes?

No.
