### PR TITLE
[Spark] Add Read support for RowCommitVersion and Row Tracking Preservation in Read/Write

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/ColumnWithDefaultExprUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ColumnWithDefaultExprUtils.scala
@@ -159,6 +159,11 @@ object ColumnWithDefaultExprUtils extends DeltaLogging {
       .map(new Column(_))
     selectExprs = selectExprs ++ rowIdExprs
 
+    val rowCommitVersionExprs = data.queryExecution.analyzed.output
+      .filter(RowCommitVersion.MetadataAttribute.isRowCommitVersionColumn)
+      .map(new Column(_))
+    selectExprs = selectExprs ++ rowCommitVersionExprs
+
     val newData = queryExecution match {
       case incrementalExecution: IncrementalExecution =>
         selectFromStreamingDataFrame(incrementalExecution, data, selectExprs: _*)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
@@ -81,7 +81,8 @@ trait DeltaColumnMappingBase extends DeltaLogging {
 
   def isInternalField(field: StructField): Boolean =
     DELTA_INTERNAL_COLUMNS.contains(field.name.toLowerCase(Locale.ROOT)) ||
-      RowIdMetadataStructField.isRowIdColumn(field)
+      RowIdMetadataStructField.isRowIdColumn(field) ||
+      RowCommitVersion.MetadataStructField.isRowCommitVersionColumn(field)
 
   def satisfiesColumnMappingProtocol(protocol: Protocol): Boolean =
     protocol.isFeatureSupported(ColumnMappingTableFeature)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -393,6 +393,10 @@ object DeltaTableUtils extends PredicateHelper
     }
   }
 
+  /** Finds and returns the file source metadata column from a dataframe */
+  def getFileMetadataColumn(df: DataFrame): Column =
+    df.metadataColumn(FileFormat.METADATA_NAME)
+
   /**
    * Update FileFormat for a plan and return the updated plan
    *

--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowCommitVersion.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowCommitVersion.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
+import org.apache.spark.sql.util.ScalaExtensions._
+
+import org.apache.spark.sql.{types, Column, DataFrame}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, FileSourceGeneratedMetadataStructField}
+import org.apache.spark.sql.catalyst.types.DataTypeUtils
+import org.apache.spark.sql.execution.datasources.FileFormat
+import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.types.{DataType, LongType, MetadataBuilder, StructField}
+
+object RowCommitVersion {
+
+  val METADATA_STRUCT_FIELD_NAME = "row_commit_version"
+
+  val QUALIFIED_COLUMN_NAME = s"${FileFormat.METADATA_NAME}.$METADATA_STRUCT_FIELD_NAME"
+
+  def createMetadataStructField(protocol: Protocol, metadata: Metadata, nullable: Boolean = false)
+    : Option[StructField] =
+    MaterializedRowCommitVersion.getMaterializedColumnName(protocol, metadata)
+      .map(MetadataStructField(_, nullable))
+
+  /**
+   * Add a new column to `dataFrame` that has the name of the materialized Row Commit Version column
+   * and holds Row Commit Versions. The column also is tagged with the appropriate metadata such
+   * that it can be used to write materialized Row Commit Versions.
+   */
+  private[delta] def preserveRowCommitVersions(
+      dataFrame: DataFrame,
+      snapshot: SnapshotDescriptor): DataFrame = {
+    if (!RowTracking.isEnabled(snapshot.protocol, snapshot.metadata)) {
+      return dataFrame
+    }
+
+    val materializedColumnName = MaterializedRowCommitVersion.getMaterializedColumnNameOrThrow(
+      snapshot.protocol, snapshot.metadata, snapshot.deltaLog.tableId)
+
+    val rowCommitVersionColumn =
+      DeltaTableUtils.getFileMetadataColumn(dataFrame).getField(METADATA_STRUCT_FIELD_NAME)
+    preserveRowCommitVersionsUnsafe(dataFrame, materializedColumnName, rowCommitVersionColumn)
+  }
+
+  private[delta] def preserveRowCommitVersionsUnsafe(
+      dataFrame: DataFrame,
+      materializedColumnName: String,
+      rowCommitVersionColumn: Column): DataFrame = {
+    dataFrame
+      .withColumn(materializedColumnName, rowCommitVersionColumn)
+      .withMetadata(materializedColumnName, MetadataStructField.metadata(materializedColumnName))
+  }
+
+  object MetadataStructField {
+    private val METADATA_COL_ATTR_KEY = "__row_commit_version_metadata_col"
+
+    def apply(materializedColumnName: String, nullable: Boolean = false): StructField =
+      StructField(
+        METADATA_STRUCT_FIELD_NAME,
+        LongType,
+        // The Row commit version field is used to read the materialized Row commit version value
+        // which is nullable. The actual Row commit version expression is created using a projection
+        // injected before the optimizer pass by the [[GenerateRowIDs] rule at which point the Row
+        // commit version field is non-nullable.
+        nullable,
+        metadata = metadata(materializedColumnName))
+
+    def unapply(field: StructField): Option[StructField] =
+      Option.when(isValid(field.dataType, field.metadata))(field)
+
+    def metadata(materializedColumnName: String): types.Metadata = new MetadataBuilder()
+      .withMetadata(
+        FileSourceGeneratedMetadataStructField.metadata(
+          METADATA_STRUCT_FIELD_NAME, materializedColumnName))
+      .putBoolean(METADATA_COL_ATTR_KEY, value = true)
+      .build()
+
+    /** Return true if the column is a Row Commit Version column. */
+    def isRowCommitVersionColumn(structField: StructField): Boolean =
+      isValid(structField.dataType, structField.metadata)
+
+    private[delta] def isValid(dataType: DataType, metadata: types.Metadata): Boolean = {
+      FileSourceGeneratedMetadataStructField.isValid(dataType, metadata) &&
+        metadata.contains(METADATA_COL_ATTR_KEY) &&
+        metadata.getBoolean(METADATA_COL_ATTR_KEY)
+    }
+  }
+
+  def columnMetadata(materializedColumnName: String): types.Metadata =
+    MetadataStructField.metadata(materializedColumnName)
+
+  object MetadataAttribute {
+    def apply(materializedColumnName: String): AttributeReference =
+      DataTypeUtils.toAttribute(MetadataStructField(materializedColumnName))
+        .withName(materializedColumnName)
+
+    def unapply(attr: Attribute): Option[Attribute] =
+      if (isRowCommitVersionColumn(attr)) Some(attr) else None
+
+    /** Return true if the column is a Row Commit Version column. */
+    def isRowCommitVersionColumn(attr: Attribute): Boolean =
+      MetadataStructField.isValid(attr.dataType, attr.metadata)
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowTracking.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowTracking.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.delta.actions.{Metadata, Protocol, TableFeatureProtocolUtils}
 
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types.StructField
 
 /**
@@ -70,6 +71,12 @@ object RowTracking {
       : Iterable[StructField] = {
     RowId.createRowIdField(protocol, metadata, nullable) ++
       RowId.createBaseRowIdField(protocol, metadata) ++
-      DefaultRowCommitVersion.createDefaultRowCommitVersionField(protocol, metadata)
+      DefaultRowCommitVersion.createDefaultRowCommitVersionField(protocol, metadata) ++
+      RowCommitVersion.createMetadataStructField(protocol, metadata, nullable)
+  }
+
+  def preserveRowTrackingColumns(dataFrame: DataFrame, snapshot: SnapshotDescriptor): DataFrame = {
+    val dfWithRowIds = RowId.preserveRowIds(dataFrame, snapshot)
+    RowCommitVersion.preserveRowCommitVersions(dfWithRowIds, snapshot)
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -16,13 +16,12 @@
 
 package org.apache.spark.sql.delta.schema
 
-// scalastyle:off import.ordering.noEmptyLine
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
 
 import org.apache.spark.sql.delta.{DeltaAnalysisException, DeltaColumnMappingMode, DeltaErrors, DeltaLog, GeneratedColumn, NoMapping, TypeWidening}
-import org.apache.spark.sql.delta.RowId
+import org.apache.spark.sql.delta.{RowCommitVersion, RowId}
 import org.apache.spark.sql.delta.actions.Protocol
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.metering.DeltaLogging
@@ -323,6 +322,8 @@ def normalizeColumnNamesInDataType(
               field.name == CDCReader.CDC_PARTITION_COL => (field.name, None)
             // Consider Row Id columns internal if Row Ids are enabled.
             case None if RowId.RowIdMetadataStructField.isRowIdColumn(field) =>
+              (field.name, None)
+            case None if RowCommitVersion.MetadataStructField.isRowCommitVersionColumn(field) =>
               (field.name, None)
             case None =>
               throw DeltaErrors.cannotResolveColumn(field.name, baseSchema)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingReadWriteSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingReadWriteSuite.scala
@@ -1,0 +1,392 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rowtracking
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog, RowCommitVersion, RowId}
+import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.rowid.RowIdTestUtils
+
+import org.apache.spark.sql.{AnalysisException, Column, DataFrame, Row}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.execution.datasources.FileFormat
+import org.apache.spark.sql.execution.datasources.parquet.ParquetTest
+import org.apache.spark.sql.functions.{col, lit, when}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{LongType, StructType}
+
+class RowTrackingReadWriteSuite extends RowIdTestUtils
+  with ParquetTest {
+
+  private val testTableName = "target"
+
+  private val testDataColumnName = "test_data"
+
+  test("select star does not read materialized columns") {
+    withAllParquetReaders {
+      withTable(testTableName) {
+        writeWithMaterializedRowCommitVersionColumns(
+          spark.range(100).toDF(testDataColumnName),
+          rowIdColumn = lit(1L),
+          rowCommitVersionColumn = lit(2L))
+
+        withAllParquetReaders {
+          val df = sql(s"SELECT * FROM $testTableName")
+          assert(df.schema.size === 1)
+          assert(df.schema.head.name === testDataColumnName)
+        }
+      }
+    }
+  }
+
+  test("write and read table without materialized columns") {
+    withTable(testTableName) {
+      withRowTrackingEnabled(enabled = true) {
+        val numRows = 5L
+        spark.range(numRows).toDF(testDataColumnName)
+          .write.format("delta").saveAsTable(testTableName)
+
+        try {
+          // Confirm that the materialized columns are not present in the Parquet file(s).
+            val deltaLog = DeltaLog.forTable(spark, TableIdentifier(testTableName))
+            val parquetDataFrame = spark.read.parquet(deltaLog.dataPath.toString)
+            checkAnswer(parquetDataFrame, (0L until numRows).map(Row(_)))
+        } catch {
+          case e: Exception => Thread.sleep(1000 * 1000)
+        }
+
+        withAllParquetReaders {
+          val df = spark.read.table(testTableName)
+            .select(
+              testDataColumnName,
+              RowId.QUALIFIED_COLUMN_NAME,
+              RowCommitVersion.QUALIFIED_COLUMN_NAME)
+          checkAnswer(df, (0L until numRows).map(i => Row(i, i, 0)))
+        }
+      }
+    }
+  }
+
+  test("write and read table with all-null materialized columns") {
+    withTable(testTableName) {
+      val numRows = 5L
+      writeWithMaterializedRowCommitVersionColumns(
+        spark.range(numRows).toDF(testDataColumnName),
+        rowIdColumn = lit(null).cast("long"),
+        rowCommitVersionColumn = lit(null).cast("long"))
+
+      // Confirm that the materialized columns are present in the Parquet file(s).
+      withSQLConf(
+        // The function writeWithMaterializedRowCommitVersionColumns initially creates
+        // an empty table with only the testDataColumnName column. After that, we write
+        // some data to the Delta table, appending some Parquet files that include
+        // both the testDataColumnName and the materialized Row Tracking Columns.
+        //
+        // PARQUET_SCHEMA_MERGING_ENABLED by default is disabled, so what then happens
+        // is we pick a random data file to infer the schema of the underlying parquet
+        // DataFrame of the Delta table in [[ParquetUtils]].
+        //
+        // Thus, that inferred schema could either contains only the testDataColumnName
+        // column or all three columns, the former leads to wrong result for the
+        // checkAnswer below.
+        //
+        // This is the intended behavior as Delta doesn't give any guarantee
+        // that the Parquet files will all have the same schema, and normally we should
+        // not read raw Parquet files from a Delta table, we are only doing this for
+        // testing purpose.
+        SQLConf.PARQUET_SCHEMA_MERGING_ENABLED.key -> "true"
+      ) {
+        val deltaLog = DeltaLog.forTable(spark, TableIdentifier(testTableName))
+        val parquetDataFrame = spark.read.parquet(deltaLog.dataPath.toString)
+        checkAnswer(parquetDataFrame, (0L until numRows).map(Row(_, null, null)))
+      }
+
+      withAllParquetReaders {
+        val df = spark.read.table(testTableName)
+          .select(
+            testDataColumnName,
+            RowId.QUALIFIED_COLUMN_NAME,
+            RowCommitVersion.QUALIFIED_COLUMN_NAME)
+        checkAnswer(df, (0L until 5L).map(i => Row(i, i, 1)))
+      }
+    }
+  }
+
+  test("write and read table with no-nulls materialized columns") {
+    withTable(testTableName) {
+      val numRows = 100
+      writeWithMaterializedRowCommitVersionColumns(
+        spark.range(numRows).toDF(testDataColumnName),
+        rowIdColumn = col(testDataColumnName) + 10,
+        rowCommitVersionColumn = col(testDataColumnName) + 100)
+
+      withAllParquetReaders {
+        val df = spark.table(testTableName)
+          .select(
+            testDataColumnName,
+            RowId.QUALIFIED_COLUMN_NAME,
+            RowCommitVersion.QUALIFIED_COLUMN_NAME)
+        val expectedAnswer = (0L until numRows).map(i => Row(i, i + 10, i + 100))
+        checkAnswer(df, expectedAnswer)
+      }
+    }
+  }
+
+  test("write and read table with mixed materialized columns") {
+    withTable(testTableName) {
+      val numRows = 100L
+      writeWithMaterializedRowCommitVersionColumns(
+        spark.range(numRows).toDF(testDataColumnName),
+        rowIdColumn =
+          when(col(testDataColumnName) % 2 === 0, col(testDataColumnName) + 10)
+            .otherwise(null),
+        rowCommitVersionColumn =
+          when(col(testDataColumnName) % 3 === 0, col(testDataColumnName) + 100)
+            .otherwise(null))
+
+      withAllParquetReaders {
+        val df = spark.table(testTableName)
+          .select(
+            testDataColumnName,
+            RowId.QUALIFIED_COLUMN_NAME,
+            RowCommitVersion.QUALIFIED_COLUMN_NAME)
+        val expectedAnswer = (0L until numRows).map { i =>
+          Row(i, if (i % 2 == 0) i + 10 else i, if (i % 3 == 0) i + 100 else 1)
+        }
+        checkAnswer(df, expectedAnswer)
+      }
+    }
+  }
+
+  test("read mixed materialized columns with filter") {
+    withTable(testTableName) {
+      val numRows = 100L
+      writeWithMaterializedRowCommitVersionColumns(
+        spark.range(numRows).toDF(testDataColumnName),
+        rowIdColumn =
+          when(col(testDataColumnName) % 2 === 0, lit(1000L))
+            .otherwise(null),
+        rowCommitVersionColumn =
+          when(col(testDataColumnName) % 3 === 0, lit(2000L))
+            .otherwise(null))
+
+      withAllParquetReaders {
+        // Read the table with a filter that does not match any of the materialized row ids and
+        // row commit versions, but that does match the default-generated ids and versions.
+        val df = spark.table(testTableName)
+          .select(
+            testDataColumnName,
+            RowId.QUALIFIED_COLUMN_NAME,
+            RowCommitVersion.QUALIFIED_COLUMN_NAME)
+          .filter(col(RowId.QUALIFIED_COLUMN_NAME) <= 100 &&
+            col(RowCommitVersion.QUALIFIED_COLUMN_NAME) <= 100)
+        val expectedAnswer = (0L until numRows)
+          .filter(i => i % 2 != 0 && i % 3 != 0)
+          .map { i => Row(i, i, 1) }
+        checkAnswer(df, expectedAnswer)
+      }
+    }
+  }
+
+  test("writing to materialized column requires correct metadata") {
+    withTable(testTableName) {
+      writeWithMaterializedRowCommitVersionColumns(
+        spark.range(100).toDF("id"),
+        rowIdColumn = lit(null),
+        rowCommitVersionColumn = lit(null))
+
+      val deltaLog = DeltaLog.forTable(spark, TableIdentifier(testTableName))
+      val materializedRowIdColumnName =
+        extractMaterializedRowIdColumnName(deltaLog).get
+      val materializedRowCommitVersionColumnName =
+        extractMaterializedRowCommitVersionColumnName(deltaLog).get
+
+      val insertStmt1 = s"INSERT INTO $testTableName (id, `$materializedRowIdColumnName`)"
+      val errorRowIds = intercept[AnalysisException](sql(insertStmt1 + " VALUES(1, 2)"))
+      checkError(
+        errorRowIds,
+        errorClass = "UNRESOLVED_COLUMN.WITH_SUGGESTION",
+        parameters = errorRowIds.messageParameters,
+        queryContext = Array(ExpectedContext(insertStmt1, 0, insertStmt1.length - 1)))
+
+      val insertStmt2 =
+        s"INSERT INTO $testTableName (id, `$materializedRowCommitVersionColumnName`)"
+      val errorRowCommitVersions = intercept[AnalysisException](sql(insertStmt2 + " VALUES(1, 2)"))
+      checkError(
+        errorRowCommitVersions,
+        errorClass = "UNRESOLVED_COLUMN.WITH_SUGGESTION",
+        parameters = errorRowCommitVersions.messageParameters,
+        queryContext = Array(ExpectedContext(insertStmt2, 0, insertStmt2.length - 1)))
+    }
+  }
+
+  test("writing to materialized column requires correct name") {
+    withRowTrackingEnabled(enabled = true) {
+      withTable(testTableName) {
+        writeWithMaterializedRowCommitVersionColumns(
+          spark.range(1).toDF(testDataColumnName),
+          rowIdColumn = lit(1L),
+          rowCommitVersionColumn = lit(2L))
+
+        checkWritingToMaterializedColumnsRequiresCorrectName()
+      }
+    }
+  }
+
+  test("writing to materialized column requires row tracking to be enabled") {
+    withTable(testTableName) {
+      writeWithMaterializedRowCommitVersionColumns(
+        spark.range(1).toDF(testDataColumnName),
+        rowIdColumn = lit(1L),
+        rowCommitVersionColumn = lit(2L))
+
+      spark.sql(s"ALTER TABLE $testTableName " +
+        s"SET TBLPROPERTIES ('${DeltaConfigs.ROW_TRACKING_ENABLED.key}' = 'false')")
+
+      checkWritingToMaterializedColumnsRequiresCorrectName()
+    }
+  }
+
+  private def checkWritingToMaterializedColumnsRequiresCorrectName(): Unit = {
+    val columnNames = Seq(
+      RowId.QUALIFIED_COLUMN_NAME,
+      s"`${FileFormat.METADATA_NAME}`.`${RowId.ROW_ID}`",
+      s"`${RowId.QUALIFIED_COLUMN_NAME}`",
+      RowId.QUALIFIED_COLUMN_NAME,
+      s"`${FileFormat.METADATA_NAME}`.`${RowId.ROW_ID}`",
+      s"`${RowId.QUALIFIED_COLUMN_NAME}`")
+
+    for (columnName <- columnNames) {
+      // Throw an error because only using the materialized column name is valid.
+      val error = intercept[AnalysisException] {
+        spark
+          .range(end = 1)
+          .toDF(testDataColumnName)
+          .withMaterializedRowIdColumn(columnName, lit(1L))
+          .write
+          .format("delta")
+          .mode("append")
+          .saveAsTable(testTableName)
+      }
+      checkError(
+        error,
+        errorClass = "UNRESOLVED_COLUMN.WITH_SUGGESTION",
+        parameters = error.messageParameters)
+    }
+
+    for (columnName <- columnNames) {
+      // Throw an error because only using the materialized column name is valid.
+      val error = intercept[AnalysisException] {
+        spark
+          .range(end = 1)
+          .toDF(testDataColumnName)
+          .withMaterializedRowCommitVersionColumn(columnName, lit(2L))
+          .write
+          .format("delta")
+          .mode("append")
+          .saveAsTable(testTableName)
+      }
+      checkError(
+        error,
+        errorClass = "UNRESOLVED_COLUMN.WITH_SUGGESTION",
+        parameters = error.messageParameters)
+    }
+  }
+
+  test("write and read with column names similar to row tracking columns in the table schema") {
+    val columnNames = Seq(
+      RowId.QUALIFIED_COLUMN_NAME,
+      RowCommitVersion.QUALIFIED_COLUMN_NAME)
+    for (columnName <- columnNames) {
+      withTable(testTableName) {
+        val numRows = 10L
+        writeWithMaterializedRowCommitVersionColumns(
+          spark.range(numRows).toDF(columnName),
+          rowIdColumn = lit(1L),
+          rowCommitVersionColumn = lit(2L))
+
+        withAllParquetReaders {
+          val df = spark.read.table(testTableName).select(
+            s"`$columnName`",
+            RowId.QUALIFIED_COLUMN_NAME,
+            RowCommitVersion.QUALIFIED_COLUMN_NAME)
+          val expectedAnswer = (0L until numRows).map(Row(_, 1L, 2L))
+          checkAnswer(df, expectedAnswer)
+        }
+      }
+    }
+  }
+
+  test("write and read with conflicting columns") {
+    withTable(testTableName) {
+      val tableSchema = new StructType()
+        .add("id", LongType)
+        .add(FileFormat.METADATA_NAME, new StructType()
+          .add(RowId.ROW_ID, LongType)
+          .add(RowCommitVersion.METADATA_STRUCT_FIELD_NAME, LongType))
+
+      writeWithMaterializedRowCommitVersionColumns(
+        spark.createDataFrame(
+          Seq(Row(1L, (11L, 111L)), Row(2L, (22L, 222L)), Row(3L, (33L, 333L))).asJava,
+          tableSchema),
+        rowIdColumn = lit(-1L),
+        rowCommitVersionColumn = lit(-2L))
+
+      withAllParquetReaders {
+        val table = spark.read.table(testTableName)
+        val metadataCol = table.metadataColumn(FileFormat.METADATA_NAME)
+        val userCol = table.col(FileFormat.METADATA_NAME)
+        val df = table.select(
+          col("id"),
+          metadataCol.getField(RowId.ROW_ID),
+          metadataCol.getField(RowCommitVersion.METADATA_STRUCT_FIELD_NAME),
+          userCol.getField(RowId.ROW_ID),
+          userCol.getField(RowCommitVersion.METADATA_STRUCT_FIELD_NAME))
+        val expectedAnswer =
+          Seq(Row(1, -1, -2, 11, 111), Row(2, -1, -2, 22, 222), Row(3, -1, -2, 33, 333))
+        checkAnswer(df, expectedAnswer)
+      }
+    }
+  }
+
+  private def writeWithMaterializedRowCommitVersionColumns(
+      df: DataFrame,
+      rowIdColumn: Column,
+      rowCommitVersionColumn: Column): Unit = {
+    withRowTrackingEnabled(enabled = true) {
+      // Create the table if it does not exist already.
+      df.limit(n = 0)
+        .write.format("delta").mode("append").saveAsTable(testTableName)
+
+      val deltaLog = DeltaLog.forTable(spark, TableIdentifier(testTableName))
+      val materializedRowIdColumnName =
+        extractMaterializedRowIdColumnName(deltaLog).get
+      val materializedRowCommitVersionName =
+        extractMaterializedRowCommitVersionColumnName(deltaLog).get
+
+      df.withMaterializedRowIdColumn(
+          materializedRowIdColumnName, rowIdColumn)
+        .withMaterializedRowCommitVersionColumn(
+          materializedRowCommitVersionName, rowCommitVersionColumn)
+        .write
+        .mode("append")
+        .format("delta")
+        .saveAsTable(testTableName)
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
1. Adding the `row_commit_version` field to the _metadata column for Delta tables, allowing us to read the `row_commit_version` from the file metadata after it is stored.
2. Adding Row Tracking preservation in Read/Write.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Added UTs.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
