### PR TITLE
[Spark] Add drop support for InCommitTimestamp table feature

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -356,14 +356,6 @@ object DeltaOperations {
       "properties" -> JsonUtils.toJson(propKeys),
       "ifExists" -> ifExists)
   }
-  /** Recorded when the table properties are set and/or removed in the same commit. */
-  case class UpdateTableProperties(
-      setProperties: Map[String, String],
-      unsetProperties: Seq[String]) extends Operation("UPDATE TBLPROPERTIES") {
-    override val parameters: Map[String, Any] = Map(
-      "setProperties" -> JsonUtils.toJson(setProperties),
-      "unsetProperties" -> JsonUtils.toJson(unsetProperties))
-  }
   /** Recorded when dropping a table feature. */
   case class DropTableFeature(
       featureName: String,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -356,6 +356,14 @@ object DeltaOperations {
       "properties" -> JsonUtils.toJson(propKeys),
       "ifExists" -> ifExists)
   }
+  /** Recorded when the table properties are set and/or removed in the same commit. */
+  case class UpdateTableProperties(
+      setProperties: Map[String, String],
+      unsetProperties: Seq[String]) extends Operation("UPDATE TBLPROPERTIES") {
+    override val parameters: Map[String, Any] = Map(
+      "setProperties" -> JsonUtils.toJson(setProperties),
+      "unsetProperties" -> JsonUtils.toJson(unsetProperties))
+  }
   /** Recorded when dropping a table feature. */
   case class DropTableFeature(
       featureName: String,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.{AlterTableSetPropertiesDeltaCommand, AlterTableUnsetPropertiesDeltaCommand, DeltaReorgTableCommand, DeltaReorgTableMode, DeltaReorgTableSpec}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.util.{Utils => DeltaUtils}
+import org.apache.spark.sql.util.ScalaExtensions._
 
 import org.apache.spark.sql.catalyst.analysis.ResolvedTable
 
@@ -126,6 +127,62 @@ case class V2CheckpointPreDowngradeCommand(table: DeltaTableV2)
     )
 
     true
+  }
+}
+
+case class InCommitTimestampsPreDowngradeCommand(table: DeltaTableV2)
+  extends PreDowngradeTableFeatureCommand
+  with DeltaLogging {
+  /**
+   * We disable the feature by:
+   * - Removing the table properties:
+   *    1. DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP
+   *    2. DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION
+   * - Setting the table property DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED to false.
+   * Technically, only setting IN_COMMIT_TIMESTAMPS_ENABLED to false is enough to disable the
+   * feature. However, we can use this opportunity to clean up the metadata.
+   *
+   * @return true if any change to the metadata (the three properties listed above) was made.
+   *         False otherwise.
+   */
+  override def removeFeatureTracesIfNeeded(): Boolean = {
+    val startTimeNs = System.nanoTime()
+    val currentMetadata = table.initialSnapshot.metadata
+    val currentTableProperties = currentMetadata.configuration
+
+    val enablementProperty = DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED
+    val ictEnabledInMetadata = enablementProperty.fromMetaData(currentMetadata)
+    val provenanceProperties = Seq(
+      DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.key,
+      DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.key)
+    val propertiesToRemove = provenanceProperties.filter(currentTableProperties.contains)
+
+    val traceRemovalNeeded = propertiesToRemove.nonEmpty || ictEnabledInMetadata
+    if (traceRemovalNeeded) {
+      val propertiesToDisable =
+        Option.when(ictEnabledInMetadata)(enablementProperty.key -> "false")
+      val desiredTableProperties = currentTableProperties
+        .filterNot{ case (k, _) => propertiesToRemove.contains(k) } ++ propertiesToDisable
+
+      table.startTransaction().commit(
+        Seq(currentMetadata.copy(configuration = desiredTableProperties.toMap)),
+        DeltaOperations.UpdateTableProperties(propertiesToDisable.toMap, propertiesToRemove))
+    }
+
+    val provenancePropertiesPresenceLogs = provenanceProperties.map { prop =>
+      prop -> currentTableProperties.contains(prop).toString
+    }
+    recordDeltaEvent(
+      table.deltaLog,
+      opType = "delta.inCommitTimestampFeatureRemovalMetrics",
+      data = Map(
+          "downgradeTimeMs" -> TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNs),
+          "traceRemovalNeeded" -> traceRemovalNeeded.toString,
+          enablementProperty.key -> ictEnabledInMetadata
+          ) ++ provenancePropertiesPresenceLogs
+
+    )
+    traceRemovalNeeded
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
@@ -164,9 +164,10 @@ case class InCommitTimestampsPreDowngradeCommand(table: DeltaTableV2)
       val desiredTableProperties = currentTableProperties
         .filterNot{ case (k, _) => propertiesToRemove.contains(k) } ++ propertiesToDisable
 
+      val deltaOperation = DeltaOperations.UnsetTableProperties(
+        (propertiesToRemove ++ propertiesToDisable.map(_._1)).toSeq, ifExists = true)
       table.startTransaction().commit(
-        Seq(currentMetadata.copy(configuration = desiredTableProperties.toMap)),
-        DeltaOperations.UpdateTableProperties(propertiesToDisable.toMap, propertiesToRemove))
+        Seq(currentMetadata.copy(configuration = desiredTableProperties.toMap)), deltaOperation)
     }
 
     val provenancePropertiesPresenceLogs = provenanceProperties.map { prop =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -659,7 +659,8 @@ object TypeWideningTableFeature extends ReaderWriterFeature(name = "typeWidening
  */
 object InCommitTimestampTableFeature
   extends WriterFeature(name = "inCommitTimestamp-dev")
-  with FeatureAutomaticallyEnabledByMetadata {
+  with FeatureAutomaticallyEnabledByMetadata
+  with RemovableFeature {
 
   override def automaticallyUpdateProtocolOfExistingTables: Boolean = true
 
@@ -668,6 +669,31 @@ object InCommitTimestampTableFeature
       spark: SparkSession): Boolean = {
     DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(metadata)
   }
+
+  override def preDowngradeCommand(table: DeltaTableV2): PreDowngradeTableFeatureCommand =
+    InCommitTimestampsPreDowngradeCommand(table)
+
+
+  /**
+   * As per the spec, we can disable ICT by just setting
+   * [[DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED]] to `false`. There is no need to remove the
+   * provenance properties. However, [[InCommitTimestampsPreDowngradeCommand]] will try to remove
+   * these properties because they can be removed as part of the same metadata update that sets
+   * [[DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED]] to `false`. We check all three properties here
+   * as well for consistency.
+   */
+  override def validateRemoval(snapshot: Snapshot): Boolean = {
+    val provenancePropertiesAbsent = Seq(
+        DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.key,
+        DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.key)
+      .forall(!snapshot.metadata.configuration.contains(_))
+    val ictEnabledInMetadata =
+      DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(snapshot.metadata)
+    provenancePropertiesAbsent && !ictEnabledInMetadata
+  }
+
+  // Writer features should directly return false, as it is only used for reader+writer features.
+  override def actionUsesFeature(action: Action): Boolean = false
 }
 
 /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -3715,7 +3715,6 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       assert(!DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(snapshot.metadata))
     }
   }
-
   // Create a table for testing that has an unsupported feature.
   private def withTestTableWithUnsupportedWriterFeature(
       emptyTable: Boolean)(testCode: String => Unit): Unit = {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -3578,11 +3578,10 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
   private def validateICTRemovalMetrics(
       usageLogs: Seq[UsageRecord],
       expectProvenanceInfoRemoval: Boolean): Unit = {
-    val dropFeatureBlob =
-      getUsageLogStats(usageLogs, "delta.inCommitTimestampFeatureRemovalMetrics")
-        .headOption
-        .getOrElse(fail("Expected a log for inCommitTimestampFeatureRemovalMetrics"))
-    val blob = JsonUtils.fromJson[Map[String, String]](dropFeatureBlob)
+    val dropFeatureBlob = usageLogs
+      .find(_.tags.get("opType").contains("delta.inCommitTimestampFeatureRemovalMetrics"))
+      .getOrElse(fail("Expected a log for inCommitTimestampFeatureRemovalMetrics"))
+    val blob = JsonUtils.fromJson[Map[String, String]](dropFeatureBlob.blob)
     assert(blob.contains("downgradeTimeMs"))
     assert(blob.get("traceRemovalNeeded").contains("true"))
     assert(blob.get(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key).contains("true"))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -3581,7 +3581,9 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       .getOrElse(fail("Expected a log for inCommitTimestampFeatureRemovalMetrics"))
     val blob = JsonUtils.fromJson[Map[String, String]](dropFeatureBlob.blob)
     assert(blob.contains("downgradeTimeMs"))
-    assert(blob.get("traceRemovalNeeded").contains("true"))
+    val traceRemovalNeeded = expectEnablementProperty || expectProvenanceTimestampProperty ||
+      expectProvenanceVersionProperty
+    assert(blob.get("traceRemovalNeeded").contains(traceRemovalNeeded.toString))
     assert(blob
       .get(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key)
       .contains(expectEnablementProperty.toString))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -3715,6 +3715,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       assert(!DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(snapshot.metadata))
     }
   }
+
   // Create a table for testing that has an unsupported feature.
   private def withTestTableWithUnsupportedWriterFeature(
       emptyTable: Boolean)(testCode: String => Unit): Unit = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Adds drop feature support for InCommitTimestamps. When the user runs DROP FEATURE, the following will happen if ICT is present in the PROTOCOL:
1. If any of the ICT-related properties are present, the first commit will:
   - Set `IN_COMMIT_TIMESTAMPS_ENABLED` = true
   - Remove `IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION` and `IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP`
2. A second commit will remove ICT from the protocol.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
New tests in the DeltaProtocolVersionSuite for the following scenarios:
1. When ICT is enabled from commit 0 onwards.
2. When ICT is enabled in some commit after 0.
3.  Dropping when the feature is not there in protocol
4. Dropping when only one provenance property is present and even the enablement property is not present
5. Dropping when none of the table properties are present

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Users will now be able to run ALTER TABLE <> DROP FEATURE inCommitTimestamps-dev on their tables.