### PR TITLE
[Kernel] Handle long values in `FieldMetadata` parsing

### DIFF
--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/types/DataTypeParser.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/types/DataTypeParser.java
@@ -177,8 +177,8 @@ public class DataTypeParser {
 
             if (value.isNull()) {
                 builder.putNull(key);
-            } else if (value.isInt()) {
-                builder.putLong(key, value.intValue());
+            } else if (value.isIntegralNumber()) { // covers both int and long
+                builder.putLong(key, value.longValue());
             } else if (value.isDouble()) {
                 builder.putDouble(key, value.doubleValue());
             } else if (value.isBoolean()) {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/types/DataTypeParserSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/types/DataTypeParserSuite.scala
@@ -146,6 +146,8 @@ class DataTypeParserSuite extends AnyFunSuite {
         |{
         |  "null" : null,
         |  "int" : 10,
+        |  "long-1" : -16070400023423400,
+        |  "long-2" : 16070400023423400,
         |  "double" : 2.22,
         |  "boolean" : true,
         |  "string" : "10",
@@ -161,6 +163,8 @@ class DataTypeParserSuite extends AnyFunSuite {
     val expectedFieldMetadataAllTypes = FieldMetadata.builder()
       .putNull("null")
       .putLong("int", 10)
+      .putLong("long-1", -16070400023423400L)
+      .putLong("long-2", 16070400023423400L)
       .putDouble("double", 2.22)
       .putBoolean("boolean", true)
       .putString("string", "10")


### PR DESCRIPTION
## Description
Currently when parsing the `FieldMetadata` in `StructField` (as part of the schema parsing), we always assume the integral values are of `int` type, but it could be of value `long`.

## How was this patch tested?
Add couple of cases to existing test