### PR TITLE
[Spark] Extend Fuzz test For Managed Commit

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1427,8 +1427,9 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       }
       val updatedActions = UpdatedActions(
         commitInfo, metadata, protocol, snapshot.metadata, snapshot.protocol)
-      val commitResponse =
+      val commitResponse = TransactionExecutionObserver.withObserver(executionObserver) {
         effectiveTableCommitOwnerClient.commit(attemptVersion, jsonActions, updatedActions)
+      }
       // TODO(managed-commits): Use the right timestamp method on top of CommitInfo once ICT is
       //  merged.
       // If the metadata didn't change, `newMetadata` is empty, and we can re-use the old id.
@@ -2094,9 +2095,12 @@ trait OptimisticTransactionImpl extends TransactionalWrite
         commitVersion: Long,
         actions: Iterator[String],
         updatedActions: UpdatedActions): CommitResponse = {
+      // Get thread local observer for Fuzz testing purpose.
+      val executionObserver = TransactionExecutionObserver.threadObserver.get()
       val commitFile = util.FileNames.unsafeDeltaFile(logPath, commitVersion)
       val commitFileStatus =
         doCommit(logStore, hadoopConf, logPath, commitFile, commitVersion, actions)
+      executionObserver.beginBackfill()
       // TODO(managed-commits): Integrate with ICT and pass the correct commitTimestamp
       CommitResponse(Commit(
         commitVersion,
@@ -2174,7 +2178,9 @@ trait OptimisticTransactionImpl extends TransactionalWrite
   ): Commit = {
     val updatedActions =
       currentTransactionInfo.getUpdatedActions(snapshot.metadata, snapshot.protocol)
-    val commitResponse = tableCommitOwnerClient.commit(attemptVersion, jsonActions, updatedActions)
+    val commitResponse = TransactionExecutionObserver.withObserver(executionObserver) {
+      tableCommitOwnerClient.commit(attemptVersion, jsonActions, updatedActions)
+    }
     // TODO(managed-commits): Use the right timestamp method on top of CommitInfo once ICT is
     //  merged.
     val commitTimestamp = commitResponse.getCommit.getFileStatus.getModificationTime

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TransactionExecutionObserver.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TransactionExecutionObserver.scala
@@ -66,6 +66,9 @@ trait TransactionExecutionObserver
   /** Called before the first `doCommit` attempt. */
   def beginDoCommit(): Unit
 
+  /** Called after publishing the commit file but before the `backfill` attempt. */
+  def beginBackfill(): Unit
+
   /** Called once a commit succeeded. */
   def transactionCommitted(): Unit
 
@@ -119,6 +122,8 @@ object NoOpTransactionExecutionObserver extends TransactionExecutionObserver {
   override def preparingCommit[T](f: => T): T = f
 
   override def beginDoCommit(): Unit = ()
+
+  override def beginBackfill(): Unit = ()
 
   override def transactionCommitted(): Unit = ()
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/fuzzer/OptimisticTransactionPhases.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/fuzzer/OptimisticTransactionPhases.scala
@@ -19,7 +19,8 @@ package org.apache.spark.sql.delta.fuzzer
 case class OptimisticTransactionPhases(
     initialPhase: ExecutionPhaseLock,
     preparePhase: ExecutionPhaseLock,
-    commitPhase: ExecutionPhaseLock)
+    commitPhase: ExecutionPhaseLock,
+    backfillPhase: ExecutionPhaseLock)
 
 object OptimisticTransactionPhases {
 
@@ -28,6 +29,7 @@ object OptimisticTransactionPhases {
   final val INITIAL_PHASE_LABEL = PREFIX + "INIT"
   final val PREPARE_PHASE_LABEL = PREFIX + "PREPARE"
   final val COMMIT_PHASE_LABEL = PREFIX + "COMMIT"
+  final val BACKFILL_PHASE_LABEL = PREFIX + "BACKFILL"
 
   def forName(txnName: String): OptimisticTransactionPhases = {
 
@@ -37,6 +39,7 @@ object OptimisticTransactionPhases {
     OptimisticTransactionPhases(
       initialPhase = ExecutionPhaseLock(toTxnPhaseLabel(INITIAL_PHASE_LABEL)),
       preparePhase = ExecutionPhaseLock(toTxnPhaseLabel(PREPARE_PHASE_LABEL)),
-      commitPhase = ExecutionPhaseLock(toTxnPhaseLabel(COMMIT_PHASE_LABEL)))
+      commitPhase = ExecutionPhaseLock(toTxnPhaseLabel(COMMIT_PHASE_LABEL)),
+      backfillPhase = ExecutionPhaseLock(toTxnPhaseLabel(BACKFILL_PHASE_LABEL)))
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/TransactionExecutionTestMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/TransactionExecutionTestMixin.scala
@@ -124,6 +124,7 @@ trait TransactionExecutionTestMixin {
     observer.phases.initialPhase.entryBarrier.unblock()
     observer.phases.preparePhase.entryBarrier.unblock()
     observer.phases.commitPhase.entryBarrier.unblock()
+    observer.phases.backfillPhase.entryBarrier.unblock()
   }
 
   /**
@@ -145,11 +146,13 @@ trait TransactionExecutionTestMixin {
 
           // B starts and commits
           unblockAllPhases(observerB)
-          busyWaitFor(observerB.phases.commitPhase.hasLeft, timeout)
+          busyWaitFor(observerB.phases.backfillPhase.hasLeft, timeout)
 
           // A commits
           observerA.phases.commitPhase.entryBarrier.unblock()
           busyWaitFor(observerA.phases.commitPhase.hasLeft, timeout)
+          observerA.phases.backfillPhase.entryBarrier.unblock()
+          busyWaitFor(observerA.phases.backfillPhase.hasLeft, timeout)
       }
     (usageRecords, futureA, futureB)
   }
@@ -179,15 +182,17 @@ trait TransactionExecutionTestMixin {
 
           // B starts and commits
           unblockAllPhases(observerB)
-          busyWaitFor(observerB.phases.commitPhase.hasLeft, timeout)
+          busyWaitFor(observerB.phases.backfillPhase.hasLeft, timeout)
 
           // C starts and commits
           unblockAllPhases(observerC)
-          busyWaitFor(observerC.phases.commitPhase.hasLeft, timeout)
+          busyWaitFor(observerC.phases.backfillPhase.hasLeft, timeout)
 
           // A commits
           observerA.phases.commitPhase.entryBarrier.unblock()
           busyWaitFor(observerA.phases.commitPhase.hasLeft, timeout)
+          observerA.phases.backfillPhase.entryBarrier.unblock()
+          busyWaitFor(observerA.phases.backfillPhase.hasLeft, timeout)
       }
     (usageRecords, futureA, futureB, futureC)
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitTestUtils.scala
@@ -16,6 +16,8 @@
 
 package org.apache.spark.sql.delta.managedcommit
 
+import java.util.concurrent.atomic.AtomicInteger
+
 import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog, DeltaTestUtilsBase}
 import org.apache.spark.sql.delta.DeltaConfigs.MANAGED_COMMIT_OWNER_NAME
 import org.apache.spark.sql.delta.actions.{Action, CommitInfo, Metadata, Protocol}
@@ -46,7 +48,7 @@ trait ManagedCommitTestUtils
    * Runs the function `f` with managed commits default properties unset.
    * Any table created in function `f`` won't have managed commits enabled by default.
    */
-  def withoutManagedCommitsDefaultTableProperties(f: => Unit): Unit = {
+  def withoutManagedCommitsDefaultTableProperties[T](f: => T): T = {
     val commitOwnerKey = MANAGED_COMMIT_OWNER_NAME.defaultTablePropertyKey
     val oldCommitOwnerValue = spark.conf.getOption(commitOwnerKey)
     spark.conf.unset(commitOwnerKey)
@@ -128,31 +130,36 @@ class PredictableUuidInMemoryCommitOwnerClient(batchSize: Long)
   }
 }
 
+object TrackingCommitOwnerClient {
+  private val insideOperation = new ThreadLocal[Boolean] {
+    override def initialValue(): Boolean = false
+  }
+}
+
 class TrackingCommitOwnerClient(delegatingCommitOwnerClient: InMemoryCommitOwner)
   extends CommitOwnerClient {
 
-  var numCommitsCalled: Int = 0
-  var numGetCommitsCalled: Int = 0
-  var numBackfillToVersionCalled: Int = 0
-  var numRegisterTableCalled: Int = 0
-  var insideOperation: Boolean = false
+  val numCommitsCalled = new AtomicInteger(0)
+  val numGetCommitsCalled = new AtomicInteger(0)
+  val numBackfillToVersionCalled = new AtomicInteger(0)
+  val numRegisterTableCalled = new AtomicInteger(0)
 
-  def recordOperation[T](op: String)(f: => T): T = synchronized {
-    val oldInsideOperation = insideOperation
+  def recordOperation[T](op: String)(f: => T): T = {
+    val oldInsideOperation = TrackingCommitOwnerClient.insideOperation.get()
     try {
-      if (!insideOperation) {
+      if (!TrackingCommitOwnerClient.insideOperation.get()) {
         op match {
-          case "commit" => numCommitsCalled += 1
-          case "getCommits" => numGetCommitsCalled += 1
-          case "backfillToVersion" => numBackfillToVersionCalled += 1
-          case "registerTable" => numRegisterTableCalled += 1
+          case "commit" => numCommitsCalled.incrementAndGet()
+          case "getCommits" => numGetCommitsCalled.incrementAndGet()
+          case "backfillToVersion" => numBackfillToVersionCalled.incrementAndGet()
+          case "registerTable" => numRegisterTableCalled.incrementAndGet()
           case _ => ()
         }
       }
-      insideOperation = true
+      TrackingCommitOwnerClient.insideOperation.set(true)
       f
     } finally {
-      insideOperation = oldInsideOperation
+      TrackingCommitOwnerClient.insideOperation.set(oldInsideOperation)
     }
   }
 
@@ -191,9 +198,9 @@ class TrackingCommitOwnerClient(delegatingCommitOwnerClient: InMemoryCommitOwner
   override def semanticEquals(other: CommitOwnerClient): Boolean = this == other
 
   def reset(): Unit = {
-    numCommitsCalled = 0
-    numGetCommitsCalled = 0
-    numBackfillToVersionCalled = 0
+    numCommitsCalled.set(0)
+    numGetCommitsCalled.set(0)
+    numBackfillToVersionCalled.set(0)
   }
 
   override def registerTable(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR extends Fuzz test to test managed commit features. Specifically, it adds a new event phase inside commit operation, so that we can capture the backfill as a separate operation. By doing so, it is possible that multiple commits can go through before backfill and managed commit is expected to deal with various situation to return the correct output.

## How was this patch tested?
Existing fuzz tests should naturally use the extended backfill phases.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No