### PR TITLE
[Spark] Makes fields in CommitOwner-related classes private and introduces getters

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/AbstractBatchBackfillingCommitOwnerClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/AbstractBatchBackfillingCommitOwnerClient.scala
@@ -86,7 +86,7 @@ trait AbstractBatchBackfillingCommitOwnerClient extends CommitOwnerClient with L
       logStore, hadoopConf, logPath, commitVersion, actions, generateUUID())
 
     // Do the actual commit
-    val commitTimestamp = updatedActions.commitInfo.asInstanceOf[CommitInfo].getTimestamp
+    val commitTimestamp = updatedActions.getCommitInfo.asInstanceOf[CommitInfo].getTimestamp
     var commitResponse =
       commitImpl(
         logStore,
@@ -104,7 +104,7 @@ trait AbstractBatchBackfillingCommitOwnerClient extends CommitOwnerClient with L
       backfill(logStore, hadoopConf, logPath, commitVersion, fileStatus)
       val targetFile = FileNames.unsafeDeltaFile(logPath, commitVersion)
       val targetFileStatus = fs.getFileStatus(targetFile)
-      val newCommit = commitResponse.commit.copy(fileStatus = targetFileStatus)
+      val newCommit = commitResponse.getCommit.copy(fileStatus = targetFileStatus)
       commitResponse = commitResponse.copy(commit = newCommit)
     } else if (commitVersion % batchSize == 0 || mcToFsConversion) {
       logInfo(s"Making sure commits are backfilled till $commitVersion version for" +
@@ -123,9 +123,9 @@ trait AbstractBatchBackfillingCommitOwnerClient extends CommitOwnerClient with L
   private def isManagedCommitToFSConversion(
       commitVersion: Long,
       updatedActions: UpdatedActions): Boolean = {
-    val oldMetadataHasManagedCommits = updatedActions.oldMetadata.asInstanceOf[Metadata]
+    val oldMetadataHasManagedCommits = updatedActions.getOldMetadata.asInstanceOf[Metadata]
       .managedCommitOwnerName.nonEmpty
-    val newMetadataHasManagedCommits = updatedActions.newMetadata.asInstanceOf[Metadata]
+    val newMetadataHasManagedCommits = updatedActions.getNewMetadata.asInstanceOf[Metadata]
       .managedCommitOwnerName.nonEmpty
     oldMetadataHasManagedCommits && !newMetadataHasManagedCommits && commitVersion > 0
   }
@@ -146,9 +146,9 @@ trait AbstractBatchBackfillingCommitOwnerClient extends CommitOwnerClient with L
     }
     val startVersionOpt = validLastKnownBackfilledVersionOpt.map(_ + 1)
     getCommits(logPath, managedCommitTableConf, startVersionOpt, Some(version))
-      .commits
+      .getCommits
       .foreach { commit =>
-        backfill(logStore, hadoopConf, logPath, commit.version, commit.fileStatus)
+        backfill(logStore, hadoopConf, logPath, commit.getVersion, commit.getFileStatus)
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/InMemoryCommitOwner.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/InMemoryCommitOwner.scala
@@ -203,7 +203,7 @@ case class InMemoryCommitOwnerBuilder(batchSize: Long) extends CommitOwnerBuilde
   private lazy val inMemoryStore = new InMemoryCommitOwner(batchSize)
 
   /** Name of the commit-owner */
-  def name: String = "in-memory"
+  def getName: String = "in-memory"
 
   /** Returns a commit-owner based on the given conf */
   def build(conf: Map[String, String]): CommitOwnerClient = {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
@@ -977,8 +977,8 @@ class InCommitTimestampWithManagedCommitSuite
       val unbackfilledCommits =
         tableCommitOwnerClient
           .getCommits(Some(1))
-          .commits
-          .map { commit => DeltaHistoryManager.Commit(commit.version, commit.commitTimestamp)}
+          .getCommits
+          .map { commit => DeltaHistoryManager.Commit(commit.getVersion, commit.getCommitTimestamp)}
       val commits = (Seq(commit0) ++ unbackfilledCommits).toList
       // Search for the exact timestamp.
       for (commit <- commits) {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -463,7 +463,7 @@ class OptimisticTransactionSuite
 
     object RetryableNonConflictCommitOwnerBuilder$ extends CommitOwnerBuilder {
 
-      override def name: String = commitOwnerName
+      override def getName: String = commitOwnerName
 
       val commitOwnerClient: InMemoryCommitOwner = {
         new InMemoryCommitOwner(batchSize = 1000L) {
@@ -516,7 +516,7 @@ class OptimisticTransactionSuite
 
     object FileAlreadyExistsCommitOwnerBuilder extends CommitOwnerBuilder {
 
-      override def name: String = commitOwnerName
+      override def getName: String = commitOwnerName
 
       lazy val commitOwnerClient: CommitOwnerClient = {
         new InMemoryCommitOwner(batchSize = 1000L) {
@@ -835,7 +835,7 @@ class OptimisticTransactionSuite
               commitVersion: Long,
               actions: Iterator[String],
               updatedActions: UpdatedActions): CommitResponse = {
-            if (updatedActions.commitInfo.asInstanceOf[CommitInfo].operation
+            if (updatedActions.getCommitInfo.asInstanceOf[CommitInfo].operation
                 == DeltaOperations.OP_RESTORE) {
               deltaLog.startTransaction().commit(addB :: Nil, ManualUpdate)
               throw CommitFailedException(retryable = true, conflict, message = "")
@@ -846,7 +846,7 @@ class OptimisticTransactionSuite
         }
         object RetryableConflictCommitOwnerBuilder$ extends CommitOwnerBuilder {
           lazy val commitOwnerClient = new RetryableConflictCommitOwnerClient()
-          override def name: String = commitOwnerName
+          override def getName: String = commitOwnerName
           override def build(conf: Map[String, String]): CommitOwnerClient = commitOwnerClient
         }
         CommitOwnerProvider.registerBuilder(RetryableConflictCommitOwnerBuilder$)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
@@ -544,7 +544,7 @@ object ConcurrentBackfillCommitOwnerBuilder extends CommitOwnerBuilder {
   val batchSize = 5
   private lazy val concurrentBackfillCommitOwnerClient =
     ConcurrentBackfillCommitOwnerClient(synchronousBackfillThreshold = 2, batchSize)
-  override def name: String = "awaiting-commit-owner"
+  override def getName: String = "awaiting-commit-owner"
   override def build(conf: Map[String, String]): CommitOwnerClient = {
     concurrentBackfillCommitOwnerClient
   }
@@ -629,7 +629,7 @@ class SnapshotManagementParallelListingSuite extends QueryTest
         val endVersion = if (tryIncludeGapAtTheEnd) { batchSize } else { batchSize + 3 }
         withSQLConf(
             MANAGED_COMMIT_OWNER_NAME.defaultTablePropertyKey ->
-              ConcurrentBackfillCommitOwnerBuilder.name,
+              ConcurrentBackfillCommitOwnerBuilder.getName,
             DeltaSQLConf.DELTALOG_MINOR_COMPACTION_USE_FOR_READS.key -> "false") {
           withTempDir { tempDir =>
             val path = tempDir.getCanonicalPath

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/CommitOwnerClientSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/CommitOwnerClientSuite.scala
@@ -73,15 +73,15 @@ class CommitOwnerClientSuite extends QueryTest with DeltaSQLTestUtils with Share
   test("registering multiple commit-owner builders with same name") {
     object Builder1 extends CommitOwnerBuilder {
       override def build(conf: Map[String, String]): CommitOwnerClient = null
-      override def name: String = "builder-1"
+      override def getName: String = "builder-1"
     }
     object BuilderWithSameName extends CommitOwnerBuilder {
       override def build(conf: Map[String, String]): CommitOwnerClient = null
-      override def name: String = "builder-1"
+      override def getName: String = "builder-1"
     }
     object Builder3 extends CommitOwnerBuilder {
       override def build(conf: Map[String, String]): CommitOwnerClient = null
-      override def name: String = "builder-3"
+      override def getName: String = "builder-3"
     }
     CommitOwnerProvider.registerBuilder(Builder1)
     intercept[Exception] {
@@ -101,7 +101,7 @@ class CommitOwnerClientSuite extends QueryTest with DeltaSQLTestUtils with Share
           case _ => throw new IllegalArgumentException("Invalid url")
         }
       }
-      override def name: String = "cs-x"
+      override def getName: String = "cs-x"
     }
     CommitOwnerProvider.registerBuilder(Builder1)
     val cs1 = CommitOwnerProvider.getCommitOwnerClient("cs-x", Map("url" -> "url1"))
@@ -124,7 +124,7 @@ class CommitOwnerClientSuite extends QueryTest with DeltaSQLTestUtils with Share
           case _ => throw new IllegalArgumentException("Invalid url")
         }
       }
-      override def name: String = "cs-name"
+      override def getName: String = "cs-name"
     }
     CommitOwnerProvider.registerBuilder(Builder1)
     val cs1 = CommitOwnerProvider.getCommitOwnerClient("cs-name", Map("url" -> "url1"))
@@ -205,7 +205,7 @@ class CommitOwnerClientSuite extends QueryTest with DeltaSQLTestUtils with Share
       override def build(conf: Map[String, String]): CommitOwnerClient = {
         new TestCommitOwnerClient(conf("key"))
       }
-      override def name: String = "cs-name"
+      override def getName: String = "cs-name"
     }
     CommitOwnerProvider.registerBuilder(Builder1)
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitTestUtils.scala
@@ -100,7 +100,7 @@ trait ManagedCommitTestUtils
 
   def getUpdatedActionsForNonZerothCommit(commitInfo: CommitInfo): UpdatedActions = {
     val updatedActions = getUpdatedActionsForZerothCommit(commitInfo)
-    updatedActions.copy(oldMetadata = updatedActions.newMetadata)
+    updatedActions.copy(oldMetadata = updatedActions.getNewMetadata)
   }
 }
 
@@ -112,7 +112,7 @@ case class TrackingInMemoryCommitOwnerBuilder(
       new TrackingCommitOwnerClient(new PredictableUuidInMemoryCommitOwnerClient(batchSize))
     }
 
-  override def name: String = "tracking-in-memory"
+  override def getName: String = "tracking-in-memory"
   override def build(conf: Map[String, String]): CommitOwnerClient = {
     trackingInMemoryCommitOwnerClient
   }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This is the second PR in a series of PRs to move the current CommitOwner interface to its own module. PR1 is [here](https://github.com/delta-io/delta/pull/3002).

This PR makes the fields of all CommitOwner-related classes private and forces callers to use getters to access the fields. This is needed in preparation for making the CommitOwner module a Java module (the same as the existing LogStore module) and to follow Java best practices to keep fields private and only allow access through getters.

## How was this patch tested?

Simple refactor so existing tests are sufficient.

## Does this PR introduce _any_ user-facing changes?

No
