### PR TITLE
[Spark] Only attempt parsing partition path into different types if type inference is enabled

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/PartitionUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/PartitionUtils.scala
@@ -528,7 +528,7 @@ private[delta] object PartitionUtils {
       timeZone: TimeZone,
       dateFormatter: DateFormatter,
       timestampFormatter: TimestampFormatter): Literal = {
-    val decimalTry = Try {
+    def decimalTry = Try {
       // `BigDecimal` conversion can fail when the `field` is not a form of number.
       val bigDecimal = new JBigDecimal(raw)
       // It reduces the cases for decimals by disallowing values having scale (eg. `1.1`).
@@ -539,7 +539,7 @@ private[delta] object PartitionUtils {
       Literal(bigDecimal)
     }
 
-    val dateTry = Try {
+    def dateTry = Try {
       // try and parse the date, if no exception occurs this is a candidate to be resolved as
       // DateType
       dateFormatter.parse(raw)
@@ -555,7 +555,7 @@ private[delta] object PartitionUtils {
       Literal.create(dateValue, DateType)
     }
 
-    val timestampTry = Try {
+    def timestampTry = Try {
       val unescapedRaw = unescapePathName(raw)
       // try and parse the date, if no exception occurs this is a candidate to be resolved as
       // TimestampType


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
I was looking at this code path for another issue and noticed that when parsing partition values from paths (only used for the write path) without type inference we still attempt to due parsing for date/decima/timestamp types even though it's not required. We can avoid that work with a small refactoring.

## How was this patch tested?
This is a refactoring/minor optimization where existing unit tests will exercise this path

## Does this PR introduce _any_ user-facing changes?
No
