### PR TITLE
[DO_NOT_MERGE] Removing usage of new AnalysisException(String: msg) -- Option 2 adjust `DeltaAnalysisException` to expose a constructor for (String: msg)

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -295,7 +295,7 @@ trait DeltaErrorsBase
   }
 
   def invalidConstraintName(name: String): AnalysisException = {
-    new AnalysisException(s"Cannot use '$name' as the name of a CHECK constraint.")
+    new DeltaAnalysisException(s"Cannot use '$name' as the name of a CHECK constraint.")
   }
 
   def nonexistentConstraint(constraintName: String, tableName: String): AnalysisException = {
@@ -3481,7 +3481,7 @@ class DeltaIllegalStateException(
   override def getErrorClass: String = errorClass
 
   override def getMessageParameters: java.util.Map[String, String] = {
-    DeltaThrowableHelper.getParameterNames(errorClass, null)
+    DeltaThrowableHelper.getParameterNames(Option(errorClass), errorSubClass = None)
       .zip(messageParameters).toMap.asJava
   }
 }
@@ -3545,7 +3545,7 @@ class DeltaRuntimeException(
   override def getErrorClass: String = errorClass
 
   override def getMessageParameters: java.util.Map[String, String] =
-    DeltaThrowableHelper.getParameterNames(errorClass, null)
+    DeltaThrowableHelper.getParameterNames(Option(errorClass), errorSubClass = None)
       .zip(messageParameters).toMap.asJava
 }
 
@@ -3610,8 +3610,8 @@ class DeltaTablePropertyValidationFailedException(
 
   override def getMessageParameters: java.util.Map[String, String] = {
     DeltaThrowableHelper.getParameterNames(
-      "DELTA_VIOLATE_TABLE_PROPERTY_VALIDATION_FAILED",
-      subClass.tag).zip(subClass.messageParameters(table)).toMap.asJava
+      Some("DELTA_VIOLATE_TABLE_PROPERTY_VALIDATION_FAILED"),
+      Some(subClass.tag)).zip(subClass.messageParameters(table)).toMap.asJava
   }
 
   override def getErrorClass: String =

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaThrowable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaThrowable.scala
@@ -24,8 +24,7 @@ import org.apache.spark.SparkThrowable
 trait DeltaThrowable extends SparkThrowable {
   // Portable error identifier across SQL engines
   // If null, error class or SQLSTATE is not set
-  override def getSqlState: String =
-    DeltaThrowableHelper.getSqlState(this.getErrorClass.split('.').head)
+  override def getSqlState: String = DeltaThrowableHelper.getSqlState(this.getErrorClass)
 
   // True if this error is an internal error.
   override def isInternalError: Boolean = DeltaThrowableHelper.isInternalError(this.getErrorClass)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaThrowableHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaThrowableHelper.scala
@@ -63,11 +63,13 @@ object DeltaThrowableHelper
 
   def isInternalError(errorClass: String): Boolean = errorClass == "INTERNAL_ERROR"
 
-  def getParameterNames(errorClass: String, errorSubClass: String): Array[String] = {
-    val wholeErrorClass = if (errorSubClass == null) {
-      errorClass
-    } else {
-      errorClass + "." + errorSubClass
+  def getParameterNames(
+      errorClass: Option[String],
+      errorSubClass: Option[String]): Array[String] = {
+    val wholeErrorClass = (errorClass, errorSubClass) match {
+      case (Some(errorClass), Some(errorSubClass)) => errorClass + "." + errorSubClass
+      case (Some(errorClass), None) => errorClass
+      case _ => return Array.empty
     }
     val parameterizedMessage = errorClassReader.getMessageTemplate(wholeErrorClass)
     val pattern = "<[a-zA-Z0-9_-]+>".r

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ResolveDeltaMergeInto.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ResolveDeltaMergeInto.scala
@@ -78,6 +78,7 @@ object ResolveDeltaMergeInto {
         throw new DeltaAnalysisException(
           errorClass = "DELTA_MERGE_UNRESOLVED_EXPRESSION",
           messageParameters = Array(a.sql, mergeClauseType, cols),
+          cause = None,
           origin = Some(a.origin))
       }
     }
@@ -310,6 +311,7 @@ object ResolveDeltaMergeInto {
         errorClass = "DELTA_MERGE_RESOLVED_ATTRIBUTE_MISSING_FROM_INPUT",
         messageParameters = Array(missingAttributes, input,
           resolvedMerge.simpleString(SQLConf.get.maxToStringFields)),
+        cause = None,
         origin = Some(resolvedMerge.origin)
       )
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
@@ -1940,7 +1940,7 @@ class DeltaColumnMappingSuite extends QueryTest
           exception = e,
           errorClass = errorClass,
           parameters = DeltaThrowableHelper
-            .getParameterNames(errorClass, errorSubClass = null)
+            .getParameterNames(Option(errorClass), errorSubClass = None)
             .zip(invalidColumns).toMap
         )
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
