### PR TITLE
[Spark] Pass scala version as optional argument to configure_spark_with_delta_pip

### DIFF
--- a/python/delta/pip_utils.py
+++ b/python/delta/pip_utils.py
@@ -20,7 +20,8 @@ from pyspark.sql import SparkSession
 
 def configure_spark_with_delta_pip(
     spark_session_builder: SparkSession.Builder,
-    extra_packages: Optional[List[str]] = None
+    extra_packages: Optional[List[str]] = None,
+    scala_version: Optional[str] = "2.12"
 ) -> SparkSession.Builder:
     """
     Utility function to configure a SparkSession builder such that the generated SparkSession
@@ -74,7 +75,6 @@ See the online documentation for the correct usage of this function.
         '''
         raise Exception(msg) from e
 
-    scala_version = "2.12"
     maven_artifact = f"io.delta:delta-spark_{scala_version}:{delta_version}"
 
     extra_packages = extra_packages if extra_packages is not None else []


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
The PR passes scala version as optional argument to configure_spark_with_delta_pip instead of hard coding. With this approach users can either continue to work with scala version "2.12" without modifying their code or pass the version they are using in case different scala version is used

## How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Existing unit tests should continue to work as the PR doesn't contain breaking changes

## Does this PR introduce _any_ user-facing changes?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
