### PR TITLE
[Spark] Add custom not matched for insert clauses expr

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommand.scala
@@ -113,7 +113,7 @@ case class MergeIntoCommand(
           source,
           condition,
           matchedClauses,
-          notMatchedClauses,
+          notMatchedClausesForInsertExpressions,
           isInsertOnly)
 
         val mergeActions = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
@@ -63,6 +63,8 @@ trait MergeIntoCommandBase extends LeafRunnableCommand
     spark.conf.get(DeltaSQLConf.MERGE_USE_PERSISTENT_DELETION_VECTORS) &&
       DeletionVectorUtils.deletionVectorsWritable(txn.snapshot)
   }
+  protected def notMatchedClausesForInsertExpressions: Seq[DeltaMergeIntoNotMatchedClause] =
+    notMatchedClauses
 
   override val (canMergeSchema, canOverwriteSchema) = {
     // Delta options can't be passed to MERGE INTO currently, so they'll always be empty.
@@ -128,11 +130,13 @@ trait MergeIntoCommandBase extends LeafRunnableCommand
   }
 
   /** Whether this merge statement has only MATCHED clauses. */
-  protected def isMatchedOnly: Boolean = notMatchedClauses.isEmpty && matchedClauses.nonEmpty &&
+  protected def isMatchedOnly: Boolean =
+    notMatchedClauses.isEmpty && matchedClauses.nonEmpty &&
     notMatchedBySourceClauses.isEmpty
 
   /** Whether this merge statement only has only insert (NOT MATCHED) clauses. */
-  protected def isInsertOnly: Boolean = matchedClauses.isEmpty && notMatchedClauses.nonEmpty &&
+  protected def isInsertOnly: Boolean = matchedClauses.isEmpty &&
+    notMatchedClauses.nonEmpty &&
     notMatchedBySourceClauses.isEmpty
 
   /** Whether this merge statement includes inserts statements. */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/ClassicMergeExecutor.scala
@@ -387,7 +387,8 @@ trait ClassicMergeExecutor extends MergeOutputGeneration {
     val (joinedAndPrecomputedConditionsDF, clausesWithPrecompConditions) =
         generatePrecomputedConditionsAndDF(
           joinedDF,
-          clauses = matchedClauses ++ notMatchedClauses ++ notMatchedBySourceClauses)
+          clauses = matchedClauses ++ notMatchedClausesForInsertExpressions ++
+            notMatchedBySourceClauses)
 
     // In case Row IDs are preserved, get the attribute expression of the Row ID column.
     val rowIdColumnExpressionOpt =

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/InsertOnlyMergeExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/InsertOnlyMergeExecutor.scala
@@ -158,7 +158,7 @@ trait InsertOnlyMergeExecutor extends MergeOutputGeneration {
     // Precompute conditions in insert clauses and generate source data frame with precomputed
     // boolean columns and insert clauses with rewritten conditions.
     val (sourceWithPrecompConditions, insertClausesWithPrecompConditions) =
-      generatePrecomputedConditionsAndDF(preparedSourceDF, notMatchedClauses)
+      generatePrecomputedConditionsAndDF(preparedSourceDF, notMatchedClausesForInsertExpressions)
 
     // Generate output cols.
     val outputCols = generateInsertsOnlyOutputCols(
@@ -184,7 +184,7 @@ trait InsertOnlyMergeExecutor extends MergeOutputGeneration {
       targetWriteColNames: Seq[String]
     ): Seq[Column] = {
 
-    val outputExprs = notMatchedClauses.head.resolvedActions.map(_.expr)
+    val outputExprs = notMatchedClausesForInsertExpressions.head.resolvedActions.map(_.expr)
     assert(outputExprs.nonEmpty)
     // generate the outputDF without `CaseWhen` expressions.
     outputExprs.zip(targetWriteColNames).zipWithIndex.map { case ((expr, name), i) =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Make `notMatchedClauses` a custom `def`

## How was this patch tested?

Unit tests

## Does this PR introduce _any_ user-facing changes?

No