### PR TITLE
[Spark] Add nextObserver and the PhaseLockingExecutionObserver for the Concurrency Testing Framework

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/fuzzer/ExecutionPhaseLock.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/fuzzer/ExecutionPhaseLock.scala
@@ -65,4 +65,7 @@ case class ExecutionPhaseLock(
     waitToEnter()
     leave()
   }
+
+  /** Blocks at this point until the phase has been left. */
+  def waitToLeave(): Unit = exitBarrier.waitToPass()
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/fuzzer/PhaseLockingExecutionObserver.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/fuzzer/PhaseLockingExecutionObserver.scala
@@ -16,7 +16,6 @@
 
 package org.apache.spark.sql.delta.fuzzer
 
-
 /**
  * Trait representing execution observers that rely on phases with entry and exit barriers to
  * control the order of execution of the observed code paths. See [[ExecutionPhaseLock]].

--- a/spark/src/main/scala/org/apache/spark/sql/delta/fuzzer/PhaseLockingExecutionObserver.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/fuzzer/PhaseLockingExecutionObserver.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.fuzzer
+
+
+/**
+ * Trait representing execution observers that rely on phases with entry and exit barriers to
+ * control the order of execution of the observed code paths. See [[ExecutionPhaseLock]].
+ */
+trait PhaseLockingExecutionObserver {
+
+  val phaseLocks: Seq[ExecutionPhaseLock]
+
+  /** Return `true` if we have left all phases, `false` otherwise. */
+  def allPhasesHavePassed: Boolean = phaseLocks.forall(_.hasLeft)
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/fuzzer/PhaseLockingTransactionExecutionObserver.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/fuzzer/PhaseLockingTransactionExecutionObserver.scala
@@ -16,11 +16,27 @@
 
 package org.apache.spark.sql.delta.fuzzer
 
-import org.apache.spark.sql.delta.{OptimisticTransaction, TransactionExecutionObserver}
+import org.apache.spark.sql.delta.OptimisticTransaction
+import org.apache.spark.sql.delta.TransactionExecutionObserver
 
 private[delta] class PhaseLockingTransactionExecutionObserver(
     val phases: OptimisticTransactionPhases)
-  extends TransactionExecutionObserver {
+  extends TransactionExecutionObserver
+  with PhaseLockingExecutionObserver {
+
+  override val phaseLocks: Seq[ExecutionPhaseLock] = Seq(
+    phases.initialPhase,
+    phases.preparePhase,
+    phases.commitPhase)
+
+  /**
+   * When set to true this observer will automatically update the thread's current observer to
+   * the next one. Also, it will not unblock the exit barrier of the commit phase automatically.
+   * Instead, the caller will have to automatically unblock it. This allows writing tests that
+   * can capture errors caused by code written between the end of the last txn and the start of
+   * the next txn.
+   */
+  @volatile protected var autoAdvanceNextObserver: Boolean = false
 
   override def startingTransaction(f: => OptimisticTransaction): OptimisticTransaction =
     phases.initialPhase.execute(f)
@@ -29,14 +45,52 @@ private[delta] class PhaseLockingTransactionExecutionObserver(
 
   override def beginDoCommit(): Unit = phases.commitPhase.waitToEnter()
 
-  override def transactionCommitted(): Unit = phases.commitPhase.leave()
-
-  override def transactionAborted(): Unit = {
-    if (!phases.commitPhase.hasEntered) {
-      // If an Exception was thrown earlier we may not have called `beginDoCommit`, yet.
-      phases.commitPhase.passThrough()
+  override def transactionCommitted(): Unit = {
+    if (nextObserver.nonEmpty && autoAdvanceNextObserver) {
+      waitForCommitPhaseAndAdvanceToNextObserver()
     } else {
       phases.commitPhase.leave()
     }
   }
+
+  override def transactionAborted(): Unit = {
+    if (!phases.commitPhase.hasEntered) {
+      phases.commitPhase.waitToEnter()
+    }
+    if (nextObserver.nonEmpty && autoAdvanceNextObserver) {
+      waitForCommitPhaseAndAdvanceToNextObserver()
+    } else {
+      phases.commitPhase.leave()
+    }
+  }
+
+  /*
+   * Wait for the commit phase to pass but do not unblock it so that callers can write tests
+   * that capture errors caused by code between the end of the last txn and the start of the
+   * new txn. After the commit phase is passed, update the thread observer of the thread to
+   * the next observer.
+   */
+  def waitForCommitPhaseAndAdvanceToNextObserver(): Unit = {
+    require(nextObserver.nonEmpty)
+    phases.commitPhase.waitToLeave()
+    advanceToNextThreadObserver()
+  }
+
+  /**
+   * Set the next observer, which will replace the txn observer on the thread after a successful
+   * commit. This method only works as expected if we haven't entered the commit phase yet.
+   *
+   * Note that when a next observer is set, the caller needs to manually unblock the exit barrier
+   * of the commit phase.
+   *
+   * For example, see [[waitForCommitPhaseAndAdvanceToNextObserver]].
+   */
+  def setNextObserver(
+      nextTxnObserver: TransactionExecutionObserver,
+      autoAdvance: Boolean): Unit = {
+    setNextObserver(nextTxnObserver)
+    autoAdvanceNextObserver = autoAdvance
+  }
+
+  override def advanceToNextThreadObserver(): Unit = super.advanceToNextThreadObserver()
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/fuzzer/PhaseLockingTransactionExecutionObserver.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/fuzzer/PhaseLockingTransactionExecutionObserver.scala
@@ -16,8 +16,7 @@
 
 package org.apache.spark.sql.delta.fuzzer
 
-import org.apache.spark.sql.delta.OptimisticTransaction
-import org.apache.spark.sql.delta.TransactionExecutionObserver
+import org.apache.spark.sql.delta.{OptimisticTransaction, TransactionExecutionObserver}
 
 private[delta] class PhaseLockingTransactionExecutionObserver(
     val phases: OptimisticTransactionPhases)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Add the `nextObserver` and the `PhaseLockingExecutionObserver` for the Concurrency Testing Framework, as we will need it to write Row Tracking Backfill conflicts with other commands tests when we add Row Tracking Backfill.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Added UTs.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
