### PR TITLE
[Delta Uniform] Trigger iceberg conversion for restore and clone command

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1995,9 +1995,8 @@ trait OptimisticTransactionImpl extends TransactionalWrite
 
   def containsPostCommitHook(hook: PostCommitHook): Boolean = postCommitHooks.contains(hook)
 
-<<<<<<< HEAD
+
   /** Executes the registered post commit hooks. */
-=======
   protected def runRegisteredPostCommitHooks(
       version: Long,
       postCommitSnapshot: Snapshot,
@@ -2008,7 +2007,6 @@ trait OptimisticTransactionImpl extends TransactionalWrite
   /**
    * Executes post commit hooks.
    */
->>>>>>> cbac6468 (Squashed commits:)
   protected def runPostCommitHooks(
       version: Long,
       postCommitSnapshot: Snapshot,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2ESuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2ESuite.scala
@@ -54,6 +54,24 @@ abstract class UniFormE2EIcebergSuiteBase extends UniFormE2ETest {
     }
   }
 
+  test("Restore to a specific version") {
+    withTable(testTableName) {
+      write(
+        s"""CREATE TABLE `$testTableName` (col1 INT) USING DELTA
+           |TBLPROPERTIES (
+           |  'delta.enableIcebergCompatV2' = 'true',
+           |  'delta.universalFormat.enabledFormats' = 'iceberg'
+           |)""".stripMargin)
+      (1 to 4).foreach{ i =>
+        write(s"INSERT INTO `$testTableName` VALUES ($i)")
+      }
+      readAndVerify(testTableName, "col1", "col1", Seq(Row(1), Row(2), Row(3), Row(4)))
+
+      write(s"RESTORE `$testTableName` TO VERSION AS OF 2")
+      readAndVerify(testTableName, "col1", "col1", Seq(Row(1), Row(2)))
+    }
+  }
+
   test("Nested struct schema test") {
     withTable(testTableName) {
       write(s"""CREATE TABLE $testTableName


### PR DESCRIPTION
## Description

**_Background:_** currently the restore command and clone command will not trigger the iceberg conversion process. Therefore, the iceberg metadata will fall behind, causing discrepancy between delta reader and iceberg reader.

**_Proposed Change:_** This PR solves the issue via invoking a iceberg conversion process after table restores.

## How was this patch tested?

E2E Tests

## Does this PR introduce _any_ user-facing changes?
No
