### PR TITLE
[Spark] MERGE INTO: turn on schema evolution when WITH SCHEMA EVOLUTION is given in SQL command

### DIFF
--- a/spark/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
+++ b/spark/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
@@ -264,8 +264,8 @@ class DeltaMergeBuilder private(
   }
 
   /**
-   * Enable schema evolution for the merge operation. This allows the schema of the target table
-   * to be automatically updated based on the schema of the source table.
+   * Enable schema evolution for the merge operation. This allows the schema of the target
+   * table/columns to be automatically updated based on the schema of the source table/columns.
    *
    * @since 3.2.0
    */

--- a/spark/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
+++ b/spark/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
@@ -275,7 +275,7 @@ class DeltaMergeBuilder private(
       this.source,
       this.onCondition,
       this.whenClauses)
-      builder.schemaEvolutionEnabled = true
+    builder.schemaEvolutionEnabled = true
     builder
   }
 

--- a/spark/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
+++ b/spark/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
@@ -158,12 +158,12 @@ class DeltaMergeBuilder private(
   with Logging
   {
 
-    def this(
-        targetTable: DeltaTable,
-        source: DataFrame,
-        onCondition: Column,
-        whenClauses: Seq[DeltaMergeIntoClause]) =
-      this(targetTable, source, onCondition, whenClauses, schemaEvolutionEnabled = false)
+  def this(
+      targetTable: DeltaTable,
+      source: DataFrame,
+      onCondition: Column,
+      whenClauses: Seq[DeltaMergeIntoClause]) =
+    this(targetTable, source, onCondition, whenClauses, schemaEvolutionEnabled = false)
 
   /**
    * Build the actions to perform when the merge condition was matched.  This returns

--- a/spark/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
+++ b/spark/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
@@ -328,7 +328,11 @@ class DeltaMergeBuilder private(
   @Unstable
   private[delta] def withClause(clause: DeltaMergeIntoClause): DeltaMergeBuilder = {
     new DeltaMergeBuilder(
-      this.targetTable, this.source, this.onCondition, this.whenClauses :+ clause)
+      this.targetTable,
+      this.source,
+      this.onCondition,
+      this.whenClauses :+ clause,
+      this.schemaEvolutionEnabled)
   }
 
   private def mergePlan: DeltaMergeInto = {

--- a/spark/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
+++ b/spark/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
@@ -152,12 +152,18 @@ class DeltaMergeBuilder private(
     private val targetTable: DeltaTable,
     private val source: DataFrame,
     private val onCondition: Column,
-    private val whenClauses: Seq[DeltaMergeIntoClause])
+    private val whenClauses: Seq[DeltaMergeIntoClause],
+    private val schemaEvolutionEnabled: Boolean)
   extends AnalysisHelper
   with Logging
   {
 
-  private var schemaEvolutionEnabled: Boolean = false
+    def this(
+        targetTable: DeltaTable,
+        source: DataFrame,
+        onCondition: Column,
+        whenClauses: Seq[DeltaMergeIntoClause]) =
+      this(targetTable, source, onCondition, whenClauses, schemaEvolutionEnabled = false)
 
   /**
    * Build the actions to perform when the merge condition was matched.  This returns
@@ -270,13 +276,12 @@ class DeltaMergeBuilder private(
    * @since 3.2.0
    */
   def withSchemaEvolution(): DeltaMergeBuilder = {
-    val builder = new DeltaMergeBuilder(
+    new DeltaMergeBuilder(
       this.targetTable,
       this.source,
       this.onCondition,
-      this.whenClauses)
-    builder.schemaEvolutionEnabled = true
-    builder
+      this.whenClauses,
+      schemaEvolutionEnabled = true)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/deltaMerge.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/deltaMerge.scala
@@ -269,7 +269,7 @@ case class DeltaMergeIntoNotMatchedBySourceDeleteClause(condition: Option[Expres
  *
  * The syntax of the MERGE statement is as follows.
  * {{{
- *    MERGE INTO <target_table_with_alias>
+ *    MERGE [WITH SCHEMA EVOLUTION] INTO <target_table_with_alias>
  *    USING <source_table_with_alias>
  *    ON <search_condition>
  *    [ WHEN MATCHED [ AND <condition> ] THEN <matched_action> ]
@@ -319,7 +319,7 @@ case class DeltaMergeInto(
     matchedClauses: Seq[DeltaMergeIntoMatchedClause],
     notMatchedClauses: Seq[DeltaMergeIntoNotMatchedClause],
     notMatchedBySourceClauses: Seq[DeltaMergeIntoNotMatchedBySourceClause],
-    migrateSchema: Boolean,
+    withSchemaEvolution: Boolean,
     finalSchema: Option[StructType])
   extends Command with SupportsSubquery {
 
@@ -338,7 +338,8 @@ object DeltaMergeInto {
       target: LogicalPlan,
       source: LogicalPlan,
       condition: Expression,
-      whenClauses: Seq[DeltaMergeIntoClause]): DeltaMergeInto = {
+      whenClauses: Seq[DeltaMergeIntoClause],
+      withSchemaEvolution: Boolean): DeltaMergeInto = {
     val notMatchedClauses = whenClauses.collect { case x: DeltaMergeIntoNotMatchedClause => x }
     val matchedClauses = whenClauses.collect { case x: DeltaMergeIntoMatchedClause => x }
     val notMatchedBySourceClauses =
@@ -381,7 +382,7 @@ object DeltaMergeInto {
       matchedClauses,
       notMatchedClauses,
       notMatchedBySourceClauses,
-      migrateSchema = false,
+      withSchemaEvolution,
       finalSchema = Some(target.schema))
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -532,7 +532,10 @@ class DeltaAnalysis(session: SparkSession)
           newTarget,
           merge.sourceTable,
           merge.mergeCondition,
-          matchedActions ++ notMatchedActions ++ notMatchedBySourceActions
+          matchedActions ++ notMatchedActions ++ notMatchedBySourceActions,
+          // We are waiting for Spark to support the SQL "WITH SCHEMA EVOLUTION" syntax.
+          // After that this argument will be `merge.withSchemaEvolution`.
+          withSchemaEvolution = false
         )
 
         ResolveDeltaMergeInto.resolveReferencesAndSchema(deltaMerge, conf)(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -533,7 +533,7 @@ class DeltaAnalysis(session: SparkSession)
           merge.sourceTable,
           merge.mergeCondition,
           matchedActions ++ notMatchedActions ++ notMatchedBySourceActions,
-          // We are waiting for Spark to support the SQL "WITH SCHEMA EVOLUTION" syntax.
+          // TODO: We are waiting for Spark to support the SQL "WITH SCHEMA EVOLUTION" syntax.
           // After that this argument will be `merge.withSchemaEvolution`.
           withSchemaEvolution = false
         )

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableMerge.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableMerge.scala
@@ -58,7 +58,7 @@ case class PreprocessTableMerge(override val conf: SQLConf)
       matched,
       notMatched,
       notMatchedBySource,
-      migrateSchema,
+      withSchemaEvolution,
       finalSchemaOpt) = mergeInto
 
     if (finalSchemaOpt.isEmpty) {
@@ -108,7 +108,7 @@ case class PreprocessTableMerge(override val conf: SQLConf)
           whenClauses = matched ++ notMatched ++ notMatchedBySource,
           identityColumns = additionalColumns,
           generatedColumns = generatedColumns,
-          allowStructEvolution = migrateSchema,
+          allowStructEvolution = withSchemaEvolution,
           finalSchema = finalSchema)
         m.copy(m.condition, alignedActions)
       case m: DeltaMergeIntoMatchedDeleteClause => m // Delete does not need reordering
@@ -121,7 +121,7 @@ case class PreprocessTableMerge(override val conf: SQLConf)
           whenClauses = matched ++ notMatched ++ notMatchedBySource,
           identityColumns = additionalColumns,
           generatedColumns,
-          migrateSchema,
+          allowStructEvolution = withSchemaEvolution,
           finalSchema)
         m.copy(m.condition, alignedActions)
       case m: DeltaMergeIntoNotMatchedBySourceDeleteClause => m // Delete does not need reordering
@@ -178,7 +178,7 @@ case class PreprocessTableMerge(override val conf: SQLConf)
             castIfNeeded(
               a.expr,
               targetAttrib.dataType,
-              allowStructEvolution = migrateSchema,
+              allowStructEvolution = withSchemaEvolution,
               targetAttrib.name),
             targetColNameResolved = true)
         }.getOrElse {
@@ -215,7 +215,8 @@ case class PreprocessTableMerge(override val conf: SQLConf)
           processedMatched,
           processedNotMatched,
           processedNotMatchedBySource,
-          finalSchemaOpt),
+          migratedSchema = finalSchemaOpt,
+          schemaEvolutionEnabled = withSchemaEvolution),
         now)
     } else {
       DeltaMergeInto(
@@ -225,7 +226,7 @@ case class PreprocessTableMerge(override val conf: SQLConf)
         processedMatched,
         processedNotMatched,
         processedNotMatchedBySource,
-        migrateSchema,
+        withSchemaEvolution,
         finalSchemaOpt)
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ResolveDeltaMergeInto.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ResolveDeltaMergeInto.scala
@@ -44,7 +44,7 @@ object ResolveDeltaMergeInto {
       matchedClauses,
       notMatchedClauses,
       notMatchedBySourceClauses,
-      _,
+      withSchemaEvolution,
       _) = merge
 
     /**
@@ -82,7 +82,7 @@ object ResolveDeltaMergeInto {
       }
     }
 
-    val canAutoMigrate = conf.getConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE)
+    val canAutoMigrate = withSchemaEvolution || conf.getConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE)
     /**
      * Resolves a clause using the given plans (used for resolving the action exprs) and
      * returns the resolved clause.
@@ -295,7 +295,7 @@ object ResolveDeltaMergeInto {
       resolvedMatchedClauses,
       resolvedNotMatchedClauses,
       resolvedNotMatchedBySourceClauses,
-      migrateSchema = canAutoMigrate,
+      withSchemaEvolution = canAutoMigrate,
       finalSchema = Some(finalSchema))
 
     // Its possible that pre-resolved expressions (e.g. `sourceDF("key") = targetDF("key")`) have

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
@@ -66,7 +66,8 @@ case class MergeIntoCommand(
     matchedClauses: Seq[DeltaMergeIntoMatchedClause],
     notMatchedClauses: Seq[DeltaMergeIntoNotMatchedClause],
     notMatchedBySourceClauses: Seq[DeltaMergeIntoNotMatchedBySourceClause],
-    migratedSchema: Option[StructType])
+    migratedSchema: Option[StructType],
+    schemaEvolutionEnabled: Boolean = false)
   extends MergeIntoCommandBase
   with InsertOnlyMergeExecutor
   with ClassicMergeExecutor {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
@@ -54,6 +54,7 @@ trait MergeIntoCommandBase extends LeafRunnableCommand
   val notMatchedClauses: Seq[DeltaMergeIntoNotMatchedClause]
   val notMatchedBySourceClauses: Seq[DeltaMergeIntoNotMatchedBySourceClause]
   val migratedSchema: Option[StructType]
+  val schemaEvolutionEnabled: Boolean
 
   protected def shouldWritePersistentDeletionVectors(
       spark: SparkSession,
@@ -64,10 +65,11 @@ trait MergeIntoCommandBase extends LeafRunnableCommand
 
   override val (canMergeSchema, canOverwriteSchema) = {
     // Delta options can't be passed to MERGE INTO currently, so they'll always be empty.
-    // The methods in options check if the auto migration flag is on, in which case schema evolution
+    // The methods in options check if user has instructed to turn on schema evolution for this
+    // statement, or the auto migration DeltaSQLConf is on, in which case schema evolution
     // will be allowed.
     val options = new DeltaOptions(Map.empty[String, String], conf)
-    (options.canMergeSchema, options.canOverwriteSchema)
+    (schemaEvolutionEnabled || options.canMergeSchema, options.canOverwriteSchema)
   }
 
   @transient protected lazy val sc: SparkContext = SparkContext.getOrCreate()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSQLSuite.scala
@@ -386,8 +386,10 @@ class MergeIntoSQLSuite extends MergeIntoSuiteBase
 
 trait MergeIntoSQLColumnMappingSuiteBase extends DeltaColumnMappingSelectedTestMixin {
   override protected def runOnlyTests: Seq[String] =
-    Seq("schema evolution - new nested column with update non-* and insert * - " +
-      "array of struct - longer target")
+    Seq(
+      "schema evolution - new nested column with update non-* and insert * - " +
+        "array of struct - longer target - on via DeltaSQLConf"
+    )
 }
 
 class MergeIntoSQLIdColumnMappingSuite extends MergeIntoSQLSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSchemaEvolutionSuite.scala
@@ -81,11 +81,11 @@ trait MergeIntoSchemaEvolutionMixin {
 
         if (error != null) {
           val ex = intercept[AnalysisException] {
-            executeMergeFunction(s"delta.`$tempPath` t", s"source s", cond, clauses.toSeq)
+            executeMergeFunction(s"delta.`$tempPath` t", "source s", cond, clauses.toSeq)
           }
           errorContains(Utils.exceptionString(ex), error)
         } else {
-          executeMergeFunction(s"delta.`$tempPath` t", s"source s", cond, clauses.toSeq)
+          executeMergeFunction(s"delta.`$tempPath` t", "source s", cond, clauses.toSeq)
           checkAnswer(
             spark.read.format("delta").load(tempPath),
             df.collect())

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSchemaEvolutionSuite.scala
@@ -86,9 +86,7 @@ trait MergeIntoSchemaEvolutionMixin {
           errorContains(Utils.exceptionString(ex), error)
         } else {
           executeMergeFunction(s"delta.`$tempPath` t", "source s", cond, clauses.toSeq)
-          checkAnswer(
-            spark.read.format("delta").load(tempPath),
-            df.collect())
+          checkAnswer(spark.read.format("delta").load(tempPath), df.collect())
           assert(spark.read.format("delta").load(tempPath).schema.asNullable ===
             df.schema.asNullable)
         }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoTestUtils.scala
@@ -96,18 +96,14 @@ trait MergeIntoSQLTestUtils extends DeltaSQLTestUtils with MergeIntoTestUtils {
       insert: String): Unit =
     sql(basicMergeStmt(target, source, condition, update, insert))
 
-  protected def mergeStmt(
-      target: String,
-      source: String,
-      condition: String,
-      clauses: MergeClause*): String =
-    s"MERGE INTO $target USING $source ON $condition\n" + clauses.map(_.sql).mkString("\n")
-
   override protected def executeMerge(
       tgt: String,
       src: String,
       cond: String,
-      clauses: MergeClause*): Unit = sql(mergeStmt(tgt, src, cond, clauses: _*))
+      clauses: MergeClause*): Unit = {
+    val clausesStr = clauses.map(_.sql).mkString("\n")
+    sql(s"MERGE INTO $tgt USING $src ON $cond\n$clausesStr")
+  }
 }
 
 trait MergeIntoScalaTestUtils extends MergeIntoTestUtils {
@@ -131,8 +127,14 @@ trait MergeIntoScalaTestUtils extends MergeIntoTestUtils {
       tgt: String,
       src: String,
       cond: String,
-      clauses: MergeClause*): Unit = {
+      clauses: MergeClause*): Unit =
+    getMergeBuilder(tgt, src, cond, clauses: _*).execute()
 
+  private def getMergeBuilder(
+      tgt: String,
+      src: String,
+      cond: String,
+      clauses: MergeClause*): DeltaMergeBuilder = {
     def buildClause(clause: MergeClause, mergeBuilder: DeltaMergeBuilder)
       : DeltaMergeBuilder = clause match {
       case _: MatchedClause =>
@@ -198,8 +200,7 @@ trait MergeIntoScalaTestUtils extends MergeIntoTestUtils {
     clauses.foreach { clause =>
       mergeBuilder = buildClause(clause, mergeBuilder)
     }
-    mergeBuilder.execute()
-    deltaTable.toDF
+    mergeBuilder
   }
 
   protected def parseUpdate(update: Seq[String]): Map[String, String] = {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoTestUtils.scala
@@ -102,7 +102,7 @@ trait MergeIntoSQLTestUtils extends DeltaSQLTestUtils with MergeIntoTestUtils {
       cond: String,
       clauses: MergeClause*): Unit = {
     val clausesStr = clauses.map(_.sql).mkString("\n")
-    sql(s"MERGE INTO $tgt USING $src ON $cond\n$clausesStr")
+    sql(s"MERGE INTO $tgt USING $src ON $cond\n" + clausesStr)
   }
 }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/cdc/MergeCDCSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/cdc/MergeCDCSuite.scala
@@ -99,12 +99,12 @@ trait MergeCDCTests extends QueryTest
 
           if (expectErrorContains != null) {
             val ex = intercept[Exception] {
-              executeMerge(s"delta.`$tempPath` t", s"source s", mergeCondition,
+              executeMerge(s"delta.`$tempPath` t", "source s", mergeCondition,
                 clauses.toSeq: _*)
             }
             assert(ex.getMessage.contains(expectErrorContains))
           } else {
-            executeMerge(s"delta.`$tempPath` t", s"source s", mergeCondition,
+            executeMerge(s"delta.`$tempPath` t", "source s", mergeCondition,
               clauses.toSeq: _*)
             checkAnswer(
               spark.read.format("delta").load(tempPath),


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR teaches the `MERGE INTO` command to turn on schema evolution when there exists `WITH SCHEMA EVOLUTION` keywords in the commands.

Changes in this PR are:

1. Modify case classes `MergeIntoCommand` and `DeltaMergeInto` to store schema evolution enablement information.
2. For `DeltaMergeInto`, we reuse the existing migrateSchema fields instead of adding a new one.
3. Scala user-facing `DeltaMergeBuilder` API.

Changed to be done but not in this PR:

1. Python user-facing DeltaMergeBuilder API.
2. Extend schema evolution tests to test `WITH SCHEMA EVOLUTION` keywords.

## How was this patch tested?

Improving the existing tests.



## Does this PR introduce _any_ user-facing changes?

This PR allows user to turn on automatic scheme evolution for a specific MERGE command by issuing `MERGE WITH SCHEMA EVOLUTION INTO ...` SQL commands.
