### PR TITLE
Move OutputTimestampType to `DeltaSQLConf`

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaParquetFileFormat.scala
@@ -265,11 +265,8 @@ case class DeltaParquetFileFormat(
        dataSchema: StructType): OutputWriterFactory = {
     val factory = super.prepareWrite(sparkSession, job, options, dataSchema)
     val conf = ContextUtil.getConfiguration(job)
-    // If the key is not set explicitly, default to INT64 for Iceberg compatability
-    if (!sparkSession.conf.contains(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key)) {
-      conf.set(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key,
-        SQLConf.ParquetOutputTimestampType.TIMESTAMP_MICROS.toString)
-    }
+    conf.set(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key,
+      sparkSession.conf.get(DeltaSQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE))
     if (IcebergCompatV2.isEnabled(metadata)) {
       // For Uniform with IcebergCompatV2, we need to write nested field IDs for list and map
       // types to the parquet schema. Spark currently does not support it so we hook in our

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -554,6 +554,21 @@ trait DeltaSQLConfBase {
       .checkValue(_ > 0, "threadPoolSize must be positive")
       .createWithDefault(5)
 
+  val PARQUET_OUTPUT_TIMESTAMP_TYPE =
+    buildConf("parquet.outputTimestampType")
+      .doc(
+        """
+          |Sets which Parquet timestamp type to use when Spark writes data to Parquet files:
+          |INT96 is a non-standard but commonly used timestamp type in Parquet.
+          |TIMESTAMP_MICROS is a standard timestamp type in Parquet,
+          |which stores number of microseconds from the Unix epoch.
+          |TIMESTAMP_MILLIS is also standard, but with millisecond precision,
+          |which means Spark has to truncate the microsecond portion of its timestamp value.
+          |""".stripMargin)
+      .stringConf
+      .checkValues(Set("INT96", "TIMESTAMP_MICROS", "TIMESTAMP_MILLIS"))
+      .createWithDefaultString("TIMESTAMP_MICROS")
+
   //////////////////////////////////////////////
   // DynamoDB Commit Coordinator-specific configs
   /////////////////////////////////////////////

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
@@ -360,7 +360,7 @@ class DeltaParquetTimestampFormatSuite extends DeltaParquetFileFormatSuiteBase {
 
   test("Write Parquet timestamp with explicit INT96") {
     withTempDir { tempDir =>
-      spark.conf.set(SQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key,
+      spark.conf.set(DeltaSQLConf.PARQUET_OUTPUT_TIMESTAMP_TYPE.key,
         SQLConf.ParquetOutputTimestampType.INT96.toString)
       writeDatesDataframe(tempDir)
       val parquetSchema = getSchemaFromFirstFileInDirectory(tempDir)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
