### PR TITLE
[Spark] Make DeltaHistoryManager.getHistory aware of ICT

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
@@ -628,12 +628,12 @@ abstract class DeltaHistoryManagerBase extends DeltaTimeTravelTests
         assert(filterUsageRecords(usageRecords, "deltaLog.update").size === expectedLogUpdates)
       }
 
-      testGetHistory(start = 0, endOpt = Some(2), versions = Seq(2, 1, 0), expectedLogUpdates = 0)
-      testGetHistory(start = 1, endOpt = Some(1), versions = Seq(1), expectedLogUpdates = 0)
+      testGetHistory(start = 0, endOpt = Some(3), versions = Seq(2, 1, 0), expectedLogUpdates = 0)
+      testGetHistory(start = 1, endOpt = Some(2), versions = Seq(1), expectedLogUpdates = 0)
       testGetHistory(start = 2, endOpt = None, versions = Seq(3, 2), expectedLogUpdates = 1)
-      testGetHistory(start = 1, endOpt = Some(5), versions = Seq(3, 2, 1), expectedLogUpdates = 1)
+      testGetHistory(start = 1, endOpt = Some(6), versions = Seq(3, 2, 1), expectedLogUpdates = 1)
       testGetHistory(start = 4, endOpt = None, versions = Seq.empty, expectedLogUpdates = 1)
-      testGetHistory(start = 2, endOpt = Some(1), versions = Seq.empty, expectedLogUpdates = 0)
+      testGetHistory(start = 2, endOpt = Some(2), versions = Seq.empty, expectedLogUpdates = 0)
     }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
@@ -628,12 +628,12 @@ abstract class DeltaHistoryManagerBase extends DeltaTimeTravelTests
         assert(filterUsageRecords(usageRecords, "deltaLog.update").size === expectedLogUpdates)
       }
 
-      testGetHistory(start = 0, endOpt = Some(3), versions = Seq(2, 1, 0), expectedLogUpdates = 0)
-      testGetHistory(start = 1, endOpt = Some(2), versions = Seq(1), expectedLogUpdates = 0)
+      testGetHistory(start = 0, endOpt = Some(2), versions = Seq(2, 1, 0), expectedLogUpdates = 0)
+      testGetHistory(start = 1, endOpt = Some(1), versions = Seq(1), expectedLogUpdates = 0)
       testGetHistory(start = 2, endOpt = None, versions = Seq(3, 2), expectedLogUpdates = 1)
-      testGetHistory(start = 1, endOpt = Some(6), versions = Seq(3, 2, 1), expectedLogUpdates = 1)
+      testGetHistory(start = 1, endOpt = Some(5), versions = Seq(3, 2, 1), expectedLogUpdates = 1)
       testGetHistory(start = 4, endOpt = None, versions = Seq.empty, expectedLogUpdates = 1)
-      testGetHistory(start = 2, endOpt = Some(2), versions = Seq.empty, expectedLogUpdates = 0)
+      testGetHistory(start = 2, endOpt = Some(1), versions = Seq.empty, expectedLogUpdates = 0)
     }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
@@ -675,7 +675,7 @@ class InCommitTimestampSuite
           assert(hist.timestamp.getTime == expectedTimestamp)
         }
         // Try fetching only the non-ICT commits.
-        val nonICTHistory = deltaLog.history.getHistory(start = 0, end = Some(ictEnablementVersion))
+        val nonICTHistory = deltaLog.history.getHistory(start = 0, end = Some(ictEnablementVersion - 1))
         assert(nonICTHistory.length == ictEnablementVersion)
         nonICTHistory.reverse.zipWithIndex.foreach { case (hist, version) =>
           assert(hist.getVersion == version)
@@ -694,7 +694,7 @@ class InCommitTimestampSuite
             assert(hist.timestamp.getTime == getInCommitTimestamp(deltaLog, version))
           }
         // Try fetching some non-ICT + some ICT commits.
-        val mixedHistory = deltaLog.history.getHistory(start = 2, end = Some(7))
+        val mixedHistory = deltaLog.history.getHistory(start = 2, end = Some(6))
         assert(mixedHistory.length == 5)
         mixedHistory
           .reverse
@@ -933,7 +933,7 @@ class InCommitTimestampSuite
         assert(hist.timestamp.getTime == getInCommitTimestamp(deltaLog, version))
       }
       // Try fetching a limited subset of the history.
-      val historySubset = deltaLog.history.getHistory(start = 2, end = Some(3))
+      val historySubset = deltaLog.history.getHistory(start = 2, end = Some(2))
       assert(historySubset.length == 1)
       assert(historySubset.head.timestamp.getTime == getInCommitTimestamp(deltaLog, 2))
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
@@ -675,7 +675,8 @@ class InCommitTimestampSuite
           assert(hist.timestamp.getTime == expectedTimestamp)
         }
         // Try fetching only the non-ICT commits.
-        val nonICTHistory = deltaLog.history.getHistory(start = 0, end = Some(ictEnablementVersion - 1))
+        val nonICTHistory =
+          deltaLog.history.getHistory(start = 0, end = Some(ictEnablementVersion - 1))
         assert(nonICTHistory.length == ictEnablementVersion)
         nonICTHistory.reverse.zipWithIndex.foreach { case (hist, version) =>
           assert(hist.getVersion == version)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Return the ICT (In-Commit Timestamp) timestamp for ICT-enabled ranges in DeltaHistoryManager.getHistory when ICT is currently enabled.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
New tests:
1. When all of history has ICT enabled.
2. When requested history is not an ICT range.
3. When requested range contains both ICT and non-ICT commits.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No visible differences for the user, the timestamp returned by `DESCRIBE HISTORY` will be different depending on whether ICT is currently enabled.