### PR TITLE
[Kernel][Infra] Fix the java checkstyle for Kernel's Meta file

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -345,10 +345,25 @@ lazy val kernelApi = (project in file("kernel/kernel-api"))
     Compile / sourceGenerators += Def.task {
       val file = (Compile / sourceManaged).value / "io" / "delta" / "kernel" / "Meta.java"
       IO.write(file,
-        s"""package io.delta.kernel;
+        s"""/*
+           | * Copyright (2024) The Delta Lake Project Authors.
+           | *
+           | * Licensed under the Apache License, Version 2.0 (the "License");
+           | * you may not use this file except in compliance with the License.
+           | * You may obtain a copy of the License at
+           | *
+           | * http://www.apache.org/licenses/LICENSE-2.0
+           | *
+           | * Unless required by applicable law or agreed to in writing, software
+           | * distributed under the License is distributed on an "AS IS" BASIS,
+           | * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+           | * See the License for the specific language governing permissions and
+           | * limitations under the License.
+           | */
+           |package io.delta.kernel;
            |
-           |final public class Meta {
-           |  public static final String KERNEL_VERSION = "${version.value}";
+           |public final class Meta {
+           |    public static final String KERNEL_VERSION = "${version.value}";
            |}
            |""".stripMargin)
       Seq(file)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Merging https://github.com/delta-io/delta/pull/3019 broke the `kernelApi/checkstyle` which is failing CI jobs since it's original tests ran before https://github.com/delta-io/delta/commit/8cdf411d2c3e483a483595d117619c4aa6e15faa was committed.

## How was this patch tested?

Checked locally that `kernelApi/checkstyle` passes.

