### PR TITLE
[Spark] Refactor CommitStore getCommits and backfillToVersion API params

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -2109,7 +2109,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
     override def getCommits(
         logPath: Path,
         managedCommitTableConf: Map[String, String],
-        startVersion: Long,
+        startVersion: Option[Long],
         endVersion: Option[Long]): GetCommitsResponse =
       GetCommitsResponse(Seq.empty, -1)
 
@@ -2118,8 +2118,8 @@ trait OptimisticTransactionImpl extends TransactionalWrite
         hadoopConf: Configuration,
         logPath: Path,
         managedCommitTableConf: Map[String, String],
-        startVersion: Long,
-        endVersion: Option[Long]): Unit = {}
+        version: Long,
+        lastKnownBackfilledVersion: Option[Long] = None): Unit = {}
 
     /**
      * [[FileSystemBasedCommitOwnerClient]] is supposed to be treated as a singleton object for a

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -488,7 +488,8 @@ class Snapshot(
     if (minUnbackfilledVersion <= version) {
       val hadoopConf = deltaLog.newDeltaHadoopConf()
       tableCommitOwnerClient.backfillToVersion(
-        startVersion = minUnbackfilledVersion, endVersion = Some(version))
+        version,
+        lastKnownBackfilledVersion = Some(minUnbackfilledVersion - 1))
       val fs = deltaLog.logPath.getFileSystem(hadoopConf)
       val expectedBackfilledDeltaFile = FileNames.unsafeDeltaFile(deltaLog.logPath, version)
       if (!fs.exists(expectedBackfilledDeltaFile)) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -163,7 +163,7 @@ trait SnapshotManagement { self: DeltaLog =>
       val threadPool = SnapshotManagement.commitOwnerGetCommitsThreadPool
       def getCommitsTask(async: Boolean): GetCommitsResponse = {
         recordFrameProfile("DeltaLog", s"CommitOwnerClient.getCommits.async=$async") {
-          tableCommitOwnerClient.getCommits(startVersion, endVersion = versionToLoad)
+          tableCommitOwnerClient.getCommits(Some(startVersion), endVersion = versionToLoad)
         }
       }
       val unbackfilledCommitsResponseFuture =

--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/CommitOwnerClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/CommitOwnerClient.scala
@@ -119,22 +119,28 @@ trait CommitOwnerClient {
   def getCommits(
       logPath: Path,
       managedCommitTableConf: Map[String, String],
-      startVersion: Long,
+      startVersion: Option[Long] = None,
       endVersion: Option[Long] = None): GetCommitsResponse
 
   /**
-   * API to ask the Commit-Owner to backfill all commits >= 'startVersion' and <= `endVersion`.
+   * API to ask the Commit-Owner to backfill all commits > `lastKnownBackfilledVersion` and
+   * <= `endVersion`.
    *
    * If this API returns successfully, that means the backfill must have been completed, although
    * the Commit-Owner may not be aware of it yet.
+   *
+   * @param version The version till which the Commit-Owner should backfill.
+   * @param lastKnownBackfilledVersion The last known version that was backfilled by Commit-Owner
+   *                                   before this API was called. If it's None or invalid, then the
+   *                                   Commit-Owner should backfill from the beginning of the table.
    */
   def backfillToVersion(
       logStore: LogStore,
       hadoopConf: Configuration,
       logPath: Path,
       managedCommitTableConf: Map[String, String],
-      startVersion: Long,
-      endVersion: Option[Long]): Unit
+      version: Long,
+      lastKnownBackfilledVersion: Option[Long]): Unit
 
   /**
    * Determines whether this [[CommitOwnerClient]] is semantically equal to another

--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/TableCommitOwnerClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/TableCommitOwnerClient.scala
@@ -49,16 +49,16 @@ case class TableCommitOwnerClient(
   }
 
   def getCommits(
-      startVersion: Long,
+      startVersion: Option[Long] = None,
       endVersion: Option[Long] = None): GetCommitsResponse = {
     commitOwnerClient.getCommits(logPath, tableConf, startVersion, endVersion)
   }
 
   def backfillToVersion(
-      startVersion: Long,
-      endVersion: Option[Long]): Unit = {
+      version: Long,
+      lastKnownBackfilledVersion: Option[Long] = None): Unit = {
     commitOwnerClient.backfillToVersion(
-      logStore, hadoopConf, logPath, tableConf, startVersion, endVersion)
+      logStore, hadoopConf, logPath, tableConf, version, lastKnownBackfilledVersion)
   }
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogMinorCompactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogMinorCompactionSuite.scala
@@ -43,7 +43,7 @@ class DeltaLogMinorCompactionSuite extends QueryTest
       endVersion: Long): Unit = {
     val deltaLog = DeltaLog.forTable(spark, tablePath)
     deltaLog.update().tableCommitOwnerClientOpt.foreach { tableCommitOwnerClient =>
-      tableCommitOwnerClient.backfillToVersion(startVersion = 0, Some(endVersion))
+      tableCommitOwnerClient.backfillToVersion(endVersion)
     }
     val logReplay = new InMemoryLogReplay(
       minFileRetentionTimestamp = 0,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
@@ -976,7 +976,7 @@ class InCommitTimestampWithManagedCommitSuite
       val commitFileProvider = DeltaCommitFileProvider(deltaLog.update())
       val unbackfilledCommits =
         tableCommitOwnerClient
-          .getCommits(1)
+          .getCommits(Some(1))
           .commits
           .map { commit => DeltaHistoryManager.Commit(commit.version, commit.commitTimestamp)}
       val commits = (Seq(commit0) ++ unbackfilledCommits).toList

--- a/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
@@ -510,7 +510,7 @@ case class ConcurrentBackfillCommitOwnerClient(
   override def getCommits(
       logPath: Path,
       managedCommitTableConf: Map[String, String],
-      startVersion: Long,
+      startVersion: Option[Long],
       endVersion: Option[Long]): GetCommitsResponse = {
     if (ConcurrentBackfillCommitOwnerClient.beginConcurrentBackfills) {
       CountDownLatchLogStore.listFromCalled.await()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/CommitOwnerClientSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/CommitOwnerClientSuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.test.SharedSparkSession
 class CommitOwnerClientSuite extends QueryTest with DeltaSQLTestUtils with SharedSparkSession
   with DeltaSQLCommandTest {
 
-  trait TestCommitOwnerClientBase extends CommitOwnerClient {
+  private trait TestCommitOwnerClientBase extends CommitOwnerClient {
     override def commit(
         logStore: LogStore,
         hadoopConf: Configuration,
@@ -47,7 +47,7 @@ class CommitOwnerClientSuite extends QueryTest with DeltaSQLTestUtils with Share
     override def getCommits(
       logPath: Path,
       managedCommitTableConf: Map[String, String],
-      startVersion: Long,
+      startVersion: Option[Long],
       endVersion: Option[Long] = None): GetCommitsResponse = GetCommitsResponse(Seq.empty, -1)
 
     override def backfillToVersion(
@@ -55,14 +55,14 @@ class CommitOwnerClientSuite extends QueryTest with DeltaSQLTestUtils with Share
         hadoopConf: Configuration,
         logPath: Path,
         managedCommitTableConf: Map[String, String],
-        startVersion: Long,
-        endVersion: Option[Long]): Unit = {}
+        version: Long,
+        lastKnownBackfilledVersion: Option[Long]): Unit = {}
 
     override def semanticEquals(other: CommitOwnerClient): Boolean = this == other
   }
 
-  class TestCommitOwnerClient1 extends TestCommitOwnerClientBase
-  class TestCommitOwnerClient2 extends TestCommitOwnerClientBase
+  private class TestCommitOwnerClient1 extends TestCommitOwnerClientBase
+  private class TestCommitOwnerClient2 extends TestCommitOwnerClientBase
 
   override def beforeEach(): Unit = {
     super.beforeEach()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitTestUtils.scala
@@ -171,7 +171,7 @@ class TrackingCommitOwnerClient(delegatingCommitOwnerClient: InMemoryCommitOwner
   override def getCommits(
       logPath: Path,
       managedCommitTableConf: Map[String, String],
-      startVersion: Long,
+      startVersion: Option[Long],
       endVersion: Option[Long] = None): GetCommitsResponse = recordOperation("getCommits") {
     delegatingCommitOwnerClient.getCommits(
       logPath, managedCommitTableConf, startVersion, endVersion)
@@ -182,10 +182,10 @@ class TrackingCommitOwnerClient(delegatingCommitOwnerClient: InMemoryCommitOwner
       hadoopConf: Configuration,
       logPath: Path,
       managedCommitTableConf: Map[String, String],
-      startVersion: Long,
-      endVersion: Option[Long]): Unit = recordOperation("backfillToVersion") {
+      version: Long,
+      lastKnownBackfilledVersion: Option[Long]): Unit = recordOperation("backfillToVersion") {
     delegatingCommitOwnerClient.backfillToVersion(
-      logStore, hadoopConf, logPath, managedCommitTableConf, startVersion, endVersion)
+      logStore, hadoopConf, logPath, managedCommitTableConf, version, lastKnownBackfilledVersion)
   }
 
   override def semanticEquals(other: CommitOwnerClient): Boolean = this == other


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

- We use optional startVersion and optional endVersion for getCommits now.
- We use optional lastKnownBackfilledVersion and a required version for backfillToVersion now since the consumers of backfillToVersion must know the version.

## How was this patch tested?

Various existing UTs

## Does this PR introduce _any_ user-facing changes?

No