### PR TITLE
[Spark] [Delta X-Compile] Refactor AnalysisException to DeltaAnalysisException (batch 3) 

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -422,6 +422,12 @@
     ],
     "sqlState" : "42703"
   },
+  "DELTA_COLUMN_MISSING_DATA_TYPE" : {
+    "message" : [
+      "The data type of the column <colName> was not provided."
+    ],
+    "sqlState" : "42601"
+  },
   "DELTA_COLUMN_NOT_FOUND" : {
     "message" : [
       "Unable to find the column `<columnName>` given [<columnList>]"
@@ -443,8 +449,9 @@
   "DELTA_COLUMN_PATH_NOT_NESTED" : {
     "message" : [
       "Expected <columnPath> to be a nested data type, but found <other>. Was looking for the",
-      "index of <column> in a nested field",
-      ""
+      "index of <column> in a nested field.",
+      "Schema:",
+      "<schema>"
     ],
     "sqlState" : "42704"
   },
@@ -585,6 +592,18 @@
     ],
     "sqlState" : "42K03"
   },
+  "DELTA_CREATE_TABLE_IDENTIFIER_LOCATION_MISMATCH" : {
+    "message" : [
+      "Creating path-based Delta table with a different location isn't supported. Identifier: <identifier>, Location: <location>"
+    ],
+    "sqlState" : "0AKDC"
+  },
+  "DELTA_CREATE_TABLE_MISSING_TABLE_NAME_OR_LOCATION" : {
+    "message" : [
+      "Table name or location has to be specified."
+    ],
+    "sqlState" : "42601"
+  },
   "DELTA_CREATE_TABLE_SCHEME_MISMATCH" : {
     "message" : [
       "The specified schema does not match the existing schema at <path>.",
@@ -689,6 +708,13 @@
       "Index <columnIndex> to drop column is lower than 0"
     ],
     "sqlState" : "42KD8"
+  },
+  "DELTA_DROP_COLUMN_ON_SINGLE_FIELD_SCHEMA" : {
+    "message" : [
+      "Cannot drop column from a schema with a single column. Schema:",
+      "<schema>"
+    ],
+    "sqlState" : "0AKDC"
   },
   "DELTA_DUPLICATE_COLUMNS_FOUND" : {
     "message" : [
@@ -956,7 +982,9 @@
       "<value>",
       "followed by the name of the column (only if that column is a struct type).",
       "e.g. mymap.key.mykey",
-      "If the column is a basic type, mymap.key or mymap.value is sufficient."
+      "If the column is a basic type, mymap.key or mymap.value is sufficient.",
+      "Schema:",
+      "<schema>"
     ],
     "sqlState" : "KD003"
   },
@@ -1092,9 +1120,9 @@
   "DELTA_INCORRECT_ARRAY_ACCESS_BY_NAME" : {
     "message" : [
       "An ArrayType was found. In order to access elements of an ArrayType, specify",
-      "<rightName>",
-      "Instead of <wrongName>",
-      ""
+      "<rightName> instead of <wrongName>.",
+      "Schema:",
+      "<schema>"
     ],
     "sqlState" : "KD003"
   },
@@ -2790,6 +2818,35 @@
   "_LEGACY_ERROR_TEMP_DELTA_0007" : {
     "message" : [
       "<message>"
+    ]
+  },
+  "_LEGACY_ERROR_TEMP_DELTA_0008" : {
+    "message" : [
+      "Error while searching for position of column <column>.",
+      "Schema:",
+      "<schema>",
+      "Error:",
+      "<message>"
+    ]
+  },
+  "_LEGACY_ERROR_TEMP_DELTA_0009" : {
+    "message" : [
+      "<optionalPrefixMessage>Updating nested fields is only supported for StructType."
+    ]
+  },
+  "_LEGACY_ERROR_TEMP_DELTA_0010" : {
+    "message" : [
+      "<optionalPrefixMessage>Found unsupported expression <expression> while parsing target column name parts."
+    ]
+  },
+  "_LEGACY_ERROR_TEMP_DELTA_0011" : {
+    "message" : [
+      "Failed to resolve plan."
+    ]
+  },
+  "_LEGACY_ERROR_TEMP_DELTA_0012" : {
+    "message" : [
+      "Could not resolve expression: <expression>"
     ]
   }
 }

--- a/spark/src/main/scala/io/delta/tables/DeltaColumnBuilder.scala
+++ b/spark/src/main/scala/io/delta/tables/DeltaColumnBuilder.scala
@@ -128,7 +128,7 @@ class DeltaColumnBuilder private[tables](
     }
     val fieldMetadata = metadataBuilder.build()
     if (dataType == null) {
-      throw DeltaErrors.analysisException(s"The data type of the column $colName is not provided")
+      throw DeltaErrors.columnBuilderMissingDataType(colName)
     }
     StructField(
       colName,

--- a/spark/src/main/scala/io/delta/tables/DeltaTableBuilder.scala
+++ b/spark/src/main/scala/io/delta/tables/DeltaTableBuilder.scala
@@ -305,7 +305,7 @@ class DeltaTableBuilder private[tables](
   @Evolving
   def execute(): DeltaTable = withActiveSession(spark) {
     if (identifier == null && location.isEmpty) {
-      throw DeltaErrors.analysisException("Table name or location has to be specified")
+      throw DeltaErrors.createTableMissingTableNameOrLocation()
     }
 
     if (this.identifier == null) {
@@ -317,9 +317,7 @@ class DeltaTableBuilder private[tables](
 
     if (DeltaTableUtils.isValidPath(tableId) && location.nonEmpty
         && tableId.table != location.get) {
-      throw DeltaErrors.analysisException(
-        s"Creating path-based Delta table with a different location isn't supported. "
-          + s"Identifier: $identifier, Location: ${location.get}")
+      throw DeltaErrors.createTableIdentifierLocationMismatch(identifier, location.get)
     }
 
     val table = spark.sessionState.sqlParser.parseMultipartIdentifier(identifier)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -35,11 +35,9 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.JsonUtils
 import io.delta.sql.DeltaSparkSessionExtension
 import org.apache.hadoop.fs.{ChecksumException, Path}
-import org.json4s.JValue
 
 import org.apache.spark.{SparkConf, SparkEnv, SparkException}
 import org.apache.spark.sql.{AnalysisException, SparkSession}
-import org.apache.spark.sql.catalyst.ExtendedAnalysisException
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
@@ -257,15 +255,6 @@ trait DeltaErrorsBase
     colNames.map(formatColumn).mkString("[", ", ", "]")
 
   def formatSchema(schema: StructType): String = schema.treeString
-
-  def analysisException(
-      msg: String,
-      line: Option[Int] = None,
-      startPosition: Option[Int] = None,
-      plan: Option[LogicalPlan] = None,
-      cause: Option[Throwable] = None): AnalysisException = {
-    new ExtendedAnalysisException(msg, line, startPosition, plan, cause)
-  }
 
   def notNullColumnMissingException(constraint: Constraints.NotNull): Throwable = {
     new DeltaInvariantViolationException(
@@ -1626,10 +1615,10 @@ trait DeltaErrorsBase
       messageParameters = Array(option, operation))
   }
 
-  def foundMapTypeColumnException(key: String, value: String): Throwable = {
+  def foundMapTypeColumnException(key: String, value: String, schema: StructType): Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_FOUND_MAP_TYPE_COLUMN",
-      messageParameters = Array(key, value)
+      messageParameters = Array(key, value, schema.treeString)
     )
   }
   def columnNotInSchemaException(column: String, schema: StructType): Throwable = {
@@ -2601,20 +2590,28 @@ trait DeltaErrorsBase
     )
   }
 
-  def incorrectArrayAccessByName(rightName: String, wrongName: String): Throwable = {
+  def incorrectArrayAccessByName(
+      rightName: String,
+      wrongName: String,
+      schema: StructType): Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_INCORRECT_ARRAY_ACCESS_BY_NAME",
-      messageParameters = Array(rightName, wrongName)
+      messageParameters = Array(rightName, wrongName, schema.treeString)
     )
   }
 
-  def columnPathNotNested(columnPath: String, other: DataType, column: Seq[String]): Throwable = {
+  def columnPathNotNested(
+      columnPath: String,
+      other: DataType,
+      column: Seq[String],
+      schema: StructType): Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_COLUMN_PATH_NOT_NESTED",
       messageParameters = Array(
         s"$columnPath",
         s"$other",
-        s"${SchemaUtils.prettyFieldName(column)}"
+        s"${SchemaUtils.prettyFieldName(column)}",
+        schema.treeString
       )
     )
   }
@@ -3273,6 +3270,38 @@ trait DeltaErrorsBase
       errorClass = "DELTA_MERGE_ADD_VOID_COLUMN",
       messageParameters = Array(toSQLId(columnName))
     )
+  }
+
+  def columnBuilderMissingDataType(colName: String): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_COLUMN_MISSING_DATA_TYPE",
+      messageParameters = Array(toSQLId(colName)))
+  }
+
+  def createTableMissingTableNameOrLocation(): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_CREATE_TABLE_MISSING_TABLE_NAME_OR_LOCATION",
+      messageParameters = Array.empty)
+  }
+
+  def createTableIdentifierLocationMismatch(identifier: String, location: String): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_CREATE_TABLE_IDENTIFIER_LOCATION_MISMATCH",
+      messageParameters = Array(identifier, location))
+  }
+
+  def dropColumnOnSingleFieldSchema(schema: StructType): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_DROP_COLUMN_ON_SINGLE_FIELD_SCHEMA",
+      messageParameters = Array(schema.treeString))
+  }
+
+  def errorFindingColumnPosition(
+      columnPath: Seq[String], schema: StructType, extraErrMsg: String): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "_LEGACY_ERROR_TEMP_DELTA_0008",
+      messageParameters = Array(
+        UnresolvedAttribute(columnPath).name, schema.treeString, extraErrMsg))
   }
 }
 

--- a/spark/src/test/scala/io/delta/tables/DeltaTableBuilderSuite.scala
+++ b/spark/src/test/scala/io/delta/tables/DeltaTableBuilderSuite.scala
@@ -242,7 +242,7 @@ class DeltaTableBuilderSuite extends QueryTest with SharedSparkSession with Delt
         .nullable(true)
         .build()
     }
-    assert(e.getMessage == "The data type of the column value is not provided")
+    assert(e.getMessage.contains("The data type of the column `value` was not provided"))
   }
 
   testCreateTable("create_table") { table =>
@@ -323,7 +323,7 @@ class DeltaTableBuilderSuite extends QueryTest with SharedSparkSession with Delt
     val e = intercept[AnalysisException] {
       io.delta.tables.DeltaTable.create().addColumn("c1", "int").execute()
     }
-    assert(e.getMessage.equals("Table name or location has to be specified"))
+    assert(e.getMessage.contains("Table name or location has to be specified"))
   }
 
   test("partitionedBy only should contain columns in the schema") {
@@ -345,7 +345,7 @@ class DeltaTableBuilderSuite extends QueryTest with SharedSparkSession with Delt
           .location("src/test/resources/delta/dbr_8_0_non_generated_columns")
           .execute()
       }
-      assert(e.getMessage.startsWith(
+      assert(e.getMessage.contains(
         "Creating path-based Delta table with a different location isn't supported."))
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDropColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDropColumnSuite.scala
@@ -148,7 +148,7 @@ class DeltaDropColumnSuite extends QueryTest
       val e = intercept[AnalysisException] {
         drop("t1", "b.d" :: Nil)
       }
-      assert(e.getMessage.contains("Cannot drop column from a struct type with a single field"))
+      assert(e.getMessage.contains("Cannot drop column from a schema with a single column"))
 
       // can drop the parent column
       drop("t1", "b" :: Nil)
@@ -157,7 +157,7 @@ class DeltaDropColumnSuite extends QueryTest
       val e2 = intercept[AnalysisException] {
         drop("t1", "map" :: Nil)
       }
-      assert(e2.getMessage.contains("Cannot drop column from a struct type with a single field"))
+      assert(e2.getMessage.contains("Cannot drop column from a schema with a single column"))
 
       spark.sql("alter table t1 add column (e struct<e1 string, e2 string>)")
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1802,17 +1802,19 @@ trait DeltaErrorsSuiteBase
         Some("Subqueries are not supported in the dummyOp (condition = 'col1')."))
     }
     {
+      val schema = StructType(Array(StructField("foo", IntegerType)))
       val e = intercept[DeltaAnalysisException] {
-        throw DeltaErrors.foundMapTypeColumnException("dummyKey", "dummyVal")
+        throw DeltaErrors.foundMapTypeColumnException("dummyKey", "dummyVal", schema)
       }
       checkErrorMessage(e, Some("DELTA_FOUND_MAP_TYPE_COLUMN"), Some("KD003"),
-        Some("""A MapType was found. In order to access the key or value of a MapType, specify one
+        Some(s"""A MapType was found. In order to access the key or value of a MapType, specify one
           |of:
           |dummyKey or
           |dummyVal
           |followed by the name of the column (only if that column is a struct type).
           |e.g. mymap.key.mykey
-          |If the column is a basic type, mymap.key or mymap.value is sufficient.""".stripMargin))
+          |If the column is a basic type, mymap.key or mymap.value is sufficient.
+          |Schema:\n""".stripMargin + schema.treeString))
     }
     {
       val e = intercept[DeltaAnalysisException] {
@@ -2056,29 +2058,25 @@ trait DeltaErrorsSuiteBase
         Some("You can't use replaceWhere in conjunction with an overwrite by filter"))
     }
     {
+      val schema = StructType(Array(StructField("foo", IntegerType)))
       val e = intercept[DeltaAnalysisException] {
-        throw DeltaErrors.incorrectArrayAccessByName("rightName", "wrongName")
+        throw DeltaErrors.incorrectArrayAccessByName("rightName", "wrongName", schema)
       }
-
-      val msg =
-        s"""An ArrayType was found. In order to access elements of an ArrayType, specify
-           |rightName
-           |Instead of wrongName
-           |""".stripMargin
-      checkErrorMessage(e, Some("DELTA_INCORRECT_ARRAY_ACCESS_BY_NAME"), Some("KD003"),
-        Some(msg))
+      val msg = "An ArrayType was found. In order to access elements of an ArrayType, specify\n" +
+        s"rightName instead of wrongName.\nSchema:\n${schema.treeString}"
+      checkErrorMessage(e, Some("DELTA_INCORRECT_ARRAY_ACCESS_BY_NAME"), Some("KD003"), Some(msg))
     }
     {
       val columnPath = "colPath"
       val other = IntegerType
       val column = Seq("col1", "col2")
+      val schema = StructType(Array(StructField("foo", IntegerType)))
       val e = intercept[DeltaAnalysisException] {
-        throw DeltaErrors.columnPathNotNested(columnPath, other, column)
+        throw DeltaErrors.columnPathNotNested(columnPath, other, column, schema)
       }
-      val msg =
-        s"""Expected $columnPath to be a nested data type, but found $other. Was looking for the
-           |index of ${SchemaUtils.prettyFieldName(column)} in a nested field
-           |""".stripMargin
+      val msg = s"Expected $columnPath to be a nested data type, but found $other. Was looking " +
+          s"for the\nindex of ${SchemaUtils.prettyFieldName(column)} in a nested field.\nSchema:\n" +
+          s"${schema.treeString}"
       checkErrorMessage(e, Some("DELTA_COLUMN_PATH_NOT_NESTED"), Some("42704"),
         Some(msg))
     }
@@ -2914,6 +2912,17 @@ trait DeltaErrorsSuiteBase
     }
     {
       val e = intercept[DeltaAnalysisException] {
+        throw DeltaErrors.columnBuilderMissingDataType("col1")
+      }
+      checkErrorMessage(
+        e,
+        Some("DELTA_COLUMN_MISSING_DATA_TYPE"),
+        Some("42601"),
+        Some("The data type of the column `col1` was not provided.")
+      )
+    }
+    {
+      val e = intercept[DeltaAnalysisException] {
         throw DeltaErrors.foundViolatingConstraintsForColumnChange(
           "UPDATE", "col1", Map("foo" -> "bar"))
       }
@@ -2925,6 +2934,53 @@ trait DeltaErrorsSuiteBase
           s"""Cannot UPDATE column col1 because this column is referenced by the following
              |check constraint(s):
              |foo -> bar""".stripMargin)
+      )
+    }
+    {
+      val e = intercept[DeltaAnalysisException] {
+        throw DeltaErrors.createTableMissingTableNameOrLocation()
+      }
+      checkErrorMessage(
+        e,
+        Some("DELTA_CREATE_TABLE_MISSING_TABLE_NAME_OR_LOCATION"),
+        Some("42601"),
+        Some("Table name or location has to be specified.")
+      )
+    }
+    {
+      val e = intercept[DeltaAnalysisException] {
+        throw DeltaErrors.createTableIdentifierLocationMismatch("delta.`somePath1`", "somePath2")
+      }
+      checkErrorMessage(
+        e,
+        Some("DELTA_CREATE_TABLE_IDENTIFIER_LOCATION_MISMATCH"),
+        Some("0AKDC"),
+        Some("Creating path-based Delta table with a different location isn't supported. Identifier: delta.`somePath1`, Location: somePath2")
+      )
+    }
+    {
+      val schema = StructType(Seq(StructField("col1", IntegerType)))
+      val e = intercept[DeltaAnalysisException] {
+        throw DeltaErrors.dropColumnOnSingleFieldSchema(schema)
+      }
+      checkErrorMessage(
+        e,
+        Some("DELTA_DROP_COLUMN_ON_SINGLE_FIELD_SCHEMA"),
+        Some("0AKDC"),
+        Some(s"Cannot drop column from a schema with a single column. Schema:\n${schema.treeString}")
+      )
+    }
+    {
+      val schema = StructType(Seq(StructField("col1", IntegerType)))
+      val e = intercept[DeltaAnalysisException] {
+        throw DeltaErrors.errorFindingColumnPosition(Seq("col2"), schema, "foo")
+      }
+      checkErrorMessage(
+        e,
+        Some("_LEGACY_ERROR_TEMP_DELTA_0008"),
+        None,
+        Some(s"Error while searching for position of column col2.\nSchema:" +
+          s"\n${schema.treeString}\nError:\nfoo")
       )
     }
     {
@@ -3056,6 +3112,60 @@ trait DeltaErrorsSuiteBase
         Some("2D521"),
         Some("MetadataChangedException: The metadata of the Delta table has been changed by a concurrent update."),
         startWith = true
+      )
+    }
+    {
+      val e = intercept[DeltaAnalysisException] {
+        throw new DeltaAnalysisException(
+          errorClass = "_LEGACY_ERROR_TEMP_DELTA_0009",
+          messageParameters = Array("prefixMsg - "))
+      }
+      checkErrorMessage(
+        e,
+        Some("_LEGACY_ERROR_TEMP_DELTA_0009"),
+        None,
+        Some("prefixMsg - Updating nested fields is only supported for StructType."))
+    }
+    {
+      val expr = "someExp".expr
+      val e = intercept[DeltaAnalysisException] {
+        throw new DeltaAnalysisException(
+          errorClass = "_LEGACY_ERROR_TEMP_DELTA_0010",
+          messageParameters = Array("prefixMsg - ", expr.sql))
+      }
+      checkErrorMessage(
+        e,
+        Some("_LEGACY_ERROR_TEMP_DELTA_0010"),
+        None,
+        Some(s"prefixMsg - Found unsupported expression ${expr.sql} while parsing target column " +
+            s"name parts.")
+      )
+    }
+    {
+      val e = intercept[DeltaAnalysisException] {
+        throw new DeltaAnalysisException(
+          errorClass = "_LEGACY_ERROR_TEMP_DELTA_0011",
+          messageParameters = Array.empty)
+      }
+      checkErrorMessage(
+        e,
+        Some("_LEGACY_ERROR_TEMP_DELTA_0011"),
+        None,
+        Some("Failed to resolve plan.")
+      )
+    }
+    {
+      val exprs = Seq("1".expr, "2".expr)
+      val e = intercept[DeltaAnalysisException] {
+        throw new DeltaAnalysisException(
+          errorClass = "_LEGACY_ERROR_TEMP_DELTA_0012",
+          messageParameters = Array(exprs.mkString(",")))
+      }
+      checkErrorMessage(
+        e,
+        Some("_LEGACY_ERROR_TEMP_DELTA_0012"),
+        None,
+        Some(s"Could not resolve expression: ${exprs.mkString(",")}")
       )
     }
   }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

We want Delta to cross-compile against both Spark 3.5 and Spark Master (4.0).

Unfortunately, the constructor `new AnalysisException("msg")` became protected in Spark 4.0, meaning that all such occurances do not compile against Spark 3.5.

Thus, we decided to:
- replace `AnalysisException` with `DeltaAnalysisException`
- use errorClasses
- assign temporary error classes when needed to speed this along

This PR fixes all remaining related compilation errors.

## How was this patch tested?

New UTs in `DeltaErrorsSuite`.

Also, cherry-picked to the oss-cross-compile branch (https://github.com/delta-io/delta/pull/2780) and cross-compiled:
- (this branch) Spark 3.5: ✅ 
- (this branch) Spark 4.0: no remaining compilation errors.
