### PR TITLE
[Protocol] Correct Delta Spec DV version field byte range

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1660,7 +1660,7 @@ The concrete format is as follows, with all numerical values written in big endi
 
 Bytes | Name | Description
 -|-|-
-0 — 1 | version | The format version of this file: `1` for the format described here.
+0 | version | The format version of this file: `1` for the format described here.
 `repeat for each DV i` | | For each DV
 `<start of i>` — `<start of i> + 3` | dataSize | Size of this DV’s data (without the checksum)
 `<start of i> + 4` — `<start of i> + 4 + dataSize - 1` | bitmapData | One 64-bit RoaringBitmap serialised as described above.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Protocol)

## Description

The protocol spec accidentally described the version field for the DV file format as being `0 - 1`, i.e. a 2-byte range, but in truth it's only a single byte. This was likely a left-over from when the spec describe the ranges with exclusive bounds, rather than inclusive. This PR corrects this to clarify that only byte 0 contains the version number.

## How was this patch tested?

n/a

## Does this PR introduce _any_ user-facing changes?

No.
