### PR TITLE
[Kernel] Add monotonic inCommitTimestamp and read support for inCommitTimestamp

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
@@ -23,26 +23,43 @@ import io.delta.kernel.exceptions.CheckpointAlreadyExistsException;
 import io.delta.kernel.exceptions.TableNotFoundException;
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.snapshot.SnapshotManager;
+import io.delta.kernel.internal.util.Clock;
 
 public class TableImpl implements Table {
     public static Table forPath(Engine engine, String path) {
+        return forPath(engine, path, System::currentTimeMillis);
+    }
+
+    /**
+     * Instantiate a table object for the Delta Lake table at the given path. It takes an additional
+     * parameter called {@link Clock} which helps in testing.
+     *
+     * @param engine {@link Engine} instance to use in Delta Kernel.
+     * @param path location of the table.
+     * @param clock {@link Clock} instance to use for time-related operations.
+     *
+     * @return an instance of {@link Table} representing the Delta table at the given path
+     */
+    public static Table forPath(Engine engine, String path, Clock clock) {
         String resolvedPath;
         try {
             resolvedPath = engine.getFileSystemClient().resolvePath(path);
         } catch (IOException io) {
             throw new RuntimeException(io);
         }
-        return new TableImpl(resolvedPath);
+        return new TableImpl(resolvedPath, clock);
     }
 
     private final SnapshotManager snapshotManager;
     private final String tablePath;
+    private final Clock clock;
 
-    public TableImpl(String tablePath) {
+    public TableImpl(String tablePath, Clock clock) {
         this.tablePath = tablePath;
         final Path dataPath = new Path(tablePath);
         final Path logPath = new Path(dataPath, "_delta_log");
         this.snapshotManager = new SnapshotManager(logPath, dataPath);
+        this.clock = clock;
     }
 
     @Override
@@ -79,6 +96,10 @@ public class TableImpl implements Table {
             String engineInfo,
             Operation operation) {
         return new TransactionBuilderImpl(this, engineInfo, operation);
+    }
+
+    public Clock getClock() {
+        return clock;
     }
 
     protected Path getDataPath() {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -155,7 +155,8 @@ public class TransactionBuilderImpl implements TransactionBuilder {
                 metadata,
                 setTxnOpt,
                 shouldUpdateMetadata,
-                shouldUpdateProtocol);
+                shouldUpdateProtocol,
+                table.getClock());
     }
 
     /**
@@ -205,6 +206,11 @@ public class TransactionBuilderImpl implements TransactionBuilder {
     private class InitialSnapshot extends SnapshotImpl {
         InitialSnapshot(Path dataPath, LogReplay logReplay, Metadata metadata, Protocol protocol) {
             super(dataPath, LogSegment.empty(table.getLogPath()), logReplay, protocol, metadata);
+        }
+
+        @Override
+        public long getTimestamp(Engine engine) {
+            return -1L;
         }
     }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/Clock.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/Clock.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.util;
+
+/**
+ * An interface to represent clocks, so that they can be mocked out in unit tests.
+ */
+public interface Clock {
+    /** @return Current system time, in ms. */
+    long getTimeMillis();
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ManualClock.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/ManualClock.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.util;
+
+/**
+ * A clock whose time can be manually set and modified.
+ */
+public class ManualClock implements Clock {
+    private long timeMillis;
+    public ManualClock(long timeMillis) {
+        this.timeMillis = timeMillis;
+    }
+
+    /**
+     * @param timeToSet new time (in milliseconds) that the clock should represent
+     */
+    public synchronized void setTime(long timeToSet) {
+        this.timeMillis = timeToSet;
+        this.notifyAll();
+    }
+
+    @Override
+    public long getTimeMillis() {
+        return timeMillis;
+    }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Add read support for inCommitTimestamp and ensure the increasing monotonicity of inCommitTimestamp assuming that there are no conflicts to prepare for the complete inCommitTimestamp support with conflict resolution in Kernel.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Add unit tests to verify that the read of inCommitTimestamp is correct and inCommitTimestamp is monotonic.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, user can enable monotonic inCommitTimestamp assuming that there are no conflicts by enabling its property.
