### PR TITLE
[Kernel] Add Delta log replay metrics in active file list construction

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActiveAddFilesIterator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActiveAddFilesIterator.java
@@ -19,6 +19,9 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.FilteredColumnarBatch;
@@ -49,7 +52,9 @@ import static io.delta.kernel.internal.replay.LogReplayUtils.prepareSelectionVec
  * with a selection vector indicating which AddFiles are still active in the table
  * (have not been tombstoned).
  */
-class ActiveAddFilesIterator implements CloseableIterator<FilteredColumnarBatch> {
+public class ActiveAddFilesIterator implements CloseableIterator<FilteredColumnarBatch> {
+    private static final Logger logger = LoggerFactory.getLogger(ActiveAddFilesIterator.class);
+
     private final Engine engine;
     private final Path tableRoot;
 
@@ -66,6 +71,12 @@ class ActiveAddFilesIterator implements CloseableIterator<FilteredColumnarBatch>
     private boolean[] selectionVectorBuffer;
     private ExpressionEvaluator tableRootVectorGenerator;
     private boolean closed;
+
+    /**
+     * Metrics capturing the state reconstruction log replay. These counters are updated as the
+     * iterator is consumed and printed when the iterator is closed.
+     */
+    private LogReplayMetrics metrics = new LogReplayMetrics();
 
     ActiveAddFilesIterator(
             Engine engine,
@@ -110,6 +121,12 @@ class ActiveAddFilesIterator implements CloseableIterator<FilteredColumnarBatch>
     public void close() throws IOException {
         closed = true;
         Utils.closeCloseables(iter);
+        if (logger.isInfoEnabled()) {
+            // Log the metrics of the log replay of actions that are consumed so far.
+            // If the iterator is closed before consuming all the actions, the metrics will be
+            // partial.
+            logger.info("Log replay metrics: {}", metrics);
+        }
     }
 
     /**
@@ -166,6 +183,7 @@ class ActiveAddFilesIterator implements CloseableIterator<FilteredColumnarBatch>
                 ).map(DeletionVectorDescriptor::getUniqueId);
                 final UniqueFileActionTuple key = new UniqueFileActionTuple(pathAsUri, dvId);
                 tombstonesFromJson.add(key);
+                metrics.incNumTombstonesSeen();
             }
         }
 
@@ -182,6 +200,11 @@ class ActiveAddFilesIterator implements CloseableIterator<FilteredColumnarBatch>
                 continue; // selectionVector will be `false` at rowId by default
             }
 
+            metrics.incNumAddFilesSeen();
+            if (!isFromCheckpoint) {
+                metrics.incNumAddFilesSeenFromDeltaFiles();
+            }
+
             final String path = getAddFilePath(addsVector, rowId);
             final URI pathAsUri = pathToUri(path);
             final Optional<String> dvId = Optional.ofNullable(getAddFileDV(addsVector, rowId))
@@ -194,7 +217,8 @@ class ActiveAddFilesIterator implements CloseableIterator<FilteredColumnarBatch>
 
             if (!alreadyReturned) {
                 // Note: No AddFile will appear twice in a checkpoint, so we only need
-                //       non-checkpoint AddFiles in the set
+                //       non-checkpoint AddFiles in the set. When stats are recomputed the same
+                //       AddFile is added with stats without remove it first.
                 if (!isFromCheckpoint) {
                     addFilesFromJson.add(key);
                 }
@@ -202,7 +226,10 @@ class ActiveAddFilesIterator implements CloseableIterator<FilteredColumnarBatch>
                 if (!alreadyDeleted) {
                     doSelect = true;
                     selectionVectorBuffer[rowId] = true;
+                    metrics.incNumActiveAddFiles();
                 }
+            } else {
+                metrics.incNumDuplicateAddFiles();
             }
 
             if (!doSelect) {
@@ -253,5 +280,14 @@ class ActiveAddFilesIterator implements CloseableIterator<FilteredColumnarBatch>
         ColumnVector removeFileVector, int rowId) {
         return DeletionVectorDescriptor.fromColumnVector(
             removeFileVector.getChild(REMOVE_FILE_DV_ORDINAL), rowId);
+    }
+
+    /**
+     * Returns the metrics for the log replay. Currently used in tests only.
+     * Caution: The metrics should be fetched only after the iterator is closed, to avoid reading
+     * incomplete metrics.
+     */
+    public LogReplayMetrics getMetrics() {
+        return metrics;
     }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActiveAddFilesIterator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActiveAddFilesIterator.java
@@ -121,12 +121,10 @@ public class ActiveAddFilesIterator implements CloseableIterator<FilteredColumna
     public void close() throws IOException {
         closed = true;
         Utils.closeCloseables(iter);
-        if (logger.isInfoEnabled()) {
-            // Log the metrics of the log replay of actions that are consumed so far.
-            // If the iterator is closed before consuming all the actions, the metrics will be
-            // partial.
-            logger.info("Log replay metrics: {}", metrics);
-        }
+
+        // Log the metrics of the log replay of actions that are consumed so far. If the iterator
+        // is closed before consuming all the actions, the metrics will be partial.
+        logger.info("Active add file finding log replay metrics: {}", metrics);
     }
 
     /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplayMetrics.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplayMetrics.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.replay;
+
+/**
+ * Class capturing various metrics during log replay. This class can be used in places where
+ * actions from the logs are replayed, and we want to capture some metrics.
+ */
+public class LogReplayMetrics {
+    /**
+     * Number of `AddFile` actions seen in log replay both from checkpoint files and delta files.
+     */
+    private long numAddFilesSeen = 0;
+
+    /**
+     * Number of `AddFile` actions seen in log replay from delta files.
+     */
+    private long numAddFilesSeenFromDeltaFiles = 0;
+
+    /**
+     * Number of active `AddFile`s that survived (i.e. belong to the table state) the log replay.
+     */
+    private long numActiveAddFiles = 0;
+
+    /**
+     * Number of `AddFile`s that are duplicates. Same `AddFile` (with the same path and DV) can be
+     * present in multiple commit files. This happens when stats collection is run on the table in
+     * which the same `AddFile` will be added with `stats` without removing it first.
+     */
+    private long numDuplicateAddFiles = 0;
+
+    /**
+     * Number of `RemoveFile`s seen in log replay both from delta files (not from checkpoint).
+     */
+    private long numTombstonesSeen = 0;
+
+    public void incNumAddFilesSeen() {
+        numAddFilesSeen++;
+    }
+
+    public void incNumAddFilesSeenFromDeltaFiles() {
+        numAddFilesSeenFromDeltaFiles++;
+    }
+
+    public void incNumActiveAddFiles() {
+        numActiveAddFiles++;
+    }
+
+    public void incNumDuplicateAddFiles() {
+        numDuplicateAddFiles++;
+    }
+
+    public void incNumTombstonesSeen() {
+        numTombstonesSeen++;
+    }
+
+
+    public long getNumAddFilesSeen() {
+        return numAddFilesSeen;
+    }
+
+    public long getNumAddFilesSeenFromDeltaFiles() {
+        return numAddFilesSeenFromDeltaFiles;
+    }
+
+    public long getNumActiveAddFiles() {
+        return numActiveAddFiles;
+    }
+
+    public long getNumDuplicateAddFiles() {
+        return numDuplicateAddFiles;
+    }
+
+    public long getNumTombstonesSeen() {
+        return numTombstonesSeen;
+    }
+
+    /**
+     * Returns a summary of the metrics.
+     */
+    @Override
+    public String toString() {
+        return String.format(
+            "Number of AddFiles seen: %d\n" +
+            "Number of AddFiles seen from delta files: %d\n" +
+            "Number of active AddFiles: %d\n" +
+            "Number of duplicate AddFiles: %d\n" +
+            "Number of tombstones seen: %d\n",
+            numAddFilesSeen,
+            numAddFilesSeenFromDeltaFiles,
+            numActiveAddFiles,
+            numDuplicateAddFiles,
+            numTombstonesSeen
+        );
+    }
+}

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ActiveAddFilesLogReplayMetricsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ActiveAddFilesLogReplayMetricsSuite.scala
@@ -55,7 +55,7 @@ class ActiveAddFilesLogReplayMetricsSuite extends AnyFunSuite with TestUtils {
         for (_ <- 0 to 3) {
           appendCommit(path)
         }
-        checkpoint(path, actionsPerFile = if (multipartCheckpoint) 5 else 1000000)
+        checkpoint(path, actionsPerFile = if (multipartCheckpoint) 2 else 1000000)
         for (_ <- 4 to 9) {
           appendCommit(path)
         }
@@ -79,7 +79,7 @@ class ActiveAddFilesLogReplayMetricsSuite extends AnyFunSuite with TestUtils {
           appendCommit(path)
         } // has 8 add files
         deleteCommit(path) // version 4 - deletes 4 files and adds 1 file
-        checkpoint(path, actionsPerFile = if (multipartCheckpoint) 5 else 1000000) // version 4
+        checkpoint(path, actionsPerFile = if (multipartCheckpoint) 2 else 1000000) // version 4
         appendCommit(path) // version 5 - adds 2 files
         deleteCommit(path) // version 6 - deletes 1 file and adds 1 file
         appendCommit(path) // version 7 - adds 2 files
@@ -107,7 +107,7 @@ class ActiveAddFilesLogReplayMetricsSuite extends AnyFunSuite with TestUtils {
           appendCommit(path)
         } // activeAdds = 4
         deleteCommit(path) // ver 2 - deletes 2 files and adds 1 file, activeAdds = 3
-        checkpoint(path, actionsPerFile = if (multipartCheckpoint) 5 else 1000000) // version 2
+        checkpoint(path, actionsPerFile = if (multipartCheckpoint) 2 else 1000000) // version 2
         appendCommit(path) // ver 3 - adds 2 files, activeAdds = 5
         recomputeStats(path) // ver 4 - adds the same 5 add files again, activeAdds = 5, dupes = 5
         deleteCommit(path) // ver 5 - removes 1 file and adds 1 file, activeAdds = 5, dupes = 5

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ActiveAddFilesLogReplayMetricsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ActiveAddFilesLogReplayMetricsSuite.scala
@@ -1,0 +1,192 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults
+
+import io.delta.kernel.Table
+import io.delta.kernel.defaults.engine.DefaultEngine
+import io.delta.kernel.defaults.utils.{TestRow, TestUtils}
+import io.delta.kernel.engine.Engine
+import io.delta.kernel.internal.replay.ActiveAddFilesIterator
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.stats.StatisticsCollection
+import org.scalatest.funsuite.AnyFunSuite
+
+/**
+ * Test suite to test the metrics captured during log replay to find the active `AddFile`s
+ * in a table snapshot.
+ */
+class ActiveAddFilesLogReplayMetricsSuite extends AnyFunSuite with TestUtils {
+
+  test("active add files log replay metrics: only delta files") {
+    withTempDirAndEngine { (path, engine) =>
+      for (_ <- 0 to 9) {
+        appendCommit(path)
+      }
+      loadAndCheckLogReplayMetrics(
+        engine,
+        path,
+        expNumAddFilesSeen = 20, // each commit creates 2 files
+        expNumAddFilesSeenFromDeltaFiles = 20,
+        expNumActiveAddFiles = 20)
+    }
+  }
+
+
+  Seq(true, false).foreach { multipartCheckpoint =>
+    val checkpointStr = if (multipartCheckpoint) "multipart " else ""
+    test(s"active add files log replay metrics: ${checkpointStr}checkpoint + delta files") {
+      withTempDirAndEngine { (path, engine) =>
+        for (_ <- 0 to 3) {
+          appendCommit(path)
+        }
+        checkpoint(path, actionsPerFile = if (multipartCheckpoint) 5 else 1000000)
+        for (_ <- 4 to 9) {
+          appendCommit(path)
+        }
+
+        loadAndCheckLogReplayMetrics(
+          engine,
+          path,
+          expNumAddFilesSeen = 20, // each commit creates 2 files
+          expNumAddFilesSeenFromDeltaFiles = 12, // checkpoint is created at version 3
+          expNumActiveAddFiles = 20)
+      }
+    }
+  }
+
+  Seq(true, false).foreach { multipartCheckpoint =>
+    val checkpointStr = if (multipartCheckpoint) "multipart " else ""
+    test(s"active add files log replay metrics: ${checkpointStr}checkpoint + " +
+        s"delta files + tombstones") {
+      withTempDirAndEngine { (path, engine) =>
+        for (_ <- 0 to 3) {
+          appendCommit(path)
+        } // has 8 add files
+        deleteCommit(path) // version 4 - deletes 4 files and adds 1 file
+        checkpoint(path, actionsPerFile = if (multipartCheckpoint) 5 else 1000000) // version 4
+        appendCommit(path) // version 5 - adds 2 files
+        deleteCommit(path) // version 6 - deletes 1 file and adds 1 file
+        appendCommit(path) // version 7 - adds 2 files
+        appendCommit(path) // version 8 - adds 2 files
+        deleteCommit(path) // version 9 - deletes 2 files and adds 1 file
+
+        loadAndCheckLogReplayMetrics(
+          engine,
+          path,
+          expNumAddFilesSeen = 5 /* checkpoint */ + 8, /* delta */
+          expNumAddFilesSeenFromDeltaFiles = 8,
+          expNumActiveAddFiles = 10,
+          expNumTombstonesSeen = 3
+        )
+      }
+    }
+  }
+
+  Seq(true, false).foreach { multipartCheckpoint =>
+    val checkpointStr = if (multipartCheckpoint) "multipart " else ""
+    test(s"active add files log replay metrics: ${checkpointStr}checkpoint + delta files +" +
+        s" tombstones + duplicate adds") {
+      withTempDirAndEngine { (path, engine) =>
+        for (_ <- 0 to 1) {
+          appendCommit(path)
+        } // activeAdds = 4
+        deleteCommit(path) // ver 2 - deletes 2 files and adds 1 file, activeAdds = 3
+        checkpoint(path, actionsPerFile = if (multipartCheckpoint) 5 else 1000000) // version 2
+        appendCommit(path) // ver 3 - adds 2 files, activeAdds = 5
+        recomputeStats(path) // ver 4 - adds the same 5 add files again, activeAdds = 5, dupes = 5
+        deleteCommit(path) // ver 5 - removes 1 file and adds 1 file, activeAdds = 5, dupes = 5
+        appendCommit(path) // ver 6 - adds 2 files, activeAdds = 7, dupes = 4
+        recomputeStats(path) // ver 7 - adds the same 7 add files again, activeAdds = 7, dupes = 12
+        deleteCommit(path) // ver 8 - removes 1 file and adds 1 files, activeAdds = 7, dupes = 12
+
+        loadAndCheckLogReplayMetrics(
+          engine,
+          path,
+          expNumAddFilesSeen = 3 /* checkpoint */ + 18, /* delta */
+          expNumAddFilesSeenFromDeltaFiles = 18,
+          expNumActiveAddFiles = 7,
+          expNumTombstonesSeen = 2,
+          expNumDuplicateAddFiles = 12
+        )
+      }
+    }
+  }
+
+  /////////////////////////
+  // Test Helper Methods //
+  /////////////////////////
+  def loadAndCheckLogReplayMetrics(
+    engine: Engine,
+    tablePath: String,
+    expNumAddFilesSeen: Long,
+    expNumAddFilesSeenFromDeltaFiles: Long,
+    expNumActiveAddFiles: Long,
+    expNumDuplicateAddFiles: Long = 0L,
+    expNumTombstonesSeen: Long = 0L): Unit = {
+
+    val scanFileIter = Table.forPath(engine, tablePath)
+      .getLatestSnapshot(engine)
+      .getScanBuilder(engine)
+      .build()
+      .getScanFiles(engine)
+
+    // this will trigger the log replay, consumes actions and closes the iterator
+    scanFileIter.toSeq
+
+    val metrics = scanFileIter.asInstanceOf[ActiveAddFilesIterator].getMetrics
+    assert(metrics.getNumAddFilesSeen == expNumAddFilesSeen)
+    assert(metrics.getNumAddFilesSeenFromDeltaFiles == expNumAddFilesSeenFromDeltaFiles)
+    assert(metrics.getNumActiveAddFiles == expNumActiveAddFiles)
+    assert(metrics.getNumDuplicateAddFiles == expNumDuplicateAddFiles)
+    assert(metrics.getNumTombstonesSeen == expNumTombstonesSeen)
+
+
+    val expResults = spark.sql(s"SELECT * FROM delta.`$tablePath`").collect().map(TestRow(_))
+    checkTable(tablePath, expResults)
+  }
+
+  def withTempDirAndEngine(f: (String, Engine) => Unit): Unit = {
+    val engine = DefaultEngine.create(new Configuration() {
+      {
+        // Set the batch sizes to small so that we get to test the multiple batch scenarios.
+        set("delta.kernel.default.parquet.reader.batch-size", "2");
+        set("delta.kernel.default.json.reader.batch-size", "2");
+      }
+    })
+    withTempDir { dir => f(dir.getAbsolutePath, engine) }
+  }
+
+  def appendCommit(path: String): Unit =
+    spark.range(10).repartition(2).write.format("delta").mode("append").save(path)
+
+  def deleteCommit(path: String): Unit = {
+    spark.sql("DELETE FROM delta.`%s` WHERE id = 5".format(path))
+  }
+
+  def recomputeStats(path: String): Unit = {
+    val deltaLog = DeltaLog.forTable(spark, new Path(path))
+    StatisticsCollection.recompute(spark, deltaLog, catalogTable = None)
+  }
+
+  def checkpoint(path: String, actionsPerFile: Int): Unit = {
+    withSQLConf(DeltaSQLConf.DELTA_CHECKPOINT_PART_SIZE.key -> actionsPerFile.toString) {
+      DeltaLog.forTable(spark, path).checkpoint()
+    }
+  }
+}

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LogReplayEngineMetricsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LogReplayEngineMetricsSuite.scala
@@ -41,7 +41,15 @@ import java.util.Optional
 import scala.collection.convert.ImplicitConversions._
 import scala.collection.mutable.ArrayBuffer
 
-class LogReplayMetricsSuite extends QueryTest
+/**
+ * Suite to test the engine metrics while replaying logs for getting the table protocol and
+ * metadata (P&M) and scanning files. The metrics include how many files delta files, checkpoint
+ * files read, size of checkpoint read set, and how many times `_last_checkpoint` is read etc.
+ *
+ * The goal is to test the behavior of calls to `readJsonFiles` and `readParquetFiles` that
+ * Kernel makes. This calls determine the performance.
+ */
+class LogReplayEngineMetricsSuite extends QueryTest
     with SharedSparkSession
     with DeltaSQLCommandTest {
 


### PR DESCRIPTION
## Description
Currently, the log replay code used to find the active add files in a table snapshot is not observable. Add a few metrics to provide visibility into the log replay. These metrics are collected as the `CloseableIterator` of scan files is consumed and printed in slf4j logs when the iterator is closed. Following are the metrics collected:

* number of `AddFile` actions seen
* number of `AddFile` actions seen from delta files
* number of duplicate `AddFile` actions seen
* number of tombstones seen
* number of active `AddFile`s

## How was this patch tested?
Add unit tests with different scenarios
* deltas only
* checkpoint class/multi-parts,
* stats recompute - generates duplicate add files, 
* removes - generates tombstones)

## Does this PR introduce _any_ user-facing changes?
No, but the info level logs will have a message with the log replay metrics.
