### PR TITLE
[Spark] DynamoDBCommitOwner: add logging, get dynamic confs from sparkSession

### DIFF
--- a/spark/src/main/java/io/delta/dynamodbcommitstore/DynamoDBTableEntryConstants.java
+++ b/spark/src/main/java/io/delta/dynamodbcommitstore/DynamoDBTableEntryConstants.java
@@ -34,6 +34,10 @@ final class DynamoDBTableEntryConstants {
     public static final String TABLE_PATH = "path";
     /** The schema version of this DynamoDB table entry. */
     public static final String SCHEMA_VERSION = "schemaVersion";
+    /**
+     * Whether this commit owner has accepted any commits after `registerTable`.
+     */
+    public static final String HAS_ACCEPTED_COMMITS = "hasAcceptedCommits";
     /** The name of the field used to store unbackfilled commits. */
     public static final String COMMITS = "commits";
     /** The unbackfilled commit version. */

--- a/spark/src/main/java/io/delta/dynamodbcommitstore/ReflectionUtils.java
+++ b/spark/src/main/java/io/delta/dynamodbcommitstore/ReflectionUtils.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.dynamodbcommitstore;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import org.apache.hadoop.conf.Configuration;
+
+import java.util.Arrays;
+
+/**
+ * Utility class for reflection operations. Used to create AWS credentials provider from class name.
+ * Same as the io.delta.storage.utils.ReflectionUtils class is used in delta/storage-s3-dynamodb.
+ */
+public class ReflectionUtils {
+
+    private static boolean readsCredsFromHadoopConf(Class<?> awsCredentialsProviderClass) {
+        return Arrays.stream(awsCredentialsProviderClass.getConstructors())
+                .anyMatch(constructor -> constructor.getParameterCount() == 1 &&
+                        Arrays.equals(constructor.getParameterTypes(), new Class[]{Configuration.class}));
+    }
+
+    /**
+     * Creates a AWS credentials provider from the given provider classname and {@link Configuration}.
+     *
+     * It first checks if AWS Credentials Provider class has a constructor with Hadoop configuration
+     * as parameter.
+     *   If yes - create instance of class using this constructor.
+     *   If no - create instance with empty parameters constructor.
+     *
+     * @param credentialsProviderClassName Fully qualified name of the desired credentials provider class.
+     * @param hadoopConf Hadoop configuration, used to create instance of AWS credentials
+     *                                      provider, if supported.
+     * @return {@link AWSCredentialsProvider} object, instantiated from the class @see {credentialsProviderClassName}
+     * @throws ReflectiveOperationException When AWS credentials provider constructor do not match.
+     *                                      Indicates that the class has neither a constructor with no args
+     *                                      nor a constructor with only Hadoop configuration as argument.
+     */
+    public static AWSCredentialsProvider createAwsCredentialsProvider(
+            String credentialsProviderClassName,
+            Configuration hadoopConf) throws ReflectiveOperationException {
+        Class<?> awsCredentialsProviderClass = Class.forName(credentialsProviderClassName);
+        if (readsCredsFromHadoopConf(awsCredentialsProviderClass))
+            return (AWSCredentialsProvider) awsCredentialsProviderClass
+                    .getConstructor(Configuration.class)
+                    .newInstance(hadoopConf);
+        else
+            return (AWSCredentialsProvider) awsCredentialsProviderClass.getConstructor().newInstance();
+    }
+
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -546,6 +546,53 @@ trait DeltaSQLConfBase {
       .checkValue(_ > 0, "threadPoolSize must be positive")
       .createWithDefault(5)
 
+  //////////////////////////////////////////////
+  // DynamoDB Commit Owner-specific configs
+  /////////////////////////////////////////////
+
+  val MANAGED_COMMIT_DDB_AWS_CREDENTIALS_PROVIDER_NAME =
+    buildConf("managedCommits.commitOwner.ddb.awsCredentialsProviderName")
+      .internal()
+      .doc("The fully qualified class name of the AWS credentials provider to use for " +
+        "interacting with DynamoDB in the DynamoDB Commit Owner Client. e.g. " +
+        "com.amazonaws.auth.DefaultAWSCredentialsProviderChain.")
+      .stringConf
+      .createWithDefault("com.amazonaws.auth.DefaultAWSCredentialsProviderChain")
+
+  val MANAGED_COMMIT_DDB_SKIP_PATH_CHECK =
+    buildConf("managedCommits.commitOwner.ddb.skipPathCheck.enabled")
+      .internal()
+      .doc("When enabled, the DynamoDB Commit Owner will not enforce that the table path of the " +
+        "current Delta table matches the stored in the corresponding DynamoDB table. This " +
+        "should only be used when the observed table path for the same physical table varies " +
+        "depending on how it is accessed (e.g. abfs://path1 vs abfss://path1). Leaving this " +
+        "enabled can be dangerous as every physical copy of a Delta table with try to write to" +
+        " the same DynamoDB table.")
+      .booleanConf
+      .createWithDefault(false)
+
+  val MANAGED_COMMIT_DDB_READ_CAPACITY_UNITS =
+    buildConf("managedCommits.commitOwner.ddb.readCapacityUnits")
+      .internal()
+      .doc("Controls the provisioned read capacity units for the DynamoDB table backing the " +
+        "DynamoDB Commit Owner. This configuration is only used when the DynamoDB table is first " +
+        "provisioned and cannot be used configure an existing table.")
+      .intConf
+      .createWithDefault(5)
+
+  val MANAGED_COMMIT_DDB_WRITE_CAPACITY_UNITS =
+    buildConf("managedCommits.commitOwner.ddb.writeCapacityUnits")
+      .internal()
+      .doc("Controls the provisioned write capacity units for the DynamoDB table backing the " +
+        "DynamoDB Commit Owner. This configuration is only used when the DynamoDB table is first " +
+        "provisioned and cannot be used configure an existing table.")
+      .intConf
+      .createWithDefault(5)
+
+  //////////////////////////////////////////////
+  // DynamoDB Commit Owner-specific configs end
+  /////////////////////////////////////////////
+
   val DELTA_UPDATE_CATALOG_LONG_FIELD_TRUNCATION_THRESHOLD =
     buildConf("catalog.update.longFieldTruncationThreshold")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/CommitOwnerClientImplSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/CommitOwnerClientImplSuiteBase.scala
@@ -204,13 +204,7 @@ trait CommitOwnerClientImplSuiteBase extends QueryTest
       }
       assert(e.getMessage === "Commit version 0 must go via filesystem.")
       writeCommitZero(logPath)
-      var expectedVersion = -1
-      if (tableCommitOwnerClient.commitOwnerClient.isInstanceOf[DynamoDBCommitOwnerClient]) {
-        // DynamoDBCommitOwnerClient stores attemptVersion as the current table version when
-        // registerTable is called.
-        expectedVersion = 0
-      }
-      assert(tableCommitOwnerClient.getCommits() == GetCommitsResponse(Seq.empty, expectedVersion))
+      assert(tableCommitOwnerClient.getCommits() == GetCommitsResponse(Seq.empty, -1))
       assertBackfilled(version = 0, logPath, Some(0L))
 
       // Test backfilling functionality for commits 1 - 8


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Updates DynamoDBCommitOwner:

 - Added logging around table creation flow
 - Get wcu, rcu, and awsCredentialsProvider from SparkSession
 - Return -1 as the table version if registerTable has already been called but no actual commits have gone through the owner. This is done by tracking an extra flag in DynamoDB.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Existing tests

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, introduces new configs (see DeltaSQLConf changes) which can be used to configure the DynamoDBCommitOwner.
