### PR TITLE
[SPARK] Fix failing Spark Master test in DeltaExtensionAndCatalogSuite

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -608,8 +608,7 @@ class DeltaLog private(
    */
   protected def checkRequiredConfigurations(): Unit = {
     if (spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_REQUIRED_SPARK_CONFS_CHECK)) {
-      if (spark.conf.getOption(
-        SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key).isEmpty) {
+      if (!spark.conf.contains(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION.key)) {
         throw DeltaErrors.configureSparkSessionWithExtensionAndCatalog(None)
       }
     }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Fix failing test `DeltaLog should throw exception if spark.sql.catalog.spark_catalog config is not found` in `DeltaExtensionAndCatalogSuite` by replacing `.getOption($key).isEmpty` with `.contains($key)`

- In Spark 3.5, `spark.conf.getOption("spark.sql.catalog.spark_catalog")` returned `None`
- In Spark Master (4.0), `spark.conf.getOption("spark.sql.catalog.spark_catalog")` returned `Some("undefined")`. I'm not sure why

## How was this patch tested?

Existing UTs.

## Does this PR introduce _any_ user-facing changes?

No