### PR TITLE
[SPARK][MINOR] Code cleanup (reformatting and typo hunting)

### DIFF
--- a/spark/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
+++ b/spark/src/main/scala/io/delta/sql/DeltaSparkSessionExtension.scala
@@ -81,14 +81,14 @@ import org.apache.spark.sql.internal.SQLConf
  */
 class DeltaSparkSessionExtension extends (SparkSessionExtensions => Unit) {
   override def apply(extensions: SparkSessionExtensions): Unit = {
-    extensions.injectParser { (session, parser) =>
+    extensions.injectParser { (_, parser) =>
       new DeltaSqlParser(parser)
     }
     extensions.injectResolutionRule { session =>
       ResolveDeltaPathTable(session)
     }
     extensions.injectResolutionRule { session =>
-      new PreprocessTimeTravel(session)
+      PreprocessTimeTravel(session)
     }
     extensions.injectResolutionRule { session =>
       // To ensure the parquet field id reader is turned on, these fields are required to support
@@ -104,7 +104,7 @@ class DeltaSparkSessionExtension extends (SparkSessionExtensions => Unit) {
       new CheckUnresolvedRelationTimeTravel(session)
     }
     extensions.injectCheckRule { session =>
-      new DeltaUnsupportedOperationsCheck(session)
+      DeltaUnsupportedOperationsCheck(session)
     }
     // Rule for rewriting the place holder for range_partition_id to manually construct the
     // `RangePartitioner` (which requires an RDD to be sampled in order to determine
@@ -113,13 +113,13 @@ class DeltaSparkSessionExtension extends (SparkSessionExtensions => Unit) {
       new RangePartitionIdRewrite(session)
     }
     extensions.injectPostHocResolutionRule { session =>
-      new PreprocessTableUpdate(session.sessionState.conf)
+      PreprocessTableUpdate(session.sessionState.conf)
     }
     extensions.injectPostHocResolutionRule { session =>
-      new PreprocessTableMerge(session.sessionState.conf)
+      PreprocessTableMerge(session.sessionState.conf)
     }
     extensions.injectPostHocResolutionRule { session =>
-      new PreprocessTableDelete(session.sessionState.conf)
+      PreprocessTableDelete(session.sessionState.conf)
     }
     // Resolve new UpCast expressions that might have been introduced by [[PreprocessTableUpdate]]
     // and [[PreprocessTableMerge]].

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -399,7 +399,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
   def txnExecutionTimeMs: Option[Long] = if (commitEndNano == -1) {
     None
   } else {
-    Some(NANOSECONDS.toMillis((commitEndNano - txnStartNano)))
+    Some(NANOSECONDS.toMillis(commitEndNano - txnStartNano))
   }
 
   /** Gets the stats collector for the table at the snapshot this transaction has. */
@@ -1104,8 +1104,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       actions: Seq[Action],
       op: DeltaOperations.Operation,
       canSkipEmptyCommits: Boolean,
-      tags: Map[String, String]
-  ): Option[Long] = recordDeltaOperation(deltaLog, "delta.commit") {
+      tags: Map[String, String]): Option[Long] = recordDeltaOperation(deltaLog, "delta.commit") {
     commitStartNano = System.nanoTime()
 
     val (version, postCommitSnapshot, actualCommittedActions) = try {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowCommitVersion.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowCommitVersion.scala
@@ -32,8 +32,10 @@ object RowCommitVersion {
 
   val QUALIFIED_COLUMN_NAME = s"${FileFormat.METADATA_NAME}.$METADATA_STRUCT_FIELD_NAME"
 
-  def createMetadataStructField(protocol: Protocol, metadata: Metadata, nullable: Boolean = false)
-    : Option[StructField] =
+  def createMetadataStructField(
+      protocol: Protocol,
+      metadata: Metadata,
+      nullable: Boolean = false): Option[StructField] =
     MaterializedRowCommitVersion.getMaterializedColumnName(protocol, metadata)
       .map(MetadataStructField(_, nullable))
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/RowTracking.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/RowTracking.scala
@@ -65,11 +65,13 @@ object RowTracking {
   }
 
   /**
-   * Returns the Row Tracking metadata fields for the file's _metadata when Row Tracking
-   * is enabled.
+   * @return the Row Tracking metadata fields for the file's _metadata
+   *         when Row Tracking is enabled.
    */
-  def createMetadataStructFields(protocol: Protocol, metadata: Metadata, nullable: Boolean)
-      : Iterable[StructField] = {
+  def createMetadataStructFields(
+      protocol: Protocol,
+      metadata: Metadata,
+      nullable: Boolean): Iterable[StructField] = {
     RowId.createRowIdField(protocol, metadata, nullable) ++
       RowId.createBaseRowIdField(protocol, metadata) ++
       DefaultRowCommitVersion.createDefaultRowCommitVersionField(protocol, metadata) ++
@@ -77,12 +79,13 @@ object RowTracking {
   }
 
   /**
-   * Return a copy of tagsMap with the [[DeltaCommitTag.PreservedRowTrackingTag.key]] tag added
-   * or replaced with the new value.
+   * @param preserved The value of [[DeltaCommitTag.PreservedRowTrackingTag.key]] tag
+   * @return A copy of ``tagsMap`` with the [[DeltaCommitTag.PreservedRowTrackingTag.key]] tag added
+   *         or replaced with the new value.
    */
   private def addPreservedRowTrackingTag(
       tagsMap: Map[String, String],
-      preserved: Boolean): Map[String, String] = {
+      preserved: Boolean = true): Map[String, String] = {
     tagsMap + (DeltaCommitTag.PreservedRowTrackingTag.key -> preserved.toString)
   }
 
@@ -99,11 +102,12 @@ object RowTracking {
       tagsMap.contains(PreservedRowTrackingTag.key)) {
       return tagsMap
     }
-    addPreservedRowTrackingTag(tagsMap, preserved = true)
+    addPreservedRowTrackingTag(tagsMap)
   }
 
   def preserveRowTrackingColumns(
-      dfWithoutRowTrackingColumns: DataFrame, snapshot: SnapshotDescriptor): DataFrame = {
+      dfWithoutRowTrackingColumns: DataFrame,
+      snapshot: SnapshotDescriptor): DataFrame = {
     val dfWithRowIds = RowId.preserveRowIds(dfWithoutRowTrackingColumns, snapshot)
     RowCommitVersion.preserveRowCommitVersions(dfWithRowIds, snapshot)
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -1288,7 +1288,7 @@ case class SidecarFile(
     sizeInBytes: Long,
     modificationTime: Long,
     tags: Map[String, String] = null)
-  extends Action with CheckpointOnlyAction {
+  extends CheckpointOnlyAction {
 
   override def wrap: SingleAction = SingleAction(sidecar = this)
 
@@ -1319,7 +1319,7 @@ object SidecarFile {
 case class CheckpointMetadata(
     version: Long,
     tags: Map[String, String] = null)
-  extends Action with CheckpointOnlyAction {
+  extends CheckpointOnlyAction {
 
   override def wrap: SingleAction = SingleAction(checkpointMetadata = this)
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DMLWithDeletionVectorsHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DMLWithDeletionVectorsHelper.scala
@@ -193,8 +193,8 @@ object DMLWithDeletionVectorsHelper extends DeltaCommand {
       spark: SparkSession,
       touchedFiles: Seq[TouchedFileWithDV],
       snapshot: Snapshot): (Seq[FileAction], Map[String, Long]) = {
-    val numModifiedRows: Long = touchedFiles.map(_.numberOfModifiedRows).sum
-    val numRemovedFiles: Long = touchedFiles.count(_.isFullyReplaced())
+    val numModifiedRows = touchedFiles.map(_.numberOfModifiedRows).sum.toLong
+    val numRemovedFiles = touchedFiles.count(_.isFullyReplaced()).toLong
 
     val (fullyRemovedFiles, notFullyRemovedFiles) = touchedFiles.partition(_.isFullyReplaced())
 
@@ -399,7 +399,7 @@ object DeletionVectorBitmapGenerator {
       .withColumn(FILE_NAME_COL, fileNameColumn)
       // Filter after getting input file name as the filter might introduce a join and we
       // cannot get input file name on join's output.
-      .filter(new Column(condition))
+      .filter(Column(condition))
       .withColumn(ROW_INDEX_COL, rowIndexColumn)
 
     val df = if (tableHasDVs) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
@@ -197,8 +197,8 @@ case class MergeIntoCommand(
       deltaTxn: OptimisticTransaction,
       mergeActions: Seq[FileAction],
       startTime: Long,
-      materializeSourceReason: MergeIntoMaterializeSourceReason.MergeIntoMaterializeSourceReason)
-    : Unit = {
+      materializeSourceReason: MergeIntoMaterializeSourceReason.MergeIntoMaterializeSourceReason
+  ): Unit = {
     checkNonDeterministicSource(spark)
 
     // Metrics should be recorded before commit (where they are written to delta logs).

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -130,9 +130,10 @@ object OptimizeTableCommand {
 case class OptimizeTableCommand(
     override val child: LogicalPlan,
     userPartitionPredicates: Seq[String],
-    optimizeContext: DeltaOptimizeContext
-)(val zOrderBy: Seq[UnresolvedAttribute])
-  extends OptimizeTableCommandBase with RunnableCommand with UnaryNode {
+    optimizeContext: DeltaOptimizeContext)(
+    val zOrderBy: Seq[UnresolvedAttribute])
+  extends OptimizeTableCommandBase
+  with UnaryNode {
 
   override val otherCopyArgs: Seq[AnyRef] = zOrderBy :: Nil
 
@@ -294,7 +295,7 @@ class OptimizeExecutor(
             true
           } else {
             val deleted = candidateSetOld -- candidateSetNew
-            logWarning(s"The following compacted files were delete " +
+            logWarning(s"The following compacted files were deleted " +
               s"during checkpoint ${deleted.mkString(",")}. Aborting the compaction.")
             false
           }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
@@ -947,9 +947,9 @@ trait CDCReaderImpl extends DeltaLogging {
       isStreaming: Boolean = false): DataFrame = {
 
     val relation = HadoopFsRelation(
-      index,
-      index.partitionSchema,
-      cdcReadSchema(index.schema),
+      location = index,
+      partitionSchema = index.partitionSchema,
+      dataSchema = cdcReadSchema(index.schema),
       bucketSpec = None,
       new DeltaParquetFileFormat(index.protocol, index.metadata, isCDCRead = true),
       options = index.deltaLog.options)(spark)


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- Spark

## Description

Many of these changes are to make the code more Scala-idiomatic (and less "Pythonic") to ease code comprehension ❤️

A few typos got squashed along the way, too 😎

## How was this patch tested?

Local builds

## Does this PR introduce _any_ user-facing changes?

No