### PR TITLE
[SPARK] Optimize : SELECT COUNT(*) FROM Table WHERE partitition=1

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuery.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuery.scala
@@ -23,13 +23,12 @@ import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, DateTimeUtils}
-import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaTable, Snapshot}
+import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaTable, DeltaTableUtils, Snapshot}
 import org.apache.spark.sql.delta.commands.DeletionVectorUtils.isTableDVFree
 import org.apache.spark.sql.delta.files.TahoeLogFileIndex
 import org.apache.spark.sql.delta.stats.DeltaScanGenerator
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
-
 import java.sql.Date
 import java.util.Locale
 
@@ -41,7 +40,7 @@ import java.util.Locale
  * or the columns must be partitioned, in the latter case it uses partitionValues, a required field.
  * - Table has no deletion vectors, or query has no MIN/MAX expressions.
  * - COUNT has no DISTINCT.
- * - Query has no filters.
+ * - Query has no data filters.
  * - Query has no GROUP BY.
  * Example of valid query: SELECT COUNT(*), MIN(id), MAX(partition_col) FROM MyDeltaTable
  */
@@ -60,7 +59,9 @@ trait OptimizeMetadataOnlyDeltaQuery extends Logging {
       tahoeLogFileIndex: TahoeLogFileIndex): LogicalPlan = {
 
     val aggColumnsNames = Set(extractMinMaxFieldNames(plan).map(_.toLowerCase(Locale.ROOT)) : _*)
-    val (rowCount, columnStats) = extractCountMinMaxFromDeltaLog(tahoeLogFileIndex, aggColumnsNames)
+    val partitionFilter = extractPartitionFilters(plan)
+    val (rowCount, columnStats) =
+      extractCountMinMaxFromDeltaLog(tahoeLogFileIndex, aggColumnsNames, partitionFilter.toSeq)
 
     def checkStatsExists(attrRef: AttributeReference): Boolean = {
       columnStats.contains(attrRef.name) &&
@@ -133,6 +134,13 @@ trait OptimizeMetadataOnlyDeltaQuery extends Logging {
     }
   }
 
+  private def extractPartitionFilters(plan: Aggregate): Option[Expression] = {
+    plan.child match {
+      case Filter(cond, _) => Some(cond)
+      case _ => None
+    }
+  }
+
   /**
    * Min and max values from Delta Log stats or partitionValues.
   */
@@ -140,14 +148,15 @@ trait OptimizeMetadataOnlyDeltaQuery extends Logging {
 
   private def extractCountMinMaxFromStats(
       deltaScanGenerator: DeltaScanGenerator,
-      lowerCaseColumnNames: Set[String]): (Option[Long], Map[String, DeltaColumnStat]) = {
+      lowerCaseColumnNames: Set[String],
+      partitionFilters: Seq[Expression]): (Option[Long], Map[String, DeltaColumnStat]) = {
     val snapshot = deltaScanGenerator.snapshotToScan
 
     // Count - account for deleted rows according to deletion vectors
     val dvCardinality = coalesce(col("deletionVector.cardinality"), lit(0))
     val numLogicalRecords = (col("stats.numRecords") - dvCardinality).as("numLogicalRecords")
 
-    val filesWithStatsForScan = deltaScanGenerator.filesWithStatsForScan(Nil)
+    val filesWithStatsForScan = deltaScanGenerator.filesWithStatsForScan(partitionFilters)
     // Validate all the files has stats
     val filesStatsCount = filesWithStatsForScan.select(
       sum(numLogicalRecords).as("numLogicalRecords"),
@@ -248,10 +257,11 @@ trait OptimizeMetadataOnlyDeltaQuery extends Logging {
 
   private def extractMinMaxFromPartitionValue(
       snapshot: Snapshot,
-      lowerCaseColumnNames: Set[String]): Map[String, DeltaColumnStat] = {
+      aggColumnNames: Set[String],
+      partitionFilters: Seq[Expression]): Map[String, DeltaColumnStat] = {
 
     val partitionedColumns = snapshot.metadata.partitionSchema
-      .filter(col => lowerCaseColumnNames.contains(col.name.toLowerCase(Locale.ROOT)))
+      .filter(col => aggColumnNames.contains(col.name.toLowerCase(Locale.ROOT)))
       .map(col => (col, DeltaColumnMapping.getPhysicalName(col)))
 
     if (partitionedColumns.isEmpty) {
@@ -270,7 +280,7 @@ trait OptimizeMetadataOnlyDeltaQuery extends Logging {
           max(s"`$physicalName`").as(s"max_$physicalName"))
       }
 
-      val partitionedColumnsQuery = snapshot.allFiles
+      val partitionedColumnsQuery = snapshot.filesWithStatsForScan(partitionFilters)
         .select(partitionedColumnsValues: _*)
         .agg(partitionedColumnsAgg.head, partitionedColumnsAgg.tail: _*)
         .head()
@@ -294,17 +304,20 @@ trait OptimizeMetadataOnlyDeltaQuery extends Logging {
   */
   private def extractCountMinMaxFromDeltaLog(
       tahoeLogFileIndex: TahoeLogFileIndex,
-      lowerCaseColumnNames: Set[String]):
+      aggColumnNames: Set[String],
+      partitionFilters: Seq[Expression]):
   (Option[Long], CaseInsensitiveMap[DeltaColumnStat]) = {
     val deltaScanGen = getDeltaScanGenerator(tahoeLogFileIndex)
 
     val partitionedValues = extractMinMaxFromPartitionValue(
       deltaScanGen.snapshotToScan,
-      lowerCaseColumnNames)
+      aggColumnNames,
+      partitionFilters)
 
     val partitionedColNames = partitionedValues.keySet.map(_.toLowerCase(Locale.ROOT))
-    val dataColumnNames = lowerCaseColumnNames -- partitionedColNames
-    val (rowCount, columnStats) = extractCountMinMaxFromStats(deltaScanGen, dataColumnNames)
+    val dataColumnNames = aggColumnNames -- partitionedColNames
+    val (rowCount, columnStats) =
+      extractCountMinMaxFromStats(deltaScanGen, dataColumnNames, partitionFilters)
 
     (rowCount, CaseInsensitiveMap(columnStats ++ partitionedValues))
   }
@@ -343,6 +356,14 @@ trait OptimizeMetadataOnlyDeltaQuery extends Logging {
       case _ => false
     }
 
+    private def isFilterByPartitionCols(filters: Seq[Expression],
+                                       fileIndex: TahoeLogFileIndex): Boolean = {
+      val partitionColumns = fileIndex.deltaLog.snapshot.metadata.partitionColumns
+      filters.filterNot(f =>
+        DeltaTableUtils.isPredicatePartitionColumnsOnly(f, partitionColumns, fileIndex.spark))
+        .isEmpty
+    }
+
     private def fieldsAreAttributeReference(fields: Seq[NamedExpression]): Boolean = fields.forall {
       // Fields should be AttributeReference to avoid getting the incorrect column name
       // from stats when we create the Local Relation, example
@@ -357,10 +378,10 @@ trait OptimizeMetadataOnlyDeltaQuery extends Logging {
         Nil, // GROUP BY not supported
         aggExprs: Seq[Alias @unchecked], // Underlying type is not checked because of type erasure.
         // Alias type check is done in isStatsOptimizable.
-        PhysicalOperation(fields, Nil, DeltaTable(fileIndex: TahoeLogFileIndex)))
-          if fileIndex.partitionFilters.isEmpty &&
-            fieldsAreAttributeReference(fields) &&
-            isStatsOptimizable(aggExprs) => Some(fileIndex)
+        PhysicalOperation(fields, filters, DeltaTable(fileIndex: TahoeLogFileIndex)))
+          if fieldsAreAttributeReference(fields) &&
+            isStatsOptimizable(aggExprs) &&
+            isFilterByPartitionCols(filters, fileIndex) => Some(fileIndex)
       case Aggregate(
         Nil,
         aggExprs: Seq[Alias @unchecked],

--- a/spark/src/main/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuery.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/perf/OptimizeMetadataOnlyDeltaQuery.scala
@@ -134,9 +134,11 @@ trait OptimizeMetadataOnlyDeltaQuery extends Logging {
     }
   }
 
-  private def extractPartitionFilters(plan: Aggregate): Option[Expression] = {
-    plan.child match {
+  private def extractPartitionFilters(plan: LogicalPlan): Option[Expression] = {
+    plan match {
       case Filter(cond, _) => Some(cond)
+      case Project(_, child) => extractPartitionFilters(child)
+      case Aggregate(_, _, child) => extractPartitionFilters(child)
       case _ => None
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Running the query "SELECT COUNT(*), MIN(X), MAX(X) FROM table WHERE partition_column = 1" takes a lot of time for big tables, Spark scan all the parquet files just to return the number of rows and min max values, that information is available from Delta Logs
Resolves https://github.com/delta-io/delta/issues/1916
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Created unit tests to validate the optimization works

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
Only performance improvement
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
