### PR TITLE
[3.2] Cherrypick some Kernel + infra related commits to branch 3.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -341,6 +341,18 @@ lazy val kernelApi = (project in file("kernel/kernel-api"))
       "com.novocode" % "junit-interface" % "0.11" % "test",
       "org.slf4j" % "slf4j-log4j12" % "1.7.36" % "test"
     ),
+    // Generate the package object to provide the version information in runtime.
+    Compile / sourceGenerators += Def.task {
+      val file = (Compile / sourceManaged).value / "io" / "delta" / "kernel" / "Meta.java"
+      IO.write(file,
+        s"""package io.delta.kernel;
+           |
+           |final public class Meta {
+           |  public static final String KERNEL_VERSION = "${version.value}";
+           |}
+           |""".stripMargin)
+      Seq(file)
+    },
     javaCheckstyleSettings("kernel/dev/checkstyle.xml"),
     // Unidoc settings
     unidocSourceFilePatterns := Seq(SourceFilePattern("io/delta/kernel/")),

--- a/build.sbt
+++ b/build.sbt
@@ -1224,9 +1224,9 @@ lazy val flink = (project in file("connectors/flink"))
       IO.write(file,
         s"""package io.delta.flink.internal;
            |
-           |final public class Meta {
-           |  public static final String FLINK_VERSION = "${flinkVersion}";
-           |  public static final String CONNECTOR_VERSION = "${version.value}";
+           |public final class Meta {
+           |    public static final String FLINK_VERSION = "${flinkVersion}";
+           |    public static final String CONNECTOR_VERSION = "${version.value}";
            |}
            |""".stripMargin)
       Seq(file)
@@ -1320,9 +1320,9 @@ def javaCheckstyleSettings(checkstyleFile: String): Def.SettingsDefinition = {
   // and during tests (e.g. build/sbt test)
   Seq(
     checkstyleConfigLocation := CheckstyleConfigLocation.File(checkstyleFile),
-    checkstyleSeverityLevel := Some(CheckstyleSeverityLevel.Error),
-    (Compile / checkstyle) := (Compile / checkstyle).triggeredBy(Compile / compile).value,
-    (Test / checkstyle) := (Test / checkstyle).triggeredBy(Test / compile).value
+    checkstyleSeverityLevel := CheckstyleSeverityLevel.Error,
+    (Compile / compile) := ((Compile / compile) dependsOn (Compile / checkstyle)).value,
+    (Test / test) := ((Test / test) dependsOn (Test / checkstyle)).value
   )
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -345,10 +345,25 @@ lazy val kernelApi = (project in file("kernel/kernel-api"))
     Compile / sourceGenerators += Def.task {
       val file = (Compile / sourceManaged).value / "io" / "delta" / "kernel" / "Meta.java"
       IO.write(file,
-        s"""package io.delta.kernel;
+        s"""/*
+           | * Copyright (2024) The Delta Lake Project Authors.
+           | *
+           | * Licensed under the Apache License, Version 2.0 (the "License");
+           | * you may not use this file except in compliance with the License.
+           | * You may obtain a copy of the License at
+           | *
+           | * http://www.apache.org/licenses/LICENSE-2.0
+           | *
+           | * Unless required by applicable law or agreed to in writing, software
+           | * distributed under the License is distributed on an "AS IS" BASIS,
+           | * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+           | * See the License for the specific language governing permissions and
+           | * limitations under the License.
+           | */
+           |package io.delta.kernel;
            |
-           |final public class Meta {
-           |  public static final String KERNEL_VERSION = "${version.value}";
+           |public final class Meta {
+           |    public static final String KERNEL_VERSION = "${version.value}";
            |}
            |""".stripMargin)
       Seq(file)

--- a/connectors/flink/src/main/scala/io/delta/flink/internal/KernelDeltaLogDelegator.scala
+++ b/connectors/flink/src/main/scala/io/delta/flink/internal/KernelDeltaLogDelegator.scala
@@ -20,9 +20,9 @@ package io.delta.standalone.internal
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-
-import io.delta.kernel.{Table, TableNotFoundException}
+import io.delta.kernel.Table
 import io.delta.kernel.defaults.engine.DefaultEngine
+import io.delta.kernel.exceptions.TableNotFoundException
 import io.delta.kernel.internal.{TableImpl, SnapshotImpl => SnapshotImplKernel}
 import io.delta.standalone.VersionLog
 import io.delta.standalone.actions.{CommitInfo => CommitInfoJ}

--- a/connectors/flink/src/main/scala/io/delta/flink/internal/KernelDeltaLogDelegator.scala
+++ b/connectors/flink/src/main/scala/io/delta/flink/internal/KernelDeltaLogDelegator.scala
@@ -22,11 +22,11 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 
 import io.delta.kernel.{Table, TableNotFoundException}
-import io.delta.kernel.defaults.client.DefaultTableClient
-import io.delta.kernel.internal.{SnapshotImpl => SnapshotImplKernel, TableImpl}
+import io.delta.kernel.defaults.engine.DefaultEngine
+import io.delta.kernel.internal.{TableImpl, SnapshotImpl => SnapshotImplKernel}
 import io.delta.standalone.VersionLog
 import io.delta.standalone.actions.{CommitInfo => CommitInfoJ}
-import io.delta.standalone.internal.{SnapshotImpl => StandaloneSnapshotImpl, InitialSnapshotImpl => StandaloneInitialSnapshotImpl}
+import io.delta.standalone.internal.{InitialSnapshotImpl => StandaloneInitialSnapshotImpl, SnapshotImpl => StandaloneSnapshotImpl}
 import io.delta.standalone.internal.util.{Clock, SystemClock}
 
 class KernelOptTxn(kernelDeltaLog: KernelDeltaLogDelegator, kernelSnapshot: KernelSnapshotDelegator)
@@ -44,7 +44,7 @@ class KernelOptTxn(kernelDeltaLog: KernelDeltaLogDelegator, kernelSnapshot: Kern
  * provides features used by flink+startTransaction.
  */
 class KernelDeltaLogDelegator(
-    tableClient: DefaultTableClient,
+    engine: DefaultEngine,
     table: TableImpl,
     standaloneDeltaLog: DeltaLogImpl,
     hadoopConf: Configuration,
@@ -68,7 +68,7 @@ class KernelDeltaLogDelegator(
   override def update(): StandaloneSnapshotImpl = {
     // get latest snapshot via kernel
     val kernelSnapshot = try {
-      table.getLatestSnapshot(tableClient).asInstanceOf[SnapshotImplKernel]
+      table.getLatestSnapshot(engine).asInstanceOf[SnapshotImplKernel]
     } catch {
       case e: TableNotFoundException =>
         return new StandaloneInitialSnapshotImpl(hadoopConf, logPath, this)
@@ -82,7 +82,7 @@ class KernelDeltaLogDelegator(
       kernelSnapshotWrapper,
       hadoopConf,
       logPath,
-      kernelSnapshot.getVersion(tableClient), // note: tableClient isn't used
+      kernelSnapshot.getVersion(engine), // note: engine isn't used
       this,
       standaloneDeltaLog
     ))
@@ -128,9 +128,9 @@ object KernelDeltaLogDelegator {
     // the kernel does not
     val standaloneDeltaLog = new DeltaLogImpl(hadoopConf, logPath, dataPathFromLog, clock)
     standaloneDeltaLog.ensureLogDirectoryExist()
-    val tableClient = DefaultTableClient.create(hadoopConf)
-    val table = Table.forPath(tableClient, dataPath).asInstanceOf[TableImpl]
+    val engine = DefaultEngine.create(hadoopConf)
+    val table = Table.forPath(engine, dataPath).asInstanceOf[TableImpl]
     // Todo: Potentially we could get the resolved paths out of the table above
-    new KernelDeltaLogDelegator(tableClient, table, standaloneDeltaLog, hadoopConf, logPath, dataPathFromLog, clock)
+    new KernelDeltaLogDelegator(engine, table, standaloneDeltaLog, hadoopConf, logPath, dataPathFromLog, clock)
   }
 }

--- a/connectors/flink/src/main/scala/io/delta/flink/internal/KernelSnapshotWrapper.java
+++ b/connectors/flink/src/main/scala/io/delta/flink/internal/KernelSnapshotWrapper.java
@@ -23,10 +23,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import io.delta.kernel.data.ColumnVector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import io.delta.kernel.data.ColumnVector;
 
 import io.delta.standalone.DeltaScan;
 import io.delta.standalone.actions.AddFile;

--- a/connectors/flink/src/main/scala/io/delta/flink/internal/KernelSnapshotWrapper.java
+++ b/connectors/flink/src/main/scala/io/delta/flink/internal/KernelSnapshotWrapper.java
@@ -73,7 +73,7 @@ public class KernelSnapshotWrapper implements io.delta.standalone.Snapshot {
      */
     @Override
     public long getVersion() {
-        // WARNING: getVersion in SnapshotImpl currently doesn't use the table client, so we can
+        // WARNING: getVersion in SnapshotImpl currently doesn't use the engine so we can
         // pass null, but if this changes this code could break
         return kernelSnapshot.getVersion(null);
     }

--- a/kernel/examples/table-reader/src/main/java/io/delta/kernel/examples/BaseTableReader.java
+++ b/kernel/examples/table-reader/src/main/java/io/delta/kernel/examples/BaseTableReader.java
@@ -37,14 +37,14 @@ import org.apache.commons.cli.ParseException;
 import org.apache.hadoop.conf.Configuration;
 
 import io.delta.kernel.TableNotFoundException;
-import io.delta.kernel.client.TableClient;
+import io.delta.kernel.engine.Engine;
 import io.delta.kernel.data.FilteredColumnarBatch;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.types.*;
 import io.delta.kernel.utils.CloseableIterator;
 
-import io.delta.kernel.defaults.client.DefaultTableClient;
+import io.delta.kernel.defaults.engine.DefaultEngine;
 
 /**
  * Base class for reading Delta Lake tables using the Delta Kernel APIs.
@@ -53,11 +53,11 @@ public abstract class BaseTableReader {
     public static final int DEFAULT_LIMIT = 20;
 
     protected final String tablePath;
-    protected final TableClient tableClient;
+    protected final Engine engine;
 
     public BaseTableReader(String tablePath) {
         this.tablePath = requireNonNull(tablePath);
-        this.tableClient = DefaultTableClient.create(new Configuration());
+        this.engine = DefaultEngine.create(new Configuration());
     }
 
     /**

--- a/kernel/examples/table-reader/src/main/java/io/delta/kernel/examples/BaseTableReader.java
+++ b/kernel/examples/table-reader/src/main/java/io/delta/kernel/examples/BaseTableReader.java
@@ -36,8 +36,8 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.hadoop.conf.Configuration;
 
-import io.delta.kernel.TableNotFoundException;
 import io.delta.kernel.engine.Engine;
+import io.delta.kernel.exceptions.TableNotFoundException;
 import io.delta.kernel.data.FilteredColumnarBatch;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.expressions.Predicate;

--- a/kernel/examples/table-reader/src/main/java/io/delta/kernel/examples/MultiThreadedTableReader.java
+++ b/kernel/examples/table-reader/src/main/java/io/delta/kernel/examples/MultiThreadedTableReader.java
@@ -31,6 +31,7 @@ import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.FilteredColumnarBatch;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.examples.utils.RowSerDe;
+import io.delta.kernel.exceptions.TableNotFoundException;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;

--- a/kernel/examples/table-reader/src/main/java/io/delta/kernel/examples/MultiThreadedTableReader.java
+++ b/kernel/examples/table-reader/src/main/java/io/delta/kernel/examples/MultiThreadedTableReader.java
@@ -26,7 +26,7 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 
 import io.delta.kernel.*;
-import io.delta.kernel.client.TableClient;
+import io.delta.kernel.engine.Engine;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.FilteredColumnarBatch;
 import io.delta.kernel.data.Row;
@@ -78,15 +78,15 @@ public class MultiThreadedTableReader
 
     public int show(int limit, Optional<List<String>> columnsOpt, Optional<Predicate> predicate)
         throws TableNotFoundException {
-        Table table = Table.forPath(tableClient, tablePath);
-        Snapshot snapshot = table.getLatestSnapshot(tableClient);
-        StructType readSchema = pruneSchema(snapshot.getSchema(tableClient), columnsOpt);
+        Table table = Table.forPath(engine, tablePath);
+        Snapshot snapshot = table.getLatestSnapshot(engine);
+        StructType readSchema = pruneSchema(snapshot.getSchema(engine), columnsOpt);
 
-        ScanBuilder scanBuilder = snapshot.getScanBuilder(tableClient)
-            .withReadSchema(tableClient, readSchema);
+        ScanBuilder scanBuilder = snapshot.getScanBuilder(engine)
+            .withReadSchema(engine, readSchema);
 
         if (predicate.isPresent()) {
-            scanBuilder = scanBuilder.withFilter(tableClient, predicate.get());
+            scanBuilder = scanBuilder.withFilter(engine, predicate.get());
         }
 
         return new Reader(limit)
@@ -140,15 +140,15 @@ public class MultiThreadedTableReader
         /**
          * Get the deserialized scan state as {@link Row} object
          */
-        Row getScanRow(TableClient tableClient) {
-            return RowSerDe.deserializeRowFromJson(tableClient, stateJson);
+        Row getScanRow(Engine engine) {
+            return RowSerDe.deserializeRowFromJson(engine, stateJson);
         }
 
         /**
          * Get the deserialized scan file as {@link Row} object
          */
-        Row getScanFileRow(TableClient tableClient) {
-            return RowSerDe.deserializeRowFromJson(tableClient, fileJson);
+        Row getScanFileRow(Engine engine) {
+            return RowSerDe.deserializeRowFromJson(engine, fileJson);
         }
     }
 
@@ -199,9 +199,9 @@ public class MultiThreadedTableReader
 
         private Runnable workGenerator(Scan scan) {
             return (() -> {
-                Row scanStateRow = scan.getScanState(tableClient);
+                Row scanStateRow = scan.getScanState(engine);
                 try(CloseableIterator<FilteredColumnarBatch> scanFileIter =
-                    scan.getScanFiles(tableClient)) {
+                    scan.getScanFiles(engine)) {
 
                     while (scanFileIter.hasNext() && !stopSignal.get()) {
                         try (CloseableIterator<Row> scanFileRows = scanFileIter.next().getRows()) {
@@ -231,15 +231,15 @@ public class MultiThreadedTableReader
                     if (work == ScanFile.POISON_PILL) {
                         return; // exit as there are no more work units
                     }
-                    Row scanState = work.getScanRow(tableClient);
-                    Row scanFile = work.getScanFileRow(tableClient);
+                    Row scanState = work.getScanRow(engine);
+                    Row scanFile = work.getScanFileRow(engine);
                     FileStatus fileStatus =
                         InternalScanFileUtils.getAddFileStatus(scanFile);
                     StructType physicalReadSchema =
-                        ScanStateRow.getPhysicalDataReadSchema(tableClient, scanState);
+                        ScanStateRow.getPhysicalDataReadSchema(engine, scanState);
 
                     CloseableIterator<ColumnarBatch> physicalDataIter =
-                        tableClient.getParquetHandler().readParquetFiles(
+                        engine.getParquetHandler().readParquetFiles(
                             singletonCloseableIterator(fileStatus),
                             physicalReadSchema,
                             Optional.empty());
@@ -247,7 +247,7 @@ public class MultiThreadedTableReader
                     try (
                         CloseableIterator<FilteredColumnarBatch> dataIter =
                             Scan.transformPhysicalData(
-                                tableClient,
+                                engine,
                                 scanState,
                                 scanFile,
                                 physicalDataIter)) {

--- a/kernel/examples/table-reader/src/main/java/io/delta/kernel/examples/SingleThreadedTableReader.java
+++ b/kernel/examples/table-reader/src/main/java/io/delta/kernel/examples/SingleThreadedTableReader.java
@@ -25,6 +25,7 @@ import io.delta.kernel.*;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.FilteredColumnarBatch;
 import io.delta.kernel.data.Row;
+import io.delta.kernel.exceptions.TableNotFoundException;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;

--- a/kernel/examples/table-reader/src/main/java/io/delta/kernel/examples/SingleThreadedTableReader.java
+++ b/kernel/examples/table-reader/src/main/java/io/delta/kernel/examples/SingleThreadedTableReader.java
@@ -56,15 +56,15 @@ public class SingleThreadedTableReader
     @Override
     public int show(int limit, Optional<List<String>> columnsOpt, Optional<Predicate> predicate)
         throws TableNotFoundException, IOException {
-        Table table = Table.forPath(tableClient, tablePath);
-        Snapshot snapshot = table.getLatestSnapshot(tableClient);
-        StructType readSchema = pruneSchema(snapshot.getSchema(tableClient), columnsOpt);
+        Table table = Table.forPath(engine, tablePath);
+        Snapshot snapshot = table.getLatestSnapshot(engine);
+        StructType readSchema = pruneSchema(snapshot.getSchema(engine), columnsOpt);
 
-        ScanBuilder scanBuilder = snapshot.getScanBuilder(tableClient)
-            .withReadSchema(tableClient, readSchema);
+        ScanBuilder scanBuilder = snapshot.getScanBuilder(engine)
+            .withReadSchema(engine, readSchema);
 
         if (predicate.isPresent()) {
-            scanBuilder = scanBuilder.withFilter(tableClient, predicate.get());
+            scanBuilder = scanBuilder.withFilter(engine, predicate.get());
         }
 
         return readData(readSchema, scanBuilder.build(), limit);
@@ -95,13 +95,13 @@ public class SingleThreadedTableReader
     private int readData(StructType readSchema, Scan scan, int maxRowCount) throws IOException {
         printSchema(readSchema);
 
-        Row scanState = scan.getScanState(tableClient);
-        CloseableIterator<FilteredColumnarBatch> scanFileIter = scan.getScanFiles(tableClient);
+        Row scanState = scan.getScanState(engine);
+        CloseableIterator<FilteredColumnarBatch> scanFileIter = scan.getScanFiles(engine);
 
         int readRecordCount = 0;
         try {
             StructType physicalReadSchema =
-                ScanStateRow.getPhysicalDataReadSchema(tableClient, scanState);
+                ScanStateRow.getPhysicalDataReadSchema(engine, scanState);
             while (scanFileIter.hasNext()) {
                 FilteredColumnarBatch scanFilesBatch = scanFileIter.next();
                 try (CloseableIterator<Row> scanFileRows = scanFilesBatch.getRows()) {
@@ -110,14 +110,14 @@ public class SingleThreadedTableReader
                         FileStatus fileStatus =
                             InternalScanFileUtils.getAddFileStatus(scanFileRow);
                         CloseableIterator<ColumnarBatch> physicalDataIter =
-                            tableClient.getParquetHandler().readParquetFiles(
+                            engine.getParquetHandler().readParquetFiles(
                                 singletonCloseableIterator(fileStatus),
                                 physicalReadSchema,
                                 Optional.empty());
                         try (
                             CloseableIterator<FilteredColumnarBatch> transformedData =
                                 Scan.transformPhysicalData(
-                                    tableClient,
+                                    engine,
                                     scanState,
                                     scanFileRow,
                                     physicalDataIter)) {

--- a/kernel/examples/table-reader/src/main/java/io/delta/kernel/examples/utils/RowSerDe.java
+++ b/kernel/examples/table-reader/src/main/java/io/delta/kernel/examples/utils/RowSerDe.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import io.delta.kernel.client.TableClient;
+import io.delta.kernel.engine.Engine;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.types.*;
 
@@ -59,12 +59,12 @@ public class RowSerDe {
     /**
      * Utility method to deserialize a {@link Row} object from the JSON form.
      */
-    public static Row deserializeRowFromJson(TableClient tableClient, String jsonRowWithSchema) {
+    public static Row deserializeRowFromJson(Engine engine, String jsonRowWithSchema) {
         try {
             JsonNode jsonNode = OBJECT_MAPPER.readTree(jsonRowWithSchema);
             JsonNode schemaNode = jsonNode.get("schema");
             StructType schema =
-                tableClient.getJsonHandler().deserializeStructType(schemaNode.asText());
+                engine.getJsonHandler().deserializeStructType(schemaNode.asText());
             return parseRowFromJsonWithSchema((ObjectNode) jsonNode.get("row"), schema);
         } catch (JsonProcessingException ex) {
             throw new UncheckedIOException(ex);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
@@ -20,8 +20,8 @@ import java.io.IOException;
 import java.util.Optional;
 
 import io.delta.kernel.annotation.Evolving;
-import io.delta.kernel.client.TableClient;
 import io.delta.kernel.data.*;
+import io.delta.kernel.engine.Engine;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
@@ -47,7 +47,7 @@ public interface Scan {
     /**
      * Get an iterator of data files to scan.
      *
-     * @param tableClient {@link TableClient} instance to use in Delta Kernel.
+     * @param engine {@link Engine} instance to use in Delta Kernel.
      * @return iterator of {@link FilteredColumnarBatch}s where each selected row in
      * the batch corresponds to one scan file. Schema of each row is defined as follows:
      * <p>
@@ -87,7 +87,7 @@ public interface Scan {
      *  </ul></li>
      * </ol>
      */
-    CloseableIterator<FilteredColumnarBatch> getScanFiles(TableClient tableClient);
+    CloseableIterator<FilteredColumnarBatch> getScanFiles(Engine engine);
 
     /**
      * Get the remaining filter that is not guaranteed to be satisfied for the data Delta Kernel
@@ -101,17 +101,17 @@ public interface Scan {
      * Get the scan state associated with the current scan. This state is common across all
      * files in the scan to be read.
      *
-     * @param tableClient {@link TableClient} instance to use in Delta Kernel.
+     * @param engine {@link Engine} instance to use in Delta Kernel.
      * @return Scan state in {@link Row} format.
      */
-    Row getScanState(TableClient tableClient);
+    Row getScanState(Engine engine);
 
     /**
      * Transform the physical data read from the table data file into the logical data that expected
      * out of the Delta table.
      *
-     * @param tableClient      Connector provided {@link TableClient} implementation.
-     * @param scanState        Scan state returned by {@link Scan#getScanState(TableClient)}
+     * @param engine      Connector provided {@link Engine} implementation.
+     * @param scanState        Scan state returned by {@link Scan#getScanState(Engine)}
      * @param scanFile         Scan file from where the physical data {@code physicalDataIter} is
      *                         read from.
      * @param physicalDataIter Iterator of {@link ColumnarBatch}s containing the physical data read
@@ -123,7 +123,7 @@ public interface Scan {
      * @throws IOException when error occurs while reading the data.
      */
     static CloseableIterator<FilteredColumnarBatch> transformPhysicalData(
-            TableClient tableClient,
+            Engine engine,
             Row scanState,
             Row scanFile,
             CloseableIterator<ColumnarBatch> physicalDataIter) throws IOException {
@@ -142,8 +142,8 @@ public interface Scan {
                 if (inited) {
                     return;
                 }
-                physicalReadSchema = ScanStateRow.getPhysicalSchema(tableClient, scanState);
-                logicalReadSchema = ScanStateRow.getLogicalSchema(tableClient, scanState);
+                physicalReadSchema = ScanStateRow.getPhysicalSchema(engine, scanState);
+                logicalReadSchema = ScanStateRow.getLogicalSchema(engine, scanState);
 
                 tablePath = ScanStateRow.getTableRoot(scanState);
                 inited = true;
@@ -182,7 +182,7 @@ public interface Scan {
                     }
                     if (!dv.equals(currDV)) {
                         Tuple2<DeletionVectorDescriptor, RoaringBitmapArray> dvInfo =
-                            DeletionVectorUtils.loadNewDvAndBitmap(tableClient, tablePath, dv);
+                            DeletionVectorUtils.loadNewDvAndBitmap(engine, tablePath, dv);
                         this.currDV = dvInfo._1;
                         this.currBitmap = dvInfo._2;
                     }
@@ -197,7 +197,7 @@ public interface Scan {
                 // Add partition columns
                 nextDataBatch =
                     PartitionUtils.withPartitionColumns(
-                        tableClient.getExpressionHandler(),
+                        engine.getExpressionHandler(),
                         nextDataBatch,
                         InternalScanFileUtils.getPartitionValues(scanFile),
                         physicalReadSchema

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/ScanBuilder.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/ScanBuilder.java
@@ -17,7 +17,7 @@
 package io.delta.kernel;
 
 import io.delta.kernel.annotation.Evolving;
-import io.delta.kernel.client.TableClient;
+import io.delta.kernel.engine.Engine;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.types.StructType;
 
@@ -33,21 +33,21 @@ public interface ScanBuilder {
      * Apply the given filter expression to prune any files that do not contain data satisfying
      * the given filter.
      *
-     * @param tableClient {@link TableClient} instance to use in Delta Kernel.
+     * @param engine {@link Engine} instance to use in Delta Kernel.
      * @param predicate   a {@link Predicate} to prune the metadata or data.
      * @return A {@link ScanBuilder} with filter applied.
      */
-    ScanBuilder withFilter(TableClient tableClient, Predicate predicate);
+    ScanBuilder withFilter(Engine engine, Predicate predicate);
 
     /**
      * Apply the given <i>readSchema</i>. If the builder already has a projection applied, calling
      * this again replaces the existing projection.
      *
-     * @param tableClient {@link TableClient} instance to use in Delta Kernel.
+     * @param engine {@link Engine} instance to use in Delta Kernel.
      * @param readSchema  Subset of columns to read from the Delta table.
      * @return A {@link ScanBuilder} with projection pruning.
      */
-    ScanBuilder withReadSchema(TableClient tableClient, StructType readSchema);
+    ScanBuilder withReadSchema(Engine engine, StructType readSchema);
 
     /**
      * @return Build the {@link Scan instance}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
@@ -17,7 +17,7 @@
 package io.delta.kernel;
 
 import io.delta.kernel.annotation.Evolving;
-import io.delta.kernel.client.TableClient;
+import io.delta.kernel.engine.Engine;
 import io.delta.kernel.types.StructType;
 
 /**
@@ -31,24 +31,24 @@ public interface Snapshot {
     /**
      * Get the version of this snapshot in the table.
      *
-     * @param tableClient {@link TableClient} instance to use in Delta Kernel.
+     * @param engine {@link Engine} instance to use in Delta Kernel.
      * @return version of this snapshot in the Delta table
      */
-    long getVersion(TableClient tableClient);
+    long getVersion(Engine engine);
 
     /**
      * Get the schema of the table at this snapshot.
      *
-     * @param tableClient {@link TableClient} instance to use in Delta Kernel.
+     * @param engine {@link Engine} instance to use in Delta Kernel.
      * @return Schema of the Delta table at this snapshot.
      */
-    StructType getSchema(TableClient tableClient);
+    StructType getSchema(Engine engine);
 
     /**
      * Create a scan builder to construct a {@link Scan} to read data from this snapshot.
      *
-     * @param tableClient {@link TableClient} instance to use in Delta Kernel.
+     * @param engine {@link Engine} instance to use in Delta Kernel.
      * @return an instance of {@link ScanBuilder}
      */
-    ScanBuilder getScanBuilder(TableClient tableClient);
+    ScanBuilder getScanBuilder(Engine engine);
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Table.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Table.java
@@ -19,7 +19,9 @@ import java.io.IOException;
 
 import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.engine.Engine;
-
+import io.delta.kernel.exceptions.CheckpointAlreadyExistsException;
+import io.delta.kernel.exceptions.KernelException;
+import io.delta.kernel.exceptions.TableNotFoundException;
 import io.delta.kernel.internal.TableImpl;
 
 /**
@@ -84,6 +86,8 @@ public interface Table {
      * @param engine {@link Engine} instance to use in Delta Kernel.
      * @param versionId snapshot version to retrieve
      * @return an instance of {@link Snapshot}
+     * @throws KernelException if the provided version is less than the first available version
+     *                         or greater than the last available version
      * @since 3.2.0
      */
     Snapshot getSnapshotAsOfVersion(Engine engine, long versionId)
@@ -109,6 +113,8 @@ public interface Table {
      * @param millisSinceEpochUTC timestamp to fetch the snapshot for in milliseconds since the
      *                            unix epoch
      * @return an instance of {@link Snapshot}
+     * @throws KernelException if the provided timestamp is before the earliest available version or
+     *                         after the latest available version
      * @since 3.2.0
      */
     Snapshot getSnapshotAsOfTimestamp(Engine engine, long millisSinceEpochUTC)

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Table.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Table.java
@@ -18,7 +18,7 @@ package io.delta.kernel;
 import java.io.IOException;
 
 import io.delta.kernel.annotation.Evolving;
-import io.delta.kernel.client.TableClient;
+import io.delta.kernel.engine.Engine;
 
 import io.delta.kernel.internal.TableImpl;
 
@@ -51,42 +51,42 @@ public interface Table {
      *     </li>
      * </ul>
      *
-     * @param tableClient {@link TableClient} instance to use in Delta Kernel.
+     * @param engine {@link Engine} instance to use in Delta Kernel.
      * @param path        location of the table. Path is resolved to fully
-     *                    qualified path using the given {@code tableClient}.
+     *                    qualified path using the given {@code engine}.
      * @return an instance of {@link Table} representing the Delta table at given path
      */
-    static Table forPath(TableClient tableClient, String path) {
-        return TableImpl.forPath(tableClient, path);
+    static Table forPath(Engine engine, String path) {
+        return TableImpl.forPath(engine, path);
     }
 
     /**
      * The fully qualified path of this {@link Table} instance.
      *
-     * @param tableClient {@link TableClient} instance.
+     * @param engine {@link Engine} instance.
      * @return the table path.
      * @since 3.2.0
      */
-    String getPath(TableClient tableClient);
+    String getPath(Engine engine);
 
     /**
      * Get the latest snapshot of the table.
      *
-     * @param tableClient {@link TableClient} instance to use in Delta Kernel.
+     * @param engine {@link Engine} instance to use in Delta Kernel.
      * @return an instance of {@link Snapshot}
      */
-    Snapshot getLatestSnapshot(TableClient tableClient)
+    Snapshot getLatestSnapshot(Engine engine)
         throws TableNotFoundException;
 
     /**
      * Get the snapshot at the given {@code versionId}.
      *
-     * @param tableClient {@link TableClient} instance to use in Delta Kernel.
+     * @param engine {@link Engine} instance to use in Delta Kernel.
      * @param versionId snapshot version to retrieve
      * @return an instance of {@link Snapshot}
      * @since 3.2.0
      */
-    Snapshot getSnapshotAsOfVersion(TableClient tableClient, long versionId)
+    Snapshot getSnapshotAsOfVersion(Engine engine, long versionId)
         throws TableNotFoundException;
 
     /**
@@ -105,25 +105,25 @@ public interface Table {
      *     latest version of the table, we throw an error</li>
      * </ul>.
      *
-     * @param tableClient {@link TableClient} instance to use in Delta Kernel.
+     * @param engine {@link Engine} instance to use in Delta Kernel.
      * @param millisSinceEpochUTC timestamp to fetch the snapshot for in milliseconds since the
      *                            unix epoch
      * @return an instance of {@link Snapshot}
      * @since 3.2.0
      */
-    Snapshot getSnapshotAsOfTimestamp(TableClient tableClient, long millisSinceEpochUTC)
+    Snapshot getSnapshotAsOfTimestamp(Engine engine, long millisSinceEpochUTC)
         throws TableNotFoundException;
 
     /**
      * Checkpoint the table at given version. It writes a single checkpoint file.
      *
-     * @param tableClient {@link TableClient} instance to use.
+     * @param engine {@link Engine} instance to use.
      * @param version     Version to checkpoint.
      * @throws TableNotFoundException if the table is not found
      * @throws CheckpointAlreadyExistsException if a checkpoint already exists at the given version
      * @throws IOException for any I/O error.
      * @since 3.2.0
      */
-    void checkpoint(TableClient tableClient, long version)
+    void checkpoint(Engine engine, long version)
             throws TableNotFoundException, CheckpointAlreadyExistsException, IOException;
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/engine/Engine.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/engine/Engine.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.delta.kernel.client;
+package io.delta.kernel.engine;
 
 import io.delta.kernel.annotation.Evolving;
 
@@ -26,7 +26,7 @@ import io.delta.kernel.annotation.Evolving;
  * @since 3.0.0
  */
 @Evolving
-public interface TableClient {
+public interface Engine {
 
     /**
      * Get the connector provided {@link ExpressionHandler}.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/engine/ExpressionHandler.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/engine/ExpressionHandler.java
@@ -34,15 +34,6 @@ import io.delta.kernel.types.StructType;
  */
 @Evolving
 public interface ExpressionHandler {
-    /**
-     * Is the given expression evaluation supported on the data with given schema?
-     *
-     * @param inputSchema Schema of input data on which the expression is evaluated.
-     * @param expression Expression to check whether it is supported for evaluation.
-     * @param outputType Expected result data type.
-     * @return true if supported and false otherwise.
-     */
-    boolean isSupported(StructType inputSchema, Expression expression, DataType outputType);
 
     /**
      * Create an {@link ExpressionEvaluator} that can evaluate the given <i>expression</i> on

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/engine/ExpressionHandler.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/engine/ExpressionHandler.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.delta.kernel.client;
+package io.delta.kernel.engine;
 
 import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.data.ColumnVector;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/engine/FileReadRequest.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/engine/FileReadRequest.java
@@ -13,10 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.delta.kernel.engine;
+
+import io.delta.kernel.annotation.Evolving;
 
 /**
- * Interfaces to allow the connector to bring their own implementation of functions such
- * as reading parquet files, listing files in a file system, parsing a JSON string etc. to Delta
- * Kernel.
+ * Represents a request to read a range of bytes from a given file.
  */
-package io.delta.kernel.client;
+@Evolving
+public interface FileReadRequest {
+    /**
+     * Get the fully qualified path of the file from which to read the data.
+     */
+    String getPath();
+
+    /**
+     * Get the start offset in the file from where to start reading the data.
+     */
+    int getStartOffset();
+
+    /**
+     * Get the length of the data to read from the file starting at the <i>startOffset</i>.
+     */
+    int getReadLength();
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/engine/FileSystemClient.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/engine/FileSystemClient.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.delta.kernel.client;
+package io.delta.kernel.engine;
 
 import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/engine/JsonHandler.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/engine/JsonHandler.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.delta.kernel.client;
+package io.delta.kernel.engine;
 
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/engine/ParquetHandler.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/engine/ParquetHandler.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.delta.kernel.client;
+package io.delta.kernel.engine;
 
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/engine/package-info.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/engine/package-info.java
@@ -13,27 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.delta.kernel.client;
-
-import io.delta.kernel.annotation.Evolving;
 
 /**
- * Represents a request to read a range of bytes from a given file.
+ * Interfaces to allow the connector to bring their own implementation of functions such
+ * as reading parquet files, listing files in a file system, parsing a JSON string etc. to Delta
+ * Kernel.
  */
-@Evolving
-public interface FileReadRequest {
-    /**
-     * Get the fully qualified path of the file from which to read the data.
-     */
-    String getPath();
-
-    /**
-     * Get the start offset in the file from where to start reading the data.
-     */
-    int getStartOffset();
-
-    /**
-     * Get the length of the data to read from the file starting at the <i>startOffset</i>.
-     */
-    int getReadLength();
-}
+package io.delta.kernel.engine;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/CheckpointAlreadyExistsException.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/CheckpointAlreadyExistsException.java
@@ -13,33 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.delta.kernel.exceptions;
 
-package io.delta.kernel;
+import static java.lang.String.format;
 
 import io.delta.kernel.annotation.Evolving;
 
 /**
- * Thrown when there is no Delta table at the given location.
+ * Thrown when trying to create a checkpoint at version {@code v}, but there already exists
+ * a checkpoint at version {@code v}.
  *
- * @since 3.0.0
+ * @since 3.2.0
  */
 @Evolving
-public class TableNotFoundException
-    extends Exception {
-
-    private final String tablePath;
-
-    public TableNotFoundException(String tablePath) {
-        this.tablePath = tablePath;
-    }
-
-    public TableNotFoundException(String tablePath, Throwable cause) {
-        super(cause);
-        this.tablePath = tablePath;
-    }
-
-    @Override
-    public String getMessage() {
-        return String.format("Delta table at path `%s` is not found", tablePath);
+public class CheckpointAlreadyExistsException extends KernelException {
+    public CheckpointAlreadyExistsException(long version) {
+        super(format("Checkpoint for given version %d already exists in the table", version));
     }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/KernelException.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/KernelException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (2023) The Delta Lake Project Authors.
+ * Copyright (2024) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.delta.kernel;
-
-import static java.lang.String.format;
-
-import io.delta.kernel.annotation.Evolving;
+package io.delta.kernel.exceptions;
 
 /**
- * Thrown when trying to create a checkpoint at version {@code v}, but there already exists
- * a checkpoint at version {@code v}.
- *
- * @since 3.2.0
+ * Thrown when Kernel cannot execute the requested operation due to the operation being invalid
+ * or unsupported.
  */
-@Evolving
-public class CheckpointAlreadyExistsException extends IllegalArgumentException {
-    public CheckpointAlreadyExistsException(long version) {
-        super(format("Checkpoint for given version %d already exists in the table", version));
+public class KernelException extends RuntimeException {
+
+    public KernelException() {
+        super();
+    }
+
+    public KernelException(String message) {
+        super(message);
+    }
+
+    public KernelException(Throwable cause) {
+        super(cause);
+    }
+
+    public KernelException(String message, Throwable cause) {
+        super(message, cause);
     }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/TableNotFoundException.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/TableNotFoundException.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.exceptions;
+
+import io.delta.kernel.annotation.Evolving;
+
+/**
+ * Thrown when there is no Delta table at the given location.
+ *
+ * @since 3.0.0
+ */
+@Evolving
+public class TableNotFoundException extends KernelException {
+
+    private final String tablePath;
+
+    public TableNotFoundException(String tablePath) {
+        this(tablePath, null);
+    }
+
+    public TableNotFoundException(String tablePath, Throwable cause) {
+        super(String.format("Delta table at path `%s` is not found", tablePath), cause);
+        this.tablePath = tablePath;
+    }
+
+    /**
+     * @return the provided path where no Delta table was found
+     */
+    public String getTablePath() {
+        return tablePath;
+    }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/Predicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/Predicate.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import io.delta.kernel.annotation.Evolving;
-import io.delta.kernel.client.ExpressionHandler;
+import io.delta.kernel.engine.ExpressionHandler;
 
 /**
  * Defines predicate scalar expression which is an extension of {@link ScalarExpression}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -16,119 +16,121 @@
 package io.delta.kernel.internal;
 
 import java.sql.Timestamp;
-import java.util.Optional;
 
-import io.delta.kernel.expressions.Expression;
+import io.delta.kernel.exceptions.KernelException;
 
+/**
+ * Contains methods to create user-facing Delta exceptions.
+ */
 public final class DeltaErrors {
     private DeltaErrors() {}
 
-    // TODO update to be user-facing exception with future exception framework
-    //  (see delta-io/delta#2231) & document in method docs as needed (Table::getSnapshotAtVersion)
-    public static RuntimeException nonReconstructableStateException(
-            String tablePath, long version) {
+    public static KernelException versionBeforeFirstAvailableCommit(
+            String tablePath, long versionToLoad, long earliestVersion) {
         String message = String.format(
-            "%s: Unable to reconstruct state at version %s as the transaction log has been " +
-                "truncated due to manual deletion or the log retention policy and checkpoint " +
-                "retention policy.",
+            "%s: Cannot load table version %s as the transaction log has been truncated due to " +
+                "manual deletion or the log/checkpoint retention policy. The earliest available " +
+                "version is %s.",
             tablePath,
-            version);
-        return new RuntimeException(message);
+            versionToLoad,
+            earliestVersion);
+        return new KernelException(message);
     }
 
-    // TODO update to be user-facing exception with future exception framework
-    //  (see delta-io/delta#2231) & document in method docs as needed (Table::getSnapshotAtVersion)
-    public static RuntimeException nonExistentVersionException(
+    public static KernelException versionAfterLatestCommit(
             String tablePath, long versionToLoad, long latestVersion) {
         String message = String.format(
-            "%s: Trying to load a non-existent version %s. The latest version available is %s",
+            "%s: Cannot load table version %s as it does not exist. " +
+                "The latest available version is %s.",
             tablePath,
             versionToLoad,
             latestVersion);
-        return new RuntimeException(message);
+        return new KernelException(message);
     }
 
-    // TODO update to be user-facing exception with future exception framework
-    //  (see delta-io/delta#2231) & document in method docs as needed
-    //  (Table::getSnapshotAtTimestamp)
-    public static RuntimeException timestampEarlierThanTableFirstCommitException(
-            String tablePath, long providedTimestamp, long commitTimestamp) {
+    public static KernelException timestampBeforeFirstAvailableCommit(
+            String tablePath,
+            long providedTimestamp,
+            long earliestCommitTimestamp,
+            long earliestCommitVersion) {
         String message = String.format(
-            "%s: The provided timestamp %s ms (%s) is before the earliest version available. " +
-                "Please use a timestamp greater than or equal to %s ms (%s)",
+            "%s: The provided timestamp %s ms (%s) is before the earliest available version %s. " +
+                "Please use a timestamp greater than or equal to %s ms (%s).",
             tablePath,
             providedTimestamp,
             formatTimestamp(providedTimestamp),
-            commitTimestamp,
-            formatTimestamp(commitTimestamp));
-        return new RuntimeException(message);
+            earliestCommitVersion,
+            earliestCommitTimestamp,
+            formatTimestamp(earliestCommitTimestamp));
+        return new KernelException(message);
     }
 
-    // TODO update to be user-facing exception with future exception framework
-    //  (see delta-io/delta#2231) & document in method docs as needed
-    //  (Table::getSnapshotAtTimestamp)
-    public static RuntimeException timestampLaterThanTableLastCommit(
-            String tablePath, long providedTimestamp, long commitTimestamp, long commitVersion) {
-        String commitTimestampStr = formatTimestamp(commitTimestamp);
+    public static KernelException timestampAfterLatestCommit(
+            String tablePath,
+            long providedTimestamp,
+            long latestCommitTimestamp,
+            long latestCommitVersion) {
         String message = String.format(
-            "%s: The provided timestamp %s ms (%s) is after the latest commit with " +
-                "timestamp %s ms (%s). If you wish to query this version of the table please " +
-                "either provide the version %s or use the exact timestamp of the last " +
-                "commit %s ms (%s)",
+            "%s: The provided timestamp %s ms (%s) is after the latest available version %s. " +
+                "Please use a timestamp less than or equal to %s ms (%s).",
             tablePath,
             providedTimestamp,
             formatTimestamp(providedTimestamp),
-            commitTimestamp,
-            commitTimestampStr,
-            commitVersion,
-            commitTimestamp,
-            commitTimestampStr);
-        return new RuntimeException(message);
+            latestCommitVersion,
+            latestCommitTimestamp,
+            formatTimestamp(latestCommitTimestamp));
+        return new KernelException(message);
     }
 
-    // TODO: Change the exception to proper type as part of the exception framework
-    // (see delta-io/delta#2231)
-    /**
-     * Exception thrown when the expression evaluator doesn't support the given expression.
-     * @param expression
-     * @param reason Optional additional reason for why the expression is not supported.
-     * @return
-     */
-    public static UnsupportedOperationException unsupportedExpression(
-            Expression expression,
-            Optional<String> reason) {
+    /* ------------------------ PROTOCOL EXCEPTIONS ----------------------------- */
+
+    public static KernelException unsupportedReaderProtocol(
+            String tablePath, int tableReaderVersion) {
         String message = String.format(
-            "Expression evaluator doesn't support the expression: %s.%s",
-                expression,
-                reason.map(r -> " Reason: " + r).orElse(""));
-        return new UnsupportedOperationException(message);
+            "Unsupported Delta protocol reader version: table `%s` requires reader version %s " +
+                "which is unsupported by this version of Delta Kernel.",
+            tablePath,
+            tableReaderVersion);
+        return new KernelException(message);
     }
 
-    public static UnsupportedOperationException unsupportedReaderProtocol(int readVersion) {
-        throw new UnsupportedOperationException(
-                "Unsupported reader protocol version: " + readVersion);
+    public static KernelException unsupportedReaderFeature(
+            String tablePath, String readerFeature) {
+        String message = String.format(
+            "Unsupported Delta reader feature: table `%s` requires reader table feature \"%s\" " +
+                "which is unsupported by this version of Delta Kernel.",
+            tablePath,
+            readerFeature);
+        return new KernelException(message);
     }
 
-    public static UnsupportedOperationException unsupportedReadFeature(
-            int readProtocolVersion,
-            String readFeature) {
-        throw new UnsupportedOperationException(String.format(
-                "Unsupported reader protocol version: %s with feature: %s",
-                    readProtocolVersion, readFeature));
+    public static KernelException unsupportedWriterProtocol(
+            String tablePath, int tableWriterVersion) {
+        String message = String.format(
+            "Unsupported Delta protocol writer version: table `%s` requires writer version %s " +
+                "which is unsupported by this version of Delta Kernel.",
+            tablePath,
+            tableWriterVersion);
+        return new KernelException(message);
     }
 
-    public static UnsupportedOperationException unsupportedWriterProtocol(int writeVersion) {
-        throw new UnsupportedOperationException(
-                "Unsupported writer protocol version: " + writeVersion);
+    public static KernelException unsupportedWriterFeature(
+            String tablePath, String writerFeature) {
+        String message = String.format(
+            "Unsupported Delta writer feature: table `%s` requires writer table feature \"%s\" " +
+                "which is unsupported by this version of Delta Kernel.",
+            tablePath,
+            writerFeature);
+        return new KernelException(message);
     }
 
-    public static UnsupportedOperationException unsupportedWriteFeature(
-            int writeProtocolVersion,
-            String writeFeature) {
-        throw new UnsupportedOperationException(String.format(
-                "Unsupported writer protocol version: %s with feature: %s",
-                writeProtocolVersion, writeFeature));
+    public static KernelException columnInvariantsNotSupported() {
+        String message = "This version of Delta Kernel does not support writing to tables with " +
+            "column invariants present.";
+        return new KernelException(message);
     }
+
+    /* ------------------------ HELPER METHODS ----------------------------- */
 
     private static String formatTimestamp(long millisSinceEpochUTC) {
         return new Timestamp(millisSinceEpochUTC).toInstant().toString();

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaHistoryManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaHistoryManager.java
@@ -23,7 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.delta.kernel.TableNotFoundException;
-import io.delta.kernel.client.TableClient;
+import io.delta.kernel.engine.Engine;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
 import io.delta.kernel.internal.checkpoints.CheckpointInstance;
@@ -44,19 +44,19 @@ public final class DeltaHistoryManager {
      * exception. If the provided timestamp is before the timestamp of the earliest version of the
      * table throws an exception.
      *
-     * @param tableClient instance of {@link TableClient} to use
+     * @param engine instance of {@link Engine} to use
      * @param logPath the _delta_log path of the table
      * @param timestamp the timestamp find the version for in milliseconds since the unix epoch
      * @return the active recreatable commit version at the provided timestamp
      * @throws TableNotFoundException when there is no Delta table at the given path
      */
     public static long getActiveCommitAtTimestamp(
-            TableClient tableClient, Path logPath, long timestamp) throws TableNotFoundException {
+            Engine engine, Path logPath, long timestamp) throws TableNotFoundException {
 
-        long earliestRecreatableCommit = getEarliestRecreatableCommit(tableClient, logPath);
+        long earliestRecreatableCommit = getEarliestRecreatableCommit(engine, logPath);
 
         // Search for the commit
-        List<Commit> commits = getCommits(tableClient, logPath, earliestRecreatableCommit);
+        List<Commit> commits = getCommits(engine, logPath, earliestRecreatableCommit);
         Commit commit = lastCommitBeforeOrAtTimestamp(commits, timestamp)
             .orElseThrow(() ->
                 DeltaErrors.timestampEarlierThanTableFirstCommitException(
@@ -85,9 +85,9 @@ public final class DeltaHistoryManager {
      * We search for the earliest checkpoint we have, or whether we have the 0th delta file. This
      * method assumes that the commits are contiguous.
      */
-    private static long getEarliestRecreatableCommit(TableClient tableClient, Path logPath)
+    private static long getEarliestRecreatableCommit(Engine engine, Path logPath)
             throws TableNotFoundException {
-        try (CloseableIterator<FileStatus> files = listFrom(tableClient, logPath, 0)
+        try (CloseableIterator<FileStatus> files = listFrom(engine, logPath, 0)
             .filter(fs ->
                 FileNames.isCommitFile(getName(fs.getPath())) ||
                     FileNames.isCheckpointFile(getName(fs.getPath()))
@@ -167,12 +167,12 @@ public final class DeltaHistoryManager {
      * exist or is empty.
      */
     private static CloseableIterator<FileStatus> listFrom(
-            TableClient tableClient,
+            Engine engine,
             Path logPath,
             long startVersion) throws TableNotFoundException {
         Path tablePath = logPath.getParent();
         try {
-            CloseableIterator<FileStatus> files = tableClient
+            CloseableIterator<FileStatus> files = engine
                 .getFileSystemClient()
                 .listFrom(FileNames.listingPrefix(logPath, startVersion));
             if (!files.hasNext()) {
@@ -192,9 +192,9 @@ public final class DeltaHistoryManager {
      * Guarantees that the commits returned have both monotonically increasing versions and
      * timestamps.
      */
-    private static List<Commit> getCommits(TableClient tableClient, Path logPath, long start)
+    private static List<Commit> getCommits(Engine engine, Path logPath, long start)
             throws TableNotFoundException{
-        CloseableIterator<Commit> commits = listFrom(tableClient, logPath, start)
+        CloseableIterator<Commit> commits = listFrom(engine, logPath, start)
             .filter(fs -> FileNames.isCommitFile(getName(fs.getPath())))
             .map(fs -> new Commit(FileNames.deltaVersion(fs.getPath()), fs.getModificationTime()));
         return monotonizeCommitTimestamps(commits);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/InternalScanFileUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/InternalScanFileUtils.java
@@ -19,8 +19,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import io.delta.kernel.Scan;
-import io.delta.kernel.client.TableClient;
 import io.delta.kernel.data.Row;
+import io.delta.kernel.engine.Engine;
 import io.delta.kernel.expressions.Column;
 import io.delta.kernel.types.DataType;
 import io.delta.kernel.types.StringType;
@@ -36,7 +36,7 @@ import io.delta.kernel.internal.util.VectorUtils;
 
 /**
  * Utilities to extract information out of the scan file rows returned by
- * {@link Scan#getScanFiles(TableClient)}.
+ * {@link Scan#getScanFiles(Engine)}.
  */
 public class InternalScanFileUtils {
     private InternalScanFileUtils() {}
@@ -67,7 +67,7 @@ public class InternalScanFileUtils {
         .add(TABLE_ROOT_STRUCT_FIELD);
 
     /**
-     * Schema of the returned scan files when {@link ScanImpl#getScanFiles(TableClient, boolean)}
+     * Schema of the returned scan files when {@link ScanImpl#getScanFiles(Engine, boolean)}
      * is called with {@code includeStats=true}.
      */
     public static final StructType SCAN_FILE_SCHEMA_WITH_STATS = new StructType()

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanBuilderImpl.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 
 import io.delta.kernel.Scan;
 import io.delta.kernel.ScanBuilder;
-import io.delta.kernel.client.TableClient;
+import io.delta.kernel.engine.Engine;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.types.StructType;
 
@@ -40,7 +40,7 @@ public class ScanBuilderImpl
     private final Metadata metadata;
     private final StructType snapshotSchema;
     private final LogReplay logReplay;
-    private final TableClient tableClient;
+    private final Engine engine;
 
     private StructType readSchema;
     private Optional<Predicate> predicate;
@@ -51,19 +51,19 @@ public class ScanBuilderImpl
             Metadata metadata,
             StructType snapshotSchema,
             LogReplay logReplay,
-            TableClient tableClient) {
+            Engine engine) {
         this.dataPath = dataPath;
         this.protocol = protocol;
         this.metadata = metadata;
         this.snapshotSchema = snapshotSchema;
         this.logReplay = logReplay;
-        this.tableClient = tableClient;
+        this.engine = engine;
         this.readSchema = snapshotSchema;
         this.predicate = Optional.empty();
     }
 
     @Override
-    public ScanBuilder withFilter(TableClient tableClient, Predicate predicate) {
+    public ScanBuilder withFilter(Engine engine, Predicate predicate) {
         if (this.predicate.isPresent()) {
             throw new IllegalArgumentException("There already exists a filter in current builder");
         }
@@ -72,7 +72,7 @@ public class ScanBuilderImpl
     }
 
     @Override
-    public ScanBuilder withReadSchema(TableClient tableClient, StructType readSchema) {
+    public ScanBuilder withReadSchema(Engine engine, StructType readSchema) {
         // TODO: validate the readSchema is a subset of the table schema
         this.readSchema = readSchema;
         return this;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -22,8 +22,8 @@ import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 
 import io.delta.kernel.Scan;
-import io.delta.kernel.client.TableClient;
 import io.delta.kernel.data.*;
+import io.delta.kernel.engine.Engine;
 import io.delta.kernel.expressions.*;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
@@ -93,8 +93,8 @@ public class ScanImpl implements Scan {
      * @return data in {@link ColumnarBatch} batch format. Each row correspond to one survived file.
      */
     @Override
-    public CloseableIterator<FilteredColumnarBatch> getScanFiles(TableClient tableClient) {
-        return getScanFiles(tableClient, false);
+    public CloseableIterator<FilteredColumnarBatch> getScanFiles(Engine engine) {
+        return getScanFiles(engine, false);
     }
 
     /**
@@ -106,12 +106,12 @@ public class ScanImpl implements Scan {
      * When {@code includeStats=false} the JSON file statistics may or may not be present in the
      * returned columnar batches.
      *
-     * @param tableClient the {@link TableClient} instance to use
+     * @param engine the {@link Engine} instance to use
      * @param includeStats whether to read and include the JSON statistics
      * @return the surviving scan files as {@link FilteredColumnarBatch}s
      */
     public CloseableIterator<FilteredColumnarBatch> getScanFiles(
-            TableClient tableClient, boolean includeStats) {
+            Engine engine, boolean includeStats) {
         if (accessedScanFiles) {
             throw new IllegalStateException("Scan files are already fetched from this instance");
         }
@@ -134,12 +134,12 @@ public class ScanImpl implements Scan {
                                         partitionColToStructFieldMap.get())));
 
         // Apply partition pruning
-        scanFileIter = applyPartitionPruning(tableClient, scanFileIter);
+        scanFileIter = applyPartitionPruning(engine, scanFileIter);
 
         // Apply data skipping
         if (hasDataSkippingFilter) {
             // there was a usable data skipping filter --> apply data skipping
-            scanFileIter = applyDataSkipping(tableClient, scanFileIter, dataSkippingFilter.get());
+            scanFileIter = applyDataSkipping(engine, scanFileIter, dataSkippingFilter.get());
         }
 
         // TODO when !includeStats drop the stats column if present before returning
@@ -147,7 +147,7 @@ public class ScanImpl implements Scan {
     }
 
     @Override
-    public Row getScanState(TableClient tableClient) {
+    public Row getScanState(Engine engine) {
         // Physical equivalent of the logical read schema.
         StructType physicalReadSchema = ColumnMapping.convertToPhysicalSchema(
             readSchema,
@@ -207,7 +207,7 @@ public class ScanImpl implements Scan {
     }
 
     private CloseableIterator<FilteredColumnarBatch> applyPartitionPruning(
-        TableClient tableClient,
+        Engine engine,
         CloseableIterator<FilteredColumnarBatch> scanFileIter) {
         Optional<Predicate> partitionPredicate = getPartitionsFilters();
         if (!partitionPredicate.isPresent()) {
@@ -232,7 +232,7 @@ public class ScanImpl implements Scan {
                 FilteredColumnarBatch next = scanFileIter.next();
                 if (predicateEvaluator == null) {
                     predicateEvaluator =
-                        tableClient.getExpressionHandler().getPredicateEvaluator(
+                        engine.getExpressionHandler().getPredicateEvaluator(
                             next.getData().getSchema(),
                             predicateOnScanFileBatch);
                 }
@@ -258,7 +258,7 @@ public class ScanImpl implements Scan {
     }
 
     private CloseableIterator<FilteredColumnarBatch> applyDataSkipping(
-            TableClient tableClient,
+            Engine engine,
             CloseableIterator<FilteredColumnarBatch> scanFileIter,
             DataSkippingPredicate dataSkippingFilter) {
         // Get the stats schema
@@ -280,15 +280,14 @@ public class ScanImpl implements Scan {
                 Arrays.asList(dataSkippingFilter, Literal.ofBoolean(true))),
             AlwaysTrue.ALWAYS_TRUE);
 
-        PredicateEvaluator predicateEvaluator = tableClient
+        PredicateEvaluator predicateEvaluator = engine
             .getExpressionHandler()
             .getPredicateEvaluator(prunedStatsSchema, filterToEval);
 
         return scanFileIter.map(filteredScanFileBatch -> {
 
             ColumnVector newSelectionVector = predicateEvaluator.eval(
-                DataSkippingUtils.parseJsonStats(
-                    tableClient,
+                DataSkippingUtils.parseJsonStats(engine,
                     filteredScanFileBatch,
                     prunedStatsSchema
                 ),

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableFeatures.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableFeatures.java
@@ -34,7 +34,8 @@ public class TableFeatures {
     // Helper Methods //
     ////////////////////
 
-    public static void validateReadSupportedTable(Protocol protocol, Metadata metadata) {
+    public static void validateReadSupportedTable(
+            Protocol protocol, Metadata metadata, String tablePath) {
         switch (protocol.getMinReaderVersion()) {
             case 1:
                 break;
@@ -54,12 +55,13 @@ public class TableFeatures {
                         case "v2Checkpoint":
                             break;
                         default:
-                            throw DeltaErrors.unsupportedReadFeature(3, readerFeature);
+                            throw DeltaErrors.unsupportedReaderFeature(tablePath, readerFeature);
                     }
                 }
                 break;
             default:
-                throw unsupportedReaderProtocol(protocol.getMinReaderVersion());
+                throw DeltaErrors.unsupportedReaderProtocol(
+                    tablePath, protocol.getMinReaderVersion());
         }
     }
 
@@ -79,7 +81,8 @@ public class TableFeatures {
     public static void validateWriteSupportedTable(
             Protocol protocol,
             Metadata metadata,
-            StructType tableSchema) {
+            StructType tableSchema,
+            String tablePath) {
         int minWriterVersion = protocol.getMinWriterVersion();
         switch (minWriterVersion) {
             case 1:
@@ -87,20 +90,20 @@ public class TableFeatures {
             case 2:
                 // Append-only and column invariants are the writer features added in version 2
                 // Append-only is supported, but not the invariants
-                validateNoInvariants(minWriterVersion, tableSchema);
+                validateNoInvariants(tableSchema);
                 break;
             case 3:
                 // Check constraints are added in version 3
-                throw unsupportedWriterProtocol(minWriterVersion);
+                throw unsupportedWriterProtocol(tablePath, minWriterVersion);
             case 4:
                 // CDF and generated columns are writer features added in version 4
-                throw unsupportedWriterProtocol(minWriterVersion);
+                throw unsupportedWriterProtocol(tablePath, minWriterVersion);
             case 5:
                 // Column mapping is the only one writer feature added in version 5
-                throw unsupportedWriterProtocol(minWriterVersion);
+                throw unsupportedWriterProtocol(tablePath, minWriterVersion);
             case 6:
                 // Identity is the only one writer feature added in version 6
-                throw unsupportedWriterProtocol(minWriterVersion);
+                throw unsupportedWriterProtocol(tablePath, minWriterVersion);
             case 7:
                 for (String writerFeature : protocol.getWriterFeatures()) {
                     switch (writerFeature) {
@@ -108,20 +111,20 @@ public class TableFeatures {
                         case "appendOnly":
                             break;
                         default:
-                            throw unsupportedWriteFeature(7, writerFeature);
+                            throw unsupportedWriterFeature(tablePath, writerFeature);
                     }
                 }
                 break;
             default:
-                throw unsupportedWriterProtocol(minWriterVersion);
+                throw unsupportedWriterProtocol(tablePath, minWriterVersion);
         }
     }
 
-    private static void validateNoInvariants(int minWriterVersion, StructType tableSchema) {
+    private static void validateNoInvariants(StructType tableSchema) {
         boolean hasInvariants = tableSchema.fields().stream().anyMatch(
                 field -> field.getMetadata().contains("delta.invariants"));
         if (hasInvariants) {
-            throw unsupportedWriteFeature(minWriterVersion, "invariants");
+            throw columnInvariantsNotSupported();
         }
     }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
@@ -18,16 +18,16 @@ package io.delta.kernel.internal;
 import java.io.IOException;
 
 import io.delta.kernel.*;
-import io.delta.kernel.client.TableClient;
+import io.delta.kernel.engine.Engine;
 
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.snapshot.SnapshotManager;
 
 public class TableImpl implements Table {
-    public static Table forPath(TableClient tableClient, String path) {
+    public static Table forPath(Engine engine, String path) {
         String resolvedPath;
         try {
-            resolvedPath = tableClient.getFileSystemClient().resolvePath(path);
+            resolvedPath = engine.getFileSystemClient().resolvePath(path);
         } catch (IOException io) {
             throw new RuntimeException(io);
         }
@@ -45,30 +45,30 @@ public class TableImpl implements Table {
     }
 
     @Override
-    public String getPath(TableClient tableClient) {
+    public String getPath(Engine engine) {
         return tablePath;
     }
 
     @Override
-    public Snapshot getLatestSnapshot(TableClient tableClient) throws TableNotFoundException {
-        return snapshotManager.buildLatestSnapshot(tableClient);
+    public Snapshot getLatestSnapshot(Engine engine) throws TableNotFoundException {
+        return snapshotManager.buildLatestSnapshot(engine);
     }
 
     @Override
-    public Snapshot getSnapshotAsOfVersion(TableClient tableClient, long versionId)
+    public Snapshot getSnapshotAsOfVersion(Engine engine, long versionId)
         throws TableNotFoundException {
-        return snapshotManager.getSnapshotAt(tableClient, versionId);
+        return snapshotManager.getSnapshotAt(engine, versionId);
     }
 
     @Override
-    public Snapshot getSnapshotAsOfTimestamp(TableClient tableClient, long millisSinceEpochUTC)
+    public Snapshot getSnapshotAsOfTimestamp(Engine engine, long millisSinceEpochUTC)
         throws TableNotFoundException {
-        return snapshotManager.getSnapshotForTimestamp(tableClient, millisSinceEpochUTC);
+        return snapshotManager.getSnapshotForTimestamp(engine, millisSinceEpochUTC);
     }
 
     @Override
-    public void checkpoint(TableClient tableClient, long version)
+    public void checkpoint(Engine engine, long version)
             throws TableNotFoundException, CheckpointAlreadyExistsException, IOException {
-        snapshotManager.checkpoint(tableClient, version);
+        snapshotManager.checkpoint(engine, version);
     }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
@@ -19,7 +19,8 @@ import java.io.IOException;
 
 import io.delta.kernel.*;
 import io.delta.kernel.engine.Engine;
-
+import io.delta.kernel.exceptions.CheckpointAlreadyExistsException;
+import io.delta.kernel.exceptions.TableNotFoundException;
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.snapshot.SnapshotManager;
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/Metadata.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/Metadata.java
@@ -19,8 +19,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 import static java.util.Objects.requireNonNull;
 
-import io.delta.kernel.client.TableClient;
 import io.delta.kernel.data.*;
+import io.delta.kernel.engine.Engine;
 import io.delta.kernel.types.*;
 
 import io.delta.kernel.internal.data.GenericRow;
@@ -32,14 +32,14 @@ import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 public class Metadata {
 
     public static Metadata fromColumnVector(
-            ColumnVector vector, int rowId, TableClient tableClient) {
+            ColumnVector vector, int rowId, Engine engine) {
         if (vector.isNullAt(rowId)) {
             return null;
         }
 
         final String schemaJson = requireNonNull(vector.getChild(4), rowId, "schemaString")
             .getString(rowId);
-        StructType schema = tableClient.getJsonHandler().deserializeStructType(schemaJson);
+        StructType schema = engine.getJsonHandler().deserializeStructType(schemaJson);
 
         return new Metadata(
             requireNonNull(vector.getChild(0), rowId, "id").getString(rowId),

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/checkpoints/Checkpointer.java
@@ -23,9 +23,9 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.delta.kernel.client.TableClient;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.Row;
+import io.delta.kernel.engine.Engine;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
 
@@ -81,10 +81,10 @@ public class Checkpointer {
      * Find the last complete checkpoint before (strictly less than) a given version.
      */
     public static Optional<CheckpointInstance> findLastCompleteCheckpointBefore(
-            TableClient tableClient,
+            Engine engine,
             Path tableLogPath,
             long version) {
-        return findLastCompleteCheckpointBeforeHelper(tableClient, tableLogPath, version)._1;
+        return findLastCompleteCheckpointBeforeHelper(engine, tableLogPath, version)._1;
     }
 
     /**
@@ -93,7 +93,7 @@ public class Checkpointer {
      */
     protected static Tuple2<Optional<CheckpointInstance>, Long>
             findLastCompleteCheckpointBeforeHelper(
-                    TableClient tableClient,
+                    Engine engine,
                     Path tableLogPath,
                     long version) {
         CheckpointInstance upperBoundCheckpoint = new CheckpointInstance(version);
@@ -111,7 +111,7 @@ public class Checkpointer {
         while (currentVersion >= 0) {
             try {
                 long searchLowerBound = Math.max(0, currentVersion - 1000);
-                CloseableIterator<FileStatus> deltaLogFileIter = tableClient.getFileSystemClient()
+                CloseableIterator<FileStatus> deltaLogFileIter = engine.getFileSystemClient()
                         .listFrom(FileNames.listingPrefix(tableLogPath, searchLowerBound));
 
                 List<CheckpointInstance> checkpoints = new ArrayList<>();
@@ -181,20 +181,20 @@ public class Checkpointer {
     /**
      * Returns information about the most recent checkpoint.
      */
-    public Optional<CheckpointMetaData> readLastCheckpointFile(TableClient tableClient) {
-        return loadMetadataFromFile(tableClient, 0 /* tries */);
+    public Optional<CheckpointMetaData> readLastCheckpointFile(Engine engine) {
+        return loadMetadataFromFile(engine, 0 /* tries */);
     }
 
     /**
      * Write the given data to last checkpoint metadata file.
-     * @param tableClient {@link TableClient} instance to use for writing
+     * @param engine {@link Engine} instance to use for writing
      * @param checkpointMetaData Checkpoint metadata to write
      * @throws IOException For any I/O issues.
      */
     public void writeLastCheckpointFile(
-            TableClient tableClient,
+            Engine engine,
             CheckpointMetaData checkpointMetaData) throws IOException {
-        tableClient.getJsonHandler()
+        engine.getJsonHandler()
                 .writeJsonFileAtomically(
                         lastCheckpointFilePath.toString(),
                         singletonCloseableIterator(checkpointMetaData.toRow()),
@@ -204,10 +204,10 @@ public class Checkpointer {
     /**
      * Loads the checkpoint metadata from the _last_checkpoint file.
      * <p>
-     * @param tableClient {@link TableClient instance to use}
+     * @param engine {@link Engine instance to use}
      * @param tries Number of times already tried to load the metadata before this call.
      */
-    private Optional<CheckpointMetaData> loadMetadataFromFile(TableClient tableClient, int tries) {
+    private Optional<CheckpointMetaData> loadMetadataFromFile(Engine engine, int tries) {
         if (tries >= 3) {
             // We have tried 3 times and failed. Assume the checkpoint metadata file is corrupt.
             logger.warn(
@@ -222,7 +222,7 @@ public class Checkpointer {
                     lastCheckpointFilePath.toString(), 0 /* size */, 0 /* modTime */);
 
             try (CloseableIterator<ColumnarBatch> jsonIter =
-                         tableClient.getJsonHandler().readJsonFiles(
+                         engine.getJsonHandler().readJsonFiles(
                                  singletonCloseableIterator(lastCheckpointFile),
                                  CheckpointMetaData.READ_SCHEMA,
                                  Optional.empty())) {
@@ -240,7 +240,7 @@ public class Checkpointer {
                         lastCheckpointFilePath,
                         tries);
                 Thread.sleep(1000);
-                return loadMetadataFromFile(tableClient, tries + 1);
+                return loadMetadataFromFile(engine, tries + 1);
             }
         } catch (FileNotFoundException ex) {
             return Optional.empty(); // there is no point retrying
@@ -254,7 +254,7 @@ public class Checkpointer {
                     lastCheckpointFilePath, tries);
             logger.warn(msg, ex);
             // we can retry until max tries are exhausted
-            return loadMetadataFromFile(tableClient, tries + 1);
+            return loadMetadataFromFile(engine, tries + 1);
         }
     }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ScanStateRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ScanStateRow.java
@@ -20,8 +20,8 @@ import java.util.stream.IntStream;
 import static java.util.stream.Collectors.toMap;
 
 import io.delta.kernel.Scan;
-import io.delta.kernel.client.TableClient;
 import io.delta.kernel.data.Row;
+import io.delta.kernel.engine.Engine;
 import io.delta.kernel.types.*;
 
 import io.delta.kernel.internal.actions.Metadata;
@@ -74,50 +74,50 @@ public class ScanStateRow extends GenericRow {
 
     /**
      * Utility method to get the logical schema from the scan state {@link Row} returned by
-     * {@link Scan#getScanState(TableClient)}.
+     * {@link Scan#getScanState(Engine)}.
      *
-     * @param tableClient instance of {@link TableClient} to use.
+     * @param engine instance of {@link Engine} to use.
      * @param scanState   Scan state {@link Row}
      * @return Logical schema to read from the data files.
      */
-    public static StructType getLogicalSchema(TableClient tableClient, Row scanState) {
+    public static StructType getLogicalSchema(Engine engine, Row scanState) {
         String serializedSchema =
             scanState.getString(COL_NAME_TO_ORDINAL.get("logicalSchemaString"));
-        return tableClient.getJsonHandler().deserializeStructType(serializedSchema);
+        return engine.getJsonHandler().deserializeStructType(serializedSchema);
     }
 
     /**
      * Utility method to get the physical schema from the scan state {@link Row} returned by
-     * {@link Scan#getScanState(TableClient)}.
+     * {@link Scan#getScanState(Engine)}.
      *
-     * @param tableClient instance of {@link TableClient} to use.
+     * @param engine instance of {@link Engine} to use.
      * @param scanState   Scan state {@link Row}
      * @return Physical schema to read from the data files.
      */
-    public static StructType getPhysicalSchema(TableClient tableClient, Row scanState) {
+    public static StructType getPhysicalSchema(Engine engine, Row scanState) {
         String serializedSchema =
             scanState.getString(COL_NAME_TO_ORDINAL.get("physicalSchemaString"));
-        return tableClient.getJsonHandler().deserializeStructType(serializedSchema);
+        return engine.getJsonHandler().deserializeStructType(serializedSchema);
     }
 
     /**
      * Utility method to get the physical data read schema from the scan state {@link Row}
-     * returned by {@link Scan#getScanState(TableClient)}. This schema is used to request data
+     * returned by {@link Scan#getScanState(Engine)}. This schema is used to request data
      * from the scan files for the query.
      *
-     * @param tableClient instance of {@link TableClient} to use.
+     * @param engine instance of {@link Engine} to use.
      * @param scanState   Scan state {@link Row}
      * @return Physical schema to read from the data files.
      */
-    public static StructType getPhysicalDataReadSchema(TableClient tableClient, Row scanState) {
+    public static StructType getPhysicalDataReadSchema(Engine engine, Row scanState) {
         String serializedSchema =
             scanState.getString(COL_NAME_TO_ORDINAL.get("physicalDataReadSchemaString"));
-        return tableClient.getJsonHandler().deserializeStructType(serializedSchema);
+        return engine.getJsonHandler().deserializeStructType(serializedSchema);
     }
 
     /**
      * Get the list of partition column names from the scan state {@link Row} returned by
-     * {@link Scan#getScanState(TableClient)}.
+     * {@link Scan#getScanState(Engine)}.
      *
      * @param scanState Scan state {@link Row}
      * @return List of partition column names according to the scan state.
@@ -129,7 +129,7 @@ public class ScanStateRow extends GenericRow {
 
     /**
      * Get the column mapping mode from the scan state {@link Row} returned by
-     * {@link Scan#getScanState(TableClient)}.
+     * {@link Scan#getScanState(Engine)}.
      */
     public static String getColumnMappingMode(Row scanState) {
         Map<String, String> configuration = VectorUtils.toJavaMap(
@@ -139,7 +139,7 @@ public class ScanStateRow extends GenericRow {
 
     /**
      * Get the table root from scan state {@link Row} returned by
-     * {@link Scan#getScanState(TableClient)}
+     * {@link Scan#getScanState(Engine)}
      *
      * @param scanState Scan state {@link Row}
      * @return Fully qualified path to the location of the table.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/deletionvectors/DeletionVectorStoredBitmap.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/deletionvectors/DeletionVectorStoredBitmap.java
@@ -22,8 +22,8 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.zip.CRC32;
 
-import io.delta.kernel.client.FileReadRequest;
-import io.delta.kernel.client.FileSystemClient;
+import io.delta.kernel.engine.FileReadRequest;
+import io.delta.kernel.engine.FileSystemClient;
 import io.delta.kernel.utils.CloseableIterator;
 
 import io.delta.kernel.internal.actions.DeletionVectorDescriptor;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/deletionvectors/DeletionVectorUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/deletionvectors/DeletionVectorUtils.java
@@ -19,7 +19,7 @@ package io.delta.kernel.internal.deletionvectors;
 import java.io.IOException;
 import java.util.Optional;
 
-import io.delta.kernel.client.TableClient;
+import io.delta.kernel.engine.Engine;
 
 import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
 import io.delta.kernel.internal.util.Tuple2;
@@ -29,14 +29,14 @@ import io.delta.kernel.internal.util.Tuple2;
  */
 public class DeletionVectorUtils {
     public static Tuple2<DeletionVectorDescriptor, RoaringBitmapArray> loadNewDvAndBitmap(
-        TableClient tableClient,
+        Engine engine,
         String tablePath,
         DeletionVectorDescriptor dv) {
         DeletionVectorStoredBitmap storedBitmap =
             new DeletionVectorStoredBitmap(dv, Optional.of(tablePath));
         try {
             RoaringBitmapArray bitmap = storedBitmap
-                .load(tableClient.getFileSystemClient());
+                .load(engine.getFileSystemClient());
             return new Tuple2<>(dv, bitmap);
         } catch (IOException e) {
             throw new RuntimeException("Couldn't load dv", e);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActionsIterator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActionsIterator.java
@@ -21,9 +21,9 @@ import java.io.UncheckedIOException;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import io.delta.kernel.client.TableClient;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.engine.Engine;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
@@ -48,7 +48,7 @@ import static io.delta.kernel.internal.util.Utils.toCloseableIterator;
  * Users must pass in a `readSchema` to select which actions and sub-fields they want to consume.
  */
 class ActionsIterator implements CloseableIterator<ActionWrapper> {
-    private final TableClient tableClient;
+    private final Engine engine;
 
     private final Optional<Predicate> checkpointPredicate;
 
@@ -76,11 +76,11 @@ class ActionsIterator implements CloseableIterator<ActionWrapper> {
     private boolean closed;
 
     ActionsIterator(
-            TableClient tableClient,
+            Engine engine,
             List<FileStatus> files,
             StructType readSchema,
             Optional<Predicate> checkpointPredicate) {
-        this.tableClient = tableClient;
+        this.engine = engine;
         this.checkpointPredicate = checkpointPredicate;
         this.filesList = new LinkedList<>();
         this.filesList.addAll(
@@ -188,12 +188,12 @@ class ActionsIterator implements CloseableIterator<ActionWrapper> {
 
         final CloseableIterator<ColumnarBatch> topLevelIter;
         if (fileName.endsWith(".parquet")) {
-            topLevelIter = tableClient.getParquetHandler().readParquetFiles(
+            topLevelIter = engine.getParquetHandler().readParquetFiles(
                     singletonCloseableIterator(file),
                     modifiedReadSchema,
                     checkpointPredicate);
         } else if (fileName.endsWith(".json")) {
-            topLevelIter = tableClient.getJsonHandler().readJsonFiles(
+            topLevelIter = engine.getJsonHandler().readJsonFiles(
                     singletonCloseableIterator(file),
                     modifiedReadSchema,
                     checkpointPredicate);
@@ -279,7 +279,7 @@ class ActionsIterator implements CloseableIterator<ActionWrapper> {
                     // on (faster metadata & protocol loading in subsequent runs by remembering
                     // the version of the last version where the metadata and protocol are found).
                     final CloseableIterator<ColumnarBatch> dataIter =
-                            tableClient.getJsonHandler().readJsonFiles(
+                            engine.getJsonHandler().readJsonFiles(
                                     singletonCloseableIterator(nextFile),
                                     readSchema,
                                     Optional.empty());
@@ -303,7 +303,7 @@ class ActionsIterator implements CloseableIterator<ActionWrapper> {
                     // optimizations like reading multiple files in parallel.
                     CloseableIterator<FileStatus> checkpointFiles =
                             retrieveRemainingCheckpointFiles(nextLogFile);
-                    CloseableIterator<ColumnarBatch> dataIter = tableClient.getParquetHandler()
+                    CloseableIterator<ColumnarBatch> dataIter = engine.getParquetHandler()
                             .readParquetFiles(checkpointFiles, readSchema, checkpointPredicate);
 
                     long version = checkpointVersion(nextFilePath);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/CreateCheckpointIterator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/CreateCheckpointIterator.java
@@ -19,8 +19,8 @@ package io.delta.kernel.internal.replay;
 import java.io.IOException;
 import java.util.*;
 
-import io.delta.kernel.client.TableClient;
 import io.delta.kernel.data.*;
+import io.delta.kernel.engine.Engine;
 import io.delta.kernel.utils.CloseableIterator;
 
 import io.delta.kernel.internal.actions.SetTransaction;
@@ -78,7 +78,7 @@ public class CreateCheckpointIterator implements CloseableIterator<FilteredColum
     private static final int[] METADATA_ORDINAL = getPathOrdinals(CHECKPOINT_SCHEMA, "metaData");
     private static final int[] TXN_ORDINAL = getPathOrdinals(CHECKPOINT_SCHEMA, "txn");
 
-    private final TableClient tableClient;
+    private final Engine engine;
     private final LogSegment logSegment;
 
     /**
@@ -120,10 +120,10 @@ public class CreateCheckpointIterator implements CloseableIterator<FilteredColum
     /////////////////
 
     public CreateCheckpointIterator(
-            TableClient tableClient,
+            Engine engine,
             LogSegment logSegment,
             long minFileRetentionTimestampMillis) {
-        this.tableClient = tableClient;
+        this.engine = engine;
         this.logSegment = logSegment;
         this.minFileRetentionTimestampMillis = minFileRetentionTimestampMillis;
     }
@@ -170,8 +170,7 @@ public class CreateCheckpointIterator implements CloseableIterator<FilteredColum
 
     private void initActionIterIfRequired() {
         if (this.actionsIter == null) {
-            this.actionsIter = new ActionsIterator(
-                    tableClient,
+            this.actionsIter = new ActionsIterator(engine,
                     logSegment.allLogFilesReversed(),
                     CHECKPOINT_SCHEMA,
                     Optional.empty() /* checkpoint predicate */);
@@ -368,7 +367,7 @@ public class CreateCheckpointIterator implements CloseableIterator<FilteredColum
     }
 
     private ColumnVector createSelectionVector(boolean[] selectionVectorBuffer, int size) {
-        return tableClient.getExpressionHandler()
+        return engine.getExpressionHandler()
                 .createSelectionVector(selectionVectorBuffer, 0, size);
     }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
@@ -247,7 +247,8 @@ public class LogReplay {
 
                             if (protocol != null) {
                                 // Stop since we have found the latest Protocol and Metadata.
-                                TableFeatures.validateReadSupportedTable(protocol, metadata);
+                                TableFeatures.validateReadSupportedTable(
+                                    protocol, metadata, dataPath.toString());
                                 return new Tuple2<>(protocol, metadata);
                             }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
@@ -19,10 +19,10 @@ package io.delta.kernel.internal.replay;
 import java.io.IOException;
 import java.util.Optional;
 
-import io.delta.kernel.client.TableClient;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.FilteredColumnarBatch;
+import io.delta.kernel.engine.Engine;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.types.StringType;
 import io.delta.kernel.types.StructType;
@@ -115,21 +115,21 @@ public class LogReplay {
 
     private final Path dataPath;
     private final LogSegment logSegment;
-    private final TableClient tableClient;
+    private final Engine engine;
     private final Tuple2<Protocol, Metadata> protocolAndMetadata;
 
     public LogReplay(
             Path logPath,
             Path dataPath,
             long snapshotVersion,
-            TableClient tableClient,
+            Engine engine,
             LogSegment logSegment,
             Optional<SnapshotHint> snapshotHint) {
         assertLogFilesBelongToTable(logPath, logSegment.allLogFilesUnsorted());
 
         this.dataPath = dataPath;
         this.logSegment = logSegment;
-        this.tableClient = tableClient;
+        this.engine = engine;
         this.protocolAndMetadata = loadTableProtocolAndMetadata(snapshotHint, snapshotVersion);
     }
 
@@ -168,12 +168,11 @@ public class LogReplay {
             boolean shouldReadStats,
             Optional<Predicate> checkpointPredicate) {
         final CloseableIterator<ActionWrapper> addRemoveIter =
-                new ActionsIterator(
-                        tableClient,
+                new ActionsIterator(engine,
                         logSegment.allLogFilesReversed(),
                         getAddRemoveReadSchema(shouldReadStats),
                         checkpointPredicate);
-        return new ActiveAddFilesIterator(tableClient, addRemoveIter, dataPath);
+        return new ActiveAddFilesIterator(engine, addRemoveIter, dataPath);
     }
 
     ////////////////////
@@ -204,8 +203,7 @@ public class LogReplay {
         Metadata metadata = null;
 
         try (CloseableIterator<ActionWrapper> reverseIter =
-                     new ActionsIterator(
-                             tableClient,
+                     new ActionsIterator(engine,
                              logSegment.allLogFilesReversed(),
                              PROTOCOL_METADATA_READ_SCHEMA,
                              Optional.empty())) {
@@ -245,7 +243,7 @@ public class LogReplay {
 
                     for (int i = 0; i < metadataVector.getSize(); i++) {
                         if (!metadataVector.isNullAt(i)) {
-                            metadata = Metadata.fromColumnVector(metadataVector, i, tableClient);
+                            metadata = Metadata.fromColumnVector(metadataVector, i, engine);
 
                             if (protocol != null) {
                                 // Stop since we have found the latest Protocol and Metadata.
@@ -288,8 +286,7 @@ public class LogReplay {
 
     private Optional<Long> loadLatestTransactionVersion(String applicationId) {
         try (CloseableIterator<ActionWrapper> reverseIter =
-                     new ActionsIterator(
-                             tableClient,
+                     new ActionsIterator(engine,
                              logSegment.allLogFilesReversed(),
                              SET_TRANSACTION_READ_SCHEMA,
                              Optional.empty())) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
@@ -17,10 +17,10 @@ package io.delta.kernel.internal.skipping;
 
 import java.util.*;
 
-import io.delta.kernel.client.TableClient;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.FilteredColumnarBatch;
+import io.delta.kernel.engine.Engine;
 import io.delta.kernel.expressions.*;
 import io.delta.kernel.types.*;
 import static io.delta.kernel.internal.InternalScanFileUtils.ADD_FILE_ORDINAL;
@@ -34,11 +34,11 @@ public class DataSkippingUtils {
      * return the parsed JSON stats from the scan files.
      */
     public static ColumnarBatch parseJsonStats(
-            TableClient tableClient, FilteredColumnarBatch scanFileBatch, StructType statsSchema) {
+            Engine engine, FilteredColumnarBatch scanFileBatch, StructType statsSchema) {
         ColumnVector statsVector = scanFileBatch.getData()
             .getColumnVector(ADD_FILE_ORDINAL)
             .getChild(ADD_FILE_STATS_ORDINAL);
-        return tableClient.getJsonHandler()
+        return engine.getJsonHandler()
             .parseJson(statsVector, statsSchema, scanFileBatch.getSelectionVector());
     }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -29,7 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.delta.kernel.*;
-import io.delta.kernel.client.TableClient;
+import io.delta.kernel.engine.Engine;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
 
@@ -101,76 +101,75 @@ public class SnapshotManager {
     /**
      * Construct the latest snapshot for given table.
      *
-     * @param tableClient Instance of {@link TableClient} to use.
+     * @param engine Instance of {@link Engine} to use.
      * @return
      * @throws TableNotFoundException
      */
-    public Snapshot buildLatestSnapshot(TableClient tableClient)
+    public Snapshot buildLatestSnapshot(Engine engine)
         throws TableNotFoundException {
-        return getSnapshotAtInit(tableClient);
+        return getSnapshotAtInit(engine);
     }
 
     /**
      * Construct the snapshot for the given table at the version provided.
      *
-     * @param tableClient Instance of {@link TableClient} to use.
+     * @param engine Instance of {@link Engine} to use.
      * @param version     The snapshot version to construct
      * @return a {@link Snapshot} of the table at version {@code version}
      * @throws TableNotFoundException
      */
     public Snapshot getSnapshotAt(
-            TableClient tableClient,
+            Engine engine,
             long version) throws TableNotFoundException {
 
-        Optional<LogSegment> logSegmentOpt = getLogSegmentForVersion(
-            tableClient,
+        Optional<LogSegment> logSegmentOpt = getLogSegmentForVersion(engine,
             Optional.empty(), /* startCheckpointOpt */
             Optional.of(version) /* versionToLoadOpt */);
 
         return logSegmentOpt
-            .map(logSegment -> createSnapshot(logSegment, tableClient))
+            .map(logSegment -> createSnapshot(logSegment, engine))
             .orElseThrow(() -> new TableNotFoundException(tablePath.toString()));
     }
 
     /**
      * Construct the snapshot for the given table at the provided timestamp.
      *
-     * @param tableClient         Instance of {@link TableClient} to use.
+     * @param engine         Instance of {@link Engine} to use.
      * @param millisSinceEpochUTC timestamp to fetch the snapshot for in milliseconds since the
      *                            unix epoch
      * @return a {@link Snapshot} of the table at the provided timestamp
      * @throws TableNotFoundException
      */
     public Snapshot getSnapshotForTimestamp(
-            TableClient tableClient, long millisSinceEpochUTC) throws TableNotFoundException {
+            Engine engine, long millisSinceEpochUTC) throws TableNotFoundException {
         long startTimeMillis = System.currentTimeMillis();
         long versionToRead = DeltaHistoryManager.getActiveCommitAtTimestamp(
-                tableClient, logPath, millisSinceEpochUTC);
+            engine, logPath, millisSinceEpochUTC);
         logger.info("{}: Took {}ms to fetch version at timestamp {}",
                 tablePath,
                 System.currentTimeMillis() - startTimeMillis,
                 millisSinceEpochUTC);
 
-        return getSnapshotAt(tableClient, versionToRead);
+        return getSnapshotAt(engine, versionToRead);
     }
 
-    public void checkpoint(TableClient tableClient, long version)
+    public void checkpoint(Engine engine, long version)
             throws TableNotFoundException, IOException {
         logger.info("{}: Starting checkpoint for version: {}", tablePath, version);
         // Get the snapshot corresponding the version
-        SnapshotImpl snapshot = (SnapshotImpl) getSnapshotAt(tableClient, version);
+        SnapshotImpl snapshot = (SnapshotImpl) getSnapshotAt(engine, version);
 
         // Check if writing to the given table protocol version/features is supported in Kernel
         validateWriteSupportedTable(
-                snapshot.getProtocol(), snapshot.getMetadata(), snapshot.getSchema(tableClient));
+                snapshot.getProtocol(), snapshot.getMetadata(), snapshot.getSchema(engine));
 
         Path checkpointPath = FileNames.checkpointFileSingular(logPath, version);
 
         long numberOfAddFiles = 0;
         try (CreateCheckpointIterator checkpointDataIter =
-                     snapshot.getCreateCheckpointIterator(tableClient)) {
+                     snapshot.getCreateCheckpointIterator(engine)) {
             // Write the iterator actions to the checkpoint using the Parquet handler
-            tableClient.getParquetHandler()
+            engine.getParquetHandler()
                     .writeParquetFileAtomically(
                             checkpointPath.toString(),
                             checkpointDataIter);
@@ -187,7 +186,7 @@ public class SnapshotManager {
                 new CheckpointMetaData(version, numberOfAddFiles, Optional.empty());
 
         Checkpointer checkpointer = new Checkpointer(logPath);
-        checkpointer.writeLastCheckpointFile(tableClient, checkpointMetaData);
+        checkpointer.writeLastCheckpointFile(engine, checkpointMetaData);
 
         logger.info("{}: Last checkpoint metadata file is written for version: {}",
                 tablePath, version);
@@ -217,11 +216,11 @@ public class SnapshotManager {
      * Get an iterator of files in the _delta_log directory starting with the startVersion.
      */
     private CloseableIterator<FileStatus> listFrom(
-            TableClient tableClient,
+            Engine engine,
             long startVersion)
             throws IOException {
         logger.debug("{}: startVersion: {}", tablePath, startVersion);
-        return tableClient
+        return engine
             .getFileSystemClient()
             .listFrom(FileNames.listingPrefix(logPath, startVersion));
     }
@@ -243,13 +242,12 @@ public class SnapshotManager {
      * with the startVersion. Returns None if no files are found or the directory is missing.
      */
     private Optional<CloseableIterator<FileStatus>> listFromOrNone(
-        TableClient tableClient,
+        Engine engine,
         long startVersion) {
         // LIST the directory, starting from the provided lower bound (treat missing dir as empty).
         // NOTE: "empty/missing" is _NOT_ equivalent to "contains no useful commit files."
         try {
-            CloseableIterator<FileStatus> results = listFrom(
-                tableClient,
+            CloseableIterator<FileStatus> results = listFrom(engine,
                 startVersion);
             if (results.hasNext()) {
                 return Optional.of(results);
@@ -277,7 +275,7 @@ public class SnapshotManager {
      * None if the listing returned no files at all.
      */
     protected final Optional<List<FileStatus>> listDeltaAndCheckpointFiles(
-        TableClient tableClient,
+        Engine engine,
         long startVersion,
         Optional<Long> versionToLoad) {
         versionToLoad.ifPresent(v ->
@@ -290,8 +288,7 @@ public class SnapshotManager {
             ));
         logger.debug("startVersion: {}, versionToLoad: {}", startVersion, versionToLoad);
 
-        return listFromOrNone(
-            tableClient,
+        return listFromOrNone(engine,
             startVersion).map(fileStatusesIter -> {
                 final List<FileStatus> output = new ArrayList<>();
 
@@ -337,28 +334,27 @@ public class SnapshotManager {
      * Load the Snapshot for this Delta table at initialization. This method uses the
      * `lastCheckpoint` file as a hint on where to start listing the transaction log directory.
      */
-    private SnapshotImpl getSnapshotAtInit(TableClient tableClient)
+    private SnapshotImpl getSnapshotAtInit(Engine engine)
         throws TableNotFoundException {
         Checkpointer checkpointer = new Checkpointer(logPath);
         Optional<CheckpointMetaData> lastCheckpointOpt =
-            checkpointer.readLastCheckpointFile(tableClient);
+            checkpointer.readLastCheckpointFile(engine);
         if (!lastCheckpointOpt.isPresent()) {
             logger.warn("{}: Last checkpoint file is missing or corrupted. " +
                     "Will search for the checkpoint files directly.", tablePath);
         }
         Optional<LogSegment> logSegmentOpt =
-            getLogSegmentFrom(tableClient, lastCheckpointOpt);
+            getLogSegmentFrom(engine, lastCheckpointOpt);
 
         return logSegmentOpt
             .map(logSegment -> createSnapshot(
-                logSegment,
-                tableClient))
+                logSegment, engine))
             .orElseThrow(() -> new TableNotFoundException(tablePath.toString()));
     }
 
     private SnapshotImpl createSnapshot(
             LogSegment initSegment,
-            TableClient tableClient) {
+            Engine engine) {
         final String startingFromStr = initSegment
             .checkpointVersionOpt
             .map(v -> format("starting from checkpoint version %s.", v))
@@ -373,8 +369,7 @@ public class SnapshotManager {
             logPath,
             tablePath,
             initSegment.version,
-            initSegment,
-            tableClient,
+            initSegment, engine,
             initSegment.lastCommitTimestamp,
             Optional.ofNullable(latestSnapshotHint.get())
         );
@@ -386,7 +381,7 @@ public class SnapshotManager {
                 startingFromStr);
 
         final SnapshotHint hint = new SnapshotHint(
-            snapshot.getVersion(tableClient),
+            snapshot.getVersion(engine),
             snapshot.getProtocol(),
             snapshot.getMetadata());
 
@@ -402,10 +397,9 @@ public class SnapshotManager {
      * @param startingCheckpoint A checkpoint that we can start our listing from
      */
     private Optional<LogSegment> getLogSegmentFrom(
-        TableClient tableClient,
+        Engine engine,
         Optional<CheckpointMetaData> startingCheckpoint) {
-        return getLogSegmentForVersion(
-            tableClient,
+        return getLogSegmentForVersion(engine,
             startingCheckpoint.map(x -> x.version),
             Optional.empty());
     }
@@ -427,7 +421,7 @@ public class SnapshotManager {
      * startCheckpoint. None, if the delta log directory was missing or empty.
      */
     public Optional<LogSegment> getLogSegmentForVersion(
-        TableClient tableClient,
+        Engine engine,
         Optional<Long> startCheckpoint,
         Optional<Long> versionToLoad) {
         // Only use startCheckpoint if it is <= versionToLoad
@@ -440,7 +434,7 @@ public class SnapshotManager {
             long beforeVersion = versionToLoad.get() + 1;
             long startTimeMillis = System.currentTimeMillis();
             startCheckpointToUse =
-                    findLastCompleteCheckpointBefore(tableClient, logPath, beforeVersion)
+                    findLastCompleteCheckpointBefore(engine, logPath, beforeVersion)
                     .map(x -> x.version);
 
             logger.info("{}: Took {}ms to load last checkpoint before version {}",
@@ -456,15 +450,14 @@ public class SnapshotManager {
 
         long startTimeMillis = System.currentTimeMillis();
         final Optional<List<FileStatus>> newFiles =
-            listDeltaAndCheckpointFiles(tableClient, startVersion, versionToLoad);
+            listDeltaAndCheckpointFiles(engine, startVersion, versionToLoad);
         logger.info("{}: Took {}ms to list the files after starting checkpoint",
                 tablePath,
                 System.currentTimeMillis() - startTimeMillis);
 
         startTimeMillis = System.currentTimeMillis();
         try {
-            return getLogSegmentForVersion(
-                    tableClient,
+            return getLogSegmentForVersion(engine,
                     startCheckpointToUse,
                     versionToLoad,
                     newFiles);
@@ -480,7 +473,7 @@ public class SnapshotManager {
      * and will then try to construct a new LogSegment using that.
      */
     protected Optional<LogSegment> getLogSegmentForVersion(
-        TableClient tableClient,
+        Engine engine,
         Optional<Long> startCheckpointOpt,
         Optional<Long> versionToLoadOpt,
         Optional<List<FileStatus>> filesOpt) {
@@ -519,8 +512,7 @@ public class SnapshotManager {
         } else if (newFiles.isEmpty()) {
             // The directory may be deleted and recreated and we may have stale state in our
             // DeltaLog singleton, so try listing from the first version
-            return getLogSegmentForVersion(
-                tableClient,
+            return getLogSegmentForVersion(engine,
                 Optional.empty(),
                 versionToLoadOpt);
         }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
@@ -28,9 +28,9 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import static java.util.Arrays.asList;
 
-import io.delta.kernel.client.ExpressionHandler;
-import io.delta.kernel.client.TableClient;
 import io.delta.kernel.data.*;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.engine.ExpressionHandler;
 import io.delta.kernel.expressions.*;
 import io.delta.kernel.types.*;
 import static io.delta.kernel.expressions.AlwaysFalse.ALWAYS_FALSE;
@@ -191,7 +191,7 @@ public class PartitionUtils {
     /**
      * Utility method to rewrite the partition predicate referring to the table schema as predicate
      * referring to the {@code partitionValues} in scan files read from Delta log. The scan file
-     * batch is returned by the {@link io.delta.kernel.Scan#getScanFiles(TableClient)}.
+     * batch is returned by the {@link io.delta.kernel.Scan#getScanFiles(Engine)}.
      * <p>
      * E.g. given predicate on partition columns:
      *   {@code p1 = 'new york' && p2 >= 26} where p1 is of type string and p2 is of int

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/DeltaHistoryManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/DeltaHistoryManagerSuite.scala
@@ -19,10 +19,9 @@ import java.io.FileNotFoundException
 
 import scala.reflect.ClassTag
 
+import io.delta.kernel.exceptions.TableNotFoundException
 import org.scalatest.funsuite.AnyFunSuite
-
 import io.delta.kernel.utils.FileStatus
-import io.delta.kernel.TableNotFoundException
 import io.delta.kernel.test.MockFileSystemClientUtils
 
 class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
@@ -66,12 +65,12 @@ class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtil
     checkGetActiveCommitAtTimestampError[RuntimeException](
       deltaFiles,
       -1,
-      DeltaErrors.timestampEarlierThanTableFirstCommitException(dataPath.toString, -1, 0).getMessage
+      DeltaErrors.timestampBeforeFirstAvailableCommit(dataPath.toString, -1, 0, 0).getMessage
     )
     checkGetActiveCommitAtTimestampError[RuntimeException](
       deltaFiles,
       21,
-      DeltaErrors.timestampLaterThanTableLastCommit(dataPath.toString, 21, 20, 2).getMessage
+      DeltaErrors.timestampAfterLatestCommit(dataPath.toString, 21, 20, 2).getMessage
     )
   }
 
@@ -87,12 +86,12 @@ class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtil
     checkGetActiveCommitAtTimestampError[RuntimeException](
       deltaFiles,
       -1,
-      DeltaErrors.timestampEarlierThanTableFirstCommitException(dataPath.toString, -1, 0).getMessage
+      DeltaErrors.timestampBeforeFirstAvailableCommit(dataPath.toString, -1, 0, 0).getMessage
     )
     checkGetActiveCommitAtTimestampError[RuntimeException](
       deltaFiles,
       21,
-      DeltaErrors.timestampLaterThanTableLastCommit(dataPath.toString, 21, 20, 2).getMessage
+      DeltaErrors.timestampAfterLatestCommit(dataPath.toString, 21, 20, 2).getMessage
     )
   }
 
@@ -106,12 +105,12 @@ class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtil
     checkGetActiveCommitAtTimestampError[RuntimeException](
       deltaFiles,
       8,
-      DeltaErrors.timestampEarlierThanTableFirstCommitException(dataPath.toString, 8, 20).getMessage
+      DeltaErrors.timestampBeforeFirstAvailableCommit(dataPath.toString, 8, 20, 2).getMessage
     )
     checkGetActiveCommitAtTimestampError[RuntimeException](
       deltaFiles,
       31,
-      DeltaErrors.timestampLaterThanTableLastCommit(dataPath.toString, 31, 30, 3).getMessage
+      DeltaErrors.timestampAfterLatestCommit(dataPath.toString, 31, 30, 3).getMessage
     )
   }
 
@@ -123,12 +122,12 @@ class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtil
     checkGetActiveCommitAtTimestampError[RuntimeException](
       deltaFiles,
       8,
-      DeltaErrors.timestampEarlierThanTableFirstCommitException(dataPath.toString, 8, 20).getMessage
+      DeltaErrors.timestampBeforeFirstAvailableCommit(dataPath.toString, 8, 20, 2).getMessage
     )
     checkGetActiveCommitAtTimestampError[RuntimeException](
       deltaFiles,
       21,
-      DeltaErrors.timestampLaterThanTableLastCommit(dataPath.toString, 21, 20, 2).getMessage
+      DeltaErrors.timestampAfterLatestCommit(dataPath.toString, 21, 20, 2).getMessage
     )
   }
 
@@ -142,12 +141,12 @@ class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtil
     checkGetActiveCommitAtTimestampError[RuntimeException](
       deltaFiles,
       8,
-      DeltaErrors.timestampEarlierThanTableFirstCommitException(dataPath.toString, 8, 20).getMessage
+      DeltaErrors.timestampBeforeFirstAvailableCommit(dataPath.toString, 8, 20, 2).getMessage
     )
     checkGetActiveCommitAtTimestampError[RuntimeException](
       deltaFiles,
       31,
-      DeltaErrors.timestampLaterThanTableLastCommit(dataPath.toString, 31, 30, 3).getMessage
+      DeltaErrors.timestampAfterLatestCommit(dataPath.toString, 31, 30, 3).getMessage
     )
   }
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/DeltaHistoryManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/DeltaHistoryManagerSuite.scala
@@ -32,7 +32,7 @@ class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtil
     timestamp: Long,
     expectedVersion: Long): Unit = {
     val activeCommit = DeltaHistoryManager.getActiveCommitAtTimestamp(
-      createMockFSListFromTableClient(fileList),
+      createMockFSListFromEngine(fileList),
       logPath,
       timestamp
     )
@@ -46,7 +46,7 @@ class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtil
     expectedErrorMessageContains: String)(implicit classTag: ClassTag[T]): Unit = {
     val e = intercept[T] {
       DeltaHistoryManager.getActiveCommitAtTimestamp(
-        createMockFSListFromTableClient(fileList),
+        createMockFSListFromEngine(fileList),
         logPath,
         timestamp
       )
@@ -155,7 +155,7 @@ class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtil
     // Non-existent path
     intercept[TableNotFoundException](
       DeltaHistoryManager.getActiveCommitAtTimestamp(
-        createMockFSListFromTableClient(p => throw new FileNotFoundException(p)),
+        createMockFSListFromEngine(p => throw new FileNotFoundException(p)),
         logPath,
         0
       )
@@ -163,7 +163,7 @@ class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtil
     // Empty _delta_log directory
     intercept[TableNotFoundException](
       DeltaHistoryManager.getActiveCommitAtTimestamp(
-        createMockFSListFromTableClient(p => Seq()),
+        createMockFSListFromEngine(p => Seq()),
         logPath,
         0
       )

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
@@ -202,7 +202,7 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
       }.getOrElse((Seq.empty, Seq.empty))
 
       val logSegmentOpt = snapshotManager.getLogSegmentForVersion(
-        createMockFSListFromTableClient(listFromProvider(deltas ++ checkpointFiles)("/"),
+        createMockFSListFromEngine(listFromProvider(deltas ++ checkpointFiles)("/"),
           new MockSidecarParquetHandler(expectedSidecars),
           new MockSidecarJsonHandler(expectedSidecars)),
         Optional.empty(),
@@ -300,7 +300,7 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
       expectedErrorMessageContains: String = "")(implicit classTag: ClassTag[T]): Unit = {
     val e = intercept[T] {
       snapshotManager.getLogSegmentForVersion(
-        createMockFSListFromTableClient(files),
+        createMockFSListFromEngine(files),
         startCheckpoint,
         versionToLoad
       )
@@ -424,7 +424,7 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
   test("getLogSegmentForVersion: empty delta log") {
     // listDeltaAndCheckpointFiles = Optional.empty()
     val logSegmentOpt = snapshotManager.getLogSegmentForVersion(
-      createMockFSListFromTableClient(Seq.empty),
+      createMockFSListFromEngine(Seq.empty),
       Optional.empty(),
       Optional.empty()
     )
@@ -475,7 +475,7 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
     }
     for (checkpointV <- Seq(10, 20)) {
       val logSegmentOpt = snapshotManager.getLogSegmentForVersion(
-        createMockFSListFromTableClient(listFrom(checkpointV)(_)),
+        createMockFSListFromEngine(listFrom(checkpointV)(_)),
         Optional.of(checkpointV),
         Optional.empty()
       )
@@ -687,7 +687,7 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
       expectedErrorMessageContains = "Could not find any delta files for version 10"
     )
     val logSegment = snapshotManager.getLogSegmentForVersion(
-      createMockFSListFromTableClient(fileList),
+      createMockFSListFromEngine(fileList),
       Optional.empty(),
       Optional.empty()
     )
@@ -833,7 +833,7 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
       val checkpoints = singularCheckpointFileStatuses(validVersions)
       val deltas = deltaFileStatuses(deltaVersions)
       val logSegmentOpt = snapshotManager.getLogSegmentForVersion(
-        createMockFSListFromTableClient(deltas ++ corruptedCheckpoint ++ checkpoints),
+        createMockFSListFromEngine(deltas ++ corruptedCheckpoint ++ checkpoints),
         Optional.empty(),
         Optional.empty()
       )
@@ -854,7 +854,7 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
   test("getLogSegmentForVersion: corrupt _last_checkpoint with empty delta log") {
     // listDeltaAndCheckpointFiles = Optional.empty()
     val logSegmentOpt = snapshotManager.getLogSegmentForVersion(
-      createMockFSListFromTableClient(Seq.empty),
+      createMockFSListFromEngine(Seq.empty),
       Optional.of(1),
       Optional.empty()
     )

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
@@ -453,13 +453,13 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
       files = deltaFileStatuses(Seq(0L)),
       versionToLoad = Optional.of(15),
       expectedErrorMessageContains =
-        "Trying to load a non-existent version 15. The latest version available is 0"
+        "Cannot load table version 15 as it does not exist. The latest available version is 0"
     )
     testExpectedError[RuntimeException](
       files = deltaFileStatuses((10L until 13L)) ++ singularCheckpointFileStatuses(Seq(10L)),
       versionToLoad = Optional.of(15),
       expectedErrorMessageContains =
-        "Trying to load a non-existent version 15. The latest version available is 12"
+        "Cannot load table version 15 as it does not exist. The latest available version is 12"
     )
   }
 
@@ -512,13 +512,13 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
     testExpectedError[RuntimeException](
       files,
       versionToLoad = Optional.of(15),
-      expectedErrorMessageContains = "Unable to reconstruct state at version 15"
+      expectedErrorMessageContains = "Cannot load table version 15"
     )
     testExpectedError[RuntimeException](
       files,
       startCheckpoint = Optional.of(20),
       versionToLoad = Optional.of(15),
-      expectedErrorMessageContains = "Unable to reconstruct state at version 15"
+      expectedErrorMessageContains = "Cannot load table version 15"
     )
   }
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableFeaturesSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableFeaturesSuite.scala
@@ -16,6 +16,7 @@
 package io.delta.kernel.internal
 
 import io.delta.kernel.data.{ArrayValue, ColumnVector, MapValue}
+import io.delta.kernel.exceptions.KernelException
 import io.delta.kernel.internal.TableFeatures.validateWriteSupportedTable
 import io.delta.kernel.internal.actions.{Format, Metadata, Protocol}
 import io.delta.kernel.internal.util.InternalUtils.singletonStringColumnVector
@@ -84,15 +85,15 @@ class TableFeaturesSuite extends AnyFunSuite {
     protocol: Protocol,
     metadata: Metadata = null,
     schema: StructType = createTestSchema()): Unit = {
-    validateWriteSupportedTable(protocol, metadata, schema)
+    validateWriteSupportedTable(protocol, metadata, schema, "/test/table")
   }
 
   def checkUnsupported(
     protocol: Protocol,
     metadata: Metadata = null,
     schema: StructType = createTestSchema()): Unit = {
-    intercept[UnsupportedOperationException] {
-      validateWriteSupportedTable(protocol, metadata, schema)
+    intercept[KernelException] {
+      validateWriteSupportedTable(protocol, metadata, schema, "/test/table")
     }
   }
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockEngineUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockEngineUtils.scala
@@ -136,12 +136,6 @@ trait BaseMockExpressionHandler extends ExpressionHandler {
       outputType: DataType): ExpressionEvaluator =
     throw new UnsupportedOperationException("not supported in this test suite")
 
-  override def isSupported(
-      inputSchema: StructType,
-      expression: Expression,
-      outputType: DataType): Boolean =
-    throw new UnsupportedOperationException("not supported in this test suite")
-
   override def createSelectionVector(values: Array[Boolean], from: Int, to: Int): ColumnVector =
     throw new UnsupportedOperationException("not supported in this test suite")
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockEngineUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockEngineUtils.scala
@@ -15,7 +15,7 @@
  */
 package io.delta.kernel.test
 
-import io.delta.kernel.client._
+import io.delta.kernel.engine._
 import io.delta.kernel.data.{ColumnVector, ColumnarBatch, FilteredColumnarBatch, Row}
 import io.delta.kernel.expressions.{Column, Expression, ExpressionEvaluator, Predicate, PredicateEvaluator}
 import io.delta.kernel.types.{DataType, StructType}
@@ -26,7 +26,7 @@ import java.util
 import java.util.Optional
 
 /**
- * Contains broiler plate code for mocking [[TableClient]] and its sub-interfaces.
+ * Contains broiler plate code for mocking [[Engine]] and its sub-interfaces.
  *
  * A concrete class is created for each sub-interface (e.g. [[FileSystemClient]]) with
  * default implementation (unsupported). Test suites can override a specific API(s)
@@ -40,20 +40,20 @@ import java.util.Optional
  *     }
  *   }
  *
- *   val myMockTableClient = mockTableClient(fileSystemClient = myMockFileSystemClient)
+ *   val myMockEngine = mockEngine(fileSystemClient = myMockFileSystemClient)
  * }}}
  */
-trait MockTableClientUtils {
+trait MockEngineUtils {
   /**
-   * Create a mock TableClient with the given components. If a component is not provided, it will
+   * Create a mock Engine with the given components. If a component is not provided, it will
    * throw an exception when accessed.
    */
-  def mockTableClient(
+  def mockEngine(
     fileSystemClient: FileSystemClient = null,
     jsonHandler: JsonHandler = null,
     parquetHandler: ParquetHandler = null,
-    expressionHandler: ExpressionHandler = null): TableClient = {
-    new TableClient() {
+    expressionHandler: ExpressionHandler = null): Engine = {
+    new Engine() {
       override def getExpressionHandler: ExpressionHandler =
         Option(expressionHandler).getOrElse(
           throw new UnsupportedOperationException("not supported in this test suite"))
@@ -102,7 +102,7 @@ trait BaseMockJsonHandler extends JsonHandler {
 /**
  * Base class for mocking [[ParquetHandler]]
  */
-trait BaseMockParquetHandler extends ParquetHandler with MockTableClientUtils {
+trait BaseMockParquetHandler extends ParquetHandler with MockEngineUtils {
   override def readParquetFiles(
       fileIter: CloseableIterator[FileStatus],
       physicalSchema: StructType,

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockFileSystemClientUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockFileSystemClientUtils.scala
@@ -17,7 +17,7 @@ package io.delta.kernel.test
 
 import java.util.UUID
 
-import io.delta.kernel.client._
+import io.delta.kernel.engine._
 import io.delta.kernel.internal.fs.Path
 import io.delta.kernel.internal.util.FileNames
 import io.delta.kernel.internal.util.Utils.toCloseableIterator
@@ -31,7 +31,7 @@ import scala.collection.JavaConverters._
  *
  * [[MockListFromFileSystemClient]] - mocks the `listFrom` API within [[FileSystemClient]].
  */
-trait MockFileSystemClientUtils extends MockTableClientUtils {
+trait MockFileSystemClientUtils extends MockEngineUtils {
 
   val dataPath = new Path("/fake/path/to/table/")
   val logPath = new Path(dataPath, "_delta_log")
@@ -86,7 +86,7 @@ trait MockFileSystemClientUtils extends MockTableClientUtils {
     }
   }
 
-  /* Create input function for createMockTableClient to implement listFrom from a list of
+  /* Create input function for createMockEngine to implement listFrom from a list of
    * file statuses.
    */
   def listFromProvider(files: Seq[FileStatus])(filePath: String): Seq[FileStatus] = {
@@ -94,34 +94,34 @@ trait MockFileSystemClientUtils extends MockTableClientUtils {
   }
 
   /**
-   * Create a mock [[TableClient]] to mock the [[FileSystemClient.listFrom]] calls using
+   * Create a mock [[Engine]] to mock the [[FileSystemClient.listFrom]] calls using
    * the given contents. The contents are filtered depending upon the list from path prefix.
    */
-  def createMockFSListFromTableClient(
+  def createMockFSListFromEngine(
       contents: Seq[FileStatus],
       parquetHandler: ParquetHandler,
-      jsonHandler: JsonHandler): TableClient = {
-    mockTableClient(fileSystemClient =
+      jsonHandler: JsonHandler): Engine = {
+    mockEngine(fileSystemClient =
       new MockListFromFileSystemClient(listFromProvider(contents)),
       parquetHandler = parquetHandler,
       jsonHandler = jsonHandler)
   }
 
   /**
-   * Create a mock [[TableClient]] to mock the [[FileSystemClient.listFrom]] calls using
+   * Create a mock [[Engine]] to mock the [[FileSystemClient.listFrom]] calls using
    * the given contents. The contents are filtered depending upon the list from path prefix.
    */
-  def createMockFSListFromTableClient(contents: Seq[FileStatus]): TableClient = {
-    mockTableClient(fileSystemClient =
+  def createMockFSListFromEngine(contents: Seq[FileStatus]): Engine = {
+    mockEngine(fileSystemClient =
       new MockListFromFileSystemClient(listFromProvider(contents)))
   }
 
   /**
-   * Create a mock [[TableClient]] to mock the [[FileSystemClient.listFrom]] calls using
+   * Create a mock [[Engine]] to mock the [[FileSystemClient.listFrom]] calls using
    * [[MockListFromFileSystemClient]].
    */
-  def createMockFSListFromTableClient(listFromProvider: String => Seq[FileStatus]): TableClient = {
-    mockTableClient(fileSystemClient = new MockListFromFileSystemClient(listFromProvider))
+  def createMockFSListFromEngine(listFromProvider: String => Seq[FileStatus]): Engine = {
+    mockEngine(fileSystemClient = new MockListFromFileSystemClient(listFromProvider))
   }
 }
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultEngine.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultEngine.java
@@ -13,20 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.delta.kernel.defaults.client;
+package io.delta.kernel.defaults.engine;
 
 import org.apache.hadoop.conf.Configuration;
 
-import io.delta.kernel.client.*;
+import io.delta.kernel.engine.*;
 
 /**
- * Default implementation of {@link TableClient} based on Hadoop APIs.
+ * Default implementation of {@link Engine} based on Hadoop APIs.
  */
-public class DefaultTableClient
-    implements TableClient {
+public class DefaultEngine
+    implements Engine {
     private final Configuration hadoopConf;
 
-    protected DefaultTableClient(Configuration hadoopConf) {
+    protected DefaultEngine(Configuration hadoopConf) {
         this.hadoopConf = hadoopConf;
     }
 
@@ -51,12 +51,12 @@ public class DefaultTableClient
     }
 
     /**
-     * Create an instance of {@link DefaultTableClient}.
+     * Create an instance of {@link DefaultEngine}.
      *
      * @param hadoopConf Hadoop configuration to use.
-     * @return an instance of {@link DefaultTableClient}.
+     * @return an instance of {@link DefaultEngine}.
      */
-    public static DefaultTableClient create(Configuration hadoopConf) {
-        return new DefaultTableClient(hadoopConf);
+    public static DefaultEngine create(Configuration hadoopConf) {
+        return new DefaultEngine(hadoopConf);
     }
 }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultExpressionHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultExpressionHandler.java
@@ -38,17 +38,6 @@ import io.delta.kernel.defaults.internal.expressions.DefaultPredicateEvaluator;
  * Default implementation of {@link ExpressionHandler}
  */
 public class DefaultExpressionHandler implements ExpressionHandler {
-    @Override
-    public boolean isSupported(StructType inputSchema, Expression expression, DataType outputType) {
-        // There is no extra cost to create an expression handler in default implementation in
-        // addition to checking the expression support. So we can just use `getEvaluator`.
-        try {
-            getEvaluator(inputSchema, expression, outputType);
-            return true;
-        } catch (UnsupportedOperationException e) {
-            return false;
-        }
-    }
 
     @Override
     public ExpressionEvaluator getEvaluator(

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultExpressionHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultExpressionHandler.java
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.delta.kernel.defaults.client;
+package io.delta.kernel.defaults.engine;
 
 import java.util.Arrays;
 import java.util.Optional;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
-import io.delta.kernel.client.ExpressionHandler;
 import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.engine.ExpressionHandler;
 import io.delta.kernel.expressions.Expression;
 import io.delta.kernel.expressions.ExpressionEvaluator;
 import io.delta.kernel.expressions.Predicate;

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultFileSystemClient.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultFileSystemClient.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.delta.kernel.defaults.client;
+package io.delta.kernel.defaults.engine;
 
 import java.io.*;
 
@@ -22,8 +22,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
-import io.delta.kernel.client.FileReadRequest;
-import io.delta.kernel.client.FileSystemClient;
+import io.delta.kernel.engine.FileReadRequest;
+import io.delta.kernel.engine.FileSystemClient;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultJsonHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultJsonHandler.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.delta.kernel.defaults.client;
+package io.delta.kernel.defaults.engine;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
@@ -26,8 +26,8 @@ import io.delta.storage.LogStore;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.*;
 
-import io.delta.kernel.client.JsonHandler;
 import io.delta.kernel.data.*;
+import io.delta.kernel.engine.JsonHandler;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.types.*;
 import io.delta.kernel.utils.CloseableIterator;

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultParquetHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultParquetHandler.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.delta.kernel.defaults.client;
+package io.delta.kernel.defaults.engine;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -24,9 +24,9 @@ import io.delta.storage.LogStore;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.*;
 
-import io.delta.kernel.client.ParquetHandler;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.FilteredColumnarBatch;
+import io.delta.kernel.engine.ParquetHandler;
 import io.delta.kernel.expressions.Column;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.types.StructType;

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/package-info.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/package-info.java
@@ -15,7 +15,7 @@
  */
 
 /**
- * Default implementation of {@link io.delta.kernel.client.TableClient} interface and
- * the sub-interfaces exposed by the {@link io.delta.kernel.client.TableClient}.
+ * Default implementation of {@link io.delta.kernel.engine.Engine} interface and
+ * the sub-interfaces exposed by the {@link io.delta.kernel.engine.Engine}.
  */
-package io.delta.kernel.defaults.client;
+package io.delta.kernel.defaults.engine;

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/DefaultEngineErrors.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/DefaultEngineErrors.java
@@ -17,9 +17,9 @@ package io.delta.kernel.defaults.internal;
 
 import static java.lang.String.format;
 
-public class DefaultTableClientErrors {
+public class DefaultEngineErrors {
 
-    // TODO update to be table client exception with future exception framework
+    // TODO update to be engine exception with future exception framework
     //  (see delta-io/delta#2231)
     public static IllegalArgumentException canNotInstantiateLogStore(String logStoreClassName) {
         return new IllegalArgumentException(

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/DefaultEngineErrors.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/DefaultEngineErrors.java
@@ -17,12 +17,26 @@ package io.delta.kernel.defaults.internal;
 
 import static java.lang.String.format;
 
+import io.delta.kernel.expressions.Expression;
+
 public class DefaultEngineErrors {
 
-    // TODO update to be engine exception with future exception framework
-    //  (see delta-io/delta#2231)
     public static IllegalArgumentException canNotInstantiateLogStore(String logStoreClassName) {
         return new IllegalArgumentException(
                 format("Can not instantiate `LogStore` class: %s", logStoreClassName));
+    }
+
+    /**
+     * Exception for when the default expression evaluator cannot evaluate an expression.
+     * @param expression the unsupported expression
+     * @param reason reason for why the expression is not supported/cannot be evaluated
+     */
+    public static UnsupportedOperationException unsupportedExpressionException(
+            Expression expression, String reason) {
+        String message = format(
+            "Default expression evaluator cannot evaluate the expression: %s. Reason: %s",
+            expression,
+            reason);
+        return new UnsupportedOperationException(message);
     }
 }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/DefaultRowBasedColumnarBatch.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/DefaultRowBasedColumnarBatch.java
@@ -29,7 +29,7 @@ import io.delta.kernel.defaults.internal.data.vector.DefaultSubFieldVector;
 
 /**
  * {@link ColumnarBatch} wrapper around list of {@link Row} objects.
- *  TODO: We should change the {@link io.delta.kernel.defaults.client.DefaultJsonHandler} to
+ *  TODO: We should change the {@link io.delta.kernel.defaults.engine.DefaultJsonHandler} to
  *  generate data in true columnar format than wrapping a set of rows with a columnar batch
  *  interface.
  */

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
@@ -21,9 +21,9 @@ import java.util.stream.Collectors;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
-import io.delta.kernel.client.ExpressionHandler;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.engine.ExpressionHandler;
 import io.delta.kernel.expressions.*;
 import io.delta.kernel.types.*;
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
@@ -27,14 +27,15 @@ import io.delta.kernel.engine.ExpressionHandler;
 import io.delta.kernel.expressions.*;
 import io.delta.kernel.types.*;
 
-import io.delta.kernel.internal.DeltaErrors;
 import static io.delta.kernel.internal.util.ExpressionUtils.getLeft;
 import static io.delta.kernel.internal.util.ExpressionUtils.getRight;
 import static io.delta.kernel.internal.util.ExpressionUtils.getUnaryChild;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 
+
 import io.delta.kernel.defaults.internal.data.vector.DefaultBooleanVector;
 import io.delta.kernel.defaults.internal.data.vector.DefaultConstantVector;
+import static io.delta.kernel.defaults.internal.DefaultEngineErrors.unsupportedExpressionException;
 import static io.delta.kernel.defaults.internal.expressions.DefaultExpressionUtils.booleanWrapperVector;
 import static io.delta.kernel.defaults.internal.expressions.DefaultExpressionUtils.childAt;
 import static io.delta.kernel.defaults.internal.expressions.DefaultExpressionUtils.compare;
@@ -64,9 +65,9 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
         ExpressionTransformResult transformResult =
             new ExpressionTransformer(inputSchema).visit(expression);
         if (!transformResult.outputType.equivalent(outputType)) {
-            String reason = format(
-                    "Can not create an expression handler returns result of type %s", outputType);
-            throw DeltaErrors.unsupportedExpression(expression, Optional.of(reason));
+            String reason = String.format(
+                "Expression %s does not match expected output type %s", expression, outputType);
+            throw unsupportedExpressionException(expression, reason);
         }
         this.expression = transformResult.expression;
     }
@@ -151,8 +152,9 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
                         transformBinaryComparator(predicate),
                         BooleanType.BOOLEAN);
                 default:
-                    throw DeltaErrors.unsupportedExpression(
-                            predicate, Optional.of("unsupported expression encountered"));
+                    // We should never reach this based on the ExpressionVisitor
+                    throw new IllegalStateException(
+                        String.format("%s is not a recognized comparator", predicate.getName()));
             }
         }
 
@@ -193,9 +195,9 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
             if (partitionColType instanceof StructType ||
                 partitionColType instanceof ArrayType ||
                 partitionColType instanceof MapType) {
-                throw DeltaErrors.unsupportedExpression(
+                throw unsupportedExpressionException(
                         partitionValue,
-                        Optional.of("unsupported partition data type: " + partitionColType));
+                        "unsupported partition data type: " + partitionColType);
             }
             return new ExpressionTransformResult(
                 new PartitionValueExpression(serializedPartValueInput.expression, partitionColType),
@@ -251,22 +253,22 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
                 .map(this::visit)
                 .collect(Collectors.toList());
             if (children.size() == 0) {
-                throw DeltaErrors.unsupportedExpression(
-                    coalesce, Optional.of("Coalesce requires at least one expression"));
+                throw unsupportedExpressionException(
+                    coalesce, "Coalesce requires at least one expression");
             }
             // TODO support least-common-type resolution
             long numDistinctTypes = children.stream().map(e -> e.outputType)
                 .distinct()
                 .count();
             if (numDistinctTypes > 1) {
-                throw DeltaErrors.unsupportedExpression(
+                throw unsupportedExpressionException(
                         coalesce,
-                        Optional.of("Coalesce is only supported for arguments of the same type"));
+                        "Coalesce is only supported for arguments of the same type");
             }
             // TODO support other data types besides boolean (just needs tests)
             if (!(children.get(0).outputType instanceof BooleanType)) {
-                throw new UnsupportedOperationException(
-                    "Coalesce is only supported for boolean type expressions");
+                throw unsupportedExpressionException(
+                    coalesce, "Coalesce is only supported for boolean type expressions");
             }
             return new ExpressionTransformResult(
                 new ScalarExpression(
@@ -305,7 +307,7 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
                     String msg = format("operands are of different types which are not " +
                             "comparable: left type=%s, right type=%s",
                             leftResult.outputType, rightResult.outputType);
-                    throw DeltaErrors.unsupportedExpression(predicate, Optional.of(msg));
+                    throw unsupportedExpressionException(predicate, msg);
                 }
             }
             return new Predicate(predicate.getName(), left, right);
@@ -437,9 +439,9 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
                     }
                     break;
                 default:
-                    throw DeltaErrors.unsupportedExpression(
-                            predicate,
-                            Optional.of("unsupported expression encountered"));
+                    // We should never reach this based on the ExpressionVisitor
+                    throw new IllegalStateException(
+                        String.format("%s is not a recognized comparator", predicate.getName()));
             }
 
             return new DefaultBooleanVector(numRows, Optional.of(nullability), result);

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ElementAtEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ElementAtEvaluator.java
@@ -16,7 +16,6 @@
 package io.delta.kernel.defaults.internal.expressions;
 
 import java.util.Arrays;
-import java.util.Optional;
 import static java.lang.String.format;
 
 import io.delta.kernel.data.ColumnVector;
@@ -27,10 +26,10 @@ import io.delta.kernel.types.DataType;
 import io.delta.kernel.types.MapType;
 import io.delta.kernel.types.StringType;
 
-import io.delta.kernel.internal.DeltaErrors;
 import io.delta.kernel.internal.util.Utils;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 
+import static io.delta.kernel.defaults.internal.DefaultEngineErrors.unsupportedExpressionException;
 import static io.delta.kernel.defaults.internal.expressions.ImplicitCastExpression.canCastTo;
 
 /**
@@ -60,7 +59,7 @@ class ElementAtEvaluator {
                 String reason = format(
                         "lookup key type (%s) is different from the map key type (%s)",
                         lookupKeyType, asMapType.getKeyType());
-                throw DeltaErrors.unsupportedExpression(elementAt, Optional.of(reason));
+                throw unsupportedExpressionException(elementAt, reason);
             }
         }
         return new ScalarExpression(elementAt.getName(), Arrays.asList(mapInput, lookupKey));

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ImplicitCastExpression.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ImplicitCastExpression.java
@@ -24,7 +24,7 @@ import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.expressions.Expression;
 import io.delta.kernel.types.DataType;
 
-import io.delta.kernel.defaults.client.DefaultExpressionHandler;
+import io.delta.kernel.defaults.engine.DefaultExpressionHandler;
 
 /**
  * An implicit cast expression to convert the input type to another given type. Here is the valid

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/logstore/LogStoreProvider.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/logstore/LogStoreProvider.java
@@ -20,7 +20,7 @@ import java.util.*;
 import io.delta.storage.*;
 import org.apache.hadoop.conf.Configuration;
 
-import io.delta.kernel.defaults.internal.DefaultTableClientErrors;
+import io.delta.kernel.defaults.internal.DefaultEngineErrors;
 
 /**
  * Utility class to provide the correct {@link LogStore} based on the scheme of the path.
@@ -66,7 +66,7 @@ public class LogStoreProvider {
                         .getConstructor(Configuration.class)
                         .newInstance(hadoopConf);
             } catch (Exception e) {
-                throw DefaultTableClientErrors.canNotInstantiateLogStore(classNameFromConfig);
+                throw DefaultEngineErrors.canNotInstantiateLogStore(classNameFromConfig);
             }
         }
 
@@ -85,7 +85,7 @@ public class LogStoreProvider {
                     .getConstructor(Configuration.class)
                     .newInstance(hadoopConf);
         } catch (Exception e) {
-            throw DefaultTableClientErrors.canNotInstantiateLogStore(defaultClassName);
+            throw DefaultEngineErrors.canNotInstantiateLogStore(defaultClassName);
         }
     }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/CheckpointV2ReadSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/CheckpointV2ReadSuite.scala
@@ -19,7 +19,7 @@ import java.io.File
 
 import scala.collection.JavaConverters._
 
-import io.delta.kernel.defaults.client.DefaultTableClient
+import io.delta.kernel.defaults.engine.DefaultEngine
 import io.delta.kernel.defaults.utils.{TestRow, TestUtils}
 import io.delta.kernel.internal.checkpoints.CheckpointInstance
 import io.delta.kernel.internal.{InternalScanFileUtils, SnapshotImpl}
@@ -39,7 +39,7 @@ import org.apache.spark.sql.types.{BooleanType, IntegerType, LongType, MapType, 
 class CheckpointV2ReadSuite extends AnyFunSuite with TestUtils {
   private final val supportedFileFormats = Seq("json", "parquet")
 
-  override lazy val defaultTableClient = DefaultTableClient.create(new Configuration() {
+  override lazy val defaultEngine = DefaultEngine.create(new Configuration() {
     {
       // Set the batch sizes to small so that we get to test the multiple batch scenarios.
       set("delta.kernel.default.parquet.reader.batch-size", "2");
@@ -78,7 +78,7 @@ class CheckpointV2ReadSuite extends AnyFunSuite with TestUtils {
       snapshotFromSpark.protocol.readerFeatureNames)
     assert(snapshotImpl.getProtocol.getWriterFeatures.asScala.toSet ==
       snapshotFromSpark.protocol.writerFeatureNames)
-    assert(snapshot.getVersion(defaultTableClient) == snapshotFromSpark.version)
+    assert(snapshot.getVersion(defaultEngine) == snapshotFromSpark.version)
 
     // Validate that snapshot read from most recent checkpoint. For most cases, given a checkpoint
     // interval of 2, this will be the most recent even version.
@@ -93,7 +93,7 @@ class CheckpointV2ReadSuite extends AnyFunSuite with TestUtils {
 
 
     // Validate AddFiles from sidecars found against Spark connector.
-    val scan = snapshot.getScanBuilder(defaultTableClient).build()
+    val scan = snapshot.getScanBuilder(defaultEngine).build()
     val foundFiles =
       collectScanFileRows(scan).map(InternalScanFileUtils.getAddFileStatus).map(
         _.getPath.split('/').last).toSet

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/CreateCheckpointSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/CreateCheckpointSuite.scala
@@ -16,24 +16,25 @@
 package io.delta.kernel.defaults
 
 import io.delta.golden.GoldenTableUtils.goldenTablePath
-import io.delta.kernel.client.TableClient
-import io.delta.kernel.defaults.client.DefaultTableClient
 import io.delta.kernel.defaults.utils.{TestRow, TestUtils}
 import io.delta.kernel.{CheckpointAlreadyExistsException, Table, TableNotFoundException}
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
+
 import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate
 import org.apache.spark.sql.delta.actions.{AddFile, Metadata, RemoveFile}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.{DeltaLog, VersionNotFoundException}
 import org.apache.spark.sql.types.{IntegerType, StructType}
 import org.scalatest.funsuite.AnyFunSuite
-
 import java.io.File
 
+import io.delta.kernel.defaults.engine.DefaultEngine
+import io.delta.kernel.engine.Engine
+
 /**
- * Test suite for `io.delta.kernel.Table.checkpoint(TableClient, version)`
+ * Test suite for `io.delta.kernel.Table.checkpoint(engine, version)`
  */
 class CreateCheckpointSuite extends AnyFunSuite with TestUtils {
 
@@ -44,7 +45,7 @@ class CreateCheckpointSuite extends AnyFunSuite with TestUtils {
   Seq(true, false).foreach { includeRemoves =>
     val testMsgUpdate = if (includeRemoves) " and removes" else ""
     test(s"commits containing adds$testMsgUpdate, and no previous checkpoint") {
-      withTempDirAndTableClient { (tablePath, tc) =>
+      withTempDirAndEngine { (tablePath, tc) =>
         addData(tablePath, alternateBetweenAddsAndRemoves = includeRemoves, numberIter = 10)
 
         // before creating checkpoint, read and save the expected results using Spark
@@ -79,7 +80,7 @@ class CreateCheckpointSuite extends AnyFunSuite with TestUtils {
 
       test(s"commits containing adds$testMsgUpdate, and a previous checkpoint " +
         s"created using Spark (actions/perfile): $sparkCheckpointActionPerFile") {
-        withTempDirAndTableClient { (tablePath, tc) =>
+        withTempDirAndEngine { (tablePath, tc) =>
           addData(tablePath, includeRemoves, numberIter = 6)
 
           // checkpoint using Spark
@@ -110,7 +111,7 @@ class CreateCheckpointSuite extends AnyFunSuite with TestUtils {
   }
 
   test("commits with metadata updates") {
-    withTempDirAndTableClient { (tablePath, tc) =>
+    withTempDirAndEngine { (tablePath, tc) =>
       addData(path = tablePath, alternateBetweenAddsAndRemoves = true, numberIter = 16)
 
       // makes the latest table version 16
@@ -141,7 +142,7 @@ class CreateCheckpointSuite extends AnyFunSuite with TestUtils {
   }
 
   test("commits with protocol updates") {
-    withTempDirAndTableClient { (tablePath, tc) =>
+    withTempDirAndEngine { (tablePath, tc) =>
       addData(path = tablePath, alternateBetweenAddsAndRemoves = true, numberIter = 16)
 
       spark.sql(
@@ -175,7 +176,7 @@ class CreateCheckpointSuite extends AnyFunSuite with TestUtils {
   }
 
   test("commits with set transactions") {
-    withTempDirAndTableClient { (tablePath, tc) =>
+    withTempDirAndEngine { (tablePath, tc) =>
       def idempotentAppend(appId: String, version: Int): Unit = {
         spark.range(end = 10).repartition(2).write.format("delta")
           .option("txnAppId", appId)
@@ -220,7 +221,7 @@ class CreateCheckpointSuite extends AnyFunSuite with TestUtils {
 
   Seq(None, Some("2 days"), Some("0 days")).foreach { retentionInterval =>
     test(s"checkpoint contains all not expired tombstones: $retentionInterval") {
-      withTempDirAndTableClient { (tablePath, tc) =>
+      withTempDirAndEngine { (tablePath, tc) =>
         def addFile(path: String): AddFile = AddFile(
           path = path,
           partitionValues = Map.empty,
@@ -296,7 +297,7 @@ class CreateCheckpointSuite extends AnyFunSuite with TestUtils {
   }
 
   test("try creating checkpoint on a non-existent table") {
-    withTempDirAndTableClient { (path, tc) =>
+    withTempDirAndEngine { (path, tc) =>
       Seq(0, 1, 2).foreach { checkpointVersion =>
         val ex = intercept[TableNotFoundException] {
           kernelCheckpoint(tc, path, checkpointVersion)
@@ -308,7 +309,7 @@ class CreateCheckpointSuite extends AnyFunSuite with TestUtils {
 
   test("try creating checkpoint at version that already has a " +
     "checkpoint or a version that doesn't exist") {
-    withTempDirAndTableClient { (path, tc) =>
+    withTempDirAndEngine { (path, tc) =>
       for (_ <- 0 to 3) {
         appendCommit(path)
       }
@@ -328,7 +329,7 @@ class CreateCheckpointSuite extends AnyFunSuite with TestUtils {
   }
 
   test("create a checkpoint on a existing table") {
-    withTempDirAndTableClient { (tablePath, tc) =>
+    withTempDirAndEngine { (tablePath, tc) =>
       copyTable("time-travel-start-start20-start40", tablePath)
 
       // before creating checkpoint, read and save the expected results using Spark
@@ -342,7 +343,7 @@ class CreateCheckpointSuite extends AnyFunSuite with TestUtils {
   }
 
   test("try create a checkpoint on a unsupported table feature table") {
-    withTempDirAndTableClient { (tablePath, tc) =>
+    withTempDirAndEngine { (tablePath, tc) =>
       copyTable("dv-with-columnmapping", tablePath)
 
       val ex2 = intercept[Exception] {
@@ -379,7 +380,7 @@ class CreateCheckpointSuite extends AnyFunSuite with TestUtils {
     }
   }
 
-  def kernelCheckpoint(tc: TableClient, tablePath: String, checkpointVersion: Long): Unit = {
+  def kernelCheckpoint(tc: Engine, tablePath: String, checkpointVersion: Long): Unit = {
     Table.forPath(tc, tablePath).checkpoint(tc, checkpointVersion)
   }
 
@@ -428,15 +429,15 @@ class CreateCheckpointSuite extends AnyFunSuite with TestUtils {
       s"Cannot time travel Delta table to version ${beforeVersion - 1}"))
   }
 
-  def withTempDirAndTableClient(f: (String, TableClient) => Unit): Unit = {
-    val tableClient = DefaultTableClient.create(new Configuration() {
+  def withTempDirAndEngine(f: (String, Engine) => Unit): Unit = {
+    val engine = DefaultEngine.create(new Configuration() {
       {
         // Set the batch sizes to small so that we get to test the multiple batch scenarios.
         set("delta.kernel.default.parquet.reader.batch-size", "200");
         set("delta.kernel.default.json.reader.batch-size", "200");
       }
     })
-    withTempDir { dir => f(dir.getAbsolutePath, tableClient) }
+    withTempDir { dir => f(dir.getAbsolutePath, engine) }
   }
 
   def checkpointFilePath(tablePath: String, checkpointVersion: Long): String = {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/CreateCheckpointSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/CreateCheckpointSuite.scala
@@ -17,7 +17,7 @@ package io.delta.kernel.defaults
 
 import io.delta.golden.GoldenTableUtils.goldenTablePath
 import io.delta.kernel.defaults.utils.{TestRow, TestUtils}
-import io.delta.kernel.{CheckpointAlreadyExistsException, Table, TableNotFoundException}
+import io.delta.kernel.Table
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
@@ -32,6 +32,7 @@ import java.io.File
 
 import io.delta.kernel.defaults.engine.DefaultEngine
 import io.delta.kernel.engine.Engine
+import io.delta.kernel.exceptions.{CheckpointAlreadyExistsException, TableNotFoundException}
 
 /**
  * Test suite for `io.delta.kernel.Table.checkpoint(engine, version)`
@@ -324,7 +325,7 @@ class CreateCheckpointSuite extends AnyFunSuite with TestUtils {
       val ex2 = intercept[Exception] {
         kernelCheckpoint(tc, path, checkpointVersion = 5)
       }
-      assert(ex2.getMessage.contains("Trying to load a non-existent version 5"))
+      assert(ex2.getMessage.contains("Cannot load table version 5 as it does not exist"))
     }
   }
 
@@ -349,8 +350,8 @@ class CreateCheckpointSuite extends AnyFunSuite with TestUtils {
       val ex2 = intercept[Exception] {
         kernelCheckpoint(tc, tablePath, checkpointVersion = 5)
       }
-      assert(ex2.getMessage.contains(
-        "Unsupported writer protocol version: 7 with feature: deletionVectors"))
+      assert(ex2.getMessage.contains("Unsupported Delta writer feature") &&
+        ex2.getMessage.contains("writer table feature \"deletionVectors\""))
     }
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeletionVectorSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeletionVectorSuite.scala
@@ -50,7 +50,7 @@ class DeletionVectorSuite extends AnyFunSuite with TestUtils {
     checkTable(
       path = goldenTablePath("dv-partitioned-with-checkpoint"),
       expectedAnswer = expectedResult.map(TestRow.fromTuple(_)),
-      tableClient = defaultTableClient
+      engine = defaultEngine
     )
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
@@ -189,7 +189,7 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
 
   test("invalid path") {
     val invalidPath = "/path/to/non-existent-directory"
-    val table = Table.forPath(defaultTableClient, invalidPath)
+    val table = Table.forPath(defaultEngine, invalidPath)
 
     def expectTableNotFoundException(fn: () => Unit): Unit = {
       val ex = intercept[TableNotFoundException] {
@@ -198,11 +198,11 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
       assert(ex.getMessage().contains(s"Delta table at path `file:$invalidPath` is not found"))
     }
 
-    expectTableNotFoundException(() => table.getLatestSnapshot(defaultTableClient))
+    expectTableNotFoundException(() => table.getLatestSnapshot(defaultEngine))
     expectTableNotFoundException(() =>
-      table.getSnapshotAsOfTimestamp(defaultTableClient, 1))
+      table.getSnapshotAsOfTimestamp(defaultEngine, 1))
     expectTableNotFoundException(() =>
-      table.getSnapshotAsOfVersion(defaultTableClient, 1))
+      table.getSnapshotAsOfVersion(defaultEngine, 1))
   }
 
   test("table deleted after the `Table` creation") {
@@ -211,11 +211,11 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
       val target = new File(temp.getCanonicalPath)
       FileUtils.copyDirectory(source, target)
 
-      val table = Table.forPath(defaultTableClient, target.getCanonicalPath)
+      val table = Table.forPath(defaultEngine, target.getCanonicalPath)
       // delete the table and try to get the snapshot. Expect a failure.
       FileUtils.deleteDirectory(target)
       val ex = intercept[TableNotFoundException] {
-        table.getLatestSnapshot(defaultTableClient)
+        table.getLatestSnapshot(defaultEngine)
       }
       assert(ex.getMessage.contains(
         s"Delta table at path `file:${target.getCanonicalPath}` is not found"))
@@ -264,8 +264,8 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
     val path = "file:" + goldenTablePath("data-reader-partition-values")
 
     // for now we don't support timestamp type partition columns so remove from read columns
-    val readCols = Table.forPath(defaultTableClient, path).getLatestSnapshot(defaultTableClient)
-      .getSchema(defaultTableClient)
+    val readCols = Table.forPath(defaultEngine, path).getLatestSnapshot(defaultEngine)
+      .getSchema(defaultEngine)
       .withoutField("as_timestamp")
       .fields()
       .asScala
@@ -582,7 +582,7 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
   test("table protocol version greater than reader protocol version") {
     val e = intercept[Exception] {
       latestSnapshot(goldenTablePath("deltalog-invalid-protocol-version"))
-        .getScanBuilder(defaultTableClient)
+        .getScanBuilder(defaultEngine)
         .build()
     }
     assert(e.getMessage.contains("Unsupported reader protocol version"))
@@ -624,8 +624,8 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
       )
       // Cannot read a version that does not exist
       val e = intercept[RuntimeException] {
-        Table.forPath(defaultTableClient, path)
-          .getSnapshotAsOfVersion(defaultTableClient, 11)
+        Table.forPath(defaultEngine, path)
+          .getSnapshotAsOfVersion(defaultEngine, 11)
       }
       assert(e.getMessage.contains(
         "Trying to load a non-existent version 11. The latest version available is 10"))
@@ -657,8 +657,8 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
 
       // Cannot read a version that has been truncated
       val e = intercept[RuntimeException] {
-        Table.forPath(defaultTableClient, tablePath)
-          .getSnapshotAsOfVersion(defaultTableClient, 9)
+        Table.forPath(defaultEngine, tablePath)
+          .getSnapshotAsOfVersion(defaultEngine, 9)
       }
       assert(e.getMessage.contains("Unable to reconstruct state at version 9"))
       // Can read version 10
@@ -793,8 +793,8 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
     withTempDir { dir =>
       new File(dir, "_delta_log").mkdirs()
       intercept[TableNotFoundException] {
-        Table.forPath(defaultTableClient, dir.getCanonicalPath)
-          .getSnapshotAsOfTimestamp(defaultTableClient, 0L)
+        Table.forPath(defaultEngine, dir.getCanonicalPath)
+          .getSnapshotAsOfTimestamp(defaultEngine, 0L)
       }
     }
   }
@@ -802,8 +802,8 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
   test("getSnapshotAtTimestamp: empty folder no _delta_log dir") {
     withTempDir { dir =>
       intercept[TableNotFoundException] {
-        Table.forPath(defaultTableClient, dir.getCanonicalPath)
-          .getSnapshotAsOfTimestamp(defaultTableClient, 0L)
+        Table.forPath(defaultEngine, dir.getCanonicalPath)
+          .getSnapshotAsOfTimestamp(defaultEngine, 0L)
       }
     }
   }
@@ -812,8 +812,8 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
     withTempDir { dir =>
       spark.range(20).write.format("parquet").mode("overwrite").save(dir.getCanonicalPath)
       intercept[TableNotFoundException] {
-        Table.forPath(defaultTableClient, dir.getCanonicalPath)
-          .getSnapshotAsOfTimestamp(defaultTableClient, 0L)
+        Table.forPath(defaultEngine, dir.getCanonicalPath)
+          .getSnapshotAsOfTimestamp(defaultEngine, 0L)
       }
     }
   }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultExpressionHandlerSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultExpressionHandlerSuite.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.delta.kernel.defaults.client
+package io.delta.kernel.defaults.engine
 
 import io.delta.kernel.defaults.utils.ExpressionTestUtils
 import io.delta.kernel.types.BooleanType.BOOLEAN

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultExpressionHandlerSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultExpressionHandlerSuite.scala
@@ -76,36 +76,6 @@ class DefaultExpressionHandlerSuite extends AnyFunSuite with ExpressionTestUtils
     assert(ex.getMessage.contains("values is null"))
   }
 
-  val tableSchema = new StructType()
-    .add("d1", INTEGER)
-    .add("d2", STRING)
-    .add("d3", new StructType()
-      .add("d31", BOOLEAN)
-      .add("d32", LONG))
-    .add("p1", INTEGER)
-    .add("p2", STRING)
-  val unsupportedExpr = Map(
-    (unsupported("d1"), BOOLEAN) -> false, // unsupported function
-    (lt(col("d1"), int(12)), BOOLEAN) -> true,
-    (lt(col("d1"), int(12)), INTEGER) -> false, // output type is not supported
-    (lt(nestedCol("d3.d32"), int(12)), BOOLEAN) -> true, // implicit conversion from int to long
-    (gt(col("d1"), str("sss")), STRING) -> false, // unexpected input type to > operator
-    // unsupported expression in one of the AND inputs
-    (and(gt(col("d2"), str("sss")), unsupported("d2")), BOOLEAN) -> false,
-    // both unsupported expressions in AND inputs
-    (and(gt(nestedCol("d3.d31"), str("sss")), unsupported("d2")), BOOLEAN) -> false,
-    // unsupported expression in one of the OR inputs
-    (or(gt(col("p2"), str("sss")), unsupported("d2")), BOOLEAN) -> false,
-    // both unsupported expressions in OR inputs
-    (or(gt(nestedCol("d3.d31"), str("sss")), unsupported("d2")), BOOLEAN) -> false
-  ).foreach {
-    case ((expr, outputType), expected) =>
-      test(s"is expression supported: $expr -> $outputType") {
-        assert(
-          new DefaultExpressionHandler().isSupported(tableSchema, expr, outputType) == expected)
-      }
-  }
-
   private def selectionVector(values: Array[Boolean], from: Int, to: Int) = {
     new DefaultExpressionHandler().createSelectionVector(values, from, to)
   }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultFileSystemClientSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultFileSystemClientSuite.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.delta.kernel.defaults.client
+package io.delta.kernel.defaults.engine
 
 import java.io.FileNotFoundException
 
@@ -25,7 +25,7 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class DefaultFileSystemClientSuite extends AnyFunSuite with TestUtils {
 
-  val fsClient = defaultTableClient.getFileSystemClient
+  val fsClient = defaultEngine.getFileSystemClient
   val fs = FileSystem.get(configuration)
 
   test("list from file") {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultJsonHandlerSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultJsonHandlerSuite.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.delta.kernel.defaults.client
+package io.delta.kernel.defaults.engine
 
 import java.math.{BigDecimal => JBigDecimal}
 import java.util.Optional
@@ -34,7 +34,7 @@ class DefaultJsonHandlerSuite extends AnyFunSuite with TestUtils with DefaultVec
   val jsonHandler = new DefaultJsonHandler(new Configuration {
     set("delta.kernel.default.json.reader.batch-size", "1")
   })
-  val fsClient = defaultTableClient.getFileSystemClient
+  val fsClient = defaultEngine.getFileSystemClient
 
   /////////////////////////////////////////////////////////////////////////////////////////////////
   // Tests for parseJson for statistics eligible types (additional in TestDefaultJsonHandler.java)

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultParquetHandlerSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultParquetHandlerSuite.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.delta.kernel.defaults.client
+package io.delta.kernel.defaults.engine
 
 import io.delta.golden.GoldenTableUtils.goldenTableFile
 import io.delta.kernel.defaults.internal.parquet.ParquetSuiteBase

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetSuiteBase.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetSuiteBase.scala
@@ -216,7 +216,7 @@ trait ParquetSuiteBase extends TestUtils {
       .filter(path => path.endsWith(".parquet"))
       .map(path => FileStatus.of(path, 0L, 0L))
 
-    val data = defaultTableClient.getParquetHandler.readParquetFiles(
+    val data = defaultEngine.getParquetHandler.readParquetFiles(
       toCloseableIterator(parquetFiles.asJava),
       readSchema,
       predicate)

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -25,10 +25,10 @@ import scala.collection.mutable.ArrayBuffer
 
 import io.delta.golden.GoldenTableUtils
 import io.delta.kernel.{Scan, Snapshot, Table}
-import io.delta.kernel.client.TableClient
-import io.delta.kernel.data.{ColumnVector, ColumnarBatch, FilteredColumnarBatch, MapValue, Row}
-import io.delta.kernel.defaults.client.DefaultTableClient
+import io.delta.kernel.data.{ColumnarBatch, ColumnVector, FilteredColumnarBatch, MapValue, Row}
+import io.delta.kernel.defaults.engine.DefaultEngine
 import io.delta.kernel.defaults.internal.data.vector.DefaultGenericVector
+import io.delta.kernel.engine.Engine
 import io.delta.kernel.expressions.{Column, Predicate}
 import io.delta.kernel.internal.InternalScanFileUtils
 import io.delta.kernel.internal.data.ScanStateRow
@@ -38,6 +38,7 @@ import io.delta.kernel.types._
 import io.delta.kernel.utils.CloseableIterator
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.shaded.org.apache.commons.io.FileUtils
+
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.{types => sparktypes}
 import org.apache.spark.sql.catalyst.plans.SQLHelper
@@ -46,7 +47,7 @@ import org.scalatest.Assertions
 trait TestUtils extends Assertions with SQLHelper {
 
   lazy val configuration = new Configuration()
-  lazy val defaultTableClient = DefaultTableClient.create(configuration)
+  lazy val defaultEngine = DefaultEngine.create(configuration)
 
   lazy val spark = SparkSession
     .builder()
@@ -101,7 +102,7 @@ trait TestUtils extends Assertions with SQLHelper {
       if (predicate.isEmpty) {
         new FilteredColumnarBatch(batch, Optional.empty())
       } else {
-        val predicateEvaluator = defaultTableClient.getExpressionHandler
+        val predicateEvaluator = defaultEngine.getExpressionHandler
           .getPredicateEvaluator(batch.getSchema, predicate.get)
         val selVector = predicateEvaluator.eval(batch, Optional.empty())
         new FilteredColumnarBatch(batch, Optional.of(selVector))
@@ -122,20 +123,20 @@ trait TestUtils extends Assertions with SQLHelper {
     testFunc(tablePath)
   }
 
-  def latestSnapshot(path: String, tableClient: TableClient = defaultTableClient): Snapshot = {
-    Table.forPath(tableClient, path)
-      .getLatestSnapshot(tableClient)
+  def latestSnapshot(path: String, engine: Engine = defaultEngine): Snapshot = {
+    Table.forPath(engine, path)
+      .getLatestSnapshot(engine)
   }
 
   def tableSchema(path: String): StructType = {
-    Table.forPath(defaultTableClient, path)
-      .getLatestSnapshot(defaultTableClient)
-      .getSchema(defaultTableClient)
+    Table.forPath(defaultEngine, path)
+      .getLatestSnapshot(defaultEngine)
+      .getSchema(defaultEngine)
   }
 
   def hasColumnMappingId(str: String): Boolean = {
-    val table = Table.forPath(defaultTableClient, str)
-    val schema = table.getLatestSnapshot(defaultTableClient).getSchema(defaultTableClient)
+    val table = Table.forPath(defaultEngine, str)
+    val schema = table.getLatestSnapshot(defaultEngine).getSchema(defaultEngine)
     schema.fields().asScala.exists { field =>
       field.getMetadata.contains(ColumnMapping.COLUMN_MAPPING_ID_KEY)
     }
@@ -156,8 +157,8 @@ trait TestUtils extends Assertions with SQLHelper {
     }
   }
 
-  def collectScanFileRows(scan: Scan, tableClient: TableClient = defaultTableClient): Seq[Row] = {
-    scan.getScanFiles(tableClient).toSeq
+  def collectScanFileRows(scan: Scan, engine: Engine = defaultEngine): Seq[Row] = {
+    scan.getScanFiles(engine).toSeq
       .flatMap(_.getRows.toSeq)
   }
 
@@ -166,18 +167,18 @@ trait TestUtils extends Assertions with SQLHelper {
     readSchema: StructType = null,
     filter: Predicate = null,
     expectedRemainingFilter: Predicate = null,
-    tableClient: TableClient = defaultTableClient): Seq[Row] = {
+    engine: Engine = defaultEngine): Seq[Row] = {
 
     val result = ArrayBuffer[Row]()
 
-    var scanBuilder = snapshot.getScanBuilder(tableClient)
+    var scanBuilder = snapshot.getScanBuilder(engine)
 
     if (readSchema != null) {
-      scanBuilder = scanBuilder.withReadSchema(tableClient, readSchema)
+      scanBuilder = scanBuilder.withReadSchema(engine, readSchema)
     }
 
     if (filter != null) {
-      scanBuilder = scanBuilder.withFilter(tableClient, filter)
+      scanBuilder = scanBuilder.withFilter(engine, filter)
     }
 
     val scan = scanBuilder.build()
@@ -188,21 +189,21 @@ trait TestUtils extends Assertions with SQLHelper {
         actRemainingPredicate.toString === Optional.ofNullable(expectedRemainingFilter).toString)
     }
 
-    val scanState = scan.getScanState(tableClient);
-    val fileIter = scan.getScanFiles(tableClient)
+    val scanState = scan.getScanState(engine);
+    val fileIter = scan.getScanFiles(engine)
 
-    val physicalDataReadSchema = ScanStateRow.getPhysicalDataReadSchema(tableClient, scanState)
+    val physicalDataReadSchema = ScanStateRow.getPhysicalDataReadSchema(engine, scanState)
     fileIter.forEach { fileColumnarBatch =>
       fileColumnarBatch.getRows().forEach { scanFileRow =>
         val fileStatus = InternalScanFileUtils.getAddFileStatus(scanFileRow)
-        val physicalDataIter = tableClient.getParquetHandler().readParquetFiles(
+        val physicalDataIter = engine.getParquetHandler().readParquetFiles(
           singletonCloseableIterator(fileStatus),
           physicalDataReadSchema,
           Optional.empty())
         var dataBatches: CloseableIterator[FilteredColumnarBatch] = null
         try {
           dataBatches = Scan.transformPhysicalData(
-            tableClient,
+            engine,
             scanState,
             scanFileRow,
             physicalDataIter)
@@ -282,7 +283,7 @@ trait TestUtils extends Assertions with SQLHelper {
    * @param path fully qualified path of the table to check
    * @param expectedAnswer expected rows
    * @param readCols subset of columns to read; if null then all columns will be read
-   * @param tableClient table client to use to read the table
+   * @param engine engine to use to read the table
    * @param expectedSchema expected schema to check for; if null then no check is performed
    * @param filter Filter to select a subset of rows form the table
    * @param expectedRemainingFilter Remaining predicate out of the `filter` that is not enforced
@@ -293,7 +294,7 @@ trait TestUtils extends Assertions with SQLHelper {
     path: String,
     expectedAnswer: Seq[TestRow],
     readCols: Seq[String] = null,
-    tableClient: TableClient = defaultTableClient,
+    engine: Engine = defaultEngine,
     expectedSchema: StructType = null,
     filter: Predicate = null,
     version: Option[Long] = None,
@@ -304,40 +305,40 @@ trait TestUtils extends Assertions with SQLHelper {
     assert(version.isEmpty || timestamp.isEmpty, "Cannot provide both a version and timestamp")
 
     val snapshot = if (version.isDefined) {
-      Table.forPath(tableClient, path)
-        .getSnapshotAsOfVersion(tableClient, version.get)
+      Table.forPath(engine, path)
+        .getSnapshotAsOfVersion(engine, version.get)
     } else if (timestamp.isDefined) {
-      Table.forPath(tableClient, path)
-        .getSnapshotAsOfTimestamp(tableClient, timestamp.get)
+      Table.forPath(engine, path)
+        .getSnapshotAsOfTimestamp(engine, timestamp.get)
     } else {
-      latestSnapshot(path, tableClient)
+      latestSnapshot(path, engine)
     }
 
     val readSchema = if (readCols == null) {
       null
     } else {
-      val schema = snapshot.getSchema(tableClient)
+      val schema = snapshot.getSchema(engine)
       new StructType(readCols.map(schema.get(_)).asJava)
     }
 
     if (expectedSchema != null) {
       assert(
-        expectedSchema == snapshot.getSchema(tableClient),
+        expectedSchema == snapshot.getSchema(engine),
         s"""
            |Expected schema does not match actual schema:
            |Expected schema: $expectedSchema
-           |Actual schema: ${snapshot.getSchema(tableClient)}
+           |Actual schema: ${snapshot.getSchema(engine)}
            |""".stripMargin
       )
     }
 
     expectedVersion.foreach { version =>
-      assert(version == snapshot.getVersion(defaultTableClient),
+      assert(version == snapshot.getVersion(defaultEngine),
         s"Expected version $version does not match actual version" +
-          s" ${snapshot.getVersion(defaultTableClient)}")
+          s" ${snapshot.getVersion(defaultEngine)}")
     }
 
-    val result = readSnapshot(snapshot, readSchema, filter, expectedRemainingFilter, tableClient)
+    val result = readSnapshot(snapshot, readSchema, filter, expectedRemainingFilter, engine)
     checkAnswer(result, expectedAnswer)
   }
 

--- a/project/FlinkMimaExcludes.scala
+++ b/project/FlinkMimaExcludes.scala
@@ -20,5 +20,10 @@ import com.typesafe.tools.mima.core._
  * The list of Mima errors to exclude in the Flink project.
  */
 object FlinkMimaExcludes {
-  val ignoredABIProblems = Seq()
+  // scalastyle:off line.size.limit
+
+  val ignoredABIProblems = Seq(
+    // We can ignore internal changes
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("io.delta.standalone.internal.KernelDeltaLogDelegator.this")
+  )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -45,7 +45,7 @@ libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionSch
 
 addSbtPlugin("net.aichler" % "sbt-jupiter-interface" % "0.9.1")
 
-addSbtPlugin("com.etsy" % "sbt-checkstyle-plugin" % "3.1.1")
+addSbtPlugin("software.purpledragon" % "sbt-checkstyle-plugin" % "4.0.1")
 // By default, sbt-checkstyle-plugin uses checkstyle version 6.15, but we should set it to use the
 // same version as Spark
-dependencyOverrides += "com.puppycrawl.tools" % "checkstyle" % "8.43"
+dependencyOverrides += "com.puppycrawl.tools" % "checkstyle" % "9.3"


### PR DESCRIPTION
3a668e9917a98121c3db36883213b9680ff6812c [Kernel] Add a meta file containing the Kernel version.
1523e071dba1b001767d7042ca6fef9fc1139acf [Kernel] Rename TableClient to Engine
db10a33afd166b18e42ffbdb86f8d8cf022524e1 [Build] Fix Java checkstyle plugin to work with SBT upgrade
c1018a15667b6bc07d5b42e7a329a765a7b11435 [Kernel][Infra] Fix the java checkstyle for Kernel's Meta file
f4555f545895ac474bce01fa4f84e7795a4fb0ea [Kernel] Remove unused ExpressionHandler.isSupported(...) for now
c8bbd5b6db29ab4607a34ffb5b5023f78fe61869 [Kernel] Refactor all user-facing exceptions to be "KernelExceptions"