### PR TITLE
[Spark] [Delta X-Compile] Fix tests for both Spark 3.5 and Spark Master (batch 3)

### DIFF
--- a/spark/src/main/scala-spark-3.5/shims/DeltaInvariantCheckerExecShims.scala
+++ b/spark/src/main/scala-spark-3.5/shims/DeltaInvariantCheckerExecShims.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.constraints
+
+import org.apache.spark.sql.catalyst.optimizer.ReplaceExpressions
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+
+trait DeltaInvariantCheckerOptimizerShims { self: RuleExecutor[LogicalPlan] =>
+  val DELTA_INVARIANT_CHECKER_OPTIMIZER_BATCHES = Seq(
+    Batch("Finish Analysis", Once, ReplaceExpressions)
+  )
+}

--- a/spark/src/main/scala-spark-3.5/shims/DeltaTableValueFunctionsShims.scala
+++ b/spark/src/main/scala-spark-3.5/shims/DeltaTableValueFunctionsShims.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.catalyst.expressions.Expression
+
+object DeltaTableValueFunctionsShims {
+
+  /**
+   * Handles a breaking change between Spark 3.5 and Spark Master (4.0).
+   *
+   * In Spark 4.0, SPARK-46331 [https://github.com/apache/spark/pull/44261] removed CodegenFallback
+   * from a subset of DateTime expressions, making the `now()` expression unevaluable.
+   */
+  def evaluateTimeOption(value: Expression): String = {
+    value.eval().toString
+  }
+}

--- a/spark/src/main/scala-spark-master/shims/DeltaInvariantCheckerExecShims.scala
+++ b/spark/src/main/scala-spark-master/shims/DeltaInvariantCheckerExecShims.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.constraints
+
+import org.apache.spark.sql.catalyst.optimizer.{ReplaceExpressions, RewriteWithExpression}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+
+trait DeltaInvariantCheckerOptimizerShims { self: RuleExecutor[LogicalPlan] =>
+  val DELTA_INVARIANT_CHECKER_OPTIMIZER_BATCHES = Seq(
+    Batch("Finish Analysis", Once, ReplaceExpressions),
+    Batch("Rewrite With expression", Once, RewriteWithExpression)
+  )
+}

--- a/spark/src/main/scala-spark-master/shims/DeltaTableValueFunctionsShims.scala
+++ b/spark/src/main/scala-spark-master/shims/DeltaTableValueFunctionsShims.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.util.AnalysisHelper
+
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.optimizer.ComputeCurrentTime
+
+object DeltaTableValueFunctionsShims {
+
+  /**
+   * Handles a breaking change between Spark 3.5 and Spark Master (4.0).
+   *
+   * In Spark 4.0, SPARK-46331 [https://github.com/apache/spark/pull/44261] removed CodegenFallback
+   * from a subset of DateTime expressions, making the `now()` expression unevaluable.
+   */
+  def evaluateTimeOption(value: Expression): String = {
+    val fakePlan = AnalysisHelper.FakeLogicalPlan(Seq(value), Nil)
+    val timestampExpression = ComputeCurrentTime(fakePlan).expressions.head
+    timestampExpression.eval().toString
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTableValueFunctions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTableValueFunctions.scala
@@ -115,7 +115,7 @@ trait CDCStatementBase extends DeltaTableValueFunction {
         case _: IntegerType | LongType => (keyPrefix + "Version") -> value.eval().toString
         case _: StringType => (keyPrefix + "Timestamp") -> value.eval().toString
         case _: TimestampType => (keyPrefix + "Timestamp") -> {
-          val time = value.eval().toString
+          val time = DeltaTableValueFunctionsShims.evaluateTimeOption(value)
           val fmt = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
           // when evaluated the time is represented with microseconds, which needs to be trimmed.
           fmt.format(new Date(time.toLong / 1000))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/constraints/DeltaInvariantCheckerExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/constraints/DeltaInvariantCheckerExec.scala
@@ -103,10 +103,10 @@ case class DeltaInvariantCheckerExec(
 object DeltaInvariantCheckerExec {
 
   // Specialized optimizer to run necessary rules so that the check expressions can be evaluated.
-  object DeltaInvariantCheckerOptimizer extends RuleExecutor[LogicalPlan] {
-    final override protected def batches = Seq(
-      Batch("Finish Analysis", Once, ReplaceExpressions)
-    )
+  object DeltaInvariantCheckerOptimizer
+      extends RuleExecutor[LogicalPlan]
+      with DeltaInvariantCheckerOptimizerShims {
+    final override protected def batches = DELTA_INVARIANT_CHECKER_OPTIMIZER_BATCHES
   }
 
   /** Build the extractor for a particular column. */


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR is batch 3. This PR fixes 2 tests in 2 suites for Delta on Spark Master using shimming.

## How was this patch tested?

Existing UTs

## Does this PR introduce _any_ user-facing changes?

No
