### PR TITLE
[PySpark] Add schema evolution config to PySpark `DeltaMergeBuilder`

### DIFF
--- a/python/delta/tables.py
+++ b/python/delta/tables.py
@@ -1013,6 +1013,19 @@ class DeltaMergeBuilder(object):
         new_jbuilder = self.__getNotMatchedBySourceBuilder(condition).delete()
         return DeltaMergeBuilder(self._spark, new_jbuilder)
 
+    @since(3.2)  # type: ignore[arg-type]
+    def withSchemaEvolution(self) -> "DeltaMergeBuilder":
+        """
+        Enable schema evolution for the merge operation. This allows the target table schema to
+        be automatically updated based on the schema of the source DataFrame.
+
+        See :py:class:`~delta.tables.DeltaMergeBuilder` for complete usage details.
+
+        :return: this builder
+        """
+        new_jbuilder = self._jbuilder.withSchemaEvolution()
+        return DeltaMergeBuilder(self._spark, new_jbuilder)
+
     @since(0.4)  # type: ignore[arg-type]
     def execute(self) -> None:
         """


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [X] PySpark

## Description

This PR continues from https://github.com/delta-io/delta/pull/2737 to add a `withSchemaEvolution()` method for `DeltaMergeBuilder` in PySpark.


## How was this patch tested?

New unit tests.

## Does this PR introduce _any_ user-facing changes?

Yes, this PR allows the user to turn on schema evolution for MERGE in PySpark by calling the `table.merge(...).withSchemaEvolution()` method.