### PR TITLE
[Kernel] Update ConflictChecker to perform conflict resolution of ICT

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -141,7 +141,7 @@ public class SnapshotImpl implements Snapshot {
      * @return the timestamp of the latest commit
      */
     public long getTimestamp(Engine engine) {
-        if (TableConfig.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(metadata)) {
+        if (TableConfig.isICTEnabled(metadata)) {
             if (!inCommitTimestampOpt.isPresent()) {
                 try {
                     Optional<CommitInfo> commitInfoOpt = CommitInfo.getCommitInfoOpt(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -187,6 +187,10 @@ public class TableConfig<T> {
         return validatedConfigurations;
     }
 
+    public static Boolean isICTEnabled(Metadata metadata) {
+        return IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(metadata);
+    }
+
     private void validate(String value) {
         T parsedValue = fromString.apply(value);
         if (!validator.test(parsedValue)) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableFeatures.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableFeatures.java
@@ -215,7 +215,7 @@ public class TableFeatures {
             Metadata metadata, String feature) {
         switch (feature) {
             case "inCommitTimestamp-preview":
-                return TableConfig.IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(metadata);
+                return TableConfig.isICTEnabled(metadata);
             default:
                 return false;
         }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -152,12 +152,13 @@ public class TransactionImpl
                             rebaseState.getLatestCommitTimestamp(),
                             attemptCommitInfo.getInCommitTimestamp());
                     if (updatedInCommitTimestamp.isPresent()) {
-                        Optional<Metadata> metadataWithICTInfo = getUpdatedMetadataAfterConflict(
-                                engine,
-                                updatedInCommitTimestamp.get(),
-                                metadata,
-                                rebaseState.getLatestVersion()
-                        );
+                        Optional<Metadata> metadataWithICTInfo =
+                                getMetadataWithUpdatedICTEnablementInfo(
+                                        engine,
+                                        updatedInCommitTimestamp.get(),
+                                        metadata,
+                                        rebaseState.getLatestVersion()
+                                );
                         metadataWithICTInfo.ifPresent(this::updateMetadata);
                     }
                     attemptCommitInfo.setInCommitTimestamp(updatedInCommitTimestamp);
@@ -208,7 +209,7 @@ public class TransactionImpl
         return attemptInCommitTimestamp;
     }
 
-    private Optional<Metadata> getUpdatedMetadataAfterConflict(
+    private Optional<Metadata> getMetadataWithUpdatedICTEnablementInfo(
             Engine engine,
             Long updatedInCommitTimestamp,
             Metadata attemptMetadata,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -149,8 +149,8 @@ public class TransactionImpl
                     commitAsVersion = newCommitAsVersion;
                     Optional<Long> updatedInCommitTimestamp =
                             getUpdatedInCommitTimestampAfterConflict(
-                            rebaseState.getLatestCommitTimestamp(),
-                            attemptCommitInfo.getInCommitTimestamp());
+                                    rebaseState.getLatestCommitTimestamp(),
+                                    attemptCommitInfo.getInCommitTimestamp());
                     if (updatedInCommitTimestamp.isPresent()) {
                         Optional<Metadata> metadataWithICTInfo =
                                 getMetadataWithUpdatedICTEnablementInfo(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -136,8 +136,6 @@ public class TransactionImpl
             do {
                 logger.info("Committing transaction as version = {}.", commitAsVersion);
                 try {
-                    // TODO Update the attemptCommitInfo and metadata based on the conflict
-                    // resolution.
                     return doCommit(engine, commitAsVersion, attemptCommitInfo, dataActions);
                 } catch (FileAlreadyExistsException fnfe) {
                     logger.info("Concurrent write detected when committing as version = {}. " +
@@ -149,6 +147,20 @@ public class TransactionImpl
                             "New commit version %d should be greater than the previous commit " +
                                     "attempt version %d.", newCommitAsVersion, commitAsVersion);
                     commitAsVersion = newCommitAsVersion;
+                    Optional<Long> updatedInCommitTimestamp =
+                            getUpdatedInCommitTimestampAfterConflict(
+                            rebaseState.getLatestCommitTimestamp(),
+                            attemptCommitInfo.getInCommitTimestamp());
+                    if (updatedInCommitTimestamp.isPresent()) {
+                        Optional<Metadata> metadataWithICTInfo = getUpdatedMetadataAfterConflict(
+                                engine,
+                                updatedInCommitTimestamp.get(),
+                                metadata,
+                                rebaseState.getLatestVersion()
+                        );
+                        metadataWithICTInfo.ifPresent(this::updateMetadata);
+                    }
+                    attemptCommitInfo.setInCommitTimestamp(updatedInCommitTimestamp);
                 }
                 numRetries++;
             } while (numRetries < NUM_TXN_RETRIES);
@@ -184,6 +196,30 @@ public class TransactionImpl
                     metadataWithICTInfo.ifPresent(this::updateMetadata);
                 }
         );
+    }
+
+    private Optional<Long> getUpdatedInCommitTimestampAfterConflict(
+            long winningCommitTimestamp, Optional<Long> attemptInCommitTimestamp) {
+        if (attemptInCommitTimestamp.isPresent()) {
+            long updatedInCommitTimestamp = Math.max(
+                    attemptInCommitTimestamp.get(), winningCommitTimestamp + 1);
+            return Optional.of(updatedInCommitTimestamp);
+        }
+        return attemptInCommitTimestamp;
+    }
+
+    private Optional<Metadata> getUpdatedMetadataAfterConflict(
+            Engine engine,
+            Long updatedInCommitTimestamp,
+            Metadata attemptMetadata,
+            Long lastWinningVersion) {
+        long nextAvailableVersion = lastWinningVersion + 1L;
+        return InCommitTimestampUtils.getUpdatedMetadataWithICTEnablementInfo(
+                engine,
+                updatedInCommitTimestamp,
+                readSnapshot,
+                attemptMetadata,
+                nextAvailableVersion);
     }
 
     private TransactionCommitResult doCommit(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/SingleAction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/SingleAction.java
@@ -47,7 +47,8 @@ public class SingleAction {
             // .add("add", AddFile.FULL_SCHEMA) // not needed for blind appends
             // .add("remove", RemoveFile.FULL_SCHEMA) // not needed for blind appends
             .add("metaData", Metadata.FULL_SCHEMA)
-            .add("protocol", Protocol.FULL_SCHEMA);
+            .add("protocol", Protocol.FULL_SCHEMA)
+            .add("commitInfo", CommitInfo.FULL_SCHEMA);
     // Once we start supporting domain metadata/row tracking enabled tables, we should add the
     // schema for domain metadata fields here.
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ConflictChecker.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ConflictChecker.java
@@ -160,9 +160,11 @@ public class ConflictChecker {
         }
 
         /**
-         * Return the latest CommitTimestamp of the table.
+         * Return the latest commit timestamp of the table. For ICT enabled tables, this is the
+         * ICT of the latest winning transaction commit file. For non-ICT enabled tables, this
+         * is the modification time of the latest winning transaction commit file.
          *
-         * @return latest CommitTimestamp of the table.
+         * @return latest commit timestamp of the table.
          */
         public long getLatestCommitTimestamp() {
             return latestCommitTimestamp;
@@ -259,6 +261,17 @@ public class ConflictChecker {
         }
     }
 
+    /**
+     * Get the last commit timestamp of the table. For ICT enabled tables, this is the ICT of the
+     * latest winning transaction commit file. For non-ICT enabled tables, this is the modification
+     * time of the latest winning transaction commit file.
+     *
+     * @param engine                {@link Engine} instance to use
+     * @param lastWinningVersion    last winning version of the table
+     * @param winningCommits        list of winning transaction commit files
+     * @param winningCommitInfoOpt  winning commit info
+     * @return last commit timestamp of the table
+     */
     private long getLastCommitTimestamp(
             Engine engine,
             long lastWinningVersion,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ConflictChecker.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ConflictChecker.java
@@ -27,8 +27,10 @@ import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
 
 import io.delta.kernel.internal.*;
+import io.delta.kernel.internal.actions.CommitInfo;
 import io.delta.kernel.internal.actions.SetTransaction;
 import io.delta.kernel.internal.util.FileNames;
+import static io.delta.kernel.internal.TableConfig.IN_COMMIT_TIMESTAMPS_ENABLED;
 import static io.delta.kernel.internal.actions.SingleAction.CONFLICT_RESOLUTION_SCHEMA;
 import static io.delta.kernel.internal.util.FileNames.deltaFile;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
@@ -44,6 +46,7 @@ public class ConflictChecker {
     private static final int PROTOCOL_ORDINAL = CONFLICT_RESOLUTION_SCHEMA.indexOf("protocol");
     private static final int METADATA_ORDINAL = CONFLICT_RESOLUTION_SCHEMA.indexOf("metaData");
     private static final int TXN_ORDINAL = CONFLICT_RESOLUTION_SCHEMA.indexOf("txn");
+    private static final int COMMITINFO_ORDINAL = CONFLICT_RESOLUTION_SCHEMA.indexOf("commitInfo");
 
     // Snapshot of the table read by the transaction that encountered the conflict
     // (a.k.a the losing transaction)
@@ -88,6 +91,7 @@ public class ConflictChecker {
 
     public TransactionRebaseState resolveConflicts(Engine engine) throws ConcurrentWriteException {
         List<FileStatus> winningCommits = getWinningCommitFiles(engine);
+        Optional<CommitInfo> winningCommitInfoOpt = Optional.empty();
 
         // no winning commits. why did we get the transaction conflict?
         checkState(!winningCommits.isEmpty(), "No winning commits found.");
@@ -99,21 +103,33 @@ public class ConflictChecker {
                 CONFLICT_RESOLUTION_SCHEMA,
                 Optional.empty())) {
 
-            actionsIterator.forEachRemaining(actionBatch -> {
+            List<ActionWrapper> actionBatchList = new ArrayList<>();
+            actionsIterator.forEachRemaining(actionBatchList::add);
+            for (int i = 0; i < actionBatchList.size(); i++) {
+                ActionWrapper actionBatch = actionBatchList.get(i);
                 checkArgument(!actionBatch.isFromCheckpoint());  // no checkpoints should be read
                 ColumnarBatch batch = actionBatch.getColumnarBatch();
+                if (i == actionBatchList.size() - 1) {
+                    CommitInfo commitInfo =
+                            getCommitInfo(batch.getColumnVector(COMMITINFO_ORDINAL));
+                    winningCommitInfoOpt = Optional.ofNullable(commitInfo);
+                }
 
                 handleProtocol(batch.getColumnVector(PROTOCOL_ORDINAL));
                 handleMetadata(batch.getColumnVector(METADATA_ORDINAL));
                 handleTxn(batch.getColumnVector(TXN_ORDINAL));
-            });
+            }
         } catch (IOException ioe) {
             throw new UncheckedIOException("Error reading actions from winning commits.", ioe);
         }
 
         // if we get here, we have successfully rebased (i.e no logical conflicts)
         // against the winning transactions
-        return new TransactionRebaseState(getLastWinningTxnVersion(winningCommits));
+        long lastWinningVersion = getLastWinningTxnVersion(winningCommits);
+        return new TransactionRebaseState(
+                lastWinningVersion,
+                getLastCommitTimestamp(
+                        engine, lastWinningVersion, winningCommits, winningCommitInfoOpt));
     }
 
     /**
@@ -128,9 +144,11 @@ public class ConflictChecker {
      */
     public static class TransactionRebaseState {
         private final long latestVersion;
+        private final long latestCommitTimestamp;
 
-        public TransactionRebaseState(long latestVersion) {
+        public TransactionRebaseState(long latestVersion, long latestCommitTimestamp) {
             this.latestVersion = latestVersion;
+            this.latestCommitTimestamp = latestCommitTimestamp;
         }
 
         /**
@@ -140,6 +158,15 @@ public class ConflictChecker {
          */
         public long getLatestVersion() {
             return latestVersion;
+        }
+
+        /**
+         * Return the latest CommitTimestamp of the table.
+         *
+         * @return latest CommitTimestamp of the table.
+         */
+        public long getLatestCommitTimestamp() {
+            return latestCommitTimestamp;
         }
     }
 
@@ -171,6 +198,21 @@ public class ConflictChecker {
                 throw DeltaErrors.metadataChangedException();
             }
         }
+    }
+
+    /**
+     * Get the commit info from the winning transactions.
+     *
+     * @param commitInfoVector commit info rows from the winning transactions
+     * @return the commit info
+     */
+    private CommitInfo getCommitInfo(ColumnVector commitInfoVector) {
+        for (int rowId = 0; rowId < commitInfoVector.getSize(); rowId++) {
+            if (!commitInfoVector.isNullAt(rowId)) {
+                return CommitInfo.fromColumnVector(commitInfoVector, rowId);
+            }
+        }
+        return null;
     }
 
     private void handleTxn(ColumnVector txnVector) {
@@ -216,6 +258,25 @@ public class ConflictChecker {
             throw new UncheckedIOException(
                     "Error listing files from " + firstWinningCommitFile, ioe);
         }
+    }
+
+    private long getLastCommitTimestamp(
+            Engine engine,
+            long lastWinningVersion,
+            List<FileStatus> winningCommits,
+            Optional<CommitInfo> winningCommitInfoOpt) {
+        FileStatus lastWinningTxn = winningCommits.get(winningCommits.size() - 1);
+        long winningCommitTimestamp = -1L;
+        if (snapshot.getVersion(engine) == -1 ||
+                !IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(snapshot.getMetadata())) {
+            winningCommitTimestamp = lastWinningTxn.getModificationTime();
+        } else {
+            winningCommitTimestamp = CommitInfo.getRequiredInCommitTimestamp(
+                    winningCommitInfoOpt,
+                    String.valueOf(lastWinningVersion),
+                    snapshot.getDataPath());
+        }
+        return winningCommitTimestamp;
     }
 
     private long getLastWinningTxnVersion(List<FileStatus> winningCommits) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/InCommitTimestampUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/InCommitTimestampUtils.java
@@ -23,7 +23,7 @@ import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.SnapshotImpl;
 import io.delta.kernel.internal.TableConfig;
 import io.delta.kernel.internal.actions.Metadata;
-import static io.delta.kernel.internal.TableConfig.IN_COMMIT_TIMESTAMPS_ENABLED;
+import static io.delta.kernel.internal.TableConfig.isICTEnabled;
 
 public class InCommitTimestampUtils {
 
@@ -72,10 +72,9 @@ public class InCommitTimestampUtils {
         //
         // WARNING: To ensure that this function returns true if ICT is enabled during the first
         // commit, we explicitly handle the case where the readSnapshot.version is -1.
-        boolean isICTCurrentlyEnabled =
-                IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(currentTransactionMetadata);
+        boolean isICTCurrentlyEnabled = isICTEnabled(currentTransactionMetadata);
         boolean wasICTEnabledInReadSnapshot = readSnapshot.getVersion(engine) != -1 &&
-                IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(readSnapshot.getMetadata());
+                isICTEnabled(readSnapshot.getMetadata());
         return isICTCurrentlyEnabled && !wasICTEnabledInReadSnapshot;
     }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/InCommitTimestampSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/InCommitTimestampSuite.scala
@@ -130,7 +130,7 @@ class InCommitTimestampSuite extends DeltaTableWriteSuiteBase {
 
       val ver1Snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
       val ver1Timestamp = ver1Snapshot.getTimestamp(engine)
-      assert(IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(ver1Snapshot.getMetadata))
+      assert(isICTEnabled(ver1Snapshot.getMetadata))
 
       clock.setTime(startTime - 10000)
       appendData(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Update ConflictChecker to perform conflict resolution of inCommitTimestamp and complete the inCommitTimestamp support in Kernel.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Add unit tests to verify the conflict resolution of timestamps and enablement version.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, user can enable monotonic inCommitTimestamp by enabling its property.