### PR TITLE
[Kernel][Writes] Example connector programs using the Kernel Write APIs

### DIFF
--- a/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/BaseTableReader.java
+++ b/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/BaseTableReader.java
@@ -28,9 +28,6 @@ import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
@@ -132,38 +129,19 @@ public abstract class BaseTableReader {
      */
     protected static Options baseOptions() {
         return new Options()
-            .addRequiredOption("t", "table", true, "Fully qualified table path")
-            .addOption("c", "columns", true,
-                "Comma separated list of columns to read from the table. " +
-                    "Ex. --columns=id,name,address")
-            .addOption(
-                Option.builder()
-                    .option("l")
-                    .longOpt("limit")
-                    .hasArg(true)
-                    .desc("Maximum number of rows to read from the table (default 20).")
-                    .type(Number.class)
-                    .build()
-            );
-    }
-
-    /**
-     * Helper method to parse the command line arguments.
-     */
-    protected static CommandLine parseArgs(Options options, String[] args) {
-        CommandLineParser cliParser = new DefaultParser();
-
-        try {
-            return cliParser.parse(options, args);
-        } catch (ParseException parseException) {
-            new HelpFormatter().printHelp(
-                "java " + SingleThreadedTableReader.class.getCanonicalName(),
-                options,
-                true
-            );
-        }
-        System.exit(-1);
-        return null;
+                .addRequiredOption("t", "table", true, "Fully qualified table path")
+                .addOption("c", "columns", true,
+                        "Comma separated list of columns to read from the table. " +
+                                "Ex. --columns=id,name,address")
+                .addOption(
+                        Option.builder()
+                                .option("l")
+                                .longOpt("limit")
+                                .hasArg(true)
+                                .desc("Maximum number of rows to read from the table (default 20).")
+                                .type(Number.class)
+                                .build()
+                );
     }
 
     protected static Optional<List<String>> parseColumnList(CommandLine cli, String optionName) {

--- a/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/BaseTableWriter.java
+++ b/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/BaseTableWriter.java
@@ -155,7 +155,7 @@ public class BaseTableWriter {
         return new ColumnVector() {
             @Override
             public DataType getDataType() {
-                return StringType.STRING;
+                return IntegerType.INTEGER;
             }
 
             @Override
@@ -239,7 +239,7 @@ public class BaseTableWriter {
         return new ColumnVector() {
             @Override
             public DataType getDataType() {
-                return IntegerType.INTEGER;
+                return StringType.STRING;
             }
 
             @Override

--- a/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/BaseTableWriter.java
+++ b/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/BaseTableWriter.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.examples;
+
+import java.util.*;
+
+import org.apache.hadoop.conf.Configuration;
+
+import io.delta.kernel.TransactionCommitResult;
+import io.delta.kernel.data.*;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.types.*;
+
+import io.delta.kernel.defaults.engine.DefaultEngine;
+
+import io.delta.kernel.defaults.internal.data.DefaultColumnarBatch;
+
+public class BaseTableWriter {
+
+    protected final Engine engine = DefaultEngine.create(new Configuration());
+
+    /**
+     * Schema used in examples for table create and/or writes
+     */
+    protected final StructType exampleTableSchema = new StructType()
+            .add("id", IntegerType.INTEGER)
+            .add("name", StringType.STRING)
+            .add("address", StringType.STRING)
+            .add("salary", DoubleType.DOUBLE);
+
+
+    /**
+     * Schema and partition columns used in examples for partitioned table create and/or writes.
+     */
+    protected final StructType examplePartitionedTableSchema = new StructType()
+            .add("id", IntegerType.INTEGER)
+            .add("name", StringType.STRING)
+            .add("city", StringType.STRING)
+            .add("salary", DoubleType.DOUBLE);
+    protected final List<String> examplePartitionColumns = Collections.singletonList("city");
+
+
+    void verifyCommitSuccess(String tablePath, TransactionCommitResult result) {
+        // Verify the commit was successful
+        if (result.getVersion() >= 0) {
+            System.out.println("Table created successfully at: " + tablePath);
+        } else {
+            // This should never happen. If there is a reason for table be not created
+            // `Transaction.commit` always throws an exception.
+            throw new RuntimeException("Table creation failed");
+        }
+    }
+
+    /**
+     * Create data batch for a un-partitioned table with schema {@link #exampleTableSchema}.
+     *
+     * @param offset Offset that affects the generated data.
+     * @return
+     */
+    FilteredColumnarBatch generateUnpartitionedDataBatch(int offset) {
+        ColumnVector[] vectors = new ColumnVector[exampleTableSchema.length()];
+        // Create a batch with 5 rows
+
+        // id
+        vectors[0] = intVector(
+                Arrays.asList(offset, 1 + offset, 2 + offset, 3 + offset, 4 + offset));
+
+        // name
+        vectors[1] = stringVector(
+                Arrays.asList("Alice", "Bob", "Charlie", "David", "Eve"));
+
+        // address
+        vectors[2] = stringVector(
+                Arrays.asList(
+                        "123 Main St",
+                        "456 Elm St",
+                        "789 Cedar St",
+                        "101 Oak St",
+                        "121 Pine St"));
+
+        // salary
+        vectors[3] = doubleVector(
+                Arrays.asList(
+                        100.0d + offset,
+                        200.0d + offset,
+                        300.0d + offset,
+                        400.0d + offset,
+                        500.0d + offset));
+
+        ColumnarBatch batch = new DefaultColumnarBatch(5, exampleTableSchema, vectors);
+        return new FilteredColumnarBatch(
+                batch, // data
+                // Optional selection vector. If want to write only a subset of rows from the batch.
+                Optional.empty());
+    }
+
+    /**
+     * Create data batch for a partitioned table with schema {@link #examplePartitionedTableSchema}.
+     *
+     * @param offset Offset that affects the generated data.
+     * @param city   City value for the partition column.
+     * @return
+     */
+    FilteredColumnarBatch generatedPartitionedDataBatch(int offset, String city) {
+        ColumnVector[] vectors = new ColumnVector[examplePartitionedTableSchema.length()];
+        // Create a batch with 5 rows
+
+        // id
+        vectors[0] = intVector(
+                Arrays.asList(offset, 1 + offset, 2 + offset, 3 + offset, 4 + offset));
+
+        // name
+        vectors[1] = stringVector(
+                Arrays.asList("Alice", "Bob", "Charlie", "David", "Eve"));
+
+        // city - given city is a partition column we expect the batch to contain the same
+        // value for all rows.
+        vectors[2] = stringSingleValueVector(city, 5);
+
+        // salary
+        vectors[3] = doubleVector(
+                Arrays.asList(
+                        100.0d + offset,
+                        200.0d + offset,
+                        300.0d + offset,
+                        400.0d + offset,
+                        500.0d + offset));
+
+        ColumnarBatch batch = new DefaultColumnarBatch(5, examplePartitionedTableSchema, vectors);
+        return new FilteredColumnarBatch(
+                batch, // data
+                // Optional selection vector. If want to write only a subset of rows from the batch.
+                Optional.empty());
+    }
+
+
+    //////////////////////// Helper methods to create ColumnVectors ////////////////////////
+    // These are sample vectors which can be created as wrappers as engine specific       //
+    // vector types.                                                                      //
+    ////////////////////////////////////////////////////////////////////////////////////////
+    static ColumnVector intVector(List<Integer> data) {
+        return new ColumnVector() {
+            @Override
+            public DataType getDataType() {
+                return IntegerType.INTEGER;
+            }
+
+            @Override
+            public int getSize() {
+                return data.size();
+            }
+
+            @Override
+            public void close() {
+            }
+
+            @Override
+            public boolean isNullAt(int rowId) {
+                return false;
+            }
+
+            @Override
+            public int getInt(int rowId) {
+                return data.get(rowId);
+            }
+        };
+    }
+
+    static ColumnVector doubleVector(List<Double> data) {
+        return new ColumnVector() {
+            @Override
+            public DataType getDataType() {
+                return DoubleType.DOUBLE;
+            }
+
+            @Override
+            public int getSize() {
+                return data.size();
+            }
+
+            @Override
+            public void close() {
+            }
+
+            @Override
+            public boolean isNullAt(int rowId) {
+                return data.get(rowId) == null;
+            }
+
+            @Override
+            public double getDouble(int rowId) {
+                return data.get(rowId);
+            }
+        };
+    }
+
+    static ColumnVector stringVector(List<String> data) {
+        return new ColumnVector() {
+            @Override
+            public DataType getDataType() {
+                return StringType.STRING;
+            }
+
+            @Override
+            public int getSize() {
+                return data.size();
+            }
+
+            @Override
+            public void close() {
+            }
+
+            @Override
+            public boolean isNullAt(int rowId) {
+                return data.get(rowId) == null;
+            }
+
+            @Override
+            public String getString(int rowId) {
+                return data.get(rowId);
+            }
+        };
+    }
+
+    static ColumnVector stringSingleValueVector(String value, int size) {
+        return new ColumnVector() {
+            @Override
+            public DataType getDataType() {
+                return IntegerType.INTEGER;
+            }
+
+            @Override
+            public int getSize() {
+                return size;
+            }
+
+            @Override
+            public void close() {
+
+            }
+
+            @Override
+            public boolean isNullAt(int rowId) {
+                return value == null;
+            }
+
+            @Override
+            public String getString(int rowId) {
+                return value;
+            }
+        };
+    }
+
+
+}

--- a/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/BaseTableWriter.java
+++ b/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/BaseTableWriter.java
@@ -155,7 +155,7 @@ public class BaseTableWriter {
         return new ColumnVector() {
             @Override
             public DataType getDataType() {
-                return IntegerType.INTEGER;
+                return StringType.STRING;
             }
 
             @Override

--- a/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/CreateTable.java
+++ b/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/CreateTable.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.examples;
+
+import org.apache.commons.cli.Options;
+
+import io.delta.kernel.*;
+import io.delta.kernel.utils.CloseableIterable;
+import static io.delta.kernel.examples.utils.Utils.parseArgs;
+
+/**
+ * Example program to create a Delta table (no data is written) using the Kernel APIs.
+ * <p>
+ * Creates two tables with the following schema and partition columns in the input given directory
+ * location.
+ * <pre>
+ *     Table 1: un-partitioned table
+ *     CREATE TABLE example (id INT, name STRING, address STRING, salary DECIMAL(1, 3))
+ *
+ *     Table 2: partitioned table
+ *     CREATE TABLE example_partitioned (id INT, name STRING, salary DECIMAL(1, 3), city STRING))
+ *     PARTITIONED BY (city)
+ * </pre>
+ * <p>
+ * <p>
+ * It prints the table locations at the end of the successful execution.
+ */
+public class CreateTable extends BaseTableWriter {
+    public static void main(String[] args)
+            throws Exception {
+        Options options = new Options()
+                .addOption("l", "location", true, "Locations where the sample tables are created");
+
+        new CreateTable().runExamples(parseArgs(options, args).getOptionValue("location"));
+    }
+
+    public void runExamples(String location) {
+        createUnpartitionedTable(location + "/example");
+        createPartitionedTable(location + "/example_partitioned");
+    }
+
+    public void createUnpartitionedTable(String tablePath) {
+        // Create a `Table` object with the given destination table path
+        Table table = Table.forPath(engine, tablePath);
+
+        // Create a transaction builder to build the transaction
+        TransactionBuilder txnBuilder =
+                table.createTransactionBuilder(
+                        engine,
+                        "Examples", /* engineInfo */
+                        Operation.CREATE_TABLE);
+
+        // Set the schema of the new table on the transaction builder
+        txnBuilder = txnBuilder.withSchema(engine, exampleTableSchema);
+
+        // Build the transaction
+        Transaction txn = txnBuilder.build(engine);
+
+        // Commit the transaction.
+        // As we are just creating the table and not adding any data, the `dataActions` is empty.
+        TransactionCommitResult commitResult =
+                txn.commit(
+                        engine,
+                        CloseableIterable.emptyIterable() /* dataActions */);
+
+        // Check the transaction commit result
+        verifyCommitSuccess(tablePath, commitResult);
+    }
+
+    public void createPartitionedTable(String tablePath) {
+        // Create a `Table` object with the given destination table path
+        Table table = Table.forPath(engine, tablePath);
+
+        // Create a transaction builder to build the transaction
+        TransactionBuilder txnBuilder =
+                table.createTransactionBuilder(
+                        engine,
+                        "Examples", /* engineInfo */
+                        Operation.CREATE_TABLE);
+
+        txnBuilder = txnBuilder
+                // Set the schema of the new table
+                .withSchema(engine, examplePartitionedTableSchema)
+                // set the partition columns of the new table
+                .withPartitionColumns(engine, examplePartitionColumns);
+
+        // Build the transaction
+        Transaction txn = txnBuilder.build(engine);
+
+        // Commit the transaction.
+        // As we are just creating the table and not adding any data, the `dataActions` is empty.
+        TransactionCommitResult commitResult =
+                txn.commit(
+                        engine,
+                        CloseableIterable.emptyIterable() /* dataActions */);
+
+        // Check the transaction commit result
+        verifyCommitSuccess(tablePath, commitResult);
+    }
+}

--- a/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/CreateTableAndInsertData.java
+++ b/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/CreateTableAndInsertData.java
@@ -1,0 +1,423 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.examples;
+
+import java.io.IOException;
+import java.util.*;
+
+import org.apache.commons.cli.Options;
+
+import io.delta.kernel.*;
+import io.delta.kernel.data.FilteredColumnarBatch;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.expressions.Literal;
+import io.delta.kernel.utils.*;
+import static io.delta.kernel.examples.utils.Utils.parseArgs;
+
+import static io.delta.kernel.internal.util.Utils.toCloseableIterator;
+
+/**
+ * Example program that demonstrates how to:
+ *
+ * <ul>
+ *     <li>
+ *         create a partiitoned and unpartitioned table and insert data into it
+ *         (Basically the CREATE TABLE AS <query> command).
+ *     </li>
+ *     <li>
+ *          Insert into an existing table
+ *      </li>
+ *      <li>
+ *          Idempotent data write to a table.
+ *      </li>
+ * </ul>
+ */
+public class CreateTableAndInsertData extends BaseTableWriter {
+    public static void main(String[] args) throws IOException {
+        Options options = new Options()
+                .addOption("l", "location", true, "Locations where the sample tables are created");
+
+        new CreateTableAndInsertData().runExamples(
+                parseArgs(options, args).getOptionValue("location"));
+
+    }
+
+    public void runExamples(String location) throws IOException {
+        String unpartitionedTblPath = location + "/example";
+        String partitionTblPath = location + "/example_partitioned";
+
+        // CTAS example for unpartitioned tables
+        createTableWithSampleData(unpartitionedTblPath);
+
+        // CTAS example for partitioned tables
+        createPartitionedTableWithSampleData(partitionTblPath);
+
+        // Insert into an existing table.
+        insertDataIntoUnpartitionedTable(unpartitionedTblPath);
+
+        // Example of idempotent inserts
+        idempotentInserts(unpartitionedTblPath);
+
+        // Example of checkpointg
+        insertWithOptionalCheckpoint(unpartitionedTblPath);
+    }
+
+    public TransactionCommitResult createTableWithSampleData(String tablePath) throws IOException {
+        // Create a `Table` object with the given destination table path
+        Table table = Table.forPath(engine, tablePath);
+
+        // Create a transaction builder to build the transaction
+        TransactionBuilder txnBuilder =
+                table.createTransactionBuilder(
+                        engine,
+                        "Examples", /* engineInfo */
+                        Operation.CREATE_TABLE);
+
+        // Set the schema of the new table on the transaction builder
+        txnBuilder = txnBuilder.withSchema(engine, exampleTableSchema);
+
+        // Build the transaction
+        Transaction txn = txnBuilder.build(engine);
+
+        // Get the transaction state
+        Row txnState = txn.getTransactionState(engine);
+
+        // Generate the sample data for the table that confirms to the table schema
+        FilteredColumnarBatch batch1 = generateUnpartitionedDataBatch(5 /* offset */);
+        FilteredColumnarBatch batch2 = generateUnpartitionedDataBatch(10 /* offset */);
+        FilteredColumnarBatch batch3 = generateUnpartitionedDataBatch(25 /* offset */);
+        CloseableIterator<FilteredColumnarBatch> data =
+                toCloseableIterator(Arrays.asList(batch1, batch2, batch3).iterator());
+
+        // First transform the logical data to physical data that needs to be written to the Parquet
+        // files
+        CloseableIterator<FilteredColumnarBatch> physicalData =
+                Transaction.transformLogicalData(
+                        engine,
+                        txnState,
+                        data,
+                        // partition values - as this table is unpartitioned, it should be empty
+                        Collections.emptyMap());
+
+        // Get the write context
+        DataWriteContext writeContext = Transaction.getWriteContext(
+                engine,
+                txnState,
+                // partition values - as this table is unpartitioned, it should be empty
+                Collections.emptyMap());
+
+
+        // Now write the physical data to Parquet files
+        CloseableIterator<DataFileStatus> dataFiles = engine.getParquetHandler()
+                .writeParquetFiles(
+                        writeContext.getTargetDirectory(),
+                        physicalData,
+                        writeContext.getStatisticsColumns());
+
+
+        // Now convert the data file status to data actions that needs to be written to the Delta
+        // table log
+        CloseableIterator<Row> dataActions =
+                Transaction.generateAppendActions(engine, txnState, dataFiles, writeContext);
+
+
+        // Create a iterable out of the data actions. If the contents are too big to fit in memory,
+        // the connector may choose to write the data actions to a temporary file and return an
+        // iterator that reads from the file.
+        CloseableIterable<Row> dataActionsIterable =
+                CloseableIterable.inMemoryIterable(dataActions);
+
+        // Commit the transaction.
+        TransactionCommitResult commitResult = txn.commit(engine, dataActionsIterable);
+
+        // Check the transaction commit result
+        verifyCommitSuccess(tablePath, commitResult);
+
+        return commitResult;
+    }
+
+    public TransactionCommitResult createPartitionedTableWithSampleData(String tablePath) throws IOException {
+        // Create a `Table` object with the given destination table path
+        Table table = Table.forPath(engine, tablePath);
+
+        // Create a transaction builder to build the transaction
+        TransactionBuilder txnBuilder =
+                table.createTransactionBuilder(
+                        engine,
+                        "Examples", /* engineInfo */
+                        Operation.CREATE_TABLE);
+
+        txnBuilder = txnBuilder
+                // Set the schema of the new table
+                .withSchema(engine, examplePartitionedTableSchema)
+                // set the partition columns of the new table
+                .withPartitionColumns(engine, examplePartitionColumns);
+
+        // Build the transaction
+        Transaction txn = txnBuilder.build(engine);
+
+        // Get the transaction state
+        Row txnState = txn.getTransactionState(engine);
+
+        List<Row> dataActions = new ArrayList<>();
+
+        // Generate the sample data for three partitions. Process each partition separately.
+        // This is just an example. In a real-world scenario, the data may come from different
+        // partitions. Connectors already have the capability to partition by partition values
+        // before writing to the table
+
+        // In the test data `city` is a partition column
+        for (String city : Arrays.asList("San Francisco", "Campbell", "San Jose")) {
+            FilteredColumnarBatch batch1 = generatedPartitionedDataBatch(
+                    5 /* offset */, city /* partition value */);
+            FilteredColumnarBatch batch2 = generatedPartitionedDataBatch(
+                    5 /* offset */, city /* partition value */);
+            FilteredColumnarBatch batch3 = generatedPartitionedDataBatch(
+                    10 /* offset */, city /* partition value */);
+
+            CloseableIterator<FilteredColumnarBatch> data =
+                    toCloseableIterator(Arrays.asList(batch1, batch2, batch3).iterator());
+
+            // Create partition value map
+            Map<String, Literal> partitionValues =
+                    Collections.singletonMap(
+                            "city", // partition column name
+                            // partition value. Depending upon the parition column type, the
+                            // partition value should be created. In this example, the partition
+                            // column is of type StringType, so we are creating a string literal.
+                            Literal.ofString(city));
+
+
+            // First transform the logical data to physical data that needs to be written
+            // to the Parquet
+            // files
+            CloseableIterator<FilteredColumnarBatch> physicalData =
+                    Transaction.transformLogicalData(engine, txnState, data, partitionValues);
+
+            // Get the write context
+            DataWriteContext writeContext =
+                    Transaction.getWriteContext(engine, txnState, partitionValues);
+
+
+            // Now write the physical data to Parquet files
+            CloseableIterator<DataFileStatus> dataFiles = engine.getParquetHandler()
+                    .writeParquetFiles(
+                            writeContext.getTargetDirectory(),
+                            physicalData,
+                            writeContext.getStatisticsColumns());
+
+
+            // Now convert the data file status to data actions that needs to be written to the Delta
+            // table log
+            CloseableIterator<Row> partitionDataActions = Transaction.generateAppendActions(
+                    engine,
+                    txnState,
+                    dataFiles,
+                    writeContext);
+
+            // Now add all the partition data actions to the main data actions list. In a
+            // distributed query engine, the partition data is written to files at tasks on executor
+            // nodes. The data actions are collected at the driver node and then written to the
+            // Delta table log using the `Transaction.commit`
+            while (partitionDataActions.hasNext()) {
+                dataActions.add(partitionDataActions.next());
+            }
+        }
+
+
+        // Create a iterable out of the data actions. If the contents are too big to fit in memory,
+        // the connector may choose to write the data actions to a temporary file and return an
+        // iterator that reads from the file.
+        CloseableIterable<Row> dataActionsIterable = CloseableIterable.inMemoryIterable(
+                toCloseableIterator(dataActions.iterator()));
+
+        // Commit the transaction.
+        TransactionCommitResult commitResult = txn.commit(engine, dataActionsIterable);
+
+        // Check the transaction commit result
+        verifyCommitSuccess(tablePath, commitResult);
+
+        return commitResult;
+    }
+
+
+    public TransactionCommitResult insertDataIntoUnpartitionedTable(String tablePath) throws IOException {
+        // Create a `Table` object with the given destination table path
+        Table table = Table.forPath(engine, tablePath);
+
+        // Create a transaction builder to build the transaction
+        TransactionBuilder txnBuilder =
+                table.createTransactionBuilder(
+                        engine,
+                        "Examples", /* engineInfo */
+                        Operation.CREATE_TABLE);
+
+        // Build the transaction - no need to provide the schema as the table already exists.
+        Transaction txn = txnBuilder.build(engine);
+
+        // Get the transaction state
+        Row txnState = txn.getTransactionState(engine);
+
+        // Generate the sample data for the table that confirms to the table schema
+        FilteredColumnarBatch batch1 = generateUnpartitionedDataBatch(5 /* offset */);
+        FilteredColumnarBatch batch2 = generateUnpartitionedDataBatch(10 /* offset */);
+        FilteredColumnarBatch batch3 = generateUnpartitionedDataBatch(25 /* offset */);
+        CloseableIterator<FilteredColumnarBatch> data =
+                toCloseableIterator(Arrays.asList(batch1, batch2, batch3).iterator());
+
+        // First transform the logical data to physical data that needs to be written to the Parquet
+        // files
+        CloseableIterator<FilteredColumnarBatch> physicalData =
+                Transaction.transformLogicalData(
+                        engine,
+                        txnState,
+                        data,
+                        // partition values - as this table is unpartitioned, it should be empty
+                        Collections.emptyMap());
+
+        // Get the write context
+        DataWriteContext writeContext = Transaction.getWriteContext(
+                engine,
+                txnState,
+                // partition values - as this table is unpartitioned, it should be empty
+                Collections.emptyMap());
+
+
+        // Now write the physical data to Parquet files
+        CloseableIterator<DataFileStatus> dataFiles = engine.getParquetHandler()
+                .writeParquetFiles(
+                        writeContext.getTargetDirectory(),
+                        physicalData,
+                        writeContext.getStatisticsColumns());
+
+
+        // Now convert the data file status to data actions that needs to be written to the Delta
+        // table log
+        CloseableIterator<Row> dataActions =
+                Transaction.generateAppendActions(engine, txnState, dataFiles, writeContext);
+
+
+        // Create a iterable out of the data actions. If the contents are too big to fit in memory,
+        // the connector may choose to write the data actions to a temporary file and return an
+        // iterator that reads from the file.
+        CloseableIterable<Row> dataActionsIterable =
+                CloseableIterable.inMemoryIterable(dataActions);
+
+        // Commit the transaction.
+        TransactionCommitResult commitResult = txn.commit(engine, dataActionsIterable);
+
+        // Check the transaction commit result
+        verifyCommitSuccess(tablePath, commitResult);
+
+        return commitResult;
+    }
+
+    public TransactionCommitResult idempotentInserts(String tablePath) throws IOException {
+        // Create a `Table` object with the given destination table path
+        Table table = Table.forPath(engine, tablePath);
+
+        // Create a transaction builder to build the transaction
+        TransactionBuilder txnBuilder =
+                table.createTransactionBuilder(
+                        engine,
+                        "Examples", /* engineInfo */
+                        Operation.CREATE_TABLE);
+
+        // Set the transaction identifiers for idempotent writes
+        // Delta/Kernel makes sure that there exists only one transaction in the Delta log
+        // with the given application id and txn version
+        txnBuilder = txnBuilder.withTransactionId(
+                engine,
+                "my app id", /* application id */
+                100 /* txn version */);
+
+        // Build the transaction - no need to provide the schema as the table already exists.
+        Transaction txn = txnBuilder.build(engine);
+
+        // Get the transaction state
+        Row txnState = txn.getTransactionState(engine);
+
+        // Generate the sample data for the table that confirms to the table schema
+        FilteredColumnarBatch batch1 = generateUnpartitionedDataBatch(5 /* offset */);
+        FilteredColumnarBatch batch2 = generateUnpartitionedDataBatch(10 /* offset */);
+        FilteredColumnarBatch batch3 = generateUnpartitionedDataBatch(25 /* offset */);
+        CloseableIterator<FilteredColumnarBatch> data =
+                toCloseableIterator(Arrays.asList(batch1, batch2, batch3).iterator());
+
+        // First transform the logical data to physical data that needs to be written to the Parquet
+        // files
+        CloseableIterator<FilteredColumnarBatch> physicalData =
+                Transaction.transformLogicalData(
+                        engine,
+                        txnState,
+                        data,
+                        // partition values - as this table is unpartitioned, it should be empty
+                        Collections.emptyMap());
+
+        // Get the write context
+        DataWriteContext writeContext = Transaction.getWriteContext(
+                engine,
+                txnState,
+                // partition values - as this table is unpartitioned, it should be empty
+                Collections.emptyMap());
+
+
+        // Now write the physical data to Parquet files
+        CloseableIterator<DataFileStatus> dataFiles = engine.getParquetHandler()
+                .writeParquetFiles(
+                        writeContext.getTargetDirectory(),
+                        physicalData,
+                        writeContext.getStatisticsColumns());
+
+
+        // Now convert the data file status to data actions that needs to be written to the Delta
+        // table log
+        CloseableIterator<Row> dataActions =
+                Transaction.generateAppendActions(engine, txnState, dataFiles, writeContext);
+
+
+        // Create a iterable out of the data actions. If the contents are too big to fit in memory,
+        // the connector may choose to write the data actions to a temporary file and return an
+        // iterator that reads from the file.
+        CloseableIterable<Row> dataActionsIterable =
+                CloseableIterable.inMemoryIterable(dataActions);
+
+        // Commit the transaction.
+        TransactionCommitResult commitResult = txn.commit(engine, dataActionsIterable);
+
+        // Check the transaction commit result
+        verifyCommitSuccess(tablePath, commitResult);
+        return commitResult;
+    }
+
+    public void insertWithOptionalCheckpoint(String tablePath) throws IOException {
+        boolean didCheckpoint = false;
+        // insert data multiple times to trigger a checkpoint. By default checkpoint is needed
+        // for every 10 versions.
+        for (int i = 0; i < 12; i++) {
+            TransactionCommitResult commitResult = insertDataIntoUnpartitionedTable(tablePath);
+            if (commitResult.isReadyForCheckpoint()) {
+                // Checkpoint the table
+                Table.forPath(engine, tablePath).checkpoint(engine, commitResult.getVersion());
+                didCheckpoint = true;
+            }
+        }
+
+        if (!didCheckpoint) {
+            throw new RuntimeException("Table should have checkpointed by now");
+        }
+    }
+}

--- a/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/MultiThreadedTableReader.java
+++ b/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/MultiThreadedTableReader.java
@@ -37,6 +37,8 @@ import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
 
+import static io.delta.kernel.examples.utils.Utils.parseArgs;
+
 import io.delta.kernel.internal.InternalScanFileUtils;
 import io.delta.kernel.internal.data.ScanStateRow;
 import io.delta.kernel.internal.util.Utils;

--- a/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/SingleThreadedTableReader.java
+++ b/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/SingleThreadedTableReader.java
@@ -31,6 +31,8 @@ import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
 
+import static io.delta.kernel.examples.utils.Utils.parseArgs;
+
 import io.delta.kernel.internal.InternalScanFileUtils;
 import io.delta.kernel.internal.data.ScanStateRow;
 import static io.delta.kernel.internal.util.Utils.singletonCloseableIterator;

--- a/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/utils/Utils.java
+++ b/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/utils/Utils.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.examples.utils;
+
+import org.apache.commons.cli.*;
+
+import io.delta.kernel.examples.SingleThreadedTableReader;
+
+public class Utils {
+
+    /**
+     * Helper method to parse the command line arguments.
+     */
+    public static CommandLine parseArgs(Options options, String[] args) {
+        CommandLineParser cliParser = new DefaultParser();
+
+        try {
+            return cliParser.parse(options, args);
+        } catch (ParseException parseException) {
+            new HelpFormatter().printHelp(
+                    "java " + SingleThreadedTableReader.class.getCanonicalName(),
+                    options,
+                    true
+            );
+        }
+        System.exit(-1);
+        return null;
+    }
+}

--- a/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/integration/WriteIntegrationTestSuite.java
+++ b/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/integration/WriteIntegrationTestSuite.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.integration;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Optional;
+import java.util.UUID;
+
+import io.delta.kernel.examples.*;
+
+/**
+ * Test suite that runs various integration tests for sanity testing the staged/released artifacts.
+ * It only verifies the number of rows in the results and not the specific values of rows. For full
+ * scale results verification we rely on unit tests which are run as part of the CI jobs.
+ */
+public class WriteIntegrationTestSuite {
+
+    public static void main(String[] args) throws Exception {
+        new WriteIntegrationTestSuite().runTests();
+    }
+
+
+    public void runTests() throws Exception {
+        verifyRowCount(
+                "Create un-partitioned table",
+                0 /* expected row count */,
+                tblLocation -> new CreateTable().createUnpartitionedTable(tblLocation)
+        );
+
+        verifyRowCount(
+                "Create partitioned table",
+                0 /* expected row count */,
+                tblLocation -> new CreateTable().createPartitionedTable(tblLocation)
+        );
+
+        verifyRowCount(
+                "Create un-partitioned table and insert data",
+                15 /* expected row count */,
+                tblLocation -> new CreateTableAndInsertData().createTableWithSampleData(tblLocation)
+        );
+
+        verifyRowCount(
+                "Create partitioned table and insert data",
+                45 /* expected row count */,
+                tblLocation ->
+                        new CreateTableAndInsertData()
+                                .createPartitionedTableWithSampleData(tblLocation)
+        );
+
+        verifyRowCount(
+                "insert data into an existing table",
+                30 /* expected row count */,
+                tblLocation -> {
+                    CreateTableAndInsertData createTableAndInsertData =
+                            new CreateTableAndInsertData();
+                    createTableAndInsertData.createTableWithSampleData(tblLocation);
+                    createTableAndInsertData.insertDataIntoUnpartitionedTable(tblLocation);
+                });
+
+        verifyRowCount(
+                "idempotent inserts into a table",
+                30 /* expected row count */,
+                tblLocation -> {
+                    CreateTableAndInsertData createTableAndInsertData =
+                            new CreateTableAndInsertData();
+                    createTableAndInsertData.createTableWithSampleData(tblLocation);
+                    createTableAndInsertData.idempotentInserts(tblLocation);
+                });
+
+
+        verifyRowCount(
+                "inserts with an optional checkpoint",
+                195 /* expected row count */,
+                tblLocation -> {
+                    CreateTableAndInsertData createTableAndInsertData =
+                            new CreateTableAndInsertData();
+                    createTableAndInsertData.createTableWithSampleData(tblLocation);
+                    createTableAndInsertData.insertWithOptionalCheckpoint(tblLocation);
+                });
+    }
+
+    private void verifyRowCount(String testName, int expectedRowCount, CheckedFunction<String> test)
+            throws Exception {
+        System.out.println("\n========== TEST START: " + testName + " ==============");
+        try {
+            String tblLocation = tmpLocation();
+
+            test.apply(tblLocation);
+
+            SingleThreadedTableReader reader = new SingleThreadedTableReader(tblLocation);
+            // Select a large number of rows (1M), so that everything in the table is read.
+            int actRowCount = reader.show(1_000_000, Optional.empty(), Optional.empty());
+            if (actRowCount != expectedRowCount) {
+                throw new RuntimeException(String.format(
+                        "Test (%s) failed: expected row count = %s, actual row count = %s",
+                        testName, expectedRowCount, actRowCount));
+            }
+        } finally {
+            System.out.println("========== TEST END: " + testName + " ==============\n");
+        }
+    }
+
+    private String tmpLocation() throws IOException {
+        return Files.createTempDirectory("delta" + UUID.randomUUID()).toString();
+    }
+
+    interface CheckedFunction<T> {
+        void apply(T tblLocation) throws Exception;
+    }
+}

--- a/kernel/examples/run-kernel-examples.py
+++ b/kernel/examples/run-kernel-examples.py
@@ -62,14 +62,16 @@ def run_multi_threaded_examples(version, maven_repo, examples_root_dir, golden_t
 
 
 def run_integration_tests(version, maven_repo, examples_root_dir, golden_tables_dir):
-    main_class = "io.delta.kernel.integration.ReadIntegrationTestSuite"
-    project_dir = path.join(examples_root_dir, "kernel-examples")
-    with WorkingDirectory(project_dir):
-        cmd = ["mvn", "package", "exec:java", f"-Dexec.mainClass={main_class}",
-               f"-Dstaging.repo.url={maven_repo}",
-               f"-Ddelta-kernel.version={version}",
-               f"-Dexec.args={golden_tables_dir}"]
-        run_cmd(cmd, stream_output=True)
+
+    main_classes = ["io.delta.kernel.integration.ReadIntegrationTestSuite", "io.delta.kernel.integration.WriteIntegrationTestSuite"]
+    for main_class in main_classes:
+        project_dir = path.join(examples_root_dir, "kernel-examples")
+        with WorkingDirectory(project_dir):
+            cmd = ["mvn", "package", "exec:java", f"-Dexec.mainClass={main_class}",
+                  f"-Dstaging.repo.url={maven_repo}",
+                  f"-Ddelta-kernel.version={version}",
+                  f"-Dexec.args={golden_tables_dir}"]
+            run_cmd(cmd, stream_output=True)
 
 
 def run_example(version, maven_repo, project_dir, main_class, test_cases):


### PR DESCRIPTION
## Description
Sample connector programs using the Kernel write APIs to
* create unpartitioned table
* create partitioned table
* create unpartitioned table and insert data into it (CTAS)
* create partitioned table and insert data into it (CTAS)
* insert into an existing unpartitioned table
* idempotent inserts
* insert with optional checkpoint

Also run these examples as part of the integration tests for release verification

## How was this patch tested?
Manually ran 
```
$ kernel/examples/run-kernel-examples.py --use-local

$ kernel/examples/run-kernel-examples.py --version 3.2.0 --maven-repo https://oss.sonatype.org/content/repositories/iodelta-1138
```