### PR TITLE
[Spark] Remove deprecated FileNames.deltaFile method

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/FileNames.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/FileNames.scala
@@ -43,18 +43,6 @@ object FileNames {
   def unsafeDeltaFile(path: Path, version: Long): Path = new Path(path, f"$version%020d.json")
 
   /**
-   * Returns the delta (json format) path for a given delta file.
-   * WARNING: This API is unsafe and deprecated. It can resolve to incorrect paths if the table has
-   * Managed Commits. It will be removed in future versions.
-   * Use DeltaCommitFileProvider(snapshot).deltaFile instead to guarantee accurate paths or
-   * unsafeDeltaFile for potentially incorrect file name resolution.
-   */
-  @deprecated(
-    "This method is deprecated and will be removed in future versions. " +
-      "Use DeltaCommitFileProvider(snapshot).deltaFile or unsafeDeltaFile instead")
-  def deltaFile(path: Path, version: Long): Path = unsafeDeltaFile(path, version)
-
-  /**
    * Returns the un-backfilled uuid formatted delta (json format) path for a given version.
    *
    * @param logPath The root path of the delta log.


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

- Clients are expected to use DeltaCommitFileProvider instead.
- FileNames.unsafeDeltaFile can be used in case the clients knows for sure the file has been backfilled.

## How was this patch tested?

Build

## Does this PR introduce _any_ user-facing changes?

No