### PR TITLE
Spark cross compilation shim v1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -116,7 +116,7 @@ lazy val spark = (project in file("spark"))
       "org.apache.spark" %% "spark-sql" % sparkVersion % "test" classifier "tests",
       "org.apache.spark" %% "spark-hive" % sparkVersion % "test" classifier "tests",
     ),
-    Compile / unmanagedSourceDirectories := Seq((baseDirectory in Compile).value, "src", "shim-spark-3.5"),
+    Compile / unmanagedSourceDirectories ++= Seq((baseDirectory in Compile).value / "src" / "shim-spark-3.5"),
     // For adding staged Spark RC versions, Ex:
     // resolvers += "Apche Spark 3.5.0 (RC1) Staging" at "https://repository.apache.org/content/repositories/orgapachespark-1444/",
     Compile / packageBin / mappings := (Compile / packageBin / mappings).value ++

--- a/build.sbt
+++ b/build.sbt
@@ -116,6 +116,7 @@ lazy val spark = (project in file("spark"))
       "org.apache.spark" %% "spark-sql" % sparkVersion % "test" classifier "tests",
       "org.apache.spark" %% "spark-hive" % sparkVersion % "test" classifier "tests",
     ),
+    Compile / unmanagedSourceDirectories := Seq((baseDirectory in Compile).value, "src", "shim-spark-3.5"),
     // For adding staged Spark RC versions, Ex:
     // resolvers += "Apche Spark 3.5.0 (RC1) Staging" at "https://repository.apache.org/content/repositories/orgapachespark-1444/",
     Compile / packageBin / mappings := (Compile / packageBin / mappings).value ++

--- a/spark/src/main/scala/io/delta/tables/execution/VacuumTableCommand.scala
+++ b/spark/src/main/scala/io/delta/tables/execution/VacuumTableCommand.scala
@@ -77,7 +77,7 @@ object VacuumTableCommand {
       dryRun: Boolean): VacuumTableCommand = {
     val child = UnresolvedDeltaPathOrIdentifier(path, table, "VACUUM")
     val unresolvedInventoryTable = inventoryTable.map(rt =>
-      UnresolvedTable(rt.nameParts, "VACUUM", relationTypeMismatchHint = None))
+      UnresolvedTableShim.createUnresolvedTable(rt.nameParts, "VACUUM", relationTypeMismatchHint = None))
     VacuumTableCommand(child, horizonHours, unresolvedInventoryTable, inventoryQuery, dryRun)
   }
 }

--- a/spark/src/main/scala/io/delta/tables/execution/VacuumTableCommand.scala
+++ b/spark/src/main/scala/io/delta/tables/execution/VacuumTableCommand.scala
@@ -29,6 +29,8 @@ import org.apache.spark.sql.delta.commands.VacuumCommand.getDeltaTable
 import org.apache.spark.sql.execution.command.{LeafRunnableCommand, RunnableCommand}
 import org.apache.spark.sql.types.StringType
 
+import foo.bar.UnresolvedTableShim
+
 /**
  * The `vacuum` command implementation for Spark SQL. Example SQL:
  * {{{
@@ -77,7 +79,8 @@ object VacuumTableCommand {
       dryRun: Boolean): VacuumTableCommand = {
     val child = UnresolvedDeltaPathOrIdentifier(path, table, "VACUUM")
     val unresolvedInventoryTable = inventoryTable.map(rt =>
-      UnresolvedTableShim.createUnresolvedTable(rt.nameParts, "VACUUM", relationTypeMismatchHint = None))
+      UnresolvedTableShim.createUnresolvedTable(
+        rt.nameParts, "VACUUM", relationTypeMismatchHint = None))
     VacuumTableCommand(child, horizonHours, unresolvedInventoryTable, inventoryQuery, dryRun)
   }
 }

--- a/spark/src/shim-spark-3.5/UnresolvedTableShim.scala
+++ b/spark/src/shim-spark-3.5/UnresolvedTableShim.scala
@@ -1,10 +1,28 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package foo.bar
+
 import org.apache.spark.sql.catalyst.analysis.UnresolvedTable
 
 object UnresolvedTableShim {
   def createUnresolvedTable(
       tableNameParts: Seq[String],
       commandName: String,
-      relationTypeMismatchHint: Option[String] = None) = {
+      relationTypeMismatchHint: Option[String] = None): UnresolvedTable = {
     UnresolvedTable(tableNameParts, commandName, relationTypeMismatchHint)
   }
 }

--- a/spark/src/shim-spark-3.5/UnresolvedTableShim.scala
+++ b/spark/src/shim-spark-3.5/UnresolvedTableShim.scala
@@ -1,0 +1,10 @@
+import org.apache.spark.sql.catalyst.analysis.UnresolvedTable
+
+object UnresolvedTableShim {
+  def createUnresolvedTable(
+      tableNameParts: Seq[String],
+      commandName: String,
+      relationTypeMismatchHint: Option[String] = None) = {
+    UnresolvedTable(tableNameParts, commandName, relationTypeMismatchHint)
+  }
+}

--- a/spark/src/shim-spark-4.0/UnresolvedTableShim.scala
+++ b/spark/src/shim-spark-4.0/UnresolvedTableShim.scala
@@ -1,0 +1,10 @@
+import org.apache.spark.sql.catalyst.analysis.UnresolvedTable
+
+object UnresolvedTableShim {
+  def createUnresolvedTable(
+      tableNameParts: Seq[String],
+      commandName: String,
+      relationTypeMismatchHint: Option[String] = None) = {
+    UnresolvedTable(tableNameParts, commandName)
+  }
+}

--- a/spark/src/shim-spark-4.0/UnresolvedTableShim.scala
+++ b/spark/src/shim-spark-4.0/UnresolvedTableShim.scala
@@ -1,10 +1,26 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import org.apache.spark.sql.catalyst.analysis.UnresolvedTable
 
 object UnresolvedTableShim {
   def createUnresolvedTable(
       tableNameParts: Seq[String],
       commandName: String,
-      relationTypeMismatchHint: Option[String] = None) = {
+      relationTypeMismatchHint: Option[String] = None): UnresolvedTable = {
     UnresolvedTable(tableNameParts, commandName)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
