### PR TITLE
[SPARK] Fix infinite loops when has foldable dataFilter in data skipping

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
@@ -382,6 +382,8 @@ trait DataSkippingReaderBase
      */
     private def constructDataFilters(dataFilter: Expression):
         Option[DataSkippingPredicate] = dataFilter match {
+      // If dataFilter is foldable, cannot be skipped.
+      case e if e.foldable => None
       // Push skipping predicate generation through the AND:
       //
       // constructDataFilters(AND(a, b))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaTests.scala
@@ -1873,23 +1873,25 @@ trait DataSkippingDeltaTestsBase extends QueryTest
 
   test("fix infinite loops when has foldable dataFilter in data skipping") {
     withTempDir { dir =>
-      Seq((1, 2)).toDF("a", "b").write.format("delta").save(dir.getAbsolutePath + "/t1")
-      Seq(1).toDF("a").write.format("delta").save(dir.getAbsolutePath + "/t2")
-      Seq((1, 2)).toDF("a", "c").write.format("delta").save(dir.getAbsolutePath + "/t3")
-      spark.read.format("delta").load(dir.getAbsolutePath + "/t1").createTempView("t1")
-      spark.read.format("delta").load(dir.getAbsolutePath + "/t2").createTempView("t2")
-      spark.read.format("delta").load(dir.getAbsolutePath + "/t3").createTempView("t3")
-      spark.sql(
-        """
-          |select t.*,t3.a as c from
-          |(
-          |select * from t1
-          |union all
-          |select *,1 as b from t2
-          |) t, t3
-          |where t.a=t3.a
-          |and (t.a > 1 or (t.b = 1 and t3.c=1))
-          |""".stripMargin).collect()
+      withTempView("t1", "t2", "t3") {
+        Seq((1, 2)).toDF("a", "b").write.format("delta").save(dir.getAbsolutePath + "/t1")
+        Seq(1).toDF("a").write.format("delta").save(dir.getAbsolutePath + "/t2")
+        Seq((1, 2)).toDF("a", "c").write.format("delta").save(dir.getAbsolutePath + "/t3")
+        spark.read.format("delta").load(dir.getAbsolutePath + "/t1").createTempView("t1")
+        spark.read.format("delta").load(dir.getAbsolutePath + "/t2").createTempView("t2")
+        spark.read.format("delta").load(dir.getAbsolutePath + "/t3").createTempView("t3")
+        spark.sql(
+          """
+            |select t.*,t3.a as c from
+            |(
+            |select * from t1
+            |union all
+            |select *,1 as b from t2
+            |) t, t3
+            |where t.a=t3.a
+            |and (t.a > 1 or (t.b = 1 and t3.c=1))
+            |""".stripMargin).collect()
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR to fix #2904. 
I have submitted PR to spark for optimize predicate after push extra predicate through join(https://github.com/apache/spark/pull/46085), but this is spark's plan optimizer, we can't guarantee whether predicates like `1=1` will be generated in other situations.

## How was this patch tested?

New unit test.

## Does this PR introduce _any_ user-facing changes?

No.
