### PR TITLE
[Spark] Make ConflictCheckerPredicateEliminationUnitSuite work Spark 4.0

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/ConflictCheckerPredicateEliminationUnitSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ConflictCheckerPredicateEliminationUnitSuite.scala
@@ -19,11 +19,10 @@ package org.apache.spark.sql.delta
 import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
 import org.apache.spark.sql.delta.util.DeltaSparkPlanUtils
 
-import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.{Column, QueryTest}
 import org.apache.spark.sql.catalyst.dsl.expressions.DslExpression
-import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
-import org.apache.spark.sql.catalyst.expressions.ScalarSubquery
-import org.apache.spark.sql.functions.{col, rand, udf}
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, Rand, ScalarSubquery}
+import org.apache.spark.sql.functions.{col, udf}
 import org.apache.spark.sql.test.SharedSparkSession
 
 /**
@@ -39,7 +38,7 @@ class ConflictCheckerPredicateEliminationUnitSuite
   val simpleExpressionB: Expression = (col("b") === "test").expr
 
   val deterministicExpression: Expression = (col("c") > 5L).expr
-  val nonDeterministicExpression: Expression = (col("c") > rand()).expr
+  val nonDeterministicExpression: Expression = (col("c") > new Column(Rand(0))).expr
   lazy val deterministicSubquery: Expression = {
     val df = spark.sql("SELECT 5")
     df.collect()


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Update `ConflictCheckerPredicateEliminationUnitSuite` to work with Spark 4.0 where `rand()` returns an `UnresolvedFunction` instead of `Rand()` expression.

## How was this patch tested?

Test-only change.

## Does this PR introduce _any_ user-facing changes?

No