### PR TITLE
[Spark] Use location as the table path

### DIFF
--- a/examples/scala/src/main/scala/example/IcebergCompatV2.scala
+++ b/examples/scala/src/main/scala/example/IcebergCompatV2.scala
@@ -27,19 +27,16 @@ import org.apache.spark.sql.SparkSession
  * A standalone HMS can be created using the following docker command.
  *  ************************************************************
  *  docker run -d -p 9083:9083 --env SERVICE_NAME=metastore \
- *  --name metastore-standalone apache/hive:4.0.0-beta-1
+ *  --name metastore-standalone apache/hive:4.0.0
  *  ************************************************************
  *  The URL of this standalone HMS is thrift://localhost:9083
- *
- *  By default this hms will use `/opt/hive/data/warehouse` as warehouse path.
- *  Please make sure this path exists or change it prior to running the example.
  */
 object IcebergCompatV2 {
 
   def main(args: Array[String]): Unit = {
     // Update this according to the metastore config
     val port = 9083
-    val warehousePath = "/opt/hive/data/warehouse/"
+    val warehousePath = FileUtils.getTempDirectoryPath()
 
     if (!UniForm.hmsReady(port)) {
       print("HMS not available. Exit.")

--- a/examples/scala/src/main/scala/example/UniForm.scala
+++ b/examples/scala/src/main/scala/example/UniForm.scala
@@ -28,19 +28,16 @@ import org.apache.spark.sql.SparkSession
  * A standalone HMS can be created using the following docker command.
  *  ************************************************************
  *  docker run -d -p 9083:9083 --env SERVICE_NAME=metastore \
- *  --name metastore-standalone apache/hive:4.0.0-beta-1
+ *  --name metastore-standalone apache/hive:4.0.0
  *  ************************************************************
  *  The URL of this standalone HMS is thrift://localhost:9083
- *
- *  By default this hms will use `/opt/hive/data/warehouse` as warehouse path.
- *  Please make sure this path exists or change it prior to running the example.
  */
 object UniForm {
 
   def main(args: Array[String]): Unit = {
     // Update this according to the metastore config
     val port = 9083
-    val warehousePath = "/opt/hive/data/warehouse/"
+    val warehousePath = FileUtils.getTempDirectoryPath()
 
     if (!hmsReady(port)) {
       print("HMS not available. Exit.")

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
@@ -400,6 +400,7 @@ class IcebergConversionTransaction(
       hiveCatalog
         .buildTable(icebergTableId, icebergSchema)
         .withPartitionSpec(partitionSpec)
+        .withLocation(this.tablePath.toString)
         .withProperties(properties.asJava)
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (fill in here)

## Description

This will include the table path, to avoid defaulting to the path that Hive suggests.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
