### PR TITLE
[CI] Disable running unidoc from the spark CI tests for now

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -69,9 +69,6 @@ def run_sbt_tests(root_dir, test_group, coverage, scala_version=None):
         # when no scala version is specified, run test with only the specified scala version
         cmd += ["++ %s" % scala_version, test_cmd]  # build/sbt ... "++ 2.13.8" "project/test" ...
 
-    if is_running_spark_tests:
-        cmd += ["unidoc"]
-
     if coverage:
         cmd += ["coverageAggregate", "coverageOff"]
     cmd += ["-v"]  # show java options used


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [X] Other (fill in here)

## Description

This removes compiling unidoc from the spark CI tests since we've seen a flaky failure on #2727.

We will follow up and create a separate job just for unidoc (which makes more sense anyways as it should run for changes in any of the projects.)

## How was this patch tested?

CI runs.
