### PR TITLE
[Spark] Don't use fixed tahoe id for testing

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1348,7 +1348,8 @@ trait OptimisticTransactionImpl extends TransactionalWrite
         UpdatedActions(commitInfo, newMetadata, newProtocolOpt))
       // TODO(managed-commits): Use the right timestamp method on top of CommitInfo once ICT is
       //  merged.
-      acStatsCollector.finalizeStats(deltaLog.tableId)
+      // If the metadata didn't change, `newMetadata` is empty, and we can re-use the old id.
+      acStatsCollector.finalizeStats(newMetadata.map(_.id).getOrElse(this.snapshot.metadata.id))
       spark.sessionState.conf.setConf(
         DeltaSQLConf.DELTA_LAST_COMMIT_VERSION_IN_SESSION,
         Some(attemptVersion))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -961,7 +961,7 @@ case class Format(
  * any data already present in the table is still valid after any change.
  */
 case class Metadata(
-    id: String = if (Utils.isTesting) "testId" else java.util.UUID.randomUUID().toString,
+    id: String = java.util.UUID.randomUUID().toString,
     name: String = null,
     description: String = null,
     format: Format = Format(),

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -181,6 +181,18 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
+  val DELTA_INCLUDE_TABLE_ID_IN_FILE_INDEX_COMPARISON =
+    buildConf("includeTableIdInFileIndexComparison")
+      .internal()
+      .doc(
+        """
+          |Include the deltaLog.tableId field in equals and hashCode for TahoeLogFileIndex.
+          |The field is unstable, so including it can lead semantic violations for equals and
+          |hashCode.""".stripMargin)
+      .booleanConf
+      // TODO: Phase this out towards `false` eventually remove the flag altogether again.
+      .createWithDefault(true)
+
   val DELTA_ALLOW_CREATE_EMPTY_SCHEMA_TABLE =
     buildConf("createEmptySchemaTable.enabled")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -487,9 +487,7 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
       """"size":10,"dataChange":false}}""".stripMargin)
 
   {
-    // We want this metadata to be lazy so it is instantiated after `SparkFunSuite::beforeAll`.
-    // This will ensure that `Utils.isTesting` returns true and that its id is set to 'testId'.
-    lazy val metadata = Metadata(createdTime = Some(2222))
+    val metadata = Metadata(id = "testId", createdTime = Some(2222))
     testActionSerDe(
       "Metadata (with all defaults) - json serialization/deserialization",
       metadata,
@@ -499,9 +497,8 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
 
   {
     val schemaStr = new StructType().add("a", "long").json
-    // We want this metadata to be lazy so it is instantiated after `SparkFunSuite::beforeAll`.
-    // This will ensure that `Utils.isTesting` returns true and that its id is set to 'testId'.
-    lazy val metadata = Metadata(
+    val metadata = Metadata(
+      id = "testId",
       name = "t1",
       description = "desc",
       format = Format(provider = "parquet", options = Map("o1" -> "v1")),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -1164,6 +1164,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
 
       // Create a checkpoint so that logs before checkpoint can be expired and deleted
       writersLog.checkpoint()
+      val tahoeId = deltaLog.tableId // This isn't stable, but it shouldn't change during the test.
 
       testStream(df)(
         StartStream(Trigger.ProcessingTime("10 seconds"), new StreamManualClock),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

 * Do not use the literal "testId" for every single tahoeId in testing. This can hide issues where we use the wrong id (for example as key in a map).
 * Fix one of these issues with the partition stats for auto compaction, where we used a completely random tableId as the key, rather than than the tableId that commitLarge just wrote.
 * Add a (temporary) flag to not include the tahoeId in the equals and hashCode methods of TahoeLogFileIndex. Having an unstable external field there is prone to race conditions (of the form this != this) and losing instances in hash sets/maps. So ideally we should make this the default.

## How was this patch tested?

Testing-only PR.

## Does this PR introduce _any_ user-facing changes?

No.