### PR TITLE
[Spark] Delete disabled flaky DeltaLogSuite test case

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -689,27 +689,6 @@ class DeltaLogSuite extends QueryTest
     }
   }
 
-  ignore("DeltaLog should throw exception when unable to create log directory " +
-    "with silent filesystem failure") {
-    withTempDir { dir =>
-      val path = dir.getCanonicalPath
-      val log = DeltaLog.forTable(spark, new Path(path))
-      val fs = log.logPath.getFileSystem(log.newDeltaHadoopConf())
-
-      // Set parent directory to be read-only.
-      // Attempting to create a child file/directory should fail.
-      // Both the log directory and commit directory are typically created as part
-      // of ensureLogDirectoryExist(), so we need to create the log
-      // directory ourselves if we want to apply permissions.
-      fs.mkdirs(log.logPath, new FsPermission(444))
-
-      val e = intercept[DeltaIOException] {
-        log.ensureLogDirectoryExist()
-      }
-      checkError(e, "DELTA_CANNOT_CREATE_LOG_PATH")
-    }
-  }
-
   test("DeltaLog should throw exception when unable to create log directory " +
     "with filesystem IO Exception") {
     withTempDir { dir =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Delete a currently ignored test case.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
N/A (only a test removal)
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
