### PR TITLE
[Spark] Apply filters pushed down into DeltaCDFRelation

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceUtils.scala
@@ -103,5 +103,5 @@ object DeltaSourceUtils {
         UnresolvedAttribute(attribute), expressions.Literal.create(s"%${value}%"))
     case sources.AlwaysTrue() => expressions.Literal.TrueLiteral
     case sources.AlwaysFalse() => expressions.Literal.FalseLiteral
-  }.reduce(expressions.And)
+  }.reduceOption(expressions.And).getOrElse(expressions.Literal.TrueLiteral)
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSQLSuite.scala
@@ -115,7 +115,7 @@ class DeltaCDCSQLSuite extends DeltaCDCSuiteBase with DeltaColumnMappingTestUtil
             .withColumn("_change_type", lit("insert")))
       }
       assert(plans.map(_.executedPlan).toString
-        .contains("PushedFilters: [IsNotNull(id), LessThan(id,5)]"))
+        .contains("PushedFilters: [*IsNotNull(id), *LessThan(id,5)]"))
     }
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR modifies `DeltaCDFRelation` to apply the filters that are pushed down into this. This enables both partition pruning and row group skipping to happen when reading the Change Data Feed.

## How was this patch tested?

Unit tests

## Does this PR introduce _any_ user-facing changes?

No
