### PR TITLE
[Kernel] Rename snapshot time-travel APIs to be consistent with SQL syntax

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Table.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Table.java
@@ -66,7 +66,7 @@ public interface Table {
      * @return an instance of {@link Snapshot}
      * @since 3.2.0
      */
-    Snapshot getSnapshotAtVersion(TableClient tableClient, long versionId)
+    Snapshot getSnapshotAsOfVersion(TableClient tableClient, long versionId)
         throws TableNotFoundException;
 
     /**
@@ -91,6 +91,6 @@ public interface Table {
      * @return an instance of {@link Snapshot}
      * @since 3.2.0
      */
-    Snapshot getSnapshotAtTimestamp(TableClient tableClient, long millisSinceEpochUTC)
+    Snapshot getSnapshotAsOfTimestamp(TableClient tableClient, long millisSinceEpochUTC)
         throws TableNotFoundException;
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
@@ -62,13 +62,13 @@ public class TableImpl implements Table {
     }
 
     @Override
-    public Snapshot getSnapshotAtVersion(TableClient tableClient, long versionId)
+    public Snapshot getSnapshotAsOfVersion(TableClient tableClient, long versionId)
         throws TableNotFoundException {
         return snapshotManager.getSnapshotAt(tableClient, versionId);
     }
 
     @Override
-    public Snapshot getSnapshotAtTimestamp(TableClient tableClient, long millisSinceEpochUTC)
+    public Snapshot getSnapshotAsOfTimestamp(TableClient tableClient, long millisSinceEpochUTC)
         throws TableNotFoundException {
         return snapshotManager.getSnapshotForTimestamp(tableClient, millisSinceEpochUTC);
     }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
@@ -618,7 +618,7 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
       // Cannot read a version that does not exist
       val e = intercept[RuntimeException] {
         Table.forPath(defaultTableClient, path)
-          .getSnapshotAtVersion(defaultTableClient, 11)
+          .getSnapshotAsOfVersion(defaultTableClient, 11)
       }
       assert(e.getMessage.contains(
         "Trying to load a non-existent version 11. The latest version available is 10"))
@@ -651,7 +651,7 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
       // Cannot read a version that has been truncated
       val e = intercept[RuntimeException] {
         Table.forPath(defaultTableClient, tablePath)
-          .getSnapshotAtVersion(defaultTableClient, 9)
+          .getSnapshotAsOfVersion(defaultTableClient, 9)
       }
       assert(e.getMessage.contains("Unable to reconstruct state at version 9"))
       // Can read version 10
@@ -787,7 +787,7 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
       new File(dir, "_delta_log").mkdirs()
       intercept[TableNotFoundException] {
         Table.forPath(defaultTableClient, dir.getCanonicalPath)
-          .getSnapshotAtTimestamp(defaultTableClient, 0L)
+          .getSnapshotAsOfTimestamp(defaultTableClient, 0L)
       }
     }
   }
@@ -796,7 +796,7 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
     withTempDir { dir =>
       intercept[TableNotFoundException] {
         Table.forPath(defaultTableClient, dir.getCanonicalPath)
-          .getSnapshotAtTimestamp(defaultTableClient, 0L)
+          .getSnapshotAsOfTimestamp(defaultTableClient, 0L)
       }
     }
   }
@@ -806,7 +806,7 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
       spark.range(20).write.format("parquet").mode("overwrite").save(dir.getCanonicalPath)
       intercept[TableNotFoundException] {
         Table.forPath(defaultTableClient, dir.getCanonicalPath)
-          .getSnapshotAtTimestamp(defaultTableClient, 0L)
+          .getSnapshotAsOfTimestamp(defaultTableClient, 0L)
       }
     }
   }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -305,10 +305,10 @@ trait TestUtils extends Assertions with SQLHelper {
 
     val snapshot = if (version.isDefined) {
       Table.forPath(tableClient, path)
-        .getSnapshotAtVersion(tableClient, version.get)
+        .getSnapshotAsOfVersion(tableClient, version.get)
     } else if (timestamp.isDefined) {
       Table.forPath(tableClient, path)
-        .getSnapshotAtTimestamp(tableClient, timestamp.get)
+        .getSnapshotAsOfTimestamp(tableClient, timestamp.get)
     } else {
       latestSnapshot(path, tableClient)
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Renames the snapshot time travel APIs on `Table` to be consistent with SQL syntax.

## How was this patch tested?

Just refactoring existing tests suffice.

## Does this PR introduce _any_ user-facing changes?

Neither changed API has been released yet so no.
