### PR TITLE
[Kernel][Writes] Remove the target file size in `ParquetHandler.writeParquetFiles` API

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/client/ParquetHandler.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/client/ParquetHandler.java
@@ -77,7 +77,6 @@ public interface ParquetHandler {
      * @param directoryPath Location where the data files should be written.
      * @param dataIter      Iterator of data batches to write. It is the responsibility of the calle
      *                      to close the iterator.
-     * @param maxFileSize   Target maximum size of the created Parquet file in bytes.
      * @param statsColumns  List of columns to collect statistics for. The statistics collection is
      *                      optional. If the implementation does not support statistics collection,
      *                      it is ok to return no statistics.
@@ -93,7 +92,6 @@ public interface ParquetHandler {
     CloseableIterator<DataFileStatus> writeParquetFiles(
             String directoryPath,
             CloseableIterator<FilteredColumnarBatch> dataIter,
-            long maxFileSize,
             List<Column> statsColumns) throws IOException;
 
     /**

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockTableClientUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockTableClientUtils.scala
@@ -112,7 +112,6 @@ trait BaseMockParquetHandler extends ParquetHandler with MockTableClientUtils {
   override def writeParquetFiles(
       directoryPath: String,
       dataIter: CloseableIterator[FilteredColumnarBatch],
-      maxFileSize: Long,
       statsColumns: util.List[Column]): CloseableIterator[DataFileStatus] =
     throw new UnsupportedOperationException("not supported in this test suite")
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultParquetHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultParquetHandler.java
@@ -101,10 +101,9 @@ public class DefaultParquetHandler implements ParquetHandler {
     public CloseableIterator<DataFileStatus> writeParquetFiles(
             String directoryPath,
             CloseableIterator<FilteredColumnarBatch> dataIter,
-            long maxFileSize,
             List<Column> statsColumns) throws IOException {
         ParquetFileWriter batchWriter =
-            new ParquetFileWriter(hadoopConf, new Path(directoryPath), maxFileSize, statsColumns);
+            new ParquetFileWriter(hadoopConf, new Path(directoryPath), statsColumns);
         return batchWriter.write(dataIter);
     }
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFileWriter.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetFileWriter.java
@@ -53,6 +53,10 @@ import static io.delta.kernel.defaults.internal.parquet.ParquetStatsReader.readD
  * {@link ParquetWriter} through {@link RecordConsumer}.
  */
 public class ParquetFileWriter {
+    public static final String TARGET_FILE_SIZE_CONF =
+            "delta.kernel.default.parquet.writer.targetMaxFileSize";
+    public static final long DEFAULT_TARGET_FILE_SIZE = 128 * 1024 * 1024; // 128MB
+
     private final Configuration configuration;
     private final boolean writeAsSingleFile;
     private final Path location;
@@ -63,18 +67,19 @@ public class ParquetFileWriter {
 
     /**
      * Create writer to write data into one or more files depending upon the
-     * {@code targetMaxFileSize} value and the given data.
+     * {@code delta.kernel.default.parquet.writer.targetMaxFileSize} value and the given data.
      */
     public ParquetFileWriter(
             Configuration configuration,
             Path location,
-            long targetMaxFileSize,
             List<Column> statsColumns) {
         this.configuration = requireNonNull(configuration, "configuration is null");
         this.location = requireNonNull(location, "directory is null");
+        // Default target file size is 128 MB.
+        this.targetMaxFileSize =
+                configuration.getLong(TARGET_FILE_SIZE_CONF, DEFAULT_TARGET_FILE_SIZE);
         checkArgument(
                 targetMaxFileSize > 0, "Invalid target Parquet file size: " + targetMaxFileSize);
-        this.targetMaxFileSize = targetMaxFileSize;
         this.statsColumns = requireNonNull(statsColumns, "statsColumns is null");
         this.writeAsSingleFile = false;
     }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetSuiteBase.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetSuiteBase.scala
@@ -26,6 +26,7 @@ import io.delta.kernel.internal.util.ColumnMapping
 import io.delta.kernel.internal.util.Utils.toCloseableIterator
 import io.delta.kernel.types.{ArrayType, DataType, MapType, StructType}
 import io.delta.kernel.utils.{DataFileStatus, FileStatus}
+import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.hadoop.metadata.ParquetMetadata
 
@@ -188,8 +189,10 @@ trait ParquetSuiteBase extends TestUtils {
     location: String,
     targetFileSize: Long = 1024 * 1024,
     statsColumns: Seq[Column] = Seq.empty): Seq[DataFileStatus] = {
+    val conf = new Configuration(configuration);
+    conf.setLong(ParquetFileWriter.TARGET_FILE_SIZE_CONF, targetFileSize)
     val parquetWriter = new ParquetFileWriter(
-      configuration, new Path(location), targetFileSize, statsColumns.asJava)
+      conf, new Path(location), statsColumns.asJava)
 
     parquetWriter.write(toCloseableIterator(filteredData.asJava.iterator())).toSeq
   }


### PR DESCRIPTION
Currently Delta protocol doesn't enforce any particular target file size for writes. Remove the `maxFileSize` argument from the `ParquetHandler.writeParquetFiles` API. In future if this is really needed, we can add it back.

In order for the existing tests to pass, the `DefaultParquetHandler` takes the target file size as config in the Hadoop configuration.
