### PR TITLE
[SPARK][VARIANT] Add Variant as a delta source to enable writing with DF API and more tests

### DIFF
--- a/spark/src/main/scala-spark-3.5/shims/CreatableRelationProviderShims.scala
+++ b/spark/src/main/scala-spark-3.5/shims/CreatableRelationProviderShims.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.sources
+
+import org.apache.spark.sql.types.DataType
+
+trait CreatableRelationProviderShim extends CreatableRelationProvider {
+
+  /**
+   * The `supportsDataType` method is not defined in Spark 3.5 but is overidden by `DeltaDataSource`
+   * in Spark 4.0.
+   */
+  def supportsDataType(dt: DataType): Boolean = throw new UnsupportedOperationException(
+    "This method is not defined in Spark 3.5."
+  )
+}

--- a/spark/src/main/scala-spark-master/shims/CreatableRelationProviderShims.scala
+++ b/spark/src/main/scala-spark-master/shims/CreatableRelationProviderShims.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.sources
+
+/**
+ * Spark 4.0 added additional methods to `CreatableRelationProvider`, such as `supportsDataType`,
+ * that can be overridden by child classes and need to be shimmed when compiling with Spark 3.5.
+ */
+trait CreatableRelationProviderShim extends CreatableRelationProvider

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
@@ -42,6 +42,7 @@ import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.execution.streaming.{Sink, Source}
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.streaming.OutputMode
+import org.apache.spark.sql.types.{DataType, VariantShims}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -50,7 +51,7 @@ class DeltaDataSource
   extends RelationProvider
   with StreamSourceProvider
   with StreamSinkProvider
-  with CreatableRelationProvider
+  with CreatableRelationProviderShim
   with DataSourceRegister
   with TableProvider
   with DeltaLogging {
@@ -250,6 +251,14 @@ class DeltaDataSource
         options = dfOptions
       ).toBaseRelation
     }
+  }
+
+  /**
+   * Extend the default `supportsDataType` to allow VariantType.
+   * Implemented by `CreatableRelationProviderShim`.
+   */
+  override def supportsDataType(dt: DataType): Boolean = {
+    VariantShims.isVariantType(dt) || super.supportsDataType(dt)
   }
 
   override def shortName(): String = {

--- a/spark/src/test/scala-spark-3.5/shims/DeltaExcludedBySparkVersionTestMixinShims.scala
+++ b/spark/src/test/scala-spark-3.5/shims/DeltaExcludedBySparkVersionTestMixinShims.scala
@@ -29,4 +29,15 @@ trait DeltaExcludedBySparkVersionTestMixinShims extends QueryTest {
       (implicit pos: org.scalactic.source.Position): Unit = {
     test(testName, testTags: _*)(testFun)(pos)
   }
+
+  /**
+   * Tests that are meant for Delta compiled against Spark Master Release only. Ignored since this
+   * is the Spark Latest Release shim.
+   */
+  protected def testSparkMasterOnly(
+      testName: String, testTags: org.scalatest.Tag*)
+      (testFun: => Any)
+      (implicit pos: org.scalactic.source.Position): Unit = {
+    ignore(testName, testTags: _*)(testFun)(pos)
+  }
 }

--- a/spark/src/test/scala-spark-master/shims/DeltaExcludedBySparkVersionTestMixinShims.scala
+++ b/spark/src/test/scala-spark-master/shims/DeltaExcludedBySparkVersionTestMixinShims.scala
@@ -31,4 +31,15 @@ trait DeltaExcludedBySparkVersionTestMixinShims extends QueryTest {
     ignore(testName + " (Spark Latest Release Only)", testTags: _*)(testFun)(pos)
   }
 
+  /**
+   * Tests that are meant for Delta compiled against Spark Master (4.0+). Executed since this is the
+   * Spark Master shim.
+   */
+  protected def testSparkMasterOnly(
+      testName: String, testTags: org.scalatest.Tag*)
+      (testFun: => Any)
+      (implicit pos: org.scalactic.source.Position): Unit = {
+    test(testName, testTags: _*)(testFun)(pos)
+  }
+
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Adds Variant as a delta source to enable writing with DF API and more tests

## How was this patch tested?

Writing variant using `df.write.format("delta").save(...)" works in tests.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
