### PR TITLE
[Spark] Apply Column Mapping to filters pushed to Parquet scan

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
@@ -569,6 +569,18 @@ trait DeltaColumnMappingBase extends DeltaLogging {
   }
 
   /**
+   * Returns a map from the logical name paths to the physical name paths for the given schema.
+   * The logical name path is the result of splitting a multi-part identifier, and the physical name
+   * path is result of replacing all names in the logical name path with their physical names.
+   */
+  def getLogicalNameToPhysicalNameMap(schema: StructType): Map[Seq[String], Seq[String]] = {
+    val physicalSchema = renameColumns(schema)
+    val logicalSchemaFieldPaths = SchemaMergingUtils.explode(schema).map(_._1)
+    val physicalSchemaFieldPaths = SchemaMergingUtils.explode(physicalSchema).map(_._1)
+    logicalSchemaFieldPaths.zip(physicalSchemaFieldPaths).toMap
+  }
+
+  /**
    * Returns true if Column Mapping mode is enabled and the newMetadata's schema, when compared to
    * the currentMetadata's schema, is indicative of a DROP COLUMN operation.
    *


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR fixes a correctness bug when Column Mapping is enabled. The issue occurs when a column is renamed to the physical name of another column. If a query filters on this column then the Parquet scan incorrectly applies this filter to the other column. This PR fixes this problem by translating the column names in the filters from logical to physical in `DeltaParquetFileFormat` before passing them on to `ParquetFileFormat`. 

## How was this patch tested?

Added a unit test to `DeltaColumnMappingSuite`.

## Does this PR introduce _any_ user-facing changes?

No 
