### PR TITLE
[Spark] Fix error message formatting in DeltaCommitFileProvider

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaCommitFileProvider.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaCommitFileProvider.scala
@@ -50,10 +50,10 @@ case class DeltaCommitFileProvider(
 
   def deltaFile(version: Long): Path = {
     if (version > maxVersionInclusive) {
-      throw new IllegalStateException("Cannot resolve Delta table at version $version as the " +
-        "state is currently at version $maxVersion. The requested version may be incorrect or " +
-        "the state may be outdated. Please verify the requested version, update the state if " +
-        "necessary, and try again")
+      throw new IllegalStateException(s"Cannot resolve Delta table at version $version as the " +
+        s"state is currently at version $maxVersionInclusive. The requested version may be " +
+        s"incorrect or the state may be outdated. Please verify the requested version, update " +
+        s"the state if necessary, and try again")
     }
     uuids.get(version) match {
       case Some(uuid) => FileNames.unbackfilledDeltaFile(resolvedPath, version, Some(uuid))


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Make sure that version and maxVersionInclusive are formatted correctly.

## How was this patch tested?

Build

## Does this PR introduce _any_ user-facing changes?

No
