### PR TITLE
[Spark] Expose uncertainty in isDeltaTable resolution via exceptions

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -18,13 +18,16 @@ package org.apache.spark.sql.delta
 
 // scalastyle:off import.ordering.noEmptyLine
 import scala.util.{Failure, Success, Try}
+import scala.util.control.NonFatal
 
 import org.apache.spark.sql.delta.files.{TahoeFileIndex, TahoeLogFileIndex}
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.skipping.clustering.temp.{ClusterByTransform => TempClusterByTransform}
 import org.apache.spark.sql.delta.sources.{DeltaSourceUtils, DeltaSQLConf}
 import org.apache.hadoop.fs.{FileSystem, Path}
 
+import org.apache.spark.internal.{LoggingShims, MDC}
 import org.apache.spark.sql.{Column, DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{NoSuchTableException, UnresolvedLeafNode, UnresolvedTable}
@@ -197,6 +200,30 @@ object DeltaTableUtils extends PredicateHelper
 
   /** Finds the root of a Delta table given a path if it exists. */
   def findDeltaTableRoot(fs: FileSystem, path: Path): Option[Path] = {
+    findDeltaTableRoot(
+      fs,
+      path,
+      throwOnError = SparkSession.active.conf.get(DeltaSQLConf.DELTA_IS_DELTA_TABLE_THROW_ON_ERROR))
+  }
+
+  /** Finds the root of a Delta table given a path if it exists. */
+  private[delta] def findDeltaTableRoot(
+      fs: FileSystem,
+      path: Path,
+      throwOnError: Boolean): Option[Path] = {
+    if (throwOnError) {
+      findDeltaTableRootThrowOnError(fs, path)
+    } else {
+      findDeltaTableRootNoExceptions(fs, path)
+    }
+  }
+
+  /**
+   * Finds the root of a Delta table given a path if it exists.
+   *
+   * Does not throw any exceptions, but returns `None` when uncertain (old behaviour).
+   */
+  private def findDeltaTableRootNoExceptions(fs: FileSystem, path: Path): Option[Path] = {
     var currentPath = path
     while (currentPath != null && currentPath.getName != "_delta_log" &&
         currentPath.getName != "_samples") {
@@ -207,6 +234,50 @@ object DeltaTableUtils extends PredicateHelper
       currentPath = currentPath.getParent
     }
     None
+  }
+
+  /**
+   * Finds the root of a Delta table given a path if it exists.
+   *
+   * If there are errors and no root could be found, throw the first error (new behaviour)
+   */
+  private def findDeltaTableRootThrowOnError(fs: FileSystem, path: Path): Option[Path] = {
+    var firstError: Option[Throwable] = None
+    // Return `None` if `firstError` is empty, throw `firstError` otherwise.
+    def noneOrError(): Option[Path] = {
+      firstError match {
+        case Some(ex) =>
+          throw ex
+        case None =>
+          None
+      }
+    }
+    var currentPath = path
+    while (currentPath != null && currentPath.getName != "_delta_log" &&
+        currentPath.getName != "_samples") {
+      val deltaLogPath = safeConcatPaths(currentPath, "_delta_log")
+      try {
+        if (fs.exists(deltaLogPath)) {
+          return Option(currentPath)
+        }
+      } catch {
+        case NonFatal(ex) if currentPath == path =>
+          // Store errors for the first path, but keep going up the hierarchy,
+          // in case the error at this level does not matter and the delta log is found at a parent.
+          firstError = Some(ex)
+        case NonFatal(ex) =>
+          // If we find errors higher up the path we either treat it as a non-Delta table or
+          // return the error we found at the original path, if any.
+          // This gives us best-effort detection of delta logs in the hierarchy, but with more
+          // useful error messages when access was actually missing.
+          logWarning(log"Access error while exploring path hierarchy for a delta log."
+            + log"original path=${MDC(DeltaLogKeys.PATH, path)}, "
+            + log"path with error=${MDC(DeltaLogKeys.PATH2, currentPath)}", ex)
+          return noneOrError()
+      }
+      currentPath = currentPath.getParent
+    }
+    noneOrError()
   }
 
   /** Whether a path should be hidden for delta-related file operations, such as Vacuum and Fsck. */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -936,6 +936,19 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
+  val DELTA_IS_DELTA_TABLE_THROW_ON_ERROR =
+    buildConf("isDeltaTable.throwOnError")
+      .internal()
+      .doc("""
+        | If checking the path provided to isDeltaTable (or findDeltaTableRoot) throws an exception,
+        | then propagate this exception unless a _delta_log directory is found in an
+        | accessible parent.
+        | When disabled, such any exception leads to a result indicating that this is not a
+        | Delta table.
+        |""".stripMargin)
+      .booleanConf
+      .createWithDefault(Utils.isTesting)
+
   val DELTA_LEGACY_STORE_WRITER_OPTIONS_AS_PROPS =
     buildConf("legacy.storeOptionsAsProperties")
       .internal()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

- Add a new codepath (disabled by default except in testing) to `findDeltaTableRoot` (which is the implementation of `isDeltaTable`), that throws the first exception if the passed in path is not accessible, and no accessible parent is found to contain a `_delta_log` folder.
- This improves error reporting on permission errors, which current often get misreported as `t is not a DeltaTable`.
- This also reduces the risk for transient cloud storage errors causing us to silently resolve a DeltaTable as a non-Delta table, which can lead to inconsistencies in how we process it when we check multiple times.
  - Note that this is still not ideal, we could still end up with a situation where we the first path is accessible but a child of the Delta Table, such as a partition, but then when we check the path that actually does contain the `_delta_log` we get a transient error and wrongly resolve it as not a Delta table. Ultimately, this kind of parent resolution really has been and continues to be best-effort. But at least the case where we are pointed at the correct folder behaves more sane now.

The new path is only enabled in unit tests for now. Flag flip PR will follow separately.

## How was this patch tested?

Existing tests (showing that there is no behaviour change in the "happy path").

## Does this PR introduce _any_ user-facing changes?

No, they will only apply on the flag-flip PR.
