### PR TITLE
[Kernel[Writes] Add methods to encode Delta Log actions as `Row` objects

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.actions;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.delta.kernel.data.Row;
+import io.delta.kernel.types.*;
+
+import io.delta.kernel.internal.data.GenericRow;
+
+/**
+ * Delta log action representing a commit information action. According to the Delta protocol
+ * there isn't any specific schema for this action, but we use the following schema:
+ * <ul>
+ *     <li>timestamp: Long - Milliseconds since epoch UTC of when this commit happened</li>
+ *     <li>engineInfo: String - Engine that made this commit</li>
+ *     <li>operation: String - Operation (e.g. insert, delete, merge etc.)</li>
+ * </ul>
+ * The Delta-Spark connector adds lot more fields to this action. We can add them as needed.
+ */
+public class CommitInfo {
+
+    public static StructType FULL_SCHEMA = new StructType()
+            .add("timestamp", LongType.LONG)
+            .add("engineInfo", StringType.STRING)
+            .add("operation", StringType.STRING);
+
+    private final long timestamp;
+    private final String engineInfo;
+    private final String operation;
+
+    public CommitInfo(long timestamp, String engineInfo, String operation) {
+        this.timestamp = timestamp;
+        this.engineInfo = engineInfo;
+        this.operation = operation;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public String getEngineInfo() {
+        return engineInfo;
+    }
+
+    public String getOperation() {
+        return operation;
+    }
+
+    /**
+     * Encode as a {@link Row} object with the schema {@link CommitInfo#FULL_SCHEMA}.
+     *
+     * @return {@link Row} object with the schema {@link CommitInfo#FULL_SCHEMA}
+     */
+    public Row toRow() {
+        Map<Integer, Object> commitInfo = new HashMap<>();
+        commitInfo.put(0, timestamp);
+        commitInfo.put(1, engineInfo);
+        commitInfo.put(2, operation);
+
+        return new GenericRow(CommitInfo.FULL_SCHEMA, commitInfo);
+    }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/Metadata.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/Metadata.java
@@ -20,11 +20,10 @@ import java.util.stream.Collectors;
 import static java.util.Objects.requireNonNull;
 
 import io.delta.kernel.client.TableClient;
-import io.delta.kernel.data.ArrayValue;
-import io.delta.kernel.data.ColumnVector;
-import io.delta.kernel.data.MapValue;
+import io.delta.kernel.data.*;
 import io.delta.kernel.types.*;
 
+import io.delta.kernel.internal.data.GenericRow;
 import io.delta.kernel.internal.lang.Lazy;
 import io.delta.kernel.internal.util.VectorUtils;
 import static io.delta.kernel.internal.util.InternalUtils.requireNonNull;
@@ -58,11 +57,11 @@ public class Metadata {
         );
     }
 
-    public static final StructType READ_SCHEMA = new StructType()
+    public static final StructType FULL_SCHEMA = new StructType()
         .add("id", StringType.STRING, false /* nullable */)
         .add("name", StringType.STRING, true /* nullable */)
         .add("description", StringType.STRING, true /* nullable */)
-        .add("format", Format.READ_SCHEMA, false /* nullable */)
+        .add("format", Format.FULL_SCHEMA, false /* nullable */)
         .add("schemaString", StringType.STRING, false /* nullable */)
         .add("partitionColumns",
             new ArrayType(StringType.STRING, false /* contains null */),
@@ -163,6 +162,25 @@ public class Metadata {
 
     public Map<String, String> getConfiguration() {
         return Collections.unmodifiableMap(configuration.get());
+    }
+
+    /**
+     * Encode as a {@link Row} object with the schema {@link Metadata#FULL_SCHEMA}.
+     *
+     * @return {@link Row} object with the schema {@link Metadata#FULL_SCHEMA}
+     */
+    public Row toRow() {
+        Map<Integer, Object> metadataMap = new HashMap<>();
+        metadataMap.put(0, id);
+        metadataMap.put(1, name.orElse(null));
+        metadataMap.put(2, description.orElse(null));
+        metadataMap.put(3, format.toRow());
+        metadataMap.put(4, schemaString);
+        metadataMap.put(5, partitionColumns);
+        metadataMap.put(6, createdTime.orElse(null));
+        metadataMap.put(7, configurationMapValue);
+
+        return new GenericRow(Metadata.FULL_SCHEMA, metadataMap);
     }
 
     /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/Protocol.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/Protocol.java
@@ -15,16 +15,18 @@
  */
 package io.delta.kernel.internal.actions;
 
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.data.Row;
 import io.delta.kernel.types.ArrayType;
 import io.delta.kernel.types.IntegerType;
 import io.delta.kernel.types.StringType;
 import io.delta.kernel.types.StructType;
 
+import io.delta.kernel.internal.data.GenericRow;
 import io.delta.kernel.internal.util.VectorUtils;
+import static io.delta.kernel.internal.util.VectorUtils.stringArrayValue;
 
 public class Protocol {
 
@@ -43,7 +45,7 @@ public class Protocol {
         );
     }
 
-    public static final StructType READ_SCHEMA = new StructType()
+    public static final StructType FULL_SCHEMA = new StructType()
         .add("minReaderVersion", IntegerType.INTEGER, false /* nullable */)
         .add("minWriterVersion", IntegerType.INTEGER, false /* nullable */)
         .add("readerFeatures", new ArrayType(StringType.STRING, false /* contains null */))
@@ -90,5 +92,20 @@ public class Protocol {
         sb.append(", writerFeatures=").append(writerFeatures);
         sb.append('}');
         return sb.toString();
+    }
+
+    /**
+     * Encode as a {@link Row} object with the schema {@link Protocol#FULL_SCHEMA}.
+     *
+     * @return {@link Row} object with the schema {@link Protocol#FULL_SCHEMA}
+     */
+    public Row toRow() {
+        Map<Integer, Object> protocolMap = new HashMap<>();
+        protocolMap.put(0, minReaderVersion);
+        protocolMap.put(1, minWriterVersion);
+        protocolMap.put(2, readerFeatures == null ? null : stringArrayValue(readerFeatures));
+        protocolMap.put(3, writerFeatures == null ? null : stringArrayValue(writerFeatures));
+
+        return new GenericRow(Protocol.FULL_SCHEMA, protocolMap);
     }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/SetTransaction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/SetTransaction.java
@@ -15,18 +15,21 @@
  */
 package io.delta.kernel.internal.actions;
 
-import java.util.Optional;
+import java.util.*;
 
 import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.data.Row;
 import io.delta.kernel.types.LongType;
 import io.delta.kernel.types.StringType;
 import io.delta.kernel.types.StructType;
+
+import io.delta.kernel.internal.data.GenericRow;
 
 /**
  * Delta log action representing a transaction identifier action.
  */
 public class SetTransaction {
-    public static final StructType READ_SCHEMA = new StructType()
+    public static final StructType FULL_SCHEMA = new StructType()
         .add("appId", StringType.STRING, false /* nullable */)
         .add("version", LongType.LONG, false /* nullable*/)
         .add("lastUpdated", LongType.LONG, true /* nullable*/);
@@ -46,10 +49,7 @@ public class SetTransaction {
     private final long version;
     private final Optional<Long> lastUpdated;
 
-    public SetTransaction(
-        String appId,
-        Long version,
-        Optional<Long> lastUpdated) {
+    public SetTransaction(String appId, Long version, Optional<Long> lastUpdated) {
         this.appId = appId;
         this.version = version;
         this.lastUpdated = lastUpdated;
@@ -65,5 +65,19 @@ public class SetTransaction {
 
     public Optional<Long> getLastUpdated() {
         return lastUpdated;
+    }
+
+    /**
+     * Encode as a {@link Row} object with the schema {@link SetTransaction#FULL_SCHEMA}.
+     *
+     * @return {@link Row} object with the schema {@link SetTransaction#FULL_SCHEMA}
+     */
+    public Row toRow() {
+        Map<Integer, Object> setTransactionMap = new HashMap<>();
+        setTransactionMap.put(0, appId);
+        setTransactionMap.put(1, version);
+        setTransactionMap.put(2, lastUpdated.orElse(null));
+
+        return new GenericRow(SetTransaction.FULL_SCHEMA, setTransactionMap);
     }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/SingleAction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/SingleAction.java
@@ -15,7 +15,13 @@
  */
 package io.delta.kernel.internal.actions;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import io.delta.kernel.data.Row;
 import io.delta.kernel.types.StructType;
+
+import io.delta.kernel.internal.data.GenericRow;
 
 public class SingleAction {
     /**
@@ -23,11 +29,66 @@ public class SingleAction {
      * of new checkpoint.
      */
     public static StructType CHECKPOINT_SCHEMA = new StructType()
-            .add("txn", SetTransaction.READ_SCHEMA)
+            .add("txn", SetTransaction.FULL_SCHEMA)
             .add("add", AddFile.FULL_SCHEMA)
             .add("remove", RemoveFile.FULL_SCHEMA)
-            .add("metaData", Metadata.READ_SCHEMA)
-            .add("protocol", Protocol.READ_SCHEMA);
+            .add("metaData", Metadata.FULL_SCHEMA)
+            .add("protocol", Protocol.FULL_SCHEMA);
     // Once we start supporting updating CDC or domain metadata enabled tables, we should add the
     // schema for those fields here.
+
+    // Schema to use when writing out the single action to the Delta Log.
+    public static StructType FULL_SCHEMA = new StructType()
+            .add("txn", SetTransaction.FULL_SCHEMA)
+            .add("add", AddFile.SCHEMA_WITH_STATS)
+            .add("remove", new StructType())
+            .add("metaData", Metadata.FULL_SCHEMA)
+            .add("protocol", Protocol.FULL_SCHEMA)
+            .add("cdc", new StructType())
+            .add("commitInfo", CommitInfo.FULL_SCHEMA);
+    // Once we start supporting updating CDC or domain metadata enabled tables, we should add the
+    // schema for those fields here.
+
+    private static final int TXN_ORDINAL = FULL_SCHEMA.indexOf("txn");
+    private static final int ADD_FILE_ORDINAL = FULL_SCHEMA.indexOf("add");
+    private static final int REMOVE_FILE_ORDINAL = FULL_SCHEMA.indexOf("remove");
+    private static final int METADATA_ORDINAL = FULL_SCHEMA.indexOf("metaData");
+    private static final int PROTOCOL_ORDINAL = FULL_SCHEMA.indexOf("protocol");
+    private static final int COMMIT_INFO_ORDINAL = FULL_SCHEMA.indexOf("commitInfo");
+
+    public static Row createAddFileSingleAction(Row addFile) {
+        Map<Integer, Object> singleActionValueMap = new HashMap<>();
+        singleActionValueMap.put(ADD_FILE_ORDINAL, addFile);
+        return new GenericRow(FULL_SCHEMA, singleActionValueMap);
+    }
+
+    public static Row createProtocolSingleAction(Row protocol) {
+        Map<Integer, Object> singleActionValueMap = new HashMap<>();
+        singleActionValueMap.put(PROTOCOL_ORDINAL, protocol);
+        return new GenericRow(FULL_SCHEMA, singleActionValueMap);
+    }
+
+    public static Row createMetadataSingleAction(Row metadata) {
+        Map<Integer, Object> singleActionValueMap = new HashMap<>();
+        singleActionValueMap.put(METADATA_ORDINAL, metadata);
+        return new GenericRow(FULL_SCHEMA, singleActionValueMap);
+    }
+
+    public static Row createRemoveFileSingleAction(Row remove) {
+        Map<Integer, Object> singleActionValueMap = new HashMap<>();
+        singleActionValueMap.put(REMOVE_FILE_ORDINAL, remove);
+        return new GenericRow(FULL_SCHEMA, singleActionValueMap);
+    }
+
+    public static Row createCommitInfoSingleAction(Row commitInfo) {
+        Map<Integer, Object> singleActionValueMap = new HashMap<>();
+        singleActionValueMap.put(COMMIT_INFO_ORDINAL, commitInfo);
+        return new GenericRow(FULL_SCHEMA, singleActionValueMap);
+    }
+
+    public static Row createTxnSingleAction(Row txn) {
+        Map<Integer, Object> singleActionValueMap = new HashMap<>();
+        singleActionValueMap.put(TXN_ORDINAL, txn);
+        return new GenericRow(FULL_SCHEMA, singleActionValueMap);
+    }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
@@ -62,8 +62,8 @@ public class LogReplay {
 
     /** Read schema when searching for the latest Protocol and Metadata. */
     public static final StructType PROTOCOL_METADATA_READ_SCHEMA = new StructType()
-        .add("protocol", Protocol.READ_SCHEMA)
-        .add("metaData", Metadata.READ_SCHEMA);
+        .add("protocol", Protocol.FULL_SCHEMA)
+        .add("metaData", Metadata.FULL_SCHEMA);
 
     /** We don't need to read the entire RemoveFile, only the path and dv info */
     private static StructType REMOVE_FILE_SCHEMA = new StructType()
@@ -72,7 +72,7 @@ public class LogReplay {
 
     /** Read schema when searching for just the transaction identifiers */
     public static final StructType SET_TRANSACTION_READ_SCHEMA = new StructType()
-        .add("txn", SetTransaction.READ_SCHEMA);
+        .add("txn", SetTransaction.FULL_SCHEMA);
 
     private static StructType getAddSchema(boolean shouldReadStats) {
         return shouldReadStats ? AddFile.SCHEMA_WITH_STATS :

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/VectorUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/VectorUtils.java
@@ -27,6 +27,7 @@ import io.delta.kernel.data.Row;
 import io.delta.kernel.types.*;
 
 import io.delta.kernel.internal.data.StructRow;
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 
 public final class VectorUtils {
 
@@ -69,6 +70,97 @@ public final class VectorUtils {
             values.put((K) key, (V) value);
         }
         return values;
+    }
+
+    /**
+     * Creates an {@link ArrayValue} from list of strings. The type {@code array(string)} is a
+     * common occurrence in Delta Log schema. We don't have any non-string array type in Delta Log.
+     * If we end up needing to support other types, we can make this generic.
+     *
+     * @param values list of strings
+     * @return an {@link ArrayValue} with the given values of type {@link StringType}
+     */
+    public static ArrayValue stringArrayValue(List<String> values) {
+        return new ArrayValue() {
+            @Override
+            public int getSize() {
+                return values.size();
+            }
+
+            @Override
+            public ColumnVector getElements() {
+                return stringVector(values);
+            }
+        };
+    }
+
+    /**
+     * Creates a {@link MapValue} from map of string keys and string values. The type
+     * {@code map(string -> string)} is a common occurrence in Delta Log schema.
+     *
+     * @param keyValues
+     * @return
+     */
+    public static MapValue stringStringMapValue(Map<String, String> keyValues) {
+        List<String> keys = new ArrayList<>();
+        List<String> values = new ArrayList<>();
+        for (Map.Entry<String, String> entry : keyValues.entrySet()) {
+            keys.add(entry.getKey());
+            values.add(entry.getValue());
+        }
+        return new MapValue() {
+            @Override
+            public int getSize() {
+                return values.size();
+            }
+
+            @Override
+            public ColumnVector getKeys() {
+                return stringVector(keys);
+            }
+
+            @Override
+            public ColumnVector getValues() {
+                return stringVector(values);
+            }
+        };
+    }
+
+    /**
+     * Utility method to create a {@link ColumnVector} for given list of strings.
+     *
+     * @param values list of strings
+     * @return a {@link ColumnVector} with the given values of type {@link StringType}
+     */
+    public static ColumnVector stringVector(List<String> values) {
+        return new ColumnVector() {
+            @Override
+            public DataType getDataType() {
+                return StringType.STRING;
+            }
+
+            @Override
+            public int getSize() {
+                return values.size();
+            }
+
+            @Override
+            public void close() {
+                // no-op
+            }
+
+            @Override
+            public boolean isNullAt(int rowId) {
+                checkArgument(rowId >= 0 && rowId < values.size(), "Invalid rowId: " + rowId);
+                return values.get(rowId) == null;
+            }
+
+            @Override
+            public String getString(int rowId) {
+                checkArgument(rowId >= 0 && rowId < values.size(), "Invalid rowId: " + rowId);
+                return values.get(rowId);
+            }
+        };
     }
 
     /**


### PR DESCRIPTION
(Split from larger PR #2944)

Add `toRow` for each of the action objects. Also add any missing actions such as `CommitInfo`.

Also
* Rename `READ_SCHEMA` to `FULL_SCHEMA` when all columns in an action are present. `READ_SCHEMA` is a term used to read just the subset of columns, but in some actions, it also represents the full schema.
* Utility method to create single action `Row` object from a specific actions. Eg. `createMetadataSingleAction(Metadata metadata)` returns a `Row` of single action schema with `metaData` column representing the given `metadata` object.
