### PR TITLE
[Spark] Add annotation for merge materialize source stage of merge

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -804,6 +804,7 @@ private[delta] object DeltaOperationMetrics {
     "numTargetFilesRemoved", // number of files removed from the sink(target)
     "numTargetChangeFilesAdded", // number of CDC files
     "executionTimeMs",  // time taken to execute the entire operation
+    "materializeSourceTimeMs", // time taken to materialize source (or determine it's not needed)
     "scanTimeMs", // time taken to scan the files for matches
     "rewriteTimeMs", // time taken to rewrite the matched files
     "numTargetDeletionVectorsAdded", // number of deletion vectors added

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeStats.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeStats.scala
@@ -96,6 +96,7 @@ case class MergeStats(
 
     // Timings
     executionTimeMs: Long,
+    materializeSourceTimeMs: Long,
     scanTimeMs: Long,
     rewriteTimeMs: Long,
 
@@ -166,6 +167,7 @@ object MergeStats {
 
       // Timings
       executionTimeMs = metrics("executionTimeMs").value,
+      materializeSourceTimeMs = metrics("materializeSourceTimeMs").value,
       scanTimeMs = metrics("scanTimeMs").value,
       rewriteTimeMs = metrics("rewriteTimeMs").value,
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoDVsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoDVsSuite.scala
@@ -57,6 +57,7 @@ trait MergeIntoDVsTests extends MergeIntoSQLSuite with DeletionVectorsTestUtils 
   }
 
   protected override lazy val expectedOpTypes: Set[String] = Set(
+    "delta.dml.merge.materializeSource",
     "delta.dml.merge.findTouchedFiles",
     "delta.dml.merge.writeModifiedRowsOnly",
     "delta.dml.merge.writeDeletionVectors",

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoMetricsBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoMetricsBase.scala
@@ -1344,7 +1344,8 @@ object MergeIntoMetricsBase extends QueryTest with SharedSparkSession {
   val mergeFileMetrics = Set(
     "numTargetFilesAdded", "numTargetFilesRemoved", "numTargetBytesAdded", "numTargetBytesRemoved")
   // Metrics related with execution times.
-  val mergeTimeMetrics = Set("executionTimeMs", "scanTimeMs", "rewriteTimeMs")
+  val mergeTimeMetrics = Set(
+    "executionTimeMs", "materializeSourceTimeMs", "scanTimeMs", "rewriteTimeMs")
   // Metrics related with CDF. Available only when CDF is available.
   val mergeCdfMetrics = Set("numTargetChangeFilesAdded")
   // DV Metrics.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
@@ -3284,7 +3284,10 @@ abstract class MergeIntoSuiteBase
   }
 
   protected lazy val expectedOpTypes: Set[String] = Set(
-    "delta.dml.merge.findTouchedFiles", "delta.dml.merge.writeAllChanges", "delta.dml.merge")
+    "delta.dml.merge.materializeSource",
+    "delta.dml.merge.findTouchedFiles",
+    "delta.dml.merge.writeAllChanges",
+    "delta.dml.merge")
 
   test("insert only merge - recorded operation") {
     var events: Seq[UsageRecord] = Seq.empty
@@ -3317,7 +3320,9 @@ abstract class MergeIntoSuiteBase
     }.map(_.opType.get.typeName).toSet
 
     assert(opTypes == Set(
-      "delta.dml.merge", "delta.dml.merge.writeInsertsOnlyWhenNoMatchedClauses"))
+      "delta.dml.merge",
+      "delta.dml.merge.materializeSource",
+      "delta.dml.merge.writeInsertsOnlyWhenNoMatchedClauses"))
   }
 
   test("recorded operations - write inserts only") {
@@ -3353,6 +3358,7 @@ abstract class MergeIntoSuiteBase
   }
 
   protected lazy val expectedOpTypesInsertOnly: Set[String] = Set(
+    "delta.dml.merge.materializeSource",
     "delta.dml.merge.findTouchedFiles",
     "delta.dml.merge.writeInsertsOnlyWhenNoMatches",
     "delta.dml.merge")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Originally MERGE source materialization was lazy, and triggered when the source was used for the first time. Because of that, it couldn't be cleanly separated as a stage. Since it was changed to be eager, we can now annotate it, which should make it easier to find in Spark UI.

## How was this patch tested?

Merge materialize source stage is now annotated:
![image](https://github.com/user-attachments/assets/5a468cda-ffae-40d4-9054-dcfca681c470)

Unit tests validate that the new stage is present in MERGE commit metrics.

## Does this PR introduce _any_ user-facing changes?

No
