### PR TITLE
Use lazy val for DeltaSharingFileIndex.queryCustomTablePath

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingFileIndex.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingFileIndex.scala
@@ -53,7 +53,7 @@ case class DeltaSharingFileIndex(
     with SupportsRowIndexFilters
     with DeltaFileFormat
     with Logging {
-  private val queryCustomTablePath = client.getProfileProvider.getCustomTablePath(
+  private lazy val queryCustomTablePath = client.getProfileProvider.getCustomTablePath(
     params.path.toString
   )
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [X] Other (Delta Sharing)

## Description
Fix on an edge case: Use lazy val for DeltaSharingFileIndex.queryCustomTablePath, to allow the table path to be resolved at execution time, to match the table path used in CachedTableManager.INSTANCE.register(: https://github.com/delta-io/delta-sharing/blob/main/client/src/main/scala/org/apache/spark/delta/sharing/PreSignedUrlCache.scala#L181, and allow the query to find the pre-signed urls for the delta sharing table. 

## How was this patch tested?
Unit Tests

## Does this PR introduce _any_ user-facing changes?
No
