### PR TITLE
[Spark] Use binary encoding for DV descriptor in file metadata

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
@@ -341,7 +341,7 @@ case class DeltaParquetFileFormat(
             s"Unexpected row index filter type: ${unexpectedFilterType}")
         }
         rowIndexFilter.createInstance(
-          DeletionVectorDescriptor.fromJson(dvDescriptorOpt.get.asInstanceOf[String]),
+          DeletionVectorDescriptor.deserializeFromBase64(dvDescriptorOpt.get.asInstanceOf[String]),
           serializableHadoopConf.value,
           tablePath.map(new Path(_)))
       } else if (dvDescriptorOpt.isDefined || filterTypeOpt.isDefined) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/deletionvectors/StoredBitmap.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/deletionvectors/StoredBitmap.scala
@@ -22,7 +22,6 @@ import org.apache.spark.sql.delta.DeltaErrors
 import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
-import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.util.Utils
@@ -97,7 +96,7 @@ case class DeletionVectorStoredBitmap(
 
   override def cardinality: Long = dvDescriptor.cardinality
 
-  override lazy val getUniqueId: String = JsonUtils.toJson(dvDescriptor)
+  override lazy val getUniqueId: String = dvDescriptor.serializeToBase64()
 
   private def isEmpty: Boolean = dvDescriptor.isEmpty
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/files/TahoeFileIndex.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/files/TahoeFileIndex.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.delta.actions.{AddFile, Metadata, Protocol}
 import org.apache.spark.sql.delta.implicits._
 import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.hadoop.fs.FileStatus
 import org.apache.hadoop.fs.Path
 
@@ -129,7 +128,7 @@ abstract class TahoeFileIndex(
 
     if (addFile.deletionVector != null) {
       metadata.put(DeltaParquetFileFormat.FILE_ROW_INDEX_FILTER_ID_ENCODED,
-        JsonUtils.toJson(addFile.deletionVector))
+        addFile.deletionVector.serializeToBase64())
 
       // Set the filter type to IF_CONTAINED by default to let [[DeltaParquetFileFormat]] filter
       // out rows unless a filter type was explicitly provided in rowIndexFilters. This can happen


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

The Deletion Vector descriptor of each file is currently serialized in file's custom metadata as a JSON string. We can reduce the size of the descriptor by using a custom binary encoding. Note that the serialized DV descriptor is never persisted to disk so this change is safe.

## How was this patch tested?

Updated existing new tests.

## Does this PR introduce _any_ user-facing changes?

No
