### PR TITLE
[Spark] Throw exception when additional listing also doesn't reconcile the listing gap in testing

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -528,7 +528,13 @@ class DeltaLogSuite extends QueryTest
           deltaLog.newDeltaHadoopConf())
         .filter(!_.getPath.getName.startsWith("_"))
         .foreach(f => fs.delete(f.getPath, true))
-
+      if (coordinatedCommitsEnabledInTests) {
+        val oc = CommitCoordinatorProvider.getCommitCoordinatorClient(
+          "tracking-in-memory",
+          Map.empty[String, String],
+          spark)
+        oc.asInstanceOf[TrackingCommitCoordinatorClient].removeCommitTestOnly(deltaLog.logPath, 1)
+      }
       checkAnswer(
         spark.read.format("delta").load(path),
         spark.range(10).toDF()


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

We already log the failure scenario when additional file-system listing also can't reconcile the gap between concurrent file-system listing and commit-owner calls.

With this PR, we will throw an exception if the above condition is triggered while testing.


## How was this patch tested?

UTs

## Does this PR introduce _any_ user-facing changes?

No
