### PR TITLE
[Spark] Fix O(n^2) issue in find last complete checkpoint before

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaLogGroupingIterator.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaLogGroupingIterator.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.util
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.sql.delta.util.FileNames.{CheckpointFile, DeltaFile}
+import org.apache.hadoop.fs.FileStatus
+
+/**
+ * An iterator that groups same types of files by version.
+ * Note that this class could handle only Checkpoints and Delta files.
+ * For example for an input iterator:
+ * - 11.checkpoint.0.1.parquet
+ * - 11.checkpoint.1.1.parquet
+ * - 11.json
+ * - 12.checkpoint.parquet
+ * - 12.json
+ * - 13.json
+ * - 14.json
+ * - 15.checkpoint.0.1.parquet
+ * - 15.checkpoint.1.1.parquet
+ * - 15.checkpoint.<uuid>.parquet
+ * - 15.json
+ *  This will return:
+ *  - (11, Seq(11.checkpoint.0.1.parquet, 11.checkpoint.1.1.parquet, 11.json))
+ *  - (12, Seq(12.checkpoint.parquet, 12.json))
+ *  - (13, Seq(13.json))
+ *  - (14, Seq(14.json))
+ *  - (15, Seq(15.checkpoint.0.1.parquet, 15.checkpoint.1.1.parquet, 15.checkpoint.<uuid>.parquet,
+ *             15.json))
+ */
+class DeltaLogGroupingIterator(
+  checkpointAndDeltas: Iterator[FileStatus]) extends Iterator[(Long, ArrayBuffer[FileStatus])] {
+
+  private val bufferedIterator = checkpointAndDeltas.buffered
+
+  /**
+   * Validates that the underlying file is a checkpoint/delta file and returns the corresponding
+   * version.
+   */
+  private def getFileVersion(file: FileStatus): Long = {
+    file match {
+      case DeltaFile(_, version) => version
+      case CheckpointFile(_, version) => version
+      case _ =>
+        throw new IllegalStateException(
+          s"${file.getPath} is not a valid commit file / checkpoint file")
+    }
+  }
+
+  override def hasNext: Boolean = bufferedIterator.hasNext
+
+  override def next(): (Long, ArrayBuffer[FileStatus]) = {
+    val first = bufferedIterator.next()
+    val buffer = scala.collection.mutable.ArrayBuffer(first)
+    val firstFileVersion = getFileVersion(first)
+    while (bufferedIterator.headOption.exists(getFileVersion(_) == firstFileVersion)) {
+      buffer += bufferedIterator.next()
+    }
+    firstFileVersion -> buffer
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/FindLastCompleteCheckpointSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/FindLastCompleteCheckpointSuite.scala
@@ -1,0 +1,293 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.CheckpointInstance.Format
+import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
+import org.apache.spark.sql.delta.managedcommit.ManagedCommitBaseSuite
+import org.apache.spark.sql.delta.storage.LocalLogStore
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.util.FileNames
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileStatus, Path}
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+class FindLastCompleteCheckpointSuite
+  extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest
+  with ManagedCommitBaseSuite {
+
+  protected override def sparkConf: SparkConf = {
+    super.sparkConf
+      .set("spark.delta.logStore.class", classOf[CustomListingLogStore].getName)
+  }
+
+  private def pathToFileStatus(path: Path, length: Long = 20): FileStatus = {
+    SerializableFileStatus(path.toString, length, isDir = true, modificationTime = 0L).toFileStatus
+  }
+
+  private def commitFiles(logPath: Path, versions: Seq[Long]): Seq[FileStatus] = {
+    versions.map { version => pathToFileStatus(FileNames.unsafeDeltaFile(logPath, version)) }
+  }
+
+  private def singleCheckpointFiles(
+      logPath: Path, versions: Seq[Long],
+      length: Long = 20): Seq[FileStatus] = {
+    versions.map { v => pathToFileStatus(FileNames.checkpointFileSingular(logPath, v), length) }
+  }
+
+  private def multipartCheckpointFiles(
+      logPath: Path,
+      versions: Seq[Long],
+      numParts: Int,
+      length: Long = 20): Seq[FileStatus] = {
+    versions.flatMap { version =>
+      FileNames.checkpointFileWithParts(logPath, version, numParts).map(pathToFileStatus(_, length))
+    }
+  }
+
+  private def checksumFiles(logPath: Path, versions: Seq[Long]): Seq[FileStatus] = {
+    versions.map { version => pathToFileStatus(FileNames.checksumFile(logPath, version)) }
+  }
+
+  test("findLastCompleteCheckpoint without any argument") {
+    withTempDir { dir =>
+      val log = DeltaLog.forTable(spark, dir.getAbsolutePath)
+      val logPath = log.logPath
+      val logStore = log.store.asInstanceOf[CustomListingLogStore]
+
+      // Case-1: Multiple checkpoint exists in table dir
+      logStore.customListingResult = Some(
+        commitFiles(logPath, 0L to 3000) ++
+          singleCheckpointFiles(logPath, Seq(100, 200, 1000, 2000))
+      )
+      assert(log.findLastCompleteCheckpointBefore().contains(CheckpointInstance(version = 2000)))
+      assert(logStore.listFromCount == 1)
+      assert(logStore.elementsConsumedFromListFromIter == 3005)
+      logStore.reset()
+
+      // Case-2: No checkpoint exists in table dir
+      logStore.customListingResult = Some(commitFiles(logPath, 0L to 3000))
+      assert(log.findLastCompleteCheckpointBefore().isEmpty)
+      assert(logStore.listFromCount == 1)
+      assert(logStore.elementsConsumedFromListFromIter == 3001)
+      logStore.reset()
+
+      // Case-3: Multiple checkpoints for same version exists in table dir
+      logStore.customListingResult = Some(
+        commitFiles(logPath, 0L to 3000) ++
+          singleCheckpointFiles(logPath, Seq(100, 200, 1000, 2000)) ++
+          multipartCheckpointFiles(logPath, Seq(300, 2000), numParts = 4)
+      )
+      assert(log.findLastCompleteCheckpointBefore().contains(
+        CheckpointInstance(version = 2000, Format.WITH_PARTS, numParts = Some(4))))
+      assert(logStore.listFromCount == 1)
+      assert(logStore.elementsConsumedFromListFromIter == 3013)
+      logStore.reset()
+    }
+  }
+
+  test("findLastCompleteCheckpoint with an upperBound which exists") {
+    withTempDir { dir =>
+      val log = DeltaLog.forTable(spark, dir.getAbsolutePath)
+      val logPath = log.logPath
+      val logStore = log.store.asInstanceOf[CustomListingLogStore]
+      logStore.reset()
+
+      // Case-1: The upperBound exists and it should not be returned
+      logStore.customListingResult = Some(
+        commitFiles(logPath, 0L to 3000) ++
+          singleCheckpointFiles(logPath, Seq(100, 200, 1000, 2000))
+      )
+      assert(
+        log.findLastCompleteCheckpointBefore(Some(CheckpointInstance(version = 2000)))
+          .contains(CheckpointInstance(version = 1000)))
+      assert(logStore.listFromCount == 1)
+      assert(logStore.elementsConsumedFromListFromIter == 1002 + 2) // commits + checkpoint
+      logStore.reset()
+
+      // Case-2: The exact upperBound (a multi-part checkpoint) doesn't exist but another single
+      // part checkpoint for same version exists.
+      logStore.customListingResult = Some(
+        commitFiles(logPath, 0L to 3000) ++
+          singleCheckpointFiles(logPath, Seq(100, 200, 1000, 2000))
+      )
+      var sentinelCheckpoint =
+        CheckpointInstance(version = 2000, Format.WITH_PARTS, numParts = Some(4))
+      assert(log.findLastCompleteCheckpointBefore(Some(sentinelCheckpoint))
+        .contains(CheckpointInstance(version = 2000)))
+      assert(logStore.listFromCount == 1)
+      assert(logStore.elementsConsumedFromListFromIter == 1002 + 2) // commits + checkpoint
+      logStore.reset()
+
+      // Case-3: The last complete checkpoint doesn't exist in last 1000 elements and needs
+      // multiple iterations.
+      logStore.customListingResult = Some(
+        commitFiles(logPath, 0L to 2500) ++
+          singleCheckpointFiles(logPath, Seq(100, 150))
+      )
+      assert(
+        log.findLastCompleteCheckpointBefore(2200)
+          .contains(CheckpointInstance(version = 150)))
+      assert(logStore.listFromCount == 3)
+      // the first listing will consume 1000 elements from 1200 to 2201 => 1002 commits
+      // the second listing will consume 1000 elements from 200 to 1201 => 1002 commits
+      // the third listing will consume 501 elements from 0 to 201 => 202 commits + 2 checkpoints
+      assert(logStore.elementsConsumedFromListFromIter == 2208) // commits + checkpoint
+      logStore.reset()
+    }
+  }
+
+  for (passSentinelInstance <- BOOLEAN_DOMAIN)
+  test("findLastCompleteCheckpoint ignores 0B files " +
+      s"[passSentinelInstance: $passSentinelInstance]") {
+    withTempDir { dir =>
+      val log = DeltaLog.forTable(spark, dir.getAbsolutePath)
+      val logPath = log.logPath
+      val logStore = log.store.asInstanceOf[CustomListingLogStore]
+      logStore.reset()
+
+      val lastCommitVersion = 1400
+      val sentinelInstance =
+        if (passSentinelInstance) Some(CheckpointInstance(version = 1200)) else None
+      val expectedListCount = if (passSentinelInstance) 2 else 1
+      def getExpectedFileCount(filesPerCheckpoint: Int): Int = {
+        if (passSentinelInstance) {
+          // commits and checkpoints from 200 to 1201 => 1002 + 1-checkpoint
+          // commits and checkpoints from 0 to 201 => 202 + 2-checkpoint
+          1204 + 3 * filesPerCheckpoint
+        } else {
+          val totalCommits = lastCommitVersion + 1 // commit starts from 0
+          totalCommits + 2 * filesPerCheckpoint
+        }
+      }
+
+      // Case-1: `findLastCompleteCheckpointBefore` invoked without upperBound, with 0B single part
+      // checkpoint.
+      logStore.customListingResult = Some(
+        commitFiles(logPath, 0L to lastCommitVersion) ++
+        singleCheckpointFiles(logPath, Seq(100), length = 20) ++
+        singleCheckpointFiles(logPath, Seq(200), length = 0))
+      assert(
+        log.findLastCompleteCheckpointBefore(sentinelInstance)
+          .contains(CheckpointInstance(version = 100)))
+      assert(logStore.listFromCount == expectedListCount)
+      assert(logStore.elementsConsumedFromListFromIter ===
+        getExpectedFileCount(filesPerCheckpoint = 1))
+      logStore.reset()
+
+      // Case-2: `findLastCompleteCheckpointBefore` invoked with upperBound, with a multi-part
+      // checkpoint having one of the part as 0B.
+      val badCheckpointV200 = {
+        val checkpointV200 = multipartCheckpointFiles(logPath, Seq(200), numParts = 4)
+        SerializableFileStatus.fromStatus(checkpointV200.head).copy(length = 0).toFileStatus +:
+          checkpointV200.tail
+      }
+      logStore.customListingResult = Some(
+        commitFiles(logPath, 0L to lastCommitVersion) ++
+        multipartCheckpointFiles(logPath, Seq(100), numParts = 4) ++
+        badCheckpointV200
+      )
+      assert(log.findLastCompleteCheckpointBefore(sentinelInstance)
+        .contains(CheckpointInstance(version = 100, Format.WITH_PARTS, numParts = Some(4))))
+      assert(logStore.listFromCount == expectedListCount)
+      assert(logStore.elementsConsumedFromListFromIter ===
+        getExpectedFileCount(filesPerCheckpoint = 4))
+      logStore.reset()
+    }
+  }
+
+  for (passSentinelInstance <- BOOLEAN_DOMAIN)
+  test("findLastCompleteCheckpoint ignores incomplete multi-part checkpoint " +
+      s"[passSentinelInstance: $passSentinelInstance]") {
+    withTempDir { dir =>
+      val log = DeltaLog.forTable(spark, dir.getAbsolutePath)
+      val logPath = log.logPath
+      val logStore = log.store.asInstanceOf[CustomListingLogStore]
+      logStore.reset()
+
+      val lastCommitVersion = 1400
+      val sentinelInstance =
+        if (passSentinelInstance) Some(CheckpointInstance(version = 1200)) else None
+      val expectedListCount = if (passSentinelInstance) 2 else 1
+
+      def getExpectedFileCount(fileInCheckpointV200: Int, filesInCheckpointV100: Int): Int = {
+        if (passSentinelInstance) {
+          // commits and checkpoints from 200 to 1201 => 1002 + 1-checkpoint
+          // commits and checkpoints from 0 to 201 => 202 + 2-checkpoint
+          1204 + (fileInCheckpointV200 + fileInCheckpointV200 + filesInCheckpointV100)
+        } else {
+          val totalCommits = lastCommitVersion + 1 // commit starts from 0
+          totalCommits + (fileInCheckpointV200 + filesInCheckpointV100)
+        }
+      }
+
+      // Case-1: `findLastCompleteCheckpointBefore` invoked, with 0B single part checkpoint.
+      logStore.customListingResult = Some(
+        commitFiles(logPath, 0L to lastCommitVersion) ++
+          multipartCheckpointFiles(logPath, Seq(100), numParts = 4, length = 20) ++
+          multipartCheckpointFiles(logPath, Seq(200), numParts = 4, length = 20).take(3))
+      assert(
+        log.findLastCompleteCheckpointBefore(sentinelInstance)
+          .contains(CheckpointInstance(100, Format.WITH_PARTS, numParts = Some(4))))
+      assert(logStore.listFromCount == expectedListCount)
+      assert(logStore.elementsConsumedFromListFromIter ===
+        getExpectedFileCount(fileInCheckpointV200 = 3, filesInCheckpointV100 = 4))
+      logStore.reset()
+    }
+  }
+
+}
+
+/**
+ * A custom log store that allows to provide custom listing results. This is useful to test
+ * `DeltaLog.findLastCompleteCheckpointBefore` method.
+ */
+class CustomListingLogStore(
+  sparkConf: SparkConf,
+  hadoopConf: Configuration) extends LocalLogStore(sparkConf, hadoopConf) {
+
+  var listFromCount = 0
+  var elementsConsumedFromListFromIter = 0
+  // The custom listing result that will be returned by `listFrom` method. If this is None, then
+  // the default listing result from the actual filesystem will be returned.
+  var customListingResult: Option[Seq[FileStatus]] = None
+
+  override def listFrom(path: Path, hadoopConf: Configuration): Iterator[FileStatus] = {
+    customListingResult.map { results =>
+      listFromCount += 1
+      results
+        .sortBy(_.getPath)
+        .dropWhile(_.getPath.toString < path.toString)
+        .toIterator
+        .map { file =>
+          elementsConsumedFromListFromIter += 1
+          file
+        }
+    }.getOrElse(super.listFrom(path, hadoopConf))
+  }
+
+  def reset(): Unit = {
+    listFromCount = 0
+    elementsConsumedFromListFromIter = 0
+    customListingResult = None
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/util/DeltaLogGroupingIteratorSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/util/DeltaLogGroupingIteratorSuite.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.util
+
+import org.apache.spark.sql.delta.SerializableFileStatus
+
+import org.apache.spark.SparkFunSuite
+
+class DeltaLogGroupingIteratorSuite extends SparkFunSuite {
+
+  test("DeltaLogGroupingIterator") {
+    val paths = Seq(
+      // both checkpoint and commit file present for v1
+      "file://a/b/_delta_log/1.checkpoint.parquet",
+      "file://a/b/_delta_log/1.json",
+
+      // only json file present for v2
+      "file://a/b/_delta_log/2.json",
+      // v3 missing
+
+      // multiple types of checkpoint present for v4
+      "file://a/b/_delta_log/4.checkpoint.parquet",
+      "file://a/b/_delta_log/4.checkpoint.uuid.parquet",
+      "file://a/b/_delta_log/4.checkpoint.json.parquet",
+      "file://a/b/_delta_log/4.checkpoint.0.1.parquet",
+      "file://a/b/_delta_log/4.checkpoint.1.1.parquet",
+      "file://a/b/_delta_log/4.json",
+      // v5, v6 with single checkpoint file
+      "file://a/b/_delta_log/5.checkpoint.parquet",
+      "file://a/b/_delta_log/5.json",
+      "file://a/b/_delta_log/6.checkpoint.parquet",
+      // no checkpoint files in the end
+      "file://a/b/_delta_log/6.json",
+      "file://a/b/_delta_log/7.json",
+      "file://a/b/_delta_log/8.json",
+      "file://a/b/_delta_log/9.json",
+      "file://a/b/_delta_log/11.checkpoint.0.1.parquet",
+      "file://a/b/_delta_log/11.checkpoint.1.1.parquet",
+      "file://a/b/_delta_log/11.checkpoint.uuid.parquet",
+      "file://a/b/_delta_log/12.checkpoint.parquet",
+      "file://a/b/_delta_log/14.json"
+    )
+    val fileStatuses = paths.map { path =>
+      SerializableFileStatus(path, length = 10, isDir = false, modificationTime = 1).toFileStatus
+    }.toIterator
+    val groupedFileStatuses = new DeltaLogGroupingIterator(fileStatuses)
+    val groupedPaths = groupedFileStatuses.toIndexedSeq.map { case (version, files) =>
+      (version, files.map(_.getPath.toString).toList)
+    }
+    assert(groupedPaths === Seq(
+      1 -> List("file://a/b/_delta_log/1.checkpoint.parquet", "file://a/b/_delta_log/1.json"),
+      2 -> List("file://a/b/_delta_log/2.json"),
+      4 -> List(
+        "file://a/b/_delta_log/4.checkpoint.parquet",
+        "file://a/b/_delta_log/4.checkpoint.uuid.parquet",
+        "file://a/b/_delta_log/4.checkpoint.json.parquet",
+        "file://a/b/_delta_log/4.checkpoint.0.1.parquet",
+        "file://a/b/_delta_log/4.checkpoint.1.1.parquet",
+        "file://a/b/_delta_log/4.json"),
+      5 -> List("file://a/b/_delta_log/5.checkpoint.parquet", "file://a/b/_delta_log/5.json"),
+      6 -> List("file://a/b/_delta_log/6.checkpoint.parquet", "file://a/b/_delta_log/6.json"),
+      7 -> List("file://a/b/_delta_log/7.json"),
+      8 -> List("file://a/b/_delta_log/8.json"),
+      9 -> List("file://a/b/_delta_log/9.json"),
+      11 -> List(
+        "file://a/b/_delta_log/11.checkpoint.0.1.parquet",
+        "file://a/b/_delta_log/11.checkpoint.1.1.parquet",
+        "file://a/b/_delta_log/11.checkpoint.uuid.parquet"),
+      12 -> List("file://a/b/_delta_log/12.checkpoint.parquet"),
+      14 -> List("file://a/b/_delta_log/14.json")
+    ))
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR fixes an O(n^2) issue in `find last complete checkpoint before` method.

Today the `findLastCompleteCheckpointBefore` tries to find the last checkpoint before a given version. In order to do this, it do following:
findLastCompleteCheckpointBefore(10000):
1. List from 9000
2. List from 8000
3. List from 7000
...

Each of these listing today lists to the end as they completely ignore delta files and try to list with takeWhile with version clause:

```
    listFrom(..)
          .filter { file => isCheckpointFile(file) && file.getLen != 0 }
          .map{ file => CheckpointInstance(file.getPath) }
          .takeWhile(tv => (cur == 0 || tv.version <= cur) && tv < upperBoundCv)
```

This PR tries to fix this issue by terminating each listing early by checking if we have crossed a deltaFile for untilVersion.

In addition to this, we also optimize how much to list in each iteration.
E.g. After this PR, findLastCompleteCheckpointBefore(10000) will need:
1. Iteration-1 lists from 9000 to 10000.
2. Iteration-2 lists from 8000 to 9000.
3. Iteration-3 lists from 7000 to 8000.
4. and so on...


## How was this patch tested?

UT
