### PR TITLE
[Spark] Make ManagedCommit a preview feature

### DIFF
--- a/spark/src/main/java/io/delta/dynamodbcommitstore/ManagedCommitUtils.java
+++ b/spark/src/main/java/io/delta/dynamodbcommitstore/ManagedCommitUtils.java
@@ -31,7 +31,7 @@ public class ManagedCommitUtils {
 
     /** The configuration key for the managed commit owner. */
     private static final String MANAGED_COMMIT_OWNER_CONF_KEY =
-            "delta.managedCommits.commitOwner-dev";
+            "delta.managedCommits.commitOwner-preview";
 
     /**
      * Creates a new unbackfilled delta file path for the given commit version.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -737,7 +737,7 @@ trait DeltaConfigsBase extends DeltaLogging {
     helpMessage = "needs to be a boolean.")
 
   val MANAGED_COMMIT_OWNER_NAME = buildConfig[Option[String]](
-    "managedCommits.commitOwner-dev",
+    "managedCommits.commitOwner-preview",
     null,
     v => Option(v),
     _ => true,
@@ -748,14 +748,14 @@ trait DeltaConfigsBase extends DeltaLogging {
       |""".stripMargin)
 
   val MANAGED_COMMIT_OWNER_CONF = buildConfig[Map[String, String]](
-    "managedCommits.commitOwnerConf-dev",
+    "managedCommits.commitOwnerConf-preview",
     null,
     v => JsonUtils.fromJson[Map[String, String]](Option(v).getOrElse("{}")),
     _ => true,
     "A string-to-string map of configuration properties for the managed commit-owner.")
 
   val MANAGED_COMMIT_TABLE_CONF = buildConfig[Map[String, String]](
-    "managedCommits.tableConf-dev",
+    "managedCommits.tableConf-preview",
     null,
     v => JsonUtils.fromJson[Map[String, String]](Option(v).getOrElse("{}")),
     _ => true,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -675,7 +675,7 @@ object V2CheckpointTableFeature
 
 /** Table feature to represent tables whose commits are managed by separate commit-owner */
 object ManagedCommitTableFeature
-  extends WriterFeature(name = "managed-commit-dev")
+  extends WriterFeature(name = "managed-commit-preview")
     with FeatureAutomaticallyEnabledByMetadata
     with RemovableFeature {
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -343,7 +343,8 @@ object TableFeature {
       V2CheckpointTableFeature,
       RowTrackingFeature,
       InCommitTimestampTableFeature,
-      VariantTypeTableFeature)
+      VariantTypeTableFeature,
+      ManagedCommitTableFeature)
     if (DeltaUtils.isTesting) {
       features ++= Set(
         TestLegacyWriterFeature,
@@ -362,9 +363,7 @@ object TableFeature {
         TestFeatureWithTransitiveDependency,
         TestWriterFeatureWithTransitiveDependency,
         // Identity columns are under development and only available in testing.
-        IdentityColumnsTableFeature,
-        // managed-commits are under development and only available in testing.
-        ManagedCommitTableFeature)
+        IdentityColumnsTableFeature)
     }
     val featureMap = features.map(f => f.name.toLowerCase(Locale.ROOT) -> f).toMap
     require(features.size == featureMap.size, "Lowercase feature names must not duplicate.")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Renames the ManagedCommit feature and config names by replacing -dev with -preview to indicate that it is in preview phase.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
No new tests.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No