### PR TITLE
[TEST-ONLY] Fix generating FileActions with unescaped path

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -864,6 +864,8 @@ object AddFile {
  *
  * Since old tables would not have `extendedFileMetadata` and `size` field, we should make them
  * nullable by setting their type Option.
+ *
+ * [[path]] is URL-encoded.
  */
 // scalastyle:off
 case class RemoveFile(
@@ -919,6 +921,8 @@ case class RemoveFile(
  * A change file containing CDC data for the Delta version it's within. Non-CDC readers should
  * ignore this, CDC readers should scan all ChangeFiles in a version rather than computing
  * changes from AddFile and RemoveFile actions.
+ *
+ * [[path]] is URL-encoded.
  */
 case class AddCDCFile(
     override val path: String,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
@@ -96,7 +96,8 @@ trait DeltaTimeTravelTests extends QueryTest
       deltaLog: DeltaLog, commits: Long*): Unit = {
     var startVersion = deltaLog.snapshot.version + 1
     commits.foreach { ts =>
-      val action = createTestAddFile(path = startVersion.toString, modificationTime = startVersion)
+      val action =
+        createTestAddFile(encodedPath = startVersion.toString, modificationTime = startVersion)
       deltaLog.startTransaction().commitManually(action)
       modifyCommitTimestamp(deltaLog, startVersion, ts)
       startVersion += 1

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -60,7 +60,7 @@ class DeltaLogSuite extends QueryTest
 
     (1 to 15).foreach { i =>
       val txn = log1.startTransaction()
-      val file = createTestAddFile(path = i.toString) :: Nil
+      val file = createTestAddFile(encodedPath = i.toString) :: Nil
       val delete: Seq[Action] = if (i > 1) {
         RemoveFile(i - 1 toString, Some(System.currentTimeMillis()), true) :: Nil
       } else {
@@ -82,7 +82,7 @@ class DeltaLogSuite extends QueryTest
 
       // Commit data so the in-memory state isn't consistent with an empty log.
       val txn = log.startTransaction()
-      val files = (1 to 10).map(f => createTestAddFile(path = f.toString))
+      val files = (1 to 10).map(f => createTestAddFile(encodedPath = f.toString))
       txn.commitManually(files: _*)
       log.checkpoint()
 
@@ -116,7 +116,7 @@ class DeltaLogSuite extends QueryTest
       val checkpointInterval = log.checkpointInterval()
       for (f <- 0 until (checkpointInterval * 2)) {
         val txn = log.startTransaction()
-        txn.commitManually(createTestAddFile(path = f.toString))
+        txn.commitManually(createTestAddFile(encodedPath = f.toString))
       }
 
       def collectReservoirStateRDD(rdd: RDD[_]): Seq[RDD[_]] = {
@@ -141,7 +141,7 @@ class DeltaLogSuite extends QueryTest
     (1 to 5).foreach { i =>
       val txn = log1.startTransaction()
       val file = if (i > 1) {
-        createTestAddFile(path = i.toString) :: Nil
+        createTestAddFile(encodedPath = i.toString) :: Nil
       } else {
         Metadata(configuration = Map(DeltaConfigs.CHECKPOINT_INTERVAL.key -> "10")) :: Nil
       }
@@ -158,7 +158,7 @@ class DeltaLogSuite extends QueryTest
 
     (6 to 15).foreach { i =>
       val txn = log1.startTransaction()
-      val file = createTestAddFile(path = i.toString) :: Nil
+      val file = createTestAddFile(encodedPath = i.toString) :: Nil
       val delete: Seq[Action] = if (i > 1) {
         RemoveFile(i - 1 toString, Some(System.currentTimeMillis()), true) :: Nil
       } else {
@@ -206,7 +206,7 @@ class DeltaLogSuite extends QueryTest
       val checkpointInterval = log.checkpointInterval()
       for (f <- 0 to checkpointInterval) {
         val txn = log.startTransaction()
-        txn.commitManually(createTestAddFile(path = f.toString))
+        txn.commitManually(createTestAddFile(encodedPath = f.toString))
       }
       val lastCheckpointOpt = log.readLastCheckpointFile()
       assert(lastCheckpointOpt.isDefined)
@@ -323,7 +323,8 @@ class DeltaLogSuite extends QueryTest
 
       // Add a new transaction to replay logs using the previous snapshot. If it contained
       // AddFile("foo") and RemoveFile("foo"), "foo" would get removed and fail this test.
-      val otherAdd = createTestAddFile(path = "bar", modificationTime = System.currentTimeMillis())
+      val otherAdd =
+        createTestAddFile(encodedPath = "bar", modificationTime = System.currentTimeMillis())
       log.startTransaction().commit(otherAdd :: Nil, DeltaOperations.ManualUpdate)
 
       assert(log.update().allFiles.collect().find(_.path == "foo")
@@ -398,7 +399,7 @@ class DeltaLogSuite extends QueryTest
         // Create a checkpoint regularly
         for (f <- 0 to checkpointInterval) {
           val txn = log.startTransaction()
-          val addFile = createTestAddFile(path = f.toString)
+          val addFile = createTestAddFile(encodedPath = f.toString)
           if (f == 0) {
             txn.commitManually(addFile)
           } else {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -341,13 +341,13 @@ object DeltaTestUtils extends DeltaTestUtilsBase {
    * Creates an AddFile that can be used for tests where the exact parameters do not matter.
    */
   def createTestAddFile(
-      path: String = "foo",
+      encodedPath: String = "foo",
       partitionValues: Map[String, String] = Map.empty,
       size: Long = 1L,
       modificationTime: Long = 1L,
       dataChange: Boolean = true,
       stats: String = "{\"numRecords\": 1}"): AddFile = {
-    AddFile(path, partitionValues, size, modificationTime, dataChange, stats)
+    AddFile(encodedPath, partitionValues, size, modificationTime, dataChange, stats)
   }
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
@@ -70,7 +70,8 @@ class DeltaTimeTravelSuite extends QueryTest
   private def generateCommitsCheap(deltaLog: DeltaLog, commits: Long*): Unit = {
     var startVersion = deltaLog.snapshot.version + 1
     commits.foreach { ts =>
-      val action = createTestAddFile(path = startVersion.toString, modificationTime = startVersion)
+      val action =
+        createTestAddFile(encodedPath = startVersion.toString, modificationTime = startVersion)
       deltaLog.startTransaction().commitManually(action)
       modifyCommitTimestamp(deltaLog, startVersion, ts)
       startVersion += 1

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionLegacyTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionLegacyTests.scala
@@ -35,9 +35,9 @@ trait OptimisticTransactionLegacyTests
   with SharedSparkSession
   with DeltaSQLCommandTest {
 
-  private val addA = createTestAddFile(path = "a")
-  private val addB = createTestAddFile(path = "b")
-  private val addC = createTestAddFile(path = "c")
+  private val addA = createTestAddFile(encodedPath = "a")
+  private val addB = createTestAddFile(encodedPath = "b")
+  private val addC = createTestAddFile(encodedPath = "c")
 
   import testImplicits._
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -47,8 +47,8 @@ class OptimisticTransactionSuite
   import testImplicits._
 
   // scalastyle:off: removeFile
-  private val addA = createTestAddFile(path = "a")
-  private val addB = createTestAddFile(path = "b")
+  private val addA = createTestAddFile(encodedPath = "a")
+  private val addB = createTestAddFile(encodedPath = "b")
 
   /* ************************** *
    * Allowed concurrent actions *

--- a/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuerySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuerySuite.scala
@@ -747,9 +747,9 @@ class OptimizeMetadataOnlyDeltaQuerySuite
       val log = DeltaLog.forTable(spark, tempPath)
       val txn = log.startTransaction()
       txn.commitManually(
-        DeltaTestUtils.createTestAddFile(path = "1.parquet", stats = "{\"numRecords\": 0}"),
-        DeltaTestUtils.createTestAddFile(path = "2.parquet", stats = "{\"numRecords\": 0}"),
-        DeltaTestUtils.createTestAddFile(path = "3.parquet", stats = "{\"numRecords\": 0}"))
+        DeltaTestUtils.createTestAddFile(encodedPath = "1.parquet", stats = "{\"numRecords\": 0}"),
+        DeltaTestUtils.createTestAddFile(encodedPath = "2.parquet", stats = "{\"numRecords\": 0}"),
+        DeltaTestUtils.createTestAddFile(encodedPath = "3.parquet", stats = "{\"numRecords\": 0}"))
 
       withSQLConf(DeltaSQLConf.DELTA_OPTIMIZE_METADATA_QUERY_ENABLED.key -> "true") {
         val queryDf = spark.sql(s"SELECT COUNT(*) FROM delta.`$tempPath`")


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description


This PR fixes an issue (in `DeltaVacuumSuite`) where we generate `RemoveFile`s with an unescaped absolute path.
It also improves the naming of a util method to emphasize the path that should be escaped.


## How was this patch tested?

Test-only.

## Does this PR introduce _any_ user-facing changes?

No.