### PR TITLE
[Spark] Add Preserving Row Tracking in Merge

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
@@ -208,12 +208,13 @@ case class MergeIntoCommand(
     val finalActions = createSetTransaction(spark, targetDeltaLog).toSeq ++ mergeActions
     deltaTxn.commitIfNeeded(
       actions = finalActions,
-      DeltaOperations.Merge(
+      op = DeltaOperations.Merge(
         predicate = Option(condition),
         matchedPredicates = matchedClauses.map(DeltaOperations.MergePredicate(_)),
         notMatchedPredicates = notMatchedClauses.map(DeltaOperations.MergePredicate(_)),
         notMatchedBySourcePredicates =
-          notMatchedBySourceClauses.map(DeltaOperations.MergePredicate(_))))
+          notMatchedBySourceClauses.map(DeltaOperations.MergePredicate(_))),
+      tags = RowTracking.addPreservedRowTrackingTagIfNotSet(deltaTxn.snapshot))
     val stats = collectMergeStats(deltaTxn, materializeSourceReason)
     recordDeltaEvent(targetDeltaLog, "delta.dml.merge.stats", data = stats)
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeOutputGeneration.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeOutputGeneration.scala
@@ -514,7 +514,7 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
       }
     }
 
-    sourceDF
+    sourceDf
       // `explode()` creates a [[Generator]] which can't handle non-deterministic expressions that
       // we use to increment metric counters. We first project the CDC array so that the expressions
       // are evaluated before we explode the array.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeOutputGeneration.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeOutputGeneration.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.delta.commands.merge
 
 import scala.collection.mutable
 
+import org.apache.spark.sql.delta.{RowCommitVersion, RowId}
 import org.apache.spark.sql.delta.commands.MergeIntoCommandBase
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 
@@ -98,6 +99,8 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
    */
   protected def generateWriteAllChangesOutputCols(
       targetWriteCols: Seq[Expression],
+      rowIdColumnExpressionOpt: Option[NamedExpression],
+      rowCommitVersionColumnExpressionOpt: Option[NamedExpression],
       targetWriteColNames: Seq[String],
       noopCopyExprs: Seq[Expression],
       clausesWithPrecompConditions: Seq[DeltaMergeIntoClause],
@@ -109,6 +112,8 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
     // ==== Generate N + 2 (N + 4 preserving Row Tracking) expressions for MATCHED clauses ====
     val processedMatchClauses: Seq[ProcessedClause] = generateAllActionExprs(
       targetWriteCols,
+      rowIdColumnExpressionOpt,
+      rowCommitVersionColumnExpressionOpt,
       clausesWithPrecompConditions.collect { case c: DeltaMergeIntoMatchedClause => c },
       cdcEnabled,
       shouldCountDeletedRows)
@@ -120,12 +125,19 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
     // N + 1 (or N + 2 with CDC, N + 4 preserving Row Tracking and CDC) expressions to delete the
     // unmatched source row when it should not be inserted. `target.output` will produce NULLs
     // which will get deleted eventually.
-    val deleteSourceRowExprs = (targetWriteCols :+ Literal.TrueLiteral) ++
-      (if (cdcEnabled) Seq(CDC_TYPE_NOT_CDC) else Nil)
+
+    val deleteSourceRowExprs =
+      (targetWriteCols ++
+        rowIdColumnExpressionOpt.map(_ => Literal(null)) ++
+        rowCommitVersionColumnExpressionOpt.map(_ => Literal(null)) ++
+        Seq(Literal(true))) ++
+        (if (cdcEnabled) Seq(CDC_TYPE_NOT_CDC) else Seq())
 
     // ==== Generate N + 2 (N + 4 preserving Row Tracking) expressions for NOT MATCHED clause ====
     val processedNotMatchClauses: Seq[ProcessedClause] = generateAllActionExprs(
       targetWriteCols,
+      rowIdColumnExpressionOpt,
+      rowCommitVersionColumnExpressionOpt,
       clausesWithPrecompConditions.collect { case c: DeltaMergeIntoNotMatchedClause => c },
       cdcEnabled,
       shouldCountDeletedRows)
@@ -137,6 +149,8 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
     // === Generate N + 2 (N + 4 with Row Tracking) expressions for NOT MATCHED BY SOURCE clause ===
     val processedNotMatchBySourceClauses: Seq[ProcessedClause] = generateAllActionExprs(
       targetWriteCols,
+      rowIdColumnExpressionOpt,
+      rowCommitVersionColumnExpressionOpt,
       clausesWithPrecompConditions.collect { case c: DeltaMergeIntoNotMatchedBySourceClause => c },
       cdcEnabled,
       shouldCountDeletedRows)
@@ -187,7 +201,17 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
         ifSourceRowNull -> notMatchedBySourceExprs(i),
         ifTargetRowNull -> notMatchedExprs(i)),
         /*  otherwise  */ matchedExprs(i))
-      Column(Alias(caseWhen, name)())
+      if (rowIdColumnExpressionOpt.exists(_.name == name)) {
+        // Add Row ID metadata to allow writing the column.
+        Column(Alias(caseWhen, name)(
+          explicitMetadata = Some(RowId.columnMetadata(name))))
+      } else if (rowCommitVersionColumnExpressionOpt.exists(_.name == name)) {
+        // Add Row Commit Versions metadata to allow writing the column.
+        Column(Alias(caseWhen, name)(
+          explicitMetadata = Some(RowCommitVersion.columnMetadata(name))))
+      } else {
+        Column(Alias(caseWhen, name)())
+      }
     }
     logDebug("writeAllChanges: join output expressions\n\t" + seqToString(outputCols.map(_.expr)))
     outputCols
@@ -206,6 +230,11 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
    * UPDATE, DELETE and/or INSERT action(s).
    * @param targetWriteCols List of output column expressions from the target table. Used to
    *                        generate CDC data for DELETE.
+   * @param rowIdColumnExpressionOpt The optional Row ID preservation column with the physical
+   *                                 Row ID name, it stores stable Row IDs of the table.
+   * @param rowCommitVersionColumnExpressionOpt The optional Row Commit Version preservation
+   *                                 column with the physical Row Commit Version name, it stores
+   *                                 stable Row Commit Versions.
    * @param clausesWithPrecompConditions List of merge clauses with precomputed conditions. Action
    *                                     expressions are generated for each of these clauses.
    * @param cdcEnabled Whether the generated expressions should include CDC information.
@@ -217,6 +246,8 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
    */
   protected def generateAllActionExprs(
       targetWriteCols: Seq[Expression],
+      rowIdColumnExpressionOpt: Option[NamedExpression],
+      rowCommitVersionColumnExpressionOpt: Option[NamedExpression],
       clausesWithPrecompConditions: Seq[DeltaMergeIntoClause],
       cdcEnabled: Boolean,
       shouldCountDeletedRows: Boolean): Seq[ProcessedClause] = {
@@ -230,6 +261,8 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
             valueToReturn = false)
           // Generate update expressions and set ROW_DROPPED_COL = false
           u.resolvedActions.map(_.expr) ++
+            rowIdColumnExpressionOpt ++
+            rowCommitVersionColumnExpressionOpt.map(_ => Literal(null)) ++
             Seq(incrCountExpr) ++
             (if (cdcEnabled) Some(Literal(CDC_TYPE_UPDATE_POSTIMAGE)) else None)
         case u: DeltaMergeIntoNotMatchedBySourceUpdateClause =>
@@ -238,6 +271,8 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
             valueToReturn = false)
           // Generate update expressions and set ROW_DROPPED_COL = false
           u.resolvedActions.map(_.expr) ++
+            rowIdColumnExpressionOpt ++
+            rowCommitVersionColumnExpressionOpt.map(_ => Literal(null)) ++
             Seq(incrCountExpr) ++
             (if (cdcEnabled) Some(Literal(CDC_TYPE_UPDATE_POSTIMAGE)) else None)
         case _: DeltaMergeIntoMatchedDeleteClause =>
@@ -252,6 +287,8 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
           }
           // Generate expressions to set the ROW_DROPPED_COL = true and mark as a DELETE
           targetWriteCols ++
+            rowIdColumnExpressionOpt ++
+            rowCommitVersionColumnExpressionOpt ++
             Seq(incrCountExpr) ++
             (if (cdcEnabled) Some(CDC_TYPE_DELETE) else None)
         case _: DeltaMergeIntoNotMatchedBySourceDeleteClause =>
@@ -266,6 +303,8 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
           }
           // Generate expressions to set the ROW_DROPPED_COL = true and mark as a DELETE
           targetWriteCols ++
+            rowIdColumnExpressionOpt ++
+            rowCommitVersionColumnExpressionOpt ++
             Seq(incrCountExpr) ++
             (if (cdcEnabled) Some(CDC_TYPE_DELETE) else None)
         case i: DeltaMergeIntoNotMatchedInsertClause =>
@@ -273,6 +312,8 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
             names = Seq("numTargetRowsInserted"),
             valueToReturn = false)
           i.resolvedActions.map(_.expr) ++
+            rowIdColumnExpressionOpt.map(_ => Literal(null)) ++
+            rowCommitVersionColumnExpressionOpt.map(_ => Literal(null)) ++
             Seq(incrInsertedCountExpr) ++
             (if (cdcEnabled) Some(Literal(CDC_TYPE_INSERT)) else None)
       }
@@ -346,6 +387,8 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
       outputCols: Seq[Column],
       outputColNames: Seq[String],
       noopCopyExprs: Seq[Expression],
+      rowIdColumnNameOpt: Option[String],
+      rowCommitVersionColumnNameOpt: Option[String],
       deduplicateDeletes: DeduplicateCDFDeletes): DataFrame = {
     import org.apache.spark.sql.delta.commands.cdc.CDCReader._
     // The main partition just needs to swap in the CDC_TYPE_NOT_CDC value.
@@ -416,12 +459,16 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
         sourceDf,
         cdcArray,
         cdcToMainDataArray,
+        rowIdColumnNameOpt,
+        rowCommitVersionColumnNameOpt,
         outputColNames)
     } else {
       packAndExplodeCDCOutput(
         sourceDf,
         cdcArray,
         cdcToMainDataArray,
+        rowIdColumnNameOpt,
+        rowCommitVersionColumnNameOpt,
         outputColNames,
         dedupColumns = Nil)
     }
@@ -440,6 +487,11 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
    * @param cdcToMainDataArray Transforms the packed CDC data to add the main data output, i.e. rows
    *                           that are inserted or updated and will be written to the main
    *                           partition.
+   * @param rowIdColumnNameOpt The optional Row ID preservation column with the physical Row ID
+   *                           name, it stores stable Row IDs.
+   * @param rowCommitVersionColumnNameOpt The optional Row Commit Version preservation column
+   *                                      with the physical Row Commit Version name, it stores
+   *                                      stable Row Commit Versions.
    * @param outputColNames All the main and CDC columns to use in the output.
    * @param dedupColumns Additional columns to add to enable deduplication.
    */
@@ -447,15 +499,25 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
       sourceDf: DataFrame,
       cdcArray: Column,
       cdcToMainDataArray: Column,
+      rowIdColumnNameOpt: Option[String],
+      rowCommitVersionColumnNameOpt: Option[String],
       outputColNames: Seq[String],
       dedupColumns: Seq[Column]): DataFrame = {
     val unpackedCols = outputColNames.map { name =>
+      if (rowIdColumnNameOpt.contains(name)) {
+        // Add metadata to allow writing the column although it is not part of the schema.
+        col(s"packedData.`$name`").as(name, RowId.columnMetadata(name))
+      } else if (rowCommitVersionColumnNameOpt.contains(name)) {
+        col(s"packedData.`$name`").as(name, RowCommitVersion.columnMetadata(name))
+      } else {
         col(s"packedData.`$name`").as(name)
+      }
     }
-    sourceDf
+
+    sourceDF
       // `explode()` creates a [[Generator]] which can't handle non-deterministic expressions that
       // we use to increment metric counters. We first project the CDC array so that the expressions
-      // are evaluated before we explode the array,
+      // are evaluated before we explode the array.
       .select(cdcArray.as("projectedCDC") +: dedupColumns: _*)
       .select(explode(col("projectedCDC")).as("packedCdc") +: dedupColumns: _*)
       .select(explode(cdcToMainDataArray).as("packedData") +: dedupColumns: _*)
@@ -480,6 +542,8 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
       df: DataFrame,
       cdcArray: Column,
       cdcToMainDataArray: Column,
+      rowIdColumnNameOpt: Option[String],
+      rowCommitVersionColumnNameOpt: Option[String],
       outputColNames: Seq[String]): DataFrame = {
     val dedupColumns = if (deduplicateDeletes.includesInserts) {
       Seq(col(TARGET_ROW_INDEX_COL), col(SOURCE_ROW_INDEX_COL))
@@ -491,6 +555,8 @@ trait MergeOutputGeneration { self: MergeIntoCommandBase =>
       df,
       cdcArray,
       cdcToMainDataArray,
+      rowIdColumnNameOpt,
+      rowCommitVersionColumnNameOpt,
       outputColNames,
       dedupColumns
     )

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingMergeSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingMergeSuite.scala
@@ -1,0 +1,604 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rowid
+
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.sql.{Dataset, Row}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.functions.{col, lit}
+
+trait RowTrackingMergeSuiteBase extends RowIdTestUtils
+  with MergeHelpers {
+  import testImplicits._
+
+  protected def dvsEnabled: Boolean = true
+  protected def cdfEnabled: Boolean = false
+
+  protected val SOURCE_TABLE_NAME = "source"
+  protected val TARGET_TABLE_NAME = "target"
+
+  private val MANAGED_TABLE_NAMES = Seq(SOURCE_TABLE_NAME, TARGET_TABLE_NAME)
+
+  protected val numRows = 4000
+  protected val numUnmatchedRows = 2000
+
+  // Source table with 4000 rows with 'key' 2000 until 6000.
+  protected def createSourceTable(tableName: String, lastModifiedVersion: Long): Unit = {
+    spark.range(start = numUnmatchedRows, end = numUnmatchedRows + numRows).toDF("key")
+      .withColumn("stored_id", col("key"))
+      .withColumn("last_modified_version", lit(lastModifiedVersion))
+      .write.format("delta").saveAsTable(tableName)
+  }
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    spark.conf.set(DeltaConfigs.ROW_TRACKING_ENABLED.defaultTablePropertyKey, value = "true")
+
+    createSourceTable(SOURCE_TABLE_NAME, lastModifiedVersion = 1L)
+  }
+
+  override protected def afterAll(): Unit = {
+    for (table <- MANAGED_TABLE_NAMES) {
+      sql(s"DROP TABLE IF EXISTS $table")
+    }
+  }
+
+  protected def withTestTable(
+      tableName: String,
+      partitionedTarget: Boolean,
+      lastModifiedVersion: Long = 0L)(f: => Unit): Unit = {
+    withTable(tableName) {
+      val targetCreationDF = spark.range(end = numRows)
+        .toDF("key")
+        .withColumn("stored_id", col("key"))
+        .withColumn("last_modified_version", lit(lastModifiedVersion))
+
+      val clusteredTargetCreationWriter =
+        if (partitionedTarget) {
+          targetCreationDF
+            .withColumn("partition", lit(0))
+            .repartition(numPartitions = 2)
+            .write
+            .partitionBy("partition")
+        } else {
+          targetCreationDF
+            .repartition(numPartitions = 2)
+            .write
+        }
+      clusteredTargetCreationWriter.format("delta").saveAsTable(tableName)
+
+      f
+    }
+  }
+
+  protected def executeMerge(
+      targetReference: String,
+      sourceReference: String,
+      clauses: MergeClause*): Unit = {
+    val mergeSQL =
+      s"""MERGE INTO $targetReference AS t
+         |USING $sourceReference AS s
+         |ON s.key = t.key
+         |${clauses.map(_.sql).mkString("\n")}
+         |""".stripMargin
+    sql(mergeSQL)
+  }
+
+  /**
+   * Create a test validating stable Row IDs and Row Commit Versions in MERGE. The test uses a fixed
+   * source table and a modifiable target table. By default the source and the target table have
+   * rows not matched in a join on 'key'.
+   *
+   *                  source table                                   target table
+   *
+   *                                                  |  key  | stored_id | last_modified_version |
+   *                                                  |  0    |   0       |           0           |
+   *                                                  |  1    |   1       |           0           |
+   *                                                  |  ...  |   ...     |          ...          |
+   *   |  key  | stored_id | last_modified_version |  |  1999 |   1999    |           0           |
+   *   |  2000 |   2000    |           1           |  |  2000 |   2000    |           0           |
+   *   |  2001 |   2001    |           1           |  |  2001 |   2001    |           0           |
+   *   |  ...  |   ...     |          ...          |  |  ...  |   ...     |          ...          |
+   *   |  3999 |   3999    |           1           |  |  3999 |   3999    |           0           |
+   *   |  4000 |   4000    |           1           |
+   *   |  ...  |   ...     |          ...          |
+   *   |  5999 |   5999    |           1           |
+   *
+   * Tests also include CDF validation, which only works if 'key' is not changed in update clauses.
+   */
+  protected def rowTrackingMergeTests(name: String)(
+    partitionedTarget: Boolean = false,
+    targetAsView: Boolean = false,
+    source: Option[String] = None,
+    targetTablePostSetupAction: Option[() => Unit] = None,
+    sqlConfs: Seq[(String, String)] = Seq.empty)(
+    clauses: MergeClause*)(
+    expected: Seq[Row],
+    numFilesAfterMerge: Option[Int] = None): Unit = {
+    test(name) {
+      withTestTable(TARGET_TABLE_NAME, partitionedTarget) {
+        // Post setup actions can be used to modify the target table, for example by inserting
+        // more rows into it.
+        targetTablePostSetupAction.foreach(_.apply())
+
+        val preMergeRowIdMapping = getPreMergeRowIdMapping
+
+        val sourceReference = source.getOrElse {
+          if (partitionedTarget) {
+            s"(SELECT *, 0 AS partition FROM $SOURCE_TABLE_NAME)"
+          } else {
+            SOURCE_TABLE_NAME
+          }
+        }
+
+        val targetReference = if (targetAsView) {
+          sql(s"CREATE TEMPORARY VIEW target_view AS SELECT * FROM $TARGET_TABLE_NAME")
+          "target_view"
+        } else {
+          TARGET_TABLE_NAME
+        }
+
+        val deltaLog = DeltaLog.forTable(spark, TableIdentifier(TARGET_TABLE_NAME))
+        withSQLConf(sqlConfs: _*) {
+          checkRowTrackingMarkedAsPreservedForCommit(deltaLog) {
+            checkFileActionInvariantBeforeAndAfterOperation(deltaLog) {
+              checkHighWatermarkBeforeAndAfterOperation(deltaLog) {
+                executeMerge(targetReference, sourceReference, clauses: _*)
+              }
+            }
+          }
+        }
+
+        checkAnswer(sql(s"SELECT key, last_modified_version FROM $TARGET_TABLE_NAME"), expected)
+
+        validateRowIdsPostMerge(preMergeRowIdMapping)
+        validateRowCommitVersionsPostMerge()
+
+        if (numFilesAfterMerge.isDefined) {
+          assert(targetTableFiles().count() === numFilesAfterMerge.get,
+            s"Expected ${numFilesAfterMerge.get} but got ${targetTableFiles().collect().mkString}")
+        }
+
+        if (cdfEnabled && targetTablePostSetupAction.isEmpty) {
+          assert(deltaLog.update().version === 1, "Table has been modified more than once.")
+
+          // Only read CDF from version 1 (the version after the MERGE)
+          val cdfResult = CDCReader.changesToBatchDF(
+              deltaLog,
+              start = 1,
+              end = 1,
+              spark,
+              useCoarseGrainedCDC = true)
+              .select("stored_id",
+                "key",
+                "last_modified_version",
+                "_change_type")
+              .collect()
+
+          val initialTableDf = spark.read.format("delta")
+            .option("versionAsOf", 0)
+            .table(TARGET_TABLE_NAME)
+            .select("*", "_metadata.row_id")
+            .alias("initial")
+
+          val postMergeTableDf = spark.read.format("delta")
+            .option("versionAsOf", 1)
+            .table(TARGET_TABLE_NAME)
+            .select("*", "_metadata.row_id")
+            .alias("postMerge")
+
+          // Outer join the table at the state before the merge with the state after the MERGE on
+          // 'key' under the assumption that 'key' is not altered by the MERGE.
+          val joinedInitialAndPost = initialTableDf
+            .join(postMergeTableDf, usingColumn = "key", joinType = "fullouter")
+            .select(
+              "initial.key",
+              "initial.stored_id",
+              "initial.last_modified_version",
+              "initial.row_id",
+              "postMerge.key",
+              "postMerge.stored_id",
+              "postMerge.last_modified_version",
+              "postMerge.row_id")
+            .collect()
+
+          joinedInitialAndPost.foreach {
+            case Row(_, storedIdInitial, lastModifiedVersionInitial, rowIdInitial,
+                _, storedIdPostMerge, lastModifiedVersionPostMerge, rowIdPostMerge) =>
+              if (lastModifiedVersionPostMerge == null) { // Row has been deleted.
+                val cdfEntries =
+                  cdfResult.filter(row => row.getAs("stored_id") == storedIdInitial)
+
+                assert(cdfEntries.length === 1,
+                  s"Invalid number of CDF entries for deleted row with stored_id = " +
+                    s"$storedIdInitial. ${cdfEntries.mkString}")
+                assert(cdfEntries.head.getAs[String]("_change_type") === "delete",
+                s"Invalid _change_type (!= delete) for inserted row with stored_id = " +
+                  s" $storedIdInitial")
+                assert(rowIdInitial.asInstanceOf[Long] < numRows,
+                  "Row ID for delete row not from initial range")
+              } else if (lastModifiedVersionInitial == null) { // Row has been inserted.
+                val cdfEntries =
+                  cdfResult.filter(row => row.getAs("stored_id") == storedIdPostMerge)
+
+                assert(cdfEntries.length === 1,
+                  s"Invalid number of CDF entries for inserted row with stored_id = " +
+                    s" $storedIdPostMerge. ${cdfEntries.mkString}")
+                assert(cdfEntries.head.getAs[String]("_change_type") === "insert",
+                  s"Invalid _change_type (!= insert) for row with stored_id = $storedIdPostMerge")
+                assert(rowIdPostMerge.asInstanceOf[Long] >= numRows,
+                  "Row ID for inserted row from initial range")
+              } else { // Row has been updated or is unchanged.
+                val cdfEntries =
+                  cdfResult.filter(row => row.getAs("stored_id") == storedIdPostMerge)
+
+                if (lastModifiedVersionInitial != lastModifiedVersionPostMerge) {
+                  // Row has been updated
+                  assert(cdfEntries.length === 2,
+                    s"Invalid number of CDF entries for updated/copied row with " +
+                      s"stored_id = $storedIdPostMerge. ${cdfEntries.mkString}")
+                } else { // Row is untouched or copied.
+                  assert(Seq(0, 2).contains(cdfEntries.length),
+                    s"Invalid number of CDF entries for updated/copied row with " +
+                      s"stored_id = $storedIdPostMerge. ${cdfEntries.mkString}")
+                }
+              }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * This method retrieves the mapping of stored_id to row_id from the target table
+   * before the merge operation.
+   * It groups the collected data by stored_id and ensures that each stored_id
+   * is associated with only row_id.
+   *
+   * @return A Map of stored_id to row_id before the merge operation.
+   */
+  protected def getPreMergeRowIdMapping: Map[Long, Long] = {
+    spark.table(TARGET_TABLE_NAME)
+      .select("stored_id", RowId.QUALIFIED_COLUMN_NAME)
+      .as[(Long, Long)]
+      .collect()
+      .groupBy(_._1)
+      .mapValues { values =>
+        assert(values.length === 1)
+        values.head._2
+      }.toMap
+  }
+
+  /**
+   * This method validates the row ids after the merge operation.
+   * It ensures that the rows that existed before the merge
+   * operation have kept their original row ids.
+   * For the newly inserted rows, it checks that they have been assigned fresh row ids
+   * that are greater than any row id before the merge operation.
+   *
+   * @param preMergeRowIdMapping The mapping of stored_id to row_id before the merge operation.
+   */
+  def validateRowIdsPostMerge(preMergeRowIdMapping: Map[Long, Long]): Unit = {
+    val highestRowIdPreMerge = preMergeRowIdMapping.values.max
+
+    val rowsAfterMerge = spark.read.table(TARGET_TABLE_NAME)
+      .select("stored_id", RowId.QUALIFIED_COLUMN_NAME)
+      .as[(Long, Long)]
+      .collect()
+
+    val (otherRows, insertedRows) =
+      rowsAfterMerge.partition { case (storedId, _) => preMergeRowIdMapping.contains(storedId) }
+
+    // Validate that rows kept their stable Row IDs.
+    otherRows.foreach { case (storedId, rowId) =>
+      assert(preMergeRowIdMapping(storedId) === rowId,
+        s"Row ID has change for row with stored_id = $storedId")
+    }
+
+    assert(insertedRows.length === insertedRows.map { case (_, rowId) => rowId }.distinct.length,
+      s"Row IDs are not unique for inserted rows: ${insertedRows.mkString}")
+
+    // Validate that inserted rows received a fresh Row ID.
+    insertedRows.foreach { case (storedId, rowId) =>
+      assert(rowId > highestRowIdPreMerge,
+        s"Row ID not fresh for inserted row with stored_id $storedId")
+    }
+  }
+
+  /**
+   * This method validates the row commit versions after the merge operation.
+   * It ensures that the row commit version for each row in the target table
+   * matches its last_modified_version.
+   * This is to ensure that the row commit version is updated correctly during
+   * the merge operation.
+   */
+  def validateRowCommitVersionsPostMerge(): Unit = {
+    val rowsAfterMerge = spark.read.table(TARGET_TABLE_NAME)
+      .select("stored_id", "last_modified_version", RowCommitVersion.QUALIFIED_COLUMN_NAME)
+      .as[(Long, Long, Long)]
+      .collect()
+
+    rowsAfterMerge.foreach { case (storedId, lastModifiedVersion, rowCommitVersion) =>
+      assert(rowCommitVersion === lastModifiedVersion,
+        s"row commit version does not match for row with stored_id $storedId")
+    }
+  }
+
+  private def targetTableFiles(): Dataset[AddFile] = {
+    val targetTableIdentifier = TableIdentifier(TARGET_TABLE_NAME)
+    DeltaLog.forTableWithSnapshot(spark, targetTableIdentifier)._2.allFiles
+  }
+}
+
+trait RowTrackingMergeCommonTests extends RowTrackingMergeSuiteBase {
+
+  rowTrackingMergeTests("INSERT NOT MATCHED only MERGE")()(
+    clauses = insert("*"))(
+    // The old rows that are in the target initially and the added rows.
+    expected = (0 until numRows).map(Row(_, 0L))
+      ++ (0 until numUnmatchedRows).map(id => Row(numRows + id, 1L))
+  )
+
+  rowTrackingMergeTests("DELETE MATCHED only MERGE")()(
+    clauses = delete())(
+    // All unmatched rows.
+    expected = (0 until numUnmatchedRows).map(Row(_, 0L))
+  )
+
+  rowTrackingMergeTests("UPDATE MATCHED only MERGE")()(
+    clauses = update("*"))(
+    // Matched rows updated, other rows untouched.
+    expected = (0 until numUnmatchedRows).map(Row(_, 0L))
+      ++ (numUnmatchedRows until numRows).map(Row(_, 1L))
+  )
+
+  rowTrackingMergeTests("DELETE WHEN NOT MATCHED BY SOURCE only MERGE")()(
+    clauses = deleteNotMatched())(
+    // Unmatched rows only.
+    expected = (numUnmatchedRows until numRows).map(Row(_, 0L))
+  )
+
+  rowTrackingMergeTests("UPDATE only WHEN NOT MATCHED BY SOURCE MERGE")()(
+    clauses = updateNotMatched("last_modified_version = 1"))(
+    // All rows not matched by source updated.
+    expected = (0 until numUnmatchedRows).map(Row(_, 1L))
+      ++ (numUnmatchedRows until numRows).map(Row(_, 0L))
+  )
+
+  rowTrackingMergeTests("UPDATE + DELETE WHEN NOT MATCHED BY SOURCE MERGE")()(
+    clauses =
+      deleteNotMatched("t.stored_id % 2 = 0"), updateNotMatched("last_modified_version = 1"))(
+    expected = (0 until numUnmatchedRows).filter(_ % 2 == 1).map(Row(_, 1L)) ++
+               (numUnmatchedRows until numRows).map(Row(_, 0L)))
+
+  rowTrackingMergeTests("UPDATE only with source rows matching multiple target rows")(
+    // Duplicate all target rows.
+    targetTablePostSetupAction = Some(() => {
+      spark.read.table(TARGET_TABLE_NAME)
+        .withColumn("stored_id", col("stored_id") + numRows)
+        .withColumn("last_modified_version", lit(1L))
+        .write.mode("append").format("delta").saveAsTable(TARGET_TABLE_NAME) }))(
+    clauses = update("t.last_modified_version = 2"))(
+    // Updated 'key' and 'last_modified_version' for matched rows.
+    expected = (0 until numUnmatchedRows).flatMap(id => Seq(Row(id, 0L), Row(id, 1L)))
+      ++ (numUnmatchedRows until numRows).flatMap(id => Seq(Row(id, 2L), Row(id, 2L)))
+  )
+
+  rowTrackingMergeTests("DELETE only with source rows matching multiple target rows")(
+    // Duplicate all target rows.
+    targetTablePostSetupAction = Some(() => {
+      spark.read.table(TARGET_TABLE_NAME)
+        .withColumn("stored_id", col("stored_id") + numRows)
+        .withColumn("last_modified_version", lit(1L))
+        .write.mode("append").format("delta").saveAsTable(TARGET_TABLE_NAME) }))(
+    clauses = delete())(
+    // Deleted all matches (2 target rows per source row).
+    expected = (0 until numUnmatchedRows).flatMap(id => Seq(Row(id, 0L), Row(id, 1L)))
+  )
+
+  rowTrackingMergeTests("Target is accessed through a view")(targetAsView = true)(
+    clauses = update("*"))(
+    expected = (0 until numUnmatchedRows).map(Row(_, 0L)) // Untouched.
+      ++ (numUnmatchedRows until numRows).map(Row(_, 1L)) // Updated.
+  )
+
+  rowTrackingMergeTests("Optimized writes on partitioned table")(partitionedTarget = true)(
+    clauses = update("*", "s.key % 2 = 0"), delete(), insert("*"), deleteNotMatched())(
+    expected = (numUnmatchedRows.until(numRows, step = 2)).map(Row(_, 1L)) // Updated.
+      ++ (numRows until numRows + numUnmatchedRows).map(Row(_, 1L)), // Inserted.
+    numFilesAfterMerge = Some(1)
+  )
+
+  rowTrackingMergeTests("Optimized writes disabled on partitioned table")(
+    partitionedTarget = true,
+    sqlConfs = Seq(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED.key -> "false"))(
+    clauses = update("*", "s.key % 2 = 0"), delete(), insert("*"), deleteNotMatched())(
+    expected = (numUnmatchedRows.until(numRows, step = 2)).map(Row(_, 1L)) // Updated.
+      ++ (numRows until numRows + numUnmatchedRows).map(Row(_, 1L)), // Inserted.
+    numFilesAfterMerge = Some(1)
+  )
+
+  rowTrackingMergeTests("Optimized writes on un-partitioned table")(
+    sqlConfs = Seq(DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED.key -> "true"))(
+    clauses = update("*", "s.stored_id % 2 = 0"), delete(), insert("*"), deleteNotMatched())(
+    expected = (numUnmatchedRows.until(numRows, step = 2)).map(Row(_, 1L)) // Updated.
+        ++ (numRows until numRows + numUnmatchedRows).map(Row(_, 1L)), // Inserted.
+    numFilesAfterMerge = Some(1)
+  )
+
+  rowTrackingMergeTests("Source and target referencing to the same table")(
+    source = Some(s"(SELECT key, stored_id, 1L as last_modified_version FROM $TARGET_TABLE_NAME)"))(
+    clauses = update("*"))(
+    // All rows updated.
+    expected = (0 until numRows).map(Row(_, 1L))
+  )
+
+  test("Multiple merges into the same table") {
+    val numMerges = 5
+    require(numMerges <= numUnmatchedRows)
+
+    withTable(TARGET_TABLE_NAME) {
+      // Create the target table using half the rows from the source table.
+      spark.table(SOURCE_TABLE_NAME)
+        .withColumn("last_modified_version", lit(0L))
+        .filter("key % 2 = 0")
+        .repartition(numPartitions = 2)
+        .write
+        .format("delta")
+        .saveAsTable(TARGET_TABLE_NAME)
+
+      val preMergeRowIdMapping = getPreMergeRowIdMapping
+
+      // Give the target the same rows as the source table, one row at a time.
+      for (i <- 0 until numMerges) {
+        executeMerge(
+          TARGET_TABLE_NAME,
+          sourceReference = s"(SELECT ${numUnmatchedRows + i} AS key)",
+          clauses =
+            update(s"last_modified_version = ${i + 1}"),
+            insert(s"(key, stored_id, last_modified_version) VALUES (key, key, ${i + 1})"))
+      }
+
+      checkAnswer(sql(s"SELECT key, last_modified_version FROM $TARGET_TABLE_NAME"),
+        // Updated rows.
+        (0 until numMerges).map(i => Row(numUnmatchedRows + i, i + 1))
+          // Untouched rows.
+          ++ (numUnmatchedRows + numMerges + 1).until(numRows + numUnmatchedRows, step = 2)
+            .map(Row(_, 0L))
+      )
+
+      validateRowIdsPostMerge(preMergeRowIdMapping)
+      validateRowCommitVersionsPostMerge()
+    }
+  }
+
+  test("Row tracking marked as not preserved when row tracking disabled") {
+    withRowTrackingEnabled(enabled = false) {
+      withTestTable(TARGET_TABLE_NAME, partitionedTarget = false) {
+        val log = DeltaLog.forTable(spark, TableIdentifier(TARGET_TABLE_NAME))
+        assert(!rowTrackingMarkedAsPreservedForCommit(log)(
+          executeMerge(
+            TARGET_TABLE_NAME,
+            SOURCE_TABLE_NAME,
+            clauses = update("*"), insert("*"))))
+      }
+    }
+  }
+
+  test("schema evolution, extra nested column in source - update") {
+    withTable(TARGET_TABLE_NAME) {
+      import testImplicits._
+      val targetData = Seq((0L, 0L, 0L, (1, 10)), (1L, 1L, 0L, (2, 2000)))
+        .toDF("key", "stored_id", "last_modified_version", "x")
+        .selectExpr(
+          "key",
+          "stored_id",
+          "last_modified_version",
+          "named_struct('a', x._1, 'c', x._2) as x")
+      targetData.repartition(1).write.format("delta").saveAsTable(TARGET_TABLE_NAME)
+
+      val sourceData = Seq((0L, 0L, 1L, (10, 100, 10000)))
+        .toDF("key", "stored_id", "last_modified_version", "x")
+        .selectExpr(
+          "key",
+          "stored_id",
+          "last_modified_version",
+          "named_struct('a', x._1, 'b', x._2, 'c', x._3) as x")
+
+      val preMergeRowIdMapping = getPreMergeRowIdMapping
+      withTempView("src") {
+        sourceData.createOrReplaceTempView("src")
+        withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true") {
+          executeMerge(
+            TARGET_TABLE_NAME,
+            sourceReference = "src",
+            clauses = update("*"))
+        }
+      }
+      checkAnswer(sql(s"SELECT stored_id, last_modified_version FROM $TARGET_TABLE_NAME"),
+        Seq(Row(0L, 1L), Row(1L, 0L)))
+      validateRowIdsPostMerge(preMergeRowIdMapping)
+      validateRowCommitVersionsPostMerge()
+    }
+  }
+}
+
+trait RowTrackingMergeDVTests extends RowTrackingMergeSuiteBase
+  with DeletionVectorsTestUtils {
+
+  override protected def dvsEnabled: Boolean = true
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    enableDeletionVectors(spark, delete = true, update = true, merge = true)
+  }
+}
+
+trait RowTrackingMergeCDFTests extends RowTrackingMergeSuiteBase {
+
+  override def cdfEnabled: Boolean = true
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    spark.conf.set(DeltaConfigs.CHANGE_DATA_FEED.defaultTablePropertyKey, value = true)
+  }
+}
+
+trait RowTrackingMergeWithoutDVTests extends RowTrackingMergeCommonTests {
+
+  override protected def dvsEnabled: Boolean = false
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    spark.conf.set(DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.defaultTablePropertyKey,
+      value = "false")
+    spark.conf.set(DeltaSQLConf.MERGE_USE_PERSISTENT_DELETION_VECTORS.key, value = false)
+  }
+}
+
+class RowTrackingMergeSuite extends RowTrackingMergeCommonTests
+
+class RowTrackingMergeDVSuite extends RowTrackingMergeSuite
+  with RowTrackingMergeDVTests
+
+class RowTrackingMergeCDFSuite extends RowTrackingMergeSuite
+  with RowTrackingMergeCDFTests
+
+class RowTrackingMergeCDFDVSuite extends RowTrackingMergeSuite
+  with RowTrackingMergeDVTests with RowTrackingMergeCDFTests
+
+class RowTrackingMergeWithoutDVSuite extends RowTrackingMergeCommonTests
+  with RowTrackingMergeWithoutDVTests
+
+class RowTrackingMergeWithoutDVCDFSuite extends RowTrackingMergeCommonTests
+  with RowTrackingMergeWithoutDVTests with RowTrackingMergeCDFTests
+
+class RowTrackingMergeColumnNameMappingSuite extends RowTrackingMergeCommonTests
+  with DeltaColumnMappingEnableNameMode
+
+class RowTrackingMergeColumnIdMappingSuite extends RowTrackingMergeCommonTests
+  with DeltaColumnMappingEnableIdMode
+
+class RowTrackingMergeColumnNameMappingCDFDVSuite extends RowTrackingMergeCommonTests
+  with DeltaColumnMappingEnableNameMode with RowTrackingMergeDVTests with RowTrackingMergeCDFTests
+
+class RowTrackingMergeColumnIdMappingCDFDVSuite extends RowTrackingMergeCommonTests
+  with DeltaColumnMappingEnableIdMode with RowTrackingMergeDVTests with RowTrackingMergeCDFTests


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Preserve row IDs in Merge by reading the metadata column and writing it out to the physical column.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Existing UTs.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
