### PR TITLE
[Spark] Extend various Delta Suites to Managed Commits

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
@@ -581,7 +581,7 @@ class CheckpointsSuite
 
       // Delete the commit files 0-9, so that we are forced to read the checkpoint file
       val logPath = new Path(new File(target, "_delta_log").getAbsolutePath)
-      for (i <- 0 to 10) {
+      for (i <- 0 to 9) {
         val file = new File(FileNames.unsafeDeltaFile(logPath, version = i).toString)
         file.delete()
       }
@@ -818,6 +818,7 @@ class CheckpointsSuite
   private def writeAllActionsInV2Manifest(
       snapshot: Snapshot,
       v2CheckpointFormat: V2Checkpoint.Format): Path = {
+    snapshot.ensureCommitFilesBackfilled()
     val checkpointMetadata = CheckpointMetadata(version = snapshot.version)
     val actionsDS = snapshot.stateDS
       .where("checkpointMetadata is null and " +
@@ -1062,15 +1063,15 @@ class FakeGCSFileSystemValidatingCommits extends FakeGCSFileSystemValidatingChec
   override protected def shouldValidateFilePattern(f: Path): Boolean = f.getName.contains(".json")
 }
 
-class ManagedCommitBatch1BackFillCheckpointsSuite extends CheckpointsSuite {
+class CheckpointsWithManagedCommitBatch1Suite extends CheckpointsSuite {
   override val managedCommitBackfillBatchSize: Option[Int] = Some(1)
 }
 
-class ManagedCommitBatch2BackFillCheckpointsSuite extends CheckpointsSuite {
+class CheckpointsWithManagedCommitBatch2Suite extends CheckpointsSuite {
   override val managedCommitBackfillBatchSize: Option[Int] = Some(2)
 }
 
-class ManagedCommitBatch20BackFillCheckpointsSuite extends CheckpointsSuite {
-  override val managedCommitBackfillBatchSize: Option[Int] = Some(20)
+class CheckpointsWithManagedCommitBatch100Suite extends CheckpointsSuite {
+  override val managedCommitBackfillBatchSize: Option[Int] = Some(100)
 }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogMinorCompactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogMinorCompactionSuite.scala
@@ -440,15 +440,15 @@ class DeltaLogMinorCompactionSuite extends QueryTest
   }
 }
 
-class ManagedCommitBatchBackfill1DeltaLogMinorCompactionSuite extends DeltaLogMinorCompactionSuite {
+class DeltaLogMinorCompactionWithManagedCommitBatch1Suite extends DeltaLogMinorCompactionSuite {
   override val managedCommitBackfillBatchSize: Option[Int] = Some(1)
 }
 
-class ManagedCommitBatchBackFill2DeltaLogMinorCompactionSuite extends DeltaLogMinorCompactionSuite {
+class DeltaLogMinorCompactionWithManagedCommitBatch2Suite extends DeltaLogMinorCompactionSuite {
   override val managedCommitBackfillBatchSize: Option[Int] = Some(2)
 }
 
-class ManagedCommitBatchBackFill20DeltaLogMinorCompactionSuite
+class DeltaLogMinorCompactionWithManagedCommitBatch100Suite
     extends DeltaLogMinorCompactionSuite {
-  override val managedCommitBackfillBatchSize: Option[Int] = Some(20)
+  override val managedCommitBackfillBatchSize: Option[Int] = Some(100)
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
@@ -795,6 +795,6 @@ class DeltaTimeTravelSuite extends QueryTest
   }
 }
 
-class ManagedCommitFill1DeltaTimeTravelSuite extends DeltaTimeTravelSuite {
+class DeltaTimeTravelWithManagedCommitBatch1Suite extends DeltaTimeTravelSuite {
   override def managedCommitBackfillBatchSize: Option[Int] = Some(1)
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.delta.storage.LogStore.logStoreClassConfKey
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
-import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
+import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, FileNames, JsonUtils}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.FileStatus
 import org.apache.hadoop.fs.Path
@@ -45,7 +45,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.storage.StorageLevel
 
 class SnapshotManagementSuite extends QueryTest with DeltaSQLTestUtils with SharedSparkSession
-  with DeltaSQLCommandTest {
+  with DeltaSQLCommandTest with ManagedCommitBaseSuite {
 
 
   /**
@@ -304,6 +304,12 @@ class SnapshotManagementSuite extends QueryTest with DeltaSQLTestUtils with Shar
       // Delete delta files
       new File(tempDir, "_delta_log").listFiles().filter(_.getName.endsWith(".json"))
         .foreach(_.delete())
+      if (managedCommitsEnabledInTests) {
+        new File(new File(tempDir, "_delta_log"), "_commits")
+          .listFiles()
+          .filter(_.getName.endsWith(".json"))
+          .foreach(_.delete())
+      }
       makeCorruptCheckpointFile(path, checkpointVersion = 0, shouldBeEmpty = false)
       val e = intercept[IllegalStateException] {
         staleLog.update()
@@ -459,10 +465,34 @@ class SnapshotManagementSuite extends QueryTest with DeltaSQLTestUtils with Shar
       val oldLogSegment = log.snapshot.logSegment
       spark.range(10).write.format("delta").save(path)
       val newLogSegment = log.snapshot.logSegment
-      assert(log.getLogSegmentAfterCommit(None, oldLogSegment.checkpointProvider) === newLogSegment)
+      assert(log.getLogSegmentAfterCommit(
+        log.snapshot.tableCommitOwnerClientOpt,
+        oldLogSegment.checkpointProvider) === newLogSegment)
       spark.range(10).write.format("delta").mode("append").save(path)
-      assert(log.getLogSegmentAfterCommit(None, oldLogSegment.checkpointProvider)
-        === log.snapshot.logSegment)
+      val fs = log.logPath.getFileSystem(log.newDeltaHadoopConf())
+      val commitFileProvider = DeltaCommitFileProvider(log.snapshot)
+      intercept[IllegalArgumentException] {
+        val commitFile = fs.getFileStatus(commitFileProvider.deltaFile(1))
+        val commit = Commit(
+          version = 1,
+          fileStatus = commitFile,
+          commitTimestamp = 0)
+        // Version exists, but not contiguous with old logSegment
+        log.getLogSegmentAfterCommit(1, None, oldLogSegment, commit, None, EmptyCheckpointProvider)
+      }
+      intercept[IllegalArgumentException] {
+        val commitFile = fs.getFileStatus(commitFileProvider.deltaFile(0))
+        val commit = Commit(
+          version = 0,
+          fileStatus = commitFile,
+          commitTimestamp = 0)
+
+        // Version exists, but newLogSegment already contains it
+        log.getLogSegmentAfterCommit(0, None, newLogSegment, commit, None, EmptyCheckpointProvider)
+      }
+      assert(log.getLogSegmentAfterCommit(
+        log.snapshot.tableCommitOwnerClientOpt,
+        oldLogSegment.checkpointProvider) === log.snapshot.logSegment)
     }
   }
 
@@ -486,6 +516,18 @@ class SnapshotManagementSuite extends QueryTest with DeltaSQLTestUtils with Shar
       spark.read.format("delta").load(path).collect()
     }
   }
+}
+
+class SnapshotManagementWithManagedCommitBatch1Suite extends SnapshotManagementSuite {
+  override def managedCommitBackfillBatchSize: Option[Int] = Some(1)
+}
+
+class SnapshotManagementWithManagedCommitBatch2Suite extends SnapshotManagementSuite {
+  override def managedCommitBackfillBatchSize: Option[Int] = Some(2)
+}
+
+class SnapshotManagementWithManagedCommitBatch100Suite extends SnapshotManagementSuite {
+  override def managedCommitBackfillBatchSize: Option[Int] = Some(100)
 }
 
 class CountDownLatchLogStore(sparkConf: SparkConf, hadoopConf: Configuration)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitTestUtils.scala
@@ -79,12 +79,13 @@ trait ManagedCommitTestUtils
     test(s"$testName [Backfill batch size: None]") {
       f(None)
     }
-    val managedCommitOwnerConf = Map("randomConf" -> "randomConfValue")
-    val managedCommitOwnerJson = JsonUtils.toJson(managedCommitOwnerConf)
-    withSQLConf(
-        DeltaConfigs.MANAGED_COMMIT_OWNER_NAME.defaultTablePropertyKey -> "in-memory",
-        DeltaConfigs.MANAGED_COMMIT_OWNER_CONF.defaultTablePropertyKey -> managedCommitOwnerJson) {
-      testWithDifferentBackfillInterval(testName) { backfillBatchSize =>
+    testWithDifferentBackfillInterval(testName) { backfillBatchSize =>
+      val managedCommitOwnerConf = Map("randomConf" -> "randomConfValue")
+      val managedCommitOwnerJson = JsonUtils.toJson(managedCommitOwnerConf)
+      withSQLConf(
+          DeltaConfigs.MANAGED_COMMIT_OWNER_NAME.defaultTablePropertyKey -> "tracking-in-memory",
+          DeltaConfigs.MANAGED_COMMIT_OWNER_CONF.defaultTablePropertyKey ->
+            managedCommitOwnerJson) {
         f(Some(backfillBatchSize))
       }
     }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Extend various Delta suites to use Managed Commits.

Bug fix: During listing delta-files, Filter initial list to exclude files with versions beyond initialListingMaxDeltaVersionSeen to prevent duplicating non-delta files with higher versions in the combined list

## How was this patch tested?

UTs

## Does this PR introduce _any_ user-facing changes?

No
