### PR TITLE
Update delta-streaming.md to reflect `maxBytesPerTrigger` is ignored for `Trigger.AvailableNow`

### DIFF
--- a/docs/source/delta-streaming.md
+++ b/docs/source/delta-streaming.md
@@ -41,7 +41,7 @@ spark.readStream.delta("/tmp/delta/events")
 The following options are available to control micro-batches:
 
 - `maxFilesPerTrigger`: How many new files to be considered in every micro-batch. The default is 1000.
-- `maxBytesPerTrigger`: How much data gets processed in each micro-batch. This option sets a "soft max", meaning that a batch processes approximately this amount of data and may process more than the limit in order to make the streaming query move forward in cases when the smallest input unit is larger than this limit. If you use `Trigger.Once` for your streaming, this option is ignored. This is not set by default.
+- `maxBytesPerTrigger`: How much data gets processed in each micro-batch. This option sets a "soft max", meaning that a batch processes approximately this amount of data and may process more than the limit in order to make the streaming query move forward in cases when the smallest input unit is larger than this limit. If you use `Trigger.Once` or `Trigger.AvailableNow` for your streaming, this option is ignored. This is not set by default.
 
 If you use `maxBytesPerTrigger` in conjunction with `maxFilesPerTrigger`, the micro-batch processes data until either the `maxFilesPerTrigger` or `maxBytesPerTrigger` limit is reached.
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
`maxBytesPerTrigger` is currently ignored for streaming delta table reads when using `Trigger.Once` (see https://github.com/delta-io/delta/issues/843) `Trigger.Once` is now deprecated in favor of `Trigger.AvailableNow` (https://github.com/apache/spark/commit/66b1f79b72855af35351ff995492f2c13872dac5). Based on my testing this behavior is carried over to `AvailableNow` as well. If this is indeed correct and expected behavior then this PR updates the docs. If this is not correct then this is an issue to be resolved and the PR should be rejected.

## How was this patch tested?
Observed behavior of stream while using the different triggers. 

## Does this PR introduce _any_ user-facing changes?
No. Docs only

