### PR TITLE
[Kernel] Throw `KernelException` when `VOID` type is encountered

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -203,6 +203,11 @@ public final class DeltaErrors {
         return new ProtocolChangedException(attemptVersion);
     }
 
+    public static KernelException voidTypeEncountered() {
+        return new KernelException(
+                "Failed to parse the schema. Encountered unsupported Delta data type: VOID");
+    }
+
     /* ------------------------ HELPER METHODS ----------------------------- */
     private static String formatTimestamp(long millisSinceEpochUTC) {
         return new Timestamp(millisSinceEpochUTC).toInstant().toString();

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/types/DataTypeParser.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/types/DataTypeParser.java
@@ -23,6 +23,8 @@ import java.util.regex.Pattern;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import io.delta.kernel.types.*;
+
+import io.delta.kernel.internal.DeltaErrors;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 
 /**
@@ -258,6 +260,10 @@ public class DataTypeParser {
             return BasePrimitiveType.createPrimitive(name);
         } else if (name.equals("decimal")) {
             return DecimalType.USER_DEFAULT;
+        } else if ("void".equalsIgnoreCase(name)) {
+            // Earlier versions of Delta had VOID type which is not specified in Delta Protocol.
+            // It is not readable or writable. Throw a user-friendly error message.
+            throw DeltaErrors.voidTypeEncountered();
         } else {
             // decimal has a special pattern with a precision and scale
             Matcher decimalMatcher = FIXED_DECIMAL_PATTERN.matcher(name);
@@ -267,6 +273,9 @@ public class DataTypeParser {
                 return new DecimalType(precision, scale);
             }
 
+            // We have encountered a type that is beyond the specification of the protocol
+            // checks. This must be an invalid type (according to protocol) and
+            // not an unsupported data type by Kernel.
             throw new IllegalArgumentException(
                 String.format("%s is not a supported delta data type", name));
         }


### PR DESCRIPTION
## Description
Minor fix to throw `KernelException` when `VOID` type is encountered as it is an unsupported data type in Kernel.

## How was this patch tested?
Test