### PR TITLE
[Delta Uniform] Compute correct MAX_ID in column mapping on a schema with nested fields and already have IDs assigned

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
@@ -197,8 +197,7 @@ trait DeltaColumnMappingBase extends DeltaLogging {
 
   private def metadataToMap[T <: Map[_, _]](metadata: SparkMetadata)(implicit m: Manifest[T]): T = {
     implicit val formats: DefaultFormats.type = DefaultFormats
-    val keyValuePairs = parse(metadata.json).extract[T]
-    keyValuePairs
+    parse(metadata.json).extract[T]
   }
 
   def hasPhysicalName(field: StructField): Boolean =

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
@@ -26,6 +26,8 @@ import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.{SchemaMergingUtils, SchemaUtils}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.json4s.DefaultFormats
+import org.json4s.jackson.JsonMethods._
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
@@ -188,6 +190,17 @@ trait DeltaColumnMappingBase extends DeltaLogging {
   def getNestedColumnIds(field: StructField): SparkMetadata =
     field.metadata.getMetadata(COLUMN_MAPPING_METADATA_NESTED_IDS_KEY)
 
+  def getNestedColumnIdsAsLong(field: StructField): Iterable[Long] = {
+    val nestedColumnMetadata = getNestedColumnIds(field)
+    metadataToMap[Map[String, Long]](nestedColumnMetadata).values
+  }
+
+  private def metadataToMap[T <: Map[_, _]](metadata: SparkMetadata)(implicit m: Manifest[T]): T = {
+    implicit val formats: DefaultFormats.type = DefaultFormats
+    val keyValuePairs = parse(metadata.json).extract[T]
+    keyValuePairs
+  }
+
   def hasPhysicalName(field: StructField): Boolean =
     field.metadata.contains(COLUMN_MAPPING_PHYSICAL_NAME_KEY)
 
@@ -304,6 +317,10 @@ trait DeltaColumnMappingBase extends DeltaLogging {
     SchemaMergingUtils.transformColumns(schema)((_, f, _) => {
       if (hasColumnId(f)) {
         maxId = maxId max getColumnId(f)
+        if (hasNestedColumnIds(f)) {
+          val nestedIds = getNestedColumnIdsAsLong(f)
+          maxId = maxId max (if (nestedIds.nonEmpty) nestedIds.max else 0)
+        }
       }
       f
     })


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
Propose a fix to prevent delta table got duplicate ids assigned when schema have nested fields and ids assigned.

**Issue**: today when we are assigning column's ids we first compute the `maxId` of existing columns and assign ids for new fields from `maxId + 1`. However, the existing code doesn't consider nested ids when computing the `maxId`, so it's possible to have duplicate ids assigned to different columns - which causes failure of uniform iceberg conversion since iceberg requires that id is unique for each column.

**Proposed fix**: we are adding the logic to consider nested fields' ids when computing `maxId`. 

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
