### PR TITLE
[Kernel][Writes] Allow transaction retries for blind append

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/MetadataChangedException.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/MetadataChangedException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.exceptions;
+
+import io.delta.kernel.annotation.Evolving;
+
+/**
+ * Thrown when the metadata of the Delta table has changed between the time of transaction start
+ * and the time of commit.
+ *
+ * @since 3.2.0
+ */
+@Evolving
+public class MetadataChangedException extends ConcurrentWriteException {
+    public MetadataChangedException() {
+        super("The metadata of the Delta table has been changed by a concurrent update. " +
+                "Please try the operation again.");
+    }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/ProtocolChangedException.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/exceptions/ProtocolChangedException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.exceptions;
+
+
+import io.delta.kernel.annotation.Evolving;
+
+/**
+ * Thrown when the protocol of the Delta table has changed between the time of transaction start
+ * and the time of commit.
+ *
+ * @since 3.2.0
+ */
+@Evolving
+public class ProtocolChangedException extends ConcurrentWriteException {
+    private static final String helpfulMsgForNewTables = " This happens when multiple writers " +
+            "are writing to an empty directory. Creating the table ahead of time will avoid this " +
+            "conflict.";
+
+    public ProtocolChangedException(long attemptVersion) {
+        super(String.format("Transaction has encountered a conflict and can not be committed. " +
+                "Query needs to be re-executed using the latest version of the table.%s",
+                attemptVersion == 0 ? helpfulMsgForNewTables : ""));
+    }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -195,6 +195,14 @@ public final class DeltaErrors {
         return new ConcurrentTransactionException(appId, txnVersion, lastUpdated);
     }
 
+    public static KernelException metadataChangedException() {
+        return new MetadataChangedException();
+    }
+
+    public static KernelException protocolChangedException(long attemptVersion) {
+        return new ProtocolChangedException(attemptVersion);
+    }
+
     /* ------------------------ HELPER METHODS ----------------------------- */
     private static String formatTimestamp(long millisSinceEpochUTC) {
         return new Timestamp(millisSinceEpochUTC).toInstant().toString();

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -119,11 +119,12 @@ public class TransactionImpl
             long commitAsVersion = readSnapshot.getVersion(engine) + 1;
             int numRetries = 0;
             do {
+                logger.info("Committing transaction as version = {}.", commitAsVersion);
                 try {
                     return doCommit(engine, commitAsVersion, dataActions);
                 } catch (FileAlreadyExistsException fnfe) {
-                    logger.info("Concurrent write detected. " +
-                            "Trying to resolve conflicts and retry commit.");
+                    logger.info("Concurrent write detected when committing as version = {}. " +
+                            "Trying to resolve conflicts and retry commit.", commitAsVersion);
                     TransactionRebaseState rebaseState = ConflictChecker
                             .resolveConflicts(engine, readSnapshot, commitAsVersion, this);
                     long newCommitAsVersion = rebaseState.getLatestVersion() + 1;
@@ -139,6 +140,7 @@ public class TransactionImpl
         }
 
         // we have exhausted the number of retries, give up.
+        logger.info("Exhausted maximum retries ({}) for committing transaction.", NUM_TXN_RETRIES);
         throw new ConcurrentWriteException();
     }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -32,10 +32,13 @@ import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.internal.actions.*;
 import io.delta.kernel.internal.data.TransactionStateRow;
 import io.delta.kernel.internal.fs.Path;
+import io.delta.kernel.internal.replay.ConflictChecker;
+import io.delta.kernel.internal.replay.ConflictChecker.TransactionRebaseState;
 import io.delta.kernel.internal.util.FileNames;
 import io.delta.kernel.internal.util.VectorUtils;
 import static io.delta.kernel.internal.TableConfig.CHECKPOINT_INTERVAL;
 import static io.delta.kernel.internal.actions.SingleAction.*;
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 import static io.delta.kernel.internal.util.Preconditions.checkState;
 import static io.delta.kernel.internal.util.Utils.toCloseableIterator;
 
@@ -43,6 +46,13 @@ public class TransactionImpl
         implements Transaction {
     public static final int DEFAULT_READ_VERSION = 1;
     public static final int DEFAULT_WRITE_VERSION = 2;
+
+    /**
+     * Number of retries for concurrent write exceptions to resolve conflicts and retry commit. In
+     * Delta-Spark, for historical reasons the number of retries is really high (10m). We are
+     * starting with a lower number for now. If this is not sufficient we can update it.
+     */
+    private static final int NUM_TXN_RETRIES = 200;
 
     private final UUID txnId = UUID.randomUUID();
 
@@ -95,13 +105,41 @@ public class TransactionImpl
     }
 
     @Override
-    public TransactionCommitResult commit(
-            Engine engine,
-            CloseableIterable<Row> dataActions)
+    public TransactionCommitResult commit(Engine engine, CloseableIterable<Row> dataActions)
             throws ConcurrentWriteException {
-        checkState(
-                !closed,
-                "Transaction is already attempted to commit. Create a new transaction.");
+        try {
+            checkState(!closed,
+                    "Transaction is already attempted to commit. Create a new transaction.");
+
+            long commitAsVersion = readSnapshot.getVersion(engine) + 1;
+            int numRetries = 0;
+            do {
+                try {
+                    return doCommit(engine, commitAsVersion, dataActions);
+                } catch (FileAlreadyExistsException fnfe) {
+                    TransactionRebaseState rebaseState = ConflictChecker
+                            .resolveConflicts(engine, readSnapshot, commitAsVersion, this);
+                    long newCommitAsVersion = rebaseState.getLatestVersion() + 1;
+                    checkArgument(commitAsVersion < newCommitAsVersion,
+                            "New commit version %d should be greater than the previous commit " +
+                                    "attempt version %d.", newCommitAsVersion, commitAsVersion);
+                    commitAsVersion = newCommitAsVersion;
+                }
+                numRetries++;
+            } while (numRetries < NUM_TXN_RETRIES);
+        } finally {
+            closed = true;
+        }
+
+        // we have exhausted the number of retries, give up.
+        throw new ConcurrentWriteException();
+    }
+
+    private TransactionCommitResult doCommit(
+            Engine engine,
+            long commitAsVersion,
+            CloseableIterable<Row> dataActions)
+            throws FileAlreadyExistsException {
         List<Row> metadataActions = new ArrayList<>();
         metadataActions.add(createCommitInfoSingleAction(generateCommitAction()));
         if (isNewTable) {
@@ -117,33 +155,38 @@ public class TransactionImpl
             CloseableIterator<Row> dataAndMetadataActions =
                     toCloseableIterator(metadataActions.iterator()).combine(stageDataIter);
 
-            try {
-                long readVersion = readSnapshot.getVersion(engine);
-                if (readVersion == -1) {
-                    // New table, create a delta log directory
-                    if (!engine.getFileSystemClient().mkdirs(logPath.toString())) {
-                        throw new RuntimeException(
-                                "Failed to create delta log directory: " + logPath);
-                    }
+            if (commitAsVersion == 0) {
+                // New table, create a delta log directory
+                if (!engine.getFileSystemClient().mkdirs(logPath.toString())) {
+                    throw new RuntimeException(
+                            "Failed to create delta log directory: " + logPath);
                 }
-
-                long newVersion = readVersion + 1;
-                // Write the staged data to a delta file
-                engine.getJsonHandler().writeJsonFileAtomically(
-                        FileNames.deltaFile(logPath, newVersion),
-                        dataAndMetadataActions,
-                        false /* overwrite */);
-
-                return new TransactionCommitResult(newVersion, isReadyForCheckpoint(newVersion));
-            } catch (FileAlreadyExistsException e) {
-                // TODO: Resolve conflicts and retry commit
-                throw new ConcurrentWriteException();
             }
+
+            // Write the staged data to a delta file
+            engine.getJsonHandler().writeJsonFileAtomically(
+                    FileNames.deltaFile(logPath, commitAsVersion),
+                    dataAndMetadataActions,
+                    false /* overwrite */);
+
+            return new TransactionCommitResult(
+                    commitAsVersion,
+                    isReadyForCheckpoint(commitAsVersion));
+        } catch (FileAlreadyExistsException e) {
+            throw e;
         } catch (IOException ioe) {
             throw new RuntimeException(ioe);
-        } finally {
-            closed = true;
         }
+    }
+
+    public boolean isBlindAppend() {
+        // For now, Kernel just supports blind append.
+        // Change this when read-after-write is supported.
+        return true;
+    }
+
+    public Optional<SetTransaction> getSetTxnOpt() {
+        return setTxnOpt;
     }
 
     private Row generateCommitAction() {
@@ -162,12 +205,6 @@ public class TransactionImpl
         return newVersion > 0 && newVersion % checkpointInterval == 0;
     }
 
-    private boolean isBlindAppend() {
-        // For now, Kernel just supports blind append.
-        // Change this when read-after-write is supported.
-        return true;
-    }
-
     private Map<String, String> getOperationParameters() {
         if (isNewTable) {
             List<String> partitionCols = VectorUtils.toJavaList(metadata.getPartitionColumns());
@@ -182,7 +219,7 @@ public class TransactionImpl
     /**
      * Get the part of the schema of the table that needs the statistics to be collected per file.
      *
-     * @param engine      {@link Engine} instance to use.
+     * @param engine           {@link Engine} instance to use.
      * @param transactionState State of the transaction
      * @return
      */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/SingleAction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/SingleAction.java
@@ -37,6 +37,20 @@ public class SingleAction {
     // Once we start supporting updating CDC or domain metadata enabled tables, we should add the
     // schema for those fields here.
 
+    /**
+     * Schema to use when reading the winning commit files for conflict resolution. This schema
+     * is just for resolving conflicts when doing a blind append. It doesn't cover case when the
+     * txn is reading data from the table and updating the table.
+     */
+    public static StructType CONFLICT_RESOLUTION_SCHEMA = new StructType()
+            .add("txn", SetTransaction.FULL_SCHEMA)
+            // .add("add", AddFile.FULL_SCHEMA) // not needed for blind appends
+            // .add("remove", RemoveFile.FULL_SCHEMA) // not needed for blind appends
+            .add("metaData", Metadata.FULL_SCHEMA)
+            .add("protocol", Protocol.FULL_SCHEMA);
+    // Once we start supporting domain metadata/row tracking enabled tables, we should add the
+    // schema for domain metadata fields here.
+
     // Schema to use when writing out the single action to the Delta Log.
     public static StructType FULL_SCHEMA = new StructType()
             .add("txn", SetTransaction.FULL_SCHEMA)

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ConflictChecker.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ConflictChecker.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.replay;
+
+import java.io.*;
+import java.util.*;
+import static java.lang.String.format;
+
+import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.data.ColumnarBatch;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.exceptions.ConcurrentWriteException;
+import io.delta.kernel.utils.CloseableIterator;
+import io.delta.kernel.utils.FileStatus;
+
+import io.delta.kernel.internal.*;
+import io.delta.kernel.internal.actions.SetTransaction;
+import io.delta.kernel.internal.util.FileNames;
+import static io.delta.kernel.internal.actions.SingleAction.CONFLICT_RESOLUTION_SCHEMA;
+import static io.delta.kernel.internal.util.FileNames.deltaFile;
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+import static io.delta.kernel.internal.util.Preconditions.checkState;
+
+/**
+ * Class containing the conflict resolution logic when writing to a Delta table.
+ * <p>
+ * Currently, the support is to allow blind appends. Later on this can be extended to add support
+ * for read-after-write scenarios.
+ */
+public class ConflictChecker {
+    private static final int PROTOCOL_ORDINAL = CONFLICT_RESOLUTION_SCHEMA.indexOf("protocol");
+    private static final int METADATA_ORDINAL = CONFLICT_RESOLUTION_SCHEMA.indexOf("metaData");
+    private static final int TXN_ORDINAL = CONFLICT_RESOLUTION_SCHEMA.indexOf("txn");
+
+    // Snapshot of the table read by the transaction that encountered the conflict
+    // (a.k.a the losing transaction)
+    private final SnapshotImpl snapshot;
+
+    // Losing transaction
+    private final TransactionImpl transaction;
+    private final long attemptVersion;
+
+    private ConflictChecker(
+            SnapshotImpl snapshot,
+            TransactionImpl transaction,
+            long attemptVersion) {
+        this.snapshot = snapshot;
+        this.transaction = transaction;
+        this.attemptVersion = attemptVersion;
+    }
+
+    /**
+     * Resolve conflicts between the losing transaction and the winning transactions and return a
+     * rebase state that the losing transaction needs to rebase against before attempting the
+     * commit.
+     *
+     * @param engine      {@link Engine} instance to use
+     * @param snapshot    {@link SnapshotImpl} of the table when the losing transaction has started
+     * @param transaction {@link TransactionImpl} that encountered the conflict (a.k.a the losing
+     *                    transaction)
+     * @return {@link TransactionRebaseState} that the losing transaction needs to rebase against
+     * @throws ConcurrentWriteException if there are logical conflicts between the losing
+     *                                  transaction and the winning transactions that cannot be
+     *                                  resolved.
+     */
+    public static TransactionRebaseState resolveConflicts(
+            Engine engine,
+            SnapshotImpl snapshot,
+            long attemptVersion,
+            TransactionImpl transaction) throws ConcurrentWriteException {
+        checkArgument(transaction.isBlindAppend(), "Current support is for blind appends only.");
+        return new ConflictChecker(snapshot, transaction, attemptVersion)
+                .resolveConflicts(engine);
+    }
+
+    public TransactionRebaseState resolveConflicts(Engine engine) throws ConcurrentWriteException {
+        List<FileStatus> winningCommits = getWinningCommitFiles(engine);
+
+        // no winning commits. why did we get the transaction conflict?
+        checkState(!winningCommits.isEmpty(), "No winning commits found.");
+
+        // Read the actions from the winning commits
+        try (ActionsIterator actionsIterator = new ActionsIterator(
+                engine,
+                winningCommits,
+                CONFLICT_RESOLUTION_SCHEMA,
+                Optional.empty())) {
+
+            actionsIterator.forEachRemaining(actionBatch -> {
+                checkArgument(!actionBatch.isFromCheckpoint());  // no checkpoints should be read
+                ColumnarBatch batch = actionBatch.getColumnarBatch();
+
+                handleProtocol(batch.getColumnVector(PROTOCOL_ORDINAL));
+                handleMetadata(batch.getColumnVector(METADATA_ORDINAL));
+                handleTxn(batch.getColumnVector(TXN_ORDINAL));
+            });
+        } catch (IOException ioe) {
+            throw new UncheckedIOException("Error reading actions from winning commits.", ioe);
+        }
+
+        // if we get here, we have successfully rebased (i.e no logical conflicts)
+        // against the winning transactions
+        return new TransactionRebaseState(getLastWinningTxnVersion(winningCommits));
+    }
+
+    /**
+     * Class containing the rebase state from winning transactions that the current transaction
+     * needs to rebase against before attempting the commit.
+     * <p>
+     * Currently, the rebase state is just the latest winning version of the table. In future once
+     * we start supporting read-after-write, domain metadata, row tracking, etc., we will have more
+     * state to add. For example read-after-write will need to know the files deleted in the winning
+     * transactions to make sure the same files are not deleted by the current (losing)
+     * transaction.
+     */
+    public static class TransactionRebaseState {
+        private final long latestVersion;
+
+        public TransactionRebaseState(long latestVersion) {
+            this.latestVersion = latestVersion;
+        }
+
+        /**
+         * Return the latest winning version of the table.
+         *
+         * @return latest winning version of the table.
+         */
+        public long getLatestVersion() {
+            return latestVersion;
+        }
+    }
+
+    /**
+     * Any protocol changes between the losing transaction and the winning transactions are not
+     * allowed. In future once we start supporting more table features on the write side, this can
+     * be changed to handle safe protocol changes. For now the write support in Kernel is supported
+     * at a very first version of the protocol.
+     *
+     * @param protocolVector protocol rows from the winning transactions
+     */
+    private void handleProtocol(ColumnVector protocolVector) {
+        for (int rowId = 0; rowId < protocolVector.getSize(); rowId++) {
+            if (!protocolVector.isNullAt(rowId)) {
+                throw DeltaErrors.protocolChangedException(attemptVersion);
+            }
+        }
+    }
+
+    /**
+     * Any metadata changes between the losing transaction and the winning transactions are not
+     * allowed.
+     *
+     * @param metadataVector metadata rows from the winning transactions
+     */
+    private void handleMetadata(ColumnVector metadataVector) {
+        for (int rowId = 0; rowId < metadataVector.getSize(); rowId++) {
+            if (!metadataVector.isNullAt(rowId)) {
+                throw DeltaErrors.metadataChangedException();
+            }
+        }
+    }
+
+    private void handleTxn(ColumnVector txnVector) {
+        // Check if the losing transaction has any txn identifier. If it does, go through the
+        // winning transactions and make sure that the losing transaction is valid from a
+        // idempotent perspective.
+        Optional<SetTransaction> losingTxnIdOpt = transaction.getSetTxnOpt();
+        losingTxnIdOpt.ifPresent(losingTxnId -> {
+            for (int rowId = 0; rowId < txnVector.getSize(); rowId++) {
+                SetTransaction winningTxn = SetTransaction.fromColumnVector(txnVector, rowId);
+                if (winningTxn != null &&
+                        winningTxn.getAppId().equals(losingTxnId.getAppId()) &&
+                        winningTxn.getVersion() >= losingTxnId.getVersion()) {
+                    throw DeltaErrors.concurrentTransaction(
+                            losingTxnId.getAppId(),
+                            losingTxnId.getVersion(),
+                            winningTxn.getVersion());
+                }
+            }
+        });
+    }
+
+    private List<FileStatus> getWinningCommitFiles(Engine engine) {
+        String firstWinningCommitFile =
+                deltaFile(snapshot.getLogPath(), snapshot.getVersion(engine) + 1);
+
+        try (CloseableIterator<FileStatus> files = engine.getFileSystemClient()
+                .listFrom(firstWinningCommitFile)) {
+            // Filter out all winning transaction commit files.
+            List<FileStatus> winningCommitFiles = new ArrayList<>();
+            while (files.hasNext()) {
+                FileStatus file = files.next();
+                if (FileNames.isCommitFile(file.getPath())) {
+                    winningCommitFiles.add(file);
+                }
+            }
+
+            return ensureNoGapsInWinningCommits(winningCommitFiles);
+        } catch (FileNotFoundException nfe) {
+            // no winning commits. why did we get here?
+            throw new IllegalStateException("No winning commits found.", nfe);
+        } catch (IOException ioe) {
+            throw new UncheckedIOException(
+                    "Error listing files from " + firstWinningCommitFile, ioe);
+        }
+    }
+
+    private long getLastWinningTxnVersion(List<FileStatus> winningCommits) {
+        FileStatus lastWinningTxn = winningCommits.get(winningCommits.size() - 1);
+        return FileNames.deltaVersion(lastWinningTxn.getPath());
+    }
+
+    private static List<FileStatus> ensureNoGapsInWinningCommits(List<FileStatus> winningCommits) {
+        long lastVersion = -1;
+        for (FileStatus commit : winningCommits) {
+            long version = FileNames.deltaVersion(commit.getPath());
+            checkState(lastVersion == -1 || version == lastVersion + 1,
+                    format("Gaps in Delta log commit files. Expected version %d but got %d",
+                            (lastVersion + 1), version));
+            lastVersion = version;
+        }
+        return winningCommits;
+    }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ConflictChecker.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ConflictChecker.java
@@ -199,7 +199,7 @@ public class ConflictChecker {
 
         try (CloseableIterator<FileStatus> files = engine.getFileSystemClient()
                 .listFrom(firstWinningCommitFile)) {
-            // Filter out all winning transaction commit files.
+            // Select all winning transaction commit files.
             List<FileStatus> winningCommitFiles = new ArrayList<>();
             while (files.hasNext()) {
                 FileStatus file = files.next();

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
@@ -38,7 +38,7 @@ import io.delta.kernel.types.TimestampNTZType.TIMESTAMP_NTZ
 import io.delta.kernel.types.TimestampType.TIMESTAMP
 import io.delta.kernel.types._
 import io.delta.kernel.utils.CloseableIterable.{emptyIterable, inMemoryIterable}
-import io.delta.kernel.utils.CloseableIterator
+import io.delta.kernel.utils.{CloseableIterable, CloseableIterator}
 
 import java.util.Optional
 import scala.collection.JavaConverters._
@@ -678,7 +678,8 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
       val data = Seq(Map("part1" -> ofInt(1), "part2" -> ofInt(2)) -> dataPartitionBatches1)
       var expData = Seq.empty[TestRow] // as the data in inserted, update this.
 
-      def addDataWithTxnId(newTbl: Boolean, appId: String, txnVer: Long, expTblVer: Long): Unit = {
+      def prepTxnAndActions(newTbl: Boolean, appId: String, txnVer: Long)
+      : (Transaction, CloseableIterable[Row]) = {
         var txnBuilder = createWriteTxnBuilder(Table.forPath(engine, tblPath))
 
         if (appId != null) txnBuilder = txnBuilder.withTransactionId(engine, appId, txnVer)
@@ -694,7 +695,12 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
             stageData(txn.getTransactionState(engine), partValues, partData)
           }.reduceLeft(_ combine _))
 
-        val commitResult = txn.commit(engine, combinedActions)
+        (txn, combinedActions)
+      }
+
+      def commitAndVerify(newTbl: Boolean, txn: Transaction,
+          actions: CloseableIterable[Row], expTblVer: Long): Unit = {
+        val commitResult = txn.commit(engine, actions)
 
         expData = expData ++ data.flatMap(_._2).flatMap(_.toTestRows)
 
@@ -702,6 +708,11 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
         val expPartCols = if (newTbl) testPartitionColumns else null
         verifyCommitInfo(tblPath, version = expTblVer, expPartCols, operation = WRITE)
         verifyWrittenContent(tblPath, testPartitionSchema, expData)
+      }
+
+      def addDataWithTxnId(newTbl: Boolean, appId: String, txnVer: Long, expTblVer: Long): Unit = {
+        val (txn, combinedActions) = prepTxnAndActions(newTbl, appId, txnVer)
+        commitAndVerify(newTbl, txn, combinedActions, expTblVer)
       }
 
       def expFailure(appId: String, txnVer: Long, latestTxnVer: Long)(fn: => Any): Unit = {
@@ -738,8 +749,97 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
         addDataWithTxnId(newTbl = false, "txnAppId2", txnVer = 0, expTblVer = 4)
       }
 
-      // TODO: Add a test case where there are concurrent transactions with same app id
-      // and only one of them succeeds. Will be added once conflict resolution is handled
+      // Start a transaction (txnAppId2, 2), but don't commit it yet
+      val (txn, combinedActions) = prepTxnAndActions(newTbl = false, "txnAppId2", txnVer = 2)
+      // Now start a new transaction with the same id (txnAppId2, 2) and commit it
+      addDataWithTxnId(newTbl = false, "txnAppId2", txnVer = 2, expTblVer = 4)
+      // Now try to commit the previous transaction (txnAppId2, 2) - should fail
+      expFailure("txnAppId2", txnVer = 2, latestTxnVer = 2) {
+        commitAndVerify(newTbl = false, txn, combinedActions, expTblVer = 5)
+      }
+
+      // Start a transaction (txnAppId2, 3), but don't commit it yet
+      val (txn2, combinedActions2) = prepTxnAndActions(newTbl = false, "txnAppId2", txnVer = 3)
+      // Now start a new transaction with the different id (txnAppId1, 10) and commit it
+      addDataWithTxnId(newTbl = false, "txnAppId1", txnVer = 10, expTblVer = 5)
+      // Now try to commit the previous transaction (txnAppId2, 3) - should pass
+      commitAndVerify(newTbl = false, txn2, combinedActions2, expTblVer = 6)
+    }
+  }
+
+  test("conflicts - creating new table - table created by other txn after current txn start") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val losingTx = createTestTxn(engine, tablePath, Some(testSchema))
+
+      // don't commit losingTxn, instead create a new txn and commit it
+      val winningTx = createTestTxn(engine, tablePath, Some(testSchema))
+      val winningTxResult = winningTx.commit(engine, emptyIterable())
+
+      // now attempt to commit the losingTxn
+      val ex = intercept[ProtocolChangedException] {
+        losingTx.commit(engine, emptyIterable())
+      }
+      assert(ex.getMessage.contains(
+        "Transaction has encountered a conflict and can not be committed."))
+      // helpful message for table creation conflict
+      assert(ex.getMessage.contains("This happens when multiple writers are " +
+        "writing to an empty directory. Creating the table ahead of time will avoid " +
+        "this conflict."))
+
+      verifyCommitResult(winningTxResult, expVersion = 0, expIsReadyForCheckpoint = false)
+      verifyCommitInfo(tablePath = tablePath, version = 0)
+      verifyWrittenContent(tablePath, testSchema, Seq.empty)
+    }
+  }
+
+  test("conflicts - table metadata has changed after the losing txn has started") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val testData = Seq(Map.empty[String, Literal] -> dataBatches1)
+
+      // create a new table and commit it
+      appendData(engine, tablePath, isNewTable = true, testSchema, partCols = Seq.empty, testData)
+
+      // start the losing transaction
+      val losingTx = createTestTxn(engine, tablePath)
+
+      // don't commit losingTxn, instead create a new txn (that changes metadata) and commit it
+      spark.sql("ALTER TABLE delta.`" + tablePath + "` ADD COLUMN newCol INT")
+
+      // now attempt to commit the losingTxn
+      val ex = intercept[MetadataChangedException] {
+        losingTx.commit(engine, emptyIterable())
+      }
+      assert(ex.getMessage.contains("The metadata of the Delta table has been changed " +
+        "by a concurrent update. Please try the operation again."))
+    }
+  }
+
+  test("conflicts - concurrent data append after the losing txn has started") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val testData = Seq(Map.empty[String, Literal] -> dataBatches1)
+      var expData = Seq.empty[TestRow]
+
+      // create a new table and commit it
+      appendData(engine, tablePath, isNewTable = true, testSchema, partCols = Seq.empty, testData)
+      expData ++= testData.flatMap(_._2).flatMap(_.toTestRows)
+
+      // start the losing transaction
+      val txn1 = createTestTxn(engine, tablePath)
+
+      // don't commit txn1 yet, instead create a new txn (that appends metadata) and commit it
+      appendData(engine, tablePath, data = testData)
+      expData ++= testData.flatMap(_._2).flatMap(_.toTestRows)
+
+      // add data using the txn1
+      val txn1State = txn1.getTransactionState(engine)
+      val actions = inMemoryIterable(stageData(txn1State, Map.empty, dataBatches2))
+      expData ++= dataBatches2.flatMap(_.toTestRows)
+
+      val txn1Result = txn1.commit(engine, actions)
+
+      verifyCommitResult(txn1Result, expVersion = 2, expIsReadyForCheckpoint = false)
+      verifyCommitInfo(tablePath = tablePath, version = 0, operation = WRITE)
+      verifyWrittenContent(tablePath, testSchema, expData)
     }
   }
 
@@ -828,6 +928,14 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
 
   def createWriteTxnBuilder(table: Table): TransactionBuilder = {
     table.createTransactionBuilder(defaultEngine, testEngineInfo, Operation.WRITE)
+  }
+
+  def createTestTxn(
+    engine: Engine, tablePath: String, schema: Option[StructType] = None): Transaction = {
+    val table = Table.forPath(engine, tablePath)
+    var txnBuilder = table.createTransactionBuilder(engine, testEngineInfo, CREATE_TABLE)
+    schema.foreach(s => txnBuilder = txnBuilder.withSchema(engine, s))
+    txnBuilder.build(engine)
   }
 
   def generateData(


### PR DESCRIPTION
## Description
Currently, Kernel throws an exception when there is a conflict (i.e., there already exists a committed file at a given version). We should retry the transaction as the current support is just for blind appends. Retry checks if there are no logical conflicts (`metadata`, `protocol` or `txn` (Set Tranaction)) conflicts that affect the blind append.

## How was this patch tested?
Tests for protocol, metadata and setTxn conflicts. Also tests to verify blind appends are retried and committed.