### PR TITLE
[Kernel] Adding logging in few important places to help in debugging

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
@@ -154,11 +154,13 @@ public class Checkpointer {
                 }
                 currentVersion -= 1000; // search for checkpoint in previous 1000 entries
             } catch (IOException e) {
-                logger.warn("Failed to list checkpoint files for version {}. ", currentVersion, e);
+                String msg = String.format("Failed to list checkpoint files for version %s in %s.",
+                        version, tableLogPath);
+                logger.warn(msg, e);
                 return new Tuple2<>(Optional.empty(), numberOfFilesSearched);
             }
         }
-        logger.info("No complete checkpoint found before version {}", version);
+        logger.info("No complete checkpoint found before version {} in {}", version, tableLogPath);
         return new Tuple2<>(Optional.empty(), numberOfFilesSearched);
     }
 


### PR DESCRIPTION
## Description
Add log4j logging in the following cases:
1) Time taken to get the version for a given timestamp in time travel
2) When the `_last_checkpoint` metadata file is missing or corrupted.
3) Time to find the last completed checkpoint before a version.
4) Time to list the delta files after a given last checkpoint
5) Time to construct a `LogSegment`
6) Time to construct a snapshot with a `LogSegment` (includes loading P&M)

## How was this patch tested?
Manually verified.