### PR TITLE
Make test in DeltaSourceSuite Spark 3.5 only

### DIFF
--- a/spark/src/test/scala-spark-3.5/shims/DeltaExcludedBySparkVersionTestMixinShims.scala
+++ b/spark/src/test/scala-spark-3.5/shims/DeltaExcludedBySparkVersionTestMixinShims.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.QueryTest
+
+trait DeltaExcludedBySparkVersionTestMixinShims extends QueryTest {
+  /**
+   * Tests that are meant for Delta compiled against Spark Latest Release only. Executed since this
+   * is the Spark Latest Release shim.
+   */
+  protected def testSparkLatestOnly(
+      testName: String, testTags: org.scalatest.Tag*)
+      (testFun: => Any)
+      (implicit pos: org.scalactic.source.Position): Unit = {
+    test(testName, testTags: _*)(testFun)(pos)
+  }
+}

--- a/spark/src/test/scala-spark-master/shims/DeltaExcludedBySparkVersionTestMixinShims.scala
+++ b/spark/src/test/scala-spark-master/shims/DeltaExcludedBySparkVersionTestMixinShims.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.QueryTest
+
+trait DeltaExcludedBySparkVersionTestMixinShims extends QueryTest {
+
+  /**
+   * Tests that are meant for Delta compiled against Spark Latest Release only. Ignored since this
+   * is the Spark Master shim.
+   */
+  protected def testSparkLatestOnly(
+      testName: String, testTags: org.scalatest.Tag*)
+      (testFun: => Any)
+      (implicit pos: org.scalactic.source.Position): Unit = {
+    ignore(testName + " (Spark Latest Release Only)", testTags: _*)(testFun)(pos)
+  }
+
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -48,7 +48,8 @@ import org.apache.spark.util.{ManualClock, Utils}
 
 class DeltaSourceSuite extends DeltaSourceSuiteBase
   with DeltaColumnMappingTestUtils
-  with DeltaSQLCommandTest {
+  with DeltaSQLCommandTest
+  with DeltaExcludedBySparkVersionTestMixinShims {
 
   import testImplicits._
 
@@ -1657,7 +1658,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
     }
   }
 
-  test("startingVersion: user defined start works with mergeSchema") {
+  testSparkLatestOnly("startingVersion: user defined start works with mergeSchema") {
     withTempDir { inputDir =>
       withTempView("startingVersionTest") {
         spark.range(10)


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Disable test `DeltaSourceSuite :: startingVersion: user defined start works with mergeSchema` in `delta-spark` when running against Spark Master. i.e. it only runs against Spark 3.5. This is because it recently broke due to changes in Spark Master.

Further investigation is required.

## How was this patch tested?

Local tests and CI tests.

## Does this PR introduce _any_ user-facing changes?

No