### PR TITLE
[Other] Adds coordinated commits-related interfaces and definitions to storage module

### DIFF
--- a/storage/src/main/java/io/delta/storage/commit/Commit.java
+++ b/storage/src/main/java/io/delta/storage/commit/Commit.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit;
+
+import org.apache.hadoop.fs.FileStatus;
+
+/**
+ * Representation of a commit file
+ */
+public class Commit {
+
+  private long version;
+
+  private FileStatus fileStatus;
+
+  private long commitTimestamp;
+
+  public Commit(long version, FileStatus fileStatus, long commitTimestamp) {
+    this.version = version;
+    this.fileStatus = fileStatus;
+    this.commitTimestamp = commitTimestamp;
+  }
+
+  public long getVersion() {
+    return version;
+  }
+
+  public FileStatus getFileStatus() {
+    return fileStatus;
+  }
+
+  public long getCommitTimestamp() {
+    return commitTimestamp;
+  }
+
+  public Commit withFileStatus(FileStatus fileStatus) {
+    return new Commit(version, fileStatus, commitTimestamp);
+  }
+
+  public Commit withCommitTimestamp(long commitTimestamp) {
+      return new Commit(version, fileStatus, commitTimestamp);
+  }
+}

--- a/storage/src/main/java/io/delta/storage/commit/CommitCoordinatorClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/CommitCoordinatorClient.java
@@ -58,7 +58,7 @@ public interface CommitCoordinatorClient {
    *                       This will go through the CommitCoordinatorClient and the client is
    *                       free to choose when it wants to backfill this commit.
    * @param currentMetadata The metadata of the table at currentTableVersion
-   * @param currentProtocol The protocol of the table at currentTableVersion   *
+   * @param currentProtocol The protocol of the table at currentTableVersion
    * @return A map of key-value pairs which is issued by the commit coordinator to identify the
    *         table. This should be stored in the table's metadata. This information needs to be
    *         passed to the {@link #commit}, {@link #getCommits}, and {@link #backfillToVersion}

--- a/storage/src/main/java/io/delta/storage/commit/CommitCoordinatorClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/CommitCoordinatorClient.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import io.delta.storage.commit.actions.AbstractMetadata;
+import io.delta.storage.commit.actions.AbstractProtocol;
+import io.delta.storage.LogStore;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+
+/**
+ * The CommitCoordinatorClient is responsible for communicating with the commit coordinator
+ * and backfilling commits. It has four main APIs that need to be implemented
+ *
+ * <ul>
+ * <li>Commit a new version of the table. See {@link #commit}.</li>
+ * <li>Ensure that commits are backfilled if/when needed. See {@link #backfillToVersion}</li>
+ * <li>Tracks and returns unbackfilled commits. See {@link #getCommits}.</li>
+ * <li>Determine the table config during commit coordinator registration.
+ *     See {@link #registerTable}</li>
+ * </ul>
+ */
+public interface CommitCoordinatorClient {
+
+  /**
+   * API to register the table represented by the given `logPath` at the provided
+   * currentTableVersion with the commit coordinator this commit coordinator client represents.
+   *
+   * This API is called when the table is being converted from a file system table to a
+   * coordinated-commit table.
+   *
+   * When a new coordinated-commit table is being created, the currentTableVersion will be -1 and
+   * the upgrade commit needs to be a file system commit which will write the backfilled file
+   * directly.
+   *
+   * @param logPath The path to the delta log of the table that should be converted
+   * @param currentVersion The currentTableVersion is the version of the table just before
+   *                       conversion. currentTableVersion + 1 represents the commit that
+   *                       will do the conversion. This must be backfilled atomically.
+   *                       currentTableVersion + 2 represents the first commit after conversion.
+   *                       This will go through the CommitCoordinatorClient and the client is
+   *                       free to choose when it wants to backfill this commit.
+   * @param currentMetadata The metadata of the table at currentTableVersion
+   * @param currentProtocol The protocol of the table at currentTableVersion   *
+   * @return A map of key-value pairs which is issued by the commit coordinator to identify the
+   *         table. This should be stored in the table's metadata. This information needs to be
+   *         passed to the {@link #commit}, {@link #getCommits}, and {@link #backfillToVersion}
+   *         APIs to identify the table.
+   */
+  Map<String, String> registerTable(
+    Path logPath,
+    long currentVersion,
+    AbstractMetadata currentMetadata,
+    AbstractProtocol currentProtocol);
+
+  /**
+   * API to commit the given set of actions to the table represented by logPath at the
+   * given commitVersion.
+   *
+   * @param logStore The log store to use for writing the commit file.
+   * @param hadoopConf The Hadoop configuration required to access the file system.
+   * @param logPath The path to the delta log of the table that should be committed to.
+   * @param tableConf The table configuration that was returned by the commit coordinator
+   *                  client during registration.
+   * @param commitVersion The version of the commit that is being committed.
+   * @param actions The actions that need to be committed.
+   * @param updatedActions The commit info and any metadata or protocol changes that are made
+   *                       as part of this commit.
+   * @return CommitResponse which contains the file status of the committed commit file. If the
+   *         commit is already backfilled, then the file status could be omitted from the response
+   *         and the client could retrieve the information by itself.
+   */
+  CommitResponse commit(
+    LogStore logStore,
+    Configuration hadoopConf,
+    Path logPath,
+    Map<String, String> tableConf,
+    long commitVersion,
+    Iterator<String> actions,
+    UpdatedActions updatedActions);
+
+  /**
+   * API to get the unbackfilled commits for the table represented by the given logPath.
+   * Commits older than startVersion or newer than endVersion (if given) are ignored. The
+   * returned commits are contiguous and in ascending version order.
+   *
+   * Note that the first version returned by this API may not be equal to startVersion. This
+   * happens when some versions starting from startVersion have already been backfilled and so
+   * the commit coordinator may have stopped tracking them.
+   *
+   * The returned latestTableVersion is the maximum commit version ratified by the commit
+   * coordinator. Note that returning latestTableVersion as -1 is acceptable only if the commit
+   * coordinator never ratified any version, i.e. it never accepted any unbackfilled commit.
+   *
+   * @param tablePath The path to the delta log of the table for which the unbackfilled
+   *                  commits should be retrieved.
+   * @param tableConf The table configuration that was returned by the commit coordinator
+   *                  during registration.
+   * @param startVersion The minimum version of the commit that should be returned. Can be null.
+   * @param endVersion The maximum version of the commit that should be returned. Can be null.
+   * @return GetCommitsResponse which has a list of {@link Commit}s and the latestTableVersion which is
+   *         tracked by {@link CommitCoordinatorClient}.
+   */
+  GetCommitsResponse getCommits(
+    Path tablePath,
+    Map<String, String> tableConf,
+    Long startVersion,
+    Long endVersion);
+
+  /**
+   * API to ask the commit coordinator client to backfill all commits up to {@code version}
+   * and notify the commit coordinator.
+   *
+   * If this API returns successfully, that means the backfill must have been completed, although
+   * the commit coordinator may not be aware of it yet.
+   *
+   * @param logStore The log store to use for writing the backfilled commits.
+   * @param hadoopConf The Hadoop configuration required to access the file system.
+   * @param logPath The path to the delta log of the table that should be backfilled.
+   * @param tableConf The table configuration that was returned by the commit coordinator
+   *                  during registration.
+   * @param version The version till which the commit coordinator client should backfill.
+   * @param lastKnownBackfilledVersion The last known version that was backfilled before this API
+   *                                   was called. If it is None or invalid, then the commit
+   *                                   coordinator client should backfill from the beginning of
+   *                                   the table. Can be null.
+   */
+  void backfillToVersion(
+    LogStore logStore,
+    Configuration hadoopConf,
+    Path logPath,
+    Map<String, String> tableConf,
+    long version,
+    Long lastKnownBackfilledVersion);
+
+  /**
+   * Determines whether this CommitCoordinatorClient is semantically equal to another
+   * CommitCoordinatorClient.
+   *
+   * Semantic equality is determined by each CommitCoordinatorClient implementation based on
+   * whether the two instances can be used interchangeably when invoking any of the
+   * CommitCoordinatorClient APIs, such as {@link #commit}, {@link #getCommits}, etc. For example,
+   * both instances might be pointing to the same underlying endpoint.
+   */
+  Boolean semanticEquals(CommitCoordinatorClient other);
+}

--- a/storage/src/main/java/io/delta/storage/commit/CommitFailedException.java
+++ b/storage/src/main/java/io/delta/storage/commit/CommitFailedException.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import io.delta.storage.LogStore;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+
+/**
+ * Exception raised by
+ * {@link io.delta.storage.commit.CommitCoordinatorClient#commit(LogStore, Configuration, Path, Map, long, Iterator, UpdatedActions)}
+ *
+ * <pre>
+ *  | retryable | conflict  | meaning                                                         |
+ *  |   no      |   no      | something bad happened (e.g. auth failure)                      |
+ *  |   no      |   yes     | permanent transaction conflict (e.g. multi-table commit failed) |
+ *  |   yes     |   no      | transient error (e.g. network hiccup)                           |
+ *  |   yes     |   yes     | physical conflict (allowed to rebase and retry)                 |
+ *  </pre>
+ */
+public class CommitFailedException extends Exception {
+
+  private boolean retryable;
+
+  private boolean conflict;
+
+  private String message;
+
+  public CommitFailedException(boolean retryable, boolean conflict, String message) {
+    this.retryable = retryable;
+    this.conflict = conflict;
+    this.message = message;
+  }
+
+  public boolean getRetryable() {
+    return retryable;
+  }
+
+  public boolean getConflict() {
+    return conflict;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+}

--- a/storage/src/main/java/io/delta/storage/commit/CommitResponse.java
+++ b/storage/src/main/java/io/delta/storage/commit/CommitResponse.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import io.delta.storage.LogStore;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+
+/**
+ * Response container for
+ * {@link io.delta.storage.commit.CommitCoordinatorClient#commit(LogStore, Configuration, Path, Map, long, Iterator, UpdatedActions)}.
+ */
+public class CommitResponse {
+
+  private Commit commit;
+
+  public CommitResponse(Commit commit) {
+    this.commit = commit;
+  }
+
+  public Commit getCommit() {
+    return commit;
+  }
+}
+

--- a/storage/src/main/java/io/delta/storage/commit/GetCommitsResponse.java
+++ b/storage/src/main/java/io/delta/storage/commit/GetCommitsResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hadoop.fs.Path;
+
+/**
+ * Response container for
+ * {@link io.delta.storage.commit.CommitCoordinatorClient#getCommits(Path, Map, Long, Long)}.
+ */
+public class GetCommitsResponse {
+
+  private List<Commit> commits;
+
+  private long latestTableVersion;
+
+  public GetCommitsResponse(List<Commit> commits, long latestTableVersion) {
+    this.commits = commits;
+    this.latestTableVersion = latestTableVersion;
+  }
+
+  public List<Commit> getCommits() {
+    return commits;
+  }
+
+  public long getLatestTableVersion() {
+    return latestTableVersion;
+  }
+}
+

--- a/storage/src/main/java/io/delta/storage/commit/UpdatedActions.java
+++ b/storage/src/main/java/io/delta/storage/commit/UpdatedActions.java
@@ -21,7 +21,7 @@ import io.delta.storage.commit.actions.AbstractMetadata;
 import io.delta.storage.commit.actions.AbstractProtocol;
 
 /**
- * A container class to inform the CommitOwnerClient about any changes in Protocol/Metadata
+ * A container class to inform the CommitCoordinatorClient about any changes in Protocol/Metadata
  */
 public class UpdatedActions {
 

--- a/storage/src/main/java/io/delta/storage/commit/UpdatedActions.java
+++ b/storage/src/main/java/io/delta/storage/commit/UpdatedActions.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit;
+
+import io.delta.storage.commit.actions.AbstractCommitInfo;
+import io.delta.storage.commit.actions.AbstractMetadata;
+import io.delta.storage.commit.actions.AbstractProtocol;
+
+/**
+ * A container class to inform the CommitOwnerClient about any changes in Protocol/Metadata
+ */
+public class UpdatedActions {
+
+  private AbstractCommitInfo commitInfo;
+
+  private AbstractMetadata newMetadata;
+
+  private AbstractProtocol newProtocol;
+
+  private AbstractMetadata oldMetadata;
+
+  private AbstractProtocol oldProtocol;
+
+  public UpdatedActions(
+      AbstractCommitInfo commitInfo,
+      AbstractMetadata newMetadata,
+      AbstractProtocol newProtocol,
+      AbstractMetadata oldMetadata,
+      AbstractProtocol oldProtocol) {
+    this.commitInfo = commitInfo;
+    this.newMetadata = newMetadata;
+    this.newProtocol = newProtocol;
+    this.oldMetadata = oldMetadata;
+    this.oldProtocol = oldProtocol;
+  }
+
+  public AbstractCommitInfo getCommitInfo() {
+    return commitInfo;
+  }
+
+  public AbstractMetadata getNewMetadata() {
+    return newMetadata;
+  }
+
+  public AbstractProtocol getNewProtocol() {
+    return newProtocol;
+  }
+
+  public AbstractMetadata getOldMetadata() {
+    return oldMetadata;
+  }
+
+  public AbstractProtocol getOldProtocol() {
+    return oldProtocol;
+  }
+}

--- a/storage/src/main/java/io/delta/storage/commit/actions/AbstractCommitInfo.java
+++ b/storage/src/main/java/io/delta/storage/commit/actions/AbstractCommitInfo.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.actions;
+
+/**
+ * Interface for objects that represents the base information for a commit.
+ * Commits need to provide an in-commit timestamp. This timestamp is used
+ * to specify the exact time the commit happened and determines the target
+ * version for time-based time travel queries.
+ */
+public interface AbstractCommitInfo {
+
+  /**
+   * Get the timestamp of the commit as millis after the epoch.
+   */
+  long getCommitTimestamp();
+}

--- a/storage/src/main/java/io/delta/storage/commit/actions/AbstractMetadata.java
+++ b/storage/src/main/java/io/delta/storage/commit/actions/AbstractMetadata.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.actions;
+
+import java.util.Map;
+import java.util.List;
+
+/**
+ * Interface for metadata actions in Delta. The metadata defines the metadata
+ * of the table.
+ */
+public interface AbstractMetadata {
+
+  /**
+   * A unique table identifier.
+   */
+  String getId();
+
+  /**
+   * User-specified table identifier.
+   */
+  String getName();
+
+  /**
+   * User-specified table description.
+   */
+  String getDescription();
+
+  /** The table provider format. */
+  String getProvider();
+
+  /** The format options */
+  Map<String, String> getFormatOptions();
+
+  /**
+   * The table schema in string representation.
+   */
+  String getSchemaString();
+
+  /**
+   * List of partition columns.
+   */
+  List<String> getPartitionColumns();
+
+  /**
+   * The table properties defined on the table.
+   */
+  Map<String, String> getConfiguration();
+
+  /**
+   * Timestamp for the creation of this metadata.
+   */
+  Long getCreatedTime();
+}

--- a/storage/src/main/java/io/delta/storage/commit/actions/AbstractProtocol.java
+++ b/storage/src/main/java/io/delta/storage/commit/actions/AbstractProtocol.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit.actions;
+
+import java.util.Set;
+
+/**
+ * Interface for protocol actions in Delta. The protocol defines the requirements
+ * that readers and writers of the table need to meet.
+ */
+public interface AbstractProtocol {
+
+  /**
+   * The minimum reader version required to read the table.
+   */
+  int getMinReaderVersion();
+
+  /**
+   * The minimum writer version required to read the table.
+   */
+  int getMinWriterVersion();
+
+  /**
+   * The reader features that need to be supported to read the table.
+   */
+  Set<String> getReaderFeatures();
+
+  /**
+   * The writer features that need to be supported to write the table.
+   */
+  Set<String> getWriterFeatures();
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (storage module)

## Description

This PR takes the existing definitions in CommitCoordinatorClient.scala and converts them to java classes/interfaces in the storage module. This is in preparation for replacing the CommitCoordinatorClient in Spark Delta with a generic java-based module that can be implemented in any Delta client.

## How was this patch tested?

This PR only copies existing definitions to java classes/interfaces in the storage module. These new classes/interfaces are not in use yet so no tests are required.

## Does this PR introduce _any_ user-facing changes?

No
