### PR TITLE
[Spark] Use DeltaSQLTestUtils in more test suites

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DDLTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DDLTestUtils.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.delta
 
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
 
 import org.apache.spark.sql.{QueryTest, SparkSession}
 import org.apache.spark.sql.test.SharedSparkSession
@@ -114,7 +114,11 @@ case class IdentityColumnSpec(
   }
 }
 
-trait DDLTestUtils extends QueryTest with SharedSparkSession with DeltaSQLCommandTest {
+trait DDLTestUtils
+  extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLTestUtils
+  with DeltaSQLCommandTest {
   protected object DDLType extends Enumeration {
     val CREATE, REPLACE, CREATE_OR_REPLACE = Value
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.delta.actions.{Action, AddCDCFile, AddFile, Metadata
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.schema.SchemaMergingUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.format.converter.ParquetMetadataConverter
@@ -43,7 +43,10 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 // scalastyle:on import.ordering.noEmptyLine
 
-trait DeltaColumnMappingSuiteUtils extends SharedSparkSession with DeltaSQLCommandTest {
+trait DeltaColumnMappingSuiteUtils
+  extends SharedSparkSession
+  with DeltaSQLTestUtils
+  with DeltaSQLCommandTest {
 
 
   protected def supportedModes: Seq[String] = Seq("id", "name")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.delta.DeltaTestUtils.Plans
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
 import org.apache.spark.sql.delta.util.FileNames
 import io.delta.tables.{DeltaTable => IODeltaTable}
 import org.apache.hadoop.fs.FileStatus
@@ -483,7 +483,8 @@ trait DeltaTestUtilsForTempViews
  * cleaning it up after each test.
  */
 trait DeltaDMLTestUtils
-  extends DeltaTestUtilsBase
+  extends DeltaSQLTestUtils
+  with DeltaTestUtilsBase
   with BeforeAndAfterEach {
   self: SharedSparkSession =>
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnTest.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnTest.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.schema.{DeltaInvariantViolationException, InvariantViolationException, SchemaUtils}
 import org.apache.spark.sql.delta.sources.DeltaSourceUtils.GENERATION_EXPRESSION_METADATA_KEY
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import io.delta.tables.DeltaTableBuilder
 
@@ -42,7 +42,8 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{ArrayType, DateType, IntegerType, MetadataBuilder, StringType, StructField, StructType, TimestampType}
 import org.apache.spark.unsafe.types.UTF8String
 
-trait GeneratedColumnTest extends QueryTest with SharedSparkSession with DeltaSQLCommandTest {
+trait GeneratedColumnTest extends QueryTest with SharedSparkSession with DeltaSQLCommandTest
+    with DeltaSQLTestUtils {
 
 
   protected def sqlDate(date: String): java.sql.Date = {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/RestoreTableSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/RestoreTableSuiteBase.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.delta.actions.{Protocol, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.{TABLE_FEATURES_MIN_READER_VERSION, TABLE_FEATURES_MIN_WRITER_VERSION}
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.FileNames
 
@@ -33,6 +33,7 @@ import org.apache.spark.sql.types._
 
 /** Base suite containing the restore tests. */
 trait RestoreTableSuiteBase extends QueryTest with SharedSparkSession
+  with DeltaSQLTestUtils
   with DeltaSQLCommandTest {
 
   import testImplicits._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdTestUtils.scala
@@ -29,9 +29,8 @@ import org.apache.parquet.hadoop.metadata.BlockMetaData
 
 import org.apache.spark.sql.{Column, DataFrame}
 import org.apache.spark.sql.execution.datasources.FileFormat
-import org.apache.spark.sql.execution.datasources.parquet.ParquetTest
 
-trait RowIdTestUtils extends RowTrackingTestUtils with DeltaSQLCommandTest with ParquetTest {
+trait RowIdTestUtils extends RowTrackingTestUtils with DeltaSQLCommandTest {
   val QUALIFIED_BASE_ROW_ID_COLUMN_NAME = s"${FileFormat.METADATA_NAME}.${RowId.BASE_ROW_ID}"
 
   protected def getRowIdRangeInclusive(f: AddFile): (Long, Long) = {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingTestUtils.scala
@@ -19,12 +19,18 @@ package org.apache.spark.sql.delta.rowtracking
 import org.apache.spark.sql.delta.{DeltaConfigs, RowTrackingFeature}
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.execution.datasources.parquet.ParquetTest
 import org.apache.spark.sql.test.SharedSparkSession
 
-trait RowTrackingTestUtils extends QueryTest with SharedSparkSession {
+trait RowTrackingTestUtils
+  extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLTestUtils
+  with ParquetTest {
   lazy val rowTrackingFeatureName: String =
     TableFeatureProtocolUtils.propertyKey(RowTrackingFeature)
   lazy val defaultRowTrackingFeatureProperty: String =


### PR DESCRIPTION
## Description
Follow-up from https://github.com/delta-io/delta/pull/3365
Mix in `DeltaSQLTestUtils` in more test suites so that they use the Delta temp dir creation helpers.

## How was this patch tested?
Test-only
