### PR TITLE
[Spark] Add postCommit as a separate phase for FuzzTest

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -2053,6 +2053,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
 
     commitEndNano = System.nanoTime()
 
+    executionObserver.beginPostCommit()
     val postCommitSnapshot = deltaLog.updateAfterCommit(
       attemptVersion,
       commit,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TransactionExecutionObserver.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TransactionExecutionObserver.scala
@@ -69,6 +69,9 @@ trait TransactionExecutionObserver
   /** Called after publishing the commit file but before the `backfill` attempt. */
   def beginBackfill(): Unit
 
+  /** Called after backfill but before the `postCommit` attempt. */
+  def beginPostCommit(): Unit
+
   /** Called once a commit succeeded. */
   def transactionCommitted(): Unit
 
@@ -102,6 +105,8 @@ object NoOpTransactionExecutionObserver extends TransactionExecutionObserver {
   override def beginDoCommit(): Unit = ()
 
   override def beginBackfill(): Unit = ()
+
+  override def beginPostCommit(): Unit = ()
 
   override def transactionCommitted(): Unit = ()
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/fuzzer/OptimisticTransactionPhases.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/fuzzer/OptimisticTransactionPhases.scala
@@ -20,7 +20,8 @@ case class OptimisticTransactionPhases(
     initialPhase: ExecutionPhaseLock,
     preparePhase: ExecutionPhaseLock,
     commitPhase: ExecutionPhaseLock,
-    backfillPhase: ExecutionPhaseLock)
+    backfillPhase: ExecutionPhaseLock,
+    postCommitPhase: ExecutionPhaseLock)
 
 object OptimisticTransactionPhases {
 
@@ -30,6 +31,7 @@ object OptimisticTransactionPhases {
   final val PREPARE_PHASE_LABEL = PREFIX + "PREPARE"
   final val COMMIT_PHASE_LABEL = PREFIX + "COMMIT"
   final val BACKFILL_PHASE_LABEL = PREFIX + "BACKFILL"
+  final val POST_COMMIT_PHASE_LABEL = PREFIX + "POST_COMMIT"
 
   def forName(txnName: String): OptimisticTransactionPhases = {
 
@@ -40,6 +42,7 @@ object OptimisticTransactionPhases {
       initialPhase = ExecutionPhaseLock(toTxnPhaseLabel(INITIAL_PHASE_LABEL)),
       preparePhase = ExecutionPhaseLock(toTxnPhaseLabel(PREPARE_PHASE_LABEL)),
       commitPhase = ExecutionPhaseLock(toTxnPhaseLabel(COMMIT_PHASE_LABEL)),
-      backfillPhase = ExecutionPhaseLock(toTxnPhaseLabel(BACKFILL_PHASE_LABEL)))
+      backfillPhase = ExecutionPhaseLock(toTxnPhaseLabel(BACKFILL_PHASE_LABEL)),
+      postCommitPhase = ExecutionPhaseLock(toTxnPhaseLabel(POST_COMMIT_PHASE_LABEL)))
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/fuzzer/PhaseLockingTransactionExecutionObserver.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/fuzzer/PhaseLockingTransactionExecutionObserver.scala
@@ -27,7 +27,8 @@ private[delta] class PhaseLockingTransactionExecutionObserver(
     phases.initialPhase,
     phases.preparePhase,
     phases.commitPhase,
-    phases.backfillPhase)
+    phases.backfillPhase,
+    phases.postCommitPhase)
 
   /**
    * When set to true this observer will automatically update the thread's current observer to
@@ -52,11 +53,16 @@ private[delta] class PhaseLockingTransactionExecutionObserver(
     phases.backfillPhase.waitToEnter()
   }
 
+  override def beginPostCommit(): Unit = {
+    phases.backfillPhase.leave()
+    phases.postCommitPhase.waitToEnter()
+  }
+
   override def transactionCommitted(): Unit = {
     if (nextObserver.nonEmpty && autoAdvanceNextObserver) {
-      waitForCommitPhaseAndAdvanceToNextObserver()
+      waitForLastPhaseAndAdvanceToNextObserver()
     } else {
-      phases.backfillPhase.leave()
+      phases.postCommitPhase.leave()
     }
   }
 
@@ -67,25 +73,31 @@ private[delta] class PhaseLockingTransactionExecutionObserver(
       }
       phases.commitPhase.leave()
     }
-    if (!phases.backfillPhase.hasEntered) {
-      phases.backfillPhase.waitToEnter()
+    if (!phases.backfillPhase.hasLeft) {
+      if (!phases.backfillPhase.hasEntered) {
+        phases.backfillPhase.waitToEnter()
+      }
+      phases.backfillPhase.leave()
+    }
+    if (!phases.postCommitPhase.hasEntered) {
+      phases.postCommitPhase.waitToEnter()
     }
     if (nextObserver.nonEmpty && autoAdvanceNextObserver) {
-      waitForCommitPhaseAndAdvanceToNextObserver()
+      waitForLastPhaseAndAdvanceToNextObserver()
     } else {
-      phases.backfillPhase.leave()
+      phases.postCommitPhase.leave()
     }
   }
 
   /*
-   * Wait for the backfill phase to pass but do not unblock it so that callers can write tests
+   * Wait for the last phase to pass but do not unblock it so that callers can write tests
    * that capture errors caused by code between the end of the last txn and the start of the
    * new txn. After the commit phase is passed, update the thread observer of the thread to
    * the next observer.
    */
-  def waitForCommitPhaseAndAdvanceToNextObserver(): Unit = {
+  def waitForLastPhaseAndAdvanceToNextObserver(): Unit = {
     require(nextObserver.nonEmpty)
-    phases.backfillPhase.waitToLeave()
+    phases.postCommitPhase.waitToLeave()
     advanceToNextThreadObserver()
   }
 
@@ -96,7 +108,7 @@ private[delta] class PhaseLockingTransactionExecutionObserver(
    * Note that when a next observer is set, the caller needs to manually unblock the exit barrier
    * of the commit phase.
    *
-   * For example, see [[waitForCommitPhaseAndAdvanceToNextObserver]].
+   * For example, see [[waitForLastPhaseAndAdvanceToNextObserver]].
    */
   def setNextObserver(
       nextTxnObserver: TransactionExecutionObserver,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/TransactionExecutionTestMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/TransactionExecutionTestMixin.scala
@@ -125,6 +125,7 @@ trait TransactionExecutionTestMixin {
     observer.phases.preparePhase.entryBarrier.unblock()
     observer.phases.commitPhase.entryBarrier.unblock()
     observer.phases.backfillPhase.entryBarrier.unblock()
+    observer.phases.postCommitPhase.entryBarrier.unblock()
   }
 
   /**
@@ -146,13 +147,15 @@ trait TransactionExecutionTestMixin {
 
           // B starts and commits
           unblockAllPhases(observerB)
-          busyWaitFor(observerB.phases.backfillPhase.hasLeft, timeout)
+          busyWaitFor(observerB.phases.postCommitPhase.hasLeft, timeout)
 
           // A commits
           observerA.phases.commitPhase.entryBarrier.unblock()
           busyWaitFor(observerA.phases.commitPhase.hasLeft, timeout)
           observerA.phases.backfillPhase.entryBarrier.unblock()
           busyWaitFor(observerA.phases.backfillPhase.hasLeft, timeout)
+          observerA.phases.postCommitPhase.entryBarrier.unblock()
+          busyWaitFor(observerA.phases.postCommitPhase.hasLeft, timeout)
       }
     (usageRecords, futureA, futureB)
   }
@@ -182,17 +185,19 @@ trait TransactionExecutionTestMixin {
 
           // B starts and commits
           unblockAllPhases(observerB)
-          busyWaitFor(observerB.phases.backfillPhase.hasLeft, timeout)
+          busyWaitFor(observerB.phases.postCommitPhase.hasLeft, timeout)
 
           // C starts and commits
           unblockAllPhases(observerC)
-          busyWaitFor(observerC.phases.backfillPhase.hasLeft, timeout)
+          busyWaitFor(observerC.phases.postCommitPhase.hasLeft, timeout)
 
           // A commits
           observerA.phases.commitPhase.entryBarrier.unblock()
           busyWaitFor(observerA.phases.commitPhase.hasLeft, timeout)
           observerA.phases.backfillPhase.entryBarrier.unblock()
           busyWaitFor(observerA.phases.backfillPhase.hasLeft, timeout)
+          observerA.phases.postCommitPhase.entryBarrier.unblock()
+          busyWaitFor(observerA.phases.postCommitPhase.hasLeft, timeout)
       }
     (usageRecords, futureA, futureB, futureC)
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR adds a separate phase "post commit" for fuzz test. Previously, we treat commit + post commit as a single phase and this made a limitation for the fuzz testing coverage. With post commit being a separate phase, we can add more fine-grained control for new fuzz scenarios.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
The PR itself is adding more capability to the fuzz test. Existing unit tests should cover all other behavior remaining the same. 

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
