### PR TITLE
[Spark][WIP] Leverage type widening in Delta streaming source

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -651,6 +651,7 @@ trait DeltaSourceBase extends Source
           // This is only allowed when we are "backfilling", i.e. the stream progress is older than
           // the analyzed table version. Any schema change past the analysis should still throw
           // exception, because additive schema changes MUST be taken into account.
+          allowTypeWidening = true,
           allowMissingColumns =
             isStreamingFromColumnMappingTable &&
               allowUnsafeStreamingReadOnColumnMappingSchemaChanges &&
@@ -670,7 +671,8 @@ trait DeltaSourceBase extends Source
         // and if it works (including that `schemaChange` should not tighten the nullability
         // constraint from `schema`), it is a retryable exception.
         val retryable = !backfilling && SchemaUtils.isReadCompatible(
-          schema, schemaChange, forbidTightenNullability = shouldForbidTightenNullability)
+          schema, schemaChange, forbidTightenNullability = shouldForbidTightenNullability,
+          allowTypeWidening = true)
         throw DeltaErrors.schemaChangedException(
           schema,
           schemaChange,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaStreamTest.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaStreamTest.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.io.File
+
+import org.apache.spark.SparkThrowable
+import org.apache.spark.sql.{DataFrame, Row, SaveMode}
+import org.apache.spark.sql.streaming.StreamTest
+import org.apache.spark.sql.types.StructType
+
+/**
+ * Extends the streaming testing framework from [[StreamTest]] to provide testing helpers
+ * for Delta streaming sources.
+ */
+trait DeltaStreamTest extends StreamTest with DeltaStreamActions {
+
+  /** Convenience helper to create a streaming df from a delta table path. */
+  def readStreamFromPath(path: File, options: Map[String, String] = Map.empty): DataFrame =
+    spark.readStream.options(options).format("delta").load(path.getCanonicalPath)
+}
+
+/**
+ * Defines Delta-specific test actions that can be passed to the `testStream` method.
+ */
+trait DeltaStreamActions { self: StreamTest =>
+  /**
+   * Overwrite the Delta table at the given path to change its schema while preserving its history
+   * and keeping the same table ID.
+   */
+  object OverwriteTable {
+    def apply(path: File, schema: StructType): AssertOnQuery =
+      Execute("ChangeSchema") { _ =>
+        spark.createDataFrame(sparkContext.emptyRDD[Row], schema)
+          .write
+          .format("delta")
+          .mode(SaveMode.Overwrite)
+          .option("overwriteSchema", "true")
+          .save(path.getCanonicalPath)
+      }
+  }
+
+  /**
+   * Check that the schema of the Delta table at the given path matches the expected schema.
+   */
+  object CheckSchema {
+    def apply(deltaPath: File, expectedSchema: StructType): AssertOnQuery =
+      Execute("CheckSchema") { q =>
+        q.processAllAvailable()
+        val schema = spark.read.format("delta").load(deltaPath.getCanonicalPath).schema
+        assert(schema === expectedSchema)
+      }
+  }
+
+  /**
+   * Check that the stream fails because of a schema change.
+   */
+  object ExpectSchemaChangeFailure {
+    def apply(readSchema: String, dataSchema: String, isRetryable: Boolean): StreamAction = {
+      def matchSchemaStr(schema: String): String = StructType.fromDDL(schema).map { field =>
+        s"${field.name}: ${field.dataType.typeName}"
+      }.mkString("(?s).*", ".*", ".*")
+
+      def checkError(exception: SparkThrowable): Unit =
+        checkErrorMatchPVals(
+          exception = exception,
+          errorClass = "DELTA_SCHEMA_CHANGED_WITH_VERSION",
+          parameters = Map(
+            "version" -> ".*",
+            "readSchema" -> matchSchemaStr(readSchema),
+            "dataSchema" -> matchSchemaStr(dataSchema)
+          )
+        )
+
+      ExpectFailure[DeltaIllegalStateException] { ex =>
+        checkError(ex.asInstanceOf[DeltaIllegalStateException])
+      }
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTypeWideningSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTypeWideningSchemaEvolutionSuite.scala
@@ -39,7 +39,6 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
 class DeltaTypeWideningSchemaEvolutionSuite
     extends QueryTest
     with DeltaDMLTestUtils
-    with DeltaSQLCommandTest
     with DeltaTypeWideningTestMixin
     with DeltaMergeIntoTypeWideningSchemaEvolutionTests
     with DeltaInsertTypeWideningSchemaEvolutionTeststs {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTypeWideningStreamingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTypeWideningStreamingSuite.scala
@@ -18,7 +18,6 @@ package org.apache.spark.sql.delta
 
 import java.io.File
 
-import org.apache.spark.sql.execution.streaming.sources.MemorySink
 import org.apache.spark.sql.types._
 
 /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTypeWideningStreamingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTypeWideningStreamingSuite.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.io.File
+
+import org.apache.spark.sql.execution.streaming.sources.MemorySink
+import org.apache.spark.sql.types._
+
+/**
+ * Suite covering type widening and type changes in Delta streaming sources.
+ */
+class DeltaTypeWideningStreamingSourceSuite extends DeltaTypeWideningStreamingSourceTests
+
+trait DeltaTypeWideningStreamingSourceTests
+  extends DeltaStreamTest
+  with DeltaTypeWideningTestMixin {
+
+  import testImplicits._
+
+  test("delta source - widening type change then restore back") {
+    withTempDir { dir =>
+      sql(s"CREATE TABLE delta.`$dir` (a byte) USING DELTA")
+      val checkpointDir = new File(dir, "sink_checkpoint")
+
+      testStream(readStreamFromPath(dir))(
+        StartStream(checkpointLocation = checkpointDir.toString),
+        Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (1)") },
+        Execute { _ => sql(s"ALTER TABLE delta.`$dir`ALTER COLUMN a TYPE long") },
+        Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (2)") },
+        // Widening a column type requires restarting the stream so that the new, wider schema is
+        // used to process the batch.
+        ExpectSchemaChangeFailure(readSchema = "a byte", dataSchema = "a long", isRetryable = true)
+      )
+
+      val widenedSchema = new StructType()
+        .add("a", LongType, nullable = true,
+          metadata = typeWideningMetadata(version = 2, ByteType, LongType))
+
+      testStream(readStreamFromPath(dir, options = Map("ignoreDeletes" -> "true")))(
+        StartStream(checkpointLocation = checkpointDir.toString),
+        CheckSchema(dir, widenedSchema),
+        CheckAnswer(2),
+        // Restore will narrow the type back. This doesn't require restarting the stream as the
+        // wider schema can still be used to process the batch.
+        Execute { _ => sql(s"RESTORE delta.`$dir` VERSION AS OF 1") },
+        Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (3)") },
+        CheckSchema(dir, StructType.fromDDL("a byte")),
+        CheckAnswer(2, 3)
+      )
+    }
+  }
+
+  test("delta source - narrowing type change then restore back") {
+    withTempDir { dir =>
+      sql(s"CREATE TABLE delta.`$dir` (a decimal(14, 2)) USING DELTA")
+      val checkpointDir = new File(dir, "sink_checkpoint")
+
+      testStream(readStreamFromPath(dir, options = Map("ignoreDeletes" -> "true")))(
+        StartStream(checkpointLocation = checkpointDir.toString),
+        OverwriteTable(dir, StructType.fromDDL("a decimal(6, 1)")),
+        Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (1.1)") },
+        // Narrowing a column type doesn't require restarting the stream as the initial wider schema
+        // can still be used to process the batch.
+        CheckSchema(dir, StructType.fromDDL("a decimal(6, 1)")),
+        CheckAnswer(1.1),
+        // Restore will widen the type back. This doesn't require restarting the stream either as
+        // the initial wider schema can still be used to process the batch.
+        Execute { _ => sql(s"RESTORE delta.`$dir` VERSION AS OF 0") },
+        Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (2.2)") },
+        CheckSchema(dir, StructType.fromDDL("a decimal(14, 2)")),
+        CheckAnswer(1.1, 2.2)
+      )
+    }
+  }
+
+  test("delta source - arbitrary type changes are not supported") {
+    withTempDir { dir =>
+      sql(s"CREATE TABLE delta.`$dir` (a byte) USING DELTA")
+      val checkpointDir = new File(dir, "sink_checkpoint")
+
+      testStream(readStreamFromPath(dir))(
+        StartStream(checkpointLocation = checkpointDir.toString),
+        Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (1)") },
+        OverwriteTable(dir, StructType.fromDDL("a string")),
+        Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES ('two')") },
+        ExpectSchemaChangeFailure(
+          readSchema = "a byte", dataSchema = "a string", isRetryable = false)
+      )
+
+      // Try restarting the stream even though the error is not retryable and it will fail again.
+      testStream(readStreamFromPath(dir))(
+        StartStream(checkpointLocation = checkpointDir.toString),
+        ExpectSchemaChangeFailure(
+          readSchema = "a string", dataSchema = "a byte", isRetryable = false)
+      )
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTypeWideningSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTypeWideningSuite.scala
@@ -51,7 +51,6 @@ class DeltaTypeWideningSuite
   extends QueryTest
     with ParquetTest
     with RowTrackingTestUtils
-    with DeltaSQLCommandTest
     with DeltaTypeWideningTestMixin
     with DeltaTypeWideningDropFeatureTestMixin
     with DeltaTypeWideningAlterTableTests
@@ -67,8 +66,10 @@ class DeltaTypeWideningSuite
 /**
  * Test mixin that enables type widening by default for all tests in the suite.
  */
-trait DeltaTypeWideningTestMixin extends SharedSparkSession with DeltaDMLTestUtils {
-  self: QueryTest =>
+trait DeltaTypeWideningTestMixin
+  extends SharedSparkSession
+    with DeltaSQLCommandTest
+    with DeltaDMLTestUtils { self: QueryTest =>
 
   import testImplicits._
 


### PR DESCRIPTION
## Description
This change relaxes the condition on read-compatible type changes that the Delta streaming source can handle and recover from.

The type widening feature guarantees that all parquet readers now support reading values using a wider schema type - see `TypeWidening.isTypeChangeSupported` for the list of supported conversions.
This effectively means that the corresponding type changes are read-compatible in the context of Delta streaming sources, whether the feature is effectively enabled on the source table or not. 

## How was this patch tested?
Added tests `DeltaTypeWideningStreamingSourceSuite` cover widening, narrowing and arbitrary type changes.

## Does this PR introduce _any_ user-facing changes?
Yes. Applying a widening type change to a Delta table used as a streaming source will propagate that type change to the streaming sink instead of failing.
The write to the sink will still fail if that sink doesn't support type changes (e.g. the Delta streaming sink).

