### PR TITLE
[Kernel][Expressions] Add TIMEADD expression to handle TIMESTAMP mill…

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/ScalarExpression.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/ScalarExpression.java
@@ -44,6 +44,15 @@ import java.util.stream.Collectors;
  *             argument. If all arguments are null returns null
  *         <li>Since version: 3.1.0
  *       </ul>
+ *   <li>Name: <code>TIMEADD</code>
+ *       <ul>
+ *         <li>Semantic: <code>TIMEADD(colExpr, milliseconds)</code>. Add the specified number of
+ *             milliseconds to the timestamp represented by <i>colExpr</i>. The adjustment does not
+ *             alter the original value but returns a new timestamp increased by the given
+ *             milliseconds. Ex: `TIMEADD(timestampColumn, 1000)` returns a timestamp 1 second
+ *             later.
+ *         <li>Since version: 3.3.0
+ *       </ul>
  * </ol>
  *
  * @since 3.0.0

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/VectorTestUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/VectorTestUtils.scala
@@ -15,10 +15,11 @@
  */
 package io.delta.kernel.test
 
-import java.lang.{Boolean => BooleanJ, Double => DoubleJ, Float => FloatJ}
 import io.delta.kernel.data.{ColumnVector, MapValue}
 import io.delta.kernel.internal.util.VectorUtils
 import io.delta.kernel.types._
+
+import java.lang.{Boolean => BooleanJ, Double => DoubleJ, Float => FloatJ}
 import scala.collection.JavaConverters._
 
 trait VectorTestUtils {
@@ -34,6 +35,21 @@ trait VectorTestUtils {
       override def isNullAt(rowId: Int): Boolean = values(rowId) == null
 
       override def getBoolean(rowId: Int): Boolean = values(rowId)
+    }
+  }
+
+  protected def timestampVector(values: Seq[Long]): ColumnVector = {
+    new ColumnVector {
+      override def getDataType: DataType = TimestampType.TIMESTAMP
+
+      override def getSize: Int = values.length
+
+      override def close(): Unit = {}
+
+      override def isNullAt(rowId: Int): Boolean = values(rowId) == -1
+
+      // Values are stored as Longs representing milliseconds since epoch
+      override def getLong(rowId: Int): Long = values(rowId)
     }
   }
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/DefaultJsonRow.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/DefaultJsonRow.java
@@ -22,6 +22,7 @@ import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.MapValue;
 import io.delta.kernel.data.Row;
+import io.delta.kernel.defaults.internal.DefaultKernelUtils;
 import io.delta.kernel.defaults.internal.data.vector.DefaultGenericVector;
 import io.delta.kernel.internal.util.InternalUtils;
 import io.delta.kernel.types.*;
@@ -255,6 +256,11 @@ public class DefaultJsonRow implements Row {
       throwIfTypeMismatch("timestamp", jsonValue.isTextual(), jsonValue);
       Instant time = OffsetDateTime.parse(jsonValue.textValue()).toInstant();
       return ChronoUnit.MICROS.between(Instant.EPOCH, time);
+    }
+
+    if (dataType instanceof TimestampNTZType) {
+      throwIfTypeMismatch("timestamp_ntz", jsonValue.isTextual(), jsonValue);
+      return DefaultKernelUtils.parseTimestampNTZ(jsonValue.textValue());
     }
 
     if (dataType instanceof StructType) {

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionVisitor.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionVisitor.java
@@ -59,6 +59,8 @@ abstract class ExpressionVisitor<R> {
 
   abstract R visitCoalesce(ScalarExpression ifNull);
 
+  abstract R visitTimeAdd(ScalarExpression timeAdd);
+
   abstract R visitLike(Predicate predicate);
 
   final R visit(Expression expression) {
@@ -106,6 +108,8 @@ abstract class ExpressionVisitor<R> {
         return visitIsNull(new Predicate(name, children));
       case "COALESCE":
         return visitCoalesce(expression);
+      case "TIMEADD":
+        return visitTimeAdd(expression);
       case "LIKE":
         return visitLike(new Predicate(name, children));
       default:

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
@@ -15,35 +15,33 @@
  */
 package io.delta.kernel.defaults
 
-import java.math.{BigDecimal => JBigDecimal}
-import java.sql.Date
-import java.time.{Instant, OffsetDateTime}
-import java.time.temporal.ChronoUnit
-import java.util.Optional
-
-import scala.collection.JavaConverters._
-
 import io.delta.golden.GoldenTableUtils.goldenTablePath
+import io.delta.kernel.data.{ColumnVector, ColumnarBatch, FilteredColumnarBatch, Row}
+import io.delta.kernel.defaults.engine.{DefaultEngine, DefaultJsonHandler, DefaultParquetHandler}
+import io.delta.kernel.defaults.utils.{ExpressionTestUtils, TestUtils}
+import io.delta.kernel.engine.{Engine, JsonHandler, ParquetHandler}
+import io.delta.kernel.expressions.Literal._
+import io.delta.kernel.expressions._
+import io.delta.kernel.internal.util.InternalUtils
+import io.delta.kernel.internal.{InternalScanFileUtils, ScanImpl}
+import io.delta.kernel.types.IntegerType.INTEGER
+import io.delta.kernel.types.StringType.STRING
+import io.delta.kernel.types.StructType
+import io.delta.kernel.utils.{CloseableIterator, FileStatus}
+import io.delta.kernel.{Scan, Snapshot, Table}
 import org.apache.hadoop.conf.Configuration
-import org.apache.spark.sql.{Row => SparkRow}
 import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog}
 import org.apache.spark.sql.types.{IntegerType => SparkIntegerType, StructField => SparkStructField, StructType => SparkStructType}
+import org.apache.spark.sql.{Row => SparkRow}
 import org.scalatest.funsuite.AnyFunSuite
 
-import io.delta.kernel.engine.{JsonHandler, ParquetHandler, Engine}
-import io.delta.kernel.data.{ColumnarBatch, ColumnVector, FilteredColumnarBatch, Row}
-import io.delta.kernel.expressions.{AlwaysFalse, AlwaysTrue, And, Column, Or, Predicate, ScalarExpression}
-import io.delta.kernel.expressions.Literal._
-import io.delta.kernel.types.StructType
-import io.delta.kernel.types.StringType.STRING
-import io.delta.kernel.types.IntegerType.INTEGER
-import io.delta.kernel.utils.{CloseableIterator, FileStatus}
-import io.delta.kernel.{Scan, Snapshot, Table}
-import io.delta.kernel.internal.util.InternalUtils
-import io.delta.kernel.internal.{InternalScanFileUtils, ScanImpl}
-import io.delta.kernel.defaults.engine.{DefaultJsonHandler, DefaultParquetHandler, DefaultEngine}
-import io.delta.kernel.defaults.utils.{ExpressionTestUtils, TestUtils}
+import java.math.{BigDecimal => JBigDecimal}
+import java.sql.Date
+import java.time.temporal.ChronoUnit
+import java.time.{Instant, OffsetDateTime}
+import java.util.Optional
+import scala.collection.JavaConverters._
 
 class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with SQLHelper {
 
@@ -158,9 +156,16 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
   }
 
   /* Where timestampStr is in the format of "yyyy-MM-dd'T'HH:mm:ss.SSSXXX" */
-  def getTimestampPredicate(expr: String, col: Column, timestampStr: String): Predicate = {
+  def getTimestampPredicate(expr: String, col: Column,
+                            timestampStr: String, timeStampType: String): Predicate = {
     val time = OffsetDateTime.parse(timestampStr)
-    new Predicate(expr, col, ofTimestamp(ChronoUnit.MICROS.between(Instant.EPOCH, time)))
+    new Predicate(expr, col,
+      if (timeStampType.equalsIgnoreCase("timestamp")) {
+        ofTimestamp(ChronoUnit.MICROS.between(Instant.EPOCH, time))
+      } else {
+        ofTimestampNtz(ChronoUnit.MICROS.between(Instant.EPOCH, time))
+      }
+    )
   }
 
   //////////////////////////////////////////////////////////////////////////////////
@@ -806,38 +811,42 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
     )
   )
 
-  // TODO (delta-io/delta#2462) JSON serialization truncates to milliseconds, to safely skip for
-  //  timestamp stats we need to add a millisecond to any max stat (requires time add expression)
-  ignore("data skipping - on TIMESTAMP type") {
-    withTempDir { tempDir =>
-      val data = "2019-09-09 01:02:03.456789"
-      val df = Seq(data).toDF("strTs")
-        .selectExpr(
-          s"CAST(strTs AS TIMESTAMP) AS ts",
-          s"STRUCT(CAST(strTs AS TIMESTAMP) AS ts) AS nested")
+  Seq("TIMESTAMP", "TIMESTAMP_NTZ").foreach { dataType =>
+    test(s"data skipping - on $dataType type") {
+      withTempDir { tempDir =>
+        withSparkTimeZone("UTC") {
+          val data = "2019-09-09 01:02:03.456789"
+          val df = Seq(data).toDF("strTs")
+            .selectExpr(
+              s"CAST(strTs AS $dataType) AS ts",
+              s"STRUCT(CAST(strTs AS $dataType) AS ts) AS nested")
 
-      val r = DeltaLog.forTable(spark, tempDir.getCanonicalPath)
-      df.coalesce(1).write.format("delta").save(r.dataPath.toString)
+          val r = DeltaLog.forTable(spark, tempDir.getCanonicalPath)
+          df.coalesce(1).write.format("delta").save(r.dataPath.toString)
+        }
 
-      checkSkipping(
-        tempDir.getCanonicalPath,
-        hits = Seq(
-          getTimestampPredicate(">=", col("ts"), "2019-09-09T01:02:03.456789-07:00"),
-          getTimestampPredicate("<=", col("ts"), "2019-09-09T01:02:03.456789-07:00"),
-          getTimestampPredicate(
-            ">=", nestedCol("nested.ts"), "2019-09-09T01:02:03.456789-07:00"),
-          getTimestampPredicate(
-            "<=", nestedCol("nested.ts"), "2019-09-09T01:02:03.456789-07:00")
-        ),
-        misses = Seq(
-          getTimestampPredicate(">=", col("ts"), "2019-09-09T01:02:03.457001-07:00"),
-          getTimestampPredicate("<=", col("ts"), "2019-09-09T01:02:03.455999-07:00"),
-          getTimestampPredicate(
-            ">=", nestedCol("nested.ts"), "2019-09-09T01:02:03.457001-07:00"),
-          getTimestampPredicate(
-            "<=", nestedCol("nested.ts"), "2019-09-09T01:02:03.455999-07:00")
+        checkSkipping(
+          tempDir.getCanonicalPath,
+          hits = Seq(
+            getTimestampPredicate("=", col("ts"), "2019-09-09T01:02:03.456789Z", dataType),
+            getTimestampPredicate(">=", col("ts"), "2019-09-09T01:02:03.456789Z", dataType),
+            getTimestampPredicate("<=", col("ts"), "2019-09-09T01:02:03.456789Z", dataType),
+            getTimestampPredicate(
+              ">=", nestedCol("nested.ts"), "2019-09-09T01:02:03.456789Z", dataType),
+            getTimestampPredicate(
+              "<=", nestedCol("nested.ts"), "2019-09-09T01:02:03.456789Z", dataType)
+          ),
+          misses = Seq(
+            getTimestampPredicate("=", col("ts"), "2019-09-09T01:02:03.457001Z", dataType),
+            getTimestampPredicate(">=", col("ts"), "2019-09-09T01:02:03.457001Z", dataType),
+            getTimestampPredicate("<=", col("ts"), "2019-09-09T01:02:03.455999Z", dataType),
+            getTimestampPredicate(
+              ">=", nestedCol("nested.ts"), "2019-09-09T01:02:03.457001Z", dataType),
+            getTimestampPredicate(
+              "<=", nestedCol("nested.ts"), "2019-09-09T01:02:03.455999Z", dataType)
+          )
         )
-      )
+      }
     }
   }
 
@@ -869,11 +878,7 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
           equals(col("c8"), ofBoolean(true)),
           equals(col("c8"), ofBoolean(false)),
           greaterThan(col("c9"), ofDecimal(JBigDecimal.valueOf(1.5), 3, 2)),
-          // TODO (delta-io/delta#2462) we don't currently skip for timestamps but this will still
-          //  be a hit once we do
-          getTimestampPredicate(">=", col("c5"), "2001-01-01T01:00:00-07:00"),
-          // TODO (delta-io/delta#2462) once we skip for timestamps this should be a miss
-          getTimestampPredicate(">=", col("c5"), "2003-01-01T01:00:00-07:00")
+          getTimestampPredicate(">=", col("c5"), "2001-01-01T01:00:00-07:00", "TIMESTAMP")
         ),
         misses = Seq(
           equals(col("c1"), ofInt(10)),
@@ -881,7 +886,8 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
           lessThan(col("c3"), ofFloat(0.5f)),
           greaterThan(col("c4"), ofFloat(5.0f)),
           equals(col("c6"), ofDate(InternalUtils.daysSinceEpoch(Date.valueOf("2003-02-02")))),
-          greaterThan(col("c9"), ofDecimal(JBigDecimal.valueOf(2.5), 3, 2))
+          greaterThan(col("c9"), ofDecimal(JBigDecimal.valueOf(2.5), 3, 2)),
+          getTimestampPredicate(">=", col("c5"), "2003-01-01T01:00:00-07:00", "TIMESTAMP")
         )
       )
     }
@@ -925,10 +931,7 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
           equals(col("cc8"), ofBoolean(true)),
           equals(col("cc8"), ofBoolean(false)),
           greaterThan(col("cc9"), ofDecimal(JBigDecimal.valueOf(1.5), 3, 2)),
-          // We don't currently skip for timestamps but this will still be a hit once we do
-          getTimestampPredicate(">=", col("cc5"), "2001-01-01T01:00:00-07:00"),
-          // Once we skip for timestamps this should be a miss
-          getTimestampPredicate(">=", col("cc5"), "2003-01-01T01:00:00-07:00")
+          getTimestampPredicate(">=", col("cc5"), "2001-01-01T01:00:00-07:00", "TIMESTAMP")
         ),
         misses = Seq(
           equals(col("cc1"), ofInt(10)),
@@ -936,6 +939,7 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
           lessThan(col("cc3"), ofFloat(0.5f)),
           greaterThan(col("cc4"), ofFloat(5.0f)),
           equals(col("cc6"), ofDate(InternalUtils.daysSinceEpoch(Date.valueOf("2003-02-02")))),
+          getTimestampPredicate(">=", col("cc5"), "2003-01-01T01:00:00-07:00", "TIMESTAMP"),
           greaterThan(col("cc9"), ofDecimal(JBigDecimal.valueOf(2.5), 3, 2))
         )
       )
@@ -948,10 +952,10 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
       spark.sql(
         s"""CREATE TABLE delta.`$tablePath`(
            |c1 long, c2 STRING, c3 FLOAT, c4 DOUBLE, c5 TIMESTAMP, c6 DATE,
-           |c7 BINARY, c8 BOOLEAN, c9 DECIMAL(3, 2)
+           |c7 BINARY, c8 BOOLEAN, c9 DECIMAL(3, 2), c10 TIMESTAMP_NTZ
            |) USING delta
            |TBLPROPERTIES(
-           |'delta.dataSkippingStatsColumns' = 'c1,c2,c3,c4,c5,c6,c9',
+           |'delta.dataSkippingStatsColumns' = 'c1,c2,c3,c4,c5,c6,c9,c10',
            |'delta.columnMapping.mode' = 'name',
            |'delta.minReaderVersion' = '2',
            |'delta.minWriterVersion' = '5'
@@ -962,8 +966,10 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
       spark.sql(s"alter table delta.`$tablePath` drop COLUMN c8")
       spark.sql(
         s"""insert into delta.`$tablePath` values
-           |(1, 1.0, 1.0, TIMESTAMP'2001-01-01 01:00', DATE'2001-01-01', 1.0),
-           |(2, 2.0, 2.0, TIMESTAMP'2002-02-02 02:00', DATE'2002-02-02', 2.0)
+           |(1, 1.0, 1.0, TIMESTAMP'2001-01-01 01:00', DATE'2001-01-01',
+           |1.0, TIMESTAMP_NTZ'2001-01-01 01:00'),
+           |(2, 2.0, 2.0, TIMESTAMP'2002-02-02 02:00', DATE'2002-02-02',
+           |2.0, TIMESTAMP_NTZ'2002-02-02 02:00')
            |""".stripMargin)
       checkSkipping(
         tablePath,
@@ -973,17 +979,17 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
           greaterThan(col("c4"), ofFloat(1.0f)),
           equals(col("c6"), ofDate(InternalUtils.daysSinceEpoch(Date.valueOf("2002-02-02")))),
           greaterThan(col("c9"), ofDecimal(JBigDecimal.valueOf(1.5), 3, 2)),
-          // We don't currently skip for timestamps but this will still be a hit once we do
-          getTimestampPredicate(">=", col("c5"), "2001-01-01T01:00:00-07:00"),
-          // Once we skip for timestamps this should be a miss
-          getTimestampPredicate(">=", col("c5"), "2003-01-01T01:00:00-07:00")
+          getTimestampPredicate(">=", col("c5"), "2001-01-01T01:00:00-07:00", "TIMESTAMP"),
+          getTimestampPredicate(">=", col("c10"), "2001-01-01T01:00:00-07:00", "TIMESTAMP_NTZ")
         ),
         misses = Seq(
           equals(col("c1"), ofInt(10)),
           lessThan(col("c3"), ofFloat(0.5f)),
           greaterThan(col("c4"), ofFloat(5.0f)),
           equals(col("c6"), ofDate(InternalUtils.daysSinceEpoch(Date.valueOf("2003-02-02")))),
-          greaterThan(col("c9"), ofDecimal(JBigDecimal.valueOf(2.5), 3, 2))
+          greaterThan(col("c9"), ofDecimal(JBigDecimal.valueOf(2.5), 3, 2)),
+          getTimestampPredicate(">=", col("c5"), "2003-01-01T01:00:00-07:00", "TIMESTAMP"),
+          getTimestampPredicate(">=", col("c10"), "2003-01-01T01:00:00-07:00", "TIMESTAMP_NTZ")
         )
       )
     }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
@@ -15,23 +15,23 @@
  */
 package io.delta.kernel.defaults.internal.expressions
 
+import io.delta.kernel.data.{ColumnVector, ColumnarBatch}
+import io.delta.kernel.defaults.internal.data.DefaultColumnarBatch
+import io.delta.kernel.defaults.internal.data.vector.{DefaultIntVector, DefaultStructVector}
+import io.delta.kernel.defaults.utils.DefaultKernelTestUtils.getValueAsObject
+import io.delta.kernel.expressions.AlwaysFalse.ALWAYS_FALSE
+import io.delta.kernel.expressions.AlwaysTrue.ALWAYS_TRUE
+import io.delta.kernel.expressions.Literal._
+import io.delta.kernel.expressions._
+import io.delta.kernel.internal.util.InternalUtils
+import io.delta.kernel.types._
+import org.scalatest.funsuite.AnyFunSuite
+
 import java.lang.{Boolean => BooleanJ}
 import java.math.{BigDecimal => BigDecimalJ}
 import java.sql.{Date, Timestamp}
 import java.util
 import java.util.Optional
-
-import io.delta.kernel.data.{ColumnarBatch, ColumnVector}
-import io.delta.kernel.defaults.internal.data.DefaultColumnarBatch
-import io.delta.kernel.defaults.internal.data.vector.{DefaultIntVector, DefaultStructVector}
-import io.delta.kernel.defaults.utils.DefaultKernelTestUtils.getValueAsObject
-import io.delta.kernel.expressions._
-import io.delta.kernel.expressions.AlwaysFalse.ALWAYS_FALSE
-import io.delta.kernel.expressions.AlwaysTrue.ALWAYS_TRUE
-import io.delta.kernel.expressions.Literal._
-import io.delta.kernel.internal.util.InternalUtils
-import io.delta.kernel.types._
-import org.scalatest.funsuite.AnyFunSuite
 
 class DefaultExpressionEvaluatorSuite extends AnyFunSuite with ExpressionSuiteBase {
   test("evaluate expression: literal") {
@@ -305,6 +305,80 @@ class DefaultExpressionEvaluatorSuite extends AnyFunSuite with ExpressionSuiteBa
     // TODO support other types besides boolean
     checkUnsupportedTypes(IntegerType.INTEGER, IntegerType.INTEGER,
       "Coalesce is only supported for boolean type expressions")
+  }
+
+  test("evaluate expression: TIMEADD with TIMESTAMP columns") {
+    val timestampColumn = timestampVector(Seq[Long](
+      1577836800000000L, // 2020-01-01 00:00:00.000
+      1577836800123456L, // 2020-01-01 00:00:00.123456
+      -1               // Representing null
+    ))
+
+    val durationColumn = longVector(Seq[Long](
+      1000,   // 1 second in milliseconds
+      100,    // 0.1 second in milliseconds
+      -1
+    ): _*)
+
+    val schema = new StructType()
+      .add("timestamp", TimestampType.TIMESTAMP)
+      .add("duration", LongType.LONG)
+
+    val batch = new DefaultColumnarBatch(
+      timestampColumn.getSize, schema, Array(timestampColumn, durationColumn))
+
+    // TimeAdd expression adds milliseconds to timestamps
+    val timeAddExpr = new ScalarExpression(
+      "TIMEADD",
+      util.Arrays.asList(new Column("timestamp"), new Column("duration"))
+    )
+
+    val expectedTimestamps = Seq[Long](
+      1577836801000000L, // 2020-01-01 00:00:01.000
+      1577836800123456L + 100000, // 2020-01-01 00:00:00.123556
+      -1                  // Null should propagate
+    )
+
+    val expOutputVector = timestampVector(expectedTimestamps)
+    val actOutputVector = evaluator(schema, timeAddExpr, TimestampType.TIMESTAMP).eval(batch)
+
+    checkTimestampVectors(actOutputVector, expOutputVector)
+  }
+
+  def checkUnsupportedTimeAddTypes(
+    col1Type: DataType, col2Type: DataType): Unit = {
+    val schema = new StructType()
+      .add("timestamp", col1Type)
+      .add("duration", col2Type)
+    val batch = new DefaultColumnarBatch(5, schema,
+      Array(testColumnVector(5, col1Type), testColumnVector(5, col2Type)))
+
+    val timeAddExpr = new ScalarExpression(
+      "TIMEADD",
+      util.Arrays.asList(new Column("timestamp"), new Column("duration"))
+    )
+
+    val e = intercept[IllegalArgumentException] {
+      val evaluator = new DefaultExpressionEvaluator(schema, timeAddExpr, col1Type)
+      evaluator.eval(batch)
+    }
+    assert(e.getMessage.contains("TIMEADD requires a timestamp and a Long"))
+  }
+
+  // Test to ensure TIMEADD requires the first argument to be a TimestampType
+  // and the second to be a LongType
+  test("TIMEADD with unsupported types") {
+    // Check invalid timestamp column type
+    checkUnsupportedTimeAddTypes(
+      IntegerType.INTEGER, IntegerType.INTEGER)
+
+    // Check invalid duration column type
+    checkUnsupportedTimeAddTypes(
+      TimestampType.TIMESTAMP, StringType.STRING)
+
+    // Check valid type but with unsupported operations
+    checkUnsupportedTimeAddTypes(
+      TimestampType.TIMESTAMP, FloatType.FLOAT)
   }
 
   test("evaluate expression: like") {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/ExpressionSuiteBase.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/ExpressionSuiteBase.scala
@@ -17,6 +17,7 @@ package io.delta.kernel.defaults.internal.expressions
 
 import io.delta.kernel.data.{ColumnVector, ColumnarBatch}
 import io.delta.kernel.defaults.internal.data.DefaultColumnarBatch
+import io.delta.kernel.defaults.utils.DefaultKernelTestUtils.getValueAsObject
 import io.delta.kernel.defaults.utils.{DefaultVectorTestUtils, TestUtils}
 import io.delta.kernel.expressions._
 import io.delta.kernel.types._
@@ -62,6 +63,19 @@ trait ExpressionSuiteBase extends TestUtils with DefaultVectorTestUtils {
           actual.getBoolean(rowId) === expected.getBoolean(rowId),
           s"unexpected value at $rowId"
         )
+      }
+    }
+  }
+
+  protected def checkTimestampVectors(actual: ColumnVector, expected: ColumnVector): Unit = {
+    assert(actual.getSize === expected.getSize)
+    for (rowId <- 0 until actual.getSize) {
+      if (expected.isNullAt(rowId)) {
+        assert(actual.isNullAt(rowId), s"Expected null at row $rowId")
+      } else {
+        val expectedValue = getValueAsObject(expected, rowId).asInstanceOf[Long]
+        val actualValue = getValueAsObject(actual, rowId).asInstanceOf[Long]
+        assert(actualValue === expectedValue, s"Unexpected value at row $rowId")
       }
     }
   }


### PR DESCRIPTION
…isecond truncation of Max statistics for accurate data skipping

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Addresses #2462. 
Adds a `TIMEADD` scalar expression to the data skipping logic. This addresses issues arising from TIMESTAMP being truncated to millisecond precision when serialized to JSON. For example, a file containing only `01:02:03.456789` will be written with `min == max == 01:02:03.456`, so we must consider it to contain the range from `01:02:03.456 to 01:02:03.457`.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Unit tests. 
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.