### PR TITLE
Explicitly throw when sync iceberg conversion fails

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2226,6 +2226,12 @@
     ],
     "sqlState" : "XXKDS"
   },
+  "DELTA_UNIVERSAL_FORMAT_CONVERSION_FAILED" : {
+    "message" : [
+      "Failed to convert the table version <version> to the universal format <format>. <message>"
+    ],
+    "sqlState" : "KD00E"
+  },
   "DELTA_UNIVERSAL_FORMAT_VIOLATION" : {
     "message" : [
       "The validation of Universal Format (<format>) has failed: <violation>"

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3170,6 +3170,16 @@ trait DeltaErrorsBase
     )
   }
 
+  def universalFormatConversionFailedException(
+      failedOnCommitVersion: Long,
+      format: String,
+      errorMessage: String): Throwable = {
+    new DeltaRuntimeException(
+      errorClass = "DELTA_UNIVERSAL_FORMAT_CONVERSION_FAILED",
+      messageParameters = Array(s"$failedOnCommitVersion", format, errorMessage)
+    )
+  }
+
   def invalidAutoCompactType(value: String): Throwable = {
     new DeltaIllegalArgumentException(
       errorClass = "DELTA_INVALID_AUTO_COMPACT_TYPE",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/IcebergConverterHook.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/IcebergConverterHook.scala
@@ -16,10 +16,14 @@
 
 package org.apache.spark.sql.delta.hooks
 
+import scala.util.control.NonFatal
+
 import org.apache.spark.sql.delta.{OptimisticTransactionImpl, Snapshot, UniversalFormat}
+import org.apache.spark.sql.delta.DeltaErrors
 import org.apache.spark.sql.delta.actions.{Action, Metadata}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf.DELTA_UNIFORM_ICEBERG_SYNC_CONVERT_ENABLED
+import org.apache.commons.lang3.exception.ExceptionUtils
 
 import org.apache.spark.sql.SparkSession
 
@@ -47,9 +51,30 @@ object IcebergConverterHook extends PostCommitHook with DeltaLogging {
     val converter = postCommitSnapshot.deltaLog.icebergConverter
     if (spark.sessionState.conf.getConf(DELTA_UNIFORM_ICEBERG_SYNC_CONVERT_ENABLED) ||
          !UniversalFormat.icebergEnabled(txn.snapshot.metadata)) { // UniForm was not enabled
-      converter.convertSnapshot(postCommitSnapshot, txn)
+      try {
+        converter.convertSnapshot(postCommitSnapshot, txn)
+      } catch {
+        case NonFatal(e) =>
+          logError(s"Error when writing Iceberg metadata synchronously", e)
+          recordDeltaEvent(
+            txn.deltaLog,
+            "delta.iceberg.conversion.sync.error",
+            data = Map(
+              "exception" -> ExceptionUtils.getMessage(e),
+              "stackTrace" -> ExceptionUtils.getStackTrace(e)
+            )
+          )
+          throw e
+      }
     } else {
       converter.enqueueSnapshotForConversion(postCommitSnapshot, txn)
     }
+  }
+
+  // Always throw when sync Iceberg conversion fails. Async conversion exception
+  // is handled in the async thread.
+  override def handleError(spark: SparkSession, error: Throwable, version: Long): Unit = {
+    throw DeltaErrors.universalFormatConversionFailedException(
+      version, "iceberg", ExceptionUtils.getMessage(error))
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

sync iceberg conversion happens when enabled with session config, or uniform iceberg is turned on for the first time. This explicitly throws when sync iceberg conversion fails so user knows conversion status.

## How was this patch tested?

UT
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
