### PR TITLE
[Spark] Migrate logging code to use Spark Structured Logging

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -25,6 +25,7 @@ import scala.util.control.NonFatal
 
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta.actions.{Action, CheckpointMetadata, Metadata, SidecarFile, SingleAction}
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.storage.LogStore
@@ -37,6 +38,7 @@ import org.apache.hadoop.mapred.{JobConf, TaskAttemptContextImpl, TaskAttemptID}
 import org.apache.hadoop.mapreduce.{Job, TaskType}
 
 import org.apache.spark.TaskContext
+import org.apache.spark.internal.MDC
 import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.{Column, DataFrame, Dataset, Row, SparkSession}
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
@@ -274,7 +276,7 @@ trait Checkpoints extends DeltaLogging {
           opType,
           data = Map("exception" -> e.getMessage(), "stackTrace" -> e.getStackTrace())
         )
-        logWarning(s"Error when writing checkpoint-related files", e)
+        logWarning("Error when writing checkpoint-related files", e)
         val throwError = Utils.isTesting ||
           spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_CHECKPOINT_THROW_EXCEPTION_WHEN_FAILED)
         if (throwError) throw e
@@ -379,8 +381,9 @@ trait Checkpoints extends DeltaLogging {
         case _: FileNotFoundException =>
           None
         case NonFatal(e) if tries < 3 =>
-          logWarning(s"Failed to parse $LAST_CHECKPOINT. This may happen if there was an error " +
-            "during read operation, or a file appears to be partial. Sleeping and trying again.", e)
+          logWarning(log"Failed to parse ${MDC(DeltaLogKeys.PATH, LAST_CHECKPOINT)}. " +
+            log"This may happen if there was an error during read operation, " +
+            log"or a file appears to be partial. Sleeping and trying again.", e)
           Thread.sleep(1000)
           loadMetadataFromFile(tries + 1)
         case NonFatal(e) =>
@@ -390,7 +393,8 @@ trait Checkpoints extends DeltaLogging {
             data = Map("exception" -> Utils.exceptionString(e))
           )
 
-          logWarning(s"$LAST_CHECKPOINT is corrupted. Will search the checkpoint files directly", e)
+          logWarning(log"${MDC(DeltaLogKeys.PATH, LAST_CHECKPOINT)} is corrupted. " +
+            log"Will search the checkpoint files directly", e)
           // Hit a partial file. This could happen on Azure as overwriting _last_checkpoint file is
           // not atomic. We will try to list all files to find the latest checkpoint and restore
           // LastCheckpointInfo from it.
@@ -460,7 +464,7 @@ trait Checkpoints extends DeltaLogging {
         // available checkpoint.
         .filterNot(cv => cv.version < 0 || cv.version == CheckpointInstance.MaxValue.version)
         .getOrElse {
-          logInfo(s"Try to find Delta last complete checkpoint")
+          logInfo("Try to find Delta last complete checkpoint")
           eventData("listingFromZero") = true.toString
           return findLastCompleteCheckpoint()
         }
@@ -469,7 +473,8 @@ trait Checkpoints extends DeltaLogging {
     eventData("upperBoundCheckpointType") = upperBoundCv.format.name
     var iterations: Long = 0L
     var numFilesScanned: Long = 0L
-    logInfo(s"Try to find Delta last complete checkpoint before version ${upperBoundCv.version}")
+    logInfo(log"Try to find Delta last complete checkpoint before version " +
+      log"${MDC(DeltaLogKeys.VERSION, upperBoundCv.version)}")
     var listingEndVersion = upperBoundCv.version
 
     // Do a backward listing from the upperBoundCv version. We list in chunks of 1000 versions.
@@ -512,12 +517,14 @@ trait Checkpoints extends DeltaLogging {
         getLatestCompleteCheckpointFromList(checkpoints, Some(upperBoundCv.version))
       eventData("numFilesScanned") = numFilesScanned.toString
       if (lastCheckpoint.isDefined) {
-        logInfo(s"Delta checkpoint is found at version ${lastCheckpoint.get.version}")
+        logInfo(log"Delta checkpoint is found at version " +
+          log"${MDC(DeltaLogKeys.VERSION, lastCheckpoint.get.version)}")
         return lastCheckpoint
       }
       listingEndVersion = listingEndVersion - 1000
     }
-    logInfo(s"No checkpoint found for Delta table before version ${upperBoundCv.version}")
+    logInfo(log"No checkpoint found for Delta table before version " +
+      log"${MDC(DeltaLogKeys.VERSION, upperBoundCv.version)}")
     None
   }
 
@@ -1054,7 +1061,8 @@ object Checkpoints
       try {
         fs.delete(tempPath, false)
       } catch { case NonFatal(e) =>
-        logWarning(s"Error while deleting the temporary checkpoint part file $tempPath", e)
+        logWarning(log"Error while deleting the temporary checkpoint part file " +
+          log"${MDC(DeltaLogKeys.PATH, tempPath)}", e)
       }
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checksum.scala
@@ -25,6 +25,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
 
 import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.FileSizeHistogram
@@ -34,6 +35,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import org.apache.hadoop.fs.FileStatus
 import org.apache.hadoop.fs.Path
 
+import org.apache.spark.internal.MDC
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.streaming.CheckpointFileManager
 import org.apache.spark.util.Utils
@@ -99,12 +101,14 @@ trait RecordChecksum extends DeltaLogging {
         eventData("operationSucceeded") = true
       } catch {
         case NonFatal(e) =>
-          logWarning(s"Failed to write the checksum for version: $version", e)
+          logWarning(log"Failed to write the checksum for version: " +
+            log"${MDC(DeltaLogKeys.VERSION, version)}", e)
           stream.cancel()
       }
     } catch {
       case NonFatal(e) =>
-        logWarning(s"Failed to write the checksum for version: $version", e)
+        logWarning(log"Failed to write the checksum for version: " +
+          log"${MDC(DeltaLogKeys.VERSION, version)}", e)
     }
     recordDeltaEvent(
       deltaLog,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -24,12 +24,14 @@ import scala.collection.mutable
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.coordinatedcommits.UpdatedActions
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.DeltaSparkPlanUtils.CheckDeterministicOptions
 import org.apache.spark.sql.delta.util.FileNames
 import org.apache.hadoop.fs.FileStatus
 
+import org.apache.spark.internal.{MDC, MessageWithContext}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionSet, Or}
 import org.apache.spark.sql.types.StructType
@@ -653,13 +655,16 @@ private[delta] class ConflictChecker(
   protected def logMetrics(): Unit = {
     val totalTimeTakenMs = System.currentTimeMillis() - startTimeMs
     val timingStr = timingStats.keys.toSeq.sorted.map(k => s"$k=${timingStats(k)}").mkString(",")
-    logInfo(s"[$logPrefix] Timing stats against $winningCommitVersion " +
-      s"[$timingStr, totalTimeTakenMs: $totalTimeTakenMs]")
+    logInfo(log"[" + logPrefix + log"] Timing stats against " +
+      log"${MDC(DeltaLogKeys.VERSION, winningCommitVersion)} " +
+      log"[${MDC(DeltaLogKeys.TIME_STATS, timingStr)}, totalTimeTakenMs: " +
+      log"${MDC(DeltaLogKeys.TIME_MS, totalTimeTakenMs)}]")
   }
 
-  protected lazy val logPrefix: String = {
+  protected lazy val logPrefix: MessageWithContext = {
     def truncate(uuid: String): String = uuid.split("-").head
-    s"[tableId=${truncate(initialCurrentTransactionInfo.readSnapshot.metadata.id)}," +
-      s"txnId=${truncate(initialCurrentTransactionInfo.txnId)}] "
+    log"[tableId=${MDC(DeltaLogKeys.TABLE_ID,
+      truncate(initialCurrentTransactionInfo.readSnapshot.metadata.id))}," +
+    log"txnId=${MDC(DeltaLogKeys.TXN_ID, truncate(initialCurrentTransactionInfo.txnId))}] "
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLogFileIndex.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLogFileIndex.scala
@@ -16,10 +16,11 @@
 
 package org.apache.spark.sql.delta
 
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.util.FileNames
 import org.apache.hadoop.fs._
 
-import org.apache.spark.internal.Logging
+import org.apache.spark.internal.{LoggingShims, MDC}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.datasources.{FileFormat, FileIndex, PartitionDirectory}
@@ -39,7 +40,7 @@ case class DeltaLogFileIndex private (
     format: FileFormat,
     files: Array[FileStatus])
   extends FileIndex
-  with Logging {
+  with LoggingShims {
 
   import DeltaLogFileIndex._
 
@@ -81,7 +82,7 @@ case class DeltaLogFileIndex private (
   override def toString: String =
     s"DeltaLogFileIndex($format, numFilesInSegment: ${files.size}, totalFileSize: $sizeInBytes)"
 
-  logInfo(s"Created $this")
+  logInfo(log"Created ${MDC(DeltaLogKeys.FILE_INDEX, this)}")
 }
 
 object DeltaLogFileIndex {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTableIdentifier.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTableIdentifier.scala
@@ -17,11 +17,12 @@
 package org.apache.spark.sql.delta
 
 // scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSourceUtils
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.internal.Logging
+import org.apache.spark.internal.MDC
 import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 // scalastyle:on import.ordering.noEmptyLine
@@ -82,8 +83,8 @@ object DeltaTableIdentifier extends DeltaLogging {
         catalog.databaseExists(identifier.database.get) && catalog.tableExists(identifier)
       } catch {
         case e: AnalysisException if gluePermissionError(e) =>
-          logWarning("Received an access denied error from Glue. Will check to see if this " +
-            s"identifier ($identifier) is path based.", e)
+          logWarning(log"Received an access denied error from Glue. Will check to see if this " +
+            log"identifier (${MDC(DeltaLogKeys.TABLE_NAME, identifier)}) is path based.", e)
           false
       }
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.delta.coordinatedcommits._
 import org.apache.spark.sql.delta.files._
 import org.apache.spark.sql.delta.hooks.{CheckpointHook, GenerateSymlinkManifest, HudiConverterHook, IcebergConverterHook, PostCommitHook, UpdateCatalogFactory}
 import org.apache.spark.sql.delta.implicits.addFileEncoder
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.{SchemaMergingUtils, SchemaUtils}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -48,6 +49,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 
 import org.apache.spark.SparkException
+import org.apache.spark.internal.{MDC, MessageWithContext}
 import org.apache.spark.sql.{AnalysisException, Column, DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions._
@@ -643,7 +645,9 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       protocol, oldMetadata = snapshot.metadata, newMetadataTmp)
 
     assertMetadata(newMetadataTmp)
-    logInfo(s"Updated metadata from ${newMetadata.getOrElse("-")} to $newMetadataTmp")
+    logInfo(log"Updated metadata from " +
+      log"${MDC(DeltaLogKeys.METADATA_OLD, newMetadata.getOrElse("-"))} to " +
+      log"${MDC(DeltaLogKeys.METADATA_NEW, newMetadataTmp)}")
     newMetadata = Some(newMetadataTmp)
   }
 
@@ -1209,7 +1213,8 @@ trait OptimisticTransactionImpl extends TransactionalWrite
 
       val (commitVersion, postCommitSnapshot, updatedCurrentTransactionInfo) =
         doCommitRetryIteratively(firstAttemptVersion, currentTransactionInfo, isolationLevelToUse)
-      logInfo(s"Committed delta #$commitVersion to ${deltaLog.logPath}")
+      logInfo(log"Committed delta #${MDC(DeltaLogKeys.VERSION, commitVersion)} to " +
+        log"${MDC(DeltaLogKeys.PATH, deltaLog.logPath)}")
       (commitVersion, postCommitSnapshot, updatedCurrentTransactionInfo.actions)
     } catch {
       case e: DeltaConcurrentModificationException =>
@@ -1565,17 +1570,20 @@ trait OptimisticTransactionImpl extends TransactionalWrite
           // FS -> CC conversion
           val (commitCoordinatorName, commitCoordinatorConf) =
             CoordinatedCommitsUtils.getCoordinatedCommitsConfs(finalMetadata)
-          logInfo(s"Table ${deltaLog.logPath} transitioning from file-system based table to " +
-            s"coordinated-commits table: [commit-coordinator: $commitCoordinatorName, " +
-            s"conf: $commitCoordinatorConf]")
+          logInfo(log"Table ${MDC(DeltaLogKeys.PATH, deltaLog.logPath)} transitioning from " +
+            log"file-system based table to coordinated-commits table: " +
+            log"[commit-coordinator: ${MDC(DeltaLogKeys.COORDINATOR_NAME, commitCoordinatorName)}" +
+            log", conf: ${MDC(DeltaLogKeys.COORDINATOR_CONF, commitCoordinatorConf)}]")
           newCoordinatedCommitsTableConf = Some(newCommitCoordinatorClient.registerTable(
             deltaLog.logPath, readVersion, finalMetadata, protocol))
         case (None, Some(readCommitCoordinatorClient)) =>
           // CC -> FS conversion
           val (newOwnerName, newOwnerConf) =
             CoordinatedCommitsUtils.getCoordinatedCommitsConfs(snapshot.metadata)
-          logInfo(s"Table ${deltaLog.logPath} transitioning from coordinated-commits table to " +
-            s"file-system table: [commit-coordinator: $newOwnerName, conf: $newOwnerConf]")
+          logInfo(log"Table ${MDC(DeltaLogKeys.PATH, deltaLog.logPath)} transitioning from " +
+            log"coordinated-commits table to file-system table: " +
+            log"[commit-coordinator: ${MDC(DeltaLogKeys.COORDINATOR_NAME, newOwnerName)}, " +
+            log"conf: ${MDC(DeltaLogKeys.COORDINATOR_CONF, newOwnerConf)}]")
         case (Some(newCommitCoordinatorClient), Some(readCommitCoordinatorClient))
             if !readCommitCoordinatorClient.semanticsEquals(newCommitCoordinatorClient) =>
           // CC1 -> CC2 conversion is not allowed.
@@ -1615,7 +1623,9 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       throw DeltaErrors.invalidCommittedVersion(attemptVersion, currentSnapshot.version)
     }
 
-    logInfo(s"Committed delta #$attemptVersion to ${deltaLog.logPath}. Wrote $commitSize actions.")
+    logInfo(log"Committed delta #${MDC(DeltaLogKeys.VERSION, attemptVersion)} to " +
+      log"${MDC(DeltaLogKeys.PATH, deltaLog.logPath)}. Wrote " +
+      log"${MDC(DeltaLogKeys.NUM_ACTIONS, commitSize)} actions.")
 
     deltaLog.checkpoint(currentSnapshot)
     currentSnapshot
@@ -2014,8 +2024,9 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       isolationLevel: IsolationLevel): Snapshot = {
     val actions = currentTransactionInfo.finalActionsToCommit
     logInfo(
-      s"Attempting to commit version $attemptVersion with ${actions.size} actions with " +
-        s"$isolationLevel isolation level")
+      log"Attempting to commit version ${MDC(DeltaLogKeys.VERSION, attemptVersion)} with " +
+      log"${MDC(DeltaLogKeys.NUM_ACTIONS, actions.size)} actions with " +
+      log"${MDC(DeltaLogKeys.ISOLATION_LEVEL, isolationLevel)} isolation level")
 
     if (readVersion > -1 && metadata.id != snapshot.metadata.id) {
       val msg = s"Change in the table id detected in txn. Table id for txn on table at " +
@@ -2270,8 +2281,8 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       assert(mismatch.isEmpty,
         s"Expected ${mismatch.map(_._1).mkString(",")} but got ${mismatch.map(_._2).mkString(",")}")
 
-      val logPrefixStr = s"[attempt $attemptNumber]"
-      val txnDetailsLogStr = {
+      val logPrefix = log"[attempt ${MDC(DeltaLogKeys.ATTEMPT, attemptNumber)}] "
+      val txnDetailsLog = {
         var adds = 0L
         var removes = 0L
         currentTransactionInfo.actions.foreach {
@@ -2279,12 +2290,17 @@ trait OptimisticTransactionImpl extends TransactionalWrite
           case _: RemoveFile => removes += 1
           case _ =>
         }
-        s"$adds adds, $removes removes, ${readPredicates.size} read predicates, " +
-          s"${readFiles.size} read files"
+        log"${MDC(DeltaLogKeys.NUM_ACTIONS, adds)} adds, " +
+        log"${MDC(DeltaLogKeys.NUM_ACTIONS2, removes)} removes, " +
+        log"${MDC(DeltaLogKeys.NUM_PREDICATES, readPredicates.size)} read predicates, " +
+        log"${MDC(DeltaLogKeys.NUM_FILES, readFiles.size)} read files"
       }
 
-      logInfo(s"$logPrefixStr Checking for conflicts with versions " +
-        s"[$checkVersion, $nextAttemptVersion) with current txn having $txnDetailsLogStr")
+      logInfo(logPrefix +
+        log"Checking for conflicts with versions " +
+        log"[${MDC(DeltaLogKeys.VERSION, checkVersion)}, " +
+        log"${MDC(DeltaLogKeys.VERSION2, nextAttemptVersion)}) " +
+        log"with current txn having " + txnDetailsLog)
 
       var updatedCurrentTransactionInfo = currentTransactionInfo
       (checkVersion until nextAttemptVersion)
@@ -2294,13 +2310,19 @@ trait OptimisticTransactionImpl extends TransactionalWrite
           updatedCurrentTransactionInfo,
           otherCommitFileStatus,
           commitIsolationLevel)
-        logInfo(s"$logPrefixStr No conflicts in version $otherCommitVersion, " +
-          s"${clock.getTimeMillis() - commitAttemptStartTimeMillis} ms since start")
+        logInfo(logPrefix +
+          log"No conflicts in version ${MDC(DeltaLogKeys.VERSION, otherCommitVersion)}, " +
+          log"${MDC(DeltaLogKeys.DURATION,
+            clock.getTimeMillis() - commitAttemptStartTimeMillis)} ms since start")
       }
 
-      logInfo(s"$logPrefixStr No conflicts with versions [$checkVersion, $nextAttemptVersion) " +
-        s"with current txn having $txnDetailsLogStr, " +
-        s"${clock.getTimeMillis() - commitAttemptStartTimeMillis} ms since start")
+      logInfo(logPrefix +
+        log"No conflicts with versions " +
+        log"[${MDC(DeltaLogKeys.VERSION, checkVersion)}, " +
+        log"${MDC(DeltaLogKeys.VERSION2, nextAttemptVersion)}) " +
+        log"with current txn having " + txnDetailsLog +
+        log"${MDC(DeltaLogKeys.TIME_MS, clock.getTimeMillis() - commitAttemptStartTimeMillis)} " +
+        log"ms since start")
       (nextAttemptVersion, updatedCurrentTransactionInfo)
     }
   }
@@ -2369,8 +2391,9 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       hook.run(spark, this, version, postCommitSnapshot, committedActions)
     } catch {
       case NonFatal(e) =>
-        logWarning(s"Error when executing post-commit hook ${hook.name} " +
-          s"for commit $version", e)
+        logWarning(log"Error when executing post-commit hook " +
+          log"${MDC(DeltaLogKeys.HOOK_NAME, hook.name)} " +
+          log"for commit ${MDC(DeltaLogKeys.VERSION, version)}", e)
         recordDeltaEvent(deltaLog, "delta.commit.hook.failure", data = Map(
           "hook" -> hook.name,
           "version" -> version,
@@ -2383,28 +2406,29 @@ trait OptimisticTransactionImpl extends TransactionalWrite
   private[delta] def unregisterPostCommitHooksWhere(predicate: PostCommitHook => Boolean): Unit =
     postCommitHooks --= postCommitHooks.filter(predicate)
 
-  protected lazy val logPrefix: String = {
+  protected lazy val logPrefix: MessageWithContext = {
     def truncate(uuid: String): String = uuid.split("-").head
-    s"[tableId=${truncate(snapshot.metadata.id)},txnId=${truncate(txnId)}] "
+    log"[tableId=${MDC(DeltaLogKeys.METADATA_ID, truncate(snapshot.metadata.id))}," +
+    log"txnId=${MDC(DeltaLogKeys.TXN_ID, truncate(txnId))}] "
   }
 
-  override def logInfo(msg: => String): Unit = {
+  def logInfo(msg: MessageWithContext): Unit = {
     super.logInfo(logPrefix + msg)
   }
 
-  override def logWarning(msg: => String): Unit = {
+  def logWarning(msg: MessageWithContext): Unit = {
     super.logWarning(logPrefix + msg)
   }
 
-  override def logWarning(msg: => String, throwable: Throwable): Unit = {
+  def logWarning(msg: MessageWithContext, throwable: Throwable): Unit = {
     super.logWarning(logPrefix + msg, throwable)
   }
 
-  override def logError(msg: => String): Unit = {
+  def logError(msg: MessageWithContext): Unit = {
     super.logError(logPrefix + msg)
   }
 
-  override def logError(msg: => String, throwable: Throwable): Unit = {
+  def logError(msg: MessageWithContext, throwable: Throwable): Unit = {
     super.logError(logPrefix + msg, throwable)
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ProvidesUniFormConverters.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ProvidesUniFormConverters.scala
@@ -36,10 +36,10 @@ trait ProvidesUniFormConverters { self: DeltaLog =>
     constructor.newInstance(spark)
   } catch {
     case e: ClassNotFoundException =>
-      logError(s"Failed to find Iceberg converter class", e)
+      logError("Failed to find Iceberg converter class", e)
       throw DeltaErrors.icebergClassMissing(spark.sparkContext.getConf, e)
     case e: InvocationTargetException =>
-      logError(s"Got error when creating an Iceberg converter", e)
+      logError("Got error when creating an Iceberg converter", e)
       // The better error is within the cause
       throw ExceptionUtils.getRootCause(e)
   }
@@ -51,10 +51,10 @@ trait ProvidesUniFormConverters { self: DeltaLog =>
     constructor.newInstance(spark)
   } catch {
     case e: ClassNotFoundException =>
-      logError(s"Failed to find Hudi converter class", e)
+      logError("Failed to find Hudi converter class", e)
       throw DeltaErrors.hudiClassMissing(spark.sparkContext.getConf, e)
     case e: InvocationTargetException =>
-      logError(s"Got error when creating an Hudi converter", e)
+      logError("Got error when creating an Hudi converter", e)
       // The better error is within the cause
       throw ExceptionUtils.getRootCause(e)
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -22,6 +22,7 @@ import scala.collection.mutable
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.actions.Action.logSchema
 import org.apache.spark.sql.delta.coordinatedcommits.{CommitCoordinatorClient, CommitCoordinatorProvider, CoordinatedCommitsUtils, TableCommitCoordinatorClient}
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -34,6 +35,7 @@ import org.apache.spark.sql.delta.util.StateCache
 import org.apache.spark.sql.util.ScalaExtensions._
 import org.apache.hadoop.fs.{FileStatus, Path}
 
+import org.apache.spark.internal.{MDC, MessageWithContext}
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.StructType
@@ -506,31 +508,32 @@ class Snapshot(
     spark.createDataFrame(spark.sparkContext.emptyRDD[Row], logSchema)
 
 
-  override def logInfo(msg: => String): Unit = {
-    super.logInfo(s"[tableId=${deltaLog.tableId}] " + msg)
+  def logInfo(msg: MessageWithContext): Unit = {
+    super.logInfo(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, deltaLog.tableId)}] " + msg)
   }
 
-  override def logWarning(msg: => String): Unit = {
-    super.logWarning(s"[tableId=${deltaLog.tableId}] " + msg)
+  def logWarning(msg: MessageWithContext): Unit = {
+    super.logWarning(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, deltaLog.tableId)}] " + msg)
   }
 
-  override def logWarning(msg: => String, throwable: Throwable): Unit = {
-    super.logWarning(s"[tableId=${deltaLog.tableId}] " + msg, throwable)
+  def logWarning(msg: MessageWithContext, throwable: Throwable): Unit = {
+    super.logWarning(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, deltaLog.tableId)}] " + msg,
+      throwable)
   }
 
-  override def logError(msg: => String): Unit = {
-    super.logError(s"[tableId=${deltaLog.tableId}] " + msg)
+  def logError(msg: MessageWithContext): Unit = {
+    super.logError(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, deltaLog.tableId)}] " + msg)
   }
 
-  override def logError(msg: => String, throwable: Throwable): Unit = {
-    super.logError(s"[tableId=${deltaLog.tableId}] " + msg, throwable)
+  def logError(msg: MessageWithContext, throwable: Throwable): Unit = {
+    super.logError(log"[tableId=${MDC(DeltaLogKeys.TABLE_ID, deltaLog.tableId)}] " + msg, throwable)
   }
 
   override def toString: String =
     s"${getClass.getSimpleName}(path=$path, version=$version, metadata=$metadata, " +
       s"logSegment=$logSegment, checksumOpt=$checksumOpt)"
 
-  logInfo(s"Created snapshot $this")
+  logInfo(log"Created snapshot ${MDC(DeltaLogKeys.SNAPSHOT, this)}")
   init()
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
@@ -18,9 +18,11 @@ package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.delta.actions.{Action, Metadata, Protocol}
 import org.apache.spark.sql.delta.commands.WriteIntoDelta
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.SchemaUtils
 
+import org.apache.spark.internal.MDC
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.types.{ArrayType, MapType, NullType}
@@ -154,8 +156,8 @@ object UniversalFormat extends DeltaLogging {
                   remainingSupportedFormats.mkString(","))
             }
 
-            logInfo(s"[tableId=$tableId] IcebergCompat is being disabled. Auto-disabling " +
-              "Universal Format (Iceberg), too.")
+            logInfo(log"[${MDC(DeltaLogKeys.TABLE_ID, tableId)}] " +
+              log"IcebergCompat is being disabled. Auto-disabling Universal Format (Iceberg), too.")
 
             (None, Some(newestMetadata.copy(configuration = newConfiguration)))
           } else {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
@@ -25,9 +25,11 @@ import org.apache.spark.sql.delta.actions.{AddFile, Metadata, Protocol}
 import org.apache.spark.sql.delta.actions.Protocol.extractAutomaticallyEnabledFeatures
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.convert.{ConvertTargetTable, ConvertUtils}
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.hadoop.fs.Path
 
+import org.apache.spark.internal.MDC
 import org.apache.spark.sql.{Column, Dataset, Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
@@ -88,7 +90,8 @@ case class CloneTableCommand(
     }
 
     /** Log clone command information */
-    logInfo("Cloning " + sourceTable.description + s" to $targetPath")
+    logInfo(log"Cloning ${MDC(DeltaLogKeys.TABLE_DESC, sourceTable.description)} to " +
+      log"${MDC(DeltaLogKeys.PATH, targetPath)}")
 
     // scalastyle:off deltahadoopconfiguration
     val hdpConf = sparkSession.sessionState.newHadoopConf()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/OptimizeTableCommand.scala
@@ -27,12 +27,14 @@ import org.apache.spark.sql.delta.DeltaOperations.Operation
 import org.apache.spark.sql.delta.actions.{Action, AddFile, DeletionVectorDescriptor, FileAction, RemoveFile}
 import org.apache.spark.sql.delta.commands.optimize._
 import org.apache.spark.sql.delta.files.SQLMetricsReporting
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.BinPackingUtils
 
 import org.apache.spark.SparkContext
 import org.apache.spark.SparkContext.SPARK_JOB_GROUP_ID
+import org.apache.spark.internal.MDC
 import org.apache.spark.sql.{AnalysisException, Encoders, Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedTable}
@@ -458,8 +460,9 @@ class OptimizeExecutor(
           true
         } else {
           val deleted = candidateSetOld -- candidateSetNew
-          logWarning(s"The following compacted files were deleted " +
-            s"during checkpoint ${deleted.mkString(",")}. Aborting the compaction.")
+          logWarning(log"The following compacted files were deleted " +
+            log"during checkpoint ${MDC(DeltaLogKeys.PATHS, deleted.mkString(","))}. " +
+            log"Aborting the compaction.")
           false
         }
       }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -30,12 +30,14 @@ import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.columnmapping.RemoveColumnMappingCommand
 import org.apache.spark.sql.delta.constraints.{CharVarcharConstraint, Constraints}
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.schema.{SchemaMergingUtils, SchemaUtils}
 import org.apache.spark.sql.delta.schema.SchemaUtils.transformSchema
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.StatisticsCollection
 import org.apache.hadoop.fs.Path
 
+import org.apache.spark.internal.MDC
 import org.apache.spark.sql.{AnalysisException, Column, Row, SparkSession}
 import org.apache.spark.sql.catalyst.analysis.{Resolver, UnresolvedAttribute}
 import org.apache.spark.sql.catalyst.catalog.CatalogUtils
@@ -1021,8 +1023,8 @@ case class AlterTableAddConstraintDeltaCommand(
           throw a.copy(context = Array.empty)
       }
 
-      logInfo(s"Checking that $exprText is satisfied for existing data. " +
-        "This will require a full table scan.")
+      logInfo(log"Checking that ${MDC(DeltaLogKeys.EXPR, exprText)} " +
+        log"is satisfied for existing data. This will require a full table scan.")
       recordDeltaOperation(
           txn.snapshot.deltaLog,
           "delta.ddl.alter.addConstraint.checkExisting") {
@@ -1099,7 +1101,8 @@ case class AlterTableClusterByDeltaCommand(
     val snapshot = deltaLog.update()
     if (clusteringColumns.isEmpty &&
       !ClusteredTableUtils.isSupported(snapshot.protocol)) {
-      logInfo(s"Skipping ALTER TABLE CLUSTER BY NONE on a non-clustered table: ${table.name()}.")
+      logInfo(log"Skipping ALTER TABLE CLUSTER BY NONE on a non-clustered table: " +
+        log"${MDC(DeltaLogKeys.TABLE_NAME, table.name())}.")
       recordDeltaEvent(
         deltaLog,
         "delta.ddl.alter.clusterBy",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
@@ -24,12 +24,14 @@ import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
 import org.apache.spark.sql.delta.files.{CdcAddFileIndex, TahoeChangeFileIndex, TahoeFileIndexWithSnapshotDescriptor, TahoeRemoveFileIndex}
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.{DeltaDataSource, DeltaSource, DeltaSourceUtils, DeltaSQLConf}
 import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
 import org.apache.spark.sql.util.ScalaExtensions.OptionExt
 
+import org.apache.spark.internal.MDC
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Column, DataFrame, Dataset, Row, SparkSession, SQLContext}
 import org.apache.spark.sql.catalyst.InternalRow
@@ -300,8 +302,8 @@ trait CDCReaderImpl extends DeltaLogging {
     }
 
     logInfo(
-      s"startingVersion: ${startingVersion.version}, " +
-        s"endingVersion: ${endingVersionOpt.map(_.version)}")
+      log"startingVersion: ${MDC(DeltaLogKeys.START_VERSION, startingVersion.version)}, " +
+      log"endingVersion: ${MDC(DeltaLogKeys.END_VERSION, endingVersionOpt.map(_.version))}")
 
     val startingSnapshot = snapshotToUse.deltaLog.getSnapshotAt(startingVersion.version)
     val columnMappingEnabledAtStartingVersion =

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ConvertUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ConvertUtils.scala
@@ -95,10 +95,10 @@ trait ConvertUtilsBase extends DeltaLogging {
       }
     } catch {
       case e: ClassNotFoundException =>
-        logError(s"Failed to find Iceberg class", e)
+        logError("Failed to find Iceberg class", e)
         throw DeltaErrors.icebergClassMissing(spark.sparkContext.getConf, e)
       case e: InvocationTargetException =>
-        logError(s"Got error when creating an Iceberg Converter", e)
+        logError("Got error when creating an Iceberg Converter", e)
         // The better error is within the cause
         throw ExceptionUtils.getRootCause(e)
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/AbstractBatchBackfillingCommitCoordinatorClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/AbstractBatchBackfillingCommitCoordinatorClient.scala
@@ -23,18 +23,21 @@ import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.TransactionExecutionObserver
 import org.apache.spark.sql.delta.actions.CommitInfo
 import org.apache.spark.sql.delta.actions.Metadata
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.storage.LogStore
 import org.apache.spark.sql.delta.util.FileNames
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 
-import org.apache.spark.internal.Logging
+import org.apache.spark.internal.{LoggingShims, MDC}
 
 /**
  * An abstract [[CommitCoordinatorClient]] which triggers backfills every n commits.
  * - every commit version which satisfies `commitVersion % batchSize == 0` will trigger a backfill.
  */
-trait AbstractBatchBackfillingCommitCoordinatorClient extends CommitCoordinatorClient with Logging {
+trait AbstractBatchBackfillingCommitCoordinatorClient
+  extends CommitCoordinatorClient
+    with LoggingShims {
 
   /**
    * Size of batch that should be backfilled. So every commit version which satisfies
@@ -69,12 +72,15 @@ trait AbstractBatchBackfillingCommitCoordinatorClient extends CommitCoordinatorC
       throw CommitFailedException(
         retryable = false, conflict = false, message = "Commit version 0 must go via filesystem.")
     }
-    logInfo(s"Attempting to commit version $commitVersion on table $tablePath")
+    logInfo(log"Attempting to commit version " +
+      log"${MDC(DeltaLogKeys.VERSION, commitVersion)} on table " +
+      log"${MDC(DeltaLogKeys.PATH, tablePath)}")
     val fs = logPath.getFileSystem(hadoopConf)
     if (batchSize <= 1) {
       // Backfill until `commitVersion - 1`
-      logInfo(s"Making sure commits are backfilled until ${commitVersion - 1} version for" +
-        s" table ${tablePath.toString}")
+      logInfo(log"Making sure commits are backfilled until " +
+        log"${MDC(DeltaLogKeys.VERSION, commitVersion - 1)} version for" +
+        log" table ${MDC(DeltaLogKeys.PATH, tablePath.toString)}")
       backfillToVersion(
         logStore,
         hadoopConf,
@@ -110,8 +116,9 @@ trait AbstractBatchBackfillingCommitCoordinatorClient extends CommitCoordinatorC
       val newCommit = commitResponse.getCommit.copy(fileStatus = targetFileStatus)
       commitResponse = commitResponse.copy(commit = newCommit)
     } else if (commitVersion % batchSize == 0 || mcToFsConversion) {
-      logInfo(s"Making sure commits are backfilled till $commitVersion version for" +
-        s"table ${tablePath.toString}")
+      logInfo(log"Making sure commits are backfilled till " +
+        log"${MDC(DeltaLogKeys.VERSION, commitVersion)} " +
+        log"version for table ${MDC(DeltaLogKeys.PATH, tablePath.toString)}")
       backfillToVersion(
         logStore,
         hadoopConf,
@@ -119,7 +126,8 @@ trait AbstractBatchBackfillingCommitCoordinatorClient extends CommitCoordinatorC
         coordinatedCommitsTableConf,
         commitVersion)
     }
-    logInfo(s"Commit $commitVersion done successfully on table $tablePath")
+    logInfo(log"Commit ${MDC(DeltaLogKeys.VERSION, commitVersion)} done successfully on table " +
+      log"${MDC(DeltaLogKeys.PATH, tablePath)}")
     commitResponse
   }
 
@@ -163,7 +171,8 @@ trait AbstractBatchBackfillingCommitCoordinatorClient extends CommitCoordinatorC
       version: Long,
       fileStatus: FileStatus): Unit = {
     val targetFile = FileNames.unsafeDeltaFile(logPath, version)
-    logInfo(s"Backfilling commit ${fileStatus.getPath} to ${targetFile.toString}")
+    logInfo(log"Backfilling commit ${MDC(DeltaLogKeys.PATH, fileStatus.getPath)} to " +
+      log"${MDC(DeltaLogKeys.PATH2, targetFile.toString)}")
     val commitContentIterator = logStore.readAsIterator(fileStatus, hadoopConf)
     try {
       logStore.write(
@@ -174,7 +183,7 @@ trait AbstractBatchBackfillingCommitCoordinatorClient extends CommitCoordinatorC
       registerBackfill(logPath, version)
     } catch {
       case _: FileAlreadyExistsException =>
-        logInfo(s"The backfilled file $targetFile already exists.")
+        logInfo(log"The backfilled file ${MDC(DeltaLogKeys.FILE_NAME, targetFile)} already exists.")
     } finally {
       commitContentIterator.close()
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
@@ -20,6 +20,7 @@ import scala.util.control.NonFatal
 
 import org.apache.spark.sql.delta.{CoordinatedCommitsTableFeature, DeltaConfig, DeltaConfigs, DeltaLog, Snapshot, SnapshotDescriptor}
 import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.storage.LogStore
 import org.apache.spark.sql.delta.util.FileNames
@@ -27,6 +28,7 @@ import org.apache.spark.sql.delta.util.FileNames.{DeltaFile, UnbackfilledDeltaFi
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 
+import org.apache.spark.internal.MDC
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.util.Utils
 
@@ -293,11 +295,12 @@ object CoordinatedCommitsUtils extends DeltaLogging {
           actionsIter,
           overwrite,
           hadoopConf)
-        logInfo(s"Delta file ${unbackfilledDeltaFile.getPath.toString} backfilled to path" +
-          s" ${backfilledFilePath.toString}.")
+        logInfo(log"Delta file ${MDC(DeltaLogKeys.PATH, unbackfilledDeltaFile.getPath.toString)} " +
+          log"backfilled to path ${MDC(DeltaLogKeys.PATH2, backfilledFilePath.toString)}.")
       } else {
         numAlreadyBackfilledFiles += 1
-        logInfo(s"Delta file ${unbackfilledDeltaFile.getPath.toString} already backfilled.")
+        logInfo(log"Delta file ${MDC(DeltaLogKeys.PATH, unbackfilledDeltaFile.getPath.toString)} " +
+          log"already backfilled.")
       }
     }
     recordDeltaEvent(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryCommitCoordinator.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryCommitCoordinator.scala
@@ -22,10 +22,12 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
 import scala.collection.mutable
 
 import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.storage.LogStore
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 
+import org.apache.spark.internal.MDC
 import org.apache.spark.sql.SparkSession
 
 class InMemoryCommitCoordinator(val batchSize: Long)
@@ -133,7 +135,8 @@ class InMemoryCommitCoordinator(val batchSize: Long)
       tableData.commitsMap(commitVersion) = commit
       tableData.updateLastRatifiedCommit(commitVersion)
 
-      logInfo(s"Added commit file ${commitFile.getPath} to commit-coordinator.")
+      logInfo(log"Added commit file ${MDC(DeltaLogKeys.PATH, commitFile.getPath)} " +
+        log"to commit-coordinator.")
       CommitResponse(commit)
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/files/DeltaSourceSnapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/files/DeltaSourceSnapshot.scala
@@ -20,10 +20,12 @@ import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.delta.{DeltaLog, DeltaTableUtils, Snapshot}
 import org.apache.spark.sql.delta.actions.SingleAction
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.sources.IndexedFile
 import org.apache.spark.sql.delta.stats.DataSkippingReader
 import org.apache.spark.sql.delta.util.StateCache
 
+import org.apache.spark.internal.MDC
 import org.apache.spark.sql.{Dataset, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.functions._
@@ -50,7 +52,8 @@ class DeltaSourceSnapshot(
     val (part, data) = filters.partition { e =>
       DeltaTableUtils.isPredicatePartitionColumnsOnly(e, partitionCols, spark)
     }
-    logInfo(s"Classified filters: partition: $part, data: $data")
+    logInfo(log"Classified filters: partition: ${MDC(DeltaLogKeys.PARTITION_FILTER, part)}, " +
+      log"data: ${MDC(DeltaLogKeys.DATA_FILTER, data)}")
     (part, data)
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AutoCompact.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/AutoCompact.scala
@@ -21,10 +21,12 @@ import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.commands.{DeltaOptimizeContext, OptimizeExecutor}
 import org.apache.spark.sql.delta.commands.optimize._
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.AutoCompactPartitionStats
 
+import org.apache.spark.internal.MDC
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions.Expression
@@ -156,7 +158,7 @@ trait AutoCompactBase extends PostCommitHook with DeltaLogging {
         metrics
       } catch {
         case e: Throwable =>
-          logError("Auto Compaction failed with: " + e.getMessage)
+          logError(log"Auto Compaction failed with: ${MDC(DeltaLogKeys.ERROR, e.getMessage)}")
           recordDeltaEvent(
             txn.deltaLog,
             opType = "delta.autoCompaction.error",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
@@ -22,12 +22,14 @@ import java.net.URI
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.commands.DeletionVectorUtils.isTableDVFree
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.storage.LogStore
 import org.apache.spark.sql.delta.util.DeltaFileOperations
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkEnv
+import org.apache.spark.internal.MDC
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils
@@ -308,9 +310,9 @@ trait GenerateSymlinkManifestImpl extends PostCommitHook with DeltaLogging with 
         }.collect().toSet
       }
 
-    logInfo(s"Generated manifest partitions for $deltaLogDataPath " +
-      s"[${newManifestPartitionRelativePaths.size}]:\n\t" +
-      newManifestPartitionRelativePaths.mkString("\n\t"))
+    logInfo(log"Generated manifest partitions for ${MDC(DeltaLogKeys.PATH, deltaLogDataPath)} " +
+      log"[${MDC(DeltaLogKeys.NUM_PARTITIONS, newManifestPartitionRelativePaths.size)}]:\n\t" +
+      log"${MDC(DeltaLogKeys.PATHS, newManifestPartitionRelativePaths.mkString("\n\t"))}")
 
     newManifestPartitionRelativePaths
   }
@@ -334,8 +336,9 @@ trait GenerateSymlinkManifestImpl extends PostCommitHook with DeltaLogging with 
       fs.delete(absPathToDelete, true)
     }
 
-    logInfo(s"Deleted manifest partitions [${partitionRelativePathsToDelete.size}]:\n\t" +
-      partitionRelativePathsToDelete.mkString("\n\t"))
+    logInfo(log"Deleted manifest partitions [" +
+      log"${MDC(DeltaLogKeys.NUM_FILES, partitionRelativePathsToDelete.size)}]:\n\t" +
+      log"${MDC(DeltaLogKeys.PATHS, partitionRelativePathsToDelete.mkString("\n\t"))}")
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/UpdateCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/UpdateCatalog.scala
@@ -28,11 +28,13 @@ import org.apache.spark.sql.delta.skipping.clustering.{ClusteredTableUtils, Clus
 import org.apache.spark.sql.delta.skipping.clustering.temp.ClusterBySpec
 import org.apache.spark.sql.delta.{DeltaConfigs, DeltaTableIdentifier, OptimisticTransactionImpl, Snapshot}
 import org.apache.spark.sql.delta.actions.{Action, Metadata}
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.threads.DeltaThreadPool
 import org.apache.commons.lang3.exception.ExceptionUtils
 
+import org.apache.spark.internal.MDC
 import org.apache.spark.internal.config.ConfigEntry
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -196,8 +198,9 @@ trait UpdateCatalogBase extends PostCommitHook with DeltaLogging {
                 "exceptionMsg" -> ExceptionUtils.getMessage(e),
                 "stackTrace" -> ExceptionUtils.getStackTrace(e))
             )
-            logWarning(s"Failed to update the catalog for ${table.identifier} with the latest " +
-              s"table information.", e)
+            logWarning(log"Failed to update the catalog for " +
+              log"${MDC(DeltaLogKeys.TABLE_NAME, table.identifier)} with the latest " +
+              log"table information.", e)
         }
       }
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/logging/DeltaLogKeys.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/logging/DeltaLogKeys.scala
@@ -124,6 +124,7 @@ trait DeltaLogKeysBase {
   case object TABLE_NAME extends LogKeyShims
   case object TAG extends LogKeyShims
   case object TBL_PROPERTIES extends LogKeyShims
+  case object THREAD_NAME extends LogKeyShims
   case object TIMESTAMP extends LogKeyShims
   case object TIMESTAMP2 extends LogKeyShims
   case object TIME_MS extends LogKeyShims

--- a/spark/src/main/scala/org/apache/spark/sql/delta/logging/DeltaLogKeys.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/logging/DeltaLogKeys.scala
@@ -45,9 +45,94 @@ import org.apache.spark.internal.LogKeyShims
  * should be defined here for standardization.
  */
 trait DeltaLogKeysBase {
+  case object APP_ID extends LogKeyShims
+  case object ATTEMPT extends LogKeyShims
+  case object BATCH_ID extends LogKeyShims
+  case object CLASS_NAME extends LogKeyShims
+  case object COLUMN_NAME extends LogKeyShims
+  case object COMPACTION_INFO_NEW extends LogKeyShims
+  case object COMPACTION_INFO_OLD extends LogKeyShims
+  case object CONFIG extends LogKeyShims
+  case object COORDINATOR_CONF extends LogKeyShims
+  case object COORDINATOR_NAME extends LogKeyShims
+  case object COUNT extends LogKeyShims
+  case object DATA_FILTER extends LogKeyShims
+  case object DATE extends LogKeyShims
+  case object DIR extends LogKeyShims
+  case object DRY_RUN extends LogKeyShims
+  case object DURATION extends LogKeyShims
+  case object END_INDEX extends LogKeyShims
+  case object END_OFFSET extends LogKeyShims
+  case object END_VERSION extends LogKeyShims
+  case object ERROR extends LogKeyShims
   case object EXECUTOR_ID extends LogKeyShims
+  case object EXPR extends LogKeyShims
+  case object FILE_ACTION_NEW extends LogKeyShims
+  case object FILE_ACTION_OLD extends LogKeyShims
+  case object FILE_INDEX extends LogKeyShims
+  case object FILE_NAME extends LogKeyShims
+  case object FILE_STATUS extends LogKeyShims
+  case object FILE_SYSTEM_SCHEME extends LogKeyShims
+  case object FILTER extends LogKeyShims
+  case object HOOK_NAME extends LogKeyShims
+  case object INDEX extends LogKeyShims
+  case object ISOLATION_LEVEL extends LogKeyShims
+  case object IS_INIT_SNAPSHOT extends LogKeyShims
+  case object IS_PATH_TABLE extends LogKeyShims
+  case object JOB_ID extends LogKeyShims
   case object MAX_SIZE extends LogKeyShims
+  case object MESSAGE extends LogKeyShims
+  case object METADATA_ID extends LogKeyShims
+  case object METADATA_NEW extends LogKeyShims
+  case object METADATA_OLD extends LogKeyShims
+  case object METRICS extends LogKeyShims
   case object MIN_SIZE extends LogKeyShims
+  case object NUM_ACTIONS extends LogKeyShims
+  case object NUM_ACTIONS2 extends LogKeyShims
+  case object NUM_BYTES extends LogKeyShims
+  case object NUM_DIRS extends LogKeyShims
+  case object NUM_FILES extends LogKeyShims
+  case object NUM_FILES2 extends LogKeyShims
+  case object NUM_PARTITIONS extends LogKeyShims
+  case object NUM_PREDICATES extends LogKeyShims
+  case object NUM_RECORDS extends LogKeyShims
+  case object NUM_RECORDS_ACTUAL extends LogKeyShims
+  case object NUM_RECORDS_EXPECTED extends LogKeyShims
+  case object OFFSET extends LogKeyShims
+  case object OPERATION extends LogKeyShims
+  case object OPERATION2 extends LogKeyShims
+  case object OP_NAME extends LogKeyShims
+  case object OP_TYPE extends LogKeyShims
+  case object PARTITION_FILTER extends LogKeyShims
+  case object PATH extends LogKeyShims
+  case object PATH2 extends LogKeyShims
+  case object PATHS extends LogKeyShims
+  case object PROTOCOL extends LogKeyShims
+  case object QUERY_ID extends LogKeyShims
+  case object RDD_ID extends LogKeyShims
+  case object SCHEMA extends LogKeyShims
+  case object SEGMENT extends LogKeyShims
+  case object SIZE extends LogKeyShims
+  case object SNAPSHOT extends LogKeyShims
+  case object START_INDEX extends LogKeyShims
+  case object START_VERSION extends LogKeyShims
+  case object STATS extends LogKeyShims
+  case object STATUS extends LogKeyShims
+  case object TABLE_DESC extends LogKeyShims
+  case object TABLE_FEATURES extends LogKeyShims
+  case object TABLE_ID extends LogKeyShims
+  case object TABLE_NAME extends LogKeyShims
+  case object TAG extends LogKeyShims
+  case object TBL_PROPERTIES extends LogKeyShims
+  case object TIMESTAMP extends LogKeyShims
+  case object TIMESTAMP2 extends LogKeyShims
+  case object TIME_MS extends LogKeyShims
+  case object TIME_STATS extends LogKeyShims
+  case object TXN_ID extends LogKeyShims
+  case object URI extends LogKeyShims
+  case object VACUUM_STATS extends LogKeyShims
+  case object VERSION extends LogKeyShims
+  case object VERSION2 extends LogKeyShims
 }
 
 object DeltaLogKeys extends DeltaLogKeysBase

--- a/spark/src/main/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuery.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuery.scala
@@ -111,7 +111,7 @@ trait OptimizeMetadataOnlyDeltaQuery extends Logging {
         Seq(InternalRow.fromSeq(rewrittenAggregationValues)))
       r
     } else {
-      logInfo(s"Query can't be optimized using metadata because stats are missing")
+      logInfo("Query can't be optimized using metadata because stats are missing")
       plan
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/ImplicitMetadataOperation.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/ImplicitMetadataOperation.scala
@@ -21,9 +21,11 @@ import org.apache.spark.sql.delta.skipping.clustering.temp.ClusterBySpec
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.{DomainMetadata, Metadata, Protocol}
 import org.apache.spark.sql.delta.constraints.Constraints
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.util.PartitionUtils
 
+import org.apache.spark.internal.MDC
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.FileSourceGeneratedMetadataStructField
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
@@ -133,7 +135,7 @@ trait ImplicitMetadataOperation extends DeltaLogging {
       txn.updateMetadataForTableOverwrite(newMetadata)
     } else if (isNewSchema && canMergeSchema && !isNewPartitioning
         ) {
-      logInfo(s"New merged schema: ${mergedSchema.treeString}")
+      logInfo(log"New merged schema: ${MDC(DeltaLogKeys.SCHEMA, mergedSchema.treeString)}")
       recordDeltaEvent(txn.deltaLog, "delta.ddl.mergeSchema")
       if (rearrangeOnly) {
         throw DeltaErrors.unexpectedDataChangeException("Change the Delta table schema")

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -24,12 +24,14 @@ import org.apache.spark.sql.delta.{DeltaAnalysisException, DeltaColumnMappingMod
 import org.apache.spark.sql.delta.{RowCommitVersion, RowId}
 import org.apache.spark.sql.delta.actions.Protocol
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.SchemaMergingUtils._
 import org.apache.spark.sql.delta.sources.DeltaSourceUtils.GENERATION_EXPRESSION_METADATA_KEY
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.util.ScalaExtensions._
 
+import org.apache.spark.internal.MDC
 import org.apache.spark.sql._
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.{Resolver, UnresolvedAttribute}
@@ -1396,7 +1398,8 @@ def normalizeColumnNamesInDataType(
       }
     } catch {
       case NonFatal(e) =>
-        logWarning(s"Failed to log undefined types for table ${deltaLog.logPath}", e)
+        logWarning(log"Failed to log undefined types for table " +
+          log"${MDC(DeltaLogKeys.PATH, deltaLog.logPath)}", e)
     }
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceCDCSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceCDCSupport.scala
@@ -19,7 +19,9 @@ package org.apache.spark.sql.delta.sources
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.actions.DomainMetadata
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 
+import org.apache.spark.internal.MDC
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.util.Utils
 
@@ -214,9 +216,13 @@ trait DeltaSourceCDCSupport { self: DeltaSource =>
           isStreaming = true)
         .fileChangeDf
     }
-    logInfo(s"Getting CDC dataFrame for delta_log_path=${deltaLog.logPath} with " +
-      s"startVersion=$startVersion, startIndex=$startIndex, " +
-      s"isInitialSnapshot=$isInitialSnapshot, endOffset=$endOffset took timeMs=$duration ms")
+    logInfo(log"Getting CDC dataFrame for delta_log_path=" +
+      log"${MDC(DeltaLogKeys.PATH, deltaLog.logPath)} with " +
+      log"startVersion=${MDC(DeltaLogKeys.START_VERSION, startVersion)}, " +
+      log"startIndex=${MDC(DeltaLogKeys.START_INDEX, startIndex)}, " +
+      log"isInitialSnapshot=${MDC(DeltaLogKeys.IS_INIT_SNAPSHOT, isInitialSnapshot)}, " +
+      log"endOffset=${MDC(DeltaLogKeys.END_OFFSET, endOffset)} took timeMs=" +
+      log"${MDC(DeltaLogKeys.DURATION, duration)} ms")
     result
   }
 
@@ -319,9 +325,12 @@ trait DeltaSourceCDCSupport { self: DeltaSource =>
       }
     }
 
-    logInfo(s"Getting CDC file changes for delta_log_path=${deltaLog.logPath} with " +
-      s"fromVersion=$fromVersion, fromIndex=$fromIndex, isInitialSnapshot=$isInitialSnapshot " +
-      s"took timeMs=$duration ms")
+    logInfo(log"Getting CDC file changes for delta_log_path=" +
+      log"${MDC(DeltaLogKeys.PATH, deltaLog.logPath)} with " +
+      log"fromVersion=${MDC(DeltaLogKeys.START_VERSION, fromVersion)}, fromIndex=" +
+      log"${MDC(DeltaLogKeys.START_INDEX, fromIndex)}, " +
+      log"isInitialSnapshot=${MDC(DeltaLogKeys.IS_INIT_SNAPSHOT, isInitialSnapshot)} took timeMs=" +
+      log"${MDC(DeltaLogKeys.DURATION, duration)} ms")
     result
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/storage/DelegatingLogStore.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/storage/DelegatingLogStore.scala
@@ -21,11 +21,13 @@ import java.util.Locale
 import scala.collection.mutable
 
 import org.apache.spark.sql.delta.DeltaErrors
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
 
 import org.apache.spark.SparkEnv
+import org.apache.spark.internal.MDC
 
 
 /**
@@ -72,7 +74,8 @@ class DelegatingLogStore(hadoopConf: Configuration)
               case lsa: LogStoreAdaptor => s"LogStoreAdapter(${lsa.logStoreImpl.getClass.getName})"
               case _ => logStore.getClass.getName
             }
-            logInfo(s"LogStore `$actualLogStoreClassName` is used for scheme `$scheme`")
+            logInfo(log"LogStore ${MDC(DeltaLogKeys.CLASS_NAME, actualLogStoreClassName)} " +
+              log"is used for scheme ${MDC(DeltaLogKeys.FILE_SYSTEM_SCHEME, scheme)}")
 
             logStore
           }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaProgressReporter.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaProgressReporter.scala
@@ -16,11 +16,13 @@
 
 package org.apache.spark.sql.delta.util
 
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
+
 import org.apache.spark.SparkContext
-import org.apache.spark.internal.Logging
+import org.apache.spark.internal.{LoggingShims, MDC}
 import org.apache.spark.sql.SparkSession
 
-trait DeltaProgressReporter extends Logging {
+trait DeltaProgressReporter extends LoggingShims {
   /**
    * Report a log to indicate some command is running.
    */
@@ -28,9 +30,10 @@ trait DeltaProgressReporter extends Logging {
       statusCode: String,
       defaultMessage: String,
       data: Map[String, Any] = Map.empty)(body: => T): T = {
-    logInfo(s"$statusCode: $defaultMessage")
+    logInfo(log"${MDC(DeltaLogKeys.STATUS, statusCode)}: " +
+      log"${MDC(DeltaLogKeys.MESSAGE, defaultMessage)}")
     val t = withJobDescription(defaultMessage)(body)
-    logInfo(s"$statusCode: Done")
+    logInfo(log"${MDC(DeltaLogKeys.STATUS, statusCode)}: Done")
     t
   }
   /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Migrate Delta's logging code to use Spark structured logging. Structured logging will be introduced in Spark 4.0, as highlighted in the [preview release of Spark 4.0 | Apache Spark](https://spark.apache.org/news/spark-4.0.0-preview1.html). Note that the feature is turned off by default and the output log message will remain unchanged.

Resolves #3145 
## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Existing tests.
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No