### PR TITLE
[Kernel][Writes] `ParquetHandler` and `JsonHandler` API changes

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/client/JsonHandler.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/client/JsonHandler.java
@@ -114,11 +114,17 @@ public interface JsonHandler {
      *     <li>{@code array}: {@code null} value elements are written to file</li>
      * </ul>
      *
-     * @param filePath Fully qualified destination file path
-     * @param data     Iterator of {@link Row} objects where each row should be serialized as JSON
-     *                 and written as separate line in the destination file.
-     * @throws FileAlreadyExistsException if the file already exists.
+     * @param filePath  Fully qualified destination file path
+     * @param data      Iterator of {@link Row} objects where each row should be serialized as JSON
+     *                  and written as separate line in the destination file.
+     * @param overwrite If {@code true}, the file is overwritten if it already exists. If
+     *                  {@code false} and a file exists {@link FileAlreadyExistsException} is
+     *                  thrown.
+     * @throws FileAlreadyExistsException if the file already exists and {@code overwrite} is false.
      * @throws IOException                if any other I/O error occurs.
      */
-    void writeJsonFileAtomically(String filePath, CloseableIterator<Row> data) throws IOException;
+    void writeJsonFileAtomically(
+            String filePath,
+            CloseableIterator<Row> data,
+            boolean overwrite) throws IOException;
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/client/ParquetHandler.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/client/ParquetHandler.java
@@ -17,6 +17,7 @@
 package io.delta.kernel.client;
 
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 import java.util.List;
 import java.util.Optional;
 
@@ -94,4 +95,17 @@ public interface ParquetHandler {
             CloseableIterator<FilteredColumnarBatch> dataIter,
             long maxFileSize,
             List<Column> statsColumns) throws IOException;
+
+    /**
+     * Write the given data as a Parquet file. This call either succeeds in creating the file with
+     * given contents or no file is created at all. It won't leave behind a partially written file.
+     * <p>
+     * @param filePath  Fully qualified destination file path
+     * @param data      Iterator of {@link FilteredColumnarBatch}
+     * @throws FileAlreadyExistsException if the file already exists and {@code overwrite} is false.
+     * @throws IOException                if any other I/O error occurs.
+     */
+    void writeParquetFileAtomically(
+            String filePath,
+            CloseableIterator<FilteredColumnarBatch> data) throws IOException;
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/Preconditions.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/Preconditions.java
@@ -64,4 +64,17 @@ public class Preconditions {
                     String.format(String.valueOf(message), args));
         }
     }
+
+    /**
+     * Ensures the truth of an expression involving the state of the calling instance.
+     *
+     * @param expression a boolean expression
+     * @param errorMessage the exception message to use if the check fails
+     * @throws IllegalStateException if {@code expression} is false
+     */
+    public static void checkState(boolean expression, String errorMessage) {
+        if (!expression) {
+            throw new IllegalStateException(String.valueOf(errorMessage));
+        }
+    }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/Preconditions.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/Preconditions.java
@@ -74,7 +74,7 @@ public class Preconditions {
      */
     public static void checkState(boolean expression, String errorMessage) {
         if (!expression) {
-            throw new IllegalStateException(String.valueOf(errorMessage));
+            throw new IllegalStateException(errorMessage);
         }
     }
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockTableClientUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockTableClientUtils.scala
@@ -16,12 +16,13 @@
 package io.delta.kernel.test
 
 import io.delta.kernel.client._
-import io.delta.kernel.data.{ColumnVector, ColumnarBatch, Row}
-import io.delta.kernel.expressions.{Expression, ExpressionEvaluator, Predicate, PredicateEvaluator}
+import io.delta.kernel.data.{ColumnVector, ColumnarBatch, FilteredColumnarBatch, Row}
+import io.delta.kernel.expressions.{Column, Expression, ExpressionEvaluator, Predicate, PredicateEvaluator}
 import io.delta.kernel.types.{DataType, StructType}
-import io.delta.kernel.utils.{CloseableIterator, FileStatus}
+import io.delta.kernel.utils.{CloseableIterator, DataFileStatus, FileStatus}
 
 import java.io.ByteArrayInputStream
+import java.util
 import java.util.Optional
 
 /**
@@ -91,7 +92,10 @@ trait BaseMockJsonHandler extends JsonHandler {
       predicate: Optional[Predicate]): CloseableIterator[ColumnarBatch] =
     throw new UnsupportedOperationException("not supported in this test suite")
 
-  override def writeJsonFileAtomically(filePath: String, data: CloseableIterator[Row]): Unit =
+  override def writeJsonFileAtomically(
+      filePath: String,
+      data: CloseableIterator[Row],
+      overwrite: Boolean): Unit =
     throw new UnsupportedOperationException("not supported in this test suite")
 }
 
@@ -103,6 +107,18 @@ trait BaseMockParquetHandler extends ParquetHandler {
       fileIter: CloseableIterator[FileStatus],
       physicalSchema: StructType,
       predicate: Optional[Predicate]): CloseableIterator[ColumnarBatch] =
+    throw new UnsupportedOperationException("not supported in this test suite")
+
+  override def writeParquetFiles(
+      directoryPath: String,
+      dataIter: CloseableIterator[FilteredColumnarBatch],
+      maxFileSize: Long,
+      statsColumns: util.List[Column]): CloseableIterator[DataFileStatus] =
+    throw new UnsupportedOperationException("not supported in this test suite")
+
+  override def writeParquetFileAtomically(
+      filePath: String,
+      data: CloseableIterator[FilteredColumnarBatch]): Unit =
     throw new UnsupportedOperationException("not supported in this test suite")
 }
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultJsonHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultJsonHandler.java
@@ -20,10 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.delta.storage.LogStore;
 import org.apache.hadoop.conf.Configuration;
@@ -32,7 +29,7 @@ import org.apache.hadoop.fs.*;
 import io.delta.kernel.client.JsonHandler;
 import io.delta.kernel.data.*;
 import io.delta.kernel.expressions.Predicate;
-import io.delta.kernel.types.StructType;
+import io.delta.kernel.types.*;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
 
@@ -185,8 +182,10 @@ public class DefaultJsonHandler implements JsonHandler {
      * @throws IOException
      */
     @Override
-    public void writeJsonFileAtomically(String filePath, CloseableIterator<Row> data)
-            throws IOException {
+    public void writeJsonFileAtomically(
+            String filePath,
+            CloseableIterator<Row> data,
+            boolean overwrite) throws IOException {
         Path path = new Path(filePath);
         LogStore logStore = LogStoreProvider.getLogStore(hadoopConf, path.toUri().getScheme());
         try {
@@ -203,7 +202,7 @@ public class DefaultJsonHandler implements JsonHandler {
                             return JsonUtils.rowToJson(data.next());
                         }
                     },
-                    false /* overwrite */,
+                    overwrite,
                     hadoopConf);
         } finally {
             Utils.closeCloseables(data);

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultParquetHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultParquetHandler.java
@@ -16,21 +16,27 @@
 package io.delta.kernel.defaults.client;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.Optional;
+import java.io.UncheckedIOException;
+import java.util.*;
+import static java.lang.String.format;
 
+import io.delta.storage.LogStore;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.*;
 
 import io.delta.kernel.client.ParquetHandler;
-import io.delta.kernel.data.*;
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.data.FilteredColumnarBatch;
 import io.delta.kernel.expressions.Column;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.*;
+import io.delta.kernel.utils.FileStatus;
 
 import io.delta.kernel.internal.util.Utils;
+import static io.delta.kernel.internal.util.Preconditions.checkState;
 
+import io.delta.kernel.defaults.internal.logstore.LogStoreProvider;
 import io.delta.kernel.defaults.internal.parquet.ParquetFileReader;
 import io.delta.kernel.defaults.internal.parquet.ParquetFileWriter;
 
@@ -99,5 +105,63 @@ public class DefaultParquetHandler implements ParquetHandler {
         ParquetFileWriter batchWriter =
             new ParquetFileWriter(hadoopConf, new Path(directoryPath), maxFileSize, statsColumns);
         return batchWriter.write(dataIter);
+    }
+
+    /**
+     * Makes use of {@link LogStore} implementations in `delta-storage` to atomically write the data
+     * to a file depending upon the destination filesystem.
+     *
+     * @param filePath Fully qualified destination file path
+     * @param data     Iterator of {@link FilteredColumnarBatch}
+     * @throws IOException
+     */
+    @Override
+    public void writeParquetFileAtomically(
+            String filePath,
+            CloseableIterator<FilteredColumnarBatch> data) throws IOException {
+        Path targetPath = new Path(filePath);
+        LogStore logStore =
+                LogStoreProvider.getLogStore(hadoopConf, targetPath.toUri().getScheme());
+
+        boolean useRename = logStore.isPartialWriteVisible(targetPath, hadoopConf);
+
+        Path writePath = targetPath;
+        if (useRename) {
+            // In order to atomically write the file, write to a temp file and rename to target path
+            String tempFileName = format(".%s.%s.tmp", targetPath.getName(), UUID.randomUUID());
+            writePath = new Path(targetPath.getParent(), tempFileName);
+        }
+        ParquetFileWriter fileWriter = new ParquetFileWriter(hadoopConf, writePath);
+
+        DataFileStatus writtenFile = null;
+
+        try (CloseableIterator<DataFileStatus> status = fileWriter.write(data)) {
+            while (status.hasNext()) {
+                checkState(writtenFile == null, "expected to write exactly one file");
+                writtenFile = status.next();
+            }
+        } catch (UncheckedIOException uio) {
+            throw uio.getCause();
+        }
+
+        checkState(writtenFile != null, "expected to write one output file");
+        if (useRename) {
+            FileSystem fs = targetPath.getFileSystem(hadoopConf);
+            boolean renameDone = false;
+            try {
+                renameDone = fs.rename(writePath, targetPath);
+                if (!renameDone) {
+                    if (fs.exists(targetPath)) {
+                        throw new java.nio.file.FileAlreadyExistsException(
+                                "target file already exists: " + targetPath);
+                    }
+                    throw new IOException("Failed to rename the file");
+                }
+            } finally {
+                if (!renameDone) {
+                    fs.delete(writePath, false /* recursive */);
+                }
+            }
+        }
     }
 }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFileWriter.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFileWriter.java
@@ -61,6 +61,10 @@ public class ParquetFileWriter {
 
     private long currentFileNumber; // used to generate the unique file names.
 
+    /**
+     * Create writer to write data into one or more files depending upon the
+     * {@code targetMaxFileSize} value and the given data.
+     */
     public ParquetFileWriter(
             Configuration configuration,
             Path location,
@@ -75,6 +79,9 @@ public class ParquetFileWriter {
         this.writeAsSingleFile = false;
     }
 
+    /**
+     * Create writer to write the data exactly into one file.
+     */
     public ParquetFileWriter(Configuration configuration, Path destPath) {
         this.configuration = requireNonNull(configuration, "configuration is null");
         this.writeAsSingleFile = true;
@@ -146,6 +153,9 @@ public class ParquetFileWriter {
                     boolean maxFileSizeReached;
                     do {
                         consumeNextRow(writer);
+                        // If we are writing a single file, then don't need to check for the current
+                        // file size. Otherwise see if the current file size reached the target file
+                        // size.
                         maxFileSizeReached =
                                 !writeAsSingleFile && writer.getDataSize() >= targetMaxFileSize;
                         // Keep writing until max file is reached or no more data to write

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/client/DefaultJsonHandlerSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/client/DefaultJsonHandlerSuite.scala
@@ -497,19 +497,26 @@ class DefaultJsonHandlerSuite extends AnyFunSuite with TestUtils with VectorTest
       assert(batch.getSize == 2)
 
       val filePath = tempDir + "/1.json"
-      jsonHandler.writeJsonFileAtomically(filePath, batch.getRows)
+      def writeAndVerify(overwrite: Boolean): Unit = {
+        jsonHandler.writeJsonFileAtomically(filePath, batch.getRows, overwrite)
 
-      // read it back and verify the contents are correct
-      val source = scala.io.Source.fromFile(filePath)
-      val result = try source.getLines().mkString(",") finally source.close()
+        // read it back and verify the contents are correct
+        val source = scala.io.Source.fromFile(filePath)
+        val result = try source.getLines().mkString(",") finally source.close()
 
-      // remove the whitespaces from the input to compare
-      assert(input.map(_.replaceAll(" ", "")).mkString(",") === result)
-
-      // Try to write as same file and expect an error
-      intercept[FileAlreadyExistsException] {
-        jsonHandler.writeJsonFileAtomically(filePath, batch.getRows)
+        // remove the whitespaces from the input to compare
+        assert(input.map(_.replaceAll(" ", "")).mkString(",") === result)
       }
+
+      writeAndVerify(overwrite = false)
+
+      // Try to write as same file with overwrite as false and expect an error
+      intercept[FileAlreadyExistsException] {
+        jsonHandler.writeJsonFileAtomically(filePath, batch.getRows, false /* overwrite */)
+      }
+
+      // Try to write as file with overwrite set to true
+      writeAndVerify(overwrite = true)
     }
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/client/DefaultParquetHandlerSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/client/DefaultParquetHandlerSuite.scala
@@ -51,7 +51,7 @@ class DefaultParquetHandlerSuite extends AnyFunSuite with ParquetSuiteBase {
           filePath,
           toCloseableIterator(dataToWrite.asJava.iterator()))
 
-        // Uses both park and Kernel to read and verify the content is same as the one written.
+        // Uses both Spark and Kernel to read and verify the content is same as the one written.
         verifyContent(tempDir.getAbsolutePath, dataToWrite)
       }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/client/DefaultParquetHandlerSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/client/DefaultParquetHandlerSuite.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults.client
+
+import io.delta.golden.GoldenTableUtils.goldenTableFile
+import io.delta.kernel.defaults.internal.parquet.ParquetSuiteBase
+import io.delta.kernel.internal.util.Utils.toCloseableIterator
+import org.apache.hadoop.conf.Configuration
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.nio.file.FileAlreadyExistsException
+import scala.collection.JavaConverters._
+
+class DefaultParquetHandlerSuite extends AnyFunSuite with ParquetSuiteBase {
+
+  val parquetHandler = new DefaultParquetHandler(new Configuration {
+    set("delta.kernel.default.parquet.reader.batch-size", "10")
+  })
+
+  /////////////////////////////////////////////////////////////////////////////////////////////////
+  // Tests for `writeParquetFileAtomically`. Test for `writeParquetFiles` are covered in
+  // `ParquetFileWriterSuite` as this API implementation by itself doesn't have any special logic.
+  /////////////////////////////////////////////////////////////////////////////////////////////////
+  test("atomic write of a single Parquet file") {
+    withTempDir { tempDir =>
+      val inputLocation = goldenTableFile("parquet-all-types").toString
+
+      val dataToWrite =
+        readParquetUsingKernelAsColumnarBatches(inputLocation, tableSchema(inputLocation))
+          .map(_.toFiltered)
+      assert(dataToWrite.size === 1)
+      assert(dataToWrite.head.getData.getSize === 200)
+
+      val filePath = tempDir + "/1.parquet"
+
+      def writeAndVerify(): Unit = {
+        parquetHandler.writeParquetFileAtomically(
+          filePath,
+          toCloseableIterator(dataToWrite.asJava.iterator()))
+
+        // Uses both park and Kernel to read and verify the content is same as the one written.
+        verifyContent(tempDir.getAbsolutePath, dataToWrite)
+      }
+
+      writeAndVerify()
+
+      // Try to write as same file and expect an error
+      intercept[FileAlreadyExistsException] {
+        parquetHandler.writeParquetFileAtomically(
+          filePath,
+          toCloseableIterator(dataToWrite.asJava.iterator()))
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description
(extracted out the `TableClient` related changes from #2941)

At a high level, the requirements for writing files (either JSON or Parquet) are as follows:
* Write given data into one or more Parquet files (for writing the data or v2 checkpoint sidecar files)
   * `ParquetHandler.writeParquetFiles` is used in this case. 
* Write given data into exactly one atomically file (i.e either the file is created with full content or no file is created at all) (checkpoint classic, delta commit file, v2 cp manifest file)
   * JSON: `JsonHandler.writeJsonFileAtomically` with `overwrite = false`
   * Parquet: `ParquetHandler.writeParquetFileAtomically`
* Write given data atomically into a file (overwrite if it exists) (`_last_checkpoint`)
   * JSON: `JsonHandler.writeJsonFileAtomically` with `overwrite = true` 
* Not supported: Write given data atomically in one or more files (multi-part checkpoint - this is not possible and the reason for creating checkpoint v2 to get around this issue.

In this PR following API are added/updated and also the default implementation for the same.

```
interface ParquetHandler {
  ... existing APIs ...
  
    /**
     * Write the given data as a Parquet file. This call either succeeds in creating the file with
     * given contents or no file is created at all. It won't leave behind a partially written file.
     * <p>
     * @param filePath  Fully qualified destination file path
     * @param data      Iterator of {@link FilteredColumnarBatch}
     * @throws FileAlreadyExistsException if the file already exists and {@code overwrite} is false.
     * @throws IOException                if any other I/O error occurs.
     */
    void writeParquetFileAtomically(
            String filePath,
            CloseableIterator<FilteredColumnarBatch> data) throws IOException;
}
```

The `DefaultParquetHandler` implements the above API using `LogStore`s from `delta-storage` module to achieve the atomicity.

For writing the `_last_checkpoint` file, update the existing `JsonHandler.writeJsonFileAtomically` to take an option `overwrite`.

```
    void writeJsonFileAtomically(
            String filePath,
            CloseableIterator<Row> data,
            boolean overwrite) throws IOException;
```

## How was this patch tested?
Unittests.
