### PR TITLE
[Spark] Column mapping removal: support tables with deletion vectors, column constraints and generated columns.

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
@@ -96,7 +96,7 @@ trait DeltaColumnMappingBase extends DeltaLogging {
     // No change.
     (oldMode == newMode) ||
       // Downgrade allowed with a flag.
-      (removalAllowed && (oldMode == NameMapping && newMode == NoMapping)) ||
+      (removalAllowed && (oldMode != NoMapping && newMode == NoMapping)) ||
       // Upgrade always allowed.
       (oldMode == NoMapping && newMode == NameMapping)
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/RemoveColumnMappingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/RemoveColumnMappingSuite.scala
@@ -248,7 +248,7 @@ class RemoveColumnMappingSuite extends RemoveColumnMappingSuiteUtils {
          |)
          |USING delta
          |TBLPROPERTIES (
-         |  '${DeltaConfigs.COLUMN_MAPPING_MODE.key}' = 'name'
+         |  '${DeltaConfigs.COLUMN_MAPPING_MODE.key}' = 'name',
          |  'delta.minReaderVersion' = '2',
          |  'delta.minWriterVersion' = '5')
          |""".stripMargin)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/RemoveColumnMappingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/RemoveColumnMappingSuite.scala
@@ -248,7 +248,9 @@ class RemoveColumnMappingSuite extends RemoveColumnMappingSuiteUtils {
          |)
          |USING delta
          |TBLPROPERTIES (
-         |  '${DeltaConfigs.COLUMN_MAPPING_MODE.key}' = 'name')
+         |  '${DeltaConfigs.COLUMN_MAPPING_MODE.key}' = 'name'
+         |  'delta.minReaderVersion' = '2',
+         |  'delta.minWriterVersion' = '5')
          |""".stripMargin)
     // Insert data into the table.
     spark.range(totalRows)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Add additional tests for tables with deletion vectors, generated columns and column constraints for column mapping removal.



## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
New unit tests
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No