### PR TITLE
[Kernel][Writes] Add `TableFeatures.validateWriteSupportedTable` utility method

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -104,6 +104,32 @@ public final class DeltaErrors {
         return new UnsupportedOperationException(message);
     }
 
+    public static UnsupportedOperationException unsupportedReaderProtocol(int readVersion) {
+        throw new UnsupportedOperationException(
+                "Unsupported reader protocol version: " + readVersion);
+    }
+
+    public static UnsupportedOperationException unsupportedReadFeature(
+            int readProtocolVersion,
+            String readFeature) {
+        throw new UnsupportedOperationException(String.format(
+                "Unsupported reader protocol version: %s with feature: %s",
+                    readProtocolVersion, readFeature));
+    }
+
+    public static UnsupportedOperationException unsupportedWriterProtocol(int writeVersion) {
+        throw new UnsupportedOperationException(
+                "Unsupported writer protocol version: " + writeVersion);
+    }
+
+    public static UnsupportedOperationException unsupportedWriteFeature(
+            int writeProtocolVersion,
+            String writeFeature) {
+        throw new UnsupportedOperationException(String.format(
+                "Unsupported writer protocol version: %s with feature: %s",
+                writeProtocolVersion, writeFeature));
+    }
+
     private static String formatTimestamp(long millisSinceEpochUTC) {
         return new Timestamp(millisSinceEpochUTC).toInstant().toString();
     }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableFeatures.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableFeatures.java
@@ -18,8 +18,12 @@ package io.delta.kernel.internal;
 
 import java.util.List;
 
-import io.delta.kernel.internal.actions.*;
+import io.delta.kernel.types.StructType;
+
+import io.delta.kernel.internal.actions.Metadata;
+import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.util.ColumnMapping;
+import static io.delta.kernel.internal.DeltaErrors.*;
 
 /**
  * Contains utility methods related to the Delta table feature support in protocol.
@@ -49,14 +53,74 @@ public class TableFeatures {
                         case "vacuumProtocolCheck":
                             break;
                         default:
-                            throw new UnsupportedOperationException(
-                                    "Unsupported table feature: " + readerFeature);
+                            throw DeltaErrors.unsupportedReadFeature(3, readerFeature);
                     }
                 }
                 break;
             default:
-                throw new UnsupportedOperationException(
-                        "Unsupported reader protocol version: " + protocol.getMinReaderVersion());
+                throw unsupportedReaderProtocol(protocol.getMinReaderVersion());
+        }
+    }
+
+    /**
+     * Utility method to validate whether the given table is supported for writing from Kernel.
+     * Currently, the support is as follows:
+     * <ul>
+     *     <li>protocol writer version 1.</li>
+     *     <li>protocol writer version 2 only with appendOnly feature enabled.</li>
+     *     <li>protocol writer version 7 with "appendOnly" feature enabled.</li>
+     * </ul>
+     *
+     * @param protocol    Table protocol
+     * @param metadata    Table metadata
+     * @param tableSchema Table schema
+     */
+    public static void validateWriteSupportedTable(
+            Protocol protocol,
+            Metadata metadata,
+            StructType tableSchema) {
+        int minWriterVersion = protocol.getMinWriterVersion();
+        switch (minWriterVersion) {
+            case 1:
+                break;
+            case 2:
+                // Append-only and column invariants are the writer features added in version 2
+                // Append-only is supported, but not the invariants
+                validateNoInvariants(minWriterVersion, tableSchema);
+                break;
+            case 3:
+                // Check constraints are added in version 3
+                throw unsupportedWriterProtocol(minWriterVersion);
+            case 4:
+                // CDF and generated columns are writer features added in version 4
+                throw unsupportedWriterProtocol(minWriterVersion);
+            case 5:
+                // Column mapping is the only one writer feature added in version 5
+                throw unsupportedWriterProtocol(minWriterVersion);
+            case 6:
+                // Identity is the only one writer feature added in version 6
+                throw unsupportedWriterProtocol(minWriterVersion);
+            case 7:
+                for (String writerFeature : protocol.getWriterFeatures()) {
+                    switch (writerFeature) {
+                        // Only supported writer features as of today in Kernel
+                        case "appendOnly":
+                            break;
+                        default:
+                            throw unsupportedWriteFeature(7, writerFeature);
+                    }
+                }
+                break;
+            default:
+                throw unsupportedWriterProtocol(minWriterVersion);
+        }
+    }
+
+    private static void validateNoInvariants(int minWriterVersion, StructType tableSchema) {
+        boolean hasInvariants = tableSchema.fields().stream().anyMatch(
+                field -> field.getMetadata().contains("delta.invariants"));
+        if (hasInvariants) {
+            throw unsupportedWriteFeature(minWriterVersion, "invariants");
         }
     }
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableFeaturesSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableFeaturesSuite.scala
@@ -1,0 +1,154 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal
+
+import io.delta.kernel.data.{ArrayValue, ColumnVector, MapValue}
+import io.delta.kernel.internal.TableFeatures.validateWriteSupportedTable
+import io.delta.kernel.internal.actions.{Format, Metadata, Protocol}
+import io.delta.kernel.internal.util.InternalUtils.singletonStringColumnVector
+import io.delta.kernel.types._
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.util.{Collections, Optional}
+import scala.collection.JavaConverters._
+
+/**
+ * Suite that tests Kernel throws error when it receives a unsupported protocol and metadata
+ */
+class TableFeaturesSuite extends AnyFunSuite {
+  test("validate write supported: protocol 1") {
+    checkSupported(createTestProtocol(minWriterVersion = 1))
+  }
+
+  test("validateWriteSupported: protocol 2") {
+    checkSupported(createTestProtocol(minWriterVersion = 2))
+  }
+
+  test("validateWriteSupported: protocol 2 with appendOnly") {
+    checkSupported(
+      createTestProtocol(minWriterVersion = 2),
+      metadata = createTestMetadata(withAppendOnly = true))
+  }
+
+  test("validateWriteSupported: protocol 2 with invariants") {
+    checkUnsupported(
+      createTestProtocol(minWriterVersion = 2),
+      metadata = createTestMetadata(),
+      schema = createTestSchema(includeInvariant = true))
+  }
+
+  test("validateWriteSupported: protocol 2, with appendOnly and invariants") {
+    checkUnsupported(
+      createTestProtocol(minWriterVersion = 2),
+      metadata = createTestMetadata(),
+      schema = createTestSchema(includeInvariant = true))
+  }
+
+  Seq(3, 4, 5, 6).foreach { minWriterVersion =>
+    test(s"validateWriteSupported: protocol $minWriterVersion") {
+      checkUnsupported(createTestProtocol(minWriterVersion = minWriterVersion))
+    }
+  }
+
+  test("validateWriteSupported: protocol 7 with no additional writer features") {
+    checkSupported(createTestProtocol(minWriterVersion = 7))
+  }
+
+  test("validateWriteSupported: protocol 7 with appendOnly") {
+    checkSupported(createTestProtocol(minWriterVersion = 7, writerFeatures = "appendOnly"))
+  }
+
+  Seq("invariants", "checkConstraints", "generatedColumns", "allowColumnDefaults", "changeDataFeed",
+      "columnMapping", "identityColumns", "deletionVectors", "rowTracking", "timestampNtz",
+      "domainMetadata", "v2Checkpoint", "icebergCompatV1", "icebergCompatV2", "clustering",
+      "vacuumProtocolCheck").foreach { unsupportedWriterFeature =>
+    test(s"validateWriteSupported: protocol 7 with $unsupportedWriterFeature") {
+      checkUnsupported(createTestProtocol(minWriterVersion = 7, unsupportedWriterFeature))
+    }
+  }
+
+  def checkSupported(
+    protocol: Protocol,
+    metadata: Metadata = null,
+    schema: StructType = createTestSchema()): Unit = {
+    validateWriteSupportedTable(protocol, metadata, schema)
+  }
+
+  def checkUnsupported(
+    protocol: Protocol,
+    metadata: Metadata = null,
+    schema: StructType = createTestSchema()): Unit = {
+    intercept[UnsupportedOperationException] {
+      validateWriteSupportedTable(protocol, metadata, schema)
+    }
+  }
+
+  def createTestProtocol(minWriterVersion: Int, writerFeatures: String*): Protocol = {
+    new Protocol(
+      // minReaderVersion - it doesn't matter as the read fails anyway before the writer check
+      0,
+      minWriterVersion,
+      // reader features - it doesn't matter as the read fails anyway before the writer check
+      Collections.emptyList(),
+      writerFeatures.toSeq.asJava
+    )
+  }
+
+  def createTestMetadata(withAppendOnly: Boolean = false): Metadata = {
+    var config: Map[String, String] = Map()
+    if (withAppendOnly) {
+      config = Map("delta.appendOnly" -> "true");
+    }
+    new Metadata(
+      "id",
+      Optional.of("name"),
+      Optional.of("description"),
+      new Format("parquet", Collections.emptyMap()),
+      "sss",
+      new StructType(),
+      new ArrayValue() { // partitionColumns
+        override def getSize = 1
+
+        override def getElements: ColumnVector = singletonStringColumnVector("c3")
+      },
+      Optional.empty(),
+      new MapValue() { // conf
+        override def getSize = 1
+
+        override def getKeys: ColumnVector = singletonStringColumnVector("delta.appendOnly")
+
+        override def getValues: ColumnVector =
+          singletonStringColumnVector(if (withAppendOnly) "false" else "true")
+      }
+    )
+  }
+
+  def createTestSchema(
+    includeInvariant: Boolean = false): StructType = {
+    var structType = new StructType()
+      .add("c1", IntegerType.INTEGER)
+      .add("c2", StringType.STRING)
+    if (includeInvariant) {
+      structType = structType.add(
+        "c3",
+        TimestampType.TIMESTAMP,
+        FieldMetadata.builder()
+          .putString("delta.invariants", "{\"expression\": { \"expression\": \"x > 3\"} }")
+          .build())
+    }
+    structType
+  }
+}


### PR DESCRIPTION
## Description
(Split from #2941)

Add a utility method to check if the table is of protocol/features that current insert APIs being planned support writing into. The current plan is to give a write support similar to that Standalone, which is at (minReaderVersion = 1 and minWriterVersion = 2 with `appendOnly` support).

## How was this patch tested?
Unittests
