### PR TITLE
[BUG] Default columns is also a reader feature, the PROTOCOL doc is wrong.

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1601,7 +1601,7 @@ Feature | Name | Readers or Writers?
 [Column Invariants](#column-invariants) | `invariants` | Writers only
 [`CHECK` constraints](#check-constraints) | `checkConstraints` | Writers only
 [Generated Columns](#generated-columns) | `generatedColumns` | Writers only
-[Default Columns](#default-columns) | `allowColumnDefaults` | Writers only
+[Default Columns](#default-columns) | `allowColumnDefaults` | Readers and Writers
 [Change Data Feed](#add-cdc-file) | `changeDataFeed` | Writers only
 [Column Mapping](#column-mapping) | `columnMapping` | Readers and writers
 [Identity Columns](#identity-columns) | `identityColumns` | Writers only


### PR DESCRIPTION
The docs here correctly state that enabling Default Columns will prevent older versions without the Default Column feature from reading the table: https://docs.delta.io/3.1.0/delta-default-columns.html
The PROTOCOL doc conflicts with the above. I tested and confirmed that Default Columns is a table feature that requires the reader to support.

Signed-off-by: Miles Cole <m.w.c.360@gmail.com>

#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Documentation needs updating

## How was this patch tested?
Just documentation

## Does this PR introduce _any_ user-facing changes?
No
