### PR TITLE
[Spark] Drop Type widening feature: read Parquet footers to collect files to rewrite

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/TypeWidening.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TypeWidening.scala
@@ -111,33 +111,4 @@ object TypeWidening {
         )
     }
   }
-
-  /**
-   * Filter the given list of files to only keep files that were written before the latest type
-   * change, if any. These older files contain a column or field with a type that is different than
-   * in the current table schema and must be rewritten when dropping the type widening table feature
-   * to make the table readable by readers that don't support the feature.
-   */
-  def filterFilesRequiringRewrite(snapshot: Snapshot, files: Seq[AddFile]): Seq[AddFile] =
-     TypeWideningMetadata.getLatestTypeChangeVersion(snapshot.metadata.schema) match {
-      case Some(latestVersion) =>
-        files.filter(_.defaultRowCommitVersion match {
-            case Some(version) => version < latestVersion
-            // Files written before the type widening table feature was added to the table don't
-            // have a defaultRowCommitVersion. That does mean they were written before the latest
-            // type change.
-            case None => true
-        })
-      case None =>
-        Seq.empty
-    }
-
-
-  /**
-   * Return the number of files that were written before the latest type change and that then
-   * contain a column or field with a type that is different from the current able schema.
-   */
-  def numFilesRequiringRewrite(snapshot: Snapshot): Long = {
-    filterFilesRequiringRewrite(snapshot, snapshot.allFiles.collect()).size
-  }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaReorgTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaReorgTableCommand.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.delta.commands
 
-import org.apache.spark.sql.delta.{Snapshot, TypeWidening}
+import org.apache.spark.sql.delta.{DeltaColumnMapping, Snapshot}
 import org.apache.spark.sql.delta.actions.AddFile
 
 import org.apache.spark.sql.{Row, SparkSession}
@@ -97,14 +97,15 @@ sealed trait DeltaReorgOperation {
    * Collects files that need to be processed by the reorg operation from the list of candidate
    * files.
    */
-  def filterFilesToReorg(snapshot: Snapshot, files: Seq[AddFile]): Seq[AddFile]
+  def filterFilesToReorg(spark: SparkSession, snapshot: Snapshot, files: Seq[AddFile]): Seq[AddFile]
 }
 
 /**
  * Reorg operation to purge files with soft deleted rows.
  */
 class DeltaPurgeOperation extends DeltaReorgOperation {
-  override def filterFilesToReorg(snapshot: Snapshot, files: Seq[AddFile]): Seq[AddFile] =
+  override def filterFilesToReorg(spark: SparkSession, snapshot: Snapshot, files: Seq[AddFile])
+    : Seq[AddFile] =
     files.filter { file =>
       (file.deletionVector != null && file.numPhysicalRecords.isEmpty) ||
         file.numDeletedRecords > 0L
@@ -115,7 +116,8 @@ class DeltaPurgeOperation extends DeltaReorgOperation {
  * Reorg operation to upgrade the iceberg compatibility version of a table.
  */
 class DeltaUpgradeUniformOperation(icebergCompatVersion: Int) extends DeltaReorgOperation {
-  override def filterFilesToReorg(snapshot: Snapshot, files: Seq[AddFile]): Seq[AddFile] = {
+  override def filterFilesToReorg(spark: SparkSession, snapshot: Snapshot, files: Seq[AddFile])
+    : Seq[AddFile] = {
     def shouldRewriteToBeIcebergCompatible(file: AddFile): Boolean = {
       if (file.tags == null) return true
       val icebergCompatVersion = file.tags.getOrElse(AddFile.Tags.ICEBERG_COMPAT_VERSION.name, "0")
@@ -129,7 +131,12 @@ class DeltaUpgradeUniformOperation(icebergCompatVersion: Int) extends DeltaReorg
  * Internal reorg operation to rewrite files to conform to the current table schema when dropping
  * the type widening table feature.
  */
-class DeltaRewriteTypeWideningOperation extends DeltaReorgOperation {
-  override def filterFilesToReorg(snapshot: Snapshot, files: Seq[AddFile]): Seq[AddFile] =
-    TypeWidening.filterFilesRequiringRewrite(snapshot, files)
+class DeltaRewriteTypeWideningOperation extends DeltaReorgOperation with ReorgTableHelper {
+  override def filterFilesToReorg(spark: SparkSession, snapshot: Snapshot, files: Seq[AddFile])
+    : Seq[AddFile] = {
+    val physicalSchema = DeltaColumnMapping.renameColumns(snapshot.schema)
+    filterParquetFiles(spark, snapshot, files) {
+      schema => fileHasDifferentTypes(schema, physicalSchema)
+    }
+  }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaReorgTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaReorgTableCommand.scala
@@ -135,7 +135,7 @@ class DeltaRewriteTypeWideningOperation extends DeltaReorgOperation with ReorgTa
   override def filterFilesToReorg(spark: SparkSession, snapshot: Snapshot, files: Seq[AddFile])
     : Seq[AddFile] = {
     val physicalSchema = DeltaColumnMapping.renameColumns(snapshot.schema)
-    filterParquetFiles(spark, snapshot, files) {
+    filterParquetFilesOnExecutors(spark, files, snapshot) {
       schema => fileHasDifferentTypes(schema, physicalSchema)
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaReorgTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaReorgTableCommand.scala
@@ -135,7 +135,7 @@ class DeltaRewriteTypeWideningOperation extends DeltaReorgOperation with ReorgTa
   override def filterFilesToReorg(spark: SparkSession, snapshot: Snapshot, files: Seq[AddFile])
     : Seq[AddFile] = {
     val physicalSchema = DeltaColumnMapping.renameColumns(snapshot.schema)
-    filterParquetFilesOnExecutors(spark, files, snapshot) {
+    filterParquetFilesOnExecutors(spark, files, snapshot, ignoreCorruptFiles = false) {
       schema => fileHasDifferentTypes(schema, physicalSchema)
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -264,8 +264,10 @@ class OptimizeExecutor(
       val partitionSchema = txn.metadata.partitionSchema
 
       val filesToProcess = optimizeContext.reorg match {
-        case Some(reorgOperation) => reorgOperation.filterFilesToReorg(txn.snapshot, candidateFiles)
-        case None => filterCandidateFileList(minFileSize, maxDeletedRowsRatio, candidateFiles)
+        case Some(reorgOperation) =>
+          reorgOperation.filterFilesToReorg(sparkSession, txn.snapshot, candidateFiles)
+        case None =>
+          filterCandidateFileList(minFileSize, maxDeletedRowsRatio, candidateFiles)
       }
       val partitionsToCompact = filesToProcess.groupBy(_.partitionValues).toSeq
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ReorgTableHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ReorgTableHelper.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands
+
+import org.apache.spark.sql.delta.Snapshot
+import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.commands.VacuumCommand.generateCandidateFileMap
+import org.apache.spark.sql.delta.schema.SchemaMergingUtils
+import org.apache.spark.sql.delta.util.DeltaFileOperations
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileStatus, Path}
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.execution.datasources.parquet.{ParquetFileFormat, ParquetToSparkSchemaConverter}
+import org.apache.spark.sql.types.{AtomicType, StructField, StructType}
+import org.apache.spark.util.SerializableConfiguration
+
+trait ReorgTableHelper {
+  /**
+   * Determine whether `fileSchema` has any columns that has a type that differ from
+   * `tablePhysicalSchema`.
+   */
+  protected def fileHasDifferentTypes(
+      fileSchema: StructType,
+      tablePhysicalSchema: StructType): Boolean = {
+    SchemaMergingUtils.transformColumns(fileSchema, tablePhysicalSchema) {
+      case (_, StructField(_, fileType: AtomicType, _, _),
+      Some(StructField(_, tableType: AtomicType, _, _)), _) if fileType != tableType =>
+        return true
+      case (_, field, _, _) => field
+    }
+    false
+  }
+
+  /**
+   * Apply a filter on the list of AddFile to only keep the files that have their physical parquet
+   * schema that satisfies the given filter function.
+   */
+  protected def filterParquetFiles(
+      spark: SparkSession, snapshot: Snapshot, files: Seq[AddFile])(
+      filterFileFn: StructType => Boolean)
+    : Seq[AddFile] = {
+    val serializedConf = new SerializableConfiguration(snapshot.deltaLog.newDeltaHadoopConf())
+    val ignoreCorruptFiles = spark.sessionState.conf.ignoreCorruptFiles
+    val assumeBinaryIsString = spark.sessionState.conf.isParquetBinaryAsString
+    val assumeInt96IsTimestamp = spark.sessionState.conf.isParquetINT96AsTimestamp
+    val dataPath = new Path(snapshot.deltaLog.dataPath.toString)
+
+    filterParquetFiles(files, dataPath, serializedConf.value, ignoreCorruptFiles,
+      assumeBinaryIsString, assumeInt96IsTimestamp)(filterFileFn)
+  }
+
+  protected def filterParquetFiles(
+      files: Seq[AddFile],
+      dataPath: Path,
+      configuration: Configuration,
+      ignoreCorruptFiles: Boolean,
+      assumeBinaryIsString: Boolean,
+      assumeInt96IsTimestamp: Boolean)(
+      filterFileFn: StructType => Boolean): Seq[AddFile] = {
+    val nameToAddFileMap = generateCandidateFileMap(dataPath, files)
+
+    val fileStatuses = nameToAddFileMap.map { case (absPath, addFile) =>
+      new FileStatus(
+        /* length */ addFile.size,
+        /* isDir */ false,
+        /* blockReplication */ 0,
+        /* blockSize */ 1,
+        /* modificationTime */ addFile.modificationTime,
+        new Path(absPath)
+      )
+    }
+
+    val footers = DeltaFileOperations.readParquetFootersInParallel(
+      configuration,
+      fileStatuses.toList,
+      ignoreCorruptFiles)
+
+    val converter =
+      new ParquetToSparkSchemaConverter(assumeBinaryIsString, assumeInt96IsTimestamp)
+
+    val filesNeedToRewrite = footers.filter { footer =>
+      val fileSchema = ParquetFileFormat.readSchemaFromFooter(footer, converter)
+      filterFileFn(fileSchema)
+    }.map(_.getFile.toString)
+    filesNeedToRewrite.map(absPath => nameToAddFileMap(absPath))
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ReorgTableHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ReorgTableHelper.scala
@@ -31,7 +31,7 @@ import org.apache.spark.util.SerializableConfiguration
 
 trait ReorgTableHelper extends Serializable {
   /**
-   * Determine whether `fileSchema` has any columns that has a type that differ from
+   * Determine whether `fileSchema` has any columns that has a type that differs from
    * `tablePhysicalSchema`.
    */
   protected def fileHasDifferentTypes(
@@ -39,7 +39,7 @@ trait ReorgTableHelper extends Serializable {
       tablePhysicalSchema: StructType): Boolean = {
     SchemaMergingUtils.transformColumns(fileSchema, tablePhysicalSchema) {
       case (_, StructField(_, fileType: AtomicType, _, _),
-      Some(StructField(_, tableType: AtomicType, _, _)), _) if fileType != tableType =>
+        Some(StructField(_, tableType: AtomicType, _, _)), _) if fileType != tableType =>
         return true
       case (_, field, _, _) => field
     }
@@ -47,8 +47,8 @@ trait ReorgTableHelper extends Serializable {
   }
 
   /**
-   * Apply a filter on the list of AddFile to only keep the files that have their physical parquet
-   * schema that satisfies the given filter function.
+   * Apply a filter on the list of AddFile to only keep the files that have physical parquet schema
+   * that satisfies the given filter function.
    *
    * Note: Filtering happens on the executors: **any variable captured by `filterFileFn` must be
    * Serializable**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ReorgTableHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ReorgTableHelper.scala
@@ -56,11 +56,11 @@ trait ReorgTableHelper extends Serializable {
   protected def filterParquetFilesOnExecutors(
       spark: SparkSession,
       files: Seq[AddFile],
-      snapshot: Snapshot)(
+      snapshot: Snapshot,
+      ignoreCorruptFiles: Boolean)(
       filterFileFn: StructType => Boolean): Seq[AddFile] = {
 
     val serializedConf = new SerializableConfiguration(snapshot.deltaLog.newDeltaHadoopConf())
-    val ignoreCorruptFiles = spark.sessionState.conf.ignoreCorruptFiles
     val assumeBinaryIsString = spark.sessionState.conf.isParquetBinaryAsString
     val assumeInt96IsTimestamp = spark.sessionState.conf.isParquetINT96AsTimestamp
     val dataPath = new Path(snapshot.deltaLog.dataPath.toString)


### PR DESCRIPTION
## What changes were proposed in this pull request?
The initial approach to identify files that contain a type that differs from the table schema and that must be rewritten before dropping the type widening table feature is convoluted and turns out to be more brittle than intended.

This change switches instead to directly reading the file schema from the Parquet footer and rewriting all files that have a mismatching type.

### Additional Context
Files are identified using their default row commit version (a part of the row tracking feature) and matched against type changes previously applied to the table and recorded in the table metadata: any file written before the latest type change should use a different type and must be rewritten.

This requires multiple pieces of information to be accurately tracked:
- Default row commit versions must be correctly assigned to all files. E.p. files that are copied over without modification must never be assigned a new default row commit version. On the other hand, default row commit versions are preserved across CLONE but these versions don't match anything in the new cloned table.
- Type change history must be reliably recorded and preserved across schema changes, e.g. column mapping.

Any bug will likely lead to files not being correctly rewritten before removing the table feature, potentially leaving the table in an unreadable state.



## How was this patch tested?
Tests added in previous PR to cover CLONE and RESTORE: https://github.com/delta-io/delta/pull/3053
Tests added and updated in this PR to cover rewriting files with different column types when removing the table feature.
