### PR TITLE
[Kernel][Defaults] Add field id validation when writing data to Parquet files

### DIFF
--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetSchemaUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetSchemaUtils.java
@@ -422,8 +422,8 @@ class ParquetSchemaUtils {
   }
 
   /**
-   * Validator for checking that the field ids in the schema. As any schema visitor goes through the
-   * schema {@link StructType}, the visitor can call this validator to check:
+   * Validator for checking that the field ids in the schema are valid. Any visitor that recursively
+   * visits the fields in the schema {@link StructType} can call this validator to check:
    *
    * <ul>
    *   <li>Field ids should be unique within the schema.
@@ -444,7 +444,7 @@ class ParquetSchemaUtils {
     AtomicBoolean seenFieldWithNoId = new AtomicBoolean();
     AtomicBoolean seenFieldWithId = new AtomicBoolean();
     AtomicBoolean seenNestedFieldWithId = new AtomicBoolean();
-    AtomicBoolean seemNestedWithWithNoId = new AtomicBoolean();
+    AtomicBoolean seemNestedWithNoId = new AtomicBoolean();
 
     return (fieldIdOpt, isNestedFieldId) -> {
       if (fieldIdOpt.isPresent()) {
@@ -454,7 +454,7 @@ class ParquetSchemaUtils {
         if (isNestedFieldId) {
           seenNestedFieldWithId.set(true);
           checkArgument(
-              !seemNestedWithWithNoId.get() && !seenFieldWithNoId.get(),
+              !seemNestedWithNoId.get() && !seenFieldWithNoId.get(),
               "Some of the fields are missing field ids.\n%s",
               structType);
         } else {
@@ -466,7 +466,7 @@ class ParquetSchemaUtils {
         }
       } else {
         if (isNestedFieldId) {
-          seemNestedWithWithNoId.set(true);
+          seemNestedWithNoId.set(true);
           checkArgument(
               !seenNestedFieldWithId.get() && !seenFieldWithId.get(),
               "Some of the fields are missing field ids.\n%s",

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetSchemaUtilsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetSchemaUtilsSuite.scala
@@ -19,9 +19,10 @@ import io.delta.kernel.defaults.internal.parquet.ParquetSchemaUtils.pruneSchema
 import io.delta.kernel.defaults.utils.TestUtils
 import io.delta.kernel.internal.util.ColumnMapping
 import io.delta.kernel.internal.util.ColumnMapping.PARQUET_FIELD_NESTED_IDS_METADATA_KEY
-import io.delta.kernel.types.{ArrayType, DoubleType, FieldMetadata, IntegerType, LongType, MapType, StructType}
+import io.delta.kernel.types.IntegerType.INTEGER
+import io.delta.kernel.types.LongType.LONG
+import io.delta.kernel.types.{ArrayType, DoubleType, FieldMetadata, MapType, StructType}
 import org.apache.parquet.schema.MessageTypeParser
-import org.apache.spark.sql.types.StructField
 import org.scalatest.funsuite.AnyFunSuite
 
 class ParquetSchemaUtilsSuite extends AnyFunSuite with TestUtils {
@@ -54,17 +55,17 @@ class ParquetSchemaUtilsSuite extends AnyFunSuite with TestUtils {
   private val testParquetFileDeltaSchema = new StructType()
     .add("f0",
       new StructType()
-        .add("f00", IntegerType.INTEGER, fieldMetadata(2))
-        .add("f01", LongType.LONG, fieldMetadata(3)),
+        .add("f00", INTEGER, fieldMetadata(2))
+        .add("f01", LONG, fieldMetadata(3)),
       fieldMetadata(1))
-    .add("f1", new ArrayType(IntegerType.INTEGER, false), fieldMetadata(4))
+    .add("f1", new ArrayType(INTEGER, false), fieldMetadata(4))
     .add(
       "f2",
       new MapType(
         new StructType()
-          .add("key_f0", IntegerType.INTEGER, fieldMetadata(10))
-          .add("key_f1", IntegerType.INTEGER, fieldMetadata(11)),
-        IntegerType.INTEGER,
+          .add("key_f0", INTEGER, fieldMetadata(10))
+          .add("key_f1", INTEGER, fieldMetadata(11)),
+        INTEGER,
         false
       ),
       fieldMetadata(7))
@@ -82,7 +83,7 @@ class ParquetSchemaUtilsSuite extends AnyFunSuite with TestUtils {
       .add( // nested column pruning
         "f0",
         new StructType()
-          .add("f00", IntegerType.INTEGER, fieldMetadata(2)),
+          .add("f00", INTEGER, fieldMetadata(2)),
         fieldMetadata(1)
       )
 
@@ -109,11 +110,11 @@ class ParquetSchemaUtilsSuite extends AnyFunSuite with TestUtils {
       .add( // nested column has extra column that is not present in the file
         "f0",
         new StructType()
-          .add("f00", IntegerType.INTEGER, fieldMetadata(2))
-          .add("f02", IntegerType.INTEGER, fieldMetadata(15)),
+          .add("f00", INTEGER, fieldMetadata(2))
+          .add("f02", INTEGER, fieldMetadata(15)),
         fieldMetadata(1)
       )
-      .add("f4", IntegerType.INTEGER, fieldMetadata(14))
+      .add("f4", INTEGER, fieldMetadata(14))
 
     // pruned parquet file schema shouldn't have the column "f4"
     val expectedParquetSchema = MessageTypeParser.parseMessageType(
@@ -139,8 +140,8 @@ class ParquetSchemaUtilsSuite extends AnyFunSuite with TestUtils {
       .add( // nested column has extra column that is not present in the file
         "f0",
         new StructType()
-          .add("F00", IntegerType.INTEGER) // no field id and with case-insensitive column name
-          .add("f01", IntegerType.INTEGER, fieldMetadata(3))
+          .add("F00", INTEGER) // no field id and with case-insensitive column name
+          .add("f01", INTEGER, fieldMetadata(3))
         // no field id for struct f0
       )
 
@@ -170,7 +171,7 @@ class ParquetSchemaUtilsSuite extends AnyFunSuite with TestUtils {
         "f0",
         new StructType()
           // physical name in the file is f00, but the same field id
-          .add("f00_new", IntegerType.INTEGER, fieldMetadata(2)),
+          .add("f00_new", INTEGER, fieldMetadata(2)),
         fieldMetadata(1)
       )
 
@@ -211,7 +212,7 @@ class ParquetSchemaUtilsSuite extends AnyFunSuite with TestUtils {
       .add(
         "f0",
         new StructType()
-          .add("f00", IntegerType.INTEGER, fieldMetadata(2)),
+          .add("f00", INTEGER, fieldMetadata(2)),
         fieldMetadata(1)
       )
 
@@ -241,8 +242,8 @@ class ParquetSchemaUtilsSuite extends AnyFunSuite with TestUtils {
       new StructType()
         .add("f0",
           new StructType()
-            .add("f00", new ArrayType(LongType.LONG, false), fieldMetadata(2, ("f00.element", 3)))
-            .add("f01", new MapType(IntegerType.INTEGER, IntegerType.INTEGER, true),
+            .add("f00", new ArrayType(LONG, false), fieldMetadata(2, ("f00.element", 3)))
+            .add("f01", new MapType(INTEGER, INTEGER, true),
               fieldMetadata(4, ("f01.key", 5), ("f01.value", 6))),
           fieldMetadata(1)),
       // Expected parquet schema
@@ -268,14 +269,14 @@ class ParquetSchemaUtilsSuite extends AnyFunSuite with TestUtils {
       // Delta schema - input
       new StructType()
         .add("f1",
-          new ArrayType(IntegerType.INTEGER, true),
+          new ArrayType(INTEGER, true),
           fieldMetadata(1, ("f1.element", 2)))
         .add("f2",
           new MapType(
             new StructType()
-              .add("key_f0", IntegerType.INTEGER, fieldMetadata(6))
-              .add("key_f1", IntegerType.INTEGER, fieldMetadata(7)),
-            IntegerType.INTEGER,
+              .add("key_f0", INTEGER, fieldMetadata(6))
+              .add("key_f1", INTEGER, fieldMetadata(7)),
+            INTEGER,
             true
           ),
           fieldMetadata(3, ("f2.key", 4), ("f2.value", 5))),
@@ -302,18 +303,18 @@ class ParquetSchemaUtilsSuite extends AnyFunSuite with TestUtils {
       // Delta schema - input
       new StructType()
         .add("f3",
-          new ArrayType(new ArrayType(IntegerType.INTEGER, false), false),
+          new ArrayType(new ArrayType(INTEGER, false), false),
           fieldMetadata(0, ("f3.element", 1), ("f3.element.element", 2)))
         .add("f4",
           new MapType(
             new MapType(
               new StructType()
-                .add("key_f0", IntegerType.INTEGER, fieldMetadata(3))
-                .add("key_f1", IntegerType.INTEGER, fieldMetadata(4)),
-              IntegerType.INTEGER,
+                .add("key_f0", INTEGER, fieldMetadata(3))
+                .add("key_f1", INTEGER, fieldMetadata(4)),
+              INTEGER,
               false
             ),
-            IntegerType.INTEGER,
+            INTEGER,
             false
           ),
           fieldMetadata(5,
@@ -349,6 +350,100 @@ class ParquetSchemaUtilsSuite extends AnyFunSuite with TestUtils {
     test(s"icebergCompatV2 - nested fields are converted to parquet schema - $testName") {
       val actParquetSchema = ParquetSchemaUtils.toParquetSchema(deltaSchema)
       assert(actParquetSchema === expectedParquetSchema)
+    }
+  }
+
+  Seq(
+    (
+      "field id validation: no negative field id",
+      // Delta schema - input
+      new StructType()
+        .add("f0",
+          new StructType()
+            .add("f00", new ArrayType(LONG, false), fieldMetadata(-1))
+            .add("f01", new MapType(INTEGER, INTEGER, true), fieldMetadata(4)),
+          fieldMetadata(1)),
+      // Expected error message
+      "Field id should be non-negative."
+    ),
+    (
+      "field id validation: no negative nested field id",
+      // Delta schema - input
+      new StructType()
+        .add("f0",
+          new StructType()
+            .add("f00", new ArrayType(LONG, false), fieldMetadata(1, ("f00.element", -1)))
+            .add("f01", new MapType(INTEGER, INTEGER, true), fieldMetadata(4)),
+          fieldMetadata(0)),
+      // Expected error message
+      "Field id should be non-negative."
+    ),
+    (
+      "field id validation: no duplicate field id",
+      // Delta schema - input
+      new StructType()
+        .add("f0",
+          new StructType()
+            .add("f00", new ArrayType(LONG, false), fieldMetadata(1, ("f00.element", 1)))
+            .add("f01", new MapType(INTEGER, INTEGER, true), fieldMetadata(4)),
+          fieldMetadata(1)),
+      // Expected error message
+      "Field id should be unique."
+    ),
+    (
+      "field id validation: no duplicate nested field id",
+      // Delta schema - input
+      new StructType()
+        .add("f0",
+          new StructType()
+            .add("f00", new ArrayType(LONG, false), fieldMetadata(1, ("f00.element", 2)))
+            .add("f01", new MapType(INTEGER, INTEGER, true), fieldMetadata(2)),
+          fieldMetadata(1)),
+      // Expected error message
+      "Field id should be unique."
+    ),
+    (
+      "field id validation: missing field ids",
+      // Delta schema - input
+      new StructType()
+        .add("f0",
+          new StructType()
+            .add("f00", new ArrayType(LONG, false))
+            .add("f01", new MapType(INTEGER, INTEGER, true), fieldMetadata(4)),
+          fieldMetadata(1)),
+      // Expected error message
+      "Some of the fields are missing field ids."
+    ),
+    (
+      "field id validation: missing nested field ids",
+      // Delta schema - input
+      new StructType()
+        .add("f0",
+          new StructType()
+            .add("f00", new ArrayType(LONG, false), fieldMetadata(1, ("f00.element", 2)))
+            .add("f01", new MapType(INTEGER, INTEGER, true), fieldMetadata(4)), // missing nested id
+          fieldMetadata(0)),
+      // Expected error message
+      "Some of the fields are missing field ids."
+    ),
+    (
+      "field id validation: missing field ids but have nested fields",
+      // Delta schema - input
+      new StructType()
+        .add("f0",
+          new StructType()
+            .add("f00", new ArrayType(LONG, false), fieldMetadata(1, ("f00.element", 2)))
+            .add("f01", new MapType(INTEGER, INTEGER, true), fieldMetadata(4, ("f01.key", 5)))
+        ), // missing field id for f0
+      // Expected error message
+      "Some of the fields are missing field ids."
+    )
+  ).foreach { case (testName, deltaSchema, expectedErrorMsg) =>
+    test(testName) {
+      val ex = intercept[IllegalArgumentException] {
+        ParquetSchemaUtils.toParquetSchema(deltaSchema)
+      }
+      assert(ex.getMessage.contains(expectedErrorMsg))
     }
   }
 


### PR DESCRIPTION
## Description
(stacked on top of #3504, see the latest commit)

Add validation of field IDs in the given schema of data before writing to the Parquet files.

## How was this patch tested?
UTs