### PR TITLE
[Kernel][LogReplay] Make a single read request for all checkpoint files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -283,6 +283,8 @@ lazy val kernelDefaults = (project in file("kernel/kernel-defaults"))
       "commons-io" % "commons-io" % "2.8.0" % "test",
       "com.novocode" % "junit-interface" % "0.11" % "test",
       "org.slf4j" % "slf4j-log4j12" % "1.7.36" % "test",
+      "org.openjdk.jmh" % "jmh-core" % "1.37" % "test",
+      "org.openjdk.jmh" % "jmh-generator-annprocess" % "1.37" % "test",
 
       "org.apache.spark" %% "spark-hive" % sparkVersion % "test" classifier "tests",
       "org.apache.spark" %% "spark-sql" % sparkVersion % "test" classifier "tests",

--- a/connectors/golden-tables/src/test/scala/io/delta/golden/GoldenTables.scala
+++ b/connectors/golden-tables/src/test/scala/io/delta/golden/GoldenTables.scala
@@ -378,6 +378,7 @@ class GoldenTables extends QueryTest with SharedSparkSession {
 
     val commitInfoFile = CommitInfo(
       version = Some(0L),
+      inCommitTimestamp = None,
       timestamp = new Timestamp(1540415658000L),
       userId = Some("user_0"),
       userName = Some("username_0"),

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActionsIterator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActionsIterator.java
@@ -18,10 +18,7 @@ package io.delta.kernel.internal.replay;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.Iterator;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Optional;
+import java.util.*;
 
 import io.delta.kernel.client.TableClient;
 import io.delta.kernel.data.ColumnarBatch;
@@ -31,7 +28,9 @@ import io.delta.kernel.utils.FileStatus;
 
 import io.delta.kernel.internal.util.FileNames;
 import io.delta.kernel.internal.util.Utils;
+import static io.delta.kernel.internal.util.FileNames.checkpointVersion;
 import static io.delta.kernel.internal.util.Utils.singletonCloseableIterator;
+import static io.delta.kernel.internal.util.Utils.toCloseableIterator;
 
 /**
  * This class takes as input a list of delta files (.json, .checkpoint.parquet) and produces an
@@ -45,17 +44,19 @@ class ActionsIterator implements CloseableIterator<ActionWrapper> {
     private final TableClient tableClient;
 
     /**
-     * Iterator over the files.
+     * Linked list of iterator files (commit files and/or checkpoint files)
+     * {@link LinkedList} to allow removing the head of the list and also to peek at the head
+     * of the list. The {@link Iterator} doesn't provide a way to peek.
      * <p>
-     * Each file will be split (by 1, or more) to yield an iterator of FileDataReadResults.
+     * Each of these files return an iterator of {@link ColumnarBatch} containing the actions
      */
-    private final Iterator<FileStatus> filesIter;
+    private final LinkedList<FileStatus> filesList;
 
     private final StructType readSchema;
 
     /**
      * The current (ColumnarBatch, isFromCheckpoint) tuple. Whenever this iterator
-     * is exhausted, we will try and fetch the next one from the `filesIter`.
+     * is exhausted, we will try and fetch the next one from the `filesList`.
      * <p>
      * If it is ever empty, that means there are no more batches to produce.
      */
@@ -68,7 +69,8 @@ class ActionsIterator implements CloseableIterator<ActionWrapper> {
             List<FileStatus> files,
             StructType readSchema) {
         this.tableClient = tableClient;
-        this.filesIter = files.iterator();
+        this.filesList = new LinkedList<>();
+        this.filesList.addAll(files);
         this.readSchema = readSchema;
         this.actionsIter = Optional.empty();
     }
@@ -115,7 +117,7 @@ class ActionsIterator implements CloseableIterator<ActionWrapper> {
 
     /**
      * If the current `actionsIter` has no more elements, this function finds the next
-     * non-empty file in `filesIter` and uses it to set `actionsIter`.
+     * non-empty file in `filesList` and uses it to set `actionsIter`.
      */
     private void tryEnsureNextActionsIterIsReady() {
         if (actionsIter.isPresent()) {
@@ -132,7 +134,7 @@ class ActionsIterator implements CloseableIterator<ActionWrapper> {
         }
 
         // Search for the next non-empty file and use that iter
-        while (filesIter.hasNext()) {
+        while (!filesList.isEmpty()) {
             actionsIter = Optional.of(getNextActionsIter());
 
             if (actionsIter.get().hasNext()) {
@@ -149,23 +151,22 @@ class ActionsIterator implements CloseableIterator<ActionWrapper> {
     }
 
     /**
-     * Get the next file from `filesIter` (.json or .checkpoint.parquet), contextualize it
+     * Get the next file from `filesList` (.json or .checkpoint.parquet), contextualize it
      * (allow the connector to split it), and then read it + inject the `isFromCheckpoint`
      * information.
      * <p>
-     * Requires that `filesIter.hasNext` is true.
+     * Requires that `filesList.isEmpty` is false.
      */
     private CloseableIterator<ActionWrapper> getNextActionsIter() {
-        final FileStatus nextFile = filesIter.next();
-
-        // TODO: [#1965] It should be possible to read our JSON and parquet files
-        //       many-at-once instead of one at a time.
-
+        final FileStatus nextFile = filesList.pop();
         try {
             if (nextFile.getPath().endsWith(".json")) {
                 final long fileVersion = FileNames.deltaVersion(nextFile.getPath());
 
-                // Read that file
+                // We can not read multiple JSON files in parallel (like the checkpoint files),
+                // because each one has a different version, and we need to associate the version
+                // with actions read from the JSON file for further optimizations later on.
+
                 final CloseableIterator<ColumnarBatch> dataIter =
                     tableClient.getJsonHandler().readJsonFiles(
                         singletonCloseableIterator(nextFile),
@@ -174,12 +175,17 @@ class ActionsIterator implements CloseableIterator<ActionWrapper> {
 
                 return combine(dataIter, false /* isFromCheckpoint */, fileVersion);
             } else if (nextFile.getPath().endsWith(".parquet")) {
-                final long fileVersion = FileNames.checkpointVersion(nextFile.getPath());
+                final long fileVersion = checkpointVersion(nextFile.getPath());
 
-                // Read that file
+                // Try to retrieve the remaining checkpoint files (if there are any) and issue
+                // read request for all in one go, so that the {@link ParquetHandler} can do
+                // optimizations like reading multiple files in parallel.
+                CloseableIterator<FileStatus> checkpointFilesIter =
+                        retrieveRemainingCheckpointFiles(nextFile, fileVersion);
+
                 final CloseableIterator<ColumnarBatch> dataIter =
                     tableClient.getParquetHandler().readParquetFiles(
-                        singletonCloseableIterator(nextFile),
+                        checkpointFilesIter,
                         readSchema,
                         Optional.empty());
 
@@ -217,5 +223,33 @@ class ActionsIterator implements CloseableIterator<ActionWrapper> {
                 fileReadDataIter.close();
             }
         };
+    }
+
+    /**
+     * Given a checkpoint file, retrieve all the files that are part of the same checkpoint.
+     * <p>
+     * This is done by looking at the file name and finding all the files that have the same
+     * version number.
+     */
+    private CloseableIterator<FileStatus> retrieveRemainingCheckpointFiles(
+            FileStatus checkpointFile,
+            long version) {
+
+        // Filter out all the files that are not part of the same checkpoint
+        final List<FileStatus> checkpointFiles = new ArrayList<>();
+
+        // Add the already retrieved checkpoint file to the list.
+        checkpointFiles.add(checkpointFile);
+
+        while (filesList.peek() != null &&
+                filesList.peek().getPath().endsWith(".parquet") &&
+                checkpointVersion(filesList.peek().getPath()) == version) {
+            checkpointFiles.add(filesList.pop());
+        }
+
+        // Remove the files from the list
+        filesList.removeAll(checkpointFiles);
+
+        return toCloseableIterator(checkpointFiles.iterator());
     }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/BasePrimitiveType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/BasePrimitiveType.java
@@ -27,7 +27,7 @@ public abstract class BasePrimitiveType extends DataType {
      * Create a primitive type {@link DataType}
      *
      * @param primitiveTypeName Primitive type name.
-     * @return
+     * @return {@link DataType} for given primitive type name
      */
     public static DataType createPrimitive(String primitiveTypeName) {
         return Optional.ofNullable(nameToPrimitiveTypeMap.get().get(primitiveTypeName))

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultTableClient.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultTableClient.java
@@ -54,7 +54,7 @@ public class DefaultTableClient
      * Create an instance of {@link DefaultTableClient}.
      *
      * @param hadoopConf Hadoop configuration to use.
-     * @return
+     * @return an instance of {@link DefaultTableClient}.
      */
     public static DefaultTableClient create(Configuration hadoopConf) {
         return new DefaultTableClient(hadoopConf);

--- a/kernel/kernel-defaults/src/test/java/io/delta/kernel/defaults/benchmarks/BenchmarkParallelCheckpointReading.java
+++ b/kernel/kernel-defaults/src/test/java/io/delta/kernel/defaults/benchmarks/BenchmarkParallelCheckpointReading.java
@@ -113,15 +113,15 @@ public class BenchmarkParallelCheckpointReading {
     @BenchmarkMode(Mode.AverageTime)
     public void benchmark(BenchmarkData benchmarkData, Blackhole blackhole) throws Exception {
         TableClient tableClient = createTableClient(benchmarkData.parallelReaderCount);
-        Table table = Table.forPath(
-                createTableClient(benchmarkData.parallelReaderCount),
-                testTablePath);
+        Table table = Table.forPath(tableClient, testTablePath);
 
         Snapshot snapshot = table.getLatestSnapshot(tableClient);
         ScanBuilder scanBuilder = snapshot.getScanBuilder(tableClient);
         Scan scan = scanBuilder.build();
 
+        // Scan state is not used, but get it so that we simulate the real use case.
         Row row = scan.getScanState(tableClient);
+        blackhole.consume(row); // To avoid dead code elimination by the JIT compiler
         long fileSize = 0;
         try (CloseableIterator<FilteredColumnarBatch> batchIter = scan.getScanFiles(tableClient)) {
             while (batchIter.hasNext()) {

--- a/kernel/kernel-defaults/src/test/java/io/delta/kernel/defaults/benchmarks/BenchmarkParallelCheckpointReading.java
+++ b/kernel/kernel-defaults/src/test/java/io/delta/kernel/defaults/benchmarks/BenchmarkParallelCheckpointReading.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.defaults.benchmarks;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.*;
+import static java.util.concurrent.Executors.newFixedThreadPool;
+
+import org.apache.hadoop.conf.Configuration;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.delta.kernel.*;
+import io.delta.kernel.client.ParquetHandler;
+import io.delta.kernel.client.TableClient;
+import io.delta.kernel.data.*;
+import io.delta.kernel.expressions.Predicate;
+import io.delta.kernel.types.StructType;
+import io.delta.kernel.utils.CloseableIterator;
+import io.delta.kernel.utils.FileStatus;
+
+import io.delta.kernel.internal.util.Utils;
+
+import io.delta.kernel.defaults.client.DefaultParquetHandler;
+import io.delta.kernel.defaults.client.DefaultTableClient;
+
+import io.delta.kernel.defaults.internal.parquet.ParquetFileReader;
+
+/**
+ * Benchmark to measure the performance of reading multi-part checkpoint files, using a custom
+ * ParquetHandler that reads the files in parallel. To run this benchmark (from delta repo root):
+ * 1) Generate the test table by following the instructions at `testTablePath` member variable.
+ * $ build/sbt
+ * sbt:delta> project kernelDefaults
+ * sbt:delta> set fork in run := true
+ * sbt:delta> test:runMain io.delta.kernel.defaults.benchmarks.BenchmarkParallelCheckpointReading
+ */
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3)
+@Fork(1)
+public class BenchmarkParallelCheckpointReading {
+
+    /**
+     * Following are the steps to generate a simple large table with multi-part checkpoint files
+     * <p>
+     * bin/spark-shell --packages io.delta:delta-spark_2.12:3.1.0 \ --conf
+     * "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \ --conf
+     * "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog" \ --conf
+     * "spark.databricks.delta.checkpoint.partSize=100000"
+     * <p>
+     * # Within the Spark shell, run the following commands
+     * <p>
+     * spark.range(0, 100000) .withColumn("pCol", 'id % 100000) .repartition(10)
+     * .write.format("delta") .partitionBy("pCol") .mode("append")
+     * .save("~/test-tables/large-table")
+     * <p>
+     * # Repeat the above steps for each of the next ranges # 100000 to 200000, 200000 to 300000 etc
+     * until enough log entries are reached.
+     * <p>
+     * # Then create a checkpoint import org.apache.spark.sql.delta.DeltaLog
+     * <p>
+     * # This step create a multi-part checkpoint with each checkpoint containing 100K records.
+     * DeltaLog.forTable(spark, "~/test-tables/large-table").checkpoint()
+     */
+    private static final String testTablePath = "<TODO> fill the path here";
+
+    @State(Scope.Benchmark)
+    public static class BenchmarkData {
+        // Variations of number of threads to read the multi-part checkpoint files
+        // When thread count is 0, we read using the current default parquet handler implementation
+        // In all other cases we use the custom parallel parquet handler implementation defined
+        // in this benchmark
+        @Param({"0", "1", "2", "4", "10", "20"})
+        private int parallelReaderCount = 0;
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    public void benchmark(BenchmarkData benchmarkData, Blackhole blackhole) throws Exception {
+        TableClient tableClient = createTableClient(benchmarkData.parallelReaderCount);
+        Table table = Table.forPath(
+                createTableClient(benchmarkData.parallelReaderCount),
+                testTablePath);
+
+        Snapshot snapshot = table.getLatestSnapshot(tableClient);
+        ScanBuilder scanBuilder = snapshot.getScanBuilder(tableClient);
+        Scan scan = scanBuilder.build();
+
+        Row row = scan.getScanState(tableClient);
+        long fileSize = 0;
+        try (CloseableIterator<FilteredColumnarBatch> batchIter = scan.getScanFiles(tableClient)) {
+            while (batchIter.hasNext()) {
+                FilteredColumnarBatch batch = batchIter.next();
+                try (CloseableIterator<Row> rowIter = batch.getRows()) {
+                    while (rowIter.hasNext()) {
+                        Row r = rowIter.next();
+                        long size = r.getStruct(0).getLong(2);
+                        fileSize += size;
+                    }
+                }
+            }
+        }
+
+        // Consume the result to avoid dead code elimination by the JIT compiler
+        blackhole.consume(fileSize);
+    }
+
+    public static void main(String[] args) throws Exception {
+        org.openjdk.jmh.Main.main(args);
+    }
+
+    private static TableClient createTableClient(int numberOfParallelThreads) {
+        Configuration hadoopConf = new Configuration();
+        if (numberOfParallelThreads <= 0) {
+            return DefaultTableClient.create(hadoopConf);
+        }
+
+        return new DefaultTableClient(hadoopConf) {
+            @Override
+            public ParquetHandler getParquetHandler() {
+                return new ParallelParquetHandler(hadoopConf, numberOfParallelThreads);
+            }
+        };
+    }
+
+    /**
+     * Custom implementation of {@link ParquetHandler} to read the Parquet files in parallel. Reason
+     * for this not being in the {@link DefaultParquetHandler} is that this implementation keeps the
+     * contents of the Parquet files in memory, which is not suitable for default implementation
+     * without a proper design that allows limits on the memory usage. If the parallel reading of
+     * checkpoint becomes a common in connectors, we can look at adding the functionality in the
+     * default implementation.
+     */
+    static class ParallelParquetHandler extends DefaultParquetHandler {
+        private final Configuration hadoopConf;
+        private final int numberOfParallelThreads;
+
+        ParallelParquetHandler(Configuration hadoopConf, int numberOfParallelThreads) {
+            super(hadoopConf);
+            this.hadoopConf = hadoopConf;
+            this.numberOfParallelThreads = numberOfParallelThreads;
+        }
+
+        @Override
+        public CloseableIterator<ColumnarBatch> readParquetFiles(
+                CloseableIterator<FileStatus> fileIter,
+                StructType physicalSchema,
+                Optional<Predicate> predicate) throws IOException {
+            return new CloseableIterator<ColumnarBatch>() {
+                // Executor service will be closed as part of the returned `CloseableIterator`'s
+                // close method.
+                private final ExecutorService executorService =
+                        newFixedThreadPool(numberOfParallelThreads);
+                private Iterator<Future<List<ColumnarBatch>>> futuresIter;
+                private Iterator<ColumnarBatch> currentBatchIter;
+
+                @Override
+                public void close() throws IOException {
+                    Utils.closeCloseables(fileIter, () -> executorService.shutdown());
+                }
+
+                @Override
+                public boolean hasNext() {
+                    submitReadRequestsIfNotDone();
+                    if (currentBatchIter != null && currentBatchIter.hasNext()) {
+                        return true;
+                    }
+
+                    if (futuresIter.hasNext()) {
+                        try {
+                            currentBatchIter = futuresIter.next().get().iterator();
+                            return hasNext();
+                        } catch (InterruptedException | ExecutionException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                    return false;
+                }
+
+                @Override
+                public ColumnarBatch next() {
+                    return currentBatchIter.next();
+                }
+
+                private void submitReadRequestsIfNotDone() {
+                    if (futuresIter != null) {
+                        return;
+                    }
+                    List<Future<List<ColumnarBatch>>> futures = new ArrayList<>();
+                    while (fileIter.hasNext()) {
+                        String path = fileIter.next().getPath();
+                        futures.add(
+                                executorService.submit(
+                                        () -> parquetFileReader(path, physicalSchema)));
+                    }
+                    futuresIter = futures.iterator();
+                }
+            };
+        }
+
+        List<ColumnarBatch> parquetFileReader(String filePath, StructType readSchema) {
+            ParquetFileReader reader = new ParquetFileReader(hadoopConf);
+            try (CloseableIterator<ColumnarBatch> batchIter = reader.read(filePath, readSchema)) {
+                List<ColumnarBatch> batches = new ArrayList<>();
+                while (batchIter.hasNext()) {
+                    batches.add(batchIter.next());
+                }
+                return batches;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
Currently, the `kernel-api` reads one file (either checkpoint or commit file) at a time. Once the file is fully read, then the next file is read request is issued. This makes reading large checkpoints split over multiple files slower. Instead `kernel-api` could issue read requests for all checkpoint files at once (in case of multi-part checkpoints) using the `ParquetHandler.readParquetFiles` and let the implementations of the `ParquetHandler` prefetch or using multiple threads to read the checkpoint parts concurrently.

This PR makes the change to `kernel-api` to issue one read request for all checkpoint files that need to be read for state reconstructions.

Resolves #2668
Resolves #1965

## How was this patch tested?
Existing tests and a benchmark with a test only parallel parquet reader. Here are the sample benchmark results with the test only parallel Parquet reader. `Score` tells the average time to construct the Delta table state. `parallelReaderCount` indicates the number of parallel Parquet reading threads used.

```
Benchmark                                     (parallelReaderCount)  Mode  Cnt     Score     Error  Units
BenchmarkParallelCheckpointReading.benchmark                      0  avgt    5  1565.520 ±  20.551  ms/op
BenchmarkParallelCheckpointReading.benchmark                      1  avgt    5  1064.850 ±  19.699  ms/op
BenchmarkParallelCheckpointReading.benchmark                      2  avgt    5   785.918 ± 176.285  ms/op
BenchmarkParallelCheckpointReading.benchmark                      4  avgt    5   729.487 ±  51.470  ms/op
BenchmarkParallelCheckpointReading.benchmark                     10  avgt    5   693.757 ±  41.252  ms/op
BenchmarkParallelCheckpointReading.benchmark                     20  avgt    5   702.656 ±  19.145  ms/op
```

