### PR TITLE
[Spark] Makes LogSegment comparison aware of coordinated commits

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.delta.DeltaConfigs.{CHECKPOINT_INTERVAL, COORDINATED
 import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
 import org.apache.spark.sql.delta.InitialSnapshot
+import org.apache.spark.sql.delta.LogSegment
 import org.apache.spark.sql.delta.Snapshot
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -37,7 +38,7 @@ import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
-import org.apache.spark.sql.delta.util.FileNames.{CompactedDeltaFile, DeltaFile}
+import org.apache.spark.sql.delta.util.FileNames.{CompactedDeltaFile, DeltaFile, UnbackfilledDeltaFile}
 import io.delta.storage.LogStore
 import io.delta.storage.commit.{CommitCoordinatorClient, CommitResponse, GetCommitsResponse => JGetCommitsResponse, UpdatedActions}
 import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
@@ -522,39 +523,95 @@ class CoordinatedCommitsSuite
       Seq(1).toDF.write.format("delta").mode("overwrite").save(tablePath)
       val log = DeltaLog.forTable(spark, tablePath)
       assert(getDeltasInPostCommitSnapshot(log) === Seq("0.json"))
-      log.update()
+      assert(log.unsafeVolatileSnapshot.getLastKnownBackfilledVersion == 0)
+      var snapshot = log.update()
       assert(getDeltasInPostCommitSnapshot(log) === Seq("0.json"))
+      assert(snapshot.getLastKnownBackfilledVersion == 0)
 
       // Commit 1
       Seq(2).toDF.write.format("delta").mode("append").save(tablePath) // version 1
+      // Note: The assert for backfillInterval = 1 only works because with a batch
+      // size of 1, the AbstractBatchBackfillingCommitCoordinator synchronously
+      // backfills a commit and then directly returns the backfilled commit information
+      // from the commit() call so the post commit snapshot creation directly appends
+      // the backfilled commit to the LogSegment.
+      //
+      // The expected behavior before update() is:
+      // Backfill interval 1 : post commit snapshot contains 0.json, 1.json, lkbv = 1
+      // Backfill interval 2 : post commit snapshot contains 0.json, 1.uuid.json, lkbv = 0
+      // Backfill interval 10: post commit snapshot contains 0.json, 1.uuid.json, lkbv = 0
       val commit1 = if (backfillInterval < 2) "1.json" else "1.uuid-1.json"
+      var backfillVersion = if (backfillInterval < 2) 1 else 0
       assert(getDeltasInPostCommitSnapshot(log) === Seq("0.json", commit1))
-      log.update()
+      assert(log.unsafeVolatileSnapshot.getLastKnownBackfilledVersion == backfillVersion)
+      snapshot = log.update()
+      // The expected behavior after update() is:
+      // Backfill interval 1 : post commit snapshot contains 0.json, 1.json, lkbv = 1
+      // Backfill interval 2 : post commit snapshot contains 0.json, 1.uuid.json, lkbv = 0
+      // Backfill interval 10: post commit snapshot contains 0.json, 1.uuid.json, lkbv = 0
       assert(getDeltasInPostCommitSnapshot(log) === Seq("0.json", commit1))
+      assert(snapshot.getLastKnownBackfilledVersion == backfillVersion)
 
       // Commit 2
       Seq(3).toDF.write.format("delta").mode("append").save(tablePath) // version 2
+      // The expected behavior before update() is:
+      // Backfill interval 1 : post commit snapshot contains
+      //   0.json, 1.json, 2.json lkbv = 2
+      // Backfill interval 2 : post commit snapshot contains
+      //   0.json, 1.uuid.json, 2.uuid.json lkbv = 0
+      // Backfill interval 10: post commit snapshot contains
+      //   0.json, 1.uuid.json, 2.uuid.json, lkbv = 0
       val commit2 = if (backfillInterval < 2) "2.json" else "2.uuid-2.json"
+      backfillVersion = if (backfillInterval < 2) 2 else 0
       assert(getDeltasInPostCommitSnapshot(log) === Seq("0.json", commit1, commit2))
-      log.update()
-      if (backfillInterval <= 2) {
-        // backfill would have happened at commit 2. Next deltaLog.update will pickup the backfilled
-        // files.
-        assert(getDeltasInPostCommitSnapshot(log) === Seq("0.json", "1.json", "2.json"))
-      } else {
-        assert(getDeltasInPostCommitSnapshot(log) ===
-          Seq("0.json", "1.uuid-1.json", "2.uuid-2.json"))
-      }
+      assert(log.unsafeVolatileSnapshot.getLastKnownBackfilledVersion == backfillVersion)
+      snapshot = log.update()
+      // backfill would have happened at commit 2 for batchSize = 2 but we do not swap
+      // the snapshot that contains the unbackfilled commits with the updated snapshot
+      // (which contains the backfilled commits) during update because they are identical
+      // and swapping would lead to losing the cached state. However, we update the
+      // effective last known backfilled version on the snapshot.
+      //
+      // The expected behavior after update is
+      // Backfill interval 1 : post commit snapshot contains
+      //   0.json, 1.json, 2.json lkbv = 2
+      // Backfill interval 2 : post commit snapshot contains
+      //   0.json, 1.uuid.json, 2.uuid.json lkbv = 0 lkbv = 2
+      // Backfill interval 10: post commit snapshot contains
+      //   0.json, 1.uuid.json, 2.uuid.json lkbv = 0
+      backfillVersion = if (backfillInterval <= 2) 2 else 0
+      assert(getDeltasInPostCommitSnapshot(log) === Seq("0.json", commit1, commit2))
+      assert(snapshot.getLastKnownBackfilledVersion == backfillVersion)
 
       // Commit 3
       Seq(4).toDF.write.format("delta").mode("append").save(tablePath)
       val commit3 = if (backfillInterval < 2) "3.json" else "3.uuid-3.json"
-      if (backfillInterval <= 2) {
-        assert(getDeltasInPostCommitSnapshot(log) === Seq("0.json", "1.json", "2.json", commit3))
-      } else {
-        assert(getDeltasInPostCommitSnapshot(log) ===
-          Seq("0.json", "1.uuid-1.json", "2.uuid-2.json", commit3))
-      }
+      // The post commit snapshot is a new snapshot and so its lastKnownBackfilledVersion
+      // member is calculated from the LogSegment. Given that the LogSegment for
+      // batchInterval > 1 only contains 0 as the only backfilled commit, we need
+      // to set the expected backfillVersion to 0 here for backfillIntervals > 1.
+      //
+      // The expected behavior before update() is:
+      // Backfill interval 1 : post commit snapshot contains
+      //   0.json, 1.json, 2.json, 3.json lkbv = 3
+      // Backfill interval 2 : post commit snapshot contains
+      //   0.json, 1.uuid.json, 2.uuid.json, 3.uuid.json lkbv = 0
+      // Backfill interval 10: post commit snapshot contains
+      //   0.json, 1.uuid.json, 2.uuid.json, 3.uuid.json lkbv = 0
+      backfillVersion = if (backfillInterval < 2) 3 else 0
+      assert(getDeltasInPostCommitSnapshot(log) === Seq("0.json", commit1, commit2, commit3))
+      assert(log.unsafeVolatileSnapshot.getLastKnownBackfilledVersion == backfillVersion)
+      snapshot = log.update()
+      // The expected behavior after update() is:
+      // Backfill interval 1 : post commit snapshot contains
+      //   0.json, 1.json, 2.json, 3.json lkbv = 3
+      // Backfill interval 2 : post commit snapshot contains
+      //   0.json, 1.uuid.json, 2.uuid.json, 3.uuid.json lkbv = 2
+      // Backfill interval 10: post commit snapshot contains
+      //   0.json, 1.uuid.json, 2.uuid.json, 3.uuid.json lkbv = 0
+      backfillVersion = if (backfillInterval < 2) 3 else if (backfillInterval == 2) 2 else 0
+      assert(getDeltasInPostCommitSnapshot(log) === Seq("0.json", commit1, commit2, commit3))
+      assert(snapshot.getLastKnownBackfilledVersion == backfillVersion)
 
       checkAnswer(sql(s"SELECT * FROM delta.`$tablePath`"), Seq(Row(1), Row(2), Row(3), Row(4)))
     }
@@ -1114,6 +1171,97 @@ class CoordinatedCommitsSuite
       assert(usageObj("numUnbackfilledFiles").asInstanceOf[Int] === 3)
       assert(usageObj("numAlreadyBackfilledFiles").asInstanceOf[Int] === 0)
     }
+  }
+
+  test("LogSegment comparison does not swap snapshots that only differ in " +
+    "backfilled/unbackfilled commits") {
+    // Use a batch size of two so we don't immediately backfill in
+    // the AbstractBatchBackfillingCommitCoordinatorClient and so the
+    // CommitResponse contains the UUID-based commit.
+    CommitCoordinatorProvider.registerBuilder(
+      TrackingInMemoryCommitCoordinatorBuilder(batchSize = 2))
+
+    withTempDir { tempDir =>
+      val tablePath = tempDir.getAbsolutePath
+      val log = DeltaLog.forTable(spark, tablePath)
+
+      // Version 0 -- backfilled by default
+      makeCommitAndAssertSnapshotState(
+        data = Seq(0),
+        expectedLastKnownBackfilledVersion = 0,
+        expectedNumUnbackfilledCommits = 0,
+        expectedLastKnownBackfilledFile = FileNames.unsafeDeltaFile(log.logPath, 0),
+        log, tablePath)
+      // Version 1 -- not backfilled immediately because of batchSize = 2
+      makeCommitAndAssertSnapshotState(
+        data = Seq(1),
+        expectedLastKnownBackfilledVersion = 0,
+        expectedNumUnbackfilledCommits = 1,
+        expectedLastKnownBackfilledFile = FileNames.unsafeDeltaFile(log.logPath, 0),
+        log, tablePath)
+      // Version 2 -- backfills versions 1 and 2
+      makeCommitAndAssertSnapshotState(
+        data = Seq(2),
+        expectedLastKnownBackfilledVersion = 2,
+        expectedNumUnbackfilledCommits = 2,
+        expectedLastKnownBackfilledFile = FileNames.unsafeDeltaFile(log.logPath, 0),
+        log, tablePath)
+      // Version 3 -- not backfilled immediately because of batchSize = 2
+      makeCommitAndAssertSnapshotState(
+        data = Seq(3),
+        expectedLastKnownBackfilledVersion = 2,
+        expectedNumUnbackfilledCommits = 3,
+        expectedLastKnownBackfilledFile = FileNames.unsafeDeltaFile(log.logPath, 0),
+        log, tablePath)
+      // Version 4 -- backfills versions 3 and 4
+      makeCommitAndAssertSnapshotState(
+        data = Seq(4),
+        expectedLastKnownBackfilledVersion = 4,
+        expectedNumUnbackfilledCommits = 4,
+        expectedLastKnownBackfilledFile = FileNames.unsafeDeltaFile(log.logPath, 0),
+        log, tablePath)
+      // Trigger a checkpoint
+      log.checkpoint(log.update())
+      // Version 5 -- not backfilled immediately because of batchSize 2
+      makeCommitAndAssertSnapshotState(
+        data = Seq(5),
+        expectedLastKnownBackfilledVersion = 4,
+        expectedNumUnbackfilledCommits = 1,
+        expectedLastKnownBackfilledFile = FileNames.checkpointFileSingular(log.logPath, 4),
+        log, tablePath)
+      // Version 6 -- backfills versions 5 and 6
+      makeCommitAndAssertSnapshotState(
+        data = Seq(6),
+        expectedLastKnownBackfilledVersion = 6,
+        expectedNumUnbackfilledCommits = 2,
+        expectedLastKnownBackfilledFile = FileNames.checkpointFileSingular(log.logPath, 4),
+        log, tablePath)
+    }
+  }
+
+  private def makeCommitAndAssertSnapshotState(
+      data: Seq[Long],
+      expectedLastKnownBackfilledVersion: Long,
+      expectedNumUnbackfilledCommits: Long,
+      expectedLastKnownBackfilledFile: Path,
+      log: DeltaLog,
+      tablePath: String): Unit = {
+    data.toDF().write.format("delta").mode("overwrite").save(tablePath)
+    val snapshot = log.update()
+    val segment = snapshot.logSegment
+    var numUnbackfilledCommits = 0
+    segment.deltas.foreach {
+      case UnbackfilledDeltaFile(_, _, _) => numUnbackfilledCommits += 1
+      case _ => // do nothing
+    }
+    assert(snapshot.getLastKnownBackfilledVersion == expectedLastKnownBackfilledVersion)
+    assert(numUnbackfilledCommits == expectedNumUnbackfilledCommits)
+    val lastKnownBackfilledFile = CoordinatedCommitsUtils
+      .getLastBackfilledFile(segment.deltas).getOrElse(
+        segment.checkpointProvider.topLevelFiles.head
+      )
+    assert(lastKnownBackfilledFile.getPath == expectedLastKnownBackfilledFile,
+      s"$lastKnownBackfilledFile did not equal $expectedLastKnownBackfilledFile")
   }
 
   for (ignoreMissingCCImpl <- BOOLEAN_DOMAIN)


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR updates the comparison (equals) method of LogSegments to consider coordinated commits. The reason for this change is as follows: The current comparison logic determines whether a LogSegment is equal to another LogSegment, if the deltas match and the modification time of the last delta is equal for both LogSegments. However, on a coordinated commits table, this may not be true anymore. This is because after a commit, we update the LogSegment by appending the last commit to it to create the post commit snapshot. In a coordinated commits table, this will be a UUID commit. However, by the next time DeltaLog.update is called, that UUID commit could have already been backfilled and so the LogSegment determined as part of the update call will contain the backfilled commit, which will have a different modification time compared to its UUID counterpart. As a result, even though the LogSegments represent identical table states, they would be identified as different.

The problem is that if we determine that the LogSegment from the previous snapshot is different to the LogSegment created by update, we will swap the old snapshot with the new snapshot. However, if these are indeed identical, then the swapping is not necessary and leads to Delta losing any cached state on the swapped out snapshot. This can lead to unnecessary slowdowns.

This PR fixes this issue by updating the LogSegment comparison logic. Instead of comparing the last file in the segment, we compare the minimum last backfilled file across both segments. For example, if segment 1 contains files 0.json, 1.json, 2.uuid.json, and 3.uuid.json and segment 2 contains 0.json, 1.json, 2.json, and 3.json, we compare 1.json and if that matches in both segments, we assume that the segments are equal (they also need to match in length of their deltas).

In addition to the LogSegment comparison fix, we also introduce a new member on Snapshot, that captures the correct last known backfilled version. In the example above, segment 1 would report 1.json as the last known backfilled version but segment 2 already contains 3.json as the last known backfilled version. To correctly determine, whether all commits for a specific table version (snapshot) have been backfilled, we update this state on the snapshot whenever we detect a stale LogSegment.

## How was this patch tested?

Updated existing and added new unit tests.

## Does this PR introduce _any_ user-facing changes?

No
