### PR TITLE
[Kernel][Test] Add test for reading a shallow cloned table

### DIFF
--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
@@ -601,6 +601,19 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
     }
   }
 
+  test("read a shallow cloned table") {
+    withTempDir { tempDir =>
+      val target = tempDir.getCanonicalPath
+      val source = goldenTablePath("data-reader-partition-values")
+      spark.sql(s"CREATE TABLE delta.`$target` SHALLOW CLONE delta.`$source`")
+
+      val expAnswer = spark.read.format("delta").load(source).collect().map(TestRow(_)).toSeq
+
+      assert(expAnswer.size == 3)
+      checkTable(target, expAnswer)
+    }
+  }
+
   //////////////////////////////////////////////////////////////////////////////////
   // getSnapshotAtVersion end-to-end tests (log segment tests in SnapshotManagerSuite)
   //////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Shallow cloned tests have `AddFile`s with an absolute path to the source table location. Normally the path is relative to the table root. Add a test to verify that reading works in Kernel.