### PR TITLE
[#3423] Fix unnecessary DynamoDB GET calls during LogStore::listFrom VACUUM calls

### DIFF
--- a/storage-s3-dynamodb/src/main/java/io/delta/storage/BaseExternalLogStore.java
+++ b/storage-s3-dynamodb/src/main/java/io/delta/storage/BaseExternalLogStore.java
@@ -130,6 +130,8 @@ public abstract class BaseExternalLogStore extends HadoopFileSystemLogStore {
         final FileSystem fs = path.getFileSystem(hadoopConf);
         final Path resolvedPath = stripUserInfo(fs.makeQualified(path));
 
+        // VACUUM operations may use this LogStore::listFrom API. We don't need to attempt to
+        // perform a fix/recovery during such operations that are not listing the _delta_log.
         if (isDeltaLogPath(resolvedPath)) {
             final Path tablePath = getTablePath(resolvedPath);
             final Optional<ExternalCommitEntry> entry = getLatestExternalEntry(tablePath);
@@ -476,11 +478,9 @@ public abstract class BaseExternalLogStore extends HadoopFileSystemLogStore {
         }
     }
 
-    /**
-     * Returns true if this path is equal to or contained within a _delta_log folder.
-     * Visible for testing.
-     */
-    static boolean isDeltaLogPath(Path normalizedPath) {
+    /** Returns true if this path is contained within a _delta_log folder. */
+    @VisibleForTesting
+    protected boolean isDeltaLogPath(Path normalizedPath) {
         return Arrays.stream(normalizedPath
             .toUri()
             .toString()

--- a/storage-s3-dynamodb/src/test/java/io/delta/storage/MemoryLogStore.java
+++ b/storage-s3-dynamodb/src/test/java/io/delta/storage/MemoryLogStore.java
@@ -29,9 +29,17 @@ import java.util.Optional;
  * database)
  */
 public class MemoryLogStore extends BaseExternalLogStore {
+    private int numGetLatestExternalEntryCalls;
+
     public MemoryLogStore(Configuration hadoopConf) {
         super(hadoopConf);
+
+        this.numGetLatestExternalEntryCalls = 0;
     }
+
+    ///////////////////
+    // API Overrides //
+    ///////////////////
 
     @Override
     protected void putExternalEntry(
@@ -69,6 +77,8 @@ public class MemoryLogStore extends BaseExternalLogStore {
 
     @Override
     protected Optional<ExternalCommitEntry> getLatestExternalEntry(Path tablePath) {
+        numGetLatestExternalEntryCalls++;
+
         final Path fixedTablePath = new Path(fixPathSchema(tablePath.toString()));
         return hashMap
             .values()
@@ -76,6 +86,18 @@ public class MemoryLogStore extends BaseExternalLogStore {
             .filter(item -> item.tablePath.equals(fixedTablePath))
             .max(Comparator.comparing(ExternalCommitEntry::absoluteFilePath));
     }
+
+    ///////////////////////
+    // Counter Accessors //
+    ///////////////////////
+
+    public int numGetLatestExternalEntryCalls() {
+        return numGetLatestExternalEntryCalls;
+    }
+
+    ////////////////////
+    // Static Helpers //
+    ////////////////////
 
     /**
      * ExternalLogStoreSuite sometimes uses "failing:" scheme prefix to inject errors during tests

--- a/storage-s3-dynamodb/src/test/java/io/delta/storage/MemoryLogStore.java
+++ b/storage-s3-dynamodb/src/test/java/io/delta/storage/MemoryLogStore.java
@@ -29,6 +29,9 @@ import java.util.Optional;
  * database)
  */
 public class MemoryLogStore extends BaseExternalLogStore {
+    public static String IS_DELTA_LOG_PATH_OVERRIDE_KEY =
+        "spark.hadoop.io.delta.storage.MemoryLogStore.isDeltaLogPath.alwaysTrue";
+
     public static int numGetLatestExternalEntryCalls = 0;
 
     public MemoryLogStore(Configuration hadoopConf) {
@@ -83,6 +86,15 @@ public class MemoryLogStore extends BaseExternalLogStore {
             .stream()
             .filter(item -> item.tablePath.equals(fixedTablePath))
             .max(Comparator.comparing(ExternalCommitEntry::absoluteFilePath));
+    }
+
+    @Override
+    protected boolean isDeltaLogPath(Path normalizedPath) {
+        if (initHadoopConf.getBoolean(IS_DELTA_LOG_PATH_OVERRIDE_KEY, false)) {
+            return true; // hardcoded to return true
+        } else {
+            return super.isDeltaLogPath(normalizedPath); // only return true if in _delta_log folder
+        }
     }
 
     ////////////////////

--- a/storage-s3-dynamodb/src/test/java/io/delta/storage/MemoryLogStore.java
+++ b/storage-s3-dynamodb/src/test/java/io/delta/storage/MemoryLogStore.java
@@ -90,7 +90,7 @@ public class MemoryLogStore extends BaseExternalLogStore {
 
     @Override
     protected boolean isDeltaLogPath(Path normalizedPath) {
-        if (initHadoopConf.getBoolean(IS_DELTA_LOG_PATH_OVERRIDE_KEY, false)) {
+        if (initHadoopConf().getBoolean(IS_DELTA_LOG_PATH_OVERRIDE_KEY, false)) {
             return true; // hardcoded to return true
         } else {
             return super.isDeltaLogPath(normalizedPath); // only return true if in _delta_log folder

--- a/storage-s3-dynamodb/src/test/java/io/delta/storage/MemoryLogStore.java
+++ b/storage-s3-dynamodb/src/test/java/io/delta/storage/MemoryLogStore.java
@@ -29,12 +29,10 @@ import java.util.Optional;
  * database)
  */
 public class MemoryLogStore extends BaseExternalLogStore {
-    private int numGetLatestExternalEntryCalls;
+    public static int numGetLatestExternalEntryCalls = 0;
 
     public MemoryLogStore(Configuration hadoopConf) {
         super(hadoopConf);
-
-        this.numGetLatestExternalEntryCalls = 0;
     }
 
     ///////////////////
@@ -85,14 +83,6 @@ public class MemoryLogStore extends BaseExternalLogStore {
             .stream()
             .filter(item -> item.tablePath.equals(fixedTablePath))
             .max(Comparator.comparing(ExternalCommitEntry::absoluteFilePath));
-    }
-
-    ///////////////////////
-    // Counter Accessors //
-    ///////////////////////
-
-    public int numGetLatestExternalEntryCalls() {
-        return numGetLatestExternalEntryCalls;
     }
 
     ////////////////////

--- a/storage-s3-dynamodb/src/test/scala/io/delta/storage/ExternalLogStoreSuite.scala
+++ b/storage-s3-dynamodb/src/test/scala/io/delta/storage/ExternalLogStoreSuite.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.delta.FakeFileSystem
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.storage.LogStoreAdaptor
 import org.apache.spark.sql.delta.util.FileNames
+import org.apache.spark.sql.functions.col
 
 /////////////////////
 // Base Test Suite //
@@ -92,7 +93,12 @@ class ExternalLogStoreSuite extends org.apache.spark.sql.delta.PublicLogStoreSui
 
           val path = tempDir.getCanonicalPath
 
-          spark.range(100).repartition(1).write.format("delta").save(path)
+          spark.range(100)
+              .withColumn("part", col("id") % 10)
+              .write
+              .format("delta")
+              .partitionBy("part")
+              .save(path)
 
           spark.sql(s"DELETE FROM delta.`$path`")
 

--- a/storage-s3-dynamodb/src/test/scala/io/delta/storage/ExternalLogStoreSuite.scala
+++ b/storage-s3-dynamodb/src/test/scala/io/delta/storage/ExternalLogStoreSuite.scala
@@ -39,6 +39,12 @@ class ExternalLogStoreSuite extends org.apache.spark.sql.delta.PublicLogStoreSui
   override protected val publicLogStoreClassName: String =
     classOf[MemoryLogStore].getName
 
+  protected override def beforeEach(): Unit = {
+    super.beforeEach()
+
+    MemoryLogStore.numGetLatestExternalEntryCalls = 0
+  }
+
   testHadoopConf(
     expectedErrMsg = "No FileSystem for scheme \"fake\"",
     "fs.fake.impl" -> classOf[FakeFileSystem].getName,

--- a/storage/src/main/java/io/delta/storage/LogStore.java
+++ b/storage/src/main/java/io/delta/storage/LogStore.java
@@ -56,7 +56,7 @@ import java.util.Iterator;
  */
 public abstract class LogStore {
 
-  protected final Configuration initHadoopConf;
+  protected Configuration initHadoopConf;
 
   public LogStore(Configuration initHadoopConf) {
     this.initHadoopConf = initHadoopConf;

--- a/storage/src/main/java/io/delta/storage/LogStore.java
+++ b/storage/src/main/java/io/delta/storage/LogStore.java
@@ -56,7 +56,7 @@ import java.util.Iterator;
  */
 public abstract class LogStore {
 
-  protected Configuration initHadoopConf;
+  private Configuration initHadoopConf;
 
   public LogStore(Configuration initHadoopConf) {
     this.initHadoopConf = initHadoopConf;

--- a/storage/src/main/java/io/delta/storage/LogStore.java
+++ b/storage/src/main/java/io/delta/storage/LogStore.java
@@ -56,7 +56,7 @@ import java.util.Iterator;
  */
 public abstract class LogStore {
 
-  private Configuration initHadoopConf;
+  protected final Configuration initHadoopConf;
 
   public LogStore(Configuration initHadoopConf) {
     this.initHadoopConf = initHadoopConf;


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Resolves #3423.

This PR updates the logic in `BaseExternalLogStore::listFrom` so that it does not make a request to get the latest entry from the external store (which is used to perform recovery operations) in the event that a non `_delta_log` file is being listed.

This is useful for VACUUM operations which may do hundreds or thousands of list calls in the table directory and nested partition directories of parquet files. This is NOT the `_delta_log`. Thus, checking the external store during these list calls is (1) useless and unwanted as we are not listing the `_delta_log` so clearly now isn't the time to attempt to do a fixup, and (2) expensive.

This PR makes it so that future VACUUM operations do not perform unnecessary calls to the external store (e.g. DyanamoDB).

## How was this patch tested?

Unit tests and an integration test that actually runs VACUUM and compares the number of external store calls using the old/new logic. I ran that test myself 50 times, too, and it passed every time (therefore, not flaky).

## Does this PR introduce _any_ user-facing changes?

No
