### PR TITLE
Assert schema in `DeltaParquetFileFormatSuite`

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaParquetFileFormatSuite.scala
@@ -340,12 +340,18 @@ class DeltaParquetTimestampFormatSuite extends DeltaParquetFileFormatSuiteBase {
   }
 
   private def assertDataframe(tempDir: File): Unit = {
-    val readTimestamps =
+    val df =
       spark.read.format("delta")
       .load(tempDir.toString)
+
+    assert(df.schema.fields.length == 1)
+    assert(df.schema.head.dataType == TimestampType)
+
+    val readTimestamps = df
       .sort("eventTimeString")
-      .toLocalIterator().asScala.toList
-    assert(readTimestamps.map(_.getTimestamp(0))== timestamps)
+      .toLocalIterator()
+      .asScala.toList
+    assert(readTimestamps.map(_.getTimestamp(0)) == timestamps)
   }
 
   test("Write Parquet timestamp without any config") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
