### PR TITLE
[INFRA] Fix and create new workflow to compile delta-spark examples

### DIFF
--- a/.github/workflows/spark_examples_test.yaml
+++ b/.github/workflows/spark_examples_test.yaml
@@ -45,8 +45,11 @@ jobs:
       - name: Run Delta Spark Local Publishing and Examples Compilation
         # examples/scala/build.sbt will compile against the local Delta relase version (e.g. 3.2.0-SNAPSHOT).
         # Thus, we need to publishM2 first so those jars are locally accessible.
+        # We publish storage explicitly so that it is available for the Scala 2.13 build. As a java project
+        # it is typically only released when publishing for Scala 2.12.
         run: |
           build/sbt clean
+          build/sbt storage/publishM2
           build/sbt "++ $SCALA_VERSION publishM2"
           cd examples/scala && build/sbt "++ $SCALA_VERSION compile"
         if: steps.git-diff.outputs.diff

--- a/.github/workflows/spark_examples_test.yaml
+++ b/.github/workflows/spark_examples_test.yaml
@@ -1,4 +1,4 @@
-name: "Delta Spark Tests"
+name: "Delta Spark Local Publishing and Examples Compilation"
 on: [push, pull_request]
 jobs:
   test:
@@ -35,36 +35,18 @@ jobs:
           # the above directories when we use the key for the first time. After that, each run will
           # just use the cache. The cache is immutable so we need to use a new key when trying to
           # cache new stuff.
-          key: delta-sbt-cache-spark3.2-scala${{ matrix.scala }}
+          key: delta-sbt-cache-spark-examples-scala${{ matrix.scala }}
       - name: Install Job dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
           sudo apt install libedit-dev
-          sudo apt install python3-pip --fix-missing
-          sudo pip3 install pipenv==2021.5.29
-          curl https://pyenv.run | bash
-          export PATH="~/.pyenv/bin:$PATH"
-          eval "$(pyenv init -)"
-          eval "$(pyenv virtualenv-init -)"
-          pyenv install 3.8.18
-          pyenv global system 3.8.18
-          pipenv --python 3.8 install
-          pipenv run pip install pyspark==3.5.0
-          pipenv run pip install flake8==3.5.0 pypandoc==1.3.3
-          pipenv run pip install importlib_metadata==3.10.0
-          pipenv run pip install mypy==0.982
-          pipenv run pip install cryptography==37.0.4
-          pipenv run pip install twine==4.0.1
-          pipenv run pip install wheel==0.33.4
-          pipenv run pip install setuptools==41.1.0
-          pipenv run pip install pydocstyle==3.0.0
-          pipenv run pip install pandas==1.1.3
-          pipenv run pip install pyarrow==8.0.0
-          pipenv run pip install numpy==1.20.3
         if: steps.git-diff.outputs.diff
-      - name: Run Scala/Java and Python tests
-        # when changing TEST_PARALLELISM_COUNT make sure to also change it in spark_master_test.yaml
+      - name: Run Delta Spark Local Publishing and Examples Compilation
+        # examples/scala/build.sbt will compile against the local Delta relase version (e.g. 3.2.0-SNAPSHOT).
+        # Thus, we need to publishM2 first so those jars are locally accessible.
         run: |
-          TEST_PARALLELISM_COUNT=2 pipenv run python run-tests.py --group spark
+          build/sbt clean
+          build/sbt "++ $SCALA_VERSION publishM2"
+          cd examples/scala && build/sbt "++ $SCALA_VERSION compile"
         if: steps.git-diff.outputs.diff

--- a/examples/scala/build.sbt
+++ b/examples/scala/build.sbt
@@ -20,8 +20,15 @@ organizationName := "example"
 
 val scala212 = "2.12.18"
 val scala213 = "2.13.13"
-val deltaVersion = "3.0.0"
 val icebergVersion = "1.4.1"
+val defaultDeltaVersion = {
+  val versionFileContent = IO.read(file("../../version.sbt"))
+  val versionRegex = """.*version\s*:=\s*"([^"]+)".*""".r
+  versionRegex.findFirstMatchIn(versionFileContent) match {
+    case Some(m) => m.group(1)
+    case None => throw new Exception("Could not parse version from version.sbt")
+  }
+}
 
 def getMajorMinor(version: String): (Int, Int) = {
   val majorMinor = Try {
@@ -58,7 +65,7 @@ val getScalaVersion = settingKey[String](
   s"get scala version from environment variable SCALA_VERSION. If it doesn't exist, use $scala213"
 )
 val getDeltaVersion = settingKey[String](
-  s"get delta version from environment variable DELTA_VERSION. If it doesn't exist, use $deltaVersion"
+  s"get delta version from environment variable DELTA_VERSION. If it doesn't exist, use $defaultDeltaVersion"
 )
 val getDeltaArtifactName = settingKey[String](
   s"get delta artifact name based on the delta version. either `delta-core` or `delta-spark`."
@@ -68,13 +75,14 @@ val getIcebergSparkRuntimeArtifactName = settingKey[String](
 )
 getScalaVersion := {
   sys.env.get("SCALA_VERSION") match {
-    case Some("2.12") =>
+    case Some("2.12") | Some(`scala212`) =>
       scala212
-    case Some("2.13") =>
+    case Some("2.13") | Some(`scala213`) =>
       scala213
     case Some(v) =>
       println(
-        s"[warn] Invalid  SCALA_VERSION. Expected 2.12 or 2.13 but got $v. Fallback to $scala213."
+        s"[warn] Invalid  SCALA_VERSION. Expected one of {2.12, $scala212, 2.13, $scala213} but " +
+        s"got $v. Fallback to $scala213."
       )
       scala213
     case None =>
@@ -88,10 +96,11 @@ version := "0.1.0"
 getDeltaVersion := {
   sys.env.get("DELTA_VERSION") match {
     case Some(v) =>
-      println(s"Using Delta version $v")
+      println(s"Using DELTA_VERSION Delta version $v")
       v
     case None =>
-      deltaVersion
+      println(s"Using default Delta version $defaultDeltaVersion")
+      defaultDeltaVersion
   }
 }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [X] Other (INFRA)

## Description

Create new workflow `spark_examples_test.yaml` that compiles the `examples/scala/build.sbt` project.

Also fixes such compilation so that it uses the local jars (previously it was incorrectly hardcoded to Delta 3.0).

This requires running `publishM2` beforehand.

## How was this patch tested?

CI tests and specifically tested on a commit that uses a new `clusterBy` API in 3.2: https://github.com/delta-io/delta/pull/3012

## Does this PR introduce _any_ user-facing changes?

No.
