### PR TITLE
Record type widening metadata

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1963,7 +1963,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
   }
 
   /** Returns the version that the first attempt will try to commit at. */
-  protected def getFirstAttemptVersion: Long = readVersion + 1L
+  private[delta] def getFirstAttemptVersion: Long = readVersion + 1L
 
   /** Returns the conflicting commit information */
   protected def getConflictingVersions(previousAttemptVersion: Long): Seq[FileStatus] = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TypeWideningMetadata.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TypeWideningMetadata.scala
@@ -126,6 +126,9 @@ private[delta] object TypeWideningMetadata {
 
     SchemaMergingUtils.transformColumns(schema, oldSchema) {
       case (_, newField, Some(oldField), _) =>
+        // Record the version the transaction will attempt to use in the type change metadata. If
+        // there's a conflict with another transaction, the version in the metadata will be updated
+        // during conflict resolution. See [[ConflictChecker.updateTypeWideningMetadata()]].
         val typeChanges =
           collectTypeChanges(oldField.dataType, newField.dataType, txn.getFirstAttemptVersion)
         TypeWideningMetadata(typeChanges).appendToField(newField)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TypeWideningMetadata.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TypeWideningMetadata.scala
@@ -1,0 +1,192 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.schema.SchemaMergingUtils
+import org.apache.spark.sql.util.ScalaExtensions._
+
+import org.apache.spark.sql.types._
+
+/**
+ * Information corresponding to a single type change.
+ * @param version   The version of the table where the type change was made.
+ * @param fromType  The original type before the type change.
+ * @param toType    The new type after the type change.
+ * @param fieldPath The path inside nested maps and arrays to the field where the type change was
+ *                  made. Each path element is either `key`/`value` for maps or `element` for
+ *                  arrays. The path is empty if the type change was applied inside a map or array.
+ */
+private[delta] case class TypeChange(
+    version: Long,
+    fromType: DataType,
+    toType: DataType,
+    fieldPath: Seq[String]) {
+  import TypeChange._
+
+  /** Serialize this type change to a [[Metadata]] object. */
+  def toMetadata: Metadata = {
+    val builder = new MetadataBuilder()
+      .putLong(TABLE_VERSION_METADATA_KEY, version)
+      .putString(FROM_TYPE_METADATA_KEY, fromType.typeName)
+      .putString(TO_TYPE_METADATA_KEY, toType.typeName)
+    if (fieldPath.nonEmpty) {
+      builder.putString(FIELD_PATH_METADATA_KEY, fieldPath.mkString("."))
+    }
+    builder.build()
+  }
+}
+
+private[delta] object TypeChange {
+  val TABLE_VERSION_METADATA_KEY: String = "tableVersion"
+  val FROM_TYPE_METADATA_KEY: String = "fromType"
+  val TO_TYPE_METADATA_KEY: String = "toType"
+  val FIELD_PATH_METADATA_KEY: String = "fieldPath"
+
+   /** Deserialize this type change from a [[Metadata]] object. */
+  def fromMetadata(metadata: Metadata): TypeChange = {
+    val fieldPath = if (metadata.contains(FIELD_PATH_METADATA_KEY)) {
+      metadata.getString(FIELD_PATH_METADATA_KEY).split("\\.").toSeq
+    } else {
+      Seq.empty
+    }
+    TypeChange(
+      version = metadata.getLong(TABLE_VERSION_METADATA_KEY),
+      fromType = DataType.fromDDL(metadata.getString(FROM_TYPE_METADATA_KEY)),
+      toType = DataType.fromDDL(metadata.getString(TO_TYPE_METADATA_KEY)),
+      fieldPath
+    )
+  }
+}
+
+/**
+ * Represents all type change information for a single struct field
+ * @param typeChanges The type changes that have been applied to the field.
+ */
+private[delta] case class TypeWideningMetadata(typeChanges: Seq[TypeChange]) {
+
+  import TypeWideningMetadata._
+
+  /**
+   * Add the type changes to the metadata of the given field, preserving any pre-existing type
+   * widening metadata.
+   */
+  def appendToField(field: StructField): StructField = {
+    if (typeChanges.isEmpty) return field
+
+    val existingTypeChanges = fromField(field).map(_.typeChanges).getOrElse(Seq.empty)
+    val allTypeChanges = existingTypeChanges ++ typeChanges
+
+    val newMetadata = new MetadataBuilder().withMetadata(field.metadata)
+      .putMetadataArray(TYPE_CHANGES_METADATA_KEY, allTypeChanges.map(_.toMetadata).toArray)
+      .build()
+    field.copy(metadata = newMetadata)
+  }
+}
+
+private[delta] object TypeWideningMetadata {
+  val TYPE_CHANGES_METADATA_KEY: String = "delta.typeChanges"
+
+  /** Read the type widening metadata from the given field. */
+  def fromField(field: StructField): Option[TypeWideningMetadata] = {
+    Option.when(field.metadata.contains(TYPE_CHANGES_METADATA_KEY)) {
+      val typeChanges = field.metadata.getMetadataArray(TYPE_CHANGES_METADATA_KEY)
+        .map { changeMetadata =>
+          TypeChange.fromMetadata(changeMetadata)
+        }.toSeq
+      TypeWideningMetadata(typeChanges)
+    }
+  }
+
+  /**
+   * Computes the type changes from `oldSchema` to `schema` and adds corresponding type change
+   * metadata to `schema`.
+   */
+  def addTypeWideningMetadata(
+      txn: OptimisticTransaction,
+      schema: StructType,
+      oldSchema: StructType): StructType = {
+
+    if (!TypeWidening.isEnabled(txn.protocol, txn.metadata)) return schema
+
+    if (DataType.equalsIgnoreNullability(schema, oldSchema)) return schema
+
+    SchemaMergingUtils.transformColumns(schema, oldSchema) {
+      case (_, newField, Some(oldField), _) =>
+        val typeChanges =
+          collectTypeChanges(oldField.dataType, newField.dataType, txn.getFirstAttemptVersion)
+        TypeWideningMetadata(typeChanges).appendToField(newField)
+      case (_, newField, None, _) =>
+        // The field was just added, no need to process.
+        newField
+    }
+  }
+
+  /**
+   * Recursively collect primitive type changes inside nested maps and arrays between `fromType` and
+   * `toType`. The `version` is the version of the table where the type change was made.
+   */
+  private def collectTypeChanges(fromType: DataType, toType: DataType, version: Long)
+    : Seq[TypeChange] = (fromType, toType) match {
+    case (from: MapType, to: MapType) =>
+      collectTypeChanges(from.keyType, to.keyType, version).map { typeChange =>
+        typeChange.copy(fieldPath = "key" +: typeChange.fieldPath)
+      } ++
+      collectTypeChanges(from.valueType, to.valueType, version).map { typeChange =>
+        typeChange.copy(fieldPath = "value" +: typeChange.fieldPath)
+      }
+    case (from: ArrayType, to: ArrayType) =>
+      collectTypeChanges(from.elementType, to.elementType, version).map { typeChange =>
+        typeChange.copy(fieldPath = "element" +: typeChange.fieldPath)
+      }
+    case (fromType: AtomicType, toType: AtomicType) if fromType != toType =>
+        Seq(TypeChange(
+          version,
+          fromType,
+          toType,
+          fieldPath = Seq.empty
+        ))
+    case (_: AtomicType, _: AtomicType) => Seq.empty
+    // Don't recurse inside structs, `collectTypeChanges` should be called directly on each struct
+    // fields instead to only collect type changes inside these fields.
+    case (_: StructType, _: StructType) => Seq.empty
+  }
+
+  /**
+   * Change the `tableVersion` value in the type change metadata present in `schema`. Used during
+   * conflict resolution to update the version associated with the transaction is incremented.
+   */
+  def updateTypeChangeVersion(schema: StructType, fromVersion: Long, toVersion: Long): StructType =
+    SchemaMergingUtils.transformColumns(schema) {
+      case (_, field, _) =>
+        fromField(field) match {
+          case Some(typeWideningMetadata) =>
+            val updatedTypeChanges = typeWideningMetadata.typeChanges.map {
+              case typeChange if typeChange.version == fromVersion =>
+                typeChange.copy(version = toVersion)
+              case olderTypeChange => olderTypeChange
+            }
+            val newMetadata = new MetadataBuilder().withMetadata(field.metadata)
+              .putMetadataArray(
+                TYPE_CHANGES_METADATA_KEY,
+                updatedTypeChanges.map(_.toMetadata).toArray)
+              .build()
+            field.copy(metadata = newMetadata)
+
+          case None => field
+        }
+    }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaMergingUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaMergingUtils.scala
@@ -334,6 +334,52 @@ object SchemaMergingUtils {
   }
 
   /**
+   * Transform (nested) columns in `schema` by walking down `schema` and `other` simultaneously.
+   * This allows comparing the two schemas and transforming `schema` based on the comparison.
+   * Columns or fields present only in `other` are ignored while `None` is passed to the transform
+   * function for columns or fields missing in `other`.
+   * @param schema Schema to transform.
+   * @param other Schema to compare with.
+   * @param tf Function to apply. The function arguments are the full path of the current field to
+   *           transform, the current field in `schema` and, if present, the corresponding field in
+   *           `other`.
+   */
+  def transformColumns(
+      schema: StructType,
+      other: StructType)(
+    tf: (Seq[String], StructField, Option[StructField], Resolver) => StructField): StructType = {
+    def transform[E <: DataType](path: Seq[String], dt: E, otherDt: E): E = {
+      val newDt = (dt, otherDt) match {
+        case (struct: StructType, otherStruct: StructType) =>
+          val otherFields = SchemaMergingUtils.toFieldMap(otherStruct.fields, caseSensitive = true)
+          StructType(struct.map { field =>
+            val otherField = otherFields.get(field.name)
+            val newField = tf(path, field, otherField, DELTA_COL_RESOLVER)
+            otherField match {
+              case Some(other) =>
+                newField.copy(
+                  dataType = transform(path :+ field.name, field.dataType, other.dataType)
+                )
+              case None => newField
+            }
+          })
+        case (map: MapType, otherMap: MapType) =>
+          map.copy(
+            keyType = transform(path :+ "key", map.keyType, otherMap.keyType),
+            valueType = transform(path :+ "value", map.valueType, otherMap.valueType)
+          )
+        case (array: ArrayType, otherArray: ArrayType) =>
+          array.copy(
+            elementType = transform(path :+ "element", array.elementType, otherArray.elementType)
+          )
+        case _ => dt
+      }
+      newDt.asInstanceOf[E]
+    }
+    transform(Seq.empty, schema, other)
+  }
+
+  /**
    *
    * Taken from DataType
    *

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTypeWideningMetadataSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTypeWideningMetadataSuite.scala
@@ -1,0 +1,505 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.types._
+
+/**
+ * Suite covering the[[TypeWideningMetadata]] and [[TypeChange]] classes used to handle the metadata
+ * recorded by the Type Widening table feature in the table schema.
+ */
+class DeltaTypeWideningMetadataSuite extends QueryTest with DeltaSQLCommandTest {
+  private val testTableName: String = "delta_type_widening_metadata_test"
+
+  /** A dummy transaction to be used by tests covering `addTypeWideningMetadata`. */
+  private lazy val txn: OptimisticTransaction = {
+    val table = spark.sessionState.catalog.getTableMetadata(TableIdentifier(testTableName))
+    DeltaLog.forTable(spark, TableIdentifier(testTableName))
+        .startTransaction(catalogTableOpt = Some(table))
+  }
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    sql(s"CREATE TABLE $testTableName (a int) USING delta " +
+      s"TBLPROPERTIES ('${DeltaConfigs.ENABLE_TYPE_WIDENING.key}' = 'true')")
+  }
+
+  override protected def afterAll(): Unit = {
+    try {
+      sql(s"DROP TABLE IF EXISTS $testTableName")
+    } finally {
+      super.afterAll()
+    }
+  }
+
+  /**
+   * Short-hand to build the metadata for a type change to cut down on repetition.
+   */
+  private def typeChangeMetadata(
+      version: Long,
+      fromType: String,
+      toType: String,
+      path: String = ""): Metadata = {
+    val builder = new MetadataBuilder()
+      .putLong("tableVersion", version)
+      .putString("fromType", fromType)
+      .putString("toType", toType)
+    if (path.nonEmpty) {
+      builder.putString("fieldPath", path)
+    }
+    builder.build()
+  }
+
+  test("toMetadata/fromMetadata with empty path") {
+    val typeChange = TypeChange(version = 1, IntegerType, LongType, Seq.empty)
+    assert(typeChange.toMetadata === typeChangeMetadata(version = 1, "integer", "long"))
+    assert(TypeChange.fromMetadata(typeChange.toMetadata) === typeChange)
+  }
+
+  test("toMetadata/fromMetadata with non-empty path") {
+    val typeChange = TypeChange(10, DateType, TimestampNTZType, Seq("key", "element"))
+    assert(typeChange.toMetadata ===
+      typeChangeMetadata(version = 10, "date", "timestamp_ntz", "key.element"))
+    assert(TypeChange.fromMetadata(typeChange.toMetadata) === typeChange)
+  }
+
+  test("fromField with no type widening metadata") {
+    val field = StructField("a", IntegerType)
+    assert(TypeWideningMetadata.fromField(field) === None)
+  }
+
+  test("fromField with empty type widening metadata") {
+    val field = StructField("a", IntegerType, metadata = new MetadataBuilder()
+      .putMetadataArray("delta.typeChanges", Array.empty[Metadata])
+      .build()
+    )
+    assert(TypeWideningMetadata.fromField(field) === Some(TypeWideningMetadata(Seq.empty)))
+    val otherField = StructField("a", IntegerType)
+    // Empty type widening metadata is discarded.
+    assert(TypeWideningMetadata.fromField(field).get.appendToField(otherField) ===
+      StructField("a", IntegerType))
+  }
+
+  test("fromField with single type change") {
+    val field = StructField("a", IntegerType, metadata = new MetadataBuilder()
+      .putMetadataArray("delta.typeChanges", Array(
+        typeChangeMetadata(version = 1, "integer", "long")
+      )).build()
+    )
+    assert(TypeWideningMetadata.fromField(field) ===
+      Some(TypeWideningMetadata(Seq(TypeChange(1, IntegerType, LongType, Seq.empty)))))
+    val otherField = StructField("a", IntegerType)
+    assert(TypeWideningMetadata.fromField(field).get.appendToField(otherField) === field)
+  }
+
+  test("fromField with multiple type changes") {
+    val field = StructField("a", IntegerType, metadata = new MetadataBuilder()
+      .putMetadataArray("delta.typeChanges", Array(
+        typeChangeMetadata(version = 1, "integer", "long"),
+        typeChangeMetadata(version = 10, "decimal(5,0)", "decimal(10,2)", "element.element")
+      )).build()
+    )
+    assert(TypeWideningMetadata.fromField(field) ===
+      Some(TypeWideningMetadata(Seq(
+        TypeChange(1, IntegerType, LongType, Seq.empty),
+        TypeChange(10, DecimalType(5, 0), DecimalType(10, 2), Seq("element", "element"))))))
+    val otherField = StructField("a", IntegerType)
+    assert(TypeWideningMetadata.fromField(field).get.appendToField(otherField) === field)
+  }
+
+  test("appendToField on field with no type widening metadata") {
+    val field = StructField("a", IntegerType)
+    // Adding empty type widening metadata should not change the field.
+    val emptyMetadata = TypeWideningMetadata(Seq.empty)
+    assert(emptyMetadata.appendToField(field) === field)
+    assert(TypeWideningMetadata.fromField(emptyMetadata.appendToField(field)).isEmpty)
+
+    // Adding single type change should add the metadata to the field and not otherwise change it.
+    val singleMetadata = TypeWideningMetadata(Seq(
+      TypeChange(1, IntegerType, LongType, Seq.empty)))
+    assert(singleMetadata.appendToField(field) === field.copy(metadata =
+      new MetadataBuilder()
+        .putMetadataArray("delta.typeChanges", Array(
+          typeChangeMetadata(version = 1, "integer", "long")
+        )).build()
+      )
+    )
+    val singleMetadataFromField =
+      TypeWideningMetadata.fromField(singleMetadata.appendToField(field))
+    assert(singleMetadataFromField.contains(singleMetadata))
+
+    // Adding multiple type changes should add the metadata to the field and not otherwise change
+    // it.
+    val multipleMetadata = TypeWideningMetadata(Seq(
+      TypeChange(1, IntegerType, LongType, Seq.empty),
+      TypeChange(6, FloatType, DoubleType, Seq("value"))))
+    assert(multipleMetadata.appendToField(field) === field.copy(metadata =
+      new MetadataBuilder()
+        .putMetadataArray("delta.typeChanges", Array(
+          typeChangeMetadata(version = 1, "integer", "long"),
+          typeChangeMetadata(version = 6, "float", "double", "value")
+        )).build()
+      )
+    )
+
+    val multipleMetadataFromField =
+      TypeWideningMetadata.fromField(multipleMetadata.appendToField(field))
+    assert(multipleMetadataFromField.contains(multipleMetadata))
+  }
+
+  test("appendToField on field with existing type widening metadata") {
+    val field = StructField("a", IntegerType,
+      metadata = new MetadataBuilder()
+        .putMetadataArray("delta.typeChanges", Array(
+          typeChangeMetadata(version = 1, "integer", "long")
+        )).build()
+    )
+    // Adding empty type widening metadata should not change the field.
+    val emptyMetadata = TypeWideningMetadata(Seq.empty)
+    assert(emptyMetadata.appendToField(field) === field)
+    assert(TypeWideningMetadata.fromField(emptyMetadata.appendToField(field)).contains(
+      TypeWideningMetadata(Seq(
+        TypeChange(1, IntegerType, LongType, Seq.empty)))
+    ))
+
+    // Adding single type change should add the metadata to the field and not otherwise change it.
+    val singleMetadata = TypeWideningMetadata(Seq(
+      TypeChange(5, DecimalType(18, 0), DecimalType(19, 0), Seq.empty)))
+
+    assert(singleMetadata.appendToField(field) === field.copy(
+      metadata = new MetadataBuilder()
+        .putMetadataArray("delta.typeChanges", Array(
+          typeChangeMetadata(version = 1, "integer", "long"),
+          typeChangeMetadata(version = 5, "decimal(18,0)", "decimal(19,0)")
+        )).build()
+    ))
+    val singleMetadataFromField =
+      TypeWideningMetadata.fromField(singleMetadata.appendToField(field))
+
+    assert(singleMetadataFromField.contains(TypeWideningMetadata(Seq(
+      TypeChange(1, IntegerType, LongType, Seq.empty),
+      TypeChange(5, DecimalType(18, 0), DecimalType(19, 0), Seq.empty)))
+    ))
+
+    // Adding multiple type changes should add the metadata to the field and not otherwise change
+    // it.
+    val multipleMetadata = TypeWideningMetadata(Seq(
+      TypeChange(5, DecimalType(18, 0), DecimalType(19, 0), Seq.empty),
+      TypeChange(6, FloatType, DoubleType, Seq("value"))))
+
+    assert(multipleMetadata.appendToField(field) === field.copy(
+      metadata = new MetadataBuilder()
+        .putMetadataArray("delta.typeChanges", Array(
+          typeChangeMetadata(version = 1, "integer", "long"),
+          typeChangeMetadata(version = 5, "decimal(18,0)", "decimal(19,0)"),
+          typeChangeMetadata(version = 6, "float", "double", "value")
+        )).build()
+    ))
+    val multipleMetadataFromField =
+      TypeWideningMetadata.fromField(multipleMetadata.appendToField(field))
+
+    assert(multipleMetadataFromField.contains(TypeWideningMetadata(Seq(
+      TypeChange(1, IntegerType, LongType, Seq.empty),
+      TypeChange(5, DecimalType(18, 0), DecimalType(19, 0), Seq.empty),
+      TypeChange(6, FloatType, DoubleType, Seq("value"))))
+    ))
+  }
+
+  test("addTypeWideningMetadata with no type changes") {
+    for {
+      (oldSchema, newSchema) <- Seq(
+        ("a short", "a short"),
+        ("a short", "a short NOT NULL"),
+        ("a short NOT NULL", "a short"),
+        ("a short NOT NULL", "a short COMMENT 'a comment'"),
+        ("a string, b int", "b int, a string"),
+        ("a struct<s1: date, s2: long>", "a struct<s2: long, s1: date>"),
+        ("a struct<s1: short COMMENT 'a comment'>", "a struct<s1: short>"),
+        ("a struct<s1: short>", "a struct<s1: short COMMENT 'a comment'>"),
+        ("a map<int, long>", "m map<int, long>"),
+        ("a array<timestamp>", "a array<timestamp>"),
+        ("a map<array<timestamp>, int>", "a map<array<timestamp>, int>"),
+        ("a array<struct<s1: byte>>", "a array<struct<s1: byte>>")
+      ).map { case (oldStr, newStr) => StructType.fromDDL(oldStr) -> StructType.fromDDL(newStr) }
+    } {
+      withClue(s"oldSchema = $oldSchema, newSchema = $newSchema") {
+        val schema = TypeWideningMetadata.addTypeWideningMetadata(txn, newSchema, oldSchema)
+        assert(schema === newSchema)
+      }
+    }
+  }
+
+  test("addTypeWideningMetadata on top-level fields") {
+    var schema =
+      StructType.fromDDL("i long, d decimal(15, 4), a array<double>, m map<short, int>")
+    val firstOldSchema =
+      StructType.fromDDL("i short, d decimal(6, 2), a array<byte>, m map<byte, int>")
+    val secondOldSchema =
+      StructType.fromDDL("i int, d decimal(10, 4), a array<int>, m map<short, byte>")
+
+    schema = TypeWideningMetadata.addTypeWideningMetadata(txn, schema, firstOldSchema)
+
+    assert(schema("i") === StructField("i", LongType,
+      metadata = new MetadataBuilder()
+        .putMetadataArray("delta.typeChanges", Array(
+          typeChangeMetadata(version = 1, "short", "long")
+        )).build()
+    ))
+
+    assert(schema("d") === StructField("d", DecimalType(15, 4),
+      metadata = new MetadataBuilder()
+        .putMetadataArray("delta.typeChanges", Array(
+          typeChangeMetadata(version = 1, "decimal(6,2)", "decimal(15,4)")
+        )).build()
+    ))
+
+    assert(schema("a") === StructField("a", ArrayType(DoubleType),
+      metadata = new MetadataBuilder()
+        .putMetadataArray("delta.typeChanges", Array(
+          typeChangeMetadata(version = 1, "byte", "double", "element")
+        )).build()
+    ))
+
+    assert(schema("m") === StructField("m", MapType(ShortType, IntegerType),
+      metadata = new MetadataBuilder()
+        .putMetadataArray("delta.typeChanges", Array(
+          typeChangeMetadata(version = 1, "byte", "short", "key")
+        )).build()
+    ))
+
+    // Second type change on all fields.
+    schema = TypeWideningMetadata.addTypeWideningMetadata(txn, schema, secondOldSchema)
+
+    assert(schema("i") === StructField("i", LongType,
+      metadata = new MetadataBuilder()
+        .putMetadataArray("delta.typeChanges", Array(
+          typeChangeMetadata(version = 1, "short", "long"),
+          typeChangeMetadata(version = 1, "integer", "long")
+        )).build()
+    ))
+
+    assert(schema("d") === StructField("d", DecimalType(15, 4),
+      metadata = new MetadataBuilder()
+        .putMetadataArray("delta.typeChanges", Array(
+          typeChangeMetadata(version = 1, "decimal(6,2)", "decimal(15,4)"),
+          typeChangeMetadata(version = 1, "decimal(10,4)", "decimal(15,4)")
+        )).build()
+    ))
+
+    assert(schema("a") === StructField("a", ArrayType(DoubleType),
+      metadata = new MetadataBuilder()
+        .putMetadataArray("delta.typeChanges", Array(
+          typeChangeMetadata(version = 1, "byte", "double", "element"),
+          typeChangeMetadata(version = 1, "integer", "double", "element")
+        )).build()
+    ))
+
+    assert(schema("m") === StructField("m", MapType(ShortType, IntegerType),
+      metadata = new MetadataBuilder()
+        .putMetadataArray("delta.typeChanges", Array(
+          typeChangeMetadata(version = 1, "byte", "short", "key"),
+          typeChangeMetadata(version = 1, "byte", "integer", "value")
+        )).build()
+    ))
+  }
+
+  test("addTypeWideningMetadata on nested fields") {
+    var schema = StructType.fromDDL(
+      "s struct<i: long, a: array<map<int, long>>, m: map<map<long, int>, array<long>>>")
+    val firstOldSchema = StructType.fromDDL(
+      "s struct<i: short, a: array<map<byte, long>>, m: map<map<int, int>, array<long>>>")
+    val secondOldSchema = StructType.fromDDL(
+      "s struct<i: int, a: array<map<int, int>>, m: map<map<long, int>, array<int>>>")
+
+    // First type change on all struct fields.
+    schema = TypeWideningMetadata.addTypeWideningMetadata(txn, schema, firstOldSchema)
+    var struct = schema("s").dataType.asInstanceOf[StructType]
+
+    assert(struct("i") === StructField("i", LongType,
+      metadata = new MetadataBuilder()
+        .putMetadataArray("delta.typeChanges", Array(
+          typeChangeMetadata(version = 1, "short", "long")
+        )).build()
+    ))
+
+    assert(struct("a") === StructField("a", ArrayType(MapType(IntegerType, LongType)),
+      metadata = new MetadataBuilder()
+        .putMetadataArray("delta.typeChanges", Array(
+          typeChangeMetadata(version = 1, "byte", "integer", "element.key")
+        )).build()
+    ))
+
+    assert(struct("m") === StructField("m",
+      MapType(MapType(LongType, IntegerType), ArrayType(LongType)),
+      metadata = new MetadataBuilder()
+        .putMetadataArray("delta.typeChanges", Array(
+          typeChangeMetadata(version = 1, "integer", "long", "key.key")
+        )).build()
+    ))
+
+    // Second type change on all struct fields.
+    schema = TypeWideningMetadata.addTypeWideningMetadata(txn, schema, secondOldSchema)
+    struct = schema("s").dataType.asInstanceOf[StructType]
+
+    assert(struct("i") === StructField("i", LongType,
+      metadata = new MetadataBuilder()
+        .putMetadataArray("delta.typeChanges", Array(
+          typeChangeMetadata(version = 1, "short", "long"),
+          typeChangeMetadata(version = 1, "integer", "long")
+        )).build()
+    ))
+
+    assert(struct("a") === StructField("a", ArrayType(MapType(IntegerType, LongType)),
+      metadata = new MetadataBuilder()
+        .putMetadataArray("delta.typeChanges", Array(
+          typeChangeMetadata(version = 1, "byte", "integer", "element.key"),
+          typeChangeMetadata(version = 1, "integer", "long", "element.value")
+        )).build()
+    ))
+
+    assert(struct("m") === StructField("m",
+      MapType(MapType(LongType, IntegerType), ArrayType(LongType)),
+      metadata = new MetadataBuilder()
+        .putMetadataArray("delta.typeChanges", Array(
+          typeChangeMetadata(version = 1, "integer", "long", "key.key"),
+          typeChangeMetadata(version = 1, "integer", "long", "value.element")
+        )).build()
+    ))
+  }
+
+  test("addTypeWideningMetadata with added and removed fields") {
+    val newSchema = StructType.fromDDL("a int, b long, d int")
+    val oldSchema = StructType.fromDDL("a int, b int, c int")
+
+    val schema = TypeWideningMetadata.addTypeWideningMetadata(txn, newSchema, oldSchema)
+    assert(schema("a") === StructField("a", IntegerType))
+    assert(schema("d") === StructField("d", IntegerType))
+    assert(!schema.contains("c"))
+
+    assert(schema("b") === StructField("b", LongType,
+      metadata = new MetadataBuilder()
+        .putMetadataArray("delta.typeChanges", Array(
+          typeChangeMetadata(version = 1, "integer", "long")
+        )).build()
+    ))
+  }
+
+  test("addTypeWideningMetadata with different field position") {
+    val initialSchema = StructType.fromDDL("a short, b int, s struct<c: int, d: long>")
+    val secondSchema = StructType.fromDDL("b int, a short, s struct<d: long, c: int>")
+
+    val schema = TypeWideningMetadata.addTypeWideningMetadata(txn, initialSchema, secondSchema)
+    // No type widening metadata is added.
+    assert(schema("a") === StructField("a", ShortType))
+    assert(schema("b") === StructField("b", IntegerType))
+    assert(schema("s") ===
+      StructField("s", new StructType()
+        .add("c", IntegerType)
+        .add("d", LongType)))
+  }
+
+  test("updateTypeChangeVersion with no type changes") {
+    val schema = new StructType().add("a", IntegerType)
+    assert(TypeWideningMetadata.updateTypeChangeVersion(schema, 1, 4) === schema)
+  }
+
+  test("updateTypeChangeVersion with field with single type change") {
+    val schema = new StructType()
+      .add("a", IntegerType, nullable = true, metadata = new MetadataBuilder()
+        .putMetadataArray("delta.typeChanges", Array(
+          typeChangeMetadata(version = 1, "integer", "long")
+        ))
+        .build()
+      )
+
+    assert(TypeWideningMetadata.updateTypeChangeVersion(schema, 1, 4) ===
+      new StructType()
+        .add("a", IntegerType, nullable = true, metadata = new MetadataBuilder()
+          .putMetadataArray("delta.typeChanges", Array(
+            typeChangeMetadata(version = 4, "integer", "long")
+          ))
+          .build()
+        )
+    )
+  }
+
+  test("updateTypeChangeVersion with field with multiple type changes") {
+    val schema = new StructType()
+      .add("a", IntegerType, nullable = true, metadata = new MetadataBuilder()
+          .putMetadataArray("delta.typeChanges", Array(
+            typeChangeMetadata(version = 1, "integer", "long"),
+            typeChangeMetadata(version = 6, "float", "double", "value")
+          ))
+        .build()
+      )
+
+    // Update matching one of the type changes.
+    assert(TypeWideningMetadata.updateTypeChangeVersion(schema, 1, 4) ===
+      new StructType()
+      .add("a", IntegerType, nullable = true, metadata = new MetadataBuilder()
+          .putMetadataArray("delta.typeChanges", Array(
+            typeChangeMetadata(version = 4, "integer", "long"),
+            typeChangeMetadata(version = 6, "float", "double", "value")
+          ))
+        .build()
+      )
+    )
+
+    // Update doesn't match any of the recorded type changes.
+    assert(
+      TypeWideningMetadata.updateTypeChangeVersion(schema, 3, 4) === schema
+    )
+  }
+
+  test("updateTypeChangeVersion with multiple fields with a type change") {
+    val schema = new StructType()
+      .add("a", IntegerType, nullable = true, metadata = new MetadataBuilder()
+          .putMetadataArray("delta.typeChanges", Array(
+            typeChangeMetadata(version = 1, "integer", "long")
+          ))
+        .build())
+      .add("b", ArrayType(IntegerType), nullable = true, metadata = new MetadataBuilder()
+          .putMetadataArray("delta.typeChanges", Array(
+            typeChangeMetadata(version = 1, "short", "integer", "element")
+          ))
+        .build())
+
+    // Update both type changes.
+    assert(TypeWideningMetadata.updateTypeChangeVersion(schema, 1, 4) ===
+      new StructType()
+      .add("a", IntegerType, nullable = true, metadata = new MetadataBuilder()
+          .putMetadataArray("delta.typeChanges", Array(
+            typeChangeMetadata(version = 4, "integer", "long")
+          ))
+        .build())
+      .add("b", ArrayType(IntegerType), nullable = true, metadata = new MetadataBuilder()
+          .putMetadataArray("delta.typeChanges", Array(
+            typeChangeMetadata(version = 4, "short", "integer", "element")
+          ))
+        .build())
+    )
+
+    // Update doesn't match any of the recorded type changes.
+    assert(
+      TypeWideningMetadata.updateTypeChangeVersion(schema, 3, 4) === schema
+    )
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTypeWideningMetadataSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTypeWideningMetadataSuite.scala
@@ -43,11 +43,8 @@ class DeltaTypeWideningMetadataSuite extends QueryTest with DeltaSQLCommandTest 
   }
 
   override protected def afterAll(): Unit = {
-    try {
-      sql(s"DROP TABLE IF EXISTS $testTableName")
-    } finally {
-      super.afterAll()
-    }
+    sql(s"DROP TABLE IF EXISTS $testTableName")
+    super.afterAll()
   }
 
   /**


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)


## What changes were proposed in this pull request?
This change is part of the type widening table feature.
Type widening feature request: https://github.com/delta-io/delta/issues/2622
Type Widening protocol RFC: https://github.com/delta-io/delta/pull/2624

It introduces metadata to record information about type changes that were applied using `ALTER TABLE`. This metadata is stored in table schema, as specified in https://github.com/delta-io/delta/pull/2624/files#diff-114dec1ec600a6305fe7117bed7acb46e94180cdb1b8da63b47b12d6c40760b9R28

For example, changing a top-level column `a` from `int` to `long` will update the schema to include metadata:
```
{
    "name" : "a",
    "type" : "long",
    "nullable" : true,
    "metadata" : { 
      "delta.typeChanges": [
        {
          "tableVersion": 1,
          "fromType": "integer",
          "toType": "long"
        },
        {
          "tableVersion": 5,
          "fromType": "integer",
          "toType": "long"
        }
      ]
    }
  }
```

## How was this patch tested?
- A new test suite `DeltaTypeWideningMetadataSuite` is created to cover methods handling type widening metadata.
- Tests covering adding metadata to the schema when running `ALTER TABLE CHANGE COLUMN` are added to `DeltaTypeWideningSuite`
