### PR TITLE
[Standalone] AddFile Long Tags Accessor + Memory Optimization

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -780,8 +780,9 @@ case class AddFile(
     }
   }
 
+  // Don't use lazy val because we want to save memory.
   @JsonIgnore
-  lazy val insertionTime: Long = tag(AddFile.Tags.INSERTION_TIME).map(_.toLong)
+  def insertionTime: Long = longTag(AddFile.Tags.INSERTION_TIME)
     // From modification time in milliseconds to microseconds.
     .getOrElse(TimeUnit.MICROSECONDS.convert(modificationTime, TimeUnit.MILLISECONDS))
 
@@ -791,6 +792,9 @@ case class AddFile(
 
 
   def tag(tag: AddFile.Tags.KeyType): Option[String] = getTag(tag.name)
+
+  def longTag(tagKey: AddFile.Tags.KeyType): Option[Long] =
+    tag(tagKey).map(_.toLong)
 
   def copyWithTag(tag: AddFile.Tags.KeyType, value: String): AddFile =
     copy(tags = Option(tags).getOrElse(Map.empty) + (tag.name -> value))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [x] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR introduces AddFile.longTag which factors out the pattern `tag(...).map(_.toLong)` and also converts the insertion time tag lazy val to a method in order to save memory.

## How was this patch tested?

Existing unit tests.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No
