### PR TITLE
[Spark] Ensure commit directory is created for old and new tables

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -467,8 +467,8 @@ class DeltaLog private(
 
   def isSameLogAs(otherLog: DeltaLog): Boolean = this.compositeId == otherLog.compositeId
 
-  /** Creates the log directory if it does not exist. */
-  def ensureLogDirectoryExist(): Unit = {
+  /** Creates the log directory and commit directory if it does not exist. */
+  def createLogDirectoriesIfNotExists(): Unit = {
     val fs = logPath.getFileSystem(newDeltaHadoopConf())
     def createDirIfNotExists(path: Path): Unit = {
       // Optimistically attempt to create the directory first without checking its existence.
@@ -498,14 +498,6 @@ class DeltaLog private(
       }
     }
     createDirIfNotExists(FileNames.commitDirPath(logPath))
-  }
-
-  /**
-   * Create the log directory. Unlike `ensureLogDirectoryExist`, this method doesn't check whether
-   * the log directory exists and it will ignore the return value of `mkdirs`.
-   */
-  def createLogDirectory(): Unit = {
-    logPath.getFileSystem(newDeltaHadoopConf()).mkdirs(logPath)
   }
 
   /* ------------  *

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
@@ -189,7 +189,7 @@ abstract class CloneTableBase(
     }
 
     if (txn.readVersion < 0) {
-      destinationTable.createLogDirectory()
+      destinationTable.createLogDirectoriesIfNotExists()
     }
 
     val metadataToUpdate = determineTargetMetadata(txn.snapshot, deltaOperation.name)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
@@ -346,7 +346,7 @@ abstract class ConvertToDeltaCommandBase(
       convertProperties: ConvertTarget,
       targetTable: ConvertTargetTable): Seq[Row] =
     recordDeltaOperation(txn.deltaLog, "delta.convert") {
-    txn.deltaLog.ensureLogDirectoryExist()
+    txn.deltaLog.createLogDirectoriesIfNotExists()
     val targetPath = new Path(convertProperties.targetDir)
     // scalastyle:off deltahadoopconfiguration
     val sessionHadoopConf = spark.sessionState.newHadoopConf()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -223,7 +223,7 @@ case class WriteIntoDelta(
 
     if (txn.readVersion < 0) {
       // Initialize the log path
-      deltaLog.createLogDirectory()
+      deltaLog.createLogDirectoriesIfNotExists()
     }
 
     val (newFiles, addFiles, deletedFiles) = (mode, replaceWhere) match {

--- a/spark/src/test/scala/io/delta/tables/DeltaTableSuite.scala
+++ b/spark/src/test/scala/io/delta/tables/DeltaTableSuite.scala
@@ -537,7 +537,7 @@ class DeltaTableHadoopOptionsSuite extends QueryTest
       // create a table with a default Protocol.
       val testSchema = spark.range(1).schema
       val log = DeltaLog.forTable(spark, new Path(path), fsOptions)
-      log.ensureLogDirectoryExist()
+      log.createLogDirectoriesIfNotExists()
       log.store.write(
         FileNames.unsafeDeltaFile(log.logPath, 0),
         Iterator(Metadata(schemaString = testSchema.json).json, Protocol(0, 0).json),
@@ -563,7 +563,7 @@ class DeltaTableHadoopOptionsSuite extends QueryTest
       // create a table with a default Protocol.
       val testSchema = spark.range(1).schema
       val log = DeltaLog.forTable(spark, new Path(path), fsOptions)
-      log.ensureLogDirectoryExist()
+      log.createLogDirectoriesIfNotExists()
       log.store.write(
         FileNames.unsafeDeltaFile(log.logPath, 0),
         Iterator(Metadata(schemaString = testSchema.json).json, Protocol(1, 2).json),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableSuiteBase.scala
@@ -686,7 +686,7 @@ trait CloneTableSuiteBase extends QueryTest
     val log = DeltaLog.forTable(spark, source)
     // make sure to have a dummy schema because we can't have empty schema table by default
     val newSchema = new StructType().add("id", IntegerType, nullable = true)
-    log.ensureLogDirectoryExist()
+    log.createLogDirectoriesIfNotExists()
     log.store.write(
       unsafeDeltaFile(log.logPath, 0),
       Iterator(Metadata(schemaString = newSchema.json).json, sourceProtocol.json),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -61,7 +61,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       path: File,
       schema: StructType = testTableSchema): DeltaLog = {
     val log = DeltaLog.forTable(spark, path)
-    log.ensureLogDirectoryExist()
+    log.createLogDirectoriesIfNotExists()
     log.store.write(
       unsafeDeltaFile(log.logPath, 0),
       Iterator(Metadata(schemaString = schema.json).json, protocol.json),
@@ -410,7 +410,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
   test("access with protocol too high") {
     withTempDir { path =>
       val log = DeltaLog.forTable(spark, path)
-      log.ensureLogDirectoryExist()
+      log.createLogDirectoriesIfNotExists()
       log.store.write(
         unsafeDeltaFile(log.logPath, 0),
         Iterator(Metadata().json, Protocol(Integer.MAX_VALUE, Integer.MAX_VALUE).json),
@@ -1228,7 +1228,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
   test("create a table with no protocol") {
     withTempDir { path =>
       val log = DeltaLog.forTable(spark, path)
-      log.ensureLogDirectoryExist()
+      log.createLogDirectoriesIfNotExists()
       log.store.write(
         unsafeDeltaFile(log.logPath, 0),
         Iterator(Metadata().json),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
@@ -48,7 +48,7 @@ class DeltaTableFeatureSuite
       path: File,
       schema: StructType = testTableSchema): DeltaLog = {
     val log = DeltaLog.forTable(spark, path)
-    log.ensureLogDirectoryExist()
+    log.createLogDirectoriesIfNotExists()
     log.store.write(
       unsafeDeltaFile(log.logPath, 0),
       Iterator(Metadata(schemaString = schema.json).json, protocol.json),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
@@ -386,7 +386,7 @@ trait DescribeDeltaHistorySuiteBase
     val writerVersion = Action.supportedProtocolVersion().minWriterVersion
     withTempDir { path =>
       val log = DeltaLog.forTable(spark, path)
-      log.ensureLogDirectoryExist()
+      log.createLogDirectoriesIfNotExists()
       log.store.write(
         FileNames.unsafeDeltaFile(log.logPath, 0),
         Iterator(


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

- Remove `createLogDirectory` and replace all usages with `ensureLogDirectoryExists` since the latter is optimized for creation rather than existence check now. Rename it `createLogDirectoriesIfNotExists`
- Ensure commit directory is created on existing tables from older releases when manged-commits is enabled.

## How was this patch tested?

UTs

## Does this PR introduce _any_ user-facing changes?

No
