### PR TITLE
[Spark] Register API with managed-commits

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -74,7 +74,7 @@ private[delta] case class CurrentTransactionInfo(
     case m: Metadata => newMetadata = Some(m)
     case _ => // do nothing
   }
-  def getUpdateActions(
+  def getUpdatedActions(
       oldMetadata: Metadata,
       oldProtocol: Protocol): UpdatedActions = {
     UpdatedActions(commitInfo.get, metadata, protocol, oldMetadata, oldProtocol)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -68,15 +68,17 @@ private[delta] case class CurrentTransactionInfo(
    */
   lazy val finalActionsToCommit: Seq[Action] = commitInfo ++: actions
 
-  var newMetadata: Option[Metadata] = None
-  var newProtocol: Option[Protocol] = None
+  private var newMetadata: Option[Metadata] = None
 
   actions.foreach {
     case m: Metadata => newMetadata = Some(m)
-    case p: Protocol => newProtocol = Some(p)
     case _ => // do nothing
   }
-  def getUpdateActions(): UpdatedActions = UpdatedActions(commitInfo.get, newMetadata, newProtocol)
+  def getUpdateActions(
+      oldMetadata: Metadata,
+      oldProtocol: Protocol): UpdatedActions = {
+    UpdatedActions(commitInfo.get, metadata, protocol, oldMetadata, oldProtocol)
+  }
 
   /** Whether this transaction wants to make any [[Metadata]] update */
   lazy val metadataChanged: Boolean = newMetadata.nonEmpty

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -754,6 +754,14 @@ trait DeltaConfigsBase extends DeltaLogging {
     _ => true,
     "A string-to-string map of configuration properties for the managed commit owner.")
 
+  val MANAGED_COMMIT_TABLE_CONF = buildConfig[Map[String, String]](
+    "managedCommits.tableConf-dev",
+    null,
+    v => JsonUtils.fromJson[Map[String, String]](Option(v).getOrElse("{}")),
+    _ => true,
+    "A string-to-string map of configuration properties for describing the table to" +
+      " managed commit owner.")
+
   val IN_COMMIT_TIMESTAMPS_ENABLED = buildConfig[Boolean](
     "enableInCommitTimestamps-dev",
     false.toString,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -35,13 +35,13 @@ import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.files._
 import org.apache.spark.sql.delta.hooks.{CheckpointHook, GenerateSymlinkManifest, HudiConverterHook, IcebergConverterHook, PostCommitHook, UpdateCatalogFactory}
 import org.apache.spark.sql.delta.implicits.addFileEncoder
-import org.apache.spark.sql.delta.managedcommit.{Commit, CommitFailedException, CommitResponse, CommitStore, GetCommitsResponse, UpdatedActions}
+import org.apache.spark.sql.delta.managedcommit._
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.{SchemaMergingUtils, SchemaUtils}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats._
 import org.apache.spark.sql.delta.storage.LogStore
-import org.apache.spark.sql.delta.util.DeltaCommitFileProvider
+import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, JsonUtils}
 import org.apache.spark.sql.util.ScalaExtensions._
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
@@ -378,7 +378,8 @@ trait OptimisticTransactionImpl extends TransactionalWrite
 
   // The commit store of a table shouldn't change. If it is changed by a concurrent commit, then it
   // will be detected as a conflict and the transaction will anyway fail.
-  private[delta] val preCommitCommitStoreOpt: Option[CommitStore] = snapshot.commitStoreOpt
+  private[delta] val readSnapshotTableCommitStoreOpt: Option[TableCommitStore] =
+    snapshot.tableCommitStoreOpt
 
   /**
    * Generates a timestamp which is greater than the commit timestamp
@@ -1123,36 +1124,33 @@ trait OptimisticTransactionImpl extends TransactionalWrite
         tags = if (tags.nonEmpty) Some(tags) else None,
         txnId = Some(txnId))
 
-      // Validate that the [[DeltaConfigs.MANAGED_COMMIT_PROVIDER_CONF]] is json parse-able.
-      DeltaConfigs.MANAGED_COMMIT_OWNER_CONF.fromMetaData(metadata)
-
       val firstAttemptVersion = getFirstAttemptVersion
-      val updatedMetadataOpt = commitInfo.inCommitTimestamp.flatMap { inCommitTimestamp =>
-        InCommitTimestampUtils.getUpdatedMetadataWithICTEnablementInfo(
-          inCommitTimestamp,
-          snapshot,
-          metadata,
-          firstAttemptVersion)
+      val updatedActions = if (newMetadata.nonEmpty) {
+        val metadataUpdatedWithManagedCommitInfo = updateMetadataWithManagedCommitConfs()
+        val metadataUpdatedWithIctInfo = updateMetadataWithInCommitTimestamp(commitInfo)
+
+        val updatedActions =
+          if (metadataUpdatedWithIctInfo || metadataUpdatedWithManagedCommitInfo) {
+            preparedActions.map {
+              case _: Metadata => metadata
+              case other => other
+            }
+          } else preparedActions
+        updatedActions
+      } else {
+        preparedActions
       }
-      val updatedActions = updatedMetadataOpt.map { updatedMetadata =>
-          preparedActions.map {
-            case _: Metadata => updatedMetadata
-            case other => other
-          }
-        }
-        .getOrElse(preparedActions)
-      val updatedMetadata = updatedMetadataOpt.getOrElse(metadata)
       val currentTransactionInfo = CurrentTransactionInfo(
         txnId = txnId,
         readPredicates = readPredicates.toSeq,
         readFiles = readFiles.toSet,
         readWholeTable = readTheWholeTable,
         readAppIds = readTxn.toSet,
-        metadata = updatedMetadata,
+        metadata = metadata,
         protocol = protocol,
         actions = updatedActions,
         readSnapshot = snapshot,
-        commitInfo = Option(commitInfo),
+        commitInfo = Some(commitInfo),
         readRowIdHighWatermark = readRowIdHighWatermark,
         domainMetadata = domainMetadata)
 
@@ -1174,8 +1172,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       executionObserver.beginDoCommit()
 
       val (commitVersion, postCommitSnapshot, updatedCurrentTransactionInfo) =
-        doCommitRetryIteratively(
-          firstAttemptVersion, currentTransactionInfo, isolationLevelToUse)
+        doCommitRetryIteratively(firstAttemptVersion, currentTransactionInfo, isolationLevelToUse)
       logInfo(s"Committed delta #$commitVersion to ${deltaLog.logPath}")
       (commitVersion, postCommitSnapshot, updatedCurrentTransactionInfo.actions)
     } catch {
@@ -1195,6 +1192,71 @@ trait OptimisticTransactionImpl extends TransactionalWrite
     executionObserver.transactionCommitted()
     Some(version)
   }
+
+  /**
+   * This method makes the necessary changes to Metadata based on ICT: If ICT is getting enabled as
+   * part of this commit, then it updates the Metadata with the ICT enablement information.
+   *
+   * @param commitInfo commitInfo for the commit
+   * @return true if changes were made to Metadata else false.
+   */
+  protected def updateMetadataWithInCommitTimestamp(commitInfo: CommitInfo): Boolean = {
+    val firstAttemptVersion = getFirstAttemptVersion
+    commitInfo.inCommitTimestamp.foreach { inCommitTimestamp =>
+      InCommitTimestampUtils.getUpdatedMetadataWithICTEnablementInfo(
+        inCommitTimestamp,
+        snapshot,
+        metadata,
+        firstAttemptVersion).map { metadataWithIctInfo =>
+          newMetadata = Some(metadataWithIctInfo)
+          return true
+        }
+    }
+    return false
+  }
+
+  /**
+   * This method makes the necessary changes to Metadata based on managed-commit: If the table is
+   * being converted from file-system to managed commits, then it registers the table with the
+   * CommitStore and updates the Metadata with the necessary configuration information from the
+   * CommitStore.
+   *
+   * @return A boolean which represents whether we have updated the table Metadata with
+   *         managed-commit information. If no changed were made, returns false.
+   */
+  protected def updateMetadataWithManagedCommitConfs(): Boolean = {
+    validateManagedCommitConfInMetadata(newMetadata)
+    val newManagedCommitTableConfOpt = {
+      val finalMetadata = metadata
+      val finalProtocol = protocol
+      registerTableForManagedCommitsIfNeeded(finalMetadata, finalProtocol)
+    }
+    val newManagedCommitTableConf = newManagedCommitTableConfOpt.getOrElse {
+      return false
+    }
+
+    // FS to MC conversion
+    val finalMetadata = metadata
+    val managedCommitTableConfJson = JsonUtils.toJson(newManagedCommitTableConf)
+    val extraKVConf = DeltaConfigs.MANAGED_COMMIT_TABLE_CONF.key -> managedCommitTableConfJson
+    newMetadata = Some(finalMetadata.copy(
+      configuration = finalMetadata.configuration + extraKVConf))
+    true
+  }
+
+  protected def validateManagedCommitConfInMetadata(newMetadataOpt: Option[Metadata]): Unit = {
+    // Validate that the [[DeltaConfigs.MANAGED_COMMIT_OWNER_CONF]] is json parse-able.
+    // Also do this validation if this table property has changed.
+    newMetadataOpt
+      .filter { newMetadata =>
+        val newManagedCommitConf =
+          newMetadata.configuration.get(DeltaConfigs.MANAGED_COMMIT_OWNER_CONF.key)
+        val oldManagedCommitConf =
+          snapshot.metadata.configuration.get(DeltaConfigs.MANAGED_COMMIT_OWNER_CONF.key)
+        newManagedCommitConf != oldManagedCommitConf
+      }.foreach(DeltaConfigs.MANAGED_COMMIT_OWNER_CONF.fromMetaData)
+  }
+
 
   /** Whether to skip recording the commit in DeltaLog */
   protected def skipRecordingEmptyCommitAllowed(isolationLevelToUse: IsolationLevel): Boolean = {
@@ -1277,15 +1339,12 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       // Initialize everything needed to maintain auto-compaction stats.
       partitionsAddedToOpt = Some(new mutable.HashSet[Map[String, String]])
       val acStatsCollector = createAutoCompactStatsCollector()
-      val updatedMetadataOpt = commitInfo.inCommitTimestamp.flatMap { inCommitTimestamp =>
-          InCommitTimestampUtils.getUpdatedMetadataWithICTEnablementInfo(
-            inCommitTimestamp,
-            snapshot,
-            metadata,
-            attemptVersion)
-        }
+      val finalProtocol = newProtocolOpt.getOrElse(protocol)
+      updateMetadataWithManagedCommitConfs()
+      updateMetadataWithInCommitTimestamp(commitInfo)
+
       var allActions =
-        Seq(commitInfo, updatedMetadataOpt.getOrElse(metadata)).toIterator ++
+        Iterator(commitInfo, metadata) ++
           nonProtocolMetadataActions ++
           newProtocolOpt.toIterator
       allActions = allActions.map { action =>
@@ -1338,14 +1397,13 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       val fsWriteStartNano = System.nanoTime()
       val jsonActions = allActions.map(_.json)
       val hadoopConf = deltaLog.newDeltaHadoopConf()
-      val commitStore = preCommitCommitStoreOpt.getOrElse(new FileSystemBasedCommitStore(deltaLog))
-      val commitResponse = commitStore.commit(
-        deltaLog.store,
-        hadoopConf,
-        deltaLog.logPath,
-        attemptVersion,
-        jsonActions,
-        UpdatedActions(commitInfo, newMetadata, newProtocolOpt))
+      val effectiveCommitStore = readSnapshotTableCommitStoreOpt.getOrElse {
+        val fileSystemCommitStore = new FileSystemBasedCommitStore(deltaLog)
+        TableCommitStore(fileSystemCommitStore, deltaLog, snapshot.metadata.managedCommitTableConf)
+      }
+      val updatedActions = UpdatedActions(
+        commitInfo, metadata, finalProtocol, snapshot.metadata, snapshot.protocol)
+      val commitResponse = effectiveCommitStore.commit(attemptVersion, jsonActions, updatedActions)
       // TODO(managed-commits): Use the right timestamp method on top of CommitInfo once ICT is
       //  merged.
       // If the metadata didn't change, `newMetadata` is empty, and we can re-use the old id.
@@ -1417,6 +1475,57 @@ trait OptimisticTransactionImpl extends TransactionalWrite
             throw e
         }
     }
+  }
+
+  /**
+   * This method registers the table with the CommitStore if the table is transitioning from
+   * file-system based table to managed-commit table.
+   * @param finalMetadata the effective [[Metadata]] of the table. Note that this refers to the
+   *                      new metadata if this commit is updating the table Metadata.
+   * @param finalProtocol the effective [[Protocol]] of the table. Note that this refers to the
+   *                      new protocol if this commit is updating the table Protocol.
+   * @return The new managed-commit table metadata if the table is transitioning from file-system
+   *         based table to managed-commit table. Otherwise, None.
+   *         This metadata should be added to the [[Metadata.configuration]] before doing the
+   *         commit.
+   */
+  protected def registerTableForManagedCommitsIfNeeded(
+      finalMetadata: Metadata,
+      finalProtocol: Protocol): Option[Map[String, String]] = {
+    val (oldOwnerName, oldOwnerConf) = CommitOwner.getManagedCommitConfs(snapshot.metadata)
+    var newManagedCommitTableConf: Option[Map[String, String]] = None
+    if (finalMetadata.configuration != snapshot.metadata.configuration || snapshot.version == -1L) {
+      val newCommitStoreOpt = CommitStoreProvider.getCommitStore(finalMetadata, finalProtocol)
+      (newCommitStoreOpt, readSnapshotTableCommitStoreOpt) match {
+        case (Some(newCommitStore), None) =>
+          // FS -> MC conversion
+          val (commitOwnerName, commitOwnerConf) = CommitOwner.getManagedCommitConfs(finalMetadata)
+          logInfo(s"Table ${deltaLog.logPath} transitioning from file-system based table to " +
+            s"managed-commit table: [commit owner: $commitOwnerName, conf: $commitOwnerConf]")
+          newManagedCommitTableConf = Some(
+            newCommitStore.registerTable(deltaLog.logPath, readVersion, finalMetadata, protocol))
+        case (None, Some(readCommitStore)) =>
+          // MC -> FS conversion
+          val (newOwnerName, newOwnerConf) = CommitOwner.getManagedCommitConfs(snapshot.metadata)
+          logInfo(s"Table ${deltaLog.logPath} transitioning from managed-commit table to " +
+            s"file-system table: [commit owner: $newOwnerName, conf: $newOwnerConf]")
+        case (Some(newCommitStore), Some(readCommitStore))
+            if !readCommitStore.semanticsEquals(newCommitStore) =>
+          // MC1 -> MC2 conversion is not allowed.
+          // In order to transfer the table from one commit-owner to another, transfer the table
+          // from current commit-owner to filesystem first and then filesystem to the commit-owner.
+          val (newOwnerName, newOwnerConf) = CommitOwner.getManagedCommitConfs(finalMetadata)
+          val message = s"Transition of table ${deltaLog.logPath} from one commit-owner to" +
+            s" another commit-owner is not allowed: [old commit owner: $oldOwnerName," +
+            s" new commit owner: $newOwnerName, old commit owner conf: $oldOwnerConf," +
+            s" new commit owner conf: $newOwnerConf]."
+          throw new IllegalStateException(message)
+        case _ =>
+          // no owner change
+          ()
+      }
+    }
+    newManagedCommitTableConf
   }
 
   /** Update the table now that the commit has been made, and write a checkpoint. */
@@ -1737,6 +1846,8 @@ trait OptimisticTransactionImpl extends TransactionalWrite
 
     var commitVersion = attemptVersion
     var updatedCurrentTransactionInfo = currentTransactionInfo
+    val isFsToMcCommit =
+      snapshot.metadata.managedCommitOwnerName.isEmpty && metadata.managedCommitOwnerName.nonEmpty
     val maxRetryAttempts = spark.conf.get(DeltaSQLConf.DELTA_MAX_RETRY_COMMIT_ATTEMPTS)
     val maxNonConflictRetryAttempts =
       spark.conf.get(DeltaSQLConf.DELTA_MAX_NON_CONFLICT_RETRY_COMMIT_ATTEMPTS)
@@ -1757,7 +1868,11 @@ trait OptimisticTransactionImpl extends TransactionalWrite
           committed = true
           return (commitVersion, postCommitSnapshot, updatedCurrentTransactionInfo)
         } catch {
-          case _: FileAlreadyExistsException if preCommitCommitStoreOpt.isEmpty =>
+          case _: FileAlreadyExistsException if isFsToMcCommit =>
+            // Don't retry if this commit tries to upgrade the table from filesystem to managed
+            // commits and the first attempt failed due to a conflict.
+            throw DeltaErrors.concurrentWriteException(conflictingCommit = None)
+          case _: FileAlreadyExistsException if readSnapshotTableCommitStoreOpt.isEmpty =>
             // For filesystem based tables, we use LogStore to do the commit. On a conflict,
             // LogStore returns FileAlreadyExistsException necessitating conflict resolution.
             // For commit-stores, FileAlreadyExistsException isn't expected under normal operations
@@ -1922,6 +2037,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
         logStore: LogStore,
         hadoopConf: Configuration,
         logPath: Path,
+        managedCommitTableConf: Map[String, String],
         commitVersion: Long,
         actions: Iterator[String],
         updatedActions: UpdatedActions): CommitResponse = {
@@ -1948,13 +2064,17 @@ trait OptimisticTransactionImpl extends TransactionalWrite
     }
 
     override def getCommits(
-        logPath: Path, startVersion: Long, endVersion: Option[Long]): GetCommitsResponse =
+        logPath: Path,
+        managedCommitTableConf: Map[String, String],
+        startVersion: Long,
+        endVersion: Option[Long]): GetCommitsResponse =
       GetCommitsResponse(Seq.empty, -1)
 
     override def backfillToVersion(
         logStore: LogStore,
         hadoopConf: Configuration,
         logPath: Path,
+        managedCommitTableConf: Map[String, String],
         startVersion: Long,
         endVersion: Option[Long]): Unit = {}
 
@@ -1980,7 +2100,10 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       jsonActions: Iterator[String],
       currentTransactionInfo: CurrentTransactionInfo)
       : (Option[VersionChecksum], Commit) = {
-    val commitStore = preCommitCommitStoreOpt.getOrElse(new FileSystemBasedCommitStore(deltaLog))
+    val commitStore = readSnapshotTableCommitStoreOpt.getOrElse {
+      val fileSystemCommitStore = new FileSystemBasedCommitStore(deltaLog)
+      TableCommitStore(fileSystemCommitStore, deltaLog, snapshot.metadata.managedCommitTableConf)
+    }
     val commitFile =
       writeCommitFileImpl(attemptVersion, jsonActions, commitStore, currentTransactionInfo)
     (None, commitFile)
@@ -1989,16 +2112,12 @@ trait OptimisticTransactionImpl extends TransactionalWrite
   protected def writeCommitFileImpl(
     attemptVersion: Long,
     jsonActions: Iterator[String],
-    commitStore: CommitStore,
+    tableCommitStore: TableCommitStore,
     currentTransactionInfo: CurrentTransactionInfo
   ): Commit = {
-    val commitResponse = commitStore.commit(
-      deltaLog.store,
-      deltaLog.newDeltaHadoopConf(),
-      deltaLog.logPath,
-      attemptVersion,
-      jsonActions,
-      currentTransactionInfo.getUpdateActions())
+    val updatedActions =
+      currentTransactionInfo.getUpdateActions(snapshot.metadata, snapshot.protocol)
+    val commitResponse = tableCommitStore.commit(attemptVersion, jsonActions, updatedActions)
     // TODO(managed-commits): Use the right timestamp method on top of CommitInfo once ICT is
     //  merged.
     val commitTimestamp = commitResponse.commit.fileStatus.getModificationTime
@@ -2096,7 +2215,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
   protected def getConflictingVersions(previousAttemptVersion: Long): Seq[FileStatus] = {
     assert(previousAttemptVersion == preCommitLogSegment.version + 1)
     val (newPreCommitLogSegment, newCommitFileStatuses) =
-      deltaLog.getUpdatedLogSegment(preCommitLogSegment, preCommitCommitStoreOpt)
+      deltaLog.getUpdatedLogSegment(preCommitLogSegment, readSnapshotTableCommitStoreOpt)
     assert(preCommitLogSegment.version + newCommitFileStatuses.size ==
       newPreCommitLogSegment.version)
     preCommitLogSegment = newPreCommitLogSegment

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -1030,8 +1030,26 @@ case class Metadata(
    * can be used to create partition filters from data filters of these non-partition columns.
    */
   @JsonIgnore
-  lazy val optimizablePartitionExpressions: Map[String, Seq[OptimizablePartitionExpression]]
-  = GeneratedColumn.getOptimizablePartitionExpressions(schema, partitionSchema)
+  lazy val optimizablePartitionExpressions: Map[String, Seq[OptimizablePartitionExpression]] =
+    GeneratedColumn.getOptimizablePartitionExpressions(schema, partitionSchema)
+
+  /**
+   * The name of commit-owner which arbitrates the commits to the table. This must be available
+   * if this is a managed-commit table.
+   */
+  @JsonIgnore
+  lazy val managedCommitOwnerName: Option[String] =
+    DeltaConfigs.MANAGED_COMMIT_OWNER_NAME.fromMetaData(this)
+
+  /** The configuration to uniquely identify the commit-owner for managed-commit. */
+  @JsonIgnore
+  lazy val managedCommitOwnerConf: Map[String, String] =
+    DeltaConfigs.MANAGED_COMMIT_OWNER_CONF.fromMetaData(this)
+
+  /** The table specific configuration for managed-commit. */
+  @JsonIgnore
+  lazy val managedCommitTableConf: Map[String, String] =
+    DeltaConfigs.MANAGED_COMMIT_TABLE_CONF.fromMetaData(this)
 
   override def wrap: SingleAction = SingleAction(metaData = this)
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/InMemoryCommitStore.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/InMemoryCommitStore.scala
@@ -21,13 +21,42 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
 
 import scala.collection.mutable
 
+import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
 import org.apache.spark.sql.delta.storage.LogStore
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 
 class InMemoryCommitStore(val batchSize: Long) extends AbstractBatchBackfillingCommitStore {
 
-  private[managedcommit] class PerTableData(var maxCommitVersion: Long = -1) {
+  /**
+   * @param maxCommitVersion represents the max commit version known for the table. This is
+   *                         initialized at the time of pre-registration and updated whenever a
+   *                         commit is successfully added to the commit store.
+   * @param active represents whether this commit-store has ratified any commit or not.
+   * |----------------------------|------------------|---------------------------|
+   * |        State               | maxCommitVersion |          active           |
+   * |----------------------------|------------------|---------------------------|
+   * | Table is pre-registered    | currentVersion+1 |          false            |
+   * |----------------------------|------------------|---------------------------|
+   * | Table is pre-registered    |       X          |          true             |
+   * | and more commits are done  |                  |                           |
+   * |----------------------------|------------------|---------------------------|
+   */
+  private[managedcommit] class PerTableData(
+    var maxCommitVersion: Long = -1,
+    var active: Boolean = false
+  ) {
+    def updateLastRatifiedCommit(commitVersion: Long): Unit = {
+      active = true
+      maxCommitVersion = commitVersion
+    }
+
+    /**
+     * Returns the last ratified commit version for the table. If no commits have been done from
+     * commit store yet, returns -1.
+     */
+    def lastRatifiedCommitVersion: Long = if (!active) -1 else maxCommitVersion
+
     // Map from version to Commit data
     val commitsMap: mutable.SortedMap[Long, Commit] = mutable.SortedMap.empty
     // We maintain maxCommitVersion explicitly since commitsMap might be empty
@@ -38,10 +67,10 @@ class InMemoryCommitStore(val batchSize: Long) extends AbstractBatchBackfillingC
   private[managedcommit] val perTableMap = new ConcurrentHashMap[Path, PerTableData]()
 
   private[managedcommit] def withWriteLock[T](logPath: Path)(operation: => T): T = {
-    val lock = perTableMap
-      .computeIfAbsent(logPath, _ => new PerTableData()) // computeIfAbsent is atomic
-      .lock
-      .writeLock()
+    val tableData = Option(perTableMap.get(logPath)).getOrElse {
+      throw new IllegalArgumentException(s"Unknown table $logPath.")
+    }
+    val lock = tableData.lock.writeLock()
     lock.lock()
     try {
       operation
@@ -51,10 +80,11 @@ class InMemoryCommitStore(val batchSize: Long) extends AbstractBatchBackfillingC
   }
 
   private[managedcommit] def withReadLock[T](logPath: Path)(operation: => T): T = {
-    val lock = perTableMap
-      .computeIfAbsent(logPath, _ => new PerTableData()) // computeIfAbsent is atomic
-      .lock
-      .readLock()
+    val tableData = perTableMap.get(logPath)
+    if (tableData == null) {
+      throw new IllegalArgumentException(s"Unknown table $logPath.")
+    }
+    val lock = tableData.lock.readLock()
     lock.lock()
     try {
       operation
@@ -74,6 +104,7 @@ class InMemoryCommitStore(val batchSize: Long) extends AbstractBatchBackfillingC
       logStore: LogStore,
       hadoopConf: Configuration,
       logPath: Path,
+      managedCommitTableConf: Map[String, String],
       commitVersion: Long,
       commitFile: FileStatus,
       commitTimestamp: Long): CommitResponse = {
@@ -89,7 +120,7 @@ class InMemoryCommitStore(val batchSize: Long) extends AbstractBatchBackfillingC
 
       val commit = Commit(commitVersion, commitFile, commitTimestamp)
       tableData.commitsMap(commitVersion) = commit
-      tableData.maxCommitVersion = commitVersion
+      tableData.updateLastRatifiedCommit(commitVersion)
 
       logInfo(s"Added commit file ${commitFile.getPath} to commit-store.")
       CommitResponse(commit)
@@ -98,6 +129,7 @@ class InMemoryCommitStore(val batchSize: Long) extends AbstractBatchBackfillingC
 
   override def getCommits(
       logPath: Path,
+      managedCommitTableConf: Map[String, String],
       startVersion: Long,
       endVersion: Option[Long]): GetCommitsResponse = {
     withReadLock[GetCommitsResponse](logPath) {
@@ -106,7 +138,7 @@ class InMemoryCommitStore(val batchSize: Long) extends AbstractBatchBackfillingC
       val effectiveEndVersion =
         endVersion.getOrElse(tableData.commitsMap.lastOption.map(_._1).getOrElse(startVersion))
       val commitsInRange = tableData.commitsMap.range(startVersion, effectiveEndVersion + 1)
-      GetCommitsResponse(commitsInRange.values.toSeq, tableData.maxCommitVersion)
+      GetCommitsResponse(commitsInRange.values.toSeq, tableData.lastRatifiedCommitVersion)
     }
   }
 
@@ -115,7 +147,7 @@ class InMemoryCommitStore(val batchSize: Long) extends AbstractBatchBackfillingC
       backfilledVersion: Long): Unit = {
     withWriteLock(logPath) {
       val tableData = perTableMap.get(logPath)
-      if (backfilledVersion > tableData.maxCommitVersion) {
+      if (backfilledVersion > tableData.lastRatifiedCommitVersion) {
         throw new IllegalArgumentException(
           s"Unexpected backfill version: $backfilledVersion. " +
             s"Max backfill version: ${tableData.maxCommitVersion}")
@@ -126,11 +158,28 @@ class InMemoryCommitStore(val batchSize: Long) extends AbstractBatchBackfillingC
     }
   }
 
-  def registerTable(logPath: Path, maxCommitVersion: Long): Unit = {
-    val newPerTableData = new PerTableData(maxCommitVersion)
-    if (perTableMap.putIfAbsent(logPath, newPerTableData) != null) {
-      throw new IllegalStateException(s"Table $logPath already exists in the commit store.")
-    }
+  override def registerTable(
+      logPath: Path,
+      currentVersion: Long,
+      currentMetadata: Metadata,
+      currentProtocol: Protocol): Map[String, String] = {
+    val newPerTableData = new PerTableData(currentVersion + 1)
+    perTableMap.compute(logPath, (_, existingData) => {
+      if (existingData != null) {
+        if (existingData.lastRatifiedCommitVersion != -1) {
+          throw new IllegalStateException(s"Table $logPath already exists in the commit store.")
+        }
+        // If lastRatifiedCommitVersion is -1 i.e. the commit store has never attempted any commit
+        // for this table => this table was just pre-registered. If there is another newer
+        // pre-registration request, we can take it else we should reject pre-registration request
+        // for older versions.
+        if (existingData.maxCommitVersion >= currentVersion) {
+          throw new IllegalStateException(s"Table $logPath already registered with commit store")
+        }
+      }
+      newPerTableData
+    })
+    Map.empty
   }
 
   override def semanticEquals(other: CommitStore): Boolean = this == other

--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/InMemoryCommitStore.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/InMemoryCommitStore.scala
@@ -170,10 +170,9 @@ class InMemoryCommitStore(val batchSize: Long) extends AbstractBatchBackfillingC
           throw new IllegalStateException(s"Table $logPath already exists in the commit store.")
         }
         // If lastRatifiedCommitVersion is -1 i.e. the commit store has never attempted any commit
-        // for this table => this table was just pre-registered. If there is another newer
-        // pre-registration request, we can take it else we should reject pre-registration request
-        // for older versions.
-        if (existingData.maxCommitVersion >= currentVersion) {
+        // for this table => this table was just pre-registered. If there is another
+        // pre-registration request for an older version, we reject it and table can't go backward.
+        if (currentVersion < existingData.maxCommitVersion) {
           throw new IllegalStateException(s"Table $logPath already registered with commit store")
         }
       }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/TableCommitStore.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/TableCommitStore.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.managedcommit
+
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.actions.Metadata
+import org.apache.spark.sql.delta.storage.LogStore
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+
+/**
+ * A wrapper around CommitStore that provides a more user-friendly API for committing/accessing
+ * commits to a specific table. This class takes care of passing the table specific configuration
+ * to the underlying CommitStore e.g. logPath / logStore / managedCommitTableConf / hadoopConf.
+ *
+ * @param commitStore the underlying [[CommitStore]]
+ * @param logPath the path to the log directory
+ * @param tableConf the table specific managed-commit configuration
+ * @param hadoopConf hadoop configuration
+ * @param logStore the log store
+ */
+case class TableCommitStore(
+    commitStore: CommitStore,
+    logPath: Path,
+    tableConf: Map[String, String],
+    hadoopConf: Configuration,
+    logStore: LogStore) {
+
+  def commit(
+      commitVersion: Long,
+      actions: Iterator[String],
+      updatedActions: UpdatedActions): CommitResponse = {
+    commitStore.commit(
+      logStore, hadoopConf, logPath, tableConf, commitVersion, actions, updatedActions)
+  }
+
+  def getCommits(
+      startVersion: Long,
+      endVersion: Option[Long] = None): GetCommitsResponse = {
+    commitStore.getCommits(logPath, tableConf, startVersion, endVersion)
+  }
+
+  def backfillToVersion(
+      startVersion: Long,
+      endVersion: Option[Long]): Unit = {
+    commitStore.backfillToVersion(
+      logStore, hadoopConf, logPath, tableConf, startVersion, endVersion)
+  }
+
+  /**
+   * Checks whether the signature of the underlying backing [[CommitStore]] is the same as the
+   * given `otherCommitStore`
+   */
+  def semanticsEquals(otherCommitStore: CommitStore): Boolean = {
+    CommitStore.semanticEquals(Some(commitStore), Some(otherCommitStore))
+  }
+
+  /**
+   * Checks whether the signature of the underlying backing [[CommitStore]] is the same as the
+   * given `otherCommitStore`
+   */
+  def semanticsEquals(otherTableCommitStore: TableCommitStore): Boolean = {
+    semanticsEquals(otherTableCommitStore.commitStore)
+  }
+}
+
+object TableCommitStore {
+    def apply(
+      commitStore: CommitStore,
+      deltaLog: DeltaLog,
+      managedCommitTableConf: Map[String, String]): TableCommitStore = {
+    val hadoopConf = deltaLog.newDeltaHadoopConf()
+    new TableCommitStore(
+      commitStore, deltaLog.logPath, managedCommitTableConf, hadoopConf, deltaLog.store)
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointsSuite.scala
@@ -84,7 +84,8 @@ class CheckpointsSuite
   }
 
   protected override def sparkConf = {
-    // Set the gs LogStore impl to `LocalLogStore` so that it will work with `FakeGCSFileSystem`.
+    // Set the gs LogStore impl to `LocalLogStore` so that it will work with
+    // `FakeGCSFileSystemValidatingCheckpoint`.
     // The default one is `HDFSLogStore` which requires a `FileContext` but we don't have one.
     super.sparkConf.set("spark.delta.logStore.gs.impl", classOf[LocalLogStore].getName)
   }
@@ -228,23 +229,22 @@ class CheckpointsSuite
     assert(!Checkpoints.isGCSPath(conf, new Path("/foo")))
     // Set the default file system and verify we can detect it
     conf.set("fs.defaultFS", "gs://foo/")
-    conf.set("fs.gs.impl", classOf[FakeGCSFileSystem].getName)
+    conf.set("fs.gs.impl", classOf[FakeGCSFileSystemValidatingCheckpoint].getName)
     conf.set("fs.gs.impl.disable.cache", "true")
     assert(Checkpoints.isGCSPath(conf, new Path("/foo")))
   }
 
   test("SC-86940: writing a GCS checkpoint should happen in a new thread") {
     withTempDir { tempDir =>
-      val path = tempDir.getCanonicalPath
-      spark.range(1).write.format("delta").save(path)
-
-      // Use `FakeGCSFileSystem` which will verify we write in a separate gcs thread.
+      // Use `FakeGCSFileSystemValidatingCheckpoint` which will verify we write in a separate gcs
+      // thread.
       withSQLConf(
-          "fs.gs.impl" -> classOf[FakeGCSFileSystem].getName,
+          "fs.gs.impl" -> classOf[FakeGCSFileSystemValidatingCheckpoint].getName,
           "fs.gs.impl.disable.cache" -> "true") {
+        val gsPath = s"gs://${tempDir.getCanonicalPath}"
+        spark.range(1).write.format("delta").save(gsPath)
         DeltaLog.clearCache()
-        val gsPath = new Path(s"gs://${tempDir.getCanonicalPath}")
-        val deltaLog = DeltaLog.forTable(spark, gsPath)
+        val deltaLog = DeltaLog.forTable(spark, new Path(gsPath))
         deltaLog.checkpoint()
       }
     }
@@ -1018,15 +1018,15 @@ class V2CheckpointManifestOverwriteSuite
   }
 }
 
-/**
- * A fake GCS file system to verify delta commits are written in a separate gcs thread.
- */
-class FakeGCSFileSystem extends RawLocalFileSystem {
+/** A fake GCS file system to verify delta checkpoints are written in a separate gcs thread. */
+class FakeGCSFileSystemValidatingCheckpoint extends RawLocalFileSystem {
   override def getScheme: String = "gs"
   override def getUri: URI = URI.create("gs:/")
 
-  private def assertGCSThread(f: Path): Unit = {
-    if (f.getName.contains(".json") || f.getName.contains(".checkpoint")) {
+  protected def shouldValidateFilePattern(f: Path): Boolean = f.getName.contains(".checkpoint")
+
+  protected def assertGCSThread(f: Path): Unit = {
+    if (shouldValidateFilePattern(f)) {
       assert(
         Thread.currentThread().getName.contains("delta-gcs-"),
         s"writing $f was happening in non gcs thread: ${Thread.currentThread()}")
@@ -1055,6 +1055,11 @@ class FakeGCSFileSystem extends RawLocalFileSystem {
     assertGCSThread(f)
     super.create(f, overwrite, bufferSize, replication, blockSize, progress)
   }
+}
+
+/** A fake GCS file system to verify delta commits are written in a separate gcs thread. */
+class FakeGCSFileSystemValidatingCommits extends FakeGCSFileSystemValidatingCheckpoint {
+  override protected def shouldValidateFilePattern(f: Path): Boolean = f.getName.contains(".json")
 }
 
 class ManagedCommitBatch1BackFillCheckpointsSuite extends CheckpointsSuite {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogMinorCompactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogMinorCompactionSuite.scala
@@ -42,13 +42,8 @@ class DeltaLogMinorCompactionSuite extends QueryTest
       startVersion: Long,
       endVersion: Long): Unit = {
     val deltaLog = DeltaLog.forTable(spark, tablePath)
-    deltaLog.update().commitStoreOpt.foreach { commitStore =>
-      commitStore.backfillToVersion(
-        deltaLog.store,
-        deltaLog.newDeltaHadoopConf(),
-        deltaLog.logPath,
-        startVersion = 0,
-        Some(endVersion))
+    deltaLog.update().tableCommitStoreOpt.foreach { commitStore =>
+      commitStore.backfillToVersion(startVersion = 0, Some(endVersion))
     }
     val logReplay = new InMemoryLogReplay(
       minFileRetentionTimestamp = 0,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/LogStoreSuite.scala
@@ -184,9 +184,9 @@ trait GCSLogStoreSuiteBase extends LogStoreSuiteBase {
 
   test("gcs write should happen in a new thread") {
     withTempDir { tempDir =>
-      // Use `FakeGCSFileSystem` to verify we write in the correct thread.
+      // Use `FakeGCSFileSystemValidatingCommits` to verify we write in the correct thread.
       withSQLConf(
-        "fs.gs.impl" -> classOf[FakeGCSFileSystem].getName,
+        "fs.gs.impl" -> classOf[FakeGCSFileSystemValidatingCommits].getName,
         "fs.gs.impl.disable.cache" -> "true") {
         val store = createLogStore(spark)
         store.write(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -465,15 +465,21 @@ class OptimisticTransactionSuite
 
       override def name: String = commitStoreName
 
-      override def build(conf: Map[String, String]): CommitStore = {
-        new CommitStore {
+      val commitStore: InMemoryCommitStore = {
+        new InMemoryCommitStore(batchSize = 1000L) {
           override def commit(
               logStore: LogStore,
               hadoopConf: Configuration,
               tablePath: Path,
+              tableConf: Map[String, String],
               commitVersion: Long,
               actions: Iterator[String],
               updatedActions: UpdatedActions): CommitResponse = {
+            // Fail all commits except first one
+            if (commitVersion == 0) {
+              return super.commit(
+                logStore, hadoopConf, tablePath, tableConf, commitVersion, actions, updatedActions)
+            }
             commitAttempts += 1
             throw CommitFailedException(
               retryable = true,
@@ -481,19 +487,9 @@ class OptimisticTransactionSuite
                 commitAttempts <= (initialNonConflictErrors + initialConflictErrors),
               message = "")
           }
-          override def getCommits(
-              tablePath: Path,
-              startVersion: Long,
-              endVersion: Option[Long]): GetCommitsResponse = GetCommitsResponse(Seq.empty, -1)
-          override def backfillToVersion(
-              logStore: LogStore,
-              hadoopConf: Configuration,
-              logPath: Path,
-              startVersion: Long,
-              endVersion: Option[Long]): Unit = {}
-          override def semanticEquals(other: CommitStore): Boolean = this == other
         }
       }
+      override def build(conf: Map[String, String]): CommitStore = commitStore
     }
 
     CommitStoreProvider.registerBuilder(RetryableNonConflictCommitStoreBuilder)
@@ -522,31 +518,27 @@ class OptimisticTransactionSuite
 
       override def name: String = commitStoreName
 
-      override def build(conf: Map[String, String]): CommitStore = {
-        new CommitStore {
+      lazy val commitStore: CommitStore = {
+        new InMemoryCommitStore(batchSize = 1000L) {
           override def commit(
               logStore: LogStore,
               hadoopConf: Configuration,
               tablePath: Path,
+              tableConf: Map[String, String],
               commitVersion: Long,
               actions: Iterator[String],
               updatedActions: UpdatedActions): CommitResponse = {
+            // Fail all commits except first one
+            if (commitVersion == 0) {
+              return super.commit(
+                logStore, hadoopConf, tablePath, tableConf, commitVersion, actions, updatedActions)
+            }
             commitAttempts += 1
             throw new FileAlreadyExistsException("Commit-File Already Exists")
           }
-          override def getCommits(
-              tablePath: Path,
-              startVersion: Long,
-              endVersion: Option[Long]): GetCommitsResponse = GetCommitsResponse(Seq.empty, -1)
-          override def backfillToVersion(
-              logStore: LogStore,
-              hadoopConf: Configuration,
-              logPath: Path,
-              startVersion: Long,
-              endVersion: Option[Long]): Unit = {}
-          override def semanticEquals(other: CommitStore): Boolean = this == other
         }
       }
+      override def build(conf: Map[String, String]): CommitStore = commitStore
     }
 
     CommitStoreProvider.registerBuilder(FileAlreadyExistsCommitStoreBuilder)
@@ -838,6 +830,7 @@ class OptimisticTransactionSuite
               logStore: LogStore,
               hadoopConf: Configuration,
               tablePath: Path,
+              tableConf: Map[String, String],
               commitVersion: Long,
               actions: Iterator[String],
               updatedActions: UpdatedActions): CommitResponse = {
@@ -845,7 +838,8 @@ class OptimisticTransactionSuite
               deltaLog.startTransaction().commit(addB :: Nil, ManualUpdate)
               throw CommitFailedException(retryable = true, conflict, message = "")
             }
-            super.commit(logStore, hadoopConf, tablePath, commitVersion, actions, updatedActions)
+            super.commit(
+              logStore, hadoopConf, tablePath, tableConf, commitVersion, actions, updatedActions)
           }
         }
         object RetryableConflictCommitStoreBuilder extends CommitStoreBuilder {
@@ -856,8 +850,6 @@ class OptimisticTransactionSuite
         CommitStoreProvider.registerBuilder(RetryableConflictCommitStoreBuilder)
         val conf = Map(DeltaConfigs.MANAGED_COMMIT_OWNER_NAME.key -> commitStoreName)
         deltaLog.startTransaction().commit(Seq(Metadata(configuration = conf)), ManualUpdate)
-        RetryableConflictCommitStoreBuilder.commitStore.registerTable(
-          logPath = deltaLog.logPath, maxCommitVersion = 0)
         deltaLog.startTransaction().commit(addA :: Nil, ManualUpdate)
         val records = Log4jUsageLogger.track {
           // commitLarge must fail because of a conflicting commit at version-2.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
@@ -509,6 +509,7 @@ case class ConcurrentBackfillCommitStore(
   private val deferredBackfills: mutable.Map[Long, () => Unit] = mutable.Map.empty
   override def getCommits(
       logPath: Path,
+      managedCommitTableConf: Map[String, String],
       startVersion: Long,
       endVersion: Option[Long]): GetCommitsResponse = {
     if (ConcurrentBackfillCommitStore.beginConcurrentBackfills) {
@@ -517,7 +518,7 @@ case class ConcurrentBackfillCommitStore(
       deferredBackfills.keys.toSeq.sorted.foreach((version: Long) => deferredBackfills(version)())
       deferredBackfills.clear()
     }
-    super.getCommits(logPath, startVersion, endVersion)
+    super.getCommits(logPath, managedCommitTableConf, startVersion, endVersion)
   }
   override def backfill(
       logStore: LogStore,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/CommitStoreSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/CommitStoreSuite.scala
@@ -35,6 +35,7 @@ class CommitStoreSuite extends QueryTest with DeltaSQLTestUtils with SharedSpark
         logStore: LogStore,
         hadoopConf: Configuration,
         logPath: Path,
+        managedCommitTableConf: Map[String, String],
         commitVersion: Long,
         actions: Iterator[String],
         updatedActions: UpdatedActions): CommitResponse = {
@@ -43,6 +44,7 @@ class CommitStoreSuite extends QueryTest with DeltaSQLTestUtils with SharedSpark
 
     override def getCommits(
       logPath: Path,
+      managedCommitTableConf: Map[String, String],
       startVersion: Long,
       endVersion: Option[Long] = None): GetCommitsResponse = GetCommitsResponse(Seq.empty, -1)
 
@@ -50,6 +52,7 @@ class CommitStoreSuite extends QueryTest with DeltaSQLTestUtils with SharedSpark
         logStore: LogStore,
         hadoopConf: Configuration,
         logPath: Path,
+        managedCommitTableConf: Map[String, String],
         startVersion: Long,
         endVersion: Option[Long]): Unit = {}
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitSuite.scala
@@ -890,10 +890,12 @@ class ManagedCommitSuite
       assert(!oldProtocol.readerAndWriterFeatures.contains(V2CheckpointTableFeature))
       val newProtocol =
         oldProtocol.copy(
-            minReaderVersion = TableFeatureProtocolUtils.TABLE_FEATURES_MIN_READER_VERSION,
-            minWriterVersion = TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION)
-          .withReaderFeatures(Seq(V2CheckpointTableFeature.name))
-          .withWriterFeatures(Seq(ManagedCommitTableFeature.name))
+          minReaderVersion = TableFeatureProtocolUtils.TABLE_FEATURES_MIN_READER_VERSION,
+          minWriterVersion = TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION,
+          readerFeatures =
+            Some(oldProtocol.readerFeatures.getOrElse(Set.empty) + V2CheckpointTableFeature.name),
+          writerFeatures =
+            Some(oldProtocol.writerFeatures.getOrElse(Set.empty) + ManagedCommitTableFeature.name))
       assert(cs.numRegisterTableCalled === 0)
       assert(cs.numCommitsCalled === 0)
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitSuite.scala
@@ -19,12 +19,14 @@ package org.apache.spark.sql.delta.managedcommit
 import java.io.File
 
 import com.databricks.spark.util.Log4jUsageLogger
-import org.apache.spark.sql.delta.DeltaConfigs.{MANAGED_COMMIT_OWNER_CONF, MANAGED_COMMIT_OWNER_NAME}
+import org.apache.spark.sql.delta.{DeltaOperations, ManagedCommitTableFeature, V2CheckpointTableFeature}
+import org.apache.spark.sql.delta.CommitStoreGetCommitsFailedException
+import org.apache.spark.sql.delta.DeltaConfigs.{MANAGED_COMMIT_OWNER_CONF, MANAGED_COMMIT_OWNER_NAME, ROW_TRACKING_ENABLED}
 import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
 import org.apache.spark.sql.delta.InitialSnapshot
 import org.apache.spark.sql.delta.Snapshot
-import org.apache.spark.sql.delta.actions.{Action, Metadata}
+import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.storage.LogStore
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
@@ -61,7 +63,7 @@ class ManagedCommitSuite
     CommitStoreProvider.clearNonDefaultBuilders()
   }
 
-  test("Optimistic Transaction errors out if 0th commit is not backfilled") {
+  test("0th commit happens via filesystem") {
     val commitStoreName = "nobackfilling-commit-store"
     object NoBackfillingCommitStoreBuilder extends CommitStoreBuilder {
 
@@ -73,17 +75,11 @@ class ManagedCommitSuite
               logStore: LogStore,
               hadoopConf: Configuration,
               logPath: Path,
+              managedCommitTableConf: Map[String, String],
               commitVersion: Long,
               actions: Iterator[String],
               updatedActions: UpdatedActions): CommitResponse = {
-            val uuidFile =
-              FileNames.unbackfilledDeltaFile(logPath, commitVersion)
-            logStore.write(uuidFile, actions, overwrite = false, hadoopConf)
-            val uuidFileStatus = uuidFile.getFileSystem(hadoopConf).getFileStatus(uuidFile)
-            val commitTime = uuidFileStatus.getModificationTime
-            commitImpl(logStore, hadoopConf, logPath, commitVersion, uuidFileStatus, commitTime)
-
-            CommitResponse(Commit(commitVersion, uuidFileStatus, commitTime))
+            throw new IllegalStateException("Fail commit request")
           }
         }
     }
@@ -92,11 +88,11 @@ class ManagedCommitSuite
     withSQLConf(MANAGED_COMMIT_OWNER_NAME.defaultTablePropertyKey -> commitStoreName) {
       withTempDir { tempDir =>
         val tablePath = tempDir.getAbsolutePath
-        val ex = intercept[IllegalStateException] {
-          Seq(1).toDF.write.format("delta").save(tablePath)
-        }
-        assert(ex.getMessage.contains(s"Expected 0th commit to be written" +
-          s" to file:$tablePath/_delta_log/00000000000000000000.json"))
+        Seq(1).toDF.write.format("delta").save(tablePath)
+        val log = DeltaLog.forTable(spark, tablePath)
+        assert(log.store.listFrom(FileNames.listingPrefix(log.logPath, 0L)).exists { f =>
+          f.getPath.getName === "00000000000000000000.json"
+        })
       }
     }
   }
@@ -120,7 +116,7 @@ class ManagedCommitSuite
             assert(FileNames.isDeltaFile(new Path(commitPath)))
             FileNames.deltaVersion(new Path(commitPath))
           }
-      assert(unbackfilledCommitVersions === Array(0, 1, 2))
+      assert(unbackfilledCommitVersions === Array(1, 2))
       checkAnswer(sql(s"SELECT * FROM delta.`$tablePath`"), Seq(Row(2), Row(3)))
     }
   }
@@ -161,18 +157,17 @@ class ManagedCommitSuite
       deltaLog1.startTransaction().commitManually()
       val snapshotV2 = deltaLog1.update()
       assert(snapshotV2.version === 2)
-      assert(snapshotV2.commitStoreOpt.isEmpty)
+      assert(snapshotV2.tableCommitStoreOpt.isEmpty)
       DeltaLog.clearCache()
 
       // Add new commit to convert FS table to managed-commit table
       val deltaLog2 = DeltaLog.forTable(spark, tablePath)
       enableManagedCommit(deltaLog2, commitOwner = "tracking-in-memory")
-      commitStore.registerTable(deltaLog2.logPath, 3)
       deltaLog2.startTransaction().commitManually(createTestAddFile("f2"))
       deltaLog2.startTransaction().commitManually()
       val snapshotV5 = deltaLog2.unsafeVolatileSnapshot
       assert(snapshotV5.version === 5)
-      assert(snapshotV5.commitStoreOpt.nonEmpty)
+      assert(snapshotV5.tableCommitStoreOpt.nonEmpty)
       // only delta 4/5 will be un-backfilled and should have two dots in filename (x.uuid.json)
       assert(snapshotV5.logSegment.deltas.count(_.getPath.getName.count(_ == '.') == 2) === 2)
 
@@ -192,6 +187,7 @@ class ManagedCommitSuite
       val clock = new ManualClock(System.currentTimeMillis())
       val log = DeltaLog.forTable(spark, new Path(tablePath), clock)
       assert(log.unsafeVolatileSnapshot.isInstanceOf[InitialSnapshot])
+      assert(log.unsafeVolatileSnapshot.tableCommitStoreOpt.isEmpty)
       assert(log.getCapturedSnapshot().updateTimestamp == clock.getTimeMillis())
       clock.advance(500)
       log.update()
@@ -263,17 +259,8 @@ class ManagedCommitSuite
             configuration = oldMetadataConf - MANAGED_COMMIT_OWNER_NAME.key)
           val newMetadata2 = oldMetadata.copy(
             configuration = oldMetadataConf + (MANAGED_COMMIT_OWNER_NAME.key -> builder2.name))
-          log.store.write(
-            FileNames.unsafeDeltaFile(log.logPath, 2),
-            Seq(newMetadata1.json).toIterator,
-            overwrite = false,
-            conf)
-          log.store.write(
-            FileNames.unsafeDeltaFile(log.logPath, 3),
-            Seq(newMetadata2.json).toIterator,
-            overwrite = false,
-            conf)
-          cs2.registerTable(log.logPath, maxCommitVersion = 3)
+          log.startTransaction().commitManually(newMetadata1)
+          log.startTransaction().commitManually(newMetadata2)
 
           // Also backfill commit 0, 1 -- which the spec mandates when the commit owner changes.
           // commit 0 should already be backfilled
@@ -294,7 +281,7 @@ class ManagedCommitSuite
         assert(builder1.numBuildCalled == 0)
         assert(builder2.numBuildCalled == 1)
         val snapshotV3 = DeltaLog.forTable(spark, tablePath).unsafeVolatileSnapshot
-        assert(snapshotV3.commitStoreOpt === Some(cs2))
+        assert(snapshotV3.tableCommitStoreOpt.map(_.commitStore) === Some(cs2))
         assert(snapshotV3.version === 3)
 
         // Step-4: Write more commits using new owner
@@ -356,13 +343,14 @@ class ManagedCommitSuite
 
       override def getCommits(
         logPath: Path,
+        managedCommitTableConf: Map[String, String],
         startVersion: Long,
         endVersion: Option[Long]): GetCommitsResponse = {
         if (failAttempts.contains(numGetCommitsCalled + 1)) {
           numGetCommitsCalled += 1
           throw new IllegalStateException("Injected failure")
         }
-        super.getCommits(logPath, startVersion, endVersion)
+        super.getCommits(logPath, managedCommitTableConf, startVersion, endVersion)
       }
     }
     case class TrackingInMemoryCommitStoreBuilder(
@@ -408,7 +396,7 @@ class ManagedCommitSuite
           configuration = oldMetadataConf - MANAGED_COMMIT_OWNER_NAME.key)
         val newMetadata2 = oldMetadata.copy(
           configuration = oldMetadataConf + (MANAGED_COMMIT_OWNER_NAME.key -> "in-memory-2"))
-        assert(log.update().commitStoreOpt.get === cs1)
+        assert(log.update().tableCommitStoreOpt.get.commitStore === cs1)
         log.startTransaction().commitManually(newMetadata1) // version 3
         (1 to 3).foreach { v =>
           // backfill commit 1 and 2 also as 3/4 are written directly to FS.
@@ -418,10 +406,9 @@ class ManagedCommitSuite
             actions = log.store.read(segment.deltas(v).getPath).toIterator,
             overwrite = true)
         }
-        assert(log.update().commitStoreOpt === None)
+        assert(log.update().tableCommitStoreOpt === None)
         log.startTransaction().commitManually(newMetadata2) // version 4
-        cs2.registerTable(log.logPath, maxCommitVersion = 4)
-        assert(log.update().commitStoreOpt.get === cs2)
+        assert(log.update().tableCommitStoreOpt.get.commitStore === cs2)
 
         // Step-6
         Seq(4).toDF.write.format("delta").mode("append").save(tablePath) // version 5
@@ -435,14 +422,15 @@ class ManagedCommitSuite
         clock.setTime(System.currentTimeMillis())
         resetMetrics()
         cs2.failAttempts = Set(1, 2) // fail 0th and 1st attempt, 2nd attempt will succeed.
-        val ex1 = intercept[IllegalStateException] { oldDeltaLog.update() }
+        val ex1 = intercept[CommitStoreGetCommitsFailedException] { oldDeltaLog.update() }
         assert((cs1.numGetCommitsCalled, cs2.numGetCommitsCalled) === (1, 1))
         assert(ex1.getMessage.contains("Injected failure"))
         assert(oldDeltaLog.unsafeVolatileSnapshot.version == 1)
         assert(oldDeltaLog.getCapturedSnapshot().updateTimestamp != clock.getTimeMillis())
 
         // Attempt-2
-        val ex2 = intercept[IllegalStateException] { oldDeltaLog.update() } // 2nd update also fails
+        // 2nd update also fails
+        val ex2 = intercept[CommitStoreGetCommitsFailedException] { oldDeltaLog.update() }
         assert((cs1.numGetCommitsCalled, cs2.numGetCommitsCalled) === (2, 2))
         assert(ex2.getMessage.contains("Injected failure"))
         assert(oldDeltaLog.unsafeVolatileSnapshot.version == 1)
@@ -587,7 +575,6 @@ class ManagedCommitSuite
       // switch is made
       // commit 3
       enableManagedCommit(DeltaLog.forTable(spark, tablePath), "tracking-in-memory")
-      commitStore.registerTable(deltaLog1.logPath, maxCommitVersion = 3)
       // commit 4
       Seq(1).toDF.write.format("delta").mode("overwrite").save(tablePath)
       // the old deltaLog objects still points to version 2
@@ -636,4 +623,310 @@ class ManagedCommitSuite
     val newMetadata = oldMetadata.copy(configuration = oldMetadata.configuration + commitOwnerConf)
     deltaLog.startTransaction().commitManually(newMetadata)
   }
+
+  test("tableConf returned from registration API is recorded in deltaLog and passed " +
+      "to CommitStore in future for all the APIs") {
+    val tableConf = Map("tableID" -> "random-u-u-i-d", "1" -> "2")
+    val trackingCommitStore = new TrackingCommitStore(new InMemoryCommitStore(batchSize = 10) {
+      override def registerTable(
+          logPath: Path,
+          currentVersion: Long,
+          currentMetadata: Metadata,
+          currentProtocol: Protocol): Map[String, String] = {
+        super.registerTable(logPath, currentVersion, currentMetadata, currentProtocol)
+        tableConf
+      }
+
+      override def getCommits(
+          logPath: Path,
+          managedCommitTableConf: Map[String, String],
+          startVersion: Long,
+          endVersion: Option[Long]): GetCommitsResponse = {
+        assert(managedCommitTableConf === tableConf)
+        super.getCommits(logPath, managedCommitTableConf, startVersion, endVersion)
+      }
+
+      override def commit(
+          logStore: LogStore,
+          hadoopConf: Configuration,
+          logPath: Path,
+          managedCommitTableConf: Map[String, String],
+          commitVersion: Long,
+          actions: Iterator[String],
+          updatedActions: UpdatedActions): CommitResponse = {
+        assert(managedCommitTableConf === tableConf)
+        super.commit(logStore, hadoopConf, logPath, managedCommitTableConf,
+          commitVersion, actions, updatedActions)
+      }
+
+      override def backfillToVersion(
+          logStore: LogStore,
+          hadoopConf: Configuration,
+          logPath: Path,
+          managedCommitTableConf: Map[String, String],
+          startVersion: Long,
+          endVersionOpt: Option[Long]): Unit = {
+        assert(managedCommitTableConf === tableConf)
+        super.backfillToVersion(
+          logStore, hadoopConf, logPath, managedCommitTableConf, startVersion, endVersionOpt)
+      }
+    })
+    val builder = TrackingInMemoryCommitStoreBuilder(batchSize = 10, Some(trackingCommitStore))
+    CommitStoreProvider.registerBuilder(builder)
+    withTempDir { tempDir =>
+      val tablePath = tempDir.getAbsolutePath
+      val log = DeltaLog.forTable(spark, tablePath)
+      val commitOwnerConf = Map(MANAGED_COMMIT_OWNER_NAME.key -> builder.name)
+      val newMetadata = Metadata().copy(configuration = commitOwnerConf)
+      log.startTransaction().commitManually(newMetadata)
+      assert(log.unsafeVolatileSnapshot.version === 0)
+      assert(log.unsafeVolatileSnapshot.metadata.managedCommitTableConf === tableConf)
+
+      log.startTransaction().commitManually(createTestAddFile("f1"))
+      log.startTransaction().commitManually(createTestAddFile("f2"))
+      log.checkpoint()
+      log.startTransaction().commitManually(createTestAddFile("f2"))
+
+      assert(trackingCommitStore.numCommitsCalled > 0)
+      assert(trackingCommitStore.numGetCommitsCalled > 0)
+      assert(trackingCommitStore.numBackfillToVersionCalled > 0)
+    }
+  }
+
+  for (upgradeExistingTable <- BOOLEAN_DOMAIN)
+  testWithDifferentBackfillInterval("upgrade + downgrade [FS -> MC1 -> FS -> MC2]," +
+      s" upgradeExistingTable = $upgradeExistingTable") { backfillInterval =>
+    withoutManagedCommitsDefaultTableProperties {
+      CommitStoreProvider.clearNonDefaultBuilders()
+      val builder1 = TrackingInMemoryCommitStoreBuilder(batchSize = backfillInterval)
+      val builder2 = new TrackingInMemoryCommitStoreBuilder(batchSize = backfillInterval) {
+        override def name: String = "tracking-in-memory-2"
+      }
+
+      Seq(builder1, builder2).foreach(CommitStoreProvider.registerBuilder(_))
+      val cs1 = builder1.trackingInMemoryCommitStore.asInstanceOf[TrackingCommitStore]
+      val cs2 = builder2.trackingInMemoryCommitStore.asInstanceOf[TrackingCommitStore]
+
+      withTempDir { tempDir =>
+        val tablePath = tempDir.getAbsolutePath
+        val log = DeltaLog.forTable(spark, tablePath)
+        val fs = log.logPath.getFileSystem(log.newDeltaHadoopConf())
+
+        var upgradeStartVersion = 0L
+        // Create a non-managed commit table if we are testing upgrade for existing tables
+        if (upgradeExistingTable) {
+          log.startTransaction().commitManually(Metadata())
+          assert(log.unsafeVolatileSnapshot.version === 0)
+          log.startTransaction().commitManually(createTestAddFile("1"))
+          assert(log.unsafeVolatileSnapshot.version === 1)
+          assert(log.unsafeVolatileSnapshot.tableCommitStoreOpt.isEmpty)
+          upgradeStartVersion = 2L
+        }
+
+        // Upgrade the table
+        // [upgradeExistingTable = false] Commit-0
+        // [upgradeExistingTable = true] Commit-2
+        val commitOwnerConf = Map(MANAGED_COMMIT_OWNER_NAME.key -> builder1.name)
+        val newMetadata = Metadata().copy(configuration = commitOwnerConf)
+        log.startTransaction().commitManually(newMetadata)
+        assert(log.unsafeVolatileSnapshot.version === upgradeStartVersion)
+        assert(log.unsafeVolatileSnapshot.metadata.managedCommitOwnerName === Some(builder1.name))
+        assert(log.unsafeVolatileSnapshot.tableCommitStoreOpt.nonEmpty)
+        assert(log.unsafeVolatileSnapshot.metadata.managedCommitTableConf === Map.empty)
+        // upgrade commit always filesystem based
+        assert(fs.exists(FileNames.unsafeDeltaFile(log.logPath, upgradeStartVersion)))
+        assert(Seq(cs1, cs2).map(_.numCommitsCalled) == Seq(0, 0))
+        assert(Seq(cs1, cs2).map(_.numRegisterTableCalled) == Seq(1, 0))
+
+        // Do couple of commits on the managed-commit table
+        // [upgradeExistingTable = false] Commit-1/2
+        // [upgradeExistingTable = true] Commit-3/4
+        (1 to 2).foreach { versionOffset =>
+          val version = upgradeStartVersion + versionOffset
+          log.startTransaction().commitManually(createTestAddFile(s"$versionOffset"))
+          assert(log.unsafeVolatileSnapshot.version === version)
+          assert(log.unsafeVolatileSnapshot.tableCommitStoreOpt.nonEmpty)
+          assert(log.unsafeVolatileSnapshot.metadata.managedCommitOwnerName.nonEmpty)
+          assert(log.unsafeVolatileSnapshot.metadata.managedCommitOwnerConf === Map.empty)
+          assert(log.unsafeVolatileSnapshot.metadata.managedCommitTableConf === Map.empty)
+          assert(cs1.numCommitsCalled === versionOffset)
+          val backfillExpected = if (version % backfillInterval == 0) true else false
+          assert(fs.exists(FileNames.unsafeDeltaFile(log.logPath, version)) == backfillExpected)
+        }
+
+        // Downgrade the table
+        // [upgradeExistingTable = false] Commit-3
+        // [upgradeExistingTable = true] Commit-5
+        val newMetadata2 = Metadata().copy(configuration = Map("downgraded_at" -> "v2"))
+        log.startTransaction().commitManually(newMetadata2)
+        assert(log.unsafeVolatileSnapshot.version === upgradeStartVersion + 3)
+        assert(log.unsafeVolatileSnapshot.tableCommitStoreOpt.isEmpty)
+        assert(log.unsafeVolatileSnapshot.metadata.managedCommitOwnerName.isEmpty)
+        assert(log.unsafeVolatileSnapshot.metadata.managedCommitOwnerConf === Map.empty)
+        assert(log.unsafeVolatileSnapshot.metadata.managedCommitTableConf === Map.empty)
+        assert(log.unsafeVolatileSnapshot.metadata === newMetadata2)
+        // This must have increased by 1 as downgrade commit happens via CommitStore.
+        assert(Seq(cs1, cs2).map(_.numCommitsCalled) == Seq(3, 0))
+        assert(Seq(cs1, cs2).map(_.numRegisterTableCalled) == Seq(1, 0))
+        (0 to 3).foreach { version =>
+          assert(fs.exists(FileNames.unsafeDeltaFile(log.logPath, version)))
+        }
+
+        // Do commit after downgrade is over
+        // [upgradeExistingTable = false] Commit-4
+        // [upgradeExistingTable = true] Commit-6
+        log.startTransaction().commitManually(createTestAddFile("post-upgrade-file"))
+        assert(log.unsafeVolatileSnapshot.version === upgradeStartVersion + 4)
+        // no commit store after downgrade
+        assert(log.unsafeVolatileSnapshot.tableCommitStoreOpt.isEmpty)
+        assert(log.unsafeVolatileSnapshot.metadata.managedCommitTableConf === Map.empty)
+        // Metadata is same as what we added at time of downgrade
+        assert(log.unsafeVolatileSnapshot.metadata === newMetadata2)
+        // State reconstruction should give correct results
+        var expectedFileNames = Set("1", "2", "post-upgrade-file")
+        assert(log.unsafeVolatileSnapshot.allFiles.collect().toSet ===
+          expectedFileNames.map(name => createTestAddFile(name, dataChange = false)))
+        // Commit Store should not be invoked for commit API.
+        // Register table API should not be called until the end
+        assert(Seq(cs1, cs2).map(_.numCommitsCalled) == Seq(3, 0))
+        assert(Seq(cs1, cs2).map(_.numRegisterTableCalled) == Seq(1, 0))
+        // 4th file is directly written to FS in backfilled way.
+        assert(fs.exists(FileNames.unsafeDeltaFile(log.logPath, upgradeStartVersion + 4)))
+
+        // Now transfer the table to another commit owner
+        // [upgradeExistingTable = false] Commit-5
+        // [upgradeExistingTable = true] Commit-7
+        val commitOwnerConf2 = Map(MANAGED_COMMIT_OWNER_NAME.key -> builder2.name)
+        val oldMetadata3 = log.unsafeVolatileSnapshot.metadata
+        val newMetadata3 = oldMetadata3.copy(
+          configuration = oldMetadata3.configuration ++ commitOwnerConf2)
+        log.startTransaction().commitManually(newMetadata3, createTestAddFile("upgrade-2-file"))
+        assert(log.unsafeVolatileSnapshot.version === upgradeStartVersion + 5)
+        assert(log.unsafeVolatileSnapshot.tableCommitStoreOpt.nonEmpty)
+        assert(log.unsafeVolatileSnapshot.metadata.managedCommitOwnerName === Some(builder2.name))
+        assert(log.unsafeVolatileSnapshot.metadata.managedCommitOwnerConf === Map.empty)
+        assert(log.unsafeVolatileSnapshot.metadata.managedCommitTableConf === Map.empty)
+        expectedFileNames = Set("1", "2", "post-upgrade-file", "upgrade-2-file")
+        assert(log.unsafeVolatileSnapshot.allFiles.collect().toSet ===
+          expectedFileNames.map(name => createTestAddFile(name, dataChange = false)))
+        assert(Seq(cs1, cs2).map(_.numCommitsCalled) == Seq(3, 0))
+        assert(Seq(cs1, cs2).map(_.numRegisterTableCalled) == Seq(1, 1))
+
+        // Make 1 more commit, this should go to new owner
+        log.startTransaction().commitManually(newMetadata3, createTestAddFile("4"))
+        expectedFileNames = Set("1", "2", "post-upgrade-file", "upgrade-2-file", "4")
+        assert(log.unsafeVolatileSnapshot.allFiles.collect().toSet ===
+          expectedFileNames.map(name => createTestAddFile(name, dataChange = false)))
+        assert(Seq(cs1, cs2).map(_.numCommitsCalled) == Seq(3, 1))
+        assert(Seq(cs1, cs2).map(_.numRegisterTableCalled) == Seq(1, 1))
+        assert(log.unsafeVolatileSnapshot.version === upgradeStartVersion + 6)
+      }
+    }
+  }
+
+  test("transfer from one commit-owner to another commit-owner fails [MC-1 -> MC-2 fails]") {
+    CommitStoreProvider.clearNonDefaultBuilders()
+    val builder1 = TrackingInMemoryCommitStoreBuilder(batchSize = 10)
+    val builder2 = new TrackingInMemoryCommitStoreBuilder(batchSize = 10) {
+      override def name: String = "tracking-in-memory-2"
+    }
+    Seq(builder1, builder2).foreach(CommitStoreProvider.registerBuilder(_))
+
+    withTempDir { tempDir =>
+      val tablePath = tempDir.getAbsolutePath
+      val log = DeltaLog.forTable(spark, tablePath)
+      // A new table will automatically get `tracking-in-memory` as the whole suite is configured to
+      // use it as default commit store via [[MANAGED_COMMIT_OWNER_NAME.defaultTablePropertyKey]].
+      log.startTransaction().commitManually(Metadata())
+      assert(log.unsafeVolatileSnapshot.version === 0L)
+      assert(log.unsafeVolatileSnapshot.tableCommitStoreOpt.nonEmpty)
+
+      // Change commit owner
+      val newCommitOwnerConf = Map(MANAGED_COMMIT_OWNER_NAME.key -> builder2.name)
+      val oldMetadata = log.unsafeVolatileSnapshot.metadata
+      val newMetadata = oldMetadata.copy(
+        configuration = oldMetadata.configuration ++ newCommitOwnerConf)
+      val ex = intercept[IllegalStateException] {
+        log.startTransaction().commitManually(newMetadata)
+      }
+      assert(ex.getMessage.contains("from one commit-owner to another commit-owner is not allowed"))
+    }
+  }
+
+  testWithoutManagedCommits("FS -> MC upgrade is not retried on a conflict") {
+    val builder = TrackingInMemoryCommitStoreBuilder(batchSize = 10)
+    CommitStoreProvider.registerBuilder(builder)
+
+    withTempDir { tempDir =>
+      val tablePath = tempDir.getAbsolutePath
+      val log = DeltaLog.forTable(spark, tablePath)
+      val commitOwnerConf = Map(MANAGED_COMMIT_OWNER_NAME.key -> builder.name)
+      val newMetadata = Metadata().copy(configuration = commitOwnerConf)
+      val txn = log.startTransaction() // upgrade txn started
+      log.startTransaction().commitManually(createTestAddFile("f1"))
+      intercept[io.delta.exceptions.ConcurrentWriteException] {
+        txn.commitManually(newMetadata) // upgrade txn committed
+      }
+    }
+  }
+
+  testWithoutManagedCommits("FS -> MC upgrade with commitLarge API") {
+    val builder = TrackingInMemoryCommitStoreBuilder(batchSize = 10)
+    val cs = builder.trackingInMemoryCommitStore.asInstanceOf[TrackingCommitStore]
+    CommitStoreProvider.registerBuilder(builder)
+    withTempDir { tempDir =>
+      val tablePath = tempDir.getAbsolutePath
+      Seq(1).toDF.write.format("delta").save(tablePath)
+      Seq(1).toDF.write.mode("overwrite").format("delta").save(tablePath)
+      var log = DeltaLog.forTable(spark, tablePath)
+      assert(log.unsafeVolatileSnapshot.version === 1L)
+      assert(log.unsafeVolatileSnapshot.tableCommitStoreOpt.isEmpty)
+
+      val commitOwnerConf = Map(MANAGED_COMMIT_OWNER_NAME.key -> builder.name)
+      val oldMetadata = log.unsafeVolatileSnapshot.metadata
+      val newMetadata = oldMetadata.copy(
+        configuration = oldMetadata.configuration ++ commitOwnerConf)
+      val oldProtocol = log.unsafeVolatileSnapshot.protocol
+      assert(!oldProtocol.readerAndWriterFeatures.contains(V2CheckpointTableFeature))
+      val newProtocol =
+        oldProtocol.copy(
+            minReaderVersion = TableFeatureProtocolUtils.TABLE_FEATURES_MIN_READER_VERSION,
+            minWriterVersion = TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION)
+          .withReaderFeatures(Seq(V2CheckpointTableFeature.name))
+          .withWriterFeatures(Seq(ManagedCommitTableFeature.name))
+      assert(cs.numRegisterTableCalled === 0)
+      assert(cs.numCommitsCalled === 0)
+
+      val txn = log.startTransaction()
+      txn.updateMetadataForNewTable(newMetadata)
+      txn.commitLarge(
+        spark,
+        Seq(SetTransaction("app-1", 1, None)).toIterator,
+        Some(newProtocol),
+        DeltaOperations.TestOperation("TEST"),
+        Map.empty,
+        Map.empty)
+      log = DeltaLog.forTable(spark, tablePath)
+      assert(cs.numRegisterTableCalled === 1)
+      assert(cs.numCommitsCalled === 0)
+      assert(log.unsafeVolatileSnapshot.version === 2L)
+
+      Seq(V2CheckpointTableFeature, ManagedCommitTableFeature).foreach { feature =>
+        assert(log.unsafeVolatileSnapshot.protocol.isFeatureSupported(feature))
+      }
+
+      assert(log.unsafeVolatileSnapshot.tableCommitStoreOpt.nonEmpty)
+      assert(log.unsafeVolatileSnapshot.metadata.managedCommitOwnerName === Some(builder.name))
+      assert(log.unsafeVolatileSnapshot.metadata.managedCommitOwnerConf === Map.empty)
+      assert(log.unsafeVolatileSnapshot.metadata.managedCommitTableConf === Map.empty)
+
+      Seq(3).toDF.write.mode("append").format("delta").save(tablePath)
+      assert(cs.numRegisterTableCalled === 1)
+      assert(cs.numCommitsCalled === 1)
+      assert(log.unsafeVolatileSnapshot.version === 3L)
+      assert(log.unsafeVolatileSnapshot.tableCommitStoreOpt.nonEmpty)
+
+    }
+  }
 }
+

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitTestUtils.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.delta.managedcommit
 
 import org.apache.spark.sql.delta.{DeltaConfigs, DeltaTestUtilsBase}
 import org.apache.spark.sql.delta.DeltaConfigs.MANAGED_COMMIT_OWNER_NAME
+import org.apache.spark.sql.delta.actions.{CommitInfo, Metadata, Protocol}
 import org.apache.spark.sql.delta.storage.LogStore
 import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.hadoop.conf.Configuration
@@ -29,15 +30,27 @@ import org.apache.spark.sql.test.SharedSparkSession
 trait ManagedCommitTestUtils
   extends DeltaTestUtilsBase { self: SparkFunSuite with SharedSparkSession =>
 
+  /**
+   * Runs a specific test with managed commits default properties unset.
+   * Any table created in this test won't have managed commits enabled by default.
+   */
   def testWithoutManagedCommits(testName: String)(f: => Unit): Unit = {
     test(testName) {
-      val oldCommitOwnerValue = spark.conf.get(MANAGED_COMMIT_OWNER_NAME.defaultTablePropertyKey)
-      try {
-        spark.conf.unset(MANAGED_COMMIT_OWNER_NAME.defaultTablePropertyKey)
-        f
-      } finally {
-        spark.conf.set(MANAGED_COMMIT_OWNER_NAME.defaultTablePropertyKey, oldCommitOwnerValue)
-      }
+      withoutManagedCommitsDefaultTableProperties { f }
+    }
+  }
+
+  /**
+   * Runs the function `f` with managed commits default properties unset.
+   * Any table created in function `f`` won't have managed commits enabled by default.
+   */
+  def withoutManagedCommitsDefaultTableProperties(f: => Unit): Unit = {
+    val oldCommitOwnerValue = spark.conf.get(MANAGED_COMMIT_OWNER_NAME.defaultTablePropertyKey)
+    try {
+      spark.conf.unset(MANAGED_COMMIT_OWNER_NAME.defaultTablePropertyKey)
+      f
+    } finally {
+      spark.conf.set(MANAGED_COMMIT_OWNER_NAME.defaultTablePropertyKey, oldCommitOwnerValue)
     }
   }
 
@@ -71,12 +84,27 @@ trait ManagedCommitTestUtils
       }
     }
   }
+
+  def getUpdatedActionsForZerothCommit(
+      commitInfo: CommitInfo,
+      oldMetadata: Metadata = Metadata()): UpdatedActions = {
+    val newMetadataConfiguration =
+      oldMetadata.configuration +
+        (DeltaConfigs.MANAGED_COMMIT_OWNER_NAME.key -> "tracking-in-memory")
+    val newMetadata = oldMetadata.copy(configuration = newMetadataConfiguration)
+    UpdatedActions(commitInfo, newMetadata, Protocol(), oldMetadata, Protocol())
+  }
+
+  def getUpdatedActionsForNonZerothCommit(commitInfo: CommitInfo): UpdatedActions = {
+    val updatedActions = getUpdatedActionsForZerothCommit(commitInfo)
+    updatedActions.copy(oldMetadata = updatedActions.newMetadata)
+  }
 }
 
 case class TrackingInMemoryCommitStoreBuilder(
     batchSize: Long,
     defaultCommitStoreOpt: Option[CommitStore] = None) extends CommitStoreBuilder {
-  private lazy val trackingInMemoryCommitStore =
+  lazy val trackingInMemoryCommitStore =
     defaultCommitStoreOpt.getOrElse {
       new TrackingCommitStore(new PredictableUuidInMemoryCommitStore(batchSize))
     }
@@ -86,7 +114,7 @@ case class TrackingInMemoryCommitStoreBuilder(
 }
 
 class PredictableUuidInMemoryCommitStore(batchSize: Long) extends InMemoryCommitStore(batchSize) {
-  var nextUuidSuffix = 0L
+  var nextUuidSuffix = 1L
   override def generateUUID(): String = {
     nextUuidSuffix += 1
     s"uuid-${nextUuidSuffix - 1}"
@@ -97,16 +125,20 @@ class TrackingCommitStore(delegatingCommitStore: InMemoryCommitStore) extends Co
 
   var numCommitsCalled: Int = 0
   var numGetCommitsCalled: Int = 0
+  var numBackfillToVersionCalled: Int = 0
+  var numRegisterTableCalled: Int = 0
   var insideOperation: Boolean = false
 
   def recordOperation[T](op: String)(f: => T): T = synchronized {
     val oldInsideOperation = insideOperation
     try {
       if (!insideOperation) {
-        if (op == "commit") {
-          numCommitsCalled += 1
-        } else if (op == "getCommits") {
-          numGetCommitsCalled += 1
+        op match {
+          case "commit" => numCommitsCalled += 1
+          case "getCommits" => numGetCommitsCalled += 1
+          case "backfillToVersion" => numBackfillToVersionCalled += 1
+          case "registerTable" => numRegisterTableCalled += 1
+          case _ => ()
         }
       }
       insideOperation = true
@@ -120,40 +152,47 @@ class TrackingCommitStore(delegatingCommitStore: InMemoryCommitStore) extends Co
       logStore: LogStore,
       hadoopConf: Configuration,
       logPath: Path,
+      managedCommitTableConf: Map[String, String],
       commitVersion: Long,
       actions: Iterator[String],
       updatedActions: UpdatedActions): CommitResponse = recordOperation("commit") {
-    delegatingCommitStore
-      .commit(logStore, hadoopConf, logPath, commitVersion, actions, updatedActions)
+    delegatingCommitStore.commit(
+      logStore, hadoopConf, logPath, managedCommitTableConf, commitVersion, actions, updatedActions)
   }
 
   override def getCommits(
       logPath: Path,
+      managedCommitTableConf: Map[String, String],
       startVersion: Long,
       endVersion: Option[Long] = None): GetCommitsResponse = recordOperation("getCommits") {
-    delegatingCommitStore.getCommits(logPath, startVersion, endVersion)
+    delegatingCommitStore.getCommits(logPath, managedCommitTableConf, startVersion, endVersion)
   }
 
   override def backfillToVersion(
       logStore: LogStore,
       hadoopConf: Configuration,
       logPath: Path,
+      managedCommitTableConf: Map[String, String],
       startVersion: Long,
-      endVersion: Option[Long]): Unit = {
-    delegatingCommitStore.backfillToVersion(logStore, hadoopConf, logPath, startVersion, endVersion)
+      endVersion: Option[Long]): Unit = recordOperation("backfillToVersion") {
+    delegatingCommitStore.backfillToVersion(
+      logStore, hadoopConf, logPath, managedCommitTableConf, startVersion, endVersion)
   }
 
   override def semanticEquals(other: CommitStore): Boolean = this == other
 
-  def registerTable(
-      logPath: Path,
-      maxCommitVersion: Long): Unit = {
-    delegatingCommitStore.registerTable(logPath, maxCommitVersion)
-  }
-
   def reset(): Unit = {
     numCommitsCalled = 0
     numGetCommitsCalled = 0
+    numBackfillToVersionCalled = 0
+  }
+
+  override def registerTable(
+      logPath: Path,
+      currentVersion: Long,
+      currentMetadata: Metadata,
+      currentProtocol: Protocol): Map[String, String] = recordOperation("registerTable") {
+    delegatingCommitStore.registerTable(logPath, currentVersion, currentMetadata, currentProtocol)
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR adds a register API with managed commits.

1. Initial snapshot shouldn't have CommitStore.

2. Introduce concept of managedCommitTableConf. This info is unique to the table. e.g. tableId etc.
- with this change, now configuration has 2 table properties related to managed commits:
2.1 `managedCommitOwnerName` - name of the MC Owner
2.2 `managedCommitOwnerConf` - configuration related to owner
2.3 `managedCommitTableConf` - managed commit configuration related to table

`2.1` and `2.2` are used to initialize CommitStore.
`2.3` is passed as an argument to CommitStore{commit/getCommits/backfillUpto} APIs as it is needed to uniquely identify the table by the owner.

3. CommitStore pre-registration support. If a table is transitioning for FS -> MC, we register with commit-store and get the `managedCommitTableConf` for it. This conf is then set in Metadata.

4. This PR moves the `FS -> MC` commit (or 0th commit) to filesystem as forcing to go it via Commit Owner adds additional complexity and doesn't give any major advantage. So whenever a transition is happening, the commit goes through previous owner:
i.e. For FS -> MC, commit goes through FS. For MC -> FS, commit goes through MC.

5. This PR also introduces a `TableCommitStore` which is a helper class / simplified version of CommitStore. It takes care of passing basic things by itself. e.g. logPath, managedCommitTableMetadata, hadoopConf, logPath.


## How was this patch tested?

UTs

## Does this PR introduce _any_ user-facing changes?

No