### PR TITLE
[Spark] Fix CDC Commit Timestamp value under different Timezones

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/files/CdcAddFileIndex.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/files/CdcAddFileIndex.scala
@@ -39,6 +39,9 @@ import org.apache.spark.sql.types.StructType
  * @param path The table's data path.
  * @param snapshot The snapshot where we read CDC from.
  * @param rowIndexFilters Map from <b>URI-encoded</b> file path to a row index filter type.
+ *
+ * Note: Please also consider other CDC-related file indexes like [[TahoeChangeFileIndex]]
+ * and [[TahoeRemoveFileIndex]] when modifying this file index.
  */
 class CdcAddFileIndex(
     spark: SparkSession,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSQLSuite.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 
 import org.apache.spark.sql.{AnalysisException, DataFrame}
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.util.DateTimeTestUtils._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.LongType
 
@@ -218,43 +219,46 @@ class DeltaCDCSQLSuite extends DeltaCDCSuiteBase with DeltaColumnMappingTestUtil
 
   test("resolve expression for timestamp function") {
     val tbl = "tbl"
-    withTable(tbl) {
-      createTblWithThreeVersions(tblName = Some(tbl))
+    withDefaultTimeZone(UTC) {
+      withTable(tbl) {
+        createTblWithThreeVersions(tblName = Some(tbl))
 
-      val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tbl))
+        val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tbl))
 
-      val currentTime = new Date().getTime
-      modifyDeltaTimestamp(deltaLog, 0, currentTime - 100000)
-      modifyDeltaTimestamp(deltaLog, 1, currentTime)
-      modifyDeltaTimestamp(deltaLog, 2, currentTime + 100000)
+        val currentTime = new Date().getTime
+        modifyDeltaTimestamp(deltaLog, 0, currentTime - 100000)
+        modifyDeltaTimestamp(deltaLog, 1, currentTime)
+        modifyDeltaTimestamp(deltaLog, 2, currentTime + 100000)
 
-      val readDf = sql(s"SELECT * FROM table_changes('$tbl', 0, now())")
-      checkCDCAnswer(
-        DeltaLog.forTable(spark, TableIdentifier("tbl")),
-        readDf,
-        spark.range(20)
-          .withColumn("_change_type", lit("insert"))
-          .withColumn("_commit_version", (col("id") / 10).cast(LongType))
+        val readDf = sql(s"SELECT * FROM table_changes('$tbl', 0, now())")
+        checkCDCAnswer(
+          DeltaLog.forTable(spark, TableIdentifier("tbl")),
+          readDf,
+          spark.range(20)
+            .withColumn("_change_type", lit("insert"))
+            .withColumn("_commit_version", (col("id") / 10).cast(LongType))
         )
 
-      // more complex expression
-      val readDf2 = sql(s"SELECT * FROM table_changes('$tbl', 0, now() + interval 5 seconds)")
-      checkCDCAnswer(
-        DeltaLog.forTable(spark, TableIdentifier("tbl")),
-        readDf2,
-        spark.range(20)
-          .withColumn("_change_type", lit("insert"))
-          .withColumn("_commit_version", (col("id") / 10).cast(LongType))
-      )
-      val readDf3 = sql("SELECT * FROM table_changes" +
-        s"('$tbl', string(date_sub(current_date(), 1)), string(now()))")
-      checkCDCAnswer(
-        DeltaLog.forTable(spark, TableIdentifier("tbl")),
-        readDf2,
-        spark.range(20)
-          .withColumn("_change_type", lit("insert"))
-          .withColumn("_commit_version", (col("id") / 10).cast(LongType))
-      )
+        // more complex expression
+        val readDf2 = sql(s"SELECT * FROM table_changes('$tbl', 0, now() + interval 5 seconds)")
+        checkCDCAnswer(
+          DeltaLog.forTable(spark, TableIdentifier("tbl")),
+          readDf2,
+          spark.range(20)
+            .withColumn("_change_type", lit("insert"))
+            .withColumn("_commit_version", (col("id") / 10).cast(LongType))
+        )
+
+        val readDf3 = sql("SELECT * FROM table_changes" +
+          s"('$tbl', string(date_sub(current_date(), 1)), string(now()))")
+        checkCDCAnswer(
+          DeltaLog.forTable(spark, TableIdentifier("tbl")),
+          readDf3,
+          spark.range(20)
+            .withColumn("_change_type", lit("insert"))
+            .withColumn("_commit_version", (col("id") / 10).cast(LongType))
+        )
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
The CDC's `_commit_timestamp` is incorrect when we try to read/display it under a different Spark Session's timezone `spark.sql.session.timeZone` (e.g. `America/Chicago`, `Asia/Ho_Chi_Minh`, ...). 

In this PR, we address this issue by taking into account timezone to capture the precise point in time when we convert `CDCDataSpec`'s [Java Timestamp](https://github.com/delta-io/delta/blob/master/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala#L173) field to [Spark's Timestamp](https://github.com/delta-io/delta/blob/master/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala#L80) for the `_commit_timestamp` column for all CDC's file indexes (`CDCAddFileIndex`, `TahoeRemoveFileIndex`, `TahoeChangeFileIndex`).

This is needed in order for CDF to work properly under a different timezone than `UTC`.

## How was this patch tested?
Added UT, some minor UTs fix to take into account timezone.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
Yes.

- CDC's `_commit_timestamp` should now be correct when we try to read/display it under a different Spark Session's timezone `spark.sql.session.timeZone` (e.g.` America/Chicago`, `Asia/Ho_Chi_Minh`, ...).
- This is a user-facing change compared to the released Delta Lake versions and within the unreleased branches such as master.

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
