### PR TITLE
Fix typo in Spark Master test workflow

### DIFF
--- a/.github/workflows/spark_master_test.yaml
+++ b/.github/workflows/spark_master_test.yaml
@@ -43,7 +43,7 @@ jobs:
           sudo apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
           sudo apt install libedit-dev
         if: steps.git-diff.outputs.diff
-      - name: Run Scala Master tests
+      - name: Run Spark Master tests
         run: |
           build/sbt -DsparkVersion=master "++ ${{ matrix.scala }}" clean spark/test
         if: steps.git-diff.outputs.diff


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [X] Other (INFRA)

## Description

Rename Spark Master github workflow name

## How was this patch tested?

CI test

## Does this PR introduce _any_ user-facing changes?

No
