### PR TITLE
[Spark] Add Row Tracking Backfill Conflict Checker RemoveFile rule

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -312,10 +312,10 @@ private[delta] class ConflictChecker(
     if (winningCommitSummary.isRowTrackingBackfillTxn) {
       recordTime(timerPhaseName) {
         val backfillActionMap = winningCommitSummary.addedFilePathToActionMap
-        // Copy over the base row ID and row commit version assigned so that the AddFiles and
-        // RemoveFiles have matching base row ID and row commit version. If an AddFile is
-        // re-committed, it should have the same base row ID and row commit version as the one
-        // assigned by Backfill.
+        // Copy over the base row ID and default row commit version assigned so that the AddFiles
+        // and RemoveFiles have matching base row ID and default row commit version.
+        // If an AddFile is re-committed, it should have the same base row ID and
+        // default row commit version as the one assigned by Backfill.
         val newActions = currentTransactionInfo.actions.map {
           case a: AddFile if backfillActionMap.contains(a.path) =>
             val backfillAction = backfillActionMap(a.path)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit
 
 import scala.collection.mutable
 
+import org.apache.spark.sql.delta.DeltaOperations.ROW_TRACKING_BACKFILL_OPERATION_NAME
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.coordinatedcommits.UpdatedActions
@@ -60,7 +61,8 @@ private[delta] case class CurrentTransactionInfo(
     val readSnapshot: Snapshot,
     val commitInfo: Option[CommitInfo],
     val readRowIdHighWatermark: Long,
-    val domainMetadata: Seq[DomainMetadata]) {
+    val domainMetadata: Seq[DomainMetadata],
+    val op: DeltaOperations.Operation) {
 
   /**
    * Final actions to commit - including the [[CommitInfo]] which should always come first so we can
@@ -96,6 +98,9 @@ private[delta] case class CurrentTransactionInfo(
    */
   val partitionSchemaAtReadTime: StructType = readSnapshot.metadata.partitionSchema
 
+  // Whether this is a row tracking backfill transaction or not.
+  val isRowTrackingBackfillTxn = op.name == ROW_TRACKING_BACKFILL_OPERATION_NAME
+
   def isConflict(winningTxn: SetTransaction): Boolean = readAppIds.contains(winningTxn.appId)
 }
 
@@ -111,8 +116,14 @@ private[delta] class WinningCommitSummary(val actions: Seq[Action], val commitVe
   val protocol: Option[Protocol] = actions.collectFirst { case a: Protocol => a }
   val commitInfo: Option[CommitInfo] = actions.collectFirst { case a: CommitInfo => a }.map(
     ci => ci.copy(version = Some(commitVersion)))
+  // Whether this is a row tracking backfill transaction or not.
+  val isRowTrackingBackfillTxn =
+    commitInfo.exists(_.operation == ROW_TRACKING_BACKFILL_OPERATION_NAME)
   val removedFiles: Seq[RemoveFile] = actions.collect { case a: RemoveFile => a }
   val addedFiles: Seq[AddFile] = actions.collect { case a: AddFile => a }
+  // This is used in resolveRowTrackingBackfillConflicts.
+  lazy val addedFilePathToActionMap: Map[String, AddFile] =
+    addedFiles.map(af => (af.path, af)).toMap
   val isBlindAppendOption: Option[Boolean] = commitInfo.flatMap(_.isBlindAppend)
   val blindAppendAddedFiles: Seq[AddFile] = if (isBlindAppendOption.getOrElse(false)) {
     addedFiles
@@ -159,6 +170,7 @@ private[delta] class ConflictChecker(
     // Perform cheap check for transaction dependencies before we start checks files.
     checkForUpdatedApplicationTransactionIdsThatCurrentTxnDependsOn()
 
+    resolveRowTrackingBackfillConflicts()
     // Row Tracking reconciliation. We perform this before the file checks to ensure that
     // no files have duplicate row IDs and avoid interacting with files that don't comply with
     // the protocol.
@@ -234,6 +246,88 @@ private[delta] class ConflictChecker(
       if (!isDowngradeCommitValid) {
         throw DeltaErrors.dropTableFeatureConflictRevalidationFailed(
           winningCommitSummary.commitInfo)
+      }
+    }
+  }
+
+  /**
+   * RowTrackingBackfill (or backfill for short) is a special operation that materializes and
+   * recommits all existing files in table using one or several commits to ensure that every AddFile
+   * has a base row ID and a default row commit version. When enabling row tracking on an existing
+   * table, the following occurs:
+   *    1. (If necessary) Protocol upgrade + Table Feature Support is added
+   *    2. RowTrackingBackfill commit(s)
+   *    3. Table property and metadata are updated.
+   * RowTrackingBackfill does not do any data change. It doesn't matter whether a file is
+   * recommitted after the table feature support from Backfill or some other concurrent transaction;
+   * every AddFile just needs to have a base row ID somehow. However, correctness issues can arise
+   * if we don't do the checks in this method.
+   *
+   * Check that RowTrackingBackfill is not resurrecting files that were removed concurrently and
+   * that an AddFile and its corresponding RemoveFile have the same base row ID. To do this, we:
+   *    1. remove AddFile's from a backfill commit if an AddFile or a RemoveFile with the same path
+   *       was added in the winning concurrent transactions. Files in a winning transaction can be
+   *       removed from backfill because they were already re-committed.
+   *    2. copy over base row IDs and default row commit versions if the current transaction re-adds
+   *       or delete an AddFile with the same path as an Addfile from a winning backfill commit.
+   */
+  private def resolveRowTrackingBackfillConflicts(): Unit = {
+    // If row tracking is not supported, there can be no backfill commit.
+    if (!RowTracking.isSupported(currentTransactionInfo.protocol)) {
+      assert(!currentTransactionInfo.isRowTrackingBackfillTxn)
+      assert(!winningCommitSummary.isRowTrackingBackfillTxn)
+      return
+    }
+
+    val timerPhaseName = "checked-row-tracking-backfill"
+    if (currentTransactionInfo.isRowTrackingBackfillTxn) {
+      recordTime(timerPhaseName) {
+        // Any winning commit seen by backfill must have row IDs, because
+        // `reassignOverlappingRowIds` will add a base row ID to all files. So we don't need
+        // Backfill to commit the same file again.
+        val filePathsToRemoveFromBackfill = winningCommitSummary.actions.collect {
+          case a: AddFile => a.path
+          case r: RemoveFile => r.path
+        }.toSet
+
+        // Remove files from this Backfill commit if they were removed or re-committed by
+        // a concurrent winning txn.
+        if (filePathsToRemoveFromBackfill.nonEmpty) {
+          val newActions = currentTransactionInfo.actions.filterNot {
+            case a: AddFile => filePathsToRemoveFromBackfill.contains(a.path)
+            case d: DomainMetadata if RowTrackingMetadataDomain.isSameDomain(d) => false
+            case _ => throw new IllegalStateException(
+              "RowTrackingBackfill commit has an unexpected action")
+          }
+
+          val newReadFiles = currentTransactionInfo.readFiles.filterNot(
+            a => filePathsToRemoveFromBackfill.contains(a.path))
+
+          currentTransactionInfo = currentTransactionInfo.copy(
+            actions = newActions, readFiles = newReadFiles)
+        }
+      }
+    }
+
+    if (winningCommitSummary.isRowTrackingBackfillTxn) {
+      recordTime(timerPhaseName) {
+        val backfillActionMap = winningCommitSummary.addedFilePathToActionMap
+        // Copy over the base row ID and row commit version assigned so that the AddFiles and
+        // RemoveFiles have matching base row ID and row commit version. If an AddFile is
+        // re-committed, it should have the same base row ID and row commit version as the one
+        // assigned by Backfill.
+        val newActions = currentTransactionInfo.actions.map {
+          case a: AddFile if backfillActionMap.contains(a.path) =>
+            val backfillAction = backfillActionMap(a.path)
+            a.copy(baseRowId = backfillAction.baseRowId,
+              defaultRowCommitVersion = backfillAction.defaultRowCommitVersion)
+          case r: RemoveFile if backfillActionMap.contains(r.path) =>
+            val backfillAction = backfillActionMap(r.path)
+            r.copy(baseRowId = backfillAction.baseRowId,
+              defaultRowCommitVersion = backfillAction.defaultRowCommitVersion)
+          case a => a
+        }
+        currentTransactionInfo = currentTransactionInfo.copy(actions = newActions)
       }
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -251,10 +251,10 @@ private[delta] class ConflictChecker(
   }
 
   /**
-   * RowTrackingBackfill (or backfill for short) is a special operation that materializes and
-   * recommits all existing files in table using one or several commits to ensure that every AddFile
-   * has a base row ID and a default row commit version. When enabling row tracking on an existing
-   * table, the following occurs:
+   * RowTrackingBackfill (or backfill for short in this paragraph) is a special operation that
+   * materializes and recommits all existing files in table using one or several commits to ensure
+   * that every AddFile has a base row ID and a default row commit version. When enabling
+   * row tracking on an existing table, the following occurs:
    *    1. (If necessary) Protocol upgrade + Table Feature Support is added
    *    2. RowTrackingBackfill commit(s)
    *    3. Table property and metadata are updated.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -251,7 +251,7 @@ private[delta] class ConflictChecker(
   }
 
   /**
-   * RowTrackingBackfill (or backfill for short in this paragraph) is a special operation that
+   * RowTrackingBackfill (or backfill for short for this function) is a special operation that
    * materializes and recommits all existing files in table using one or several commits to ensure
    * that every AddFile has a base row ID and a default row commit version. When enabling
    * row tracking on an existing table, the following occurs:

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1263,7 +1263,8 @@ trait OptimisticTransactionImpl extends TransactionalWrite
         readSnapshot = snapshot,
         commitInfo = Some(commitInfo),
         readRowIdHighWatermark = readRowIdHighWatermark,
-        domainMetadata = domainMetadata)
+        domainMetadata = domainMetadata,
+        op = op)
 
       // Register post-commit hooks if any
       lazy val hasFileActions = preparedActions.exists {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
@@ -262,7 +262,7 @@ class RowTrackingConflictResolutionSuite extends QueryTest
       val finalFiles = log.update().allFiles.collect()
       finalFiles.foreach(a => assert(a.baseRowId.nonEmpty))
       assertRowIdsAreValid(log)
-      assert(finalFiles.map(_.path).toSet == Seq(file3, file4).map(_.path).toSet)
+      assert(finalFiles.map(_.path).toSet === Seq(file3, file4).map(_.path).toSet)
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
@@ -16,17 +16,27 @@
 
 package org.apache.spark.sql.delta.rowtracking
 
-import org.apache.spark.sql.delta.{DeltaLog, DeltaOperations, RowId, RowTrackingFeature}
+import org.apache.spark.sql.delta.{DeletionVectorsTestUtils, DeltaLog, DeltaOperations, DeltaTestUtils, FileMetadataMaterializationTracker, OptimisticTransaction, RowId, RowTrackingFeature}
+import org.apache.spark.sql.delta.DeltaOperations.{ManualUpdate, Truncate}
 import org.apache.spark.sql.delta.actions.{Action, AddFile}
+import org.apache.spark.sql.delta.actions.{Metadata, RemoveFile}
+import org.apache.spark.sql.delta.commands.backfill.{BackfillBatchIterator, BackfillCommandStats, RowTrackingBackfillBatch, RowTrackingBackfillExecutor}
+import org.apache.spark.sql.delta.deletionvectors.RoaringBitmapArray
 import org.apache.spark.sql.delta.rowid.RowIdTestUtils
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.expressions.{EqualTo, Literal}
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.{IntegerType, StructType}
 
 class RowTrackingConflictResolutionSuite extends QueryTest
-  with SharedSparkSession with RowIdTestUtils {
+  with DeletionVectorsTestUtils
+  with SharedSparkSession
+  with RowIdTestUtils {
 
   private val testTableName = "test_table"
 
@@ -145,6 +155,174 @@ class RowTrackingConflictResolutionSuite extends QueryTest
       txn.commit(Seq(addFile(filePath)), DeltaOperations.ManualUpdate)
 
       assertRowIdsAreValid(deltaLog)
+    }
+  }
+
+  /**
+   * Setup a test table with four files and return these files to the caller.
+   */
+  private def setupTableAndGetAllFiles(log: DeltaLog): (AddFile, AddFile, AddFile, AddFile) = {
+    val f1 = DeltaTestUtils.createTestAddFile(encodedPath = "a", partitionValues = Map("x" -> "1"))
+    val f2 = DeltaTestUtils.createTestAddFile(encodedPath = "b", partitionValues = Map("x" -> "1"))
+    val f3 = DeltaTestUtils.createTestAddFile(encodedPath = "c", partitionValues = Map("x" -> "2"))
+    val f4 = DeltaTestUtils.createTestAddFile(encodedPath = "d", partitionValues = Map("x" -> "2"))
+
+    val setupActions: Seq[Action] = Seq(
+      Metadata(
+        schemaString = new StructType().add("x", IntegerType).json,
+        partitionColumns = Seq("x")),
+      f1,
+      f2,
+      f3,
+      f4,
+      Action.supportedProtocolVersion().withFeature(RowTrackingFeature)
+    )
+
+    log.startTransaction().commit(setupActions, ManualUpdate)
+
+    (f1, f2, f3, f4)
+  }
+
+  /** Add a dummy DV to a file in a table. */
+  private def addDVToFileInTable(deltaLog: DeltaLog, file: AddFile): (AddFile, RemoveFile) = {
+    val dv = writeDV(deltaLog, RoaringBitmapArray(0L))
+    updateFileDV(file, dv)
+  }
+
+  /** Execute backfill on the table associated with the delta log passed in. */
+  private def executeBackfill(log: DeltaLog, backfillTxn: OptimisticTransaction): Unit = {
+    val maxBatchesInParallel = 1
+    val backfillStats = BackfillCommandStats(
+      backfillTxn.txnId,
+      nameOfTriggeringOperation = DeltaOperations.OP_SET_TBLPROPERTIES,
+      maxNumBatchesInParallel = maxBatchesInParallel)
+    val backfillExecutor = new RowTrackingBackfillExecutor(
+      spark,
+      backfillTxn,
+      FileMetadataMaterializationTracker.noopTracker,
+      maxBatchesInParallel,
+      backfillStats
+    )
+    val filesToBackfill =
+      RowTrackingBackfillExecutor.getCandidateFilesToBackfill(log.update())
+    val batches = new BackfillBatchIterator(
+      filesToBackfill,
+      FileMetadataMaterializationTracker.noopTracker,
+      maxNumFilesPerBin = 4,
+      constructBatch = RowTrackingBackfillBatch(_))
+
+    backfillExecutor.run(batches)
+  }
+
+  test("Backfill conflict with a delete, Delete wins") {
+    withTempDir { dir =>
+      val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
+
+      // Setup
+      val (file1, file2, file3, file4) = setupTableAndGetAllFiles(log)
+
+      // Start Backfill.
+      val backfillTxn = log.startTransaction()
+
+      // A delete occurs in parallel. Delete wins.
+      val deleteTxn = log.startTransaction()
+      deleteTxn.filterFiles(EqualTo('x, Literal(1)) :: Nil)
+      val deleteActions = Seq(file1.remove, file2.remove)
+      // Truncate is a data-changing operation.
+      deleteTxn.commit(deleteActions, Truncate())
+
+      // Finish backfill.
+      executeBackfill(log, backfillTxn)
+
+      val finalFiles = log.update().allFiles.collect()
+      finalFiles.foreach(a => assert(a.baseRowId.nonEmpty))
+      assertRowIdsAreValid(log)
+      assert(finalFiles.map(_.path).toSet === Seq(file3, file4).map(_.path).toSet)
+    }
+  }
+
+  test("Backfill conflicts with a delete, Backfill wins") {
+    withTempDir { dir =>
+      val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
+      // Setup
+      val (file1, file2, file3, file4) = setupTableAndGetAllFiles(log)
+
+      // Start delete
+      val deleteTxn = log.startTransaction()
+      deleteTxn.filterFiles(EqualTo('x, Literal(1)) :: Nil)
+
+      // Backfill occurs in parallel and wins.
+      val backfillTxn = log.startTransaction()
+      executeBackfill(log, backfillTxn)
+
+      val deleteActions = Seq(file1.remove, file2.remove)
+      // Truncate is a data-changing operation.
+      deleteTxn.commit(deleteActions, Truncate())
+
+      val finalFiles = log.update().allFiles.collect()
+      finalFiles.foreach(a => assert(a.baseRowId.nonEmpty))
+      assertRowIdsAreValid(log)
+      assert(finalFiles.map(_.path).toSet == Seq(file3, file4).map(_.path).toSet)
+    }
+  }
+
+  test("Backfill conflicts with a DV delete, Delete wins") {
+    withTempDir { dir =>
+      val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
+
+      // Setup
+      val (file1, file2, file3, file4) = setupTableAndGetAllFiles(log)
+      enableDeletionVectorsInTable(log)
+
+      // Start Backfill
+      val backfillTxn = log.startTransaction()
+
+      // A delete occurs in parallel. Delete wins.
+      val deleteTxn = log.startTransaction()
+      deleteTxn.filterFiles(EqualTo('x, Literal(1)) :: Nil)
+      val (addFile1WithDV, removeFile1) = addDVToFileInTable(log, file1)
+      val (addFile2WithDV, removeFile2) = addDVToFileInTable(log, file2)
+      val deleteActions = Seq(addFile1WithDV, removeFile1, addFile2WithDV, removeFile2)
+      // Truncate is a data-changing operation.
+      deleteTxn.commit(deleteActions, Truncate())
+
+      // Finish Backfill
+      executeBackfill(log, backfillTxn)
+
+      val finalFiles = log.update().allFiles.collect()
+      finalFiles.foreach(a => assert(a.baseRowId.nonEmpty))
+      assertRowIdsAreValid(log)
+      val allFiles = Seq(file1, file2, file3, file4)
+      assert(finalFiles.map(_.path).toSet === allFiles.map(_.path).toSet)
+    }
+  }
+
+  test("Backfill conflicts with a DV delete, Backfill wins") {
+    withTempDir { dir =>
+      val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
+      // Setup
+      val (file1, file2, file3, file4) = setupTableAndGetAllFiles(log)
+      enableDeletionVectorsInTable(log)
+
+      // Start delete
+      val deleteTxn = log.startTransaction()
+      deleteTxn.filterFiles(EqualTo('x, Literal(1)) :: Nil)
+
+      // Backfill occurs in parallel and wins.
+      val backfillTxn = log.startTransaction()
+      executeBackfill(log, backfillTxn)
+
+      val (addFile1WithDV, removeFile1) = addDVToFileInTable(log, file1)
+      val (addFile2WithDV, removeFile2) = addDVToFileInTable(log, file2)
+      val deleteActions = Seq(addFile1WithDV, removeFile1, addFile2WithDV, removeFile2)
+      // Truncate is a data-changing operation.
+      deleteTxn.commit(deleteActions, Truncate())
+
+      val finalFiles = log.update().allFiles.collect()
+      finalFiles.foreach(a => assert(a.baseRowId.nonEmpty))
+      assertRowIdsAreValid(log)
+      val allFiles = Seq(file1, file2, file3, file4)
+      assert(finalFiles.map(_.path).toSet === allFiles.map(_.path).toSet)
     }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
@@ -215,10 +215,9 @@ class RowTrackingConflictResolutionSuite extends QueryTest
   }
 
   /** Check if base row IDs and default row commit versions have been assigned. */
-  def assertBaseRowIDsAndDefaultRowCommitVersionsAssigned(log: DeltaLog): Unit = {
-    val files = log.update().allFiles.collect()
-    files.foreach(a => assert(a.baseRowId.nonEmpty))
-    files.foreach(a => assert(a.defaultRowCommitVersion.nonEmpty))
+  def assertBaseRowIDsAndDefaultRowCommitVersionsAssigned(finalFiles: Seq[AddFile]): Unit = {
+    finalFiles.foreach(addedFile => assert(addedFile.baseRowId.nonEmpty))
+    finalFiles.foreach(addedFile => assert(addedFile.defaultRowCommitVersion.nonEmpty))
   }
 
   test("Backfill conflict with a delete, Delete wins") {
@@ -241,7 +240,8 @@ class RowTrackingConflictResolutionSuite extends QueryTest
       // Finish backfill.
       executeBackfill(log, backfillTxn)
 
-      assertBaseRowIDsAndDefaultRowCommitVersionsAssigned(log)
+      val finalFiles = log.update().allFiles.collect()
+      assertBaseRowIDsAndDefaultRowCommitVersionsAssigned(finalFiles)
       assertRowIdsAreValid(log)
       assert(finalFiles.map(_.path).toSet === Seq(file3, file4).map(_.path).toSet)
     }
@@ -265,7 +265,8 @@ class RowTrackingConflictResolutionSuite extends QueryTest
       // Truncate is a data-changing operation.
       deleteTxn.commit(deleteActions, Truncate())
 
-      assertBaseRowIDsAndDefaultRowCommitVersionsAssigned(log)
+      val finalFiles = log.update().allFiles.collect()
+      assertBaseRowIDsAndDefaultRowCommitVersionsAssigned(finalFiles)
       assertRowIdsAreValid(log)
       assert(finalFiles.map(_.path).toSet === Seq(file3, file4).map(_.path).toSet)
     }
@@ -294,7 +295,8 @@ class RowTrackingConflictResolutionSuite extends QueryTest
       // Finish Backfill
       executeBackfill(log, backfillTxn)
 
-      assertBaseRowIDsAndDefaultRowCommitVersionsAssigned(log)
+      val finalFiles = log.update().allFiles.collect()
+      assertBaseRowIDsAndDefaultRowCommitVersionsAssigned(finalFiles)
       assertRowIdsAreValid(log)
       val allFiles = Seq(file1, file2, file3, file4)
       assert(finalFiles.map(_.path).toSet === allFiles.map(_.path).toSet)
@@ -322,7 +324,8 @@ class RowTrackingConflictResolutionSuite extends QueryTest
       // Truncate is a data-changing operation.
       deleteTxn.commit(deleteActions, Truncate())
 
-      assertBaseRowIDsAndDefaultRowCommitVersionsAssigned(log)
+      val finalFiles = log.update().allFiles.collect()
+      assertBaseRowIDsAndDefaultRowCommitVersionsAssigned(finalFiles)
       assertRowIdsAreValid(log)
       val allFiles = Seq(file1, file2, file3, file4)
       assert(finalFiles.map(_.path).toSet === allFiles.map(_.path).toSet)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/RowTrackingConflictResolutionSuite.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.delta.rowid.RowIdTestUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.dsl.expressions._
@@ -37,6 +38,9 @@ class RowTrackingConflictResolutionSuite extends QueryTest
   with DeletionVectorsTestUtils
   with SharedSparkSession
   with RowIdTestUtils {
+
+  override def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaSQLConf.DELTA_ROW_TRACKING_BACKFILL_ENABLED.key, "true")
 
   private val testTableName = "test_table"
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
`RowTrackingBackfill` (or backfill for short) is a special operation that materializes and recommits all existing files in table using one or several commits to ensure that every AddFile has a base row ID and default Row Commit Version.

In this PR, we add a new rule to `ConflictChecker` that resolve concurrent conflicts involving Backfill. We check that RowTrackingBackfill is not resurrecting files that were removed concurrently and that an AddFile and its corresponding RemoveFile have the same base row ID and default RCV. We also add logic to skip certain concurrency checks if it involves Backfill.

This opens up a lot of interesting Conflict Resolutions cases to test, so we will add more UTs revolving conflict checking/resolutions between Backfill and other operations with different scenario in the next PRs.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Added ConflictResolution UTs.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
