### PR TITLE
[Spark] Introduce stable type widening table feature

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -430,7 +430,7 @@ class DeltaLog private(
     val protocolEnabledFeatures = targetProtocol.writerFeatureNames
       .flatMap(TableFeature.featureNameToFeature)
     val activeFeatures =
-      Protocol.extractAutomaticallyEnabledFeatures(spark, targetMetadata, Some(targetProtocol))
+      Protocol.extractAutomaticallyEnabledFeatures(spark, targetMetadata, targetProtocol)
     val activeButNotEnabled = activeFeatures.diff(protocolEnabledFeatures)
     if (activeButNotEnabled.nonEmpty) {
       throw DeltaErrors.tableFeatureMismatchException(activeButNotEnabled.map(_.name))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
@@ -300,7 +300,7 @@ case class TypeWideningPreDowngradeCommand(table: DeltaTableV2)
    * @return Return true if files were rewritten or metadata was removed. False otherwise.
    */
   override def removeFeatureTracesIfNeeded(): Boolean = {
-    if (TypeWideningStableTableFeature.validateRemoval(table.initialSnapshot)) return false
+    if (TypeWideningTableFeature.validateRemoval(table.initialSnapshot)) return false
 
     val startTimeNs = System.nanoTime()
     val properties = Seq(DeltaConfigs.ENABLE_TYPE_WIDENING.key)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
@@ -284,7 +284,7 @@ case class TypeWideningPreDowngradeCommand(table: DeltaTableV2)
    * @return Return true if files were rewritten or metadata was removed. False otherwise.
    */
   override def removeFeatureTracesIfNeeded(): Boolean = {
-    if (TypeWideningTableFeature.validateRemoval(table.initialSnapshot)) return false
+    if (TypeWideningStableTableFeature.validateRemoval(table.initialSnapshot)) return false
 
     val startTimeNs = System.nanoTime()
     val properties = Seq(DeltaConfigs.ENABLE_TYPE_WIDENING.key)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -781,6 +781,10 @@ object TypeWideningPreviewTableFeature
  * when setting the type widening table property as the feature is still in preview in this version.
  * The feature spec is finalized though and by supporting the stable feature here we guarantee that
  * this version can already read any table created in the future.
+ *
+ * Note: Users can manually add both the preview and stable features to a table using ADD FEATURE,
+ * although that's undocumented for type widening. This is allowed: the two feature specifications
+ * are compatible and supported.
  */
 object TypeWideningTableFeature
   extends TypeWideningTableFeatureBase(name = "typeWidening")

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -345,7 +345,7 @@ object TableFeature {
       ColumnMappingTableFeature,
       TimestampNTZTableFeature,
       TypeWideningPreviewTableFeature,
-      TypeWideningStableTableFeature,
+      TypeWideningTableFeature,
       IcebergCompatV1TableFeature,
       IcebergCompatV2TableFeature,
       DeletionVectorsTableFeature,
@@ -773,7 +773,7 @@ object TypeWideningPreviewTableFeature
       metadata: Metadata,
       spark: SparkSession): Boolean = isTypeWideningSupportNeededByMetadata(metadata) &&
     // Don't automatically enable the preview feature if the stable feature is already supported.
-    !protocol.isFeatureSupported(TypeWideningStableTableFeature)
+    !protocol.isFeatureSupported(TypeWideningTableFeature)
 }
 
 /**
@@ -782,7 +782,7 @@ object TypeWideningPreviewTableFeature
  * The feature spec is finalized though and by supporting the stable feature here we guarantee that
  * this version can already read any table created in the future.
  */
-object TypeWideningStableTableFeature
+object TypeWideningTableFeature
   extends TypeWideningTableFeatureBase(name = "typeWidening")
 
 /**
@@ -1076,6 +1076,7 @@ object TestRemovableWriterWithHistoryTruncationFeature
   val TABLE_PROP_KEY = "_123TestRemovableWriterWithHistoryTruncationFeature321_"
 
   override def metadataRequiresFeatureToBeEnabled(
+      protocol: Protocol,
       metadata: Metadata,
       spark: SparkSession): Boolean = {
     metadata.configuration.get(TABLE_PROP_KEY).exists(_.toBoolean)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TypeWidening.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TypeWidening.scala
@@ -27,7 +27,7 @@ object TypeWidening {
    * Returns whether the protocol version supports the Type Widening table feature.
    */
   def isSupported(protocol: Protocol): Boolean =
-    Seq(TypeWideningPreviewTableFeature, TypeWideningStableTableFeature)
+    Seq(TypeWideningPreviewTableFeature, TypeWideningTableFeature)
       .exists(protocol.isFeatureSupported)
 
   /**
@@ -42,7 +42,7 @@ object TypeWidening {
       throw new IllegalStateException(
         s"Table property '${DeltaConfigs.ENABLE_TYPE_WIDENING.key}' is " +
           s"set on the table but this table version doesn't support table feature " +
-          s"'${TableFeatureProtocolUtils.propertyKey(TypeWideningStableTableFeature)}'.")
+          s"'${TableFeatureProtocolUtils.propertyKey(TypeWideningTableFeature)}'.")
     }
     isEnabled
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TypeWidening.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TypeWidening.scala
@@ -27,7 +27,8 @@ object TypeWidening {
    * Returns whether the protocol version supports the Type Widening table feature.
    */
   def isSupported(protocol: Protocol): Boolean =
-    protocol.isFeatureSupported(TypeWideningTableFeature)
+    Seq(TypeWideningPreviewTableFeature, TypeWideningStableTableFeature)
+      .exists(protocol.isFeatureSupported)
 
   /**
    * Returns whether Type Widening is enabled on this table version. Checks that Type Widening is
@@ -41,7 +42,7 @@ object TypeWidening {
       throw new IllegalStateException(
         s"Table property '${DeltaConfigs.ENABLE_TYPE_WIDENING.key}' is " +
           s"set on the table but this table version doesn't support table feature " +
-          s"'${TableFeatureProtocolUtils.propertyKey(TypeWideningTableFeature)}'.")
+          s"'${TableFeatureProtocolUtils.propertyKey(TypeWideningStableTableFeature)}'.")
     }
     isEnabled
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableCommand.scala
@@ -197,7 +197,7 @@ abstract class CloneConvertedSource(spark: SparkSession) extends CloneSource {
   def protocol: Protocol = {
     // This is quirky but necessary to add table features such as column mapping if the default
     // protocol version supports table features.
-    Protocol().withFeatures(extractAutomaticallyEnabledFeatures(spark, metadata))
+    Protocol().withFeatures(extractAutomaticallyEnabledFeatures(spark, metadata, Protocol()))
   }
 
   override val clock: Clock = new SystemClock()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
@@ -986,7 +986,8 @@ trait CDCReaderImpl extends DeltaLogging {
    * Determine if the metadata provided has cdc enabled or not.
    */
   def isCDCEnabledOnTable(metadata: Metadata, spark: SparkSession): Boolean = {
-    ChangeDataFeedTableFeature.metadataRequiresFeatureToBeEnabled(metadata, spark)
+    ChangeDataFeedTableFeature.metadataRequiresFeatureToBeEnabled(
+      protocol = Protocol(), metadata, spark)
   }
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingTestUtils.scala
@@ -261,7 +261,9 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
         Protocol.forNewTable(spark, Some(metadata)).minWriterVersion.toString))
     if (snapshot.protocol.supportsReaderFeatures || snapshot.protocol.supportsWriterFeatures) {
       props ++=
-        Protocol.minProtocolComponentsFromAutomaticallyEnabledFeatures(spark, metadata)._3
+        Protocol.minProtocolComponentsFromAutomaticallyEnabledFeatures(
+          spark, metadata, snapshot.protocol)
+          ._3
           .map(f => (
             s"${TableFeatureProtocolUtils.FEATURE_PROP_PREFIX}${f.name}",
             TableFeatureProtocolUtils.FEATURE_PROP_SUPPORTED))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
@@ -329,11 +329,12 @@ class DeltaTableFeatureSuite
   test("Table features are not automatically enabled by default table property settings") {
     withTable("tbl") {
       spark.range(10).write.format("delta").saveAsTable("tbl")
-      val metadata = DeltaLog.forTable(spark, TableIdentifier("tbl")).update().metadata
+      val snapshot = DeltaLog.forTable(spark, TableIdentifier("tbl")).update()
       TableFeature.allSupportedFeaturesMap.values.foreach {
         case feature: FeatureAutomaticallyEnabledByMetadata =>
           assert(
-            !feature.metadataRequiresFeatureToBeEnabled(metadata, spark),
+            !feature.metadataRequiresFeatureToBeEnabled(
+              snapshot.protocol, snapshot.metadata, spark),
             s"""
                |${feature.name} is automatically enabled by the default metadata. This will lead to
                |the inability of reading existing tables that do not have the feature enabled and

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTableFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTableFeatureSuite.scala
@@ -575,7 +575,7 @@ trait TypeWideningTableFeatureTests extends RowTrackingTestUtils with TypeWideni
 
     assert(protocol.isFeatureSupported(TypeWideningPreviewTableFeature) === preview,
       s"Expected the preview feature to be ${supported(preview)} but it is ${supported(!preview)}.")
-    assert(protocol.isFeatureSupported(TypeWideningStableTableFeature) === stable,
+    assert(protocol.isFeatureSupported(TypeWideningTableFeature) === stable,
       s"Expected the stable feature to be ${supported(stable)} but it is ${supported(!stable)}.")
     assert(TypeWidening.isSupported(protocol) === preview || stable,
       s"Expected type widening to be ${supported(preview || stable)} but it is " +
@@ -593,7 +593,7 @@ trait TypeWideningTableFeatureTests extends RowTrackingTestUtils with TypeWideni
     // The stable feature isn't supported and can't be dropped.
     assertFeatureSupported(preview = true, stable = false)
     dropTableFeature(
-      feature = TypeWideningStableTableFeature,
+      feature = TypeWideningTableFeature,
       expectedOutcome = ExpectedOutcome.FAIL_FEATURE_NOT_PRESENT,
       expectedNumFilesRewritten = 0,
       expectedColumnTypes = Map("a" -> ByteType)
@@ -625,7 +625,7 @@ trait TypeWideningTableFeatureTests extends RowTrackingTestUtils with TypeWideni
     assertFeatureSupported(preview = false, stable = false)
     // This is undocumented for type widening but users can manually add the preview/stable feature
     // to the table instead of using the table property.
-    addTableFeature(tempPath, TypeWideningStableTableFeature)
+    addTableFeature(tempPath, TypeWideningTableFeature)
     assertFeatureSupported(preview = false, stable = true)
 
     addTableFeature(tempPath, TypeWideningPreviewTableFeature)
@@ -636,7 +636,7 @@ trait TypeWideningTableFeatureTests extends RowTrackingTestUtils with TypeWideni
     sql(s"ALTER TABLE delta.`$tempPath` CHANGE COLUMN a TYPE int")
     // Dropping the stable feature doesn't also drop the preview feature.
     dropTableFeature(
-      feature = TypeWideningStableTableFeature,
+      feature = TypeWideningTableFeature,
       expectedOutcome = ExpectedOutcome.FAIL_CURRENT_VERSION_USES_FEATURE,
       expectedNumFilesRewritten = 1,
       expectedColumnTypes = Map("a" -> IntegerType)
@@ -645,7 +645,7 @@ trait TypeWideningTableFeatureTests extends RowTrackingTestUtils with TypeWideni
 
     advancePastRetentionPeriod()
     dropTableFeature(
-      feature = TypeWideningStableTableFeature,
+      feature = TypeWideningTableFeature,
       expectedOutcome = ExpectedOutcome.SUCCESS,
       expectedNumFilesRewritten = 0,
       expectedColumnTypes = Map("a" -> IntegerType)
@@ -668,7 +668,7 @@ trait TypeWideningTableFeatureTests extends RowTrackingTestUtils with TypeWideni
     sql(s"CREATE TABLE delta.`$tempPath` (a byte) USING DELTA " +
       s"TBLPROPERTIES ('${DeltaConfigs.ENABLE_TYPE_WIDENING.key}' = 'false')")
 
-    addTableFeature(tempPath, TypeWideningStableTableFeature)
+    addTableFeature(tempPath, TypeWideningTableFeature)
     assertFeatureSupported(preview = false, stable = true)
 
     // Enable the table property, this should keep the stable feature but not add the preview one.
@@ -686,7 +686,7 @@ trait TypeWideningTableFeatureTests extends RowTrackingTestUtils with TypeWideni
     )
     // The stable table feature can be dropped.
     dropTableFeature(
-      feature = TypeWideningStableTableFeature,
+      feature = TypeWideningTableFeature,
       expectedOutcome = ExpectedOutcome.FAIL_CURRENT_VERSION_USES_FEATURE,
       expectedNumFilesRewritten = 1,
       expectedColumnTypes = Map("a" -> IntegerType)
@@ -695,7 +695,7 @@ trait TypeWideningTableFeatureTests extends RowTrackingTestUtils with TypeWideni
 
     advancePastRetentionPeriod()
     dropTableFeature(
-      feature = TypeWideningStableTableFeature,
+      feature = TypeWideningTableFeature,
       expectedOutcome = ExpectedOutcome.SUCCESS,
       expectedNumFilesRewritten = 0,
       expectedColumnTypes = Map("a" -> IntegerType)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTableFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTableFeatureSuite.scala
@@ -628,6 +628,8 @@ trait TypeWideningTableFeatureTests extends RowTrackingTestUtils with TypeWideni
     addTableFeature(tempPath, TypeWideningTableFeature)
     assertFeatureSupported(preview = false, stable = true)
 
+    // Users can manually add both features to the table that way: this is allowed, the two
+    // specifications are compatible and supported.
     addTableFeature(tempPath, TypeWideningPreviewTableFeature)
     assertFeatureSupported(preview = true, stable = true)
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTestMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTestMixin.scala
@@ -124,7 +124,10 @@ trait TypeWideningDropFeatureTestMixin
 
   /** Expected outcome of dropping the type widening table feature. */
   object ExpectedOutcome extends Enumeration {
-    val SUCCESS, FAIL_CURRENT_VERSION_USES_FEATURE, FAIL_HISTORICAL_VERSION_USES_FEATURE = Value
+    val SUCCESS,
+    FAIL_CURRENT_VERSION_USES_FEATURE,
+    FAIL_HISTORICAL_VERSION_USES_FEATURE,
+    FAIL_FEATURE_NOT_PRESENT = Value
   }
 
   /**
@@ -133,14 +136,14 @@ trait TypeWideningDropFeatureTestMixin
    * files all contain the expected type for specified columns.
    */
   def dropTableFeature(
+      feature: TableFeature = TypeWideningPreviewTableFeature,
       expectedOutcome: ExpectedOutcome.Value,
       expectedNumFilesRewritten: Long,
       expectedColumnTypes: Map[String, DataType]): Unit = {
     val snapshot = deltaLog.update()
     // Need to directly call ALTER TABLE command to pass our deltaLog with manual clock.
-    val dropFeature = AlterTableDropFeatureDeltaCommand(
-      DeltaTableV2(spark, deltaLog.dataPath),
-      TypeWideningTableFeature.name)
+    val dropFeature =
+      AlterTableDropFeatureDeltaCommand(DeltaTableV2(spark, deltaLog.dataPath), feature.name)
 
     expectedOutcome match {
       case ExpectedOutcome.SUCCESS =>
@@ -150,7 +153,7 @@ trait TypeWideningDropFeatureTestMixin
           exception = intercept[DeltaTableFeatureException] { dropFeature.run(spark) },
           errorClass = "DELTA_FEATURE_DROP_WAIT_FOR_RETENTION_PERIOD",
           parameters = Map(
-            "feature" -> TypeWideningTableFeature.name,
+            "feature" -> feature.name,
             "logRetentionPeriodKey" -> DeltaConfigs.LOG_RETENTION.key,
             "logRetentionPeriod" -> DeltaConfigs.LOG_RETENTION
               .fromMetaData(snapshot.metadata).toString,
@@ -163,7 +166,7 @@ trait TypeWideningDropFeatureTestMixin
           exception = intercept[DeltaTableFeatureException] { dropFeature.run(spark) },
           errorClass = "DELTA_FEATURE_DROP_HISTORICAL_VERSIONS_EXIST",
           parameters = Map(
-            "feature" -> TypeWideningTableFeature.name,
+            "feature" -> feature.name,
             "logRetentionPeriodKey" -> DeltaConfigs.LOG_RETENTION.key,
             "logRetentionPeriod" -> DeltaConfigs.LOG_RETENTION
               .fromMetaData(snapshot.metadata).toString,
@@ -171,13 +174,22 @@ trait TypeWideningDropFeatureTestMixin
               DeltaConfigs.TABLE_FEATURE_DROP_TRUNCATE_HISTORY_LOG_RETENTION
                 .fromMetaData(snapshot.metadata).toString)
         )
+      case ExpectedOutcome.FAIL_FEATURE_NOT_PRESENT =>
+        checkError(
+          exception = intercept[DeltaTableFeatureException] { dropFeature.run(spark) },
+          errorClass = "DELTA_FEATURE_DROP_FEATURE_NOT_PRESENT",
+          parameters = Map("feature" -> feature.name)
+        )
+    }
+
+    if (expectedOutcome != ExpectedOutcome.FAIL_FEATURE_NOT_PRESENT) {
+      assert(!TypeWideningMetadata.containsTypeWideningMetadata(deltaLog.update().schema))
     }
 
     // Check the number of files rewritten.
     assert(getNumRemoveFilesSinceVersion(snapshot.version + 1) === expectedNumFilesRewritten,
       s"Expected $expectedNumFilesRewritten file(s) to be rewritten but found " +
         s"${getNumRemoveFilesSinceVersion(snapshot.version + 1)} rewritten file(s).")
-    assert(!TypeWideningMetadata.containsTypeWideningMetadata(deltaLog.update().schema))
 
     // Check that all files now contain the expected data types.
     expectedColumnTypes.foreach { case (colName, expectedType) =>


### PR DESCRIPTION

## Description

This is the first step in transitioning the type widening table feature from preview to stable.
Requirement: the protocol spec is finalized and the final version doesn't contain any backward-incompatible changes. See https://github.com/delta-io/delta/pull/3297

This change introduces a new table feature `typeWidening` for the final, stable phase of type widening. Both the preview and stable table features are supported simultaneously - the current implementation respects both the protocol spec used during the preview and the finalized protocol spec.

The stable feature isn't enabled automatically though as type widening is still in preview. The preview feature `typeWidening-preview` is the default feature enabled when the type widening table property is set. 

The second step of the transition will be at GA time, to make the stable feature the default, automatically enabled one.
During the transition period, all clients will support any table that enabled the feature during both the preview, and later on during the GA phase.

## How was this patch tested?
Added tests covering enabling in combination preview / stable features
Added a test in particular to ensure that the preview feature doesn't get enabled automatically if the stable feature is already enabled.

## Does this PR introduce _any_ user-facing changes?
DBR now supports all tables that enable the type widening table feature, both now during the preview and in the future after the feature transitions to GA.
