### PR TITLE
[Spark] Always create checkpoint when dropping reader+writer features

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -751,7 +751,7 @@ private[sql] object TestRemovableWriterFeature
   }
 
   override def validateRemoval(snapshot: Snapshot): Boolean =
-    !snapshot.metadata.configuration.contains(TABLE_PROP_KEY)
+    !snapshot.metadata.configuration.get(TABLE_PROP_KEY).exists(_.toBoolean)
 
   override def preDowngradeCommand(table: DeltaTableV2): PreDowngradeTableFeatureCommand =
     TestWriterFeaturePreDowngradeCommand(table)
@@ -772,10 +772,10 @@ private[sql] object TestRemovableReaderWriterFeature
   }
 
   override def validateRemoval(snapshot: Snapshot): Boolean =
-    !snapshot.metadata.configuration.contains(TABLE_PROP_KEY)
+    !snapshot.metadata.configuration.get(TABLE_PROP_KEY).exists(_.toBoolean)
 
   override def actionUsesFeature(action: Action): Boolean = action match {
-    case m: Metadata => m.configuration.contains(TABLE_PROP_KEY)
+    case m: Metadata => m.configuration.get(TABLE_PROP_KEY).exists(_.toBoolean)
     case _ => false
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -750,6 +750,7 @@ private[sql] object TestRemovableWriterFeature
     metadata.configuration.get(TABLE_PROP_KEY).exists(_.toBoolean)
   }
 
+  /** Make sure the property is not enabled on the table. */
   override def validateRemoval(snapshot: Snapshot): Boolean =
     !snapshot.metadata.configuration.get(TABLE_PROP_KEY).exists(_.toBoolean)
 
@@ -771,6 +772,7 @@ private[sql] object TestRemovableReaderWriterFeature
     metadata.configuration.get(TABLE_PROP_KEY).exists(_.toBoolean)
   }
 
+  /** Make sure the property is not enabled on the table. */
   override def validateRemoval(snapshot: Snapshot): Boolean =
     !snapshot.metadata.configuration.get(TABLE_PROP_KEY).exists(_.toBoolean)
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -324,6 +324,7 @@ case class AlterTableDropFeatureDeltaCommand(
         // the feature. This intends to help slow-moving tables to qualify for history truncation
         // asap. The checkpoint is based on a new commit to avoid creating a checkpoint
         // on a commit that still contains traces of the removed feature.
+        // Note, the checkpoint is created in both executions of DROP FEATURE command.
         createEmptyCommitAndCheckpoint(startTimeNs)
 
         // If the pre-downgrade command made changes, then the table's historical versions

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -2881,9 +2881,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     }
   }
 
-  for (reDisable <- BOOLEAN_DOMAIN)
-  test("Try removing reader+writer feature but re-enable feature after disablement " +
-      s"reDisable: $reDisable") {
+  test("Try removing reader+writer feature but re-enable feature after disablement") {
     withTempDir { dir =>
       val clock = new ManualClock(System.currentTimeMillis())
       val deltaLog = DeltaLog.forTable(spark, dir, clock)
@@ -2913,11 +2911,8 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
           "logRetentionPeriod" -> "30 days",
           "truncateHistoryLogRetentionPeriod" -> truncateHistoryDefaultLogRetention.toString))
 
-      val deltaRetentionMillis = deltaLog.deltaRetentionMillis(deltaLog.update().metadata)
-      require(deltaRetentionMillis === TimeUnit.DAYS.toMillis(30))
-
-      // Ten days have passed.
-      clock.advance(TimeUnit.DAYS.toMillis(10))
+      // Advance clock.
+      clock.advance(TimeUnit.DAYS.toMillis(1) + TimeUnit.MINUTES.toMillis(5))
 
       // Generate commit.
       spark.range(120, 140).write.format("delta").mode("append").save(dir.getCanonicalPath)
@@ -2929,46 +2924,23 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         Map(TestRemovableReaderWriterFeature.TABLE_PROP_KEY -> true.toString))
         .run(spark)
 
-      // Disable by removing property.
-      if (reDisable) {
-        val properties = Seq(TestRemovableReaderWriterFeature.TABLE_PROP_KEY)
-        AlterTableUnsetPropertiesDeltaCommand(v2Table, properties, ifExists = true).run(spark)
-      }
-
-      // The retention period has passed since the disablement.
-      clock.advance(
-        deltaRetentionMillis - TimeUnit.DAYS.toMillis(10) + TimeUnit.MINUTES.toMillis(5))
-
-      DeltaLog.clearCache()
-
       // Feature was enabled again in the middle of the timeframe. The feature traces are
       // are cleaned up again and we get a new "Wait for retention period message."
       val e2 = intercept[DeltaTableFeatureException] {
         AlterTableDropFeatureDeltaCommand(
-          DeltaTableV2(spark, deltaLog.dataPath),
-          TestRemovableReaderWriterFeature.name).run(spark)
+          table = DeltaTableV2(spark, deltaLog.dataPath),
+          featureName = TestRemovableReaderWriterFeature.name,
+          truncateHistory = true).run(spark)
         }
 
-      // If the property is re-disabled we pick up the issue during the history check.
-      if (reDisable) {
-        checkError(
-          exception = e2,
-          errorClass = "DELTA_FEATURE_DROP_HISTORICAL_VERSIONS_EXIST",
-          parameters = Map(
-            "feature" -> TestRemovableReaderWriterFeature.name,
-            "logRetentionPeriodKey" -> "delta.logRetentionDuration",
-            "logRetentionPeriod" -> "30 days",
-            "truncateHistoryLogRetentionPeriod" -> truncateHistoryDefaultLogRetention.toString))
-      } else {
-        checkError(
-          exception = e2,
-          errorClass = "DELTA_FEATURE_DROP_WAIT_FOR_RETENTION_PERIOD",
-          parameters = Map(
-            "feature" -> TestRemovableReaderWriterFeature.name,
-            "logRetentionPeriodKey" -> "delta.logRetentionDuration",
-            "logRetentionPeriod" -> "30 days",
-            "truncateHistoryLogRetentionPeriod" -> truncateHistoryDefaultLogRetention.toString))
-      }
+      checkError(
+        exception = e2,
+        errorClass = "DELTA_FEATURE_DROP_WAIT_FOR_RETENTION_PERIOD",
+        parameters = Map(
+          "feature" -> TestRemovableReaderWriterFeature.name,
+          "logRetentionPeriodKey" -> "delta.logRetentionDuration",
+          "logRetentionPeriod" -> "30 days",
+          "truncateHistoryLogRetentionPeriod" -> truncateHistoryDefaultLogRetention.toString))
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -2881,11 +2881,8 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     }
   }
 
-  for {
-    reEnablePropertyValue <- BOOLEAN_DOMAIN
-    reDisable <- BOOLEAN_DOMAIN
-  } test("Try removing reader+writer feature but re-enable feature after disablement " +
-      s"reEnablePropertyValue: $reEnablePropertyValue " +
+  for (reDisable <- BOOLEAN_DOMAIN)
+  test("Try removing reader+writer feature but re-enable feature after disablement " +
       s"reDisable: $reDisable") {
     withTempDir { dir =>
       val clock = new ManualClock(System.currentTimeMillis())
@@ -2929,7 +2926,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       val v2Table = DeltaTableV2(spark, deltaLog.dataPath)
       AlterTableSetPropertiesDeltaCommand(
         v2Table,
-        Map(TestRemovableReaderWriterFeature.TABLE_PROP_KEY -> reEnablePropertyValue.toString))
+        Map(TestRemovableReaderWriterFeature.TABLE_PROP_KEY -> true.toString))
         .run(spark)
 
       // Disable by removing property.
@@ -2942,8 +2939,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       clock.advance(
         deltaRetentionMillis - TimeUnit.DAYS.toMillis(10) + TimeUnit.MINUTES.toMillis(5))
 
-      // Cleanup logs.
-      deltaLog.cleanUpExpiredLogs(deltaLog.update())
+      DeltaLog.clearCache()
 
       // Feature was enabled again in the middle of the timeframe. The feature traces are
       // are cleaned up again and we get a new "Wait for retention period message."

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -3451,7 +3451,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       sql(
         s"""ALTER TABLE delta.`${dir.getPath}` SET TBLPROPERTIES (
            |'${TestRemovableReaderWriterFeature.TABLE_PROP_KEY}'='false'
-           |)""")
+           |)""".stripMargin)
 
       // Pretend retention period has passed.
       val clockAdvanceMillis = DeltaConfigs.getMilliSeconds(truncateHistoryDefaultLogRetention)
@@ -3463,7 +3463,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         TestRemovableReaderWriterFeature.name,
         truncateHistory = true).run(spark)
 
-      assert(targetLog.update().protocol == Protocol(3, 7))
+      assert(targetLog.update().protocol == Protocol(1, 1))
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
In the DROP FEATURE command we generate a checkpoint after cleaning reader+writer feature traces to allow metadata cleaning operations to truncate history before the cleanup. However, the checkpoint is not created if the cleanup operation does not do any work. This might cause an issue in some cases if the cleanup operation does not perform any work but there are historical traces that needed to be truncated. A scenario like this may occur if the user manually cleans the feature traces before invoking the DROP FEATURE command. This PR resolves this issue by relaxing the conditions the checkpoint is created. Note, this has as a side effect to create a checkpoint in both invocations of the DROP FEATURE command.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Added a new test in DeltaProtocolVersionSuite.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.
