### PR TITLE
[Spark] Fix logging failure in deltaAssert helper

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/metering/DeltaLogging.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/metering/DeltaLogging.scala
@@ -152,7 +152,7 @@ trait DeltaLogging
     : Unit = {
     if (Utils.isTesting) {
       assert(check, msg)
-    } else {
+    } else if (!check) {
       recordDeltaEvent(
         deltaLog = deltaLog,
         opType = s"delta.assertions.$name",


### PR DESCRIPTION
## Description
Fix helper method `deltaAssert` introduced in https://github.com/delta-io/delta/pull/2709 to not log failures when the assertion holds.

## How was this patch tested?
The helper intentionally behaves differently in tests and in production (failing vs. logging), there's no easy/meaningful way to test the prod behavior from tests.
