### PR TITLE
[Kernel][Tests] Fix test failure when running in non-UTC tz env

### DIFF
--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
@@ -619,10 +619,11 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
       val source = goldenTablePath("data-reader-partition-values")
       spark.sql(s"CREATE TABLE delta.`$target` SHALLOW CLONE delta.`$source`")
 
-      val expAnswer = spark.read.format("delta").load(source).collect().map(TestRow(_)).toSeq
-
-      assert(expAnswer.size == 3)
-      checkTable(target, expAnswer)
+      withSparkTimeZone("UTC") {
+        val expAnswer = spark.read.format("delta").load(source).collect().map(TestRow(_)).toSeq
+        assert(expAnswer.size == 3)
+        checkTable(target, expAnswer)
+      }
     }
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
@@ -1008,7 +1008,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
     // verify data using Spark reader.
     // Spark reads the timestamp partition columns in local timezone vs. Kernel reads in UTC. We
     // need to set the timezone to UTC before reading the data using Spark to make the tests pass
-    withSparkTimeZone("UTC") { () =>
+    withSparkTimeZone("UTC") {
       val resultSpark = spark.sql(s"SELECT * FROM delta.`$path`").collect().map(TestRow(_))
       checkAnswer(resultSpark, expData)
     }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -484,11 +484,11 @@ trait TestUtils extends Assertions with SQLHelper {
     }
   }
 
-  def withSparkTimeZone(timeZone: String)(fn: () => Unit): Unit = {
+  def withSparkTimeZone(timeZone: String)(fn: => Unit): Unit = {
     val prevTimeZone = spark.conf.get("spark.sql.session.timeZone")
     try {
       spark.conf.set("spark.sql.session.timeZone", timeZone)
-      fn()
+      fn
     } finally {
       spark.conf.set("spark.sql.session.timeZone", prevTimeZone)
     }


### PR DESCRIPTION
## Description
Currently, Spark interprets the timestamp partition columns in the local zone and Kernel in UTC. Delta protocol specifies no details on what timezone to use. This is a known issue and in Kernel we decided to always interpret as UTC to avoid timezone issues. Fix here is when getting the expected results using Spark, set the timezone to UTC to get the same values as Kernel.

## How was this patch tested?
Ran locally on Pacific timezone test env
