### PR TITLE
[Spark] Fix dropping type widening feature with multipart identifiers

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
@@ -256,22 +256,15 @@ case class TypeWideningPreDowngradeCommand(table: DeltaTableV2)
     val numFilesToRewrite = TypeWidening.numFilesRequiringRewrite(table.initialSnapshot)
     if (numFilesToRewrite == 0L) return 0L
 
-    // Get the table Id and catalog from the delta table to build a ResolvedTable plan for the reorg
-    // command.
+    // Wrap `table` in a ResolvedTable that can be passed to DeltaReorgTableCommand. The catalog &
+    // table ID won't be used by DeltaReorgTableCommand.
     import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
-    val tableId = table.spark
-      .sessionState
-      .sqlParser
-      .parseTableIdentifier(table.name).nameParts.asIdentifier
     val catalog = table.spark.sessionState.catalogManager.currentCatalog.asTableCatalog
+    val tableId = Seq(table.name()).asIdentifier
 
     val reorg = DeltaReorgTableCommand(
-      ResolvedTable.create(
-        catalog,
-        tableId,
-        table
-      ),
-      DeltaReorgTableSpec(DeltaReorgTableMode.REWRITE_TYPE_WIDENING, None)
+      target = ResolvedTable.create(catalog, tableId, table),
+      reorgTableSpec = DeltaReorgTableSpec(DeltaReorgTableMode.REWRITE_TYPE_WIDENING, None)
     )(Nil)
 
     reorg.run(table.spark)


### PR DESCRIPTION
## Description
Fix an issue found while testing the Delta 3.2 RC2:
Dropping the type widening table feature may fail parsing the table identifier:

```
ALTER TABLE default.type_widening_int DROP FEATURE 'typeWidening-preview' TRUNCATE HISTORY;

[PARSE_SYNTAX_ERROR] Syntax error at or near '.'.(line 1, pos 21)

== SQL ==
spark_catalog.default.type_widening_int
```

Parsing the table identifier isn't needed as it's not used by the REORG operation that rewrite files when dropping the feature. This change skip parsing the table identifier and directly passes the table name to the REORG command

## How was this patch tested?
Added test covering the issue
