### PR TITLE
Fix concating paths with relative filenames that contain colon ':'

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableUtilsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableUtilsSuite.scala
@@ -51,6 +51,18 @@ class DeltaTableUtilsSuite extends SharedSparkSession with DeltaSQLCommandTest {
       new Path("s3://my-bucket/subfolder/_delta_log"))
     assert(DeltaTableUtils.safeConcatPaths(basePathEmpty, "_delta_log") ==
       new Path("s3://my-bucket/_delta_log"))
+    assert(DeltaTableUtils.safeConcatPaths(basePath, "_delta/_log") ==
+      new Path("s3://my-bucket/subfolder/_delta/_log"))
+    assert(DeltaTableUtils.safeConcatPaths(basePathEmpty, "_delta/_log") ==
+      new Path("s3://my-bucket/_delta/_log"))
+    assert(DeltaTableUtils.safeConcatPaths(basePath, "part-2024-03-05T16:08:53.002.csv") ==
+      new Path("s3://my-bucket/subfolder/part-2024-03-05T16:08:53.002.csv"))
+    assert(DeltaTableUtils.safeConcatPaths(basePathEmpty, "part-2024-03-05T16:08:53.002.csv") ==
+      new Path("s3://my-bucket/part-2024-03-05T16:08:53.002.csv"))
+    assert(DeltaTableUtils.safeConcatPaths(basePath, "part/2024-03-05T16:08:53.002.csv") ==
+      new Path("s3://my-bucket/subfolder/part/2024-03-05T16:08:53.002.csv"))
+    assert(DeltaTableUtils.safeConcatPaths(basePathEmpty, "part/2024-03-05T16:08:53.002.csv") ==
+      new Path("s3://my-bucket/part/2024-03-05T16:08:53.002.csv"))
   }
 
   test("removeInternalMetadata") {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR fixes an issue where the `safeConcatPaths` method throws an exception when the `relativeChildPath` contains a colon `:`. Such a character is not allowed in Hadoop paths due to ambiguity (`aa:bb.csv` can be interpreted as an absolute path like `aa://bb.csv` where `aa` is the scheme), but is allowed in many file systems such as S3. Thus we need to handle this case.

The fix here is to prepend a `/` so that Hadoop will know that everything after `/` belongs to the path, not the scheme.

## How was this patch tested?

New tests.

## Does this PR introduce _any_ user-facing changes?

Nope.