### PR TITLE
[Spark][Sharing] Update delta sharing client to version 1.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -429,7 +429,7 @@ lazy val sharing = (project in file("sharing"))
     libraryDependencies ++= Seq(
       "org.apache.spark" %% "spark-sql" % defaultSparkVersion % "provided",
 
-      "io.delta" %% "delta-sharing-client" % "1.0.5",
+      "io.delta" %% "delta-sharing-client" % "1.1.0",
 
       // Test deps
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test",

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingCDFUtilsSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingCDFUtilsSuite.scala
@@ -80,7 +80,10 @@ class TestDeltaSharingClientForCDFUtils(
     responseFormat: String = DeltaSharingRestClient.RESPONSE_FORMAT_DELTA,
     readerFeatures: String = "",
     queryTablePaginationEnabled: Boolean = false,
-    maxFilesPerReq: Int = 100000)
+    maxFilesPerReq: Int = 100000,
+    enableAsyncQuery: Boolean = false,
+    asyncQueryPollIntervalMillis: Long = 10000L,
+    asyncQueryMaxDuration: Long = 600000L)
     extends DeltaSharingClient {
 
   import CDFTesTUtils._

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingFileIndexSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingFileIndexSuite.scala
@@ -92,7 +92,10 @@ class TestDeltaSharingClientForFileIndex(
     responseFormat: String = DeltaSharingRestClient.RESPONSE_FORMAT_DELTA,
     readerFeatures: String = "",
     queryTablePaginationEnabled: Boolean = false,
-    maxFilesPerReq: Int = 100000)
+    maxFilesPerReq: Int = 100000,
+    enableAsyncQuery: Boolean = false,
+    asyncQueryPollIntervalMillis: Long = 10000L,
+    asyncQueryMaxDuration: Long = 600000L)
     extends DeltaSharingClient {
 
   import TestUtils._

--- a/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
@@ -50,7 +50,10 @@ private[spark] class TestClientForDeltaFormatSharing(
     responseFormat: String = DeltaSharingRestClient.RESPONSE_FORMAT_DELTA,
     readerFeatures: String = "",
     queryTablePaginationEnabled: Boolean = false,
-    maxFilesPerReq: Int = 100000)
+    maxFilesPerReq: Int = 100000,
+    enableAsyncQuery: Boolean = false,
+    asyncQueryPollIntervalMillis: Long = 10000L,
+    asyncQueryMaxDuration: Long = 600000L)
     extends DeltaSharingClient {
 
   assert(


### PR DESCRIPTION

#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Upgrade delta-sharing-client to v1.1.0

## How was this patch tested?

Existing test

## Does this PR introduce _any_ user-facing changes?

No.
