### PR TITLE
[Spark] Update deltaLog.getHistory to serve [start, end] version range

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
@@ -68,7 +68,7 @@ class DeltaHistoryManager(
   }
 
   /**
-   * Get the commit information of the Delta table from commit `[start, end)`. If `end` is `None`,
+   * Get the commit information of the Delta table from commit `[start, end]`. If `end` is `None`,
    * we return all commits from start to now.
    */
   def getHistory(
@@ -77,7 +77,7 @@ class DeltaHistoryManager(
     import org.apache.spark.sql.delta.implicits._
     val conf = getSerializableHadoopConf
     val logPath = deltaLog.logPath.toString
-    val snapshot = endOpt.map(end => deltaLog.getSnapshotAt(end - 1)).getOrElse(deltaLog.update())
+    val snapshot = endOpt.map(end => deltaLog.getSnapshotAt(end)).getOrElse(deltaLog.update())
     val commitFileProvider = DeltaCommitFileProvider(snapshot)
     // We assume that commits are contiguous, therefore we try to load all of them in order
     val info = spark.range(start, snapshot.version + 1)


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Previously, `deltaLog.getHistory(start, endOpt)` served the `[start, endOpt]` range. However, this behavior was accidentally changed in #2799 to serve the `[start, endOpt)` range.

We revert it back to the original behavior and also update the function comment.

## How was this patch tested?

UTs

## Does this PR introduce _any_ user-facing changes?

No