### PR TITLE
[Spark] Add drop support for managed commits

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitUtils.scala
@@ -16,15 +16,16 @@
 
 package org.apache.spark.sql.delta.managedcommit
 
-import org.apache.spark.sql.delta.{DeltaLog, ManagedCommitTableFeature, SnapshotDescriptor}
+import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog, ManagedCommitTableFeature, Snapshot, SnapshotDescriptor}
 import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
+import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.storage.LogStore
 import org.apache.spark.sql.delta.util.FileNames
 import org.apache.spark.sql.delta.util.FileNames.{DeltaFile, UnbackfilledDeltaFile}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 
-object ManagedCommitUtils {
+object ManagedCommitUtils extends DeltaLogging {
 
   /**
    * Returns an iterator of commit files starting from startVersion.
@@ -136,5 +137,86 @@ object ManagedCommitUtils {
       case Some(name) => (Some(name), metadata.managedCommitOwnerConf)
       case None => (None, Map.empty)
     }
+  }
+
+  /**
+   * The main table properties used to instantiate a TableCommitOwnerClient.
+   */
+  val TABLE_PROPERTY_KEYS: Seq[String] = Seq(
+    DeltaConfigs.MANAGED_COMMIT_OWNER_NAME.key,
+    DeltaConfigs.MANAGED_COMMIT_OWNER_CONF.key,
+    DeltaConfigs.MANAGED_COMMIT_TABLE_CONF.key)
+
+  /**
+   * Returns true if any ManagedCommit-related table properties is present in the metadata.
+   */
+  def tablePropertiesPresent(metadata: Metadata): Boolean = {
+    val managedCommitProperties = Seq(
+      DeltaConfigs.MANAGED_COMMIT_OWNER_NAME.key,
+      DeltaConfigs.MANAGED_COMMIT_OWNER_CONF.key,
+      DeltaConfigs.MANAGED_COMMIT_TABLE_CONF.key)
+    managedCommitProperties.exists(metadata.configuration.contains)
+  }
+
+  /**
+   * Returns true if the snapshot is backed by unbackfilled commits.
+   */
+  def unbackfilledCommitsPresent(snapshot: Snapshot): Boolean = {
+    snapshot.logSegment.deltas.exists {
+      case FileNames.UnbackfilledDeltaFile(_, _, _) => true
+      case _ => false
+    }
+  }
+
+  /**
+   * This method takes care of backfilling any unbackfilled delta files when managed commit is
+   * not enabled on the table (i.e. commit-owner is not present) but there are still unbackfilled
+   * delta files in the table. This can happen if an error occurred during the MC -> FS commit
+   * where the commit-owner was able to register the downgrade commit but it failed to backfill
+   * it. This method must be invoked before doing the next commit as otherwise there will be a
+   * gap in the backfilled commit sequence.
+   */
+  def backfillWhenManagedCommitDisabled(snapshot: Snapshot): Unit = {
+    if (snapshot.tableCommitOwnerClientOpt.nonEmpty) {
+      // Managed commits is enabled on the table. Don't backfill as backfills are managed by
+      // commit-owners.
+      return
+    }
+    val unbackfilledFilesAndVersions = snapshot.logSegment.deltas.collect {
+      case UnbackfilledDeltaFile(unbackfilledDeltaFile, version, _) =>
+        (unbackfilledDeltaFile, version)
+    }
+    if (unbackfilledFilesAndVersions.isEmpty) return
+    // Managed commits are disabled on the table but the table still has un-backfilled files.
+    val deltaLog = snapshot.deltaLog
+    val hadoopConf = deltaLog.newDeltaHadoopConf()
+    val fs = deltaLog.logPath.getFileSystem(hadoopConf)
+    val overwrite = !deltaLog.store.isPartialWriteVisible(deltaLog.logPath, hadoopConf)
+    var numAlreadyBackfilledFiles = 0L
+    unbackfilledFilesAndVersions.foreach { case (unbackfilledDeltaFile, version) =>
+      val backfilledFilePath = FileNames.unsafeDeltaFile(deltaLog.logPath, version)
+      if (!fs.exists(backfilledFilePath)) {
+        val actionsIter = deltaLog.store.readAsIterator(unbackfilledDeltaFile.getPath, hadoopConf)
+        deltaLog.store.write(
+          backfilledFilePath,
+          actionsIter,
+          overwrite,
+          hadoopConf)
+        logInfo(s"Delta file ${unbackfilledDeltaFile.getPath.toString} backfilled to path" +
+          s" ${backfilledFilePath.toString}.")
+      } else {
+        numAlreadyBackfilledFiles += 1
+        logInfo(s"Delta file ${unbackfilledDeltaFile.getPath.toString} already backfilled.")
+      }
+    }
+    recordDeltaEvent(
+      deltaLog,
+      opType = "delta.managedCommit.backfillWhenManagedCommitSupportedAndDisabled",
+      data = Map(
+        "numUnbackfilledFiles" -> unbackfilledFilesAndVersions.size,
+        "unbackfilledFiles" -> unbackfilledFilesAndVersions.map(_._1.getPath.toString),
+        "numAlreadyBackfilledFiles" -> numAlreadyBackfilledFiles
+      )
+    )
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -29,12 +29,16 @@ import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils._
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.{AlterTableDropFeatureDeltaCommand, AlterTableSetPropertiesDeltaCommand, AlterTableUnsetPropertiesDeltaCommand}
+import org.apache.spark.sql.delta.managedcommit._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.storage.LogStore
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.FileNames
 import org.apache.spark.sql.delta.util.FileNames.{unsafeDeltaFile, DeltaFile}
 import org.apache.spark.sql.delta.util.JsonUtils
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{AnalysisException, QueryTest, SaveMode}
@@ -3847,6 +3851,156 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         expectProvenanceVersionProperty = false)
     }
   }
+
+  // ---- Managed Commit Drop Feature Tests ----
+  private def setUpManagedCommitTable(dir: File, mcBuilder: CommitOwnerBuilder): Unit = {
+    CommitOwnerProvider.clearNonDefaultBuilders()
+    CommitOwnerProvider.registerBuilder(mcBuilder)
+    val tablePath = dir.getAbsolutePath
+    val log = DeltaLog.forTable(spark, tablePath)
+    val fs = log.logPath.getFileSystem(log.newDeltaHadoopConf())
+    val commitOwnerConf = Map(DeltaConfigs.MANAGED_COMMIT_OWNER_NAME.key -> mcBuilder.getName)
+    val newMetadata = Metadata().copy(configuration = commitOwnerConf)
+    log.startTransaction().commitManually(newMetadata)
+    assert(log.unsafeVolatileSnapshot.version === 0)
+    assert(log.unsafeVolatileSnapshot.metadata.managedCommitOwnerName === Some(mcBuilder.getName))
+    assert(log.unsafeVolatileSnapshot.tableCommitOwnerClientOpt.nonEmpty)
+    assert(log.unsafeVolatileSnapshot.metadata.managedCommitTableConf === Map.empty)
+    // upgrade commit always filesystem based
+    assert(fs.exists(FileNames.unsafeDeltaFile(log.logPath, 0)))
+
+    // Do a couple of commits on the managed-commit table
+    (1 to 2).foreach { version =>
+      log.startTransaction()
+        .commitManually(DeltaTestUtils.createTestAddFile(s"$version"))
+      assert(log.unsafeVolatileSnapshot.version === version)
+      assert(log.unsafeVolatileSnapshot.tableCommitOwnerClientOpt.nonEmpty)
+      assert(log.unsafeVolatileSnapshot.metadata.managedCommitOwnerName.nonEmpty)
+      assert(log.unsafeVolatileSnapshot.metadata.managedCommitOwnerConf === Map.empty)
+      assert(log.unsafeVolatileSnapshot.metadata.managedCommitTableConf === Map.empty)
+    }
+  }
+
+  private def validateManagedCommitsDropLogs(
+      usageLogs: Seq[UsageRecord],
+      expectTablePropertiesPresent: Boolean,
+      expectUnbackfilledCommitsPresent: Boolean,
+      exceptionMessageOpt: Option[String] = None): Unit = {
+    val dropFeatureBlob = usageLogs
+      .find(_.tags.get("opType").contains("delta.managedCommitFeatureRemovalMetrics"))
+      .getOrElse(fail("Expected a log for managedCommitFeatureRemovalMetrics"))
+    val blob = JsonUtils.fromJson[Map[String, String]](dropFeatureBlob.blob)
+    assert(blob.contains("downgradeTimeMs"))
+    val expectTraceRemovalNeeded = expectTablePropertiesPresent || expectUnbackfilledCommitsPresent
+    assert(blob.get("traceRemovalNeeded").contains(expectTraceRemovalNeeded.toString))
+    Seq(
+        DeltaConfigs.MANAGED_COMMIT_OWNER_NAME.key,
+        DeltaConfigs.MANAGED_COMMIT_TABLE_CONF.key).foreach { prop =>
+      assert(blob.get(prop).contains(expectTablePropertiesPresent.toString))
+    }
+    // MANAGED_COMMIT_OWNER_CONF is not used by "in-memory" commit owner.
+    assert(blob
+      .get("postDisablementUnbackfilledCommitsPresent")
+      .contains(expectUnbackfilledCommitsPresent.toString))
+    assert(
+      blob.get(DeltaConfigs.MANAGED_COMMIT_OWNER_CONF.key).contains("false"))
+    assert(blob.get("traceRemovalSuccess").contains(exceptionMessageOpt.isEmpty.toString))
+    exceptionMessageOpt.foreach { exceptionMessage =>
+      assert(blob.get("traceRemovalException").contains(exceptionMessage))
+    }
+  }
+
+  test("basic managed commit feature drop") {
+    withTempDir { dir =>
+      val mcBuilder = TrackingInMemoryCommitOwnerBuilder(batchSize = 1000)
+      setUpManagedCommitTable(dir, mcBuilder)
+      val log = DeltaLog.forTable(spark, dir)
+      val usageLogs = Log4jUsageLogger.track {
+        AlterTableDropFeatureDeltaCommand(
+          DeltaTableV2(spark, log.dataPath),
+          ManagedCommitTableFeature.name)
+          .run(spark)
+      }
+      val snapshot = log.update()
+      assert(
+        !ManagedCommitUtils.TABLE_PROPERTY_KEYS.exists(snapshot.metadata.configuration.contains(_)))
+      assert(!snapshot.protocol.writerFeatures.exists(_.contains(ManagedCommitTableFeature.name)))
+      validateManagedCommitsDropLogs(
+        usageLogs, expectTablePropertiesPresent = true, expectUnbackfilledCommitsPresent = false)
+    }
+  }
+
+  test("backfill failure during managed commit feature drop") {
+    withTempDir { dir =>
+      var shouldFailBackfill = true
+      val alternatingFailureBackfillClient =
+        new TrackingCommitOwnerClient(new InMemoryCommitOwner(1000) {
+          override def backfillToVersion(
+            logStore: LogStore,
+            hadoopConf: Configuration,
+            logPath: Path,
+            managedCommitTableConf: Map[String, String],
+            startVersion: Long,
+            endVersionOpt: Option[Long]): Unit = {
+            // Backfill fails on every other attempt.
+            if (shouldFailBackfill) {
+              shouldFailBackfill = !shouldFailBackfill
+              throw new IllegalStateException("backfill failed")
+            } else {
+              super.backfillToVersion(
+                logStore, hadoopConf, logPath, managedCommitTableConf, startVersion, endVersionOpt)
+            }
+          }
+        })
+      val mcBuilder =
+        TrackingInMemoryCommitOwnerBuilder(100, Some(alternatingFailureBackfillClient))
+      setUpManagedCommitTable(dir, mcBuilder)
+      val log = DeltaLog.forTable(spark, dir)
+      val usageLogs = Log4jUsageLogger.track {
+        val e = intercept[IllegalStateException] {
+          AlterTableDropFeatureDeltaCommand(
+            DeltaTableV2(spark, log.dataPath),
+            ManagedCommitTableFeature.name)
+            .run(spark)
+        }
+
+        assert(e.getMessage.contains("backfill failed"))
+      }
+      validateManagedCommitsDropLogs(
+        usageLogs,
+        expectTablePropertiesPresent = true,
+        expectUnbackfilledCommitsPresent = false,
+        exceptionMessageOpt = Some("backfill failed"))
+      def backfilledCommitExists(v: Long): Boolean = {
+        val fs = log.logPath.getFileSystem(log.newDeltaHadoopConf())
+        fs.exists(FileNames.unsafeDeltaFile(log.logPath, v))
+      }
+      // Backfill of the commit which disables managed commits failed.
+      assert(!backfilledCommitExists(3))
+      // The commit owner still tracks the commit that disables it.
+      val commitsFromCommitOwner =
+        log.snapshot.tableCommitOwnerClientOpt.get.getCommits(Some(3))
+      assert(commitsFromCommitOwner.getCommits.exists(_.getVersion == 3))
+      // The next drop attempt will also trigger an explicit backfill.
+      val usageLogs2 = Log4jUsageLogger.track {
+        AlterTableDropFeatureDeltaCommand(
+          DeltaTableV2(spark, log.dataPath),
+          ManagedCommitTableFeature.name)
+          .run(spark)
+      }
+      validateManagedCommitsDropLogs(
+        usageLogs2, expectTablePropertiesPresent = false, expectUnbackfilledCommitsPresent = true)
+      val snapshot = log.update()
+      assert(snapshot.version === 4)
+      assert(backfilledCommitExists(3))
+      // The protocol downgrade commit is performed through logstore directly.
+      assert(backfilledCommitExists(4))
+      assert(
+        !ManagedCommitUtils.TABLE_PROPERTY_KEYS.exists(snapshot.metadata.configuration.contains(_)))
+      assert(!snapshot.protocol.writerFeatures.exists(_.contains(ManagedCommitTableFeature.name)))
+    }
+  }
+  // ---- End Managed Commit Drop Feature Tests ----
 
   // Create a table for testing that has an unsupported feature.
   private def withTestTableWithUnsupportedWriterFeature(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Adds table feature phaseout support for managed commits.
Fixes the ManagedCommit table feature --> correctly marks it as a WriterFeature instead of a ReaderWriterFeature.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
New tests in DeltaProtocolVersionSuite.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, the drop table command now works for managed commits.