### PR TITLE
[Spark] Makes CommitOwnerClient independent of Delta Spark dependencies

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -21,7 +21,7 @@ import scala.collection.mutable
 
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.actions.Action.logSchema
-import org.apache.spark.sql.delta.managedcommit.{CommitOwnerClient, CommitOwnerProvider, TableCommitOwnerClient}
+import org.apache.spark.sql.delta.managedcommit.{CommitOwnerClient, CommitOwnerProvider, ManagedCommitUtils, TableCommitOwnerClient}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -234,7 +234,7 @@ class Snapshot(
    */
   val tableCommitOwnerClientOpt: Option[TableCommitOwnerClient] = initializeTableCommitOwner()
   protected def initializeTableCommitOwner(): Option[TableCommitOwnerClient] = {
-    CommitOwnerProvider.getTableCommitOwner(this)
+    ManagedCommitUtils.getTableCommitOwner(this)
   }
 
   /** Number of columns to collect stats on for data skipping */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -28,6 +28,7 @@ import scala.util.control.NonFatal
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.commands.DeletionVectorUtils
+import org.apache.spark.sql.delta.managedcommit.{AbstractCommitInfo, AbstractMetadata, AbstractProtocol}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.{JsonUtils, Utils => DeltaUtils}
 import org.apache.spark.sql.delta.util.FileNames
@@ -37,7 +38,6 @@ import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind._
 import com.fasterxml.jackson.databind.annotation.{JsonDeserialize, JsonSerialize}
 import com.fasterxml.jackson.databind.node.ObjectNode
-
 import org.apache.hadoop.fs.{FileStatus, Path}
 
 import org.apache.spark.internal.Logging
@@ -135,6 +135,7 @@ case class Protocol private (
     @JsonInclude(Include.NON_ABSENT)
     writerFeatures: Option[Set[String]])
   extends Action
+  with AbstractProtocol
   with TableFeatureSupport {
   // Correctness check
   // Reader and writer versions must match the status of reader and writer features
@@ -176,6 +177,14 @@ case class Protocol private (
   }
 
   override def toString: String = s"Protocol($simpleString)"
+
+  override def getMinReaderVersion: Int = minReaderVersion
+
+  override def getMinWriterVersion: Int = minWriterVersion
+
+  override def getReaderFeatures: Option[Set[String]] = readerFeatures
+
+  override def getWriterFeatures: Option[Set[String]] = writerFeatures
 }
 
 object Protocol {
@@ -948,7 +957,6 @@ case class AddCDCFile(
   override def numLogicalRecords: Option[Long] = None
 }
 
-
 case class Format(
     provider: String = "parquet",
     // If we support `options` in future, we should not store any file system options since they may
@@ -969,7 +977,7 @@ case class Metadata(
     partitionColumns: Seq[String] = Nil,
     configuration: Map[String, String] = Map.empty,
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
-    createdTime: Option[Long] = None) extends Action {
+    createdTime: Option[Long] = None) extends Action with AbstractMetadata {
 
   // The `schema` and `partitionSchema` methods should be vals or lazy vals, NOT
   // defs, because parsing StructTypes from JSON is extremely expensive and has
@@ -1043,6 +1051,26 @@ case class Metadata(
     DeltaConfigs.MANAGED_COMMIT_TABLE_CONF.fromMetaData(this)
 
   override def wrap: SingleAction = SingleAction(metaData = this)
+
+  override def getId: String = id
+
+  override def getName: String = name
+
+  override def getDescription: String = description
+
+  @JsonIgnore
+  override def getProvider: String = format.provider
+
+  @JsonIgnore
+  override def getFormatOptions: Map[String, String] = format.options
+
+  override def getSchemaString: String = schemaString
+
+  override def getPartitionColumns: Seq[String] = partitionColumns
+
+  override def getConfiguration: Map[String, String] = configuration
+
+  override def getCreatedTime: Option[Long] = createdTime
 }
 
 /**
@@ -1095,11 +1123,21 @@ case class CommitInfo(
     userMetadata: Option[String],
     tags: Option[Map[String, String]],
     engineInfo: Option[String],
-    txnId: Option[String]) extends Action with CommitMarker {
+    txnId: Option[String]) extends Action with CommitMarker with AbstractCommitInfo {
   override def wrap: SingleAction = SingleAction(commitInfo = this)
 
   override def withTimestamp(timestamp: Long): CommitInfo = {
     this.copy(timestamp = new Timestamp(timestamp))
+  }
+
+  // We need to explicitly ignore this field during serialization as Jackson
+  // by default calls all public getters of an object, which would lead to
+  // either an exception or the inCommitTimestamp being serialized twice.
+  @JsonIgnore
+  override def getCommitTimestamp: Long = {
+    inCommitTimestamp.getOrElse {
+      throw DeltaErrors.missingCommitTimestamp(version.map(_.toString).getOrElse("unknown"))
+    }
   }
 
   override def getTimestamp: Long = timestamp.getTime

--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/AbstractBatchBackfillingCommitOwnerClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/AbstractBatchBackfillingCommitOwnerClient.scala
@@ -20,6 +20,7 @@ import java.nio.file.FileAlreadyExistsException
 import java.util.UUID
 
 import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.actions.CommitInfo
 import org.apache.spark.sql.delta.actions.Metadata
 import org.apache.spark.sql.delta.storage.LogStore
 import org.apache.spark.sql.delta.util.FileNames
@@ -80,7 +81,7 @@ trait AbstractBatchBackfillingCommitOwnerClient extends CommitOwnerClient with L
       logStore, hadoopConf, logPath, commitVersion, actions, generateUUID())
 
     // Do the actual commit
-    val commitTimestamp = updatedActions.commitInfo.getTimestamp
+    val commitTimestamp = updatedActions.commitInfo.asInstanceOf[CommitInfo].getTimestamp
     var commitResponse =
       commitImpl(
         logStore,
@@ -112,8 +113,10 @@ trait AbstractBatchBackfillingCommitOwnerClient extends CommitOwnerClient with L
   private def isManagedCommitToFSConversion(
       commitVersion: Long,
       updatedActions: UpdatedActions): Boolean = {
-    val oldMetadataHasManagedCommits = updatedActions.oldMetadata.managedCommitOwnerName.nonEmpty
-    val newMetadataHasManagedCommits = updatedActions.newMetadata.managedCommitOwnerName.nonEmpty
+    val oldMetadataHasManagedCommits = updatedActions.oldMetadata.asInstanceOf[Metadata]
+      .managedCommitOwnerName.nonEmpty
+    val newMetadataHasManagedCommits = updatedActions.newMetadata.asInstanceOf[Metadata]
+      .managedCommitOwnerName.nonEmpty
     oldMetadataHasManagedCommits && !newMetadataHasManagedCommits && commitVersion > 0
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/InMemoryCommitOwner.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/InMemoryCommitOwner.scala
@@ -170,8 +170,8 @@ class InMemoryCommitOwner(val batchSize: Long)
   override def registerTable(
       logPath: Path,
       currentVersion: Long,
-      currentMetadata: Metadata,
-      currentProtocol: Protocol): Map[String, String] = {
+      currentMetadata: AbstractMetadata,
+      currentProtocol: AbstractProtocol): Map[String, String] = {
     val newPerTableData = new PerTableData(currentVersion + 1)
     perTableMap.compute(logPath, (_, existingData) => {
       if (existingData != null) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/abstractActions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/abstractActions.scala
@@ -58,7 +58,7 @@ trait AbstractMetadata {
 
 /**
  * Interface for commit info actions in Delta. The commit info at the least needs
- * to provide a commit timestamp for specify when the commmit happened.
+ * to provide a commit timestamp to specify when the commit happened.
  */
 trait AbstractCommitInfo {
   def getCommitTimestamp: Long

--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/abstractActions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/abstractActions.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.managedcommit
+
+/**
+ * Interface for protocol actions in Delta. The protocol defines the requirements
+ * that readers and writers of the table need to meet.
+ */
+trait AbstractProtocol {
+  /** The minimum reader version required to read the table. */
+  def getMinReaderVersion: Int
+  /** The minimum writer version required to read the table. */
+  def getMinWriterVersion: Int
+  /** The reader features that need to be supported to read the table. */
+  def getReaderFeatures: Option[Set[String]]
+  /** The writer features that need to be supported to write the table. */
+  def getWriterFeatures: Option[Set[String]]
+}
+
+/**
+ * Interface for metadata actions in Delta. The metadata defines any metadata
+ * that can be set on a table.
+ */
+trait AbstractMetadata {
+  /** A unique table identifier. */
+  def getId: String
+  /** User-specified table identifier. */
+  def getName: String
+  /** User-specified table description. */
+  def getDescription: String
+  /** The table provider format. */
+  def getProvider: String
+  /** The format options */
+  def getFormatOptions: Map[String, String]
+  /** The table schema in string representation. */
+  def getSchemaString: String
+  /** List of partition columns. */
+  def getPartitionColumns: Seq[String]
+  /** The table properties defined on the table. */
+  def getConfiguration: Map[String, String]
+  /** Timestamp for the creation of this metadata. */
+  def getCreatedTime: Option[Long]
+}
+
+/**
+ * Interface for commit info actions in Delta. The commit info at the least needs
+ * to provide a commit timestamp for specify when the commmit happened.
+ */
+trait AbstractCommitInfo {
+  def getCommitTimestamp: Long
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -835,7 +835,8 @@ class OptimisticTransactionSuite
               commitVersion: Long,
               actions: Iterator[String],
               updatedActions: UpdatedActions): CommitResponse = {
-            if (updatedActions.commitInfo.operation == DeltaOperations.OP_RESTORE) {
+            if (updatedActions.commitInfo.asInstanceOf[CommitInfo].operation
+                == DeltaOperations.OP_RESTORE) {
               deltaLog.startTransaction().commit(addB :: Nil, ManualUpdate)
               throw CommitFailedException(retryable = true, conflict, message = "")
             }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/CommitOwnerClientSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/CommitOwnerClientSuite.scala
@@ -237,14 +237,14 @@ class CommitOwnerClientSuite extends QueryTest with DeltaSQLTestUtils with Share
 
   /**
    * We expect the Protocol action to have the same fields as AbstractProtocol (part of the
-   * CommitStore interface). With this if any change has happened in the Protocol of the table,
-   * the same change is propagated to the CommitStore as AbstractProtocol. The CommitStore can
-   * access the changes using getters and decide to act on the changes based on the spec of
-   * the commit-owner.
+   * CommitOwnerClient interface). With this if any change has happened in the Protocol of the
+   * table, the same change is propagated to the CommitOwnerClient as AbstractProtocol. The
+   * CommitOwnerClient can access the changes using getters and decide to act on the changes
+   * based on the spec of the commit owner.
    *
    * This test case ensures that any new field added in the Protocol action is also accessible in
-   * the CommitStore via the getter. If the new field is something which we do not expect to be
-   * passed to the CommitStore, the test needs to be modified accordingly.
+   * the CommitOwnerClient via the getter. If the new field is something which we do not expect to
+   * be passed to the CommitOwnerClient, the test needs to be modified accordingly.
    */
   test("AbstractProtocol should have getter methods for all fields in Protocol") {
     val missingFields = checkMissing[AbstractProtocol, Protocol]()
@@ -255,14 +255,14 @@ class CommitOwnerClientSuite extends QueryTest with DeltaSQLTestUtils with Share
 
   /**
    * We expect the Metadata action to have the same fields as AbstractMetadata (part of the
-   * CommitStore interface). With this if any change has happened in the Metadata of the table,
-   * the same change is propagated to the CommitStore as AbstractMetadata. The CommitStore can
-   * access the changes using getters and decide to act on the changes based on the spec of
-   * the commit-owner.
+   * CommitOwnerClient interface). With this if any change has happened in the Metadata of the
+   * table, the same change is propagated to the CommitOwnerClient as AbstractMetadata. The
+   * CommitOwnerClient can access the changes using getters and decide to act on the changes
+   * based on the spec of the commit owner.
    *
    * This test case ensures that any new field added in the Metadata action is also accessible in
-   * the CommitStore via the getter. If the new field is something which we do not expect to be
-   * passed to the CommitStore, the test needs to be modified accordingly.
+   * the CommitOwnerClient via the getter. If the new field is something which we do not expect to
+   * be passed to the CommitOwnerClient, the test needs to be modified accordingly.
    */
   test("BaseMetadata should have getter methods for all fields in Metadata") {
     val missingFields = checkMissing[AbstractMetadata, Metadata]()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitSuite.scala
@@ -636,8 +636,8 @@ class ManagedCommitSuite
           override def registerTable(
             logPath: Path,
             currentVersion: Long,
-            currentMetadata: Metadata,
-            currentProtocol: Protocol): Map[String, String] = {
+            currentMetadata: AbstractMetadata,
+            currentProtocol: AbstractProtocol): Map[String, String] = {
             super.registerTable(logPath, currentVersion, currentMetadata, currentProtocol)
             tableConf
           }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitTestUtils.scala
@@ -199,8 +199,8 @@ class TrackingCommitOwnerClient(delegatingCommitOwnerClient: InMemoryCommitOwner
   override def registerTable(
       logPath: Path,
       currentVersion: Long,
-      currentMetadata: Metadata,
-      currentProtocol: Protocol): Map[String, String] = recordOperation("registerTable") {
+      currentMetadata: AbstractMetadata,
+      currentProtocol: AbstractProtocol): Map[String, String] = recordOperation("registerTable") {
     delegatingCommitOwnerClient.registerTable(
       logPath, currentVersion, currentMetadata, currentProtocol)
   }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR is the first in a series of PRs that refactors the current CommitOwnerClient interface to become its own module. This is similar to `storage` module that currently exists and contains the LogStore interface and its implementations. In this PR, we remove any Delta Spark dependencies from the CommitOwnerClient in preparation for it to be moved outside of Delta Spark.

## How was this patch tested?

Added tests to check equivalence of newly introduced AbstractProtocol/AbstractMetadata with Protocol/Metadata.

## Does this PR introduce _any_ user-facing changes?

No
