### PR TITLE
[Spark] Extend DeltaLogSuite to have ManagedCommit coverage

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -742,7 +742,6 @@ class DeltaLogSuite extends QueryTest
     }
   }
 
-  // This test needs to be extended to Managed Commits once DeltaLogSuite gets extended.
   test("DeltaFileProviderUtils.getDeltaFilesInVersionRange") {
     withTempDir { dir =>
       val path = dir.getCanonicalPath
@@ -761,7 +760,14 @@ class DeltaLogSuite extends QueryTest
       assert(FileNames.getFileVersion(fileV2) === 2)
       assert(FileNames.getFileVersion(fileV3) === 3)
 
-      assert(filesAreUnbackfilledArray === Seq(false, false, false))
+      val backfillInterval = managedCommitBackfillBatchSize.getOrElse(0L)
+      if (backfillInterval == 0 || backfillInterval == 1) {
+        assert(filesAreUnbackfilledArray === Seq(false, false, false))
+      } else if (backfillInterval == 2) {
+        assert(filesAreUnbackfilledArray === Seq(false, false, true))
+      } else {
+        assert(filesAreUnbackfilledArray === Seq(true, true, true))
+      }
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitTestUtils.scala
@@ -177,6 +177,13 @@ class TrackingCommitOwnerClient(delegatingCommitOwnerClient: InMemoryCommitOwner
       logPath, managedCommitTableConf, startVersion, endVersion)
   }
 
+  def removeCommitTestOnly(
+      logPath: Path,
+      commitVersion: Long
+  ): Unit = {
+    delegatingCommitOwnerClient.perTableMap.get(logPath).commitsMap.remove(commitVersion)
+  }
+
   override def backfillToVersion(
       logStore: LogStore,
       hadoopConf: Configuration,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Extends DeltaLogSuite to test ManagedCommit. DeltaLogSuite already has a good coverage for Delta, hence use this suite to test MangaedCommit enabled table as well.

## How was this patch tested?
This PR itself is a test.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
