### PR TITLE
[Spark] Add CLONE support for clustered tables.

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DomainMetadataUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DomainMetadataUtils.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.delta.actions.{Action, DomainMetadata, Protocol}
+import org.apache.spark.sql.delta.clustering.ClusteringMetadataDomain
 import org.apache.spark.sql.delta.metering.DeltaLogging
 
 object DomainMetadataUtils extends DeltaLogging {
@@ -26,6 +27,10 @@ object DomainMetadataUtils extends DeltaLogging {
   // List of metadata domains that will be copied from the table we are restoring to.
   private val METADATA_DOMAIN_TO_COPY_FOR_RESTORE_TABLE =
     METADATA_DOMAINS_TO_REMOVE_FOR_REPLACE_TABLE
+
+  // List of metadata domains that will be copied from the table on a CLONE operation.
+  private val METADATA_DOMAIN_TO_COPY_FOR_CLONE_TABLE: Set[String] = Set(
+    ClusteringMetadataDomain.domainName)
 
   /**
    * Returns whether the protocol version supports the [[DomainMetadata]] action.
@@ -94,6 +99,16 @@ object DomainMetadataUtils extends DeltaLogging {
       sourceDomainMetadatas: Seq[DomainMetadata]): Seq[DomainMetadata] = {
     sourceDomainMetadatas.filter { m =>
       METADATA_DOMAIN_TO_COPY_FOR_RESTORE_TABLE.contains(m.domain)
+    }
+  }
+
+  /**
+   *  Generates sequence of DomainMetadata to commit for CLONE TABLE command.
+   */
+  def handleDomainMetadataForCloneTable(
+      sourceDomainMetadatas: Seq[DomainMetadata]): Seq[DomainMetadata] = {
+    sourceDomainMetadatas.filter { m =>
+      METADATA_DOMAIN_TO_COPY_FOR_CLONE_TABLE.contains(m.domain)
     }
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
@@ -22,6 +22,7 @@ import java.util.UUID
 
 import scala.collection.JavaConverters._
 
+import org.apache.spark.sql.delta.skipping.clustering.ClusteredTableUtils
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.metering.DeltaLogging
@@ -226,6 +227,14 @@ abstract class CloneTableBase(
           // CLONE does not preserve Row IDs and Commit Versions
           copiedFile.copy(baseRowId = None, defaultRowCommitVersion = None)
         }
+      sourceTable.snapshot.foreach { sourceSnapshot =>
+
+        // Handle DomainMetadata for cloning a table.
+        if (deltaOperation.name == DeltaOperations.OP_CLONE) {
+          actions ++=
+            DomainMetadataUtils.handleDomainMetadataForCloneTable(sourceSnapshot.domainMetadata)
+        }
+      }
       val sourceName = sourceTable.name
       // Override source table metadata with user-defined table properties
       val context = Map[String, String]()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
@@ -20,12 +20,19 @@ import java.io.File
 
 import org.apache.spark.sql.delta.skipping.ClusteredTableTestUtils
 import org.apache.spark.sql.delta.{DeltaAnalysisException, DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode, DeltaConfigs, DeltaLog, DeltaUnsupportedOperationException}
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.SkippingEligibleDataType
 import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest}
+import io.delta.tables.DeltaTable
 
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.{AnalysisException, Dataset, QueryTest, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
+import org.apache.spark.sql.catalyst.plans.logical.CloneTableStatement
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{ArrayType, IntegerType, StructField, StructType}
 
@@ -663,6 +670,60 @@ trait ClusteredTableDDLSuiteBase
             "columns" -> "col1.col12",
             "schema" -> snapshot.statCollectionLogicalSchema.treeString)
         )
+      }
+    }
+  }
+
+  testQuietly("validate CLONE on clustered table") {
+    import testImplicits._
+    val srcTable = "SrcTbl"
+    val dstTable = "DestTbl"
+    Seq(true, false).foreach { useSQL =>
+      withTable(srcTable, dstTable) {
+        // Create the source table.
+        sql(s"CREATE TABLE $srcTable (col1 INT, col2 INT, col3 INT) " +
+          s"USING delta CLUSTER BY (col1, col2)")
+        val tableIdent = new TableIdentifier(srcTable)
+        (1 to 100).map(i => (i, i + 1000, i + 100)).toDF("col1", "col2", "col3")
+          .repartitionByRange(100, col("col1"))
+          .write.format("delta").mode("append").saveAsTable(srcTable)
+
+        // Force clustering on the source table.
+        val (_, srcSnapshot) = DeltaLog.forTableWithSnapshot(spark, tableIdent)
+        val ingestionSize = srcSnapshot.allFiles.collect().map(_.size).sum
+        withSQLConf(
+          DeltaSQLConf.DELTA_OPTIMIZE_MAX_FILE_SIZE.key -> (ingestionSize / 4).toString) {
+          runOptimize(srcTable) { res =>
+            assert(res.numFilesAdded === 4)
+            assert(res.numFilesRemoved === 100)
+          }
+        }
+
+        // Create destination table as a clone of the source table.
+        if (useSQL) {
+          sql(s"CREATE TABLE $dstTable SHALLOW CLONE $srcTable")
+        } else {
+          val sourceIdentifier = Identifier.of(
+            TableIdentifier(srcTable).database.toArray, TableIdentifier(srcTable).table)
+          val sourceRelation = DataSourceV2Relation.create(
+            DeltaTableV2(spark, TableIdentifier(srcTable), ""), None, Some(sourceIdentifier))
+          val clone = CloneTableStatement(
+            sourceRelation,
+            UnresolvedRelation(TableIdentifier(dstTable)),
+            ifNotExists = false,
+            isReplaceCommand = false,
+            isCreateCommand = true,
+            tablePropertyOverrides = Map.empty[String, String],
+            targetLocation = None)
+
+          Dataset.ofRows(spark, clone).collect()
+          DeltaTable.forName(spark, dstTable)
+        }
+
+        // Validate clustering columns and that clustering columns in stats schema.
+        val (_, dstSnapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(dstTable))
+        verifyClusteringColumns(TableIdentifier(dstTable), "col1,col2")
+        ClusteredTableUtils.validateClusteringColumnsInStatsSchema(dstSnapshot, Seq("col1", "col2"))
       }
     }
   }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Adds support for CLONE operation on clustered tables.

## How was this patch tested?
Test added to `ClusteredTableDDLSuite`

## Does this PR introduce _any_ user-facing changes?
No.
