### PR TITLE
 [Sharing]Use bytes length for file size in DeltaSharingLogFileStatus

### DIFF
--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaFormatSharingSourceSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaFormatSharingSourceSuite.scala
@@ -354,6 +354,7 @@ class DeltaFormatSharingSourceSuite
     withTempDirs { (inputDir, outputDir, checkpointDir) =>
       val deltaTableName = "delta_table_restart_special"
       withTable(deltaTableName) {
+        // scalastyle:off nonascii
         sql(s"""CREATE TABLE $deltaTableName (`第一列` STRING) USING DELTA""".stripMargin)
         val sharedTableName = "shared_streaming_table_special"
         prepareMockedClientMetadata(deltaTableName, sharedTableName)
@@ -376,6 +377,7 @@ class DeltaFormatSharingSourceSuite
               .format("delta")
               .option("checkpointLocation", checkpointDir.toString)
               .start(outputDir.toString)
+            // scalastyle:on nonascii
 
             try {
               q.processAllAvailable()

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaSuite.scala
@@ -1006,6 +1006,7 @@ trait DeltaSharingDataSourceDeltaSuiteBase
     withTempDir { tempDir =>
       val deltaTableName = "delta_table_special"
       withTable(deltaTableName) {
+        // scalastyle:off nonascii
         sql(s"""CREATE TABLE $deltaTableName (`第一列` INT, c2 STRING)
                |USING DELTA PARTITIONED BY (c2)
                |""".stripMargin)
@@ -1026,6 +1027,7 @@ trait DeltaSharingDataSourceDeltaSuiteBase
         val expectedSchema: StructType = new StructType()
           .add("第一列", IntegerType)
           .add("c2", StringType)
+        // scalastyle:on nonascii
         val expected = spark.read.format("delta").table(deltaTableName)
 
         def test(tablePath: String): Unit = {
@@ -1053,6 +1055,7 @@ trait DeltaSharingDataSourceDeltaSuiteBase
     withTempDir { tempDir =>
       val deltaTableName = "delta_table_cdf_special"
       withTable(deltaTableName) {
+        // scalastyle:off nonascii
         sql(s"""CREATE TABLE $deltaTableName (`第一列` INT, c2 STRING)
                |USING DELTA PARTITIONED BY (c2)
                |TBLPROPERTIES (delta.enableChangeDataFeed = true)
@@ -1066,6 +1069,7 @@ trait DeltaSharingDataSourceDeltaSuiteBase
           }
           sql(s"INSERT INTO $deltaTableName VALUES ${valuesBuilder.result().mkString(",")}")
           sql(s"""UPDATE $deltaTableName SET `第一列` = `第一列` + 100 where c2 = "${iteration}"""")
+          // scalastyle:on nonascii
           sql(s"""DELETE FROM $deltaTableName where c2 = "${iteration}"""")
         }
 

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaSuite.scala
@@ -1002,6 +1002,120 @@ trait DeltaSharingDataSourceDeltaSuiteBase
     }
   }
 
+  test("DeltaSharingDataSource able to read data with special chars") {
+    withTempDir { tempDir =>
+      val deltaTableName = "delta_table_special"
+      withTable(deltaTableName) {
+        sql(s"""CREATE TABLE $deltaTableName (`第一列` INT, c2 STRING)
+               |USING DELTA PARTITIONED BY (c2)
+               |""".stripMargin)
+        // The table operations take about 6~10 seconds.
+        for (i <- 0 to 99) {
+          val iteration = s"iteration $i"
+          val valuesBuilder = Seq.newBuilder[String]
+          for (j <- 0 to 99) {
+            valuesBuilder += s"""(${i * 10 + j}, "$iteration")"""
+          }
+          sql(s"INSERT INTO $deltaTableName VALUES ${valuesBuilder.result().mkString(",")}")
+        }
+
+        val sharedTableName = "shared_table_more"
+        prepareMockedClientAndFileSystemResult(deltaTableName, sharedTableName)
+        prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+
+        val expectedSchema: StructType = new StructType()
+          .add("第一列", IntegerType)
+          .add("c2", StringType)
+        val expected = spark.read.format("delta").table(deltaTableName)
+
+        def test(tablePath: String): Unit = {
+          assert(
+            expectedSchema == spark.read
+              .format("deltaSharing")
+              .option("responseFormat", "delta")
+              .load(tablePath)
+              .schema
+          )
+          val df =
+            spark.read.format("deltaSharing").option("responseFormat", "delta").load(tablePath)
+          checkAnswer(df, expected)
+        }
+
+        withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
+          val profileFile = prepareProfileFile(tempDir)
+          test(s"${profileFile.getCanonicalPath}#share1.default.$sharedTableName")
+        }
+        // BEGIN-EDGE
+        withSQLConf(getUnityCatalogClassesSQLConf.toSeq: _*) {
+          val ucTableFullName = s"catalog.schema.$sharedTableName"
+          test(s"uc-deltasharing://$ucTableFullName#$ucTableFullName")
+        }
+        // END-EDGE
+      }
+    }
+  }
+
+  test("DeltaSharingDataSource able to read cdf with special chars") {
+    withTempDir { tempDir =>
+      val deltaTableName = "delta_table_cdf_special"
+      withTable(deltaTableName) {
+        sql(s"""CREATE TABLE $deltaTableName (`第一列` INT, c2 STRING)
+               |USING DELTA PARTITIONED BY (c2)
+               |TBLPROPERTIES (delta.enableChangeDataFeed = true)
+               |""".stripMargin)
+        // The table operations take about 20~30 seconds.
+        for (i <- 0 to 9) {
+          val iteration = s"iteration $i"
+          val valuesBuilder = Seq.newBuilder[String]
+          for (j <- 0 to 49) {
+            valuesBuilder += s"""(${i * 10 + j}, "$iteration")"""
+          }
+          sql(s"INSERT INTO $deltaTableName VALUES ${valuesBuilder.result().mkString(",")}")
+          sql(s"""UPDATE $deltaTableName SET `第一列` = `第一列` + 100 where c2 = "${iteration}"""")
+          sql(s"""DELETE FROM $deltaTableName where c2 = "${iteration}"""")
+        }
+
+        val sharedTableName = "shard_table_cdf_special"
+        prepareMockedClientGetTableVersion(deltaTableName, sharedTableName)
+        Seq(0, 10, 20, 30).foreach { startingVersion =>
+          prepareMockedClientAndFileSystemResultForCdf(
+            deltaTableName,
+            sharedTableName,
+            startingVersion
+          )
+
+          val expected = spark.read
+            .format("delta")
+            .option("readChangeFeed", "true")
+            .option("startingVersion", startingVersion)
+            .table(deltaTableName)
+
+          def test(tablePath: String): Unit = {
+            val df = spark.read
+              .format("deltaSharing")
+              .option("responseFormat", "delta")
+              .option("readChangeFeed", "true")
+              .option("startingVersion", startingVersion)
+              .load(tablePath)
+            checkAnswer(df, expected)
+            assert(df.count() > 0)
+          }
+
+          withSQLConf(getDeltaSharingClassesSQLConf.toSeq: _*) {
+            val profileFile = prepareProfileFile(tempDir)
+            test(profileFile.getCanonicalPath + s"#share1.default.$sharedTableName")
+          }
+          // BEGIN-EDGE
+          withSQLConf(getUnityCatalogClassesSQLConf.toSeq: _*) {
+            val ucTableFullName = s"catalog.schema.$sharedTableName"
+            test(s"uc-deltasharing://$ucTableFullName#$ucTableFullName")
+          }
+          // END-EDGE
+        }
+      }
+    }
+  }
+
   /**
    * deletion vector tests
    */

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaSuite.scala
@@ -1045,12 +1045,6 @@ trait DeltaSharingDataSourceDeltaSuiteBase
           val profileFile = prepareProfileFile(tempDir)
           test(s"${profileFile.getCanonicalPath}#share1.default.$sharedTableName")
         }
-        // BEGIN-EDGE
-        withSQLConf(getUnityCatalogClassesSQLConf.toSeq: _*) {
-          val ucTableFullName = s"catalog.schema.$sharedTableName"
-          test(s"uc-deltasharing://$ucTableFullName#$ucTableFullName")
-        }
-        // END-EDGE
       }
     }
   }
@@ -1105,12 +1099,6 @@ trait DeltaSharingDataSourceDeltaSuiteBase
             val profileFile = prepareProfileFile(tempDir)
             test(profileFile.getCanonicalPath + s"#share1.default.$sharedTableName")
           }
-          // BEGIN-EDGE
-          withSQLConf(getUnityCatalogClassesSQLConf.toSeq: _*) {
-            val ucTableFullName = s"catalog.schema.$sharedTableName"
-            test(s"uc-deltasharing://$ucTableFullName#$ucTableFullName")
-          }
-          // END-EDGE
         }
       }
     }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [X] Other (Delta Sharing)

## Description
Use bytes length for file size in DeltaSharingLogFileStatus, to match the actual size of the bytes in SeekableByteArrayInputStream, this is to avoid the length difference caused by non utf-8 characters.

## How was this patch tested?
Unit Test

## Does this PR introduce _any_ user-facing changes?
No