### PR TITLE
[Spark]Optimize Directory Creation in ensureLogDirectoryExists method

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -439,15 +439,28 @@ class DeltaLog private(
   def ensureLogDirectoryExist(): Unit = {
     val fs = logPath.getFileSystem(newDeltaHadoopConf())
     def createDirIfNotExists(path: Path): Unit = {
-      var success = false
-      try {
-        success = fs.exists(path) || fs.mkdirs(path)
+      // Optimistically attempt to create the directory first without checking its existence.
+      // This is efficient because we're assuming it's more likely that the directory doesn't
+      // exist and it saves an filesystem existence check in that case.
+      val (success, mkdirsIOExceptionOpt) = try {
+        // Return value of false should mean the directory already existed (not an error) but
+        // we will verify below because we're paranoid about buggy FileSystem implementations.
+        (fs.mkdirs(path), None)
       } catch {
+        // Only needed because buggy Hadoop FileSystem.mkdir wrongly throws on existing dir.
         case io: IOException =>
-          throw DeltaErrors.cannotCreateLogPathException(logPath.toString, io)
+          val dirExists =
+            try {
+              fs.getFileStatus(path).isDirectory
+            } catch {
+              case NonFatal(_) => false
+            }
+          (dirExists, Some(io))
       }
       if (!success) {
-        throw DeltaErrors.cannotCreateLogPathException(logPath.toString)
+        throw DeltaErrors.cannotCreateLogPathException(
+          logPath = logPath.toString,
+          cause = mkdirsIOExceptionOpt.orNull)
       }
     }
     createDirIfNotExists(FileNames.commitDirPath(logPath))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -447,7 +447,9 @@ class DeltaLog private(
         // we will verify below because we're paranoid about buggy FileSystem implementations.
         (fs.mkdirs(path), None)
       } catch {
-        // Only needed because buggy Hadoop FileSystem.mkdir wrongly throws on existing dir.
+        // A FileAlreadyExistsException is expected if a non-directory object exists but an explicit
+        // check is needed because buggy Hadoop FileSystem.mkdir wrongly throws the exception even
+        // on existing directories.
         case io: IOException =>
           val dirExists =
             try {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/CheckpointHook.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/CheckpointHook.scala
@@ -33,8 +33,6 @@ object CheckpointHook extends PostCommitHook {
       committedActions: Seq[Action]): Unit = {
     if (!txn.needsCheckpoint) return
 
-    txn.deltaLog.ensureLogDirectoryExist()
-
     // Since the postCommitSnapshot isn't guaranteed to match committedVersion, we have to
     // explicitly checkpoint the snapshot at the committedVersion.
     val cp = postCommitSnapshot.checkpointProvider


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR updates the ensureLogDirectoryExist method to optimistically handle directory creation by attempting to create the directory before checking its existence. This is efficient because we're assuming it's more likely that the directory doesn't exist and it saves an filesystem existence check in that case.

Cloud Hadoop implementations are expected to throw org.apache.hadoop.fs.FileAlreadyExistsException if the file already exists. e.g. [S3AFileSystem.java](https://github.com/apache/hadoop/blob/fc166d3aec7c95110a8cd4ef6ce1fbf4955107e5/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java#L3763)

Unix-based File Systems are expected to throw java.nio.file.FileAlreadyExistsException if the file already exists.

To cover all bases, including unforeseen file systems, it retains a final existence check for exceptions outside these specific cases, ensuring robustness without compromising functionality.

## How was this patch tested?

Existing UTs

## Does this PR introduce _any_ user-facing changes?

No