### PR TITLE
[Spark] Use Coordinated Commits Properties from SparkSession during CLONE

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -366,6 +366,24 @@
     ],
     "sqlState" : "42613"
   },
+  "DELTA_CLONE_CANNOT_OVERRIDE_COORDINATED_COMMITS" : {
+    "message" : [
+      "Cannot override coordinated commits configurations for an existing target table that already has coordinated commits enabled during CLONE."
+    ],
+    "sqlState" : "42616"
+  },
+  "DELTA_CLONE_CONF_OVERRIDE_NOT_SUPPORTED" : {
+    "message" : [
+      "Configuration \"<configuration>\" cannot be overridden with CLONE command."
+    ],
+    "sqlState" : "42616"
+  },
+  "DELTA_CLONE_MUST_OVERRIDE_ALL_COORDINATED_COMMITS_CONFS" : {
+    "message" : [
+      "During CLONE, either all coordinated commits configurations i.e.\"delta.coordinatedCommits.commitCoordinator-preview\", \"delta.coordinatedCommits.commitCoordinatorConf-preview\" must be overridden or none of them."
+    ],
+    "sqlState" : "42616"
+  },
   "DELTA_CLONE_UNSUPPORTED_SOURCE" : {
     "message" : [
       "Unsupported clone source '<name>', whose format is <format>.",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
@@ -25,6 +25,7 @@ import scala.collection.JavaConverters._
 import org.apache.spark.sql.delta.skipping.clustering.ClusteredTableUtils
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsUtils
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util._
@@ -194,7 +195,7 @@ abstract class CloneTableBase(
       destinationTable.createLogDirectoriesIfNotExists()
     }
 
-    val metadataToUpdate = determineTargetMetadata(txn.snapshot, deltaOperation.name)
+    val metadataToUpdate = determineTargetMetadata(spark, txn.snapshot, deltaOperation.name)
     // Don't merge in the default properties when cloning, or we'll end up with different sets of
     // properties between source and target.
     txn.updateMetadata(metadataToUpdate, ignoreDefaultProperties = true)
@@ -283,6 +284,15 @@ abstract class CloneTableBase(
     }
   }
 
+  // SparkSession default configurations are used for Commit Coordinator configurations for a new
+  // table created as part of CLONE.
+  private def fetchDefaultCoordinatedCommitsConfigurations(
+      spark: SparkSession): Map[String, String] = {
+    CoordinatedCommitsUtils.TABLE_PROPERTY_CONFS.flatMap { conf =>
+      spark.conf.getOption(conf.defaultTablePropertyKey).map(value => conf.key -> value)
+    }.toMap
+  }
+
   /**
    * Prepares the source metadata by making it compatible with the existing target metadata.
    */
@@ -299,6 +309,11 @@ abstract class CloneTableBase(
       // Set the ID equal to the target ID
       clonedMetadata = clonedMetadata.copy(id = targetSnapshot.metadata.id)
     }
+
+    // Coordinated Commit configurations are never copied over to the target table.
+    clonedMetadata = clonedMetadata.copy(configuration =
+      clonedMetadata.configuration.filterKeys(
+        !CoordinatedCommitsUtils.TABLE_PROPERTY_KEYS.contains(_)).toMap)
     clonedMetadata
   }
 
@@ -321,17 +336,80 @@ abstract class CloneTableBase(
     }
   }
 
+  // Priority of Coordinated Commits configurations:
+  // 1: Explicit Configuration overrides provided by the user.
+  // 2: Table properties of the existing target table.
+  // 3: Default SparkSession configurations.
+  private def determineCoordinatedCommitsConfigurations(
+      spark: SparkSession,
+      targetSnapshot: SnapshotDescriptor,
+      validatedOverrides: Map[String, String]): Map[String, String] = {
+    // Update clonedMetadata's configuration by replacing coordinated-commits related entries
+    // based on targetSnapshot's configuration
+    val existingTargetConfs: Map[String, String] =
+      if (tableExists(targetSnapshot)) {
+        targetSnapshot.metadata.configuration
+          .filterKeys(CoordinatedCommitsUtils.TABLE_PROPERTY_KEYS.contains)
+          .toMap
+      } else {
+        Map.empty
+      }
+    if (validatedOverrides.nonEmpty) {
+      if (existingTargetConfs.nonEmpty) {
+        throw new DeltaIllegalArgumentException(
+          "DELTA_CLONE_CANNOT_OVERRIDE_COORDINATED_COMMITS",
+          Array.empty)
+      }
+      Seq(
+          DeltaConfigs.COORDINATED_COMMITS_COORDINATOR_NAME.key,
+          DeltaConfigs.COORDINATED_COMMITS_COORDINATOR_CONF.key).foreach { key =>
+        if (!validatedOverrides.contains(key)) {
+          throw new DeltaIllegalArgumentException(
+            errorClass = "DELTA_CLONE_MUST_OVERRIDE_ALL_COORDINATED_COMMITS_CONFS",
+            messageParameters = Array.empty)
+        }
+      }
+      Seq(DeltaConfigs.COORDINATED_COMMITS_TABLE_CONF.key).foreach { key =>
+        if (validatedOverrides.contains(key)) {
+          throw new DeltaIllegalArgumentException(
+            errorClass = "DELTA_CLONE_CONF_OVERRIDE_NOT_SUPPORTED",
+            messageParameters = Array(key))
+        }
+      }
+      validatedOverrides
+    } else if (tableExists(targetSnapshot)) {
+      existingTargetConfs
+    } else {
+      fetchDefaultCoordinatedCommitsConfigurations(spark)
+    }
+  }
+
   /**
    * Determines the expected metadata of the target.
    */
   private def determineTargetMetadata(
+      spark: SparkSession,
       targetSnapshot: SnapshotDescriptor,
       opName: String) : Metadata = {
     var metadata = prepareSourceMetadata(targetSnapshot, opName)
     val validatedConfigurations = DeltaConfigs.validateConfigurations(tablePropertyOverrides)
-    // Merge source configuration and table property overrides
-    metadata = metadata.copy(
-      configuration = metadata.configuration ++ validatedConfigurations)
+
+    // Finalize Coordinated Commits configurations for the target
+    val coordinatedCommitsConfigurationOverrides =
+      validatedConfigurations.filterKeys(CoordinatedCommitsUtils.TABLE_PROPERTY_KEYS.contains).toMap
+    val validatedConfigurationsWithoutCoordinatedCommits =
+      validatedConfigurations -- coordinatedCommitsConfigurationOverrides.keys
+    val finalCoordinatedCommitsConfigurations = determineCoordinatedCommitsConfigurations(
+      spark,
+      targetSnapshot,
+      coordinatedCommitsConfigurationOverrides)
+
+    // Merge source configuration, table property overrides and coordinated-commits configurations.
+    metadata = metadata.copy(configuration =
+      metadata.configuration ++
+        validatedConfigurationsWithoutCoordinatedCommits ++
+        finalCoordinatedCommitsConfigurations)
+
     verifyMetadataInvariants(targetSnapshot, metadata)
     metadata
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
@@ -232,23 +232,21 @@ object CoordinatedCommitsUtils extends DeltaLogging {
       abstractMetadata, DeltaConfigs.COORDINATED_COMMITS_TABLE_CONF)
   }
 
+  val TABLE_PROPERTY_CONFS = Seq(
+    DeltaConfigs.COORDINATED_COMMITS_COORDINATOR_NAME,
+    DeltaConfigs.COORDINATED_COMMITS_COORDINATOR_CONF,
+    DeltaConfigs.COORDINATED_COMMITS_TABLE_CONF)
+
   /**
    * The main table properties used to instantiate a TableCommitCoordinatorClient.
    */
-  val TABLE_PROPERTY_KEYS: Seq[String] = Seq(
-    DeltaConfigs.COORDINATED_COMMITS_COORDINATOR_NAME.key,
-    DeltaConfigs.COORDINATED_COMMITS_COORDINATOR_CONF.key,
-    DeltaConfigs.COORDINATED_COMMITS_TABLE_CONF.key)
+  val TABLE_PROPERTY_KEYS: Seq[String] = TABLE_PROPERTY_CONFS.map(_.key)
 
   /**
    * Returns true if any CoordinatedCommits-related table properties is present in the metadata.
    */
   def tablePropertiesPresent(metadata: Metadata): Boolean = {
-    val coordinatedCommitsProperties = Seq(
-      DeltaConfigs.COORDINATED_COMMITS_COORDINATOR_NAME.key,
-      DeltaConfigs.COORDINATED_COMMITS_COORDINATOR_CONF.key,
-      DeltaConfigs.COORDINATED_COMMITS_TABLE_CONF.key)
-    coordinatedCommitsProperties.exists(metadata.configuration.contains)
+    TABLE_PROPERTY_KEYS.exists(metadata.configuration.contains)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryCommitCoordinator.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryCommitCoordinator.scala
@@ -199,6 +199,12 @@ class InMemoryCommitCoordinator(val batchSize: Long)
     Map.empty
   }
 
+  def dropTable(logPath: Path): Unit = {
+    withWriteLock(logPath) {
+      perTableMap.remove(logPath)
+    }
+  }
+
   override def semanticEquals(other: CommitCoordinatorClient): Boolean = this == other
 }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

For CLONE, the priority order for Coordinated Commits related settings is:
1. Explicit overrides with the CLONE command
2. SparkSession defaults

Note, we never pick the Coordinated Commits related settings from the source metadata even if the above two are not set.


## How was this patch tested?

UTs

## Does this PR introduce _any_ user-facing changes?

No
