### PR TITLE
[Kernel] Expose the "stats" field in returned scan files in `ScanImpl` using a boolean parameter

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/InternalScanFileUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/InternalScanFileUtils.java
@@ -56,14 +56,23 @@ public class InternalScanFileUtils {
 
     // TODO update this when stats columns are dropped from the returned scan files
     /**
-     * Scan file rows may have an additional column "add.stats" at the end of the "add" columns
-     * that is not represented in the schema here.
+     * Schema of the returned scan files. May have an additional column "add.stats" at the end of
+     * the "add" columns that is not represented in the schema here. This column is conditionally
+     * read when a valid data skipping filter can be generated.
      */
     public static final StructType SCAN_FILE_SCHEMA = new StructType()
         .add("add", AddFile.SCHEMA_WITHOUT_STATS)
         // NOTE: table root is temporary, until the path in `add.path` is converted to
         // an absolute path. https://github.com/delta-io/delta/issues/2089
-        .add(TABLE_ROOT_COL_NAME, TABLE_ROOT_DATA_TYPE);
+        .add(TABLE_ROOT_STRUCT_FIELD);
+
+    /**
+     * Schema of the returned scan files when {@link ScanImpl#getScanFiles(TableClient, boolean)}
+     * is called with {@code includeStats=true}.
+     */
+    public static final StructType SCAN_FILE_SCHEMA_WITH_STATS = new StructType()
+        .add("add", AddFile.SCHEMA_WITH_STATS)
+        .add(TABLE_ROOT_STRUCT_FIELD);
 
     public static final int ADD_FILE_ORDINAL = SCAN_FILE_SCHEMA.indexOf("add");
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -108,7 +108,7 @@ public class ScanImpl implements Scan {
      *
      * @param tableClient the {@link TableClient} instance to use
      * @param includeStats whether to read and include the JSON statistics
-     * @return
+     * @return the surviving scan files as {@link FilteredColumnarBatch}s
      */
     public CloseableIterator<FilteredColumnarBatch> getScanFiles(
             TableClient tableClient, boolean includeStats) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -102,7 +102,7 @@ public class ScanImpl implements Scan {
      *
      * When {@code includeStats=true} the JSON file statistics are always read from the log and
      * included in the returned columnar batches which have schema
-     * {@link InternalScanFileUtils.SCAN_FILE_SCHEMA_WITH_STATS}.
+     * {@link InternalScanFileUtils#SCAN_FILE_SCHEMA_WITH_STATS}.
      * When {@code includeStats=false} the JSON file statistics may or may not be present in the
      * returned columnar batches.
      *


### PR DESCRIPTION
## Description
Add a private API `ScanImpl.getScanFiles(TableClient tableClient, boolean includeStats)` to enable connectors to fetch the `stats` as part of the returned scan file rows. By default `stats` are not read unless there is a predicate on data columns.

The main reason why we are not making this a public API yet is that currently, the `ColumnarBatch` interface has no way to remove a nested column vector before returning it to the connector. It requires major work on the expression interfaces. Until we have that, this is a workaround for connectors that are interested in the `stats` field in scan files.

## How was this patch tested?
UTs