### PR TITLE
[Standalone] docs: fix broken links in Connectors README

### DIFF
--- a/connectors/README.md
+++ b/connectors/README.md
@@ -9,16 +9,16 @@ See [Delta Standalone](https://docs.delta.io/latest/delta-standalone.html) for d
 
 ## Hive Connector
 
-Read Delta tables directly from Apache Hive using the [Hive Connector](/hive/README.md). See the dedicated [README.md](/hive/README.md) for more details.
+Read Delta tables directly from Apache Hive using the [Hive Connector](hive/README.md). See the dedicated [README.md](hive/README.md) for more details.
 
 ## Flink/Delta Connector
 
-Use the [Flink/Delta Connector](flink/README.md) to read and write Delta tables from Apache Flink applications. The connector includes a sink for writing to Delta tables from Apache Flink, and a source for reading Delta tables using Apache Flink (still in progress.) See the dedicated [README.md](/flink/README.md) for more details.
+Use the [Flink/Delta Connector](flink/README.md) to read and write Delta tables from Apache Flink applications. The connector includes a sink for writing to Delta tables from Apache Flink, and a source for reading Delta tables using Apache Flink (still in progress.) See the dedicated [README.md](flink/README.md) for more details.
 
 ## sql-delta-import
 
-[sql-delta-import](/sql-delta-import/readme.md) allows for importing data from a JDBC source into a Delta table.
+[sql-delta-import](sql-delta-import/readme.md) allows for importing data from a JDBC source into a Delta table.
 
 ## Power BI connector
-The connector for [Microsoft Power BI](https://powerbi.microsoft.com/) is basically just a custom Power Query function that allows you to read a Delta table from any file-based [data source supported by Microsoft Power BI](https://docs.microsoft.com/en-us/power-bi/connect-data/desktop-data-sources). Details can be found in the dedicated [README.md](/powerbi/README.md).
+The connector for [Microsoft Power BI](https://powerbi.microsoft.com/) is basically just a custom Power Query function that allows you to read a Delta table from any file-based [data source supported by Microsoft Power BI](https://docs.microsoft.com/en-us/power-bi/connect-data/desktop-data-sources). Details can be found in the dedicated [README.md](powerbi/README.md).
 


### PR DESCRIPTION
removing '/' prefix to internal links to fix 404 errors

<img width="1099" alt="image" src="https://github.com/delta-io/delta/assets/68642378/a8a38794-3004-4910-82ee-461c17c6fa48">
