### PR TITLE
[Spark] Minor refactor in Delta Protocol Transition Suite

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolTransitionsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolTransitionsSuite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.test.SharedSparkSession
 
 trait DeltaProtocolTransitionsBaseSuite
-  extends QueryTest
+    extends QueryTest
     with SharedSparkSession
     with DeltaSQLCommandTest {
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolTransitionsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolTransitionsSuite.scala
@@ -86,7 +86,6 @@ trait DeltaProtocolTransitionsBaseSuite
       assert(deltaLog.update().protocol === expectedProtocol)
     }
   }
-
 }
 
 class DeltaProtocolTransitionsSuite extends DeltaProtocolTransitionsBaseSuite {
@@ -685,4 +684,3 @@ class DeltaProtocolTransitionsSuite extends DeltaProtocolTransitionsBaseSuite {
     }
   }
 }
-

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolTransitionsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolTransitionsSuite.scala
@@ -28,8 +28,8 @@ import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.test.SharedSparkSession
 
-class DeltaProtocolTransitionsSuite
-    extends QueryTest
+trait DeltaProtocolTransitionsBaseSuite
+  extends QueryTest
     with SharedSparkSession
     with DeltaSQLCommandTest {
 
@@ -86,6 +86,10 @@ class DeltaProtocolTransitionsSuite
       assert(deltaLog.update().protocol === expectedProtocol)
     }
   }
+
+}
+
+class DeltaProtocolTransitionsSuite extends DeltaProtocolTransitionsBaseSuite {
 
   test("CREATE TABLE default protocol versions") {
     testProtocolTransition(
@@ -681,3 +685,4 @@ class DeltaProtocolTransitionsSuite
     }
   }
 }
+


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Minor refactor in `DeltaProtocolTransitionsSuite`.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Test only PR.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.