### PR TITLE
[Spark] Add ConflictCheckerRowIdSuite

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConcurrencyHelpers.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConcurrencyHelpers.scala
@@ -43,4 +43,15 @@ object ConcurrencyHelpers {
     } while (deadline.hasTimeLeft())
     false
   }
+
+  def withOptimisticTransaction[T](
+    activeTransaction: Option[OptimisticTransaction])(block: => T): T = {
+    if (activeTransaction.isDefined) {
+      OptimisticTransaction.withActive(activeTransaction.get) {
+        block
+      }
+    } else {
+      block
+    }
+  }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/TransactionExecutionTestMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/TransactionExecutionTestMixin.scala
@@ -1,0 +1,194 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.concurrency
+
+import java.util.concurrent.{ExecutorService, TimeUnit}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
+
+import com.databricks.spark.util.{Log4jUsageLogger, UsageRecord}
+import org.apache.spark.sql.delta.{ConcurrencyHelpers, OptimisticTransaction, TransactionExecutionObserver}
+import org.apache.spark.sql.delta.fuzzer.{OptimisticTransactionPhases, PhaseLockingTransactionExecutionObserver => TransactionObserver}
+
+import org.apache.spark.SparkException
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.util.ThreadUtils
+
+trait TransactionExecutionTestMixin {
+  self: PhaseLockingTestMixin with SharedSparkSession with Logging =>
+
+  /**
+   * Timeout used when waiting for individual phases of instrumented operations to complete.
+   */
+  val timeout: FiniteDuration = 120.seconds
+
+  /** Run a given function `fn` inside the given `executor` within a [[TransactionObserver]] */
+  private[delta] def runFunctionWithObserver(
+      name: String,
+      executorService: ExecutorService,
+      fn: () => Array[Row]): (TransactionObserver, Future[Array[Row]]) = {
+    val observer =
+      new TransactionObserver(OptimisticTransactionPhases.forName(s"observer-txn-$name"))
+    implicit val ec = ExecutionContext.fromExecutorService(executorService)
+    val txn = OptimisticTransaction.getActive()
+    val future = Future {
+      ConcurrencyHelpers.withOptimisticTransaction(txn) {
+        spark.withActive(
+          try {
+            TransactionExecutionObserver.withObserver(observer) {
+              fn()
+            }
+          } catch {
+            case ex: Exception =>
+              logError(s"Error on test thread", ex)
+              throw ex
+          }
+        )
+      }
+    }
+    (observer, future)
+  }
+
+  /** Run a given `queryString` inside the given `executor` */
+  def runQueryWithObserver(name: String, executor: ExecutorService, queryString: String)
+    : (TransactionObserver, Future[Array[Row]]) = {
+    def fn(): Array[Row] = spark.sql(queryString).collect()
+    runFunctionWithObserver(name, executor, fn)
+  }
+
+  /**
+   * Run `functions` with the ordering defined by `observerOrdering` function.
+   * This function returns the usage records generated during the run of these queries and also
+   * futures for each of the query results.
+   */
+  private[delta] def runFunctionsWithOrderingFromObserver(functions: Seq[() => Array[Row]])
+      (observerOrdering: (Seq[TransactionObserver]) => Unit)
+      : (Seq[UsageRecord], Seq[Future[Array[Row]]]) = {
+
+    val executors = functions.zipWithIndex.map { case (_, index) =>
+      ThreadUtils.newDaemonSingleThreadExecutor(threadName = s"executor-txn-$index")
+    }
+    try {
+      val (observers, futures) = functions.zipWithIndex.map { case (fn, index) =>
+        runFunctionWithObserver(name = s"query-$index", executors(index), fn)
+      }.unzip
+      val usageRecords = Log4jUsageLogger.track {
+        // Run the observer ordering function.
+        observerOrdering(observers)
+
+        // wait for futures to succeed or fail
+        for (future <- futures) {
+          try {
+            ThreadUtils.awaitResult(future, timeout)
+          } catch {
+            case _: SparkException =>
+              // pass
+              true
+          }
+        }
+      }
+      (usageRecords, futures)
+    } finally {
+      for (executor <- executors) {
+        executor.shutdownNow()
+        executor.awaitTermination(timeout.toMillis, TimeUnit.MILLISECONDS)
+      }
+    }
+  }
+
+  /** Unblocks all phases before the `commitPhase` for [[TransactionObserver]] */
+  def unblockUntilPreCommit(observer: TransactionObserver): Unit = {
+    observer.phases.initialPhase.entryBarrier.unblock()
+    observer.phases.preparePhase.entryBarrier.unblock()
+  }
+
+  /** Unblocks all phases for [[TransactionObserver]] so that corresponding query can finish. */
+  def unblockAllPhases(observer: TransactionObserver): Unit = {
+    observer.phases.initialPhase.entryBarrier.unblock()
+    observer.phases.preparePhase.entryBarrier.unblock()
+    observer.phases.commitPhase.entryBarrier.unblock()
+  }
+
+  /**
+   * Run 2 transactions A, B with following order:
+   *
+   * t1 -------------------------------------- TxnA starts
+   * t2 --------- TxnB starts
+   * t3 --------- TxnB commits
+   * t6 -------------------------------------- TxnA commits
+   */
+  def runTxnsWithOrder__A_Start__B__A_End(txnA: () => Array[Row], txnB: () => Array[Row])
+      : (Seq[UsageRecord], Future[Array[Row]], Future[Array[Row]]) = {
+    val (usageRecords, Seq(futureA, futureB)) =
+      runFunctionsWithOrderingFromObserver(Seq(txnA, txnB)) {
+        case (observerA :: observerB :: Nil) =>
+          // A starts
+          unblockUntilPreCommit(observerA)
+          busyWaitFor(observerA.phases.preparePhase.hasEntered, timeout)
+
+          // B starts and commits
+          unblockAllPhases(observerB)
+          busyWaitFor(observerB.phases.commitPhase.hasLeft, timeout)
+
+          // A commits
+          observerA.phases.commitPhase.entryBarrier.unblock()
+          busyWaitFor(observerA.phases.commitPhase.hasLeft, timeout)
+      }
+    (usageRecords, futureA, futureB)
+  }
+
+  /**
+   * Run 3 queries A, B, C with following order:
+   *
+   * t1 -------------------------------------- TxnA starts
+   * t2 --------- TxnB starts
+   * t3 --------- TxnB commits
+   * t4 ----------------- TxnC starts
+   * t5 ----------------- TxnC commits
+   * t6 -------------------------------------- TxnA commits
+   */
+  def runTxnsWithOrder__A_Start__B__C__A_End(
+      txnA: () => Array[Row],
+      txnB: () => Array[Row],
+      txnC: () => Array[Row])
+      : (Seq[UsageRecord], Future[Array[Row]], Future[Array[Row]], Future[Array[Row]]) = {
+
+    val (usageRecords, Seq(futureA, futureB, futureC)) =
+      runFunctionsWithOrderingFromObserver(Seq(txnA, txnB, txnC)) {
+        case (observerA :: observerB :: observerC :: Nil) =>
+          // A starts
+          unblockUntilPreCommit(observerA)
+          busyWaitFor(observerA.phases.preparePhase.hasEntered, timeout)
+
+          // B starts and commits
+          unblockAllPhases(observerB)
+          busyWaitFor(observerB.phases.commitPhase.hasLeft, timeout)
+
+          // C starts and commits
+          unblockAllPhases(observerC)
+          busyWaitFor(observerC.phases.commitPhase.hasLeft, timeout)
+
+          // A commits
+          observerA.phases.commitPhase.entryBarrier.unblock()
+          busyWaitFor(observerA.phases.commitPhase.hasLeft, timeout)
+      }
+    (usageRecords, futureA, futureB, futureC)
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/ConflictCheckerRowIdSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/ConflictCheckerRowIdSuite.scala
@@ -1,0 +1,159 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rowid
+
+import java.io.File
+
+import scala.concurrent.duration.Duration
+
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
+import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
+import org.apache.spark.sql.delta.concurrency.PhaseLockingTestMixin
+import org.apache.spark.sql.delta.concurrency.TransactionExecutionTestMixin
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
+
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.util.ThreadUtils
+
+class ConflictCheckerRowIdSuite extends QueryTest
+  with SharedSparkSession
+  with PhaseLockingTestMixin
+  with TransactionExecutionTestMixin
+  with RowIdTestUtils {
+
+  protected def appendRows(dir: File, numRows: Int, numFiles: Int): Unit = {
+    withRowTrackingEnabled(enabled = true) {
+      spark.range(start = 0, end = numRows, step = 1, numPartitions = numFiles)
+        .write.format("delta").mode("append").save(dir.getAbsolutePath)
+    }
+  }
+
+  protected def setIsolationLevel(tableDir: File): Unit = {
+    spark.sql(
+      s"""ALTER TABLE delta.`${tableDir.getAbsolutePath}`
+         |SET TBLPROPERTIES ('${DeltaConfigs.ISOLATION_LEVEL.key}' = '$Serializable')
+         |""".stripMargin
+    )
+  }
+
+  test("concurrent transactions do not assign overlapping row IDs") {
+    withTempDir { tempDir =>
+      appendRows(tempDir, numRows = 100, numFiles = 1)
+
+      setIsolationLevel(tempDir)
+
+      def txnA(): Array[Row] = {
+        appendRows(tempDir, numRows = 1000, numFiles = 2)
+        Array.empty
+      }
+
+      def txnB(): Array[Row] = {
+        appendRows(tempDir, numRows = 1500, numFiles = 3)
+        Array.empty
+      }
+
+      val (_, futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureA, Duration.Inf)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+
+      val log = DeltaLog.forTable(spark, tempDir)
+      assertRowIdsAreValid(log)
+    }
+  }
+
+  test("re-added files keep their row ids") {
+    withTempDir { tempDir =>
+      appendRows(tempDir, numRows = 100, numFiles = 3)
+
+      setIsolationLevel(tempDir)
+
+      val log = DeltaLog.forTable(spark, tempDir)
+      val filesBefore = log.update().allFiles.collect()
+      val baseRowIdsBefore = filesBefore.map(f => f.path -> f.baseRowId.get).toMap
+
+      def txnA(): Array[Row] = {
+        log.startTransaction().commit(filesBefore, ManualUpdate)
+        Array.empty
+      }
+
+      def txnB(): Array[Row] = {
+        appendRows(tempDir, numRows = 113, numFiles = 2)
+        Array.empty
+      }
+
+      val (_, futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      ThreadUtils.awaitResult(futureA, Duration.Inf)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+
+      assertRowIdsAreValid(log)
+      val filesAfter = log.update().allFiles.collect()
+      val baseRowIdsAfter = filesAfter.map(f => f.path -> f.baseRowId.get).toMap
+      filesBefore.foreach { file =>
+        assert(baseRowIdsBefore(file.path) === baseRowIdsAfter(file.path))
+      }
+    }
+  }
+
+  test("Re-added files keep their row IDs after conflict with txn not " +
+    "updating high watermark") {
+    withTempDir { dir =>
+      appendRows(dir, numRows = 10, numFiles = 2)
+      setIsolationLevel(dir)
+
+      val log = DeltaLog.forTable(spark, dir)
+      val filesBefore = log.update().allFiles.collect()
+      assert(filesBefore.length === 2)
+
+      // Adds one file that will change the high water mark, and one file that was
+      // in the table before.
+      def txnA(): Array[Row] = {
+        val file1 = createTestAddFile()
+        val oldFile = filesBefore.last
+        log.startTransaction().commit(Seq(oldFile, file1), ManualUpdate)
+        Array.empty
+      }
+
+      // Adds another file that was in the table before, so we have a conflict
+      // with a txn that does not change the high water mark.
+      def txnB(): Array[Row] = {
+        log.startTransaction().commit(Seq(filesBefore.head), ManualUpdate)
+        Array.empty
+      }
+
+      // One more transaction to change the high water mark, which will lead to txnA reassigning
+      // its row IDs.
+      def txnC(): Array[Row] = {
+        appendRows(dir, numRows = 30, numFiles = 3)
+        Array.empty
+      }
+
+      val (_, futureA, futureB, futureC) = runTxnsWithOrder__A_Start__B__C__A_End(txnA, txnB, txnC)
+      ThreadUtils.awaitResult(futureA, Duration.Inf)
+      ThreadUtils.awaitResult(futureB, Duration.Inf)
+      ThreadUtils.awaitResult(futureC, Duration.Inf)
+      assertRowIdsAreValid(log)
+
+      val baseRowIdsAfter = log.update().allFiles.collect().map(f => f.path -> f.baseRowId).toMap
+      filesBefore.foreach { file =>
+        assert(file.baseRowId === baseRowIdsAfter(file.path))
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Add the `ConflictCheckerRowIdSuite`, to test the Row Tracking's Conflict Checker logic. We want to ensure that each row ID can only be assigned by one transaction. If we detect that a concurrent transaction also assigned row IDs, then we will assign different row IDs to the files added by the current transaction.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Add UTs.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
