### PR TITLE
[Kernel] TableConfig support more properties.

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -104,7 +104,7 @@ public class TableConfig<T> {
         this.helpMessage = helpMessage;
     }
 
-    public String getKey() {
+    public String key() {
         return key;
     }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -60,6 +60,31 @@ public class TableConfig<T> {
             "needs to be a positive integer."
     );
 
+    public static final TableConfig<Long> LOG_RETENTION = new TableConfig<>(
+            "delta.logRetentionDuration",
+            "interval 30 days",
+            IntervalParserUtils::safeParseIntervalAsMillis,
+            value -> value >= 0,
+            "needs to be provided as a calendar interval such as '2 weeks'. Months "
+                + "and years are not accepted. You may specify '365 days' for a year instead."
+        );
+
+    public static final TableConfig<Boolean> ENABLE_EXPIRED_LOG_CLEANUP = new TableConfig<>(
+            "delta.enableExpiredLogCleanup",
+            "true",
+        Boolean::valueOf,
+            value -> true,
+            "needs to be a boolean."
+    );
+
+    public static final TableConfig<Boolean> IS_APPEND_ONLY = new TableConfig<>(
+        "delta.appendOnly",
+        "false",
+        Boolean::valueOf,
+        value -> true,
+        "needs to be a boolean."
+    );
+
     private final String key;
     private final String defaultValue;
     private final Function<String, T> fromString;
@@ -77,6 +102,10 @@ public class TableConfig<T> {
         this.fromString = fromString;
         this.validator = validator;
         this.helpMessage = helpMessage;
+    }
+
+    public String getKey() {
+        return key;
     }
 
     /**


### PR DESCRIPTION
The kernel config only has properties `TOMBSTONE_RETENTION` and `CHECKPOINT_INTERVAL`, we need support more.