### PR TITLE
Automatic type widening in INSERT

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -66,7 +66,7 @@ import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.execution.streaming.StreamingRelation
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{ArrayType, DataType, IntegerType, MapType, StructField, StructType}
+import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
@@ -81,8 +81,8 @@ class DeltaAnalysis(session: SparkSession)
   override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsDown {
     // INSERT INTO by ordinal and df.insertInto()
     case a @ AppendDelta(r, d) if !a.isByName &&
-        needsSchemaAdjustmentByOrdinal(d.name(), a.query, r.schema) =>
-      val projection = resolveQueryColumnsByOrdinal(a.query, r.output, d.name())
+        needsSchemaAdjustmentByOrdinal(d, a.query, r.schema) =>
+      val projection = resolveQueryColumnsByOrdinal(a.query, r.output, d)
       if (projection != a.query) {
         a.copy(query = projection)
       } else {
@@ -208,8 +208,8 @@ class DeltaAnalysis(session: SparkSession)
 
     // INSERT OVERWRITE by ordinal and df.insertInto()
     case o @ OverwriteDelta(r, d) if !o.isByName &&
-        needsSchemaAdjustmentByOrdinal(d.name(), o.query, r.schema) =>
-      val projection = resolveQueryColumnsByOrdinal(o.query, r.output, d.name())
+        needsSchemaAdjustmentByOrdinal(d, o.query, r.schema) =>
+      val projection = resolveQueryColumnsByOrdinal(o.query, r.output, d)
       if (projection != o.query) {
         val aliases = AttributeMap(o.query.output.zip(projection.output).collect {
           case (l: AttributeReference, r: AttributeReference) if !l.sameRef(r) => (l, r)
@@ -245,9 +245,9 @@ class DeltaAnalysis(session: SparkSession)
     case o @ DynamicPartitionOverwriteDelta(r, d) if o.resolved
       =>
       val adjustedQuery = if (!o.isByName &&
-          needsSchemaAdjustmentByOrdinal(d.name(), o.query, r.schema)) {
+          needsSchemaAdjustmentByOrdinal(d, o.query, r.schema)) {
         // INSERT OVERWRITE by ordinal and df.insertInto()
-        resolveQueryColumnsByOrdinal(o.query, r.output, d.name())
+        resolveQueryColumnsByOrdinal(o.query, r.output, d)
       } else if (o.isByName && o.origin.sqlText.nonEmpty &&
           needsSchemaAdjustmentByName(o.query, r.output, d)) {
         // INSERT OVERWRITE by name
@@ -850,12 +850,14 @@ class DeltaAnalysis(session: SparkSession)
    * type column/field.
    */
   private def resolveQueryColumnsByOrdinal(
-      query: LogicalPlan, targetAttrs: Seq[Attribute], tblName: String): LogicalPlan = {
+      query: LogicalPlan, targetAttrs: Seq[Attribute], deltaTable: DeltaTableV2): LogicalPlan = {
     // always add a Cast. it will be removed in the optimizer if it is unnecessary.
     val project = query.output.zipWithIndex.map { case (attr, i) =>
       if (i < targetAttrs.length) {
         val targetAttr = targetAttrs(i)
-        addCastToColumn(attr, targetAttr, tblName)
+        addCastToColumn(attr, targetAttr, deltaTable.name(),
+          allowTypeWidening = allowTypeWidening(deltaTable)
+        )
       } else {
         attr
       }
@@ -890,7 +892,9 @@ class DeltaAnalysis(session: SparkSession)
         .getOrElse {
           throw DeltaErrors.missingColumn(attr, targetAttrs)
         }
-      addCastToColumn(attr, targetAttr, deltaTable.name())
+      addCastToColumn(attr, targetAttr, deltaTable.name(),
+        allowTypeWidening = allowTypeWidening(deltaTable)
+      )
     }
     Project(project, query)
   }
@@ -898,19 +902,38 @@ class DeltaAnalysis(session: SparkSession)
   private def addCastToColumn(
       attr: Attribute,
       targetAttr: Attribute,
-      tblName: String): NamedExpression = {
+      tblName: String,
+      allowTypeWidening: Boolean): NamedExpression = {
     val expr = (attr.dataType, targetAttr.dataType) match {
       case (s, t) if s == t =>
         attr
       case (s: StructType, t: StructType) if s != t =>
-        addCastsToStructs(tblName, attr, s, t)
+        addCastsToStructs(tblName, attr, s, t, allowTypeWidening)
       case (ArrayType(s: StructType, sNull: Boolean), ArrayType(t: StructType, tNull: Boolean))
           if s != t && sNull == tNull =>
-        addCastsToArrayStructs(tblName, attr, s, t, sNull)
+        addCastsToArrayStructs(tblName, attr, s, t, sNull, allowTypeWidening)
+      case (s: AtomicType, t: AtomicType)
+        if allowTypeWidening && TypeWidening.isTypeChangeSupportedForSchemaEvolution(t, s) =>
+        // Keep the type from the query, the target schema will be updated to widen the existing
+        // type to match it.
+        attr
       case _ =>
         getCastFunction(attr, targetAttr.dataType, targetAttr.name)
     }
     Alias(expr, targetAttr.name)(explicitMetadata = Option(targetAttr.metadata))
+  }
+
+  /**
+   * Whether inserting values that have a wider type than the table has is allowed. In that case,
+   * values are not downcasted to the current table type and the table schema is updated instead to
+   * use the wider type.
+   */
+  private def allowTypeWidening(deltaTable: DeltaTableV2): Boolean = {
+    val options = new DeltaOptions(Map.empty[String, String], conf)
+    options.canMergeSchema && TypeWidening.isEnabled(
+      deltaTable.initialSnapshot.protocol,
+      deltaTable.initialSnapshot.metadata
+    )
   }
 
   /**
@@ -919,18 +942,19 @@ class DeltaAnalysis(session: SparkSession)
    * skips this step, we see if we need to perform any schema adjustment here.
    */
   private def needsSchemaAdjustmentByOrdinal(
-      tableName: String,
+      deltaTable: DeltaTableV2,
       query: LogicalPlan,
       schema: StructType): Boolean = {
     val output = query.output
     if (output.length < schema.length) {
-      throw DeltaErrors.notEnoughColumnsInInsert(tableName, output.length, schema.length)
+      throw DeltaErrors.notEnoughColumnsInInsert(deltaTable.name(), output.length, schema.length)
     }
     // Now we should try our best to match everything that already exists, and leave the rest
     // for schema evolution to WriteIntoDelta
     val existingSchemaOutput = output.take(schema.length)
     existingSchemaOutput.map(_.name) != schema.map(_.name) ||
-      !SchemaUtils.isReadCompatible(schema.asNullable, existingSchemaOutput.toStructType)
+      !SchemaUtils.isReadCompatible(schema.asNullable, existingSchemaOutput.toStructType,
+        allowTypeWidening = allowTypeWidening(deltaTable))
   }
 
   /**
@@ -984,7 +1008,10 @@ class DeltaAnalysis(session: SparkSession)
     }
     val specifiedTargetAttrs = targetAttrs.filter(col => userSpecifiedNames.contains(col.name))
     !SchemaUtils.isReadCompatible(
-      specifiedTargetAttrs.toStructType.asNullable, query.output.toStructType)
+      specifiedTargetAttrs.toStructType.asNullable,
+      query.output.toStructType,
+      allowTypeWidening = allowTypeWidening(deltaTable)
+    )
   }
 
   // Get cast operation for the level of strictness in the schema a user asked for
@@ -1014,7 +1041,8 @@ class DeltaAnalysis(session: SparkSession)
       tableName: String,
       parent: NamedExpression,
       source: StructType,
-      target: StructType): NamedExpression = {
+      target: StructType,
+      allowTypeWidening: Boolean): NamedExpression = {
     if (source.length < target.length) {
       throw DeltaErrors.notEnoughColumnsInInsert(
         tableName, source.length, target.length, Some(parent.qualifiedName))
@@ -1025,12 +1053,20 @@ class DeltaAnalysis(session: SparkSession)
           case t: StructType =>
             val subField = Alias(GetStructField(parent, i, Option(name)), target(i).name)(
               explicitMetadata = Option(metadata))
-            addCastsToStructs(tableName, subField, nested, t)
+            addCastsToStructs(tableName, subField, nested, t, allowTypeWidening)
           case o =>
             val field = parent.qualifiedName + "." + name
             val targetName = parent.qualifiedName + "." + target(i).name
             throw DeltaErrors.cannotInsertIntoColumn(tableName, field, targetName, o.simpleString)
         }
+
+      case (StructField(name, dt: AtomicType, _, _), i) if i < target.length && allowTypeWidening &&
+        TypeWidening.isTypeChangeSupportedForSchemaEvolution(
+          target(i).dataType.asInstanceOf[AtomicType], dt) =>
+        val targetAttr = target(i)
+        Alias(
+          GetStructField(parent, i, Option(name)),
+          targetAttr.name)(explicitMetadata = Option(targetAttr.metadata))
       case (other, i) if i < target.length =>
         val targetAttr = target(i)
         Alias(
@@ -1054,9 +1090,11 @@ class DeltaAnalysis(session: SparkSession)
       parent: NamedExpression,
       source: StructType,
       target: StructType,
-      sourceNullable: Boolean): Expression = {
+      sourceNullable: Boolean,
+      allowTypeWidening: Boolean): Expression = {
     val structConverter: (Expression, Expression) => Expression = (_, i) =>
-      addCastsToStructs(tableName, Alias(GetArrayItem(parent, i), i.toString)(), source, target)
+      addCastsToStructs(
+        tableName, Alias(GetArrayItem(parent, i), i.toString)(), source, target, allowTypeWidening)
     val transformLambdaFunc = {
       val elementVar = NamedLambdaVariable("elementVar", source, sourceNullable)
       val indexVar = NamedLambdaVariable("indexVar", IntegerType, false)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -352,7 +352,8 @@ def normalizeColumnNamesInDataType(
    * new schema of a Delta table can be used with a previously analyzed LogicalPlan. Our
    * rules are to return false if:
    *   - Dropping any column that was present in the existing schema, if not allowMissingColumns
-   *   - Any change of datatype
+   *   - Any change of datatype, if not allowTypeWidening. Any non-widening change of datatype
+   *     otherwise.
    *   - Change of partition columns. Although analyzed LogicalPlan is not changed,
    *     physical structure of data is changed and thus is considered not read compatible.
    *   - If `forbidTightenNullability` = true:
@@ -373,6 +374,7 @@ def normalizeColumnNamesInDataType(
       readSchema: StructType,
       forbidTightenNullability: Boolean = false,
       allowMissingColumns: Boolean = false,
+      allowTypeWidening: Boolean = false,
       newPartitionColumns: Seq[String] = Seq.empty,
       oldPartitionColumns: Seq[String] = Seq.empty): Boolean = {
 
@@ -387,7 +389,7 @@ def normalizeColumnNamesInDataType(
     def isDatatypeReadCompatible(existing: DataType, newtype: DataType): Boolean = {
       (existing, newtype) match {
         case (e: StructType, n: StructType) =>
-          isReadCompatible(e, n, forbidTightenNullability)
+          isReadCompatible(e, n, forbidTightenNullability, allowTypeWidening = allowTypeWidening)
         case (e: ArrayType, n: ArrayType) =>
           // if existing elements are non-nullable, so should be the new element
           isNullabilityCompatible(e.containsNull, n.containsNull) &&
@@ -397,6 +399,8 @@ def normalizeColumnNamesInDataType(
           isNullabilityCompatible(e.valueContainsNull, n.valueContainsNull) &&
             isDatatypeReadCompatible(e.keyType, n.keyType) &&
             isDatatypeReadCompatible(e.valueType, n.valueType)
+        case (e: AtomicType, n: AtomicType) if allowTypeWidening =>
+          TypeWidening.isTypeChangeSupportedForSchemaEvolution(e, n)
         case (a, b) => a == b
       }
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTypeWideningSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTypeWideningSchemaEvolutionSuite.scala
@@ -35,7 +35,8 @@ class DeltaTypeWideningSchemaEvolutionSuite
     with DeltaDMLTestUtils
     with DeltaSQLCommandTest
     with DeltaTypeWideningTestMixin
-    with DeltaMergeIntoTypeWideningSchemaEvolutionTests {
+    with DeltaMergeIntoTypeWideningSchemaEvolutionTests
+    with DeltaInsertTypeWideningSchemaEvolutionTeststs {
 
   protected override def sparkConf: SparkConf = {
     super.sparkConf
@@ -356,4 +357,454 @@ trait DeltaMergeIntoTypeWideningSchemaEvolutionTests
       merge.execute()
     }
   }
+}
+
+/**
+ * Tests covering type widening during schema evolution in MERGE INTO.
+ */
+trait DeltaInsertTypeWideningSchemaEvolutionTeststs extends DeltaTypeWideningTestCases {
+  self: QueryTest with DeltaTypeWideningTestMixin with DeltaDMLTestUtils =>
+
+  import testImplicits._
+
+  for {
+    testCase <- supportedTestCases
+  } {
+    test(s"automatic type widening in insert ${testCase.fromType.sql} -> ${testCase.toType.sql}") {
+      append(testCase.initialValuesDF)
+      testCase.additionalValuesDF
+        .write
+        .mode("append")
+        .insertInto(s"delta.`$tempPath`")
+
+      assert(readDeltaTable(tempPath).schema("value").dataType === testCase.toType)
+      checkAnswer(readDeltaTable(tempPath).select("value").sort("value"),
+        testCase.expectedResult.select($"value".cast(testCase.toType)).sort("value"))
+    }
+  }
+
+  for {
+    testCase <- unsupportedTestCases
+  } {
+    test(s"unsupported automatic type widening in insert " +
+      s"${testCase.fromType.sql} -> ${testCase.toType.sql}") {
+      append(testCase.initialValuesDF)
+      // Test cases for some of the unsupported type changes may overflow while others only have
+      // values that can be implicitly cast to the narrower type - e.g. double ->float.
+      // We set storeAssignmentPolicy to LEGACY to ignore overflows, this test only ensures
+      // that the table schema didn't evolve.
+      withSQLConf(SQLConf.STORE_ASSIGNMENT_POLICY.key -> StoreAssignmentPolicy.LEGACY.toString) {
+        testCase.additionalValuesDF.write.mode("append")
+          .insertInto(s"delta.`$tempPath`")
+        assert(readDeltaTable(tempPath).schema("value").dataType === testCase.fromType)
+      }
+    }
+  }
+
+  test("type widening isn't applied in insert when schema evolution is disabled") {
+    sql(s"CREATE TABLE delta.`$tempPath` (a short) USING DELTA")
+    withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "false") {
+      // Insert integer values. This should succeed and downcast the values to short.
+      sql(s"INSERT INTO delta.`$tempPath` VALUES (1), (2)")
+      assert(readDeltaTable(tempPath).schema("a").dataType === ShortType)
+      checkAnswer(readDeltaTable(tempPath),
+        Seq(1, 2).toDF("a").select($"a".cast(ShortType)))
+    }
+
+    // Check that we would actually widen if schema evolution was enabled.
+    withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true") {
+      sql(s"INSERT INTO delta.`$tempPath` VALUES (3), (4)")
+      assert(readDeltaTable(tempPath).schema("a").dataType === IntegerType)
+      checkAnswer(readDeltaTable(tempPath), Seq(1, 2, 3, 4).toDF("a"))
+    }
+  }
+
+  /**
+   * There are **many** different ways to run an insert:
+   * - Using SQL or the dataframe v1 and v2 APIs.
+   * - Append vs. Overwrite / Partition overwrite.
+   * - Position-based vs. name-based resolution.
+   *
+   * Each take a unique path through analysis. The abstractions below captures these different
+   * inserts to allow more easily running tests with all or a subset of them.
+   *
+   * @param mode Append or Overwrite. This dictates in particular what the expected result after the
+   *             insert should be.
+   * @param name A human-readable name for the insert type displayed in the test names.
+   */
+  trait Insert {
+    val mode: SaveMode
+    val name: String
+
+    /**
+     * The method that tests will call to run the insert. Each type of insert must implement its
+     * sepcific way to run insert.
+     */
+    def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit
+
+    /** SQL keyword for this type of insert.  */
+    def intoOrOverwrite: String = if (mode == SaveMode.Append) "INTO" else "OVERWRITE"
+
+    /** The expected content of the table after the insert. */
+    def expectedResult(initialDF: DataFrame, insertedDF: DataFrame): DataFrame =
+      if (mode == SaveMode.Overwrite) insertedDF
+      else initialDF.unionByName(insertedDF, allowMissingColumns = true)
+  }
+
+  /** INSERT INTO/OVERWRITE */
+  case class SQLInsertByPosition(mode: SaveMode) extends Insert {
+    val name: String = s"INSERT $intoOrOverwrite"
+    def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit =
+      sql(s"INSERT $intoOrOverwrite target SELECT * FROM source")
+  }
+
+  /** INSERT INTO/OVERWRITE (a, b) */
+  case class SQLInsertColList(mode: SaveMode) extends Insert {
+    val name: String = s"INSERT $intoOrOverwrite (columns) - $mode"
+    def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit = {
+      val colList = columns.mkString(", ")
+      sql(s"INSERT $intoOrOverwrite target ($colList) SELECT $colList FROM source")
+    }
+  }
+
+  /** INSERT INTO/OVERWRITE BY NAME */
+  case class SQLInsertByName(mode: SaveMode) extends Insert {
+    val name: String = s"INSERT $intoOrOverwrite BY NAME - $mode"
+    def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit =
+      sql(s"INSERT $intoOrOverwrite target SELECT ${columns.mkString(", ")} FROM source")
+  }
+
+  /** INSERT INTO REPLACE WHERE */
+  object SQLInsertOverwriteReplaceWhere extends Insert {
+    val mode: SaveMode = SaveMode.Overwrite
+    val name: String = s"INSERT INTO REPLACE WHERE"
+    def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit =
+      sql(s"INSERT INTO target REPLACE WHERE $whereCol = $whereValue " +
+          s"SELECT ${columns.mkString(", ")} FROM source")
+  }
+
+  /** INSERT OVERWRITE PARTITION (part = 1) */
+  object SQLInsertOverwritePartitionByPosition extends Insert {
+    val mode: SaveMode = SaveMode.Overwrite
+    val name: String = s"INSERT OVERWRITE PARTITION (partition)"
+    def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit = {
+      val assignments = columns.filterNot(_ == whereCol).mkString(", ")
+      sql(s"INSERT OVERWRITE target PARTITION ($whereCol = $whereValue) " +
+          s"SELECT $assignments FROM source")
+    }
+  }
+
+  /** INSERT OVERWRITE PARTITION (part = 1) (a, b) */
+  object SQLInsertOverwritePartitionColList extends Insert {
+    val mode: SaveMode = SaveMode.Overwrite
+    val name: String = s"INSERT OVERWRITE PARTITION (partition) (columns)"
+    def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit = {
+      val assignments = columns.filterNot(_ == whereCol).mkString(", ")
+      sql(s"INSERT OVERWRITE target PARTITION ($whereCol = $whereValue) ($assignments) " +
+          s"SELECT $assignments FROM source")
+    }
+  }
+
+  /** df.write.mode(mode).insertInto() */
+  case class DFv1InsertInto(mode: SaveMode) extends Insert {
+    val name: String = s"DFv1 insertInto() - $mode"
+    def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit =
+      spark.read.table("source").write.mode(mode).insertInto("target")
+  }
+
+  /** df.write.mode(mode).saveAsTable() */
+  case class DFv1SaveAsTable(mode: SaveMode) extends Insert {
+    val name: String = s"DFv1 saveAsTable() - $mode"
+    def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit = {
+      spark.read.table("source").write.mode(mode).format("delta").saveAsTable("target")
+    }
+  }
+
+  /** df.writeTo.append() */
+  object DFv2Append extends Insert { self: Insert =>
+    val mode: SaveMode = SaveMode.Append
+    val name: String = "DFv2 append()"
+    def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit = {
+      spark.read.table("source").writeTo("target").append()
+    }
+  }
+
+  /** df.writeTo.overwrite() */
+  object DFv2Overwrite extends Insert { self: Insert =>
+    val mode: SaveMode = SaveMode.Overwrite
+    val name: String = s"DFv2 overwrite()"
+    def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit = {
+      spark.read.table("source").writeTo("target").overwrite(col(whereCol) === lit(whereValue))
+    }
+  }
+
+  /** df.writeTo.overwritePartitions() */
+  object DFv2OverwritePartition extends Insert { self: Insert =>
+    override val mode: SaveMode = SaveMode.Overwrite
+    val name: String = s"DFv2 overwritePartitions()"
+    def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit = {
+      spark.read.table("source").writeTo("target").overwritePartitions()
+    }
+  }
+
+  /** Collects all the types of insert previously defined. */
+  protected lazy val allInsertTypes: Seq[Insert] = Seq(
+        SQLInsertOverwriteReplaceWhere,
+        SQLInsertOverwritePartitionByPosition,
+        SQLInsertOverwritePartitionColList,
+        DFv2Append,
+        DFv2Overwrite,
+        DFv2OverwritePartition
+  ) ++ (for {
+      mode: SaveMode <- Seq(SaveMode.Append, SaveMode.Overwrite)
+      insert: Insert <- Seq(
+        SQLInsertByPosition(mode),
+        SQLInsertColList(mode),
+        SQLInsertByName(mode),
+        DFv1InsertInto(mode),
+        DFv1SaveAsTable(mode)
+      )
+    } yield insert)
+
+  /**
+   * Test runner for type evolution in INSERT.
+   * @param name             Test name
+   * @param initialSchemaDDL Initial schema of the table to be inserted into (as a DDL string).
+   * @param initialJsonData  Initial data present in the table to be inserted into (as a JSON
+   *                         string).
+   * @param partitionBy      Partition columns for the initial table.
+   * @param insertSchemaDDL  Schema of the data to be inserted (as a DDL string).
+   * @param insertJsonData   Data to be inserted (as a JSON string)
+   * @param overwriteWhere   Where clause for overwrite PARTITION / REPLACE WHERE (as
+   *                         colName -> value)
+   * @param expectedSchema   Expected schema of the table after the insert.
+   * @param includeInserts   List of insert types to run the test with. Defaults to all inserts.
+   * @param excludeInserts   List of insert types to exclude when running the test. Defaults to no
+   *                         inserts excluded.
+   */
+  def testInsertTypeEvolution(name: String)(
+      initialSchemaDDL: String,
+      initialJsonData: Seq[String],
+      partitionBy: Seq[String] = Seq.empty,
+      insertSchemaDDL: String,
+      insertJsonData: Seq[String],
+      overwriteWhere: (String, Int),
+      expectedSchema: StructType,
+      includeInserts: Seq[Insert] = allInsertTypes,
+      excludeInserts: Seq[Insert] = Seq.empty): Unit = {
+    for (insert <- includeInserts.filterNot(excludeInserts.toSet)) {
+      test(s"${insert.name} - $name") {
+        withTable("source", "target") {
+          val initialDF = readFromJSON(initialJsonData, StructType.fromDDL(initialSchemaDDL))
+          val writer = initialDF.write.format("delta")
+          if (partitionBy.nonEmpty) {
+            writer.partitionBy(partitionBy: _*)
+          }
+          writer.saveAsTable("target")
+          // Write the data to insert to a table so that we can use it in both SQL and dataframe
+          // writer inserts.
+          val insertDF = readFromJSON(insertJsonData, StructType.fromDDL(insertSchemaDDL))
+          insertDF.write.format("delta").saveAsTable("source")
+
+          insert.runInsert(
+            columns = insertDF.schema.map(_.name),
+            whereCol = overwriteWhere._1,
+            whereValue = overwriteWhere._2
+          )
+
+          val target = spark.read.table("target")
+          assert(target.schema === expectedSchema)
+          checkAnswer(target, insert.expectedResult(initialDF, insertDF))
+        }
+      }
+    }
+  }
+
+  testInsertTypeEvolution("top-level type evolution")(
+    initialSchemaDDL = "a int, b short",
+    initialJsonData = Seq("""{ "a": 1, "b": 2 }"""),
+    partitionBy = Seq("a"),
+    overwriteWhere = "a" -> 1,
+    insertSchemaDDL = "a int, b int",
+    insertJsonData = Seq("""{ "a": 1, "b": 4 }"""),
+    expectedSchema = StructType(new StructType()
+      .add("a", IntegerType)
+      .add("b", IntegerType, nullable = true,
+        metadata = typeWideningMetadata(version = 1, from = ShortType, to = IntegerType)))
+  )
+
+  testInsertTypeEvolution("top-level type evolution with column upcast")(
+    initialSchemaDDL = "a int, b short, c int",
+    initialJsonData = Seq("""{ "a": 1, "b": 2, "c": 3 }"""),
+    partitionBy = Seq("a"),
+    overwriteWhere = "a" -> 1,
+    insertSchemaDDL = "a int, b int, c short",
+    insertJsonData = Seq("""{ "a": 1, "b": 5, "c": 6 }"""),
+    expectedSchema = new StructType()
+      .add("a", IntegerType)
+      .add("b", IntegerType, nullable = true,
+        metadata = typeWideningMetadata(version = 1, from = ShortType, to = IntegerType))
+      .add("c", IntegerType)
+  )
+
+  testInsertTypeEvolution("top-level type evolution with schema evolution")(
+    initialSchemaDDL = "a int, b short",
+    initialJsonData = Seq("""{ "a": 1, "b": 2 }"""),
+    partitionBy = Seq("a"),
+    overwriteWhere = "a" -> 1,
+    insertSchemaDDL = "a int, b int, c int",
+    insertJsonData = Seq("""{ "a": 1, "b": 4, "c": 5 }"""),
+    expectedSchema = new StructType()
+      .add("a", IntegerType)
+      .add("b", IntegerType, nullable = true,
+        metadata = typeWideningMetadata(version = 1, from = ShortType, to = IntegerType))
+      .add("c", IntegerType),
+    // INSERT INTO/OVERWRITE (a, b) VALUES doesn't support schema evolution.
+    excludeInserts = Seq(
+      SQLInsertColList(SaveMode.Append),
+      SQLInsertColList(SaveMode.Overwrite),
+      SQLInsertOverwritePartitionColList)
+  )
+
+
+  testInsertTypeEvolution("nested type evolution by position")(
+    initialSchemaDDL =
+      "key int, s struct<x: short, y: short>, m map<string, short>, a array<short>",
+    initialJsonData = Seq("""{ "key": 1, "s": { "x": 1, "y": 2 }, "m": { "p": 3 }, "a": [4] }"""),
+    partitionBy = Seq("key"),
+    overwriteWhere = "key" -> 1,
+    insertSchemaDDL = "key int, s struct<x: short, y: int>, m map<string, int>, a array<int>",
+    insertJsonData = Seq("""{ "key": 1, "s": { "x": 4, "y": 5 }, "m": { "p": 6 }, "a": [7] }"""),
+    expectedSchema = new StructType()
+      .add("key", IntegerType)
+      .add("s", new StructType()
+        .add("x", ShortType)
+        .add("y", IntegerType, nullable = true,
+          metadata = typeWideningMetadata(version = 1, from = ShortType, to = IntegerType)))
+      .add("m", MapType(StringType, IntegerType), nullable = true,
+        metadata = typeWideningMetadata(
+          version = 1,
+          from = ShortType,
+          to = IntegerType,
+          path = Seq("value")))
+      .add("a", ArrayType(IntegerType), nullable = true,
+        metadata = typeWideningMetadata(
+          version = 1,
+          from = ShortType,
+          to = IntegerType,
+          path = Seq("element")))
+  )
+
+
+  testInsertTypeEvolution("nested type evolution with struct evolution by position")(
+    initialSchemaDDL =
+      "key int, s struct<x: short, y: short>, m map<string, short>, a array<short>",
+    initialJsonData = Seq("""{ "key": 1, "s": { "x": 1, "y": 2 }, "m": { "p": 3 }, "a": [4] }"""),
+    partitionBy = Seq("key"),
+    overwriteWhere = "key" -> 1,
+    insertSchemaDDL =
+      "key int, s struct<x: short, y: int, z: int>, m map<string, int>, a array<int>",
+    insertJsonData =
+      Seq("""{ "key": 1, "s": { "x": 4, "y": 5, "z": 8 }, "m": { "p": 6 }, "a": [7] }"""),
+    expectedSchema = new StructType()
+      .add("key", IntegerType)
+      .add("s", new StructType()
+        .add("x", ShortType)
+        .add("y", IntegerType, nullable = true,
+          metadata = typeWideningMetadata(version = 1, from = ShortType, to = IntegerType))
+        .add("z", IntegerType))
+      .add("m", MapType(StringType, IntegerType), nullable = true,
+        metadata = typeWideningMetadata(
+          version = 1,
+          from = ShortType,
+          to = IntegerType,
+          path = Seq("value")))
+      .add("a", ArrayType(IntegerType), nullable = true,
+        metadata = typeWideningMetadata(
+          version = 1,
+          from = ShortType,
+          to = IntegerType,
+          path = Seq("element")))
+  )
+
+
+    testInsertTypeEvolution("nested struct type evolution with field upcast")(
+    initialSchemaDDL = "key int, s struct<x: int, y: short>",
+    initialJsonData = Seq("""{ "key": 1, "s": { "x": 1, "y": 2 } }"""),
+    partitionBy = Seq("key"),
+    overwriteWhere = "key" -> 1,
+    insertSchemaDDL = "key int, s struct<x: short, y: int>",
+    insertJsonData = Seq("""{ "key": 1, "s": { "x": 4, "y": 5 } }"""),
+    expectedSchema = new StructType()
+      .add("key", IntegerType)
+      .add("s", new StructType()
+        .add("x", IntegerType)
+        .add("y", IntegerType, nullable = true,
+          metadata = typeWideningMetadata(version = 1, from = ShortType, to = IntegerType)))
+  )
+
+  // Interestingly, we introduced a special case to handle schema evolution / casting for structs
+  // directly nested into an array. This doesn't always work with maps or with elements that
+  // aren't a struct (see other tests).
+  testInsertTypeEvolution("nested struct type evolution with field upcast in array")(
+    initialSchemaDDL = "key int, a array<struct<x: int, y: short>>",
+    initialJsonData = Seq("""{ "key": 1, "a": [ { "x": 1, "y": 2 } ] }"""),
+    partitionBy = Seq("key"),
+    overwriteWhere = "key" -> 1,
+    insertSchemaDDL = "key int, a array<struct<x: short, y: int>>",
+    insertJsonData = Seq("""{ "key": 1, "a": [ { "x": 3, "y": 4 } ] }"""),
+    expectedSchema = new StructType()
+      .add("key", IntegerType)
+      .add("a", ArrayType(new StructType()
+        .add("x", IntegerType)
+        .add("y", IntegerType, nullable = true,
+          metadata = typeWideningMetadata(version = 1, from = ShortType, to = IntegerType))))
+  )
+
+  // The next two tests document inconsistencies when handling maps. Using SQL doesn't allow type
+  // evolution but using the dataframe API does.
+  testInsertTypeEvolution("nested struct type evolution with field upcast in map")(
+    initialSchemaDDL = "key int, m map<string, struct<x: int, y: short>>",
+    initialJsonData = Seq("""{ "key": 1, "m": { "a": { "x": 1, "y": 2 } } }"""),
+    partitionBy = Seq("key"),
+    overwriteWhere = "key" -> 1,
+    insertSchemaDDL = "key int, m map<string, struct<x: short, y: int>>",
+    insertJsonData = Seq("""{ "key": 1, "m": { "a": { "x": 3, "y": 4 } } }"""),
+    expectedSchema = new StructType()
+      .add("key", IntegerType)
+      // Type evolution wasn't applied in the map.
+      .add("m", MapType(StringType, new StructType()
+        .add("x", IntegerType)
+        .add("y", ShortType))),
+    excludeInserts = Seq(
+      DFv1SaveAsTable(SaveMode.Append),
+      DFv1SaveAsTable(SaveMode.Overwrite),
+      DFv2Append,
+      DFv2Overwrite,
+      DFv2OverwritePartition
+    )
+  )
+
+  testInsertTypeEvolution("nested struct type evolution with field upcast in map")(
+    initialSchemaDDL = "key int, m map<string, struct<x: int, y: short>>",
+    initialJsonData = Seq("""{ "key": 1, "m": { "a": { "x": 1, "y": 2 } } }"""),
+    partitionBy = Seq("key"),
+    overwriteWhere = "key" -> 1,
+    insertSchemaDDL = "key int, m map<string, struct<x: short, y: int>>",
+    insertJsonData = Seq("""{ "key": 1, "m": { "a": { "x": 3, "y": 4 } } }"""),
+    expectedSchema = StructType(new StructType()
+      .add("key", IntegerType)
+      // Type evolution was applied in the map.
+      .add("m", MapType(StringType, new StructType()
+        .add("x", IntegerType)
+        .add("y", IntegerType, nullable = true,
+          metadata = typeWideningMetadata(version = 1, from = ShortType, to = IntegerType))))),
+    includeInserts = Seq(
+      DFv1SaveAsTable(SaveMode.Append),
+      DFv1SaveAsTable(SaveMode.Overwrite),
+      DFv2Append,
+      DFv2Overwrite,
+      DFv2OverwritePartition
+    )
+  )
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This change is part of the type widening table feature.
Type widening feature request: https://github.com/delta-io/delta/issues/2622
Type Widening protocol RFC: https://github.com/delta-io/delta/pull/2624

It adds automatic type widening as part of schema evolution in INSERT. During resolution, when schema evolution and type widening are enabled, type differences between the input query and the target table are handled as follows:
- If the type difference qualifies for automatic type evolution: the input type is left as is, the data will be inserted with the new type and the table schema will be updated in `ImplicitMetadataOperation` (already implemented as part of MERGE support)
- If the type difference doesn't qualify for automatic type evolution: the current behavior is preserved: a cast is added from the input type to the existing target type.

## How was this patch tested?
- Tests are added to `DeltaTypeWideningAutomaticSuite` to cover type evolution in INSERT

## This PR introduces the following *user-facing* changes
The table feature is available in testing only, there's no user-facing changes as of now.

When automatic schema evolution is enabled in INSERT and the source schema contains a type that is wider than the target schema:

With type widening disabled: the type in the target schema is not changed. A cast is added to the input to insert to match the expected target type.

With type widening enabled: the type in the target schema is updated to the wider source type. 
```
-- target: key int, value short
-- source: key int, value int
INSERT INTO target SELECT * FROM source
```
After the INSERT operation, the target schema is `key int, value int`.
