### PR TITLE
[Build] Fix Java checkstyle plugin to work with SBT upgrade

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1308,7 +1308,7 @@ def javaCheckstyleSettings(checkstyleFile: String): Def.SettingsDefinition = {
   // and during tests (e.g. build/sbt test)
   Seq(
     checkstyleConfigLocation := CheckstyleConfigLocation.File(checkstyleFile),
-    checkstyleSeverityLevel := Some(CheckstyleSeverityLevel.Error),
+    checkstyleSeverityLevel := CheckstyleSeverityLevel.Error,
     (Compile / checkstyle) := (Compile / checkstyle).triggeredBy(Compile / compile).value,
     (Test / checkstyle) := (Test / checkstyle).triggeredBy(Test / compile).value
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1212,9 +1212,9 @@ lazy val flink = (project in file("connectors/flink"))
       IO.write(file,
         s"""package io.delta.flink.internal;
            |
-           |final public class Meta {
-           |  public static final String FLINK_VERSION = "${flinkVersion}";
-           |  public static final String CONNECTOR_VERSION = "${version.value}";
+           |public final class Meta {
+           |    public static final String FLINK_VERSION = "${flinkVersion}";
+           |    public static final String CONNECTOR_VERSION = "${version.value}";
            |}
            |""".stripMargin)
       Seq(file)

--- a/build.sbt
+++ b/build.sbt
@@ -1309,8 +1309,8 @@ def javaCheckstyleSettings(checkstyleFile: String): Def.SettingsDefinition = {
   Seq(
     checkstyleConfigLocation := CheckstyleConfigLocation.File(checkstyleFile),
     checkstyleSeverityLevel := CheckstyleSeverityLevel.Error,
-    (Compile / checkstyle) := (Compile / checkstyle).triggeredBy(Compile / compile).value,
-    (Test / checkstyle) := (Test / checkstyle).triggeredBy(Test / compile).value
+    (Compile / compile) := ((Compile / compile) dependsOn (Compile / checkstyle)).value,
+    (Test / test) := ((Test / test) dependsOn (Test / checkstyle)).value
   )
 }
 

--- a/connectors/flink/src/main/scala/io/delta/flink/internal/KernelSnapshotWrapper.java
+++ b/connectors/flink/src/main/scala/io/delta/flink/internal/KernelSnapshotWrapper.java
@@ -23,10 +23,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import io.delta.kernel.data.ColumnVector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import io.delta.kernel.data.ColumnVector;
 
 import io.delta.standalone.DeltaScan;
 import io.delta.standalone.actions.AddFile;

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -45,7 +45,7 @@ libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionSch
 
 addSbtPlugin("net.aichler" % "sbt-jupiter-interface" % "0.9.1")
 
-addSbtPlugin("com.etsy" % "sbt-checkstyle-plugin" % "3.1.1")
+addSbtPlugin("software.purpledragon" % "sbt-checkstyle-plugin" % "4.0.1")
 // By default, sbt-checkstyle-plugin uses checkstyle version 6.15, but we should set it to use the
 // same version as Spark
-dependencyOverrides += "com.puppycrawl.tools" % "checkstyle" % "8.43"
+dependencyOverrides += "com.puppycrawl.tools" % "checkstyle" % "9.3"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [X] Other (fill in here)

## Description

https://github.com/delta-io/delta/pull/2828 upgrades the SBT version from 1.5.5 to 1.9.9 which causes `projectName/checkstyle` to fail with
```
sbt:delta> kernelApi/checkstyle
[error] stack trace is suppressed; run last kernelApi / checkstyle for the full output
[error] (kernelApi / checkstyle) org.xml.sax.SAXParseException; lineNumber: 18; columnNumber: 10; DOCTYPE is disallowed when the feature "http://apache.org/xml/features/disallow-doctype-decl" set to true.
[error] Total time: 0 s, completed May 1, 2024 2:59:48 PM
```

This failure was silent in our CI runs for some reason, if you search the logs before that commit you can see "checkstyle" in them but no instances after. This is a little concerning but don't really have time to figure out why this was silent.

For now, upgrades versions to match Spark's current plugins which fixes the issue. See the matching Spark PR here https://github.com/apache/spark/pull/38481.

## How was this patch tested?

Ran `kernelApi/checkstyle` locally.
TODO: verify it's present in the CI runs after as well

## Does this PR introduce _any_ user-facing changes?

No.