### PR TITLE
[Spark]Handle CommitFailedException in OptimisticTransaction::commitLarge

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/CommitStore.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/CommitStore.scala
@@ -40,8 +40,8 @@ case class Commit(
  *  |   yes     |   no      | transient error (e.g. network hiccup)                           |
  *  |   yes     |   yes     | physical conflict (allowed to rebase and retry)                 |
  */
-class CommitFailedException(
-    val retryable: Boolean, val conflict: Boolean, message: String) extends Exception(message)
+case class CommitFailedException(
+    retryable: Boolean, conflict: Boolean, message: String) extends Exception(message)
 
 /** Response container for [[CommitStore.commit]] API */
 case class CommitResponse(commit: Commit)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/InMemoryCommitStore.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/InMemoryCommitStore.scala
@@ -81,7 +81,7 @@ class InMemoryCommitStore(val batchSize: Long) extends AbstractBatchBackfillingC
       val tableData = perTableMap.get(logPath)
       val expectedVersion = tableData.maxCommitVersion + 1
       if (commitVersion != expectedVersion) {
-        throw new CommitFailedException(
+        throw CommitFailedException(
           retryable = commitVersion < expectedVersion,
           conflict = commitVersion < expectedVersion,
           s"Commit version $commitVersion is not valid. Expected version: $expectedVersion.")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -19,14 +19,15 @@ package org.apache.spark.sql.delta
 // scalastyle:off import.ordering.noEmptyLine
 import java.nio.file.FileAlreadyExistsException
 
+import com.databricks.spark.util.Log4jUsageLogger
 import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
 import org.apache.spark.sql.delta.actions.{Action, AddFile, CommitInfo, Metadata, Protocol, RemoveFile, SetTransaction}
-import org.apache.spark.sql.delta.managedcommit.{Commit, CommitFailedException, CommitResponse, CommitStore, CommitStoreBuilder, CommitStoreProvider, GetCommitsResponse, UpdatedActions}
+import org.apache.spark.sql.delta.managedcommit.{Commit, CommitFailedException, CommitResponse, CommitStore, CommitStoreBuilder, CommitStoreProvider, GetCommitsResponse, InMemoryCommitStore, UpdatedActions}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.storage.LogStore
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
-import org.apache.spark.sql.delta.util.FileNames
+import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
@@ -34,6 +35,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.expressions.{EqualTo, Literal}
+import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.types.{IntegerType, StructType}
 import org.apache.spark.util.ManualClock
 
@@ -266,6 +268,11 @@ class OptimisticTransactionSuite
     actions = Seq(
       AddFile("b", Map.empty, 1, 1, dataChange = true)))
 
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    CommitStoreProvider.clearNonDefaultBuilders()
+  }
+
   test("initial commit without metadata should fail") {
     withTempDir { tempDir =>
       val log = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath))
@@ -468,7 +475,7 @@ class OptimisticTransactionSuite
               actions: Iterator[String],
               updatedActions: UpdatedActions): CommitResponse = {
             commitAttempts += 1
-            throw new CommitFailedException(
+            throw CommitFailedException(
               retryable = true,
               conflict = commitAttempts > initialNonConflictErrors &&
                 commitAttempts <= (initialNonConflictErrors + initialConflictErrors),
@@ -803,6 +810,69 @@ class OptimisticTransactionSuite
 
           assert(expectedDeltaVersion === actualDeltaVersion)
         }
+      }
+    }
+  }
+
+  BOOLEAN_DOMAIN.foreach { conflict =>
+    test(s"commitLarge should handle Commit Failed Exception with conflict: $conflict") {
+      withTempDir { tempDir =>
+        val deltaLog = DeltaLog.forTable(spark, tempDir.getAbsolutePath)
+        val commitStoreName = "retryable-conflict-commit-store"
+        class RetryableConflictCommitStore extends InMemoryCommitStore(batchSize = 5) {
+          override def commit(
+              logStore: LogStore,
+              hadoopConf: Configuration,
+              tablePath: Path,
+              commitVersion: Long,
+              actions: Iterator[String],
+              updatedActions: UpdatedActions): CommitResponse = {
+            if (updatedActions.commitInfo.operation == DeltaOperations.OP_RESTORE) {
+              deltaLog.startTransaction().commit(addB :: Nil, ManualUpdate)
+              throw CommitFailedException(retryable = true, conflict, message = "")
+            }
+            super.commit(logStore, hadoopConf, tablePath, commitVersion, actions, updatedActions)
+          }
+        }
+        object RetryableConflictCommitStoreBuilder extends CommitStoreBuilder {
+          lazy val commitStore = new RetryableConflictCommitStore()
+          override def name: String = commitStoreName
+          override def build(conf: Map[String, String]): CommitStore = commitStore
+        }
+        CommitStoreProvider.registerBuilder(RetryableConflictCommitStoreBuilder)
+        val conf = Map(DeltaConfigs.MANAGED_COMMIT_OWNER_NAME.key -> commitStoreName)
+        deltaLog.startTransaction().commit(Seq(Metadata(configuration = conf)), ManualUpdate)
+        RetryableConflictCommitStoreBuilder.commitStore.registerTable(
+          logPath = deltaLog.logPath, maxCommitVersion = 0)
+        deltaLog.startTransaction().commit(addA :: Nil, ManualUpdate)
+        val records = Log4jUsageLogger.track {
+          // commitLarge must fail because of a conflicting commit at version-2.
+          val e = intercept[Exception] {
+            deltaLog.startTransaction().commitLarge(
+              spark,
+              nonProtocolMetadataActions = (addB :: Nil).iterator,
+              newProtocolOpt = None,
+              op = DeltaOperations.Restore(Some(0), None),
+              context = Map.empty,
+              metrics = Map.empty)
+          }
+          if (conflict) {
+            assert(e.isInstanceOf[ConcurrentWriteException])
+            assert(
+              e.getMessage.contains(
+                "A concurrent transaction has written new data since the current transaction " +
+                  s"read the table. Please try the operation again"))
+          } else {
+              assert(e.isInstanceOf[CommitFailedException])
+          }
+          assert(deltaLog.update().version == 2)
+        }
+        val failureRecord = filterUsageRecords(records, "delta.commitLarge.failure")
+        assert(failureRecord.size == 1)
+        val data = JsonUtils.fromJson[Map[String, Any]](failureRecord.head.blob)
+        assert(data("fromManagedCommit") == true)
+        assert(data("fromManagedCommitConflict") == conflict)
+        assert(data("fromManagedCommitRetryable") == true)
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuiteBase.scala
@@ -31,6 +31,7 @@ import org.apache.spark.util.Utils
 trait OptimisticTransactionSuiteBase
   extends QueryTest
     with SharedSparkSession
+    with DeltaTestUtilsBase
     with DeletionVectorsTestUtils {
 
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Handle CommitFailedException in OptimisticTransaction::commitLarge depending on the values of `retryable` and `conflict` in the exception.

## How was this patch tested?

UTs to cover the scenarios

## Does this PR introduce _any_ user-facing changes?

No