### PR TITLE
[SPARK] Refactor DeltaHistoryManager to be able to take additional version arguments

### DIFF
--- a/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
+++ b/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
@@ -419,7 +419,9 @@ class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
     DescribeDeltaHistory(
       Option(ctx.path).map(string),
       Option(ctx.table).map(visitTableIdentifier),
-      Option(ctx.limit).map(_.getText.toInt))
+      Option(ctx.limit).map(_.getText.toInt),
+      None,
+      None)
   }
 
   override def visitGenerate(ctx: GenerateContext): LogicalPlan = withOrigin(ctx) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaCommitFileProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaCommitFileProvider.scala
@@ -49,9 +49,10 @@ case class DeltaCommitFileProvider(
 
   def deltaFile(version: Long): Path = {
     if (version > maxVersionInclusive) {
-      throw new IllegalStateException("Cannot resolve Delta table at version $version as the " +
-        "state is currently at version $maxVersion. The requested version may be incorrect or " +
-        "the state may be outdated. Please verify the requested version, update the state if " +
+      throw new IllegalStateException(s"Cannot resolve Delta table at version $version as the " +
+        s"state is currently at version $maxVersionInclusive. The requested" +
+        s" version may be incorrect or the state may be outdated." +
+        s" Please verify the requested version, update the state if " +
         "necessary, and try again")
     }
     uuids.get(version) match {


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
- Add additional arguments to DeltaHistoryManager for starting and ending version predicates.


## How was this patch tested?
- existing tests


## Does this PR introduce _any_ user-facing changes?
No
