### PR TITLE
[DELTA] Removes asInstanceOf[Metadata] casts

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/AbstractBatchBackfillingCommitOwnerClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/managedcommit/AbstractBatchBackfillingCommitOwnerClient.scala
@@ -126,10 +126,10 @@ trait AbstractBatchBackfillingCommitOwnerClient extends CommitOwnerClient with L
   private def isManagedCommitToFSConversion(
       commitVersion: Long,
       updatedActions: UpdatedActions): Boolean = {
-    val oldMetadataHasManagedCommit = updatedActions.getOldMetadata.asInstanceOf[Metadata]
-      .managedCommitOwnerName.nonEmpty
-    val newMetadataHasManagedCommit = updatedActions.getNewMetadata.asInstanceOf[Metadata]
-      .managedCommitOwnerName.nonEmpty
+    val oldMetadataHasManagedCommit =
+      ManagedCommitUtils.getManagedCommitOwnerName(updatedActions.getOldMetadata).nonEmpty
+    val newMetadataHasManagedCommit =
+      ManagedCommitUtils.getManagedCommitOwnerName(updatedActions.getNewMetadata).nonEmpty
     oldMetadataHasManagedCommit && !newMetadataHasManagedCommit && commitVersion > 0
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/managedcommit/ManagedCommitSuite.scala
@@ -66,6 +66,33 @@ class ManagedCommitSuite
     CommitOwnerProvider.clearNonDefaultBuilders()
   }
 
+  test("helper method that recovers config from abstract metadata works properly") {
+    val m1 = Metadata(
+      configuration = Map(MANAGED_COMMIT_OWNER_NAME.key -> "string_value")
+    )
+    assert(ManagedCommitUtils.fromAbstractMetadataAndDeltaConfig(m1, MANAGED_COMMIT_OWNER_NAME) ===
+      Some("string_value"))
+
+    val m2 = Metadata(
+      configuration = Map(MANAGED_COMMIT_OWNER_NAME.key -> "")
+    )
+    assert(ManagedCommitUtils.fromAbstractMetadataAndDeltaConfig(m2, MANAGED_COMMIT_OWNER_NAME) ===
+      Some(""))
+
+    val m3 = Metadata(
+      configuration = Map(
+        MANAGED_COMMIT_OWNER_CONF.key ->
+          """{"key1": "string_value", "key2Int": 2, "key3ComplexStr": "\"hello\""}""")
+    )
+    assert(ManagedCommitUtils.fromAbstractMetadataAndDeltaConfig(m3, MANAGED_COMMIT_OWNER_CONF) ===
+      Map("key1" -> "string_value", "key2Int" -> "2", "key3ComplexStr" -> "\"hello\""))
+
+    val m4 = Metadata()
+    assert(ManagedCommitUtils.fromAbstractMetadataAndDeltaConfig(m4, MANAGED_COMMIT_TABLE_CONF) ===
+      Map.empty)
+  }
+
+
   test("0th commit happens via filesystem") {
     val commitOwnerName = "nobackfilling-commit-owner"
     object NoBackfillingCommitOwnerBuilder$ extends CommitOwnerBuilder {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR removes the asInstanceOf[Metadata] casts in AbstractBatchBackfillingCommitOwnerClient.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Ensured the existing test suites, along with the newly added unit test for the helper function, all pass after the removal.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.