### PR TITLE
[Hudi] Support list/map data type conversion

### DIFF
--- a/hudi/src/main/scala/org/apache/spark/sql/delta/hudi/HudiSchemaUtils.scala
+++ b/hudi/src/main/scala/org/apache/spark/sql/delta/hudi/HudiSchemaUtils.scala
@@ -34,7 +34,7 @@ object HudiSchemaUtils extends DeltaLogging {
      * corresponding Avro type.
      */
     def transform[E <: DataType](elem: E, isNullable: Boolean, currentPath: String): Schema =
-      elem match {
+    elem match {
       case StructType(fields) =>
 
         val avroFields: util.List[Schema.Field] = fields.map(f =>

--- a/hudi/src/main/scala/org/apache/spark/sql/delta/hudi/HudiSchemaUtils.scala
+++ b/hudi/src/main/scala/org/apache/spark/sql/delta/hudi/HudiSchemaUtils.scala
@@ -34,7 +34,7 @@ object HudiSchemaUtils extends DeltaLogging {
      * corresponding Avro type.
      */
     def transform[E <: DataType](elem: E, isNullable: Boolean, currentPath: String): Schema =
-    elem match {
+      elem match {
       case StructType(fields) =>
 
         val avroFields: util.List[Schema.Field] = fields.map(f =>
@@ -45,12 +45,16 @@ object HudiSchemaUtils extends DeltaLogging {
         finalizeSchema(
           Schema.createRecord(currentPath, null, null, false, avroFields),
           isNullable)
-      // TODO: Add List and Map support: https://github.com/delta-io/delta/issues/2738
+
       case ArrayType(elementType, containsNull) =>
-        throw new UnsupportedOperationException("UniForm Hudi doesn't support Array columns")
+        finalizeSchema(
+          Schema.createArray(transform(elementType, containsNull, currentPath)),
+          isNullable)
 
       case MapType(keyType, valueType, valueContainsNull) =>
-        throw new UnsupportedOperationException("UniForm Hudi doesn't support Map columns")
+        finalizeSchema(
+          Schema.createMap(transform(valueType, valueContainsNull, currentPath)),
+          isNullable)
 
       case atomicType: AtomicType => convertAtomic(atomicType, isNullable)
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
@@ -101,7 +101,6 @@ object UniversalFormat extends DeltaLogging {
       if (DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.fromMetaData(newestMetadata)) {
         throw DeltaErrors.uniFormHudiDeleteVectorCompat()
       }
-      // TODO: remove once map/list support is added https://github.com/delta-io/delta/issues/2738
       SchemaUtils.findAnyTypeRecursively(newestMetadata.schema) { f =>
         f.isInstanceOf[NullType]
       } match {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
@@ -103,7 +103,7 @@ object UniversalFormat extends DeltaLogging {
       }
       // TODO: remove once map/list support is added https://github.com/delta-io/delta/issues/2738
       SchemaUtils.findAnyTypeRecursively(newestMetadata.schema) { f =>
-        f.isInstanceOf[MapType] || f.isInstanceOf[ArrayType] || f.isInstanceOf[NullType]
+        f.isInstanceOf[NullType]
       } match {
         case Some(unsupportedType) =>
           throw DeltaErrors.uniFormHudiSchemaCompat(unsupportedType)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.internal.MDC
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.types.{ArrayType, MapType, NullType}
+import org.apache.spark.sql.types.NullType
 
 /**
  * Utils to validate the Universal Format (UniForm) Delta feature (NOT a table feature).
@@ -33,8 +33,9 @@ import org.apache.spark.sql.types.{ArrayType, MapType, NullType}
  * The UniForm Delta feature governs and implements the actual conversion of Delta metadata into
  * other formats.
  *
- * Currently, UniForm only supports Iceberg. When `delta.universalFormat.enabledFormats` contains
- * "iceberg", we say that Universal Format (Iceberg) is enabled.
+ * UniForm supports both Iceberg and Hudi. When `delta.universalFormat.enabledFormats` contains
+ * "iceberg", we say that Universal Format (Iceberg) is enabled. When it contains "hudi", we say
+ * that Universal Format (Hudi) is enabled.
  *
  * [[enforceInvariantsAndDependencies]] ensures that all of UniForm's requirements for the
  * specified format are met (e.g. for 'iceberg' that IcebergCompatV1 or V2 is enabled).


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Hudi)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR adds functionality to convert Delta tables with list or map type columns to be Hudi-readable. 

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Added unit tests in ConvertToHudiSuite and tested manually with external Hudi Spark reader.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Previously users could not enable the Delta table property for Hudi conversion on tables containing list/map columns and would receive an unsupportedType error but now they can.