### PR TITLE
[Spark] Add IdentityColumn.scala

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/IdentityColumn.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/IdentityColumn.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.metering.DeltaLogging
+
+/**
+ * Provide utility methods related to IDENTITY column support for Delta.
+ */
+object IdentityColumn extends DeltaLogging {
+  case class IdentityInfo(start: Long, step: Long, highWaterMark: Option[Long])
+  // Default start and step configuration if not specified by user.
+  val defaultStart = 1
+  val defaultStep = 1
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR is part of https://github.com/delta-io/delta/issues/1959

In this PR, we introduce IdentityColumn.scala, a common file which contains most of the helpers for Identity Columns, necessary for unblocking future PRs.

## How was this patch tested?
This PR commits dead code. Existing tests pass.

## Does this PR introduce _any_ user-facing changes?
No.