### PR TITLE
[Standalone] set transaction retention action

### DIFF
--- a/connectors/standalone/src/main/scala/io/delta/standalone/internal/DeltaConfig.scala
+++ b/connectors/standalone/src/main/scala/io/delta/standalone/internal/DeltaConfig.scala
@@ -250,4 +250,17 @@ private[internal] object DeltaConfigs extends Logging {
     _ => true,
     "needs to be a boolean.",
     Some(new Protocol(0, 2)))
+
+  /**
+   * The shortest duration within which new [[Snapshot]]s will retain transaction identifiers (i.e.
+   * [[SetTransaction]]s). When a new [[Snapshot]] sees a transaction identifier older than or equal
+   * to the specified TRANSACTION_ID_RETENTION_DURATION, it considers it expired and ignores it.
+   */
+  val TRANSACTION_ID_RETENTION_DURATION = buildConfig[Option[CalendarInterval]](
+    "setTransactionRetentionDuration",
+    null,
+    v => if (v == null) None else Some(parseCalendarInterval(v)),
+    opt => opt.forall(isValidIntervalConfigValue),
+    "needs to be provided as a calendar interval such as '2 weeks'. Months " +
+      "and years are not accepted. You may specify '365 days' for a year instead.")
 }

--- a/connectors/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
+++ b/connectors/standalone/src/main/scala/io/delta/standalone/internal/DeltaLogImpl.scala
@@ -61,6 +61,13 @@ private[internal] class DeltaLogImpl private[internal](
   // retention interval...
   protected def metadata = if (snapshot == null) Metadata() else snapshot.metadataScala
 
+  /** How long to keep around SetTransaction actions before physically deleting them. */
+  def minSetTransactionRetentionInterval(metadata: Metadata): Option[Long] = {
+    DeltaConfigs.TRANSACTION_ID_RETENTION_DURATION
+      .fromMetadata(metadata)
+      .map(DeltaConfigs.getMilliSeconds)
+  }
+
   /** How long to keep around logically deleted files before physically deleting them. */
   def tombstoneRetentionMillis: Long =
     DeltaConfigs.getMilliSeconds(DeltaConfigs.TOMBSTONE_RETENTION.fromMetadata(metadata))

--- a/connectors/standalone/src/main/scala/io/delta/standalone/internal/SnapshotImpl.scala
+++ b/connectors/standalone/src/main/scala/io/delta/standalone/internal/SnapshotImpl.scala
@@ -310,10 +310,18 @@ private[internal] class SnapshotImpl(
   }
 
   /**
+   * [[SetTransaction]]s before [[minSetTransactionRetentionTimestamp]] will be considered expired
+   * and dropped from the snapshot.
+   */
+  private[delta] def minSetTransactionRetentionTimestamp: Option[Long] = {
+    deltaLog.minSetTransactionRetentionInterval(metadataScala).map(deltaLog.clock.getTimeMillis() - _)
+  }
+
+  /**
    * Reconstruct the state by applying deltas in order to the checkpoint.
    */
   protected lazy val state: State = {
-    val replay = new InMemoryLogReplay(hadoopConf, minFileRetentionTimestamp)
+    val replay = new InMemoryLogReplay(hadoopConf, minFileRetentionTimestamp, minSetTransactionRetentionTimestamp)
     val actions = loadInMemory(files).map(_.unwrap)
 
     replay.append(0, actions.iterator)


### PR DESCRIPTION
Signed-off-by: Zafer Sahin <zsahin@vectra.ai>

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [x] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description


- Expiry of set transactions exists in spark [code](https://github.com/delta-io/delta/blob/79c848f1f555e07c5d2ff368627d1414424cbef5/connectors/standalone/src/main/scala/io/delta/standalone/internal/actions/InMemoryLogReplay.scala#L4) but missing in standalone. This change adds this feature to the standalone module.
- This feature prevents snapshot to read redundant constantly growing transactions.
 
Resolves #2342


## How was this patch tested?
New unit tests are added

## Does this PR introduce _any_ user-facing changes?
Delta tables can benefit from "TRANSACTION_ID_RETENTION_DURATION" property for Standalone usage same functionality as being used by Spark.
