### PR TITLE
[Spark] Add LatestTableVersion to CommitStore GetCommits API response

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -26,8 +26,6 @@ import scala.collection.mutable.{ArrayBuffer, HashSet}
 import scala.util.control.NonFatal
 
 import com.databricks.spark.util.TagDefinitions.TAG_LOG_STORE_CLASS
-import com.databricks.sql.acl.TrustedScalaUDFRegistry
-import org.apache.spark.sql.delta.skipping.clustering.{ClusteredTableUtils, ClusteringColumnInfo}
 import org.apache.spark.sql.delta.DeltaOperations.{ChangeColumn, CreateTable, Operation, ReplaceColumns, ReplaceTable, UpdateSchema}
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions._
@@ -36,27 +34,24 @@ import org.apache.spark.sql.delta.commands.DeletionVectorUtils
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.files._
 import org.apache.spark.sql.delta.hooks.{CheckpointHook, GenerateSymlinkManifest, IcebergConverterHook, PostCommitHook, UpdateCatalogFactory}
-import org.apache.spark.sql.delta.hooks.{ChecksumHook, MinorCompactionHook, UpdateMACHook}
 import org.apache.spark.sql.delta.implicits.addFileEncoder
 import org.apache.spark.sql.delta.managedcommit.{Commit, CommitFailedException, CommitResponse, CommitStore, GetCommitsResponse, UpdatedActions}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.{SchemaMergingUtils, SchemaUtils}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats._
-import org.apache.spark.sql.delta.stats.FileSizeHistogramUtils
 import org.apache.spark.sql.delta.storage.LogStore
 import org.apache.spark.sql.util.ScalaExtensions._
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
-import org.apache.spark.SparkException
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.{AnalysisException, Column, DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.catalyst.util.{CharVarcharUtils, ResolveDefaultColumns}
 import org.apache.spark.sql.types.{StructField, StructType}
-import org.apache.spark.sql.types.VariantType
 import org.apache.spark.util.{Clock, Utils}
 
 /** Record metrics about a successful commit. */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -26,6 +26,8 @@ import scala.collection.mutable.{ArrayBuffer, HashSet}
 import scala.util.control.NonFatal
 
 import com.databricks.spark.util.TagDefinitions.TAG_LOG_STORE_CLASS
+import com.databricks.sql.acl.TrustedScalaUDFRegistry
+import org.apache.spark.sql.delta.skipping.clustering.{ClusteredTableUtils, ClusteringColumnInfo}
 import org.apache.spark.sql.delta.DeltaOperations.{ChangeColumn, CreateTable, Operation, ReplaceColumns, ReplaceTable, UpdateSchema}
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions._
@@ -34,24 +36,27 @@ import org.apache.spark.sql.delta.commands.DeletionVectorUtils
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.files._
 import org.apache.spark.sql.delta.hooks.{CheckpointHook, GenerateSymlinkManifest, IcebergConverterHook, PostCommitHook, UpdateCatalogFactory}
+import org.apache.spark.sql.delta.hooks.{ChecksumHook, MinorCompactionHook, UpdateMACHook}
 import org.apache.spark.sql.delta.implicits.addFileEncoder
-import org.apache.spark.sql.delta.managedcommit.{Commit, CommitFailedException, CommitResponse, CommitStore, UpdatedActions}
+import org.apache.spark.sql.delta.managedcommit.{Commit, CommitFailedException, CommitResponse, CommitStore, GetCommitsResponse, UpdatedActions}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.{SchemaMergingUtils, SchemaUtils}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats._
+import org.apache.spark.sql.delta.stats.FileSizeHistogramUtils
 import org.apache.spark.sql.delta.storage.LogStore
 import org.apache.spark.sql.util.ScalaExtensions._
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
-
 import org.apache.spark.SparkException
+
 import org.apache.spark.sql.{AnalysisException, Column, DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.catalyst.util.{CharVarcharUtils, ResolveDefaultColumns}
 import org.apache.spark.sql.types.{StructField, StructType}
+import org.apache.spark.sql.types.VariantType
 import org.apache.spark.util.{Clock, Utils}
 
 /** Record metrics about a successful commit. */
@@ -1911,9 +1916,9 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       logPath.getFileSystem(hadoopConf).getFileStatus(commitFile)
     }
 
-
     override def getCommits(
-      tablePath: Path, startVersion: Long, endVersion: Option[Long]): Seq[Commit] = Seq.empty
+        logPath: Path, startVersion: Long, endVersion: Option[Long]): GetCommitsResponse =
+      GetCommitsResponse(Seq.empty, -1)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -167,7 +167,7 @@ trait SnapshotManagement { self: DeltaLog =>
     //   are replaced with this method.
     val resultFromCommitStore = recordFrameProfile("DeltaLog", "CommitStore.getCommits") {
       commitStoreOpt match {
-        case Some(cs) => cs.getCommits(logPath, startVersion, endVersion = versionToLoad)
+        case Some(cs) => cs.getCommits(logPath, startVersion, endVersion = versionToLoad).commits
         case None => Seq.empty
       }
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/AbstractBatchBackfillingCommitStore.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/AbstractBatchBackfillingCommitStore.scala
@@ -112,8 +112,9 @@ trait AbstractBatchBackfillingCommitStore extends CommitStore with Logging {
       logStore: LogStore,
       hadoopConf: Configuration,
       logPath: Path): Unit = {
-    getCommits(logPath, startVersion = 0).foreach { commit =>
-      backfill(logStore, hadoopConf, logPath, commit.version, commit.fileStatus)
+    getCommits(logPath, startVersion = 0).commits.foreach{ commit =>
+      val fileStatus = commit.fileStatus
+      backfill(logStore, hadoopConf, logPath, commit.version, fileStatus)
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/AbstractBatchBackfillingCommitStore.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/AbstractBatchBackfillingCommitStore.scala
@@ -112,9 +112,8 @@ trait AbstractBatchBackfillingCommitStore extends CommitStore with Logging {
       logStore: LogStore,
       hadoopConf: Configuration,
       logPath: Path): Unit = {
-    getCommits(logPath, startVersion = 0).commits.foreach{ commit =>
-      val fileStatus = commit.fileStatus
-      backfill(logStore, hadoopConf, logPath, commit.version, fileStatus)
+    getCommits(logPath, startVersion = 0).commits.foreach { commit =>
+      backfill(logStore, hadoopConf, logPath, commit.version, commit.fileStatus)
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/CommitStore.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/CommitStore.scala
@@ -46,6 +46,9 @@ class CommitFailedException(
 /** Response container for [[CommitStore.commit]] API */
 case class CommitResponse(commit: Commit)
 
+/** Response container for [[CommitStore.getCommits]] API */
+case class GetCommitsResponse(commits: Seq[Commit], latestTableVersion: Long)
+
 /** A container class to inform the CommitStore about any changes in Protocol/Metadata */
 case class UpdatedActions(
   commitInfo: CommitInfo,
@@ -81,13 +84,17 @@ trait CommitStore {
    * Note that the first version returned by this API may not be equal to the `startVersion`. This
    * happens when few versions starting from `startVersion` are already backfilled and so
    * CommitStore may have stopped tracking them.
+   * The returned latestTableVersion is the maximum commit version ratified by the Commit-Owner.
+   * Note that returning latestTableVersion as -1 is acceptable only if the commit-owner never
+   * ratified any version i.e. it never accepted any un-backfilled commit.
    *
-   * @return a sequence of [[Commit]] which are tracked by [[CommitStore]].
+   * @return GetCommitsResponse which has a list of [[Commit]] and the latestTableVersion which are
+   *         tracked by [[CommitStore]].
    */
   def getCommits(
-      logPath: Path,
-      startVersion: Long,
-      endVersion: Option[Long] = None): Seq[Commit]
+    logPath: Path,
+    startVersion: Long,
+    endVersion: Option[Long] = None): GetCommitsResponse
 }
 
 /** A builder interface for CommitStore */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/CommitStore.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/CommitStore.scala
@@ -88,7 +88,7 @@ trait CommitStore {
    * Note that returning latestTableVersion as -1 is acceptable only if the commit-owner never
    * ratified any version i.e. it never accepted any un-backfilled commit.
    *
-   * @return GetCommitsResponse which has a list of [[Commit]] and the latestTableVersion which are
+   * @return GetCommitsResponse which has a list of [[Commit]]s and the latestTableVersion which is
    *         tracked by [[CommitStore]].
    */
   def getCommits(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/InMemoryCommitStore.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/InMemoryCommitStore.scala
@@ -100,14 +100,14 @@ class InMemoryCommitStore(val batchSize: Long) extends AbstractBatchBackfillingC
   override def getCommits(
       logPath: Path,
       startVersion: Long,
-      endVersion: Option[Long]): Seq[Commit] = {
-    withReadLock[Seq[Commit]](logPath) {
+      endVersion: Option[Long]): GetCommitsResponse = {
+    withReadLock[GetCommitsResponse](logPath) {
       val tableData = perTableMap.get(logPath)
       // Calculate the end version for the range, or use the last key if endVersion is not provided
       val effectiveEndVersion =
         endVersion.getOrElse(tableData.commitsMap.lastOption.map(_._1).getOrElse(startVersion))
       val commitsInRange = tableData.commitsMap.range(startVersion, effectiveEndVersion + 1)
-      commitsInRange.values.toSeq
+      GetCommitsResponse(commitsInRange.values.toSeq, tableData.maxCommitVersion)
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -22,7 +22,7 @@ import java.nio.file.FileAlreadyExistsException
 import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
 import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo, Metadata, Protocol, RemoveFile, SetTransaction}
-import org.apache.spark.sql.delta.managedcommit.{Commit, CommitFailedException, CommitResponse, CommitStore, CommitStoreBuilder, CommitStoreProvider, UpdatedActions}
+import org.apache.spark.sql.delta.managedcommit.{Commit, CommitFailedException, CommitResponse, CommitStore, CommitStoreBuilder, CommitStoreProvider, GetCommitsResponse, UpdatedActions}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.storage.LogStore
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
@@ -477,7 +477,7 @@ class OptimisticTransactionSuite
           override def getCommits(
               tablePath: Path,
               startVersion: Long,
-              endVersion: Option[Long]): Seq[Commit] = Seq.empty
+              endVersion: Option[Long]): GetCommitsResponse = GetCommitsResponse(Seq.empty, -1)
         }
       }
     }
@@ -523,7 +523,7 @@ class OptimisticTransactionSuite
           override def getCommits(
               tablePath: Path,
               startVersion: Long,
-              endVersion: Option[Long]): Seq[Commit] = Seq.empty
+              endVersion: Option[Long]): GetCommitsResponse = GetCommitsResponse(Seq.empty, -1)
         }
       }
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/CommitStoreSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/CommitStoreSuite.scala
@@ -44,7 +44,7 @@ class CommitStoreSuite extends QueryTest with DeltaSQLTestUtils with SharedSpark
     override def getCommits(
       logPath: Path,
       startVersion: Long,
-      endVersion: Option[Long] = None): Seq[Commit] = Seq.empty
+      endVersion: Option[Long] = None): GetCommitsResponse = GetCommitsResponse(Seq.empty, -1)
   }
 
   class TestCommitStore1 extends TestCommitStoreBase

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitTestUtils.scala
@@ -89,7 +89,7 @@ case class TrackingInMemoryCommitStore(
   override def getCommits(
       logPath: Path,
       startVersion: Long,
-      endVersion: Option[Long] = None): Seq[Commit] = recordOperation("getCommits") {
+      endVersion: Option[Long] = None): GetCommitsResponse = recordOperation("getCommits") {
     super.getCommits(logPath, startVersion, endVersion)
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
With this change, we require CommitStores to maintain and return the latestTableVersion in the getCommits API. The motivation here is for readers to get more context from CommitStore when all commits are backfilled and the Commit Response is empty.

Clients can use latestTableVersion to determine the version the table is when all commits are backfilled and the commits list is empty in the getCommits response.

## How was this patch tested?
Unit tests

## Does this PR introduce _any_ user-facing changes?
No