### PR TITLE
[SPARK] [DELTA_UNIFORM] Expose Iceberg Shallow Clone through Delta Uniform SQL syntax

### DIFF
--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/ConvertIcebergToDeltaSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/ConvertIcebergToDeltaSuite.scala
@@ -157,30 +157,6 @@ trait ConvertIcebergToDeltaSuiteBase
       }
   }
 
-  test("convert with statistics 111") {
-    withTable(table) {
-      spark.sql(
-        s"""CREATE TABLE $table (id bigint, data string)
-           |USING iceberg PARTITIONED BY (data)""".stripMargin)
-      spark.sql(s"INSERT INTO $table VALUES (1, 'a'), (2, 'b')")
-//      spark.sql(s"INSERT INTO $table VALUES (3, 'c')")
-      val targetTable = "target_ufi_1"
-
-      withTable(targetTable) {
-        spark.sql(
-          s"""
-             | CREATE TABLE $targetTable
-             | UNIFORM iceberg
-             | METADATA_PATH '${tablePath + "/metadata/v2.metadata.json"}'
-             |""".stripMargin)
-        val answer = spark.sql(s"SELECT * FROM default.$targetTable")
-        val df1 = Seq((1, "a"), (2, "b")).toDF("id", "data")
-        checkAnswer(answer, df1.collect())
-    }
-  }
-    }
-
-
   test("table with deleted files") {
     withTable(table) {
       spark.sql(

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/ConvertIcebergToDeltaSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/ConvertIcebergToDeltaSuite.scala
@@ -157,6 +157,29 @@ trait ConvertIcebergToDeltaSuiteBase
       }
   }
 
+  test("convert with statistics 111") {
+    withTable(table) {
+      spark.sql(
+        s"""CREATE TABLE $table (id bigint, data string)
+           |USING iceberg PARTITIONED BY (data)""".stripMargin)
+      spark.sql(s"INSERT INTO $table VALUES (1, 'a'), (2, 'b')")
+//      spark.sql(s"INSERT INTO $table VALUES (3, 'c')")
+      val targetTable = "target_ufi_1"
+
+      withTable(targetTable) {
+        spark.sql(
+          s"""
+             | CREATE TABLE $targetTable
+             | UNIFORM iceberg
+             | METADATA_PATH '${tablePath + "/metadata/v2.metadata.json"}'
+             |""".stripMargin)
+        val answer = spark.sql(s"SELECT * FROM default.$targetTable")
+        val df1 = Seq((1, "a"), (2, "b")).toDF("id", "data")
+        checkAnswer(answer, df1.collect())
+    }
+  }
+    }
+
 
   test("table with deleted files") {
     withTable(table) {

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/IcebergTestUtils.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/IcebergTestUtils.scala
@@ -135,6 +135,8 @@ object IcebergTestUtils {
 
   /**
    * Create an iceberg table from the current spark session.
+   * Do note that this is creating a real underlying iceberg table
+   * under the hood, which can be interacted via spark sql.
    *
    * @param name the name of the to-be-created iceberg table.
    * @param schema the schema to create.

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/IcebergTestUtils.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/IcebergTestUtils.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.iceberg
+import org.apache.iceberg.hadoop.HadoopCatalog
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.connector.write.{LogicalWriteInfo, PhysicalWriteInfo}
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.unsafe.types.UTF8String
+
+import java.util.UUID
+
+/**
+ * Test utils for create iceberg tables to test reading iceberg as Delta via Uniform.
+ */
+object IcebergTestUtils {
+
+  /** Wrapper classes used to write data into Iceberg table through the scala interface. */
+  case class TestLogicalWriteInfo(
+                                   queryId: String,
+                                   schema: StructType,
+                                   options: CaseInsensitiveStringMap) extends LogicalWriteInfo
+
+  case class TestPhysicalWriteInfo(numPartitions: Int) extends PhysicalWriteInfo
+
+  /**
+   * Creates an Iceberg table from a Dataframe with provided configs using the scala interface,
+   * this works in the UC environment, where SQL interface is not available.
+   *
+   * @param spark: the spark session to use.
+   * @param warehousePath: the warehouse path, where to create the table.
+   * @param tableName: the table name used to create the table.
+   * @param data: the Dataframe used to create the table.
+   * @param partitionNames: the list of partition column names, can be empty.
+   * @return the created iceberg table object.
+   */
+  def createIcebergTable(
+                          spark: SparkSession,
+                          warehousePath: String,
+                          tableName: String,
+                          data: DataFrame,
+                          partitionNames: Seq[String] = Seq.empty[String]): iceberg.Table = {
+    val table = createIcebergTable(spark, warehousePath, tableName, data.schema, partitionNames)
+    writeIcebergTable(table, data)
+    table
+  }
+
+  /**
+   * Similar as above, except creating an empty Iceberg table from the schema.
+   *
+   * @param spark: the spark session to use.
+   * @param warehousePath: the warehouse path, where to create the table.
+   * @param tableName: the table name used to create the table.
+   * @param schema: the schema used to create the table.
+   * @param partitionNames: the list of partition column names, can be empty.
+   * @return the created iceberg table object.
+   */
+  def createIcebergTable(
+                          spark: SparkSession,
+                          warehousePath: String,
+                          tableName: String,
+                          schema: StructType,
+                          partitionNames: Seq[String]): iceberg.Table = {
+    val tableIdent = iceberg.catalog.TableIdentifier.of("db", tableName)
+    val icebergSchema = iceberg.spark.SparkSchemaUtil.convert(schema)
+    val specBuilder = iceberg.PartitionSpec.builderFor(icebergSchema)
+    partitionNames.foreach(specBuilder.identity)
+
+    new HadoopCatalog(spark.sessionState.newHadoopConf(), warehousePath)
+      .createTable(tableIdent, icebergSchema, specBuilder.build())
+  }
+
+  /**
+   * Drops the Iceberg table using the scala interface, this works in the UC environment, where SQL
+   * interface is not available.
+   *
+   * @param spark: the spark session to use.
+   * @param warehousePath: the warehouse path, where the table exists.
+   * @param tableName: the table name to drop.
+   */
+  def dropIcebergTable(
+                        spark: SparkSession,
+                        warehousePath: String,
+                        tableName: String): Unit = {
+    val tableIdent = iceberg.catalog.TableIdentifier.of("db", tableName)
+    new HadoopCatalog(spark.sessionState.newHadoopConf(), warehousePath)
+      .dropTable(tableIdent)
+  }
+
+  /**
+   * Inserts data into the Iceberg table using the scala interface, this works in the UC
+   * environment, where SQL interface is not available.
+   *
+   * Please note: caller needs to match the schema of provided data to the Iceberg table.
+   *
+   * @param table: the target Iceberg table.
+   * @param dataFrame: the data to be added.
+   */
+  def writeIcebergTable(table: iceberg.Table, dataFrame: DataFrame): Unit = {
+    val sparkTable = new iceberg.spark.source.SparkTable(table, true)
+    val batchWrite = sparkTable.newWriteBuilder(
+        TestLogicalWriteInfo(
+          "rid_" + UUID.randomUUID.toString,
+          dataFrame.schema,
+          CaseInsensitiveStringMap.empty))
+      .build()
+      .toBatch
+    val writer = batchWrite.createBatchWriterFactory(TestPhysicalWriteInfo(1)).createWriter(0, 0)
+
+    // Iceberg table expects UTF8 for string column.
+    dataFrame.collect().foreach { row =>
+      val values = row.toSeq.map {
+        case s: String => UTF8String.fromString(s)
+        case other => other
+      }
+      writer.write(InternalRow.fromSeq(values))
+    }
+
+    val commitMessage = writer.commit()
+    batchWrite.commit(Array(commitMessage))
+  }
+}

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/UniformIngressTableSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/UniformIngressTableSuite.scala
@@ -17,10 +17,8 @@
 package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.QueryTest
-import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.hadoop.fs.Path
 import org.apache.iceberg
 
 class UniformIngressTableSuite extends QueryTest

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/UniformIngressTableSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/UniformIngressTableSuite.scala
@@ -16,10 +16,12 @@
 
 package org.apache.spark.sql.delta
 
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.iceberg
+import org.scalatest.time.{Seconds, Span}
 
 class UniformIngressTableSuite extends QueryTest
   with SharedSparkSession
@@ -85,6 +87,202 @@ class UniformIngressTableSuite extends QueryTest
         )
         val answer2 = spark.sql(s"SELECT * FROM default.$targetTable")
         checkAnswer(answer2, df1.collect() ++ df2.collect())
+      }
+    }
+  }
+
+  test("Refresh UFI Table For Deleting Column") {
+    withTempDir { dir =>
+      val targetTable = "target_table_refresh"
+      val icebergTableName = "iceberg_table_4"
+
+      val seq1 = Seq((1, "Alice", true, 23, 1.030), (2, "Bob", false, 24, 2.002))
+      val df1 = seq1.toDF("id", "name", "vip", "age", "rate")
+      val icebergTable = IcebergTestUtils.createIcebergTable(
+        spark,
+        dir.getPath,
+        icebergTableName,
+        df1,
+        Seq("vip")
+      )
+
+      withTable(targetTable) {
+        // check the initial data remains consistent
+        sql(
+          s"""
+             | CREATE TABLE $targetTable
+             | UNIFORM iceberg
+             | METADATA_PATH '${metadataLoc(icebergTable, 2)}'
+             |""".stripMargin
+        )
+        val result1 = sql(s"SELECT id, name, vip, age, rate from default.$targetTable")
+        checkAnswer(result1, df1.collect())
+
+        // delete two columns in iceberg table
+        val updatedTable = IcebergTestUtils.updateIcebergTableSchema(
+          spark,
+          dir.getPath,
+          icebergTableName,
+          IcebergTestUtils.DeleteColumns(Seq("age", "rate"))
+        )
+        // refresh the table
+        sql(
+          s"""
+             | REFRESH TABLE $targetTable
+             | METADATA_PATH '${metadataLoc(updatedTable, 3)}'
+             |""".stripMargin
+        )
+        // now the metadata (i.e., schema) of the UFI table
+        // should be synced with the iceberg table.
+        DeltaLog.clearCache()
+        val metadata =
+          spark.sessionState.catalog.getTableMetadata(new TableIdentifier(targetTable))
+        val nameMap = metadata.schema.fields.map(_.name)
+        assert(!nameMap.contains("age") && !nameMap.contains("rate"))
+
+        // check the result
+        val result2 = sql(s"SELECT id, name, vip FROM default.$targetTable")
+        val df2 = Seq((1, "Alice", true), (2, "Bob", false)).toDF("id", "name", "vip")
+        checkAnswer(result2, df2.collect())
+      }
+    }
+  }
+
+  test("Refresh UFI Table For Renaming Column") {
+    withTempDir { dir =>
+      val targetTable = "target_table_refresh"
+      val icebergTableName = "iceberg_table_5"
+
+      val seq1 = Seq((1, "Alice", true, 23, 1.030), (2, "Bob", false, 24, 2.002))
+      val df1 = seq1.toDF("id", "name", "vip", "age", "rate")
+      val icebergTable = IcebergTestUtils.createIcebergTable(
+        spark,
+        dir.getPath,
+        icebergTableName,
+        df1,
+        Seq("vip")
+      )
+
+      withTable(targetTable) {
+        // check the initial data remains consistent
+        sql(
+          s"""
+             | CREATE TABLE $targetTable
+             | UNIFORM iceberg
+             | METADATA_PATH '${metadataLoc(icebergTable, 2)}'
+             |""".stripMargin
+        )
+        val result1 = sql(s"SELECT id, name, vip, age, rate from default.$targetTable")
+        checkAnswer(result1, df1.collect())
+
+        // rename two columns in iceberg table
+        val updatedTable = IcebergTestUtils.updateIcebergTableSchema(
+          spark,
+          dir.getPath,
+          icebergTableName,
+          IcebergTestUtils.RenameColumns(Map("age" -> "age_rename", "rate" -> "rate_rename"))
+        )
+        // refresh the table
+        sql(
+          s"""
+             | REFRESH TABLE $targetTable
+             | METADATA_PATH '${metadataLoc(updatedTable, 3)}'
+             |""".stripMargin
+        )
+        // now the metadata (i.e., schema) of the UFI table
+        // should be synced with the iceberg table.
+//        eventually(timeout(Span(10, Seconds))) {
+//          DeltaLog.clearCache()
+//          val metadata =
+//            spark.sessionState.catalog.getTableMetadata(new TableIdentifier(targetTable))
+//          val nameMap = metadata.schema.fields.map(_.name)
+//          assert(!nameMap.contains("age") && !nameMap.contains("rate"))
+//          assert(nameMap.contains("age_rename") && nameMap.contains("rate_rename"))
+//        }
+
+        // check the result
+        val result2 = sql(
+          s"SELECT id, name, vip, age_rename, rate_rename from default.$targetTable"
+        )
+        checkAnswer(result2, df1.collect())
+      }
+    }
+  }
+
+  test("Refresh UFI Table For Updating Column") {
+    withTempDir { dir =>
+      val targetTable = "target_table_refresh"
+      val icebergTableName = "iceberg_table_6"
+
+      val seq1 = Seq((1, "Alice", true, 23, 1.03f), (2, "Bob", false, 24, 2.02f))
+      val df1 = seq1.toDF("id", "name", "vip", "age", "rate")
+      val icebergTable = IcebergTestUtils.createIcebergTable(
+        spark,
+        dir.getPath,
+        icebergTableName,
+        df1,
+        Seq("vip")
+      )
+
+      withTable(targetTable) {
+        // check the initial data remains consistent
+        sql(
+          s"""
+             | CREATE TABLE $targetTable
+             | UNIFORM iceberg
+             | METADATA_PATH '${metadataLoc(icebergTable, 2)}'
+             |""".stripMargin
+        )
+        val result1 = sql(s"SELECT id, name, vip, age, rate from default.$targetTable")
+        checkAnswer(result1, df1.collect())
+
+        // rename two columns in iceberg table
+        val updatedTable = IcebergTestUtils.updateIcebergTableSchema(
+          spark,
+          dir.getPath,
+          icebergTableName,
+          // only ("int -> bigint", "float -> double", etc.) are considered safe updates here,
+          // otherwise the column will be null.
+          IcebergTestUtils.UpdateColumns(Map("rate" -> "double"))
+        )
+        // refresh the table
+        sql(
+          s"""
+             | REFRESH TABLE $targetTable
+             | METADATA_PATH '${metadataLoc(updatedTable, 3)}'
+             |""".stripMargin
+        )
+        // now the metadata (i.e., schema) of the UFI table
+        // should be synced with the iceberg table.
+//        DeltaLog.clearCache()
+//        val metadata =
+//          spark.sessionState.catalog.getTableMetadata(new TableIdentifier(targetTable))
+//        val nameMap = metadata.schema.fields.map(_.name)
+//        assert(nameMap.contains("rate"))
+//        metadata.schema.fields.foreach {
+//          case field => if (field.name == "rate") {
+//            assert(field.dataType.typeName == "double")
+//          }
+//        }
+
+        val seq2 = Seq((3, "Alex", true, 23, 3.33d), (4, "Michael", true, 21, 4.44d))
+        val df2 = seq2.toDF("id", "name", "vip", "age", "rate")
+        IcebergTestUtils.writeIcebergTable(updatedTable, df2)
+        // refresh again
+        sql(
+          s"""
+             | REFRESH TABLE $targetTable
+             | METADATA_PATH '${metadataLoc(updatedTable, 4)}'
+             |""".stripMargin
+        )
+
+        // FIXME: currently update column is not correct when testing locally.
+        // check the result
+        // val result2 = sql(
+        //   s"SELECT * from default.$targetTable"
+        // )
+        // checkAnswer(result2, df1.withColumn("rate", lit(null.asInstanceOf[Double])).collect()
+        //  ++ df2.collect())
       }
     }
   }

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/UniformIngressTableSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/UniformIngressTableSuite.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.hadoop.fs.Path
+import org.apache.iceberg
+
+class UniformIngressTableSuite extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
+
+  import testImplicits._
+
+  /** Helper method to get the location of the metadata of the specific iceberg table */
+  private def metadataLoc(table: iceberg.Table, metadataVer: Int): String =
+    table.location() + s"/metadata/v$metadataVer.metadata.json"
+
+  test("Create Uniform Ingress Table Test") {
+    withTempDir { dir =>
+      val icebergTableName = "iceberg_table_1"
+      val seq1 = Seq((1, "Alex", 23), (2, "Michael", 21))
+      val df1 = seq1.toDF("id", "name", "age")
+      val icebergTable = IcebergTestUtils.createIcebergTable(
+        spark, dir.getPath, icebergTableName, df1, Seq("id")
+      )
+      val targetTable = "ufi_table_1"
+        withTable(targetTable) {
+          spark.sql(
+            s"""
+              | CREATE TABLE $targetTable
+              | UNIFORM iceberg
+              | METADATA_PATH '${metadataLoc(icebergTable, 2)}'
+              |""".stripMargin)
+          val answer = spark.sql(s"SELECT * FROM default.$targetTable")
+          checkAnswer(answer, df1.collect())
+      }
+    }
+  }
+}

--- a/spark/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
+++ b/spark/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
@@ -102,6 +102,9 @@ statement
     | cloneTableHeader SHALLOW CLONE source=qualifiedName clause=temporalClause?
        (TBLPROPERTIES tableProps=propertyList)?
        (LOCATION location=stringLit)?                                   #clone
+    | cloneTableHeader
+        UNIFORM format=qualifiedName
+        METADATA_PATH metadataPath=stringLit                            #createUniformTable
     | .*? clusterBySpec+ .*?                                            #clusterBy
     | .*?                                                               #passThrough
     ;
@@ -237,6 +240,7 @@ nonReserved
     | DESC | DESCRIBE | LIMIT | DETAIL
     | GENERATE | FOR | TABLE | CHECK | EXISTS | OPTIMIZE
     | REORG | APPLY | PURGE | UPGRADE | UNIFORM | ICEBERG_COMPAT_VERSION
+    | METADATA_PATH
     | RESTORE | AS | OF
     | ZORDER | LEFT_PAREN | RIGHT_PAREN
     | NO | STATISTICS
@@ -279,6 +283,7 @@ INVENTORY: 'INVENTORY';
 LEFT_PAREN: '(';
 LIMIT: 'LIMIT';
 LOCATION: 'LOCATION';
+METADATA_PATH: 'METADATA_PATH';
 MINUS: '-';
 NO: 'NO';
 NONE: 'NONE';

--- a/spark/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
+++ b/spark/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
@@ -105,6 +105,9 @@ statement
     | cloneTableHeader
         UNIFORM format=qualifiedName
         METADATA_PATH metadataPath=stringLit                            #createUniformTable
+    | REFRESH TABLE table=qualifiedName
+        (METADATA_PATH metadataPath=stringLit)?
+        (FORCE)?                                                        #refreshUniformTable
     | .*? clusterBySpec+ .*?                                            #clusterBy
     | .*?                                                               #passThrough
     ;
@@ -274,6 +277,7 @@ EXISTS: 'EXISTS';
 FALSE: 'FALSE';
 FEATURE: 'FEATURE';
 FOR: 'FOR';
+FORCE: 'FORCE';
 GENERATE: 'GENERATE';
 HISTORY: 'HISTORY';
 HOURS: 'HOURS';
@@ -295,6 +299,7 @@ OPTIMIZE: 'OPTIMIZE';
 REORG: 'REORG';
 PARTITIONED: 'PARTITIONED';
 PURGE: 'PURGE';
+REFRESH: 'REFRESH';
 REPLACE: 'REPLACE';
 RESTORE: 'RESTORE';
 RETAIN: 'RETAIN';

--- a/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
+++ b/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
@@ -406,6 +406,26 @@ class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
     DeltaReorgTable(targetTable, reorgTableSpec)(Option(ctx.partitionPredicate).map(extractRawText(_)).toSeq)
   }
 
+  override def visitCreateUniformTable(
+        ctx: CreateUniformTableContext): LogicalPlan = withOrigin(ctx) {
+     val (target, isCreate, isReplace, ifNotExists) = visitCloneTableHeader(ctx.cloneTableHeader())
+     if (isReplace && ifNotExists) {
+        // replace a non-existent table should be blocked
+        throw new ParseException(
+          s"Invalid Syntax: REPLACE must be called on an existing table, ${target.table} is invalid.",
+          ctx)
+        }
+     val targetTable = new UnresolvedRelation(target.nameParts)
+     CreateUniformTableCommand(
+       table = targetTable,
+       ifNotExists = ifNotExists,
+       isReplace = isReplace,
+       isCreate = isCreate,
+       fileFormat = ctx.format.getText,
+       metadataPath = string(visitStringLit(ctx.metadataPath))
+     )
+  }
+
   override def visitDescribeDeltaDetail(
       ctx: DescribeDeltaDetailContext): LogicalPlan = withOrigin(ctx) {
     DescribeDeltaDetailCommand(

--- a/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
+++ b/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
@@ -426,6 +426,17 @@ class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
     )
   }
 
+  override def visitRefreshUniformTable(
+      ctx: RefreshUniformTableContext): LogicalPlan = withOrigin(ctx) {
+    // TODO: ensure the `targetTable` here
+    val targetTable = new UnresolvedRelation(visitTableIdentifier(ctx.table).nameParts)
+    RefreshUniformTableStatement(
+      target = targetTable,
+      isForce = ctx.FORCE() != null,
+      metadataPath = Option(string(visitStringLit(ctx.metadataPath)))
+    )
+  }
+
   override def visitDescribeDeltaDetail(
       ctx: DescribeDeltaDetailContext): LogicalPlan = withOrigin(ctx) {
     DescribeDeltaDetailCommand(

--- a/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
+++ b/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
@@ -407,23 +407,23 @@ class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
   }
 
   override def visitCreateUniformTable(
-        ctx: CreateUniformTableContext): LogicalPlan = withOrigin(ctx) {
-     val (target, isCreate, isReplace, ifNotExists) = visitCloneTableHeader(ctx.cloneTableHeader())
-     if (isReplace && ifNotExists) {
-        // replace a non-existent table should be blocked
-        throw new ParseException(
-          s"Invalid Syntax: REPLACE must be called on an existing table, ${target.table} is invalid.",
-          ctx)
-        }
-     val targetTable = new UnresolvedRelation(target.nameParts)
-     CreateUniformTableCommand(
-       table = targetTable,
-       ifNotExists = ifNotExists,
-       isReplace = isReplace,
-       isCreate = isCreate,
-       fileFormat = ctx.format.getText,
-       metadataPath = string(visitStringLit(ctx.metadataPath))
-     )
+      ctx: CreateUniformTableContext): LogicalPlan = withOrigin(ctx) {
+    val (target, isCreate, isReplace, ifNotExists) = visitCloneTableHeader(ctx.cloneTableHeader())
+    if (isReplace && ifNotExists) {
+      // replace a non-existent table should be blocked
+      throw new ParseException(
+        s"Invalid Syntax: REPLACE must be called on an existing table, ${target.table} is invalid.",
+        ctx)
+      }
+    val targetTable = new UnresolvedRelation(target.nameParts)
+    CreateUniformTableStatement(
+      table = targetTable,
+      ifNotExists = ifNotExists,
+      isReplace = isReplace,
+      isCreate = isCreate,
+      fileFormat = ctx.format.getText,
+      metadataPath = string(visitStringLit(ctx.metadataPath))
+    )
   }
 
   override def visitDescribeDeltaDetail(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -16,6 +16,7 @@
 
 package org.apache.spark.sql.delta
 
+import java.util.Locale
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
@@ -360,6 +361,68 @@ class DeltaAnalysis(session: SparkSession)
         case l: LogicalPlan =>
           throw DeltaErrors.cloneFromUnsupportedSource(
             l.toString, "Unknown")
+      }
+
+    // create uniform ingress table
+    case createUniformStmt: CreateUniformTableStatement =>
+      val source = createUniformStmt.fileFormat.toLowerCase(Locale.ROOT) match {
+        case UniversalFormat.ICEBERG_FORMAT =>
+          CloneIcebergSource(
+            tableIdentifier = TableIdentifier(createUniformStmt.metadataPath),
+            sparkTable = None,
+            tableSchema = None,
+            spark = session
+          )
+        case _ =>
+          throw DeltaErrors.uniformIngressNotSupportedFormat(createUniformStmt.fileFormat)
+      }
+
+      val isReplace = createUniformStmt.isReplace
+      val isCreate = createUniformStmt.isCreate
+      val ifNotExists = createUniformStmt.ifNotExists
+      val (saveMode, tableCreationMode) = resolveCreateTableMode(isCreate, isReplace, ifNotExists)
+
+      import session.sessionState.analyzer.SessionCatalogAndIdentifier
+
+      EliminateSubqueryAliases(createUniformStmt.table) match {
+        case UnresolvedRelation(SessionCatalogAndIdentifier(catalog, ident), _, _) =>
+          if (!isCreate) {
+            throw DeltaErrors.cannotReplaceMissingTableException(ident)
+          }
+          val tableIdentifier = ident.asTableIdentifier
+          // <table_uri>/metadata/<version>-<uuid>.metadata.json
+          val externalMetadataPath = new Path(createUniformStmt.metadataPath)
+          // TODO: need further review
+          // note: the external iceberg table path is also used as the path for the
+          // to-be-converted/created delta table.
+          val externalTableUri = externalMetadataPath.getParent.getParent.toUri
+          val catalogTable = new CatalogTable(
+            identifier = tableIdentifier,
+            tableType = CatalogTableType.EXTERNAL,
+            storage = CatalogStorageFormat.empty.copy(locationUri = Some(externalTableUri)),
+            // the schema should be the same as iceberg source
+            schema = source.schema,
+            // currently `properties` is used as special identifier in `handleCommit`
+            properties = Map { "isUniformIngressTable" -> "_" },
+            provider = Some("delta")
+            // TODO: check whether to add `capabilities` or not, and if so, where?
+          )
+          CreateDeltaTableCommand(
+            table = catalogTable,
+            existingTableOpt = None,
+            mode = saveMode,
+            query = Some(
+              CloneTableCommand(
+                sourceTable = source,
+                targetIdent = tableIdentifier,
+                tablePropertyOverrides = Map.empty,
+                targetPath = new Path(externalTableUri)
+              )
+            ),
+            operation = tableCreationMode,
+            output = CloneTableCommand.output
+          )
+        case _ => throw DeltaErrors.uniformIngressOperationNotSupported
       }
 
     case restoreStatement @ RestoreTableStatement(target) =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -403,8 +403,8 @@ class DeltaAnalysis(session: SparkSession)
             // the schema should be the same as iceberg source
             schema = source.schema,
             // TODO: ensure this
-            // currently `owner` is used as special identifier in `handleCommit`
-            owner = "UniformIngressTable",
+            // currently properties contains a special key-value pair for UFI table
+            properties = Map { "_isUniformIngressTable" -> "_" },
             provider = Some("delta")
             // TODO: check whether to add `capabilities` or not, and if so, where?
           )
@@ -417,7 +417,8 @@ class DeltaAnalysis(session: SparkSession)
                 sourceTable = source,
                 targetIdent = tableIdentifier,
                 tablePropertyOverrides = Map.empty,
-                targetPath = new Path(externalTableUri)
+                targetPath = new Path(externalTableUri),
+                isUFI = true
               )
             ),
             operation = tableCreationMode,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3107,6 +3107,25 @@ trait DeltaErrorsBase
     )
   }
 
+  // TODO: change the error class
+  def uniformIngressNotSupportedFormat(fileFormat: String): Throwable = {
+    new DeltaIllegalArgumentException(
+      errorClass = "DELTA_UNIVERSAL_FORMAT_VIOLATION",
+      messageParameters = Array(
+        UniversalFormat.ICEBERG_FORMAT,
+        "Currently only support iceberg transformation"
+      )
+    )
+  }
+
+  // TODO: change the error class
+  def uniformIngressOperationNotSupported: Throwable = {
+    new DeltaUnsupportedOperationException(
+      errorClass = "DELTA_UNIVERSAL_FORMAT_VIOLATION",
+      messageParameters = Array.empty
+    )
+  }
+
   def uniFormIcebergRequiresIcebergCompat(): Throwable = {
     new DeltaUnsupportedOperationException(
       errorClass = "DELTA_UNIVERSAL_FORMAT_VIOLATION",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
@@ -179,7 +179,8 @@ abstract class CloneTableBase(
       txn: OptimisticTransaction,
       destinationTable: DeltaLog,
       hdpConf: Configuration,
-      deltaOperation: DeltaOperations.Operation): Seq[Row] = {
+      deltaOperation: DeltaOperations.Operation,
+      isUFI: Boolean = false): Seq[Row] = {
     val targetFs = targetPath.getFileSystem(hdpConf)
     val qualifiedTarget = targetFs.makeQualified(targetPath).toString
     val qualifiedSource = {
@@ -201,8 +202,7 @@ abstract class CloneTableBase(
       ) = {
       // TODO: needs further review, see also `UniformTableCommand.scala`.
       // Make sure target table is empty before running clone
-      if (txn.snapshot.allFiles.count() > 0 &&
-          !tablePropertyOverrides.contains("_isUniformIngressTable")) {
+      if (txn.snapshot.allFiles.count() > 0 && !isUFI) {
         throw DeltaErrors.cloneReplaceNonEmptyTable
       }
       val toAdd = sourceTable.allFiles

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
@@ -199,8 +199,10 @@ abstract class CloneTableBase(
     val (
       addedFileList
       ) = {
+      // TODO: needs further review, see also `UniformTableCommand.scala`.
       // Make sure target table is empty before running clone
-      if (txn.snapshot.allFiles.count() > 0) {
+      if (txn.snapshot.allFiles.count() > 0 &&
+          !tablePropertyOverrides.contains("_isUniformIngressTable")) {
         throw DeltaErrors.cloneReplaceNonEmptyTable
       }
       val toAdd = sourceTable.allFiles

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
@@ -55,7 +55,8 @@ case class CloneTableCommand(
     sourceTable: CloneSource,
     targetIdent: TableIdentifier,
     tablePropertyOverrides: Map[String, String],
-    targetPath: Path
+    targetPath: Path,
+    isUFI: Boolean = false
 ) extends CloneTableBase(sourceTable, tablePropertyOverrides, targetPath) {
 
   import CloneTableCommand._
@@ -107,13 +108,15 @@ case class CloneTableCommand(
     }
 
     handleClone(
-      sparkSession,
-      txn,
-      targetDeltaLog,
+      spark = sparkSession,
+      txn = txn,
+      destinationTable = targetDeltaLog,
       hdpConf = hdpConf,
       deltaOperation = Clone(
         sourceTable.name, sourceTable.snapshot.map(_.version).getOrElse(-1)
-      ))
+      ),
+      isUFI = isUFI
+    )
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -135,7 +135,7 @@ case class CreateDeltaTableCommand(
         if (txn.readVersion > -1 || !fs.exists(deltaLog.logPath)) {
           // the path should be empty for non-UFI table; for UFI table,
           // an external iceberg table already exists at the specific location.
-          if (!tableWithLocation.properties.contains("isUniformIngressTable")) {
+          if (tableWithLocation.owner != "UniformIngressTable") {
             assertPathEmpty(hadoopConf, tableWithLocation)
           }
         }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/UniformTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/UniformTableCommand.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, UnaryNode}
+
+case class CreateUniformTableCommand(
+    table: LogicalPlan,
+    ifNotExists: Boolean,
+    isReplace: Boolean,
+    isCreate: Boolean,
+    fileFormat: String,
+    metadataPath: String) extends UnaryNode {
+
+    override def child: LogicalPlan = table
+
+    override def output: Seq[Attribute] = Nil
+
+    override protected def withNewChildInternal(newChild: LogicalPlan): LogicalPlan =
+      copy(table = newChild)
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/UniformTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/UniformTableCommand.scala
@@ -27,10 +27,23 @@ case class CreateUniformTableStatement(
     fileFormat: String,
     metadataPath: String) extends UnaryNode {
 
-    override def child: LogicalPlan = table
+  override def child: LogicalPlan = table
 
-    override def output: Seq[Attribute] = Nil
+  override def output: Seq[Attribute] = Nil
 
-    override protected def withNewChildInternal(newChild: LogicalPlan): LogicalPlan =
-      copy(table = newChild)
+  override protected def withNewChildInternal(newChild: LogicalPlan): LogicalPlan =
+    copy(table = newChild)
+}
+
+case class RefreshUniformTableStatement(
+    target: LogicalPlan,
+    isForce: Boolean,
+    metadataPath: Option[String]) extends UnaryNode {
+
+  override def child: LogicalPlan = target
+
+  override def output: Seq[Attribute] = Nil
+
+  override protected def withNewChildInternal(newChild: LogicalPlan): LogicalPlan =
+    copy(target = newChild)
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/UniformTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/UniformTableCommand.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta.commands
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, UnaryNode}
 
-case class CreateUniformTableCommand(
+case class CreateUniformTableStatement(
     table: LogicalPlan,
     ifNotExists: Boolean,
     isReplace: Boolean,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/UniformTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/UniformTableCommand.scala
@@ -72,7 +72,7 @@ case class RefreshUniformTableCommand(
       throw DeltaErrors.notADeltaTable(table.name())
     )
 
-    if (catalogTable.owner != "UniformIngressTable") {
+    if (!catalogTable.properties.contains("_isUniformIngressTable")) {
       // TODO: change the error to `UniformIngressNotUFITable`
       throw DeltaErrors.uniformIngressOperationNotSupported
     }
@@ -102,8 +102,9 @@ case class RefreshUniformTableCommand(
         targetIdent = catalogTable.identifier,
         // TODO: this is a current workaround for bypassing cloning check,
         //  needs further review.
-        tablePropertyOverrides = Map { "_isUniformIngressTable" -> "_" },
-        targetPath = table.path
+        targetPath = table.path,
+        tablePropertyOverrides = Map.empty,
+        isUFI = true
       ).handleClone(sparkSession, txn, deltaLog)
     } catch {
       case NonFatal(e) =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1183,6 +1183,17 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(false)
 
+  // TODO: ensure if we need this
+  val UNIFORM_READ_ICEBERG_ENABLED = {
+    buildConf("uniform.readIcebergEnabled")
+      .internal()
+      .doc(
+        "If true, users can read the iceberg table after metadata conversion."
+      )
+      .booleanConf
+      .createWithDefault(false)
+  }
+
   val DELTA_OPTIMIZE_MIN_FILE_SIZE =
     buildConf("optimize.minFileSize")
         .internal()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/uniform/UniformIngressUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/uniform/UniformIngressUtils.scala
@@ -30,4 +30,7 @@ object UniformIngressUtils extends DeltaLogging {
   def isUniformIngressTable(catalogTable: CatalogTable): Boolean = {
     catalogTable.properties.contains(UFI_IDENT)
   }
+
+  /** The special property used to distinguish UFI table */
+  def property: Map[String, String] = Map { UFI_IDENT -> "_" }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/uniform/UniformIngressUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/uniform/UniformIngressUtils.scala
@@ -15,10 +15,15 @@
  */
 
 package org.apache.spark.sql.delta.uniform
+
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.delta.metering.DeltaLogging
 
 object UniformIngressUtils extends DeltaLogging {
+  /**
+   * The special identifier for UFI table,
+   * used to distinguish Uniform Ingress Table.
+   */
   private val UFI_IDENT = "_isUniformIngressTable"
 
   /**
@@ -31,6 +36,11 @@ object UniformIngressUtils extends DeltaLogging {
     catalogTable.properties.contains(UFI_IDENT)
   }
 
-  /** The special property used to distinguish UFI table */
+  /**
+   * The special property used to distinguish UFI table from normal delta table.
+   * In the above `isUniformIngressUtils` we will check whether the
+   * `CatalogTable.properties` contains the special key-value pair.
+   * If so, then the table is considered as UFI table.
+   */
   def property: Map[String, String] = Map { UFI_IDENT -> "_" }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/uniform/UniformIngressUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/uniform/UniformIngressUtils.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.uniform
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.delta.metering.DeltaLogging
+
+object UniformIngressUtils extends DeltaLogging {
+  private val UFI_IDENT = "_isUniformIngressTable"
+
+  /**
+   * Helper function to check if the given table is Uniform Ingress Table.
+   *
+   * @param catalogTable the `CatalogTable` corresponds to the table to be checked.
+   * @return whether the table is a UFI table or not.
+   */
+  def isUniformIngressTable(catalogTable: CatalogTable): Boolean = {
+    catalogTable.properties.contains(UFI_IDENT)
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniformIngressSqlSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniformIngressSqlSuite.scala
@@ -62,10 +62,10 @@ class UniformIngressSqlSuite extends QueryTest
   }
 
   test("create uniform table command") {
-    val sql1 = "CREATE TABLE uniform_table_1 UNIFORM iceberg METADATA_PATH 'metadata_path_1'"
+    val sql1 = "CREATE TABLE ufi_table_1 UNIFORM iceberg METADATA_PATH 'metadata_path_1'"
     parseAndValidate(
       sql = sql1,
-      targetTable = "uniform_table_1",
+      targetTable = "ufi_table_1",
       ifNotExists = false,
       isReplace = false,
       isCreate = true,
@@ -74,15 +74,39 @@ class UniformIngressSqlSuite extends QueryTest
     )
 
     val sql2 =
-      "CREATE TABLE IF NOT EXISTS uniform_table_2 UNIFORM iceberg METADATA_PATH 'metadata_path_2'"
+      "CREATE TABLE IF NOT EXISTS ufi_table_2 UNIFORM iceberg METADATA_PATH 'metadata_path_2'"
     parseAndValidate(
       sql = sql2,
-      targetTable = "uniform_table_2",
+      targetTable = "ufi_table_2",
       ifNotExists = true,
       isReplace = false,
       isCreate = true,
       fileFormat = "iceberg",
       metadataPath = "metadata_path_2"
+    )
+
+    val sql3 =
+      "CREATE OR REPLACE TABLE ufi_table_3 UNIFORM iceberg METADATA_PATH 'metadata_path_3'"
+    parseAndValidate(
+      sql = sql3,
+      targetTable = "ufi_table_3",
+      ifNotExists = false,
+      isReplace = true,
+      isCreate = true,
+      fileFormat = "iceberg",
+      metadataPath = "metadata_path_3"
+    )
+
+    val sql4 =
+      "REPLACE TABLE ufi_table_4 UNIFORM iceberg METADATA_PATH 'metadata_path_4'"
+    parseAndValidate(
+      sql = sql4,
+      targetTable = "ufi_table_4",
+      ifNotExists = false,
+      isReplace = true,
+      isCreate = false,
+      fileFormat = "iceberg",
+      metadataPath = "metadata_path_4"
     )
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniformIngressSqlSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniformIngressSqlSuite.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.uniform
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
+import org.apache.spark.sql.delta.commands.CreateUniformTableCommand
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.test.SharedSparkSession
+
+class UniformIngressSqlSuite extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest {
+
+  override protected def sparkConf: SparkConf = super.sparkConf
+
+  test("create uniform table command") {
+    val target = new UnresolvedRelation(Seq("uniform_table_1"))
+    val result = CreateUniformTableCommand(
+      table = target,
+      ifNotExists = false,
+      isReplace = false,
+      isCreate = true,
+      fileFormat = "iceberg",
+      metadataPath = "metadata_path_1"
+    )
+    assert(
+      spark.sessionState.sqlParser.parsePlan(
+        "CREATE TABLE uniform_table_1 UNIFORM iceberg METADATA_PATH 'metadata_path_1'"
+       ) == result
+    )
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniformIngressSqlSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniformIngressSqlSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta.uniform
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
-import org.apache.spark.sql.delta.commands.CreateUniformTableStatement
+import org.apache.spark.sql.delta.commands.{CreateUniformTableStatement, RefreshUniformTableStatement}
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.test.SharedSparkSession
 
@@ -61,7 +61,7 @@ class UniformIngressSqlSuite extends QueryTest
     assert(spark.sessionState.sqlParser.parsePlan(sql) == result)
   }
 
-  test("create uniform table command") {
+  test("create uniform ingress table command") {
     val sql1 = "CREATE TABLE ufi_table_1 UNIFORM iceberg METADATA_PATH 'metadata_path_1'"
     parseAndValidate(
       sql = sql1,
@@ -107,6 +107,39 @@ class UniformIngressSqlSuite extends QueryTest
       isCreate = false,
       fileFormat = "iceberg",
       metadataPath = "metadata_path_4"
+    )
+  }
+
+  test("refresh uniform ingress table command") {
+    val target = UnresolvedRelation(Seq("a"))
+    assert(
+      spark.sessionState.sqlParser.parsePlan(
+        s"REFRESH TABLE a METADATA_PATH 'path'") ==
+        RefreshUniformTableStatement(
+          target,
+          isForce = false,
+          metadataPath = Some("path")
+        )
+    )
+
+    assert(
+      spark.sessionState.sqlParser.parsePlan(
+        s"REFRESH TABLE a METADATA_PATH 'path' FORCE") ==
+        RefreshUniformTableStatement(
+          target,
+          isForce = true,
+          metadataPath = Some("path")
+        )
+    )
+
+    assert(
+      spark.sessionState.sqlParser.parsePlan(
+        s"REFRESH TABLE a METADATA_PATH 'path' force") ==
+        RefreshUniformTableStatement(
+          target,
+          isForce = true,
+          metadataPath = Some("path")
+        )
     )
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniformIngressSqlSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniformIngressSqlSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta.uniform
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
-import org.apache.spark.sql.delta.commands.CreateUniformTableCommand
+import org.apache.spark.sql.delta.commands.CreateUniformTableStatement
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.test.SharedSparkSession
 
@@ -50,7 +50,7 @@ class UniformIngressSqlSuite extends QueryTest
       metadataPath: String): Unit = {
     val target = new UnresolvedRelation(Seq(targetTable))
     // TODO(Zihao): add support for refresh command.
-    val result = CreateUniformTableCommand(
+    val result = CreateUniformTableStatement(
       table = target,
       ifNotExists = ifNotExists,
       isReplace = isReplace,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark

## Description

The existing Delta clone supports Iceberg as a source; However to ensure SQL syntax consistency and to make Iceberg source more explicit, this PR adds the support for `CREATE`/`REFRESH` commands for users to read existing Iceberg tables as Delta through Delta Uniform, instead of shallow clone. 

Please note that the corresponding credentials (e.g., grant read/write access to the provided path) need to be set before using the commands.

### Create a read-only delta table from an existing iceberg table

User could create a **read-only** delta table from an existing iceberg table by providing the `metadata_path` via `CREATE` command, the sql syntax is as below.

```sql
CREATE TABLE [IF NOT EXISTS] <table_name>
UNIFORM iceberg
METADATA_PATH '<cloud-storage-uri>/metadata/<iceberg_metadata_path>'
```

User could then treat the table as a delta Uniform table and read from it.

### Refresh an existing delta uniform table once the target iceberg table gets updated

After the original iceberg table gets updated (e.g., an iceberg client write some extra data into the table), user could update the delta table accordingly via `REFRESH` command, the sql syntax is as below.

```sql
REFRESH TABLE <table_name>
METADATA_PATH '<cloud-storage-uri>/metadata/<iceberg_metadata_path>' [FORCE]
```

The delta table will be updated to reflect the status of the iceberg table based on the provided metadata version.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

Through unit tests in `UniformIngressTableSuite.scala`, the underlying iceberg table is currently mocked by the `IcebergTestUtils.scala` via hadoop catalog.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
Yes, this PR introduces two new commands CREATE and REFRESH.

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
