### PR TITLE
[Delta Uniform] Trigger iceberg conversion for restore and clone command

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
@@ -24,6 +24,7 @@ import scala.util.{Success, Try}
 import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaOperations, Snapshot}
 import org.apache.spark.sql.delta.actions.{AddFile, DeletionVectorDescriptor, RemoveFile}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.hooks.IcebergConverterHook
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.DeltaFileOperations.absolutePath
 import org.apache.hadoop.fs.Path
@@ -211,7 +212,8 @@ case class RestoreTableCommand(sourceTable: DeltaTableV2)
           Some(newProtocol),
           DeltaOperations.Restore(version, timestamp),
           Map.empty,
-          metrics.mapValues(_.toString).toMap)
+          metrics.mapValues(_.toString).toMap,
+          additionalHooks = Seq(IcebergConverterHook))
 
         Seq(Row(
           metrics.get(TABLE_SIZE_AFTER_RESTORE),


### PR DESCRIPTION
## Description

**_Background:_** currently the restore command and clone command will not trigger the iceberg conversion process. Therefore, the iceberg metadata will fall behind, causing discrepancy between delta reader and iceberg reader.

**_Proposed Change:_** This PR solves the issue via invoking a iceberg conversion process after table restores.

## How was this patch tested?

E2E Tests

## Does this PR introduce _any_ user-facing changes?
No
