### PR TITLE
[Kernel][Tests] Refactor `TableClient` mocking code duplication into a single file

### DIFF
--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/DeltaHistoryManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/DeltaHistoryManagerSuite.scala
@@ -22,7 +22,8 @@ import scala.reflect.ClassTag
 import org.scalatest.funsuite.AnyFunSuite
 
 import io.delta.kernel.utils.FileStatus
-import io.delta.kernel.{MockFileSystemClientUtils, TableNotFoundException}
+import io.delta.kernel.TableNotFoundException
+import io.delta.kernel.test.MockFileSystemClientUtils
 
 class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
 
@@ -31,7 +32,7 @@ class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtil
     timestamp: Long,
     expectedVersion: Long): Unit = {
     val activeCommit = DeltaHistoryManager.getActiveCommitAtTimestamp(
-      createMockTableClient(listFromFileList(fileList)),
+      createMockFSListFromTableClient(fileList),
       logPath,
       timestamp
     )
@@ -45,7 +46,7 @@ class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtil
     expectedErrorMessageContains: String)(implicit classTag: ClassTag[T]): Unit = {
     val e = intercept[T] {
       DeltaHistoryManager.getActiveCommitAtTimestamp(
-        createMockTableClient(listFromFileList(fileList)),
+        createMockFSListFromTableClient(fileList),
         logPath,
         timestamp
       )
@@ -154,7 +155,7 @@ class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtil
     // Non-existent path
     intercept[TableNotFoundException](
       DeltaHistoryManager.getActiveCommitAtTimestamp(
-        createMockTableClient(p => throw new FileNotFoundException(p)),
+        createMockFSListFromTableClient(p => throw new FileNotFoundException(p)),
         logPath,
         0
       )
@@ -162,7 +163,7 @@ class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtil
     // Empty _delta_log directory
     intercept[TableNotFoundException](
       DeltaHistoryManager.getActiveCommitAtTimestamp(
-        createMockTableClient(p => Seq()),
+        createMockFSListFromTableClient(p => Seq()),
         logPath,
         0
       )

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
@@ -525,10 +525,11 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
     val fileList = deltaFileStatuses((0L until 10L)) ++ singularCheckpointFileStatuses(Seq(10L))
 
     /* ----------  version to load is 15 (greater than latest checkpoint/delta file) ---------- */
+    // (?) different error messages
     testExpectedError[RuntimeException](
       fileList,
       versionToLoad = Optional.of(15),
-      expectedErrorMessageContains = "Could not find any delta files for version 10"
+      expectedErrorMessageContains = "Trying to load a non-existent version 15"
     )
     testExpectedError[IllegalStateException](
       fileList,

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockFileSystemClientUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockFileSystemClientUtils.scala
@@ -26,7 +26,7 @@ import scala.collection.JavaConverters._
 /**
  * This is an extension to [[BaseMockFileSystemClient]] containing specific mock implementations
  * [[FileSystemClient]] which are shared across multiple test suite.
- * 
+ *
  * [[MockListFromFileSystemClient]] - mocks the `listFrom` API within [[FileSystemClient]].
  */
 trait MockFileSystemClientUtils extends MockTableClientUtils {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockTableClientUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockTableClientUtils.scala
@@ -1,0 +1,145 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.test
+
+import io.delta.kernel.client._
+import io.delta.kernel.data.{ColumnVector, ColumnarBatch}
+import io.delta.kernel.expressions.{Expression, ExpressionEvaluator, Predicate, PredicateEvaluator}
+import io.delta.kernel.types.{DataType, StructType}
+import io.delta.kernel.utils.{CloseableIterator, FileStatus}
+
+import java.io.ByteArrayInputStream
+import java.util.Optional
+
+/**
+ * Contains broiler plate code for mocking [[TableClient]] and its sub-interfaces.
+ *
+ * A concrete class is created for each sub-interface (e.g. [[FileSystemClient]]) with
+ * default implementation (unsupported). Test suites can override a specific API(s)
+ * in the sub-interfaces to mock the behavior as desired.
+ *
+ * Example:
+ * {{{
+ *   val myMockFileSystemClient = new BaseMockFileSystemClient() {
+ *     override def listFrom(filePath: String): CloseableIterator[FileStatus] = {
+ *        .. my mock code to return specific values for given file path ...
+ *     }
+ *   }
+ *
+ *   val myMockTableClient = mockTableClient(fileSystemClient = myMockFileSystemClient)
+ * }}}
+ */
+trait MockTableClientUtils {
+  /**
+   * Create a mock TableClient with the given components. If a component is not provided, it will
+   * throw an exception when accessed.
+   */
+  def mockTableClient(
+    fileSystemClient: FileSystemClient = null,
+    jsonHandler: JsonHandler = null,
+    parquetHandler: ParquetHandler = null,
+    expressionHandler: ExpressionHandler = null): TableClient = {
+    new TableClient() {
+      override def getExpressionHandler: ExpressionHandler =
+        Option(expressionHandler).getOrElse(
+          throw new UnsupportedOperationException("not supported in this test suite"))
+
+      override def getJsonHandler: JsonHandler =
+        Option(jsonHandler).getOrElse(
+          throw new UnsupportedOperationException("not supported in this test suite"))
+
+      override def getFileSystemClient: FileSystemClient =
+        Option(fileSystemClient).getOrElse(
+          throw new UnsupportedOperationException("not supported in this test suite"))
+
+      override def getParquetHandler: ParquetHandler =
+        Option(parquetHandler).getOrElse(
+          throw new UnsupportedOperationException("not supported in this test suite"))
+    }
+  }
+}
+
+/**
+ * Base class for mocking [[JsonHandler]]
+ */
+trait BaseMockJsonHandler extends JsonHandler {
+  override def parseJson(
+      jsonStringVector: ColumnVector,
+      outputSchema: StructType,
+      selectionVector: Optional[ColumnVector]): ColumnarBatch =
+    throw new UnsupportedOperationException("not supported in this test suite")
+
+  override def deserializeStructType(structTypeJson: String): StructType =
+    throw new UnsupportedOperationException("not supported in this test suite")
+
+  override def readJsonFiles(
+      fileIter: CloseableIterator[FileStatus],
+      physicalSchema: StructType,
+      predicate: Optional[Predicate]): CloseableIterator[ColumnarBatch] =
+    throw new UnsupportedOperationException("not supported in this test suite")
+}
+
+/**
+ * Base class for mocking [[ParquetHandler]]
+ */
+trait BaseMockParquetHandler extends ParquetHandler {
+  override def readParquetFiles(
+      fileIter: CloseableIterator[FileStatus],
+      physicalSchema: StructType,
+      predicate: Optional[Predicate]): CloseableIterator[ColumnarBatch] =
+    throw new UnsupportedOperationException("not supported in this test suite")
+}
+
+/**
+ * Base class for mocking [[ExpressionHandler]]
+ */
+trait BaseMockExpressionHandler extends ExpressionHandler {
+  override def getPredicateEvaluator(
+      inputSchema: StructType,
+      predicate: Predicate): PredicateEvaluator =
+    throw new UnsupportedOperationException("not supported in this test suite")
+
+  override def getEvaluator(
+      inputSchema: StructType,
+      expression: Expression,
+      outputType: DataType): ExpressionEvaluator =
+    throw new UnsupportedOperationException("not supported in this test suite")
+
+  override def isSupported(
+      inputSchema: StructType,
+      expression: Expression,
+      outputType: DataType): Boolean =
+    throw new UnsupportedOperationException("not supported in this test suite")
+
+  override def createSelectionVector(values: Array[Boolean], from: Int, to: Int): ColumnVector =
+    throw new UnsupportedOperationException("not supported in this test suite")
+}
+
+/**
+ * Base class for [[FileSystemClient]]
+ */
+trait BaseMockFileSystemClient extends FileSystemClient {
+  override def listFrom(filePath: String): CloseableIterator[FileStatus] =
+    throw new UnsupportedOperationException("not supported in this test suite")
+
+  override def resolvePath(path: String): String =
+    throw new UnsupportedOperationException("not supported in this test suite")
+
+  override def readFiles(
+      readRequests: CloseableIterator[FileReadRequest]): CloseableIterator[ByteArrayInputStream] =
+    throw new UnsupportedOperationException("not supported in this test suite")
+}
+


### PR DESCRIPTION
## Description
We have been duplicating the mocking `TableClient` across the test suites. Consolidate and make common utilities/classes that allow mocking `TableClient` with minimal code.

`MockTableClientUtils.scala` - is the base trait for mocking `TableClient`.

## How was this patch tested?
Just a refactor
