### PR TITLE
[Kernel][Writes] Add support of inserting data into tables

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
@@ -117,6 +117,10 @@ public interface Transaction {
             Row transactionState,
             CloseableIterator<FilteredColumnarBatch> dataIter,
             Map<String, Literal> partitionValues) {
+
+        // Note: `partitionValues` are not used as of now in this API, but taking the partition
+        // values as input forces the connector to not pass data from multiple partitions this
+        // API in a single call.
         StructType tableSchema = getLogicalSchema(engine, transactionState);
         List<String> partitionColNames = getPartitionColumnsList(transactionState);
         validateAndSanitizePartitionValues(tableSchema, partitionColNames, partitionValues);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/engine/JsonHandler.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/engine/JsonHandler.java
@@ -110,7 +110,8 @@ public interface JsonHandler {
      * <ul>
      *     <li>Primitive types: @code boolean, byte, short, int, long, float, double, string}</li>
      *     <li>{@code struct}: any element whose value is null is not written to file</li>
-     *     <li>{@code map}: only a {@code map} with {@code string} key type is supported</li>
+     *     <li>{@code map}: only a {@code map} with {@code string} key type is supported. If an
+     *     entry value is {@code null}, it should be written to the file.</li>
      *     <li>{@code array}: {@code null} value elements are written to file</li>
      * </ul>
      *

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -172,6 +172,22 @@ public final class DeltaErrors {
         return new TableAlreadyExistsException(tablePath, message);
     }
 
+    public static KernelException dataSchemaMismatch(
+            String tablePath,
+            StructType tableSchema,
+            StructType dataSchema) {
+        String msgT = "The schema of the data to be written to the table doesn't match " +
+                "the table schema. \nTable: %s\nTable schema: %s, \nData schema: %s";
+        return new KernelException(format(msgT, tablePath, tableSchema, dataSchema));
+    }
+
+    public static KernelException partitionColumnMissingInData(
+            String tablePath,
+            String partitionColumn) {
+        String msgT = "Missing partition column '%s' in the data to be written to the table '%s'.";
+        return new KernelException(format(msgT, partitionColumn, tablePath));
+    }
+
     /* ------------------------ HELPER METHODS ----------------------------- */
     private static String formatTimestamp(long millisSinceEpochUTC) {
         return new Timestamp(millisSinceEpochUTC).toInstant().toString();

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -24,6 +24,7 @@ import io.delta.kernel.*;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.exceptions.ConcurrentWriteException;
+import io.delta.kernel.expressions.Column;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterable;
 import io.delta.kernel.utils.CloseableIterator;
@@ -158,7 +159,9 @@ public class TransactionImpl
     }
 
     private boolean isBlindAppend() {
-        return isNewTable; // Later can add more conditions to determine if it is a blind append
+        // For now, Kernel just supports blind append.
+        // Change this when read-after-write is supported.
+        return true;
     }
 
     private Map<String, String> getOperationParameters() {
@@ -170,5 +173,17 @@ public class TransactionImpl
             return Collections.singletonMap("partitionBy", partitionBy);
         }
         return Collections.emptyMap();
+    }
+
+    /**
+     * Get the part of the schema of the table that needs the statistics to be collected per file.
+     *
+     * @param engine      {@link Engine} instance to use.
+     * @param transactionState State of the transaction
+     * @return
+     */
+    public static List<Column> getStatisticsColumns(Engine engine, Row transactionState) {
+        // TODO: implement this once we start supporting collecting stats
+        return Collections.emptyList();
     }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/AddFile.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/AddFile.java
@@ -15,7 +15,21 @@
  */
 package io.delta.kernel.internal.actions;
 
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.IntStream;
+import static java.util.stream.Collectors.toMap;
+
+import io.delta.kernel.data.Row;
+import io.delta.kernel.expressions.Literal;
 import io.delta.kernel.types.*;
+import io.delta.kernel.utils.DataFileStatus;
+
+import io.delta.kernel.internal.data.GenericRow;
+import io.delta.kernel.internal.fs.Path;
+import static io.delta.kernel.internal.util.InternalUtils.relativizePath;
+import static io.delta.kernel.internal.util.PartitionUtils.serializePartitionMap;
 
 /**
  * Delta log action representing an `AddFile`
@@ -57,4 +71,35 @@ public class AddFile {
                     true /* nullable */);
     // There are more fields which are added when row-id tracking and clustering is enabled.
     // When Kernel starts supporting row-ids and clustering, we should add those fields here.
+
+    private static final Map<String, Integer> COL_NAME_TO_ORDINAL =
+            IntStream.range(0, FULL_SCHEMA.length())
+                    .boxed()
+                    .collect(toMap(i -> FULL_SCHEMA.at(i).getName(), i -> i));
+
+    /**
+     * Utility to generate `AddFile` row from the given {@link DataFileStatus} and partition values.
+     */
+    public static Row convertDataFileStatus(
+            URI tableRoot,
+            DataFileStatus dataFileStatus,
+            Map<String, Literal> partitionValues,
+            boolean dataChange) {
+        Path filePath = new Path(dataFileStatus.getPath());
+        Map<Integer, Object> valueMap = new HashMap<>();
+        valueMap.put(COL_NAME_TO_ORDINAL.get("path"),
+                relativizePath(filePath, tableRoot).toString());
+        valueMap.put(COL_NAME_TO_ORDINAL.get("partitionValues"),
+                serializePartitionMap(partitionValues));
+        valueMap.put(COL_NAME_TO_ORDINAL.get("size"), dataFileStatus.getSize());
+        valueMap.put(COL_NAME_TO_ORDINAL.get("modificationTime"),
+                dataFileStatus.getModificationTime());
+        valueMap.put(COL_NAME_TO_ORDINAL.get("dataChange"), dataChange);
+        if (dataFileStatus.getStatistics().isPresent()) {
+            valueMap.put(COL_NAME_TO_ORDINAL.get("stats"),
+                    dataFileStatus.getStatistics().get().serializeAsJson());
+        }
+        // any fields not present in the valueMap are considered null
+        return new GenericRow(FULL_SCHEMA, valueMap);
+    }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/InternalUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/InternalUtils.java
@@ -181,9 +181,4 @@ public class InternalUtils {
     public static Set<String> toLowerCaseSet(Collection<String> set) {
         return set.stream().map(String::toLowerCase).collect(Collectors.toSet());
     }
-
-    public static <T> Map<String, T> toLowerCaseKeys(Map<String, T> map) {
-        return map.entrySet().stream()
-            .collect(Collectors.toMap(e -> e.getKey().toLowerCase(), Map.Entry::getValue));
-    }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/InternalUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/InternalUtils.java
@@ -16,13 +16,18 @@
 package io.delta.kernel.internal.util;
 
 import java.io.IOException;
+import java.net.URI;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
+import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.ColumnarBatch;
@@ -30,6 +35,8 @@ import io.delta.kernel.data.Row;
 import io.delta.kernel.types.DataType;
 import io.delta.kernel.types.StringType;
 import io.delta.kernel.utils.CloseableIterator;
+
+import io.delta.kernel.internal.fs.Path;
 
 public class InternalUtils {
     private static final LocalDate EPOCH_DAY = LocalDate.ofEpochDay(0);
@@ -151,5 +158,32 @@ public class InternalUtils {
                 "Expected a non-null value for column: " + columnName);
         }
         return vector;
+    }
+
+    /**
+     * Relativize the given child path with respect to the given root URI. If the child path is
+     * already a relative path, it is returned as is.
+     *
+     * @param child
+     * @param root Root directory as URI. Relativization is done with respect to this root.
+     *             The relativize operation requires conversion to URI, so the caller is expected to
+     *             convert the root directory to URI once and use it for relativizing for multiple
+     *             child paths.
+     * @return
+     */
+    public static Path relativizePath(Path child, URI root) {
+        if (child.isAbsolute()) {
+            return new Path(root.relativize(child.toUri()));
+        }
+        return child;
+    }
+
+    public static Set<String> toLowerCaseSet(Collection<String> set) {
+        return set.stream().map(String::toLowerCase).collect(Collectors.toSet());
+    }
+
+    public static <T> Map<String, T> toLowerCaseKeys(Map<String, T> map) {
+        return map.entrySet().stream()
+            .collect(Collectors.toMap(e -> e.getKey().toLowerCase(), Map.Entry::getValue));
     }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/InternalUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/InternalUtils.java
@@ -24,7 +24,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
@@ -185,10 +185,9 @@ public class PartitionUtils {
             DataType partColType = partColField.getDataType();
 
             if (!partColType.equivalent(partValue.getDataType())) {
-                throw new IllegalArgumentException(
-                        String.format(
-                                "Partition column %s is of type %s but the value provided is of type %s",
-                                partColName, partColType, partValue.getDataType()));
+                throw new IllegalArgumentException(String.format(
+                        "Partition column %s is of type %s but the value provided is of type %s",
+                        partColName, partColType, partValue.getDataType()));
             }
         });
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
@@ -31,7 +31,6 @@ import static java.util.Arrays.asList;
 import io.delta.kernel.data.*;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.engine.ExpressionHandler;
-import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.expressions.*;
 import io.delta.kernel.types.*;
 import static io.delta.kernel.expressions.AlwaysFalse.ALWAYS_FALSE;
@@ -39,9 +38,9 @@ import static io.delta.kernel.expressions.AlwaysTrue.ALWAYS_TRUE;
 
 import io.delta.kernel.internal.InternalScanFileUtils;
 import io.delta.kernel.internal.fs.Path;
-import static io.delta.kernel.internal.util.InternalUtils.toLowerCaseKeys;
 import static io.delta.kernel.internal.util.InternalUtils.toLowerCaseSet;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+import static io.delta.kernel.internal.util.SchemaUtils.casePreservingPartitionColNames;
 
 public class PartitionUtils {
     private static final DateTimeFormatter PARTITION_TIMESTAMP_FORMATTER =
@@ -140,23 +139,60 @@ public class PartitionUtils {
     }
 
     /**
-     * Validate {@code partitionValues} contains values for every partition column.
+     * Validate {@code partitionValues} contains values for every partition column in the table
+     * and the type of the value is correct. Once validated the partition values are sanitized
+     * to match the case of the partition column names in the table schema and returned
      *
-     * @param partitionColNames List of partition columns.
-     * @param partitionValues  Map of partition column to value map.
+     * @param tableSchema       Schema of the table.
+     * @param partitionColNames Partition column name. These should be from the table metadata
+     *                          that retain the same case as in the table schema.
+     * @param partitionValues   Map of partition column to value map given by the connector
+     * @return Sanitized partition values.
      */
-    public static void validatePartitionValues(
+    public static Map<String, Literal> validateAndSanitizePartitionValues(
+            StructType tableSchema,
             List<String> partitionColNames,
             Map<String, Literal> partitionValues) {
-        final Map<String, Literal> partitionValuesLowerCaseName = toLowerCaseKeys(partitionValues);
-        Set<String> partColsLowerCase = toLowerCaseSet(partitionColNames);
-        if (!partColsLowerCase.equals(partitionValuesLowerCaseName.keySet())) {
-            throw new KernelException(
+
+        if (!toLowerCaseSet(partitionColNames)
+                .equals(toLowerCaseSet(partitionValues.keySet()))) {
+            throw new IllegalArgumentException(
                     String.format(
                             "Partition values provided are not matching the partition columns. " +
                                     "Partition columns: %s, Partition values: %s",
                             partitionColNames, partitionValues));
         }
+
+        // Convert the partition column names in given `partitionValues` to schema case. Schema
+        // case is the exact case the column name was given by the connector when creating the
+        // table. Comparing the column names is case-insensitive, but preserve the case as stored
+        // in the table metadata when writing the partition column name to DeltaLog
+        // (`partitionValues` in `AddFile`) or generating the target directory for writing the
+        // data belonging to a partition.
+        Map<String, Literal> schemaCasePartitionValues =
+                casePreservingPartitionColNames(partitionColNames, partitionValues);
+
+        // validate types are the same
+        schemaCasePartitionValues.entrySet().forEach(entry -> {
+            String partColName = entry.getKey();
+            Literal partValue = entry.getValue();
+            StructField partColField = tableSchema.get(partColName);
+
+            // this shouldn't happen as we have already validated the partition column names
+            checkArgument(
+                    partColField != null,
+                    "Partition column " + partColName + " is not present in the table schema");
+            DataType partColType = partColField.getDataType();
+
+            if (!partColType.equivalent(partValue.getDataType())) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Partition column %s is of type %s but the value provided is of type %s",
+                                partColName, partColType, partValue.getDataType()));
+            }
+        });
+
+        return schemaCasePartitionValues;
     }
 
     /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
@@ -31,6 +31,7 @@ import static java.util.Arrays.asList;
 import io.delta.kernel.data.*;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.engine.ExpressionHandler;
+import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.expressions.*;
 import io.delta.kernel.types.*;
 import static io.delta.kernel.expressions.AlwaysFalse.ALWAYS_FALSE;
@@ -150,7 +151,7 @@ public class PartitionUtils {
         final Map<String, Literal> partitionValuesLowerCaseName = toLowerCaseKeys(partitionValues);
         Set<String> partColsLowerCase = toLowerCaseSet(partitionColNames);
         if (!partColsLowerCase.equals(partitionValuesLowerCaseName.keySet())) {
-            throw new IllegalArgumentException(
+            throw new KernelException(
                     String.format(
                             "Partition values provided are not matching the partition columns. " +
                                     "Partition columns: %s, Partition values: %s",

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/utils/CloseableIterable.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/utils/CloseableIterable.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.util.*;
 import java.util.function.Consumer;
 
+import io.delta.kernel.exceptions.KernelException;
+
 import static io.delta.kernel.internal.util.Utils.toCloseableIterator;
 
 /**
@@ -70,7 +72,13 @@ public interface CloseableIterable<T> extends Iterable<T>, Closeable {
                 elements.add(iter.next());
             }
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            // TODO: we may need utility methods to throw the KernelException as is
+            // without wrapping in RuntimeException.
+            if (e instanceof KernelException) {
+                throw (KernelException) e;
+            } else {
+                throw new RuntimeException(e);
+            }
         }
         return new CloseableIterable<T>() {
             @Override

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/utils/DataFileStatistics.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/utils/DataFileStatistics.java
@@ -91,4 +91,9 @@ public class DataFileStatistics {
     public Map<Column, Long> getNullCounts() {
         return nullCounts;
     }
+
+    public String serializeAsJson() {
+        // TODO: implement this
+        return "{}";
+    }
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/VectorTestUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/VectorTestUtils.scala
@@ -89,4 +89,16 @@ trait VectorTestUtils {
 
     override def getLong(rowId: Int): Long = values(rowId)
   }
+
+  def selectSingleElement(size: Int, selectRowId: Int): ColumnVector = new ColumnVector {
+    override def getDataType: DataType = BooleanType.BOOLEAN
+
+    override def getSize: Int = size
+
+    override def close(): Unit = {}
+
+    override def isNullAt(rowId: Int): Boolean = false
+
+    override def getBoolean(rowId: Int): Boolean = rowId == selectRowId
+  }
 }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultJsonHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultJsonHandler.java
@@ -16,6 +16,7 @@
 package io.delta.kernel.defaults.engine;
 
 import java.io.*;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
@@ -186,7 +187,7 @@ public class DefaultJsonHandler implements JsonHandler {
             String filePath,
             CloseableIterator<Row> data,
             boolean overwrite) throws IOException {
-        Path path = new Path(filePath);
+        Path path = new Path(URI.create(filePath));
         LogStore logStore = LogStoreProvider.getLogStore(hadoopConf, path.toUri().getScheme());
         try {
             logStore.write(

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultParquetHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultParquetHandler.java
@@ -17,6 +17,7 @@ package io.delta.kernel.defaults.engine;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.URI;
 import java.util.*;
 import static java.lang.String.format;
 
@@ -103,7 +104,7 @@ public class DefaultParquetHandler implements ParquetHandler {
             CloseableIterator<FilteredColumnarBatch> dataIter,
             List<Column> statsColumns) throws IOException {
         ParquetFileWriter batchWriter =
-            new ParquetFileWriter(hadoopConf, new Path(directoryPath), statsColumns);
+            new ParquetFileWriter(hadoopConf, new Path(URI.create(directoryPath)), statsColumns);
         return batchWriter.write(dataIter);
     }
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultParquetHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultParquetHandler.java
@@ -121,7 +121,7 @@ public class DefaultParquetHandler implements ParquetHandler {
             String filePath,
             CloseableIterator<FilteredColumnarBatch> data) throws IOException {
         try {
-            Path targetPath = new Path(filePath);
+            Path targetPath = new Path(URI.create(filePath));
             LogStore logStore =
                     LogStoreProvider.getLogStore(hadoopConf, targetPath.toUri().getScheme());
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/json/JsonUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/json/JsonUtils.java
@@ -145,9 +145,11 @@ public class JsonUtils {
             ColumnVector keys = mapValue.getKeys();
             ColumnVector values = mapValue.getValues();
             for (int i = 0; i < mapValue.getSize(); i++) {
+                gen.writeFieldName(keys.getString(i));
                 if (!values.isNullAt(i)) {
-                    gen.writeFieldName(keys.getString(i));
                     writeValue(gen, values, i, mapType.getValueType());
+                } else {
+                    gen.writeNull();
                 }
             }
             gen.writeEndObject();

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/CreateCheckpointSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/CreateCheckpointSuite.scala
@@ -37,7 +37,7 @@ import io.delta.kernel.exceptions.{CheckpointAlreadyExistsException, TableNotFou
 /**
  * Test suite for `io.delta.kernel.Table.checkpoint(engine, version)`
  */
-class CreateCheckpointSuite extends AnyFunSuite with TestUtils {
+class CreateCheckpointSuite extends DeltaTableWriteSuiteBase {
 
   ///////////
   // Tests //
@@ -402,52 +402,5 @@ class CreateCheckpointSuite extends AnyFunSuite with TestUtils {
 
     // verify using Kernel reader
     checkTable(tablePath, expResults)
-  }
-
-  def verifyLastCheckpointMetadata(tablePath: String, checkpointAt: Long, expSize: Long): Unit = {
-    val filePath = f"$tablePath/_delta_log/_last_checkpoint"
-
-    val source = scala.io.Source.fromFile(filePath)
-    val result = try source.getLines().mkString(",") finally source.close()
-
-    assert(result === s"""{"version":$checkpointAt,"size":$expSize}""")
-  }
-
-  /** Helper method to remove the delta files before the given version, to make sure the read is
-   * using a checkpoint as base for state reconstruction.
-   */
-  def deleteDeltaFilesBefore(tablePath: String, beforeVersion: Long): Unit = {
-    Seq.range(0, beforeVersion).foreach { version =>
-      val filePath = new Path(f"$tablePath/_delta_log/$version%020d.json")
-      new Path(tablePath).getFileSystem(new Configuration()).delete(filePath, false /* recursive */)
-    }
-
-    // try to query a version < beforeVersion
-    val ex = intercept[VersionNotFoundException] {
-      spark.read.format("delta").option("versionAsOf", beforeVersion - 1).load(tablePath)
-    }
-    assert(ex.getMessage().contains(
-      s"Cannot time travel Delta table to version ${beforeVersion - 1}"))
-  }
-
-  def withTempDirAndEngine(f: (String, Engine) => Unit): Unit = {
-    val engine = DefaultEngine.create(new Configuration() {
-      {
-        // Set the batch sizes to small so that we get to test the multiple batch scenarios.
-        set("delta.kernel.default.parquet.reader.batch-size", "200");
-        set("delta.kernel.default.json.reader.batch-size", "200");
-      }
-    })
-    withTempDir { dir => f(dir.getAbsolutePath, engine) }
-  }
-
-  def checkpointFilePath(tablePath: String, checkpointVersion: Long): String = {
-    f"$tablePath/_delta_log/$checkpointVersion%020d.checkpoint.parquet"
-  }
-
-  def copyTable(goldenTableName: String, targetLocation: String): Unit = {
-    val source = new File(goldenTablePath(goldenTableName))
-    val target = new File(targetLocation)
-    FileUtils.copyDirectory(source, target)
   }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWriteSuiteBase.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWriteSuiteBase.scala
@@ -1,0 +1,150 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults
+
+import io.delta.golden.GoldenTableUtils.goldenTablePath
+import io.delta.kernel.data.FilteredColumnarBatch
+import io.delta.kernel.defaults.engine.DefaultEngine
+import io.delta.kernel.defaults.utils.TestUtils
+import io.delta.kernel.engine.Engine
+import io.delta.kernel.internal.InternalScanFileUtils
+import io.delta.kernel.internal.data.ScanStateRow
+import io.delta.kernel.internal.util.Utils
+import io.delta.kernel.internal.util.Utils.singletonCloseableIterator
+import io.delta.kernel.types.StructType
+import io.delta.kernel.utils.CloseableIterator
+import io.delta.kernel.{Scan, Table, TransactionCommitResult}
+import org.apache.commons.io.FileUtils
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.delta.VersionNotFoundException
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.io.File
+import java.nio.file.{Files, Paths}
+import java.util.Optional
+import scala.collection.JavaConverters._
+
+/**
+ * Common utility methods for write test suites.
+ */
+trait DeltaTableWriteSuiteBase extends AnyFunSuite with TestUtils {
+  def withTempDirAndEngine(f: (String, Engine) => Unit): Unit = {
+    val engine = DefaultEngine.create(new Configuration() {
+      {
+        // Set the batch sizes to small so that we get to test the multiple batch/file scenarios.
+        set("delta.kernel.default.parquet.reader.batch-size", "20");
+        set("delta.kernel.default.json.reader.batch-size", "20");
+        set("delta.kernel.default.parquet.writer.targetMaxFileSize", "20");
+      }
+    })
+    withTempDir { dir => f(dir.getAbsolutePath, engine) }
+  }
+
+  def verifyLastCheckpointMetadata(tablePath: String, checkpointAt: Long, expSize: Long): Unit = {
+    val filePath = f"$tablePath/_delta_log/_last_checkpoint"
+
+    val source = scala.io.Source.fromFile(filePath)
+    val result = try source.getLines().mkString(",") finally source.close()
+
+    assert(result === s"""{"version":$checkpointAt,"size":$expSize}""")
+  }
+
+  /** Helper method to remove the delta files before the given version, to make sure the read is
+   * using a checkpoint as base for state reconstruction.
+   */
+  def deleteDeltaFilesBefore(tablePath: String, beforeVersion: Long): Unit = {
+    Seq.range(0, beforeVersion).foreach { version =>
+      val filePath = new Path(f"$tablePath/_delta_log/$version%020d.json")
+      new Path(tablePath).getFileSystem(new Configuration()).delete(filePath, false /* recursive */)
+    }
+
+    // try to query a version < beforeVersion
+    val ex = intercept[VersionNotFoundException] {
+      spark.read.format("delta").option("versionAsOf", beforeVersion - 1).load(tablePath)
+    }
+    assert(ex.getMessage().contains(
+      s"Cannot time travel Delta table to version ${beforeVersion - 1}"))
+  }
+
+  def readTableUsingKernel(
+    engine: Engine,
+    tablePath: String,
+    readSchema: StructType): Seq[FilteredColumnarBatch] = {
+    val scan = Table.forPath(engine, tablePath)
+      .getLatestSnapshot(engine)
+      .getScanBuilder(engine)
+      .withReadSchema(engine, readSchema)
+      .build()
+    val scanState = scan.getScanState(engine)
+
+    val physicalDataReadSchema = ScanStateRow.getPhysicalDataReadSchema(engine, scanState)
+    var result: Seq[FilteredColumnarBatch] = Nil
+    scan.getScanFiles(engine).forEach { fileColumnarBatch =>
+      fileColumnarBatch.getRows.forEach { scanFile =>
+        val fileStatus = InternalScanFileUtils.getAddFileStatus(scanFile)
+        val physicalDataIter = engine.getParquetHandler.readParquetFiles(
+          singletonCloseableIterator(fileStatus),
+          physicalDataReadSchema,
+          Optional.empty())
+        var dataBatches: CloseableIterator[FilteredColumnarBatch] = null
+        try {
+          dataBatches = Scan.transformPhysicalData(engine, scanState, scanFile, physicalDataIter)
+          dataBatches.forEach { dataBatch => result = result :+ dataBatch }
+        } finally {
+          Utils.closeCloseables(dataBatches)
+        }
+      }
+    }
+    result
+  }
+
+  def setCheckpointInterval(tablePath: String, interval: Int): Unit = {
+    spark.sql(s"ALTER TABLE delta.`$tablePath` " +
+      s"SET TBLPROPERTIES ('delta.checkpointInterval' = '$interval')")
+  }
+
+  def dataFileCount(tablePath: String): Int = {
+    Files.walk(Paths.get(tablePath)).iterator().asScala
+      .count(path => path.toString.endsWith(".parquet") && !path.toString.contains("_delta_log"))
+  }
+
+  def checkpointFilePath(tablePath: String, checkpointVersion: Long): String = {
+    f"$tablePath/_delta_log/$checkpointVersion%020d.checkpoint.parquet"
+  }
+
+  def assertCheckpointExists(tablePath: String, atVersion: Long): Unit = {
+    val cpPath = checkpointFilePath(tablePath, checkpointVersion = atVersion)
+    assert(new File(cpPath).exists())
+  }
+
+  def copyTable(goldenTableName: String, targetLocation: String): Unit = {
+    val source = new File(goldenTablePath(goldenTableName))
+    val target = new File(targetLocation)
+    FileUtils.copyDirectory(source, target)
+  }
+
+  def checkpointIfReady(
+    engine: Engine,
+    tablePath: String,
+    result: TransactionCommitResult,
+    expSize: Long): Unit = {
+    if (result.isReadyForCheckpoint) {
+      Table.forPath(engine, tablePath).checkpoint(engine, result.getVersion)
+      verifyLastCheckpointMetadata(tablePath, checkpointAt = result.getVersion, expSize)
+    }
+  }
+}

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/json/JsonUtilsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/json/JsonUtilsSuite.scala
@@ -122,7 +122,7 @@ class JsonUtilsSuite extends AnyFunSuite with TestUtils with VectorTestUtils {
       ),
       """{
         |"c0":{"24":200,"25":201},
-        |"c1":{"25":203},
+        |"c1":{"27":null,"25":203},
         |"c3":{}
         |}""".stripMargin
     ),

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -455,6 +455,16 @@ trait TestUtils extends Assertions with SQLHelper {
     }
   }
 
+  def withSparkTimeZone(timeZone: String)(fn: () => Unit): Unit = {
+    val prevTimeZone = spark.conf.get("spark.sql.session.timeZone")
+    try {
+      spark.conf.set("spark.sql.session.timeZone", timeZone)
+      fn()
+    } finally {
+      spark.conf.set("spark.sql.session.timeZone", prevTimeZone)
+    }
+  }
+
   /**
    * Builds a MapType ColumnVector from a sequence of maps.
    */

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -19,26 +19,23 @@ import java.io.{File, FileNotFoundException}
 import java.math.{BigDecimal => BigDecimalJ}
 import java.nio.file.Files
 import java.util.{Optional, TimeZone, UUID}
-
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
-
 import io.delta.golden.GoldenTableUtils
 import io.delta.kernel.{Scan, Snapshot, Table}
-import io.delta.kernel.data.{ColumnarBatch, ColumnVector, FilteredColumnarBatch, MapValue, Row}
+import io.delta.kernel.data.{ColumnVector, ColumnarBatch, FilteredColumnarBatch, MapValue, Row}
 import io.delta.kernel.defaults.engine.DefaultEngine
 import io.delta.kernel.defaults.internal.data.vector.DefaultGenericVector
 import io.delta.kernel.engine.Engine
 import io.delta.kernel.expressions.{Column, Predicate}
 import io.delta.kernel.internal.InternalScanFileUtils
 import io.delta.kernel.internal.data.ScanStateRow
-import io.delta.kernel.internal.util.ColumnMapping
+import io.delta.kernel.internal.util.{ColumnMapping, Utils}
 import io.delta.kernel.internal.util.Utils.singletonCloseableIterator
 import io.delta.kernel.types._
 import io.delta.kernel.utils.CloseableIterator
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.shaded.org.apache.commons.io.FileUtils
-
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.{types => sparktypes}
 import org.apache.spark.sql.catalyst.plans.SQLHelper
@@ -235,6 +232,38 @@ trait TestUtils extends Assertions with SQLHelper {
           }
         } finally {
           dataBatches.close()
+        }
+      }
+    }
+    result
+  }
+
+  def readTableUsingKernel(
+    engine: Engine,
+    tablePath: String,
+    readSchema: StructType): Seq[FilteredColumnarBatch] = {
+    val scan = Table.forPath(engine, tablePath)
+      .getLatestSnapshot(engine)
+      .getScanBuilder(engine)
+      .withReadSchema(engine, readSchema)
+      .build()
+    val scanState = scan.getScanState(engine)
+
+    val physicalDataReadSchema = ScanStateRow.getPhysicalDataReadSchema(engine, scanState)
+    var result: Seq[FilteredColumnarBatch] = Nil
+    scan.getScanFiles(engine).forEach { fileColumnarBatch =>
+      fileColumnarBatch.getRows.forEach { scanFile =>
+        val fileStatus = InternalScanFileUtils.getAddFileStatus(scanFile)
+        val physicalDataIter = engine.getParquetHandler.readParquetFiles(
+          singletonCloseableIterator(fileStatus),
+          physicalDataReadSchema,
+          Optional.empty())
+        var dataBatches: CloseableIterator[FilteredColumnarBatch] = null
+        try {
+          dataBatches = Scan.transformPhysicalData(engine, scanState, scanFile, physicalDataIter)
+          dataBatches.forEach { dataBatch => result = result :+ dataBatch }
+        } finally {
+          Utils.closeCloseables(dataBatches)
         }
       }
     }


### PR DESCRIPTION
## Description
(Split from #2944)

Adds support for inserting data into the table.

## How was this patch tested?
Tests for inserting into partitioned and unpartitioned tables with various combinations of the types, partition values etc. Also tests the checkpoint is ready to create.