### PR TITLE
[DOCS] Update `releases.md` to mention that Delta Spark 3.2 uses Spark 3.5

### DIFF
--- a/docs/source/releases.md
+++ b/docs/source/releases.md
@@ -17,6 +17,7 @@ The following table lists <Delta> versions and their compatible <AS> versions.
 
 | <Delta> version | <AS> version |
 | --- | --- |
+| 3.2.x | 3.5.x |
 | 3.1.x | 3.5.x |
 | 3.0.x | 3.5.x |
 | 2.4.x | 3.4.x |


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [X] Other (DOCS)

## Description

Update `releases.md` to mention that Delta Spark 3.2 uses Spark 3.5

## How was this patch tested?

Trivial

## Does this PR introduce _any_ user-facing changes?

No
