### PR TITLE
[Spark] [Delta X-Compile] Fix tests for both Spark 3.5 and Spark Maser (batch 4)

### DIFF
--- a/spark/src/test/scala-spark-3.5/shims/ImplicitDMLCastingSuiteShims.scala
+++ b/spark/src/test/scala-spark-3.5/shims/ImplicitDMLCastingSuiteShims.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+object ImplicitDMLCastingSuiteShims {
+  /**
+   * Discrepancy in error message between Spark 3.5 and Master (4.0) due to SPARK-47798
+   * (https://github.com/apache/spark/pull/45981)
+   */
+  val NUMERIC_VALUE_OUT_OF_RANGE_ERROR_MSG = "NUMERIC_VALUE_OUT_OF_RANGE"
+}

--- a/spark/src/test/scala-spark-master/shims/ImplicitDMLCastingSuiteShims.scala
+++ b/spark/src/test/scala-spark-master/shims/ImplicitDMLCastingSuiteShims.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+object ImplicitDMLCastingSuiteShims {
+  /**
+   * Discrepancy in error message between Spark 3.5 and Master (4.0) due to SPARK-47798
+   * (https://github.com/apache/spark/pull/45981)
+   */
+  val NUMERIC_VALUE_OUT_OF_RANGE_ERROR_MSG = "NUMERIC_VALUE_OUT_OF_RANGE.WITH_SUGGESTION"
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ImplicitDMLCastingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ImplicitDMLCastingSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.delta
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 
+import org.apache.spark.sql.delta.ImplicitDMLCastingSuiteShims._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaExceptionTestUtils, DeltaSQLCommandTest}
 
@@ -143,7 +144,7 @@ class ImplicitDMLCastingSuite extends QueryTest
         assert(failureCause.toString.contains(testConfig.exceptionAnsiCast))
 
         val sparkThrowable = failureCause.asInstanceOf[SparkThrowable]
-        assert(Seq("CAST_OVERFLOW", "NUMERIC_VALUE_OUT_OF_RANGE", "CAST_INVALID_INPUT")
+        assert(Seq("CAST_OVERFLOW", NUMERIC_VALUE_OUT_OF_RANGE_ERROR_MSG, "CAST_INVALID_INPUT")
           .contains(sparkThrowable.getErrorClass))
       case Some(failureCause) if !sqlConfig.followAnsiEnabled =>
         assert(sqlConfig.storeAssignmentPolicy === SQLConf.StoreAssignmentPolicy.ANSI)


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR is batch 4. This PR fixes 20 tests in 1 suite for Delta on Spark Master using shimming.

## How was this patch tested?

Existing UTs

## Does this PR introduce _any_ user-facing changes?

No