### PR TITLE
[Spark] Validate the expression in AlterTableAddConstraintDeltaCommand

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -40,7 +40,7 @@ import org.apache.spark.sql.{AnalysisException, Column, Row, SparkSession}
 import org.apache.spark.sql.catalyst.analysis.{Resolver, UnresolvedAttribute}
 import org.apache.spark.sql.catalyst.catalog.CatalogUtils
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.plans.logical.{IgnoreCachedData, QualifiedColType}
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, IgnoreCachedData, QualifiedColType}
 import org.apache.spark.sql.catalyst.util.{CharVarcharUtils, SparkCharVarcharUtils}
 import org.apache.spark.sql.connector.catalog.TableCatalog
 import org.apache.spark.sql.connector.catalog.TableChange.{After, ColumnPosition, First}
@@ -1005,17 +1005,26 @@ case class AlterTableAddConstraintDeltaCommand(
           (Constraints.checkConstraintPropertyName(name) -> exprText)
       )
 
-      val expr = sparkSession.sessionState.sqlParser.parseExpression(exprText)
-      if (expr.dataType != BooleanType) {
-        throw DeltaErrors.checkConstraintNotBoolean(name, exprText)
+      val df = txn.snapshot.deltaLog.createDataFrame(txn.snapshot, txn.filterFiles())
+      val unresolvedExpr = sparkSession.sessionState.sqlParser.parseExpression(exprText)
+
+      try {
+        df.where(new Column(unresolvedExpr)).queryExecution.analyzed
+      } catch {
+        case a: AnalysisException
+            if a.errorClass.contains("DATATYPE_MISMATCH.FILTER_NOT_BOOLEAN") =>
+          throw DeltaErrors.checkConstraintNotBoolean(name, exprText)
+        case a: AnalysisException =>
+          // Strip out the context of the DataFrame that was used to analyze the expression.
+          throw a.copy(context = Array.empty)
       }
+
       logInfo(s"Checking that $exprText is satisfied for existing data. " +
         "This will require a full table scan.")
       recordDeltaOperation(
           txn.snapshot.deltaLog,
           "delta.ddl.alter.addConstraint.checkExisting") {
-        val df = txn.snapshot.deltaLog.createDataFrame(txn.snapshot, txn.filterFiles())
-        val n = df.where(new Column(Or(Not(expr), IsUnknown(expr)))).count()
+        val n = df.where(new Column(Or(Not(unresolvedExpr), IsUnknown(unresolvedExpr)))).count()
 
         if (n > 0) {
           throw DeltaErrors.newCheckConstraintViolated(n, table.name(), exprText)


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR fixes an internal error thrown from `AlterTableAddConstraintDeltaCommand`. This error is thrown when adding a CHECK constraint with a non-existent column in the expression. The error is thrown when we check if the expressions returns a boolean. This works correctly for most expressions, but will result in an exception if the data type of the unresolved column is checked.

This PR fixes this issue by making the analyzer responsible for checking whether the expression returns a boolean by wrapping the expression with a `Filter` node.

## How was this patch tested?

Added a test

## Does this PR introduce _any_ user-facing changes?

Yes, `ALTER TABLE ... ADD CONSTRAINT ... CHECK` will now throw a `UNRESOLVED_COLUMN` error instead of a `INTERNAL_ERROR` in the case described above.