### PR TITLE
[Spark] Fix validation of clustering columns

### DIFF
--- a/spark/src/test/scala/io/delta/tables/DeltaTableBuilderSuite.scala
+++ b/spark/src/test/scala/io/delta/tables/DeltaTableBuilderSuite.scala
@@ -474,7 +474,7 @@ class DeltaTableBuilderSuite
 
       val deltaLog = DeltaLog.forTable(spark, TableIdentifier("test"))
       val metadata = deltaLog.snapshot.metadata
-      verifyClusteringColumns(TableIdentifier("test"), "c1")
+      verifyClusteringColumns(TableIdentifier("test"), Seq("c1"))
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/skipping/ClusteredTableTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/skipping/ClusteredTableTestUtils.scala
@@ -53,12 +53,7 @@ trait ClusteredTableTestUtilsBase extends SparkFunSuite with SharedSparkSession 
 
   def verifyClusteringColumnsInDomainMetadata(
       snapshot: Snapshot,
-      expectedLogicalClusteringColumns: String): Unit = {
-    val logicalColumnNames = if (expectedLogicalClusteringColumns.trim.isEmpty) {
-      Seq.empty[String]
-    } else {
-      expectedLogicalClusteringColumns.split(",").map(_.trim).toSeq
-    }
+      logicalColumnNames: Seq[String]): Unit = {
     val expectedClusteringColumns = logicalColumnNames.map(ClusteringColumn(snapshot.schema, _))
     val actualClusteringColumns =
       ClusteredTableUtils.getClusteringColumnsOptional(snapshot).orNull
@@ -215,7 +210,7 @@ trait ClusteredTableTestUtilsBase extends SparkFunSuite with SharedSparkSession 
 
   def verifyClusteringColumns(
       tableIdentifier: TableIdentifier,
-      expectedLogicalClusteringColumns: String
+      expectedLogicalClusteringColumns: Seq[String]
     ): Unit = {
     val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, tableIdentifier)
     verifyClusteringColumnsInternal(
@@ -227,7 +222,7 @@ trait ClusteredTableTestUtilsBase extends SparkFunSuite with SharedSparkSession 
 
   def verifyClusteringColumns(
       dataPath: String,
-      expectedLogicalClusteringColumns: String): Unit = {
+      expectedLogicalClusteringColumns: Seq[String]): Unit = {
     val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, dataPath)
     verifyClusteringColumnsInternal(
       snapshot,
@@ -239,7 +234,7 @@ trait ClusteredTableTestUtilsBase extends SparkFunSuite with SharedSparkSession 
   def verifyClusteringColumnsInternal(
       snapshot: Snapshot,
       tableNameOrPath: String,
-      expectedLogicalClusteringColumns: String
+      expectedLogicalClusteringColumns: Seq[String]
     ): Unit = {
     assert(ClusteredTableUtils.isSupported(snapshot.protocol) === true)
     verifyClusteringColumnsInDomainMetadata(snapshot, expectedLogicalClusteringColumns)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
@@ -565,7 +565,7 @@ trait ClusteredTableDDLWithColumnMappingV2Base extends ClusteredTableDDLWithColu
     }
   }
 
-  test("validate create table commas in the column name") {
+  test("validate create table with commas in the column name") {
     withClusteredTable(testTable, "`col1,a` BIGINT", "`col1,a`") {
       verifyClusteringColumns(TableIdentifier(testTable), Seq("`col1,a`"))
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/IncrementalZCubeClusteringSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/IncrementalZCubeClusteringSuite.scala
@@ -240,7 +240,7 @@ class IncrementalZCubeClusteringSuite extends QueryTest
         assert(getZCubeIds(table).size == 2)
 
         sql(s"ALTER TABLE $table CLUSTER BY (col2, col1)")
-        verifyClusteringColumns(TableIdentifier(table), "col2, col1")
+        verifyClusteringColumns(TableIdentifier(table), Seq("col2", "col1"))
         // Incremental clustering won't touch those clustered files with different clustering
         // columns, so re-clustering should be a no-op.
         withSQLConf(


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Currently, clustering columns are validating by parsing a list of clustering columns. This is super brittle, and breaks when any clustering column has a comma in the name. Fix that by passing a list of clustering columns directly.

This fix resolves https://github.com/delta-io/delta/issues/3265

## How was this patch tested?
Test-only change.

## Does this PR introduce _any_ user-facing changes?
No.