### PR TITLE
[Kernel] Retry `_last_checkpoint` loading in case of failures

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
@@ -125,7 +125,8 @@ public class Checkpointer {
                 // Checkpoint has no data. This is a valid case on some file systems where the
                 // contents are not visible until the file stream is closed.
                 // Sleep for one second and retry.
-                logger.warn("Last checkpoint file {} has no data. " +
+                logger.warn(
+                        "Last checkpoint file {} has no data. " +
                                 "Retrying after 1sec. (current attempt = {})",
                         lastCheckpointFilePath,
                         tries);
@@ -138,7 +139,8 @@ public class Checkpointer {
             Thread.currentThread().interrupt();
             return Optional.empty();
         } catch (Exception ex) {
-            String msg = String.format("Failed to load checkpoint metadata from file %s. " +
+            String msg = String.format(
+                    "Failed to load checkpoint metadata from file %s. " +
                             "Retrying after 1sec. (current attempt = %s)",
                     lastCheckpointFilePath, tries);
             logger.warn(msg, ex);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
@@ -15,11 +15,12 @@
  */
 package io.delta.kernel.internal.checkpoints;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.io.FileNotFoundException;
+import java.util.*;
 import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.delta.kernel.client.TableClient;
 import io.delta.kernel.data.ColumnarBatch;
@@ -35,6 +36,8 @@ import static io.delta.kernel.internal.util.Utils.singletonCloseableIterator;
  * Class to load the {@link CheckpointMetaData} from `_last_checkpoint` file.
  */
 public class Checkpointer {
+    private static final Logger logger = LoggerFactory.getLogger(Checkpointer.class);
+
     /**
      * The name of the last checkpoint file
      */
@@ -86,28 +89,61 @@ public class Checkpointer {
      * Returns information about the most recent checkpoint.
      */
     public Optional<CheckpointMetaData> readLastCheckpointFile(TableClient tableClient) {
-        return loadMetadataFromFile(tableClient);
+        return loadMetadataFromFile(tableClient, 0 /* tries */);
     }
 
     /**
      * Loads the checkpoint metadata from the _last_checkpoint file.
+     * <p>
+     * @param tableClient {@link TableClient instance to use}
+     * @param tries Number of times already tried to load the metadata before this call.
      */
-    private Optional<CheckpointMetaData> loadMetadataFromFile(TableClient tableClient) {
-        try {
-            // For now we use file size = 0 and modification time = 0, in the future we should use
-            // listFrom to retrieve the real values see delta-io/delta#2140
-            FileStatus lastCheckpointFile = FileStatus.of(lastCheckpointFilePath.toString(), 0, 0);
-
-            try(CloseableIterator<ColumnarBatch> jsonIter =
-                tableClient.getJsonHandler().readJsonFiles(
-                    singletonCloseableIterator(lastCheckpointFile),
-                    CheckpointMetaData.READ_SCHEMA,
-                    Optional.empty())) {
-                Optional<Row> checkpointRow = InternalUtils.getSingularRow(jsonIter);
-                return checkpointRow.map(CheckpointMetaData::fromRow);
-            }
-        } catch (Exception ex) {
+    private Optional<CheckpointMetaData> loadMetadataFromFile(TableClient tableClient, int tries) {
+        if (tries >= 3) {
+            // We have tried 3 times and failed. Assume the checkpoint metadata file is corrupt.
+            logger.warn(
+                    "Failed to load checkpoint metadata from file {} after 3 attempts.",
+                    lastCheckpointFilePath);
             return Optional.empty();
+        }
+        try {
+            // Use arbitrary values for size and mod time as they are not available.
+            // We could list and find the values, but it is an unnecessary FS call.
+            FileStatus lastCheckpointFile = FileStatus.of(
+                    lastCheckpointFilePath.toString(), 0 /* size */, 0 /* modTime */);
+
+            try (CloseableIterator<ColumnarBatch> jsonIter =
+                         tableClient.getJsonHandler().readJsonFiles(
+                                 singletonCloseableIterator(lastCheckpointFile),
+                                 CheckpointMetaData.READ_SCHEMA,
+                                 Optional.empty())) {
+                Optional<Row> checkpointRow = InternalUtils.getSingularRow(jsonIter);
+                if (checkpointRow.isPresent()) {
+                    return Optional.of(CheckpointMetaData.fromRow(checkpointRow.get()));
+                }
+
+                // Checkpoint has no data. This is a valid case on some file systems where the
+                // contents are not visible until the file stream is closed.
+                // Sleep for one second and retry.
+                logger.warn("Last checkpoint file {} has no data. " +
+                                "Retrying after 1sec. (current attempt = {})",
+                        lastCheckpointFilePath,
+                        tries);
+                Thread.sleep(1000);
+                return loadMetadataFromFile(tableClient, tries + 1);
+            }
+        } catch (FileNotFoundException ex) {
+            return Optional.empty(); // there is no point retrying
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            return Optional.empty();
+        } catch (Exception ex) {
+            String msg = String.format("Failed to load checkpoint metadata from file %s. " +
+                            "Retrying after 1sec. (current attempt = %s)",
+                    lastCheckpointFilePath, tries);
+            logger.warn(msg, ex);
+            // we can retry until max tries are exhausted
+            return loadMetadataFromFile(tableClient, tries + 1);
         }
     }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -172,9 +172,9 @@ public class SnapshotManager {
      * Get an iterator of files in the _delta_log directory starting with the startVersion.
      */
     private CloseableIterator<FileStatus> listFrom(
-        TableClient tableClient,
-        long startVersion)
-        throws IOException {
+            TableClient tableClient,
+            long startVersion)
+            throws IOException {
         logger.debug("startVersion: {}", startVersion);
         return tableClient
             .getFileSystemClient()

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checkpoints/CheckpointerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checkpoints/CheckpointerSuite.scala
@@ -1,0 +1,185 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.checkpoints
+
+import io.delta.kernel.client._
+import io.delta.kernel.data.{ColumnVector, ColumnarBatch}
+import io.delta.kernel.expressions.Predicate
+import io.delta.kernel.internal.fs.Path
+import io.delta.kernel.internal.util.Utils
+import io.delta.kernel.types.{DataType, LongType, StructType}
+import io.delta.kernel.utils.{CloseableIterator, FileStatus}
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.io.{FileNotFoundException, IOException}
+import java.util.Optional
+
+class CheckpointerSuite extends AnyFunSuite {
+  import CheckpointerSuite._
+
+  test("load a valid last checkpoint metadata file") {
+    val jsonHandler = new TestJsonHandler(maxFailures = 0)
+    val lastCheckpoint = new Checkpointer(VALID_LAST_CHECKPOINT_FILE_TABLE)
+      .readLastCheckpointFile(mockTableClient(jsonHandler))
+    assertValidCheckpointMetadata(lastCheckpoint)
+    assert(jsonHandler.currentFailCount == 0)
+  }
+
+  test("load a zero-sized last checkpoint metadata file") {
+    val jsonHandler = new TestJsonHandler(maxFailures = 0)
+    val lastCheckpoint = new Checkpointer(ZERO_SIZED_LAST_CHECKPOINT_FILE_TABLE)
+      .readLastCheckpointFile(mockTableClient(jsonHandler))
+    assert(!lastCheckpoint.isPresent)
+    assert(jsonHandler.currentFailCount == 0)
+  }
+
+  test("load an invalid last checkpoint metadata file") {
+    val jsonHandler = new TestJsonHandler(maxFailures = 0)
+    val lastCheckpoint = new Checkpointer(INVALID_LAST_CHECKPOINT_FILE_TABLE)
+      .readLastCheckpointFile(mockTableClient(jsonHandler))
+    assert(!lastCheckpoint.isPresent)
+    assert(jsonHandler.currentFailCount == 0)
+  }
+
+  test("retry metadata loading - succeeds at third attempt") {
+    val jsonHandler = new TestJsonHandler(maxFailures = 2)
+    val lastCheckpoint = new Checkpointer(VALID_LAST_CHECKPOINT_FILE_TABLE)
+      .readLastCheckpointFile(mockTableClient(jsonHandler))
+    assertValidCheckpointMetadata(lastCheckpoint)
+    assert(jsonHandler.currentFailCount == 2)
+  }
+
+  test("retry metadata loading - exceeds max failures") {
+    val jsonHandler = new TestJsonHandler(maxFailures = 4)
+    val lastCheckpoint = new Checkpointer(VALID_LAST_CHECKPOINT_FILE_TABLE)
+      .readLastCheckpointFile(mockTableClient(jsonHandler))
+    assert(!lastCheckpoint.isPresent)
+    assert(jsonHandler.currentFailCount == 3) // 3 is the max retries
+  }
+
+  test("try to load when the file is missing") {
+    val jsonHandler = new TestJsonHandler(maxFailures = 0)
+    val lastCheckpoint = new Checkpointer(LAST_CHECKPOINT_FILE_NOT_FOUND_TABLE)
+      .readLastCheckpointFile(mockTableClient(jsonHandler))
+    assert(!lastCheckpoint.isPresent)
+    assert(jsonHandler.currentFailCount == 0)
+  }
+
+  /** Assert that the checkpoint metadata is same as [[SAMPLE_LAST_CHECKPOINT_FILE_CONTENT]] */
+  def assertValidCheckpointMetadata(actual: Optional[CheckpointMetaData]): Unit = {
+    assert(actual.isPresent)
+    val metadata = actual.get()
+    assert(metadata.version == 40L)
+    assert(metadata.size == 44L)
+    assert(metadata.parts == Optional.of(20L))
+  }
+}
+
+object CheckpointerSuite {
+  val SAMPLE_LAST_CHECKPOINT_FILE_CONTENT: ColumnarBatch = new ColumnarBatch {
+    override def getSchema: StructType = CheckpointMetaData.READ_SCHEMA
+
+    override def getColumnVector(ordinal: Int): ColumnVector = {
+      ordinal match {
+        case 0 => longVector(40) // version
+        case 1 => longVector(44) // size
+        case 2 => longVector(20); // parts
+      }
+    }
+
+    override def getSize: Int = 1
+  }
+
+  val ZERO_ENTRIES_COLUMNAR_BATCH: ColumnarBatch = new ColumnarBatch {
+    override def getSchema: StructType = CheckpointMetaData.READ_SCHEMA
+
+    // empty vector for all columns
+    override def getColumnVector(ordinal: Int): ColumnVector = longVector()
+
+    override def getSize: Int = 0
+  }
+
+  val VALID_LAST_CHECKPOINT_FILE_TABLE = new Path("/valid")
+  val ZERO_SIZED_LAST_CHECKPOINT_FILE_TABLE = new Path("/zero_sized")
+  val INVALID_LAST_CHECKPOINT_FILE_TABLE = new Path("/invalid")
+  val LAST_CHECKPOINT_FILE_NOT_FOUND_TABLE = new Path("/filenotfoundtable")
+
+  def longVector(values: Long*): ColumnVector = new ColumnVector {
+    override def getDataType: DataType = LongType.LONG
+
+    override def getSize: Int = 1
+
+    override def close(): Unit = {}
+
+    override def isNullAt(rowId: Int): Boolean = false
+
+    override def getLong(rowId: Int): Long = values(rowId)
+  }
+
+  def mockTableClient(jsonHandler: JsonHandler): TableClient = {
+    new TableClient() {
+      override def getExpressionHandler: ExpressionHandler =
+        throw new UnsupportedOperationException("not supported for in this test suite")
+
+      override def getJsonHandler: JsonHandler = jsonHandler
+
+      override def getFileSystemClient: FileSystemClient =
+        throw new UnsupportedOperationException("not supported for in this test suite")
+
+      override def getParquetHandler: ParquetHandler =
+        throw new UnsupportedOperationException("not supported for in this test suite")
+    }
+  }
+}
+
+/** `maxFailures` allows how many times to fail before returning the valid data */
+class TestJsonHandler(maxFailures: Int) extends JsonHandler {
+  import CheckpointerSuite._
+  var currentFailCount = 0;
+
+  override def parseJson(
+      jsonStringVector: ColumnVector,
+      outputSchema: StructType,
+      selectionVector: Optional[ColumnVector]): ColumnarBatch =
+    throw new UnsupportedOperationException("not supported for in this test suite")
+
+  override def deserializeStructType(structTypeJson: String): StructType =
+    throw new UnsupportedOperationException("not supported for in this test suite")
+
+  override def readJsonFiles(
+      fileIter: CloseableIterator[FileStatus],
+      physicalSchema: StructType,
+      predicate: Optional[Predicate]): CloseableIterator[ColumnarBatch] = {
+    val file = fileIter.next()
+    val path = new Path(file.getPath)
+
+    if (currentFailCount < maxFailures) {
+      currentFailCount += 1
+      throw new IOException("Retryable exception")
+    }
+
+    Utils.singletonCloseableIterator(
+      path.getParent match {
+        case VALID_LAST_CHECKPOINT_FILE_TABLE => SAMPLE_LAST_CHECKPOINT_FILE_CONTENT
+        case ZERO_SIZED_LAST_CHECKPOINT_FILE_TABLE => ZERO_ENTRIES_COLUMNAR_BATCH
+        case INVALID_LAST_CHECKPOINT_FILE_TABLE =>
+          throw new IOException("Invalid last checkpoint file")
+        case LAST_CHECKPOINT_FILE_NOT_FOUND_TABLE =>
+          throw new FileNotFoundException("File not found")
+        case _ => throw new IOException("Unknown table")
+      })
+  }
+}

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checkpoints/CheckpointerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checkpoints/CheckpointerSuite.scala
@@ -30,6 +30,9 @@ import java.util.Optional
 class CheckpointerSuite extends AnyFunSuite {
   import CheckpointerSuite._
 
+  //////////////////////////////////////////////////////////////////////////////////
+  // readLastCheckpointFile tests
+  //////////////////////////////////////////////////////////////////////////////////
   test("load a valid last checkpoint metadata file") {
     val jsonHandler = new TestJsonHandler(maxFailures = 0)
     val lastCheckpoint = new Checkpointer(VALID_LAST_CHECKPOINT_FILE_TABLE)
@@ -54,7 +57,7 @@ class CheckpointerSuite extends AnyFunSuite {
     assert(jsonHandler.currentFailCount == 0)
   }
 
-  test("retry metadata loading - succeeds at third attempt") {
+  test("retry last checkpoint metadata loading - succeeds at third attempt") {
     val jsonHandler = new TestJsonHandler(maxFailures = 2)
     val lastCheckpoint = new Checkpointer(VALID_LAST_CHECKPOINT_FILE_TABLE)
       .readLastCheckpointFile(mockTableClient(jsonHandler))
@@ -62,7 +65,7 @@ class CheckpointerSuite extends AnyFunSuite {
     assert(jsonHandler.currentFailCount == 2)
   }
 
-  test("retry metadata loading - exceeds max failures") {
+  test("retry last checkpoint metadata loading - exceeds max failures") {
     val jsonHandler = new TestJsonHandler(maxFailures = 4)
     val lastCheckpoint = new Checkpointer(VALID_LAST_CHECKPOINT_FILE_TABLE)
       .readLastCheckpointFile(mockTableClient(jsonHandler))


### PR DESCRIPTION
## Description
Currently, Kernel stops on first failure at loading the `_last_checkpoint` file (which contains info about the last checkpoint). We should have mechanisms to retry just like how Delta-Spark retries on retryable failures. More details are [here](https://docs.google.com/document/d/13Nock1I8-143Dwidj8rMpgt3wAicrOI2OvDJt3OufOQ/edit?usp=sharing).


## How was this patch tested?
Added mock unittests

## Does this PR introduce _any_ user-facing changes?

