### PR TITLE
[Spark] InCommitTimestamp: Use clock.currentTimeMillis() instead of nanoTime() in commitLarge

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1337,10 +1337,11 @@ trait OptimisticTransactionImpl extends TransactionalWrite
 
     try {
       val tags = Map.empty[String, String]
+      val commitTimestampMs = clock.getTimeMillis()
       val commitInfo = CommitInfo(
-        NANOSECONDS.toMillis(commitStartNano),
+        commitTimestampMs,
         operation = op.name,
-        generateInCommitTimestampForFirstCommitAttempt(NANOSECONDS.toMillis(commitStartNano)),
+        generateInCommitTimestampForFirstCommitAttempt(commitTimestampMs),
         operationParameters = op.jsonEncodedValues,
         context,
         readVersion = Some(readVersion),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
@@ -163,7 +163,7 @@ class InCommitTimestampSuite
           Map.empty)
       }
       val ver1Snapshot = deltaLog.snapshot
-      val retrievedTimestamp = getInCommitTimestamp(deltaLog, 1)
+      val retrievedTimestamp = getInCommitTimestamp(deltaLog, version = 1)
       assert(ver1Snapshot.timestamp == retrievedTimestamp)
       assert(ver1Snapshot.timestamp == expectedCommit1Time)
       assert(filterUsageRecords(usageRecords, "delta.commit.large").length == 1)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
@@ -143,7 +143,7 @@ class InCommitTimestampSuite
     }
   }
 
-   for (useCommitLarge <- BOOLEAN_DOMAIN)
+  for (useCommitLarge <- BOOLEAN_DOMAIN)
   test("txn.commit should use clock.currentTimeMillis() for ICT" +
     s" [useCommitLarge: $useCommitLarge]") {
     withTempDir { tempDir =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
@@ -143,6 +143,31 @@ class InCommitTimestampSuite
     }
   }
 
+  test("txn.commit should use clock.currentTimeMillis() for ICT") {
+    withTempDir { tempDir =>
+      spark.range(2).write.format("delta").save(tempDir.getAbsolutePath)
+      // Clear the DeltaLog cache so that a new DeltaLog is created with the manual clock.
+      DeltaLog.clearCache()
+      val expectedCommit1Time = System.currentTimeMillis()
+      val clock = new ManualClock(expectedCommit1Time)
+      val deltaLog = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath), clock)
+      val ver0Snapshot = deltaLog.snapshot
+      assert(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(ver0Snapshot.metadata))
+      val usageRecords = Log4jUsageLogger.track {
+        deltaLog.startTransaction().commit(
+          Seq(createTestAddFile("1")),
+          DeltaOperations.ManualUpdate,
+          Map.empty
+        )
+      }
+      val ver1Snapshot = deltaLog.snapshot
+      val retrievedTimestamp = getInCommitTimestamp(deltaLog, version = 1)
+      assert(ver1Snapshot.timestamp == retrievedTimestamp)
+      assert(ver1Snapshot.timestamp == expectedCommit1Time)
+      assert(filterUsageRecords(usageRecords, "delta.commit").length == 1)
+    }
+  }
+
   test("commitLarge should use clock.currentTimeMillis() for ICT") {
     withTempDir { tempDir =>
       spark.range(2).write.format("delta").save(tempDir.getAbsolutePath)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
@@ -160,15 +160,15 @@ class InCommitTimestampSuite
           deltaLog.startTransaction().commitLarge(
             spark,
             Seq(createTestAddFile("1")).toIterator,
-            None,
+            newProtocolOpt = None,
             DeltaOperations.ManualUpdate,
-            Map.empty,
-            Map.empty)
+            context = Map.empty,
+            metrics = Map.empty)
         } else {
           deltaLog.startTransaction().commit(
             Seq(createTestAddFile("1")),
             DeltaOperations.ManualUpdate,
-            Map.empty
+            tags = Map.empty
           )
         }
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
@@ -143,7 +143,9 @@ class InCommitTimestampSuite
     }
   }
 
-  test("txn.commit should use clock.currentTimeMillis() for ICT") {
+   for (useCommitLarge <- BOOLEAN_DOMAIN)
+  test("txn.commit should use clock.currentTimeMillis() for ICT" +
+    s" [useCommitLarge: $useCommitLarge]") {
     withTempDir { tempDir =>
       spark.range(2).write.format("delta").save(tempDir.getAbsolutePath)
       // Clear the DeltaLog cache so that a new DeltaLog is created with the manual clock.
@@ -154,44 +156,28 @@ class InCommitTimestampSuite
       val ver0Snapshot = deltaLog.snapshot
       assert(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(ver0Snapshot.metadata))
       val usageRecords = Log4jUsageLogger.track {
-        deltaLog.startTransaction().commit(
-          Seq(createTestAddFile("1")),
-          DeltaOperations.ManualUpdate,
-          Map.empty
-        )
+        if (useCommitLarge) {
+          deltaLog.startTransaction().commitLarge(
+            spark,
+            Seq(createTestAddFile("1")).toIterator,
+            None,
+            DeltaOperations.ManualUpdate,
+            Map.empty,
+            Map.empty)
+        } else {
+          deltaLog.startTransaction().commit(
+            Seq(createTestAddFile("1")),
+            DeltaOperations.ManualUpdate,
+            Map.empty
+          )
+        }
       }
       val ver1Snapshot = deltaLog.snapshot
       val retrievedTimestamp = getInCommitTimestamp(deltaLog, version = 1)
       assert(ver1Snapshot.timestamp == retrievedTimestamp)
       assert(ver1Snapshot.timestamp == expectedCommit1Time)
-      assert(filterUsageRecords(usageRecords, "delta.commit").length == 1)
-    }
-  }
-
-  test("commitLarge should use clock.currentTimeMillis() for ICT") {
-    withTempDir { tempDir =>
-      spark.range(2).write.format("delta").save(tempDir.getAbsolutePath)
-      // Clear the DeltaLog cache so that a new DeltaLog is created with the manual clock.
-      DeltaLog.clearCache()
-      val expectedCommit1Time = System.currentTimeMillis()
-      val clock = new ManualClock(expectedCommit1Time)
-      val deltaLog = DeltaLog.forTable(spark, new Path(tempDir.getCanonicalPath), clock)
-      val ver0Snapshot = deltaLog.snapshot
-      assert(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetaData(ver0Snapshot.metadata))
-      val usageRecords = Log4jUsageLogger.track {
-        deltaLog.startTransaction().commitLarge(
-          spark,
-          Seq(createTestAddFile("1")).toIterator,
-          None,
-          DeltaOperations.ManualUpdate,
-          Map.empty,
-          Map.empty)
-      }
-      val ver1Snapshot = deltaLog.snapshot
-      val retrievedTimestamp = getInCommitTimestamp(deltaLog, version = 1)
-      assert(ver1Snapshot.timestamp == retrievedTimestamp)
-      assert(ver1Snapshot.timestamp == expectedCommit1Time)
-      assert(filterUsageRecords(usageRecords, "delta.commit.large").length == 1)
+      val expectedOpType = if (useCommitLarge) "delta.commit.large" else "delta.commit"
+      assert(filterUsageRecords(usageRecords, expectedOpType).length == 1)
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
@@ -143,7 +143,7 @@ class InCommitTimestampSuite
     }
   }
 
-  test("commitLarge should use System.currentTimeMillis() for ICT") {
+  test("commitLarge should use clock.currentTimeMillis() for ICT") {
     withTempDir { tempDir =>
       spark.range(2).write.format("delta").save(tempDir.getAbsolutePath)
       // Clear the DeltaLog cache so that a new DeltaLog is created with the manual clock.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
We currently use NANOSECONDS.toMillis(System.nanoTime()) for generating the ICT when `commitLarge` is called. However, this usage of System.nanoTime() is not correct as it should only be used for measuring time difference, not to get an approximate wall clock time. This leads to scenarios where the ICT becomes very small (e.g. 1 Jan 1970) sometimes because some systems return a very small number when System.nanoTime() is called. This PR changes this so that clock.getCurrentTimeMillis() is used instead.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Added a test case to ensure that `clock.getCurrentTimeMillis()` is being used.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No