### PR TITLE
[Kernel][Writes] Add `FileSystemClient.mkdirs` API

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/client/FileSystemClient.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/client/FileSystemClient.java
@@ -67,4 +67,14 @@ public interface FileSystemClient {
     CloseableIterator<ByteArrayInputStream> readFiles(
         CloseableIterator<FileReadRequest> readRequests)
         throws IOException;
+
+    /**
+     * Create a directory at the given path including parent directories. This mimicks the behavior
+     * of `mkdir -p` in Unix.
+     *
+     * @param path Full qualified path to create a directory at.
+     * @return true if the directory was created successfully, false otherwise.
+     * @throws IOException for any IO error.
+     */
+    boolean mkdirs(String path) throws IOException;
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockTableClientUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockTableClientUtils.scala
@@ -160,4 +160,7 @@ trait BaseMockFileSystemClient extends FileSystemClient {
   override def readFiles(
       readRequests: CloseableIterator[FileReadRequest]): CloseableIterator[ByteArrayInputStream] =
     throw new UnsupportedOperationException("not supported in this test suite")
+
+  override def mkdirs(path: String): Boolean =
+    throw new UnsupportedOperationException("not supported in this test suite")
 }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileSystemClient.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultFileSystemClient.java
@@ -97,6 +97,13 @@ public class DefaultFileSystemClient
                 getStream(elem.getPath(), elem.getStartOffset(), elem.getReadLength()));
     }
 
+    @Override
+    public boolean mkdirs(String path) throws IOException {
+        Path pathObject = new Path(path);
+        FileSystem fs = pathObject.getFileSystem(hadoopConf);
+        return fs.mkdirs(pathObject);
+    }
+
     private ByteArrayInputStream getStream(String filePath, int offset, int size) {
         Path path = new Path(filePath);
         try {


### PR DESCRIPTION
## Description
(Split from larger PR #2944)

This API allows the creation of an initial delta log directory when the table is created.
