### PR TITLE
[Spark] [Delta X-Compile] Refactor AnalysisException to DeltaAnalysisException (batch 2)

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -1329,6 +1329,12 @@
     ],
     "sqlState" : "40000"
   },
+  "DELTA_MERGE_ADD_VOID_COLUMN" : {
+    "message" : [
+      "Cannot add column <newColumn> with type VOID. Please explicitly specify a non-void type."
+    ],
+    "sqlState" : "42K09"
+  },
   "DELTA_MERGE_INCOMPATIBLE_DATATYPE" : {
     "message" : [
       "Failed to merge incompatible data types <currentDataType> and <updateDataType>"
@@ -1522,6 +1528,12 @@
   "DELTA_NON_BOOLEAN_CHECK_CONSTRAINT" : {
     "message" : [
       "CHECK constraint '<name>' (<expr>) should be a boolean expression."
+    ],
+    "sqlState" : "42621"
+  },
+  "DELTA_NON_DETERMINISTIC_EXPRESSION_IN_GENERATED_COLUMN" : {
+    "message" : [
+      "Found <expr>. A generated column cannot use a non deterministic expression."
     ],
     "sqlState" : "42621"
   },
@@ -2712,6 +2724,30 @@
       "Delta configuration:",
       "<configuration>",
       "If you would like to merge the configurations (update existing fields and insert new ones), set the SQL configuration `<metadataCheckSqlConf>` to false."
+    ]
+  },
+  "_LEGACY_ERROR_TEMP_DELTA_0004" : {
+    "message" : [
+      "Cannot <operation> column <columnName> because this column is referenced by the following",
+      "check constraint(s):",
+      "<constraints>"
+    ]
+  },
+  "_LEGACY_ERROR_TEMP_DELTA_0005" : {
+    "message" : [
+      "Cannot <operation> column <columnName> because this column is referenced by the following",
+      "generated column(s):",
+      "<generatedColumns>"
+    ]
+  },
+  "_LEGACY_ERROR_TEMP_DELTA_0006" : {
+    "message" : [
+      "Inconsistent IDENTITY metadata for column <colName> detected: <hasStart>, <hasStep>, <hasInsert>"
+    ]
+  },
+  "_LEGACY_ERROR_TEMP_DELTA_0007" : {
+    "message" : [
+      "<message>"
     ]
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3270,7 +3270,7 @@ trait DeltaErrorsBase
   def mergeAddVoidColumn(columnName: String): Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_MERGE_ADD_VOID_COLUMN",
-      messageParameters = Array(columnName)
+      messageParameters = Array(toSQLId(columnName))
     )
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1739,8 +1739,9 @@ trait DeltaErrorsBase
   }
 
   def generatedColumnsNonDeterministicExpression(expr: Expression): Throwable = {
-    new AnalysisException(
-      s"Found ${expr.sql}. A generated column cannot use a non deterministic expression")
+    new DeltaAnalysisException(
+      errorClass = "DELTA_NON_DETERMINISTIC_EXPRESSION_IN_GENERATED_COLUMN",
+      messageParameters = Array(s"${expr.sql}"))
   }
 
   def generatedColumnsAggregateExpression(expr: Expression): Throwable = {
@@ -2074,24 +2075,20 @@ trait DeltaErrorsBase
       operation: String,
       columnName: String,
       constraints: Map[String, String]): Throwable = {
-    val plural = if (constraints.size > 1) "s" else ""
-    new AnalysisException(
-      s"""
-        |Cannot $operation column $columnName because this column is referenced by the following
-        | check constraint$plural:\n\t${constraints.mkString("\n\t")}
-        |""".stripMargin)
+    new DeltaAnalysisException(
+      errorClass = "_LEGACY_ERROR_TEMP_DELTA_0004",
+      messageParameters = Array(operation, toSQLId(columnName), constraints.mkString("\n"))
+    )
   }
 
   def foundViolatingGeneratedColumnsForColumnChange(
       operation: String,
       columnName: String,
       fields: Seq[StructField]): Throwable = {
-    val plural = if (fields.size > 1) "s" else ""
-    new AnalysisException(
-      s"""
-         |Cannot $operation column $columnName because this column is referenced by the following
-         | generated column$plural:\n\t${fields.map(_.name).mkString("\n\t")}
-         |""".stripMargin)
+    new DeltaAnalysisException(
+      errorClass = "_LEGACY_ERROR_TEMP_DELTA_0005",
+      messageParameters = Array(operation, toSQLId(columnName), fields.map(_.name).mkString("\n"))
+    )
   }
 
   def missingColumnsInInsertInto(column: String): Throwable = {
@@ -2416,8 +2413,10 @@ trait DeltaErrorsBase
       hasStart: Boolean,
       hasStep: Boolean,
       hasInsert: Boolean): Throwable = {
-    new AnalysisException(s"Inconsistent IDENTITY metadata for column $colName " +
-      s"detected: $hasStart, $hasStep, $hasInsert")
+    new DeltaAnalysisException(
+      errorClass = "_LEGACY_ERROR_TEMP_DELTA_0006",
+      messageParameters = Array(toSQLId(colName), s"$hasStart", s"$hasStep", s"$hasInsert")
+    )
   }
 
   def activeSparkSessionNotFound(): Throwable = {
@@ -3267,6 +3266,13 @@ trait DeltaErrorsBase
       errorClass = "DELTA_CREATE_TABLE_SET_CLUSTERING_TABLE_FEATURE_NOT_ALLOWED",
       messageParameters = Array(tableFeature))
   }
+
+  def mergeAddVoidColumn(columnName: String): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_MERGE_ADD_VOID_COLUMN",
+      messageParameters = Array(toSQLId(columnName))
+    )
+  }
 }
 
 object DeltaErrors extends DeltaErrorsBase
@@ -3436,7 +3442,10 @@ class MetadataMismatchErrorBuilder {
   }
 
   def finalizeAndThrow(conf: SQLConf): Unit = {
-    throw new AnalysisException(bits.mkString("\n"))
+    throw new DeltaAnalysisException(
+      errorClass = "_LEGACY_ERROR_TEMP_DELTA_0007",
+      messageParameters = Array(bits.mkString("\n"))
+    )
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2077,7 +2077,7 @@ trait DeltaErrorsBase
       constraints: Map[String, String]): Throwable = {
     new DeltaAnalysisException(
       errorClass = "_LEGACY_ERROR_TEMP_DELTA_0004",
-      messageParameters = Array(operation, toSQLId(columnName), constraints.mkString("\n"))
+      messageParameters = Array(operation, columnName, constraints.mkString("\n"))
     )
   }
 
@@ -2087,7 +2087,7 @@ trait DeltaErrorsBase
       fields: Seq[StructField]): Throwable = {
     new DeltaAnalysisException(
       errorClass = "_LEGACY_ERROR_TEMP_DELTA_0005",
-      messageParameters = Array(operation, toSQLId(columnName), fields.map(_.name).mkString("\n"))
+      messageParameters = Array(operation, columnName, fields.map(_.name).mkString("\n"))
     )
   }
 
@@ -2415,7 +2415,7 @@ trait DeltaErrorsBase
       hasInsert: Boolean): Throwable = {
     new DeltaAnalysisException(
       errorClass = "_LEGACY_ERROR_TEMP_DELTA_0006",
-      messageParameters = Array(toSQLId(colName), s"$hasStart", s"$hasStep", s"$hasInsert")
+      messageParameters = Array(colName, s"$hasStart", s"$hasStep", s"$hasInsert")
     )
   }
 
@@ -3270,7 +3270,7 @@ trait DeltaErrorsBase
   def mergeAddVoidColumn(columnName: String): Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_MERGE_ADD_VOID_COLUMN",
-      messageParameters = Array(toSQLId(columnName))
+      messageParameters = Array(columnName)
     )
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
@@ -160,10 +160,7 @@ trait MergeIntoCommandBase extends LeafRunnableCommand
       // queries that add void columns.
       val newNullColumn = SchemaUtils.findNullTypeColumn(migratedSchema.get)
       if (newNullColumn.isDefined) {
-        throw new AnalysisException(
-          s"""Cannot add column '${newNullColumn.get}' with type 'void'. Please explicitly specify a
-              |non-void type.""".stripMargin.replaceAll("\n", " ")
-        )
+        throw DeltaErrors.mergeAddVoidColumn(newNullColumn.get)
       }
     }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2957,7 +2957,7 @@ trait DeltaErrorsSuiteBase
         e,
         Some("DELTA_MERGE_ADD_VOID_COLUMN"),
         Some("42K09"),
-        Some(s"Cannot add column fooCol with type VOID. Please explicitly specify a non-void type.")
+        Some(s"Cannot add column `fooCol` with type VOID. Please explicitly specify a non-void type.")
       )
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2908,7 +2908,7 @@ trait DeltaErrorsSuiteBase
         Some("_LEGACY_ERROR_TEMP_DELTA_0004"),
         None,
         Some(
-          s"""Cannot UPDATE column `col1` because this column is referenced by the following
+          s"""Cannot UPDATE column col1 because this column is referenced by the following
              |check constraint(s):
              |foo -> bar""".stripMargin)
       )
@@ -2923,7 +2923,7 @@ trait DeltaErrorsSuiteBase
         Some("_LEGACY_ERROR_TEMP_DELTA_0005"),
         None,
         Some(
-          s"""Cannot UPDATE column `col1` because this column is referenced by the following
+          s"""Cannot UPDATE column col1 because this column is referenced by the following
              |generated column(s):
              |col2""".stripMargin)
       )
@@ -2936,7 +2936,7 @@ trait DeltaErrorsSuiteBase
         e,
         Some("_LEGACY_ERROR_TEMP_DELTA_0006"),
         None,
-        Some(s"Inconsistent IDENTITY metadata for column `col1` detected: true, true, true")
+        Some(s"Inconsistent IDENTITY metadata for column col1 detected: true, true, true")
       )
     }
     {
@@ -2957,7 +2957,7 @@ trait DeltaErrorsSuiteBase
         e,
         Some("DELTA_MERGE_ADD_VOID_COLUMN"),
         Some("42K09"),
-        Some(s"Cannot add column `fooCol` with type VOID. Please explicitly specify a non-void type.")
+        Some(s"Cannot add column fooCol with type VOID. Please explicitly specify a non-void type.")
       )
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2886,6 +2886,80 @@ trait DeltaErrorsSuiteBase
         Some("0AKDC"),
         Some("Operation not allowed: FOO_OP cannot be performed on a view."))
     }
+    {
+      val expr = "1".expr
+      val e = intercept[DeltaAnalysisException] {
+        throw DeltaErrors.generatedColumnsNonDeterministicExpression(expr)
+      }
+      checkErrorMessage(
+        e,
+        Some("DELTA_NON_DETERMINISTIC_EXPRESSION_IN_GENERATED_COLUMN"),
+        Some("42621"),
+        Some(s"Found ${expr.sql}. A generated column cannot use a non deterministic expression.")
+      )
+    }
+    {
+      val e = intercept[DeltaAnalysisException] {
+        throw DeltaErrors.foundViolatingConstraintsForColumnChange(
+          "UPDATE", "col1", Map("foo" -> "bar"))
+      }
+      checkErrorMessage(
+        e,
+        Some("_LEGACY_ERROR_TEMP_DELTA_0004"),
+        None,
+        Some(
+          s"""Cannot UPDATE column `col1` because this column is referenced by the following
+             |check constraint(s):
+             |foo -> bar""".stripMargin)
+      )
+    }
+    {
+      val e = intercept[DeltaAnalysisException] {
+        throw DeltaErrors.foundViolatingGeneratedColumnsForColumnChange(
+          "UPDATE", "col1", Seq(StructField("col2", IntegerType)))
+      }
+      checkErrorMessage(
+        e,
+        Some("_LEGACY_ERROR_TEMP_DELTA_0005"),
+        None,
+        Some(
+          s"""Cannot UPDATE column `col1` because this column is referenced by the following
+             |generated column(s):
+             |col2""".stripMargin)
+      )
+    }
+    {
+      val e = intercept[DeltaAnalysisException] {
+        throw DeltaErrors.identityColumnInconsistentMetadata("col1", true, true, true)
+      }
+      checkErrorMessage(
+        e,
+        Some("_LEGACY_ERROR_TEMP_DELTA_0006"),
+        None,
+        Some(s"Inconsistent IDENTITY metadata for column `col1` detected: true, true, true")
+      )
+    }
+    {
+      val errorBuilder = new MetadataMismatchErrorBuilder()
+      val schema1 = StructType(Seq(StructField("c0", IntegerType)))
+      val schema2 = StructType(Seq(StructField("c0", StringType)))
+      errorBuilder.addSchemaMismatch(schema1, schema2, "id")
+      val e = intercept[DeltaAnalysisException] {
+        errorBuilder.finalizeAndThrow(spark.sessionState.conf)
+      }
+      assert(e.getErrorClass == "_LEGACY_ERROR_TEMP_DELTA_0007")
+    }
+    {
+      val e = intercept[DeltaAnalysisException] {
+        throw DeltaErrors.mergeAddVoidColumn("fooCol")
+      }
+      checkErrorMessage(
+        e,
+        Some("DELTA_MERGE_ADD_VOID_COLUMN"),
+        Some("42K09"),
+        Some(s"Cannot add column `fooCol` with type VOID. Please explicitly specify a non-void type.")
+      )
+    }
   }
 }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSchemaEvolutionSuite.scala
@@ -990,7 +990,7 @@ trait MergeIntoSchemaEvolutionBaseTests {
     targetData = Seq((1, 1)).toDF("key", "value"),
     sourceData = Seq((1, 100, null), (2, 200, null)).toDF("key", "value", "extra"),
     clauses = update("*") :: insert("*") :: Nil,
-    expectErrorContains = "Cannot add column 'extra' with type 'void'",
+    expectErrorContains = "Cannot add column `extra` with type VOID",
     expectedWithoutEvolution = Seq((1, 100), (2, 200)).toDF("key", "value")
   )
 
@@ -1500,7 +1500,7 @@ trait MergeIntoNestedStructEvolutionTests {
         new StructType()
           .add("a", new StructType().add("x", IntegerType).add("z", NullType))),
     clauses = update("*") :: Nil,
-    expectErrorContains = "Cannot add column 'value.a.z' with type 'void'",
+    expectErrorContains = "Cannot add column `value`.`a`.`z` with type VOID",
     expectErrorWithoutEvolutionContains = "All nested columns must match")
 
   // scalastyle:off line.size.limit


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

We want Delta to cross-compile against both Spark 3.5 and Spark Master (4.0).

Unfortunately, the constructor `new AnalysisException("msg")` became protected in Spark 4.0, meaning that all such occurances do not compile against Spark 3.5.

Thus, we decided to:
- replace `AnalysisException` with `DeltaAnalysisException`
- use errorClasses
- assign temporary error classes when needed to speed this along

This PR fixes compilation errors [6, 11] of ~20.

## How was this patch tested?

New UTs in `DeltaErrorsSuite`.

Also, cherry-picked to the oss-cross-compile branch (https://github.com/delta-io/delta/pull/2780) and cross-compiled:
- (this branch) Spark 3.5: ✅ 
- (this branch) Spark 4.0: 10 compilation errors. (the oss-cross-compile branch has 16 compilation errors, this is expected)

## Does this PR introduce _any_ user-facing changes?

No
