### PR TITLE
[Spark] Add a Delta config to enable/disable the workaround of handling colons ':' in paths

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -974,6 +974,17 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(false)
 
+  val DELTA_WORK_AROUND_COLONS_IN_HADOOP_PATHS =
+    buildConf("workAroundColonsInHadoopPaths.enabled")
+      .internal()
+      .doc("""
+             |When enabled, Delta will work around to allow colons in file paths. Normally Hadoop
+             |does not support colons in file paths due to ambiguity, but some file systems like
+             |S3 allow them.
+             |""".stripMargin)
+      .booleanConf
+      .createWithDefault(true)
+
   val REPLACEWHERE_DATACOLUMNS_ENABLED =
     buildConf("replaceWhere.dataColumns.enabled")
       .doc(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableUtilsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableUtilsSuite.scala
@@ -55,14 +55,23 @@ class DeltaTableUtilsSuite extends SharedSparkSession with DeltaSQLCommandTest {
       new Path("s3://my-bucket/subfolder/_delta/_log"))
     assert(DeltaTableUtils.safeConcatPaths(basePathEmpty, "_delta/_log") ==
       new Path("s3://my-bucket/_delta/_log"))
-    assert(DeltaTableUtils.safeConcatPaths(basePath, "part-2024-03-05T16:08:53.002.csv") ==
-      new Path("s3://my-bucket/subfolder/part-2024-03-05T16:08:53.002.csv"))
-    assert(DeltaTableUtils.safeConcatPaths(basePathEmpty, "part-2024-03-05T16:08:53.002.csv") ==
-      new Path("s3://my-bucket/part-2024-03-05T16:08:53.002.csv"))
-    assert(DeltaTableUtils.safeConcatPaths(basePath, "part/2024-03-05T16:08:53.002.csv") ==
-      new Path("s3://my-bucket/subfolder/part/2024-03-05T16:08:53.002.csv"))
-    assert(DeltaTableUtils.safeConcatPaths(basePathEmpty, "part/2024-03-05T16:08:53.002.csv") ==
-      new Path("s3://my-bucket/part/2024-03-05T16:08:53.002.csv"))
+
+    withSQLConf(DeltaSQLConf.DELTA_WORK_AROUND_COLONS_IN_HADOOP_PATHS.key -> "false") {
+      assert(intercept[IllegalArgumentException] {
+        DeltaTableUtils.safeConcatPaths(basePath, "part-2024-03-05T16:08:53.002.csv")
+      }.getMessage.contains("Relative path in absolute URI"))
+    }
+
+    withSQLConf(DeltaSQLConf.DELTA_WORK_AROUND_COLONS_IN_HADOOP_PATHS.key -> "true") {
+      assert(DeltaTableUtils.safeConcatPaths(basePath, "part-2024-03-05T16:08:53.002.csv") ==
+        new Path("s3://my-bucket/subfolder/part-2024-03-05T16:08:53.002.csv"))
+      assert(DeltaTableUtils.safeConcatPaths(basePathEmpty, "part-2024-03-05T16:08:53.002.csv") ==
+        new Path("s3://my-bucket/part-2024-03-05T16:08:53.002.csv"))
+      assert(DeltaTableUtils.safeConcatPaths(basePath, "part/2024-03-05T16:08:53.002.csv") ==
+        new Path("s3://my-bucket/subfolder/part/2024-03-05T16:08:53.002.csv"))
+      assert(DeltaTableUtils.safeConcatPaths(basePathEmpty, "part/2024-03-05T16:08:53.002.csv") ==
+        new Path("s3://my-bucket/part/2024-03-05T16:08:53.002.csv"))
+    }
   }
 
   test("removeInternalMetadata") {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR follows https://github.com/delta-io/delta/pull/3153 and introduces a Delta config to enable or disable the workaround of handling colons ':' in paths. The value of this config is `true` by default.

## How was this patch tested?

Existing tests.

## Does this PR introduce _any_ user-facing changes?

No, unless the user encountered any problem, which is very unlikely. 