### PR TITLE
[Spark] Make naming of manage commit consistent

### DIFF
--- a/protocol_rfcs/managed-commits.md
+++ b/protocol_rfcs/managed-commits.md
@@ -1,7 +1,7 @@
 # Managed Commits
 **Associated Github issue for discussions: https://github.com/delta-io/delta/issues/2598**
 
-This RFC proposes a new table feature `managedCommits` which changes the way Delta Lake performs commits.
+This RFC proposes a new table feature `managedCommit` which changes the way Delta Lake performs commits.
 
 Today’s Delta commit protocol relies on the filesystem to provide commit atomicity. This feature request is to allow Delta tables which gets commit atomicity using an external commit-owner and not
 the filesystem (s3, abfs etc). This allows us to deal with various limitations of Delta:
@@ -324,13 +324,13 @@ the seemingly-extra files might think the table metadata was corrupted.
 
 The managed-commit feature is supported and active when:
 - The table must be on Writer Version 7.
-- The table has a `protocol` action with `writerFeatures` containing the feature `managedCommits`.
-- The table has a metadata property `delta.managedCommits.commitOwner` in the [change-metadata](#change-metadata)'s configuration.
-- The table may have a metadata property `delta.managedCommits.commitOwnerConf` in the [change-metadata](#change-metadata)'s configuration. The value of this property is a json-coded string-to-string map.
+- The table has a `protocol` action with `writerFeatures` containing the feature `managedCommit`.
+- The table has a metadata property `delta.managedCommit.commitOwner` in the [change-metadata](#change-metadata)'s configuration.
+- The table may have a metadata property `delta.managedCommit.commitOwnerConf` in the [change-metadata](#change-metadata)'s configuration. The value of this property is a json-coded string-to-string map.
     - A commit-owner can store additional information (e.g. configuration information such as service endpoints) in this field, for use by the commit-owner client (it is opaque to the Delta client).
     - This field should never include secrets such as auth tokens or credentials, because any reader with access to the table's storage location can see them.
 
-Note that a table is in invalid state if the change-metadata contains the `delta.managedCommits.commitOwner` property but the table does not have the `managedCommits` feature in the `protocol` action (or vice versa).
+Note that a table is in invalid state if the change-metadata contains the `delta.managedCommit.commitOwner` property but the table does not have the `managedCommit` feature in the `protocol` action (or vice versa).
 
 E.g.
 ```json
@@ -342,8 +342,8 @@ E.g.
       "partitionColumns":[],
       "configuration":{
          "appendOnly": "true",
-         "delta.managedCommits.commitOwner": "commit-owner-1",
-         "delta.managedCommits.commitOwnerConf":
+         "delta.managedCommit.commitOwner": "commit-owner-1",
+         "delta.managedCommit.commitOwnerConf":
              "{\"endpoint\":\"http://sample-url.com/commit\", \"authenticationMode\":\"oauth2\"}"
       }
    }

--- a/spark/src/main/java/io/delta/dynamodbcommitstore/DynamoDBCommitOwnerClientBuilder.java
+++ b/spark/src/main/java/io/delta/dynamodbcommitstore/DynamoDBCommitOwnerClientBuilder.java
@@ -42,7 +42,7 @@ public class DynamoDBCommitOwnerClientBuilder implements CommitOwnerBuilder {
      * commits for this owner. The value of this key is stored in the `conf`
      * which is passed to the `build` method.
      */
-    private static final String MANAGED_COMMITS_TABLE_NAME_KEY = "managedCommitsTableName";
+    private static final String MANAGED_COMMITS_TABLE_NAME_KEY = "managedCommitTableName";
     /**
      * The endpoint of the DynamoDB service. The value of this key is stored in the
      * `conf` which is passed to the `build` method.
@@ -51,7 +51,7 @@ public class DynamoDBCommitOwnerClientBuilder implements CommitOwnerBuilder {
 
     @Override
     public CommitOwnerClient build(SparkSession spark, Map<String, String> conf) {
-        String managedCommitsTableName = conf.get(MANAGED_COMMITS_TABLE_NAME_KEY).getOrElse(() -> {
+        String managedCommitTableName = conf.get(MANAGED_COMMITS_TABLE_NAME_KEY).getOrElse(() -> {
             throw new RuntimeException(MANAGED_COMMITS_TABLE_NAME_KEY + " not found");
         });
         String dynamoDBEndpoint = conf.get(DYNAMO_DB_ENDPOINT_KEY).getOrElse(() -> {
@@ -72,7 +72,7 @@ public class DynamoDBCommitOwnerClientBuilder implements CommitOwnerBuilder {
                     spark.sessionState().newHadoopConf()
             );
             return getDynamoDBCommitOwnerClient(
-                    managedCommitsTableName,
+                    managedCommitTableName,
                     dynamoDBEndpoint,
                     ddbClient,
                     BACKFILL_BATCH_SIZE,
@@ -86,7 +86,7 @@ public class DynamoDBCommitOwnerClientBuilder implements CommitOwnerBuilder {
     }
 
     protected DynamoDBCommitOwnerClient getDynamoDBCommitOwnerClient(
-            String managedCommitsTableName,
+            String managedCommitTableName,
             String dynamoDBEndpoint,
             AmazonDynamoDB ddbClient,
             long backfillBatchSize,
@@ -95,7 +95,7 @@ public class DynamoDBCommitOwnerClientBuilder implements CommitOwnerBuilder {
             boolean skipPathCheck
     ) throws IOException {
         return new DynamoDBCommitOwnerClient(
-                managedCommitsTableName,
+                managedCommitTableName,
                 dynamoDBEndpoint,
                 ddbClient,
                 backfillBatchSize,

--- a/spark/src/main/java/io/delta/dynamodbcommitstore/DynamoDBCommitOwnerClientBuilder.java
+++ b/spark/src/main/java/io/delta/dynamodbcommitstore/DynamoDBCommitOwnerClientBuilder.java
@@ -42,7 +42,7 @@ public class DynamoDBCommitOwnerClientBuilder implements CommitOwnerBuilder {
      * commits for this owner. The value of this key is stored in the `conf`
      * which is passed to the `build` method.
      */
-    private static final String MANAGED_COMMITS_TABLE_NAME_KEY = "dynamoDBManagedCommitsTableName";
+    private static final String MANAGED_COMMITS_TABLE_NAME_KEY = "dynamoDBTableName";
     /**
      * The endpoint of the DynamoDB service. The value of this key is stored in the
      * `conf` which is passed to the `build` method.

--- a/spark/src/main/java/io/delta/dynamodbcommitstore/DynamoDBCommitOwnerClientBuilder.java
+++ b/spark/src/main/java/io/delta/dynamodbcommitstore/DynamoDBCommitOwnerClientBuilder.java
@@ -42,7 +42,7 @@ public class DynamoDBCommitOwnerClientBuilder implements CommitOwnerBuilder {
      * commits for this owner. The value of this key is stored in the `conf`
      * which is passed to the `build` method.
      */
-    private static final String MANAGED_COMMITS_TABLE_NAME_KEY = "managedCommitTableName";
+    private static final String MANAGED_COMMITS_TABLE_NAME_KEY = "dynamoDBManagedCommitsTableName";
     /**
      * The endpoint of the DynamoDB service. The value of this key is stored in the
      * `conf` which is passed to the `build` method.

--- a/spark/src/main/java/io/delta/dynamodbcommitstore/ManagedCommitUtils.java
+++ b/spark/src/main/java/io/delta/dynamodbcommitstore/ManagedCommitUtils.java
@@ -31,7 +31,7 @@ public class ManagedCommitUtils {
 
     /** The configuration key for the managed commit owner. */
     private static final String MANAGED_COMMIT_OWNER_CONF_KEY =
-            "delta.managedCommits.commitOwner-preview";
+            "delta.managedCommit.commitOwner-preview";
 
     /**
      * Creates a new unbackfilled delta file path for the given commit version.
@@ -68,10 +68,10 @@ public class ManagedCommitUtils {
     public static boolean isManagedCommitToFSConversion(
             Long commitVersion,
             UpdatedActions updatedActions) {
-        boolean oldMetadataHasManagedCommits =
+        boolean oldMetadataHasManagedCommit =
                 !getManagedCommitOwner(updatedActions.getOldMetadata()).isEmpty();
-        boolean newMetadataHasManagedCommits =
+        boolean newMetadataHasManagedCommit =
                 !getManagedCommitOwner(updatedActions.getNewMetadata()).isEmpty();
-        return oldMetadataHasManagedCommits && !newMetadataHasManagedCommits && commitVersion > 0;
+        return oldMetadataHasManagedCommit && !newMetadataHasManagedCommit && commitVersion > 0;
     }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -737,7 +737,7 @@ trait DeltaConfigsBase extends DeltaLogging {
     helpMessage = "needs to be a boolean.")
 
   val MANAGED_COMMIT_OWNER_NAME = buildConfig[Option[String]](
-    "managedCommits.commitOwner-preview",
+    "managedCommit.commitOwner-preview",
     null,
     v => Option(v),
     _ => true,
@@ -748,14 +748,14 @@ trait DeltaConfigsBase extends DeltaLogging {
       |""".stripMargin)
 
   val MANAGED_COMMIT_OWNER_CONF = buildConfig[Map[String, String]](
-    "managedCommits.commitOwnerConf-preview",
+    "managedCommit.commitOwnerConf-preview",
     null,
     v => JsonUtils.fromJson[Map[String, String]](Option(v).getOrElse("{}")),
     _ => true,
     "A string-to-string map of configuration properties for the managed commit-owner.")
 
   val MANAGED_COMMIT_TABLE_CONF = buildConfig[Map[String, String]](
-    "managedCommits.tableConf-preview",
+    "managedCommit.tableConf-preview",
     null,
     v => JsonUtils.fromJson[Map[String, String]](Option(v).getOrElse("{}")),
     _ => true,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1245,7 +1245,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
    */
   protected def updateMetadataWithManagedCommitConfs(): Boolean = {
     validateManagedCommitConfInMetadata(newMetadata)
-    val newManagedCommitTableConfOpt = registerTableForManagedCommitsIfNeeded(metadata, protocol)
+    val newManagedCommitTableConfOpt = registerTableForManagedCommitIfNeeded(metadata, protocol)
     val newManagedCommitTableConf = newManagedCommitTableConfOpt.getOrElse {
       return false
     }
@@ -1515,7 +1515,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
    *         This metadata should be added to the [[Metadata.configuration]] before doing the
    *         commit.
    */
-  protected def registerTableForManagedCommitsIfNeeded(
+  protected def registerTableForManagedCommitIfNeeded(
       finalMetadata: Metadata,
       finalProtocol: Protocol): Option[Map[String, String]] = {
     val (oldOwnerName, oldOwnerConf) = ManagedCommitUtils.getManagedCommitConfs(snapshot.metadata)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -674,7 +674,7 @@ object V2CheckpointTableFeature
 
 /** Table feature to represent tables whose commits are managed by separate commit-owner */
 object ManagedCommitTableFeature
-  extends WriterFeature(name = "managed-commit-preview")
+  extends WriterFeature(name = "managedCommitPreview")
     with FeatureAutomaticallyEnabledByMetadata
     with RemovableFeature {
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -674,7 +674,7 @@ object V2CheckpointTableFeature
 
 /** Table feature to represent tables whose commits are managed by separate commit-owner */
 object ManagedCommitTableFeature
-  extends WriterFeature(name = "managedCommitPreview")
+  extends WriterFeature(name = "managedCommit-preview")
     with FeatureAutomaticallyEnabledByMetadata
     with RemovableFeature {
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/AbstractBatchBackfillingCommitOwnerClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/AbstractBatchBackfillingCommitOwnerClient.scala
@@ -126,11 +126,11 @@ trait AbstractBatchBackfillingCommitOwnerClient extends CommitOwnerClient with L
   private def isManagedCommitToFSConversion(
       commitVersion: Long,
       updatedActions: UpdatedActions): Boolean = {
-    val oldMetadataHasManagedCommits = updatedActions.getOldMetadata.asInstanceOf[Metadata]
+    val oldMetadataHasManagedCommit = updatedActions.getOldMetadata.asInstanceOf[Metadata]
       .managedCommitOwnerName.nonEmpty
-    val newMetadataHasManagedCommits = updatedActions.getNewMetadata.asInstanceOf[Metadata]
+    val newMetadataHasManagedCommit = updatedActions.getNewMetadata.asInstanceOf[Metadata]
       .managedCommitOwnerName.nonEmpty
-    oldMetadataHasManagedCommits && !newMetadataHasManagedCommits && commitVersion > 0
+    oldMetadataHasManagedCommit && !newMetadataHasManagedCommit && commitVersion > 0
   }
 
   protected def generateUUID(): String = UUID.randomUUID().toString

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -539,7 +539,7 @@ trait DeltaSQLConfBase {
       .createWithDefault(20)
 
   val MANAGED_COMMIT_GET_COMMITS_THREAD_POOL_SIZE =
-    buildStaticConf("managedCommits.getCommits.threadPoolSize")
+    buildStaticConf("managedCommit.getCommits.threadPoolSize")
       .internal()
       .doc("The size of the thread pool for listing files from the commit-owner.")
       .intConf
@@ -551,7 +551,7 @@ trait DeltaSQLConfBase {
   /////////////////////////////////////////////
 
   val MANAGED_COMMIT_DDB_AWS_CREDENTIALS_PROVIDER_NAME =
-    buildConf("managedCommits.commitOwner.ddb.awsCredentialsProviderName")
+    buildConf("managedCommit.commitOwner.ddb.awsCredentialsProviderName")
       .internal()
       .doc("The fully qualified class name of the AWS credentials provider to use for " +
         "interacting with DynamoDB in the DynamoDB Commit Owner Client. e.g. " +
@@ -560,7 +560,7 @@ trait DeltaSQLConfBase {
       .createWithDefault("com.amazonaws.auth.DefaultAWSCredentialsProviderChain")
 
   val MANAGED_COMMIT_DDB_SKIP_PATH_CHECK =
-    buildConf("managedCommits.commitOwner.ddb.skipPathCheck.enabled")
+    buildConf("managedCommit.commitOwner.ddb.skipPathCheck.enabled")
       .internal()
       .doc("When enabled, the DynamoDB Commit Owner will not enforce that the table path of the " +
         "current Delta table matches the stored in the corresponding DynamoDB table. This " +
@@ -572,7 +572,7 @@ trait DeltaSQLConfBase {
       .createWithDefault(false)
 
   val MANAGED_COMMIT_DDB_READ_CAPACITY_UNITS =
-    buildConf("managedCommits.commitOwner.ddb.readCapacityUnits")
+    buildConf("managedCommit.commitOwner.ddb.readCapacityUnits")
       .internal()
       .doc("Controls the provisioned read capacity units for the DynamoDB table backing the " +
         "DynamoDB Commit Owner. This configuration is only used when the DynamoDB table is first " +
@@ -581,7 +581,7 @@ trait DeltaSQLConfBase {
       .createWithDefault(5)
 
   val MANAGED_COMMIT_DDB_WRITE_CAPACITY_UNITS =
-    buildConf("managedCommits.commitOwner.ddb.writeCapacityUnits")
+    buildConf("managedCommit.commitOwner.ddb.writeCapacityUnits")
       .internal()
       .doc("Controls the provisioned write capacity units for the DynamoDB table backing the " +
         "DynamoDB Commit Owner. This configuration is only used when the DynamoDB table is first " +

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -551,7 +551,7 @@ trait DeltaSQLConfBase {
   /////////////////////////////////////////////
 
   val MANAGED_COMMIT_DDB_AWS_CREDENTIALS_PROVIDER_NAME =
-    buildConf("managedCommit.commitOwner.ddb.awsCredentialsProviderName")
+    buildConf("managedCommit.commitOwner.dynamodb.awsCredentialsProviderName")
       .internal()
       .doc("The fully qualified class name of the AWS credentials provider to use for " +
         "interacting with DynamoDB in the DynamoDB Commit Owner Client. e.g. " +
@@ -560,7 +560,7 @@ trait DeltaSQLConfBase {
       .createWithDefault("com.amazonaws.auth.DefaultAWSCredentialsProviderChain")
 
   val MANAGED_COMMIT_DDB_SKIP_PATH_CHECK =
-    buildConf("managedCommit.commitOwner.ddb.skipPathCheck.enabled")
+    buildConf("managedCommit.commitOwner.dynamodb.skipPathCheckEnabled")
       .internal()
       .doc("When enabled, the DynamoDB Commit Owner will not enforce that the table path of the " +
         "current Delta table matches the stored in the corresponding DynamoDB table. This " +
@@ -572,7 +572,7 @@ trait DeltaSQLConfBase {
       .createWithDefault(false)
 
   val MANAGED_COMMIT_DDB_READ_CAPACITY_UNITS =
-    buildConf("managedCommit.commitOwner.ddb.readCapacityUnits")
+    buildConf("managedCommit.commitOwner.dynamodb.readCapacityUnits")
       .internal()
       .doc("Controls the provisioned read capacity units for the DynamoDB table backing the " +
         "DynamoDB Commit Owner. This configuration is only used when the DynamoDB table is first " +
@@ -581,7 +581,7 @@ trait DeltaSQLConfBase {
       .createWithDefault(5)
 
   val MANAGED_COMMIT_DDB_WRITE_CAPACITY_UNITS =
-    buildConf("managedCommit.commitOwner.ddb.writeCapacityUnits")
+    buildConf("managedCommit.commitOwner.dynamodb.writeCapacityUnits")
       .internal()
       .doc("Controls the provisioned write capacity units for the DynamoDB table backing the " +
         "DynamoDB Commit Owner. This configuration is only used when the DynamoDB table is first " +

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -499,7 +499,7 @@ class DeltaLogSuite extends QueryTest
           deltaLog.newDeltaHadoopConf())
         .filter(!_.getPath.getName.startsWith("_"))
         .foreach(f => fs.delete(f.getPath, true))
-      if (managedCommitsEnabledInTests) {
+      if (managedCommitEnabledInTests) {
         // For Managed Commit table with a commit that is not backfilled, we can't use
         // 00000000002.json yet. Contact commit store to get uuid file path to malform json file.
         val oc = CommitOwnerProvider.getCommitOwnerClient(
@@ -598,7 +598,7 @@ class DeltaLogSuite extends QueryTest
 
       val log = DeltaLog.forTable(spark, path)
       var commitFilePath = FileNames.unsafeDeltaFile(log.logPath, 1L)
-      if (managedCommitsEnabledInTests) {
+      if (managedCommitEnabledInTests) {
         // For Managed Commit table with a commit that is not backfilled, we can't use
         // 00000000001.json yet. Contact commit store to get uuid file path to malform json file.
         val oc = CommitOwnerProvider.getCommitOwnerClient(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -3920,7 +3920,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     }
   }
 
-  private def validateManagedCommitsDropLogs(
+  private def validateManagedCommitDropLogs(
       usageLogs: Seq[UsageRecord],
       expectTablePropertiesPresent: Boolean,
       expectUnbackfilledCommitsPresent: Boolean,
@@ -3964,7 +3964,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       assert(
         !ManagedCommitUtils.TABLE_PROPERTY_KEYS.exists(snapshot.metadata.configuration.contains(_)))
       assert(!snapshot.protocol.writerFeatures.exists(_.contains(ManagedCommitTableFeature.name)))
-      validateManagedCommitsDropLogs(
+      validateManagedCommitDropLogs(
         usageLogs, expectTablePropertiesPresent = true, expectUnbackfilledCommitsPresent = false)
     }
   }
@@ -4005,7 +4005,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
 
         assert(e.getMessage.contains("backfill failed"))
       }
-      validateManagedCommitsDropLogs(
+      validateManagedCommitDropLogs(
         usageLogs,
         expectTablePropertiesPresent = true,
         expectUnbackfilledCommitsPresent = false,
@@ -4027,7 +4027,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
           ManagedCommitTableFeature.name)
           .run(spark)
       }
-      validateManagedCommitsDropLogs(
+      validateManagedCommitDropLogs(
         usageLogs2, expectTablePropertiesPresent = false, expectUnbackfilledCommitsPresent = true)
       val snapshot = log.update()
       assert(snapshot.version === 4)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuiteBase.scala
@@ -92,7 +92,7 @@ trait DeltaRetentionSuiteBase extends QueryTest
   protected def getDeltaVersions(dir: File): Set[Long] = {
     val backfilledDeltaVersions = getFileVersions(getDeltaFiles(dir))
     val unbackfilledDeltaVersions = getUnbackfilledDeltaVersions(dir)
-    if (managedCommitsEnabledInTests) {
+    if (managedCommitEnabledInTests) {
       // The unbackfilled commit files (except commit 0) should be a superset of the backfilled
       // commit files since they're always deleted together in this suite.
       assert(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
@@ -305,7 +305,7 @@ class SnapshotManagementSuite extends QueryTest with DeltaSQLTestUtils with Shar
       // Delete delta files
       new File(tempDir, "_delta_log").listFiles().filter(_.getName.endsWith(".json"))
         .foreach(_.delete())
-      if (managedCommitsEnabledInTests) {
+      if (managedCommitEnabledInTests) {
         new File(new File(tempDir, "_delta_log"), "_commits")
           .listFiles()
           .filter(_.getName.endsWith(".json"))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/DynamoDBCommitOwnerClientSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/DynamoDBCommitOwnerClientSuite.scala
@@ -276,7 +276,7 @@ abstract class DynamoDBCommitOwnerClientSuite(batchSize: Long)
       }
     }
     val commitOwnerConf = JsonUtils.toJson(Map(
-      "dynamoDBManagedCommitsTableName" -> "tableName-1223",
+      "dynamoDBTableName" -> "tableName-1223",
       "dynamoDBEndpoint" -> "endpoint-1224"
     ))
     withSQLConf(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/DynamoDBCommitOwnerClientSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/DynamoDBCommitOwnerClientSuite.scala
@@ -252,21 +252,21 @@ abstract class DynamoDBCommitOwnerClientSuite(batchSize: Long)
       }
 
       override def getDynamoDBCommitOwnerClient(
-          managedCommitsTableName: String,
+          managedCommitTableName: String,
           dynamoDBEndpoint: String,
           ddbClient: AmazonDynamoDB,
           backfillBatchSize: Long,
           readCapacityUnits: Int,
           writeCapacityUnits: Int,
           skipPathCheck: Boolean): DynamoDBCommitOwnerClient = {
-        assert(managedCommitsTableName == "tableName-1223")
+        assert(managedCommitTableName == "tableName-1223")
         assert(dynamoDBEndpoint == "endpoint-1224")
         assert(backfillBatchSize == 1)
         assert(readCapacityUnits == 1226)
         assert(writeCapacityUnits == 1227)
         assert(skipPathCheck)
         new DynamoDBCommitOwnerClient(
-          managedCommitsTableName,
+          managedCommitTableName,
           dynamoDBEndpoint,
           ddbClient,
           backfillBatchSize,
@@ -276,7 +276,7 @@ abstract class DynamoDBCommitOwnerClientSuite(batchSize: Long)
       }
     }
     val commitOwnerConf = JsonUtils.toJson(Map(
-      "managedCommitsTableName" -> "tableName-1223",
+      "managedCommitTableName" -> "tableName-1223",
       "dynamoDBEndpoint" -> "endpoint-1224"
     ))
     withSQLConf(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/DynamoDBCommitOwnerClientSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/DynamoDBCommitOwnerClientSuite.scala
@@ -276,7 +276,7 @@ abstract class DynamoDBCommitOwnerClientSuite(batchSize: Long)
       }
     }
     val commitOwnerConf = JsonUtils.toJson(Map(
-      "managedCommitTableName" -> "tableName-1223",
+      "dynamoDBManagedCommitsTableName" -> "tableName-1223",
       "dynamoDBEndpoint" -> "endpoint-1224"
     ))
     withSQLConf(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitSuite.scala
@@ -712,7 +712,7 @@ class ManagedCommitSuite
   for (upgradeExistingTable <- BOOLEAN_DOMAIN)
   testWithDifferentBackfillInterval("upgrade + downgrade [FS -> MC1 -> FS -> MC2]," +
       s" upgradeExistingTable = $upgradeExistingTable") { backfillInterval =>
-    withoutManagedCommitsDefaultTableProperties {
+    withoutManagedCommitDefaultTableProperties {
       CommitOwnerProvider.clearNonDefaultBuilders()
       val builder1 = TrackingInMemoryCommitOwnerBuilder(batchSize = backfillInterval)
       val builder2 = new TrackingInMemoryCommitOwnerBuilder(batchSize = backfillInterval) {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitTestUtils.scala
@@ -39,7 +39,7 @@ trait ManagedCommitTestUtils
    */
   def testWithDefaultCommitOwnerUnset(testName: String)(f: => Unit): Unit = {
     test(testName) {
-      withoutManagedCommitsDefaultTableProperties {
+      withoutManagedCommitDefaultTableProperties {
         f
       }
     }
@@ -49,7 +49,7 @@ trait ManagedCommitTestUtils
    * Runs the function `f` with managed commits default properties unset.
    * Any table created in function `f`` won't have managed commits enabled by default.
    */
-  def withoutManagedCommitsDefaultTableProperties[T](f: => T): T = {
+  def withoutManagedCommitDefaultTableProperties[T](f: => T): T = {
     val commitOwnerKey = MANAGED_COMMIT_OWNER_NAME.defaultTablePropertyKey
     val oldCommitOwnerValue = spark.conf.getOption(commitOwnerKey)
     spark.conf.unset(commitOwnerKey)
@@ -76,7 +76,7 @@ trait ManagedCommitTestUtils
    * Run the test against a [[TrackingCommitOwnerClient]] with backfill batch size =
    * `batchBackfillSize`
    */
-  def testWithManagedCommits(backfillBatchSize: Int)(testName: String)(f: => Unit): Unit = {
+  def testWithManagedCommit(backfillBatchSize: Int)(testName: String)(f: => Unit): Unit = {
     test(s"$testName [Backfill batch size: $backfillBatchSize]") {
       CommitOwnerProvider.clearNonDefaultBuilders()
       CommitOwnerProvider.registerBuilder(TrackingInMemoryCommitOwnerBuilder(backfillBatchSize))
@@ -250,7 +250,7 @@ trait ManagedCommitBaseSuite extends SparkFunSuite with SharedSparkSession {
   // If this config is not overridden, managed commits are disabled.
   def managedCommitBackfillBatchSize: Option[Int] = None
 
-  final def managedCommitsEnabledInTests: Boolean = managedCommitBackfillBatchSize.nonEmpty
+  final def managedCommitEnabledInTests: Boolean = managedCommitBackfillBatchSize.nonEmpty
 
   override protected def sparkConf: SparkConf = {
     if (managedCommitBackfillBatchSize.nonEmpty) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
1. Replaces instances of Managed Commits with Managed Commit (without the s) in functions, configurations, and docs.
2. Renames the feature name to managedCommit-preview
3. Renames the DynamoDBCommitOwner tableConfig key to dynamoDBTableName

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Existing tests should cover this refactor.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
The managed commit table feature name has been updated to managedCommit-preview