### PR TITLE
[Kernel][Usage Guide] Migration docs for Kernel 3.2

### DIFF
--- a/kernel/USER_GUIDE.md
+++ b/kernel/USER_GUIDE.md
@@ -582,7 +582,7 @@ For best performance, you can implement your own Parquet reader and other `Engin
 Now you should be able to read the Delta table correctly.
 
 ## Migration guide
-Kernel APIs are still evolving and new features are being added. Delta authors try to make the API changes backward compatible as much as they can with each new release, but sometimes it is hard to maintain the backward compatibility for a project that is evolving rapidly.
+Kernel APIs are still evolving and new features are being added. Kernel authors try to make the API changes backward compatible as much as they can with each new release, but sometimes it is hard to maintain the backward compatibility for a project that is evolving rapidly.
 
 This section provides guidance on how to migrate your connector to the latest version of Delta Kernel. With each new release the [examples](https://github.com/delta-io/delta/tree/master/kernel/examples) are kept up-to-date with the latest API changes. You can refer to the examples to understand how to use the new APIs.
 

--- a/kernel/USER_GUIDE.md
+++ b/kernel/USER_GUIDE.md
@@ -589,7 +589,7 @@ This section provides guidance on how to migrate your connector to the latest ve
 ### Migration from Delta Lake version 3.1.0 to 3.2.0
 Following are API changes in Delta Kernel 3.2.0 that may require changes in your connector.
 
-#### Rename `TableClient` to `Engine`
+#### Rename `TableClient` to [`Engine`](https://delta-io.github.io/delta/snapshot/kernel-api/java/io/delta/kernel/engine/Engine.html)
 The `TableClient` interface has been renamed to `Engine`. This is the most significant API change in this release. The `TableClient` interface name is not exactly representing the functionality it provides. At a high level it provides capabilities such as reading Parquet files, JSON files, evaluating expressions on data and file system functionality. These are basically the heavy lift operations that Kernel depends on as a separate interface to allow the connectors to substitute their own custom implementation of the same functionality (e.g. custom Parquet reader). Essentially, these functionalities are the core of the `engine` functionalities. By renaming to `Engine`, we are representing the interface functionality with a proper name that is easy to understand.
 
 The `DefaultTableClient` has been renamed to [`DefaultEngine`](https://delta-io.github.io/delta/snapshot/kernel-defaults/java/io/delta/kernel/defaults/engine/DefaultEngine.html).


### PR DESCRIPTION
Capture the breaking API changes to enable connectors to migrate to the latest version of Kernel