### PR TITLE
[Kernel] Support clean expired log

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/engine/FileSystemClient.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/engine/FileSystemClient.java
@@ -76,4 +76,13 @@ public interface FileSystemClient {
    * @throws IOException for any IO error.
    */
   boolean mkdirs(String path) throws IOException;
+
+  /**
+   * Delete a file.
+   *
+   * @param path the path to delete.
+   * @return true if delete is successful else false.
+   * @throws IOException for any IO error.
+   */
+  boolean delete(String path) throws IOException;
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/engine/FileSystemClient.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/engine/FileSystemClient.java
@@ -78,9 +78,9 @@ public interface FileSystemClient {
   boolean mkdirs(String path) throws IOException;
 
   /**
-   * Delete a file.
+   * Delete the file at given path.
    *
-   * @param path the path to delete.
+   * @param path the path to delete. If path is a directory throws an exception.
    * @return true if delete is successful else false.
    * @throws IOException for any IO error.
    */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -79,6 +79,40 @@ public class TableConfig<T> {
           true);
 
   /**
+   * The shortest duration we have to keep logically deleted data files around before deleting them
+   * physically. This is to prevent failures in stale readers after compactions or partition
+   * overwrites.
+   *
+   * <p>Note: this value should be large enough: - It should be larger than the longest possible
+   * duration of a job if you decide to run "VACUUM" when there are concurrent readers or writers
+   * accessing the table. - If you are running a streaming query reading from the table, you should
+   * make sure the query doesn't stop longer than this value. Otherwise, the query may not be able
+   * to restart as it still needs to read old files.
+   *
+   * <p>We didn't validate the value is greater than 0. In standalone lib, the log expire time is
+   * based on day, so if we want to clean the log immediately, we need to config the value to "-1
+   * days", so here didn't validate the value. See:
+   * io.delta.standalone.internal.MetadataCleanup#cleanUpExpiredLogs().
+   */
+  public static final TableConfig<Long> LOG_RETENTION =
+      new TableConfig<>(
+          "delta.logRetentionDuration",
+          "interval 30 days",
+          (engineOpt, v) -> IntervalParserUtils.safeParseIntervalAsMillis(v),
+          value -> true,
+          "needs to be provided as a calendar interval such as '2 weeks'. Months "
+              + "and years are not accepted. You may specify '365 days' for a year instead.");
+
+  /** Whether to clean up expired checkpoints and delta logs. */
+  public static final TableConfig<Boolean> ENABLE_EXPIRED_LOG_CLEANUP =
+      new TableConfig<>(
+          "delta.enableExpiredLogCleanup",
+          "true",
+          (engineOpt, v) -> Boolean.valueOf(v),
+          value -> true,
+          "needs to be a boolean.");
+
+  /**
    * This table property is used to track the enablement of the {@code inCommitTimestamps}.
    *
    * <p>When enabled, commit metadata includes a monotonically increasing timestamp that allows for

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -93,7 +93,7 @@ public class TableConfig<T> {
           true /* editable */);
 
   /** Whether to clean up expired checkpoints and delta logs. */
-  public static final TableConfig<Boolean> ENABLE_EXPIRED_LOG_CLEANUP =
+  public static final TableConfig<Boolean> EXPIRED_LOG_CLEANUP_ENABLED =
       new TableConfig<>(
           "delta.enableExpiredLogCleanup",
           "true",

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -79,8 +79,8 @@ public class TableConfig<T> {
           true);
 
   /**
-   * The shortest duration we have to keep delta/checkpoint files around before deleting them.
-   * We can only delete delta files that are before a checkpoint.
+   * The shortest duration we have to keep delta/checkpoint files around before deleting them. We
+   * can only delete delta files that are before a checkpoint.
    */
   public static final TableConfig<Long> LOG_RETENTION =
       new TableConfig<>(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -101,7 +101,8 @@ public class TableConfig<T> {
           (engineOpt, v) -> IntervalParserUtils.safeParseIntervalAsMillis(v),
           value -> true,
           "needs to be provided as a calendar interval such as '2 weeks'. Months "
-              + "and years are not accepted. You may specify '365 days' for a year instead.");
+              + "and years are not accepted. You may specify '365 days' for a year instead.",
+          true /* editable */);
 
   /** Whether to clean up expired checkpoints and delta logs. */
   public static final TableConfig<Boolean> ENABLE_EXPIRED_LOG_CLEANUP =
@@ -110,7 +111,8 @@ public class TableConfig<T> {
           "true",
           (engineOpt, v) -> Boolean.valueOf(v),
           value -> true,
-          "needs to be a boolean.");
+          "needs to be a boolean.",
+          true /* editable */);
 
   /**
    * This table property is used to track the enablement of the {@code inCommitTimestamps}.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -79,20 +79,8 @@ public class TableConfig<T> {
           true);
 
   /**
-   * The shortest duration we have to keep logically deleted data files around before deleting them
-   * physically. This is to prevent failures in stale readers after compactions or partition
-   * overwrites.
-   *
-   * <p>Note: this value should be large enough: - It should be larger than the longest possible
-   * duration of a job if you decide to run "VACUUM" when there are concurrent readers or writers
-   * accessing the table. - If you are running a streaming query reading from the table, you should
-   * make sure the query doesn't stop longer than this value. Otherwise, the query may not be able
-   * to restart as it still needs to read old files.
-   *
-   * <p>We didn't validate the value is greater than 0. In standalone lib, the log expire time is
-   * based on day, so if we want to clean the log immediately, we need to config the value to "-1
-   * days", so here didn't validate the value. See:
-   * io.delta.standalone.internal.MetadataCleanup#cleanUpExpiredLogs().
+   * The shortest duration we have to keep delta/checkpoint files around before deleting them.
+   * We can only delete delta files that are before a checkpoint.
    */
   public static final TableConfig<Long> LOG_RETENTION =
       new TableConfig<>(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
@@ -108,7 +108,7 @@ public class TableImpl implements Table {
   @Override
   public void checkpoint(Engine engine, long version)
       throws TableNotFoundException, CheckpointAlreadyExistsException, IOException {
-    snapshotManager.checkpoint(engine, version);
+    snapshotManager.checkpoint(engine, clock, version);
   }
 
   @Override

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/lang/ListUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/lang/ListUtils.java
@@ -18,6 +18,7 @@ package io.delta.kernel.internal.lang;
 import io.delta.kernel.internal.util.Tuple2;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -33,5 +34,23 @@ public final class ListUtils {
 
   public static <T> T last(List<T> list) {
     return list.get(list.size() - 1);
+  }
+
+  /** Remove once supported JDK (build) version is 21 or above */
+  public static <T> T getFirst(List<T> list) {
+    if (list.isEmpty()) {
+      throw new NoSuchElementException();
+    } else {
+      return list.get(0);
+    }
+  }
+
+  /** Remove once supported JDK (build) version is 21 or above */
+  public static <T> T getLast(List<T> list) {
+    if (list.isEmpty()) {
+      throw new NoSuchElementException();
+    } else {
+      return list.get(list.size() - 1);
+    }
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/MetadataCleanup.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/MetadataCleanup.java
@@ -65,7 +65,7 @@ public class MetadataCleanup {
    *                   checkpoint is potential candidate to delete later if we find another
    *                   checkpoint
    *             </ul>
-   *         <li>Step 2: If the timestamp is earlier than the retention period, stop
+   *         <li>Step 2: If the timestamp falls within the retention period, stop
    *         <li>Step 3: If the file is a delta log file, add it to the `potentialFilesToDelete`
    *             list
    *         <li>Step 4: If the file is a checkpoint file, add it to the `lastSeenCheckpointFiles`

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/MetadataCleanup.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/MetadataCleanup.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.snapshot;
+
+import static io.delta.kernel.internal.TableConfig.ENABLE_EXPIRED_LOG_CLEANUP;
+import static io.delta.kernel.internal.TableConfig.LOG_RETENTION;
+
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.actions.Metadata;
+import io.delta.kernel.internal.fs.Path;
+import io.delta.kernel.internal.util.FileNames;
+import io.delta.kernel.utils.CloseableIterator;
+import io.delta.kernel.utils.FileStatus;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MetadataCleanup {
+  private static final Logger logger = LoggerFactory.getLogger(SnapshotManager.class);
+
+  public MetadataCleanup() {}
+
+  public static void doLogCleanup(Engine engine, Path tablePath, Metadata metadata)
+      throws IOException {
+    Boolean enableExpireLogCleanup = ENABLE_EXPIRED_LOG_CLEANUP.fromMetadata(engine, metadata);
+    if (!enableExpireLogCleanup) {
+      logger.info(
+          "{}: Log cleanup is disabled. Skipping the deletion of expired log files", tablePath);
+      return;
+    }
+
+    List<String> potentialLogFilesToDelete = new ArrayList<>();
+
+    long retentionMillis = LOG_RETENTION.fromMetadata(engine, metadata);
+    long fileCutOffTime = System.currentTimeMillis() - retentionMillis;
+    logger.info("{}: Starting the deletion of log files older than {}", tablePath, fileCutOffTime);
+    long numDeleted = 0;
+    try (CloseableIterator<FileStatus> files = listExpiredDeltaLogs(engine, tablePath)) {
+      while (files.hasNext()) {
+        FileStatus nextFile = files.next();
+        if (nextFile.getModificationTime() > fileCutOffTime) {
+          if (!potentialLogFilesToDelete.isEmpty()) {
+            logger.info(
+                "{}: Skipping deletion of expired log files {}, because there is no checkpoint "
+                    + "file that indicates that the log files are no longer needed. ",
+                tablePath,
+                potentialLogFilesToDelete.size());
+          }
+          break;
+        }
+
+        if (FileNames.isCheckpointFile(nextFile.getPath())) {
+          // we have encountered a checkpoint file, now we can delete all the log files
+          // in `potentialLogFilesToDelete` list
+          for (String logFile : potentialLogFilesToDelete) {
+            if (engine.getFileSystemClient().delete(logFile)) {
+              numDeleted++;
+            }
+          }
+        } else if (FileNames.isCommitFile(nextFile.getPath())) {
+          // Add it the potential delta log files to delete list. We can't delete these
+          // files until we encounter a checkpoint later that indicates that the log files
+          // are no longer needed.
+          potentialLogFilesToDelete.add(nextFile.getPath());
+        }
+      }
+    }
+    logger.info("{}: Deleted {} log files older than {}", tablePath, numDeleted, fileCutOffTime);
+  }
+
+  private static CloseableIterator<FileStatus> listExpiredDeltaLogs(Engine engine, Path tablePath)
+      throws IOException {
+    Path logPath = new Path(tablePath, "_delta_log");
+    return engine.getFileSystemClient().listFrom(FileNames.listingPrefix(logPath, 0));
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/MetadataCleanup.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/MetadataCleanup.java
@@ -77,9 +77,10 @@ public class MetadataCleanup {
    *     current time.
    * @param tablePath Table location
    * @param retentionMillis Log file retention period in milliseconds
+   * @return number of log files deleted
    * @throws IOException if an error occurs while deleting the log files
    */
-  public static void cleanupExpiredLogs(
+  public static long cleanupExpiredLogs(
       Engine engine, Clock clock, Path tablePath, long retentionMillis) throws IOException {
     checkArgument(retentionMillis >= 0, "Retention period must be non-negative");
 
@@ -172,6 +173,7 @@ public class MetadataCleanup {
       }
     }
     logger.info("{}: Deleted {} log files older than {}", tablePath, numDeleted, fileCutOffTime);
+    return numDeleted;
   }
 
   private static CloseableIterator<FileStatus> listDeltaLogs(Engine engine, Path tablePath)
@@ -186,7 +188,7 @@ public class MetadataCleanup {
   private static int deleteLogFiles(Engine engine, List<String> logFiles) throws IOException {
     int numDeleted = 0;
     for (String logFile : logFiles) {
-      if (!wrapEngineExceptionThrowsIO(
+      if (wrapEngineExceptionThrowsIO(
           () -> engine.getFileSystemClient().delete(logFile),
           "Failed to delete the log file as part of the metadata cleanup %s",
           logFile)) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/MetadataCleanup.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/MetadataCleanup.java
@@ -169,7 +169,7 @@ public class MetadataCleanup {
           lastSeenCheckpointFiles.add(nextFile.getPath());
           lastSeenCheckpointVersion = newLastSeenCheckpointVersion;
         }
-        // TODO: do we need to delete unknown file types?
+        // Ignore non-delta and non-checkpoint files.
       }
     }
     logger.info("{}: Deleted {} log files older than {}", tablePath, numDeleted, fileCutOffTime);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/MetadataCleanup.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/MetadataCleanup.java
@@ -81,6 +81,8 @@ public class MetadataCleanup {
    */
   public static void cleanupExpiredLogs(
       Engine engine, Clock clock, Path tablePath, long retentionMillis) throws IOException {
+    checkArgument(retentionMillis >= 0, "Retention period must be non-negative");
+
     List<String> potentialLogFilesToDelete = new ArrayList<>();
     long lastSeenCheckpointVersion = -1;
     List<String> lastSeenCheckpointFiles = new ArrayList<>();

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -21,7 +21,7 @@ import static io.delta.kernel.internal.TableFeatures.validateWriteSupportedTable
 import static io.delta.kernel.internal.checkpoints.Checkpointer.findLastCompleteCheckpointBefore;
 import static io.delta.kernel.internal.fs.Path.getName;
 import static io.delta.kernel.internal.replay.LogReplayUtils.assertLogFilesBelongToTable;
-import static io.delta.kernel.internal.snapshot.MetadataCleanup.doLogCleanup;
+import static io.delta.kernel.internal.snapshot.MetadataCleanup.cleanupExpiredLogs;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 import static java.lang.String.format;
 
@@ -232,7 +232,7 @@ public class SnapshotManager {
     logger.info("{}: Last checkpoint metadata file is written for version: {}", tablePath, version);
 
     logger.info("{}: Finished checkpoint for version: {}", tablePath, version);
-    doLogCleanup(engine, tablePath, snapshot.getMetadata());
+    cleanupExpiredLogs(engine, tablePath, snapshot.getMetadata());
   }
 
   ////////////////////

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -37,6 +37,7 @@ import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.lang.ListUtils;
 import io.delta.kernel.internal.replay.CreateCheckpointIterator;
 import io.delta.kernel.internal.replay.LogReplay;
+import io.delta.kernel.internal.util.Clock;
 import io.delta.kernel.internal.util.FileNames;
 import io.delta.kernel.internal.util.Tuple2;
 import io.delta.kernel.utils.CloseableIterator;
@@ -187,7 +188,8 @@ public class SnapshotManager {
     return getSnapshotAt(engine, versionToRead);
   }
 
-  public void checkpoint(Engine engine, long version) throws TableNotFoundException, IOException {
+  public void checkpoint(Engine engine, Clock clock, long version)
+      throws TableNotFoundException, IOException {
     logger.info("{}: Starting checkpoint for version: {}", tablePath, version);
     // Get the snapshot corresponding the version
     SnapshotImpl snapshot = (SnapshotImpl) getSnapshotAt(engine, version);
@@ -232,7 +234,7 @@ public class SnapshotManager {
     logger.info("{}: Last checkpoint metadata file is written for version: {}", tablePath, version);
 
     logger.info("{}: Finished checkpoint for version: {}", tablePath, version);
-    cleanupExpiredLogs(engine, tablePath, snapshot.getMetadata());
+    cleanupExpiredLogs(engine, clock, tablePath, snapshot.getMetadata());
   }
 
   ////////////////////

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -31,6 +31,7 @@ import io.delta.kernel.exceptions.CheckpointAlreadyExistsException;
 import io.delta.kernel.exceptions.InvalidTableException;
 import io.delta.kernel.exceptions.TableNotFoundException;
 import io.delta.kernel.internal.*;
+import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.checkpoints.*;
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.lang.ListUtils;
@@ -231,6 +232,45 @@ public class SnapshotManager {
     logger.info("{}: Last checkpoint metadata file is written for version: {}", tablePath, version);
 
     logger.info("{}: Finished checkpoint for version: {}", tablePath, version);
+    doLogCleanup(engine, checkpointMetaData, snapshot);
+  }
+
+  private void doLogCleanup(
+      Engine engine, CheckpointMetaData checkpointMetaData, SnapshotImpl snapshot)
+      throws IOException {
+    Metadata metadata = snapshot.getMetadata();
+    Boolean enableExpireLogCleanup =
+        TableConfig.ENABLE_EXPIRED_LOG_CLEANUP.fromMetadata(engine, metadata);
+    if (enableExpireLogCleanup) {
+      Long retentionMillis = TableConfig.LOG_RETENTION.fromMetadata(engine, metadata);
+      Long fileCutOffTime = System.currentTimeMillis() - retentionMillis;
+      logger.info(
+          "{}: Starting the deletion of log files older than {}", tablePath, fileCutOffTime);
+      int numDeleted = 0;
+      try (CloseableIterator<FileStatus> files =
+          listExpiredDeltaLogs(engine, checkpointMetaData, fileCutOffTime)) {
+        while (files.hasNext()) {
+          if (engine.getFileSystemClient().delete(files.next().getPath())) {
+            numDeleted++;
+          }
+        }
+      }
+      logger.info("{}: Deleted {} log files older than {}", tablePath, numDeleted, fileCutOffTime);
+    }
+  }
+
+  private CloseableIterator<FileStatus> listExpiredDeltaLogs(
+      Engine engine, CheckpointMetaData checkpointMetaData, Long fileCutOffTime)
+      throws IOException {
+    long threshold = checkpointMetaData.version - 1;
+    return engine
+        .getFileSystemClient()
+        .listFrom(FileNames.checkpointPrefix(logPath, 0).toUri().getPath())
+        .filter(
+            f ->
+                (FileNames.isCheckpointFile(f.getPath()) || FileNames.isCommitFile(f.getPath()))
+                    && FileNames.getFileVersion(new Path(f.getPath())) <= threshold
+                    && f.getModificationTime() <= fileCutOffTime);
   }
 
   ////////////////////

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -17,7 +17,7 @@
 package io.delta.kernel.internal.snapshot;
 
 import static io.delta.kernel.internal.DeltaErrors.wrapEngineExceptionThrowsIO;
-import static io.delta.kernel.internal.TableConfig.ENABLE_EXPIRED_LOG_CLEANUP;
+import static io.delta.kernel.internal.TableConfig.EXPIRED_LOG_CLEANUP_ENABLED;
 import static io.delta.kernel.internal.TableConfig.LOG_RETENTION;
 import static io.delta.kernel.internal.TableFeatures.validateWriteSupportedTable;
 import static io.delta.kernel.internal.checkpoints.Checkpointer.findLastCompleteCheckpointBefore;
@@ -240,7 +240,7 @@ public class SnapshotManager {
 
     // Clean up delta log files if enabled.
     Metadata metadata = snapshot.getMetadata();
-    if (ENABLE_EXPIRED_LOG_CLEANUP.fromMetadata(engine, metadata)) {
+    if (EXPIRED_LOG_CLEANUP_ENABLED.fromMetadata(engine, metadata)) {
       cleanupExpiredLogs(engine, clock, tablePath, LOG_RETENTION.fromMetadata(engine, metadata));
     } else {
       logger.info(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
@@ -110,6 +110,15 @@ public final class FileNames {
   }
 
   /**
+   * Returns the prefix of all checkpoint files for the given version. Intended for use with
+   * listFrom to get all files from this version onwards. The returned Path will not exist as a
+   * file.
+   */
+  public static Path checkpointPrefix(Path path, long version) {
+    return new Path(path, String.format("%020d.checkpoint", version));
+  }
+
+  /**
    * Returns the paths for all parts of the checkpoint up to the given version.
    *
    * <p>In a future protocol version we will write this path instead of checkpointFileSingular.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
@@ -110,15 +110,6 @@ public final class FileNames {
   }
 
   /**
-   * Returns the prefix of all checkpoint files for the given version. Intended for use with
-   * listFrom to get all files from this version onwards. The returned Path will not exist as a
-   * file.
-   */
-  public static Path checkpointPrefix(Path path, long version) {
-    return new Path(path, String.format("%020d.checkpoint", version));
-  }
-
-  /**
    * Returns the paths for all parts of the checkpoint up to the given version.
    *
    * <p>In a future protocol version we will write this path instead of checkpointFileSingular.

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/snapshot/MetadataCleanupSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/snapshot/MetadataCleanupSuite.scala
@@ -15,189 +15,242 @@
  */
 package io.delta.kernel.internal.snapshot
 
-import io.delta.kernel.engine.Engine
 import io.delta.kernel.internal.snapshot.MetadataCleanup.cleanupExpiredLogs
 import io.delta.kernel.internal.util.ManualClock
-import io.delta.kernel.test.{MockEngineUtils, MockFileSystemClientUtils, MockListFromDeleteFileSystemClient}
+import io.delta.kernel.test.{MockFileSystemClientUtils, MockListFromDeleteFileSystemClient}
 import io.delta.kernel.utils.FileStatus
 import org.scalatest.funsuite.AnyFunSuite
 
-class MetadataCleanupSuite extends AnyFunSuite with MockFileSystemClientUtils with MockEngineUtils {
+class MetadataCleanupSuite extends AnyFunSuite with MockFileSystemClientUtils {
 
-  private val multiPartCheckpointPartsSize = 4;
+  import MetadataCleanupSuite._
 
-  /** Case class containing the list of expected files in the deleted file list */
+  /* ------------------- TESTS ------------------ */
+
+  // Simple case where the Delta log directory contains only delta files and no checkpoint files
+  Seq(
+    (
+      "no files should be deleted even some of them are expired",
+      DeletedFileList(), // expected deleted files - none of them should be deleted
+      70, // current time
+      30 // retention period
+    ),
+    (
+      "no files should be deleted as none of them are expired",
+      DeletedFileList(), // expected deleted files - none of them should be deleted
+      200, // current time
+      200 // retention period
+    ),
+    (
+      "no files should be deleted as none of them are expired",
+      DeletedFileList(), // expected deleted files - none of them should be deleted
+      200, // current time
+      0 // retention period
+    )
+  ).foreach {
+    case (testName, expectedDeletedFiles, currentTime, retentionPeriod) =>
+      // _deltalog directory contents - contains only delta files
+      val logFiles = deltaFileStatuses(Seq(0, 1, 2, 3, 4, 5, 6))
+      testCleanup(testName, logFiles, expectedDeletedFiles, currentTime, retentionPeriod)
+  }
+
+  // with various checkpoint types
+  Seq("classic", "multi-part", "v2", "hybrid").foreach { checkpointType =>
+    // _deltalog directory contains a combination of delta files and checkpoint files
+
+    val logFiles = deltaFileStatuses(Seq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)) ++
+      (checkpointType match {
+        case "classic" =>
+          singularCheckpointFileStatuses(Seq(3, 6, 9, 12))
+        case "multi-part" =>
+          multiCheckpointFileStatuses(Seq(3, 6, 9, 12), multiPartCheckpointPartsSize)
+        case "v2" =>
+          v2CPFileStatuses(Seq[Long](3, 6, 9, 12))
+        case "hybrid" =>
+          singularCheckpointFileStatuses(Seq(3)) ++
+            multiCheckpointFileStatuses(Seq(6), numParts = multiPartCheckpointPartsSize) ++
+            v2CPFileStatuses(Seq[Long](9)) ++
+            singularCheckpointFileStatuses(Seq(12))
+      })
+
+    // test cases
+    Seq(
+      (
+        "delete expired delta files up to the checkpoint version, " +
+          "not all expired delta files are deleted",
+        Seq(0L, 1L, 2L), // expDeletedDeltaVersions,
+        Seq(), // expDeletedCheckpointVersions,
+        130, // current time
+        80 // retention period
+      ),
+      (
+        "expired delta files + expired checkpoint should be deleted",
+        Seq(0L, 1L, 2L, 3L, 4L, 5L), // expDeletedDeltaVersions,
+        Seq(3L), // expDeletedCheckpointVersions,
+        130, // current time
+        60 // retention period
+      ),
+      (
+        "expired delta files + expired checkpoints should be deleted",
+        Seq(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L), // expDeletedDeltaVersions,
+        Seq(3L, 6L), // expDeletedCheckpointVersions,
+        130, // current time
+        40 // retention period
+      ),
+      (
+        "all delta/checkpoint files should be except the last checkpoint file",
+        Seq(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L), // expDeletedDeltaVersions,
+        Seq(3L, 6L, 9L), // expDeletedCheckpointVersions,
+        130, // current time
+        0 // retention period
+      ),
+      (
+        "no delta/checkpoint files should be deleted as none expired",
+        Seq(), // expDeletedDeltaVersions
+        Seq(), // expDeletedDeltaVersions
+        200, // current time
+        200 // retention period
+      )
+    ).foreach {
+      case (testName, expDeletedDeltaVersions, expDeletedCheckpointVersions,
+      currentTime, retentionPeriod) =>
+
+        val expectedDeletedFiles = DeletedFileList(
+          deltaVersions = expDeletedDeltaVersions,
+          classicCheckpointVersions = checkpointType match {
+            case "classic" => expDeletedCheckpointVersions
+            case "hybrid" => expDeletedCheckpointVersions.filter(Seq(3, 12).contains(_))
+            case _ => Seq.empty
+          },
+          multipartCheckpointVersions = checkpointType match {
+            case "multi-part" => expDeletedCheckpointVersions
+            case "hybrid" => expDeletedCheckpointVersions.filter(_ == 6)
+            case _ => Seq.empty
+          },
+          v2CheckpointVersions = checkpointType match {
+            case "v2" => expDeletedCheckpointVersions
+            case "hybrid" => expDeletedCheckpointVersions.filter(_ == 9)
+            case _ => Seq.empty
+          }
+        )
+
+        val testDesc = s"$checkpointType: $testName"
+        testCleanup(testDesc, logFiles, expectedDeletedFiles, currentTime, retentionPeriod)
+    }
+  }
+
+  /* ------------------- NEGATIVE TESTS ------------------ */
+  test("metadataCleanup: invalid retention period") {
+    val e = intercept[IllegalArgumentException] {
+      cleanupExpiredLogs(
+        mockEngine(mockFsClient(Seq.empty)),
+        new ManualClock(100),
+        logPath,
+        -1 /* retentionPeriod */
+      )
+    }
+
+    assert(e.getMessage.contains("Retention period must be non-negative"))
+  }
+
+  test("incomplete checkpoints should not be considered") {
+    val logFiles = deltaFileStatuses(Seq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)) ++
+      multiCheckpointFileStatuses(Seq(3), multiPartCheckpointPartsSize)
+        // delete the third part of the checkpoint
+        .filterNot(_.getPath.contains(s"%010d.%010d".format(2, 4))) ++
+      multiCheckpointFileStatuses(Seq(6), multiPartCheckpointPartsSize) ++
+      v2CPFileStatuses(Seq(9))
+
+    // test cases
+    Seq(
+      (
+        Seq[Long](), // expDeletedDeltaVersions,
+        Seq[Long](), // expDeletedCheckpointVersions,
+        130, // current time
+        80 // retention period
+      ),
+      (
+        Seq(0L, 1L, 2L, 3L, 4L, 5L), // expDeletedDeltaVersions,
+        Seq(3L), // expDeletedCheckpointVersions,
+        130, // current time
+        60 // retention period
+      ),
+      (
+        Seq(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L), // expDeletedDeltaVersions,
+        Seq(3L, 6L), // expDeletedCheckpointVersions,
+        130, // current time
+        20 // retention period
+      )
+    ).foreach {
+      case (expDeletedDeltaVersions, expDeletedCheckpointVersions,
+      currentTime, retentionPeriod) =>
+
+        val expectedDeletedFiles = deltaFileStatuses(expDeletedDeltaVersions) ++
+          expDeletedCheckpointVersions.flatMap {
+            case v@3 => multiCheckpointFileStatuses(Seq(v), multiPartCheckpointPartsSize)
+              .filterNot(_.getPath.contains(s"%010d.%010d".format(2, 4)))
+            case v@6 => multiCheckpointFileStatuses(Seq(v), multiPartCheckpointPartsSize)
+            case v@9 => v2CPFileStatuses(Seq(v))
+          }
+
+        val fsClient = mockFsClient(logFiles)
+        cleanupExpiredLogs(
+          mockEngine(fsClient),
+          new ManualClock(currentTime),
+          logPath,
+          retentionPeriod
+        )
+
+        assert(fsClient.getDeleteCalls.toSet === expectedDeletedFiles.map(_.getPath).toSet)
+    }
+  }
+
+  /* ------------------- HELPER UTILITIES/CONSTANTS ------------------ */
+  def testCleanup(
+    testName: String,
+    logFiles: Seq[FileStatus],
+    expectedDeletedFiles: DeletedFileList,
+    currentTime: Long,
+    retentionPeriod: Long): Unit = {
+    test(s"metadataCleanup: $testName: $currentTime, $retentionPeriod") {
+      val fsClient = mockFsClient(logFiles)
+      cleanupExpiredLogs(
+        mockEngine(fsClient),
+        new ManualClock(currentTime),
+        logPath,
+        retentionPeriod
+      )
+
+      assert(fsClient.getDeleteCalls === expectedDeletedFiles.fileList())
+    }
+  }
+}
+
+object MetadataCleanupSuite extends MockFileSystemClientUtils {
+  /* ------------------- HELPER UTILITIES/CONSTANTS ------------------ */
+  private val multiPartCheckpointPartsSize = 4
+
+  /** Case class containing the list of expected files in the deleted metadata log file list */
   case class DeletedFileList(
     deltaVersions: Seq[Long] = Seq.empty,
     classicCheckpointVersions: Seq[Long] = Seq.empty,
     multipartCheckpointVersions: Seq[Long] = Seq.empty,
-    v2CheckpointVersions: Seq[Long] = Seq.empty,
-    v2CheckpointManifestFormat: String = "parquet") {
+    v2CheckpointVersions: Seq[Long] = Seq.empty) {
 
     def fileList(): Seq[String] = {
       (deltaFileStatuses(deltaVersions) ++
         singularCheckpointFileStatuses(classicCheckpointVersions) ++
         multiCheckpointFileStatuses(multipartCheckpointVersions, multiPartCheckpointPartsSize) ++
-        v2CPFileStatuses(v2CheckpointVersions, v2CheckpointManifestFormat)
+        v2CPFileStatuses(v2CheckpointVersions)
         ).sortBy(_.getPath).map(_.getPath)
     }
-  }
-
-  Seq(
-    (
-      // _deltalog directory contents - contains only delta files
-      deltaFileStatuses(Seq(0, 1, 2, 3, 4, 5, 6)),
-      Seq(
-        (
-          "no files should be deleted even some of them are expired",
-          DeletedFileList(), // expected deleted files - none of them should be deleted
-          70, // current time
-          30 // retention period
-        ),
-        (
-          "no files should be deleted as none of them are expired",
-          DeletedFileList(), // expected deleted files - none of them should be deleted
-          200, // current time
-          200 // retention period
-        )
-      )
-    ),
-    (
-      // _deltalog directory contains a combination of delta files and classic checkpoint files
-      deltaFileStatuses(Seq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)) ++
-        singularCheckpointFileStatuses(Seq(3, 6, 9)),
-      Seq(
-        (
-          "classic checkpoint: delete expired delta files up to the checkpoint version," +
-            "not all expired delta files are deleted",
-          DeletedFileList(deltaVersions = Seq(0, 1, 2)),
-          130, // current time
-          80 // retention period
-        ),
-        (
-          "classic checkpoint: expired delta files + expired checkpoint should be deleted",
-          DeletedFileList(
-            deltaVersions = Seq(0, 1, 2, 3, 4, 5),
-            classicCheckpointVersions = Seq(3)),
-          130, // current time
-          60 // retention period
-        ),
-        (
-          "classic checkpoint: expired delta files + expired checkpoints should be deleted",
-          DeletedFileList(
-            deltaVersions = Seq(0, 1, 2, 3, 4, 5, 6, 7, 8),
-            classicCheckpointVersions = Seq(3, 6)),
-          130, // current time
-          20 // retention period
-        ),
-        (
-          "classic checkpoint: no delta/checkpoint files should be deleted as none expired",
-          DeletedFileList(),
-          200, // current time
-          200 // retention period
-        )
-      )
-    ),
-    (
-      // _deltalog directory contains a combination of delta files and multi-part checkpoint files
-      deltaFileStatuses(Seq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)) ++
-        multiCheckpointFileStatuses(Seq(3, 6, 9), numParts = multiPartCheckpointPartsSize),
-      Seq(
-        (
-          "multi-part checkpoint: delete expired delta files up to the checkpoint version," +
-            "not all expired delta files are deleted",
-          DeletedFileList(deltaVersions = Seq(0, 1, 2)),
-          130, // current time
-          80 // retention period
-        ),
-        (
-          "multi-part checkpoint: expired delta files + expired checkpoint should be deleted",
-          DeletedFileList(
-            deltaVersions = Seq(0, 1, 2, 3, 4, 5),
-            multipartCheckpointVersions = Seq(3)),
-          130, // current time
-          60 // retention period
-        ),
-        (
-          "multi-part checkpoint: expired delta files + expired checkpoints should be deleted",
-          DeletedFileList(
-            deltaVersions = Seq(0, 1, 2, 3, 4, 5, 6, 7, 8),
-            multipartCheckpointVersions = Seq(3, 6)),
-          130, // current time
-          20 // retention period
-        ),
-        (
-          "multi-part checkpoint: no delta/checkpoint files should be deleted as none expired",
-          DeletedFileList(),
-          200, // current time
-          200 // retention period
-        )
-      )
-    ),
-    (
-      // _deltalog directory contains a combination of delta files and v2 checkpoint files
-      deltaFileStatuses(Seq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)) ++
-        v2CPFileStatuses(Seq[Long](3, 6, 9), "parquet"),
-      Seq(
-        (
-          "v2 checkpoint: delete expired delta files up to the checkpoint version," +
-            "not all expired delta files are deleted",
-          DeletedFileList(deltaVersions = Seq(0, 1, 2)),
-          130, // current time
-          80 // retention period
-        ),
-        (
-          "v2 checkpoint: expired delta files + expired checkpoint should be deleted",
-          DeletedFileList(
-            deltaVersions = Seq(0, 1, 2, 3, 4, 5),
-            v2CheckpointVersions = Seq(3)),
-          130, // current time
-          60 // retention period
-        ),
-        (
-          "v2 checkpoint: expired delta files + expired checkpoints should be deleted",
-          DeletedFileList(
-            deltaVersions = Seq(0, 1, 2, 3, 4, 5, 6, 7, 8),
-            v2CheckpointVersions = Seq(3, 6)),
-          130, // current time
-          20 // retention period
-        ),
-        (
-          "v2 checkpoint: no delta/checkpoint files should be deleted as none expired",
-          DeletedFileList(),
-          200, // current time
-          200 // retention period
-        )
-      )
-    )
-  ).foreach {
-    case (logFiles, testCases) =>
-      testCases.foreach {
-        case (testName, expectedDeletedFiles, currentTime, retentionPeriod) =>
-          test(s"metadataCleanup: $testName: $currentTime, $retentionPeriod") {
-            val fsClient = mockFsClient(logFiles)
-
-            cleanupExpiredLogs(
-              mockEngine(fsClient),
-              new ManualClock(currentTime),
-              logPath,
-              retentionPeriod
-            )
-
-            assert(fsClient.getDeleteCalls === expectedDeletedFiles.fileList())
-          }
-      }
   }
 
   def mockFsClient(logFiles: Seq[FileStatus]): MockListFromDeleteFileSystemClient = {
     new MockListFromDeleteFileSystemClient(logFiles)
   }
 
-  def mockEngine(fsClient: MockListFromDeleteFileSystemClient): Engine = {
-    mockEngine(fileSystemClient = fsClient)
-  }
-
-  def v2CPFileStatuses(versions: Seq[Long], format: String): Seq[FileStatus] = {
+  def v2CPFileStatuses(versions: Seq[Long]): Seq[FileStatus] = {
     // Replace the UUID with a standard UUID to make the test deterministic
     val standardUUID = "123e4567-e89b-12d3-a456-426614174000"
     val uuidPattern =
@@ -205,7 +258,7 @@ class MetadataCleanupSuite extends AnyFunSuite with MockFileSystemClientUtils wi
 
     v2CheckpointFileStatuses(
       versions.map(v => (v, true, 20)), // to (version, useUUID, numSidecars)
-      format
+      "parquet"
     ).map(_._1)
       .map(f => FileStatus.of(
         uuidPattern.replaceAllIn(f.getPath, standardUUID),

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/snapshot/MetadataCleanupSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/snapshot/MetadataCleanupSuite.scala
@@ -155,7 +155,7 @@ class MetadataCleanupSuite extends AnyFunSuite with MockFileSystemClientUtils {
         30, // retention period
         DeletedFileList(
           deltaVersions = Seq(25, 26, 27, 28),
-          multipartCheckpointVersions = Seq(25),
+          multipartCheckpointVersions = Seq(25)
         )
       ),
       (
@@ -163,7 +163,7 @@ class MetadataCleanupSuite extends AnyFunSuite with MockFileSystemClientUtils {
         10, // retention period
         DeletedFileList(
           deltaVersions = Seq(25, 26, 27, 28),
-          multipartCheckpointVersions = Seq(25),
+          multipartCheckpointVersions = Seq(25)
         )
       )
     ).foreach {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/snapshot/MetadataCleanupSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/snapshot/MetadataCleanupSuite.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.snapshot
+
+import io.delta.kernel.internal.TableConfig.{ENABLE_EXPIRED_LOG_CLEANUP, ICEBERG_COMPAT_V2_ENABLED, LOG_RETENTION}
+import io.delta.kernel.internal.actions.{Format, Metadata}
+import io.delta.kernel.internal.types.DataTypeJsonSerDe
+import io.delta.kernel.internal.util.VectorUtils
+import io.delta.kernel.internal.util.VectorUtils.stringStringMapValue
+import io.delta.kernel.test.MockFileSystemClientUtils
+import io.delta.kernel.types.StructType
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.util.{Collections, Optional}
+import scala.collection.JavaConverters._
+
+class MetadataCleanupSuite extends AnyFunSuite with MockFileSystemClientUtils {
+  // Input
+  //  1. List of delta log file contents (that includes delta and checkpoint files)
+  //  2. Current time through mocked Clock
+  //  3. Table metadata retention enabled and a period of time for
+  //  which metadata should be retained
+
+  // Output
+  // 1. List of delta log files that should be deleted
+
+
+  def metadata(logCleanupEnabled: Boolean = true, retentionMillis: Int = 24): Metadata = {
+    val configurationMap = Map(
+      ENABLE_EXPIRED_LOG_CLEANUP.getKey -> logCleanupEnabled.toString,
+      LOG_RETENTION.getKey -> retentionMillis.toString
+    )
+    new Metadata(
+      "id",
+      Optional.empty(), /* name */
+      Optional.empty(), /* description */
+      new Format(),
+      DataTypeJsonSerDe.serializeDataType(new StructType()),
+      new StructType(),
+      VectorUtils.stringArrayValue(Collections.emptyList()), // partitionColumns
+      Optional.empty(), // createdTime
+      stringStringMapValue(configurationMap.asJava) // configurationMap
+    )
+  }
+}

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/snapshot/MetadataCleanupSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/snapshot/MetadataCleanupSuite.scala
@@ -117,7 +117,7 @@ class MetadataCleanupSuite extends AnyFunSuite with MockFileSystemClientUtils wi
           200 // retention period
         )
       )
-    ),
+    )
   ).foreach {
     case (logFiles, testCases) =>
       testCases.foreach {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockEngineUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockEngineUtils.scala
@@ -159,4 +159,7 @@ trait BaseMockFileSystemClient extends FileSystemClient {
 
   override def mkdirs(path: String): Boolean =
     throw new UnsupportedOperationException("not supported in this test suite")
+
+  override def delete(path: String): Boolean =
+    throw new UnsupportedOperationException("not supported in this test suite")
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockFileSystemClientUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockFileSystemClientUtils.scala
@@ -57,7 +57,7 @@ trait MockFileSystemClientUtils extends MockEngineUtils {
     checkpointVersions.flatMap(v =>
       FileNames.checkpointFileWithParts(logPath, v, numParts).asScala
         .map(p => FileStatus.of(p.toString, v, v*10))
-    )
+    ).toSeq
   }
 
   /**

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockFileSystemClientUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockFileSystemClientUtils.scala
@@ -57,7 +57,7 @@ trait MockFileSystemClientUtils extends MockEngineUtils {
     checkpointVersions.flatMap(v =>
       FileNames.checkpointFileWithParts(logPath, v, numParts).asScala
         .map(p => FileStatus.of(p.toString, v, v*10))
-    ).toSeq
+    )
   }
 
   /**

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultFileSystemClient.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultFileSystemClient.java
@@ -99,6 +99,13 @@ public class DefaultFileSystemClient implements FileSystemClient {
     return fs.mkdirs(pathObject);
   }
 
+  @Override
+  public boolean delete(String path) throws IOException {
+    Path pathObject = new Path(path);
+    FileSystem fs = pathObject.getFileSystem(hadoopConf);
+    return fs.delete(pathObject, false);
+  }
+
   private ByteArrayInputStream getStream(String filePath, int offset, int size) {
     Path path = new Path(filePath);
     try {


### PR DESCRIPTION
Add support for metadata cleanup as part of the checkpointing. Metadata cleanup removes expired Delta table log files (delta + checkpoints) according to the table log retention configuration. Any removed delta log files must not cause the table state to be inconstructible. 