### PR TITLE
[Spark] Support Glue catalog for iceberg tables using UniForm

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
@@ -350,18 +350,18 @@ class IcebergConversionTransaction(
 
   protected def createIcebergTxn(tableOpOpt: Option[IcebergTableOp] = None):
       IcebergTransaction = {
-    val hiveCatalog = IcebergTransactionUtils.createHiveCatalog(conf)
+    val icebergCatalog = IcebergTransactionUtils.createCatalog(conf)
     val icebergTableId = IcebergTransactionUtils
       .convertSparkTableIdentifierToIcebergHive(catalogTable.identifier)
 
-    val tableExists = hiveCatalog.tableExists(icebergTableId)
+    val tableExists = icebergCatalog.tableExists(icebergTableId)
 
     def tableBuilder = {
       val properties = getIcebergPropertiesFromDeltaProperties(
         postCommitSnapshot.metadata.configuration
       )
 
-      hiveCatalog
+      icebergCatalog
         .buildTable(icebergTableId, icebergSchema)
         .withPartitionSpec(partitionSpec)
         .withProperties(properties.asJava)
@@ -371,7 +371,7 @@ class IcebergConversionTransaction(
       case WRITE_TABLE =>
         if (tableExists) {
           recordFrameProfile("IcebergConversionTransaction", "loadTable") {
-            hiveCatalog.loadTable(icebergTableId).newTransaction()
+            icebergCatalog.loadTable(icebergTableId).newTransaction()
           }
         } else {
           throw new IllegalStateException(s"Cannot write to table $tablePath. Table doesn't exist.")

--- a/icebergShaded/generate_iceberg_jars.py
+++ b/icebergShaded/generate_iceberg_jars.py
@@ -41,7 +41,8 @@ iceberg_src_compiled_jar_rel_glob_patterns = [
     "core/build/libs/iceberg-core-*.jar",
     "parquet/build/libs/iceberg-parquet-*.jar",
     "hive-metastore/build/libs/iceberg-hive-*.jar",
-    "data/build/libs/iceberg-data-*.jar"
+    "data/build/libs/iceberg-data-*.jar",
+    "aws/build/libs/iceberg-aws-*.jar"
 ]
 
 iceberg_root_dir = path.abspath(path.dirname(__file__)) # this is NOT a git dir
@@ -102,6 +103,7 @@ def generate_iceberg_jars():
         run_cmd("./gradlew :iceberg-parquet:build %s" % build_args)
         run_cmd("./gradlew :iceberg-hive-metastore:build %s" % build_args)
         run_cmd("./gradlew :iceberg-data:build %s" % build_args)
+        run_cmd("./gradlew :iceberg-aws:build %s" % build_args)
 
     print(">>> Copying JARs to lib directory")
     shutil.rmtree(iceberg_lib_dir, ignore_errors=True)

--- a/icebergShaded/iceberg_src_patches/0006-iceberg-glue-update-storage-description.patch
+++ b/icebergShaded/iceberg_src_patches/0006-iceberg-glue-update-storage-description.patch
@@ -1,0 +1,68 @@
+Add delta table properties to Glue table
+
+--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
++++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+@@ -74,6 +74,8 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
+   private final Object hadoopConf;
+   private final LockManager lockManager;
+   private FileIO fileIO;
++  private final String DELTA_VERSION_PROPERTY = "delta-version";
++  private final String DELTA_TIMESTAMP_PROPERTY = "delta-timestamp";
+
+   // Attempt to set versionId if available on the path
+   private static final DynMethods.UnboundMethod SET_VERSION_ID =
+@@ -152,6 +154,7 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
+       Table glueTable = getGlueTable();
+       checkMetadataLocation(glueTable, base);
+       Map<String, String> properties = prepareProperties(glueTable, newMetadataLocation);
++      properties.putAll(getDeltaProperties(metadata));
+       persistGlueTable(glueTable, properties, metadata);
+       commitStatus = CommitStatus.SUCCESS;
+     } catch (CommitFailedException e) {
+@@ -283,6 +286,15 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
+     }
+   }
+
++  private Map<String, String> getDeltaProperties(TableMetadata base) {
++    if (base == null) {
++      return ImmutableMap.of(DELTA_VERSION_PROPERTY, "-1");
++    }
++    return ImmutableMap.of(
++        DELTA_VERSION_PROPERTY, base.property(DELTA_VERSION_PROPERTY, "-1"),
++        DELTA_TIMESTAMP_PROPERTY, base.property(DELTA_TIMESTAMP_PROPERTY, "-1"));
++  }
++
+   private Map<String, String> prepareProperties(Table glueTable, String newMetadataLocation) {
+     Map<String, String> properties =
+         glueTable != null ? Maps.newHashMap(glueTable.parameters()) : Maps.newHashMap();
+diff --git a/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java b/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
+index 241c0098d..edf95df5b 100644
+--- a/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
++++ b/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
+@@ -47,6 +47,7 @@ import org.slf4j.Logger;
+ import org.slf4j.LoggerFactory;
+ import software.amazon.awssdk.services.glue.model.Column;
+ import software.amazon.awssdk.services.glue.model.DatabaseInput;
++import software.amazon.awssdk.services.glue.model.SerDeInfo;
+ import software.amazon.awssdk.services.glue.model.StorageDescriptor;
+ import software.amazon.awssdk.services.glue.model.TableInput;
+
+@@ -239,7 +240,17 @@ class IcebergToGlueConverter {
+       }
+
+       tableInputBuilder.storageDescriptor(
+-          storageDescriptor.location(metadata.location()).columns(toColumns(metadata)).build());
++          storageDescriptor
++              .location(metadata.location())
++              .columns(toColumns(metadata))
++              .outputFormat("org.apache.hadoop.mapred.FileOutputFormat")
++              .inputFormat("org.apache.hadoop.mapred.FileInputFormat")
++              .serdeInfo(
++                  SerDeInfo.builder()
++                      .serializationLibrary("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe")
++                      .parameters(ImmutableMap.of("path", metadata.location()))
++                      .build())
++              .build());
+     } catch (RuntimeException e) {
+       LOG.warn(
+           "Encountered unexpected exception while converting Iceberg metadata to Glue table information",


### PR DESCRIPTION

#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
- Adds GlueCatalog support for Iceberg tables using Uniform. 
- Accepts GlueCatalog as `catalog-impl` spark configuration property. 

```
spark-shell  --conf spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension  \
--conf spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog  \
--conf spark.databricks.delta.allowArbitraryProperties.enabled=true \
--conf spark.sql.catalog.spark_catalog.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog \ 
--conf spark.sql.catalog.spark_catalog.warehouse=s3://warehouse/path/delta/  \
--conf spark.jars=/home/hadoop/delta-iceberg_2.12-3.1.0.jar,/home/hadoop/url-connection-client-2.20.160.jar
```

## How was this patch tested?
- Created Delta table with uniform property - `'delta.universalFormat.enabledFormats' = 'iceberg'` 
- Verified Iceberg table created in Glue 
- Successfully read data from Iceberg table

## Does this PR introduce _any_ user-facing changes?

Yes, Users can use GlueCatalog for saving Iceberg tables to Aws Glue  