### PR TITLE
[Spark] Add list utils to DeltaCommitFileProvider

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaCommitFileProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaCommitFileProvider.scala
@@ -61,6 +61,9 @@ case class DeltaCommitFileProvider(
     }
   }
 
+  /**
+   * Lists unbackfilled delta files in a sorted order without incurring additional IO operations.
+   */
   def listSortedUnbackfilledDeltaFiles(startVersionOpt: Option[Long] = None): Seq[(Long, Path)] = {
     val minVersion = startVersionOpt.getOrElse(minUnbackfilledVersion)
     uuids

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaCommitFileProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaCommitFileProvider.scala
@@ -60,6 +60,17 @@ case class DeltaCommitFileProvider(
       case _ => FileNames.unsafeDeltaFile(resolvedPath, version)
     }
   }
+
+  def listSortedUnbackfilledDeltaFiles(startVersionOpt: Option[Long] = None): Seq[(Long, Path)] = {
+    val minVersion = startVersionOpt.getOrElse(minUnbackfilledVersion)
+    uuids
+      .toSeq
+      .sortBy(_._1)
+      .collect {
+        case (version, uuid) if version >= minVersion =>
+          (version, FileNames.unbackfilledDeltaFile(resolvedPath, version, Some(uuid)))
+      }
+  }
 }
 
 object DeltaCommitFileProvider {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Add a list util to DeltaCommitFileProvider.

## How was this patch tested?

Build

## Does this PR introduce _any_ user-facing changes?

No
