### PR TITLE
[Spark] Add additional read stable Row IDs check

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdCreateReplaceTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdCreateReplaceTableSuite.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.delta.RowId.extractHighWatermark
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION
 
 import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.test.SharedSparkSession
 
@@ -133,6 +134,9 @@ class RowIdCreateReplaceTableSuite extends QueryTest
       }
 
       assertRowIdsAreValid(log)
+
+      val df = spark.read.table("target").select("*", "_metadata.row_id")
+      checkAnswer(df, (0 until 50).map(i => Row(i, i)))
     }
   }
 
@@ -152,6 +156,9 @@ class RowIdCreateReplaceTableSuite extends QueryTest
       }
 
       assertRowIdsAreValid(log)
+
+      val df = spark.read.table("target").select("*", "_metadata.row_id")
+      checkAnswer(df, Seq(Row(0, 0), Row(1, 1)))
     }
   }
 
@@ -164,6 +171,9 @@ class RowIdCreateReplaceTableSuite extends QueryTest
 
       val log = DeltaLog.forTable(spark, TableIdentifier("target"))
       assertRowIdsAreValid(log)
+
+      val df = spark.read.table("target").select("*", "_metadata.row_id")
+      checkAnswer(df, Seq(Row(0, 0), Row(1, 1)))
     }
   }
 
@@ -176,6 +186,9 @@ class RowIdCreateReplaceTableSuite extends QueryTest
 
         val log = DeltaLog.forTable(spark, TableIdentifier("target"))
         assertRowIdsAreValid(log)
+
+        val df = spark.read.table("target").select("*", "_metadata.row_id")
+        checkAnswer(df, Seq(Row(0, 0), Row(1, 1)))
       }
     }
   }
@@ -198,14 +211,14 @@ class RowIdCreateReplaceTableSuite extends QueryTest
 
   def writeTargetTestData(withRowIds: Boolean): Unit = {
     withRowTrackingEnabled(enabled = withRowIds) {
-      spark.range(start = 0, end = 100, step = 1, numPartitions = 10)
+      spark.range(start = 0, end = 100, step = 1, numPartitions = 1)
         .write.format("delta").saveAsTable("target")
     }
   }
 
   def writeSourceTestData(withRowIds: Boolean): Unit = {
     withRowTrackingEnabled(enabled = withRowIds) {
-      spark.range(start = 0, end = numSourceRows, step = 1, numPartitions = 10)
+      spark.range(start = 0, end = numSourceRows, step = 1, numPartitions = 1)
         .write.format("delta").saveAsTable("source")
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdSuite.scala
@@ -347,6 +347,11 @@ class RowIdSuite extends QueryTest
         val log = DeltaLog.forTable(spark, dir)
         assertRowIdsAreValid(log)
         assert(extractMaterializedRowIdColumnName(log).isDefined)
+
+        val df = spark.read.format("delta").load(dir.toString)
+        checkAnswer(
+          df.select("id", "_metadata.row_id"),
+          (0 until 10).map(i => Row(i, i)))
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Add additional read stable Row IDs assertions in some tests after read stable Row Tracking is introduced in the previous PRs.
## How was this patch tested?
Added UTs.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
