### PR TITLE
[Spark] Add commit version and logical records in Delta DML metrics

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/NumRecordsStats.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/NumRecordsStats.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.actions.{Action, AddFile, RemoveFile}
+import org.apache.spark.sql.util.ScalaExtensions._
+
+/**
+ * Container class for statistics related to number of records in a Delta commit.
+ */
+case class NumRecordsStats (
+    // Number of logical records in AddFile actions with numRecords.
+    numLogicalRecordsAddedPartial: Long,
+    // Number of logical records in RemoveFile actions with numRecords.
+    numLogicalRecordsRemovedPartial: Long,
+    numDeletionVectorRecordsAdded: Long,
+    numDeletionVectorRecordsRemoved: Long,
+    numFilesAddedWithoutNumRecords: Long,
+    numFilesRemovedWithoutNumRecords: Long) {
+
+  def allFilesHaveNumRecords: Boolean =
+    numFilesAddedWithoutNumRecords == 0 && numFilesRemovedWithoutNumRecords == 0
+
+  /**
+   * The number of logical records in all AddFile actions or None if any file does not contain
+   * statistics.
+   */
+  def numLogicalRecordsAdded: Option[Long] = Option.when(numFilesAddedWithoutNumRecords == 0)(
+    numLogicalRecordsAddedPartial)
+
+  /**
+   * The number of logical records in all RemoveFile actions or None if any file does not contain
+   * statistics.
+   */
+  def numLogicalRecordsRemoved: Option[Long] = Option.when(numFilesRemovedWithoutNumRecords == 0)(
+    numLogicalRecordsRemovedPartial)
+}
+
+object NumRecordsStats {
+  def fromActions(actions: Seq[Action]): NumRecordsStats = {
+    var numFilesAdded = 0L
+    var numFilesRemoved = 0L
+    var numFilesAddedWithoutNumRecords = 0L
+    var numFilesRemovedWithoutNumRecords = 0L
+    var numLogicalRecordsAddedPartial: Long = 0L
+    var numLogicalRecordsRemovedPartial: Long = 0L
+    var numDeletionVectorRecordsAdded = 0L
+    var numDeletionVectorRecordsRemoved = 0L
+
+    actions.foreach {
+      case a: AddFile =>
+        numFilesAdded += 1
+        numLogicalRecordsAddedPartial += a.numLogicalRecords.getOrElse {
+          numFilesAddedWithoutNumRecords += 1
+          0L
+        }
+        numDeletionVectorRecordsAdded += a.numDeletedRecords
+      case r: RemoveFile =>
+        numFilesRemoved += 1
+        numLogicalRecordsRemovedPartial += r.numLogicalRecords.getOrElse {
+          numFilesRemovedWithoutNumRecords += 1
+          0L
+        }
+        numDeletionVectorRecordsRemoved = r.numDeletedRecords
+      case _ =>
+        // Do nothing
+    }
+    NumRecordsStats(
+      numLogicalRecordsAddedPartial = numLogicalRecordsAddedPartial,
+      numLogicalRecordsRemovedPartial = numLogicalRecordsRemovedPartial,
+      numDeletionVectorRecordsAdded = numDeletionVectorRecordsAdded,
+      numDeletionVectorRecordsRemoved = numDeletionVectorRecordsRemoved,
+      numFilesAddedWithoutNumRecords = numFilesAddedWithoutNumRecords,
+      numFilesRemovedWithoutNumRecords = numFilesRemovedWithoutNumRecords)
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1140,6 +1140,8 @@ trait OptimisticTransactionImpl extends TransactionalWrite
    *
    * Also skips creating the commit if the configured [[IsolationLevel]] doesn't need us to record
    * the commit from correctness perspective.
+   *
+   * Returns the new version the transaction committed or None if the commit was skipped.
    */
   def commitIfNeeded(
       actions: Seq[Action],

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1144,7 +1144,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
   def commitIfNeeded(
       actions: Seq[Action],
       op: DeltaOperations.Operation,
-      tags: Map[String, String] = Map.empty): Unit = {
+      tags: Map[String, String] = Map.empty): Option[Long] = {
     commitImpl(actions, op, canSkipEmptyCommits = true, tags = tags)
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -125,10 +125,15 @@ case class DeleteCommand(
           return Seq.empty
         }
 
-        val deleteActions = performDelete(sparkSession, deltaLog, txn)
-        txn.commitIfNeeded(actions = deleteActions,
+        val (deleteActions, deleteMetrics) = performDelete(sparkSession, deltaLog, txn)
+        val commitVersion = txn.commitIfNeeded(
+          actions = deleteActions,
           op = DeltaOperations.Delete(condition.toSeq),
           tags = RowTracking.addPreservedRowTrackingTagIfNotSet(txn.snapshot))
+        recordDeltaEvent(
+          deltaLog,
+          "delta.dml.delete.stats",
+          data = deleteMetrics.copy(commitVersion = commitVersion))
       }
       // Re-cache all cached plans(including this relation itself, if it's cached) that refer to
       // this data source relation.
@@ -149,7 +154,7 @@ case class DeleteCommand(
   def performDelete(
       sparkSession: SparkSession,
       deltaLog: DeltaLog,
-      txn: OptimisticTransaction): Seq[Action] = {
+      txn: OptimisticTransaction): (Seq[Action], DeleteMetric) = {
     import org.apache.spark.sql.delta.implicits._
 
     var numRemovedFiles: Long = 0
@@ -386,10 +391,8 @@ case class DeleteCommand(
     txn.registerSQLMetrics(sparkSession, metrics)
     sendDriverMetrics(sparkSession, metrics)
 
-    recordDeltaEvent(
-      deltaLog,
-      "delta.dml.delete.stats",
-      data = DeleteMetric(
+    val numRecordsStats = NumRecordsStats.fromActions(deleteActions)
+    val deleteMetric = DeleteMetric(
         condition = condition.map(_.sql).getOrElse("true"),
         numFilesTotal,
         numFilesAfterSkipping,
@@ -413,14 +416,16 @@ case class DeleteCommand(
         rewriteTimeMs,
         numDeletionVectorsAdded,
         numDeletionVectorsRemoved,
-        numDeletionVectorsUpdated)
-    )
+        numDeletionVectorsUpdated,
+        numLogicalRecordsAdded = numRecordsStats.numLogicalRecordsAdded,
+        numLogicalRecordsRemoved = numRecordsStats.numLogicalRecordsRemoved)
 
-    if (deleteActions.nonEmpty) {
+    val actionsToCommit = if (deleteActions.nonEmpty) {
       createSetTransaction(sparkSession, deltaLog).toSeq ++ deleteActions
     } else {
       Seq.empty
     }
+    (actionsToCommit, deleteMetric)
   }
 
   /**
@@ -541,5 +546,12 @@ case class DeleteMetric(
     rewriteTimeMs: Long,
     numDeletionVectorsAdded: Long,
     numDeletionVectorsRemoved: Long,
-    numDeletionVectorsUpdated: Long
+    numDeletionVectorsUpdated: Long,
+    @JsonDeserialize(contentAs = classOf[java.lang.Long])
+    commitVersion: Option[Long] = None,
+    isWriteCommand: Boolean = false,
+    @JsonDeserialize(contentAs = classOf[java.lang.Long])
+    numLogicalRecordsAdded: Option[Long] = None,
+    @JsonDeserialize(contentAs = classOf[java.lang.Long])
+    numLogicalRecordsRemoved: Option[Long] = None
 )

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
@@ -229,8 +229,9 @@ trait MergeIntoCommandBase extends LeafRunnableCommand
    */
   protected def collectMergeStats(
       deltaTxn: OptimisticTransaction,
-      materializeSourceReason: MergeIntoMaterializeSourceReason.MergeIntoMaterializeSourceReason)
-    : MergeStats = {
+      materializeSourceReason: MergeIntoMaterializeSourceReason.MergeIntoMaterializeSourceReason,
+      commitVersion: Option[Long],
+      numRecordsStats: NumRecordsStats): MergeStats = {
     val stats = MergeStats.fromMergeSQLMetrics(
       metrics,
       condition,
@@ -238,7 +239,10 @@ trait MergeIntoCommandBase extends LeafRunnableCommand
       notMatchedClauses,
       notMatchedBySourceClauses,
       isPartitioned = deltaTxn.metadata.partitionColumns.nonEmpty,
-      performedSecondSourceScan = performedSecondSourceScan)
+      performedSecondSourceScan = performedSecondSourceScan,
+      commitVersion = commitVersion,
+      numRecordsStats = numRecordsStats
+    )
     stats.copy(
       materializeSourceReason = Some(materializeSourceReason.toString),
       materializeSourceAttempts = Some(attempt))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeStats.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeStats.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.delta.commands.merge
 
 import scala.collection.mutable.ArrayBuffer
 
+import org.apache.spark.sql.delta.NumRecordsStats
 import org.apache.spark.sql.util.ScalaExtensions._
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import org.apache.commons.lang3.StringUtils
@@ -136,7 +137,14 @@ case class MergeStats(
     // MergeMaterializeSource stats
     materializeSourceReason: Option[String] = None,
     @JsonDeserialize(contentAs = classOf[java.lang.Long])
-    materializeSourceAttempts: Option[Long] = None
+    materializeSourceAttempts: Option[Long] = None,
+
+    @JsonDeserialize(contentAs = classOf[java.lang.Long])
+    numLogicalRecordsAdded: Option[Long],
+    @JsonDeserialize(contentAs = classOf[java.lang.Long])
+    numLogicalRecordsRemoved: Option[Long],
+    @JsonDeserialize(contentAs = classOf[java.lang.Long])
+    commitVersion: Option[Long] = None
 )
 
 object MergeStats {
@@ -148,7 +156,10 @@ object MergeStats {
       notMatchedClauses: Seq[DeltaMergeIntoNotMatchedClause],
       notMatchedBySourceClauses: Seq[DeltaMergeIntoNotMatchedBySourceClause],
       isPartitioned: Boolean,
-      performedSecondSourceScan: Boolean): MergeStats = {
+      performedSecondSourceScan: Boolean,
+      commitVersion: Option[Long],
+      numRecordsStats: NumRecordsStats
+    ): MergeStats = {
 
     def metricValueIfPartitioned(metricName: String): Option[Long] = {
       if (isPartitioned) Some(metrics(metricName).value) else None
@@ -205,6 +216,10 @@ object MergeStats {
       numTargetDeletionVectorsAdded = metrics("numTargetDeletionVectorsAdded").value,
       numTargetDeletionVectorsRemoved = metrics("numTargetDeletionVectorsRemoved").value,
       numTargetDeletionVectorsUpdated = metrics("numTargetDeletionVectorsUpdated").value,
+
+      commitVersion = commitVersion,
+      numLogicalRecordsAdded = numRecordsStats.numLogicalRecordsAdded,
+      numLogicalRecordsRemoved = numRecordsStats.numLogicalRecordsRemoved,
 
       // Deprecated fields
       updateConditionExpr = null,


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?


- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Extend `delta.dml.{merge, update, delete}.stats` metrics with the following fields:
- `commitVersion` The commit version of the DML version. This allows associating DML metrics with commit metrics and distinguishing DML operations that did not commit.
- `numLogicalRecordsAdded` and `numLogicalRecordsRemoved`: The number of logical records in AddFile and RemoveFile actions to be committed. These metrics can be compared to the row-level metrics emitted by the DML operations.

Finally, this commit adds the `isWriteCommand` field in DELETE metrics to distinguish DELETE operations that are performed in the context of WRITE commands that selectively overwrite data.


## How was this patch tested?

Log-only changes. Existing tests.

## Does this PR introduce _any_ user-facing changes?

No
