### PR TITLE
[SPARK] support sql syntax for create uniform ingress table

### DIFF
--- a/spark/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
+++ b/spark/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
@@ -102,6 +102,9 @@ statement
     | cloneTableHeader SHALLOW CLONE source=qualifiedName clause=temporalClause?
        (TBLPROPERTIES tableProps=propertyList)?
        (LOCATION location=stringLit)?                                   #clone
+    | cloneTableHeader
+        UNIFORM format=qualifiedName
+        METADATA_PATH metadataPath=stringLit                            #createUniformTable
     | .*? clusterBySpec+ .*?                                            #clusterBy
     | .*?                                                               #passThrough
     ;
@@ -237,6 +240,7 @@ nonReserved
     | DESC | DESCRIBE | LIMIT | DETAIL
     | GENERATE | FOR | TABLE | CHECK | EXISTS | OPTIMIZE
     | REORG | APPLY | PURGE | UPGRADE | UNIFORM | ICEBERG_COMPAT_VERSION
+    | METADATA_PATH
     | RESTORE | AS | OF
     | ZORDER | LEFT_PAREN | RIGHT_PAREN
     | NO | STATISTICS
@@ -279,6 +283,7 @@ INVENTORY: 'INVENTORY';
 LEFT_PAREN: '(';
 LIMIT: 'LIMIT';
 LOCATION: 'LOCATION';
+METADATA_PATH: 'METADATA_PATH';
 MINUS: '-';
 NO: 'NO';
 NONE: 'NONE';

--- a/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
+++ b/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
@@ -406,6 +406,26 @@ class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
     DeltaReorgTable(targetTable, reorgTableSpec)(Option(ctx.partitionPredicate).map(extractRawText(_)).toSeq)
   }
 
+  override def visitCreateUniformTable(
+        ctx: CreateUniformTableContext): LogicalPlan = withOrigin(ctx) {
+     val (target, isCreate, isReplace, ifNotExists) = visitCloneTableHeader(ctx.cloneTableHeader())
+     if (isReplace && ifNotExists) {
+        // replace a non-existent table should be blocked
+        throw new ParseException(
+          s"Invalid Syntax: REPLACE must be called on an existing table, ${target.table} is invalid.",
+          ctx)
+        }
+     val targetTable = new UnresolvedRelation(target.nameParts)
+     CreateUniformTableCommand(
+       table = targetTable,
+       ifNotExists = ifNotExists,
+       isReplace = isReplace,
+       isCreate = isCreate,
+       fileFormat = ctx.format.getText,
+       metadataPath = string(visitStringLit(ctx.metadataPath))
+     )
+  }
+
   override def visitDescribeDeltaDetail(
       ctx: DescribeDeltaDetailContext): LogicalPlan = withOrigin(ctx) {
     DescribeDeltaDetailCommand(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/UniformTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/UniformTableCommand.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, UnaryNode}
+
+case class CreateUniformTableCommand(
+    table: LogicalPlan,
+    ifNotExists: Boolean,
+    isReplace: Boolean,
+    isCreate: Boolean,
+    fileFormat: String,
+    metadataPath: String) extends UnaryNode {
+
+    override def child: LogicalPlan = table
+
+    override def output: Seq[Attribute] = Nil
+
+    override protected def withNewChildInternal(newChild: LogicalPlan): LogicalPlan =
+      copy(table = newChild)
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniformIngressSqlSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniformIngressSqlSuite.scala
@@ -62,10 +62,10 @@ class UniformIngressSqlSuite extends QueryTest
   }
 
   test("create uniform table command") {
-    val sql1 = "CREATE TABLE uniform_table_1 UNIFORM iceberg METADATA_PATH 'metadata_path_1'"
+    val sql1 = "CREATE TABLE ufi_table_1 UNIFORM iceberg METADATA_PATH 'metadata_path_1'"
     parseAndValidate(
       sql = sql1,
-      targetTable = "uniform_table_1",
+      targetTable = "ufi_table_1",
       ifNotExists = false,
       isReplace = false,
       isCreate = true,
@@ -74,15 +74,39 @@ class UniformIngressSqlSuite extends QueryTest
     )
 
     val sql2 =
-      "CREATE TABLE IF NOT EXISTS uniform_table_2 UNIFORM iceberg METADATA_PATH 'metadata_path_2'"
+      "CREATE TABLE IF NOT EXISTS ufi_table_2 UNIFORM iceberg METADATA_PATH 'metadata_path_2'"
     parseAndValidate(
       sql = sql2,
-      targetTable = "uniform_table_2",
+      targetTable = "ufi_table_2",
       ifNotExists = true,
       isReplace = false,
       isCreate = true,
       fileFormat = "iceberg",
       metadataPath = "metadata_path_2"
+    )
+
+    val sql3 =
+      "CREATE OR REPLACE TABLE ufi_table_3 UNIFORM iceberg METADATA_PATH 'metadata_path_3'"
+    parseAndValidate(
+      sql = sql3,
+      targetTable = "ufi_table_3",
+      ifNotExists = false,
+      isReplace = true,
+      isCreate = true,
+      fileFormat = "iceberg",
+      metadataPath = "metadata_path_3"
+    )
+
+    val sql4 =
+      "REPLACE TABLE ufi_table_4 UNIFORM iceberg METADATA_PATH 'metadata_path_4'"
+    parseAndValidate(
+      sql = sql4,
+      targetTable = "ufi_table_4",
+      ifNotExists = false,
+      isReplace = true,
+      isCreate = false,
+      fileFormat = "iceberg",
+      metadataPath = "metadata_path_4"
     )
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniformIngressSqlSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniformIngressSqlSuite.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.uniform
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
+import org.apache.spark.sql.delta.commands.CreateUniformTableCommand
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+class UniformIngressSqlSuite extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
+
+  override protected def sparkConf: SparkConf = super.sparkConf
+
+  test("create uniform table command") {
+    val target = new UnresolvedRelation(Seq("uniform_table_1"))
+    val result = CreateUniformTableCommand(
+      table = target,
+      ifNotExists = false,
+      isReplace = false,
+      isCreate = true,
+      fileFormat = "iceberg",
+      metadataPath = "metadata_path_1"
+    )
+    assert(
+      spark.sessionState.sqlParser.parsePlan(
+        "CREATE TABLE uniform_table_1 UNIFORM iceberg METADATA_PATH 'metadata_path_1'"
+       ) == result
+    )
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

this pr supports the sql syntax for create uniform ingress table, i.e.,

```text
CREATE TABLE [IF NOT EXIST] table_name 
UNIFORM file_format 
METADATA_PATH metadata_path

[CREATE OR] REPLACE TABLE table_name 
UNIFORM file_format
METADATA_PATH metadata_path
```

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

through unit test in `UniformIngressSqlSuite.scala`.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

yes, this pr adds new sql syntax for creating a uniform ingress table, the detailed syntax is shown above.

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
