### PR TITLE
[Spark] Include violating value in DELTA_EXCEED_CHAR_VARCHAR_LIMIT

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -787,7 +787,7 @@
   },
   "DELTA_EXCEED_CHAR_VARCHAR_LIMIT" : {
     "message" : [
-      "Exceeds char/varchar type length limitation. Failed check: <expr>."
+      "Value \"<value>\" exceeds char/varchar type length limitation. Failed check: <expr>."
     ],
     "sqlState" : "22001"
   },

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/InvariantViolationException.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/InvariantViolationException.scala
@@ -17,6 +17,8 @@
 package org.apache.spark.sql.delta.schema
 
 // scalastyle:off import.ordering.noEmptyLine
+import java.util
+
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.delta.{DeltaThrowable, DeltaThrowableHelper}
@@ -57,11 +59,12 @@ object DeltaInvariantViolationException {
   }
 
   def getCharVarcharLengthInvariantViolationException(
-      exprStr: String
+      exprStr: String,
+      valueStr: String
   ): DeltaInvariantViolationException = {
     new DeltaInvariantViolationException(
       errorClass = "DELTA_EXCEED_CHAR_VARCHAR_LIMIT",
-      messageParameters = Array(exprStr)
+      messageParameters = Array(valueStr, exprStr)
     )
   }
 
@@ -86,7 +89,9 @@ object DeltaInvariantViolationException {
       constraint: Constraints.Check,
       values: Map[String, Any]): DeltaInvariantViolationException = {
     if (constraint.name == CharVarcharConstraint.INVARIANT_NAME) {
-      return getCharVarcharLengthInvariantViolationException(constraint.expression.toString)
+      return getCharVarcharLengthInvariantViolationException(
+        exprStr = constraint.expression.toString,
+        valueStr = values.head._2.toString)
     }
 
     // Sort by the column name to generate consistent error messages in Scala 2.12 and 2.13.
@@ -119,4 +124,9 @@ class DeltaInvariantViolationException(
   extends InvariantViolationException(
     DeltaThrowableHelper.getMessage(errorClass, messageParameters)) with DeltaThrowable {
   override def getErrorClass: String = errorClass
+
+  override def getMessageParameters: util.Map[String, String] = {
+    DeltaThrowableHelper.getParameterNames(errorClass, errorSubClass = null)
+      .zip(messageParameters).toMap.asJava
+  }
 }

--- a/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantSuite.scala
+++ b/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantSuite.scala
@@ -522,7 +522,11 @@ class DeltaVariantSuite
       val insertException = intercept[DeltaInvariantViolationException] {
         sql("INSERT INTO tbl VALUES (cast(null as variant))")
       }
-      checkError(insertException, "DELTA_NOT_NULL_CONSTRAINT_VIOLATED")
+      checkError(
+        insertException,
+        errorClass = "DELTA_NOT_NULL_CONSTRAINT_VIOLATED",
+        parameters = Map("columnName" -> "v")
+      )
 
       sql("ALTER TABLE tbl ALTER COLUMN v DROP NOT NULL")
       // Inserting null value should work now.
@@ -541,7 +545,14 @@ class DeltaVariantSuite
       val insertException = intercept[DeltaInvariantViolationException] {
         sql("INSERT INTO tbl (select parse_json(cast(id as string)) from range(-1, 0))")
       }
-      checkError(insertException, "DELTA_VIOLATE_CONSTRAINT_WITH_VALUES")
+      checkError(
+        insertException,
+        errorClass = "DELTA_VIOLATE_CONSTRAINT_WITH_VALUES",
+        parameters = Map(
+          "constraintName" -> "variantgtezero",
+          "expression" -> "(variant_get(v, '$', 'INT') >= 0)", "values" -> " - v : -1"
+        )
+      )
 
       sql("ALTER TABLE tbl DROP CONSTRAINT variantGTEZero")
       sql("INSERT INTO tbl (select parse_json(cast(id as string)) from range(-1, 0))")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -278,16 +278,16 @@ trait DeltaErrorsSuiteBase
         Some("NOT NULL constraint violated for column: col1.\n"))
     }
     {
-      val expr = CatalystSqlParser.parseExpression("concat(\"hello \", \"world\")")
+      val expr = UnresolvedAttribute("col")
       val e = intercept[DeltaInvariantViolationException] {
         throw DeltaInvariantViolationException(
           Constraints.Check(CharVarcharConstraint.INVARIANT_NAME,
             LessThanOrEqual(Length(expr), Literal(5))),
-          Map.empty[String, Any])
+          Map("col" -> "Hello World"))
       }
       checkErrorMessage(e, Some("DELTA_EXCEED_CHAR_VARCHAR_LIMIT"), Some("22001"),
-        Some("Exceeds char/varchar type length limitation. " +
-        "Failed check: (length('concat(hello , world)) <= 5)."))
+        Some("Value \"Hello World\" exceeds char/varchar type length limitation. " +
+          "Failed check: (length('col) <= 5)."))
     }
     {
       val e = intercept[DeltaInvariantViolationException] {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR modifies the error message for the `DELTA_EXCEED_CHAR_VARCHAR_LIMIT` error class to include the value that violated the constraint.

## How was this patch tested?

Modified a test in `DeltaErrorsSuite` and added a test to `DeltaConstraintsSuite`.

## Does this PR introduce _any_ user-facing changes?

Yes, the error message for the `DELTA_EXCEED_CHAR_VARCHAR_LIMIT` error class is modified to include the value that violated the constraint.