### PR TITLE
Disentangle schema evolution in MERGE INTO command

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2490,10 +2490,10 @@ trait DeltaErrorsBase
     )
   }
 
-  def nonGeneratedColumnMissingUpdateExpression(column: Attribute): Throwable = {
+  def nonGeneratedColumnMissingUpdateExpression(columnName: String): Throwable = {
     new DeltaIllegalStateException(
       errorClass = "DELTA_NON_GENERATED_COLUMN_MISSING_UPDATE_EXPR",
-      messageParameters = Array(column.toString)
+      messageParameters = Array(columnName)
     )
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -341,85 +341,55 @@ object DeltaTableUtils extends PredicateHelper
   }
 
   /**
-   * Replace the file index in a logical plan and return the updated plan.
-   * It's a common pattern that, in Delta commands, we use data skipping to determine a subset of
-   * files that can be affected by the command, so we replace the whole-table file index in the
-   * original logical plan with a new index of potentially affected files, while everything else in
-   * the original plan, e.g., resolved references, remain unchanged.
-   *
    * Many Delta meta-queries involve nondeterminstic functions, which interfere with automatic
-   * column pruning, so columns can be manually pruned from the new scan. Note that partition
-   * columns can never be dropped even if they're not referenced in the rest of the query.
+   * column pruning, so columns can be manually pruned from the scan. Note that partition columns
+   * can never be dropped even if they're not referenced in the rest of the query.
    *
    * @param spark the spark session to use
-   * @param target the logical plan in which we replace the file index
-   * @param fileIndex the new file index
+   * @param target the logical plan in which drop columns
    * @param columnsToDrop columns to drop from the scan
-   * @param newOutput If specified, new logical output to replace the current LogicalRelation.
-   *                  Used for schema evolution to produce the new schema-evolved types from
-   *                  old files, because `target` will have the old types.
    */
-  def replaceFileIndex(
+  def dropColumns(
       spark: SparkSession,
       target: LogicalPlan,
-      fileIndex: FileIndex,
-      columnsToDrop: Seq[String],
-      newOutput: Option[Seq[AttributeReference]]): LogicalPlan = {
+      columnsToDrop: Seq[String]): LogicalPlan = {
     val resolver = spark.sessionState.analyzer.resolver
 
-    var actualNewOutput = newOutput
-    var hasChar = false
-    var newTarget = target transformDown {
-      case l @ LogicalRelation(hfsr: HadoopFsRelation, _, _, _) =>
-        // Prune columns from the scan.
-        val finalOutput = actualNewOutput.getOrElse(l.output).filterNot { col =>
-          columnsToDrop.exists(resolver(_, col.name))
-        }
-
-        // If the output columns were changed e.g. by schema evolution, we need to update
-        // the relation to expose all the columns that are expected after schema evolution.
-        val newDataSchema = StructType(finalOutput.map(attr =>
-          StructField(attr.name, attr.dataType, attr.nullable, attr.metadata)))
-        val newBaseRelation = hfsr.copy(
-          location = fileIndex, dataSchema = newDataSchema)(
-          hfsr.sparkSession)
-        l.copy(relation = newBaseRelation, output = finalOutput)
-
-      case p @ Project(projectList, _) =>
-        // Spark does char type read-side padding via an additional Project over the scan node.
-        // `newOutput` references the Project attributes, we need to translate their expression IDs
-        // so that `newOutput` references attributes from the LogicalRelation instead.
+    // Spark does char type read-side padding via an additional Project over the scan node.
+    // When char type read-side padding is applied, we need to apply column pruning for the
+    // Project as well, otherwise the Project will contain missing attributes.
+    val hasChar = target.exists {
+      case Project(projectList, _) =>
         def hasCharPadding(e: Expression): Boolean = e.exists {
           case s: StaticInvoke => s.staticObject == classOf[CharVarcharCodegenUtils] &&
             s.functionName == "readSidePadding"
           case _ => false
         }
-        val charColMapping = AttributeMap(projectList.collect {
-          case a: Alias if hasCharPadding(a.child) && a.references.size == 1 =>
-            hasChar = true
-            val tableCol = a.references.head.asInstanceOf[AttributeReference]
-            a.toAttribute -> tableCol
-        })
-        actualNewOutput = newOutput.map(_.map { attr =>
-          charColMapping.get(attr).map { tableCol =>
-            attr.withExprId(tableCol.exprId)
-          }.getOrElse(attr)
-        })
-        p
+        projectList.exists {
+          case a: Alias => hasCharPadding(a.child) && a.references.size == 1
+          case _ => false
+        }
+      case _ => false
     }
 
-    if (hasChar) {
-      // When char type read-side padding is applied, we need to apply column pruning for the
-      // Project as well, otherwise the Project will contain missing attributes.
-      newTarget = newTarget.transformUp {
-        case p @ Project(projectList, child) =>
-          val newProjectList = projectList.filter { e =>
-            e.references.subsetOf(child.outputSet)
-          }
-          p.copy(projectList = newProjectList)
-      }
+    target transformUp {
+      case l@LogicalRelation(hfsr: HadoopFsRelation, _, _, _) =>
+        // Prune columns from the scan.
+        val prunedOutput = l.output.filterNot { col =>
+          columnsToDrop.exists(resolver(_, col.name))
+        }
+
+        val prunedSchema = StructType(prunedOutput.map(attr =>
+          StructField(attr.name, attr.dataType, attr.nullable, attr.metadata)))
+        val newBaseRelation = hfsr.copy(dataSchema = prunedSchema)(hfsr.sparkSession)
+        l.copy(relation = newBaseRelation, output = prunedOutput)
+
+      case p @ Project(projectList, child) if hasChar =>
+        val newProjectList = projectList.filter { e =>
+          e.references.subsetOf(child.outputSet)
+        }
+        p.copy(projectList = newProjectList)
     }
-    newTarget
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableUpdate.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableUpdate.scala
@@ -67,11 +67,13 @@ case class PreprocessTableUpdate(sqlConf: SQLConf)
 
     val targetColNameParts = update.updateColumns.map(DeltaUpdateTable.getTargetColNameParts(_))
     val alignedUpdateExprs = generateUpdateExpressions(
-      update.child.output,
-      targetColNameParts,
-      update.updateExpressions,
-      conf.resolver,
-      generatedColumns)
+      targetSchema = update.child.schema,
+      defaultExprs = update.child.output,
+      nameParts = targetColNameParts,
+      updateExprs = update.updateExpressions,
+      resolver = conf.resolver,
+      generatedColumns = generatedColumns
+    )
     val alignedUpdateExprsAfterAddingGenerationExprs =
       if (alignedUpdateExprs.forall(_.nonEmpty)) {
         alignedUpdateExprs.map(_.get)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/UpdateExpressionsSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/UpdateExpressionsSupport.scala
@@ -196,8 +196,8 @@ trait UpdateExpressionsSupport extends SQLConfHelper with AnalysisHelper {
   }
 
   /**
-   * Given a list of target-column expressions and a set of update operations, generate a list
-   * of update expressions, which are aligned with given target-column expressions.
+   * Given a target schema and a set of update operations, generate a list of update expressions,
+   * which are aligned with the given schema.
    *
    * For update operations to nested struct fields, this method recursively walks down schema tree
    * and apply the update expressions along the way.
@@ -210,16 +210,20 @@ trait UpdateExpressionsSupport extends SQLConfHelper with AnalysisHelper {
    *
    * this method works as follows:
    *
-   * generateUpdateExpressions(targetCols=[a,z], updateOps=[(a.b, 1), (a.c, 2), (z, 3)])
-   *   generateUpdateExpressions(targetCols=[b,c,d], updateOps=[(b, 1),(c, 2)], pathPrefix=["a"])
+   * generateUpdateExpressions(
+   *   targetSchema=[a,z], originalExprs=[a, z], updateOps=[(a.b, 1), (a.c, 2), (z, 3)])
+   *   generateUpdateExpressions(
+   *     targetSchema=[b,c,d], originalExprs=[b, c, d], updateOps=[(b, 1),(c, 2)], pathPrefix=["a"])
    *     end-of-recursion
    *   -> returns (1, 2, d)
    * -> return ((1, 2, d), 3)
    *
-   * @param targetCols a list of expressions to read named columns; these named columns can be
-   *                   either the top-level attributes of a table, or the nested fields of a
-   *                   StructType column.
+   * @param targetSchema schema to follow to generate update expressions. Due to schema evolution,
+   *                     it may contain additional columns or fields not present in the original
+   *                     table schema.
    * @param updateOps a set of update operations.
+   * @param defaultExprs the expressions to use when no update operation is provided for a column
+   *                      or field. This is typically the output from the base table.
    * @param pathPrefix the path from root to the current (nested) column. Only used for printing out
    *                   full column path in error messages.
    * @param allowStructEvolution Whether to allow structs to evolve. When this is false (default),
@@ -239,8 +243,9 @@ trait UpdateExpressionsSupport extends SQLConfHelper with AnalysisHelper {
    *         expression for such column. For other cases, we will always return Some(expr).
    */
   protected def generateUpdateExpressions(
-      targetCols: Seq[NamedExpression],
+      targetSchema: StructType,
       updateOps: Seq[UpdateOperation],
+      defaultExprs: Seq[NamedExpression],
       resolver: Resolver,
       pathPrefix: Seq[String] = Nil,
       allowStructEvolution: Boolean = false,
@@ -248,18 +253,19 @@ trait UpdateExpressionsSupport extends SQLConfHelper with AnalysisHelper {
     // Check that the head of nameParts in each update operation can match a target col. This avoids
     // silently ignoring invalid column names specified in update operations.
     updateOps.foreach { u =>
-      if (!targetCols.exists(f => resolver(f.name, u.targetColNameParts.head))) {
+      if (!targetSchema.exists(f => resolver(f.name, u.targetColNameParts.head))) {
         throw DeltaErrors.updateSetColumnNotFoundException(
           (pathPrefix :+ u.targetColNameParts.head).mkString("."),
-          targetCols.map(col => (pathPrefix :+ col.name).mkString(".")))
+          targetSchema.map(f => (pathPrefix :+ f.name).mkString(".")))
       }
     }
 
     // Transform each targetCol to a possibly updated expression
-    targetCols.map { targetCol =>
+    targetSchema.map { targetCol =>
       // The prefix of a update path matches the current targetCol path.
       val prefixMatchedOps =
         updateOps.filter(u => resolver(u.targetColNameParts.head, targetCol.name))
+      val defaultExpr = defaultExprs.find(f => resolver(f.name, targetCol.name))
       // No prefix matches this target column, return its original expression.
       if (prefixMatchedOps.isEmpty) {
         // Check whether it's a generated column or not. If so, we will return `None` so that the
@@ -268,8 +274,12 @@ trait UpdateExpressionsSupport extends SQLConfHelper with AnalysisHelper {
         // update expressions yet.
         if (generatedColumns.find(f => resolver(f.name, targetCol.name)).nonEmpty) {
           None
+        } else if (defaultExpr.nonEmpty) {
+          defaultExpr
         } else {
-          Some(targetCol)
+          // This is a new column or field added by schema evolution that doesn't have an assignment
+          // in this MERGE clause. Set it to null.
+          Some(Literal(null))
         }
       } else {
         // The update operation whose path exactly matches the current targetCol path.
@@ -294,15 +304,19 @@ trait UpdateExpressionsSupport extends SQLConfHelper with AnalysisHelper {
           // that means targetCol is a complex data type, so we recursively pass along the update
           // operations to its children.
           targetCol.dataType match {
-            case StructType(fields) =>
-              val fieldExpr = targetCol
-              val childExprs = fields.zipWithIndex.map { case (field, ordinal) =>
-                Alias(GetStructField(fieldExpr, ordinal, Some(field.name)), field.name)()
+            case childSchema: StructType =>
+              val defaultChildExprs = defaultExpr match {
+                case Some(expr @ NamedExpression(_, StructType(fields))) =>
+                  fields.zipWithIndex.map { case (field, ordinal) =>
+                    Alias(GetStructField(expr, ordinal, Some(field.name)), field.name)()
+                  }
+                case _ => Array.empty[NamedExpression]
               }
               // Recursively apply update operations to the children
-              val targetExprs = generateUpdateExpressions(
-                childExprs,
+              val childTargetExprs = generateUpdateExpressions(
+                childSchema,
                 prefixMatchedOps.map(u => u.copy(targetColNameParts = u.targetColNameParts.tail)),
+                defaultChildExprs,
                 resolver,
                 pathPrefix :+ targetCol.name,
                 allowStructEvolution,
@@ -313,8 +327,8 @@ trait UpdateExpressionsSupport extends SQLConfHelper with AnalysisHelper {
                   throw DeltaErrors.cannotGenerateUpdateExpressions()
                 })
               // Reconstruct the expression for targetCol using its possibly updated children
-              val namedStructExprs = fields
-                .zip(targetExprs)
+              val namedStructExprs = childSchema
+                .zip(childTargetExprs)
                 .flatMap { case (field, expr) => Seq(Literal(field.name), expr) }
               Some(CreateNamedStruct(namedStructExprs))
 
@@ -329,7 +343,8 @@ trait UpdateExpressionsSupport extends SQLConfHelper with AnalysisHelper {
 
   /** See docs on overloaded method. */
   protected def generateUpdateExpressions(
-      targetCols: Seq[NamedExpression],
+      targetSchema: StructType,
+      defaultExprs: Seq[NamedExpression],
       nameParts: Seq[Seq[String]],
       updateExprs: Seq[Expression],
       resolver: Resolver,
@@ -338,7 +353,13 @@ trait UpdateExpressionsSupport extends SQLConfHelper with AnalysisHelper {
     val updateOps = nameParts.zip(updateExprs).map {
       case (nameParts, expr) => UpdateOperation(nameParts, expr)
     }
-    generateUpdateExpressions(targetCols, updateOps, resolver, generatedColumns = generatedColumns)
+    generateUpdateExpressions(
+      targetSchema,
+      updateOps,
+      defaultExprs,
+      resolver,
+      generatedColumns = generatedColumns
+    )
   }
 
   /**
@@ -370,23 +391,23 @@ trait UpdateExpressionsSupport extends SQLConfHelper with AnalysisHelper {
       updateTarget: LogicalPlan,
       generatedColumns: Seq[StructField],
       updateExprs: Seq[Option[Expression]],
-      finalSchemaExprs: Option[Seq[Attribute]] = None): Seq[Expression] = {
-    val targetExprs = finalSchemaExprs.getOrElse(updateTarget.output)
+      finalSchema: Option[StructType] = None): Seq[Expression] = {
+    val targetSchema = finalSchema.getOrElse(updateTarget.schema)
     assert(
-      targetExprs.size == updateExprs.length,
+      targetSchema.size == updateExprs.length,
       s"'generateUpdateExpressions' should return expressions that are aligned with the column " +
-        s"list. Expected size: ${updateTarget.output.size}, actual size: ${updateExprs.length}")
-    val attrsWithExprs = targetExprs.zip(updateExprs)
-    val exprsForProject = attrsWithExprs.flatMap {
-      case (attr, Some(expr)) =>
+        s"list. Expected size: ${targetSchema.size}, actual size: ${updateExprs.length}")
+    val schemaWithExprs = targetSchema.zip(updateExprs)
+    val exprsForProject = schemaWithExprs.flatMap {
+      case (field, Some(expr)) =>
         // Create a named expression so that we can use it in Project
-        val exprForProject = Alias(expr, attr.name)()
+        val exprForProject = Alias(expr, field.name)()
         Some(exprForProject.exprId -> exprForProject)
       case (_, None) => None
     }.toMap
     // Create a fake Project to resolve the generation expressions
     val fakePlan = Project(exprsForProject.values.toArray[NamedExpression], updateTarget)
-    attrsWithExprs.map {
+    schemaWithExprs.map {
       case (_, Some(expr)) => expr
       case (targetCol, None) =>
         // `targetCol` is a generated column and the user doesn't provide a update expression.
@@ -397,7 +418,7 @@ trait UpdateExpressionsSupport extends SQLConfHelper with AnalysisHelper {
               resolveReferencesForExpressions(SparkSession.active, expr :: Nil, fakePlan).head
             case None =>
               // Should not happen
-              throw DeltaErrors.nonGeneratedColumnMissingUpdateExpression(targetCol)
+              throw DeltaErrors.nonGeneratedColumnMissingUpdateExpression(targetCol.name)
           }
         // As `resolvedExpr` will refer to attributes in `fakePlan`, we need to manually replace
         // these attributes with their update expressions.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
@@ -388,7 +388,7 @@ trait ClassicMergeExecutor extends MergeOutputGeneration {
 
     // The target output columns need to be marked as nullable here, as they are going to be used
     // to reference the output of an outer join.
-    val targetOutputCols = getTargetOutputCols(spark, deltaTxn, makeNullable = true)
+    val targetOutputCols = getTargetOutputCols(makeNullable = true)
 
     // If there are N columns in the target table, the full outer join output will have:
     // - N columns for target table

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/InsertOnlyMergeExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/InsertOnlyMergeExecutor.scala
@@ -146,7 +146,7 @@ trait InsertOnlyMergeExecutor extends MergeOutputGeneration {
       preparedSourceDF: DataFrame,
       deltaTxn: OptimisticTransaction): DataFrame = {
 
-    val targetOutputColNames = getTargetOutputCols(spark, deltaTxn).map(_.name)
+    val targetOutputColNames = deltaTxn.metadata.schema.map(_.name)
 
     // When there is only one insert clause, there is no need for ROW_DROPPED_COL and
     // output df can be generated without CaseWhen.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1415,11 +1415,9 @@ trait DeltaErrorsSuiteBase
     }
     {
       val e = intercept[DeltaIllegalStateException] {
-        throw DeltaErrors.nonGeneratedColumnMissingUpdateExpression(
-          AttributeReference("attr1", IntegerType)(ExprId(1234567L)))
+        throw DeltaErrors.nonGeneratedColumnMissingUpdateExpression("attr1")
       }
-      val msg = "attr1#1234567 is not a generated column but is missing " +
-            "its update expression"
+      val msg = "attr1 is not a generated column but is missing its update expression"
       checkErrorMessage(e, Some("DELTA_NON_GENERATED_COLUMN_MISSING_UPDATE_EXPR"), Some("XXKDS"),
         Some(msg))
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
@@ -3062,25 +3062,9 @@ abstract class MergeIntoSuiteBase
       Option("Aggregate functions are not supported in the .* condition of MERGE operation.*")
   )
 
-  testWithTempView("test merge on temp view - basic") { isSQLTempView =>
-    withTable("tab") {
-      withTempView("src") {
-        Seq((0, 3), (1, 2)).toDF("key", "value").write.format("delta").saveAsTable("tab")
-        createTempViewFromTable("tab", isSQLTempView)
-        sql("CREATE TEMP VIEW src AS SELECT * FROM VALUES (1, 2), (3, 4) AS t(a, b)")
-        executeMerge(
-          target = "v",
-          source = "src",
-          condition = "src.a = v.key AND src.b = v.value",
-          update = "v.value = src.b + 1",
-          insert = "(v.key, v.value) VALUES (src.a, src.b)")
-        checkAnswer(spark.table("v"), Seq(Row(0, 3), Row(1, 3), Row(3, 4)))
-      }
-    }
-  }
-
-  protected def testInvalidTempViews(name: String)(
+  protected def testTempViews(name: String)(
       text: String,
+      expectedResult: Seq[Row] = null,
       expectedErrorMsgForSQLTempView: String = null,
       expectedErrorMsgForDataSetTempView: String = null,
       expectedErrorClassForSQLTempView: String = null,
@@ -3114,26 +3098,32 @@ abstract class MergeIntoSuiteBase
               expectedErrorClassForSQLTempView,
               expectedErrorClassForDataSetTempView)
           } else {
+            require(expectedResult != null)
             executeMerge(
               target = "v",
               source = "src",
               condition = "src.a = v.key AND src.b = v.value",
               update = "v.value = src.b + 1",
               insert = "(v.key, v.value) VALUES (src.a, src.b)")
-            checkAnswer(spark.table("v"), Seq(Row(0, 3), Row(1, 3), Row(3, 4)))
+            checkAnswer(spark.table("v"), expectedResult)
           }
         }
       }
     }
   }
 
-  testInvalidTempViews("subset cols")(
+  testTempViews("basic")(
+    text = "SELECT * FROM tab",
+    expectedResult = Seq(Row(0, 3), Row(1, 3), Row(3, 4))
+  )
+
+  testTempViews("subset cols")(
     text = "SELECT key FROM tab",
     expectedErrorMsgForSQLTempView = "cannot",
     expectedErrorMsgForDataSetTempView = "cannot"
   )
 
-  testInvalidTempViews("superset cols")(
+  testTempViews("superset cols")(
     text = "SELECT key, value, 1 FROM tab",
     // The analyzer can't tell whether the table originally had the extra column or not.
     expectedErrorMsgForSQLTempView =
@@ -3142,16 +3132,14 @@ abstract class MergeIntoSuiteBase
       "The schema of your Delta table has changed in an incompatible way"
   )
 
-  testInvalidTempViews("nontrivial projection")(
+  testTempViews("nontrivial projection")(
     text = "SELECT value as key, key as value FROM tab",
-    expectedErrorMsgForSQLTempView = "Attribute(s) with the same name appear",
-    expectedErrorMsgForDataSetTempView = "Attribute(s) with the same name appear"
+    expectedResult = Seq(Row(2, 1), Row(2, 1), Row(3, 0), Row(4, 3))
   )
 
-  testInvalidTempViews("view with too many internal aliases")(
+  testTempViews("view with too many internal aliases")(
     text = "SELECT * FROM (SELECT * FROM tab AS t1) AS t2",
-    expectedErrorMsgForSQLTempView = "Attribute(s) with the same name appear",
-    expectedErrorMsgForDataSetTempView = null
+    expectedResult = Seq(Row(0, 3), Row(1, 3), Row(3, 4))
   )
 
   test("merge correctly handle field metadata") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## What changes were proposed in this pull request?

### Context
Schema evolution in the MERGE INTO command relies on manually updating the plan of the target table and replace the original output attributes to match the schema after evolution.
Manually updating the target plan is unnecessarily complex, error-prone and ultimately wrong: the new attributes don't match the actual target schema that was used to resolve all expressions. This worked so far for schema evolution that only adds new fields or columns that are then implicitly filled with `null`s on read but breaks when introducing type evolution due to type mismatches that can't be reconciled.

### Changes
The target plan isn't manually updated to support schema evolution in the MERGE INTO command anymore. Instead, the original target output is used and we rely on the different expressions used to write out the data to produce an output that supports schema evolution. E.p.:
- For target columns that are assigned to by an UPDATE action: `generateUpdateExpressions` already does the heavy lifting, it is simply updated to use the actual target output instead of trying to reference the evolved schema. This allows simplifying a bit the method.
- For target columns that aren't assigned to by an UPDATE action (either columns without an assignment or with a DELETE action and the deleted row must be written to the CDC output): no-op expressions are generated by casting the target output attributes to their corresponding type after evolution in `getTargetOutputCols`.

The manual handling in `buildTargetPlanWithIndex` and `replaceFileIndex` that isn't needed anymore is removed. This in turns allow splitting `replaceFileIndex` in two methods with separate concerns: `replaceFileIndex` (already exists) and `dropColumns` to manually remove columns from the target plan.

## How was this patch tested?
This is extensively covered by existing MERGE tests, in particular:
- `MergeIntoSchemaEvolutionTests`
- `MergeCDCSuite` - `schema evolution with non-nullable schema` that covers handling non nullable fields that turn nullable due to the outer join in MERGE.
