### PR TITLE
[Flink][WIP] Support using with Flink 1.18

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ Global / default_scala_version := scala212
 
 // Dependent library versions
 val sparkVersion = "3.5.0"
-val flinkVersion = "1.16.1"
+val flinkVersion = "1.18.1"
 val hadoopVersion = "3.3.4"
 val scalaTestVersion = "3.2.15"
 val scalaTestVersionForConnectors = "3.0.8"

--- a/connectors/flink/src/main/java/io/delta/flink/internal/table/DeltaCatalog.java
+++ b/connectors/flink/src/main/java/io/delta/flink/internal/table/DeltaCatalog.java
@@ -8,7 +8,6 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import io.delta.flink.internal.table.DeltaCatalogTableHelper.DeltaMetastoreTable;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.table.api.Schema;
@@ -216,11 +215,6 @@ public class DeltaCatalog {
                         Operation.Name.SET_TABLE_PROPERTIES
                 );
             }
-
-            // Add table to metastore
-            DeltaMetastoreTable metastoreTable =
-                DeltaCatalogTableHelper.prepareMetastoreTable(table, deltaTablePath);
-            this.decoratedCatalog.createTable(tableCatalogPath, metastoreTable, ignoreIfExists);
         } else {
             // Table does not exist on filesystem, we have to create a new _delta_log
             Metadata metadata = Metadata.builder()
@@ -236,13 +230,13 @@ public class DeltaCatalog {
                 metadata,
                 Operation.Name.CREATE_TABLE
             );
-
-            DeltaMetastoreTable metastoreTable =
-                DeltaCatalogTableHelper.prepareMetastoreTable(table, deltaTablePath);
-
-            // add table to metastore
-            this.decoratedCatalog.createTable(tableCatalogPath, metastoreTable, ignoreIfExists);
         }
+
+        // Add table to metastore
+        ResolvedCatalogTable metastoreTable =
+            DeltaCatalogTableHelper.prepareMetastoreTable(table, deltaTablePath);
+
+        this.decoratedCatalog.createTable(tableCatalogPath, metastoreTable, ignoreIfExists);
     }
 
     /**

--- a/connectors/flink/src/test/java/io/delta/flink/source/RowDataDeltaSourceBuilderTestBase.java
+++ b/connectors/flink/src/test/java/io/delta/flink/source/RowDataDeltaSourceBuilderTestBase.java
@@ -11,7 +11,7 @@ import io.delta.flink.internal.options.DeltaOptionValidationException;
 import io.delta.flink.source.internal.DeltaSourceOptions;
 import io.delta.flink.source.internal.builder.DeltaSourceBuilderBase;
 import org.apache.hadoop.conf.Configuration;
-import org.codehaus.janino.util.Producer;
+import org.codehaus.commons.compiler.util.Producer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;

--- a/project/FlinkMimaExcludes.scala
+++ b/project/FlinkMimaExcludes.scala
@@ -20,5 +20,8 @@ import com.typesafe.tools.mima.core._
  * The list of Mima errors to exclude in the Flink project.
  */
 object FlinkMimaExcludes {
-  val ignoredABIProblems = Seq()
+  val ignoredABIProblems = Seq(
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("io.delta.flink.internal.table.DeltaCatalogTableHelper.prepareMetastoreTable"),
+    ProblemFilters.exclude[MissingClassProblem]("io.delta.flink.internal.table.DeltaCatalogTableHelper$DeltaMetastoreTable")
+  )
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [x] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This adds changes to support using Delta with Flink 1.18.

## Work in progress

 - [ ] Decide if the Flink version we build against really should be changed to 1.18.1
 - [ ] Update the README with version numbers that actually support newer Flink
 - [ ] Fix the Mima settings so that it does not think that things in `io.delta.flink.internal` are actually exposed API.

I think these should be done as separate PRs but I am not sure, depending on what you think I'll either do another PR for the Mima things or fix it properly in here.

## How was this patch tested?

It was tested via the test suite (on Java 8, running on arm64 macOS) and some minor manual testing.

```
[info] Passed: Total 568, Failed 0, Errors 0, Passed 565, Skipped 3
[success] Total time: 1142 s (19:02), completed Apr 9, 2024 4:36:35 PM
```

If you have any ideas on how to better test this I would love to know, since I think I can see a patch to support Flink 1.19 in my future and would love to be more confident in that one.

## Does this PR introduce _any_ user-facing changes?

No. It should not beyond supporting a newer version of Flink.

## Thanks

Thanks to @sdahlbac and @oskarskog for helping me with this, I definitely would not have had the patience to run the test suite this many without them.