### PR TITLE
Do not leak column mapping metadata during streaming read 

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
@@ -108,7 +108,9 @@ class DeltaDataSource
         .getOrElse(snapshot.schema)
     }
 
-    val schemaToUse = DeltaTableUtils.removeInternalMetadata(sqlContext.sparkSession, readSchema)
+    val schemaToUse = DeltaColumnMapping.dropColumnMappingMetadata(
+      DeltaTableUtils.removeInternalMetadata(sqlContext.sparkSession, readSchema)
+    )
     if (schemaToUse.isEmpty) {
       throw DeltaErrors.schemaNotSetException
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -215,12 +215,13 @@ trait DeltaSourceBase extends Source
   @volatile protected var hasCheckedReadIncompatibleSchemaChangesOnStreamStart: Boolean = false
 
   override val schema: StructType = {
-    val schemaWithoutCDC = DeltaTableUtils.removeInternalMetadata(spark, readSchemaAtSourceInit)
-    if (options.readChangeFeed) {
-      CDCReader.cdcReadSchema(schemaWithoutCDC)
+    val readSchema = DeltaTableUtils.removeInternalMetadata(spark, readSchemaAtSourceInit)
+    val readSchemaWithCdc = if (options.readChangeFeed) {
+      CDCReader.cdcReadSchema(readSchema)
     } else {
-      schemaWithoutCDC
+      readSchema
     }
+    DeltaColumnMapping.dropColumnMappingMetadata(readSchemaWithCdc)
   }
 
   // A dummy empty dataframe that can be returned at various point during streaming

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
@@ -1991,4 +1991,51 @@ class DeltaColumnMappingSuite extends QueryTest
       )
     }
   }
+
+  testColumnMapping("stream read from column mapping does not leak metadata") { mode =>
+    withTempDir { dir =>
+      val (t1, t2, t3) = (
+        s"t1_${System.currentTimeMillis()}",
+        s"t2_${System.currentTimeMillis()}",
+        s"t3_${System.currentTimeMillis()}"
+      )
+      withTable(t1, t2, t3) {
+        // Create source table with column mapping mode and partitioning
+        sql(
+          s"""CREATE TABLE $t1 (a INT, b STRING)
+             |USING DELTA
+             |PARTITIONED BY (b)
+             |TBLPROPERTIES (
+             |  '${DeltaConfigs.COLUMN_MAPPING_MODE.key}' = '$mode',
+             |  '${DeltaConfigs.MIN_READER_VERSION.key}' = '2',
+             |  '${DeltaConfigs.MIN_WRITER_VERSION.key}' = '5'
+             |)
+             |""".stripMargin)
+        // Insert data into source table
+        sql(s"INSERT INTO $t1 VALUES (1, 'a'), (2, 'b')")
+
+        // Stream read from source table
+        val streamDf = spark.readStream.format("delta").table(t1)
+        // Should not contain column mapping metadata
+        assert(streamDf.schema.forall(_.metadata.isEmpty))
+
+        // Create and write to another table
+        val q = streamDf.writeStream
+          .partitionBy("b")
+          .trigger(org.apache.spark.sql.streaming.Trigger.AvailableNow())
+          .format("delta")
+          .option("checkpointLocation", new File(dir, "_checkpoint1").getCanonicalPath)
+          .toTable(t2)
+        q.awaitTermination()
+
+        // Check target table Delta log
+        val deltaLog = DeltaLog.forTable(spark, TableIdentifier(t2))
+        assert(deltaLog.update().metadata.schema.forall(_.metadata.isEmpty))
+        assert(deltaLog.update().metadata.columnMappingMode == NoMapping)
+
+        // Check target table data
+        checkAnswer(spark.table(t2), Seq(Row(1, "a"), Row(2, "b")))
+      }
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Column mapping metadata should be pruned during a streaming read, just like that of batch read.

## How was this patch tested?
New UT.

## Does this PR introduce _any_ user-facing changes?
No
