### PR TITLE
[Kernel] Make some non-breaking changes to support Scala 2.13 in the future and avoid unidoc failures for missing internal packages

### DIFF
--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
@@ -762,7 +762,7 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
       .take(4)
     val deltas = deltaFileStatuses(10L to 13L)
     testExpectedError[RuntimeException](
-      corruptedCheckpointStatuses ++ deltas,
+      corruptedCheckpointStatuses.toSeq ++ deltas,
       Optional.empty(),
       Optional.empty(),
       expectedErrorMessageContains = expectedErrorMessage(10)
@@ -810,7 +810,7 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
       .map(p => FileStatus.of(p.toString, 10, 10))
       .take(4)
     testExpectedError[RuntimeException](
-      files = corruptedCheckpointStatuses ++ deltaFileStatuses(10L to 20L) ++
+      files = corruptedCheckpointStatuses.toSeq ++ deltaFileStatuses(10L to 20L) ++
         singularCheckpointFileStatuses(Seq(10L)),
       startCheckpoint = Optional.of(20),
       expectedErrorMessageContains = "Checkpoint file to load version: 20 is missing."

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultExpressionHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultExpressionHandler.java
@@ -30,10 +30,6 @@ import io.delta.kernel.types.DataType;
 import io.delta.kernel.types.StructType;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 
-import io.delta.kernel.defaults.internal.data.vector.DefaultBooleanVector;
-import io.delta.kernel.defaults.internal.expressions.DefaultExpressionEvaluator;
-import io.delta.kernel.defaults.internal.expressions.DefaultPredicateEvaluator;
-
 /**
  * Default implementation of {@link ExpressionHandler}
  */
@@ -44,12 +40,14 @@ public class DefaultExpressionHandler implements ExpressionHandler {
         StructType inputSchema,
         Expression expression,
         DataType outputType) {
-        return new DefaultExpressionEvaluator(inputSchema, expression, outputType);
+        return new  io.delta.kernel.defaults.internal.expressions.DefaultExpressionEvaluator(
+            inputSchema, expression, outputType);
     }
 
     @Override
     public PredicateEvaluator getPredicateEvaluator(StructType inputSchema, Predicate predicate) {
-        return new DefaultPredicateEvaluator(inputSchema, predicate);
+        return new io.delta.kernel.defaults.internal.expressions.DefaultPredicateEvaluator(
+            inputSchema, predicate);
     }
 
     @Override
@@ -61,6 +59,7 @@ public class DefaultExpressionHandler implements ExpressionHandler {
 
         // Make a copy of the `values` array.
         boolean[] valuesCopy = Arrays.copyOfRange(values, from, to);
-        return new DefaultBooleanVector(length, Optional.empty(), valuesCopy);
+        return new io.delta.kernel.defaults.internal.data.vector.DefaultBooleanVector(
+            length, Optional.empty(), valuesCopy);
     }
 }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultFileSystemClient.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultFileSystemClient.java
@@ -29,8 +29,6 @@ import io.delta.kernel.utils.FileStatus;
 
 import io.delta.kernel.internal.util.Utils;
 
-import io.delta.kernel.defaults.internal.logstore.LogStoreProvider;
-
 /**
  * Default implementation of {@link FileSystemClient} based on Hadoop APIs. It takes a Hadoop
  * {@link Configuration} object to interact with the file system. The following optional
@@ -73,7 +71,8 @@ public class DefaultFileSystemClient
     @Override
     public CloseableIterator<FileStatus> listFrom(String filePath) throws IOException {
         Path path = new Path(filePath);
-        LogStore logStore = LogStoreProvider.getLogStore(hadoopConf, path.toUri().getScheme());
+        LogStore logStore = io.delta.kernel.defaults.internal.logstore.LogStoreProvider.getLogStore(
+            hadoopConf, path.toUri().getScheme());
 
         return Utils.toCloseableIterator(logStore.listFrom(path, hadoopConf))
                 .map(hadoopFileStatus ->

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultJsonHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultJsonHandler.java
@@ -39,12 +39,6 @@ import io.delta.kernel.utils.FileStatus;
 import io.delta.kernel.internal.util.Utils;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 
-import io.delta.kernel.defaults.internal.data.DefaultJsonRow;
-import io.delta.kernel.defaults.internal.data.DefaultRowBasedColumnarBatch;
-import io.delta.kernel.defaults.internal.json.JsonUtils;
-import io.delta.kernel.defaults.internal.logstore.LogStoreProvider;
-import io.delta.kernel.defaults.internal.types.DataTypeParser;
-
 /**
  * Default implementation of {@link JsonHandler} based on Hadoop APIs.
  */
@@ -80,7 +74,8 @@ public class DefaultJsonHandler implements JsonHandler {
                 rows.add(null);
             }
         }
-        return new DefaultRowBasedColumnarBatch(outputSchema, rows);
+        return new io.delta.kernel.defaults.internal.data.DefaultRowBasedColumnarBatch(
+            outputSchema, rows);
     }
 
     @Override
@@ -88,7 +83,8 @@ public class DefaultJsonHandler implements JsonHandler {
         try {
             // We don't expect Java BigDecimal anywhere in a Delta schema so we use the default
             // JSON reader
-            return DataTypeParser.parseSchema(defaultObjectReader.readTree(structTypeJson));
+            return io.delta.kernel.defaults.internal.types.DataTypeParser.parseSchema(
+                defaultObjectReader.readTree(structTypeJson));
         } catch (JsonProcessingException ex) {
             throw new RuntimeException(
                 format("Could not parse JSON: %s", structTypeJson), ex);
@@ -152,7 +148,8 @@ public class DefaultJsonHandler implements JsonHandler {
                 }
                 while (currentBatchSize < maxBatchSize && hasNext());
 
-                return new DefaultRowBasedColumnarBatch(physicalSchema, rows);
+                return new io.delta.kernel.defaults.internal.data.DefaultRowBasedColumnarBatch(
+                    physicalSchema, rows);
             }
 
             private void tryOpenNextFile() throws IOException {
@@ -191,7 +188,8 @@ public class DefaultJsonHandler implements JsonHandler {
             CloseableIterator<Row> data,
             boolean overwrite) throws IOException {
         Path path = new Path(URI.create(filePath));
-        LogStore logStore = LogStoreProvider.getLogStore(hadoopConf, path.toUri().getScheme());
+        LogStore logStore = io.delta.kernel.defaults.internal.logstore.LogStoreProvider.getLogStore(
+            hadoopConf, path.toUri().getScheme());
         try {
             logStore.write(
                     path,
@@ -203,7 +201,8 @@ public class DefaultJsonHandler implements JsonHandler {
 
                         @Override
                         public String next() {
-                            return JsonUtils.rowToJson(data.next());
+                            return io.delta.kernel.defaults.internal.json.JsonUtils.rowToJson(
+                                data.next());
                         }
                     },
                     overwrite,
@@ -216,7 +215,8 @@ public class DefaultJsonHandler implements JsonHandler {
     private Row parseJson(String json, StructType readSchema) {
         try {
             final JsonNode jsonNode = objectReaderReadBigDecimals.readTree(json);
-            return new DefaultJsonRow((ObjectNode) jsonNode, readSchema);
+            return new io.delta.kernel.defaults.internal.data.DefaultJsonRow(
+                (ObjectNode) jsonNode, readSchema);
         } catch (JsonProcessingException ex) {
             throw new KernelEngineException(format("Could not parse JSON: %s", json), ex);
         }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultParquetHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultParquetHandler.java
@@ -38,10 +38,6 @@ import io.delta.kernel.internal.util.InternalUtils;
 import io.delta.kernel.internal.util.Utils;
 import static io.delta.kernel.internal.util.Preconditions.checkState;
 
-import io.delta.kernel.defaults.internal.logstore.LogStoreProvider;
-import io.delta.kernel.defaults.internal.parquet.ParquetFileReader;
-import io.delta.kernel.defaults.internal.parquet.ParquetFileWriter;
-
 /**
  * Default implementation of {@link ParquetHandler} based on Hadoop APIs.
  */
@@ -63,7 +59,8 @@ public class DefaultParquetHandler implements ParquetHandler {
             StructType physicalSchema,
             Optional<Predicate> predicate) throws IOException {
         return new CloseableIterator<ColumnarBatch>() {
-            private final ParquetFileReader batchReader = new ParquetFileReader(hadoopConf);
+            private final io.delta.kernel.defaults.internal.parquet.ParquetFileReader batchReader =
+                new io.delta.kernel.defaults.internal.parquet.ParquetFileReader(hadoopConf);
             private CloseableIterator<ColumnarBatch> currentFileReader;
 
             @Override
@@ -103,8 +100,9 @@ public class DefaultParquetHandler implements ParquetHandler {
             String directoryPath,
             CloseableIterator<FilteredColumnarBatch> dataIter,
             List<Column> statsColumns) throws IOException {
-        ParquetFileWriter batchWriter =
-            new ParquetFileWriter(hadoopConf, new Path(URI.create(directoryPath)), statsColumns);
+        io.delta.kernel.defaults.internal.parquet.ParquetFileWriter batchWriter =
+            new io.delta.kernel.defaults.internal.parquet.ParquetFileWriter(
+                hadoopConf, new Path(URI.create(directoryPath)), statsColumns);
         return batchWriter.write(dataIter);
     }
 
@@ -123,7 +121,8 @@ public class DefaultParquetHandler implements ParquetHandler {
         try {
             Path targetPath = new Path(URI.create(filePath));
             LogStore logStore =
-                    LogStoreProvider.getLogStore(hadoopConf, targetPath.toUri().getScheme());
+                io.delta.kernel.defaults.internal.logstore.LogStoreProvider.getLogStore(
+                    hadoopConf, targetPath.toUri().getScheme());
 
             boolean useRename = logStore.isPartialWriteVisible(targetPath, hadoopConf);
 
@@ -134,7 +133,9 @@ public class DefaultParquetHandler implements ParquetHandler {
                 String tempFileName = format(".%s.%s.tmp", targetPath.getName(), UUID.randomUUID());
                 writePath = new Path(targetPath.getParent(), tempFileName);
             }
-            ParquetFileWriter fileWriter = new ParquetFileWriter(hadoopConf, writePath);
+            io.delta.kernel.defaults.internal.parquet.ParquetFileWriter fileWriter =
+                new io.delta.kernel.defaults.internal.parquet.ParquetFileWriter(
+                    hadoopConf, writePath);
 
             Optional<DataFileStatus> writtenFile;
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
@@ -309,7 +309,7 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
     checkTable(
       path = path,
       expectedAnswer = expectedAnswer,
-      readCols = readCols
+      readCols = readCols.toSeq
     )
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
@@ -508,7 +508,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
       val parquetAllTypes = goldenTablePath("parquet-all-types")
       val schema = removeUnsupportedTypes(tableSchema(parquetAllTypes))
 
-      val data = readTableUsingKernel(engine, parquetAllTypes, schema).to[Seq]
+      val data = readTableUsingKernel(engine, parquetAllTypes, schema)
       val dataWithPartInfo = Seq(Map.empty[String, Literal] -> data)
 
       appendData(engine, tblPath, isNewTable = true, schema, Seq.empty, dataWithPartInfo)
@@ -551,7 +551,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
         "timestampType"
       )
       val casePreservingPartCols =
-        casePreservingPartitionColNames(schema, partCols.asJava).asScala.to[Seq]
+        casePreservingPartitionColNames(schema, partCols.asJava).asScala
 
       // get the partition values from the data batch at the given rowId
       def getPartitionValues(batch: ColumnarBatch, rowId: Int): Map[String, Literal] = {
@@ -584,7 +584,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
         }.toMap
       }
 
-      val data = readTableUsingKernel(engine, parquetAllTypes, schema).to[Seq]
+      val data = readTableUsingKernel(engine, parquetAllTypes, schema)
 
       // From the above table read data, convert each row as a new batch with partition info
       // Take the values of the partitionCols from the data and create a new batch with the
@@ -603,7 +603,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
       }
 
       appendData(engine, tblPath, isNewTable = true, schema, partCols, dataWithPartInfo)
-      verifyCommitInfo(tblPath, version = 0, casePreservingPartCols, operation = WRITE)
+      verifyCommitInfo(tblPath, version = 0, casePreservingPartCols.toSeq, operation = WRITE)
 
       var expData = dataWithPartInfo.flatMap(_._2).flatMap(_.toTestRows)
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LogReplayMetricsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LogReplayMetricsSuite.scala
@@ -386,7 +386,7 @@ trait FileReadMetrics { self: Object =>
     }
   }
 
-  def getVersionsRead: Seq[Long] = versionsRead
+  def getVersionsRead: Seq[Long] = versionsRead.toSeq
 
   def getLastCheckpointMetadataReadCalls: Int = lastCheckpointMetadataReadCalls
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestRow.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestRow.scala
@@ -110,7 +110,7 @@ object TestRow {
         case _: StructType => TestRow(row.getStruct(i))
         case _ => throw new UnsupportedOperationException("unrecognized data type")
       }
-    })
+    }.toSeq)
   }
 
   def apply(row: SparkRow): TestRow = {
@@ -133,8 +133,14 @@ object TestRow {
         case _: sparktypes.BinaryType => obj.asInstanceOf[Array[Byte]]
         case _: sparktypes.DecimalType => obj.asInstanceOf[java.math.BigDecimal]
         case arrayType: sparktypes.ArrayType =>
-          obj.asInstanceOf[Seq[Any]]
-            .map(decodeCellValue(arrayType.elementType, _))
+          obj match {
+            case s: Seq[Any] =>
+              s.map(decodeCellValue(arrayType.elementType, _))
+            case as: scala.collection.mutable.ArraySeq[Any] =>
+              as.map(decodeCellValue(arrayType.elementType, _)).toSeq
+            case _ =>
+              throw new RuntimeException("Encountered unexpected underlying type for ArrayType");
+          }
         case mapType: sparktypes.MapType => obj.asInstanceOf[Map[Any, Any]].map {
           case (k, v) =>
             decodeCellValue(mapType.keyType, k) -> decodeCellValue(mapType.valueType, v)

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -71,7 +71,7 @@ trait TestUtils extends Assertions with SQLHelper {
         while (iter.hasNext) {
           result.append(iter.next())
         }
-        result
+        result.toSeq
       } finally {
         iter.close()
       }
@@ -157,7 +157,7 @@ trait TestUtils extends Assertions with SQLHelper {
         // for all primitive types
         Seq(new Column((basePath :+ field.getName).asJava.toArray(new Array[String](0))));
       case _ => Seq.empty
-    }
+    }.toSeq
   }
 
   def collectScanFileRows(scan: Scan, engine: Engine = defaultEngine): Seq[Row] = {
@@ -235,7 +235,7 @@ trait TestUtils extends Assertions with SQLHelper {
         }
       }
     }
-    result
+    result.toSeq
   }
 
   def readTableUsingKernel(
@@ -684,7 +684,7 @@ trait TestUtils extends Assertions with SQLHelper {
             toSparkType(field.getDataType),
             field.isNullable
           )
-        })
+        }.toSeq)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

In preparation for a Spark 4.0 preview release branch (which will only support Scala 2.13) make the necessary changes to Kernel to reduce the later diff.
- Support Scala 2.13
- Avoid java doc missing import errors since we exclude any `internal/` files from the javadoc source files. For some reason this starts failing in https://github.com/delta-io/delta/pull/3122 but not before.

## How was this patch tested?

https://github.com/delta-io/delta/pull/3122 and existing tests.

## Does this PR introduce _any_ user-facing changes?

No.
