### PR TITLE
[Spark] Fix DeltaConnectPlannerSuite by copying the moved createDummySessionHolder

### DIFF
--- a/spark-connect/server/src/test/scala-spark-master/io/delta/connect/DeltaConnectPlannerSuite.scala
+++ b/spark-connect/server/src/test/scala-spark-master/io/delta/connect/DeltaConnectPlannerSuite.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.connect.config.Connect
 import org.apache.spark.sql.connect.delta.ImplicitProtoConversions._
 import org.apache.spark.sql.connect.planner.{SparkConnectPlanner, SparkConnectPlanTest}
-import org.apache.spark.sql.connect.service.SessionHolder
+import org.apache.spark.sql.connect.service.SparkConnectTestUtils
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 class DeltaConnectPlannerSuite
@@ -57,7 +57,8 @@ class DeltaConnectPlannerSuite
           )
       )
 
-      val result = new SparkConnectPlanner(SessionHolder.forTesting(spark)).transformRelation(input)
+      val result = new SparkConnectPlanner(SparkConnectTestUtils.createDummySessionHolder(spark))
+        .transformRelation(input)
       val expected = DeltaTable.forName(spark, "table").toDF.queryExecution.analyzed
       comparePlans(result, expected)
     }
@@ -83,7 +84,8 @@ class DeltaConnectPlannerSuite
           )
       )
 
-      val result = new SparkConnectPlanner(SessionHolder.forTesting(spark)).transformRelation(input)
+      val result = new SparkConnectPlanner(SparkConnectTestUtils.createDummySessionHolder(spark))
+        .transformRelation(input)
       val expected = DeltaTable.forPath(spark, dir.getAbsolutePath).toDF.queryExecution.analyzed
       comparePlans(result, expected)
     }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Fixes `DeltaConnectPlannerSuite` by replacing `SessionHolder.forTesting` with a copy of `createDummySessionHolder`, as this method got moved in the Spark master branch: https://github.com/apache/spark/commit/acb2fecb8c174fa4e2f23c843a904161151c8dfa

## How was this patch tested?
Fixes test.

## Does this PR introduce _any_ user-facing changes?
No.