### PR TITLE
[Kernel] Change `Class.forName()` usage  in the `LogStoreProvider`.

### DIFF
--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/logstore/LogStoreProvider.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/logstore/LogStoreProvider.java
@@ -93,11 +93,7 @@ public class LogStoreProvider {
      */
     private static Class<? extends LogStore> getLogStoreClass(String logStoreClassName)
             throws ClassNotFoundException {
-        return Class.forName(
-                        logStoreClassName,
-                        true /* initialize */,
-                        Thread.currentThread().getContextClassLoader())
-                .asSubclass(LogStore.class);
+        return Class.forName(logStoreClassName).asSubclass(LogStore.class);
     }
 
     private static LogStore createLogStore(


### PR DESCRIPTION
## Description

Look for the `LogStore` class more broadly in the class loader than just the thread local's class loader. The thread context class loader requires the Thread local variables to have the `LogStore` in it, but this class loader may not have all the dependencies wired up.

## How was this patch tested?
Not tested yet.

Fixes https://github.com/delta-io/delta/issues/3299.