### PR TITLE
[Kernel][Writes] Add a utility to parse interval duration in Delta table configs

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/DateTimeConstants.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/DateTimeConstants.java
@@ -1,4 +1,4 @@
-package io.delta.kernel.internal.util;/*
+/*
  * Copyright (2023) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +13,7 @@ package io.delta.kernel.internal.util;/*
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.delta.kernel.internal.util;
 
 public class DateTimeConstants {
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/DateTimeConstants.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/DateTimeConstants.java
@@ -1,0 +1,45 @@
+package io.delta.kernel.internal.util;/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public class DateTimeConstants {
+
+    public static final int MONTHS_PER_YEAR = 12;
+
+    public static final byte DAYS_PER_WEEK = 7;
+
+    public static final long HOURS_PER_DAY = 24L;
+
+    public static final long MINUTES_PER_HOUR = 60L;
+
+    public static final long SECONDS_PER_MINUTE = 60L;
+    public static final long SECONDS_PER_HOUR = MINUTES_PER_HOUR * SECONDS_PER_MINUTE;
+    public static final long SECONDS_PER_DAY = HOURS_PER_DAY * SECONDS_PER_HOUR;
+
+    public static final long MILLIS_PER_SECOND = 1000L;
+    public static final long MILLIS_PER_MINUTE = SECONDS_PER_MINUTE * MILLIS_PER_SECOND;
+    public static final long MILLIS_PER_HOUR = MINUTES_PER_HOUR * MILLIS_PER_MINUTE;
+    public static final long MILLIS_PER_DAY = HOURS_PER_DAY * MILLIS_PER_HOUR;
+
+    public static final long MICROS_PER_MILLIS = 1000L;
+    public static final long MICROS_PER_SECOND = MILLIS_PER_SECOND * MICROS_PER_MILLIS;
+    public static final long MICROS_PER_MINUTE = SECONDS_PER_MINUTE * MICROS_PER_SECOND;
+    public static final long MICROS_PER_HOUR = MINUTES_PER_HOUR * MICROS_PER_MINUTE;
+    public static final long MICROS_PER_DAY = HOURS_PER_DAY * MICROS_PER_HOUR;
+
+    public static final long NANOS_PER_MICROS = 1000L;
+    public static final long NANOS_PER_MILLIS = MICROS_PER_MILLIS * NANOS_PER_MICROS;
+    public static final long NANOS_PER_SECOND = MILLIS_PER_SECOND * NANOS_PER_MILLIS;
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/IntervalParserUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/IntervalParserUtils.java
@@ -1,0 +1,334 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.internal.util;
+
+import java.util.Locale;
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import static io.delta.kernel.internal.util.DateTimeConstants.*;
+import static io.delta.kernel.internal.util.IntervalParserUtils.ParseState.*;
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+
+/**
+ * Copy of `org/apache/spark/sql/catalyst/util/SparkIntervalUtils.scala` from Apache Spark.
+ * Delta table properties store the interval format. We need a parser in order to parse these
+ * values in Kernel.
+ */
+public class IntervalParserUtils {
+    private IntervalParserUtils() {
+    }
+
+    /**
+     * Parse the given interval string into milliseconds. For configs accepting an interval, we
+     * require the user specified string must obey: - Doesn't use months or years, since an internal
+     * like this is not deterministic. - The microseconds parsed from the string value must be a
+     * non-negative value. - Doesn't use nanoseconds part as it too granular to use
+     *
+     * @return parsed interval as microseconds.
+     */
+    public static long safeParseIntervalAsMicros(String input) {
+        checkArgument(input != null, "interval string cannot be null");
+        String inputInLowerCase = input.trim().toLowerCase(Locale.ROOT);
+        checkArgument(!inputInLowerCase.isEmpty(), "interval string cannot be empty");
+        if (!inputInLowerCase.startsWith("interval ")) {
+            inputInLowerCase = "interval " + inputInLowerCase;
+        }
+        return parseIntervalAsMicros(inputInLowerCase);
+    }
+
+
+    public static long parseIntervalAsMicros(String input) {
+        return new IntervalParser(input).toMicroSeconds();
+    }
+
+    enum ParseState {
+        PREFIX,
+        TRIM_BEFORE_SIGN,
+        SIGN,
+        TRIM_BEFORE_VALUE,
+        VALUE,
+        VALUE_FRACTIONAL_PART,
+        TRIM_BEFORE_UNIT,
+        UNIT_BEGIN,
+        UNIT_SUFFIX,
+        UNIT_END;
+    }
+
+    private static final String intervalStr = "interval";
+    private static final String yearStr = "year";
+    private static final String monthStr = "month";
+    private static final String weekStr = "week";
+    private static final String dayStr = "day";
+    private static final String hourStr = "hour";
+    private static final String minuteStr = "minute";
+    private static final String secondStr = "second";
+    private static final String millisStr = "millisecond";
+    private static final String microsStr = "microsecond";
+
+    private static class IntervalParser {
+        private final String input;
+        private String s; // trimmed input in lowercase
+        private ParseState state = ParseState.PREFIX;
+        private int i = 0;
+        private long currentValue = 0;
+        private boolean isNegative = false;
+        private int days = 0;
+        private long microseconds = 0;
+        private int fractionScale = 0;
+        private int fraction = 0;
+        private boolean pointPrefixed = false;
+
+        // Expected trimmed lower case input string.
+        IntervalParser(String input) {
+            this.input = input;
+            if (input == null) {
+                throwIAE("interval string cannot be null");
+            }
+            String inputInLowerCase = input.trim().toLowerCase(Locale.ROOT);
+            if (inputInLowerCase.isEmpty()) {
+                throwIAE(format("Error parsing '%s' to interval", input));
+            }
+            this.s = inputInLowerCase;
+        }
+
+        long toMicroSeconds() {
+            // UTF-8 encoded bytes of the trimmed input
+            byte[] bytes = s.getBytes(UTF_8);
+            checkArgument(bytes.length > 0, "Interval string cannot be empty");
+
+            while (i < bytes.length) {
+                byte b = bytes[i];
+                int initialFractionScale = (int) (NANOS_PER_SECOND / 10);
+                switch (state) {
+                    case PREFIX:
+                        if (s.startsWith(intervalStr)) {
+                            if (s.length() == intervalStr.length()) {
+                                throwIAE("interval string cannot be empty");
+                            } else if (!Character.isWhitespace(bytes[i + intervalStr.length()])) {
+                                throwIAE("invalid interval prefix " + currentWord());
+                            } else {
+                                i += intervalStr.length();
+                            }
+                        }
+                        state = ParseState.TRIM_BEFORE_SIGN;
+                        break;
+                    case TRIM_BEFORE_SIGN:
+                        trimToNextState(b, SIGN);
+                        break;
+                    case SIGN:
+                        currentValue = 0;
+                        fraction = 0;
+                        // We preset next state from SIGN to TRIM_BEFORE_VALUE. If we meet '.'
+                        // in the SIGN state, it means that the interval value we deal with here is
+                        // a numeric with only fractional part, such as '.11 second', which can be
+                        // parsed to 0.11 seconds. In this case, we need to reset next state to
+                        // `VALUE_FRACTIONAL_PART` to go parse the fraction part of the interval
+                        // value.
+                        state = TRIM_BEFORE_VALUE;
+                        fractionScale = -1;
+                        if (b == '-' || b == '+') {
+                            i++;
+                            isNegative = b == '-';
+                        } else if ('0' <= b && b <= '9') {
+                            isNegative = false;
+                        } else if (b == '.') {
+                            isNegative = false;
+                            fractionScale = initialFractionScale;
+                            pointPrefixed = true;
+                            i++;
+                            state = VALUE_FRACTIONAL_PART;
+                        } else {
+                            throwIAE(format("unrecognized number '%s'", currentWord()));
+                        }
+                        break;
+                    case TRIM_BEFORE_VALUE:
+                        trimToNextState(b, VALUE);
+                        break;
+                    case VALUE:
+                        if ('0' <= b && b <= '9') {
+                            try {
+                                currentValue = Math.addExact(
+                                        Math.multiplyExact(10, currentValue), (b - '0'));
+                            } catch (ArithmeticException e) {
+                                throwIAE(e.getMessage(), e);
+                            }
+                        } else if (Character.isWhitespace(b)) {
+                            state = TRIM_BEFORE_UNIT;
+                        } else if (b == '.') {
+                            fractionScale = initialFractionScale;
+                            state = VALUE_FRACTIONAL_PART;
+                        } else {
+                            throwIAE(format("invalid value '%s'", currentWord()));
+                        }
+                        i++;
+                        break;
+                    case VALUE_FRACTIONAL_PART:
+                        if ('0' <= b && b <= '9' && fractionScale > 0) {
+                            fraction += (b - '0') * fractionScale;
+                            fractionScale /= 10;
+                        } else if (Character.isWhitespace(b) &&
+                                (!pointPrefixed || fractionScale < initialFractionScale)) {
+                            fraction /= ((int) NANOS_PER_MICROS);
+                            state = TRIM_BEFORE_UNIT;
+                        } else if ('0' <= b && b <= '9') {
+                            throwIAE(format("interval can only support nanosecond " +
+                                    "precision, '%s' is out of range", currentWord()));
+                        } else {
+                            throwIAE(format("invalid value '%s'", currentWord()));
+                        }
+                        i += 1;
+                        break;
+                    case TRIM_BEFORE_UNIT:
+                        trimToNextState(b, UNIT_BEGIN);
+                        break;
+                    case UNIT_BEGIN:
+                        // Checks that only seconds can have the fractional part
+                        if (b != 's' && fractionScale >= 0) {
+                            throwIAE(format("'%s' cannot have fractional part", currentWord()));
+                        }
+                        if (isNegative) {
+                            currentValue = -currentValue;
+                            fraction = -fraction;
+                        }
+                        try {
+                            if (b == 'y' && matchAt(i, yearStr)) {
+                                throwIAE("year is not supported, use days instead");
+                            } else if (b == 'w' && matchAt(i, weekStr)) {
+                                long daysInWeeks = Math.multiplyExact(DAYS_PER_WEEK, currentValue);
+                                days = Math.toIntExact(Math.addExact(days, daysInWeeks));
+                                i += weekStr.length();
+                            } else if (b == 'd' && matchAt(i, dayStr)) {
+                                days = Math.addExact(days, Math.toIntExact(currentValue));
+                                i += dayStr.length();
+                            } else if (b == 'h' && matchAt(i, hourStr)) {
+                                long hoursUs = Math.multiplyExact(currentValue,
+                                        MICROS_PER_HOUR);
+                                microseconds = Math.addExact(microseconds, hoursUs);
+                                i += hourStr.length();
+                            } else if (b == 's' && matchAt(i, secondStr)) {
+                                long secondsUs = Math.multiplyExact(
+                                        currentValue,
+                                        MICROS_PER_SECOND);
+                                microseconds = Math.addExact(
+                                        Math.addExact(microseconds, secondsUs), fraction);
+                                i += secondStr.length();
+                            } else if (b == 'm') {
+                                if (matchAt(i, monthStr)) {
+                                    throwIAE("month is not supported, use days instead");
+                                } else if (matchAt(i, minuteStr)) {
+                                    long minutesUs = Math.multiplyExact(
+                                            currentValue,
+                                            MICROS_PER_MINUTE);
+                                    microseconds = Math.addExact(microseconds, minutesUs);
+                                    i += minuteStr.length();
+                                } else if (matchAt(i, millisStr)) {
+                                    long millisUs = Math.multiplyExact(
+                                            currentValue,
+                                            MICROS_PER_MILLIS);
+                                    microseconds = Math.addExact(microseconds, millisUs);
+                                    i += millisStr.length();
+                                } else if (matchAt(i, microsStr)) {
+                                    microseconds = Math.addExact(microseconds, currentValue);
+                                    i += microsStr.length();
+                                } else {
+                                    throwIAE(format("invalid unit '%s'", currentWord()));
+                                }
+                            } else {
+                                throwIAE(format("invalid unit '%s'", currentWord()));
+                            }
+                        } catch (ArithmeticException e) {
+                            throwIAE(e.getMessage(), e);
+                        }
+                        state = UNIT_SUFFIX;
+                        break;
+                    case UNIT_SUFFIX:
+                        if (b == 's') {
+                            state = UNIT_END;
+                        } else if (Character.isWhitespace(b)) {
+                            state = TRIM_BEFORE_SIGN;
+                        } else {
+                            throwIAE(format("invalid unit '%s'", currentWord()));
+                        }
+                        i++;
+                        break;
+                    case UNIT_END:
+                        if (Character.isWhitespace(b)) {
+                            i++;
+                            state = TRIM_BEFORE_SIGN;
+                        } else {
+                            throwIAE(format("invalid unit '%s'", currentWord()));
+                        }
+                        break;
+                    default:
+                        throwIAE("invalid input: " + s);
+                }
+            }
+
+            switch (state) {
+                case UNIT_SUFFIX: // fall through
+                case UNIT_END: // fall through
+                case TRIM_BEFORE_SIGN:
+                    return days * MICROS_PER_DAY + microseconds;
+                case TRIM_BEFORE_VALUE:
+                    throwIAE(format("expect a number after '%s' but hit EOL", currentWord()));
+                    break;
+                case VALUE:
+                case VALUE_FRACTIONAL_PART:
+                    throwIAE(format("expect a unit name after '%s' but hit EOL", currentWord()));
+                    break;
+                default:
+                    throwIAE(format("unknown error when parsing '%s'", currentWord()));
+            }
+
+            throwIAE("invalid interval");
+            return 0; // should never reach.
+        }
+
+        private void trimToNextState(byte b, ParseState next) {
+            if (Character.isWhitespace(b)) {
+                i++;
+            } else {
+                state = next;
+            }
+        }
+
+        private String currentWord() {
+            String sep = "\\s+";
+            String[] strings = s.split(sep);
+            int lenRight = s.substring(i).split(sep).length;
+            return strings[strings.length - lenRight];
+        }
+
+        private boolean matchAt(int i, String str) {
+            if (i + str.length() > s.length()) {
+                return false;
+            }
+            return s.substring(i, i + str.length()).equals(str);
+        }
+
+        private void throwIAE(String msg, Exception e) {
+            throw new IllegalArgumentException(
+                    format("Error parsing '%s' to interval, %s", input, msg), e);
+        }
+
+        private void throwIAE(String msg) {
+            throw new IllegalArgumentException(
+                    format("Error parsing '%s' to interval, %s", input, msg));
+        }
+    }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/IntervalParserUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/IntervalParserUtils.java
@@ -51,7 +51,6 @@ public class IntervalParserUtils {
         return parseIntervalAsMicros(inputInLowerCase);
     }
 
-
     public static long parseIntervalAsMicros(String input) {
         return new IntervalParser(input).toMicroSeconds();
     }
@@ -69,16 +68,16 @@ public class IntervalParserUtils {
         UNIT_END;
     }
 
-    private static final String intervalStr = "interval";
-    private static final String yearStr = "year";
-    private static final String monthStr = "month";
-    private static final String weekStr = "week";
-    private static final String dayStr = "day";
-    private static final String hourStr = "hour";
-    private static final String minuteStr = "minute";
-    private static final String secondStr = "second";
-    private static final String millisStr = "millisecond";
-    private static final String microsStr = "microsecond";
+    private static final String INTERVAL_STR = "interval";
+    private static final String YEAR_STR = "year";
+    private static final String MONTH_STR = "month";
+    private static final String WEEK_STR = "week";
+    private static final String DAY_STR = "day";
+    private static final String HOUR_STR = "hour";
+    private static final String MINUTE_STR = "minute";
+    private static final String SECOND_STR = "second";
+    private static final String MILLIS_STR = "millisecond";
+    private static final String MICROS_STR = "microsecond";
 
     private static class IntervalParser {
         private final String input;
@@ -116,13 +115,13 @@ public class IntervalParserUtils {
                 int initialFractionScale = (int) (NANOS_PER_SECOND / 10);
                 switch (state) {
                     case PREFIX:
-                        if (s.startsWith(intervalStr)) {
-                            if (s.length() == intervalStr.length()) {
+                        if (s.startsWith(INTERVAL_STR)) {
+                            if (s.length() == INTERVAL_STR.length()) {
                                 throwIAE("interval string cannot be empty");
-                            } else if (!Character.isWhitespace(bytes[i + intervalStr.length()])) {
+                            } else if (!Character.isWhitespace(bytes[i + INTERVAL_STR.length()])) {
                                 throwIAE("invalid interval prefix " + currentWord());
                             } else {
-                                i += intervalStr.length();
+                                i += INTERVAL_STR.length();
                             }
                         }
                         state = ParseState.TRIM_BEFORE_SIGN;
@@ -206,45 +205,45 @@ public class IntervalParserUtils {
                             fraction = -fraction;
                         }
                         try {
-                            if (b == 'y' && matchAt(i, yearStr)) {
+                            if (b == 'y' && matchAt(i, YEAR_STR)) {
                                 throwIAE("year is not supported, use days instead");
-                            } else if (b == 'w' && matchAt(i, weekStr)) {
+                            } else if (b == 'w' && matchAt(i, WEEK_STR)) {
                                 long daysInWeeks = Math.multiplyExact(DAYS_PER_WEEK, currentValue);
                                 days = Math.toIntExact(Math.addExact(days, daysInWeeks));
-                                i += weekStr.length();
-                            } else if (b == 'd' && matchAt(i, dayStr)) {
+                                i += WEEK_STR.length();
+                            } else if (b == 'd' && matchAt(i, DAY_STR)) {
                                 days = Math.addExact(days, Math.toIntExact(currentValue));
-                                i += dayStr.length();
-                            } else if (b == 'h' && matchAt(i, hourStr)) {
+                                i += DAY_STR.length();
+                            } else if (b == 'h' && matchAt(i, HOUR_STR)) {
                                 long hoursUs = Math.multiplyExact(currentValue,
                                         MICROS_PER_HOUR);
                                 microseconds = Math.addExact(microseconds, hoursUs);
-                                i += hourStr.length();
-                            } else if (b == 's' && matchAt(i, secondStr)) {
+                                i += HOUR_STR.length();
+                            } else if (b == 's' && matchAt(i, SECOND_STR)) {
                                 long secondsUs = Math.multiplyExact(
                                         currentValue,
                                         MICROS_PER_SECOND);
                                 microseconds = Math.addExact(
                                         Math.addExact(microseconds, secondsUs), fraction);
-                                i += secondStr.length();
+                                i += SECOND_STR.length();
                             } else if (b == 'm') {
-                                if (matchAt(i, monthStr)) {
+                                if (matchAt(i, MONTH_STR)) {
                                     throwIAE("month is not supported, use days instead");
-                                } else if (matchAt(i, minuteStr)) {
+                                } else if (matchAt(i, MINUTE_STR)) {
                                     long minutesUs = Math.multiplyExact(
                                             currentValue,
                                             MICROS_PER_MINUTE);
                                     microseconds = Math.addExact(microseconds, minutesUs);
-                                    i += minuteStr.length();
-                                } else if (matchAt(i, millisStr)) {
+                                    i += MINUTE_STR.length();
+                                } else if (matchAt(i, MILLIS_STR)) {
                                     long millisUs = Math.multiplyExact(
                                             currentValue,
                                             MICROS_PER_MILLIS);
                                     microseconds = Math.addExact(microseconds, millisUs);
-                                    i += millisStr.length();
-                                } else if (matchAt(i, microsStr)) {
+                                    i += MILLIS_STR.length();
+                                } else if (matchAt(i, MICROS_STR)) {
                                     microseconds = Math.addExact(microseconds, currentValue);
-                                    i += microsStr.length();
+                                    i += MICROS_STR.length();
                                 } else {
                                     throwIAE(format("invalid unit '%s'", currentWord()));
                                 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/IntervalParserUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/IntervalParserUtilsSuite.scala
@@ -40,7 +40,7 @@ class IntervalParserUtilsSuite extends AnyFunSuite {
       "foo",
       "foo 1 day",
       "month 3",
-      "year 3",
+      "year 3"
     ).foreach { input =>
       checkFromInvalidString(input, "Error parsing")
     }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/IntervalParserUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/IntervalParserUtilsSuite.scala
@@ -1,0 +1,151 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.util
+
+import io.delta.kernel.internal.util.DateTimeConstants._
+import io.delta.kernel.internal.util.IntervalParserUtils.parseIntervalAsMicros
+import org.scalatest.funsuite.AnyFunSuite
+
+/**
+ * Subset of tests from Apache Spark's `org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala`
+ */
+class IntervalParserUtilsSuite extends AnyFunSuite {
+  test("string to interval: basic") {
+    testSingleUnit("Week", 3, 21, 0)
+    testSingleUnit("DAY", 3, 3, 0)
+    testSingleUnit("HouR", 3, 0, 3 * MICROS_PER_HOUR)
+    testSingleUnit("MiNuTe", 3, 0, 3 * MICROS_PER_MINUTE)
+    testSingleUnit("Second", 3, 0, 3 * MICROS_PER_SECOND)
+    testSingleUnit("MilliSecond", 3, 0, 3 * MICROS_PER_MILLIS)
+    testSingleUnit("MicroSecond", 3, 0, 3)
+
+    checkFromInvalidString(null, "cannot be null")
+
+    Seq(
+      "",
+      "interval",
+      "foo",
+      "foo 1 day",
+      "month 3",
+      "year 3",
+    ).foreach { input =>
+      checkFromInvalidString(input, "Error parsing")
+    }
+  }
+
+  test("string to interval: interval with dangling parts should not results null") {
+    checkFromInvalidString("+", "expect a number after '+' but hit EOL")
+    checkFromInvalidString("-", "expect a number after '-' but hit EOL")
+    checkFromInvalidString("+ 2", "expect a unit name after '2' but hit EOL")
+    checkFromInvalidString("- 1", "expect a unit name after '1' but hit EOL")
+    checkFromInvalidString("1", "expect a unit name after '1' but hit EOL")
+    checkFromInvalidString("1.2", "expect a unit name after '1.2' but hit EOL")
+    checkFromInvalidString("1 day 2", "expect a unit name after '2' but hit EOL")
+    checkFromInvalidString("1 day 2.2", "expect a unit name after '2.2' but hit EOL")
+    checkFromInvalidString("1 day -", "expect a number after '-' but hit EOL")
+    checkFromInvalidString("-.", "expect a unit name after '-.' but hit EOL")
+  }
+
+  test("string to interval: multiple units") {
+    Seq(
+      "interval -1 day +3 Microseconds" -> micros(-1, 3),
+      "interval -   1 day +     3 Microseconds" -> micros(-1, 3),
+      "  interval  123  weeks   -1 day " +
+        "23 hours -22 minutes 1 second  -123  millisecond    567 microseconds " ->
+        micros(860, 81480877567L)
+    ).foreach { case (input, expected) =>
+      checkFromString(input, expected)
+    }
+  }
+
+  test("string to interval: special cases") {
+    // Support any order of interval units
+    checkFromString("1 microsecond 1 day", micros(1, 1))
+    // Allow duplicated units and summarize their values
+    checkFromString("1 day 10 day", micros(11, 0))
+    // Only the seconds units can have the fractional part
+    checkFromInvalidString("1.5 days", "'days' cannot have fractional part")
+    checkFromInvalidString("1. hour", "'hour' cannot have fractional part")
+    checkFromInvalidString("1 hourX", "invalid unit 'hourx'")
+    checkFromInvalidString("~1 hour", "unrecognized number '~1'")
+    checkFromInvalidString("1 Mour", "invalid unit 'mour'")
+    checkFromInvalidString("1 aour", "invalid unit 'aour'")
+    checkFromInvalidString("1a1 hour", "invalid value '1a1'")
+    checkFromInvalidString("1.1a1 seconds", "invalid value '1.1a1'")
+    checkFromInvalidString("2234567890 days", "integer overflow")
+    checkFromInvalidString(". seconds", "invalid value '.'")
+  }
+
+  test("string to interval: whitespaces") {
+    checkFromInvalidString(" ", "Error parsing ' ' to interval")
+    checkFromInvalidString("\n", "Error parsing '\n' to interval")
+    checkFromInvalidString("\t", "Error parsing '\t' to interval")
+    checkFromString("1 \t day \n 2 \r hour", micros(1, 2 * MICROS_PER_HOUR))
+    checkFromInvalidString("interval1 \t day \n 2 \r hour", "invalid interval prefix interval1")
+    checkFromString("interval\r1\tday", micros(1, 0))
+    // scalastyle:off nonascii
+    checkFromInvalidString("中国 interval 1 day", "unrecognized number '中国'")
+    checkFromInvalidString("interval浙江 1 day", "invalid interval prefix interval浙江")
+    checkFromInvalidString("interval 1杭州 day", "invalid value '1杭州'")
+    checkFromInvalidString("interval 1 滨江day", "invalid unit '滨江day'")
+    checkFromInvalidString("interval 1 day长河", "invalid unit 'day长河'")
+    checkFromInvalidString("interval 1 day 网商路", "unrecognized number '网商路'")
+    // scalastyle:on nonascii
+  }
+
+  test("string to interval: seconds with fractional part") {
+    checkFromString("0.1 seconds", micros(0, 100000))
+    checkFromString("1. seconds", micros(0, 1000000))
+    checkFromString("123.001 seconds", micros(0, 123001000))
+    checkFromString("1.001001 seconds", micros(0, 1001001))
+    checkFromString("1 minute 1.001001 seconds", micros(0, 61001001))
+    checkFromString("-1.5 seconds", micros(0, -1500000))
+    // truncate nanoseconds to microseconds
+    checkFromString("0.999999999 seconds", micros(0, 999999))
+    checkFromString(".999999999 seconds", micros(0, 999999))
+    checkFromInvalidString("0.123456789123 seconds", "'0.123456789123' is out of range")
+  }
+
+  private def testSingleUnit(unit: String, number: Int, days: Int, microseconds: Long): Unit = {
+    for (prefix <- Seq("interval ", "")) {
+      val input1 = prefix + number + " " + unit
+      val input2 = prefix + number + " " + unit + "s"
+      val result = micros(days, microseconds)
+      checkFromString(input1, result)
+      checkFromString(input2, result)
+    }
+  }
+
+  private def checkFromString(input: String, expected: Long): Unit = {
+    assert(parseIntervalAsMicros(input) === expected)
+  }
+
+  private def checkFromInvalidString(input: String, errorMsg: String): Unit = {
+    failFuncWithInvalidInput(input, errorMsg, s => parseIntervalAsMicros(s))
+  }
+
+  private def failFuncWithInvalidInput(
+    input: String, errorMsg: String, converter: String => Long): Unit = {
+    withClue(s"Expected to throw an exception for the invalid input: $input") {
+      val e = intercept[IllegalArgumentException](converter(input))
+      assert(e.getMessage.contains(errorMsg))
+    }
+  }
+
+  private def micros(days: Long, microseconds: Long): Long = {
+    days * MICROS_PER_DAY + microseconds
+  }
+}

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/DefaultKernelUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/DefaultKernelUtils.java
@@ -22,6 +22,7 @@ import io.delta.kernel.expressions.Column;
 import io.delta.kernel.types.DataType;
 import io.delta.kernel.types.StructType;
 
+import io.delta.kernel.internal.util.DateTimeConstants;
 import io.delta.kernel.internal.util.Tuple2;
 
 public class DefaultKernelUtils {
@@ -61,36 +62,6 @@ public class DefaultKernelUtils {
 
     public static long millisToMicros(long millis) {
         return Math.multiplyExact(millis, DateTimeConstants.MICROS_PER_MILLIS);
-    }
-
-    public static class DateTimeConstants {
-
-        public static final int MONTHS_PER_YEAR = 12;
-
-        public static final byte DAYS_PER_WEEK = 7;
-
-        public static final long HOURS_PER_DAY = 24L;
-
-        public static final long MINUTES_PER_HOUR = 60L;
-
-        public static final long SECONDS_PER_MINUTE = 60L;
-        public static final long SECONDS_PER_HOUR = MINUTES_PER_HOUR * SECONDS_PER_MINUTE;
-        public static final long SECONDS_PER_DAY = HOURS_PER_DAY * SECONDS_PER_HOUR;
-
-        public static final long MILLIS_PER_SECOND = 1000L;
-        public static final long MILLIS_PER_MINUTE = SECONDS_PER_MINUTE * MILLIS_PER_SECOND;
-        public static final long MILLIS_PER_HOUR = MINUTES_PER_HOUR * MILLIS_PER_MINUTE;
-        public static final long MILLIS_PER_DAY = HOURS_PER_DAY * MILLIS_PER_HOUR;
-
-        public static final long MICROS_PER_MILLIS = 1000L;
-        public static final long MICROS_PER_SECOND = MILLIS_PER_SECOND * MICROS_PER_MILLIS;
-        public static final long MICROS_PER_MINUTE = SECONDS_PER_MINUTE * MICROS_PER_SECOND;
-        public static final long MICROS_PER_HOUR = MINUTES_PER_HOUR * MICROS_PER_MINUTE;
-        public static final long MICROS_PER_DAY = HOURS_PER_DAY * MICROS_PER_HOUR;
-
-        public static final long NANOS_PER_MICROS = 1000L;
-        public static final long NANOS_PER_MILLIS = MICROS_PER_MILLIS * NANOS_PER_MICROS;
-        public static final long NANOS_PER_SECOND = MILLIS_PER_SECOND * NANOS_PER_MILLIS;
     }
 
     /**

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
@@ -15,20 +15,21 @@
  */
 package io.delta.kernel.defaults
 
+import io.delta.golden.GoldenTableUtils.goldenTablePath
+import io.delta.kernel.defaults.utils.{TestRow, TestUtils}
+import io.delta.kernel.internal.fs.Path
+import io.delta.kernel.internal.util.InternalUtils.daysSinceEpoch
+import io.delta.kernel.internal.util.{DateTimeConstants, FileNames}
+import io.delta.kernel.types.{LongType, StructType}
+import io.delta.kernel.{Table, TableNotFoundException}
+import org.apache.hadoop.shaded.org.apache.commons.io.FileUtils
+import org.apache.spark.sql.functions.col
+import org.scalatest.funsuite.AnyFunSuite
+
 import java.io.File
 import java.math.BigDecimal
 import java.sql.Date
 import scala.collection.JavaConverters._
-import org.apache.hadoop.shaded.org.apache.commons.io.FileUtils
-import org.scalatest.funsuite.AnyFunSuite
-import org.apache.spark.sql.functions.col
-import io.delta.golden.GoldenTableUtils.goldenTablePath
-import io.delta.kernel.{Table, TableNotFoundException}
-import io.delta.kernel.defaults.utils.{TestRow, TestUtils}
-import io.delta.kernel.internal.fs.Path
-import io.delta.kernel.internal.util.{DateTimeConstants, FileNames}
-import io.delta.kernel.internal.util.InternalUtils.daysSinceEpoch
-import io.delta.kernel.types.{LongType, StructType}
 
 class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
@@ -18,19 +18,15 @@ package io.delta.kernel.defaults
 import java.io.File
 import java.math.BigDecimal
 import java.sql.Date
-
 import scala.collection.JavaConverters._
-
 import org.apache.hadoop.shaded.org.apache.commons.io.FileUtils
 import org.scalatest.funsuite.AnyFunSuite
 import org.apache.spark.sql.functions.col
 import io.delta.golden.GoldenTableUtils.goldenTablePath
-
 import io.delta.kernel.{Table, TableNotFoundException}
-import io.delta.kernel.defaults.internal.DefaultKernelUtils
 import io.delta.kernel.defaults.utils.{TestRow, TestUtils}
 import io.delta.kernel.internal.fs.Path
-import io.delta.kernel.internal.util.FileNames
+import io.delta.kernel.internal.util.{DateTimeConstants, FileNames}
 import io.delta.kernel.internal.util.InternalUtils.daysSinceEpoch
 import io.delta.kernel.types.{LongType, StructType}
 
@@ -117,7 +113,7 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
       if (values(2) == null) {
         null
       } else {
-        values(2).asInstanceOf[Long] + DefaultKernelUtils.DateTimeConstants.MICROS_PER_HOUR * 8
+        values(2).asInstanceOf[Long] + DateTimeConstants.MICROS_PER_HOUR * 8
       }
     )
   }


### PR DESCRIPTION
Currently these configs are stored in SQL interval format. We could depend on external libraries, but to minimize the dependencies on `kernel-api`, the minimal relevant code is copied from Standalone (which was a copy of Apache Spark code). Also I couldn't find a minimal library that does just the interval parsing.