### PR TITLE
[Spark] Remove tracking usageRecords in runFunctionsWithOrderingFromObserver

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/TransactionExecutionTestMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/TransactionExecutionTestMixin.scala
@@ -112,7 +112,7 @@ trait TransactionExecutionTestMixin {
     }
   }
 
-    /** Unblocks all phases before the `commitPhase` for [[TransactionObserver]] */
+  /** Unblocks all phases before the `commitPhase` for [[TransactionObserver]] */
   def unblockUntilPreCommit(observer: TransactionObserver): Unit = {
     observer.phases.initialPhase.entryBarrier.unblock()
     observer.phases.preparePhase.entryBarrier.unblock()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/TransactionExecutionTestMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/TransactionExecutionTestMixin.scala
@@ -75,13 +75,12 @@ trait TransactionExecutionTestMixin {
 
   /**
    * Run `functions` with the ordering defined by `observerOrdering` function.
-   * This function returns the usage records generated during the run of these queries and also
-   * futures for each of the query results.
+   * This function returns futures for each of the query results.
    */
-  private[delta] def runFunctionsWithOrderingFromObserver(functions: Seq[() => Array[Row]])
+  private[delta] def runFunctionsWithOrderingFromObserver
+      (functions: Seq[() => Array[Row]])
       (observerOrdering: (Seq[TransactionObserver]) => Unit)
-      : (Seq[UsageRecord], Seq[Future[Array[Row]]]) = {
-
+      : Seq[Future[Array[Row]]] = {
     val executors = functions.zipWithIndex.map { case (_, index) =>
       ThreadUtils.newDaemonSingleThreadExecutor(threadName = s"executor-txn-$index")
     }
@@ -89,22 +88,22 @@ trait TransactionExecutionTestMixin {
       val (observers, futures) = functions.zipWithIndex.map { case (fn, index) =>
         runFunctionWithObserver(name = s"query-$index", executors(index), fn)
       }.unzip
-      val usageRecords = Log4jUsageLogger.track {
-        // Run the observer ordering function.
-        observerOrdering(observers)
 
-        // wait for futures to succeed or fail
-        for (future <- futures) {
-          try {
-            ThreadUtils.awaitResult(future, timeout)
-          } catch {
-            case _: SparkException =>
-              // pass
-              true
-          }
+      // Run the observer ordering function.
+      observerOrdering(observers)
+
+      // wait for futures to succeed or fail
+      for (future <- futures) {
+        try {
+          ThreadUtils.awaitResult(future, timeout)
+        } catch {
+          case _: SparkException =>
+            // pass
+            true
         }
       }
-      (usageRecords, futures)
+
+      futures
     } finally {
       for (executor <- executors) {
         executor.shutdownNow()
@@ -113,7 +112,7 @@ trait TransactionExecutionTestMixin {
     }
   }
 
-  /** Unblocks all phases before the `commitPhase` for [[TransactionObserver]] */
+    /** Unblocks all phases before the `commitPhase` for [[TransactionObserver]] */
   def unblockUntilPreCommit(observer: TransactionObserver): Unit = {
     observer.phases.initialPhase.entryBarrier.unblock()
     observer.phases.preparePhase.entryBarrier.unblock()
@@ -134,10 +133,12 @@ trait TransactionExecutionTestMixin {
    * t2 --------- TxnB starts
    * t3 --------- TxnB commits
    * t6 -------------------------------------- TxnA commits
+   *
+   * This function returns futures for each of the query runs.
    */
   def runTxnsWithOrder__A_Start__B__A_End(txnA: () => Array[Row], txnB: () => Array[Row])
-      : (Seq[UsageRecord], Future[Array[Row]], Future[Array[Row]]) = {
-    val (usageRecords, Seq(futureA, futureB)) =
+      : (Future[Array[Row]], Future[Array[Row]]) = {
+    val Seq(futureA, futureB) =
       runFunctionsWithOrderingFromObserver(Seq(txnA, txnB)) {
         case (observerA :: observerB :: Nil) =>
           // A starts
@@ -154,7 +155,7 @@ trait TransactionExecutionTestMixin {
           observerA.phases.backfillPhase.entryBarrier.unblock()
           busyWaitFor(observerA.phases.backfillPhase.hasLeft, timeout)
       }
-    (usageRecords, futureA, futureB)
+    (futureA, futureB)
   }
 
   /**
@@ -166,14 +167,16 @@ trait TransactionExecutionTestMixin {
    * t4 ----------------- TxnC starts
    * t5 ----------------- TxnC commits
    * t6 -------------------------------------- TxnA commits
+   *
+   * This function returns futures for each of the query runs.
    */
   def runTxnsWithOrder__A_Start__B__C__A_End(
       txnA: () => Array[Row],
       txnB: () => Array[Row],
       txnC: () => Array[Row])
-      : (Seq[UsageRecord], Future[Array[Row]], Future[Array[Row]], Future[Array[Row]]) = {
+      : (Future[Array[Row]], Future[Array[Row]], Future[Array[Row]]) = {
 
-    val (usageRecords, Seq(futureA, futureB, futureC)) =
+    val Seq(futureA, futureB, futureC) =
       runFunctionsWithOrderingFromObserver(Seq(txnA, txnB, txnC)) {
         case (observerA :: observerB :: observerC :: Nil) =>
           // A starts
@@ -194,6 +197,6 @@ trait TransactionExecutionTestMixin {
           observerA.phases.backfillPhase.entryBarrier.unblock()
           busyWaitFor(observerA.phases.backfillPhase.hasLeft, timeout)
       }
-    (usageRecords, futureA, futureB, futureC)
+    (futureA, futureB, futureC)
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/ConflictCheckerRowIdSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/ConflictCheckerRowIdSuite.scala
@@ -68,7 +68,7 @@ class ConflictCheckerRowIdSuite extends QueryTest
         Array.empty
       }
 
-      val (_, futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
       ThreadUtils.awaitResult(futureA, Duration.Inf)
       ThreadUtils.awaitResult(futureB, Duration.Inf)
 
@@ -97,7 +97,7 @@ class ConflictCheckerRowIdSuite extends QueryTest
         Array.empty
       }
 
-      val (_, futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
+      val (futureA, futureB) = runTxnsWithOrder__A_Start__B__A_End(txnA, txnB)
       ThreadUtils.awaitResult(futureA, Duration.Inf)
       ThreadUtils.awaitResult(futureB, Duration.Inf)
 
@@ -143,7 +143,7 @@ class ConflictCheckerRowIdSuite extends QueryTest
         Array.empty
       }
 
-      val (_, futureA, futureB, futureC) = runTxnsWithOrder__A_Start__B__C__A_End(txnA, txnB, txnC)
+      val (futureA, futureB, futureC) = runTxnsWithOrder__A_Start__B__C__A_End(txnA, txnB, txnC)
       ThreadUtils.awaitResult(futureA, Duration.Inf)
       ThreadUtils.awaitResult(futureB, Duration.Inf)
       ThreadUtils.awaitResult(futureC, Duration.Inf)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Remove tracking usageRecords generated from the query runs in runFunctionsWithOrderingFromObserver because it is unnecessary for our testing purpose.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Existing UTs.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
