### PR TITLE
[Spark]  Enable VACUUM logging by default

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
@@ -398,38 +398,6 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
 
 trait VacuumCommandImpl extends DeltaCommand {
 
-  private val supportedFsForLogging = Seq(
-    "wasbs", "wasbss", "abfs", "abfss", "adl", "gs", "file", "hdfs"
-  )
-
-  /**
-   * Returns whether we should record vacuum metrics in the delta log.
-   */
-  private def shouldLogVacuum(
-      spark: SparkSession,
-      deltaLog: DeltaLog,
-      hadoopConf: Configuration,
-      path: Path): Boolean = {
-    val logVacuumConf = spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_VACUUM_LOGGING_ENABLED)
-
-    if (logVacuumConf.nonEmpty) {
-      return logVacuumConf.get
-    }
-
-    val logStore = deltaLog.store
-
-    try {
-      val rawResolvedUri: URI = logStore.resolvePathOnPhysicalStorage(path, hadoopConf).toUri
-      val scheme = rawResolvedUri.getScheme
-      supportedFsForLogging.contains(scheme)
-    } catch {
-      case _: UnsupportedOperationException =>
-        logWarning("Vacuum event logging" +
-          " not enabled on this file system because we cannot detect your cloud storage type.")
-        false
-    }
-  }
-
   /**
    * Record Vacuum specific metrics in the commit log at the START of vacuum.
    *
@@ -454,7 +422,9 @@ trait VacuumCommandImpl extends DeltaCommand {
       s"deleted is $sizeOfDataToDelete (in bytes)")
 
     // We perform an empty commit in order to record information about the Vacuum
-    if (shouldLogVacuum(spark, deltaLog, deltaLog.newDeltaHadoopConf(), path)) {
+    val logEnabled = spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_VACUUM_LOGGING_ENABLED)
+    // Unless explicitly disabled, vacuum logging is enabled by default
+    if (logEnabled.getOrElse(true)) {
       val checkEnabled =
         spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_VACUUM_RETENTION_CHECK_ENABLED)
       val txn = deltaLog.startTransaction()
@@ -491,7 +461,9 @@ trait VacuumCommandImpl extends DeltaCommand {
       path: Path,
       filesDeleted: Option[Long] = None,
       dirCounts: Option[Long] = None): Unit = {
-    if (shouldLogVacuum(spark, deltaLog, deltaLog.newDeltaHadoopConf(), path)) {
+    val logEnabled = spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_VACUUM_LOGGING_ENABLED)
+    // Unless explicitly disabled, vacuum logging is enabled by default
+    if (logEnabled.getOrElse(true)) {
       val txn = deltaLog.startTransaction()
       val status = if (filesDeleted.isEmpty && dirCounts.isEmpty) { "FAILED" } else { "COMPLETED" }
       if (filesDeleted.nonEmpty && dirCounts.nonEmpty) {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR enables VACUUM logging by-default in all scenarios. Previously, VACUUM logging is enabled by-default only for a specific list of file systems. 


## How was this patch tested?

Unit tests and manual tests. The vacuum is enabled by default for AWS.

## Does this PR introduce _any_ user-facing changes?

No.
