### PR TITLE
[Kernel] Remove unused `ExpressionHandler.isSupported(...)` for now

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/client/ExpressionHandler.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/client/ExpressionHandler.java
@@ -34,15 +34,6 @@ import io.delta.kernel.types.StructType;
  */
 @Evolving
 public interface ExpressionHandler {
-    /**
-     * Is the given expression evaluation supported on the data with given schema?
-     *
-     * @param inputSchema Schema of input data on which the expression is evaluated.
-     * @param expression Expression to check whether it is supported for evaluation.
-     * @param outputType Expected result data type.
-     * @return true if supported and false otherwise.
-     */
-    boolean isSupported(StructType inputSchema, Expression expression, DataType outputType);
 
     /**
      * Create an {@link ExpressionEvaluator} that can evaluate the given <i>expression</i> on

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockTableClientUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockTableClientUtils.scala
@@ -136,12 +136,6 @@ trait BaseMockExpressionHandler extends ExpressionHandler {
       outputType: DataType): ExpressionEvaluator =
     throw new UnsupportedOperationException("not supported in this test suite")
 
-  override def isSupported(
-      inputSchema: StructType,
-      expression: Expression,
-      outputType: DataType): Boolean =
-    throw new UnsupportedOperationException("not supported in this test suite")
-
   override def createSelectionVector(values: Array[Boolean], from: Int, to: Int): ColumnVector =
     throw new UnsupportedOperationException("not supported in this test suite")
 }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultExpressionHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/client/DefaultExpressionHandler.java
@@ -38,17 +38,6 @@ import io.delta.kernel.defaults.internal.expressions.DefaultPredicateEvaluator;
  * Default implementation of {@link ExpressionHandler}
  */
 public class DefaultExpressionHandler implements ExpressionHandler {
-    @Override
-    public boolean isSupported(StructType inputSchema, Expression expression, DataType outputType) {
-        // There is no extra cost to create an expression handler in default implementation in
-        // addition to checking the expression support. So we can just use `getEvaluator`.
-        try {
-            getEvaluator(inputSchema, expression, outputType);
-            return true;
-        } catch (UnsupportedOperationException e) {
-            return false;
-        }
-    }
 
     @Override
     public ExpressionEvaluator getEvaluator(

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/client/DefaultExpressionHandlerSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/client/DefaultExpressionHandlerSuite.scala
@@ -76,36 +76,6 @@ class DefaultExpressionHandlerSuite extends AnyFunSuite with ExpressionTestUtils
     assert(ex.getMessage.contains("values is null"))
   }
 
-  val tableSchema = new StructType()
-    .add("d1", INTEGER)
-    .add("d2", STRING)
-    .add("d3", new StructType()
-      .add("d31", BOOLEAN)
-      .add("d32", LONG))
-    .add("p1", INTEGER)
-    .add("p2", STRING)
-  val unsupportedExpr = Map(
-    (unsupported("d1"), BOOLEAN) -> false, // unsupported function
-    (lt(col("d1"), int(12)), BOOLEAN) -> true,
-    (lt(col("d1"), int(12)), INTEGER) -> false, // output type is not supported
-    (lt(nestedCol("d3.d32"), int(12)), BOOLEAN) -> true, // implicit conversion from int to long
-    (gt(col("d1"), str("sss")), STRING) -> false, // unexpected input type to > operator
-    // unsupported expression in one of the AND inputs
-    (and(gt(col("d2"), str("sss")), unsupported("d2")), BOOLEAN) -> false,
-    // both unsupported expressions in AND inputs
-    (and(gt(nestedCol("d3.d31"), str("sss")), unsupported("d2")), BOOLEAN) -> false,
-    // unsupported expression in one of the OR inputs
-    (or(gt(col("p2"), str("sss")), unsupported("d2")), BOOLEAN) -> false,
-    // both unsupported expressions in OR inputs
-    (or(gt(nestedCol("d3.d31"), str("sss")), unsupported("d2")), BOOLEAN) -> false
-  ).foreach {
-    case ((expr, outputType), expected) =>
-      test(s"is expression supported: $expr -> $outputType") {
-        assert(
-          new DefaultExpressionHandler().isSupported(tableSchema, expr, outputType) == expected)
-      }
-  }
-
   private def selectionVector(values: Array[Boolean], from: Int, to: Int) = {
     new DefaultExpressionHandler().createSelectionVector(values, from, to)
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Removes a currently unused API in `ExpressionHandler`.

See https://github.com/delta-io/delta/issues/3017 for details. **TLDR** we added this API before achieving consensus on what we want to implement and it is currently unused. Remove it for now and we can add it back later if needed.

## How was this patch tested?

N/A

## Does this PR introduce _any_ user-facing changes?

No
