### PR TITLE
Testing if increasing parallelism helps as a baseline

### DIFF
--- a/.github/workflows/spark_master_test.yaml
+++ b/.github/workflows/spark_master_test.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Run Spark Master tests
         # when changing TEST_PARALLELISM_COUNT make sure to also change it in spark_test.yaml
         run: |
-          TEST_PARALLELISM_COUNT=2 build/sbt -DsparkVersion=master "++ ${{ matrix.scala }}" clean spark/test
+          TEST_PARALLELISM_COUNT=4 build/sbt -DsparkVersion=master "++ ${{ matrix.scala }}" clean spark/test
           TEST_PARALLELISM_COUNT=2 build/sbt -DsparkVersion=master "++ ${{ matrix.scala }}" clean connectServer/test
           TEST_PARALLELISM_COUNT=2 build/sbt -DsparkVersion=master "++ ${{ matrix.scala }}" clean connectServer/assembly connectClient/test
         if: steps.git-diff.outputs.diff

--- a/.github/workflows/spark_test.yaml
+++ b/.github/workflows/spark_test.yaml
@@ -78,5 +78,5 @@ jobs:
       - name: Run Scala/Java and Python tests
         # when changing TEST_PARALLELISM_COUNT make sure to also change it in spark_master_test.yaml
         run: |
-          TEST_PARALLELISM_COUNT=2 pipenv run python run-tests.py --group spark
+          TEST_PARALLELISM_COUNT=4 pipenv run python run-tests.py --group spark
         if: steps.git-diff.outputs.diff

--- a/build.sbt
+++ b/build.sbt
@@ -447,7 +447,8 @@ lazy val spark = (project in file("spark"))
       "-Ddelta.log.cacheSize=3",
       "-Dspark.databricks.delta.delta.log.cacheSize=3",
       "-Dspark.sql.sources.parallelPartitionDiscovery.parallelism=5",
-      "-Xmx1024m"
+      "-Xmx1024m",
+      "-Dsbt.task.timings=true"
     ),
 
     // Required for testing table features see https://github.com/delta-io/delta/issues/1602


### PR DESCRIPTION
I'm just testing to see implications of bumping parallelism for spark tests, and to see if/how much it reduces spark tests as a baseline