### PR TITLE
[Spark] Rename BusyWait to ConcurrencyHelpers

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConcurrencyHelpers.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConcurrencyHelpers.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta
 
 import scala.concurrent.duration._
 
-object BusyWait {
+object ConcurrencyHelpers {
   /**
    * Keep checking if `check` returns `true` until it's the case or `waitTime` expires.
    *
@@ -28,7 +28,7 @@ object BusyWait {
    * and should not be used in production code. Production code should not use polling
    * and should instead use signalling to coordinate.
    */
-  def until(
+  def busyWaitFor(
       check: => Boolean,
       waitTime: FiniteDuration): Boolean = {
     val DEFAULT_SLEEP_TIME: Duration = 10.millis

--- a/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/PhaseLockingTestMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/PhaseLockingTestMixin.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta.concurrency
 
 import scala.concurrent.duration._
 
-import org.apache.spark.sql.delta.BusyWait
+import org.apache.spark.sql.delta.ConcurrencyHelpers
 import org.apache.spark.sql.delta.fuzzer.AtomicBarrier
 
 import org.apache.spark.SparkFunSuite
@@ -44,7 +44,7 @@ trait PhaseLockingTestMixin { self: SparkFunSuite =>
       timeout: FiniteDuration,
       // lazy evaluate so closed over states are evaluated at time of failure not invocation
       message: => String = "Exceeded deadline waiting for check to become true."): Unit = {
-    if (!BusyWait.until(check, timeout)) {
+    if (!ConcurrencyHelpers.busyWaitFor(check, timeout)) {
       fail(message)
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
We will soon add some common helper functions for the Concurrency Testing Framework, so we are renaming the object `BusyWait` to `ConcurrencyHelpers` in preparation for this.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Existing UTs, just some small name changes.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
