### PR TITLE
[Spark] Protocol version downgrade in the presence of table features

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -351,7 +351,7 @@ trait TableFeatureSupport { this: Protocol =>
   def downgradeProtocolVersionsIfNeeded: Protocol = {
     if (nativeReaderAndWriterFeatures.nonEmpty) {
       val (minReaderVersion, minWriterVersion) =
-        TableFeatureProtocolUtils.minimumRequiredVersions(nativeReaderAndWriterFeatures)
+        TableFeatureProtocolUtils.minimumRequiredVersions(readerAndWriterFeatures)
       // It is guaranteed by the definitions of WriterFeature and ReaderFeature, that we cannot
       // end up with invalid protocol versions such as (3, 3). Nevertheless,
       // we double check it here.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -289,7 +289,7 @@ trait TableFeatureSupport { this: Protocol =>
     }
 
     // When `to` protocol contains table features, protocol versions may still
-    // get downgraded. However, the resulting protocol need to support at least writer features.
+    // get downgraded. However, the resulting protocol needs to support at least writer features.
     // Note, we check the minimum required versions only when table features exist in the protocol.
     // This because we do not always downgrade the versions of protocols with no table features.
     if (!to.supportsWriterFeatures ||
@@ -395,8 +395,8 @@ trait TableFeatureSupport { this: Protocol =>
       // end up with invalid protocol versions such as (3, 3). Nevertheless,
       // we double check it here.
       val newProtocol =
-      Protocol(minReaderVersion, minWriterVersion).withFeatures(readerAndWriterFeatures)
-      require(
+        Protocol(minReaderVersion, minWriterVersion).withFeatures(readerAndWriterFeatures)
+      assert(
         newProtocol.supportsWriterFeatures,
         s"Downgraded protocol should at least support writer features, but got $newProtocol.")
       return newProtocol
@@ -406,7 +406,7 @@ trait TableFeatureSupport { this: Protocol =>
       TableFeatureProtocolUtils.minimumRequiredVersions(readerAndWriterFeatures)
     val newProtocol = Protocol(minReaderVersion, minWriterVersion)
 
-    require(
+    assert(
       !newProtocol.supportsReaderFeatures && !newProtocol.supportsWriterFeatures,
       s"Downgraded protocol should not support table features, but got $newProtocol.")
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -3366,7 +3366,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       featuresToRemove = Seq(TestRemovableWriterFeature),
       expectedDowngradedProtocol = protocolWithReaderFeature(TestRemovableReaderWriterFeature))
   }
-q
+
   test(s"Can drop reader+writer feature when there is nothing to clean") {
     withTempPath { dir =>
       val clock = new ManualClock(System.currentTimeMillis())

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -3416,8 +3416,6 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     val expectedFeatures =
       Seq(DomainMetadataTableFeature, ChangeDataFeedTableFeature, AppendOnlyTableFeature)
 
-    // Although the protocol contains legacy features, the versions are only downgraded to
-    // table feature versions.
     testProtocolVersionDowngrade(
       initialMinReaderVersion = 3,
       initialMinWriterVersion = 7,
@@ -3433,8 +3431,6 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     val expectedFeatures =
       Seq(DomainMetadataTableFeature, ChangeDataFeedTableFeature, ColumnMappingTableFeature)
 
-    // Although the protocol contains legacy features, the versions are only downgraded to
-    // table feature versions.
     testProtocolVersionDowngrade(
       initialMinReaderVersion = 3,
       initialMinWriterVersion = 7,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -3411,7 +3411,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
   }
 
   for (truncateHistory <- BOOLEAN_DOMAIN)
-  test(s"Protocol version downgrade with Table Features - include legacy features: " +
+  test(s"Protocol version downgrade with Table Features - include legacy writer features: " +
       s"truncateHistory: ${truncateHistory}") {
     val expectedFeatures =
       Seq(DomainMetadataTableFeature, ChangeDataFeedTableFeature, AppendOnlyTableFeature)
@@ -3424,6 +3424,23 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       featuresToAdd = expectedFeatures :+ TestRemovableReaderWriterFeature,
       featuresToRemove = Seq(TestRemovableReaderWriterFeature),
       expectedDowngradedProtocol = Protocol(1, 7).withFeatures(expectedFeatures),
+      truncateHistory = truncateHistory)
+  }
+
+  for (truncateHistory <- BOOLEAN_DOMAIN)
+  test(s"Protocol version downgrade with Table Features - include legacy reader features: " +
+    s"truncateHistory: ${truncateHistory}") {
+    val expectedFeatures =
+      Seq(DomainMetadataTableFeature, ChangeDataFeedTableFeature, ColumnMappingTableFeature)
+
+    // Although the protocol contains legacy features, the versions are only downgraded to
+    // table feature versions.
+    testProtocolVersionDowngrade(
+      initialMinReaderVersion = 3,
+      initialMinWriterVersion = 7,
+      featuresToAdd = expectedFeatures :+ TestRemovableReaderWriterFeature,
+      featuresToRemove = Seq(TestRemovableReaderWriterFeature),
+      expectedDowngradedProtocol = Protocol(2, 7).withFeatures(expectedFeatures),
       truncateHistory = truncateHistory)
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -3397,21 +3397,21 @@ q
   }
 
   for (truncateHistory <- BOOLEAN_DOMAIN)
-  test(s"Protocol version downgrade with Table Features - Basic test" +
+  test(s"Protocol version downgrade with Table Features - Basic test " +
       s"truncateHistory: ${truncateHistory}") {
     val expectedFeatures = Seq(RowTrackingFeature, DomainMetadataTableFeature)
 
     testProtocolVersionDowngrade(
       initialMinReaderVersion = 3,
       initialMinWriterVersion = 7,
-      featuresToAdd = expectedFeatures :+ DeletionVectorsTableFeature,
-      featuresToRemove = Seq(DeletionVectorsTableFeature),
+      featuresToAdd = expectedFeatures :+ TestRemovableReaderWriterFeature,
+      featuresToRemove = Seq(TestRemovableReaderWriterFeature),
       expectedDowngradedProtocol = Protocol(1, 7).withFeatures(expectedFeatures),
       truncateHistory = truncateHistory)
   }
 
   for (truncateHistory <- BOOLEAN_DOMAIN)
-  test(s"Protocol version downgrade with Table Features - include legacy features:" +
+  test(s"Protocol version downgrade with Table Features - include legacy features: " +
       s"truncateHistory: ${truncateHistory}") {
     val expectedFeatures =
       Seq(DomainMetadataTableFeature, ChangeDataFeedTableFeature, AppendOnlyTableFeature)
@@ -3421,8 +3421,8 @@ q
     testProtocolVersionDowngrade(
       initialMinReaderVersion = 3,
       initialMinWriterVersion = 7,
-      featuresToAdd = expectedFeatures :+ DeletionVectorsTableFeature,
-      featuresToRemove = Seq(DeletionVectorsTableFeature),
+      featuresToAdd = expectedFeatures :+ TestRemovableReaderWriterFeature,
+      featuresToRemove = Seq(TestRemovableReaderWriterFeature),
       expectedDowngradedProtocol = Protocol(1, 7).withFeatures(expectedFeatures),
       truncateHistory = truncateHistory)
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
@@ -281,6 +281,9 @@ class DeltaTableFeatureSuite
       .canDowngradeTo(Protocol(1, 1), droppedFeatureName = TestWriterFeature.name))
     assert(Protocol(1, 7).withFeature(TestWriterFeature)
       .canDowngradeTo(Protocol(1, 1), droppedFeatureName = TestWriterFeature.name))
+    // When there are no explicit features the protocol versions need to be downgraded
+    // below table features. The new protocol versions need to match exactly the supported
+    // legacy features.
     for (n <- 1 to 3) {
       assert(
         !Protocol(n, 7)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
@@ -275,12 +275,8 @@ class DeltaTableFeatureSuite
   test("protocol downgrade compatibility") {
     val tableFeatureProtocol =
       Protocol(TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION)
-    // Cannot downgrade when the original protocol does not support at a minimum writer features.
-    assert(!Protocol(1, 6).canDowngradeTo(Protocol(1, 6), droppedFeatureName = ""))
-    assert(tableFeatureProtocol.withFeature(TestWriterFeature)
-      .canDowngradeTo(Protocol(1, 1), droppedFeatureName = TestWriterFeature.name))
     assert(Protocol(1, 7).withFeature(TestWriterFeature)
-      .canDowngradeTo(Protocol(1, 1), droppedFeatureName = TestWriterFeature.name))
+      .canDowngradeTo(Protocol(1, 7), droppedFeatureName = TestWriterFeature.name))
     // When there are no explicit features the protocol versions need to be downgraded
     // below table features. The new protocol versions need to match exactly the supported
     // legacy features.
@@ -294,31 +290,13 @@ class DeltaTableFeatureSuite
           .withFeatures(Seq(TestWriterFeature, AppendOnlyTableFeature, InvariantsTableFeature))
           .canDowngradeTo(Protocol(1, 2), droppedFeatureName = TestWriterFeature.name))
     }
-    // When there are no explicit features the protocol versions need to be downgraded
-    // below table features.
-    assert(!tableFeatureProtocol.withFeature(TestWriterFeature)
-      .canDowngradeTo(tableFeatureProtocol, droppedFeatureName = TestWriterFeature.name))
-    assert(!tableFeatureProtocol.withFeature(TestWriterFeature)
-      .canDowngradeTo(Protocol(2, 7), droppedFeatureName = TestWriterFeature.name))
-    // Only one non-legacy writer feature per time.
-    assert(!tableFeatureProtocol.withFeatures(Seq(TestWriterFeature, TestRemovableWriterFeature))
-      .canDowngradeTo(tableFeatureProtocol, droppedFeatureName = TestWriterFeature.name))
-    // Remove reader+writer feature.
     assert(tableFeatureProtocol.withFeatures(Seq(TestReaderWriterFeature))
       .canDowngradeTo(Protocol(1, 1), droppedFeatureName = TestReaderWriterFeature.name))
-    // Only one non-legacy feature at a time - multiple reader+writer features.
-    assert(
-      !tableFeatureProtocol
-        .withFeatures(Seq(TestReaderWriterFeature, TestReaderWriterMetadataAutoUpdateFeature))
-        .canDowngradeTo(tableFeatureProtocol, droppedFeatureName = ""))
     assert(
       tableFeatureProtocol
         .merge(Protocol(2, 5))
         .withFeatures(Seq(TestReaderWriterFeature, TestRemovableLegacyReaderWriterFeature))
         .canDowngradeTo(Protocol(2, 5), droppedFeatureName = TestReaderWriterFeature.name))
-    // Only one feature at a time - mix of reader+writer and writer features.
-    assert(!tableFeatureProtocol.withFeatures(Seq(TestWriterFeature, TestReaderWriterFeature))
-      .canDowngradeTo(tableFeatureProtocol, droppedFeatureName = TestWriterFeature.name))
     // Downgraded protocol must be able to support all legacy table features.
     assert(
       !tableFeatureProtocol


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR adds support for protocol versions downgrade when table features exist in the protocol. The downgraded protocol versions should be the minimum required to support all available table features. For example, `Protocol(3, 7, DeletionVectors, RowTracking)` can be downgraded to `Protocol(1, 7, RowTracking)` after removing the DV feature.

## How was this patch tested?
Added new UTs in DeltaProtocolVersionSuite. Furthermore, existing UTs cover a significant part of the functionality. These these are the following:

- Downgrade protocol version on table created with (3, 7).
- Downgrade protocol version on table created with (1, 7).
- Protocol version downgrade on a table with table features and added legacy feature.
- Protocol version is not downgraded when writer features exist.
- Protocol version is not downgraded when reader+writer features exist.
- Protocol version is not downgraded when multiple reader+writer features exist.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Dropping a table feature from a table with multiple features may now result to a Protocol versions downgrade. For example, `Protocol(3, 7, DeletionVectors, RowTracking)` can now be downgraded to `Protocol(1, 7, RowTracking)`.