### PR TITLE
Fix Delta on Spark Master tests broken by error-classes.json rename

### DIFF
--- a/spark/src/main/scala-spark-3.5/shims/DeltaThrowableHelperShims.scala
+++ b/spark/src/main/scala-spark-3.5/shims/DeltaThrowableHelperShims.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+object DeltaThrowableHelperShims {
+  /**
+   * Handles a breaking change (SPARK-46810) between Spark 3.5 and Spark Master (4.0) where
+   * `error-classes.json` was renamed to `error-conditions.json`.
+   */
+  val SPARK_ERROR_CLASS_SOURCE_FILE = "error/error-classes.json"
+}

--- a/spark/src/main/scala-spark-master/shims/DeltaThrowableHelperShims.scala
+++ b/spark/src/main/scala-spark-master/shims/DeltaThrowableHelperShims.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+object DeltaThrowableHelperShims {
+  /**
+   * Handles a breaking change (SPARK-46810) between Spark 3.5 and Spark Master (4.0) where
+   * `error-classes.json` was renamed to `error-conditions.json`.
+   */
+  val SPARK_ERROR_CLASS_SOURCE_FILE = "error/error-conditions.json"
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaThrowableHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaThrowableHelper.scala
@@ -20,6 +20,8 @@ package org.apache.spark.sql.delta
 import java.io.FileNotFoundException
 import java.net.URL
 
+import org.apache.spark.sql.delta.DeltaThrowableHelperShims._
+
 import org.apache.spark.ErrorClassesJsonReader
 import org.apache.spark.util.Utils
 
@@ -42,7 +44,7 @@ object DeltaThrowableHelper
   }
 
   lazy val sparkErrorClassSource: URL = {
-    safeGetErrorClassesSource("error/error-classes.json")
+    safeGetErrorClassesSource(SPARK_ERROR_CLASS_SOURCE_FILE)
   }
 
   def deltaErrorClassSource: URL = {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

In Apache Spark https://github.com/apache/spark/commit/c5b8e60e0d5956d9f648f77ae13a1558c99adf6b, `error-classes.json` was renamed to `error-conditions.json`.

Update Delta's DeltaThrowableHelper to use the right json file when cross compiling against Spark 3.5 and Spark Master.

## How was this patch tested?

Existing UTs.

## Does this PR introduce _any_ user-facing changes?

No