### PR TITLE
[DOCS] Fixed canonical links in docs that was messing up the SEO

### DIFF
--- a/docs/shared/theme/delta/layout.html
+++ b/docs/shared/theme/delta/layout.html
@@ -22,7 +22,7 @@
   <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
   {% endblock %}
   {# CANONICAL #} 
-  <link rel="canonical" href="https://docs.delta.io/{{ pagename }}.html">
+  <link rel="canonical" href="https://docs.delta.io/latest/{{ pagename }}.html">
   {# FAVICON #}
   {% if favicon %}
     <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}"/>


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (fill in here) - Docs infra

## Description
As the title says

## How was this patch tested?
N/A

## Does this PR introduce _any_ user-facing changes?
No