### PR TITLE
[Spark] Remove preview guard for clustered table

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3272,16 +3272,6 @@ trait DeltaErrorsBase
       messageParameters = Array.empty)
   }
 
-  def clusteringTablePreviewDisabledException(): Throwable = {
-    val msg = s"""
-      |A clustered table is currently in preview and is disabled by default. Please set
-      |${DeltaSQLConf.DELTA_CLUSTERING_TABLE_PREVIEW_ENABLED.key} to true to enable it.
-      |Note that a clustered table is not recommended for production use (e.g., unsupported
-      |incremental clustering).
-      |""".stripMargin.replace("\n", " ")
-    new UnsupportedOperationException(msg)
-  }
-
   def alterTableSetClusteringTableFeatureException(tableFeature: String): Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_ALTER_TABLE_SET_CLUSTERING_TABLE_FEATURE_NOT_ALLOWED",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
@@ -257,8 +257,6 @@ class DeltaCatalog extends DelegatingCatalogExtension
   // Perform checks on ClusterBySpec.
   def validateClusterBySpec(
       maybeClusterBySpec: Option[ClusterBySpec], schema: StructType): Unit = {
-    // Validate that the preview is enabled if we are creating a clustered table.
-    ClusteredTableUtils.validatePreviewEnabled(maybeClusterBySpec)
     maybeClusterBySpec.foreach { clusterBy =>
       // Check if the specified cluster by columns exists in the table.
       val resolver = spark.sessionState.conf.resolver

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -147,8 +147,6 @@ case class OptimizeTableCommand(
     }
 
     if (ClusteredTableUtils.isSupported(txn.protocol)) {
-      // Validate that the preview is enabled if we are optimizing a clustered table.
-      ClusteredTableUtils.validatePreviewEnabled(txn.snapshot.protocol)
       if (userPartitionPredicates.nonEmpty) {
         throw DeltaErrors.clusteringWithPartitionPredicatesException(userPartitionPredicates)
       }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -132,8 +132,6 @@ case class WriteIntoDelta(
       }
     }
     val isReplaceWhere = mode == SaveMode.Overwrite && options.replaceWhere.nonEmpty
-    // Validate that the preview is enabled if we are writing to a clustered table.
-    ClusteredTableUtils.validatePreviewEnabled(txn.snapshot.protocol)
     val finalClusterBySpecOpt =
       if (mode == SaveMode.Append || isReplaceWhere) {
         clusterBySpecOpt.foreach { clusterBySpec =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableUtils.scala
@@ -49,32 +49,6 @@ trait ClusteredTableUtilsBase extends DeltaLogging {
   def clusteringProvider: String = "liquid"
 
   /**
-   * Validate the clustering table preview is enabled. If not, throw an exception.
-   * This version is used when checking existing tables with updated metadata / protocol.
-   */
-  def validatePreviewEnabled(protocol: Protocol): Unit = {
-    if (isSupported(protocol) &&
-      !SQLConf.get.getConf(DeltaSQLConf.DELTA_CLUSTERING_TABLE_PREVIEW_ENABLED) &&
-      !DeltaUtils.isTesting) {
-      throw DeltaErrors.clusteringTablePreviewDisabledException()
-    }
-  }
-
-  /**
-   * Validate the clustering table preview is enabled. If not, throw an exception.
-   * This version is used for `CREATE TABLE...` where the initial snapshot doesn't have
-   * updated metadata / protocol yet.
-   */
-  def validatePreviewEnabled(maybeClusterBySpec: Option[ClusterBySpec]): Unit = {
-    maybeClusterBySpec.foreach { _ =>
-      if (!SQLConf.get.getConf(DeltaSQLConf.DELTA_CLUSTERING_TABLE_PREVIEW_ENABLED) &&
-        !DeltaUtils.isTesting) {
-        throw DeltaErrors.clusteringTablePreviewDisabledException()
-      }
-    }
-  }
-
-  /**
    * Returns an optional [[ClusterBySpec]] from the given CatalogTable.
    */
   def getClusterBySpecOptional(table: CatalogTable): Option[ClusterBySpec] = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1667,13 +1667,6 @@ trait DeltaSQLConfBase {
   // Clustered Table
   //////////////////
 
-  val DELTA_CLUSTERING_TABLE_PREVIEW_ENABLED =
-    buildConf("clusteredTable.enableClusteringTablePreview")
-      .internal()
-      .doc("Whether to enable the clustering table preview.")
-      .booleanConf
-      .createWithDefault(false)
-
   val DELTA_NUM_CLUSTERING_COLUMNS_LIMIT =
     buildStaticConf("clusteredTable.numClusteringColumnsLimit")
       .internal()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Now that incremental clustering, ALTER TABLE CLUSTER BY and DESC DETAIL are merged, we can remove the preview guard for clustered table, to prepare for OSS 3.2 release.
## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Existing tests.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. User will no longer get the preview warning when they try out clustered table.