### PR TITLE
[Kernel] Fix the infinite loop in `CloseableIterator.map`

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/utils/CloseableIterator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/utils/CloseableIterator.java
@@ -20,7 +20,6 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 import io.delta.kernel.annotation.Evolving;
@@ -41,11 +40,6 @@ public interface CloseableIterator<T> extends Iterator<T>, Closeable {
             @Override
             public void remove() {
                 delegate.remove();
-            }
-
-            @Override
-            public void forEachRemaining(Consumer<? super U> action) {
-                this.forEachRemaining(action);
             }
 
             @Override


### PR DESCRIPTION
## Description

`CloseableIterator.map` creates new `CloseableIterator` which has wrong `forEachRemaining` impl (it calls itself). We should remove the impl and fall back on the default impl. This is a day 0 bug, not needed for 3.2 (given 3.2 is so close to release)
