### PR TITLE
[Spark] Add error codes to Delta concurrent exceptions

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -460,6 +460,36 @@
     ],
     "sqlState" : "22005"
   },
+  "DELTA_CONCURRENT_APPEND" : {
+    "message" : [
+      "ConcurrentAppendException: Files were added to <partition> by a concurrent update. <retryMsg><conflictingCommit>\nRefer to <docLink> for more details."
+    ],
+    "sqlState" : "2D521"
+  },
+  "DELTA_CONCURRENT_DELETE_DELETE" : {
+    "message" : [
+      "ConcurrentDeleteDeleteException: This transaction attempted to delete one or more files that were deleted (for example <file>) by a concurrent update. Please try the operation again.<conflictingCommit>\nRefer to <docLink> for more details."
+    ],
+    "sqlState" : "2D521"
+  },
+  "DELTA_CONCURRENT_DELETE_READ" : {
+    "message" : [
+      "ConcurrentDeleteReadException: This transaction attempted to read one or more files that were deleted (for example <file>) by a concurrent update. Please try the operation again.<conflictingCommit>\nRefer to <docLink> for more details."
+    ],
+    "sqlState" : "2D521"
+  },
+  "DELTA_CONCURRENT_TRANSACTION" : {
+    "message" : [
+      "ConcurrentTransactionException: This error occurs when multiple streaming queries are using the same checkpoint to write into this table. Did you run multiple instances of the same streaming query at the same time?<conflictingCommit>\nRefer to <docLink> for more details."
+    ],
+    "sqlState" : "2D521"
+  },
+  "DELTA_CONCURRENT_WRITE" : {
+    "message" : [
+      "ConcurrentWriteException: A concurrent transaction has written new data since the current transaction read the table. Please try the operation again.\nRefer to <docLink> for more details."
+    ],
+    "sqlState" : "2D521"
+  },
   "DELTA_CONFIGURE_SPARK_SESSION_WITH_EXTENSION_AND_CATALOG" : {
     "message" : [
       "This Delta operation requires the SparkSession to be configured with the",
@@ -1390,6 +1420,12 @@
     ],
     "sqlState" : "XXKDS"
   },
+  "DELTA_METADATA_CHANGED" : {
+    "message" : [
+      "MetadataChangedException: The metadata of the Delta table has been changed by a concurrent update. Please try the operation again.<conflictingCommit>\nRefer to <docLink> for more details."
+    ],
+    "sqlState" : "2D521"
+  },
   "DELTA_MISSING_CHANGE_DATA" : {
     "message" : [
       "Error getting change data for range [<startVersion> , <endVersion>] as change data was not",
@@ -1778,6 +1814,12 @@
       "Committing to the Delta table version <version> succeeded but error while executing post-commit hook <name><message>"
     ],
     "sqlState" : "2DKD0"
+  },
+  "DELTA_PROTOCOL_CHANGED" : {
+    "message" : [
+      "ProtocolChangedException: The protocol version of the Delta table has been changed by a concurrent update. <additionalInfo><conflictingCommit>\nRefer to <docLink> for more details."
+    ],
+    "sqlState" : "2D521"
   },
   "DELTA_PROTOCOL_PROPERTY_NOT_INT" : {
     "message" : [

--- a/spark/src/main/scala/io/delta/exceptions/DeltaConcurrentExceptions.scala
+++ b/spark/src/main/scala/io/delta/exceptions/DeltaConcurrentExceptions.scala
@@ -16,6 +16,8 @@
 
 package io.delta.exceptions
 
+import org.apache.spark.sql.delta.{DeltaThrowable, DeltaThrowableHelper}
+
 import org.apache.spark.annotation.Evolving
 
 /**
@@ -40,6 +42,13 @@ abstract class DeltaConcurrentModificationException(message: String)
 @Evolving
 class ConcurrentWriteException(message: String)
   extends org.apache.spark.sql.delta.ConcurrentWriteException(message)
+    with DeltaThrowable {
+  def this(messageParameters: Array[String]) = {
+    this(DeltaThrowableHelper.getMessage("DELTA_CONCURRENT_WRITE", messageParameters))
+  }
+  override def getErrorClass: String = "DELTA_CONCURRENT_WRITE"
+  override def getMessage: String = message
+}
 
 /**
  * :: Evolving ::
@@ -52,6 +61,13 @@ class ConcurrentWriteException(message: String)
 @Evolving
 class MetadataChangedException(message: String)
   extends org.apache.spark.sql.delta.MetadataChangedException(message)
+    with DeltaThrowable {
+  def this(messageParameters: Array[String]) = {
+    this(DeltaThrowableHelper.getMessage("DELTA_METADATA_CHANGED", messageParameters))
+  }
+  override def getErrorClass: String = "DELTA_METADATA_CHANGED"
+  override def getMessage: String = message
+}
 
 /**
  * :: Evolving ::
@@ -64,6 +80,13 @@ class MetadataChangedException(message: String)
 @Evolving
 class ProtocolChangedException(message: String)
   extends org.apache.spark.sql.delta.ProtocolChangedException(message)
+    with DeltaThrowable {
+  def this(messageParameters: Array[String]) = {
+    this(DeltaThrowableHelper.getMessage("DELTA_PROTOCOL_CHANGED", messageParameters))
+  }
+  override def getErrorClass: String = "DELTA_PROTOCOL_CHANGED"
+  override def getMessage: String = message
+}
 
 /**
  * :: Evolving ::
@@ -75,6 +98,13 @@ class ProtocolChangedException(message: String)
 @Evolving
 class ConcurrentAppendException(message: String)
   extends org.apache.spark.sql.delta.ConcurrentAppendException(message)
+    with DeltaThrowable {
+  def this(messageParameters: Array[String]) = {
+    this(DeltaThrowableHelper.getMessage("DELTA_CONCURRENT_APPEND", messageParameters))
+  }
+  override def getErrorClass: String = "DELTA_CONCURRENT_APPEND"
+  override def getMessage: String = message
+}
 
 /**
  * :: Evolving ::
@@ -86,6 +116,13 @@ class ConcurrentAppendException(message: String)
 @Evolving
 class ConcurrentDeleteReadException(message: String)
   extends org.apache.spark.sql.delta.ConcurrentDeleteReadException(message)
+    with DeltaThrowable {
+  def this(messageParameters: Array[String]) = {
+    this(DeltaThrowableHelper.getMessage("DELTA_CONCURRENT_DELETE_READ", messageParameters))
+  }
+  override def getErrorClass: String = "DELTA_CONCURRENT_DELETE_READ"
+  override def getMessage: String = message
+}
 
 /**
  * :: Evolving ::
@@ -97,6 +134,13 @@ class ConcurrentDeleteReadException(message: String)
 @Evolving
 class ConcurrentDeleteDeleteException(message: String)
   extends org.apache.spark.sql.delta.ConcurrentDeleteDeleteException(message)
+    with DeltaThrowable {
+  def this(messageParameters: Array[String]) = {
+    this(DeltaThrowableHelper.getMessage("DELTA_CONCURRENT_DELETE_DELETE", messageParameters))
+  }
+  override def getErrorClass: String = "DELTA_CONCURRENT_DELETE_DELETE"
+  override def getMessage: String = message
+}
 
 /**
  * :: Evolving ::
@@ -108,3 +152,10 @@ class ConcurrentDeleteDeleteException(message: String)
 @Evolving
 class ConcurrentTransactionException(message: String)
   extends org.apache.spark.sql.delta.ConcurrentTransactionException(message)
+    with DeltaThrowable {
+  def this(messageParameters: Array[String]) = {
+    this(DeltaThrowableHelper.getMessage("DELTA_CONCURRENT_TRANSACTION", messageParameters))
+  }
+  override def getErrorClass: String = "DELTA_CONCURRENT_TRANSACTION"
+  override def getMessage: String = message
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2958,6 +2958,89 @@ trait DeltaErrorsSuiteBase
         Some("DELTA_MERGE_ADD_VOID_COLUMN"),
         Some("42K09"),
         Some(s"Cannot add column `fooCol` with type VOID. Please explicitly specify a non-void type.")
+    }
+    {
+      val e = intercept[io.delta.exceptions.ConcurrentAppendException] {
+        throw org.apache.spark.sql.delta.DeltaErrors.concurrentAppendException(None, "p1")
+      }
+      checkErrorMessage(
+        e,
+        Some("DELTA_CONCURRENT_APPEND"),
+        Some("2D521"),
+        Some("ConcurrentAppendException: Files were added to p1 by a concurrent update. Please try the operation again."),
+        startWith = true
+      )
+    }
+    {
+      val e = intercept[io.delta.exceptions.ConcurrentDeleteReadException] {
+        throw org.apache.spark.sql.delta.DeltaErrors.concurrentDeleteReadException(None, "p1")
+      }
+      checkErrorMessage(
+        e,
+        Some("DELTA_CONCURRENT_DELETE_READ"),
+        Some("2D521"),
+        Some("ConcurrentDeleteReadException: This transaction attempted to read one or more files that were deleted (for example p1) by a concurrent update. "),
+        startWith = true
+      )
+    }
+    {
+      val e = intercept[io.delta.exceptions.ConcurrentDeleteDeleteException] {
+        throw org.apache.spark.sql.delta.DeltaErrors.concurrentDeleteDeleteException(None, "p1")
+      }
+      checkErrorMessage(
+        e,
+        Some("DELTA_CONCURRENT_DELETE_DELETE"),
+        Some("2D521"),
+        Some("ConcurrentDeleteDeleteException: This transaction attempted to delete one or more files that were deleted (for example p1) by a concurrent update. "),
+        startWith = true
+      )
+    }
+    {
+      val e = intercept[io.delta.exceptions.ConcurrentTransactionException] {
+        throw org.apache.spark.sql.delta.DeltaErrors.concurrentTransactionException(None)
+      }
+      checkErrorMessage(
+        e,
+        Some("DELTA_CONCURRENT_TRANSACTION"),
+        Some("2D521"),
+        Some("ConcurrentTransactionException: This error occurs when multiple streaming queries are using the same checkpoint to write into this table. Did you run multiple instances of the same streaming query at the same time?"),
+        startWith = true
+      )
+    }
+    {
+      val e = intercept[io.delta.exceptions.ConcurrentWriteException] {
+        throw org.apache.spark.sql.delta.DeltaErrors.concurrentWriteException(None)
+      }
+      checkErrorMessage(
+        e,
+        Some("DELTA_CONCURRENT_WRITE"),
+        Some("2D521"),
+        Some("ConcurrentWriteException: A concurrent transaction has written new data since the current transaction read the table."),
+        startWith = true
+      )
+    }
+    {
+      val e = intercept[io.delta.exceptions.ProtocolChangedException] {
+        throw org.apache.spark.sql.delta.DeltaErrors.protocolChangedException(None)
+      }
+      checkErrorMessage(
+        e,
+        Some("DELTA_PROTOCOL_CHANGED"),
+        Some("2D521"),
+        Some("ProtocolChangedException: The protocol version of the Delta table has been changed by a concurrent update."),
+        startWith = true
+      )
+    }
+    {
+      val e = intercept[io.delta.exceptions.MetadataChangedException] {
+        throw org.apache.spark.sql.delta.DeltaErrors.metadataChangedException(None)
+      }
+      checkErrorMessage(
+        e,
+        Some("DELTA_METADATA_CHANGED"),
+        Some("2D521"),
+        Some("MetadataChangedException: The metadata of the Delta table has been changed by a concurrent update."),
+        startWith = true
       )
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -110,7 +110,21 @@ trait DeltaErrorsSuiteBase
         spark,
         StructType.fromDDL("id int"),
         StructType.fromDDL("id2 int"),
-        detectedDuringStreaming = true)
+        detectedDuringStreaming = true),
+    "concurrentAppendException" ->
+      DeltaErrors.concurrentAppendException(None, "p1"),
+    "concurrentDeleteDeleteException" ->
+      DeltaErrors.concurrentDeleteDeleteException(None, "p1"),
+    "concurrentDeleteReadException" ->
+      DeltaErrors.concurrentDeleteReadException(None, "p1"),
+    "concurrentWriteException" ->
+      DeltaErrors.concurrentWriteException(None),
+    "concurrentTransactionException" ->
+      DeltaErrors.concurrentTransactionException(None),
+    "metadataChangedException" ->
+      DeltaErrors.metadataChangedException(None),
+    "protocolChangedException" ->
+      DeltaErrors.protocolChangedException(None)
   )
 
   def otherMessagesToTest: Map[String, String] = Map(
@@ -2958,6 +2972,7 @@ trait DeltaErrorsSuiteBase
         Some("DELTA_MERGE_ADD_VOID_COLUMN"),
         Some("42K09"),
         Some(s"Cannot add column `fooCol` with type VOID. Please explicitly specify a non-void type.")
+      )
     }
     {
       val e = intercept[io.delta.exceptions.ConcurrentAppendException] {


### PR DESCRIPTION
## Description
This PR bolsters the concurrent exceptions Delta throws by adding error codes to them and plugs them into the DeltaThrowable framework.

## How was this patch tested?
Added unit tests to verify the error codes get populated correctly for these exceptions.
