### PR TITLE
[Spark] Fix case sensitive of delta statistic column

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
@@ -631,7 +631,8 @@ object StatisticsCollection extends DeltaCommand {
     // Find the unique column names at this nesting depth, each with its path remainders (if any)
     val cols = statsColPaths.groupBy(_.head).mapValues(_.map(_.tail))
     val newSchema = schema.flatMap { field =>
-      cols.get(field.name).flatMap { paths =>
+      val lowerCaseFieldName = field.name.toLowerCase(Locale.ROOT)
+      cols.get(lowerCaseFieldName).flatMap { paths =>
         field.dataType match {
           case _ if paths.forall(_.isEmpty) =>
             // Convert full path to lower cases to avoid schema name contains upper case

--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
@@ -504,17 +504,18 @@ class StatsCollectionSuite
     val tableName = "delta_table_1"
     withTable(tableName) {
       sql(
-        s"create table $tableName (col1 LONG, col2 struct<col20 INT, coL21 LONG>, col3 LONG) " +
-        s"using delta TBLPROPERTIES('delta.dataSkippingStatsColumns' = 'coL1, COL2.Col20, cOl3');"
+        s"create table $tableName (cOl1 LONG, COL2 struct<COL20 INT, CoL21 LONG>, CoL3 LONG) " +
+        s"using delta TBLPROPERTIES" +
+        s"('delta.dataSkippingStatsColumns' = 'coL1, COL2.col20, COL2.col21, cOl3');"
       )
       (1 to 10).foreach { _ =>
         sql(
           s"""insert into $tableName values
-             |(1, struct(1, 1), 1), (2, struct(2, 2), 2), (3, struct(3, 3), 3),
-             |(4, struct(4, 4), 4), (5, struct(5, 5), 5), (6, struct(6, 6), 6),
-             |(7, struct(7, 7), 7), (8, struct(8, 8), 8), (9, struct(9, 9), 9),
-             |(10, struct(10, 10), 10), (null, struct(null, null), null), (-1, struct(-1, -1), -1),
-             |(null, struct(null, null), null);""".stripMargin
+             |(1, struct(1, 10), 1), (2, struct(2, 20), 2), (3, struct(3, 30), 3),
+             |(4, struct(4, 40), 4), (5, struct(5, 50), 5), (6, struct(6, 60), 6),
+             |(7, struct(7, 70), 7), (8, struct(8, 80), 8), (9, struct(9, 90), 9),
+             |(10, struct(10, 100), 10), (null, struct(null, null), null),
+             |(-1, struct(-1, -100), -1), (null, struct(null, null), null);""".stripMargin
         )
       }
       sql(s"optimize $tableName")
@@ -526,9 +527,9 @@ class StatsCollectionSuite
         .collect()
         .foreach { row =>
           assert(row(0) == 130)
-          assert(row(1).asInstanceOf[GenericRow] == Row(20, Row(20), 20))
-          assert(row(2) == Row(-1, Row(-1), -1))
-          assert(row(3) == Row(10, Row(10), 10))
+          assert(row(1).asInstanceOf[GenericRow] == Row(20, Row(20, 20), 20))
+          assert(row(2) == Row(-1, Row(-1, -100), -1))
+          assert(row(3) == Row(10, Row(10, 100), 10))
         }
     }
   }


### PR DESCRIPTION


#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR fixes a bug that happens when collecting the column attributes specified inside Delta statistic column table property.

The Delta statistic column table property translates all columns' name into lower case while table schema keep the case of each column created by customer. As a result, if there are upper case columns inside table definition, the delta statistic collection would miss these columns.

This PR fixes this issue by translating the column name to lower case while searching statistic columns.


## How was this patch tested?

Modify existing test case to cover more column character cases.