### PR TITLE
[Kernel] Rename Parquet readers to maintain consistency with Parquet writers

### DIFF
--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultParquetHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultParquetHandler.java
@@ -31,7 +31,7 @@ import io.delta.kernel.utils.*;
 
 import io.delta.kernel.internal.util.Utils;
 
-import io.delta.kernel.defaults.internal.parquet.ParquetBatchReader;
+import io.delta.kernel.defaults.internal.parquet.ParquetFileReader;
 import io.delta.kernel.defaults.internal.parquet.ParquetFileWriter;
 
 /**
@@ -55,7 +55,7 @@ public class DefaultParquetHandler implements ParquetHandler {
             StructType physicalSchema,
             Optional<Predicate> predicate) throws IOException {
         return new CloseableIterator<ColumnarBatch>() {
-            private final ParquetBatchReader batchReader = new ParquetBatchReader(hadoopConf);
+            private final ParquetFileReader batchReader = new ParquetFileReader(hadoopConf);
             private FileStatus currentFile;
             private CloseableIterator<ColumnarBatch> currentFileReader;
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ArrayColumnReader.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ArrayColumnReader.java
@@ -24,12 +24,16 @@ import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.types.ArrayType;
 
 import io.delta.kernel.defaults.internal.data.vector.DefaultArrayVector;
-import static io.delta.kernel.defaults.internal.parquet.ParquetConverters.createConverter;
+import static io.delta.kernel.defaults.internal.parquet.ParquetColumnReaders.createConverter;
 
-class ArrayConverter extends RepeatedValueConverter {
+/**
+ * Array column reader for materializing the column values from Parquet files into Kernels
+ * {@link ColumnVector}.
+ */
+class ArrayColumnReader extends RepeatedValueConverter {
     private final ArrayType typeFromClient;
 
-    ArrayConverter(int initialBatchSize, ArrayType typeFromClient, GroupType typeFromFile) {
+    ArrayColumnReader(int initialBatchSize, ArrayType typeFromClient, GroupType typeFromFile) {
         super(
             initialBatchSize,
             createElementConverter(initialBatchSize, typeFromClient, typeFromFile));

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/MapColumnReader.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/MapColumnReader.java
@@ -25,12 +25,16 @@ import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.types.MapType;
 
 import io.delta.kernel.defaults.internal.data.vector.DefaultMapVector;
-import static io.delta.kernel.defaults.internal.parquet.ParquetConverters.createConverter;
+import static io.delta.kernel.defaults.internal.parquet.ParquetColumnReaders.createConverter;
 
-class MapConverter extends RepeatedValueConverter {
+/**
+ * Map column readers for materializing the column values from Parquet files into Kernels
+ * {@link ColumnVector}.
+ */
+class MapColumnReader extends RepeatedValueConverter {
     private final MapType typeFromClient;
 
-    MapConverter(int initialBatchSize, MapType typeFromClient, GroupType typeFromFile) {
+    MapColumnReader(int initialBatchSize, MapType typeFromClient, GroupType typeFromFile) {
         super(
             initialBatchSize,
             createElementConverters(initialBatchSize, typeFromClient, typeFromFile));

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/RepeatedValueConverter.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/RepeatedValueConverter.java
@@ -23,15 +23,15 @@ import org.apache.parquet.io.api.GroupConverter;
 import io.delta.kernel.data.ColumnVector;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 
-import io.delta.kernel.defaults.internal.parquet.ParquetConverters.BaseConverter;
-import static io.delta.kernel.defaults.internal.parquet.ParquetConverters.initNullabilityVector;
-import static io.delta.kernel.defaults.internal.parquet.ParquetConverters.setNullabilityToTrue;
+import io.delta.kernel.defaults.internal.parquet.ParquetColumnReaders.BaseColumnReader;
+import static io.delta.kernel.defaults.internal.parquet.ParquetColumnReaders.initNullabilityVector;
+import static io.delta.kernel.defaults.internal.parquet.ParquetColumnReaders.setNullabilityToTrue;
 
 /**
  * Abstract implementation of Parquet converters for capturing the repeated types such as
  * list or map.
  */
-abstract class RepeatedValueConverter extends GroupConverter implements BaseConverter {
+abstract class RepeatedValueConverter extends GroupConverter implements BaseColumnReader {
     private final Collector collector;
 
     // working state
@@ -148,7 +148,7 @@ abstract class RepeatedValueConverter extends GroupConverter implements BaseConv
         public void end() {
             for (Converter converter : elementConverters) {
                 long prevRowIndex = -1; // Row indexes are not needed for nested columns
-                ((ParquetConverters.BaseConverter) converter).finalizeCurrentRow(prevRowIndex);
+                ((BaseColumnReader) converter).finalizeCurrentRow(prevRowIndex);
             }
             currentEntryIndex++;
         }
@@ -156,7 +156,7 @@ abstract class RepeatedValueConverter extends GroupConverter implements BaseConv
         ColumnVector[] getDataVectors() {
             ColumnVector[] dataVectors = new ColumnVector[elementConverters.length];
             for (int i = 0; i < elementConverters.length; i++) {
-                dataVectors[i] = ((ParquetConverters.BaseConverter) elementConverters[i])
+                dataVectors[i] = ((BaseColumnReader) elementConverters[i])
                     .getDataColumnVector(currentEntryIndex);
             }
             currentEntryIndex = 0;

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/TimestampConverters.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/TimestampConverters.java
@@ -52,7 +52,7 @@ public class TimestampConverters {
                 "TimestampType must have parquet TimeType(isAdjustedToUTC=true)");
 
             if (timestamp.getUnit() == LogicalTypeAnnotation.TimeUnit.MICROS) {
-                return new ParquetConverters.LongColumnConverter(
+                return new ParquetColumnReaders.LongColumnReader(
                     TimestampType.TIMESTAMP, initialBatchSize);
             } else if (timestamp.getUnit() == LogicalTypeAnnotation.TimeUnit.MILLIS) {
                 return new TimestampMillisConverter(initialBatchSize);
@@ -68,7 +68,7 @@ public class TimestampConverters {
         }
     }
 
-    public static class TimestampMillisConverter extends ParquetConverters.LongColumnConverter {
+    public static class TimestampMillisConverter extends ParquetColumnReaders.LongColumnReader {
 
         TimestampMillisConverter( int initialBatchSize) {
             super(TimestampType.TIMESTAMP, initialBatchSize);
@@ -80,7 +80,7 @@ public class TimestampConverters {
         }
     }
 
-    public static class TimestampBinaryConverter extends ParquetConverters.LongColumnConverter {
+    public static class TimestampBinaryConverter extends ParquetColumnReaders.LongColumnReader {
 
         TimestampBinaryConverter( int initialBatchSize) {
             super(TimestampType.TIMESTAMP, initialBatchSize);

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetSuiteBase.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetSuiteBase.scala
@@ -29,7 +29,6 @@ import io.delta.kernel.internal.util.Utils.toCloseableIterator
 import io.delta.kernel.types.{ArrayType, DataType, MapType, StructType}
 import io.delta.kernel.utils.{DataFileStatus, FileStatus}
 import org.apache.hadoop.fs.Path
-import org.apache.parquet.hadoop.ParquetFileReader
 import org.apache.parquet.hadoop.metadata.ParquetMetadata
 
 trait ParquetSuiteBase extends TestUtils {
@@ -243,7 +242,7 @@ trait ParquetSuiteBase extends TestUtils {
 
   def footer(path: String): ParquetMetadata = {
     try {
-      ParquetFileReader.readFooter(configuration, new Path(path))
+      org.apache.parquet.hadoop.ParquetFileReader.readFooter(configuration, new Path(path))
     } catch {
       case NonFatal(e) => fail(s"Failed to read footer for file: $path", e)
     }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

Rename Parquet readers to maintain consistency with Parquet writers.

Resolves https://github.com/delta-io/delta/issues/2636

## How was this patch tested?

Existing tests suffice.

## Does this PR introduce _any_ user-facing changes?

No
