### PR TITLE
Support Java8 time objects

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceUtils.scala
@@ -63,8 +63,8 @@ object DeltaSourceUtils {
     case v: Boolean => expressions.Literal.create(v)
     case v: java.sql.Date => expressions.Literal.create(v)
     case v: java.sql.Timestamp => expressions.Literal.create(v)
+    case v: java.time.Instant => expressions.Literal.create(v)
     case v: java.time.LocalDate => expressions.Literal.create(v)
-    case v: java.time.LocalDateTime => expressions.Literal.create(v)
     case v: BigDecimal => expressions.Literal.create(v)
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceUtils.scala
@@ -63,6 +63,8 @@ object DeltaSourceUtils {
     case v: Boolean => expressions.Literal.create(v)
     case v: java.sql.Date => expressions.Literal.create(v)
     case v: java.sql.Timestamp => expressions.Literal.create(v)
+    case v: java.time.LocalDate => expressions.Literal.create(v)
+    case v: java.time.LocalDateTime => expressions.Literal.create(v)
     case v: BigDecimal => expressions.Literal.create(v)
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -1607,6 +1607,20 @@ class DeltaSuite extends QueryTest
     }
   }
 
+  test("support Java8 time objects") {
+    withSQLConf(SQLConf.DATETIME_JAVA8API_ENABLED.key -> "true") {
+      val tableName = "my_table"
+      withTable(tableName) {
+        spark.sql(s"CREATE TABLE $tableName (id STRING, date DATE) USING DELTA;")
+        spark.sql(
+          s"""
+             |INSERT INTO $tableName REPLACE
+             |where (DATE IN (DATE('2024-03-11'), DATE('2024-03-13')))
+             |VALUES ('2', DATE('2024-03-13')), ('3', DATE('2024-03-11'))
+             |""".stripMargin)
+      }
+    }
+  }
 
   test("all operations with special characters in path") {
     withTempDir { dir =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -1630,7 +1630,7 @@ class DeltaSuite extends QueryTest
         spark.sql(
           s"""
              |INSERT INTO $tableName REPLACE
-             |where 
+             |where
              | (timestamp IN (TIMESTAMP('2022-12-22 15:50:00'), TIMESTAMP('2022-12-23 15:50:00')))
              | VALUES
              | ('2', TIMESTAMP('2022-12-22 15:50:00')), ('3', TIMESTAMP('2022-12-23 15:50:00'))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -1607,7 +1607,7 @@ class DeltaSuite extends QueryTest
     }
   }
 
-  test("support Java8 time object") {
+  test("support Java8 API for DATE type") {
     withSQLConf(SQLConf.DATETIME_JAVA8API_ENABLED.key -> "true") {
       val tableName = "my_table"
       withTable(tableName) {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -1630,8 +1630,10 @@ class DeltaSuite extends QueryTest
         spark.sql(
           s"""
              |INSERT INTO $tableName REPLACE
-             |where (timestamp IN (TIMESTAMP('2022-12-22 15:50:00'), TIMESTAMP('2022-12-23 15:50:00')))
-             |VALUES ('2', TIMESTAMP('2022-12-22 15:50:00')), ('3', TIMESTAMP('2022-12-23 15:50:00'))
+             |where 
+             | (timestamp IN (TIMESTAMP('2022-12-22 15:50:00'), TIMESTAMP('2022-12-23 15:50:00')))
+             | VALUES
+             | ('2', TIMESTAMP('2022-12-22 15:50:00')), ('3', TIMESTAMP('2022-12-23 15:50:00'))
              |""".stripMargin)
       }
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -1607,7 +1607,7 @@ class DeltaSuite extends QueryTest
     }
   }
 
-  test("support Java8 time objects") {
+  test("support Java8 time object") {
     withSQLConf(SQLConf.DATETIME_JAVA8API_ENABLED.key -> "true") {
       val tableName = "my_table"
       withTable(tableName) {
@@ -1617,6 +1617,21 @@ class DeltaSuite extends QueryTest
              |INSERT INTO $tableName REPLACE
              |where (DATE IN (DATE('2024-03-11'), DATE('2024-03-13')))
              |VALUES ('2', DATE('2024-03-13')), ('3', DATE('2024-03-11'))
+             |""".stripMargin)
+      }
+    }
+  }
+
+  test("support Java8 time object") {
+    withSQLConf(SQLConf.DATETIME_JAVA8API_ENABLED.key -> "true") {
+      val tableName = "my_table"
+      withTable(tableName) {
+        spark.sql(s"CREATE TABLE $tableName (id STRING, timestamp TIMESTAMP) USING DELTA;")
+        spark.sql(
+          s"""
+             |INSERT INTO $tableName REPLACE
+             |where (timestamp IN (TIMESTAMP('2022-12-22 15:50:00'), TIMESTAMP('2022-12-23 15:50:00')))
+             |VALUES ('2', TIMESTAMP('2022-12-22 15:50:00')), ('3', TIMESTAMP('2022-12-23 15:50:00'))
              |""".stripMargin)
       }
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -1622,7 +1622,7 @@ class DeltaSuite extends QueryTest
     }
   }
 
-  test("support Java8 time object") {
+  test("support Java8 API for TIMESTAMP type") {
     withSQLConf(SQLConf.DATETIME_JAVA8API_ENABLED.key -> "true") {
       val tableName = "my_table"
       withTable(tableName) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Added support for Java8 time objects when Java8Api is enabled. 

The following query fails when Java8Api is enabled:

```
INSERT INTO $tableName REPLACE
       where (DATE IN (DATE('2024-03-11'), DATE('2024-03-12')))
       VALUES ('1', DATE('2024-03-13'))
```

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Unit Test.
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
The potential public surface area for this change is limited to only external DateType, TimestampType. By default, Spark converts DateType values to java.sql.Date, TimestampType -> java.sql.Timestamp but with the SQL conf enabled, Spark uses java.time.LocalDate as the external type for DateType and java.time.Instant for TimestampType.

Necessity of fix: If users use Spark 3.0 and enable Java 8, they will be unable to parse and use dates in Delta tables correctly, leading to matching errors.