### PR TITLE
[Hudi] setCommitFileUpdates bug fix

### DIFF
--- a/hudi/src/test/scala/org/apache/spark/sql/delta/hudi/ConvertToHudiSuite.scala
+++ b/hudi/src/test/scala/org/apache/spark/sql/delta/hudi/ConvertToHudiSuite.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.avro.SchemaConverters
 import org.apache.spark.sql.delta.DeltaOperations.Truncate
 import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog, DeltaUnsupportedOperationException, OptimisticTransaction}
 import org.apache.spark.sql.delta.actions.{Action, AddFile, Metadata, RemoveFile}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.{ManualClock, Utils}
 import org.scalatest.concurrent.Eventually
@@ -210,6 +211,25 @@ class ConvertToHudiSuite extends QueryTest with Eventually {
       + s"date(from_unixtime($nowSeconds)), 32.1, 1.23, 456, 'hello world', "
       + s"timestamp(from_unixtime($nowSeconds)))")
     verifyFilesAndSchemaMatch()
+  }
+
+  test("all batches of actions are converted") {
+    withSQLConf(
+      DeltaSQLConf.HUDI_MAX_COMMITS_TO_CONVERT.key -> "3"
+    ) {
+      _sparkSession.sql(
+        s"""CREATE TABLE `$testTableName` (col1 INT)
+           | USING DELTA
+           |LOCATION '$testTablePath'""".stripMargin)
+      for (i <- 1 to 10) {
+        _sparkSession.sql(s"INSERT INTO `$testTableName` VALUES ($i)")
+      }
+      _sparkSession.sql(
+        s"""ALTER TABLE `$testTableName` SET TBLPROPERTIES (
+           |  'delta.universalFormat.enabledFormats' = 'hudi'
+           |)""".stripMargin)
+      verifyFilesAndSchemaMatch()
+    }
   }
 
   def buildHudiMetaClient(): HoodieTableMetaClient = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Hudi read support)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR fixes a bug in the Delta->Hudi metadata conversion logic. When the number of actions to convert is greater than the action batch size (can be changed by user), the previous code incorrectly only converted the last batch instead of converting all batches.
## How was this patch tested?
Unit test
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No