### PR TITLE
[Spark] Enable ICT and VacuumProtocolCheck automatically with Managed Commits

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -695,6 +695,25 @@ trait OptimisticTransactionImpl extends TransactionalWrite
     MaterializedRowCommitVersion.throwIfMaterializedColumnNameConflictsWithSchema(metadata)
   }
 
+  /**
+   * Some features require their pre-requisite features to not only be present
+   * in the protocol but also be enabled. This method sets the flags required
+   * to enable these pre-requisite features.
+   */
+  private def getMetadataWithDependentFeaturesEnabled(metadata: Metadata): Metadata = {
+    DeltaConfigs.MANAGED_COMMIT_OWNER_NAME.fromMetaData(metadata).map { _ =>
+      // managed-commits requires ICT to be enabled as per the spec.
+      // If ICT is just in Protocol and not in Metadata,
+      // then it is in a 'supported' state but not enabled.
+      // In order to enable ICT, we have to set the table property in Metadata.
+      val ictEnablementConfigOpt =
+        Option.when(!DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(metadata))(
+          (DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.key -> "true"))
+      val configWithICT = metadata.configuration ++ ictEnablementConfigOpt
+      metadata.copy(configuration = configWithICT)
+    }.getOrElse(metadata)
+  }
+
   private def setNewProtocolWithFeaturesEnabledByMetadata(metadata: Metadata): Unit = {
     val requiredProtocolOpt =
       Protocol.upgradeProtocolFromMetadataForExistingTable(spark, metadata, protocol)
@@ -1280,6 +1299,16 @@ trait OptimisticTransactionImpl extends TransactionalWrite
     commitStartNano = System.nanoTime()
     val attemptVersion = getFirstAttemptVersion
 
+    // From this point onwards, newProtocolOpt should not be used.
+    // `newProtocol` or `protocol` should be used instead.
+    // The updateMetadataAndProtocolWithRequiredFeatures method will
+    // directly update the global `newProtocol` if needed.
+    newProtocol = newProtocolOpt
+    // If a feature requires another feature to be enabled, we enable the required
+    // feature in the metadata (if needed) and add it to the protocol.
+    // e.g. Managed Commits requires ICT and VacuumProtocolCheck to be enabled.
+    updateMetadataAndProtocolWithRequiredFeatures(newMetadata)
+
     def recordCommitLargeFailure(ex: Throwable, op: DeltaOperations.Operation): Unit = {
       val managedCommitExceptionOpt = ex match {
         case e: CommitFailedException => Some(e)
@@ -1324,14 +1353,13 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       // Initialize everything needed to maintain auto-compaction stats.
       partitionsAddedToOpt = Some(new mutable.HashSet[Map[String, String]])
       val acStatsCollector = createAutoCompactStatsCollector()
-      val finalProtocol = newProtocolOpt.getOrElse(protocol)
       updateMetadataWithManagedCommitConfs()
       updateMetadataWithInCommitTimestamp(commitInfo)
 
       var allActions =
         Iterator(commitInfo, metadata) ++
           nonProtocolMetadataActions ++
-          newProtocolOpt.toIterator
+          newProtocol.toIterator
       allActions = allActions.map { action =>
         commitSize += 1
         action match {
@@ -1349,8 +1377,6 @@ trait OptimisticTransactionImpl extends TransactionalWrite
             removeFilesHistogram.foreach(_.insert(r.getFileSize))
           case _: SetTransaction =>
             numSetTransaction += 1
-          case m: Metadata =>
-            assertMetadata(m)
           case p: Protocol =>
             recordProtocolChanges(
               "delta.protocol.change",
@@ -1388,7 +1414,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
           managedCommitTableConf = snapshot.metadata.managedCommitTableConf)
       }
       val updatedActions = UpdatedActions(
-        commitInfo, metadata, finalProtocol, snapshot.metadata, snapshot.protocol)
+        commitInfo, metadata, protocol, snapshot.metadata, snapshot.protocol)
       val commitResponse =
         effectiveTableCommitOwnerClient.commit(attemptVersion, jsonActions, updatedActions)
       // TODO(managed-commits): Use the right timestamp method on top of CommitInfo once ICT is
@@ -1541,6 +1567,28 @@ trait OptimisticTransactionImpl extends TransactionalWrite
   }
 
   /**
+   * A metadata update can enable a feature that requires a protocol upgrade.
+   * Furthermore, a feature can have dependencies on other features. This method
+   * enables the dependent features in the metadata.
+   * It then updates the protocol with the features enabled by the metadata.
+   * The global `newMetadata` and `newProtocol` are updated with the new
+   * metadata and protocol if needed.
+   * @param metadataOpt The new metadata that is being set.
+   */
+  protected def updateMetadataAndProtocolWithRequiredFeatures(
+      metadataOpt: Option[Metadata]): Unit = {
+    metadataOpt.foreach { m =>
+      assertMetadata(m)
+      val metadataWithRequiredFeatureEnablementFlags = getMetadataWithDependentFeaturesEnabled(m)
+      setNewProtocolWithFeaturesEnabledByMetadata(metadataWithRequiredFeatureEnablementFlags)
+
+      // Also update `newMetadata` so that the behaviour later is consistent irrespective of whether
+      // metadata was set via `updateMetadata` or `actions`.
+      newMetadata = Some(metadataWithRequiredFeatureEnablementFlags)
+    }
+  }
+
+  /**
    * Prepare for a commit by doing all necessary pre-commit checks and modifications to the actions.
    * @return The finalized set of actions.
    */
@@ -1564,14 +1612,9 @@ trait OptimisticTransactionImpl extends TransactionalWrite
         metadataChanges.length <= 1, "Cannot change the metadata more than once in a transaction.")
     }
     // There be at most one metadata entry at this point.
-    metadataChanges.foreach { m =>
-      assertMetadata(m)
-      setNewProtocolWithFeaturesEnabledByMetadata(m)
-
-      // Also update `newMetadata` so that the behaviour later is consistent irrespective of whether
-      // metadata was set via `updateMetadata` or `actions`.
-      newMetadata = Some(m)
-    }
+    // Update the global `newMetadata` and `newProtocol` with any extra metadata and protocol
+    // changes needed for pre-requisite features.
+    updateMetadataAndProtocolWithRequiredFeatures(metadataChanges.headOption)
 
     // A protocol change can be *explicit*, i.e. specified as a Protocol action as part of the
     // commit actions, or *implicit*. Implicit protocol changes are mostly caused by setting

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -646,6 +646,9 @@ object ManagedCommitTableFeature
       spark: SparkSession): Boolean = {
     DeltaConfigs.MANAGED_COMMIT_OWNER_NAME.fromMetaData(metadata).nonEmpty
   }
+
+  override def requiredFeatures: Set[TableFeature] =
+    Set(InCommitTimestampTableFeature, VacuumProtocolCheckTableFeature)
 }
 
 object TypeWideningTableFeature extends ReaderWriterFeature(name = "typeWidening-preview")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTimeTravelSuite.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.delta
 
 import java.io.File
+import java.nio.charset.StandardCharsets.UTF_8
 import java.sql.Timestamp
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -26,15 +27,18 @@ import scala.language.implicitConversions
 
 import org.apache.spark.sql.delta.DeltaHistoryManager.BufferingLogDeletionIterator
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
+import org.apache.spark.sql.delta.actions.{Action, CommitInfo, SingleAction}
 import org.apache.spark.sql.delta.managedcommit.ManagedCommitBaseSuite
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
-import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, FileNames}
+import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, FileNames, JsonUtils}
 import org.apache.hadoop.fs.{FileStatus, Path}
 
 import org.apache.spark.sql.{functions, AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.util.ManualClock
 
 class DeltaTimeTravelSuite extends QueryTest
   with SharedSparkSession
@@ -67,11 +71,12 @@ class DeltaTimeTravelSuite extends QueryTest
   }
 
   /** Generate commits with the given timestamp in millis. */
-  private def generateCommitsCheap(deltaLog: DeltaLog, commits: Long*): Unit = {
+  private def generateCommitsCheap(deltaLog: DeltaLog, clock: ManualClock, commits: Long*): Unit = {
     var startVersion = deltaLog.snapshot.version + 1
     commits.foreach { ts =>
       val action =
         createTestAddFile(encodedPath = startVersion.toString, modificationTime = startVersion)
+      clock.setTime(ts)
       deltaLog.startTransaction().commitManually(action)
       modifyCommitTimestamp(deltaLog, startVersion, ts)
       startVersion += 1
@@ -86,8 +91,13 @@ class DeltaTimeTravelSuite extends QueryTest
       val rangeStart = startVersion * 10
       val rangeEnd = rangeStart + 10
       spark.range(rangeStart, rangeEnd).write.format("delta").mode("append").save(location)
-      val file = new File(FileNames.unsafeDeltaFile(deltaLog.logPath, startVersion).toUri)
-      file.setLastModified(ts)
+      val filePath = DeltaCommitFileProvider(deltaLog.update()).deltaFile(startVersion)
+      if (isICTEnabledForNewTables) {
+        InCommitTimestampTestUtils.overwriteICTInDeltaFile(deltaLog, filePath, Some(ts))
+      } else {
+        val file = new File(filePath.toUri)
+        file.setLastModified(ts)
+      }
       startVersion += 1
     }
   }
@@ -111,16 +121,18 @@ class DeltaTimeTravelSuite extends QueryTest
       .map(i => s"$i")
   }
 
-  private def historyTest(testName: String)(f: DeltaLog => Unit): Unit = {
+  private def historyTest(testName: String)(f: (DeltaLog, ManualClock) => Unit): Unit = {
     testQuietly(testName) {
-      withTempDir { dir => f(DeltaLog.forTable(spark, dir)) }
+      val clock = new ManualClock()
+      withTempDir { dir => f(DeltaLog.forTable(spark, dir, clock), clock) }
     }
   }
 
-  historyTest("getCommits should monotonize timestamps") { deltaLog =>
+  historyTest("getCommits should monotonize timestamps") { (deltaLog, clock) =>
     val start = 1540415658000L
     // Make the commits out of order
     generateCommitsCheap(deltaLog,
+      clock,
       start,
       start - 5.seconds, // adjusts to start + 1 ms
       start + 1.milli,   // adjusts to start + 2 ms
@@ -134,16 +146,26 @@ class DeltaTimeTravelSuite extends QueryTest
       0,
       None,
       deltaLog.newDeltaHadoopConf())
+    // Note that when InCommitTimestamps are enabled, the monotization of timestamps is not
+    // performed by getCommits. Instead, the timestamps are already monotonized before they
+    // are written in the commit.
     assert(commits.map(_.timestamp) === Seq(start,
       start + 1.millis, start + 2.millis, start + 3.millis, start + 4.millis, start + 10.seconds))
   }
 
-  historyTest("describe history timestamps are adjusted according to file timestamp") { deltaLog =>
+  historyTest("describe history timestamps are adjusted according to file timestamp") {
+      (deltaLog, clock) =>
+    if (isICTEnabledForNewTables) {
+      // File timestamp adjustment is not needed when ICT is enabled.
+      cancel("This test is not compatible with InCommitTimestamps.")
+    }
     // this is in '2018-10-24', so earlier than today. The recorded timestamps in commitInfo will
     // be much after this
     val start = 1540415658000L
     // Make the commits out of order
-    generateCommitsCheap(deltaLog, start,
+    generateCommitsCheap(deltaLog,
+      clock,
+      start,
       start - 5.seconds, // adjusts to start + 1 ms
       start + 1.milli   // adjusts to start + 2 ms
     )
@@ -153,9 +175,11 @@ class DeltaTimeTravelSuite extends QueryTest
     assert(commits.map(_.timestamp.getTime) === Seq(start + 2.millis, start + 1.milli, start))
   }
 
-  historyTest("should filter only delta files when computing earliest version") { deltaLog =>
+  historyTest("should filter only delta files when computing earliest version") {
+      (deltaLog, clock) =>
     val start = 1540415658000L
-    generateCommitsCheap(deltaLog, start, start + 10.seconds, start + 20.seconds)
+    clock.setTime(start)
+    generateCommitsCheap(deltaLog, clock, start, start + 10.seconds, start + 20.seconds)
 
     val history = new DeltaHistoryManager(deltaLog)
     assert(history.getActiveCommitAtTime(start + 15.seconds, false).version === 1)
@@ -170,11 +194,12 @@ class DeltaTimeTravelSuite extends QueryTest
     assert(e.getMessage.contains("recreatable"))
   }
 
-  historyTest("resolving commits should return commit before timestamp") { deltaLog =>
+  historyTest("resolving commits should return commit before timestamp") { (deltaLog, clock) =>
     val start = 1540415658000L
+    clock.setTime(start)
     // Make a commit every 20 minutes
     val commits = Seq.tabulate(10)(i => start + (i * 20).minutes)
-    generateCommitsCheap(deltaLog, commits: _*)
+    generateCommitsCheap(deltaLog, clock, commits: _*)
     // When maxKeys is 2, we will use the parallel search algorithm, when it is 1000, we will
     // use the linear search method
     Seq(1, 2, 1000).foreach { maxKeys =>
@@ -552,6 +577,11 @@ class DeltaTimeTravelSuite extends QueryTest
   }
 
   test("time travelling with adjusted timestamps") {
+    if (isICTEnabledForNewTables) {
+      // ICT Timestamps are always monotonically increasing. Therefore,
+      // this test is not needed when ICT is enabled.
+      cancel("This test is not compatible with InCommitTimestamps.")
+    }
     withTempDir { dir =>
       val tblLoc = dir.getCanonicalPath
       val start = 1540415658000L

--- a/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
@@ -25,7 +25,7 @@ import com.databricks.spark.util.{Log4jUsageLogger, UsageRecord}
 import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
 import org.apache.spark.sql.delta.actions.{Action, CommitInfo}
-import org.apache.spark.sql.delta.managedcommit.{CommitOwnerProvider, ManagedCommitBaseSuite, TrackingInMemoryCommitOwnerBuilder}
+import org.apache.spark.sql.delta.managedcommit.{CommitOwnerProvider, ManagedCommitBaseSuite, ManagedCommitTestUtils, TrackingInMemoryCommitOwnerBuilder}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, FileNames, JsonUtils}
@@ -39,7 +39,8 @@ class InCommitTimestampSuite
   extends QueryTest
     with SharedSparkSession
     with DeltaSQLCommandTest
-    with DeltaTestUtilsBase {
+    with DeltaTestUtilsBase
+    with ManagedCommitTestUtils {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
@@ -66,7 +67,9 @@ class InCommitTimestampSuite
     }
   }
 
-  test("Create a non-inCommitTimestamp table and then enable timestamp") {
+  // Managed Commits will also automatically enable ICT.
+  testWithDefaultCommitOwnerUnset(
+    "Create a non-inCommitTimestamp table and then enable timestamp") {
     withSQLConf(
       DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> false.toString
     ) {
@@ -257,7 +260,8 @@ class InCommitTimestampSuite
     }
   }
 
-  test("Enablement tracking works when ICT is enabled post commit 0") {
+  // Managed Commits will also automatically enable ICT.
+  testWithDefaultCommitOwnerUnset("Enablement tracking works when ICT is enabled post commit 0") {
     withSQLConf(
       DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> false.toString
     ) {
@@ -283,7 +287,8 @@ class InCommitTimestampSuite
     }
   }
 
-  test("Conflict resolution of enablement version") {
+  // Managed Commits will also automatically enable ICT.
+  testWithDefaultCommitOwnerUnset("Conflict resolution of enablement version") {
     withSQLConf(
       DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> false.toString
     ) {
@@ -318,7 +323,9 @@ class InCommitTimestampSuite
     }
   }
 
-  test("commitLarge should correctly set the enablement tracking properties") {
+  // Managed Commits will also automatically enable ICT.
+  testWithDefaultCommitOwnerUnset(
+    "commitLarge should correctly set the enablement tracking properties") {
     withTempDir { tempDir =>
       spark.range(2).write.format("delta").save(tempDir.getAbsolutePath)
       val deltaLog = DeltaLog.forTable(spark, tempDir.getAbsolutePath)
@@ -548,7 +555,8 @@ class InCommitTimestampSuite
     }
   }
 
-  test("DeltaHistoryManager.getActiveCommitAtTime: " +
+  // Managed Commits will also automatically enable ICT.
+  testWithDefaultCommitOwnerUnset("DeltaHistoryManager.getActiveCommitAtTime: " +
     "works correctly when the history has both ICT and non-ICT commits") {
     withSQLConf(
       DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> false.toString) {
@@ -632,7 +640,8 @@ class InCommitTimestampSuite
     }
   }
 
-  test("DeltaHistoryManager.getHistory --- " +
+  // Managed Commits will also automatically enable ICT.
+  testWithDefaultCommitOwnerUnset("DeltaHistoryManager.getHistory --- " +
       "works correctly when the history has both ICT and non-ICT commits") {
     withSQLConf(
       DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> false.toString) {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampTestUtils.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.actions.{Action, CommitInfo}
+import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
+import org.apache.hadoop.fs.Path
+
+object InCommitTimestampTestUtils {
+  /**
+   * Overwrites the in-commit-timestamp in the delta file with the given timestamp.
+   * It will also set operationParameters to an empty map because operationParameters
+   * serialization/deserialization is broken.
+   */
+  def overwriteICTInDeltaFile(deltaLog: DeltaLog, filePath: Path, ts: Option[Long]): Unit = {
+    val updatedActionsList = deltaLog.store
+      .readAsIterator(filePath, deltaLog.newDeltaHadoopConf())
+      .map(Action.fromJson)
+      .map {
+        case ci: CommitInfo =>
+          // operationParameters serialization/deserialization is broken as it uses a custom
+          // serializer but a default deserializer.
+          ci.copy(inCommitTimestamp = ts, operationParameters = Map.empty).json
+        case other => other.json
+      }.toList
+    deltaLog.store.write(
+      filePath, updatedActionsList.toIterator, overwrite = true, deltaLog.newDeltaHadoopConf())
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitEnablementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitEnablementSuite.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.managedcommit
+
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
+
+class ManagedCommitEnablementSuite
+  extends ManagedCommitBaseSuite
+    with DeltaSQLTestUtils
+    with DeltaSQLCommandTest
+    with ManagedCommitTestUtils {
+
+  override def managedCommitBackfillBatchSize: Option[Int] = Some(3)
+
+  import testImplicits._
+
+  private def validateManagedCommitCompleteEnablement(
+      snapshot: Snapshot, expectEnabled: Boolean): Unit = {
+    assert(DeltaConfigs.MANAGED_COMMIT_OWNER_NAME.fromMetaData(snapshot.metadata).isDefined
+      == expectEnabled)
+    Seq(ManagedCommitTableFeature, VacuumProtocolCheckTableFeature, InCommitTimestampTableFeature)
+      .foreach { feature =>
+        assert(snapshot.protocol.writerFeatures.exists(_.contains(feature.name)) == expectEnabled)
+      }
+    assert(
+      snapshot.protocol.readerFeatures.exists(_.contains(VacuumProtocolCheckTableFeature.name))
+        == expectEnabled)
+    assert(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(snapshot.metadata)
+      == expectEnabled)
+  }
+
+  // ---- Tests START: Enablement at commit 0 ----
+  test("enablement at commit 0: MC should enable ICT and VacuumProtocolCheck" +
+    " --- writeintodelta api") {
+    withTempDir { tempDir =>
+      val tablePath = tempDir.getAbsolutePath
+      Seq(1).toDF().write.format("delta").mode("overwrite").save(tablePath)
+      val log = DeltaLog.forTable(spark, tablePath)
+      validateManagedCommitCompleteEnablement(log.snapshot, expectEnabled = true)
+    }
+  }
+
+  test("enablement at commit 0: MC should enable ICT and VacuumProtocolCheck" +
+    " --- simple create table") {
+    withTempDir { tempDir =>
+      val tablePath = tempDir.getAbsolutePath
+      sql(s"CREATE TABLE delta.`$tablePath` (id LONG) USING delta")
+      val log = DeltaLog.forTable(spark, tablePath)
+      validateManagedCommitCompleteEnablement(log.snapshot, expectEnabled = true)
+    }
+  }
+
+  test("enablement at commit 0: MC should enable ICT and VacuumProtocolCheck" +
+    " --- create or replace") {
+    withTempDir { tempDir =>
+      val tablePath = tempDir.getAbsolutePath
+      Seq(1).toDF().write.format("delta").mode("overwrite").save(tablePath)
+      Seq(1).toDF().write.format("delta").mode("overwrite").save(tablePath)
+      val log = DeltaLog.forTable(spark, tablePath)
+      validateManagedCommitCompleteEnablement(log.snapshot, expectEnabled = true)
+    }
+  }
+  // ---- Tests END: Enablement at commit 0 ----
+
+  // ---- Tests START: Enablement after commit 0 ----
+  testWithDefaultCommitOwnerUnset(
+    "enablement after commit 0: MC should enable ICT and VacuumProtocolCheck" +
+      " --- update tblproperty") {
+    withTempDir { tempDir =>
+      val tablePath = tempDir.getAbsolutePath
+      Seq(1).toDF().write.format("delta").mode("overwrite").save(tablePath) // commit 0
+      Seq(1).toDF().write.format("delta").mode("append").save(tablePath) // commit 1
+      val log = DeltaLog.forTable(spark, tablePath)
+      validateManagedCommitCompleteEnablement(log.snapshot, expectEnabled = false)
+      sql(s"ALTER TABLE delta.`$tablePath` SET " + // Enable MC
+        s"TBLPROPERTIES ('${DeltaConfigs.MANAGED_COMMIT_OWNER_NAME.key}' = 'tracking-in-memory')")
+      Seq(1).toDF().write.format("delta").mode("overwrite").save(tablePath) // commit 3
+      validateManagedCommitCompleteEnablement(log.update(), expectEnabled = true)
+    }
+  }
+
+  testWithDefaultCommitOwnerUnset(
+    "enablement after commit 0: MC should enable ICT and VacuumProtocolCheck" +
+      " --- replace table") {
+    withTempDir { tempDir =>
+      val tablePath = tempDir.getAbsolutePath
+      Seq(1).toDF().write.format("delta").mode("overwrite").save(tablePath) // commit 0
+      Seq(1).toDF().write.format("delta").mode("append").save(tablePath) // commit 1
+      val log = DeltaLog.forTable(spark, tablePath)
+      validateManagedCommitCompleteEnablement(log.snapshot, expectEnabled = false)
+      sql(s"REPLACE TABLE delta.`$tablePath` (value int) USING delta " + // Enable MC
+        s"TBLPROPERTIES ('${DeltaConfigs.MANAGED_COMMIT_OWNER_NAME.key}' = 'tracking-in-memory')")
+      Seq(1).toDF().write.format("delta").mode("overwrite").save(tablePath) // commit 3
+      validateManagedCommitCompleteEnablement(log.update(), expectEnabled = true)
+    }
+  }
+  // ---- Tests END: Enablement after commit 0 ----
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitTestUtils.scala
@@ -16,9 +16,9 @@
 
 package org.apache.spark.sql.delta.managedcommit
 
-import org.apache.spark.sql.delta.{DeltaConfigs, DeltaTestUtilsBase}
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog, DeltaTestUtilsBase}
 import org.apache.spark.sql.delta.DeltaConfigs.MANAGED_COMMIT_OWNER_NAME
-import org.apache.spark.sql.delta.actions.{CommitInfo, Metadata, Protocol}
+import org.apache.spark.sql.delta.actions.{Action, CommitInfo, Metadata, Protocol}
 import org.apache.spark.sql.delta.storage.LogStore
 import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.hadoop.conf.Configuration
@@ -48,10 +48,12 @@ trait ManagedCommitTestUtils
    */
   def withoutManagedCommitsDefaultTableProperties(f: => Unit): Unit = {
     val commitOwnerKey = MANAGED_COMMIT_OWNER_NAME.defaultTablePropertyKey
-    val oldCommitOwnerValue = spark.conf.get(commitOwnerKey)
+    val oldCommitOwnerValue = spark.conf.getOption(commitOwnerKey)
     spark.conf.unset(commitOwnerKey)
     try { f } finally {
-      spark.conf.set(commitOwnerKey, oldCommitOwnerValue)
+      oldCommitOwnerValue.foreach {
+        spark.conf.set(commitOwnerKey, _)
+      }
     }
   }
 
@@ -233,5 +235,11 @@ trait ManagedCommitBaseSuite extends SparkFunSuite with SharedSparkSession {
     managedCommitBackfillBatchSize.foreach { batchSize =>
       CommitOwnerProvider.registerBuilder(TrackingInMemoryCommitOwnerBuilder(batchSize))
     }
+  }
+
+  protected def isICTEnabledForNewTables: Boolean = {
+    spark.conf.getOption(DeltaConfigs.MANAGED_COMMIT_OWNER_NAME.defaultTablePropertyKey).nonEmpty ||
+      spark.conf.getOption(
+        DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey).contains("true")
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Enabling Managed Commits will automatically:

1. Add ICT and VacuumProtocolCheck features to the protocol.
2. Enable ICT

These two features are pre-requisites for managed commit.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
New suite ManagedCommitEnablementSuite. Updated existing tests to work with ICT.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No