### PR TITLE
[Kernel] Always read the checkpoint manifest for CPV2 if sidecar files are present

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActionsIterator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActionsIterator.java
@@ -209,7 +209,7 @@ class ActionsIterator implements CloseableIterator<ActionWrapper> {
                       .readParquetFiles(
                           singletonCloseableIterator(file),
                           finalModifiedReadSchema,
-                              checkpointPredicateIncludingSidecars),
+                          checkpointPredicateIncludingSidecars),
               "Reading parquet log file `%s` with readSchema=%s and predicate=%s",
               file,
               modifiedReadSchema,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActionsIterator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActionsIterator.java
@@ -27,6 +27,8 @@ import static io.delta.kernel.internal.util.Utils.toCloseableIterator;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.engine.Engine;
+import io.delta.kernel.expressions.Column;
+import io.delta.kernel.expressions.Or;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.internal.checkpoints.SidecarFile;
 import io.delta.kernel.internal.fs.Path;
@@ -185,6 +187,17 @@ class ActionsIterator implements CloseableIterator<ActionWrapper> {
 
     long checkpointVersion = checkpointVersion(file.getPath());
 
+    // If the read schema contains Add/Remove files, we should always read the sidecar file
+    // actions from the checkpoint manifest regardless of the checkpoint predicate.
+    Optional<Predicate> checkpointPredicateIncludingSidecars;
+    if (schemaContainsAddOrRemoveFiles) {
+      Predicate containsSidecarPredicate =
+              new Predicate("IS_NOT_NULL", new Column(LogReplay.SIDECAR_FIELD_NAME));
+      checkpointPredicateIncludingSidecars =
+              checkpointPredicate.map(p -> new Or(p, containsSidecarPredicate));
+    } else {
+      checkpointPredicateIncludingSidecars = checkpointPredicate;
+    }
     final CloseableIterator<ColumnarBatch> topLevelIter;
     StructType finalModifiedReadSchema = modifiedReadSchema;
     if (fileName.endsWith(".parquet")) {
@@ -196,11 +209,11 @@ class ActionsIterator implements CloseableIterator<ActionWrapper> {
                       .readParquetFiles(
                           singletonCloseableIterator(file),
                           finalModifiedReadSchema,
-                          checkpointPredicate),
+                              checkpointPredicateIncludingSidecars),
               "Reading parquet log file `%s` with readSchema=%s and predicate=%s",
               file,
               modifiedReadSchema,
-              checkpointPredicate);
+              checkpointPredicateIncludingSidecars);
     } else if (fileName.endsWith(".json")) {
       topLevelIter =
           wrapEngineExceptionThrowsIO(
@@ -210,11 +223,11 @@ class ActionsIterator implements CloseableIterator<ActionWrapper> {
                       .readJsonFiles(
                           singletonCloseableIterator(file),
                           finalModifiedReadSchema,
-                          checkpointPredicate),
+                          checkpointPredicateIncludingSidecars),
               "Reading JSON log file `%s` with readSchema=%s and predicate=%s",
               file,
               modifiedReadSchema,
-              checkpointPredicate);
+              checkpointPredicateIncludingSidecars);
     } else {
       throw new IOException("Unrecognized top level v2 checkpoint file format: " + fileName);
     }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActionsIterator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActionsIterator.java
@@ -27,9 +27,7 @@ import static io.delta.kernel.internal.util.Utils.toCloseableIterator;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.engine.Engine;
-import io.delta.kernel.expressions.Column;
-import io.delta.kernel.expressions.Or;
-import io.delta.kernel.expressions.Predicate;
+import io.delta.kernel.expressions.*;
 import io.delta.kernel.internal.checkpoints.SidecarFile;
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.util.*;
@@ -192,9 +190,9 @@ class ActionsIterator implements CloseableIterator<ActionWrapper> {
     Optional<Predicate> checkpointPredicateIncludingSidecars;
     if (schemaContainsAddOrRemoveFiles) {
       Predicate containsSidecarPredicate =
-              new Predicate("IS_NOT_NULL", new Column(LogReplay.SIDECAR_FIELD_NAME));
+          new Predicate("IS_NOT_NULL", new Column(LogReplay.SIDECAR_FIELD_NAME));
       checkpointPredicateIncludingSidecars =
-              checkpointPredicate.map(p -> new Or(p, containsSidecarPredicate));
+          checkpointPredicate.map(p -> new Or(p, containsSidecarPredicate));
     } else {
       checkpointPredicateIncludingSidecars = checkpointPredicate;
     }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/CheckpointV2ReadSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/CheckpointV2ReadSuite.scala
@@ -20,7 +20,8 @@ import java.io.File
 import scala.collection.JavaConverters._
 
 import io.delta.kernel.defaults.engine.DefaultEngine
-import io.delta.kernel.defaults.utils.{TestRow, TestUtils}
+import io.delta.kernel.defaults.utils.{ExpressionTestUtils, TestRow, TestUtils}
+import io.delta.kernel.expressions.Literal
 import io.delta.kernel.internal.checkpoints.CheckpointInstance
 import io.delta.kernel.internal.{InternalScanFileUtils, SnapshotImpl}
 import io.delta.tables.DeltaTable
@@ -36,7 +37,7 @@ import org.apache.spark.sql.delta.test.DeltaTestImplicits.OptimisticTxnTestHelpe
 import org.apache.spark.sql.delta.util.FileNames
 import org.apache.spark.sql.types.{BooleanType, IntegerType, LongType, MapType, StringType, StructType}
 
-class CheckpointV2ReadSuite extends AnyFunSuite with TestUtils {
+class CheckpointV2ReadSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils {
   private final val supportedFileFormats = Seq("json", "parquet")
 
   override lazy val defaultEngine = DefaultEngine.create(new Configuration() {
@@ -47,9 +48,12 @@ class CheckpointV2ReadSuite extends AnyFunSuite with TestUtils {
     }
   })
 
-  def createSourceTable(tbl: String, path: String): Unit = {
-    spark.sql(s"CREATE TABLE $tbl (a INT, b STRING) USING delta CLUSTER BY (a) " +
-      s"LOCATION '$path' " +
+  def createSourceTable(
+      tbl: String,
+      path: String,
+      partitionOrClusteringSpec: String): Unit = {
+    spark.sql(s"CREATE TABLE $tbl (a INT, b STRING) USING delta " +
+      s"$partitionOrClusteringSpec BY (a) LOCATION '$path' " +
       s"TBLPROPERTIES ('delta.checkpointInterval' = '2', 'delta.checkpointPolicy'='v2')")
     spark.sql(s"INSERT INTO $tbl VALUES (1, 'a'), (2, 'b')")
     spark.sql(s"INSERT INTO $tbl VALUES (3, 'c'), (4, 'd')")
@@ -113,7 +117,7 @@ class CheckpointV2ReadSuite extends AnyFunSuite with TestUtils {
           // Create table.
           withSQLConf(DeltaSQLConf.CHECKPOINT_V2_TOP_LEVEL_FILE_FORMAT.key -> format,
             "spark.databricks.delta.clusteredTable.enableClusteringTablePreview" -> "true") {
-            createSourceTable(tbl, path.toString)
+            createSourceTable(tbl, path.toString, "CLUSTER")
 
             // Insert more data to ensure multiple ColumnarBatches created.
             spark.createDataFrame(
@@ -152,7 +156,7 @@ class CheckpointV2ReadSuite extends AnyFunSuite with TestUtils {
           withSQLConf(DeltaSQLConf.CHECKPOINT_V2_TOP_LEVEL_FILE_FORMAT.key -> format,
             DeltaSQLConf.DELTA_CHECKPOINT_PART_SIZE.key -> "1", // Ensure 1 action per checkpoint.
             "spark.databricks.delta.clusteredTable.enableClusteringTablePreview" -> "true") {
-            createSourceTable(tbl, path.toString)
+            createSourceTable(tbl, path.toString, "CLUSTER")
           }
 
           // Validate snapshot and data.
@@ -186,7 +190,7 @@ class CheckpointV2ReadSuite extends AnyFunSuite with TestUtils {
           withSQLConf(DeltaSQLConf.CHECKPOINT_V2_TOP_LEVEL_FILE_FORMAT.key -> format,
             DeltaSQLConf.DELTA_CHECKPOINT_PART_SIZE.key -> "1", // Ensure 1 action per checkpoint.
             "spark.databricks.delta.clusteredTable.enableClusteringTablePreview" -> "true") {
-            createSourceTable(tbl, path.toString)
+            createSourceTable(tbl, path.toString, "CLUSTER")
           }
 
           // Evalute Spark result before updating sidecar.
@@ -274,7 +278,7 @@ class CheckpointV2ReadSuite extends AnyFunSuite with TestUtils {
         withSQLConf(DeltaSQLConf.CHECKPOINT_V2_TOP_LEVEL_FILE_FORMAT.key -> "parquet",
           "spark.databricks.delta.clusteredTable.enableClusteringTablePreview" -> "true") {
           spark.conf.set(DeltaSQLConf.CHECKPOINT_V2_TOP_LEVEL_FILE_FORMAT.key, "parquet")
-          createSourceTable(tbl, path.toString)
+          createSourceTable(tbl, path.toString, "CLUSTER")
         }
 
         // Spark snapshot and files must be evaluated before renaming the checkpoint file.
@@ -294,6 +298,22 @@ class CheckpointV2ReadSuite extends AnyFunSuite with TestUtils {
           path = path.toString,
           expectedAnswer = (1 to 6).map(i => TestRow(i, (i - 1 + 'a').toChar.toString))
         )
+      }
+    }
+  }
+
+  test("read from table with partition predicates") {
+    withTempDir { path =>
+      val tbl = "tbl"
+      withTable(tbl) {
+        // Create source table with schema (a INT, b STRING) partitioned by a.
+        createSourceTable(tbl, path.toString, "PARTITIONED")
+
+        // Read from the source table with a partition predicate and validate the results.
+        val result = readSnapshot(
+          latestSnapshot(path.toString),
+          filter = greaterThan(col("a"), Literal.ofInt(3)))
+        checkAnswer(result, Seq(TestRow(4, "d"), TestRow(5, "e"), TestRow(6, "f")))
       }
     }
   }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/PartitionPruningSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/PartitionPruningSuite.scala
@@ -263,6 +263,28 @@ class PartitionPruningSuite extends AnyFunSuite with TestUtils with ExpressionTe
     }
   }
 
+  test("partition pruning from checkpoint") {
+    withTempDir { path =>
+      val tbl = "tbl"
+      withTable(tbl) {
+        // Create partitioned table and insert some data, ensuring that a checkpoint is created
+        // after the last insertion.
+        spark.sql(s"CREATE TABLE $tbl (a INT, b STRING) USING delta " +
+          s"PARTITIONED BY (a) LOCATION '$path' " +
+          s"TBLPROPERTIES ('delta.checkpointInterval' = '2')")
+        spark.sql(s"INSERT INTO $tbl VALUES (1, 'a'), (2, 'b')")
+        spark.sql(s"INSERT INTO $tbl VALUES (3, 'c'), (4, 'd')")
+        spark.sql(s"INSERT INTO $tbl VALUES (5, 'e'), (6, 'f')")
+
+        // Read from the source table with a partition predicate and validate the results.
+        val result = readSnapshot(
+          latestSnapshot(path.toString),
+          filter = greaterThan(col("a"), Literal.ofInt(3)))
+        checkAnswer(result, Seq(TestRow(4, "d"), TestRow(5, "e"), TestRow(6, "f")))
+      }
+    }
+  }
+
   private def readUsingSpark(tablePath: String, predicate: String): Seq[TestRow] = {
     val where = if (predicate.isEmpty) "" else s"WHERE $predicate"
     spark.sql(s"SELECT * FROM delta.`$tablePath` $where")


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description
The sidecar actions in the checkpoint manifest of a CPV2 table should always be read regardless of the checkpoint predicate, as actions satisfying the predicate may be found in the sidecar file.

## How was this patch tested?
See added test.

## Does this PR introduce _any_ user-facing changes?
No.