### PR TITLE
[Spark] Use checkError for testing DeltaAnalysisException

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameWriterV2Suite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameWriterV2Suite.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{LongType, StringType, StructType}
+import org.apache.spark.util.Utils
 
 // These tests are copied from Apache Spark (minus partition by expressions) and should work exactly
 // the same with Delta minus some writer options

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSinkSuite.scala
@@ -400,8 +400,10 @@ class DeltaSinkSuite
             .mode("append")
             .save(outputDir.getCanonicalPath)
         }
-        assert(e.getErrorClass == "DELTA_FAILED_TO_MERGE_FIELDS")
-        assert(Utils.exceptionString(e).contains("incompatible"))
+        checkError(
+          exception = e,
+          errorClass = "DELTA_FAILED_TO_MERGE_FIELDS",
+          parameters = Map("currentField" -> "id", "updateField" -> "id"))
       } finally {
         query.stop()
       }
@@ -430,9 +432,10 @@ class DeltaSinkSuite
         q.processAllAvailable()
       }
       assert(wrapperException.cause.isInstanceOf[AnalysisException])
-      assert(wrapperException.cause.asInstanceOf[AnalysisException]
-        .getErrorClass == "DELTA_FAILED_TO_MERGE_FIELDS")
-      assert(Utils.exceptionString(wrapperException.cause).contains("incompatible"))
+      checkError(
+        exception = wrapperException.cause.asInstanceOf[AnalysisException],
+        errorClass = "DELTA_FAILED_TO_MERGE_FIELDS",
+        parameters = Map("currentField" -> "id", "updateField" -> "id"))
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -1303,8 +1303,10 @@ class DeltaSuite extends QueryTest
           .mode("append")
           .save(tempDir.toString)
       }
-      assert(e.getErrorClass == "DELTA_FAILED_TO_MERGE_FIELDS")
-      assert(Utils.exceptionString(e).contains("incompatible"))
+      checkError(
+        exception = e,
+        errorClass = "DELTA_FAILED_TO_MERGE_FIELDS",
+        parameters = Map("currentField" -> "value", "updateField" -> "value"))
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
@@ -59,6 +59,16 @@ class SchemaUtilsSuite extends QueryTest
       s"Error message '$msg' didn't contain: $shouldContain")
   }
 
+  private def expectFailurePattern(shouldContainPatterns: String*)(f: => Unit): Unit = {
+    val e = intercept[AnalysisException] {
+      f
+    }
+    val patterns =
+      shouldContainPatterns.map(regex => Pattern.compile(regex, Pattern.CASE_INSENSITIVE))
+    assert(patterns.forall(_.matcher(e.getMessage).find()),
+      s"Error message '${e.getMessage}' didn't contain the patterns: $shouldContainPatterns")
+  }
+
   private def expectAnalysisErrorClass(errorClass: String, params: Map[String, String])
                                       (f: => Unit): Unit = {
     val e = intercept[AnalysisException] {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
@@ -41,7 +41,6 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
-import org.apache.spark.util.Utils
 
 class SchemaUtilsSuite extends QueryTest
   with SharedSparkSession
@@ -60,39 +59,26 @@ class SchemaUtilsSuite extends QueryTest
       s"Error message '$msg' didn't contain: $shouldContain")
   }
 
-  private def expectFailurePattern(shouldContainPatterns: String*)(f: => Unit): Unit = {
+  private def expectAnalysisErrorClass(errorClass: String, params: Map[String, String])
+                              (f: => Unit): Unit = {
     val e = intercept[AnalysisException] {
       f
     }
-    val patterns =
-      shouldContainPatterns.map(regex => Pattern.compile(regex, Pattern.CASE_INSENSITIVE))
-    assert(patterns.forall(_.matcher(e.getMessage).find()),
-      s"Error message '${e.getMessage}' didn't contain the patterns: $shouldContainPatterns")
-  }
 
-  private def expectErrorClassAndCause(errorClass: String)(shouldContain: String*)
-                                      (f: => Unit): Unit = {
-    val e = intercept[AnalysisException] {
-      f
+    @tailrec
+    def getError(ex: Throwable): Option[DeltaAnalysisException] = ex match {
+      case e: DeltaAnalysisException if e.getErrorClass() == errorClass => Some(e)
+      case e: AnalysisException => getError(e.getCause)
+      case _ => None
     }
-    val msg = Utils.exceptionString(e).toLowerCase(Locale.ROOT)
-    assert(e.getErrorClass == errorClass)
-    assert(
-      shouldContain.map(_.toLowerCase(Locale.ROOT)).forall(msg.contains),
-      s"Error cause didn't contain: $shouldContain"
-    )
-  }
 
-  private def expectErrorClassAndCausePattern(errorClass: String)
-                                             (shouldContainPatterns: String*)(f: => Unit): Unit = {
-    val e = intercept[AnalysisException] {
-      f
-    }
-    assert(e.getErrorClass == errorClass)
-    val patterns =
-      shouldContainPatterns.map(regex => Pattern.compile(regex, Pattern.CASE_INSENSITIVE))
-    assert(patterns.forall(_.matcher(Utils.exceptionString(e)).find()),
-      s"Error cause didn't contain the patterns: $shouldContainPatterns")
+    val err = getError(e)
+    assert(err.isDefined, "exception with the error class not found")
+    checkError(
+      exception = err.get,
+      errorClass = errorClass,
+      parameters = params,
+      matchPVals = true)
   }
 
   /////////////////////////////
@@ -2172,10 +2158,12 @@ class SchemaUtilsSuite extends QueryTest
         .add("b", DecimalType(18, 10))))
       .add("map", MapType(StringType, StringType))
 
-    expectErrorClassAndCause("DELTA_FAILED_TO_MERGE_FIELDS")("StringType", "IntegerType") {
+    expectAnalysisErrorClass("DELTA_MERGE_INCOMPATIBLE_DATATYPE",
+      Map("currentDataType" -> "StringType", "updateDataType" -> "IntegerType")) {
       mergeSchemas(base, new StructType().add("top", IntegerType))
     }
-    expectErrorClassAndCause("DELTA_FAILED_TO_MERGE_FIELDS")("IntegerType", "DateType") {
+    expectAnalysisErrorClass("DELTA_MERGE_INCOMPATIBLE_DATATYPE",
+      Map("currentDataType" -> "IntegerType", "updateDataType" -> "DateType")) {
       mergeSchemas(base, new StructType()
         .add("struct", new StructType().add("a", DateType)))
     }
@@ -2184,37 +2172,39 @@ class SchemaUtilsSuite extends QueryTest
     //   `StructType(StructField(a,IntegerType,true))`.
     // - In Scala 2.13, it extends `scala.collection.immutable.Seq` which returns
     //   `Seq(StructField(a,IntegerType,true))`.
-    expectErrorClassAndCausePattern("DELTA_FAILED_TO_MERGE_FIELDS")(
-      "'struct'", "StructType|Seq\\(", "MapType") {
+    expectAnalysisErrorClass("DELTA_MERGE_INCOMPATIBLE_DATATYPE",
+      Map("currentDataType" -> "(StructType|Seq)\\(.*", "updateDataType" -> "MapType\\(.*")) {
       mergeSchemas(base, new StructType()
         .add("struct", MapType(StringType, IntegerType)))
     }
-    expectErrorClassAndCause("DELTA_FAILED_TO_MERGE_FIELDS")(
-      "'array'", "DecimalType", "DoubleType") {
+    expectAnalysisErrorClass("DELTA_MERGE_INCOMPATIBLE_DATATYPE",
+      Map("currentDataType" -> "DecimalType\\(.*", "updateDataType" -> "DoubleType")) {
       mergeSchemas(base, new StructType()
         .add("array", ArrayType(new StructType().add("b", DoubleType))))
     }
-    expectErrorClassAndCause("DELTA_FAILED_TO_MERGE_FIELDS")("'array'", "scale") {
+    expectAnalysisErrorClass("DELTA_MERGE_INCOMPATIBLE_DECIMAL_TYPE",
+      Map("decimalRanges" -> "scale.*")) {
       mergeSchemas(base, new StructType()
         .add("array", ArrayType(new StructType().add("b", DecimalType(18, 12)))))
     }
-    expectErrorClassAndCause("DELTA_FAILED_TO_MERGE_FIELDS")("'array'", "precision") {
+    expectAnalysisErrorClass("DELTA_MERGE_INCOMPATIBLE_DECIMAL_TYPE",
+      Map("decimalRanges" -> "precision.*")) {
       mergeSchemas(base, new StructType()
         .add("array", ArrayType(new StructType().add("b", DecimalType(16, 10)))))
     }
     // See the above comment about `StructType`
-    expectErrorClassAndCausePattern("DELTA_FAILED_TO_MERGE_FIELDS")(
-      "'map'", "MapType", "StructType|Seq\\(") {
+    expectAnalysisErrorClass("DELTA_MERGE_INCOMPATIBLE_DATATYPE",
+      Map("currentDataType" -> "MapType\\(.*", "updateDataType" -> "(StructType|Seq)\\(.*")) {
       mergeSchemas(base, new StructType()
         .add("map", new StructType().add("b", StringType)))
     }
-    expectErrorClassAndCause("DELTA_FAILED_TO_MERGE_FIELDS")(
-      "'map'", "StringType", "IntegerType") {
+    expectAnalysisErrorClass("DELTA_MERGE_INCOMPATIBLE_DATATYPE",
+      Map("currentDataType" -> "StringType", "updateDataType" -> "IntegerType")) {
       mergeSchemas(base, new StructType()
         .add("map", MapType(StringType, IntegerType)))
     }
-    expectErrorClassAndCause("DELTA_FAILED_TO_MERGE_FIELDS")(
-      "'map'", "StringType", "IntegerType") {
+    expectAnalysisErrorClass("DELTA_MERGE_INCOMPATIBLE_DATATYPE",
+      Map("currentDataType" -> "StringType", "updateDataType" -> "IntegerType")) {
       mergeSchemas(base, new StructType()
         .add("map", MapType(IntegerType, StringType)))
     }
@@ -2286,9 +2276,11 @@ class SchemaUtilsSuite extends QueryTest
       val e = intercept[DeltaAnalysisException] {
           mergeSchemas(longType, sourceType)
         }
-      assert(e.getErrorClass == "DELTA_FAILED_TO_MERGE_FIELDS")
-      assert(Utils.exceptionString(e).contains(
-        s"Failed to merge incompatible data types LongType and ${sourceType.head.dataType}"))
+      checkError(
+        exception = e.getCause.asInstanceOf[AnalysisException],
+        errorClass = "DELTA_MERGE_INCOMPATIBLE_DATATYPE",
+        parameters = Map("currentDataType" -> "LongType",
+          "updateDataType" -> sourceType.head.dataType.toString))
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
@@ -60,7 +60,7 @@ class SchemaUtilsSuite extends QueryTest
   }
 
   private def expectAnalysisErrorClass(errorClass: String, params: Map[String, String])
-                              (f: => Unit): Unit = {
+                                      (f: => Unit): Unit = {
     val e = intercept[AnalysisException] {
       f
     }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Followup for this PR https://github.com/delta-io/delta/pull/2695, that classifies DeltaAnalysisException. This includes test change only to use checkError for exception verification.

## How was this patch tested?
existing tests changed

## Does this PR introduce _any_ user-facing changes?
No
