### PR TITLE
Disable 3 Delta Spark tests against Spark Master

### DIFF
--- a/spark/src/test/scala-spark-3.5/shims/DeltaExcludedBySparkVersionTestMixinShims.scala
+++ b/spark/src/test/scala-spark-3.5/shims/DeltaExcludedBySparkVersionTestMixinShims.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.QueryTest
+
+trait DeltaExcludedBySparkVersionTestMixinShims extends QueryTest {
+  /**
+   * Tests that are meant for Delta compiled against Spark Latest Release only. Executed since this
+   * is the Spark Latest Release shim.
+   */
+  protected def testSparkLatestOnly(
+      testName: String, testTags: org.scalatest.Tag*)
+      (testFun: => Any)
+      (implicit pos: org.scalactic.source.Position): Unit = {
+    test(testName, testTags: _*)(testFun)(pos)
+  }
+}

--- a/spark/src/test/scala-spark-master/shims/DeltaExcludedBySparkVersionTestMixinShims.scala
+++ b/spark/src/test/scala-spark-master/shims/DeltaExcludedBySparkVersionTestMixinShims.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.QueryTest
+
+trait DeltaExcludedBySparkVersionTestMixinShims extends QueryTest {
+
+  /**
+   * Tests that are meant for Delta compiled against Spark Latest Release only. Ignored since this
+   * is the Spark Master shim.
+   */
+  protected def testSparkLatestOnly(
+      testName: String, testTags: org.scalatest.Tag*)
+      (testFun: => Any)
+      (implicit pos: org.scalactic.source.Position): Unit = {
+    ignore(testName + " (Spark Latest Release Only)", testTags: _*)(testFun)(pos)
+  }
+
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -48,7 +48,8 @@ import org.apache.spark.util.{ManualClock, Utils}
 
 class DeltaSourceSuite extends DeltaSourceSuiteBase
   with DeltaColumnMappingTestUtils
-  with DeltaSQLCommandTest {
+  with DeltaSQLCommandTest
+  with DeltaExcludedBySparkVersionTestMixinShims {
 
   import testImplicits._
 
@@ -1657,7 +1658,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
     }
   }
 
-  test("startingVersion: user defined start works with mergeSchema") {
+  testSparkLatestOnly("startingVersion: user defined start works with mergeSchema") {
     withTempDir { inputDir =>
       withTempView("startingVersionTest") {
         spark.range(10)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
@@ -42,7 +42,9 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{ArrayType, DateType, IntegerType, MetadataBuilder, StringType, StructField, StructType, TimestampType}
 import org.apache.spark.unsafe.types.UTF8String
 
-trait GeneratedColumnSuiteBase extends GeneratedColumnTest {
+trait GeneratedColumnSuiteBase
+    extends GeneratedColumnTest
+    with DeltaExcludedBySparkVersionTestMixinShims {
 
   import GeneratedColumn._
   import testImplicits._
@@ -735,7 +737,7 @@ trait GeneratedColumnSuiteBase extends GeneratedColumnTest {
     }
   }
 
-  test("disallow column type evolution - nesting") {
+  testSparkLatestOnly("disallow column type evolution - nesting") {
     withTableName("disallow_column_type_evolution") { table =>
       createTable(table, None, "a SMALLINT, c1 STRUCT<a: SMALLINT>, c2 SMALLINT",
         Map("c2" -> "CAST(HASH(a - 10s) AS SMALLINT)"), Nil)
@@ -772,7 +774,9 @@ trait GeneratedColumnSuiteBase extends GeneratedColumnTest {
     }
   }
 
-  test("changing the type of a nested field named the same as the generated column") {
+  // scalastyle:off line.size.limit
+  testSparkLatestOnly("changing the type of a nested field named the same as the generated column") {
+  // scalastyle:on line.size.limit
     withTableName("disallow_column_type_evolution") { table =>
       createTable(table, None, "a INT, t STRUCT<gen: SMALLINT>, gen SMALLINT",
         Map("gen" -> "CAST(HASH(a - 10s) AS SMALLINT)"), Nil)


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Disable 3 delta-spark tests from executing against Spark Master. They execute against Spark 3.5 only.

## How was this patch tested?

CI tests.

## Does this PR introduce _any_ user-facing changes?

No
