### PR TITLE
Use correct partition/batch size for Delta Uniform iceberg conversion

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
@@ -355,8 +355,7 @@ class IcebergConverter(spark: SparkSession)
 
         snapshotToConvert.allFiles
           .repartition(numPartitions.toInt)
-          .collectResult()
-          .iterator
+          .toLocalIterator
           .asScala
           .grouped(actionBatchSize)
           .foreach { actions =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

The existing conversion logic used toLocalIterator which will spawn many Spark jobs to collect AddFiles to the driver based on default spark partition size. Mostly the default size is not good and thus conversion and commit to Iceberg will be bottlenecked.

The PR used repartition to size the partition properly to avoid the bottleneck.

## How was this patch tested?

manually tested on a 5M files table. performance improved from tens of minutes to 5 minutes.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
