### PR TITLE
[Spark] Add RowTrackingBackfillCommand

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -486,6 +486,10 @@ object DeltaOperations {
 
   sealed abstract class OptimizeOrReorg(override val name: String, predicates: Seq[Expression])
     extends OperationWithPredicates(name, predicates)
+
+  /** operation name for ROW TRACKING BACKFILL command */
+  val ROW_TRACKING_BACKFILL_OPERATION_NAME = "ROW TRACKING BACKFILL"
+
   /** parameter key to indicate whether it's an Auto Compaction */
   val AUTO_COMPACTION_PARAMETER_KEY = "auto"
 
@@ -575,6 +579,14 @@ object DeltaOperations {
     override val parameters: Map[String, Any] = Map(
       "oldClusteringColumns" -> oldClusteringColumns,
       "newClusteringColumns" -> newClusteringColumns)
+  }
+
+  /** Recorded when we backfill a Delta table's existing AddFiles with row tracking data. */
+  case class RowTrackingBackfill(
+      batchId: Int = 0) extends Operation(ROW_TRACKING_BACKFILL_OPERATION_NAME) {
+    override val parameters: Map[String, Any] = Map(
+      "batchId" -> JsonUtils.toJson(batchId)
+    )
   }
 
   private def structFieldToMap(colPath: Seq[String], field: StructField): Map[String, Any] = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/FileMetadataMaterializationTracker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/FileMetadataMaterializationTracker.scala
@@ -22,8 +22,10 @@ import java.util.concurrent.atomic.AtomicInteger
 import org.apache.spark.sql.delta.FileMetadataMaterializationTracker.TaskLevelPermitAllocator
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.internal.{LoggingShims, MDC}
+import org.apache.spark.sql.SparkSession
 
 /**
  * An instance of this class tracks and controls the materialization usage of a single command
@@ -50,6 +52,13 @@ class FileMetadataMaterializationTracker extends LoggingShims {
   @volatile private var numOverAllocatedPermits: Int = 0
 
   private val materializationMetrics = new FileMetadataMaterializationMetrics()
+
+  /**
+   * @return The collected materialization metrics for this query.
+   */
+  def getMetrics(): FileMetadataMaterializationMetrics = {
+    materializationMetrics
+  }
 
   /**
    * Signals to execute the batch early in the event that we overallocated to
@@ -176,6 +185,47 @@ object FileMetadataMaterializationTracker extends DeltaLogging {
   }
 
   /**
+   * Initialize materialization semaphore if this is the first query running on the cluster that
+   * uses the file materialization tracker.
+   */
+  private def initializeMaterializationSemaphore(spark: SparkSession): Unit = {
+    if (globalFileMaterializationLimit.compareAndSet(-1, spark.sessionState.conf.getConf(
+      DeltaSQLConf.DELTA_COMMAND_FILE_MATERIALIZATION_LIMIT))) {
+      if (globalFileMaterializationLimit.get() > 0) {
+        materializationSemaphore = new Semaphore(globalFileMaterializationLimit.get)
+      }
+    }
+  }
+
+  def withTracker(
+      origTxn: OptimisticTransaction,
+      spark: SparkSession,
+      metricsOpType: String)(f: FileMetadataMaterializationTracker => Unit): Unit = {
+    initializeMaterializationSemaphore(spark)
+    val shouldTrack = spark.conf.get(
+      DeltaSQLConf.DELTA_COMMAND_FILE_MATERIALIZATION_TRACKING_ENABLED)
+    val tracker = if (shouldTrack) {
+      new FileMetadataMaterializationTracker()
+    } else {
+      logInfo(log"File metadata materialization tracking is disabled for this query." +
+        log" Please set ${MDC(DeltaLogKeys.CONFIG,
+          DeltaSQLConf.DELTA_COMMAND_FILE_MATERIALIZATION_TRACKING_ENABLED.key)} " +
+        log"to true to enable it.")
+      noopTracker
+    }
+    try {
+      f(tracker)
+      val trackerMetrics = tracker.getMetrics()
+      logInfo(log"File metadata materialization metrics for the completed query: " +
+        log"${MDC(DeltaLogKeys.METRICS, trackerMetrics)}")
+      recordDeltaEvent(
+        deltaLog = origTxn.deltaLog,
+        opType = metricsOpType,
+        data = trackerMetrics)
+    } finally { tracker.releaseAllPermits()  }
+  }
+
+  /**
    * @return - return a version of the FileMetadataMaterializationTracker where every operation
    *         is a noop
    */
@@ -191,6 +241,10 @@ object FileMetadataMaterializationTracker extends DeltaLogging {
     override def executeBatchEarly(): Boolean = false
 
     override def releaseAllPermits(): Unit = { }
+
+    override def getMetrics(): FileMetadataMaterializationMetrics = {
+      new FileMetadataMaterializationMetrics()
+    }
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TransactionExecutionObserver.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TransactionExecutionObserver.scala
@@ -42,6 +42,14 @@ trait ChainableExecutionObserver[O] {
  */
 trait TransactionExecutionObserver
   extends ChainableExecutionObserver[TransactionExecutionObserver] {
+
+  /**
+   * Create a child instance of this observer for use in [[OptimisticTransactionImpl.split()]].
+   *
+   * It's up to each observer type what state new child needs to hold.
+   */
+  def createChild(): TransactionExecutionObserver
+
   /*
    * This is called outside the transaction object,
    * since it wraps its creation.
@@ -106,4 +114,9 @@ object NoOpTransactionExecutionObserver extends TransactionExecutionObserver {
   override def transactionCommitted(): Unit = ()
 
   override def transactionAborted(): Unit = ()
+
+  override def createChild(): TransactionExecutionObserver = {
+    // This mimics the original behaviour of this code.
+    TransactionExecutionObserver.getObserver
+  }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/BackfillBatch.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/BackfillBatch.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands.backfill
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.apache.spark.sql.delta.OptimisticTransaction
+import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.logging.DeltaLogKeys
+import org.apache.spark.sql.delta.metering.DeltaLogging
+
+import org.apache.spark.internal.MDC
+
+trait BackfillBatch extends DeltaLogging {
+  /** The files in this batch. */
+  def filesInBatch: Seq[AddFile]
+  def backfillBatchStatsOpType: String
+
+  protected def prepareFilesAndCommit(txn: OptimisticTransaction, batchId: Int): Unit
+
+  /**
+   * The main method of this trait. This method creates a child transaction object, commits the
+   * backfill batch, records metrics and updates the two atomic counters passed in.
+   *
+   * @param origTxn the original transaction from [[BackfillCommand]] that read the
+   *                table to create BackfillBatchIterator[BackfillBatch].
+   * @param batchId an integer identifier of the batch within a parent [[BackfillCommand]].
+   * @param numSuccessfulBatch an AtomicInteger which serves as a counter for the total number of
+   *                           batches that were successful.
+   * @param numFailedBatch an AtomicInteger which serves as a counter for the total number of
+   *                       batches that failed.
+   */
+  def execute(
+      origTxn: OptimisticTransaction,
+      batchId: Int,
+      numSuccessfulBatch: AtomicInteger,
+      numFailedBatch: AtomicInteger): Unit = {
+    val startTimeNs = System.nanoTime()
+
+    def recordBackfillBatchStats(txnId: String, wasSuccessful: Boolean): Unit = {
+      if (wasSuccessful) {
+        numSuccessfulBatch.incrementAndGet()
+      } else {
+        numFailedBatch.incrementAndGet()
+      }
+      val totalExecutionTimeInMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNs)
+      val batchStats = BackfillBatchStats(
+        origTxn.txnId, txnId, batchId, filesInBatch.size, totalExecutionTimeInMs, wasSuccessful)
+      recordDeltaEvent(
+        origTxn.deltaLog,
+        opType = backfillBatchStatsOpType,
+        data = batchStats
+      )
+    }
+
+    logInfo(log"Batch ${MDC(DeltaLogKeys.BATCH_ID, batchId)} starting, committing " +
+      log"${MDC(DeltaLogKeys.NUM_FILES, filesInBatch.size)} candidate files")
+    // This step is necessary to mark all files in this batch as "read" in the
+    // child transaction object `txn` and to set the read transactions ids to be the same as the
+    // parent transaction object `origTxn`, for proper conflict checking.
+    val txn = origTxn.split(filesInBatch)
+    val txnId = txn.txnId
+    try {
+      prepareFilesAndCommit(txn, batchId)
+      recordBackfillBatchStats(txnId, wasSuccessful = true)
+    } catch {
+      case t: Throwable =>
+        recordBackfillBatchStats(txnId, wasSuccessful = false)
+        throw t
+    }
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/BackfillBatchStats.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/BackfillBatchStats.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands.backfill
+
+/**
+ * Metrics for each BackfillBatch.
+ *
+ * @param parentTransactionId The transaction id associated with the parent command.
+ * @param transactionId The transaction id used in this batch.
+ * @param batchId An integer identifier of the batch within a parent BackfillCommand.
+ * @param initialNumFiles The number of files in BackfillBatch prior to conflict
+ *                        resolution.
+ * @param totalExecutionTimeInMs The total execution time in milliseconds.
+ * @param wasSuccessful Boolean indicating whether the batch was successfully committed.
+ */
+case class BackfillBatchStats(
+    parentTransactionId: String,
+    transactionId: String,
+    batchId: Int,
+    initialNumFiles: Long,
+    totalExecutionTimeInMs: Long,
+    wasSuccessful: Boolean
+)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/BackfillCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/BackfillCommand.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands.backfill
+
+import java.util.concurrent.TimeUnit
+
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.commands.DeltaCommand
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.sql.{Dataset, Row, SparkSession}
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+
+/**
+ * This command will lazily materialize AllFiles and split them into multiple backfill commits
+ * if the number of files exceeds the threshold set by
+ * [[DeltaSQLConf.DELTA_BACKFILL_MAX_NUM_FILES_PER_COMMIT]].
+ */
+trait BackfillCommand extends LeafRunnableCommand with DeltaCommand {
+  def deltaLog: DeltaLog
+  def nameOfTriggeringOperation: String
+  def catalogTable: Option[CatalogTable]
+
+  def getBackfillExecutor(
+    spark: SparkSession,
+    txn: OptimisticTransaction,
+    fileMaterializationTracker: FileMetadataMaterializationTracker,
+    maxNumBatchesInParallel: Int,
+    backfillStats: BackfillCommandStats): BackfillExecutor
+
+  def filesToBackfill(txn: OptimisticTransaction): Dataset[AddFile]
+
+  def opType: String
+
+  def constructBatch(files: Seq[AddFile]): BackfillBatch
+
+  override def run(spark: SparkSession): Seq[Row] = {
+    val maxNumBatchesInParallel =
+      spark.conf.get(DeltaSQLConf.DELTA_BACKFILL_MAX_NUM_BATCHES_IN_PARALLEL)
+    recordDeltaOperation(deltaLog, opType) {
+      val txn = deltaLog.startTransaction(catalogTable)
+      // This txn object is not used for commit. We need to do manual state transitions to make the
+      // concurrency testing framework happy.
+      txn.executionObserver.preparingCommit()
+      txn.executionObserver.beginDoCommit()
+      txn.executionObserver.beginBackfill()
+      val maxNumFilesPerCommit =
+        spark.conf.get(DeltaSQLConf.DELTA_BACKFILL_MAX_NUM_FILES_PER_COMMIT)
+      val metricsOpType = "delta.backfill.materialization.trackerMetrics"
+      FileMetadataMaterializationTracker.withTracker(txn, spark, metricsOpType) {
+        fileMaterializationTracker =>
+          val startTimeNs = System.nanoTime()
+          val backfillStats = BackfillCommandStats(
+            transactionId = txn.txnId,
+            nameOfTriggeringOperation,
+            maxNumBatchesInParallel = maxNumBatchesInParallel
+          )
+          try {
+            val backfillExecutor = getBackfillExecutor(
+              spark, txn, fileMaterializationTracker, maxNumBatchesInParallel, backfillStats)
+
+            val batches = new BackfillBatchIterator(
+              filesToBackfill(txn),
+              fileMaterializationTracker,
+              maxNumFilesPerCommit,
+              constructBatch)
+
+            try {
+              backfillExecutor.run(batches)
+            } finally {
+              batches.close()
+            }
+
+            backfillStats.wasSuccessful = true
+          } finally {
+            val totalExecutionTimeMs =
+              TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNs)
+            backfillStats.totalExecutionTimeMs = totalExecutionTimeMs
+
+            recordDeltaEvent(
+              txn.deltaLog,
+              opType = opType + ".stats",
+              data = backfillStats
+            )
+            txn.executionObserver.transactionCommitted()
+          }
+      }
+    }
+
+    Seq.empty[Row]
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/BackfillCommandStats.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/BackfillCommandStats.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands.backfill
+
+/**
+ * Metrics for the BackfillCommand.
+ *
+ * @param transactionId: The transaction id associated with this BackfillCommand that
+ *                       is the parent transaction for BackfillBatch commits.
+ * @param nameOfTriggeringOperation: The name of the operation that triggered backfill. For now,
+ *                                   this can be ALTER TABLE SET TBLPROPERTIES
+ * @param maxNumBatchesInParallel The maximum number of batches that could have run in parallel.
+ * @param totalExecutionTimeMs The total execution time in milliseconds.
+ * @param numSuccessfulBatches The number of BackfillBatch's that was successfully committed.
+ * @param numFailedBatches The number of BackfillBatch's that failed.
+ * @param wasSuccessful Boolean indicating whether this BackfillCommand didn't have any error.
+ */
+case class BackfillCommandStats(
+    transactionId: String,
+    nameOfTriggeringOperation: String,
+    maxNumBatchesInParallel: Int,
+    var totalExecutionTimeMs: Long = 0,
+    var numSuccessfulBatches: Int = 0,
+    var numFailedBatches: Int = 0,
+    var wasSuccessful: Boolean = false
+)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/BackfillExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/BackfillExecutor.scala
@@ -69,9 +69,9 @@ trait BackfillExecutor extends DeltaLogging {
       batches.zipWithIndex.foreach { case (batch, batchId) =>
         activeThreadSemaphore.acquire()
         futures += globalThreadPool.submit(() => try {
+          // Make sure each commit has the same active spark session
+          SparkSession.setActiveSession(spark)
           recordDeltaOperation(origTxn.deltaLog, backFillBatchOpType) {
-            // Make sure each commit has the same active spark session
-            SparkSession.setActiveSession(spark)
             batch.execute(origTxn, batchId, numSuccessfulBatch, numFailedBatch)
           }
         } finally {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/BackfillExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/BackfillExecutor.scala
@@ -1,0 +1,118 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands.backfill
+
+import java.util.concurrent.{Semaphore, ThreadPoolExecutor}
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.metering.DeltaLogging
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.util.ThreadUtils
+
+trait BackfillExecutor extends DeltaLogging {
+  def spark: SparkSession
+  def origTxn: OptimisticTransaction
+  def tracker: FileMetadataMaterializationTracker
+  def maxBatchesInParallel: Int
+  def backfillStats: BackfillCommandStats
+
+  def backFillBatchOpType: String
+
+  /** Execute the command by consuming an iterator of [[BackfillBatch]]. */
+  def run(batches: Iterator[BackfillBatch]): Unit = {
+    if (batches.isEmpty) {
+      logInfo(log"Backfill command did not need to update any files")
+      return
+    }
+    executeBackfillBatches(
+      batches,
+      activeThreadSemaphore = new Semaphore(maxBatchesInParallel))
+  }
+
+  /**
+   * Execute all [[BackfillBatch]] objects inside the [[Iterator]] by launching a set
+   * of background threads. Each thread handles and commits a single
+   * [[BackfillBatch]] object.
+   *
+   * @param batches               The iterator of [[BackfillBatch]] to be executed.
+   * @param activeThreadSemaphore The semaphore to control the number of concurrent
+   *                              active threads.
+   */
+  private def executeBackfillBatches(
+      batches: Iterator[BackfillBatch],
+      activeThreadSemaphore: Semaphore): Unit = {
+    // Get the thread pool to handle each batch.
+    val globalThreadPool = BackfillExecutor.getOrCreateThreadPool()
+    // The futures to wait for concurrent active batches to complete.
+    val futures = new ArrayBuffer[java.util.concurrent.Future[Unit]]
+    val numSuccessfulBatch = new AtomicInteger(0)
+    val numFailedBatch = new AtomicInteger(0)
+    try {
+      batches.zipWithIndex.foreach { case (batch, batchId) =>
+        activeThreadSemaphore.acquire()
+        futures += globalThreadPool.submit(() => try {
+          recordDeltaOperation(origTxn.deltaLog, backFillBatchOpType) {
+            // Make sure each commit has the same active spark session
+            SparkSession.setActiveSession(spark)
+            batch.execute(origTxn, batchId, numSuccessfulBatch, numFailedBatch)
+          }
+        } finally {
+          activeThreadSemaphore.release()
+          // release all the permits for the files materialized by the batch
+          if (tracker != null) {
+            tracker.releasePermits(batch.filesInBatch.length)
+          }
+        })
+      }
+      futures.foreach(_.get())
+    } catch {
+      case t: Throwable =>
+        // In case of exception we want to cancel futures that haven't started running yet. We don't
+        // want to interrupt futures that are already running because it may lead to incorrect
+        // metrics. We don't record the metric BackfillBatchStats atomically with the
+        // txn.commit call, so if we cancel the future, we may not correctly record the success.
+        val mayInterruptIfRunning = false
+        futures.foreach(_.cancel(mayInterruptIfRunning))
+        throw t
+    } finally {
+      backfillStats.numSuccessfulBatches = numSuccessfulBatch.get()
+      backfillStats.numFailedBatches = numFailedBatch.get()
+    }
+  }
+}
+
+private[delta] object BackfillExecutor extends DeltaLogging {
+
+  /** Global thread pool for all Backfill queries */
+  private var threadPool: ThreadPoolExecutor = _
+
+  /**
+   * Get existing global thread pool or create a new one if it doesn't exist.
+   */
+  private[backfill] def getOrCreateThreadPool(): ThreadPoolExecutor = synchronized {
+    if (threadPool == null) {
+      threadPool = ThreadUtils.newDaemonCachedThreadPool(
+        "deltaBackfill",
+        maxThreadNumber = 64)
+    }
+    threadPool
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillCommand.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands.backfill
+
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.actions.{AddFile, Protocol, TableFeatureProtocolUtils}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.sql.{Dataset, Row, SparkSession}
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+
+/**
+ * This command re-commits all AddFiles in the current snapshot that do not have a base row IDs.
+ * After the backfill command finishes, the snapshot has row IDs for all files. All commits
+ * afterwards must include row IDs.
+ *
+ * First, we will add the table feature support, if necessary.
+ * Then, the command will lazily materialize AllFiles and split them into multiple backfill commits
+ * if the number of files exceeds the threshold set by
+ * [[DeltaSQLConf.DELTA_BACKFILL_MAX_NUM_FILES_PER_COMMIT]].
+ *
+ * Note: We expect Backfill to be called before the table property is set. Furthermore, we do not
+ * set the table property [[DeltaConfigs.ROW_TRACKING_ENABLED]] as part of backfill. The metadata
+ * update needs to be handled by the caller.
+ */
+case class RowTrackingBackfillCommand(
+    override val deltaLog: DeltaLog,
+    override val nameOfTriggeringOperation: String,
+    override val catalogTable: Option[CatalogTable])
+  extends BackfillCommand {
+
+  override def getBackfillExecutor(
+      spark: SparkSession,
+      txn: OptimisticTransaction,
+      fileMaterializationTracker: FileMetadataMaterializationTracker,
+      maxNumBatchesInParallel: Int,
+      backfillStats: BackfillCommandStats): BackfillExecutor = {
+    new RowTrackingBackfillExecutor(
+      spark, txn, fileMaterializationTracker, maxNumBatchesInParallel, backfillStats)
+  }
+
+  override def filesToBackfill(txn: OptimisticTransaction): Dataset[AddFile] =
+    // Get a new snapshot after the protocol upgrade.
+    RowTrackingBackfillExecutor.getCandidateFilesToBackfill(deltaLog.update())
+
+  override def opType: String = "delta.rowTracking.backfill"
+
+  override def constructBatch(files: Seq[AddFile]): BackfillBatch =
+    RowTrackingBackfillBatch(files)
+
+ /**
+  * Add Row tracking table feature support. This will also upgrade the minWriterVersion if
+  * the current protocol cannot support write table feature.
+  */
+  private def upgradeProtocolIfRequired(): Unit = {
+    val snapshot = deltaLog.update()
+    if (!snapshot.protocol.isFeatureSupported(RowTrackingFeature)) {
+      val minProtocolAllowingWriteTableFeature = Protocol(
+        snapshot.protocol.minReaderVersion,
+        TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION)
+      val newProtocol = snapshot.protocol
+        .merge(minProtocolAllowingWriteTableFeature.withFeature(RowTrackingFeature))
+      deltaLog.upgradeProtocol(catalogTable, snapshot, newProtocol)
+    }
+  }
+
+  override def run(spark: SparkSession): Seq[Row] = {
+    if (!spark.sessionState.conf.getConf(
+      DeltaSQLConf.DELTA_ROW_TRACKING_BACKFILL_ENABLED)) {
+      throw new UnsupportedOperationException("Cannot enable Row IDs on an existing table.")
+    }
+
+    // Upgrade the protocol to support the table feature if it isn't already supported.
+    // This steps bounds the number of files the command must commit, since all actions after
+    // we support the table feature must have base row IDs.
+    upgradeProtocolIfRequired()
+
+    super.run(spark)
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillExecutor.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands.backfill
+
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.actions.AddFile
+import org.apache.spark.sql.delta.metering.DeltaLogging
+
+import org.apache.spark.sql.{Dataset, SparkSession}
+
+class RowTrackingBackfillExecutor(
+    override val spark: SparkSession,
+    override val origTxn: OptimisticTransaction,
+    override val tracker: FileMetadataMaterializationTracker,
+    override val maxBatchesInParallel: Int,
+    override val backfillStats: BackfillCommandStats) extends BackfillExecutor {
+  override val backFillBatchOpType = "delta.rowTracking.backfill.batch"
+}
+
+private[delta] object RowTrackingBackfillExecutor extends DeltaLogging {
+  /**
+   * Returns the dataset with the list of candidate files to backfill.
+   */
+  def getCandidateFilesToBackfill(snapshot: Snapshot): Dataset[AddFile] = {
+    // Note: We can't use txn.filterFiles() because it drops the file statistics.
+    snapshot
+      .allFiles
+      .filter(_.baseRowId.isEmpty)
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/fuzzer/PhaseLockingTransactionExecutionObserver.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/fuzzer/PhaseLockingTransactionExecutionObserver.scala
@@ -29,6 +29,13 @@ private[delta] class PhaseLockingTransactionExecutionObserver(
     phases.commitPhase,
     phases.backfillPhase)
 
+  override def createChild(): TransactionExecutionObserver = {
+    // Just return the current thread observer.
+    // This is equivalent to the behaviour of the use-site before introduction of
+    // `createChild`.
+    TransactionExecutionObserver.getObserver
+  }
+
   /**
    * When set to true this observer will automatically update the thread's current observer to
    * the next one. Also, it will not unblock the exit barrier of the commit phase automatically.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -886,6 +886,82 @@ trait DeltaSQLConfBase {
         .checkValue(_ > 0, "partSize has to be positive")
         .createOptional
 
+  /////////////////////////////////
+  // File Materialization Tracker
+  /////////////////////////////////
+
+  val DELTA_COMMAND_FILE_MATERIALIZATION_TRACKING_ENABLED =
+    buildConf("command.fileMaterializationLimit.enabled")
+      .internal()
+      .doc(
+        """
+          |When enabled, tracks the file metadata materialized on the driver and restricts the
+          |number of files materialized on the driver to be within the global file
+          |materialization limit.
+       """.stripMargin
+      )
+      .booleanConf
+      .createWithDefault(true)
+
+  val DELTA_COMMAND_FILE_MATERIALIZATION_LIMIT =
+    buildStaticConf("command.fileMaterializationLimit.softMax")
+      .internal()
+      .doc(
+        s"""
+           |The soft limit for the total number of file metadata that can be materialized at once on
+           |the driver. This config will take effect only when
+           |${DELTA_COMMAND_FILE_MATERIALIZATION_TRACKING_ENABLED.key} is enabled.
+        """.stripMargin
+      )
+      .intConf
+      .checkValue(_ >= 0, "'command.fileMaterializationLimit.softMax' must be positive")
+      .createWithDefault(10000000)
+
+  ////////////////////////
+  // BACKFILL
+  ////////////////////////
+
+  val DELTA_ROW_TRACKING_BACKFILL_ENABLED =
+    buildConf("rowTracking.backfill.enabled")
+      .internal()
+      .doc("Whether Row Tracking backfill can be performed.")
+      .booleanConf
+      .createWithDefault(false)
+
+  val DELTA_ROW_TRACKING_BACKFILL_MAX_NUM_BATCHES_IN_PARALLEL =
+    buildConf("rowTracking.backfill.maxNumBatchesInParallel")
+      .internal()
+      .doc("The maximum number of backfill batches (commits) that can run at the same time " +
+        "from a single RowTrackingBackfillCommand.")
+      .intConf
+      .checkValue(_ > 0, "'backfill.maxNumBatchesInParallel' must be positive.")
+      .createWithDefault(1)
+
+  val DELTA_BACKFILL_MAX_NUM_BATCHES_IN_PARALLEL =
+    buildConf("backfill.maxNumBatchesInParallel")
+      .internal()
+      .doc("The maximum number of backfill batches (commits) that can run at the same time " +
+        "from a single BackfillCommand.")
+      .fallbackConf(DELTA_ROW_TRACKING_BACKFILL_MAX_NUM_BATCHES_IN_PARALLEL)
+
+  val DELTA_ROW_TRACKING_BACKFILL_MAX_NUM_FILES_PER_COMMIT =
+    buildConf("rowTracking.backfill.maxNumFiles")
+      .internal()
+      .doc("The maximum number of files to include in a single commit when running " +
+        "RowTrackingBackfillCommand. The default maximum aims to keep every " +
+        "delta log entry below 100mb.")
+      .intConf
+      .checkValue(_ > 0, "'backfill.maxNumFiles' must be positive.")
+      .createWithDefault(22000)
+
+  val DELTA_BACKFILL_MAX_NUM_FILES_PER_COMMIT =
+    buildConf("backfill.maxNumFiles")
+      .internal()
+      .doc("The maximum number of files to include in a single commit when running " +
+        "BackfillCommand. The default maximum aims to keep every " +
+        "delta log entry below 100mb.")
+      .fallbackConf(DELTA_ROW_TRACKING_BACKFILL_MAX_NUM_FILES_PER_COMMIT)
+
   ////////////////////////////////////
   // Checkpoint V2 Specific Configs
   ////////////////////////////////////

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaUsageLogsOpsTypes.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaUsageLogsOpsTypes.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+object DeltaUsageLogsOpTypes {
+  final val BACKFILL_COMMAND = "delta.rowTracking.backfill.stats"
+  final val BACKFILL_BATCH = "delta.rowTracking.backfill.batch.stats"
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdTestUtils.scala
@@ -20,10 +20,14 @@ import java.io.File
 
 import scala.collection.JavaConverters._
 
+import com.databricks.spark.util.Log4jUsageLogger
 import org.apache.spark.sql.delta._
-import org.apache.spark.sql.delta.actions.{AddFile, CommitInfo}
+import org.apache.spark.sql.delta.actions.{AddFile, CommitInfo, TableFeatureProtocolUtils}
+import org.apache.spark.sql.delta.commands.backfill.{BackfillBatchStats, BackfillCommandStats}
 import org.apache.spark.sql.delta.rowtracking.RowTrackingTestUtils
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.util.JsonUtils
 import org.apache.hadoop.fs.Path
 import org.apache.parquet.hadoop.metadata.BlockMetaData
 
@@ -232,5 +236,82 @@ trait RowIdTestUtils extends RowTrackingTestUtils with DeltaSQLCommandTest {
 
   def checkRowTrackingMarkedAsPreservedForCommit(log: DeltaLog)(operation: => Unit): Unit = {
     assert(rowTrackingMarkedAsPreservedForCommit(log)(operation))
+  }
+
+  /**
+   * Capture backfill related metrics for basic validation.
+   */
+  def validateSuccessfulBackfillMetrics(
+      expectedNumSuccessfulBatches: Int,
+      nameOfTriggeringOperation: String = DeltaOperations.OP_SET_TBLPROPERTIES)
+      (testBlock: => Unit): Unit = {
+    val backfillUsageRecords = Log4jUsageLogger.track {
+      testBlock
+    }.filter(_.metric == "tahoeEvent")
+
+    val backfillRecords = backfillUsageRecords
+      .filter(_.tags.get("opType").contains(DeltaUsageLogsOpTypes.BACKFILL_COMMAND))
+    assert(backfillRecords.size === 1, "Row Tracking Backfill should have " +
+      "only been executed once.")
+
+    val backfillStats = JsonUtils.fromJson[BackfillCommandStats](backfillRecords.head.blob)
+    assert(backfillStats.wasSuccessful)
+    assert(backfillStats.numFailedBatches === 0)
+    assert(backfillStats.totalExecutionTimeMs > 0)
+    val expectedMaxNumBatchesInParallel =
+      spark.conf.get(DeltaSQLConf.DELTA_BACKFILL_MAX_NUM_BATCHES_IN_PARALLEL)
+    assert(backfillStats.maxNumBatchesInParallel === expectedMaxNumBatchesInParallel)
+    assert(backfillStats.numSuccessfulBatches === expectedNumSuccessfulBatches)
+    assert(backfillStats.nameOfTriggeringOperation === nameOfTriggeringOperation)
+
+    val parentTxnId = backfillStats.transactionId
+
+    val backfillBatchRecords = backfillUsageRecords
+      .filter(_.tags.get("opType").contains(DeltaUsageLogsOpTypes.BACKFILL_BATCH))
+    val backfillBatchStats = backfillBatchRecords.map { backfillBatchRecord =>
+      JsonUtils.fromJson[BackfillBatchStats](backfillBatchRecord.blob)
+    }
+    // Sanity check that the individual child commits were successful.
+    backfillBatchStats.foreach { backfillBatchStat =>
+      assert(backfillBatchStat.wasSuccessful)
+      assert(backfillBatchStat.totalExecutionTimeInMs > 0)
+      assert(backfillBatchStat.initialNumFiles > 0)
+      assert(backfillBatchStat.parentTransactionId === parentTxnId)
+    }
+  }
+
+  /**
+   * This triggers backfill on the test table in this suite by calling the user-facing syntax
+   * `ALTER TABLE t SET TBLPROPERTIES()`. We check for proper protocol upgrade (if any) and
+   * that the table has valid row IDs afterwards.
+   */
+  def triggerBackfillOnTestTableUsingAlterTable(
+      targetTableName: String,
+      numRowsInTable: Int,
+      log: DeltaLog): Unit = {
+    val prevMinReaderVersion = log.update().protocol.minReaderVersion
+    val prevMinWriterVersion = log.update().protocol.minWriterVersion
+
+    val rowIdPropertyKey = DeltaConfigs.ROW_TRACKING_ENABLED.key
+
+    spark.sql(s"ALTER TABLE $targetTableName SET TBLPROPERTIES ('$rowIdPropertyKey'=true)")
+
+    // Check the protocol upgrade is as expected. We should only bump the minWriterVersion if
+    // necessary and add the table feature support for row IDs.
+    val snapshot = log.update()
+    val newProtocol = snapshot.protocol
+    assert(newProtocol.isFeatureSupported(RowTrackingFeature))
+    assert(newProtocol.minReaderVersion == prevMinReaderVersion,
+      "The reader version does not need to be upgraded")
+    val expectedMinWriterVersion = Math.max(
+      prevMinWriterVersion, TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION)
+    assert(newProtocol.minWriterVersion == expectedMinWriterVersion)
+
+    // Tables should have the table property enabled at the end of ALTER TABLE command.
+    assert(RowId.isEnabled(newProtocol, snapshot.metadata))
+    val highWaterMarkBefore = -1L
+    assertRowIdsAreValid(log)
+    assertRowIdsAreLargerThanValue(log, highWaterMarkBefore)
+    assertHighWatermarkIsCorrectAfterUpdate(log, highWaterMarkBefore, numRowsInTable)
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdTestUtils.scala
@@ -301,11 +301,11 @@ trait RowIdTestUtils extends RowTrackingTestUtils with DeltaSQLCommandTest {
     val snapshot = log.update()
     val newProtocol = snapshot.protocol
     assert(newProtocol.isFeatureSupported(RowTrackingFeature))
-    assert(newProtocol.minReaderVersion == prevMinReaderVersion,
+    assert(newProtocol.minReaderVersion === prevMinReaderVersion,
       "The reader version does not need to be upgraded")
     val expectedMinWriterVersion = Math.max(
       prevMinWriterVersion, TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION)
-    assert(newProtocol.minWriterVersion == expectedMinWriterVersion)
+    assert(newProtocol.minWriterVersion === expectedMinWriterVersion)
 
     // Tables should have the table property enabled at the end of ALTER TABLE command.
     assert(RowId.isEnabled(newProtocol, snapshot.metadata))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingBackfillSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingBackfillSuite.scala
@@ -1,0 +1,594 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.rowid
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.concurrent.ExecutionException
+
+import com.databricks.spark.util.Log4jUsageLogger
+import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
+import org.apache.spark.sql.delta.actions.{AddFile, Protocol, TableFeatureProtocolUtils}
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.commands.backfill.{BackfillBatch, BackfillBatchStats, BackfillCommandStats, RowTrackingBackfillBatch, RowTrackingBackfillCommand, RowTrackingBackfillExecutor}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
+import org.apache.spark.sql.delta.util.JsonUtils
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.test.SharedSparkSession
+
+/** Test-only object that overrides a method to force a failure. */
+case class FailingRowTrackingBackfillBatch(filesInBatch: Seq[AddFile])
+  extends BackfillBatch {
+  override val backfillBatchStatsOpType = DeltaUsageLogsOpTypes.BACKFILL_BATCH
+  override def prepareFilesAndCommit(
+      txn: OptimisticTransaction,
+      batchId: Int): Unit = {
+    throw new IllegalStateException("mock exception for test")
+  }
+}
+
+class RowTrackingBackfillSuite
+    extends RowIdTestUtils
+    with SharedSparkSession {
+  protected val initialNumRows = 1000
+  protected val testTableName = "target"
+  protected val numFilesInTable = 10
+
+  override def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaSQLConf.DELTA_ROW_TRACKING_BACKFILL_ENABLED.key, "true")
+
+  protected def createTable(tableName: String): Unit = {
+    // We disable Optimize Write to ensure the right number of files are created.
+    withSQLConf(
+      DeltaSQLConf.DELTA_OPTIMIZE_WRITE_ENABLED.key -> "false"
+    ) {
+      spark.range(start = 0, end = initialNumRows, step = 1, numPartitions = numFilesInTable)
+        .write
+        .format("delta")
+        .saveAsTable(tableName)
+
+      val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(tableName))
+      assert(snapshot.allFiles.count() === numFilesInTable)
+    }
+  }
+
+  /** Create the default test table used by this suite, which has row IDs disabled. */
+  protected def withRowIdDisabledTestTable()(f: => Unit): Unit = {
+    withRowTrackingEnabled(enabled = false) {
+      withTable(testTableName) {
+        createTable(testTableName)
+        val (log, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(testTableName))
+        assertRowIdsAreNotSet(log)
+        assert(!RowTracking.isSupported(snapshot.protocol))
+        assert(!RowId.isEnabled(snapshot.protocol, snapshot.metadata))
+        f
+      }
+    }
+  }
+
+  /** Check the number of backfill commits in the Delta history. */
+  protected def assertNumBackfillCommits(expectedNumCommits: Int): Unit = {
+    val log = DeltaLog.forTable(spark, TableIdentifier(testTableName))
+    val actualNumBackfillCommits = log.history.getHistory(None)
+      .filter(_.operation == DeltaOperations.ROW_TRACKING_BACKFILL_OPERATION_NAME)
+    assert(actualNumBackfillCommits.size === expectedNumCommits)
+  }
+
+  /** Check the protocol, the number of backfill commits and the table property. */
+  protected def assertBackfillWasSuccessful(expectedNumCommits: Int): Unit = {
+    val (log, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(testTableName))
+    assert(RowTracking.isSupported(snapshot.protocol))
+    assertNumBackfillCommits(expectedNumCommits)
+    assert(RowId.isEnabled(snapshot.protocol, snapshot.metadata))
+  }
+
+  test("getCandidateFilesToBackfill returns right files on tables with row IDs disabled") {
+    withRowIdDisabledTestTable() {
+      val (log, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(testTableName))
+      val initialFilesInTable = snapshot.allFiles.collect().toSet
+      assert(initialFilesInTable.size === numFilesInTable,
+        "We expect the AddFiles to be unique in this table.")
+      // ALl files in a table with row ID disabled should require backfill.
+      val filesToBackfillBeforeTableFeatureSupport =
+        RowTrackingBackfillExecutor.getCandidateFilesToBackfill(log.update()).collect()
+      assert(filesToBackfillBeforeTableFeatureSupport.toSet === initialFilesInTable)
+      // Let's add table feature support without enabling row ID, i.e., force new files to have
+      // base row IDs. This is not the same as enabling the table property. This does not trigger
+      // backfill commits.
+      sql(
+        s"""ALTER TABLE $testTableName
+           |SET TBLPROPERTIES('$rowTrackingFeatureName' = 'supported')""".stripMargin)
+      val snapshotAfterTableSupport = log.update()
+      assert(RowTracking.isSupported(snapshotAfterTableSupport.protocol))
+      assert(!RowId.isEnabled(
+        snapshotAfterTableSupport.protocol, snapshotAfterTableSupport.metadata))
+      spark.range(end = 1).write.mode("append").insertInto(testTableName)
+      val snapshotAfterInsert = log.update()
+      assert(snapshotAfterInsert.allFiles.count() === numFilesInTable + 1)
+      // Only the files before the table feature support should need backfill.
+      val filesToBackfillAfterTableFeatureSupport =
+        RowTrackingBackfillExecutor.getCandidateFilesToBackfill(snapshotAfterInsert).collect()
+      assert(filesToBackfillAfterTableFeatureSupport.toSet === initialFilesInTable)
+    }
+  }
+
+  test("Trigger backfill by calling command directly") {
+    // No one should be calling this directly. We just want to unit test outside of ALTER TABLE.
+    withRowIdDisabledTestTable() {
+      val log = DeltaLog.forTable(spark, TableIdentifier(testTableName))
+      RowTrackingBackfillCommand(
+        log,
+        nameOfTriggeringOperation = DeltaOperations.OP_SET_TBLPROPERTIES,
+        None).run(spark)
+
+      val snapshot = log.update()
+      assert(RowTracking.isSupported(snapshot.protocol))
+      assert(!RowId.isEnabled(snapshot.protocol, snapshot.metadata))
+      assertNumBackfillCommits(expectedNumCommits = 1)
+    }
+  }
+
+  test("Calling the command directly should not trigger backfill when " +
+    "Row Tracking Backfill is not enabled") {
+    withSQLConf(DeltaSQLConf.DELTA_ROW_TRACKING_BACKFILL_ENABLED.key -> "false") {
+      // No one should be calling this directly. We just want to unit test outside of ALTER TABLE.
+      withRowIdDisabledTestTable() {
+        val log = DeltaLog.forTable(spark, TableIdentifier(testTableName))
+
+        val ex = intercept[UnsupportedOperationException] {
+          RowTrackingBackfillCommand(
+            log,
+            nameOfTriggeringOperation = DeltaOperations.OP_SET_TBLPROPERTIES,
+            None).run(spark)
+        }
+
+        assert(ex.getMessage === "Cannot enable Row IDs on an existing table.")
+      }
+    }
+  }
+
+  test("Trigger backfill using ALTER TABLE") {
+    withRowIdDisabledTestTable() {
+      val log = DeltaLog.forTable(spark, TableIdentifier(testTableName))
+      validateSuccessfulBackfillMetrics(expectedNumSuccessfulBatches = 1) {
+        triggerBackfillOnTestTableUsingAlterTable(testTableName, initialNumRows, log)
+      }
+      assertBackfillWasSuccessful(expectedNumCommits = 1)
+
+      val snapshot = log.update()
+      assertRowIdsAreValid(log)
+      assert(RowTracking.isSupported(snapshot.protocol))
+      assert(RowId.isEnabled(snapshot.protocol, snapshot.metadata))
+
+      val prevHighWatermark = RowId.extractHighWatermark(log.update()).get
+
+      // Commits after the backfill command should have row IDs.
+      val numNewRows = 100
+      spark.range(end = numNewRows).write.insertInto(testTableName)
+      assertRowIdsAreValid(log)
+      assertHighWatermarkIsCorrectAfterUpdate(log, prevHighWatermark, numNewRows)
+    }
+  }
+
+  test("Backfill respects the max file limit per commit") {
+    val maxNumFilesPerCommit = 3
+    withRowIdDisabledTestTable() {
+      withSQLConf(
+        DeltaSQLConf.DELTA_BACKFILL_MAX_NUM_FILES_PER_COMMIT.key ->
+          maxNumFilesPerCommit.toString) {
+        val expectedNumBackfillCommits =
+          Math.ceil(numFilesInTable.toDouble / maxNumFilesPerCommit.toDouble).toInt
+        validateSuccessfulBackfillMetrics(expectedNumBackfillCommits) {
+          val log = DeltaLog.forTable(spark, TableIdentifier(testTableName))
+          triggerBackfillOnTestTableUsingAlterTable(testTableName, initialNumRows, log)
+        }
+        assertBackfillWasSuccessful(expectedNumBackfillCommits)
+      }
+    }
+  }
+
+  test("Backfill on table with row tracking already enabled") {
+    withRowTrackingEnabled(enabled = true) {
+      withTable(testTableName) {
+        createTable(testTableName)
+        val (log, snapshot1) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(testTableName))
+        var snapshot = snapshot1
+        assert(RowTracking.isSupported(snapshot.protocol))
+        assert(RowId.isEnabled(snapshot.protocol, snapshot.metadata))
+
+        // ALTER TABLE should do nothing other than set the table properties.
+        validateSuccessfulBackfillMetrics(expectedNumSuccessfulBatches = 0) {
+          triggerBackfillOnTestTableUsingAlterTable(testTableName, initialNumRows, log)
+          assertNumBackfillCommits(expectedNumCommits = 0)
+        }
+
+        // Now, let's test UNSET TBLPROPERTIES
+        val rowTrackingKey = DeltaConfigs.ROW_TRACKING_ENABLED.key
+        sql(s"ALTER TABLE $testTableName UNSET TBLPROPERTIES('$rowTrackingKey')")
+        // This should not downgrade the table and it should not trigger any backfill.
+        // It will only change the table property.
+        snapshot = log.update()
+        assertNumBackfillCommits(expectedNumCommits = 0)
+        assert(RowTracking.isSupported(snapshot.protocol))
+        assert(!RowId.isEnabled(snapshot.protocol, snapshot.metadata))
+        val prevMaterializedColumnName = extractMaterializedRowIdColumnName(log)
+        // If we re-enable the table property again, we should expect the materialized column name
+        // to be the same.
+        validateSuccessfulBackfillMetrics(expectedNumSuccessfulBatches = 0) {
+          triggerBackfillOnTestTableUsingAlterTable(testTableName, initialNumRows, log)
+        }
+        assert(prevMaterializedColumnName === extractMaterializedRowIdColumnName(log))
+      }
+    }
+  }
+
+  test("Backfill on table that enabled the table feature separately") {
+    withRowIdDisabledTestTable() {
+      val log = DeltaLog.forTable(spark, TableIdentifier(testTableName))
+      // User decides to enable the table feature separately first.
+      sql(
+        s"""ALTER TABLE $testTableName
+           |SET TBLPROPERTIES('$rowTrackingFeatureName' = 'supported')""".stripMargin)
+      val snapshotAfterTableSupport = log.update()
+      assert(RowTracking.isSupported(snapshotAfterTableSupport.protocol))
+      assert(!RowId.isEnabled(
+        snapshotAfterTableSupport.protocol, snapshotAfterTableSupport.metadata))
+
+      val deltaHistory = log.history.getHistory(None)
+      // 1 commit to create table, 1 commit to upgrade protocol
+      assert(deltaHistory.size === 2)
+
+      // New data is inserted into the table. The new files should have base row ID.
+      val numNewRowsInserted = 1
+      spark.range(end = numNewRowsInserted).write.mode("append").insertInto(testTableName)
+      val snapshotAfterInsert = log.update()
+      assert(snapshotAfterInsert.allFiles.count() === numFilesInTable + 1)
+      val numRowsInTableAfterInsert = initialNumRows + numNewRowsInserted
+
+      // Trigger backfill. Only the files before the table feature support should need backfill.
+      validateSuccessfulBackfillMetrics(expectedNumSuccessfulBatches = 1) {
+        triggerBackfillOnTestTableUsingAlterTable(testTableName, numRowsInTableAfterInsert, log)
+        assertBackfillWasSuccessful(expectedNumCommits = 1)
+      }
+
+      // We should not try to upgrade the protocol again.
+      val deltaHistory2 = log.history.getHistory(None)
+      // We should have 3 more commits since the protocol upgrade:
+      // 1 commit to insert, 1 commit to backfill, 1 commit to set tbl properties.
+      assert(deltaHistory2.size === 5)
+      assertRowIdsAreValid(log)
+    }
+  }
+
+  test("Backfill should be idempotent") {
+    withRowIdDisabledTestTable() {
+      val log = DeltaLog.forTable(spark, TableIdentifier(testTableName))
+      validateSuccessfulBackfillMetrics(expectedNumSuccessfulBatches = 1) {
+        triggerBackfillOnTestTableUsingAlterTable(testTableName, initialNumRows, log)
+      }
+
+      val snapshot = log.update()
+      assert(RowId.isEnabled(snapshot.protocol, snapshot.metadata))
+
+      val materializedColumnName = extractMaterializedRowIdColumnName(log)
+      val deltaHistory = log.history.getHistory(None)
+      // 1 commit to create table, 1 commit to upgrade protocol, 1 commit for Backfill,
+      // 1 commit to set row tracking to enabled.
+      assert(deltaHistory.size === 4)
+
+      // We should not upgrade the protocol again and we should not backfill.
+      validateSuccessfulBackfillMetrics(expectedNumSuccessfulBatches = 0) {
+        triggerBackfillOnTestTableUsingAlterTable(testTableName, initialNumRows, log)
+      }
+      assert(extractMaterializedRowIdColumnName(log) === materializedColumnName,
+        "the materialized column name should not change")
+      val deltaHistory2 = log.history.getHistory(None)
+      // 1 more commit to SET TBLPROPERTIES, nothing else.
+      assert(deltaHistory2.size === 5)
+      assert(deltaHistory2.head.operation === DeltaOperations.OP_SET_TBLPROPERTIES)
+    }
+  }
+
+  test("ALTER TABLE that don't enable row tracking should not backfill") {
+    withRowIdDisabledTestTable() {
+      val rowTrackingKey = DeltaConfigs.ROW_TRACKING_ENABLED.key
+      sql(s"ALTER TABLE $testTableName SET TBLPROPERTIES('$rowTrackingKey' = false)")
+      // This should not upgrade the table protocol and it should not trigger any backfill.
+      // It will only set the table property.
+      val (log, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(testTableName))
+      assertNumBackfillCommits(expectedNumCommits = 0)
+      assert(!RowTracking.isSupported(snapshot.protocol))
+      assert(!RowId.isEnabled(snapshot.protocol, snapshot.metadata))
+    }
+  }
+
+  test("Trigger backfill using ALTER TABLE, but another property fails") {
+    withRowIdDisabledTestTable() {
+      // Enable column mapping
+      val columnMappingMode = DeltaConfigs.COLUMN_MAPPING_MODE.key
+      val minReaderKey = DeltaConfigs.MIN_READER_VERSION.key
+      val minWriterKey = DeltaConfigs.MIN_WRITER_VERSION.key
+      val rowTrackingKey = DeltaConfigs.ROW_TRACKING_ENABLED.key
+      sql(s"""ALTER TABLE $testTableName SET TBLPROPERTIES(
+             |'$minReaderKey' = '2',
+             |'$minWriterKey' = '5',
+             |'$columnMappingMode'='name')""".stripMargin)
+
+      val log = DeltaLog.forTable(spark, TableIdentifier(testTableName))
+
+      // Try to enable row IDs at the same time as we set column mapping mode to id.
+      // This should fail due to illegal column mapping mode change.
+      intercept[ColumnMappingUnsupportedException] {
+        sql(s"ALTER TABLE $testTableName SET " +
+          s"TBLPROPERTIES('$columnMappingMode'='id', '$rowTrackingKey'=true)")
+      }
+      // Despite the failure, there are side effects: the protocol is still upgraded and
+      // backfill commits occurred. However, row IDs should still be disabled because we were unable
+      // to set the property.
+      val snapshot = log.update()
+      assert(RowTracking.isSupported(snapshot.protocol))
+      assertNumBackfillCommits(expectedNumCommits = 1)
+      assert(!RowId.isEnabled(snapshot.protocol, snapshot.metadata))
+    }
+  }
+
+  /**
+   * Validate that if a user triggers backfill with other protocol changes within the ALTER TABLE
+   * command, we end up with a correct final protocol object.
+   *
+   * @param tableBelowTableFeatureLevel : Boolean indicating whether the test table has a protocol
+   *                                    writer version below table feature support prior to calling
+   *                                    the ALTER TABLE command that triggers backfill.
+   * @param isOtherTableFeatureLegacy   : Boolean indicating whether the other table feature being
+   *                                    supported along row tracking enablement is legacy (i.e. it
+   *                                    requires minWriterVersion and minReaderVersion below table
+   *                                    feature level).
+   */
+  private def checkProtocolUpgradeWithBackfill(
+      tableBelowTableFeatureLevel: Boolean,
+      isOtherTableFeatureLegacy: Boolean): Unit = {
+    val initialMinReaderVersion = ColumnMappingTableFeature.minReaderVersion
+    val initialMinWriterVersion = ColumnMappingTableFeature.minWriterVersion
+    withSQLConf(
+      DeltaConfigs.MIN_WRITER_VERSION.defaultTablePropertyKey -> initialMinWriterVersion.toString,
+      DeltaConfigs.MIN_READER_VERSION.defaultTablePropertyKey -> initialMinReaderVersion.toString
+    ) {
+      withRowIdDisabledTestTable() {
+        val (log, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(testTableName))
+        val prevProtocol = snapshot.protocol
+        val expectedInitialProtocol = Protocol(initialMinReaderVersion, initialMinWriterVersion)
+        assert(prevProtocol === expectedInitialProtocol)
+
+        // Build the TBLPROPERTIES String for the ALTER TABLE command.
+        val rowTrackingKey = DeltaConfigs.ROW_TRACKING_ENABLED.key
+        var propertiesMap: Map[String, String] = Map(rowTrackingKey -> "true")
+        if (isOtherTableFeatureLegacy) {
+          val columnMappingMode = DeltaConfigs.COLUMN_MAPPING_MODE.key
+          propertiesMap = propertiesMap ++ Map(columnMappingMode -> "name")
+        } else {
+          val deletionVectorsKey = DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.key
+          propertiesMap = propertiesMap ++ Map(deletionVectorsKey -> "true")
+        }
+        val tblPropertiesString = propertiesMap.map {
+          case (key, value) => s"'$key'='$value'"
+        }.mkString(", ")
+
+        sql(s"ALTER TABLE $testTableName SET TBLPROPERTIES($tblPropertiesString)")
+
+        val expectedFinalProtocol = if (isOtherTableFeatureLegacy) {
+          Protocol(
+            minReaderVersion = ColumnMappingTableFeature.minReaderVersion,
+            minWriterVersion = TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION)
+            .withFeature(RowTrackingFeature)
+            .withFeature(ColumnMappingTableFeature)
+            .merge(prevProtocol)
+        } else {
+          Protocol(
+            minReaderVersion = TableFeatureProtocolUtils.TABLE_FEATURES_MIN_READER_VERSION,
+            minWriterVersion = TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION)
+            .withFeature(RowTrackingFeature)
+            .withFeature(DeletionVectorsTableFeature)
+            .merge(prevProtocol)
+        }
+
+        assertBackfillWasSuccessful(expectedNumCommits = 1)
+        val finalSnapshot = log.update()
+        assert(finalSnapshot.protocol === expectedFinalProtocol)
+      }
+    }
+  }
+
+  for {
+    tableBelowTableFeatureLevel <- BOOLEAN_DOMAIN
+    isOtherTableFeatureLegacy <- BOOLEAN_DOMAIN
+  } {
+    test("ALTER TABLE does other protocol upgrade with backfill, " +
+      s"tableBelowTableFeatureLevel=$tableBelowTableFeatureLevel, " +
+      s"isOtherTableFeatureLegacy=$isOtherTableFeatureLegacy") {
+      checkProtocolUpgradeWithBackfill(tableBelowTableFeatureLevel, isOtherTableFeatureLegacy)
+    }
+  }
+
+  test("lower MIN_WRITER_VERSION along with Row ID prop can upgrade protocol") {
+    withRowIdDisabledTestTable() {
+      val (log, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(testTableName))
+      val prevProtocol = snapshot.protocol
+      assert(prevProtocol.minWriterVersion <
+        TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION)
+
+      // Try to enable row IDs at the same time as we enable column mapping mode.
+      val columnMappingMode = DeltaConfigs.COLUMN_MAPPING_MODE.key
+      val minReaderKey = DeltaConfigs.MIN_READER_VERSION.key
+      val minWriterKey = DeltaConfigs.MIN_WRITER_VERSION.key
+      val rowTrackingKey = DeltaConfigs.ROW_TRACKING_ENABLED.key
+      // If we specify lower minWriterKey along with the row tracking prop, we will
+      // do an implicit upgrade to minWriterKey = 7.
+      sql(
+        s"""ALTER TABLE $testTableName SET TBLPROPERTIES(
+           |'$minReaderKey' = '2',
+           |'$minWriterKey' = '5',
+           |'$columnMappingMode'='name',
+           |'$rowTrackingKey'=true
+           |)""".stripMargin)
+      val afterProtocol = log.update().protocol
+      assert(afterProtocol.minReaderVersion === 2)
+      assert(
+        afterProtocol.minWriterVersion ===
+          TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION)
+      assert(afterProtocol.readerFeatures === None)
+      assert(
+        afterProtocol.writerFeatures === Some((
+          prevProtocol.implicitlyAndExplicitlySupportedFeatures ++
+            Protocol(2, 5).implicitlySupportedFeatures ++
+            Set(
+              ColumnMappingTableFeature,
+              DomainMetadataTableFeature, // Required by Row Tracking
+              RowTrackingFeature))
+          .map(_.name)))
+    }
+  }
+
+  test("Backfill works with more than 1 batch in parallel") {
+    val expectedNumBackfillCommits = 4
+    val maxNumFilesPerCommit = Math.ceil(
+      numFilesInTable.toDouble / expectedNumBackfillCommits.toDouble).toInt
+    val maxNumBatchesInParallel = expectedNumBackfillCommits
+    withRowIdDisabledTestTable() {
+      withSQLConf(
+        DeltaSQLConf.DELTA_BACKFILL_MAX_NUM_FILES_PER_COMMIT.key ->
+          maxNumFilesPerCommit.toString,
+        DeltaSQLConf.DELTA_BACKFILL_MAX_NUM_BATCHES_IN_PARALLEL.key ->
+          maxNumBatchesInParallel.toString
+      ) {
+        validateSuccessfulBackfillMetrics(expectedNumBackfillCommits) {
+          val log = DeltaLog.forTable(spark, TableIdentifier(testTableName))
+          triggerBackfillOnTestTableUsingAlterTable(testTableName, initialNumRows, log)
+        }
+      }
+    }
+  }
+
+  test("BackfillCommandStats metrics are correct in case of failure") {
+    withRowIdDisabledTestTable() {
+      val (log, snapshot) = DeltaLog.forTableWithSnapshot(spark, TableIdentifier(testTableName))
+
+      val allFiles = snapshot.allFiles.collect()
+      val numFilesInSuccessfulBackfillBatch = 3
+      val filesInSuccessfulBackfill = allFiles.take(numFilesInSuccessfulBackfillBatch)
+      val numFilesInFailingBackfillBatch = 2
+      val filesInFailingBackfill = allFiles.takeRight(numFilesInFailingBackfillBatch)
+      val maxNumBatchesInParallel = 1
+      // ordered list in order to force the successful batch to execute before the failing batch.
+      val batchIterator = List(
+        RowTrackingBackfillBatch(filesInSuccessfulBackfill),
+        FailingRowTrackingBackfillBatch(filesInFailingBackfill)
+      ).iterator
+
+      val txn = log.startTransaction()
+      val backfillStats = BackfillCommandStats(
+        transactionId = txn.txnId,
+        nameOfTriggeringOperation = DeltaOperations.OP_SET_TBLPROPERTIES,
+        maxNumBatchesInParallel = maxNumBatchesInParallel)
+      val backfillExecutor = new RowTrackingBackfillExecutor(
+        spark,
+        txn,
+        FileMetadataMaterializationTracker.noopTracker,
+        maxNumBatchesInParallel,
+        backfillStats
+      )
+
+      val backfillUsageRecords = Log4jUsageLogger.track {
+        intercept[ExecutionException] {
+          backfillExecutor.run(batchIterator)
+        }
+      }.filter(_.metric == "tahoeEvent")
+
+      val backfillBatchRecords = backfillUsageRecords
+        .filter(_.tags.get("opType").contains(DeltaUsageLogsOpTypes.BACKFILL_BATCH))
+      val backfillBatchStatsSeq = backfillBatchRecords.map { backfillBatchRecord =>
+        JsonUtils.fromJson[BackfillBatchStats](backfillBatchRecord.blob)
+      }
+
+      // Check parent backfill stats. The total execution time and wasSuccessful are manipulated in
+      // RowTrackingBackfillCommand, not BackfillExecutor so it is still 0 and false respectively.
+      assert(backfillStats.numFailedBatches === 1)
+      assert(backfillStats.numSuccessfulBatches === 1)
+      assert(backfillStats.maxNumBatchesInParallel === maxNumBatchesInParallel)
+      assert(backfillStats.transactionId === txn.txnId)
+      assert(backfillStats.nameOfTriggeringOperation === DeltaOperations.OP_SET_TBLPROPERTIES)
+
+      // Check the individual batch stats
+      assert(backfillBatchStatsSeq.size === 2)
+      backfillBatchStatsSeq.foreach { backfillBatchStat =>
+        backfillBatchStat.batchId match {
+          case 0 =>
+            assert(backfillBatchStat.wasSuccessful)
+            assert(backfillBatchStat.initialNumFiles === numFilesInSuccessfulBackfillBatch)
+            assert(backfillBatchStat.totalExecutionTimeInMs > 0)
+          case 1 =>
+            assert(!backfillBatchStat.wasSuccessful)
+            assert(backfillBatchStat.initialNumFiles === numFilesInFailingBackfillBatch)
+            // Failing batch can have totalExecutionTimeInMs be 0 because it ends faster.
+            assert(backfillBatchStat.totalExecutionTimeInMs >= 0)
+          case id => fail(s"Unexpected batch id $id for RowTrackingBackfillBatch.")
+        }
+        assert(backfillBatchStat.parentTransactionId === txn.txnId)
+      }
+    }
+  }
+
+  test("BackfillBatchStats failure leads to correct metrics") {
+    withRowIdDisabledTestTable() {
+      val table = DeltaTableV2(spark, TableIdentifier(testTableName))
+
+      val filesInBackfillBatch = table.snapshot.allFiles.head(2)
+      val batch = FailingRowTrackingBackfillBatch(filesInBackfillBatch)
+      val batchId = 17
+      val numSuccessfulBatch = new AtomicInteger(0)
+      val numFailedBatch = new AtomicInteger(0)
+
+      val txn = table.startTransactionWithInitialSnapshot()
+
+      val backfillUsageRecords = Log4jUsageLogger.track {
+        intercept[IllegalStateException] {
+          batch.execute(txn, batchId, numSuccessfulBatch, numFailedBatch)
+        }
+      }.filter(_.metric == "tahoeEvent")
+
+      val backfillBatchRecords = backfillUsageRecords
+        .filter(_.tags.get("opType").contains(DeltaUsageLogsOpTypes.BACKFILL_BATCH))
+      assert(backfillBatchRecords.size === 1, "Row Tracking Backfill should have " +
+        "only been executed once.")
+      val backfillBatchStats =
+        JsonUtils.fromJson[BackfillBatchStats](backfillBatchRecords.head.blob)
+
+      assert(numSuccessfulBatch.get() === 0)
+      assert(numFailedBatch.get() === 1)
+      assert(backfillBatchStats.batchId === batchId)
+      assert(!backfillBatchStats.wasSuccessful)
+      assert(backfillBatchStats.initialNumFiles === filesInBackfillBatch.length)
+      // Failing batch can have totalExecutionTimeInMs be 0 because it ends faster.
+      assert(backfillBatchStats.totalExecutionTimeInMs >= 0)
+      assert(backfillBatchStats.parentTransactionId === txn.txnId)
+      assert(backfillBatchStats.transactionId != null && backfillBatchStats.transactionId.nonEmpty)
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
@@ -19,14 +19,19 @@ package org.apache.spark.sql.delta.rowtracking
 import org.apache.spark.sql.delta.{DeltaLog, DeltaOperations, RowId, RowTrackingFeature}
 import org.apache.spark.sql.delta.actions.{Action, AddFile}
 import org.apache.spark.sql.delta.rowid.RowIdTestUtils
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.test.SharedSparkSession
 
 class RowTrackingConflictResolutionSuite extends QueryTest
   with SharedSparkSession with RowIdTestUtils {
+
+  override def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaSQLConf.DELTA_ROW_TRACKING_BACKFILL_ENABLED.key, "true")
 
   private val testTableName = "test_table"
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
@@ -19,19 +19,14 @@ package org.apache.spark.sql.delta.rowtracking
 import org.apache.spark.sql.delta.{DeltaLog, DeltaOperations, RowId, RowTrackingFeature}
 import org.apache.spark.sql.delta.actions.{Action, AddFile}
 import org.apache.spark.sql.delta.rowid.RowIdTestUtils
-import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 
-import org.apache.spark.SparkConf
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.test.SharedSparkSession
 
 class RowTrackingConflictResolutionSuite extends QueryTest
   with SharedSparkSession with RowIdTestUtils {
-
-  override def sparkConf: SparkConf = super.sparkConf
-    .set(DeltaSQLConf.DELTA_ROW_TRACKING_BACKFILL_ENABLED.key, "true")
 
   private val testTableName = "test_table"
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Adding the [RowTrackingBackfillCommand](https://docs.google.com/document/d/1ji3zIWURSz_qugpRHjIV_2BUZPVKxYMiEFaDORt_ULA/edit#heading=h.8al9qhd83yov), the ability to assign row IDs to table rows after the table creation.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Added UTs.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
