### PR TITLE
[WIP][Kernel] Support for writing into column mapping enabled tables

### DIFF
--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaColumnMappingEnableIdMode.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaColumnMappingEnableIdMode.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults
+
+import io.delta.kernel.internal.util.ColumnMapping.ColumnMappingMode
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+
+trait DeltaColumnMappingEnableIdMode extends AnyFunSuite with BeforeAndAfterAll {
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    System.setProperty("delta.test.delta.columnMapping.mode", "id")
+  }
+
+  override protected def afterAll(): Unit = {
+    System.clearProperty("delta.test.delta.columnMapping.mode")
+    super.afterAll()
+  }
+
+  protected def columnMappingMode: String = ColumnMappingMode.ID.toString
+}

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaColumnMappingEnableNameMode.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaColumnMappingEnableNameMode.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults
+
+import io.delta.kernel.internal.util.ColumnMapping.ColumnMappingMode
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+
+trait DeltaColumnMappingEnableNameMode extends AnyFunSuite with BeforeAndAfterAll {
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    System.setProperty("delta.test.delta.columnMapping.mode", columnMappingMode)
+  }
+
+  override protected def afterAll(): Unit = {
+    System.clearProperty("delta.test.delta.columnMapping.mode")
+    super.afterAll()
+  }
+
+  protected def columnMappingMode: String = ColumnMappingMode.NAME.toString
+}

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableColumnMappingWriteSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableColumnMappingWriteSuite.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults
+
+class DeltaTableIdColumnMappingIdWriteSuite
+  extends DeltaTableWritesSuite
+    with DeltaColumnMappingEnableIdMode
+
+class DeltaTableIdColumnMappingNameWriteSuite
+  extends DeltaTableWritesSuite
+    with DeltaColumnMappingEnableNameMode


### PR DESCRIPTION
## Description
Adds support for writing data into tables with column mapping (id/name) enabled. 

PR #3393 adds support for updating metadata. This PR completes writing data with appropriate physical names/field ids into the Parquet data files.


## How was this patch tested?
Repeat the existing write test suite with column mapping mode (id/name) enabled. This avoids test code repeat. TODO: Some cleanup needs to be done here. I will push the updates.