### PR TITLE
[Kernel][Writes] Implement `Table.checkpoint` API to write a classic single file checkpoint

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/CheckpointAlreadyExistsException.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/CheckpointAlreadyExistsException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel;
+
+import static java.lang.String.format;
+
+import io.delta.kernel.annotation.Evolving;
+
+/**
+ * Thrown when trying to create a checkpoint at version {@code v}, but there already exists
+ * a checkpoint at version {@code v}.
+ *
+ * @since 3.2.0
+ */
+@Evolving
+public class CheckpointAlreadyExistsException extends IllegalArgumentException {
+    public CheckpointAlreadyExistsException(long version) {
+        super(format("Checkpoint for given version %d already exists in the table", version));
+    }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Table.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Table.java
@@ -15,6 +15,8 @@
  */
 package io.delta.kernel;
 
+import java.io.IOException;
+
 import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.client.TableClient;
 
@@ -111,4 +113,17 @@ public interface Table {
      */
     Snapshot getSnapshotAsOfTimestamp(TableClient tableClient, long millisSinceEpochUTC)
         throws TableNotFoundException;
+
+    /**
+     * Checkpoint the table at given version. It writes a single checkpoint file.
+     *
+     * @param tableClient {@link TableClient} instance to use.
+     * @param version     Version to checkpoint.
+     * @throws TableNotFoundException if the table is not found
+     * @throws CheckpointAlreadyExistsException if a checkpoint already exists at the given version
+     * @throws IOException for any I/O error.
+     * @since 3.2.0
+     */
+    void checkpoint(TableClient tableClient, long version)
+            throws TableNotFoundException, CheckpointAlreadyExistsException, IOException;
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -25,9 +25,11 @@ import io.delta.kernel.types.StructType;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.fs.Path;
+import io.delta.kernel.internal.replay.CreateCheckpointIterator;
 import io.delta.kernel.internal.replay.LogReplay;
 import io.delta.kernel.internal.snapshot.LogSegment;
 import io.delta.kernel.internal.snapshot.SnapshotHint;
+import static io.delta.kernel.internal.TableConfig.TOMBSTONE_RETENTION;
 
 /**
  * Implementation of {@link Snapshot}.
@@ -38,6 +40,7 @@ public class SnapshotImpl implements Snapshot {
     private final LogReplay logReplay;
     private final Protocol protocol;
     private final Metadata metadata;
+    private final LogSegment logSegment;
 
     public SnapshotImpl(
             Path logPath,
@@ -49,6 +52,7 @@ public class SnapshotImpl implements Snapshot {
             Optional<SnapshotHint> snapshotHint) {
         this.dataPath = dataPath;
         this.version = version;
+        this.logSegment = logSegment;
         this.logReplay = new LogReplay(
             logPath,
             dataPath,
@@ -88,6 +92,17 @@ public class SnapshotImpl implements Snapshot {
 
     public Protocol getProtocol() {
         return protocol;
+    }
+
+    public CreateCheckpointIterator getCreateCheckpointIterator(
+            TableClient tableClient) {
+        long minFileRetentionTimestampMillis =
+                System.currentTimeMillis() -TOMBSTONE_RETENTION.fromMetadata(metadata);
+        return new CreateCheckpointIterator(
+                tableClient,
+                logSegment,
+                minFileRetentionTimestampMillis
+        );
     }
 
     /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -97,7 +97,7 @@ public class SnapshotImpl implements Snapshot {
     public CreateCheckpointIterator getCreateCheckpointIterator(
             TableClient tableClient) {
         long minFileRetentionTimestampMillis =
-                System.currentTimeMillis() -TOMBSTONE_RETENTION.fromMetadata(metadata);
+                System.currentTimeMillis() - TOMBSTONE_RETENTION.fromMetadata(metadata);
         return new CreateCheckpointIterator(
                 tableClient,
                 logSegment,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import io.delta.kernel.internal.actions.Metadata;
+import io.delta.kernel.internal.util.IntervalParserUtils;
+
+/**
+ * Represents the table properties. Also provides methods to access the property values
+ * from the table metadata.
+ */
+public class TableConfig<T> {
+    /**
+     * The shortest duration we have to keep logically deleted data files around before deleting
+     * them physically.
+     *
+     * Note: this value should be large enough:
+     * <ul>
+     *     <li>It should be larger than the longest possible duration of a job if you decide to
+     *     run "VACUUM" when there are concurrent readers or writers accessing the table.</li>
+     *     <li>If you are running a streaming query reading from the table, you should make sure
+     *     the query doesn't stop longer than this value. Otherwise, the query may not be able to
+     *     restart as it still needs to read old files.</li>
+     * </ul>
+     */
+    public static final TableConfig<Long> TOMBSTONE_RETENTION = new TableConfig<>(
+            "delta.tombstoneRetentionDuration",
+            "interval 1 week",
+            IntervalParserUtils::safeParseIntervalAsMicros,
+            value -> value >= 0,
+            "needs to be provided as a calendar interval such as '2 weeks'. Months" +
+                    " and years are not accepted. You may specify '365 days' for a year instead."
+    );
+
+    private final String key;
+    private final String defaultValue;
+    private final Function<String, T> fromString;
+    private final Predicate<T> validator;
+    private final String helpMessage;
+
+    private TableConfig(
+            String key,
+            String defaultValue,
+            Function<String, T> fromString,
+            Predicate<T> validator,
+            String helpMessage) {
+        this.key = key;
+        this.defaultValue = defaultValue;
+        this.fromString = fromString;
+        this.validator = validator;
+        this.helpMessage = helpMessage;
+    }
+
+    /**
+     * Returns the value of the table property from the given metadata.
+     *
+     * @param metadata the table metadata
+     * @return the value of the table property
+     */
+    public T fromMetadata(Metadata metadata) {
+        T value = fromString.apply(metadata.getConfiguration().getOrDefault(key, defaultValue));
+        if (!validator.test(value)) {
+            throw new IllegalArgumentException(
+                    String.format("Invalid value for table property '%s': '%s'. %s",
+                            key, value, helpMessage));
+        }
+        return value;
+    }
+}
+

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -40,9 +40,9 @@ public class TableConfig<T> {
      * </ul>
      */
     public static final TableConfig<Long> TOMBSTONE_RETENTION = new TableConfig<>(
-            "delta.tombstoneRetentionDuration",
+            "delta.deletedFileRetentionDuration",
             "interval 1 week",
-            IntervalParserUtils::safeParseIntervalAsMicros,
+            IntervalParserUtils::safeParseIntervalAsMillis,
             value -> value >= 0,
             "needs to be provided as a calendar interval such as '2 weeks'. Months" +
                     " and years are not accepted. You may specify '365 days' for a year instead."

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
@@ -34,8 +34,8 @@ public class TableImpl implements Table {
         return new TableImpl(resolvedPath);
     }
 
-    private final SnapshotManager snapshotManager;
     private final String tablePath;
+    private SnapshotManager snapshotManager;
 
     public TableImpl(String tablePath) {
         this.tablePath = tablePath;
@@ -64,5 +64,11 @@ public class TableImpl implements Table {
     public Snapshot getSnapshotAsOfTimestamp(TableClient tableClient, long millisSinceEpochUTC)
         throws TableNotFoundException {
         return snapshotManager.getSnapshotForTimestamp(tableClient, millisSinceEpochUTC);
+    }
+
+    @Override
+    public void checkpoint(TableClient tableClient, long version)
+            throws TableNotFoundException, CheckpointAlreadyExistsException, IOException {
+        snapshotManager.checkpoint(tableClient, version);
     }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
@@ -34,8 +34,8 @@ public class TableImpl implements Table {
         return new TableImpl(resolvedPath);
     }
 
+    private final SnapshotManager snapshotManager;
     private final String tablePath;
-    private SnapshotManager snapshotManager;
 
     public TableImpl(String tablePath) {
         this.tablePath = tablePath;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/AddFile.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/AddFile.java
@@ -29,6 +29,10 @@ public class AddFile {
         true /* nullable */
     );
 
+    /**
+     * Schema of the {@code add} action in the Delta Log without stats. Used for constructing
+     * table snapshot to read data from the table.
+     */
     public static final StructType SCHEMA_WITHOUT_STATS = new StructType()
         .add("path", StringType.STRING, false /* nullable */)
         .add("partitionValues",
@@ -41,4 +45,16 @@ public class AddFile {
 
     public static final StructType SCHEMA_WITH_STATS = SCHEMA_WITHOUT_STATS
         .add(JSON_STATS_FIELD);
+
+    /**
+     * Full schema of the {@code add} action in the Delta Log.
+     */
+    public static final StructType FULL_SCHEMA = SCHEMA_WITHOUT_STATS
+            .add("stats", StringType.STRING, true /* nullable */)
+            .add(
+                    "tags",
+                    new MapType(StringType.STRING, StringType.STRING, true),
+                    true /* nullable */);
+    // There are more fields which are added when row-id tracking and clustering is enabled.
+    // When Kernel starts supporting row-ids and clustering, we should add those fields here.
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/RemoveFile.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/RemoveFile.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.actions;
+
+import io.delta.kernel.types.*;
+
+/**
+ * Metadata about {@code remove} action in the Delta Log.
+ */
+public class RemoveFile {
+    /**
+     * Full schema of the {@code remove} action in the Delta Log.
+     */
+    public static final StructType FULL_SCHEMA = new StructType()
+            .add("path", StringType.STRING, false /* nullable */)
+            .add("deletionTimestamp", LongType.LONG, true /* nullable */)
+            .add("dataChange", BooleanType.BOOLEAN, false /* nullable*/)
+            .add("extendedFileMetadata", BooleanType.BOOLEAN, true /* nullable */)
+            .add("partitionValues",
+                    new MapType(StringType.STRING, StringType.STRING, true),
+                    true /* nullable*/)
+            .add("size", LongType.LONG, true /* nullable*/)
+            .add("stats", StringType.STRING, true /* nullable */)
+            .add(
+                    "tags",
+                    new MapType(StringType.STRING, StringType.STRING, true),
+                    true /* nullable */)
+            .add("deletionVector", DeletionVectorDescriptor.READ_SCHEMA, true /* nullable */);
+    // There are more fields which are added when row-id tracking is enabled. When Kernel
+    // starts supporting row-ids, we should add those fields here.
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/SingleAction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/SingleAction.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.actions;
+
+import io.delta.kernel.types.StructType;
+
+public class SingleAction {
+    /**
+     * Get the schema of reading entries from Delta Log delta and checkpoint files for construction
+     * of new checkpoint.
+     */
+    public static StructType CHECKPOINT_SCHEMA = new StructType()
+            .add("txn", SetTransaction.READ_SCHEMA)
+            .add("add", AddFile.FULL_SCHEMA)
+            .add("remove", RemoveFile.FULL_SCHEMA)
+            .add("metaData", Metadata.READ_SCHEMA)
+            .add("protocol", Protocol.READ_SCHEMA);
+    // Once we start supporting updating CDC or domain metadata enabled tables, we should add the
+    // schema for those fields here.
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/CheckpointMetaData.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/CheckpointMetaData.java
@@ -15,11 +15,13 @@
  */
 package io.delta.kernel.internal.checkpoints;
 
-import java.util.Optional;
+import java.util.*;
 
 import io.delta.kernel.data.Row;
 import io.delta.kernel.types.LongType;
 import io.delta.kernel.types.StructType;
+
+import io.delta.kernel.internal.data.GenericRow;
 
 public class CheckpointMetaData {
     public static CheckpointMetaData fromRow(Row row) {
@@ -43,6 +45,15 @@ public class CheckpointMetaData {
         this.version = version;
         this.size = size;
         this.parts = parts;
+    }
+
+    public Row toRow() {
+        Map<Integer, Object> dataMap = new HashMap<>();
+        dataMap.put(0, version);
+        dataMap.put(1, size);
+        parts.ifPresent(aLong -> dataMap.put(2, aLong));
+
+        return new GenericRow(READ_SCHEMA, dataMap);
     }
 
     @Override

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
@@ -34,7 +34,7 @@ import io.delta.kernel.internal.util.*;
 import static io.delta.kernel.internal.util.Utils.singletonCloseableIterator;
 
 /**
- * Class to load the {@link CheckpointMetaData} from `_last_checkpoint` file.
+ * Class to load and write the {@link CheckpointMetaData} from `_last_checkpoint` file.
  */
 public class Checkpointer {
     private static final Logger logger = LoggerFactory.getLogger(Checkpointer.class);
@@ -183,6 +183,22 @@ public class Checkpointer {
      */
     public Optional<CheckpointMetaData> readLastCheckpointFile(TableClient tableClient) {
         return loadMetadataFromFile(tableClient, 0 /* tries */);
+    }
+
+    /**
+     * Write the given data to last checkpoint metadata file.
+     * @param tableClient {@link TableClient} instance to use for writing
+     * @param checkpointMetaData Checkpoint metadata to write
+     * @throws IOException For any I/O issues.
+     */
+    public void writeLastCheckpointFile(
+            TableClient tableClient,
+            CheckpointMetaData checkpointMetaData) throws IOException {
+        tableClient.getJsonHandler()
+                .writeJsonFileAtomically(
+                        lastCheckpointFilePath.toString(),
+                        singletonCloseableIterator(checkpointMetaData.toRow()),
+                        true /* overwrite */);
     }
 
     /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/CreateCheckpointIterator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/CreateCheckpointIterator.java
@@ -256,7 +256,9 @@ public class CreateCheckpointIterator implements CloseableIterator<FilteredColum
                     getUniqueFileAction(removePathVector, removeDvVector, rowId);
             tombstonesFromJson.add(key);
 
-            // Default is zero.
+            // Default is zero. Not sure if this the correct way, but it is same Delta Spark.
+            // Ideally this should never be zero, but we are following the same behavior as Delta
+            // Spark here.
             long deleteTimestamp = 0;
             if (!removeDeleteTimestampVector.isNullAt(rowId)) {
                 deleteTimestamp = removeDeleteTimestampVector.getLong(rowId);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/CreateCheckpointIterator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/CreateCheckpointIterator.java
@@ -1,0 +1,372 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.internal.replay;
+
+import java.io.IOException;
+import java.util.*;
+
+import io.delta.kernel.client.TableClient;
+import io.delta.kernel.data.*;
+import io.delta.kernel.utils.CloseableIterator;
+
+import io.delta.kernel.internal.actions.SetTransaction;
+import io.delta.kernel.internal.snapshot.LogSegment;
+import io.delta.kernel.internal.util.Utils;
+import static io.delta.kernel.internal.actions.SingleAction.CHECKPOINT_SCHEMA;
+import static io.delta.kernel.internal.replay.LogReplayUtils.*;
+import static io.delta.kernel.internal.util.Preconditions.checkState;
+
+/**
+ * Replays a history of actions from the transaction log to reconstruct the checkpoint state of the
+ * table. The rules for constructing the checkpoint state are defined in the Delta Protocol:
+ * <a href="https://github.com/delta-io/delta/blob/master/PROTOCOL.md#action-reconciliation">
+ * Checkpoint Reconciliation Rules</a>.
+ * <p>
+ * Currently, the following rules are implemented:
+ * <ul>
+ *     <li> The latest protocol action seen wins </li>
+ *     <li> The latest metaData action seen wins </li>
+ *     <li> For txn actions, the latest version seen for a given appId wins </li>
+ *     <li> Logical files in a table are identified by their (path, deletionVector.uniqueId)
+ *     primary key. File actions (add or remove) reference logical files, and a log can contain
+ *     any number of references to a single file.</li>
+ *     <li>To replay the log, scan all file actions and keep only the newest reference for each
+ *     logical file.</li>
+ *     <li>add actions in the result identify logical files currently present in the table
+ *     (for queries). remove actions in the result identify tombstones of logical files no
+ *     longer present in the table (for VACUUM).</li>
+ *     <li>commit info actions are not included</li>
+ * </ul>
+ * <p>
+ * Following rules are not implemented. They will be implemented as we add support for more
+ * table features over time.
+ * <ul>
+ *     <li> For domainMetadata, the latest domainMetadata seen for a given domain wins.</li>
+ * </ul>
+ */
+public class CreateCheckpointIterator implements CloseableIterator<FilteredColumnarBatch> {
+
+    private static final int[] ADD_ORDINAL = getPathOrdinals(CHECKPOINT_SCHEMA, "add");
+    private static final int[] ADD_PATH_ORDINAL =
+            getPathOrdinals(CHECKPOINT_SCHEMA, "add", "path");
+    private static final int[] ADD_DV_ORDINAL =
+            getPathOrdinals(CHECKPOINT_SCHEMA, "add", "deletionVector");
+
+    private static final int[] REMOVE_ORDINAL = getPathOrdinals(CHECKPOINT_SCHEMA, "remove");
+    private static final int[] REMOVE_PATH_ORDINAL =
+            getPathOrdinals(CHECKPOINT_SCHEMA, "remove", "path");
+    private static final int[] REMOVE_DV_ORDINAL =
+            getPathOrdinals(CHECKPOINT_SCHEMA, "remove", "deletionVector");
+    private static final int[] REMOVE_DELETE_TIMESTAMP_ORDINAL =
+            getPathOrdinals(CHECKPOINT_SCHEMA, "remove", "deletionTimestamp");
+
+    private static final int[] PROTOCOL_ORDINAL = getPathOrdinals(CHECKPOINT_SCHEMA, "protocol");
+    private static final int[] METADATA_ORDINAL = getPathOrdinals(CHECKPOINT_SCHEMA, "metaData");
+    private static final int[] TXN_ORDINAL = getPathOrdinals(CHECKPOINT_SCHEMA, "txn");
+
+    private final TableClient tableClient;
+    private final LogSegment logSegment;
+
+    /**
+     * Tombstones (i.e. RemoveFile) will be still kept in checkpoint until the tombstone timestamp
+     * is earlier than this retention timestamp.
+     */
+    private final long minFileRetentionTimestampMillis;
+
+    // State of the iterator and current batch being worked on
+    private CloseableIterator<ActionWrapper> actionsIter;
+    private boolean closed;
+    private Optional<FilteredColumnarBatch> toReturnNext = Optional.empty();
+    /**
+     * This buffer is reused across batches to keep the memory allocations minimal. It is resized as
+     * required and the array entries are reset between batches.
+     */
+    private boolean[] selectionVectorBuffer;
+
+    // Current state of the tombstones and add files from delta files
+    private final Set<UniqueFileActionTuple> tombstonesFromJson = new HashSet<>();
+    private final Set<UniqueFileActionTuple> addFilesFromJson = new HashSet<>();
+
+    // Current state of the protocol and metadata. Captures whether protocol or metadata is seen.
+    // We traverse the log in reverse, so the first encounter of protocol or metadata is considered
+    // latest.
+    private boolean isMetadataAlreadySeen;
+    private boolean isProtocolAlreadySeen;
+
+    // Current state of the transaction identifier (a.k.a. SetTransaction). We traverse the log in
+    // reverse, so storing the first seen transaction version for each appId is enough for
+    // checkpoint
+    private final Map<String, Long> txnAppIdToVersion = new HashMap<>();
+
+    // Metadata about the checkpoint to store in `_last_checkpoint` file
+    private long numberOfAddActions = 0; // final number of add actions survived in the checkpoint
+
+    /////////////////
+    // Public APIs //
+    /////////////////
+
+    public CreateCheckpointIterator(
+            TableClient tableClient,
+            LogSegment logSegment,
+            long minFileRetentionTimestampMillis) {
+        this.tableClient = tableClient;
+        this.logSegment = logSegment;
+        this.minFileRetentionTimestampMillis = minFileRetentionTimestampMillis;
+    }
+
+    @Override
+    public boolean hasNext() {
+        initActionIterIfRequired();
+        checkState(!closed, "Can't call `hasNext` on a closed iterator.");
+        return prepareNext();
+    }
+
+    @Override
+    public FilteredColumnarBatch next() {
+        checkState(!closed, "Can't call `next` on a closed iterator.");
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+
+        FilteredColumnarBatch toReturn = toReturnNext.get();
+        toReturnNext = Optional.empty();
+        return toReturn;
+    }
+
+    @Override
+    public void close() throws IOException {
+        closed = true;
+        Utils.closeCloseables(actionsIter);
+    }
+
+    /**
+     * Number of add files in the final checkpoint. Should be called once the entire data of this
+     * iterator is consumed.
+     *
+     * @return Number of add files in checkpoint.
+     */
+    public long getNumberOfAddActions() {
+        checkState(closed, "Iterator is not fully consumed yet.");
+        return numberOfAddActions;
+    }
+
+    ////////////////////////////
+    // Private Helper Methods //
+    ////////////////////////////
+
+    private void initActionIterIfRequired() {
+        if (this.actionsIter == null) {
+            this.actionsIter = new ActionsIterator(
+                    tableClient,
+                    logSegment.allLogFilesReversed(),
+                    CHECKPOINT_SCHEMA,
+                    Optional.empty() /* checkpoint predicate */);
+        }
+    }
+
+    /**
+     * Prepare the next batch to return and store it in {@link #toReturnNext}
+     *
+     * @return true if there is data to return, false otherwise.
+     */
+    private boolean prepareNext() {
+        if (toReturnNext.isPresent()) {
+            return true;
+        }
+        if (!actionsIter.hasNext()) {
+            return false;
+        }
+
+        ActionWrapper actionWrapper = actionsIter.next();
+        final ColumnarBatch actionsBatch = actionWrapper.getColumnarBatch();
+        final boolean isFromCheckpoint = actionWrapper.isFromCheckpoint();
+
+        // Prepare the selection vector to attach to the batch to indicate which records to
+        // write to checkpoint and which one or not
+        selectionVectorBuffer =
+                prepareSelectionVectorBuffer(selectionVectorBuffer, actionsBatch.getSize());
+
+        // Step 1: Update `tombstonesFromJson` with all the RemoveFiles in this columnar batch, if
+        // and only if this batch is not from a checkpoint. There's no reason to put a RemoveFile
+        // from a checkpoint into `tombstonesFromJson` since, when we generate a checkpoint,
+        // any corresponding AddFile would have been excluded already
+        if (!isFromCheckpoint) {
+            processRemoves(
+                    getVector(actionsBatch, REMOVE_ORDINAL),
+                    getVector(actionsBatch, REMOVE_PATH_ORDINAL),
+                    getVector(actionsBatch, REMOVE_DV_ORDINAL),
+                    getVector(actionsBatch, REMOVE_DELETE_TIMESTAMP_ORDINAL),
+                    selectionVectorBuffer);
+        }
+
+        // Step 2: Iterate over all the AddFiles in this columnar batch in order to build up the
+        //         selection vector. We unselect an AddFile when it was removed by a RemoveFile
+        processAdds(
+                getVector(actionsBatch, ADD_ORDINAL),
+                getVector(actionsBatch, ADD_PATH_ORDINAL),
+                getVector(actionsBatch, ADD_DV_ORDINAL),
+                isFromCheckpoint,
+                selectionVectorBuffer);
+
+        // Step 3: Process the protocol
+        final ColumnVector protocolVector = getVector(actionsBatch, PROTOCOL_ORDINAL);
+        processProtocol(protocolVector, selectionVectorBuffer);
+
+        // Step 3: Process the metadata
+        final ColumnVector metadataVector = getVector(actionsBatch, METADATA_ORDINAL);
+        processMetadata(metadataVector, selectionVectorBuffer);
+
+        // Step 4: Process the transaction identifiers
+        final ColumnVector txnVector = getVector(actionsBatch, TXN_ORDINAL);
+        processTxn(txnVector, selectionVectorBuffer);
+
+        Optional<ColumnVector> selectionVector =
+                Optional.of(createSelectionVector(selectionVectorBuffer, actionsBatch.getSize()));
+        toReturnNext = Optional.of(
+                new FilteredColumnarBatch(actionsBatch, selectionVector));
+        return true;
+    }
+
+    private void processRemoves(
+            ColumnVector removesVector,
+            ColumnVector removePathVector,
+            ColumnVector removeDvVector,
+            ColumnVector removeDeleteTimestampVector,
+            boolean[] selectionVectorBuffer) {
+        for (int rowId = 0; rowId < removesVector.getSize(); rowId++) {
+            if (removesVector.isNullAt(rowId)) {
+                continue; // selectionVector will be `false` at rowId by default
+            }
+
+            final UniqueFileActionTuple key =
+                    getUniqueFileAction(removePathVector, removeDvVector, rowId);
+            tombstonesFromJson.add(key);
+
+            // Default is zero.
+            long deleteTimestamp = 0;
+            if (!removeDeleteTimestampVector.isNullAt(rowId)) {
+                deleteTimestamp = removeDeleteTimestampVector.getLong(rowId);
+            }
+            if (deleteTimestamp > minFileRetentionTimestampMillis) {
+                // We still keep remove files in checkpoint as tombstones until the minimum
+                // retention period has passed
+                select(selectionVectorBuffer, rowId);
+            }
+        }
+    }
+
+    private void processAdds(
+            ColumnVector addsVector,
+            ColumnVector addPathVector,
+            ColumnVector addDvVector,
+            boolean isFromCheckpoint,
+            boolean[] selectionVectorBuffer) {
+        for (int rowId = 0; rowId < addsVector.getSize(); rowId++) {
+            if (addsVector.isNullAt(rowId)) {
+                continue; // selectionVector will be `false` at rowId by default
+            }
+
+            final UniqueFileActionTuple key =
+                    getUniqueFileAction(addPathVector, addDvVector, rowId);
+            final boolean alreadyDeleted = tombstonesFromJson.contains(key);
+            final boolean alreadyReturned = addFilesFromJson.contains(key);
+
+            if (!alreadyReturned) {
+                // Note: No AddFile will appear twice in a checkpoint, so we only need
+                //       non-checkpoint AddFiles in the set
+                if (!isFromCheckpoint) {
+                    addFilesFromJson.add(key);
+                }
+
+                if (!alreadyDeleted) {
+                    numberOfAddActions++;
+                    select(selectionVectorBuffer, rowId);
+                }
+            }
+        }
+    }
+
+    private void processProtocol(ColumnVector protocolVector, boolean[] selectionVectorBuffer) {
+        for (int rowId = 0; rowId < protocolVector.getSize(); rowId++) {
+            if (protocolVector.isNullAt(rowId)) {
+                continue; // selectionVector will be `false` at rowId by default
+            }
+
+            if (isProtocolAlreadySeen) {
+                // We do a reverse log replay. The latest always the one that should be written
+                // to the checkpoint. Anything after the first one shouldn't be in checkpoint
+                unselect(selectionVectorBuffer, rowId);
+            } else {
+                select(selectionVectorBuffer, rowId);
+                isProtocolAlreadySeen = true;
+            }
+        }
+    }
+
+    private void processMetadata(ColumnVector metadataVector, boolean[] selectionVectorBuffer) {
+        for (int rowId = 0; rowId < metadataVector.getSize(); rowId++) {
+            if (metadataVector.isNullAt(rowId)) {
+                continue; // selectionVector will be `false` at rowId by default
+            }
+
+            if (isMetadataAlreadySeen) {
+                // We do a reverse log replay. The latest always the one that should be written
+                // to the checkpoint. Anything after the first one shouldn't be in checkpoint
+                unselect(selectionVectorBuffer, rowId);
+            } else {
+                select(selectionVectorBuffer, rowId);
+                isMetadataAlreadySeen = true;
+            }
+        }
+    }
+
+    private void processTxn(ColumnVector txnVector, boolean[] selectionVectorBuffer) {
+        for (int rowId = 0; rowId < txnVector.getSize(); rowId++) {
+            SetTransaction txn = SetTransaction.fromColumnVector(txnVector, rowId);
+            if (txn == null) {
+                continue; // selectionVector will be `false` at rowId by default
+            }
+            if (txnAppIdToVersion.containsKey(txn.getAppId())) {
+                // We do a reverse log replay. The latest txn version is the one that should be
+                // written to the checkpoint. Anything after the first one shouldn't be in
+                // checkpoint
+                unselect(selectionVectorBuffer, rowId);
+            } else {
+                select(selectionVectorBuffer, rowId);
+                txnAppIdToVersion.put(txn.getAppId(), txn.getVersion());
+            }
+        }
+    }
+
+    private void unselect(boolean[] selectionVectorBuffer, int rowId) {
+        // Just use the java assert (which are enabled in tests) for sanity checks. This should
+        // never happen. Given this is going to be on the hot path, we want to avoid cost in
+        // production.
+        assert !selectionVectorBuffer[rowId] :
+                "Row is already marked for selection, can't unselect now: " + rowId;
+        selectionVectorBuffer[rowId] = false;
+    }
+
+    private void select(boolean[] selectionVectorBuffer, int rowId) {
+        selectionVectorBuffer[rowId] = true;
+    }
+
+    private ColumnVector createSelectionVector(boolean[] selectionVectorBuffer, int size) {
+        return tableClient.getExpressionHandler()
+                .createSelectionVector(selectionVectorBuffer, 0, size);
+    }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
@@ -17,7 +17,6 @@
 package io.delta.kernel.internal.replay;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Optional;
 
 import io.delta.kernel.client.TableClient;
@@ -28,7 +27,6 @@ import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.types.StringType;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
-import io.delta.kernel.utils.FileStatus;
 
 import io.delta.kernel.internal.TableFeatures;
 import io.delta.kernel.internal.actions.*;
@@ -36,6 +34,7 @@ import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.snapshot.LogSegment;
 import io.delta.kernel.internal.snapshot.SnapshotHint;
 import io.delta.kernel.internal.util.Tuple2;
+import static io.delta.kernel.internal.replay.LogReplayUtils.assertLogFilesBelongToTable;
 
 /**
  * Replays a history of actions, resolving them to produce the current state of the table. The
@@ -300,20 +299,5 @@ public class LogReplay {
         }
 
         return Optional.empty();
-    }
-
-    /**
-     * Verifies that a set of delta or checkpoint files to be read actually belongs to this table.
-     * Visible only for testing.
-     */
-    protected static void assertLogFilesBelongToTable(Path logPath, List<FileStatus> allFiles) {
-        String logPathStr = logPath.toString(); // fully qualified path
-        for (FileStatus fileStatus : allFiles) {
-            String filePath = fileStatus.getPath();
-            if (!filePath.startsWith(logPathStr)) {
-                throw new RuntimeException("File (" + filePath + ") doesn't belong in the " +
-                    "transaction log at " + logPathStr + ".");
-            }
-        }
     }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplayUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplayUtils.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.replay;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.*;
+
+import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.types.DataType;
+import io.delta.kernel.types.StructType;
+import io.delta.kernel.utils.FileStatus;
+
+import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
+import io.delta.kernel.internal.fs.Path;
+import io.delta.kernel.internal.util.Tuple2;
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+
+public class LogReplayUtils {
+
+    private LogReplayUtils() {
+    }
+
+    public static class UniqueFileActionTuple extends Tuple2<URI, Optional<String>> {
+        UniqueFileActionTuple(URI fileURI, Optional<String> deletionVectorId) {
+            super(fileURI, deletionVectorId);
+        }
+    }
+
+    public static UniqueFileActionTuple getUniqueFileAction(
+            ColumnVector pathVector,
+            ColumnVector dvVector,
+            int rowId) {
+        final String path = pathVector.getString(rowId);
+        final URI pathAsUri = pathToUri(path);
+        final Optional<String> dvId = Optional.ofNullable(
+                DeletionVectorDescriptor.fromColumnVector(dvVector, rowId)
+        ).map(DeletionVectorDescriptor::getUniqueId);
+
+        return new UniqueFileActionTuple(pathAsUri, dvId);
+    }
+
+    /**
+     * Verifies that a set of delta or checkpoint files to be read actually belongs to this table.
+     * Visible only for testing.
+     */
+    public static void assertLogFilesBelongToTable(Path logPath, List<FileStatus> allFiles) {
+        String logPathStr = logPath.toString(); // fully qualified path
+        for (FileStatus fileStatus : allFiles) {
+            String filePath = fileStatus.getPath();
+            if (!filePath.startsWith(logPathStr)) {
+                throw new RuntimeException("File (" + filePath + ") doesn't belong in the " +
+                        "transaction log at " + logPathStr + ".");
+            }
+        }
+    }
+
+    static boolean[] prepareSelectionVectorBuffer(boolean[] currentSelectionVector, int newSize) {
+        if (currentSelectionVector == null || currentSelectionVector.length < newSize) {
+            currentSelectionVector = new boolean[newSize];
+        } else {
+            // reset the array - if we are reusing the same buffer.
+            Arrays.fill(currentSelectionVector, false);
+        }
+        return currentSelectionVector;
+    }
+
+    static URI pathToUri(String path) {
+        try {
+            return new URI(path);
+        } catch (URISyntaxException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    /**
+     * Get the ordinals of the column path at each level. Ordinal refers position of a column within
+     * a struct type column. For example: `struct(a: struct(a1: int, b1: long))` and lookup path is
+     * `a.b1` returns `0, 1`.
+     */
+    static int[] getPathOrdinals(StructType schema, String... path) {
+        checkArgument(path.length > 0, "Invalid path");
+        int[] pathOrdinals = new int[path.length];
+        DataType currentLevelDataType = schema;
+        for (int level = 0; level < path.length; level++) {
+            checkArgument(currentLevelDataType instanceof StructType, "Invalid search path");
+            StructType asStructType = (StructType) currentLevelDataType;
+            pathOrdinals[level] = asStructType.indexOf(path[level]);
+            currentLevelDataType = asStructType.at(pathOrdinals[level]).getDataType();
+        }
+        return pathOrdinals;
+    }
+
+    /**
+     * Get the vector corresponding to the given ordinals at each level of the column path.
+     */
+    static ColumnVector getVector(ColumnarBatch batch, int[] pathOrdinals) {
+        checkArgument(pathOrdinals.length > 0, "Invalid path ordinals size");
+        ColumnVector vector = null;
+        for (int level = 0; level < pathOrdinals.length; level++) {
+            int levelOrdinal = pathOrdinals[level];
+            vector = (level == 0) ? batch.getColumnVector(levelOrdinal) :
+                    vector.getChild(levelOrdinal);
+        }
+
+        return vector;
+    }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/IntervalParserUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/IntervalParserUtils.java
@@ -35,20 +35,22 @@ public class IntervalParserUtils {
 
     /**
      * Parse the given interval string into milliseconds. For configs accepting an interval, we
-     * require the user specified string must obey: - Doesn't use months or years, since an internal
-     * like this is not deterministic. - The microseconds parsed from the string value must be a
-     * non-negative value. - Doesn't use nanoseconds part as it too granular to use
+     * require the user specified string must obey:
+     * <ul>
+     *     <li>Doesn't use months or years, since an internal like this is not deterministic.</li>
+     *     <li>Doesn't use microseconds or nanoseconds part as it too granular to use.</li>
+     * </ul>
      *
-     * @return parsed interval as microseconds.
+     * @return parsed interval as milliseconds.
      */
-    public static long safeParseIntervalAsMicros(String input) {
+    public static long safeParseIntervalAsMillis(String input) {
         checkArgument(input != null, "interval string cannot be null");
         String inputInLowerCase = input.trim().toLowerCase(Locale.ROOT);
         checkArgument(!inputInLowerCase.isEmpty(), "interval string cannot be empty");
         if (!inputInLowerCase.startsWith("interval ")) {
             inputInLowerCase = "interval " + inputInLowerCase;
         }
-        return parseIntervalAsMicros(inputInLowerCase);
+        return parseIntervalAsMicros(inputInLowerCase) / 1000; // convert to milliseconds
     }
 
     public static long parseIntervalAsMicros(String input) {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/replay/LogReplaySuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/replay/LogReplaySuite.scala
@@ -16,10 +16,9 @@
 package io.delta.kernel.internal.replay
 
 import scala.collection.JavaConverters._
-
 import io.delta.kernel.internal.fs.Path
+import io.delta.kernel.internal.replay.LogReplayUtils.assertLogFilesBelongToTable
 import io.delta.kernel.utils.FileStatus
-
 import org.scalatest.funsuite.AnyFunSuite
 
 class TestLogReplay extends AnyFunSuite {
@@ -34,7 +33,7 @@ class TestLogReplay extends AnyFunSuite {
       FileStatus.of("s3://bucket/logPath/checkpointfile2", 0L, 0L)
     ).asJava
 
-    LogReplay.assertLogFilesBelongToTable(tablePath, logFiles)
+    assertLogFilesBelongToTable(tablePath, logFiles)
   }
 
   test("assertLogFilesBelongToTable should fail for incorrect log paths") {
@@ -47,7 +46,7 @@ class TestLogReplay extends AnyFunSuite {
 
     // Test that files with incorrect log paths trigger the assertion
     val ex = intercept[RuntimeException] {
-      LogReplay.assertLogFilesBelongToTable(tablePath, logFiles)
+      assertLogFilesBelongToTable(tablePath, logFiles)
     }
     assert(ex.getMessage.contains("File (s3://bucket/invalidLogPath/deltafile2) " +
       s"doesn't belong in the transaction log at $tablePath"))

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/CreateCheckpointSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/CreateCheckpointSuite.scala
@@ -26,7 +26,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.actions.{AddFile, Metadata, RemoveFile}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.{DeltaLog, DeltaOperations, VersionNotFoundException}
+import org.apache.spark.sql.delta.{DeltaLog, VersionNotFoundException}
 import org.apache.spark.sql.types.{IntegerType, StructType}
 import org.scalatest.funsuite.AnyFunSuite
 


### PR DESCRIPTION
## Description
Implements `Table.checkpoint` API to checkpoint the table at given version

```
    /**
     * Checkpoint the table at given version. It writes a single checkpoint file.
     *
     * @param tableClient {@link TableClient} instance to use.
     * @param version     Version to checkpoint.
     * @throws TableNotFoundException if the table is not found
     * @throws CheckpointAlreadyExistsException if a checkpoint already exists at the given version
     * @throws IOException for any I/O error.
     * @since 3.2.0
     */
    void checkpoint(TableClient tableClient, long version)
            throws TableNotFoundException, CheckpointAlreadyExistsException, IOException;

```

## How was this patch tested?
Unit and integration tests. TODO: one pending test for tombstones are removed correctly.

