### PR TITLE
[Spark] Refactor several managed commit-related methods into ManagedCommitUtils

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/InMemoryCommitOwner.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/InMemoryCommitOwner.scala
@@ -109,6 +109,14 @@ class InMemoryCommitOwner(val batchSize: Long)
       commitVersion: Long,
       commitFile: FileStatus,
       commitTimestamp: Long): CommitResponse = {
+    addToMap(logPath, commitVersion, commitFile, commitTimestamp)
+  }
+
+  private[sql] def addToMap(
+      logPath: Path,
+      commitVersion: Long,
+      commitFile: FileStatus,
+      commitTimestamp: Long): CommitResponse = {
     withWriteLock[CommitResponse](logPath) {
       val tableData = perTableMap.get(logPath)
       val expectedVersion = tableData.maxCommitVersion + 1

--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitUtils.scala
@@ -16,10 +16,12 @@
 
 package org.apache.spark.sql.delta.managedcommit
 
-import org.apache.spark.sql.delta.{DeltaLog, Snapshot}
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.storage.LogStore
 import org.apache.spark.sql.delta.util.FileNames
-import org.apache.spark.sql.delta.util.FileNames.{CompactedDeltaFile, DeltaFile, UnbackfilledDeltaFile}
-import org.apache.hadoop.fs.FileStatus
+import org.apache.spark.sql.delta.util.FileNames.{DeltaFile, UnbackfilledDeltaFile}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileStatus, Path}
 
 object ManagedCommitUtils {
 
@@ -85,4 +87,25 @@ object ManagedCommitUtils {
       case 2 => tailFromSnapshot()
     }
   }
+
+  /**
+   * Write a UUID-based commit file for the specified version to the
+   * table at [[logPath]].
+   */
+  def writeCommitFile(
+      logStore: LogStore,
+      hadoopConf: Configuration,
+      logPath: Path,
+      commitVersion: Long,
+      actions: Iterator[String],
+      uuid: String): FileStatus = {
+    val commitPath = FileNames.unbackfilledDeltaFile(logPath, commitVersion, Some(uuid))
+    logStore.write(commitPath, actions, overwrite = false, hadoopConf)
+    commitPath.getFileSystem(hadoopConf).getFileStatus(commitPath)
+  }
+
+  /**
+   * Get the table path from the provided log path.
+   */
+  def getTablePath(logPath: Path): Path = logPath.getParent
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR refactors several methods that were internal to commit owner (client) implementations (AbstractBatchBackfillingCommitOwnerClient and InMemoryCommitOwner) into ManagedCommitUtils. These methods are generic and should be easily accessible to any commit owner (client) implementations so we are making them static methods.

## How was this patch tested?

Refactor only so existing tests are sufficient.

## Does this PR introduce _any_ user-facing changes?

No
