### PR TITLE
[Spark] Fix the semantic of `shouldRewriteToBeIcebergCompatible` in REORG UPGRADE UNIFORM

### DIFF
--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2ESuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2ESuite.scala
@@ -18,9 +18,12 @@ package org.apache.spark.sql.delta.uniform
 
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.uniform.{UniFormE2EIcebergSuiteBase, UniFormE2ETest}
-
 import org.apache.spark.SparkConf
+
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.delta.DeltaLog
+import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.uniform.hms.HMSTest
 
@@ -38,6 +41,56 @@ trait WriteDeltaHMSReadIceberg extends UniFormE2ETest with DeltaSQLCommandTest w
   override protected def createReaderSparkSession: SparkSession = createIcebergSparkSession
 }
 
-class UniFormE2EIcebergSuite
-  extends UniFormE2EIcebergSuiteBase
-  with WriteDeltaHMSReadIceberg
+class UniFormE2EIcebergSuite extends UniFormE2EIcebergSuiteBase with WriteDeltaHMSReadIceberg {
+  private def runReorgUpgradeUniform(icebergCompatVersion: Int): Unit = {
+    write(
+      s"""
+         | REORG TABLE $testTableName APPLY
+         | (UPGRADE UNIFORM (ICEBERG_COMPAT_VERSION = $icebergCompatVersion))
+         |""".stripMargin
+    )
+  }
+
+  private def assertTagsExistForLatestSnapshot(isNull: Boolean): Unit = {
+    val snapshot = DeltaLog.forTable(spark, new TableIdentifier(testTableName)).update()
+    snapshot.allFiles.collect().forall { addFile =>
+      if (isNull) {
+        addFile.tags == null
+      } else {
+        addFile.tags.getOrElse(AddFile.Tags.ICEBERG_COMPAT_VERSION.name, "0").contains("2")
+      }
+    }
+  }
+
+  test("Reorg Upgrade Uniform Basic Test") {
+    withTable(testTableName) {
+      write(s"CREATE TABLE $testTableName (id INT, name STRING) USING DELTA")
+      write(s"INSERT INTO $testTableName VALUES (1, 'Alex'), (2, 'Michael')")
+      assertTagsExistForLatestSnapshot(isNull = true)
+
+      runReorgUpgradeUniform(icebergCompatVersion = 2)
+      assertTagsExistForLatestSnapshot(isNull = false)
+    }
+  }
+
+  test("Reorg Upgrade Uniform V1 to V2") {
+    withTable(testTableName) {
+      write(
+        s"""
+           | CREATE TABLE $testTableName (id INT, name STRING)
+           | USING DELTA
+           | TBLPROPERTIES (
+           |   'delta.columnMapping.mode' = 'name',
+           |   'delta.enableIcebergCompatV1' = 'true',
+           |   'delta.universalFormat.enabledFormats' = 'iceberg'
+           | )
+           |""".stripMargin
+      )
+      write(s"INSERT INTO $testTableName VALUES (1, 'Alex'), (2, 'Michael')")
+      assertTagsExistForLatestSnapshot(isNull = true)
+
+      runReorgUpgradeUniform(icebergCompatVersion = 2)
+      assertTagsExistForLatestSnapshot(isNull = false)
+    }
+  }
+}

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2ESuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2ESuite.scala
@@ -41,6 +41,11 @@ trait WriteDeltaHMSReadIceberg extends UniFormE2ETest with DeltaSQLCommandTest w
 }
 
 class UniFormE2EIcebergSuite extends UniFormE2EIcebergSuiteBase with WriteDeltaHMSReadIceberg {
+  /**
+   * Upgrade the default test table to `icebergCompatVersion`.
+   *
+   * @param icebergCompatVersion the version to upgrade the table.
+   */
   private def runReorgUpgradeUniform(icebergCompatVersion: Int): Unit = {
     write(
       s"""
@@ -50,6 +55,13 @@ class UniFormE2EIcebergSuite extends UniFormE2EIcebergSuiteBase with WriteDeltaH
     )
   }
 
+  /**
+   * Check `AddFile.tags` exist or not for all the current files in
+   * the default test table.
+   *
+   * @param tagsShouldExist whether the tags should exist for the table.
+   * @param value if exist, what should the value of the tags be.
+   */
   private def assertTagsExistForLatestSnapshot(
       tagsShouldExist: Boolean,
       value: String = null): Unit = {
@@ -63,6 +75,9 @@ class UniFormE2EIcebergSuite extends UniFormE2EIcebergSuiteBase with WriteDeltaH
     }
   }
 
+  /**
+   * Add `IcebergCompatV1` tags to default test table, only used for testing.
+   */
   private def addMockIcebergCompatV1Tags(): Unit = {
     val log = DeltaLog.forTable(spark, new TableIdentifier(testTableName))
     val snapshot = log.update()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaReorgTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaReorgTableCommand.scala
@@ -131,8 +131,9 @@ class DeltaUpgradeUniformOperation(icebergCompatVersion: Int) extends DeltaReorg
     : Seq[AddFile] = {
     def shouldRewriteToBeIcebergCompatible(file: AddFile): Boolean = {
       if (file.tags == null) return true
-      val icebergCompatVersion = file.tags.getOrElse(AddFile.Tags.ICEBERG_COMPAT_VERSION.name, "0")
-      !icebergCompatVersion.exists(_.toString == icebergCompatVersion)
+      val fileIcebergCompatVersion =
+        file.tags.getOrElse(AddFile.Tags.ICEBERG_COMPAT_VERSION.name, "0")
+      fileIcebergCompatVersion != icebergCompatVersion.toString
     }
     files.filter(shouldRewriteToBeIcebergCompatible)
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
currently we utilize the helper function `shouldRewriteToBeIcebergCompatible` to filter the portion of parquet files that need to be rewritten when running `REORG UPGRADE UNIFORM` based on the tags in the `AddFile`.

however, the `DeltaUpgradeUniformOperation.icebergCompatVersion` is accidentally shadowed, which will make `shouldRewriteToBeIcebergCompatible` always return `false` if the `AddFile.tags` is not `null` - this is not the expected semantic of this function.

this PR introduces the fix for this problem and add unit tests to ensure the correctness.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
through unit tests in `UniFormE2ESuite.scala`.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
no.

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
