### PR TITLE
[Spark] Improve GetCommits validation in CommitOwnerClient tests

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/CommitOwnerClientImplSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/CommitOwnerClientImplSuiteBase.scala
@@ -70,10 +70,10 @@ trait CommitOwnerClientImplSuiteBase extends QueryTest
    * where maxVersion is the current latest version of the table.
    */
   protected def validateGetCommitsResult(
-      startVersion: Option[Long],
-      endVersion: Option[Long],
-      maxVersion: Long,
-      commitVersions: Seq[Long]): Unit
+    response: GetCommitsResponse,
+    startVersion: Option[Long],
+    endVersion: Option[Long],
+    maxVersion: Long): Unit
 
   /**
    * Checks that the commit owner state is correct in terms of
@@ -230,8 +230,8 @@ trait CommitOwnerClientImplSuiteBase extends QueryTest
         startVersion: Option[Long],
         endVersion: Option[Long],
         maxVersion: Long): Unit = {
-      val result = client.getCommits(startVersion, endVersion).getCommits.map(_.getVersion)
-      validateGetCommitsResult(startVersion, endVersion, maxVersion, result)
+      val result = client.getCommits(startVersion, endVersion)
+      validateGetCommitsResult(result, startVersion, endVersion, maxVersion)
     }
 
     withTempTableDir { tempDir =>
@@ -299,7 +299,7 @@ trait CommitOwnerClientImplSuiteBase extends QueryTest
       assertCommitFail(4, 5, retryable = true, commit(4, 6, tableCommitOwnerClient))
 
       commit(5, 5, tableCommitOwnerClient)
-      assert(tableCommitOwnerClient.getCommits() == GetCommitsResponse(Seq.empty, 5))
+      validateGetCommitsResult(tableCommitOwnerClient.getCommits(), None, None, 5)
       assertCommitFail(5, 6, retryable = true, commit(5, 5, tableCommitOwnerClient))
       assertCommitFail(7, 6, retryable = false, commit(7, 7, tableCommitOwnerClient))
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/InMemoryCommitOwnerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/InMemoryCommitOwnerSuite.scala
@@ -52,13 +52,15 @@ abstract class InMemoryCommitOwnerSuite(batchSize: Int) extends CommitOwnerClien
   }
 
   protected def validateGetCommitsResult(
+      result: GetCommitsResponse,
       startVersion: Option[Long],
       endVersion: Option[Long],
-      maxVersion: Long,
-      commitVersions: Seq[Long]): Unit = {
+      maxVersion: Long): Unit = {
+    val commitVersions = result.getCommits.map(_.getVersion)
     val lastExpectedBackfilledVersion = (maxVersion - (maxVersion % batchSize)).toInt
     val expectedVersions = lastExpectedBackfilledVersion + 1 to maxVersion.toInt
     assert(commitVersions == expectedVersions)
+    assert(result.getLatestTableVersion == maxVersion)
   }
 
   test("InMemoryCommitOwnerBuilder works as expected") {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR makes a small improvement to the recently introduced CommitOwnerClientImplSuiteBase (a base trait that can be extended by CommitOwnerClient implementation tests). The change improves how the result of a getCommits call is validated. Instead of passing in a list of versions to validateGetCommitsResult, it now accepts the entire GetCommitsResponse. This allows to do more filtering on the result and also compare the latestTableVersion that is returned as part of the response (which is now implemented in the InMemoryCommitOwnerSuite).

## How was this patch tested?

Ensure that InMemoryCommitOwnerSuite still passes

## Does this PR introduce _any_ user-facing changes?

No
