### PR TITLE
[Kernel][Clean up] Use enums for column mapping modes instead of strings

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
@@ -33,7 +33,7 @@ import io.delta.kernel.internal.data.ScanStateRow;
 import io.delta.kernel.internal.data.SelectionColumnVector;
 import io.delta.kernel.internal.deletionvectors.DeletionVectorUtils;
 import io.delta.kernel.internal.deletionvectors.RoaringBitmapArray;
-import io.delta.kernel.internal.util.ColumnMapping;
+import io.delta.kernel.internal.util.ColumnMapping.ColumnMappingMode;
 import io.delta.kernel.internal.util.PartitionUtils;
 import io.delta.kernel.internal.util.Tuple2;
 
@@ -212,13 +212,13 @@ public interface Scan {
                     );
 
                 // Change back to logical schema
-                String columnMappingMode = ScanStateRow.getColumnMappingMode(scanState);
+                ColumnMappingMode columnMappingMode = ScanStateRow.getColumnMappingMode(scanState);
                 switch (columnMappingMode) {
-                    case ColumnMapping.COLUMN_MAPPING_MODE_NAME:
-                    case ColumnMapping.COLUMN_MAPPING_MODE_ID:
+                    case NAME: // fall through
+                    case ID:
                         nextDataBatch = nextDataBatch.withNewSchema(logicalReadSchema);
                         break;
-                    case ColumnMapping.COLUMN_MAPPING_MODE_NONE:
+                    case NONE:
                         break;
                     default:
                         throw new UnsupportedOperationException(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -30,8 +30,8 @@ import io.delta.kernel.types.StringType;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.internal.actions.Metadata;
-import io.delta.kernel.internal.util.IntervalParserUtils;
-import io.delta.kernel.internal.util.VectorUtils;
+import io.delta.kernel.internal.util.*;
+import io.delta.kernel.internal.util.ColumnMapping.ColumnMappingMode;
 import static io.delta.kernel.internal.util.InternalUtils.getSingularElement;
 import static io.delta.kernel.internal.util.InternalUtils.singletonStringColumnVector;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
@@ -166,12 +166,12 @@ public class TableConfig<T> {
     /**
      * This table property is used to control the column mapping mode.
      */
-    public static final TableConfig<String> COLUMN_MAPPING_MODE =
+    public static final TableConfig<ColumnMappingMode> COLUMN_MAPPING_MODE =
             new TableConfig<>(
                     "delta.columnMapping.mode",
                     "none", /* default values */
-                    (engineOpt, v) -> String.valueOf(v),
-                    value -> "none".equals(value) || "id".equals(value) || "name".equals(value),
+                    (engineOpt, v) -> ColumnMappingMode.fromTableConfig(v),
+                    value -> true,
                     "Needs to be one of none, id, name."
             );
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -32,12 +32,14 @@ import io.delta.kernel.internal.replay.LogReplay;
 import io.delta.kernel.internal.snapshot.LogSegment;
 import io.delta.kernel.internal.snapshot.SnapshotHint;
 import io.delta.kernel.internal.util.ColumnMapping;
+import io.delta.kernel.internal.util.ColumnMapping.ColumnMappingMode;
 import io.delta.kernel.internal.util.SchemaUtils;
 import io.delta.kernel.internal.util.Tuple2;
 import static io.delta.kernel.internal.DeltaErrors.requiresSchemaForNewTable;
 import static io.delta.kernel.internal.DeltaErrors.tableAlreadyExists;
 import static io.delta.kernel.internal.TransactionImpl.DEFAULT_READ_VERSION;
 import static io.delta.kernel.internal.TransactionImpl.DEFAULT_WRITE_VERSION;
+import static io.delta.kernel.internal.util.ColumnMapping.isColumnMappingModeEnabled;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 import static io.delta.kernel.internal.util.SchemaUtils.casePreservingPartitionColNames;
 import static io.delta.kernel.internal.util.VectorUtils.stringArrayValue;
@@ -192,12 +194,10 @@ public class TransactionBuilderImpl implements TransactionBuilder {
             }
         } else {
             // New table verify the given schema and partition columns
-            String mappingMode = tableProperties
-                    .map(ColumnMapping::getColumnMappingMode)
-                    .orElse("none");
-            SchemaUtils.validateSchema(
-                    schema.get(),
-                    ColumnMapping.isColumnMappingModeEnabled(mappingMode));
+            ColumnMappingMode mappingMode = ColumnMapping.getColumnMappingMode(
+                    tableProperties.orElse(Collections.emptyMap()));
+
+            SchemaUtils.validateSchema(schema.get(), isColumnMappingModeEnabled(mappingMode));
             SchemaUtils.validatePartitionColumns(
                     schema.get(), partitionColumns.orElse(Collections.emptyList()));
         }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ScanStateRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ScanStateRow.java
@@ -27,6 +27,7 @@ import io.delta.kernel.types.*;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.util.ColumnMapping;
+import io.delta.kernel.internal.util.ColumnMapping.ColumnMappingMode;
 import io.delta.kernel.internal.util.VectorUtils;
 import static io.delta.kernel.internal.DeltaErrors.wrapEngineException;
 
@@ -132,7 +133,7 @@ public class ScanStateRow extends GenericRow {
      * Get the column mapping mode from the scan state {@link Row} returned by
      * {@link Scan#getScanState(Engine)}.
      */
-    public static String getColumnMappingMode(Row scanState) {
+    public static ColumnMappingMode getColumnMappingMode(Row scanState) {
         Map<String, String> configuration = VectorUtils.toJavaMap(
                 scanState.getMap(COL_NAME_TO_ORDINAL.get("configuration")));
         return ColumnMapping.getColumnMappingMode(configuration);

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
@@ -1013,7 +1013,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
           .commit(engine, emptyIterable())
       }
       assert(ex.getMessage.contains("Invalid value for table property " +
-        "'delta.columnMapping.mode': 'invalid'. Needs to be one of none, id, name."))
+        "'delta.columnMapping.mode': 'invalid'. Needs to be one of: [none, id, name]."))
     }
   }
 
@@ -1042,7 +1042,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
           .build(engine)
       }
       assert(ex.getMessage.contains("Invalid value for table property " +
-        "'delta.columnMapping.mode': 'invalid'. Needs to be one of none, id, name."))
+        "'delta.columnMapping.mode': 'invalid'. Needs to be one of: [none, id, name]."))
     }
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetFileWriterSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetFileWriterSuite.scala
@@ -16,14 +16,13 @@
 package io.delta.kernel.defaults.internal.parquet
 
 import java.lang.{Double => DoubleJ, Float => FloatJ}
-
 import io.delta.golden.GoldenTableUtils.{goldenTableFile, goldenTablePath}
 import io.delta.kernel.data.{ColumnarBatch, FilteredColumnarBatch}
 import io.delta.kernel.defaults.internal.DefaultKernelUtils
 import io.delta.kernel.defaults.utils.{DefaultVectorTestUtils, ExpressionTestUtils, TestRow}
 import io.delta.kernel.expressions.{Column, Literal, Predicate}
 import io.delta.kernel.internal.util.ColumnMapping
-import io.delta.kernel.internal.util.ColumnMapping.convertToPhysicalSchema
+import io.delta.kernel.internal.util.ColumnMapping.{ColumnMappingMode, convertToPhysicalSchema}
 import io.delta.kernel.types._
 import io.delta.kernel.utils.DataFileStatus
 import org.apache.spark.sql.{functions => sparkfn}
@@ -179,7 +178,7 @@ class ParquetFileWriterSuite extends AnyFunSuite
           val schema = tableSchema(inputLocation)
 
           val physicalSchema = if (hasColumnMappingId(inputLocation)) {
-            convertToPhysicalSchema(schema, schema, ColumnMapping.COLUMN_MAPPING_MODE_ID)
+            convertToPhysicalSchema(schema, schema, ColumnMappingMode.ID)
           } else {
             schema
           }


### PR DESCRIPTION
## Description
Resolve to `enum` as part of the `TableConfig` fetch methods. This avoids comparing strings and dealing with case sensitivity.

## How was this patch tested?
Existing tests.