### PR TITLE
[Spark]Use FileStatus instead of SerializableFileStatus in CommitStore APIs

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1869,7 +1869,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
         updatedActions)
       if (attemptVersion == 0L) {
         val expectedPathForCommitZero = deltaFile(deltaLog.logPath, version = 0L).toUri
-        val actualCommitPath = new Path(commitResponse.commit.serializableFileStatus.path).toUri
+        val actualCommitPath = commitResponse.commit.fileStatus.getPath.toUri
         if (actualCommitPath != expectedPathForCommitZero) {
           throw new IllegalStateException("Expected 0th commit to be written to " +
             s"$expectedPathForCommitZero but was written to $actualCommitPath")

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -200,7 +200,7 @@ trait SnapshotManagement { self: DeltaLog =>
     val resultFromCommitStoreFiltered = resultFromCommitStore
       .dropWhile(_.version <= maxDeltaVersionSeen)
       .takeWhile(commit => versionToLoad.forall(commit.version <= _))
-      .map(_.serializableFileStatus.toFileStatus)
+      .map(_.fileStatus)
       .toArray
     if (resultTuplesFromFsListingOpt.isEmpty && resultFromCommitStoreFiltered.nonEmpty) {
       throw new IllegalStateException("No files found from the file system listing, but " +

--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/CommitStore.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/CommitStore.scala
@@ -29,7 +29,7 @@ import org.apache.spark.internal.Logging
 /** Representation of a commit file */
 case class Commit(
   version: Long,
-  serializableFileStatus: SerializableFileStatus,
+  fileStatus: FileStatus,
   commitTimestamp: Long)
 
 /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/InMemoryCommitStore.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/InMemoryCommitStore.scala
@@ -21,7 +21,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
 
 import scala.collection.mutable
 
-import org.apache.spark.sql.delta.SerializableFileStatus
 import org.apache.spark.sql.delta.storage.LogStore
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
@@ -89,8 +88,7 @@ class InMemoryCommitStore(val batchSize: Long) extends AbstractBatchBackfillingC
           s"Commit version $commitVersion is not valid. Expected version: $expectedVersion.")
       }
 
-      val commit =
-        Commit(commitVersion, SerializableFileStatus.fromStatus(commitFile), commitTimestamp)
+      val commit = Commit(commitVersion, commitFile, commitTimestamp)
       tableData.commitsMap(commitVersion) = commit
       tableData.maxCommitVersion = commitVersion
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/CommitStoreSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/CommitStoreSuite.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.delta.managedcommit
 
-import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog, DeltaOperations, ManagedCommitTableFeature, SerializableFileStatus}
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog, DeltaOperations, ManagedCommitTableFeature}
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.storage.LogStore
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitSuite.scala
@@ -18,13 +18,13 @@ package org.apache.spark.sql.delta.managedcommit
 
 import java.io.File
 
-import org.apache.spark.sql.delta.{DeltaLog, SerializableFileStatus}
 import org.apache.spark.sql.delta.DeltaConfigs.{MANAGED_COMMIT_OWNER_CONF, MANAGED_COMMIT_OWNER_NAME}
+import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.storage.LogStore
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{FileStatus, Path}
+import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{QueryTest, Row}
@@ -73,8 +73,7 @@ class ManagedCommitSuite
             val commitTime = uuidFileStatus.getModificationTime
             commitImpl(logStore, hadoopConf, tablePath, commitVersion, uuidFileStatus, commitTime)
 
-            CommitResponse(
-              Commit(commitVersion, SerializableFileStatus.fromStatus(uuidFileStatus), commitTime))
+            CommitResponse(Commit(commitVersion, uuidFileStatus, commitTime))
           }
         }
     }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Similar to LogStore, we will let CommitStore depend on Hadoop FileStatus. CommitStore already depends on Hadoop Path and Hadoop Configuration.

## How was this patch tested?
Existing UTs

## Does this PR introduce _any_ user-facing changes?
No