### PR TITLE
[Kernel][Writes] Support idempotent writes

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/ConcurrentTransactionException.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/ConcurrentTransactionException.java
@@ -15,15 +15,26 @@
  */
 package io.delta.kernel.exceptions;
 
+import io.delta.kernel.TransactionBuilder;
 import io.delta.kernel.annotation.Evolving;
+import io.delta.kernel.engine.Engine;
 
 /**
- * Thrown when concurrent transaction both attempt to update the same idempotent transaction.
+ * Thrown when concurrent transaction both attempt to update the table with same transaction
+ * identifier set through {@link TransactionBuilder#withTransactionId(Engine, String, long)}
+ * (String)}.
+ * <p>
+ * Incremental processing systems (e.g., streaming systems) that track progress using their own
+ * application-specific versions need to record what progress has been made, in order to avoid
+ * duplicating data in the face of failures and retries during writes. For more information refer to
+ * the Delta protocol section <a
+ * href="https://github.com/delta-io/delta/blob/master/PROTOCOL.md#transaction-identifiers">
+ * Transaction Identifiers</a>
  *
  * @since 3.2.0
  */
 @Evolving
-public class ConcurrentTransactionException extends KernelException {
+public class ConcurrentTransactionException extends ConcurrentWriteException {
     private static final String message = "This error occurs when multiple updates are " +
             "using the same transaction identifier to write into this table.\n" +
             "Application ID: %s, Attempted version: %s, Latest version in table: %s";

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/ConcurrentTransactionException.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/ConcurrentTransactionException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.exceptions;
+
+import io.delta.kernel.annotation.Evolving;
+
+/**
+ * Thrown when concurrent transaction both attempt to update the same idempotent transaction.
+ *
+ * @since 3.2.0
+ */
+@Evolving
+public class ConcurrentTransactionException extends KernelException {
+    private static final String message = "This error occurs when multiple updates are " +
+            "using the same transaction identifier to write into this table.\n" +
+            "Application ID: %s, Attempted version: %s, Latest version in table: %s";
+
+    public ConcurrentTransactionException(String appId, long txnVersion, long lastUpdated) {
+        super(String.format(message, appId, txnVersion, lastUpdated));
+    }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/ConcurrentWriteException.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/ConcurrentWriteException.java
@@ -28,4 +28,8 @@ public class ConcurrentWriteException extends KernelException {
         super("Transaction has encountered a conflict and can not be committed. " +
                 "Query needs to be re-executed using the latest version of the table.");
     }
+
+    public ConcurrentWriteException(String message) {
+        super(message);
+    }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -188,6 +188,13 @@ public final class DeltaErrors {
         return new KernelException(format(msgT, partitionColumn, tablePath));
     }
 
+    public static KernelException concurrentTransaction(
+            String appId,
+            long txnVersion,
+            long lastUpdated) {
+        return new ConcurrentTransactionException(appId, txnVersion, lastUpdated);
+    }
+
     /* ------------------------ HELPER METHODS ----------------------------- */
     private static String formatTimestamp(long millisSinceEpochUTC) {
         return new Timestamp(millisSinceEpochUTC).toInstant().toString();

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -17,11 +17,14 @@ package io.delta.kernel.internal;
 
 import java.util.*;
 
+import static java.util.Objects.requireNonNull;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.delta.kernel.*;
 import io.delta.kernel.engine.Engine;
+import io.delta.kernel.exceptions.ConcurrentTransactionException;
 import io.delta.kernel.exceptions.TableNotFoundException;
 import io.delta.kernel.types.StructType;
 
@@ -49,6 +52,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
     private final Operation operation;
     private Optional<StructType> schema = Optional.empty();
     private Optional<List<String>> partitionColumns = Optional.empty();
+    private Optional<SetTransaction> transactionId = Optional.empty();
 
     public TransactionBuilderImpl(TableImpl table, String engineInfo, Operation operation) {
         this.table = table;
@@ -67,6 +71,19 @@ public class TransactionBuilderImpl implements TransactionBuilder {
         if (!partitionColumns.isEmpty()) {
             this.partitionColumns = Optional.of(partitionColumns);
         }
+        return this;
+    }
+
+    @Override
+    public TransactionBuilder withTransactionId(
+            Engine engine,
+            String applicationId,
+            long transactionVersion) {
+        SetTransaction txnId = new SetTransaction(
+                requireNonNull(applicationId, "applicationId is null"),
+                transactionVersion,
+                Optional.of(currentTimeMillis));
+        this.transactionId = Optional.of(txnId);
         return this;
     }
 
@@ -97,7 +114,8 @@ public class TransactionBuilderImpl implements TransactionBuilder {
                 engineInfo,
                 operation,
                 snapshot.getProtocol(),
-                snapshot.getMetadata());
+                snapshot.getMetadata(),
+                transactionId);
     }
 
     /**
@@ -131,6 +149,16 @@ public class TransactionBuilderImpl implements TransactionBuilder {
             SchemaUtils.validatePartitionColumns(
                     schema.get(), partitionColumns.orElse(Collections.emptyList()));
         }
+
+        transactionId.ifPresent(txnId -> {
+            Optional<Long> lastTxnVersion = snapshot.getLatestTransactionVersion(txnId.getAppId());
+            if (lastTxnVersion.isPresent() && lastTxnVersion.get() >= txnId.getVersion()) {
+                throw new ConcurrentTransactionException(
+                        txnId.getAppId(),
+                        txnId.getVersion(),
+                        lastTxnVersion.get());
+            }
+        });
     }
 
     private class InitialSnapshot extends SnapshotImpl {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -16,7 +16,6 @@
 package io.delta.kernel.internal;
 
 import java.util.*;
-
 import static java.util.Objects.requireNonNull;
 
 import org.slf4j.Logger;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -54,6 +54,7 @@ public class TransactionImpl
     private final Protocol protocol;
     private final Metadata metadata;
     private final SnapshotImpl readSnapshot;
+    private final Optional<SetTransaction> setTxn;
 
     private boolean closed; // To avoid trying to commit the same transaction again.
 
@@ -65,7 +66,8 @@ public class TransactionImpl
             String engineInfo,
             Operation operation,
             Protocol protocol,
-            Metadata metadata) {
+            Metadata metadata,
+            Optional<SetTransaction> setTxn) {
         this.isNewTable = isNewTable;
         this.dataPath = dataPath;
         this.logPath = logPath;
@@ -74,6 +76,7 @@ public class TransactionImpl
         this.operation = operation;
         this.protocol = protocol;
         this.metadata = metadata;
+        this.setTxn = setTxn;
     }
 
     @Override
@@ -106,6 +109,7 @@ public class TransactionImpl
             metadataActions.add(createMetadataSingleAction(metadata.toRow()));
             metadataActions.add(createProtocolSingleAction(protocol.toRow()));
         }
+        setTxn.ifPresent(setTxn -> metadataActions.add(createTxnSingleAction(setTxn.toRow())));
 
         try (CloseableIterator<Row> stageDataIter = dataActions.iterator()) {
             // Create a new CloseableIterator that will return the metadata actions followed by the

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -54,7 +54,7 @@ public class TransactionImpl
     private final Protocol protocol;
     private final Metadata metadata;
     private final SnapshotImpl readSnapshot;
-    private final Optional<SetTransaction> setTxn;
+    private final Optional<SetTransaction> setTxnOpt;
 
     private boolean closed; // To avoid trying to commit the same transaction again.
 
@@ -67,7 +67,7 @@ public class TransactionImpl
             Operation operation,
             Protocol protocol,
             Metadata metadata,
-            Optional<SetTransaction> setTxn) {
+            Optional<SetTransaction> setTxnOpt) {
         this.isNewTable = isNewTable;
         this.dataPath = dataPath;
         this.logPath = logPath;
@@ -76,7 +76,7 @@ public class TransactionImpl
         this.operation = operation;
         this.protocol = protocol;
         this.metadata = metadata;
-        this.setTxn = setTxn;
+        this.setTxnOpt = setTxnOpt;
     }
 
     @Override
@@ -109,7 +109,7 @@ public class TransactionImpl
             metadataActions.add(createMetadataSingleAction(metadata.toRow()));
             metadataActions.add(createProtocolSingleAction(protocol.toRow()));
         }
-        setTxn.ifPresent(setTxn -> metadataActions.add(createTxnSingleAction(setTxn.toRow())));
+        setTxnOpt.ifPresent(setTxn -> metadataActions.add(createTxnSingleAction(setTxn.toRow())));
 
         try (CloseableIterator<Row> stageDataIter = dataActions.iterator()) {
             // Create a new CloseableIterator that will return the metadata actions followed by the


### PR DESCRIPTION
## Description
(Split from #2944)

Adds an API on `TransactionBuilder` to take the transaction identifier for idempotent writes
```
    /*
     * Set the transaction identifier for idempotent writes. Incremental processing systems (e.g.,
     * streaming systems) that track progress using their own application-specific versions need to
     * record what progress has been made, in order to avoid duplicating data in the face of
     * failures and retries during writes. By setting the transaction identifier, the Delta table
     * can ensure that the data with same identifier is not written multiple times. For more
     * information refer to the Delta protocol section <a
     * href="https://github.com/delta-io/delta/blob/master/PROTOCOL.md#transaction-identifiers">
     * Transaction Identifiers</a>.
     *
     * @param engine             {@link Engine} instance to use.
     * @param applicationId      The application ID that is writing to the table.
     * @param transactionVersion The version of the transaction. This should be monotonically
     *                           increasing with each write for the same application ID.
     * @return updated {@link TransactionBuilder} instance.
     */
    TransactionBuilder withTransactionId(
            Engine engine,
            String applicationId,
            long transactionVersion);
```

During the transaction build, check the latest txn version of the given AppId. If it is not monotonically increasing throw `ConcurrentTransactionException`.

## How was this patch tested?
Added to `DeltaTableWriteSuite.scala`
