### PR TITLE
[Spark] Support clone and restore for Identity Columns

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/IdentityColumn.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/IdentityColumn.scala
@@ -192,6 +192,19 @@ object IdentityColumn extends DeltaLogging {
       )
     }
   }
+  /**
+   * Returns a copy of `schemaToCopy` in which the high water marks of the identity columns have
+   * been merged with the corresponding high water marks of `schemaWithHighWaterMarksToMerge`.
+   */
+  def copySchemaWithMergedHighWaterMarks(
+      schemaToCopy: StructType, schemaWithHighWaterMarksToMerge: StructType): StructType = {
+    val newHighWatermarks = getIdentityColumns(schemaWithHighWaterMarksToMerge).flatMap { f =>
+      val info = getIdentityInfo(f)
+      info.highWaterMark.map(waterMark => DeltaColumnMapping.getPhysicalName(f) -> waterMark)
+    }
+    updateSchema(schemaToCopy, newHighWatermarks)
+  }
+
   // Return IDENTITY information of column `field`. Caller must ensure `isIdentityColumn(field)`
   // is true.
   def getIdentityInfo(field: StructField): IdentityInfo = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
@@ -311,7 +311,7 @@ abstract class CloneTableBase(
     }
 
     // Coordinated Commit configurations are never copied over to the target table.
-    val filteredConfigeration = clonedMetadata.configuration
+    val filteredConfiguration = clonedMetadata.configuration
       .filterKeys(!CoordinatedCommitsUtils.TABLE_PROPERTY_KEYS.contains(_))
       .toMap
     val clonedSchema =

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
@@ -314,7 +314,12 @@ abstract class CloneTableBase(
     clonedMetadata = clonedMetadata.copy(configuration =
       clonedMetadata.configuration.filterKeys(
         !CoordinatedCommitsUtils.TABLE_PROPERTY_KEYS.contains(_)).toMap)
-    clonedMetadata
+
+    val clonedSchema =
+      IdentityColumn.copySchemaWithMergedHighWaterMarks(
+        schemaToCopy = clonedMetadata.schema,
+        schemaWithHighWaterMarksToMerge = targetSnapshot.metadata.schema)
+    clonedMetadata.copy(schemaString = clonedSchema.json)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
@@ -311,15 +311,14 @@ abstract class CloneTableBase(
     }
 
     // Coordinated Commit configurations are never copied over to the target table.
-    clonedMetadata = clonedMetadata.copy(configuration =
-      clonedMetadata.configuration.filterKeys(
-        !CoordinatedCommitsUtils.TABLE_PROPERTY_KEYS.contains(_)).toMap)
-
+    val filteredConfigeration = clonedMetadata.configuration
+      .filterKeys(!CoordinatedCommitsUtils.TABLE_PROPERTY_KEYS.contains(_))
+      .toMap
     val clonedSchema =
       IdentityColumn.copySchemaWithMergedHighWaterMarks(
         schemaToCopy = clonedMetadata.schema,
         schemaWithHighWaterMarksToMerge = targetSnapshot.metadata.schema)
-    clonedMetadata.copy(schemaString = clonedSchema.json)
+    clonedMetadata.copy(configuration = filteredConfigeration, schemaString = clonedSchema.json)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CloneTableBase.scala
@@ -318,7 +318,7 @@ abstract class CloneTableBase(
       IdentityColumn.copySchemaWithMergedHighWaterMarks(
         schemaToCopy = clonedMetadata.schema,
         schemaWithHighWaterMarksToMerge = targetSnapshot.metadata.schema)
-    clonedMetadata.copy(configuration = filteredConfigeration, schemaString = clonedSchema.json)
+    clonedMetadata.copy(configuration = filteredConfiguration, schemaString = clonedSchema.json)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
@@ -21,7 +21,7 @@ import java.sql.Timestamp
 import scala.collection.JavaConverters._
 import scala.util.{Success, Try}
 
-import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaOperations, DomainMetadataUtils, Snapshot}
+import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaOperations, DomainMetadataUtils, IdentityColumn, Snapshot}
 import org.apache.spark.sql.delta.actions.{AddFile, DeletionVectorDescriptor, RemoveFile}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -191,7 +191,13 @@ case class RestoreTableCommand(sourceTable: DeltaTableV2)
           filesToRemove.toLocalIterator().asScala
         }
 
-        txn.updateMetadata(snapshotToRestore.metadata)
+        // We need to merge the schema of the latest snapshot with the schema of the snapshot
+        // we're restoring to ensure that the high water mark is correct.
+        val mergedSchema = IdentityColumn.copySchemaWithMergedHighWaterMarks(
+          schemaToCopy = latestSnapshot.metadata.schema,
+          schemaWithHighWaterMarksToMerge = snapshotToRestore.metadata.schema)
+
+        txn.updateMetadata(snapshotToRestore.metadata.copy(schemaString = mergedSchema.json))
 
         val sourceProtocol = snapshotToRestore.protocol
         val targetProtocol = latestSnapshot.protocol

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
@@ -194,8 +194,8 @@ case class RestoreTableCommand(sourceTable: DeltaTableV2)
         // We need to merge the schema of the latest snapshot with the schema of the snapshot
         // we're restoring to ensure that the high water mark is correct.
         val mergedSchema = IdentityColumn.copySchemaWithMergedHighWaterMarks(
-          schemaToCopy = latestSnapshot.metadata.schema,
-          schemaWithHighWaterMarksToMerge = snapshotToRestore.metadata.schema)
+          schemaToCopy = snapshotToRestore.metadata.schema,
+          schemaWithHighWaterMarksToMerge = latestSnapshot.metadata.schema)
 
         txn.updateMetadata(snapshotToRestore.metadata.copy(schemaString = mergedSchema.json))
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR is part of https://github.com/delta-io/delta/issues/1959 .
It adds support for clone and restore tables with identity columns.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Clone and restore related test cases.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Users will be able to call clone and restore on tables with identity columns.