### PR TITLE
[Spark] Flip isDeltaTable.throwOnError to true

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1000,7 +1000,7 @@ trait DeltaSQLConfBase {
         | Delta table.
         |""".stripMargin)
       .booleanConf
-      .createWithDefault(Utils.isTesting)
+      .createWithDefault(true)
 
   val DELTA_LEGACY_STORE_WRITER_OPTIONS_AS_PROPS =
     buildConf("legacy.storeOptionsAsProperties")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

- Change the default value of the isDeltaTable.throwOnError flag to `true`.

## How was this patch tested?

Existing tests (was already `true` in testing).

## Does this PR introduce _any_ user-facing changes?

Resolving a Delta that is accessed by path (e.g. DeltaTable.forPath() or SELECT ... FROM delta.<path>) will now forward exceptions thrown while accessing , instead of always throwing a DELTA_MISSING_DELTA_TABLE exception.
This helps locating issues such as missing access permissions without having to through support.
