### PR TITLE
[Spark][Backport 3.2] Fix the semantic of `shouldRewriteToBeIcebergCompatible` in REORG UPGRADE UNIFORM

### DIFF
--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2ESuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2ESuite.scala
@@ -18,9 +18,11 @@ package org.apache.spark.sql.delta.uniform
 
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.uniform.{UniFormE2EIcebergSuiteBase, UniFormE2ETest}
-
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.delta.{DeltaLog, DeltaOperations}
+import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.uniform.hms.HMSTest
 
@@ -38,6 +40,97 @@ trait WriteDeltaHMSReadIceberg extends UniFormE2ETest with DeltaSQLCommandTest w
   override protected def createReaderSparkSession: SparkSession = createIcebergSparkSession
 }
 
-class UniFormE2EIcebergSuite
-  extends UniFormE2EIcebergSuiteBase
-  with WriteDeltaHMSReadIceberg
+class UniFormE2EIcebergSuite extends UniFormE2EIcebergSuiteBase with WriteDeltaHMSReadIceberg {
+  /**
+   * Upgrade the default test table to `icebergCompatVersion`.
+   *
+   * @param icebergCompatVersion the version to upgrade the table.
+   */
+  private def runReorgUpgradeUniform(icebergCompatVersion: Int): Unit = {
+    write(
+      s"""
+         | REORG TABLE $testTableName APPLY
+         | (UPGRADE UNIFORM (ICEBERG_COMPAT_VERSION = $icebergCompatVersion))
+         |""".stripMargin
+    )
+  }
+
+  /**
+   * Check `AddFile.tags` exist or not for all the current files in
+   * the default test table.
+   *
+   * @param tagsShouldExist whether the tags should exist for the table.
+   * @param value if exist, what should the value of the tags be.
+   */
+  private def assertTagsExistForLatestSnapshot(
+      tagsShouldExist: Boolean,
+      value: String = null): Unit = {
+    val snapshot = DeltaLog.forTable(spark, new TableIdentifier(testTableName)).update()
+    snapshot.allFiles.collect().forall { addFile =>
+      if (!tagsShouldExist) {
+        addFile.tags == null
+      } else {
+        addFile.tags.getOrElse(AddFile.Tags.ICEBERG_COMPAT_VERSION.name, "0") == value
+      }
+    }
+  }
+
+  /**
+   * Add `IcebergCompatV1` tags to default test table, only used for testing.
+   */
+  private def addMockIcebergCompatV1Tags(): Unit = {
+    val log = DeltaLog.forTable(spark, new TableIdentifier(testTableName))
+    val snapshot = log.update()
+    val txn = log.startTransaction(None, Some(snapshot))
+    val updatedFiles = snapshot.allFiles.collect().map { file =>
+      file.copyWithTag(AddFile.Tags.ICEBERG_COMPAT_VERSION, "1")
+    }
+    txn.commitLarge(
+      spark, updatedFiles.toIterator, None, DeltaOperations.ManualUpdate, Map.empty, Map.empty)
+  }
+
+  test("Reorg Upgrade Uniform Basic Test") {
+    withTable(testTableName) {
+      write(s"CREATE TABLE $testTableName (id INT, name STRING) USING DELTA")
+      write(s"INSERT INTO $testTableName VALUES (1, 'Alex'), (2, 'Michael')")
+      assertTagsExistForLatestSnapshot(tagsShouldExist = false)
+
+      runReorgUpgradeUniform(icebergCompatVersion = 2)
+      assertTagsExistForLatestSnapshot(tagsShouldExist = true, value = "2")
+    }
+  }
+
+  test("Reorg Upgrade Uniform V1 to V2") {
+    withTable(testTableName) {
+      write(
+        s"""
+           | CREATE TABLE $testTableName (id INT, name STRING)
+           | USING DELTA
+           | TBLPROPERTIES (
+           |   'delta.columnMapping.mode' = 'name',
+           |   'delta.enableIcebergCompatV1' = 'true',
+           |   'delta.universalFormat.enabledFormats' = 'iceberg'
+           | )
+           |""".stripMargin
+      )
+      write(s"INSERT INTO $testTableName VALUES (1, 'Alex'), (2, 'Michael')")
+      assertTagsExistForLatestSnapshot(tagsShouldExist = false)
+
+      runReorgUpgradeUniform(icebergCompatVersion = 2)
+      assertTagsExistForLatestSnapshot(tagsShouldExist = true, value = "2")
+    }
+  }
+
+  test("Reorg Upgrade Uniform Should Succeed If Tags Is Not Null") {
+    withTable(testTableName) {
+      write(s"CREATE TABLE $testTableName (id INT, name STRING) USING DELTA")
+      write(s"INSERT INTO $testTableName VALUES (1, 'Alex'), (2, 'Michael')")
+      assertTagsExistForLatestSnapshot(tagsShouldExist = false)
+      addMockIcebergCompatV1Tags()
+      assertTagsExistForLatestSnapshot(tagsShouldExist = true, value = "1")
+
+      runReorgUpgradeUniform(icebergCompatVersion = 2)
+      assertTagsExistForLatestSnapshot(tagsShouldExist = true, value = "2")
+    }
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaReorgTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaReorgTableCommand.scala
@@ -118,8 +118,9 @@ class DeltaUpgradeUniformOperation(icebergCompatVersion: Int) extends DeltaReorg
   override def filterFilesToReorg(snapshot: Snapshot, files: Seq[AddFile]): Seq[AddFile] = {
     def shouldRewriteToBeIcebergCompatible(file: AddFile): Boolean = {
       if (file.tags == null) return true
-      val icebergCompatVersion = file.tags.getOrElse(AddFile.Tags.ICEBERG_COMPAT_VERSION.name, "0")
-      !icebergCompatVersion.exists(_.toString == icebergCompatVersion)
+      val fileIcebergCompatVersion =
+        file.tags.getOrElse(AddFile.Tags.ICEBERG_COMPAT_VERSION.name, "0")
+      fileIcebergCompatVersion != icebergCompatVersion.toString
     }
     files.filter(shouldRewriteToBeIcebergCompatible)
   }


### PR DESCRIPTION
## Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
currently we utilize the helper function
`shouldRewriteToBeIcebergCompatible` to filter the portion of parquet files that need to be rewritten when running `REORG UPGRADE UNIFORM` based on the tags in the `AddFile`.

however, the `DeltaUpgradeUniformOperation.icebergCompatVersion` is accidentally shadowed, which will make
`shouldRewriteToBeIcebergCompatible` always return `false` if the `AddFile.tags` is not `null` - this is not the expected semantic of this function.

this PR introduces the fix for this problem and add unit tests to ensure the correctness.

## How was this patch tested?
through unit tests in `UniFormE2ESuite.scala`.

## Does this PR introduce _any_ user-facing changes? 
no.