### PR TITLE
[Spark] Read In-Commit Timestamp during the P&M query

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
@@ -54,6 +54,7 @@ case class VersionChecksum(
     numFiles: Long,
     numMetadata: Long,
     numProtocol: Long,
+    inCommitTimestampOpt: Option[Long],
     setTransactions: Option[Seq[SetTransaction]],
     domainMetadata: Option[Seq[DomainMetadata]],
     metadata: Metadata,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.delta.stats.DeltaStatsColumnSpec
 import org.apache.spark.sql.delta.stats.StatisticsCollection
 import org.apache.spark.sql.delta.util.FileNames
 import org.apache.spark.sql.delta.util.StateCache
+import org.apache.spark.sql.util.ScalaExtensions._
 import org.apache.hadoop.fs.{FileStatus, Path}
 
 import org.apache.spark.sql._
@@ -75,7 +76,6 @@ class Snapshot(
     override val version: Long,
     val logSegment: LogSegment,
     override val deltaLog: DeltaLog,
-    val inCommitTimestampOpt: Option[Long],
     val checksumOpt: Option[VersionChecksum]
   )
   extends SnapshotDescriptor
@@ -105,17 +105,46 @@ class Snapshot(
    * is retrieved from the CommitInfo of the latest commit which
    * can result in an IO operation.
    */
-  def timestamp: Long = {
-    if (DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(metadata)) {
-      inCommitTimestampOpt.getOrElse {
-        val commitInfoOpt = DeltaHistoryManager.getCommitInfoOpt(
-          deltaLog.store, deltaLog.logPath, version, deltaLog.newDeltaHadoopConf())
-        CommitInfo.getRequiredInCommitTimestamp(commitInfoOpt, version.toString)
-      }
-    } else {
-      logSegment.lastCommitTimestamp
+  def timestamp: Long = getInCommitTimestampOpt.getOrElse(logSegment.lastCommitTimestamp)
+
+  /**
+   * Returns the inCommitTimestamp if ICT is enabled, otherwise returns None.
+   * This potentially triggers an IO operation to read the inCommitTimestamp.
+   * This is a lazy val, so repeated calls will not trigger multiple IO operations.
+   */
+  protected lazy val getInCommitTimestampOpt: Option[Long] =
+    Option.when(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(metadata)) {
+      _reconstructedProtocolMetadataAndICT.inCommitTimestamp
+        .getOrElse {
+          val startTime = System.currentTimeMillis()
+          var exception = Option.empty[Throwable]
+          try {
+            val commitInfoOpt = DeltaHistoryManager.getCommitInfoOpt(
+              deltaLog.store,
+              deltaLog.logPath,
+              version,
+              deltaLog.newDeltaHadoopConf())
+            CommitInfo.getRequiredInCommitTimestamp(commitInfoOpt, version.toString)
+          } catch {
+            case e: Throwable =>
+              exception = Some(e)
+              throw e
+          } finally {
+            recordDeltaEvent(
+              deltaLog,
+              "delta.inCommitTimestamp.read",
+              data = Map(
+                "version" -> version,
+                "callSite" -> "Snapshot.getInCommitTimestampOpt",
+                "checkpointVersion" -> logSegment.checkpointProvider.version,
+                "durationMs" -> (System.currentTimeMillis() - startTime),
+                "exceptionMessage" -> exception.map(_.getMessage).getOrElse(""),
+                "exceptionStackTrace" -> exception.map(_.getStackTrace.mkString("\n")).getOrElse("")
+              )
+            )
+          }
+        }
     }
-  }
 
 
   private[delta] lazy val nonFileActions: Seq[Action] = {
@@ -151,17 +180,29 @@ class Snapshot(
   }
 
   /**
+   * Protocol, Metadata, and In-Commit Timestamp retrieved through
+   * `protocolMetadataAndICTReconstruction` which skips a full state reconstruction.
+   */
+  case class ReconstructedProtocolMetadataAndICT(
+      protocol: Protocol,
+      metadata: Metadata,
+      inCommitTimestamp: Option[Long])
+
+  /**
    * Generate the protocol and metadata for this snapshot. This is usually cheaper than a
    * full state reconstruction, but still only compute it when necessary.
    */
-  private lazy val (_protocol, _metadata): (Protocol, Metadata) = {
+  private lazy val _reconstructedProtocolMetadataAndICT: ReconstructedProtocolMetadataAndICT =
+      {
     // Should be small. At most 'checkpointInterval' rows, unless new commits are coming
     // in before a checkpoint can be written
     var protocol: Protocol = null
     var metadata: Metadata = null
-    protocolAndMetadataReconstruction().foreach {
-      case (p: Protocol, _) => protocol = p
-      case (_, m: Metadata) => metadata = m
+    var inCommitTimestamp: Option[Long] = None
+    protocolMetadataAndICTReconstruction().foreach {
+      case ReconstructedProtocolMetadataAndICT(p: Protocol, _, _) => protocol = p
+      case ReconstructedProtocolMetadataAndICT(_, m: Metadata, _) => metadata = m
+      case ReconstructedProtocolMetadataAndICT(_, _, ict: Option[Long]) => inCommitTimestamp = ict
     }
 
     if (protocol == null) {
@@ -182,7 +223,7 @@ class Snapshot(
       throw DeltaErrors.actionNotFoundException("metadata", version)
     }
 
-    protocol -> metadata
+    ReconstructedProtocolMetadataAndICT(protocol, metadata, inCommitTimestamp)
   }
 
   /**
@@ -230,37 +271,43 @@ class Snapshot(
 
   def checkpointSizeInBytes(): Long = checkpointProvider.effectiveCheckpointSizeInBytes()
 
-  override def metadata: Metadata = _metadata
+  override def metadata: Metadata = _reconstructedProtocolMetadataAndICT.metadata
 
-  override def protocol: Protocol = _protocol
+  override def protocol: Protocol = _reconstructedProtocolMetadataAndICT.protocol
 
   /**
    * Pulls the protocol and metadata of the table from the files that are used to compute the
    * Snapshot directly--without triggering a full state reconstruction. This is important, because
    * state reconstruction depends on protocol and metadata for correctness.
+   * If the current table version does not have a checkpoint, this function will also return the
+   * in-commit-timestamp of the latest commit if available.
    *
    * Also this method should only access methods defined in [[UninitializedCheckpointProvider]]
    * which are not present in [[CheckpointProvider]]. This is because initialization of
-   * [[Snapshot.checkpointProvider]] depends on [[Snapshot.protocolAndMetadataReconstruction()]]
-   * and so if [[Snapshot.protocolAndMetadataReconstruction()]] starts depending on
+   * [[Snapshot.checkpointProvider]] depends on [[Snapshot.protocolMetadataAndICTReconstruction()]]
+   * and so if [[Snapshot.protocolMetadataAndICTReconstruction()]] starts depending on
    * [[Snapshot.checkpointProvider]] then there will be cyclic dependency.
    */
-  protected def protocolAndMetadataReconstruction(): Array[(Protocol, Metadata)] = {
+  protected def protocolMetadataAndICTReconstruction():
+      Array[ReconstructedProtocolMetadataAndICT] = {
     import implicits._
 
-    val schemaToUse = Action.logSchema(Set("protocol", "metaData"))
+    val schemaToUse = Action.logSchema(Set("protocol", "metaData", "commitInfo"))
     val checkpointOpt = checkpointProvider.topLevelFileIndex.map { index =>
       deltaLog.loadIndex(index, schemaToUse)
         .withColumn(COMMIT_VERSION_COLUMN, lit(checkpointProvider.version))
     }
     (checkpointOpt ++ deltaFileIndexOpt.map(deltaLog.loadIndex(_, schemaToUse)).toSeq)
       .reduceOption(_.union(_)).getOrElse(emptyDF)
-      .select("protocol", "metaData", COMMIT_VERSION_COLUMN)
-      .where("protocol.minReaderVersion is not null or metaData.id is not null")
-      .as[(Protocol, Metadata, Long)]
+      .select("protocol", "metaData", "commitInfo.inCommitTimestamp", COMMIT_VERSION_COLUMN)
+      .where("protocol.minReaderVersion is not null or metaData.id is not null " +
+        s"or (commitInfo.inCommitTimestamp is not null and version = $version)")
+      .as[(Protocol, Metadata, Option[Long], Long)]
       .collect()
-      .sortBy(_._3)
-      .map { case (p, m, _) => p -> m }
+      .sortBy(_._4)
+      .map {
+        case (p, m, ict, _) => ReconstructedProtocolMetadataAndICT(p, m, ict)
+      }
   }
 
   // Reconstruct the state by applying deltas in order to the checkpoint.
@@ -370,6 +417,7 @@ class Snapshot(
     numFiles = numOfFiles,
     numMetadata = numOfMetadata,
     numProtocol = numOfProtocol,
+    inCommitTimestampOpt = getInCommitTimestampOpt,
     setTransactions = checksumOpt.flatMap(_.setTransactions),
     domainMetadata = domainMetadatasIfKnown,
     metadata = metadata,
@@ -491,7 +539,6 @@ class InitialSnapshot(
     version = -1,
     logSegment = LogSegment.empty(logPath),
     deltaLog = deltaLog,
-    inCommitTimestampOpt = None,
     checksumOpt = None
   ) {
 
@@ -512,5 +559,6 @@ class InitialSnapshot(
   override def stateDF: DataFrame = emptyDF
   override protected lazy val computedState: SnapshotState = initialState(metadata)
   override def protocol: Protocol = computedState.protocol
+  override protected lazy val getInCommitTimestampOpt: Option[Long] = None
   override def timestamp: Long = -1L
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -567,7 +567,6 @@ trait SnapshotManagement { self: DeltaLog =>
         version = segment.version,
         logSegment = segment,
         deltaLog = this,
-        inCommitTimestampOpt = None,
         checksumOpt = checksumOpt.orElse(
           readChecksum(segment.version, lastSeenChecksumFileStatusOpt))
       )

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaEncoders.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaEncoders.scala
@@ -74,8 +74,8 @@ private[delta] trait DeltaEncoders {
   private lazy val _removeFileEncoder = new DeltaEncoder[RemoveFile]
   implicit def removeFileEncoder: Encoder[RemoveFile] = _removeFileEncoder.get
 
-  private lazy val _pmvEncoder = new DeltaEncoder[(Protocol, Metadata, Long)]
-  implicit def pmvEncoder: Encoder[(Protocol, Metadata, Long)] = _pmvEncoder.get
+  private lazy val _pmtvEncoder = new DeltaEncoder[(Protocol, Metadata, Option[Long], Long)]
+  implicit def pmtvEncoder: Encoder[(Protocol, Metadata, Option[Long], Long)] = _pmtvEncoder.get
 
   private lazy val _v2CheckpointActionsEncoder = new DeltaEncoder[(CheckpointMetadata, SidecarFile)]
   implicit def v2CheckpointActionsEncoder: Encoder[(CheckpointMetadata, SidecarFile)] =

--- a/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
@@ -16,12 +16,15 @@
 
 package org.apache.spark.sql.delta
 
+import java.nio.charset.StandardCharsets.UTF_8
+
 import com.databricks.spark.util.{Log4jUsageLogger, UsageRecord}
 import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
 import org.apache.spark.sql.delta.actions.{Action, CommitInfo}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
-import org.apache.spark.sql.delta.util.FileNames
+import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.QueryTest
@@ -150,6 +153,8 @@ class InCommitTimestampSuite
         actionsWithoutCommitInfo,
         overwrite = true,
         deltaLog.newDeltaHadoopConf())
+
+      DeltaLog.clearCache()
       val latestSnapshot = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath)).snapshot
       val e = intercept[DeltaIllegalStateException] {
         latestSnapshot.timestamp
@@ -187,6 +192,7 @@ class InCommitTimestampSuite
         overwrite = true,
         deltaLog.newDeltaHadoopConf())
 
+      DeltaLog.clearCache()
       val latestSnapshot = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath)).snapshot
       val e = intercept[DeltaIllegalStateException] {
         latestSnapshot.timestamp
@@ -337,6 +343,99 @@ class InCommitTimestampSuite
       assert(observedEnablementVersion.isDefined)
       assert(observedEnablementTimestamp.get == getInCommitTimestamp(deltaLog, version = 2))
       assert(observedEnablementVersion.get == 2)
+    }
+  }
+
+  test("postCommitSnapshot.timestamp should be populated by protocolMetadataAndICTReconstruction " +
+     "when the table has no checkpoints") {
+    withTempDir { tempDir =>
+      var deltaLog: DeltaLog = null
+      var timestamp = -1L
+      spark.range(1).write.format("delta").save(tempDir.getAbsolutePath)
+      DeltaLog.clearCache()
+      val usageRecords = Log4jUsageLogger.track {
+        deltaLog = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
+        timestamp = deltaLog.snapshot.timestamp
+      }
+      assert(timestamp == getInCommitTimestamp(deltaLog, 0))
+      // No explicit read.
+      assert(filterUsageRecords(usageRecords, "delta.inCommitTimestamp.read").isEmpty)
+    }
+  }
+
+  test("snapshot.timestamp should be populated by protocolMetadataAndICTReconstruction " +
+     "during cold reads of checkpoints + deltas") {
+    withTempDir { tempDir =>
+      var deltaLog: DeltaLog = null
+      var timestamp = -1L
+      spark.range(1).write.format("delta").save(tempDir.getAbsolutePath)
+      deltaLog = DeltaLog
+        .forTable(spark, new Path(tempDir.getCanonicalPath))
+      deltaLog.createCheckpointAtVersion(0)
+      deltaLog.startTransaction().commit(Seq(createTestAddFile("c1")), ManualUpdate)
+
+      val usageRecords = Log4jUsageLogger.track {
+        DeltaLog.clearCache() // Clear the post-commit snapshot from the cache.
+        deltaLog = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
+        timestamp = deltaLog.snapshot.timestamp
+      }
+      assert(deltaLog.snapshot.checkpointProvider.version == 0)
+      assert(deltaLog.snapshot.version == 1)
+      assert(timestamp == getInCommitTimestamp(deltaLog, 1))
+      // No explicit read.
+      assert(filterUsageRecords(usageRecords, "delta.inCommitTimestamp.read").isEmpty)
+    }
+  }
+
+  test("snapshot.timestamp cannot be populated by protocolMetadataAndICTReconstruction " +
+     "during cold reads of checkpoints") {
+    withTempDir { tempDir =>
+      var deltaLog: DeltaLog = null
+      var timestamp = -1L
+      spark.range(1).write.format("delta").save(tempDir.getAbsolutePath)
+      DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath)).createCheckpointAtVersion(0)
+      val usageRecords = Log4jUsageLogger.track {
+        DeltaLog.clearCache() // Clear the post-commit snapshot from the cache.
+        deltaLog = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
+        timestamp = deltaLog.snapshot.timestamp
+      }
+      assert(deltaLog.snapshot.checkpointProvider.version == 0)
+      assert(timestamp == getInCommitTimestamp(deltaLog, 0))
+      assert(filterUsageRecords(usageRecords, "delta.inCommitTimestamp.read").length == 1)
+    }
+  }
+
+  test("Exceptions during ICT reads from file should be logged") {
+    withTempDir { tempDir =>
+      spark.range(10).write.format("delta").save(tempDir.getAbsolutePath)
+      val deltaLog =
+        DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
+      deltaLog.startTransaction().commit(Seq(createTestAddFile("1")), ManualUpdate)
+      // Remove CommitInfo from the commit.
+      val actions = deltaLog.store.readAsIterator(
+        FileNames.deltaFile(deltaLog.logPath, 1), deltaLog.newDeltaHadoopConf())
+      val actionsWithoutCommitInfo = actions.filterNot(Action.fromJson(_).isInstanceOf[CommitInfo])
+      deltaLog.store.write(
+        FileNames.deltaFile(deltaLog.logPath, 1),
+        actionsWithoutCommitInfo,
+        overwrite = true,
+        deltaLog.newDeltaHadoopConf())
+
+      DeltaLog.clearCache()
+      val latestSnapshot = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath)).snapshot
+      val usageRecords = Log4jUsageLogger.track {
+        try {
+          latestSnapshot.timestamp
+        } catch {
+          case _ : DeltaIllegalStateException => ()
+        }
+      }
+      val ictReadLog = filterUsageRecords(usageRecords, "delta.inCommitTimestamp.read").head
+      val blob = JsonUtils.fromJson[Map[String, String]](ictReadLog.blob)
+      assert(blob("version") == "1")
+      assert(blob("checkpointVersion") == "-1")
+      assert(blob("exceptionMessage").startsWith("[DELTA_MISSING_COMMIT_INFO]"))
+      assert(blob("exceptionStackTrace").contains(Snapshot.getClass.getName.stripSuffix("$")))
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

The ICT is now retrieved during the Protocol & Metadata query. The only time this query will not retrieve the ICT will be when the latest version has a checkpoint. In that case, we fall back to reading the ICT from latest commit directly.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Added multiple tests in InCommitTImestampSuite

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No