### PR TITLE
[Spark] Support create external table for clustered table

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -655,6 +655,17 @@
     ],
     "sqlState" : "42000"
   },
+  "DELTA_CREATE_TABLE_WITH_DIFFERENT_CLUSTERING" : {
+    "message" : [
+      "The specified clustering columns do not match the existing clustering columns at <path>.",
+      "== Specified ==",
+      "<specifiedColumns>",
+      "== Existing ==",
+      "<existingColumns>",
+      ""
+    ],
+    "sqlState" : "42KD7"
+  },
   "DELTA_CREATE_TABLE_WITH_DIFFERENT_PARTITIONING" : {
     "message" : [
       "The specified partitioning does not match the existing partitioning at <path>.",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -23,6 +23,7 @@ import java.util.ConcurrentModificationException
 
 import scala.collection.JavaConverters._
 
+import org.apache.spark.sql.delta.skipping.clustering.temp.{ClusterBySpec}
 import org.apache.spark.sql.delta.actions.{CommitInfo, Metadata, Protocol, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.catalog.DeltaCatalog
 import org.apache.spark.sql.delta.commands.AlterTableDropFeatureDeltaCommand
@@ -3413,6 +3414,24 @@ trait DeltaErrorsBase
     new DeltaAnalysisException(
       errorClass = "DELTA_ALTER_TABLE_CLUSTER_BY_ON_PARTITIONED_TABLE_NOT_ALLOWED",
       messageParameters = Array.empty)
+  }
+
+  def createTableWithDifferentClusteringException(
+      path: Path,
+      specifiedClusterBySpec: Option[ClusterBySpec],
+      existingClusterBySpec: Option[ClusterBySpec]): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_CREATE_TABLE_WITH_DIFFERENT_CLUSTERING",
+      messageParameters = Array(
+        path.toString,
+        specifiedClusterBySpec
+          .map(_.columnNames.map(_.toString))
+          .getOrElse(Seq.empty)
+          .mkString(", "),
+        existingClusterBySpec
+          .map(_.columnNames.map(_.toString))
+          .getOrElse(Seq.empty)
+          .mkString(", ")))
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/skipping/clustering/temp/ClusterBySpec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/skipping/clustering/temp/ClusterBySpec.scala
@@ -66,6 +66,10 @@ object ClusterBySpec {
   def toProperty(clusterBySpec: ClusterBySpec): (String, String) = {
     ClusteredTableUtils.PROP_CLUSTERING_COLUMNS -> clusterBySpec.toJson
   }
+
+  def fromColumnNames(names: Seq[String]): ClusterBySpec = {
+    ClusterBySpec(names.map(FieldReference(_)))
+  }
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Support creating a clustered table from an external location that already has a clustered table. We follow the same semantics as partitioned tables:

External location already has clustered/partitioned table:
| Create clustered/partitioned table | partitioned | clustered |
| ----------------------------------- | ------ | ----------- |
| schema not specified, cluster/partitioned by not specified | success | success |
| schema specified, cluster by/partitioned by not specified | throw `DELTA_CREATE_TABLE_WITH_DIFFERENT_PARTITIONING` | throw `DELTA_CREATE_TABLE_WITH_DIFFERENT_CLUSTERING` |
| schema specified, cluster by/partitioned by different column | throw `DELTA_CREATE_TABLE_WITH_DIFFERENT_PARTITIONING` | throw `DELTA_CREATE_TABLE_WITH_DIFFERENT_CLUSTERING` |
| schema specified, cluster by/partitioned by same column | success | success |

 External location already has non-clustered/non-partitioned table:
 | Create clustered/partitioned table | partitioned | clustered |
 | ----------------------------------- | ------ | ----------- |
 | schema specified, cluster by/partitioned by specified | throw `DELTA_CREATE_TABLE_WITH_DIFFERENT_PARTITIONING` | throw `DELTA_CREATE_TABLE_WITH_DIFFERENT_CLUSTERING` |

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Added new unit tests to cover all scenarios above.
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.