### PR TITLE
[Spark] Write INT64 by default for Timestamps

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
@@ -265,8 +265,8 @@ case class DeltaParquetFileFormat(
        dataSchema: StructType): OutputWriterFactory = {
     val factory = super.prepareWrite(sparkSession, job, options, dataSchema)
     val conf = ContextUtil.getConfiguration(job)
-    // Always write timestamp as TIMESTAMP_MICROS for Iceberg compat based on Iceberg spec
-    if (IcebergCompatV1.isEnabled(metadata) || IcebergCompatV2.isEnabled(metadata)) {
+    // If the key is not set explicitly, default to INT64 for Iceberg compatability
+    if (!sparkSession.conf.contains(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key)) {
       conf.set(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key,
         SQLConf.ParquetOutputTimestampType.TIMESTAMP_MICROS.toString)
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
@@ -16,6 +16,8 @@
 
 package org.apache.spark.sql.delta
 
+import scala.collection.JavaConverters._
+
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
 import org.apache.spark.sql.delta.files.TahoeLogFileIndex
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -26,10 +28,16 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.format.converter.ParquetMetadataConverter
 import org.apache.parquet.hadoop.ParquetFileReader
-
-import org.apache.spark.sql.{DataFrame, Dataset, QueryTest}
+import org.apache.parquet.hadoop.util.HadoopInputFile
+import org.apache.parquet.schema.MessageType
+import org.apache.spark.sql.{DataFrame, Dataset, QueryTest, Row}
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{StringType, StructField, StructType, TimestampType}
+
+import java.io.File
+import java.sql.Timestamp
 
 trait DeltaParquetFileFormatSuiteBase
     extends QueryTest
@@ -291,6 +299,74 @@ class DeltaParquetFileFormatWithPredicatePushdownSuite extends DeltaParquetFileF
         (900, notDeletedColumnValue),
         (10352, deletedColumnValue),
         (19999, deletedColumnValue))
+    }
+  }
+}
+
+class DeltaParquetTimestampFormatSuite extends DeltaParquetFileFormatSuiteBase {
+  import testImplicits._
+
+  private val timestamps = Seq(
+    Timestamp.valueOf("2024-01-01 23:00:01"),
+    Timestamp.valueOf("2024-11-30 19:25:32"),
+    Timestamp.valueOf("2026-05-09 10:12:43"),
+    Timestamp.valueOf("2026-12-29 09:22:00")
+  )
+
+  private def getSchemaFromFirstFileInDirectory(tempDir: File): MessageType = {
+    val files = tempDir.list().filter(_.contains(".parquet")).filter(!_.contains(".crc"))
+    val file = s"${tempDir}/${files(0)}"
+
+    val reader = ParquetFileReader
+      .open(HadoopInputFile.fromPath(new Path(file), new Configuration()))
+
+    val schema = reader.getFooter.getFileMetaData.getSchema
+
+    reader.close()
+
+    schema
+  }
+
+  private def writeDatesDataframe(tempDir: File): Unit = {
+    val schema = StructType(List(
+      StructField("eventTimeString", TimestampType, nullable = false)
+    ))
+    val sc = spark.sparkContext
+
+    val dfTimestamps = spark.createDataFrame(
+      sc.parallelize(timestamps.map(timestamp => Row(timestamp))), schema
+    ).coalesce(1)
+    dfTimestamps.write.format("delta").mode("append").save(tempDir.toString)
+  }
+
+  private def assertDataframe(tempDir: File): Unit = {
+    val readTimestamps =
+      spark.read.format("delta")
+      .load(tempDir.toString)
+      .sort("eventTimeString")
+      .toLocalIterator().asScala.toList
+    assert(readTimestamps.map(_.getTimestamp(0))== timestamps)
+  }
+
+  test("Write Parquet timestamp without any config") {
+    withTempDir { tempDir =>
+      writeDatesDataframe(tempDir)
+      val parquetSchema = getSchemaFromFirstFileInDirectory(tempDir)
+      assert(
+        parquetSchema.toString.contains("optional int64 eventTimeString (TIMESTAMP(MICROS,true))"))
+      assertDataframe(tempDir)
+    }
+  }
+
+  test("Write Parquet timestamp with explicit INT96") {
+    withTempDir { tempDir =>
+      spark.conf.set(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key,
+        SQLConf.ParquetOutputTimestampType.INT96.toString)
+      writeDatesDataframe(tempDir)
+      val parquetSchema = getSchemaFromFirstFileInDirectory(tempDir)
+      assert(
+        parquetSchema.toString.contains("optional int96 eventTimeString"))
+      assertDataframe(tempDir)
     }
   }
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

- Iceberg states in the spec that Timestamps should be written with INT64 physical types. There were already flags to enable this, but this PR makes this behavior the default.
- `INT96` is discouraged: https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift#L981

## How was this patch tested?

- Added new unit-tests to validate the correct behavior

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, it will default to INT64 if nothing has been set. 
