### PR TITLE
[Kernel][Connectors] Update the readme/docs to point to Kernel

### DIFF
--- a/connectors/README.md
+++ b/connectors/README.md
@@ -1,7 +1,7 @@
 > [!IMPORTANT]
-Delta Standalone is no longer actively maintained. As Delta added more features (such as deletion vectors, column mapping) in latest versions of the Delta protocol, the current Standalone APIs no longer work and require significant effort on the connector developer to support higher versions of Delta protocol features. A new initiative called [Delta Kernel](https://github.com/delta-io/delta/blob/master/kernel) has been developed to support higher Delta protocol versions with a much simpler APIs and to keep the work required to upgrade to newer protocol versions to very minimal to nothing. Connector developers are advised to use the [Delta Kernel](https://github.com/delta-io/delta/blob/master/kernel). 
+Delta Standalone is no longer actively maintained. As Delta added more features (such as deletion vectors and column mapping) in the latest versions of the Delta protocol, the current Standalone APIs no longer work on Delta tables with these newer features. It requires significant effort from the connector developer to support higher versions of Delta protocol features. A new initiative called [Delta Kernel](https://github.com/delta-io/delta/blob/master/kernel) has been developed to support higher Delta protocol versions with much simpler APIs and to keep the work required for connectors to support the newer table features as simple as upgrading the Kernel dependency version. Connector developers are advised to use the [Delta Kernel](https://github.com/delta-io/delta/blob/master/kernel). 
 
-Soon all connectors in this repo (e.g. Flink-Delta connector) will be updated to use [Delta Kernel](https://github.com/delta-io/delta/blob/master/kernel).
+Soon, all connectors in this repo (e.g., the Flink-Delta connector) will be updated to use [Delta Kernel](https://github.com/delta-io/delta/blob/master/kernel).
 
 
 ## Delta Standalone

--- a/connectors/README.md
+++ b/connectors/README.md
@@ -1,3 +1,9 @@
+> [!IMPORTANT]
+Delta Standalone is no longer actively maintained. A new initiative called [Delta Kernel](https://github.com/delta-io/delta/blob/master/kernel) has been developed to support higher Delta protocol versions with a much simpler APIs. Connector developers are advised to use the [Delta Kernel](https://github.com/delta-io/delta/blob/master/kernel). 
+
+Soon all connectors in this repo (e.g. Flink-Delta connector) will be updated to use [Delta Kernel](https://github.com/delta-io/delta/blob/master/kernel).
+
+
 ## Delta Standalone
 
 Delta Standalone, formerly known as the Delta Standalone Reader (DSR), is a JVM library to read **and write** Delta tables. Unlike https://github.com/delta-io/delta, this project doesn't use Spark to read or write tables and it has only a few transitive dependencies. It can be used by any application that cannot use a Spark cluster.

--- a/connectors/README.md
+++ b/connectors/README.md
@@ -1,5 +1,5 @@
 > [!IMPORTANT]
-Delta Standalone is no longer actively maintained. A new initiative called [Delta Kernel](https://github.com/delta-io/delta/blob/master/kernel) has been developed to support higher Delta protocol versions with a much simpler APIs. Connector developers are advised to use the [Delta Kernel](https://github.com/delta-io/delta/blob/master/kernel). 
+Delta Standalone is no longer actively maintained. As Delta added more features (such as deletion vectors, column mapping) in latest versions of the Delta protocol, the current Standalone APIs no longer work and require significant effort on the connector developer to support higher versions of Delta protocol features. A new initiative called [Delta Kernel](https://github.com/delta-io/delta/blob/master/kernel) has been developed to support higher Delta protocol versions with a much simpler APIs and to keep the work required to upgrade to newer protocol versions to very minimal to nothing. Connector developers are advised to use the [Delta Kernel](https://github.com/delta-io/delta/blob/master/kernel). 
 
 Soon all connectors in this repo (e.g. Flink-Delta connector) will be updated to use [Delta Kernel](https://github.com/delta-io/delta/blob/master/kernel).
 

--- a/docs/source/delta-apidoc.md
+++ b/docs/source/delta-apidoc.md
@@ -22,15 +22,15 @@ Delta Kernel is a library for operating on Delta tables. Specifically, it provid
 - Read Delta tables from your applications.
 - Build a connector for a distributed engine like Apache Spark™, Apache Flink, or Trino for reading massive Delta tables.
 
-More details refer [here](https://github.com/delta-io/delta/blob/branch-3.0/kernel/USER_GUIDE.md).
+For more details, refer to [here](https://github.com/delta-io/delta/blob/master/kernel/USER_GUIDE.md).
 
 - [Java API docs](api/java/kernel/index.html)
 
 ## Delta Standalone
 
-.. note:: Delta Standalone is no longer actively developed. As Delta added more features (such as deletion vectors, column mapping) in latest versions of the Delta protocol, the current Standalone APIs no longer work and require significant effort on the connector developer to support higher versions of Delta protocol features. [Delta Kernel](#delta-kernel) is developed to support higher versions of the Delta protocol with simpler APIs and keep the work required to upgrade to newer protocol versions to very minimal to nothing. Connector developers are advised to use [Delta Kernel](#delta-kernel).
+.. note:: Delta Standalone is no longer actively developed. As Delta added more features (such as deletion vectors and column mapping) in the latest versions of the Delta protocol, the current Standalone APIs no longer work on Delta tables with these newer features. It requires significant effort from the connector developer to support higher versions of Delta protocol features. A new initiative called [Delta Kernel](https://github.com/delta-io/delta/blob/master/kernel) has been developed to support higher Delta protocol versions with much simpler APIs and to keep the work required for connectors to support the newer table features as simple as upgrading the Kernel dependency version. Connector developers are advised to use the [Delta Kernel](https://github.com/delta-io/delta/blob/master/kernel).
 
-Delta Standalone, formerly known as the Delta Standalone Reader (DSR), is a JVM library to read and write Delta tables. Unlike Delta-Spark, this library doesn't use Spark to read or write tables and it has only a few transitive dependencies. It can be used by any application that cannot use a Spark cluster. More details refer [here](https://github.com/delta-io/delta/blob/master/connectors/README.md).
+Delta Standalone, formerly known as the Delta Standalone Reader (DSR), is a JVM library to read and write Delta tables. Unlike Delta-Spark, this library doesn't use Spark to read or write tables and it has only a few transitive dependencies. It can be used by any application that cannot use a Spark cluster. For more details, refer to [here](https://github.com/delta-io/delta/blob/master/connectors/README.md).
 
 - [Java API docs](api/java/standalone/index.html)
 

--- a/docs/source/delta-apidoc.md
+++ b/docs/source/delta-apidoc.md
@@ -16,16 +16,6 @@ However, there are some operations that are specific to <Delta> and you must use
 - [Java API docs](api/java/spark/index.html)
 - [Python API docs](api/python/spark/index.html)
 
-## Delta Standalone
-Delta Standalone, formerly known as the Delta Standalone Reader (DSR), is a JVM library to read and write Delta tables. Unlike Delta-Spark, this library doesn't use Spark to read or write tables and it has only a few transitive dependencies. It can be used by any application that cannot use a Spark cluster. More details refer [here](https://github.com/delta-io/delta/blob/master/connectors/README.md).
-
-- [Java API docs](api/java/standalone/index.html)
-
-## Delta Flink
-Flink/Delta Connector is a JVM library to read and write data from Apache Flink applications to Delta tables utilizing the Delta Standalone JVM library. More details refer [here](https://github.com/delta-io/delta/blob/master/connectors/flink/README.md).
-
-- [Java API docs](api/java/flink/index.html)
-
 ## Delta Kernel
 
 Delta Kernel is a library for operating on Delta tables. Specifically, it provides simple and narrow APIs for reading and writing to Delta tables without the need to understand the [Delta protocol](https://github.com/delta-io/delta/blob/master/PROTOCOL.md) details. You can use this library to do the following:
@@ -35,5 +25,18 @@ Delta Kernel is a library for operating on Delta tables. Specifically, it provid
 More details refer [here](https://github.com/delta-io/delta/blob/branch-3.0/kernel/USER_GUIDE.md).
 
 - [Java API docs](api/java/kernel/index.html)
+
+## Delta Standalone
+
+.. note:: Delta Standalone is no longer actively developed. As Delta added more features (such as deletion vectors, column mapping) in latest versions of the Delta protocol, the current Standalone APIs no longer work and require significant effort on the connector developer to support higher versions of Delta protocol features. [Delta Kernel](#delta-kernel) is developed to support higher versions of the Delta protocol with simpler APIs and keep the work required to upgrade to newer protocol versions to very minimal to nothing. Connector developers are advised to use [Delta Kernel](#delta-kernel).
+
+Delta Standalone, formerly known as the Delta Standalone Reader (DSR), is a JVM library to read and write Delta tables. Unlike Delta-Spark, this library doesn't use Spark to read or write tables and it has only a few transitive dependencies. It can be used by any application that cannot use a Spark cluster. More details refer [here](https://github.com/delta-io/delta/blob/master/connectors/README.md).
+
+- [Java API docs](api/java/standalone/index.html)
+
+## Delta Flink
+Flink/Delta Connector is a JVM library to read and write data from Apache Flink applications to Delta tables utilizing the Delta Standalone JVM library. More details refer [here](https://github.com/delta-io/delta/blob/master/connectors/flink/README.md).
+
+- [Java API docs](api/java/flink/index.html)
 
 .. include:: /shared/replacements.md

--- a/kernel/examples/README.md
+++ b/kernel/examples/README.md
@@ -17,6 +17,10 @@ This directory contains a set of example programs that show how to read a Delta 
 * [Idempotently inserting data to a Delta table](https://github.com/delta-io/delta/blob/master/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/CreateTableAndInsertData.java). Check `idempotentInserts` method.
 * [Inserting and optionally checkpointing a Delta table](https://github.com/delta-io/delta/blob/master/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/CreateTableAndInsertData.java). Check `insertWithOptionalCheckpoint` method.
 
+### More information
+- [User guide](https://github.com/delta-io/delta/blob/master/kernel/USER_GUIDE.md) on the step-by-step process of using Kernel in a standalone Java program or in a distributed processing connector for reading and writing to Delta tables.
+- Table and default Engine API Java [documentation](https://docs.delta.io/latest/api/java/kernel/index.html)
+
 
 ### Running integration tests
 To run examples by building the artifacts from code and using them:

--- a/kernel/examples/README.md
+++ b/kernel/examples/README.md
@@ -1,0 +1,32 @@
+# Delta Kernel Examples
+
+The Delta Kernel project is a set of Java libraries for building Delta connectors that can read from and write into Delta tables without the need to understand the [Delta protocol details](https://github.com/delta-io/delta/blob/master/PROTOCOL.md). Visit [Delta Kernel](../README.md) for details.
+
+This directory contains a set of example programs that show how to read a Delta table and write data into it. The goals of these examples are:
+* Connector/Delta Lake developers: to provide a starting point in using Kernel to read or write Delta tables.
+* Delta Lake developers: to verify pre-release Kernel jar as part of the Delta release verification.
+
+### Examples
+* [Reading a Delta table serially from a single thread](https://github.com/delta-io/delta/blob/master/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/SingleThreadedTableReader.java).
+* [Reading a Delta table parellelly using multiple threads](https://github.com/delta-io/delta/blob/master/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/MultiThreadedTableReader.java). This program illustrates the end-2-end usage of Delta Kernel APIs to read a table in multi-threaded and/or distributed environement. The steps are:
+  * On driver (or co-ordinator - basically the node where the planning and query execution coordination happens) fetches the list of scan file to read from Delta Kernel.
+  * Driver serializes the scan file infos (in the example to JSON) and sends them to workers (in the example worker is another thread, but it can be another node).
+  * Workers deserializes the scan file infos and makes use of Kernel to read the data.
+* [Creating Delta tables (either partitioned or un-partitioned)](https://github.com/delta-io/delta/blob/master/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/CreateTable.java)
+* [Creating and inserting data into Delta tables](https://github.com/delta-io/delta/blob/master/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/CreateTableAndInsertData.java). Contains examples for inserting data into partitioned or un-partitioned tables.
+* [Idempotently inserting data to a Delta table](https://github.com/delta-io/delta/blob/master/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/CreateTableAndInsertData.java). Check `idempotentInserts` method.
+* [Inserting and optionally checkpointing a Delta table](https://github.com/delta-io/delta/blob/master/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/CreateTableAndInsertData.java). Check `insertWithOptionalCheckpoint` method.
+
+
+### Running integration tests
+To run examples by building the artifacts from code and using them:
+
+```
+<delta-repo-root>/kernel/examples/run-kernel-examples.py --use-local
+```
+
+To run examples using artifacts from a Maven repository:
+```
+<delta-repo-root>/kernel/examples/run-kernel-examples.py --version <version> --maven-repo <staged_repo_url>
+```
+

--- a/kernel/examples/run-kernel-examples.py
+++ b/kernel/examples/run-kernel-examples.py
@@ -180,7 +180,15 @@ if __name__ == "__main__":
 
     clear_artifact_cache()
 
-    if args.use_local:
+    use_local = args.use_local
+
+    if (args.maven_repo == None and not use_local):
+       # If no maven_repo is given default to working with the locally built Kernel jars
+       print("Building the Kernel libraries locally and using them")
+       use_local = True
+
+
+    if use_local:
         with WorkingDirectory(project_root_dir):
             run_cmd(["build/sbt", "kernelGroup/publishM2", "storage/publishM2"], stream_output=True)
 


### PR DESCRIPTION
Misc. updates
* Update `connectors` README and Docs to indicate Standalone is not being actively worked on and reasons why. Also point them to Kernel
* Add a README to `kernel/examples` with an index of examples.