### PR TITLE
[PROTOCOL RFC] Variant data type

### DIFF
--- a/protocol_rfcs/README.md
+++ b/protocol_rfcs/README.md
@@ -22,6 +22,7 @@ Here is the history of all the RFCs propose/accepted/rejected since Feb 6, 2024,
 | 2023-02-09    | [type-widening.md](https://github.com/delta-io/delta/blob/master/protocol_rfcs/type-widening.md)                                  | https://github.com/delta-io/delta/issues/2623 | Type Widening                 |
 | 2023-02-14    | [managed-commits.md](https://github.com/delta-io/delta/blob/master/protocol_rfcs/managed-commits.md)                              | https://github.com/delta-io/delta/issues/2598 | Managed Commits               |
 | 2023-02-26    | [column-mapping-usage.tracking.md](https://github.com/delta-io/delta/blob/master/protocol_rfcs/column-mapping-usage-tracking.md)) | https://github.com/delta-io/delta/issues/2682 | Column Mapping Usage Tracking |
+| 2023-04-08    | [variant-type.md](https://github.com/delta-io/delta/blob/master/protocol_rfcs/variant-type.md)                                    | https://github.com/delta-io/delta/issues/2864 | Variant Data Type             |
 
 ### Accepted RFCs
 

--- a/protocol_rfcs/README.md
+++ b/protocol_rfcs/README.md
@@ -22,7 +22,7 @@ Here is the history of all the RFCs propose/accepted/rejected since Feb 6, 2024,
 | 2023-02-09    | [type-widening.md](https://github.com/delta-io/delta/blob/master/protocol_rfcs/type-widening.md)                                  | https://github.com/delta-io/delta/issues/2623 | Type Widening                 |
 | 2023-02-14    | [managed-commits.md](https://github.com/delta-io/delta/blob/master/protocol_rfcs/managed-commits.md)                              | https://github.com/delta-io/delta/issues/2598 | Managed Commits               |
 | 2023-02-26    | [column-mapping-usage.tracking.md](https://github.com/delta-io/delta/blob/master/protocol_rfcs/column-mapping-usage-tracking.md)) | https://github.com/delta-io/delta/issues/2682 | Column Mapping Usage Tracking |
-| 2023-04-08    | [variant-type.md](https://github.com/delta-io/delta/blob/master/protocol_rfcs/variant-type.md)                                    | https://github.com/delta-io/delta/issues/2864 | Variant Data Type             |
+| 2023-04-24    | [variant-type.md](https://github.com/delta-io/delta/blob/master/protocol_rfcs/variant-type.md)                                    | https://github.com/delta-io/delta/issues/2864 | Variant Data Type             |
 
 ### Accepted RFCs
 

--- a/protocol_rfcs/variant-type.md
+++ b/protocol_rfcs/variant-type.md
@@ -44,8 +44,8 @@ To support this feature:
 
 ## Variant data in Parquet
 
-The Variant data type is represented as 2 binary encoded values, according to the [Variant binary encoding specification](https://github.com/apache/spark/blob/master/common/variant/README.md).
-The 2 binary values are named `value` and `metadata`.
+The Variant data type is represented as two binary encoded values, according to the [Variant binary encoding specification](https://github.com/apache/spark/blob/master/common/variant/README.md).
+The two binary values are named `value` and `metadata`.
 
 When writing Variant data to parquet files, the Variant data is written as a single Parquet struct, with the following fields:
 
@@ -54,21 +54,22 @@ Struct field name | Parquet primitive type | Description
 value | binary | The binary-encoded Variant value, as described in [Variant binary encoding](https://github.com/apache/spark/blob/master/common/variant/README.md)
 metadata | binary | The binary-encoded Variant metadata, as described in [Variant binary encoding](https://github.com/apache/spark/blob/master/common/variant/README.md)
 
-The parquet struct must include the 2 struct fields `value` and `metadata`.
-Supported writers must write the 2 binary fields, and supported readers must read the 2 binary fields.
+The parquet struct must include the two struct fields `value` and `metadata`.
+Supported writers must write the two binary fields, and supported readers must read the two binary fields.
 Struct fields which start with `_` (underscore) can be safely ignored.
 The only non-ignorable fields must be `value` and `metadata`.
 
 ## Writer Requirements for Variant Data Type
 
 When Variant type is supported (`writerFeatures` field of a table's `protocol` action contains `variantType`), writers:
-- must write the 2 parquet struct fields, `value` and `metadata`, according to the [Variant binary encoding specification](https://github.com/apache/spark/blob/master/common/variant/README.md)
+- must write a column of type `variant` to parquet as a struct containing the fields `value` and `metadata` and storing values that conform to the [Variant binary encoding specification](https://github.com/apache/spark/blob/master/common/variant/README.md)
 - must not write additional, non-ignorable parquet struct fields. Writing additional struct fields with names starting with `_` (underscore) is allowed.
 
 ## Reader Requirements for Variant Data Type
 
 When Variant type is supported (`readerFeatures` field of a table's `protocol` action contains `variantType`), readers:
-- must be able to read the 2 parquet struct fields, `value` and `metadata`
+- must be able to read the two parquet struct fields, `value` and `metadata` and interpret them as a Variant in concordance with the [Variant binary encoding specification](https://github.com/apache/spark/blob/master/common/variant/README.md).
+- It is recommended but not required for a Delta reader to treat the struct as a single indivisible Variant field, if the reader is used in an engine or other context that supports Variant.
 - can ignore any parquet struct field names starting with `_` (underscore)
 
 ## Compatibility with other Delta Features

--- a/protocol_rfcs/variant-type.md
+++ b/protocol_rfcs/variant-type.md
@@ -2,7 +2,7 @@
 **Associated Github issue for discussions: https://github.com/delta-io/delta/issues/2864**
 
 This protocol change adds support for the Variant data type.
-The Variant data type is beneficial for storing and processing semi-structure data.
+The Variant data type is beneficial for storing and processing semi-structured data.
 
 --------
 
@@ -10,12 +10,12 @@ The Variant data type is beneficial for storing and processing semi-structure da
 
 # Variant Data Type
 
-This feature introduces the Variant data type, for processing with semi-structured data.
+This feature enables support for the Variant data type, for storing semi-structured data.
 The schema serialization method is described in [Schema Serialization Format](#schema-serialization-format).
 
 To support this feature:
 - The table must be on Reader Version 3 and Writer Version 7
-- The feature `variantType` must exist in the table `protocol`'s `readerFeatures` and `writerFeatures`, either during its creation or at a later stage.
+- The feature `variantType` must exist in the table `protocol`'s `readerFeatures` and `writerFeatures`.
 
 ## Example JSON-Encoded Delta Table Schema with Variant types
 
@@ -52,7 +52,7 @@ When writing Variant data to parquet files, the Variant data is written as a sin
 Struct field name | Parquet primitive type | Description
 -|-|-
 value | binary | The binary-encoded Variant value, as described in [Variant binary encoding](https://github.com/apache/spark/blob/master/common/variant/README.md)
-metadata | binary | The binary-encoded Variant  metadata, as described in [Variant binary encoding](https://github.com/apache/spark/blob/master/common/variant/README.md)
+metadata | binary | The binary-encoded Variant metadata, as described in [Variant binary encoding](https://github.com/apache/spark/blob/master/common/variant/README.md)
 
 The parquet struct must include the 2 struct fields `value` and `metadata`.
 Supported writers must write the 2 binary fields, and supported readers must read the 2 binary fields.
@@ -63,7 +63,7 @@ The only non-ignorable fields must be `value` and `metadata`.
 
 When Variant type is supported (`writerFeatures` field of a table's `protocol` action contains `variantType`), writers:
 - must write the 2 parquet struct fields, `value` and `metadata`, according to the [Variant binary encoding specification](https://github.com/apache/spark/blob/master/common/variant/README.md)
-- must not write additional parquet struct fields
+- must not write additional, non-ignorable parquet struct fields. Writing additional struct fields with names starting with `_` (underscore) is allowed.
 
 ## Reader Requirements for Variant Data Type
 
@@ -82,8 +82,6 @@ Generated Columns | **Supported:** A Variant column is allowed to be used as a s
 Delta CHECK Constraints | **Supported:** A Variant column is allowed to be used for a CHECK constraint expression.
 Default Column Values | **Supported:** A Variant column is allowed to have a default column value.
 Change Data Feed | **Supported:** A table using the Variant data type is allowed to enable the Delta Change Data Feed.
-Convert-to-Delta Command | **Supported:** A Variant Parquet table following the Spark Variant specification, can be converted to Delta with the CONVERT TO DELTA command.
-Create Table Clone Command | **Supported:** A Variant table following the Spark Variant specification, can be deep or shallow cloned.
 
 --------
 

--- a/protocol_rfcs/variant-type.md
+++ b/protocol_rfcs/variant-type.md
@@ -42,7 +42,6 @@ To support this feature:
 }
 ```
 
-
 ## Variant data in Parquet
 
 The Variant data type is represented as 2 binary encoded values, according to the [Variant binary encoding specification](https://github.com/apache/spark/blob/master/common/variant/README.md).
@@ -60,19 +59,31 @@ Supported writers must write the 2 binary fields, and supported readers must rea
 Struct fields which start with `_` (underscore) can be safely ignored.
 The only non-ignorable fields must be `value` and `metadata`.
 
+## Writer Requirements for Variant Data Type
+
+When Variant type is supported (`writerFeatures` field of a table's `protocol` action contains `variantType`), writers:
+- must write the 2 parquet struct fields, `value` and `metadata`, according to the [Variant binary encoding specification](https://github.com/apache/spark/blob/master/common/variant/README.md)
+- must not write additional parquet struct fields
+
+## Reader Requirements for Variant Data Type
+
+When Variant type is supported (`readerFeatures` field of a table's `protocol` action contains `variantType`), readers:
+- must be able to read the 2 parquet struct fields, `value` and `metadata`
+- can ignore any parquet struct field names starting with `_` (underscore)
+
 ## Compatibility with other Delta Features
 
 Feature | Support for Variant Data Type
 -|-
-Partition Columns | &#x2705; A Variant column is allowed to be a non-partitioned column of a partitioned table. <br/> &#x274C; Variant is not a comparable data type, so it cannot be included in a partition column.
-Clustered Tables | &#x2705; A Variant column is allowed to be a non-clustering column of a clustered table. <br/> &#x274C; Variant is not a comparable data type, so it cannot be included in a clustering column.
-Delta Column Statistics | &#x2705; A Variant column supports the `nullCount` statistic. <br/> &#x274C; Variant is not a comparable data type, so a Variant column does not support the `minValues` and `maxValues` statistics.
-Generated Columns | &#x2705; A Variant column is allowed to be used as a source in a generated column expression, as long as the Variant type is not the result type of the generated column expression. <br/> &#x274C; The Variant data type is not allowed to be the result type of a generated column expression.
-Delta CHECK Constraints | &#x2705; A Variant column is allowed to be used for a CHECK constraint expression.
-Default Column Values | &#x2705; A Variant column is allowed to have a default column value.
-Change Data Feed | &#x2705; A table using the Variant data type is allowed to enable the Delta Change Data Feed.
-Convert-to-Delta Command | &#x2705; A Variant Parquet table following the Spark Variant specification, can be converted to Delta with the CONVERT TO DELTA command.
-Create Table Clone Command | &#x2705; A Variant table following the Spark Variant specification, can be deep or shallow cloned.
+Partition Columns | **Supported:** A Variant column is allowed to be a non-partitioned column of a partitioned table. <br/> **Unsupported:** Variant is not a comparable data type, so it cannot be included in a partition column.
+Clustered Tables | **Supported:** A Variant column is allowed to be a non-clustering column of a clustered table. <br/> **Unsupported:** Variant is not a comparable data type, so it cannot be included in a clustering column.
+Delta Column Statistics | **Supported:** A Variant column supports the `nullCount` statistic. <br/> **Unsupported:** Variant is not a comparable data type, so a Variant column does not support the `minValues` and `maxValues` statistics.
+Generated Columns | **Supported:** A Variant column is allowed to be used as a source in a generated column expression, as long as the Variant type is not the result type of the generated column expression. <br/> **Unsupported:** The Variant data type is not allowed to be the result type of a generated column expression.
+Delta CHECK Constraints | **Supported:** A Variant column is allowed to be used for a CHECK constraint expression.
+Default Column Values | **Supported:** A Variant column is allowed to have a default column value.
+Change Data Feed | **Supported:** A table using the Variant data type is allowed to enable the Delta Change Data Feed.
+Convert-to-Delta Command | **Supported:** A Variant Parquet table following the Spark Variant specification, can be converted to Delta with the CONVERT TO DELTA command.
+Create Table Clone Command | **Supported:** A Variant table following the Spark Variant specification, can be deep or shallow cloned.
 
 --------
 

--- a/protocol_rfcs/variant-type.md
+++ b/protocol_rfcs/variant-type.md
@@ -1,0 +1,87 @@
+# Variant Data Type
+**Associated Github issue for discussions: https://github.com/delta-io/delta/issues/2864**
+
+This protocol change adds support for the Variant data type.
+The Variant data type is beneficial for storing and processing semi-structure data.
+
+--------
+
+> ***New Section after the [Clustered Table](#clustered-table) section***
+
+# Variant Data Type
+
+This feature introduces the Variant data type, for processing with semi-structured data.
+The schema serialization method is described in [Schema Serialization Format](#schema-serialization-format).
+
+To support this feature:
+- The table must be on Reader Version 3 and Writer Version 7
+- The feature `variantType` must exist in the table `protocol`'s `readerFeatures` and `writerFeatures`, either during its creation or at a later stage.
+
+## Example JSON-Encoded Delta Table Schema with Variant types
+
+```
+{
+  "type" : "struct",
+  "fields" : [ {
+    "name" : "raw_data",
+    "type" : "variant",
+    "nullable" : true,
+    "metadata" : { }
+  }, {
+    "name" : "variant_array",
+    "type" : {
+      "type" : "array",
+      "elementType" : {
+        "type" : "variant"
+      },
+      "containsNull" : false
+    },
+    "nullable" : false,
+    "metadata" : { }
+  } ]
+}
+```
+
+
+## Variant data in Parquet
+
+The Variant data type is represented as 2 binary encoded values, according to the [Variant binary encoding specification](https://github.com/apache/spark/blob/master/common/variant/README.md).
+The 2 binary values are named `value` and `metadata`.
+
+When writing Variant data to parquet files, the Variant data is written as a single Parquet struct, with the following fields:
+
+Struct field name | Parquet primitive type | Description
+-|-|-
+value | binary | The binary-encoded Variant value, as described in [Variant binary encoding](https://github.com/apache/spark/blob/master/common/variant/README.md)
+metadata | binary | The binary-encoded Variant  metadata, as described in [Variant binary encoding](https://github.com/apache/spark/blob/master/common/variant/README.md)
+
+The parquet struct must include the 2 struct fields `value` and `metadata`.
+Supported writers must write the 2 binary fields, and supported readers must read the 2 binary fields.
+Struct fields which start with `_` (underscore) can be safely ignored.
+The only non-ignorable fields must be `value` and `metadata`.
+
+## Compatibility with other Delta Features
+
+Feature | Support for Variant Data Type
+-|-
+Partition Columns | &#x2705; A Variant column is allowed to be a non-partitioned column of a partitioned table. <br/> &#x274C; Variant is not a comparable data type, so it cannot be included in a partition column.
+Clustered Tables | &#x2705; A Variant column is allowed to be a non-clustering column of a clustered table. <br/> &#x274C; Variant is not a comparable data type, so it cannot be included in a clustering column.
+Delta Column Statistics | &#x2705; A Variant column supports the `nullCount` statistic. <br/> &#x274C; Variant is not a comparable data type, so a Variant column does not support the `minValues` and `maxValues` statistics.
+Generated Columns | &#x2705; A Variant column is allowed to be used as a source in a generated column expression, as long as the Variant type is not the result type of the generated column expression. <br/> &#x274C; The Variant data type is not allowed to be the result type of a generated column expression.
+Delta CHECK Constraints | &#x2705; A Variant column is allowed to be used for a CHECK constraint expression.
+Default Column Values | &#x2705; A Variant column is allowed to have a default column value.
+Change Data Feed | &#x2705; A table using the Variant data type is allowed to enable the Delta Change Data Feed.
+Convert-to-Delta Command | &#x2705; A Variant Parquet table following the Spark Variant specification, can be converted to Delta with the CONVERT TO DELTA command.
+Create Table Clone Command | &#x2705; A Variant table following the Spark Variant specification, can be deep or shallow cloned.
+
+--------
+
+> ***New Sub-Section after the [Map Type](#map-type) sub-section within the [Schema Serialization Format](#schema-serialization-format) section***
+
+### Variant Type
+
+Variant data uses the Delta type name `variant` for Delta schema serialization.
+
+Field Name | Description
+-|-
+type | Always the string "variant"

--- a/protocol_rfcs/variant-type.md
+++ b/protocol_rfcs/variant-type.md
@@ -44,7 +44,7 @@ To support this feature:
 
 ## Variant data in Parquet
 
-The Variant data type is represented as two binary encoded values, according to the [Variant binary encoding specification](https://github.com/apache/spark/blob/master/common/variant/README.md).
+The Variant data type is represented as two binary encoded values, according to the [Spark Variant binary encoding specification](https://github.com/apache/spark/blob/master/common/variant/README.md).
 The two binary values are named `value` and `metadata`.
 
 When writing Variant data to parquet files, the Variant data is written as a single Parquet struct, with the following fields:
@@ -57,7 +57,6 @@ metadata | binary | The binary-encoded Variant metadata, as described in [Varian
 The parquet struct must include the two struct fields `value` and `metadata`.
 Supported writers must write the two binary fields, and supported readers must read the two binary fields.
 Struct fields which start with `_` (underscore) can be safely ignored.
-The only non-ignorable fields must be `value` and `metadata`.
 
 ## Writer Requirements for Variant Data Type
 
@@ -68,9 +67,11 @@ When Variant type is supported (`writerFeatures` field of a table's `protocol` a
 ## Reader Requirements for Variant Data Type
 
 When Variant type is supported (`readerFeatures` field of a table's `protocol` action contains `variantType`), readers:
-- must be able to read the two parquet struct fields, `value` and `metadata` and interpret them as a Variant in concordance with the [Variant binary encoding specification](https://github.com/apache/spark/blob/master/common/variant/README.md).
-- It is recommended but not required for a Delta reader to treat the struct as a single indivisible Variant field, if the reader is used in an engine or other context that supports Variant.
-- can ignore any parquet struct field names starting with `_` (underscore)
+- must recognize and tolerate a `variant` data type in a Delta schema
+- must use the correct physical schema (struct-of-binary, with fields `value` and `metadata`) when reading a Variant data type from file
+- must make the column available to the engine:
+    - [Recommended] Expose and interpret the struct-of-binary as a single Variant field in accordance with the [Spark Variant binary encoding specification](https://github.com/apache/spark/blob/master/common/variant/README.md).
+    - [Alternate] Expose the raw physical struct-of-binary, e.g. if the engine does not support Variant.
 
 ## Compatibility with other Delta Features
 

--- a/protocol_rfcs/variant-type.md
+++ b/protocol_rfcs/variant-type.md
@@ -72,6 +72,7 @@ When Variant type is supported (`readerFeatures` field of a table's `protocol` a
 - must make the column available to the engine:
     - [Recommended] Expose and interpret the struct-of-binary as a single Variant field in accordance with the [Spark Variant binary encoding specification](https://github.com/apache/spark/blob/master/common/variant/README.md).
     - [Alternate] Expose the raw physical struct-of-binary, e.g. if the engine does not support Variant.
+    - [Alternate] Convert the struct-of-binary to a string, and expose the string representation, e.g. if the engine does not support Variant.
 
 ## Compatibility with other Delta Features
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Adds the protocol changes for the Variant data type (see https://github.com/delta-io/delta/issues/2864) to the RFC folder.

## How was this patch tested?

N/A

## Does this PR introduce _any_ user-facing changes?

N/A
