### PR TITLE
[Infra] Make `checkstyle` fail when there are style errors

### DIFF
--- a/project/Checkstyle.scala
+++ b/project/Checkstyle.scala
@@ -57,21 +57,19 @@ object Checkstyle {
     // and during tests (e.g. build/sbt test)
     Seq(
       checkstyleConfigLocation := CheckstyleConfigLocation.File(checkstyleFile),
-      // if we keep the Error severity, `build/sbt` will throw an error and immediately stop at
-      // the `checkstyle` phase (if error) -> never execute the `check-report` phase of
-      // `checkstyle-report.xml` and `checkstyle-test-report.xml`. We need to ignore and throw
-      // error if exists when checking *report.xml.
-      checkstyleSeverityLevel := CheckstyleSeverityLevel.Ignore,
+      checkstyleSeverityLevel := CheckstyleSeverityLevel.Error,
 
       compileJavastyle := {
-        (Compile / checkstyle).value
-        javaCheckstyle(streams.value.log, checkstyleOutputFile.value)
+        try {(Compile / checkstyle).value}
+        finally {javaCheckstyle(streams.value.log, checkstyleOutputFile.value)}
       },
       (Compile / compile) := ((Compile / compile) dependsOn compileJavastyle).value,
 
       testJavastyle := {
-        (Test / checkstyle).value
-        javaCheckstyle(streams.value.log, (Compile / target).value / "checkstyle-test-report.xml")
+        try {(Test / checkstyle).value}
+        finally {
+          javaCheckstyle(streams.value.log, (Compile / target).value / "checkstyle-test-report.xml")
+        }
       },
       (Test / test) := ((Test / test) dependsOn (Test / testJavastyle)).value
     )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [X] Other (INFRA)

## Description

https://github.com/delta-io/delta/pull/3115 added logging for the java style checks, but incidentally made it such that `kernelApi / checkstyle` doesn't fail when there are errors (only `kernelApi / compile` fails).

This PR makes it so that `kernelApi / checkstyle` will also fail, but it will NOT log the errors. 
- I can't find a way to override the `checkstyle` task defined by the plugin. I _can_ do it for `kernelApi / Compile / checkstyle` but that doesn't seem very helpful.

## How was this patch tested?

Checked the commands locally.