### PR TITLE
[Kernel][Defaults] Minor cleanups + additional logging

### DIFF
--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultJsonHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultJsonHandler.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.fs.*;
 import io.delta.kernel.data.*;
 import io.delta.kernel.engine.JsonHandler;
 import io.delta.kernel.exceptions.KernelEngineException;
+import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.types.*;
 import io.delta.kernel.utils.CloseableIterator;
@@ -90,7 +91,7 @@ public class DefaultJsonHandler implements JsonHandler {
             // JSON reader
             return DataTypeParser.parseSchema(defaultObjectReader.readTree(structTypeJson));
         } catch (JsonProcessingException ex) {
-            throw new KernelEngineException(
+            throw new KernelException(
                 format("Could not parse schema given as JSON string: %s", structTypeJson), ex);
         }
     }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultJsonHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultJsonHandler.java
@@ -90,8 +90,8 @@ public class DefaultJsonHandler implements JsonHandler {
             // JSON reader
             return DataTypeParser.parseSchema(defaultObjectReader.readTree(structTypeJson));
         } catch (JsonProcessingException ex) {
-            throw new RuntimeException(
-                format("Could not parse JSON: %s", structTypeJson), ex);
+            throw new KernelEngineException(
+                format("Could not parse schema given as JSON string: %s", structTypeJson), ex);
         }
     }
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/DefaultEngineErrors.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/DefaultEngineErrors.java
@@ -21,9 +21,11 @@ import io.delta.kernel.expressions.Expression;
 
 public class DefaultEngineErrors {
 
-    public static IllegalArgumentException canNotInstantiateLogStore(String logStoreClassName) {
-        return new IllegalArgumentException(
-                format("Can not instantiate `LogStore` class: %s", logStoreClassName));
+    public static IllegalArgumentException canNotInstantiateLogStore(
+            String logStoreClassName, String context, Exception cause) {
+        String msg =
+                format("Can not instantiate `LogStore` class (%s): %s", context, logStoreClassName);
+        return new IllegalArgumentException(msg, cause);
     }
 
     /**

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultJsonHandlerSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/engine/DefaultJsonHandlerSuite.scala
@@ -20,6 +20,7 @@ import java.util.Optional
 import scala.collection.JavaConverters._
 import io.delta.kernel.data.ColumnVector
 import io.delta.kernel.defaults.utils.{DefaultVectorTestUtils, TestRow, TestUtils}
+import io.delta.kernel.exceptions.KernelException
 import io.delta.kernel.internal.util.InternalUtils.singletonStringColumnVector
 import io.delta.kernel.types._
 import org.apache.hadoop.conf.Configuration
@@ -335,7 +336,7 @@ class DefaultJsonHandlerSuite extends AnyFunSuite with TestUtils with DefaultVec
   }
 
   test("deserializeStructType: invalid JSON") {
-    val e = intercept[RuntimeException] {
+    val e = intercept[KernelException] {
       jsonHandler.deserializeStructType(
         """
           |{
@@ -345,7 +346,7 @@ class DefaultJsonHandlerSuite extends AnyFunSuite with TestUtils with DefaultVec
           |""".stripMargin
       )
     }
-    assert(e.getMessage.contains("Could not parse JSON"))
+    assert(e.getMessage.contains("Could not parse schema given as JSON string"))
   }
 
   test("read json files") {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/logstore/LogStoreProviderSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/logstore/LogStoreProviderSuite.scala
@@ -65,7 +65,7 @@ class LogStoreProviderSuite extends AnyFunSuite {
       LogStoreProvider.getLogStore(hadoopConf, "fake")
     )
     assert(e.getMessage.contains(
-      "Can not instantiate `LogStore` class: %s".format("java.lang.String")))
+      "Can not instantiate `LogStore` class (from config): %s".format("java.lang.String")))
   }
 }
 


### PR DESCRIPTION
## Description
Minor cleanups + additional logging.

* Pass the cause exception to `KernelException`, so that it is visible to the caller
* Add logging when the LogStore can't be created.
* Convert `RuntimeException` to `KernelException` when an invalid schema JSON string is received.

## How was this patch tested?
Existing tests