### PR TITLE
[Spark] Handle concurrent CREATE TABLE IF NOT EXISTS ... LIKE ... table commands

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -600,7 +600,7 @@ case class CreateDeltaTableCommand(
       case TableCreationModes.Create =>
         spark.sessionState.catalog.createTable(
           cleaned,
-          ignoreIfExists = existingTableOpt.isDefined,
+          ignoreIfExists = existingTableOpt.isDefined || mode == SaveMode.Ignore,
           validateLocation = false)
       case TableCreationModes.Replace | TableCreationModes.CreateOrReplace
           if existingTableOpt.isDefined =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCreateTableLikeSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCreateTableLikeSuite.scala
@@ -288,9 +288,8 @@ class DeltaCreateTableLikeSuite extends QueryTest
     withTempDir { dir =>
       withTable("t") {
         def getCatalogTable: CatalogTable = {
-          val storage =
-              CatalogStorageFormat.empty.copy(locationUri =
-                Some(new URI(s"$dir/${UUID.randomUUID().toString}")))
+          val storage = CatalogStorageFormat.empty.copy(
+            locationUri = Some(new URI(s"$dir/${UUID.randomUUID().toString}")))
           val catalogTableTarget = CatalogTable(
             identifier = TableIdentifier("t"),
             tableType = CatalogTableType.MANAGED,
@@ -309,12 +308,14 @@ class DeltaCreateTableLikeSuite extends QueryTest
           mode = SaveMode.Ignore,
           query = None,
           operation = TableCreationModes.Create).run(spark)
+        assert(spark.sessionState.catalog.tableExists(TableIdentifier("t")))
         CreateDeltaTableCommand(
           getCatalogTable,
           existingTableOpt = None, // Set to None to simulate concurrent table creation commands.
           mode = SaveMode.Ignore,
           query = None,
           operation = TableCreationModes.Create).run(spark)
+        assert(spark.sessionState.catalog.tableExists(TableIdentifier("t")))
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCreateTableLikeSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCreateTableLikeSuite.scala
@@ -17,14 +17,21 @@
 package org.apache.spark.sql.delta
 
 import java.io.File
+import java.net.URI
+import java.util.UUID
 
+import org.apache.spark.sql.delta.catalog.DeltaCatalog
+import org.apache.spark.sql.delta.commands.{CreateDeltaTableCommand, TableCreationModes}
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.scalatest.exceptions.TestFailedException
 
 import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType}
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.StructType
 
 class DeltaCreateTableLikeSuite extends QueryTest
   with SharedSparkSession
@@ -431,6 +438,42 @@ class DeltaCreateTableLikeSuite extends QueryTest
         checkTableCopy(srcTbl, targetTbl, checkDesc = false)
       }.getMessage
       assert(msg.contains("provider does not match"))
+    }
+  }
+
+  test("concurrent create Managed Catalog table commands should not fail") {
+    withTempDir { dir =>
+      withTable("t") {
+        def getCatalogTable: CatalogTable = {
+          val storage =
+            CatalogStorageFormat.empty.copy(locationUri =
+              Some(new URI(s"$dir/${UUID.randomUUID().toString}")))
+          val catalogTableTarget = CatalogTable(
+            identifier = TableIdentifier("t"),
+            tableType = CatalogTableType.MANAGED,
+            storage = storage,
+            provider = Some("delta"),
+            schema = new StructType().add("id", "long"))
+          new DeltaCatalog()
+            .verifyTableAndSolidify(
+              tableDesc = catalogTableTarget,
+              query = None,
+              existingTableOpt = None,
+              maybeClusterBySpec = None)
+        }
+        CreateDeltaTableCommand(
+          getCatalogTable,
+          existingTableOpt = None,
+          mode = SaveMode.Ignore,
+          query = None,
+          operation = TableCreationModes.Create).run(spark)
+        CreateDeltaTableCommand(
+          getCatalogTable,
+          existingTableOpt = None, // Set to None to simulate concurrent table creation commands.
+          mode = SaveMode.Ignore,
+          query = None,
+          operation = TableCreationModes.Create).run(spark)
+      }
     }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCreateTableLikeSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCreateTableLikeSuite.scala
@@ -301,7 +301,6 @@ class DeltaCreateTableLikeSuite extends QueryTest
             .verifyTableAndSolidify(
               tableDesc = catalogTableTarget,
               query = None,
-              existingTableOpt = None,
               maybeClusterBySpec = None)
         }
         CreateDeltaTableCommand(


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

When 2 or more CREATE TABLE IF NOT EXISTS table commands are run concurrently, they both think the table doesn't exist yet and the second command fails with TABLE_ALREADY_EXISTS error.

With this PR, we aim to make sure the second command end up in a no-op instead of a failure.

## How was this patch tested?

UTs

## Does this PR introduce _any_ user-facing changes?

No
