### PR TITLE
[Spark] OPTIMIZE on clustered table with no clustering columns should run compaction

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -239,7 +239,9 @@ class OptimizeExecutor(
 
   private val isClusteredTable = ClusteredTableUtils.isSupported(txn.snapshot.protocol)
 
-  private val isMultiDimClustering = isClusteredTable || zOrderByColumns.nonEmpty
+  private val isMultiDimClustering =
+    optimizeStrategy.isInstanceOf[ClusteringStrategy] ||
+    optimizeStrategy.isInstanceOf[ZOrderStrategy]
 
   private val clusteringColumns: Seq[String] = {
     if (zOrderByColumns.nonEmpty) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableStrategy.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableStrategy.scala
@@ -118,8 +118,9 @@ object OptimizeTableStrategy {
 
   private def getMode(snapshot: Snapshot, zOrderBy: Seq[String]): OptimizeTableMode.Value = {
     val isClusteredTable = ClusteredTableUtils.isSupported(snapshot.protocol)
+    val hasClusteringColumns = ClusteringColumnInfo.extractLogicalNames(snapshot).nonEmpty
     val isZOrderBy = zOrderBy.nonEmpty
-    if (isClusteredTable) {
+    if (isClusteredTable && hasClusteringColumns) {
       assert(!isZOrderBy)
       OptimizeTableMode.CLUSTERING
     } else if (isZOrderBy) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Currently, when running OPTIMIZE on a clustered table without any clustering columns(after ALTER TABLE CLUSTER BY NONE), it would fail with a long stack trace:
```
[info]   org.apache.spark.SparkException: Exception thrown in awaitResult:
[info]   at org.apache.spark.util.SparkThreadUtils$.awaitResult(SparkThreadUtils.scala:56)
[info]   at org.apache.spark.util.ThreadUtils$.awaitResult(ThreadUtils.scala:310)
[info]   at org.apache.spark.util.ThreadUtils$.parmap(ThreadUtils.scala:383)
[info]   at org.apache.spark.sql.delta.commands.OptimizeExecutor.$anonfun$optimize$1(OptimizeTableCommand.scala:276)
...
[info]   Cause: java.util.concurrent.ExecutionException: Boxed Error
[info]   at scala.concurrent.impl.Promise$.resolver(Promise.scala:87)
...
[info]   Cause: java.lang.AssertionError: assertion failed: Cannot cluster by zero columns!
[info]   at scala.Predef$.assert(Predef.scala:223)
[info]   at org.apache.spark.sql.delta.skipping.MultiDimClustering$.cluster(MultiDimClustering.scala:51)
[info]   at org.apache.spark.sql.delta.commands.OptimizeExecutor.runOptimizeBinJob(OptimizeTableCommand.scala:427)
[info]   at org.apache.spark.sql.delta.commands.OptimizeExecutor.$anonfun$optimize$6(OptimizeTableCommand.scala:277)
...
```

This change makes OPTIMIZE on a clustered table without any clustering columns run regular compaction, which is the desired behavior.
## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
This change adds a new test to verify the correct behavior. The test would fail without the fix.
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.