### PR TITLE
[Spark] Support in-place migration from unpartitioned table to clustered table

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -77,6 +77,12 @@
     ],
     "sqlState" : "42000"
   },
+  "DELTA_ALTER_TABLE_CLUSTER_BY_ON_PARTITIONED_TABLE_NOT_ALLOWED" : {
+    "message" : [
+      "ALTER TABLE CLUSTER BY cannot be applied to a partitioned table."
+    ],
+    "sqlState" : "42000"
+  },
   "DELTA_ALTER_TABLE_SET_CLUSTERING_TABLE_FEATURE_NOT_ALLOWED" : {
     "message" : [
       "Cannot enable <tableFeature> table feature using ALTER TABLE SET TBLPROPERTIES. Please use CREATE OR REPLACE TABLE CLUSTER BY to create a Delta table with clustering."

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3408,6 +3408,12 @@ trait DeltaErrorsBase
       messageParameters = Array(
         UnresolvedAttribute(columnPath).name, schema.treeString, extraErrMsg))
   }
+
+  def alterTableClusterByOnPartitionedTableException(): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_ALTER_TABLE_CLUSTER_BY_ON_PARTITIONED_TABLE_NOT_ALLOWED",
+      messageParameters = Array.empty)
+  }
 }
 
 object DeltaErrors extends DeltaErrorsBase

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
@@ -761,8 +761,8 @@ class DeltaCatalog extends DelegatingCatalogExtension
             val clusterBySpec = ClusterBySpec(c.clusteringColumns.toSeq)
             validateClusterBySpec(Some(clusterBySpec), table.schema())
           }
-          if (!ClusteredTableUtils.isSupported(table.initialSnapshot.protocol)) {
-            throw DeltaErrors.alterClusterByNotAllowedException()
+          if (table.initialSnapshot.metadata.partitionColumns.nonEmpty) {
+            throw DeltaErrors.alterTableClusterByOnPartitionedTableException()
           }
           AlterTableClusterByDeltaCommand(
             table, c.clusteringColumns.map(_.fieldNames().toSeq).toSeq).run(spark)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -148,6 +148,8 @@ case class AlterTableSetPropertiesDeltaCommand(
         case k if k == TableFeatureProtocolUtils.propertyKey(ClusteringTableFeature) =>
           throw DeltaErrors.alterTableSetClusteringTableFeatureException(
             ClusteringTableFeature.name)
+        case k if k == ClusteredTableUtils.PROP_CLUSTERING_COLUMNS =>
+          throw DeltaErrors.cannotModifyTableProperty(k)
         case _ =>
           true
       }.toMap

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -1092,6 +1092,22 @@ case class AlterTableClusterByDeltaCommand(
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val deltaLog = table.deltaLog
     ClusteredTableUtils.validateNumClusteringColumns(clusteringColumns, Some(deltaLog))
+    // If the target table is not a clustered table and there are no clustering columns being added
+    // (CLUSTER BY NONE), do not convert the table into a clustered table.
+    val snapshot = deltaLog.update()
+    if (clusteringColumns.isEmpty &&
+      !ClusteredTableUtils.isSupported(snapshot.protocol)) {
+      logInfo(s"Skipping ALTER TABLE CLUSTER BY NONE on a non-clustered table: ${table.name()}.")
+      recordDeltaEvent(
+        deltaLog,
+        "delta.ddl.alter.clusterBy",
+        data = Map(
+          "isClusterByNoneSkipped" -> true,
+          "isNewClusteredTable" -> false,
+          "oldColumnsCount" -> 0,
+          "newColumnsCount" -> 0))
+      return Seq.empty
+    }
     recordDeltaOperation(deltaLog, "delta.ddl.alter.clusterBy") {
       val txn = startTransaction()
 
@@ -1111,6 +1127,7 @@ case class AlterTableClusterByDeltaCommand(
         deltaLog,
         "delta.ddl.alter.clusterBy",
         data = Map(
+          "isClusterByNoneSkipped" -> false,
           "isNewClusteredTable" -> !ClusteredTableUtils.isSupported(txn.protocol),
           "oldColumnsCount" -> oldColumnsCount, "newColumnsCount" -> clusteringColumns.size))
       // Add clustered table properties if the current table is not clustered.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/clustering/ClusteringTableFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/clustering/ClusteringTableFeatureSuite.scala
@@ -16,12 +16,23 @@
 
 package org.apache.spark.sql.delta.clustering
 
-import org.apache.spark.sql.delta.DeltaAnalysisException
+import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions}
+import org.apache.spark.sql.delta.skipping.ClusteredTableTestUtils
+import org.apache.spark.sql.delta.skipping.clustering.ClusteredTableUtils
+import org.apache.spark.sql.delta.{DeltaAnalysisException, DeltaLog}
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.util.JsonUtils
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
 
-class ClusteringTableFeatureSuite extends SparkFunSuite with DeltaSQLCommandTest {
+class ClusteringTableFeatureSuite extends SparkFunSuite
+  with SharedSparkSession
+  with ClusteredTableTestUtils
+  with DeltaSQLCommandTest {
+  import testImplicits._
 
   test("create table without cluster by clause cannot set clustering table properties") {
     withTable("tbl") {
@@ -49,15 +60,15 @@ class ClusteringTableFeatureSuite extends SparkFunSuite with DeltaSQLCommandTest
     }
   }
 
-  test("alter table cluster by non-clustered tables is not allowed.") {
+  test("alter table cluster by partitioned tables is not allowed.") {
     withTable("tbl") {
-      sql("CREATE TABLE tbl(a INT, b STRING) USING DELTA")
+      sql("CREATE TABLE tbl(a INT, b STRING) USING DELTA PARTITIONED BY (a)")
       val e1 = intercept[DeltaAnalysisException] {
         sql("ALTER TABLE tbl CLUSTER BY (a)")
       }
       checkError(
         e1,
-        "DELTA_ALTER_TABLE_CLUSTER_BY_NOT_ALLOWED",
+        "DELTA_ALTER_TABLE_CLUSTER_BY_ON_PARTITIONED_TABLE_NOT_ALLOWED",
         parameters = Map.empty)
 
       val e2 = intercept[DeltaAnalysisException] {
@@ -65,8 +76,44 @@ class ClusteringTableFeatureSuite extends SparkFunSuite with DeltaSQLCommandTest
       }
       checkError(
         e2,
-        "DELTA_ALTER_TABLE_CLUSTER_BY_NOT_ALLOWED",
+        "DELTA_ALTER_TABLE_CLUSTER_BY_ON_PARTITIONED_TABLE_NOT_ALLOWED",
         parameters = Map.empty)
+    }
+  }
+
+   test("alter table cluster by unpartitioned non-clustered tables is supported.") {
+    val table = "tbl"
+    withTable(table) {
+      sql(s"CREATE TABLE $table (a INT, b STRING) USING DELTA")
+      val clusterByLogs = Log4jUsageLogger.track {
+        sql(s"ALTER TABLE $table CLUSTER BY (a)")
+      }.filter { e =>
+        e.metric == MetricDefinitions.EVENT_TAHOE.name &&
+          e.tags.get("opType").contains("delta.ddl.alter.clusterBy")
+      }
+      assert(clusterByLogs.nonEmpty)
+      val clusterByLogJson = JsonUtils.fromJson[Map[String, Any]](clusterByLogs.head.blob)
+      assert(!clusterByLogJson("isClusterByNoneSkipped").asInstanceOf[Boolean])
+      val (_, finalSnapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(table))
+      assert(ClusteredTableUtils.isSupported(finalSnapshot.protocol))
+
+      withSQLConf(SQLConf.MAX_RECORDS_PER_FILE.key -> "2") {
+        val df = (1 to 4).map(i => (i, i.toString)).toDF("a", "b")
+        withSQLConf(SQLConf.MAX_RECORDS_PER_FILE.key -> "1") {
+          df.write.format("delta").mode("append").saveAsTable(table)
+        }
+
+        // Optimize should cluster the data into two 2 files since MAX_RECORDS_PER_FILE is 2.
+        runOptimize(table) { metrics =>
+          assert(metrics.numFilesRemoved == 4)
+          assert(metrics.numFilesAdded == 2)
+        }
+
+        val deltaLog = DeltaLog.forTable(spark, TableIdentifier(table))
+        val files1 = deltaLog.update().allFiles.collect().toSet
+        assert(files1.size == 2)
+        assert(files1.forall(_.clusteringProvider.contains(ClusteredTableUtils.clusteringProvider)))
+      }
     }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
@@ -750,6 +750,21 @@ trait ClusteredTableDDLSuiteBase
     }
   }
 
+  test("alter table set tbl properties not allowed for clusteringColumns") {
+    withClusteredTable(testTable, "a INT, b STRING", "a") {
+      val e = intercept[DeltaUnsupportedOperationException] {
+        sql(s"""
+           |ALTER TABLE $testTable SET TBLPROPERTIES
+           |('${ClusteredTableUtils.PROP_CLUSTERING_COLUMNS}' = '[[\"b\"]]')
+           |""".stripMargin)
+      }
+      checkError(
+        e,
+        errorClass = "DELTA_CANNOT_MODIFY_TABLE_PROPERTY",
+        parameters = Map("prop" -> "clusteringColumns"))
+    }
+  }
+
   testSparkMasterOnly("Variant is not supported") {
     val e = intercept[DeltaAnalysisException] {
       createOrReplaceClusteredTable("CREATE", testTable, "id long, v variant", "v")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Support in-place migration from unpartitioned table to clustered table. If the table is an unpartitioned table and users run `ALTER TABLE CLUSTER BY` on it, it will now create a clustered table with ClusteringMetadataDomain.

Resolves #2460 
## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
New UTs.
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No