### PR TITLE
[Spark] Migrate remaining logging code to use Spark Structured Logging

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergFileManifest.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergFileManifest.scala
@@ -19,13 +19,14 @@ package org.apache.spark.sql.delta.commands.convert
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.delta.{DeltaColumnMapping, SerializableFileStatus}
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.{DateFormatter, TimestampFormatter}
 import org.apache.hadoop.fs.Path
 import org.apache.iceberg.{PartitionData, RowLevelOperationMode, StructLike, Table, TableProperties}
 import org.apache.iceberg.transforms.IcebergPartitionUtil
 
-import org.apache.spark.internal.Logging
+import org.apache.spark.internal.{LoggingShims, MDC}
 import org.apache.spark.sql.{Dataset, SparkSession}
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.types.StructType
@@ -34,7 +35,7 @@ import org.apache.spark.util.SerializableConfiguration
 class IcebergFileManifest(
     spark: SparkSession,
     table: Table,
-    partitionSchema: StructType) extends ConvertTargetFileManifest with Logging {
+    partitionSchema: StructType) extends ConvertTargetFileManifest with LoggingShims {
 
   // scalastyle:off sparkimplicits
   import spark.implicits._
@@ -109,8 +110,9 @@ class IcebergFileManifest(
 
     var numFiles = 0L
     val res = table.newScan().planFiles().iterator().asScala.grouped(schemaBatchSize).map { batch =>
-      logInfo(s"Getting file statuses for a batch of ${batch.size} of files; " +
-        s"finished $numFiles files so far")
+      logInfo(log"Getting file statuses for a batch of " +
+        log"${MDC(DeltaLogKeys.BATCH_SIZE, batch.size)} of files; " +
+        log"finished ${MDC(DeltaLogKeys.NUM_FILES, numFiles)} files so far")
       numFiles += batch.length
       val filePathWithPartValues = batch.map { fileScanTask =>
         val filePath = fileScanTask.file().path().toString

--- a/spark/src/main/scala/org/apache/spark/sql/delta/logging/DeltaLogKeys.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/logging/DeltaLogKeys.scala
@@ -48,6 +48,7 @@ trait DeltaLogKeysBase {
   case object APP_ID extends LogKeyShims
   case object ATTEMPT extends LogKeyShims
   case object BATCH_ID extends LogKeyShims
+  case object BATCH_SIZE extends LogKeyShims
   case object CLASS_NAME extends LogKeyShims
   case object COLUMN_NAME extends LogKeyShims
   case object COMPACTION_INFO_NEW extends LogKeyShims
@@ -111,6 +112,7 @@ trait DeltaLogKeysBase {
   case object QUERY_ID extends LogKeyShims
   case object RDD_ID extends LogKeyShims
   case object SCHEMA extends LogKeyShims
+  case object SCHEMA_DIFF extends LogKeyShims
   case object SEGMENT extends LogKeyShims
   case object SIZE extends LogKeyShims
   case object SNAPSHOT extends LogKeyShims


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Migrate remaining logging code to use Spark structured logging. Structured logging will be introduced in Spark 4.0, as highlighted in the [preview release of Spark 4.0 | Apache Spark](https://spark.apache.org/news/spark-4.0.0-preview1.html). Note that the feature is turned off by default and the output log message will remain unchanged.

Resolves #3145 
## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Existing tests.
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No