### PR TITLE
refactor isSameDomain for JsonMetadataDomain

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -467,7 +467,7 @@ private[delta] class ConflictChecker(
         winningDomainMetadataMap.get(domainMetadataFromCurrentTransaction.domain)) match {
         // No-conflict case.
         case (domain, None) => domain
-        case (domain, _) if RowTrackingMetadataDomain.isRowTrackingDomain(domain) => domain
+        case (domain, _) if RowTrackingMetadataDomain.isSameDomain(domain) => domain
         case (_, Some(_)) =>
           // Any conflict not specifically handled by a previous case must fail the transaction.
           throw new io.delta.exceptions.ConcurrentTransactionException(
@@ -541,7 +541,7 @@ private[delta] class ConflictChecker(
         }
         Some(a.copy(baseRowId = Some(newBaseRowId)))
       // The row ID high water mark will be replaced if it exists.
-      case d: DomainMetadata if RowTrackingMetadataDomain.isRowTrackingDomain(d) => None
+      case d: DomainMetadata if RowTrackingMetadataDomain.isSameDomain(d) => None
       case a => Some(a)
     }
     currentTransactionInfo = currentTransactionInfo.copy(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/JsonMetadataDomain.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/JsonMetadataDomain.scala
@@ -49,5 +49,7 @@ abstract class JsonMetadataDomainUtils[T: Manifest] {
 
   protected def fromJsonConfiguration(domain: DomainMetadata): T =
     JsonUtils.fromJson[T](domain.configuration)
+
+  def isSameDomain(d: DomainMetadata): Boolean = d.domain == domainName
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1599,7 +1599,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
           dataChanged = true
         }
       // Row tracking is able to resolve write conflicts regardless of isolation level.
-      case d: DomainMetadata if RowTrackingMetadataDomain.isRowTrackingDomain(d) =>
+      case d: DomainMetadata if RowTrackingMetadataDomain.isSameDomain(d) =>
         // Do nothing
       case _ =>
         hasIncompatibleActions = true

--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowId.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowId.scala
@@ -38,8 +38,6 @@ object RowId {
       case d: DomainMetadata if d.domain == domainName => Some(fromJsonConfiguration(d))
       case _ => None
     }
-
-    def isRowTrackingDomain(d: DomainMetadata): Boolean = d.domain == domainName
   }
 
   val MISSING_HIGH_WATER_MARK: Long = -1L
@@ -87,7 +85,7 @@ object RowId {
           throw DeltaErrors.rowIdAssignmentWithoutStats
         }
         a.copy(baseRowId = Some(baseRowId))
-      case d: DomainMetadata if RowTrackingMetadataDomain.isRowTrackingDomain(d) =>
+      case d: DomainMetadata if RowTrackingMetadataDomain.isSameDomain(d) =>
         throw new IllegalStateException(
           "Manually setting the Row ID high water mark is not allowed")
       case other => other


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This refactors `RowTrackingMetadataDomain.isRowTrackingDomain` to `JsonMetadataDomain.isSameDomain` so that it can be useful for other domain metadata.

## How was this patch tested?
Existing unit tests.