### PR TITLE
[Spark] Use checkError in MERGE tests instead of checking error messages

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -1490,7 +1490,7 @@
   },
   "DELTA_MERGE_UNRESOLVED_EXPRESSION" : {
     "message" : [
-      "Cannot resolve <sqlExpr> in <clause> given <cols>"
+      "Cannot resolve <sqlExpr> in <clause> given columns <cols>."
     ],
     "sqlState" : "42601"
   },

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2902,11 +2902,6 @@
       "<optionalPrefixMessage>Found unsupported expression <expression> while parsing target column name parts."
     ]
   },
-  "_LEGACY_ERROR_TEMP_DELTA_0011" : {
-    "message" : [
-      "Failed to resolve plan."
-    ]
-  },
   "_LEGACY_ERROR_TEMP_DELTA_0012" : {
     "message" : [
       "Could not resolve expression: <expression>"

--- a/spark/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
+++ b/spark/src/main/scala/io/delta/tables/DeltaMergeBuilder.scala
@@ -305,15 +305,7 @@ class DeltaMergeBuilder private(
       val resolvedMergeInto =
       ResolveDeltaMergeInto.resolveReferencesAndSchema(mergePlan, sparkSession.sessionState.conf)(
         tryResolveReferencesForExpressions(sparkSession))
-      if (!resolvedMergeInto.resolved) {
-        throw new ExtendedAnalysisException(
-          new DeltaAnalysisException(
-            errorClass = "_LEGACY_ERROR_TEMP_DELTA_0011",
-            messageParameters = Array.empty
-          ),
-          resolvedMergeInto
-        )
-      }
+
       val strippedMergeInto = resolvedMergeInto.copy(
         target = DeltaViewHelper.stripTempViewForMerge(resolvedMergeInto.target, SQLConf.get)
       )

--- a/spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/deltaMerge.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/deltaMerge.scala
@@ -356,14 +356,14 @@ object DeltaMergeInto {
     // Check that only the last MATCHED clause omits the condition.
     if (matchedClauses.length > 1 && !matchedClauses.init.forall(_.condition.nonEmpty)) {
       throw new DeltaAnalysisException(
-        errorClass = "DELTA_NON_LAST_MATCHED_CLAUSE_OMIT_CONDITION",
+        errorClass = "NON_LAST_MATCHED_CLAUSE_OMIT_CONDITION",
         messageParameters = Array.empty)
     }
 
     // Check that only the last NOT MATCHED clause omits the condition.
     if (notMatchedClauses.length > 1 && !notMatchedClauses.init.forall(_.condition.nonEmpty)) {
       throw new DeltaAnalysisException(
-        errorClass = "DELTA_NON_LAST_NOT_MATCHED_CLAUSE_OMIT_CONDITION",
+        errorClass = "NON_LAST_NOT_MATCHED_BY_TARGET_CLAUSE_OMIT_CONDITION",
         messageParameters = Array.empty)
     }
 
@@ -371,7 +371,7 @@ object DeltaMergeInto {
     if (notMatchedBySourceClauses.length > 1 &&
       !notMatchedBySourceClauses.init.forall(_.condition.nonEmpty)) {
       throw new DeltaAnalysisException(
-        errorClass = "DELTA_NON_LAST_NOT_MATCHED_BY_SOURCE_CLAUSE_OMIT_CONDITION",
+        errorClass = "NON_LAST_NOT_MATCHED_BY_SOURCE_CLAUSE_OMIT_CONDITION",
         messageParameters = Array.empty)
     }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ResolveDeltaMergeInto.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ResolveDeltaMergeInto.scala
@@ -74,7 +74,7 @@ object ResolveDeltaMergeInto {
       expr.flatMap(_.references).filter(!_.resolved).foreach { a =>
         // Note: This will throw error only on unresolved attribute issues,
         // not other resolution errors like mismatched data types.
-        val cols = "columns " + plans.flatMap(_.output).map(_.sql).mkString(", ")
+        val cols = plans.flatMap(_.output).map(_.sql).mkString(", ")
         throw new DeltaAnalysisException(
           errorClass = "DELTA_MERGE_UNRESOLVED_EXPRESSION",
           messageParameters = Array(a.sql, mergeClauseType, cols),

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -3179,19 +3179,6 @@ trait DeltaErrorsSuiteBase
       )
     }
     {
-      val e = intercept[DeltaAnalysisException] {
-        throw new DeltaAnalysisException(
-          errorClass = "_LEGACY_ERROR_TEMP_DELTA_0011",
-          messageParameters = Array.empty)
-      }
-      checkErrorMessage(
-        e,
-        Some("_LEGACY_ERROR_TEMP_DELTA_0011"),
-        None,
-        Some("Failed to resolve plan.")
-      )
-    }
-    {
       val exprs = Seq("1".expr, "2".expr)
       val e = intercept[DeltaAnalysisException] {
         throw new DeltaAnalysisException(


### PR DESCRIPTION
## Description
Migrate merge tests that rely on checking error strings directly to using the preferred way of checking error classes + parameters using `checkError`.

## How was this patch tested?
N/A, refactoring tests.