### PR TITLE
[Kernel][Writes] Update the behavior of `Table.forPath` to not throw error for empty tables

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Table.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Table.java
@@ -30,16 +30,42 @@ public interface Table {
     /**
      * Instantiate a table object for the Delta Lake table at the given path.
      *
+     * <ul>
+     *     <li>
+     *         Behavior when the table location doesn't exist:
+     *         <ul>
+     *         <li>reads will fail with a {@link TableNotFoundException}}</li>
+     *         <li>writes will create the location</li>
+     *         </ul>
+     *     </li>
+     *     <li>
+     *         Behavior when the table location exists (with contents or not) but not a Delta table
+     *         <ul>
+     *          <li>reads will fail with a {@link TableNotFoundException}</li>
+     *          <li>writes will create a Delta table to the given location. If there are any
+     *          existing files in the location that are not already part of the Delta table, they
+     *          will remain excluded as part of the Delta table.</li>
+     *         </ul>
+     *     </li>
+     * </ul>
+     *
      * @param tableClient {@link TableClient} instance to use in Delta Kernel.
-     * @param path        location where the Delta table is present. Path is resolved to fully
+     * @param path        location of the table. Path is resolved to fully
      *                    qualified path using the given {@code tableClient}.
      * @return an instance of {@link Table} representing the Delta table at given path
-     * @throws TableNotFoundException when there is no Delta table at the given path.
      */
-    static Table forPath(TableClient tableClient, String path)
-        throws TableNotFoundException {
+    static Table forPath(TableClient tableClient, String path) {
         return TableImpl.forPath(tableClient, path);
     }
+
+    /**
+     * The fully qualified path of this {@link Table} instance.
+     *
+     * @param tableClient {@link TableClient} instance.
+     * @return the table path.
+     * @since 3.2.0
+     */
+    String getPath(TableClient tableClient);
 
     /**
      * Get the latest snapshot of the table.
@@ -49,14 +75,6 @@ public interface Table {
      */
     Snapshot getLatestSnapshot(TableClient tableClient)
         throws TableNotFoundException;
-
-    /**
-     * The fully qualified path of this {@link Table} instance.
-     *
-     * @return the table path
-     * @since 3.2.0
-     */
-    String getPath();
 
     /**
      * Get the snapshot at the given {@code versionId}.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaHistoryManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaHistoryManager.java
@@ -170,17 +170,18 @@ public final class DeltaHistoryManager {
             TableClient tableClient,
             Path logPath,
             long startVersion) throws TableNotFoundException {
+        Path tablePath = logPath.getParent();
         try {
             CloseableIterator<FileStatus> files = tableClient
                 .getFileSystemClient()
                 .listFrom(FileNames.listingPrefix(logPath, startVersion));
             if (!files.hasNext()) {
                 // We treat an empty directory as table not found
-                throw new TableNotFoundException(logPath.getParent().toString()); /* use dataPath */
+                throw new TableNotFoundException(tablePath.toString());
             }
             return files;
         } catch (FileNotFoundException e) {
-            throw new TableNotFoundException(logPath.toString());
+            throw new TableNotFoundException(tablePath.toString());
         } catch (IOException io) {
             throw new RuntimeException("Failed to list the files in delta log", io);
         }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
@@ -15,26 +15,19 @@
  */
 package io.delta.kernel.internal;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 
-import io.delta.kernel.Snapshot;
-import io.delta.kernel.Table;
-import io.delta.kernel.TableNotFoundException;
+import io.delta.kernel.*;
 import io.delta.kernel.client.TableClient;
 
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.snapshot.SnapshotManager;
 
 public class TableImpl implements Table {
-    public static Table forPath(TableClient tableClient, String path)
-        throws TableNotFoundException {
-        // Resolve the path to fully qualified table path using the `TableClient` APIs
+    public static Table forPath(TableClient tableClient, String path) {
         String resolvedPath;
         try {
             resolvedPath = tableClient.getFileSystemClient().resolvePath(path);
-        } catch (FileNotFoundException fnf) {
-            throw new TableNotFoundException(path, fnf);
         } catch (IOException io) {
             throw new RuntimeException(io);
         }
@@ -52,13 +45,13 @@ public class TableImpl implements Table {
     }
 
     @Override
-    public Snapshot getLatestSnapshot(TableClient tableClient) throws TableNotFoundException {
-        return snapshotManager.buildLatestSnapshot(tableClient);
+    public String getPath(TableClient tableClient) {
+        return tablePath;
     }
 
     @Override
-    public String getPath() {
-        return tablePath;
+    public Snapshot getLatestSnapshot(TableClient tableClient) throws TableNotFoundException {
+        return snapshotManager.buildLatestSnapshot(tableClient);
     }
 
     @Override

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileSystemClient.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileSystemClient.java
@@ -87,8 +87,7 @@ public class DefaultFileSystemClient
     public String resolvePath(String path) throws IOException {
         Path pathObject = new Path(path);
         FileSystem fs = pathObject.getFileSystem(hadoopConf);
-        Path resolvedPath = fs.resolvePath(pathObject);
-        return fs.makeQualified(resolvedPath).toString();
+        return fs.makeQualified(pathObject).toString();
     }
 
     @Override

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
@@ -189,10 +189,20 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
 
   test("invalid path") {
     val invalidPath = "/path/to/non-existent-directory"
-    val ex = intercept[TableNotFoundException] {
-      Table.forPath(defaultTableClient, invalidPath)
+    val table = Table.forPath(defaultTableClient, invalidPath)
+
+    def expectTableNotFoundException(fn: () => Unit): Unit = {
+      val ex = intercept[TableNotFoundException] {
+        fn()
+      }
+      assert(ex.getMessage().contains(s"Delta table at path `file:$invalidPath` is not found"))
     }
-    assert(ex.getMessage().contains(s"Delta table at path `$invalidPath` is not found"))
+
+    expectTableNotFoundException(() => table.getLatestSnapshot(defaultTableClient))
+    expectTableNotFoundException(() =>
+      table.getSnapshotAsOfTimestamp(defaultTableClient, 1))
+    expectTableNotFoundException(() =>
+      table.getSnapshotAsOfVersion(defaultTableClient, 1))
   }
 
   test("table deleted after the `Table` creation") {
@@ -208,7 +218,7 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
         table.getLatestSnapshot(defaultTableClient)
       }
       assert(ex.getMessage.contains(
-        s"Delta table at path `file:${target.getCanonicalPath}` is not found"))
+        s"Delta table at path `${target.getCanonicalPath}` is not found"))
     }
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
@@ -218,7 +218,7 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
         table.getLatestSnapshot(defaultTableClient)
       }
       assert(ex.getMessage.contains(
-        s"Delta table at path `${target.getCanonicalPath}` is not found"))
+        s"Delta table at path `file:${target.getCanonicalPath}` is not found"))
     }
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/client/DefaultFileSystemClientSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/client/DefaultFileSystemClientSuite.scala
@@ -58,8 +58,8 @@ class DefaultFileSystemClientSuite extends AnyFunSuite with TestUtils {
   }
 
   test("resolve path on non-existent file") {
-    intercept[FileNotFoundException] {
-      fsClient.resolvePath("/non-existentfileTable/01.json")
-    }
+    val inputPath = "/non-existentfileTable/01.json"
+    val resolvedPath = fsClient.resolvePath(inputPath)
+    assert("file:" + inputPath === resolvedPath)
   }
 }


### PR DESCRIPTION
## Description
(Split from #2941)

Earlier it used to throw if the path is not valid. Now, it doesn't validate immediately. Instead the validation is done when we try to create a snapshot or other operations. We want to create tables from scratch and `Table. forPath` throwing error doesn't let us proceed.

## How was this patch tested?
Unittests
