### PR TITLE
[Spark] Writing of UUID commits should not use put-if-absent semantics

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
@@ -154,7 +154,7 @@ object CoordinatedCommitsUtils extends DeltaLogging {
       actions: Iterator[String],
       uuid: String): FileStatus = {
     val commitPath = FileNames.unbackfilledDeltaFile(logPath, commitVersion, Some(uuid))
-    logStore.write(commitPath, actions.asJava, false, hadoopConf)
+    logStore.write(commitPath, actions.asJava, true, hadoopConf)
     commitPath.getFileSystem(hadoopConf).getFileStatus(commitPath)
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR fixes the coordinated commits utils to not write UUID-based commit files with put-if-absent semantics. This is not necessary because we assume that UUID-based commit files are globally unique so we will never have concurrent writers attempting to write the same commit file.

## How was this patch tested?

Existing tests are sufficient as this only affects how a commit is written in the underlying storage layer but does not change any logic in Delta Spark.

## Does this PR introduce _any_ user-facing changes?

No
