### PR TITLE
[DOCS] vacuum duration check: add note for pyspark users

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/VacuumCommand.scala
@@ -89,6 +89,8 @@ object VacuumCommand extends VacuumCommandImpl with Serializable {
         |insert/upsert/delete/optimize, then you may turn off this check by setting:
         |spark.databricks.delta.retentionDurationCheck.enabled = false
         |
+        |For PySpark users, set as follows: spark.sql("SET spark.databricks.delta.retentionDurationCheck.enabled=false") 
+        |
         |If you are not sure, please use a value not less than "$configuredRetentionHours hours".
        """.stripMargin)
   }


### PR DESCRIPTION
The suggested action didn't work for me as a PySpark user. I'm wondering if it would be helpful to include this note so users don't have to Google like I did :)

`For PySpark users, set as follows: spark.sql("SET spark.databricks.delta.retentionDurationCheck.enabled=false") `

I'm quite new to PySpark so happy to be corrected if this is not the recommended approach here!