### PR TITLE
[Spark] Enable Row Tracking outside of testing

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -336,7 +336,8 @@ object TableFeature {
       IcebergCompatV2TableFeature,
       DeletionVectorsTableFeature,
       VacuumProtocolCheckTableFeature,
-      V2CheckpointTableFeature)
+      V2CheckpointTableFeature,
+      RowTrackingFeature)
     if (DeltaUtils.isTesting) {
       features ++= Set(
         TestLegacyWriterFeature,
@@ -355,8 +356,6 @@ object TableFeature {
         TestWriterFeatureWithTransitiveDependency,
         // managed-commits are under development and only available in testing.
         ManagedCommitTableFeature,
-        // Row IDs are still under development and only available in testing.
-        RowTrackingFeature,
         InCommitTimestampTableFeature,
         TypeWideningTableFeature)
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Delta Protocol for Row IDs was introduced in this PR: https://github.com/delta-io/delta/pull/1610

Support for writing fresh row IDs / row commit versions was introduced in the following PRs:
- https://github.com/delta-io/delta/pull/1723
- https://github.com/delta-io/delta/pull/1781
- https://github.com/delta-io/delta/pull/1896

**This is sufficient to enable row tracking on a table and write to a table that has row tracking enabled** but not to actually read row IDs / row commit versions back, which is also being added in Delta at the moment ([read BaseRowId](https://github.com/delta-io/delta/commit/283ac02c0510ce67744ff5c410ca416f7fbaa0b9). [read defaultRowCommitVersion](https://github.com/delta-io/delta/pull/2795), [read RowId](https://github.com/delta-io/delta/pull/2856)...)

Using row tracking is currently only allowed in testing, this change allows enabling row tracking outside of testing so that the upcoming Delta 3.2 release includes support for writing to tables with row tracking enabled, making Delta writers future-proof.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Tests have already been added in previous changes, this only flips the switch to let users enabled Row Tracking outside of tests.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
Users are now able to enable Row Tracking when creating a delta table:
```
CREATE TABLE tbl(a int) USING DELTA TBLPROPERTIES ('delta.enableRowTracking' = 'true')
```
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
