### PR TITLE
[Spark] Backfill commit files before checkpointing or minor compaction in managed-commits

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1918,6 +1918,13 @@ trait OptimisticTransactionImpl extends TransactionalWrite
     override def getCommits(
         logPath: Path, startVersion: Long, endVersion: Option[Long]): GetCommitsResponse =
       GetCommitsResponse(Seq.empty, -1)
+
+    override def backfillToVersion(
+        logStore: LogStore,
+        hadoopConf: Configuration,
+        logPath: Path,
+        startVersion: Long,
+        endVersion: Option[Long]): Unit = {}
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/AbstractBatchBackfillingCommitStore.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/AbstractBatchBackfillingCommitStore.scala
@@ -107,13 +107,16 @@ trait AbstractBatchBackfillingCommitStore extends CommitStore with Logging {
 
   protected def generateUUID(): String = UUID.randomUUID().toString
 
-  /** Backfills all un-backfilled commits */
-  protected def backfillToVersion(
+  override def backfillToVersion(
       logStore: LogStore,
       hadoopConf: Configuration,
-      logPath: Path): Unit = {
-    getCommits(logPath, startVersion = 0).commits.foreach { commit =>
-      backfill(logStore, hadoopConf, logPath, commit.version, commit.fileStatus)
+      logPath: Path,
+      startVersion: Long = 0,
+      endVersionOpt: Option[Long] = None): Unit = {
+    getCommits(logPath, startVersion, endVersionOpt)
+      .commits
+      .foreach { commit =>
+        backfill(logStore, hadoopConf, logPath, commit.version, commit.fileStatus)
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaCommitFileProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaCommitFileProvider.scala
@@ -20,13 +20,35 @@ import org.apache.spark.sql.delta.Snapshot
 import org.apache.spark.sql.delta.util.FileNames._
 import org.apache.hadoop.fs.Path
 
-case class DeltaCommitFileProvider(logPath: String, maxVersion: Long, uuids: Map[Long, String]) {
+/**
+ * Provides access to resolve Delta commit files names based on the commit-version.
+ *
+ * This class is part of the changes introduced to accommodate the adoption of managed-commits in
+ * Delta Lake. Previously, certain code paths assumed the existence of delta files for a specific
+ * version at a predictable path `_delta_log/$version.json`. With managed-commits, delta files may
+ * alternatively be located at `_delta_log/_commits/$version.$uuid.json`. DeltaCommitFileProvider
+ * attempts to locate the correct delta files from the Snapshot's LogSegment.
+ *
+ * @param logPath The path to the Delta table log directory.
+ * @param maxVersionInclusive The maximum version of the Delta table (inclusive).
+ * @param uuids A map of version numbers to their corresponding UUIDs.
+ */
+case class DeltaCommitFileProvider(
+    logPath: String,
+    maxVersionInclusive: Long,
+    uuids: Map[Long, String]) {
   // Ensure the Path object is reused across Delta Files but not stored as part of the object state
   // since it is not serializable.
   @transient lazy val resolvedPath: Path = new Path(logPath)
+  lazy val minUnbackfilledVersion: Long =
+    if (uuids.keys.isEmpty) {
+      maxVersionInclusive + 1
+    } else {
+      uuids.keys.min
+    }
 
   def deltaFile(version: Long): Path = {
-    if (version > maxVersion) {
+    if (version > maxVersionInclusive) {
       throw new IllegalStateException("Cannot resolve Delta table at version $version as the " +
         "state is currently at version $maxVersion. The requested version may be incorrect or " +
         "the state may be outdated. Please verify the requested version, update the state if " +

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
@@ -25,10 +25,12 @@ import scala.concurrent.duration._
 import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions, UsageRecord}
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.deletionvectors.DeletionVectorsSuite
+import org.apache.spark.sql.delta.managedcommit.ManagedCommitBaseSuite
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.storage.LocalLogStore
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
+import org.apache.spark.sql.delta.util.DeltaCommitFileProvider
 import org.apache.spark.sql.delta.util.FileNames
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
@@ -45,7 +47,8 @@ class CheckpointsSuite
   extends QueryTest
   with SharedSparkSession
   with DeltaCheckpointTestUtils
-  with DeltaSQLCommandTest {
+  with DeltaSQLCommandTest
+  with ManagedCommitBaseSuite {
 
   def testDifferentV2Checkpoints(testName: String)(f: => Unit): Unit = {
     for (checkpointFormat <- Seq(V2Checkpoint.Format.JSON.name, V2Checkpoint.Format.PARQUET.name)) {
@@ -404,7 +407,10 @@ class CheckpointsSuite
           // CDC should exist in the log as seen through getChanges, but it shouldn't be in the
           // snapshots and the checkpoint file shouldn't have a CDC column.
           val deltaLog = DeltaLog.forTable(spark, tempDir.getAbsolutePath)
-          assert(deltaLog.getChanges(1).next()._2.exists(_.isInstanceOf[AddCDCFile]))
+          val deltaPath = DeltaCommitFileProvider(deltaLog.unsafeVolatileSnapshot)
+            .deltaFile(version = 1)
+          val deltaFileContent = deltaLog.store.read(deltaPath, deltaLog.newDeltaHadoopConf())
+          assert(deltaFileContent.map(Action.fromJson).exists(_.isInstanceOf[AddCDCFile]))
           assert(deltaLog.snapshot.stateDS.collect().forall { sa => sa.cdc == null })
           deltaLog.checkpoint()
           val checkpointFile = FileNames.checkpointFileSingular(deltaLog.logPath, 1)
@@ -458,7 +464,10 @@ class CheckpointsSuite
           // CDC should exist in the log as seen through getChanges, but it shouldn't be in the
           // snapshots and the checkpoint file shouldn't have a CDC column.
           val deltaLog = DeltaLog.forTable(spark, tempDir.getAbsolutePath)
-          assert(deltaLog.getChanges(1).next()._2.exists(_.isInstanceOf[AddCDCFile]))
+          val deltaPath = DeltaCommitFileProvider(deltaLog.unsafeVolatileSnapshot)
+            .deltaFile(version = 1)
+          val deltaFileContent = deltaLog.store.read(deltaPath, deltaLog.newDeltaHadoopConf())
+          assert(deltaFileContent.map(Action.fromJson).exists(_.isInstanceOf[AddCDCFile]))
           assert(deltaLog.snapshot.stateDS.collect().forall { sa => sa.cdc == null })
           deltaLog.checkpoint()
           var sidecarCheckpointFiles = getV2CheckpointProvider(deltaLog).sidecarFileStatuses
@@ -975,5 +984,17 @@ class FakeGCSFileSystem extends RawLocalFileSystem {
     assertGCSThread(f)
     super.create(f, overwrite, bufferSize, replication, blockSize, progress)
   }
+}
+
+class ManagedCommitBatch1BackFillCheckpointsSuite extends CheckpointsSuite {
+  override val managedCommitBackfillBatchSize: Option[Int] = Some(1)
+}
+
+class ManagedCommitBatch2BackFillCheckpointsSuite extends CheckpointsSuite {
+  override val managedCommitBackfillBatchSize: Option[Int] = Some(2)
+}
+
+class ManagedCommitBatch20BackFillCheckpointsSuite extends CheckpointsSuite {
+  override val managedCommitBackfillBatchSize: Option[Int] = Some(20)
 }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -478,6 +478,12 @@ class OptimisticTransactionSuite
               tablePath: Path,
               startVersion: Long,
               endVersion: Option[Long]): GetCommitsResponse = GetCommitsResponse(Seq.empty, -1)
+          override def backfillToVersion(
+              logStore: LogStore,
+              hadoopConf: Configuration,
+              logPath: Path,
+              startVersion: Long,
+              endVersion: Option[Long]): Unit = {}
         }
       }
     }
@@ -524,6 +530,12 @@ class OptimisticTransactionSuite
               tablePath: Path,
               startVersion: Long,
               endVersion: Option[Long]): GetCommitsResponse = GetCommitsResponse(Seq.empty, -1)
+          override def backfillToVersion(
+              logStore: LogStore,
+              hadoopConf: Configuration,
+              logPath: Path,
+              startVersion: Long,
+              endVersion: Option[Long]): Unit = {}
         }
       }
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/CommitStoreSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/CommitStoreSuite.scala
@@ -45,6 +45,13 @@ class CommitStoreSuite extends QueryTest with DeltaSQLTestUtils with SharedSpark
       logPath: Path,
       startVersion: Long,
       endVersion: Option[Long] = None): GetCommitsResponse = GetCommitsResponse(Seq.empty, -1)
+
+    override def backfillToVersion(
+        logStore: LogStore,
+        hadoopConf: Configuration,
+        logPath: Path,
+        startVersion: Long,
+        endVersion: Option[Long]): Unit = {}
   }
 
   class TestCommitStore1 extends TestCommitStoreBase

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitTestUtils.scala
@@ -121,6 +121,15 @@ class TrackingCommitStore(delegatingCommitStore: InMemoryCommitStore) extends Co
     delegatingCommitStore.getCommits(logPath, startVersion, endVersion)
   }
 
+  override def backfillToVersion(
+      logStore: LogStore,
+      hadoopConf: Configuration,
+      logPath: Path,
+      startVersion: Long,
+      endVersion: Option[Long]): Unit = {
+    delegatingCommitStore.backfillToVersion(logStore, hadoopConf, logPath, startVersion, endVersion)
+  }
+
   def registerTable(
       logPath: Path,
       maxCommitVersion: Long): Unit = {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

With managed-commit, commit files are not guaranteed to be present in the _delta_log directory at the time of checkpointing or minor compactions. While it is possible to compute a checkpoint file without backfilling, writing the checkpoint file in the log directory before backfilling the relevant commits will leave gaps in the directory structure. This can cause issues for readers that are not communicating with the CommitStore.

To address this problem, we now backfill commit files up to the committedVersion before performing a checkpoint or minor compaction operation

## How was this patch tested?

UTs

## Does this PR introduce _any_ user-facing changes?

No