### PR TITLE
[Kernel] Iteratively search (1000 versions at a time) for last checkpoint before a given version

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/CheckpointInstance.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/CheckpointInstance.java
@@ -70,6 +70,13 @@ public class CheckpointInstance
         return version <= other.version;
     }
 
+    boolean isEarlierThan(CheckpointInstance other) {
+        if (other == CheckpointInstance.MAX_VALUE) {
+            return true;
+        }
+        return version < other.version;
+    }
+
     public List<Path> getCorrespondingFiles(Path path) {
         if (this == CheckpointInstance.MAX_VALUE) {
             throw new IllegalStateException("Can't get files for CheckpointVersion.MaxValue.");

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
@@ -78,7 +78,7 @@ public class Checkpointer {
     }
 
     /**
-     * Utility method to find the last complete checkpoint before a given version.
+     * Find the last complete checkpoint before (strictly less than) a given version.
      */
     public static Optional<CheckpointInstance> findLastCompleteCheckpointBefore(
             TableClient tableClient,
@@ -87,6 +87,10 @@ public class Checkpointer {
         return findLastCompleteCheckpointBeforeHelper(tableClient, tableLogPath, version)._1;
     }
 
+    /**
+     * Helper method for `findLastCompleteCheckpointBefore` which also return the number
+     * of files searched. This helps in testing
+     */
     protected static Tuple2<Optional<CheckpointInstance>, Long>
             findLastCompleteCheckpointBeforeHelper(
                     TableClient tableClient,
@@ -122,7 +126,7 @@ public class Checkpointer {
                         currentFileVersion = FileNames.checkpointVersion(fileName);
                     } else {
                         // allow all other types of files.
-                        currentFileVersion = Math.min(currentVersion, version);
+                        currentFileVersion = currentVersion;
                     }
 
                     boolean shouldContinue =
@@ -134,7 +138,7 @@ public class Checkpointer {
                     if (!shouldContinue) {
                         break;
                     }
-                    if (FileNames.isCheckpointFile(fileName)) {
+                    if (validCheckpointFile(fileStatus)) {
                         checkpoints.add(new CheckpointInstance(fileStatus.getPath()));
                     }
                     numberOfFilesSearched++;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
@@ -16,6 +16,7 @@
 package io.delta.kernel.internal.checkpoints;
 
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -29,7 +30,7 @@ import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
 
 import io.delta.kernel.internal.fs.Path;
-import io.delta.kernel.internal.util.InternalUtils;
+import io.delta.kernel.internal.util.*;
 import static io.delta.kernel.internal.util.Utils.singletonCloseableIterator;
 
 /**
@@ -74,6 +75,92 @@ public class Checkpointer {
         } else {
             return Optional.of(Collections.max(completeCheckpoints));
         }
+    }
+
+    /**
+     * Utility method to find the last complete checkpoint before a given version.
+     */
+    public static Optional<CheckpointInstance> findLastCompleteCheckpointBefore(
+            TableClient tableClient,
+            Path tableLogPath,
+            long version) {
+        return findLastCompleteCheckpointBeforeHelper(tableClient, tableLogPath, version)._1;
+    }
+
+    protected static Tuple2<Optional<CheckpointInstance>, Long>
+            findLastCompleteCheckpointBeforeHelper(
+                    TableClient tableClient,
+                    Path tableLogPath,
+                    long version) {
+        CheckpointInstance upperBoundCheckpoint = new CheckpointInstance(version);
+        logger.info("Try to find the last complete checkpoint before version {}", version);
+
+        // This is a just a tracker for testing purposes
+        long numberOfFilesSearched = 0;
+        long currentVersion = version;
+
+        // Some cloud storage APIs make a calls to fetch 1000 at a time.
+        // To make use of that observation and to avoid making more listing calls than
+        // necessary, list 1000 at a time (backwards from the given version). Search
+        // within that list if a checkpoint is found. If found stop, otherwise list the previous
+        // 1000 entries. Repeat until a checkpoint is found or there are no more delta commits.
+        while (currentVersion >= 0) {
+            try {
+                long searchLowerBound = Math.max(0, currentVersion - 1000);
+                CloseableIterator<FileStatus> deltaLogFileIter = tableClient.getFileSystemClient()
+                        .listFrom(FileNames.listingPrefix(tableLogPath, searchLowerBound));
+
+                List<CheckpointInstance> checkpoints = new ArrayList<>();
+                while (deltaLogFileIter.hasNext()) {
+                    FileStatus fileStatus = deltaLogFileIter.next();
+                    String fileName = new Path(fileStatus.getPath()).getName();
+
+                    long currentFileVersion;
+                    if (FileNames.isCommitFile(fileName)) {
+                        currentFileVersion = FileNames.deltaVersion(fileName);
+                    } else if (FileNames.isCheckpointFile(fileName)) {
+                        currentFileVersion = FileNames.checkpointVersion(fileName);
+                    } else {
+                        // allow all other types of files.
+                        currentFileVersion = Math.min(currentVersion, version);
+                    }
+
+                    boolean shouldContinue =
+                            // only consider files with version in the range and
+                            // before the target version
+                            (currentVersion == 0 || currentFileVersion <= currentVersion) &&
+                            currentFileVersion < version;
+
+                    if (!shouldContinue) {
+                        break;
+                    }
+                    if (FileNames.isCheckpointFile(fileName)) {
+                        checkpoints.add(new CheckpointInstance(fileStatus.getPath()));
+                    }
+                    numberOfFilesSearched++;
+                }
+
+                Optional<CheckpointInstance> latestCheckpoint =
+                        getLatestCompleteCheckpointFromList(checkpoints, upperBoundCheckpoint);
+
+                if (latestCheckpoint.isPresent()) {
+                    logger.info("Found the last complete checkpoint before version {} at {}",
+                            version, latestCheckpoint.get());
+                    return new Tuple2<>(latestCheckpoint, numberOfFilesSearched);
+                }
+                currentVersion -= 1000; // search for checkpoint in previous 1000 entries
+            } catch (IOException e) {
+                logger.warn("Failed to list checkpoint files for version {}. ", currentVersion, e);
+                return new Tuple2<>(Optional.empty(), numberOfFilesSearched);
+            }
+        }
+        logger.info("No complete checkpoint found before version {}", version);
+        return new Tuple2<>(Optional.empty(), numberOfFilesSearched);
+    }
+
+    private static boolean validCheckpointFile(FileStatus fileStatus) {
+        return FileNames.isCheckpointFile(new Path(fileStatus.getPath()).getName()) &&
+                fileStatus.getSize() > 0;
     }
 
     /**

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
@@ -525,11 +525,10 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
     val fileList = deltaFileStatuses((0L until 10L)) ++ singularCheckpointFileStatuses(Seq(10L))
 
     /* ----------  version to load is 15 (greater than latest checkpoint/delta file) ---------- */
-    // (?) different error messages
     testExpectedError[RuntimeException](
       fileList,
       versionToLoad = Optional.of(15),
-      expectedErrorMessageContains = "Trying to load a non-existent version 15"
+      expectedErrorMessageContains = "Could not find any delta files for version 10"
     )
     testExpectedError[IllegalStateException](
       fileList,

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checkpoints/CheckpointerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/checkpoints/CheckpointerSuite.scala
@@ -17,6 +17,7 @@ package io.delta.kernel.internal.checkpoints
 
 import io.delta.kernel.data.{ColumnVector, ColumnarBatch}
 import io.delta.kernel.expressions.Predicate
+import io.delta.kernel.internal.checkpoints.Checkpointer.findLastCompleteCheckpointBeforeHelper
 import io.delta.kernel.internal.fs.Path
 import io.delta.kernel.internal.util.Utils
 import io.delta.kernel.test.{BaseMockJsonHandler, MockFileSystemClientUtils, MockTableClientUtils}
@@ -83,6 +84,93 @@ class CheckpointerSuite extends AnyFunSuite
     assert(jsonHandler.currentFailCount == 0)
   }
 
+  //////////////////////////////////////////////////////////////////////////////////
+  // findLastCompleteCheckpointBefore tests
+  //////////////////////////////////////////////////////////////////////////////////
+  test("findLastCompleteCheckpointBefore - no checkpoints") {
+    val files = deltaFileStatuses(Seq.range(0, 25))
+
+    Seq((0, 0), (10, 10), (20, 20), (27, 25 /* no delta log files after version 24 */)).foreach {
+      case (beforeVersion, expNumFilesListed) =>
+        assertNoLastCheckpoint(files, beforeVersion, expNumFilesListed)
+    }
+  }
+
+  test("findLastCompleteCheckpointBefore - single checkpoint") {
+    // 25 delta files and 1 checkpoint file = total 26 files.
+    val files = deltaFileStatuses(Seq.range(0, 25)) ++ singularCheckpointFileStatuses(Seq(10))
+
+    Seq((0, 0), (4, 4), (9, 9), (10, 10)).foreach {
+      case (beforeVersion, expNumFilesListed) =>
+        assertNoLastCheckpoint(files, beforeVersion, expNumFilesListed)
+    }
+
+    Seq((14, 10, 15), (25, 10, 26), (27, 10, 26)).foreach {
+      case (beforeVersion, expCheckpointVersion, expNumFilesListed) =>
+        assertLastCheckpoint(files, beforeVersion, expCheckpointVersion, expNumFilesListed)
+    }
+  }
+
+  test("findLastCompleteCheckpointBefore - multi-part checkpoint") {
+    // 25 delta files and 20 checkpoint files = total 45 files.
+    val files = deltaFileStatuses(Seq.range(0, 25)) ++ multiCheckpointFileStatuses(Seq(10), 20)
+
+    Seq((0, 0), (4, 4), (9, 9), (10, 10)).foreach {
+      case (beforeVersion, expNumFilesListed) =>
+        assertNoLastCheckpoint(files, beforeVersion, expNumFilesListed)
+    }
+
+    Seq((14, 10, 14 + 20), (25, 10, 25 + 20), (27, 10, 25 + 20)).foreach {
+      case (beforeVersion, expCheckpointVersion, expNumFilesListed) =>
+        assertLastCheckpoint(files, beforeVersion, expCheckpointVersion, expNumFilesListed)
+    }
+  }
+
+  test("findLastCompleteCheckpointBefore - multi-part checkpoint per 10commits - 10K commits") {
+    // 10K delta files and 1K checkpoints * 20 files for each checkpoint = total 30K files.
+    val files = deltaFileStatuses(Seq.range(0, 10000)) ++
+      multiCheckpointFileStatuses(Seq.range(10, 10000, 10), 20)
+
+    Seq(0, 4, 9, 10).foreach { beforeVersion =>
+      val expNumFilesListed = beforeVersion
+      assertNoLastCheckpoint(files, beforeVersion, expNumFilesListed)
+    }
+
+    Seq(789, 1005, 5787, 9999).foreach { beforeVersion =>
+      val expCheckpointVersion = (beforeVersion / 10) * 10
+      // Listing size is 1000 delta versions (i.e list _delta_log/0001000* to _delta_log/0001999*)
+      val versionsListed = Math.min(beforeVersion, 1000)
+      val expNumFilesListed =
+          versionsListed /* delta files */ +
+          (versionsListed / 10) * 20 /* checkpoints */
+      assertLastCheckpoint(files, beforeVersion, expCheckpointVersion, expNumFilesListed)
+    }
+  }
+
+  test("findLastCompleteCheckpointBefore - multi-part checkpoint per 2.5K commits - 10K commits") {
+    // 10K delta files and 4 checkpoints * 50 files for each checkpoint = total 10,080 files.
+    val files = deltaFileStatuses(Seq.range(0, 10000)) ++
+      multiCheckpointFileStatuses(Seq.range(2500, 10000, 2500), 50)
+
+    Seq((0, 0), (889, 889), (1001, 1002), (2400, 2402)).foreach {
+      case (beforeVersion, expNumFilesListed) =>
+        assertNoLastCheckpoint(files, beforeVersion, expNumFilesListed)
+    }
+
+    Seq(2600, 5002, 7980, 9999).foreach { beforeVersion =>
+      val expCheckpointVersion = (beforeVersion / 2500) * 2500
+      // Listing size is 1000 delta versions (i.e list _delta_log/0001000* to _delta_log/0001999*)
+      // We list until the checkpoint is encounters in increments of 1000 versions at a time
+      val numListCalls = ((beforeVersion - expCheckpointVersion) / 1000) + 1
+      val versionsListed = 1000 * numListCalls
+      val expNumFilesListed =
+        numListCalls - 1 /* last file scanned that fails the search and stops */ +
+          versionsListed /* delta files */ +
+           50 /* one multi-part checkpoint */
+      assertLastCheckpoint(files, beforeVersion, expCheckpointVersion, expNumFilesListed)
+    }
+  }
+
   /** Assert that the checkpoint metadata is same as [[SAMPLE_LAST_CHECKPOINT_FILE_CONTENT]] */
   def assertValidCheckpointMetadata(actual: Optional[CheckpointMetaData]): Unit = {
     assert(actual.isPresent)
@@ -90,6 +178,30 @@ class CheckpointerSuite extends AnyFunSuite
     assert(metadata.version == 40L)
     assert(metadata.size == 44L)
     assert(metadata.parts == Optional.of(20L))
+  }
+
+  def assertLastCheckpoint(
+      deltaLogFiles: Seq[FileStatus],
+      beforeVersion: Long,
+      expCheckpointVersion: Long,
+      expNumFilesListed: Long): Unit = {
+    val tableClient = createMockFSListFromTableClient(deltaLogFiles)
+    val result = findLastCompleteCheckpointBeforeHelper(tableClient, logPath, beforeVersion)
+    assert(result._1.isPresent, s"Checkpoint should be found for version=$beforeVersion")
+    assert(
+      result._1.get().version === expCheckpointVersion,
+      s"Incorrect checkpoint version before version=$beforeVersion")
+    assert(result._2 === expNumFilesListed, s"Invalid number of files listed: $beforeVersion")
+  }
+
+  def assertNoLastCheckpoint(
+      deltaLogFiles: Seq[FileStatus],
+      beforeVersion: Long,
+      expNumFilesListed: Long): Unit = {
+    val tableClient = createMockFSListFromTableClient(deltaLogFiles)
+    val result = findLastCompleteCheckpointBeforeHelper(tableClient, logPath, beforeVersion)
+    assert(!result._1.isPresent, s"No checkpoint should be found for version=$beforeVersion")
+    assert(result._2 == expNumFilesListed, s"Invalid number of files listed: $beforeVersion")
   }
 }
 


### PR DESCRIPTION
## Description

Adds a utility method for iteratively searching backwards 1000 delta versions at a time from a given version to find the checkpoint. This utility method is used when loading a snapshot by version id. This is similar to how delta-spark does. More details are [here](https://docs.google.com/document/d/13Nock1I8-143Dwidj8rMpgt3wAicrOI2OvDJt3OufOQ/edit?usp=sharing).



## How was this patch tested?
Existing tests and mock unittests for granular tests.
