### PR TITLE
[Spark] Conditionally check for presence of delta file at checkpoint version

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -446,6 +446,9 @@ trait SnapshotManagement { self: DeltaLog =>
         deltaVersion(file) > newCheckpointVersion
       }
 
+      val newVersion =
+        deltasAfterCheckpoint.lastOption.map(deltaVersion).getOrElse(newCheckpoint.get.version)
+
       // Here we validate that we are able to create a valid LogSegment by just using commit deltas
       // and without considering minor-compacted deltas. We want to fail early if log is messed up
       // i.e. some commit deltas are missing (although compacted-deltas are present).
@@ -458,20 +461,19 @@ trait SnapshotManagement { self: DeltaLog =>
       // `validateLogSegmentWithoutCompactedDeltas` to false in that case.
       if (validateLogSegmentWithoutCompactedDeltas) {
         validateDeltaVersions(deltasAfterCheckpoint, newCheckpointVersion, versionToLoad)
+        // `deltas` should always contain the newVersion i.e. the latest delta version after
+        // checkpoint or the checkpoint version unless we have a bug in log cleanup.
+        if (!deltas.exists(deltaVersion(_) == newVersion)) {
+        throw new IllegalStateException(
+          s"Could not find any delta files for version $newVersion")
+        }
       }
 
-      val newVersion =
-        deltasAfterCheckpoint.lastOption.map(deltaVersion).getOrElse(newCheckpoint.get.version)
       // reuse the oldCheckpointProvider if it is same as what we are looking for.
       val checkpointProviderOpt = newCheckpoint.map { ci =>
         oldCheckpointProviderOpt
           .collect { case cp if cp.version == ci.version => cp }
           .getOrElse(ci.getCheckpointProvider(this, checkpoints, lastCheckpointInfo))
-      }
-      // In the case where `deltasAfterCheckpoint` is empty, `deltas` should still not be empty,
-      // they may just be before the checkpoint version unless we have a bug in log cleanup.
-      if (deltas.isEmpty) {
-        throw new IllegalStateException(s"Could not find any delta files for version $newVersion")
       }
       if (versionToLoad.exists(_ != newVersion)) {
         throwNonExistentVersionError(versionToLoad.get)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
@@ -258,22 +258,35 @@ class SnapshotManagementSuite extends QueryTest with DeltaSQLTestUtils with Shar
     }
   }
 
-  test("should throw a clear exception when checkpoint exists but its corresponding delta file " +
-    "doesn't exist") {
-    withTempDir { tempDir =>
-      val path = tempDir.getCanonicalPath
-      val staleLog = DeltaLog.forTable(spark, path)
-      DeltaLog.clearCache()
+  BOOLEAN_DOMAIN.foreach { deleteUnbackfilledDeltas =>
+    test(
+      "should throw a clear exception when checkpoint exists but its corresponding delta file " +
+        s"doesn't exist, deleteUnbackfilledDeltas: $deleteUnbackfilledDeltas") {
+      withTempDir { tempDir =>
+        val path = tempDir.getCanonicalPath
+        val staleLog = DeltaLog.forTable(spark, path)
+        DeltaLog.clearCache()
 
-      spark.range(10).write.format("delta").save(path)
-      DeltaLog.forTable(spark, path).checkpoint()
-      // Delete delta files
-      new File(tempDir, "_delta_log").listFiles().filter(_.getName.endsWith(".json"))
-        .foreach(_.delete())
-      val e = intercept[IllegalStateException] {
-        staleLog.update()
+        spark.range(10).write.format("delta").save(path)
+        spark.range(10).write.format("delta").mode("append").save(path)
+        DeltaLog.forTable(spark, path).checkpoint()
+        // Delete delta file at version 1
+        new File(tempDir, "_delta_log")
+          .listFiles()
+          .filter(_.getName.endsWith("1.json"))
+          .foreach(_.delete())
+        if (deleteUnbackfilledDeltas) {
+          new File(new File(tempDir, "_delta_log"), "_commits")
+            .listFiles()
+            .filter(_.getName.endsWith("1.json"))
+            .foreach(_.delete())
+        }
+        val e = intercept[Exception] {
+          staleLog.update()
+        }
+        assert(e.isInstanceOf[IllegalStateException], e)
+        assert(e.getMessage.contains("Could not find any delta files for version 1"))
       }
-      assert(e.getMessage.contains("Could not find any delta files for version 0"))
     }
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

If `validateLogSegmentWithoutCompactedDeltas` is set, check that we have a delta file at the checkpoint version if there are no newer versions.

## How was this patch tested?

UTs

## Does this PR introduce _any_ user-facing changes?

No