### PR TITLE
[Kernel][Writes] Utility method to serialize partition literals as strings

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
@@ -367,12 +367,12 @@ public class PartitionUtils {
         } else if (dataType instanceof TimestampType || dataType instanceof TimestampNTZType) {
             long microsSinceEpochUTC = (long) value;
             long seconds = microsSinceEpochUTC / 1_000_000;
-            long microsOfSecond = (microsSinceEpochUTC % 1_000_000);
-            if (microsSinceEpochUTC < 0) {
+            int microsOfSecond = (int) (microsSinceEpochUTC % 1_000_000);
+            if (microsOfSecond < 0) {
                 // also adjust for negative microsSinceEpochUTC
                 microsOfSecond = 1_000_000 + microsOfSecond;
             }
-            int nanosOfSecond = (int) (microsOfSecond * 1_000);
+            int nanosOfSecond = microsOfSecond * 1_000;
             LocalDateTime localDateTime =
                     LocalDateTime.ofEpochSecond(seconds, nanosOfSecond, ZoneOffset.UTC);
             return localDateTime.format(PARTITION_TIMESTAMP_FORMATTER);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
@@ -16,8 +16,11 @@
 package io.delta.kernel.internal.util;
 
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -35,6 +38,9 @@ import static io.delta.kernel.expressions.AlwaysTrue.ALWAYS_TRUE;
 import io.delta.kernel.internal.InternalScanFileUtils;
 
 public class PartitionUtils {
+    private static final DateTimeFormatter PARTITION_TIMESTAMP_FORMATTER =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS");
+
     private PartitionUtils() {}
 
     /**
@@ -277,7 +283,7 @@ public class PartitionUtils {
         return new And(left, right);
     }
 
-    private static Literal literalForPartitionValue(DataType dataType, String partitionValue) {
+    protected static Literal literalForPartitionValue(DataType dataType, String partitionValue) {
         if (partitionValue == null) {
             return Literal.ofNull(dataType);
         }
@@ -329,5 +335,52 @@ public class PartitionUtils {
         }
 
         throw new UnsupportedOperationException("Unsupported partition column: " + dataType);
+    }
+
+    /**
+     * Serialize the given partition value to a string according to the Delta protocol <a
+     * href="https://github.com/delta-io/delta/blob/master/PROTOCOL.md
+     * #partition-value-serialization">partition value serialization rules</a>.
+     *
+     * @param literal Literal representing the partition value of specific datatype.
+     * @return Serialized string representation of the partition value.
+     */
+    protected static String serializePartitionValue(Literal literal) {
+        Object value = literal.getValue();
+        if (value == null) {
+            return null;
+        }
+        DataType dataType = literal.getDataType();
+        if (dataType instanceof ByteType
+                || dataType instanceof ShortType
+                || dataType instanceof IntegerType
+                || dataType instanceof LongType
+                || dataType instanceof FloatType
+                || dataType instanceof DoubleType
+                || dataType instanceof BooleanType) {
+            return String.valueOf(value);
+        } else if (dataType instanceof StringType) {
+            return (String) value;
+        } else if (dataType instanceof DateType) {
+            int daysSinceEpochUTC = (int) value;
+            return LocalDate.ofEpochDay(daysSinceEpochUTC).toString();
+        } else if (dataType instanceof TimestampType || dataType instanceof TimestampNTZType) {
+            long microsSinceEpochUTC = (long) value;
+            long seconds = microsSinceEpochUTC / 1_000_000;
+            long microsOfSecond = (microsSinceEpochUTC % 1_000_000);
+            if (microsSinceEpochUTC < 0) {
+                // also adjust for negative microsSinceEpochUTC
+                microsOfSecond = 1_000_000 + microsOfSecond;
+            }
+            int nanosOfSecond = (int) (microsOfSecond * 1_000);
+            LocalDateTime localDateTime =
+                    LocalDateTime.ofEpochSecond(seconds, nanosOfSecond, ZoneOffset.UTC);
+            return localDateTime.format(PARTITION_TIMESTAMP_FORMATTER);
+        } else if (dataType instanceof DecimalType) {
+            return ((BigDecimal) value).toString();
+        } else if (dataType instanceof BinaryType) {
+            return new String((byte[]) value, StandardCharsets.UTF_8);
+        }
+        throw new UnsupportedOperationException("Unsupported partition column type: " + dataType);
     }
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/PartitionUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/PartitionUtilsSuite.scala
@@ -17,7 +17,7 @@ package io.delta.kernel.internal.util
 
 import io.delta.kernel.expressions.Literal._
 import io.delta.kernel.expressions._
-import io.delta.kernel.internal.util.PartitionUtils.{rewritePartitionPredicateOnCheckpointFileSchema, rewritePartitionPredicateOnScanFileSchema, splitMetadataAndDataPredicates}
+import io.delta.kernel.internal.util.PartitionUtils._
 import io.delta.kernel.types._
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -208,6 +208,41 @@ class PartitionUtilsSuite extends AnyFunSuite {
         assert(actCheckpointReaderPushdownPredicate.toString ===
           expCheckpointReaderPushdownPredicate)
       }
+  }
+
+  Seq(
+    ofBoolean(true) -> "true",
+    ofBoolean(false) -> "false",
+    ofNull(BooleanType.BOOLEAN) -> null,
+    ofByte(24.toByte) -> "24",
+    ofNull(ByteType.BYTE) -> null,
+    ofShort(876.toShort) -> "876",
+    ofNull(ShortType.SHORT) -> null,
+    ofInt(2342342) -> "2342342",
+    ofNull(IntegerType.INTEGER) -> null,
+    ofLong(234234223L) -> "234234223",
+    ofNull(LongType.LONG) -> null,
+    ofFloat(23423.4223f) -> "23423.422",
+    ofNull(FloatType.FLOAT) -> null,
+    ofDouble(23423.422233d) -> "23423.422233",
+    ofNull(DoubleType.DOUBLE) -> null,
+    ofString("string_val") -> "string_val",
+    ofDecimal(new java.math.BigDecimal("23423.234234"), 15, 7) -> "23423.2342340",
+    ofNull(new DecimalType(15, 7)) -> null,
+    ofNull(StringType.STRING) -> null,
+    ofBinary("binary_val".getBytes) -> "binary_val",
+    ofNull(BinaryType.BINARY) -> null,
+    ofDate(4234)  -> "1981-08-05",
+    ofNull(DateType.DATE) -> null,
+    ofTimestamp(2342342342232L) -> "1970-01-28 02:39:02.342232",
+    ofNull(TimestampType.TIMESTAMP) -> null,
+    ofTimestampNtz(-2342342342L) -> "1969-12-31 23:20:58.657658",
+    ofNull(TimestampNTZType.TIMESTAMP_NTZ) -> null
+  ).foreach { case (literal, expStr) =>
+    test(s"serialize partition value literal as string: ${literal.getDataType}($literal)") {
+      val result = serializePartitionValue(literal)
+      assert(result === expStr)
+    }
   }
 
   private def col(names: String*): Column = {


### PR DESCRIPTION
## Description
(Split from larger PR #2944)

Adds a utility method to convert the partition value literal to Delta protocol-compliant string value.

## How was this patch tested?
UTs