### PR TITLE
[Kernel][Writes] Add schema validation utils

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
@@ -52,9 +52,10 @@ public class SchemaUtils {
                 .collect(Collectors.toSet());
 
         if (uniqueColNames.size() != flattenColNames.size()) {
+            Set<String> uniqueCols = new HashSet<>();
             String duplicateColumns = flattenColNames.stream()
                     .map(String::toLowerCase)
-                    .filter(n -> !uniqueColNames.add(n))
+                    .filter(n -> !uniqueCols.add(n))
                     .collect(Collectors.joining(", "));
             throw new IllegalArgumentException(
                     "Schema contains duplicate columns: " + duplicateColumns);
@@ -64,7 +65,7 @@ public class SchemaUtils {
         if (!isColumnMappingEnabled) {
             validParquetColumnNames(flattenColNames);
         } else {
-            // when column mapping is enabled, just check the name contains no new line it.
+            // when column mapping is enabled, just check the name contains no new line in it.
             flattenColNames.forEach(name -> checkArgument(
                     !name.contains("\\n"),
                     format("Attribute name '%s' contains invalid new line characters.", name)));
@@ -72,9 +73,17 @@ public class SchemaUtils {
     }
 
     /**
-     * Returns all column names in this schema as a flat list. For example, a schema like: | - a | |
-     * - 1 | | - 2 | - b | - c | | - nest |   | - 3 will get flattened to: "a", "a.1", "a.2", "b",
-     * "c", "c.nest", "c.nest.3"
+     * Returns all column names in this schema as a flat list. For example, a schema like:
+     * <pre>
+     *   | - a
+     *   | | - 1
+     *   | | - 2
+     *   | - b
+     *   | - c
+     *   | | - nest
+     *   |   | - 3
+     *   will get flattened to: "a", "a.1", "a.2", "b", "c", "c.nest", "c.nest.3"
+     * </pre>
      */
     private static List<String> flattenNestedFieldNames(StructType schema) {
         List<String> fieldNames = new ArrayList<>();

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.util;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import static java.lang.String.format;
+
+import io.delta.kernel.types.*;
+
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+
+/**
+ * Utility methods for schema related operations such as validating the schema has no duplicate
+ * columns and the names contain only valid characters.
+ */
+public class SchemaUtils {
+
+    private SchemaUtils() {
+    }
+
+    /**
+     * Validate the schema. This method checks if the schema has no duplicate columns and the names
+     * contain only valid characters.
+     *
+     * @param schema                 the schema to validate
+     * @param isColumnMappingEnabled whether column mapping is enabled. When column mapping is
+     *                               enabled, the column names in the schema can contain special
+     *                               characters that are allowed as column names in the Parquet
+     *                               file
+     * @throws IllegalArgumentException if the schema is invalid
+     */
+    public static void validateSchema(StructType schema, boolean isColumnMappingEnabled) {
+        List<String> flattenColNames = flattenNestedFieldNames(schema);
+
+        // check there are no duplicate column names in the schema
+        Set<String> uniqueColNames = flattenColNames.stream()
+                .map(String::toLowerCase)
+                .collect(Collectors.toSet());
+
+        if (uniqueColNames.size() != flattenColNames.size()) {
+            String duplicateColumns = flattenColNames.stream()
+                    .map(String::toLowerCase)
+                    .filter(n -> !uniqueColNames.add(n))
+                    .collect(Collectors.joining(", "));
+            throw new IllegalArgumentException(
+                    "Schema contains duplicate columns: " + duplicateColumns);
+        }
+
+        // Check the column names are valid
+        if (!isColumnMappingEnabled) {
+            validParquetColumnNames(flattenColNames);
+        } else {
+            // when column mapping is enabled, just check the name contains no new line it.
+            flattenColNames.forEach(name -> checkArgument(
+                    !name.contains("\\n"),
+                    format("Attribute name '%s' contains invalid new line characters.", name)));
+        }
+    }
+
+    /**
+     * Returns all column names in this schema as a flat list. For example, a schema like: | - a | |
+     * - 1 | | - 2 | - b | - c | | - nest |   | - 3 will get flattened to: "a", "a.1", "a.2", "b",
+     * "c", "c.nest", "c.nest.3"
+     */
+    private static List<String> flattenNestedFieldNames(StructType schema) {
+        List<String> fieldNames = new ArrayList<>();
+        for (StructField field : schema.fields()) {
+            String escapedName = escapeDots(field.getName());
+            fieldNames.add(escapedName);
+            fieldNames.addAll(flattenNestedFieldNamesRecursive(escapedName, field.getDataType()));
+        }
+        return fieldNames;
+    }
+
+    private static List<String> flattenNestedFieldNamesRecursive(String prefix, DataType type) {
+        List<String> fieldNames = new ArrayList<>();
+        if (type instanceof StructType) {
+            for (StructField field : ((StructType) type).fields()) {
+                String escapedName = escapeDots(field.getName());
+                fieldNames.add(prefix + "." + escapedName);
+                fieldNames.addAll(flattenNestedFieldNamesRecursive(
+                        prefix + "." + escapedName, field.getDataType()));
+            }
+        } else if (type instanceof ArrayType) {
+            fieldNames.addAll(flattenNestedFieldNamesRecursive(
+                    prefix + ".element",
+                    ((ArrayType) type).getElementType()));
+        } else if (type instanceof MapType) {
+            MapType mapType = (MapType) type;
+            fieldNames.addAll(
+                    flattenNestedFieldNamesRecursive(prefix + ".key", mapType.getKeyType()));
+            fieldNames.addAll(
+                    flattenNestedFieldNamesRecursive(prefix + ".value", mapType.getValueType()));
+        }
+        return fieldNames;
+    }
+
+    private static String escapeDots(String name) {
+        return name.contains(".") ? "`" + name + "`" : name;
+    }
+
+    protected static void validParquetColumnNames(List<String> columnNames) {
+        for (String name : columnNames) {
+            // ,;{}()\n\t= and space are special characters in Parquet schema
+            checkArgument(
+                    !name.matches(".*[ ,;{}()\n\t=].*"),
+                    format("Attribute name '%s' contains invalid character(s) among" +
+                            " ' ,;{}()\\n\\t='.", name));
+        }
+    }
+}

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
@@ -133,6 +133,22 @@ class SchemaUtilsSuite extends AnyFunSuite {
     }
   }
 
+  test("only duplicate columns are listed in the error message") {
+    val schema = new StructType()
+      .add("top",
+        new StructType().add("a", INTEGER).add("b", INTEGER).add("c", INTEGER)
+      ).add("top",
+        new StructType().add("b", INTEGER).add("c", INTEGER).add("d", INTEGER)
+      ).add("bottom",
+        new StructType().add("b", INTEGER).add("c", INTEGER).add("d", INTEGER)
+      )
+
+    val e = intercept[IllegalArgumentException] {
+      validateSchema(schema, false /* isColumnMappingEnabled */)
+    }
+    assert(e.getMessage.contains("Schema contains duplicate columns: top, top.b, top.c"))
+  }
+
   test("duplicate column name in double nested map") {
     val keyType = new StructType()
       .add("dupColName", INTEGER)

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/SchemaUtilsSuite.scala
@@ -1,0 +1,259 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.util
+
+import io.delta.kernel.internal.util.SchemaUtils.validateSchema
+import io.delta.kernel.types.IntegerType.INTEGER
+import io.delta.kernel.types.{ArrayType, MapType, StringType, StructType}
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.util.Locale
+
+class SchemaUtilsSuite extends AnyFunSuite {
+  private def expectFailure(shouldContain: String*)(f: => Unit): Unit = {
+    val e = intercept[IllegalArgumentException] {
+      f
+    }
+    val msg = e.getMessage.toLowerCase(Locale.ROOT)
+    assert(shouldContain.map(_.toLowerCase(Locale.ROOT)).forall(msg.contains),
+      s"Error message '$msg' didn't contain: $shouldContain")
+  }
+
+  ///////////////////////////////////////////////////////////////////////////
+  // Duplicate Column Checks
+  ///////////////////////////////////////////////////////////////////////////
+
+  test("duplicate column name in top level") {
+    val schema = new StructType()
+      .add("dupColName", INTEGER)
+      .add("b", INTEGER)
+      .add("dupColName", StringType.STRING)
+    expectFailure("dupColName") {
+      validateSchema(schema, false /* isColumnMappingEnabled */)
+    }
+  }
+
+  test("duplicate column name in top level - case sensitivity") {
+    val schema = new StructType()
+      .add("dupColName", INTEGER)
+      .add("b", INTEGER)
+      .add("dupCOLNAME", StringType.STRING)
+    expectFailure("dupColName") {
+      validateSchema(schema, false /* isColumnMappingEnabled */)
+    }
+  }
+
+  test("duplicate column name for nested column + non-nested column") {
+    val schema = new StructType()
+      .add("dupColName", new StructType()
+        .add("a", INTEGER)
+        .add("b", INTEGER))
+      .add("dupColName", INTEGER)
+    expectFailure("dupColName") {
+      validateSchema(schema, false /* isColumnMappingEnabled */)
+    }
+  }
+
+  test("duplicate column name for nested column + non-nested column - case sensitivity") {
+    val schema = new StructType()
+      .add("dupColName", new StructType()
+        .add("a", INTEGER)
+        .add("b", INTEGER))
+      .add("dupCOLNAME", INTEGER)
+    expectFailure("dupCOLNAME") {
+      validateSchema(schema, false /* isColumnMappingEnabled */)
+    }
+  }
+
+  test("duplicate column name in nested level") {
+    val schema = new StructType()
+      .add("top", new StructType()
+        .add("dupColName", INTEGER)
+        .add("b", INTEGER)
+        .add("dupColName", StringType.STRING)
+      )
+    expectFailure("top.dupColName") {
+      validateSchema(schema, false /* isColumnMappingEnabled */)
+    }
+  }
+
+  test("duplicate column name in nested level - case sensitivity") {
+    val schema = new StructType()
+      .add("top", new StructType()
+        .add("dupColName", INTEGER)
+        .add("b", INTEGER)
+        .add("dupCOLNAME", StringType.STRING)
+      )
+    expectFailure("top.dupColName") {
+      validateSchema(schema, false /* isColumnMappingEnabled */)
+    }
+  }
+
+  test("duplicate column name in double nested level") {
+    val schema = new StructType()
+      .add("top", new StructType()
+        .add("b", new StructType()
+          .add("dupColName", StringType.STRING)
+          .add("c", INTEGER)
+          .add("dupColName", StringType.STRING))
+        .add("d", INTEGER)
+      )
+    expectFailure("top.b.dupColName") {
+      validateSchema(schema, false /* isColumnMappingEnabled */)
+    }
+  }
+
+  test("duplicate column name in double nested array") {
+    val schema = new StructType()
+      .add("top", new StructType()
+        .add("b", new ArrayType(
+          new ArrayType(new StructType()
+            .add("dupColName", StringType.STRING)
+            .add("c", INTEGER)
+            .add("dupColName", StringType.STRING),
+            true),
+          true))
+        .add("d", INTEGER)
+      )
+    expectFailure("top.b.element.element.dupColName") {
+      validateSchema(schema, false /* isColumnMappingEnabled */)
+    }
+  }
+
+  test("duplicate column name in double nested map") {
+    val keyType = new StructType()
+      .add("dupColName", INTEGER)
+      .add("d", StringType.STRING)
+    expectFailure("top.b.key.dupColName") {
+      val schema = new StructType()
+        .add("top", new StructType()
+          .add("b", new MapType(keyType.add("dupColName", StringType.STRING), keyType, true))
+        )
+      validateSchema(schema, false /* isColumnMappingEnabled */)
+    }
+    expectFailure("top.b.value.dupColName") {
+      val schema = new StructType()
+        .add("top", new StructType()
+          .add("b", new MapType(keyType, keyType.add("dupColName", StringType.STRING), true))
+        )
+      validateSchema(schema, false /* isColumnMappingEnabled */)
+    }
+    // This is okay
+    val schema = new StructType()
+      .add("top", new StructType()
+        .add("b", new MapType(keyType, keyType, true))
+      )
+    validateSchema(schema, false /* isColumnMappingEnabled */)
+  }
+
+  test("duplicate column name in nested array") {
+    val schema = new StructType()
+      .add("top", new ArrayType(new StructType()
+        .add("dupColName", INTEGER)
+        .add("b", INTEGER)
+        .add("dupColName", StringType.STRING), true)
+      )
+    expectFailure("top.element.dupColName") {
+      validateSchema(schema, false /* isColumnMappingEnabled */)
+    }
+  }
+
+  test("duplicate column name in nested array - case sensitivity") {
+    val schema = new StructType()
+      .add("top", new ArrayType(new StructType()
+        .add("dupColName", INTEGER)
+        .add("b", INTEGER)
+        .add("dupCOLNAME", StringType.STRING), true)
+      )
+    expectFailure("top.element.dupColName") {
+      validateSchema(schema, false /* isColumnMappingEnabled */)
+    }
+  }
+
+  test("non duplicate column because of back tick") {
+    val schema = new StructType()
+      .add("top", new StructType()
+        .add("a", INTEGER)
+        .add("b", INTEGER))
+      .add("top.a", INTEGER)
+    validateSchema(schema, false /* isColumnMappingEnabled */)
+  }
+
+  test("non duplicate column because of back tick - nested") {
+    val schema = new StructType()
+      .add("first", new StructType()
+        .add("top", new StructType()
+          .add("a", INTEGER)
+          .add("b", INTEGER))
+        .add("top.a", INTEGER))
+    validateSchema(schema, false /* isColumnMappingEnabled */)
+  }
+
+  test("duplicate column with back ticks - nested") {
+    val schema = new StructType()
+      .add("first", new StructType()
+        .add("top.a", StringType.STRING)
+        .add("b", INTEGER)
+        .add("top.a", INTEGER))
+    expectFailure("first.`top.a`") {
+      validateSchema(schema, false /* isColumnMappingEnabled */)
+    }
+  }
+
+  test("duplicate column with back ticks - nested and case sensitivity") {
+    val schema = new StructType()
+      .add("first", new StructType()
+        .add("TOP.a", StringType.STRING)
+        .add("b", INTEGER)
+        .add("top.a", INTEGER))
+    expectFailure("first.`top.a`") {
+      validateSchema(schema, false /* isColumnMappingEnabled */)
+    }
+  }
+
+  ///////////////////////////////////////////////////////////////////////////
+  // checkFieldNames
+  ///////////////////////////////////////////////////////////////////////////
+  test("check non alphanumeric column characters") {
+    val badCharacters = " ,;{}()\n\t="
+    val goodCharacters = "#.`!@$%^&*~_<>?/:"
+
+    badCharacters.foreach { char =>
+      Seq(s"a${char}b", s"${char}ab", s"ab${char}", char.toString).foreach { name =>
+        val schema = new StructType().add(name, INTEGER)
+        val e = intercept[IllegalArgumentException] {
+          validateSchema(schema, false /* isColumnMappingEnabled */)
+        }
+
+        if (char != '\n') {
+          // with column mapping disabled this should be a valid name
+          validateSchema(schema, true /* isColumnMappingEnabled */)
+        }
+
+        assert(e.getMessage.contains("invalid character"))
+      }
+    }
+
+    goodCharacters.foreach { char =>
+      // no issues here
+      Seq(s"a${char}b", s"${char}ab", s"ab${char}", char.toString).foreach { name =>
+        val schema = new StructType().add(name, INTEGER);
+        validateSchema(schema, false /* isColumnMappingEnabled */)
+        validateSchema(schema, true /* isColumnMappingEnabled */)
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description
(Split from the larger PR #2944)

These are utility to make sure the given schema when creating the table is valid (has no duplicate column names or invalid chars). The code/logic is similar to Delta-Spark/Standalone.

## How was this patch tested?
Unittests
