### PR TITLE
[Spark] Fix VARCHAR/CHAR to string conversion

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -35,6 +35,7 @@ import org.apache.spark.internal.MDC
 import org.apache.spark.sql._
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.{Resolver, UnresolvedAttribute}
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.functions.{col, struct}
 import org.apache.spark.sql.internal.SQLConf
@@ -155,6 +156,26 @@ object SchemaUtils extends DeltaLogging {
       if (f.dataType.isInstanceOf[NullType]) None else Some(generateSelectExpr(f, Nil))
     }
     df.select(selectExprs: _*)
+  }
+
+  /**
+   * Converts StringType to CHAR/VARCHAR if that is the true type as per the metadata
+   * and also strips this metadata from fields.
+   */
+  def getRawSchemaWithoutCharVarcharMetadata(schema: StructType): StructType = {
+    val fields = schema.map { field =>
+      val rawField = CharVarcharUtils.getRawType(field.metadata)
+        .map(dt => field.copy(dataType = dt))
+        .getOrElse(field)
+      val throwAwayAttrRef = AttributeReference(
+        rawField.name,
+        rawField.dataType,
+        nullable = rawField.nullable,
+        rawField.metadata)()
+      val cleanedMetadata = CharVarcharUtils.cleanAttrMetadata(throwAwayAttrRef).metadata
+      rawField.copy(metadata = cleanedMetadata)
+    }
+    StructType(fields)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1282,6 +1282,19 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
+  val DELTA_BYPASS_CHARVARCHAR_TO_STRING_FIX =
+    buildConf("alterTable.bypassCharVarcharToStringFix")
+      .internal()
+      .doc(
+        """Whether to bypass the fix for CHAR/VARCHAR to STRING type conversion in ALTER TABLE.
+          |This is a safety switch - we should only set this to true if the fix introduces some
+          |regression.
+          |The fix in question strips CHAR/VARCHAR metadata from columns and converts
+          |StringType to CHAR/VARCHAR Type temporarily during alter table column commands.
+          |""".stripMargin)
+      .booleanConf
+      .createWithDefault(false)
+
   val DELTA_CDF_ALLOW_OUT_OF_RANGE_TIMESTAMP = {
     buildConf("changeDataFeed.timestampOutOfRange.enabled")
       .doc(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Context: VARCHAR/CHAR to String column conversion was broken. https://github.com/delta-io/delta/pull/2731 was an attempted fix where we strip CHAR/VARCHAR metadata from columns in `alterDeltaTableCommands.scala` during column conversion if the target type is String.

However, this introduced a regression --- updating any metadata for a CHAR/VARCHAR column will convert it into a StringType. This is because the original fix did not account for the fact that the target data type of a VARCHAR column appears to be a String even during other types of column DDL updates that are not data type changes.


This PR:
1. Removes the changes from https://github.com/delta-io/delta/pull/2731
2. Makes it so that StringType is temporarily converted into CHAR/VARCHAR Type and the CHAR/VARCHAR metadata is stripped during column DDL updates. This fixes the original issue.
3. Guards this new change (2) behind a new flag `alterTable.bypassCharVarcharToStringFix`. In case this fix introduces a new regression, this flag can be flipped.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Introduces tests for:
1. Adding comment on a varchar column
2. Adding a default for a varchar column
3. Test for the new flag

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
