### PR TITLE
fix hanging behavior for constructDataFilters with expression like EqualTo(Literal, Literal) 

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
@@ -380,8 +380,11 @@ trait DataSkippingReaderBase
      * manifest as NULL). That case is handled separately by `verifyStatsForFilter` (which disables
      * skipping for any file that lacks the needed stats columns).
      */
-    private def constructDataFilters(dataFilter: Expression):
+    private[stats] def constructDataFilters(dataFilter: Expression):
         Option[DataSkippingPredicate] = dataFilter match {
+      // Expressions that contain only literals are not eligible for skipping.
+      case cmp: Expression if cmp.children.forall(areAllLeavesLiteral) => None
+
       // Push skipping predicate generation through the AND:
       //
       // constructDataFilters(AND(a, b))
@@ -570,6 +573,12 @@ trait DataSkippingReaderBase
 
       // Unknown expression type... can't use it for data skipping.
       case _ => None
+    }
+
+    private def areAllLeavesLiteral(e: Expression): Boolean = e match {
+      case _: Literal => true
+      case _ => if (e.children.nonEmpty) e.children.forall(areAllLeavesLiteral) else false
+      case _ => false
     }
 
     /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaConstructDataFiltersSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaConstructDataFiltersSuite.scala
@@ -21,9 +21,11 @@ import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.types.StringType
 
-class DataSkippingDeltaConstructDataFiltersSuite extends QueryTest with SharedSparkSession {
+class DataSkippingDeltaConstructDataFiltersSuite
+    extends QueryTest with SharedSparkSession with DeltaSQLCommandTest {
   test("Verify constructDataFilters doesn't hang for expressions with Literal operands.") {
     val snapshot = DeltaLog.forTable(spark, "dummy_path").update()
     val dataFilterBuilder = new snapshot.DataFiltersBuilder(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaConstructDataFiltersSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaConstructDataFiltersSuite.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.stats
+
+import org.apache.spark.sql.delta.DeltaLog
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.StringType
+
+class DataSkippingDeltaConstructDataFiltersSuite extends QueryTest with SharedSparkSession {
+  test("Verify constructDataFilters doesn't hang for expressions with Literal operands.") {
+    val snapshot = DeltaLog.forTable(spark, "dummy_path").update()
+    val dataFilterBuilder = new snapshot.DataFiltersBuilder(
+      spark, DeltaDataSkippingType.dataSkippingOnlyV1)
+
+    val literal = Literal.create("foo", StringType)
+    Seq(
+      EqualTo(literal, literal),
+      Not(EqualTo(literal, literal)),
+      EqualNullSafe(literal, literal),
+      Not(EqualNullSafe(literal, literal)),
+      LessThan(literal, literal),
+      LessThanOrEqual(literal, literal),
+      GreaterThan(literal, literal),
+      GreaterThanOrEqual(literal, literal),
+      Not(GreaterThanOrEqual(literal, literal)),
+      In(literal, Seq(literal)),
+      IsNull(literal),
+      IsNotNull(literal),
+      And(EqualTo(literal, literal), LessThan(literal, literal))
+    ).foreach { expression =>
+      assert(dataFilterBuilder.constructDataFilters(expression).isEmpty)
+    }
+  }
+
+  test("Test when the query contains EqualTo(Literal, Literal) in the filter.") {
+    setup {
+      sql(
+        """
+          |explain
+          |select
+          | *
+          |from
+          |  view1 c
+          |  join view2 cv on c.type=cv.type and c.key=cv.key
+          |  join tbl3 b on cv.name=b.name
+          |where
+          |  (
+          |       (b.name="name1" and c.type="foo")
+          |       or
+          |       (b.name="name2" and c.type="bar")
+          |  )
+          |""".stripMargin)
+    }
+  }
+
+  private def setup(f: => Unit) {
+    withTable("tbl1_foo", "tbl1_bar", "tbl2_foo", "tbl2_bar", "tbl3") {
+      Seq("foo", "bar").foreach { tableType =>
+        sql(s"CREATE TABLE tbl1_$tableType (key STRING) USING delta")
+        sql(s"CREATE TABLE tbl2_$tableType (key STRING, name STRING) USING delta")
+      }
+      sql("CREATE TABLE tbl3 (name STRING) USING delta")
+
+      withView("view1", "view2") {
+        sql(
+          s"""
+             |CREATE VIEW view1 (type, key)
+             |AS (
+             |    select 'foo' as type, * from tbl1_foo
+             |    union all
+             |    select 'bar' as type, * from tbl1_bar
+             |)
+             |""".stripMargin
+        )
+
+        sql(
+          s"""
+             |CREATE VIEW view2 (type, key, name)
+             |AS (
+             |    select 'foo' as type, * from tbl2_foo
+             |    union all
+             |    select 'bar' as type, * from tbl2_bar
+             |)
+             |""".stripMargin
+        )
+
+        f
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This fixes the hanging behavior for `constructDataFilters` with expressions like `EqualTo(Literal, Literal)`. This is due to infinite recursion caused by cases like `case EqualTo(v: Literal, a) => constructDataFilters(EqualTo(a, v))`.  This also fixes the same behavior for `EqualTo, Not(EqualTo), EqualNullSafe, LessThan, LessThanOrEqual, GreaterThan, GreaterThanOrEqual`

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
new UT `DataSkippingDeltaConstructDataFiltersSuite`

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
