### PR TITLE
[SPARK] [Delta X-Compile] Get `delta-spark` tests cross-compiling against Spark 3.5.0 and Spark Master

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/CustomCatalogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CustomCatalogSuite.scala
@@ -311,7 +311,7 @@ class DummyCatalog extends TableCatalog {
   }
   override def loadTable(ident: Identifier): Table = {
     if (!tableExists(ident)) {
-      throw new NoSuchTableException("")
+      throw new NoSuchTableException(ident)
     }
     val tablePath = getTablePath(ident.name())
     DeltaTableV2(spark = spark, path = tablePath, catalogTable = Some(createCatalogTable(ident)))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -527,9 +527,15 @@ trait DeltaErrorsSuiteBase
     {
       val e = intercept[DeltaAnalysisException] {
         throw DeltaErrors.generatedColumnsReferToWrongColumns(
-          new AnalysisException("analysis exception"))
+          new AnalysisException(
+            errorClass = "INTERNAL_ERROR",
+            messageParameters = Map("message" -> "internal test error msg"))
+        )
       }
-      checkErrorMessage(e, None, None,
+      checkErrorMessage(
+        e,
+        Some("DELTA_INVALID_GENERATED_COLUMN_REFERENCES"),
+        Some("42621"),
         Some("A generated column cannot use a non-existent column or " +
         "another generated column"))
     }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

We want Delta to be able to cross-compile against Spark 3.5 and Spark Master (4.0).

Previously we have gotten Delta production code to compile (in a branch that enables shimming).

This PR gets the test code to compile, too, using changes that are forwards-compatible with spark master.

## How was this patch tested?

Existing tests.
