### PR TITLE
[Spark] Rename FileNames.deltaFile to FileNames.unsafeDeltaFile

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingLogFileSystem.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingLogFileSystem.scala
@@ -651,7 +651,7 @@ private[sharing] object DeltaSharingLogFileSystem extends Logging {
     }
 
     for (version <- minVersion to maxVersion) {
-      val jsonFilePath = FileNames.deltaFile(new Path(deltaLogPath), version).toString
+      val jsonFilePath = FileNames.unsafeDeltaFile(new Path(deltaLogPath), version).toString
       DeltaSharingUtils.overrideIteratorBlock[String](
         getDeltaSharingLogBlockId(jsonFilePath),
         versionToJsonLogBuilderMap.getOrElse(version, Seq.empty).toIterator
@@ -778,7 +778,7 @@ private[sharing] object DeltaSharingLogFileSystem extends Logging {
 
     // Always use 0.json for snapshot queries.
     val deltaLogPath = s"${encodedTablePath.toString}/_delta_log"
-    val jsonFilePath = FileNames.deltaFile(new Path(deltaLogPath), 0).toString
+    val jsonFilePath = FileNames.unsafeDeltaFile(new Path(deltaLogPath), 0).toString
     DeltaSharingUtils.overrideIteratorBlock[String](
       getDeltaSharingLogBlockId(jsonFilePath),
       jsonLogSeq.result().toIterator
@@ -819,7 +819,7 @@ private[sharing] object DeltaSharingLogFileSystem extends Logging {
     val jsonLogStr = deltaSharingTableMetadata.protocol.deltaProtocol.json + "\n" +
       deltaSharingTableMetadata.metadata.deltaMetadata.json + "\n"
 
-    val jsonFilePath = FileNames.deltaFile(new Path(deltaLogPath), 0).toString
+    val jsonFilePath = FileNames.unsafeDeltaFile(new Path(deltaLogPath), 0).toString
     DeltaSharingUtils.overrideIteratorBlock[String](
       getDeltaSharingLogBlockId(jsonFilePath),
       Seq(jsonLogStr).toIterator

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1917,7 +1917,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
         commitVersion: Long,
         actions: Iterator[String],
         updatedActions: UpdatedActions): CommitResponse = {
-      val commitFile = util.FileNames.deltaFile(logPath, commitVersion)
+      val commitFile = util.FileNames.unsafeDeltaFile(logPath, commitVersion)
       val commitFileStatus =
         doCommit(logStore, hadoopConf, logPath, commitFile, commitVersion, actions)
       // TODO(managed-commits): Integrate with ICT and pass the correct commitTimestamp
@@ -1985,7 +1985,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
     val commitTimestamp = commitResponse.commit.fileStatus.getModificationTime
     val commitFile = commitResponse.commit.copy(commitTimestamp = commitTimestamp)
     if (attemptVersion == 0L) {
-      val expectedPathForCommitZero = deltaFile(deltaLog.logPath, version = 0L).toUri
+      val expectedPathForCommitZero = unsafeDeltaFile(deltaLog.logPath, version = 0L).toUri
       val actualCommitPath = commitResponse.commit.fileStatus.getPath.toUri
       if (actualCommitPath != expectedPathForCommitZero) {
         throw new IllegalStateException("Expected 0th commit to be written to " +

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -491,7 +491,7 @@ class Snapshot(
         startVersion = minUnbackfilledVersion,
         endVersion = Some(version))
       val fs = deltaLog.logPath.getFileSystem(hadoopConf)
-      val expectedBackfilledDeltaFile = FileNames.deltaFile(deltaLog.logPath, version)
+      val expectedBackfilledDeltaFile = FileNames.unsafeDeltaFile(deltaLog.logPath, version)
       if (!fs.exists(expectedBackfilledDeltaFile)) {
         throw new IllegalStateException("Backfilling of commit files failed. " +
           s"Expected delta file $expectedBackfilledDeltaFile not found.")

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -351,7 +351,7 @@ trait SnapshotManagement { self: DeltaLog =>
 
       if (headDeltaVersion != checkpointVersion + 1) {
         throw DeltaErrors.logFileNotFoundException(
-          deltaFile(logPath, checkpointVersion + 1),
+          unsafeDeltaFile(logPath, checkpointVersion + 1),
           lastDeltaVersion,
           unsafeVolatileMetadata) // metadata is best-effort only
       }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/AbstractBatchBackfillingCommitStore.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/AbstractBatchBackfillingCommitStore.scala
@@ -80,7 +80,7 @@ trait AbstractBatchBackfillingCommitStore extends CommitStore with Logging {
     if (commitVersion == 0 || batchSize <= 1) {
       // Always backfill zeroth commit or when batch size is configured as 1
       backfill(logStore, hadoopConf, logPath, commitVersion, fileStatus)
-      val targetFile = FileNames.deltaFile(logPath, commitVersion)
+      val targetFile = FileNames.unsafeDeltaFile(logPath, commitVersion)
       val targetFileStatus = fs.getFileStatus(targetFile)
       val newCommit = commitResponse.commit.copy(fileStatus = targetFileStatus)
       commitResponse = commitResponse.copy(commit = newCommit)
@@ -127,7 +127,7 @@ trait AbstractBatchBackfillingCommitStore extends CommitStore with Logging {
       logPath: Path,
       version: Long,
       fileStatus: FileStatus): Unit = {
-    val targetFile = FileNames.deltaFile(logPath, version)
+    val targetFile = FileNames.unsafeDeltaFile(logPath, version)
     logInfo(s"Backfilling commit ${fileStatus.getPath} to ${targetFile.toString}")
     val commitContentIterator = logStore.readAsIterator(fileStatus, hadoopConf)
     try {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaCommitFileProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaCommitFileProvider.scala
@@ -56,7 +56,7 @@ case class DeltaCommitFileProvider(
     }
     uuids.get(version) match {
       case Some(uuid) => FileNames.unbackfilledDeltaFile(resolvedPath, version, Some(uuid))
-      case _ => FileNames.deltaFile(resolvedPath, version)
+      case _ => FileNames.unsafeDeltaFile(resolvedPath, version)
     }
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/FileNames.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/FileNames.scala
@@ -34,8 +34,26 @@ object FileNames {
   private val checksumFilePattern = checksumFileRegex.pattern
   private val checkpointFilePattern = checkpointFileRegex.pattern
 
-  /** Returns the delta (json format) path for a given delta file. */
-  def deltaFile(path: Path, version: Long): Path = new Path(path, f"$version%020d.json")
+  /**
+   * Returns the delta (json format) path for a given delta file.
+   * WARNING: This API is unsafe and can resolve to incorrect paths if the table has
+   * Managed Commits.
+   * Use DeltaCommitFileProvider(snapshot).deltaFile instead to guarantee accurate paths.
+   */
+  def unsafeDeltaFile(path: Path, version: Long): Path = new Path(path, f"$version%020d.json")
+
+  /**
+   * Returns the delta (json format) path for a given delta file.
+   * WARNING: This API is unsafe and deprecated. It can resolve to incorrect paths if the table has
+   * Managed Commits. It will be removed in future versions.
+   * Use DeltaCommitFileProvider(snapshot).deltaFile instead to guarantee accurate paths or
+   * unsafeDeltaFile for potentially incorrect file name resolution.
+   */
+  @deprecated(
+    "This method is deprecated and will be removed in future versions. " +
+      "Use DeltaCommitFileProvider(snapshot).deltaFile or unsafeDeltaFile instead",
+    "15.1")
+  def deltaFile(path: Path, version: Long): Path = unsafeDeltaFile(path, version)
 
   /**
    * Returns the un-backfilled uuid formatted delta (json format) path for a given version.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/FileNames.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/FileNames.scala
@@ -51,8 +51,7 @@ object FileNames {
    */
   @deprecated(
     "This method is deprecated and will be removed in future versions. " +
-      "Use DeltaCommitFileProvider(snapshot).deltaFile or unsafeDeltaFile instead",
-    "15.1")
+      "Use DeltaCommitFileProvider(snapshot).deltaFile or unsafeDeltaFile instead")
   def deltaFile(path: Path, version: Long): Path = unsafeDeltaFile(path, version)
 
   /**

--- a/spark/src/test/scala/io/delta/tables/DeltaTableSuite.scala
+++ b/spark/src/test/scala/io/delta/tables/DeltaTableSuite.scala
@@ -515,7 +515,7 @@ class DeltaTableHadoopOptionsSuite extends QueryTest
         val time = format.parse(desiredTime).getTime
 
         val logPath = new Path(dir.getCanonicalPath, "_delta_log")
-        val file = new File(FileNames.deltaFile(logPath, 0).toString)
+        val file = new File(FileNames.unsafeDeltaFile(logPath, 0).toString)
         assert(file.setLastModified(time))
 
         val deltaTable2 = io.delta.tables.DeltaTable.forPath(spark, path, fsOptions)
@@ -539,7 +539,7 @@ class DeltaTableHadoopOptionsSuite extends QueryTest
       val log = DeltaLog.forTable(spark, new Path(path), fsOptions)
       log.ensureLogDirectoryExist()
       log.store.write(
-        FileNames.deltaFile(log.logPath, 0),
+        FileNames.unsafeDeltaFile(log.logPath, 0),
         Iterator(Metadata(schemaString = testSchema.json).json, Protocol(0, 0).json),
         overwrite = false,
         log.newDeltaHadoopConf())
@@ -565,7 +565,7 @@ class DeltaTableHadoopOptionsSuite extends QueryTest
       val log = DeltaLog.forTable(spark, new Path(path), fsOptions)
       log.ensureLogDirectoryExist()
       log.store.write(
-        FileNames.deltaFile(log.logPath, 0),
+        FileNames.unsafeDeltaFile(log.logPath, 0),
         Iterator(Metadata(schemaString = testSchema.json).json, Protocol(1, 2).json),
         overwrite = false,
         log.newDeltaHadoopConf())

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -409,7 +409,7 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
       val version = deltaTable.startTransactionWithInitialSnapshot()
         .commit(domainMetadatas, ManualUpdate)
       val committedActions = deltaLog.store.read(
-        FileNames.deltaFile(deltaLog.logPath, version),
+        FileNames.unsafeDeltaFile(deltaLog.logPath, version),
         deltaLog.newDeltaHadoopConf())
       assert(committedActions.size == 2)
       val serializedJson = committedActions.last
@@ -635,7 +635,7 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
           val version = deltaLog.startTransaction().commit(Seq(action), ManualUpdate)
           // Read the commit file and get the serialized committed actions
           val committedActions = deltaLog.store.read(
-            FileNames.deltaFile(deltaLog.logPath, version),
+            FileNames.unsafeDeltaFile(deltaLog.logPath, version),
             deltaLog.newDeltaHadoopConf())
 
           assert(committedActions.size == 2)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
@@ -581,7 +581,7 @@ class CheckpointsSuite
       // Delete the commit files 0-9, so that we are forced to read the checkpoint file
       val logPath = new Path(new File(target, "_delta_log").getAbsolutePath)
       for (i <- 0 to 10) {
-        val file = new File(FileNames.deltaFile(logPath, version = i).toString)
+        val file = new File(FileNames.unsafeDeltaFile(logPath, version = i).toString)
         file.delete()
       }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableSuiteBase.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaColumnMappingSelectedTestMixin, DeltaSQLCommandTest}
-import org.apache.spark.sql.delta.util.FileNames.{checksumFile, deltaFile}
+import org.apache.spark.sql.delta.util.FileNames.{checksumFile, unsafeDeltaFile}
 import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{Path, RawLocalFileSystem}
@@ -231,7 +231,7 @@ trait CloneTableSuiteBase extends QueryTest
       targetLocation.isEmpty && targetIsTable,
       isReplaceOperation)
 
-    val commit = deltaFile(targetLog.logPath, targetLog.unsafeVolatileSnapshot.version)
+    val commit = unsafeDeltaFile(targetLog.logPath, targetLog.unsafeVolatileSnapshot.version)
     val hadoopConf = targetLog.newDeltaHadoopConf()
     val filePaths: Seq[FileAction] = targetLog.store.read(commit, hadoopConf).flatMap { line =>
       JsonUtils.fromJson[SingleAction](line) match {
@@ -688,7 +688,7 @@ trait CloneTableSuiteBase extends QueryTest
     val newSchema = new StructType().add("id", IntegerType, nullable = true)
     log.ensureLogDirectoryExist()
     log.store.write(
-      deltaFile(log.logPath, 0),
+      unsafeDeltaFile(log.logPath, 0),
       Iterator(Metadata(schemaString = newSchema.json).json, sourceProtocol.json),
       overwrite = false,
       log.newDeltaHadoopConf())

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCStreamSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCStreamSuite.scala
@@ -50,7 +50,7 @@ trait DeltaCDCStreamSuiteBase extends StreamTest with DeltaSQLCommandTest
 
   /** Modify timestamp for a delta commit, used to test timestamp querying */
   def modifyDeltaTimestamp(deltaLog: DeltaLog, version: Long, time: Long): Unit = {
-    val file = new File(FileNames.deltaFile(deltaLog.logPath, version).toUri)
+    val file = new File(FileNames.unsafeDeltaFile(deltaLog.logPath, version).toUri)
     file.setLastModified(time)
     val crc = new File(FileNames.checksumFile(deltaLog.logPath, version).toUri)
     if (crc.exists()) {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSuite.scala
@@ -107,7 +107,7 @@ abstract class DeltaCDCSuiteBase
 
   /** Modify timestamp for a delta commit, used to test timestamp querying */
   def modifyDeltaTimestamp(deltaLog: DeltaLog, version: Long, time: Long): Unit = {
-    val file = new File(FileNames.deltaFile(deltaLog.logPath, version).toUri)
+    val file = new File(FileNames.unsafeDeltaFile(deltaLog.logPath, version).toUri)
     file.setLastModified(time)
     val crc = new File(FileNames.checksumFile(deltaLog.logPath, version).toUri)
     if (crc.exists()) {
@@ -951,7 +951,7 @@ class DeltaCDCScalaSuite extends DeltaCDCSuiteBase {
       val deltaLog = DeltaLog.forTable(spark, path)
       (0 to 3).foreach { i =>
         spark.range(i * 10, (i + 1) * 10).write.format("delta").mode("append").save(path)
-        val file = new File(FileNames.deltaFile(deltaLog.logPath, i).toUri)
+        val file = new File(FileNames.unsafeDeltaFile(deltaLog.logPath, i).toUri)
         file.setLastModified(300 - i)
       }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
@@ -63,7 +63,7 @@ trait DeltaTimeTravelTests extends QueryTest
   protected val timeFormatter = new SimpleDateFormat("yyyyMMddHHmmssSSS")
 
   protected def modifyCommitTimestamp(deltaLog: DeltaLog, version: Long, ts: Long): Unit = {
-    val file = new File(FileNames.deltaFile(deltaLog.logPath, version).toUri)
+    val file = new File(FileNames.unsafeDeltaFile(deltaLog.logPath, version).toUri)
     file.setLastModified(ts)
     val crc = new File(FileNames.checksumFile(deltaLog.logPath, version).toUri)
     if (crc.exists()) {
@@ -128,7 +128,7 @@ trait DeltaTimeTravelTests extends QueryTest
           .saveAsTable(table)
       }
       val deltaLog = DeltaLog.forTable(spark, new TableIdentifier(table))
-      val file = new File(FileNames.deltaFile(deltaLog.logPath, 0).toUri)
+      val file = new File(FileNames.unsafeDeltaFile(deltaLog.logPath, 0).toUri)
       file.setLastModified(commitList.head)
       commitList = commits.slice(1, commits.length) // we already wrote the first commit here
       var startVersion = deltaLog.snapshot.version + 1
@@ -352,7 +352,7 @@ trait DeltaTimeTravelTests extends QueryTest
         assert(e1.getMessage.contains("[0, 2]"))
 
         val deltaLog = DeltaLog.forTable(spark, getTableLocation(tblName))
-        new File(FileNames.deltaFile(deltaLog.logPath, 0).toUri).delete()
+        new File(FileNames.unsafeDeltaFile(deltaLog.logPath, 0).toUri).delete()
         // Delta Lake will create a DeltaTableV2 explicitly with time travel options in the catalog.
         // These options will be verified by DeltaHistoryManager, which will throw an
         // AnalysisException.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogMinorCompactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogMinorCompactionSuite.scala
@@ -56,7 +56,7 @@ class DeltaLogMinorCompactionSuite extends QueryTest
     val hadoopConf = deltaLog.newDeltaHadoopConf()
 
     (startVersion to endVersion).foreach { versionToRead =>
-      val file = FileNames.deltaFile(deltaLog.logPath, versionToRead)
+      val file = FileNames.unsafeDeltaFile(deltaLog.logPath, versionToRead)
       val actionsIterator = deltaLog.store.readAsIterator(file, hadoopConf).map(Action.fromJson)
       logReplay.append(versionToRead, actionsIterator)
     }
@@ -429,7 +429,7 @@ class DeltaLogMinorCompactionSuite extends QueryTest
       postSetupFunc = Some(
         (deltaLog: DeltaLog) => {
           val logPath = deltaLog.logPath
-          val deltaFileToDelete = FileNames.deltaFile(logPath, version = 4)
+          val deltaFileToDelete = FileNames.unsafeDeltaFile(logPath, version = 4)
           logPath.getFileSystem(deltaLog.newDeltaHadoopConf()).delete(deltaFileToDelete, true)
         }
       ),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -243,13 +243,13 @@ class DeltaLogSuite extends QueryTest
           s"$scheme$path", Some(200L), dataChange = false)
 
         log.store.write(
-          FileNames.deltaFile(log.logPath, 0L),
+          FileNames.unsafeDeltaFile(log.logPath, 0L),
           Iterator(Action.supportedProtocolVersion(), Metadata(), add)
             .map(a => JsonUtils.toJson(a.wrap)),
           overwrite = false,
           log.newDeltaHadoopConf())
         log.store.write(
-          FileNames.deltaFile(log.logPath, 1L),
+          FileNames.unsafeDeltaFile(log.logPath, 1L),
           Iterator(JsonUtils.toJson(rm.wrap)),
           overwrite = false,
           log.newDeltaHadoopConf())
@@ -272,13 +272,13 @@ class DeltaLogSuite extends QueryTest
           s"$scheme$path", Some(200L), dataChange = false)
 
         log.store.write(
-          FileNames.deltaFile(log.logPath, 0L),
+          FileNames.unsafeDeltaFile(log.logPath, 0L),
           Iterator(Action.supportedProtocolVersion(), Metadata(), add)
             .map(a => JsonUtils.toJson(a.wrap)),
           overwrite = false,
           log.newDeltaHadoopConf())
         log.store.write(
-          FileNames.deltaFile(log.logPath, 1L),
+          FileNames.unsafeDeltaFile(log.logPath, 1L),
           Iterator(JsonUtils.toJson(rm.wrap)),
           overwrite = false,
           log.newDeltaHadoopConf())
@@ -373,7 +373,7 @@ class DeltaLogSuite extends QueryTest
         }
         val file = AddFile("abc", Map.empty, 1, 1, true)
         log.store.write(
-          FileNames.deltaFile(log.logPath, 0L),
+          FileNames.unsafeDeltaFile(log.logPath, 0L),
           Iterator(selectedAction, file).map(a => JsonUtils.toJson(a.wrap)),
           overwrite = false,
           log.newDeltaHadoopConf())
@@ -526,14 +526,14 @@ class DeltaLogSuite extends QueryTest
       assert(deltaLog.snapshot.version === 0)
 
       deltaLog.store.write(
-        FileNames.deltaFile(deltaLog.logPath, 0),
+        FileNames.unsafeDeltaFile(deltaLog.logPath, 0),
         actions.map(_.unwrap.json).iterator,
         overwrite = false,
         deltaLog.newDeltaHadoopConf())
 
       // To avoid flakiness, we manually set the modification timestamp of the file to a later
       // second
-      new File(FileNames.deltaFile(deltaLog.logPath, 0).toUri)
+      new File(FileNames.unsafeDeltaFile(deltaLog.logPath, 0).toUri)
         .setLastModified(commitTimestamp + 5000)
 
       checkAnswer(
@@ -558,7 +558,7 @@ class DeltaLogSuite extends QueryTest
         // that we don't trigger another update, and thus don't find the commit.
         val add = AddFile(path, Map.empty, 100L, 10L, dataChange = true)
         deltaLog.store.write(
-          FileNames.deltaFile(deltaLog.logPath, 1L),
+          FileNames.unsafeDeltaFile(deltaLog.logPath, 1L),
           Iterator(JsonUtils.toJson(add.wrap)),
           overwrite = false,
           deltaLog.newDeltaHadoopConf())
@@ -582,7 +582,7 @@ class DeltaLogSuite extends QueryTest
       spark.range(1).write.format("delta").mode("append").save(path)
 
       val log = DeltaLog.forTable(spark, path)
-      val commitFilePath = FileNames.deltaFile(log.logPath, 1L)
+      val commitFilePath = FileNames.unsafeDeltaFile(log.logPath, 1L)
       val fs = log.logPath.getFileSystem(log.newDeltaHadoopConf())
       val stream = fs.open(commitFilePath)
       val reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
@@ -62,7 +62,7 @@ class DeltaOptionSuite extends QueryTest
     val deltaLog = DeltaLog.forTable(spark, tempDir)
     val version = deltaLog.snapshot.version
     val commitActions = deltaLog.store
-      .read(FileNames.deltaFile(deltaLog.logPath, version), deltaLog.newDeltaHadoopConf())
+      .read(FileNames.unsafeDeltaFile(deltaLog.logPath, version), deltaLog.newDeltaHadoopConf())
       .map(Action.fromJson)
     val fileActions = commitActions.collect { case a: FileAction => a }
 
@@ -88,7 +88,7 @@ class DeltaOptionSuite extends QueryTest
     val deltaLog = DeltaLog.forTable(spark, tempDir)
     val version = deltaLog.snapshot.version
     val commitActions = deltaLog.store
-      .read(FileNames.deltaFile(deltaLog.logPath, version), deltaLog.newDeltaHadoopConf())
+      .read(FileNames.unsafeDeltaFile(deltaLog.logPath, version), deltaLog.newDeltaHadoopConf())
       .map(Action.fromJson)
     val fileActions = commitActions.collect { case a: FileAction => a }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.FileNames
-import org.apache.spark.sql.delta.util.FileNames.{deltaFile, DeltaFile}
+import org.apache.spark.sql.delta.util.FileNames.{unsafeDeltaFile, DeltaFile}
 import org.apache.spark.sql.delta.util.JsonUtils
 
 import org.apache.spark.SparkConf
@@ -63,7 +63,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     val log = DeltaLog.forTable(spark, path)
     log.ensureLogDirectoryExist()
     log.store.write(
-      deltaFile(log.logPath, 0),
+      unsafeDeltaFile(log.logPath, 0),
       Iterator(Metadata(schemaString = schema.json).json, protocol.json),
       overwrite = false,
       log.newDeltaHadoopConf())
@@ -412,7 +412,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       val log = DeltaLog.forTable(spark, path)
       log.ensureLogDirectoryExist()
       log.store.write(
-        deltaFile(log.logPath, 0),
+        unsafeDeltaFile(log.logPath, 0),
         Iterator(Metadata().json, Protocol(Integer.MAX_VALUE, Integer.MAX_VALUE).json),
         overwrite = false,
         log.newDeltaHadoopConf())
@@ -440,7 +440,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         TABLE_FEATURES_MIN_READER_VERSION,
         TABLE_FEATURES_MIN_WRITER_VERSION).withWriterFeatures(Seq("newUnsupportedWriterFeature"))
       log.store.write(
-        deltaFile(log.logPath, snapshot.version + 1),
+        unsafeDeltaFile(log.logPath, snapshot.version + 1),
         Iterator(Metadata().json, newProtocol.json),
         overwrite = false,
         log.newDeltaHadoopConf())
@@ -608,7 +608,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       version: Long,
       protocol: Protocol): Unit = {
     log.store.write(
-      deltaFile(log.logPath, version),
+      unsafeDeltaFile(log.logPath, version),
       Iterator(
         Metadata().json,
         protocol.json),
@@ -973,7 +973,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         val txn = deltaLog.startTransaction()
         val currentVersion = txn.snapshot.version
         deltaLog.store.write(
-          deltaFile(deltaLog.logPath, currentVersion + 1),
+          unsafeDeltaFile(deltaLog.logPath, currentVersion + 1),
           Iterator(incompatibleProtocol.json),
           overwrite = false,
           hadoopConf)
@@ -983,7 +983,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
           txn.commit(AddFile("test", Map.empty, 1, 1, dataChange = true) :: Nil, ManualUpdate)
         }
         // Make sure we didn't commit anything
-        val p = deltaFile(deltaLog.logPath, currentVersion + 2)
+        val p = unsafeDeltaFile(deltaLog.logPath, currentVersion + 2)
         assert(
           !p.getFileSystem(hadoopConf).exists(p),
           s"$p should not be committed")
@@ -1230,7 +1230,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       val log = DeltaLog.forTable(spark, path)
       log.ensureLogDirectoryExist()
       log.store.write(
-        deltaFile(log.logPath, 0),
+        unsafeDeltaFile(log.logPath, 0),
         Iterator(Metadata().json),
         overwrite = false,
         log.newDeltaHadoopConf())
@@ -2207,7 +2207,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         DeltaConfigs.IS_APPEND_ONLY.key -> "false",
         DeltaConfigs.CHANGE_DATA_FEED.key -> "true"))
       log.store.write(
-        deltaFile(log.logPath, snapshot.version + 1),
+        unsafeDeltaFile(log.logPath, snapshot.version + 1),
         Iterator(m.json, p.json),
         overwrite = false,
         log.newDeltaHadoopConf())

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
@@ -107,7 +107,7 @@ class DeltaRetentionSuite extends QueryTest
           Nil
         }
         val version = txn.commit(delete ++ file, testOp)
-        val deltaFile = new File(FileNames.deltaFile(log.logPath, version).toUri)
+        val deltaFile = new File(FileNames.unsafeDeltaFile(log.logPath, version).toUri)
         deltaFile.setLastModified(clock.getTimeMillis() + i * 10000)
         val crcFile = new File(FileNames.checksumFile(log.logPath, version).toUri)
         crcFile.setLastModified(clock.getTimeMillis() + i * 10000)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -1360,7 +1360,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
 
         val deltaLog = DeltaLog.forTable(spark, tempDir)
         deltaLog.store.write(
-          FileNames.deltaFile(deltaLog.logPath, deltaLog.snapshot.version + 1),
+          FileNames.unsafeDeltaFile(deltaLog.logPath, deltaLog.snapshot.version + 1),
           // Write a large reader version to fail the streaming query
           Iterator(Protocol(minReaderVersion = Int.MaxValue).json),
           overwrite = false,
@@ -1385,7 +1385,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       val rangeStart = startVersion * 10
       val rangeEnd = rangeStart + 10
       spark.range(rangeStart, rangeEnd).write.format("delta").mode("append").save(location)
-      val file = new File(FileNames.deltaFile(deltaLog.logPath, startVersion).toUri)
+      val file = new File(FileNames.unsafeDeltaFile(deltaLog.logPath, startVersion).toUri)
       file.setLastModified(ts)
       startVersion += 1
     }
@@ -1447,7 +1447,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       val deltaLog = DeltaLog.forTable(spark, tablePath)
       assert(deltaLog.update().version == 2)
       deltaLog.checkpoint()
-      new File(FileNames.deltaFile(deltaLog.logPath, 0).toUri).delete()
+      new File(FileNames.unsafeDeltaFile(deltaLog.logPath, 0).toUri).delete()
 
       // Cannot start from version 0
       assert(intercept[StreamingQueryException] {
@@ -1522,7 +1522,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         // Add one commit and delete version 0 and version 1
         generateCommits(inputDir.getCanonicalPath, start + 60.minutes)
         (0 to 1).foreach { v =>
-          new File(FileNames.deltaFile(deltaLog.logPath, v).toUri).delete()
+          new File(FileNames.unsafeDeltaFile(deltaLog.logPath, v).toUri).delete()
         }
 
         // Although version 1 has been deleted, restarting the query should still work as we have
@@ -1618,7 +1618,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       val deltaLog = DeltaLog.forTable(spark, tablePath)
       assert(deltaLog.update().version == 2)
       deltaLog.checkpoint()
-      new File(FileNames.deltaFile(deltaLog.logPath, 0).toUri).delete()
+      new File(FileNames.unsafeDeltaFile(deltaLog.logPath, 0).toUri).delete()
 
       // Can start from version 1 even if it's not recreatable
       // TODO: currently we would error out if we couldn't construct the snapshot to check column
@@ -1979,7 +1979,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       // Create a checkpoint so that we can create a snapshot without json files before version 3
       srcLog.checkpoint()
       // Delete the first file
-      assert(new File(FileNames.deltaFile(srcLog.logPath, 1).toUri).delete())
+      assert(new File(FileNames.unsafeDeltaFile(srcLog.logPath, 1).toUri).delete())
 
       val e = intercept[StreamingQueryException] {
         val q = df.writeStream.format("delta")
@@ -2014,7 +2014,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       // Create a checkpoint so that we can create a snapshot without json files before version 3
       srcLog.checkpoint()
       // Delete the second file
-      assert(new File(FileNames.deltaFile(srcLog.logPath, 2).toUri).delete())
+      assert(new File(FileNames.unsafeDeltaFile(srcLog.logPath, 2).toUri).delete())
 
       val e = intercept[StreamingQueryException] {
         val q = df.writeStream.format("delta")
@@ -2050,7 +2050,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       // Create a checkpoint so that we can create a snapshot without json files before version 3
       srcLog.checkpoint()
       // Delete the first file
-      assert(new File(FileNames.deltaFile(srcLog.logPath, 1).toUri).delete())
+      assert(new File(FileNames.unsafeDeltaFile(srcLog.logPath, 1).toUri).delete())
 
       val q2 = df.writeStream.format("delta")
         .option("checkpointLocation", chkLocation.getCanonicalPath)
@@ -2086,7 +2086,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       // Create a checkpoint so that we can create a snapshot without json files before version 3
       srcLog.checkpoint()
       // Delete the second file
-      assert(new File(FileNames.deltaFile(srcLog.logPath, 2).toUri).delete())
+      assert(new File(FileNames.unsafeDeltaFile(srcLog.logPath, 2).toUri).delete())
 
       val q2 = df.writeStream.format("delta")
         .option("checkpointLocation", chkLocation.getCanonicalPath)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.{DeltaFileOperations, FileNames}
-import org.apache.spark.sql.delta.util.FileNames.deltaFile
+import org.apache.spark.sql.delta.util.FileNames.unsafeDeltaFile
 import org.apache.hadoop.fs.{FileSystem, FSDataInputStream, Path, PathHandle}
 
 import org.apache.spark.SparkException
@@ -2037,13 +2037,13 @@ class DeltaSuite extends QueryTest
     // changes the schema
     val actions = Seq(Action.supportedProtocolVersion(), newMetadata) ++ files.map(_.remove)
     deltaLog.store.write(
-      FileNames.deltaFile(deltaLog.logPath, snapshot.version + 1),
+      FileNames.unsafeDeltaFile(deltaLog.logPath, snapshot.version + 1),
       actions.map(_.json).iterator,
       overwrite = false,
       hadoopConf)
 
     deltaLog.store.write(
-      FileNames.deltaFile(deltaLog.logPath, snapshot.version + 2),
+      FileNames.unsafeDeltaFile(deltaLog.logPath, snapshot.version + 2),
       files.take(1).map(_.json).iterator,
       overwrite = false,
       hadoopConf)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
-import org.apache.spark.sql.delta.util.FileNames.deltaFile
+import org.apache.spark.sql.delta.util.FileNames.unsafeDeltaFile
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.QueryTest
@@ -49,7 +49,7 @@ class DeltaTableFeatureSuite
     val log = DeltaLog.forTable(spark, path)
     log.ensureLogDirectoryExist()
     log.store.write(
-      deltaFile(log.logPath, 0),
+      unsafeDeltaFile(log.logPath, 0),
       Iterator(Metadata(schemaString = schema.json).json, protocol.json),
       overwrite = false,
       log.newDeltaHadoopConf())

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
@@ -86,7 +86,7 @@ class DeltaTimeTravelSuite extends QueryTest
       val rangeStart = startVersion * 10
       val rangeEnd = rangeStart + 10
       spark.range(rangeStart, rangeEnd).write.format("delta").mode("append").save(location)
-      val file = new File(FileNames.deltaFile(deltaLog.logPath, startVersion).toUri)
+      val file = new File(FileNames.unsafeDeltaFile(deltaLog.logPath, startVersion).toUri)
       file.setLastModified(ts)
       startVersion += 1
     }
@@ -163,7 +163,7 @@ class DeltaTimeTravelSuite extends QueryTest
     val commits2 = history.getHistory(Some(10))
     assert(commits2.last.version === Some(0))
 
-    assert(new File(FileNames.deltaFile(deltaLog.logPath, 0L).toUri).delete())
+    assert(new File(FileNames.unsafeDeltaFile(deltaLog.logPath, 0L).toUri).delete())
     val e = intercept[AnalysisException] {
       history.getActiveCommitAtTime(start + 15.seconds, false).version
     }
@@ -543,7 +543,7 @@ class DeltaTimeTravelSuite extends QueryTest
       assert(e1.getMessage.contains("[0, 2]"))
 
       val deltaLog = DeltaLog.forTable(spark, tblLoc)
-      new File(FileNames.deltaFile(deltaLog.logPath, 0).toUri).delete()
+      new File(FileNames.unsafeDeltaFile(deltaLog.logPath, 0).toUri).delete()
       val e2 = intercept[AnalysisException] {
         spark.read.format("delta").option("versionAsOf", 0).load(tblLoc).collect()
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
@@ -386,7 +386,7 @@ trait DescribeDeltaHistorySuiteBase
       val log = DeltaLog.forTable(spark, path)
       log.ensureLogDirectoryExist()
       log.store.write(
-        FileNames.deltaFile(log.logPath, 0),
+        FileNames.unsafeDeltaFile(log.logPath, 0),
         Iterator(
           Metadata(schemaString = spark.range(1).schema.asNullable.json).json,
           Protocol(1, 1).json),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/EvolvabilitySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/EvolvabilitySuite.scala
@@ -66,7 +66,7 @@ class EvolvabilitySuite extends EvolvabilitySuiteBase with DeltaSQLCommandTest {
 
     // Check serialized JSON as well
     val contents = deltaLog.store.read(
-      FileNames.deltaFile(deltaLog.logPath, 0L),
+      FileNames.unsafeDeltaFile(deltaLog.logPath, 0L),
       deltaLog.newDeltaHadoopConf())
     assert(contents.exists(_.contains(""""part":null""")), "null value should be written in json")
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -349,7 +349,7 @@ class OptimisticTransactionSuite
 
       // Validate that actions in both transactions are not exactly same.
       def readActions(version: Long): Seq[Action] = {
-        log.store.read(FileNames.deltaFile(log.logPath, version), log.newDeltaHadoopConf())
+        log.store.read(FileNames.unsafeDeltaFile(log.logPath, version), log.newDeltaHadoopConf())
           .map(Action.fromJson)
       }
       def removeTxnIdAndMetricsFromActions(actions: Seq[Action]): Seq[Action] = actions.map {
@@ -379,7 +379,7 @@ class OptimisticTransactionSuite
       val version = txn.commit(Seq(), ManualUpdate)
 
       def readActions(version: Long): Seq[Action] = {
-        log.store.read(FileNames.deltaFile(log.logPath, version), log.newDeltaHadoopConf())
+        log.store.read(FileNames.unsafeDeltaFile(log.logPath, version), log.newDeltaHadoopConf())
           .map(Action.fromJson)
       }
       val actions = readActions(version)
@@ -415,7 +415,7 @@ class OptimisticTransactionSuite
       txn.updateSetTransaction("TestAppId", 1L, None)
       val version = txn.commit(Seq(SetTransaction("TestAppId", 1L, None)), ManualUpdate)
       def readActions(version: Long): Seq[Action] = {
-        log.store.read(FileNames.deltaFile(log.logPath, version), log.newDeltaHadoopConf())
+        log.store.read(FileNames.unsafeDeltaFile(log.logPath, version), log.newDeltaHadoopConf())
           .map(Action.fromJson)
       }
       assert(readActions(version).collectFirst {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/RestoreTableSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/RestoreTableSuiteBase.scala
@@ -121,7 +121,7 @@ trait RestoreTableSuiteBase extends QueryTest with SharedSparkSession
       deltaLog: DeltaLog,
       version: Int,
       timestamp: Long): Unit = {
-    val file = new File(FileNames.deltaFile(deltaLog.logPath, version).toUri)
+    val file = new File(FileNames.unsafeDeltaFile(deltaLog.logPath, version).toUri)
     file.setLastModified(timestamp)
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/S3SingleDriverLogStoreSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/S3SingleDriverLogStoreSuite.scala
@@ -46,7 +46,7 @@ trait S3SingleDriverLogStoreSuiteBase extends LogStoreSuiteBase {
   test("file system has priority over cache") {
     withTempDir { dir =>
       val store = createLogStore(spark)
-      val deltas = Seq(0, 1, 2).map(i => FileNames.deltaFile(new Path(dir.toURI), i))
+      val deltas = Seq(0, 1, 2).map(i => FileNames.unsafeDeltaFile(new Path(dir.toURI), i))
       store.write(deltas(0), Iterator("zero"), overwrite = false, sessionHadoopConf)
       store.write(deltas(1), Iterator("one"), overwrite = false, sessionHadoopConf)
       store.write(deltas(2), Iterator("two"), overwrite = false, sessionHadoopConf)
@@ -70,7 +70,7 @@ trait S3SingleDriverLogStoreSuiteBase extends LogStoreSuiteBase {
     withTempDir { dir =>
       val store = createLogStore(spark)
       val deltas =
-        Seq(0, 1, 2, 3, 4).map(i => FileNames.deltaFile(new Path(dir.toURI), i))
+        Seq(0, 1, 2, 3, 4).map(i => FileNames.unsafeDeltaFile(new Path(dir.toURI), i))
       store.write(deltas(0), Iterator("zero"), overwrite = false, sessionHadoopConf)
       store.write(deltas(1), Iterator("one"), overwrite = false, sessionHadoopConf)
       store.write(deltas(2), Iterator("two"), overwrite = false, sessionHadoopConf)
@@ -119,7 +119,7 @@ trait S3SingleDriverLogStoreSuiteBase extends LogStoreSuiteBase {
       dir.mkdir()
       val store = createLogStore(spark)
       val deltas =
-        Seq(0, 1, 2).map(i => FileNames.deltaFile(new Path(dir.toURI), i))
+        Seq(0, 1, 2).map(i => FileNames.unsafeDeltaFile(new Path(dir.toURI), i))
       store.write(deltas(0), Iterator("log version 0"), overwrite = false, sessionHadoopConf)
       store.write(deltas(1), Iterator("log version 1"), overwrite = false, sessionHadoopConf)
       store.write(deltas(2), Iterator("log version 2"), overwrite = false, sessionHadoopConf)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
@@ -78,7 +78,8 @@ class SnapshotManagementSuite extends QueryTest with DeltaSQLTestUtils with Shar
   }
 
   private def deleteLogVersion(path: String, version: Long): Unit = {
-    val deltaFile = new File(FileNames.deltaFile(new Path(path, "_delta_log"), version).toString)
+    val deltaFile = new File(
+      FileNames.unsafeDeltaFile(new Path(path, "_delta_log"), version).toString)
     assert(deltaFile.exists(), s"Could not find $deltaFile")
     assert(deltaFile.delete(), s"Failed to delete $deltaFile")
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/InMemoryCommitStoreSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/InMemoryCommitStoreSuite.scala
@@ -72,7 +72,7 @@ class InMemoryCommitStoreSuite extends QueryTest
       version: Long,
       logPath: Path,
       timestampOpt: Option[Long] = None): Unit = {
-    val delta = FileNames.deltaFile(logPath, version)
+    val delta = FileNames.unsafeDeltaFile(logPath, version)
     if (timestampOpt.isDefined) {
       assert(store.read(delta, sessionHadoopConf) == Seq(s"$version", s"${timestampOpt.get}"))
     } else {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitSuite.scala
@@ -271,16 +271,22 @@ class ManagedCommitSuite
           val newMetadata2 = oldMetadata.copy(
             configuration = oldMetadataConf + (MANAGED_COMMIT_OWNER_NAME.key -> builder2.name))
           log.store.write(
-            FileNames.deltaFile(log.logPath, 2), Seq(newMetadata1.json).toIterator, false, conf)
+            FileNames.unsafeDeltaFile(log.logPath, 2),
+            Seq(newMetadata1.json).toIterator,
+            overwrite = false,
+            conf)
           log.store.write(
-            FileNames.deltaFile(log.logPath, 3), Seq(newMetadata2.json).toIterator, false, conf)
+            FileNames.unsafeDeltaFile(log.logPath, 3),
+            Seq(newMetadata2.json).toIterator,
+            overwrite = false,
+            conf)
           cs2.registerTable(log.logPath, maxCommitVersion = 3)
 
           // Also backfill commit 0, 1 -- which the spec mandates when the commit owner changes.
           // commit 0 should already be backfilled
           assert(segment.deltas(0).getPath.getName === "00000000000000000000.json")
           log.store.write(
-            path = FileNames.deltaFile(log.logPath, 1),
+            path = FileNames.unsafeDeltaFile(log.logPath, 1),
             actions = log.store.read(segment.deltas(1).getPath, conf).toIterator,
             overwrite = true,
             conf)
@@ -415,7 +421,7 @@ class ManagedCommitSuite
           // backfill commit 1 and 2 also as 3/4 are written directly to FS.
           val segment = log.unsafeVolatileSnapshot.logSegment
           log.store.write(
-            path = FileNames.deltaFile(log.logPath, v),
+            path = FileNames.unsafeDeltaFile(log.logPath, v),
             actions = log.store.read(segment.deltas(v).getPath).toIterator,
             overwrite = true)
         }
@@ -525,7 +531,8 @@ class ManagedCommitSuite
       snapshot.ensureCommitFilesBackfilled()
 
       val commitFiles = log.listFrom(0).filter(FileNames.isDeltaFile).map(_.getPath)
-      val backfilledCommitFiles = (0 to 9).map(version => FileNames.deltaFile(log.logPath, version))
+      val backfilledCommitFiles = (0 to 9).map(
+        version => FileNames.unsafeDeltaFile(log.logPath, version))
       assert(commitFiles.toSeq == backfilledCommitFiles)
    }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdSuite.scala
@@ -118,7 +118,7 @@ class RowIdSuite extends QueryTest
         // Delete the first commit and all checksum files to force the next read to read the high
         // watermark from the checkpoint.
         val fs = log1.logPath.getFileSystem(log1.newDeltaHadoopConf())
-        fs.delete(FileNames.deltaFile(log1.logPath, version = 0), true)
+        fs.delete(FileNames.unsafeDeltaFile(log1.logPath, version = 0), true)
         fs.delete(FileNames.checksumFile(log1.logPath, version = 0), true)
         fs.delete(FileNames.checksumFile(log1.logPath, version = 1), true)
 

--- a/storage-s3-dynamodb/src/test/scala/io/delta/storage/ExternalLogStoreSuite.scala
+++ b/storage-s3-dynamodb/src/test/scala/io/delta/storage/ExternalLogStoreSuite.scala
@@ -41,11 +41,11 @@ class ExternalLogStoreSuite extends org.apache.spark.sql.delta.PublicLogStoreSui
   )
 
   def getDeltaVersionPath(logDir: File, version: Int): Path = {
-    FileNames.deltaFile(new Path(logDir.toURI), version)
+    FileNames.unsafeDeltaFile(new Path(logDir.toURI), version)
   }
 
   def getFailingDeltaVersionPath(logDir: File, version: Int): Path = {
-    FileNames.deltaFile(new Path(s"failing:${logDir.getCanonicalPath}"), version)
+    FileNames.unsafeDeltaFile(new Path(s"failing:${logDir.getCanonicalPath}"), version)
   }
 
   test("single write") {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Previously, certain code paths assumed the existence of delta files for a specific version at a predictable path `_delta_log/$version.json`. This assumption is no longer valid with managed-commits, where delta files may alternatively be located at `_delta_log/_commits/$version.$uuid.json`. We explicitly rename the old method to `unsafeDeltaFile` to warn future users about it being incorrect for tables with Managed Commits.

To not break dependent systems, plan:
1. Update all delta-spark usages to use the unsafe method. (current PR)
2. Deprecate the deltaFile method. (current PR)
3. Remove the deprecated method once it's proven to be safe. (future PR)

## How was this patch tested?

UTs

## Does this PR introduce _any_ user-facing changes?

No
