### PR TITLE
[Kernel] Write a new inCommitTimestamp in CommitInfo on every commit

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
@@ -19,6 +19,7 @@ package io.delta.kernel;
 import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.types.StructType;
+import io.delta.kernel.internal.actions.Metadata;
 
 /**
  * Represents the snapshot of a Delta table.
@@ -35,6 +36,8 @@ public interface Snapshot {
      * @return version of this snapshot in the Delta table
      */
     long getVersion(Engine engine);
+
+    Metadata getMetadata();
 
     /**
      * Get the schema of the table at this snapshot.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
@@ -37,6 +37,11 @@ public interface Snapshot {
      */
     long getVersion(Engine engine);
 
+    /**
+     * Get the metadata of the table at this snapshot.
+     *
+     * @return Metadata of the Delta table at this snapshot.
+     */
     Metadata getMetadata();
 
     /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -78,6 +78,7 @@ public class SnapshotImpl implements Snapshot {
         );
     }
 
+    @Override
     public Metadata getMetadata() {
         return metadata;
     }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -60,6 +60,14 @@ public class TableConfig<T> {
             "needs to be a positive integer."
     );
 
+    public static final TableConfig<Boolean> IN_COMMIT_TIMESTAMPS_ENABLED = new TableConfig<>(
+            "delta.enableInCommitTimestamps-preview",
+            "false",
+            Boolean::valueOf,
+            value -> true,
+            "needs to be a boolean."
+    );
+
     private final String key;
     private final String defaultValue;
     private final Function<String, T> fromString;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -60,6 +60,7 @@ public class TableConfig<T> {
             "needs to be a positive integer."
     );
 
+    /** This table property is used to track the enablement of the inCommitTimestamps. */
     public static final TableConfig<Boolean> IN_COMMIT_TIMESTAMPS_ENABLED = new TableConfig<>(
             "delta.enableInCommitTimestamps-preview",
             "false",

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -40,6 +40,7 @@ import io.delta.kernel.internal.replay.ConflictChecker.TransactionRebaseState;
 import io.delta.kernel.internal.util.FileNames;
 import io.delta.kernel.internal.util.VectorUtils;
 import static io.delta.kernel.internal.TableConfig.CHECKPOINT_INTERVAL;
+import static io.delta.kernel.internal.TableConfig.IN_COMMIT_TIMESTAMPS_ENABLED;
 import static io.delta.kernel.internal.actions.SingleAction.*;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 import static io.delta.kernel.internal.util.Preconditions.checkState;
@@ -198,8 +199,12 @@ public class TransactionImpl
         return setTxnOpt;
     }
 
-    private long generateInCommitTimestampForFirstCommitAttempt(long currentTimestamp) {
-        return currentTimestamp;
+    private Optional<Long> generateInCommitTimestampForFirstCommitAttempt(long currentTimestamp) {
+        if (IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(metadata)) {
+            return Optional.of(currentTimestamp);
+        } else {
+            return Optional.empty();
+        }
     }
 
     private Row generateCommitAction() {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -198,9 +198,16 @@ public class TransactionImpl
         return setTxnOpt;
     }
 
+    private long generateInCommitTimestampForFirstCommitAttempt(long currentTimestamp) {
+        return currentTimestamp;
+    }
+
     private Row generateCommitAction() {
+        long commitAttemptStartTime = System.currentTimeMillis();
         return new CommitInfo(
-                System.currentTimeMillis(), /* timestamp */
+                generateInCommitTimestampForFirstCommitAttempt(
+                        commitAttemptStartTime), /* inCommitTimestamp */
+                commitAttemptStartTime, /* timestamp */
                 "Kernel-" + Meta.KERNEL_VERSION + "/" + engineInfo, /* engineInfo */
                 operation.getDescription(), /* description */
                 getOperationParameters(), /* operationParameters */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
@@ -43,6 +43,7 @@ import static io.delta.kernel.internal.util.VectorUtils.stringStringMapValue;
 public class CommitInfo {
 
     public static StructType FULL_SCHEMA = new StructType()
+            .add("inCommitTimestamp", LongType.LONG, true /* nullable */)
             .add("timestamp", LongType.LONG)
             .add("engineInfo", StringType.STRING)
             .add("operation", StringType.STRING)
@@ -56,6 +57,7 @@ public class CommitInfo {
                     .boxed()
                     .collect(toMap(i -> FULL_SCHEMA.at(i).getName(), i -> i));
 
+    private final long inCommitTimestamp;
     private final long timestamp;
     private final String engineInfo;
     private final String operation;
@@ -64,18 +66,24 @@ public class CommitInfo {
     private final String txnId;
 
     public CommitInfo(
+            long inCommitTimestamp,
             long timestamp,
             String engineInfo,
             String operation,
             Map<String, String> operationParameters,
             boolean isBlindAppend,
             String txnId) {
+        this.inCommitTimestamp = inCommitTimestamp;
         this.timestamp = timestamp;
         this.engineInfo = engineInfo;
         this.operation = operation;
         this.operationParameters = Collections.unmodifiableMap(operationParameters);
         this.isBlindAppend = isBlindAppend;
         this.txnId = txnId;
+    }
+
+    public long getInCommitTimestamp() {
+        return inCommitTimestamp;
     }
 
     public long getTimestamp() {
@@ -97,6 +105,7 @@ public class CommitInfo {
      */
     public Row toRow() {
         Map<Integer, Object> commitInfo = new HashMap<>();
+        commitInfo.put(COL_NAME_TO_ORDINAL.get("inCommitTimestamp"), inCommitTimestamp);
         commitInfo.put(COL_NAME_TO_ORDINAL.get("timestamp"), timestamp);
         commitInfo.put(COL_NAME_TO_ORDINAL.get("engineInfo"), engineInfo);
         commitInfo.put(COL_NAME_TO_ORDINAL.get("operation"), operation);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
@@ -57,7 +57,7 @@ public class CommitInfo {
                     .boxed()
                     .collect(toMap(i -> FULL_SCHEMA.at(i).getName(), i -> i));
 
-    private final long inCommitTimestamp;
+    private final Optional<Long> inCommitTimestamp;
     private final long timestamp;
     private final String engineInfo;
     private final String operation;
@@ -66,7 +66,7 @@ public class CommitInfo {
     private final String txnId;
 
     public CommitInfo(
-            long inCommitTimestamp,
+            Optional<Long> inCommitTimestamp,
             long timestamp,
             String engineInfo,
             String operation,
@@ -82,7 +82,7 @@ public class CommitInfo {
         this.txnId = txnId;
     }
 
-    public long getInCommitTimestamp() {
+    public Optional<Long> getInCommitTimestamp() {
         return inCommitTimestamp;
     }
 
@@ -105,7 +105,8 @@ public class CommitInfo {
      */
     public Row toRow() {
         Map<Integer, Object> commitInfo = new HashMap<>();
-        commitInfo.put(COL_NAME_TO_ORDINAL.get("inCommitTimestamp"), inCommitTimestamp);
+        commitInfo.put(COL_NAME_TO_ORDINAL.get("inCommitTimestamp"),
+                inCommitTimestamp.orElse(null));
         commitInfo.put(COL_NAME_TO_ORDINAL.get("timestamp"), timestamp);
         commitInfo.put(COL_NAME_TO_ORDINAL.get("engineInfo"), engineInfo);
         commitInfo.put(COL_NAME_TO_ORDINAL.get("operation"), operation);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
@@ -29,6 +29,8 @@ import static io.delta.kernel.internal.util.VectorUtils.stringStringMapValue;
  * Delta log action representing a commit information action. According to the Delta protocol there
  * isn't any specific schema for this action, but we use the following schema:
  * <ul>
+ *     <li>inCommitTimestamp: Long - A monotonically increasing timestamp that represents the time
+ *     since epoch in milliseconds when the commit write was started</li>
  *     <li>timestamp: Long - Milliseconds since epoch UTC of when this commit happened</li>
  *     <li>engineInfo: String - Engine that made this commit</li>
  *     <li>operation: String - Operation (e.g. insert, delete, merge etc.)</li>

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWriteSuiteBase.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWriteSuiteBase.scala
@@ -78,6 +78,17 @@ trait DeltaTableWriteSuiteBase extends AnyFunSuite with TestUtils {
       s"SET TBLPROPERTIES ('delta.checkpointInterval' = '$interval')")
   }
 
+  def setInCommitTimestampsEnabled(tablePath: String, enabled: Boolean): Unit = {
+    spark.sql(s"ALTER TABLE delta.`$tablePath` " +
+      s"SET TBLPROPERTIES ('delta.enableInCommitTimestamps-preview' = '$enabled')")
+  }
+
+  def createTableWithInCommitTimestampsEnabled(tablePath: String, enabled: Boolean): Unit = {
+    spark.sql(s"CREATE TABLE test (a INT, b STRING) USING delta CLUSTER BY (a) " +
+      s"LOCATION '$tablePath' " +
+      s"TBLPROPERTIES ('delta.enableInCommitTimestamps-preview' = '$enabled')")
+  }
+
   def dataFileCount(tablePath: String): Int = {
     Files.walk(Paths.get(tablePath)).iterator().asScala
       .count(path => path.toString.endsWith(".parquet") && !path.toString.contains("_delta_log"))

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/InCommitTimestampSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/InCommitTimestampSuite.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults
+
+import io.delta.kernel.Operation.CREATE_TABLE
+import io.delta.kernel._
+import io.delta.kernel.engine.Engine
+import io.delta.kernel.internal.actions.SingleAction
+import io.delta.kernel.internal.fs.Path
+import io.delta.kernel.internal.util.FileNames
+import io.delta.kernel.internal.util.Utils.singletonCloseableIterator
+import io.delta.kernel.types.IntegerType.INTEGER
+import io.delta.kernel.types._
+import io.delta.kernel.utils.CloseableIterable.emptyIterable
+
+import java.util.Optional
+import scala.collection.JavaConverters._
+import scala.collection.immutable.Seq
+
+class InCommitTimestampSuite extends DeltaTableWriteSuiteBase {
+  val testEngineInfo = "test-engine"
+  val testSchema = new StructType().add("id", INTEGER)
+
+  private def getInCommitTimestamp(engine: Engine, table: Table, version: Long): Long = {
+    val logPath = new Path(table.getPath(engine), "_delta_log")
+    val file = engine
+      .getFileSystemClient
+      .listFrom(FileNames.listingPrefix(logPath, version)).next
+    val row =
+      engine.getJsonHandler.readJsonFiles(
+        singletonCloseableIterator(file),
+        SingleAction.FULL_SCHEMA,
+        Optional.empty()).toSeq.map(batch => batch.getRows.next).head
+    val commitInfoOrd = row.getSchema.indexOf("commitInfo")
+    val commitInfoRow = row.getStruct(commitInfoOrd)
+    val inCommitTimestampOrd = commitInfoRow.getSchema.indexOf("inCommitTimestamp")
+    commitInfoRow.getLong(inCommitTimestampOrd)
+  }
+
+  test("Enable ICT on commit 0") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      val beforeCommitAttemptStartTime = System.currentTimeMillis
+      val table = Table.forPath(engine, tablePath)
+      val txnBuilder = table.createTransactionBuilder(engine, testEngineInfo, CREATE_TABLE)
+
+      val txn = txnBuilder
+        .withSchema(engine, testSchema)
+        .build(engine)
+
+      txn.commit(engine, emptyIterable())
+
+      assert(getInCommitTimestamp(engine, table, 0) >= beforeCommitAttemptStartTime)
+    }
+  }
+}


### PR DESCRIPTION
Write a non-monotonic timestamp in a new inCommitTimestamp field in CommitInfo on every commit.
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
