### PR TITLE
[Spark] Remove -preview from Coordinated Commits configs

### DIFF
--- a/spark/src/main/java/io/delta/dynamodbcommitcoordinator/CoordinatedCommitsUtils.java
+++ b/spark/src/main/java/io/delta/dynamodbcommitcoordinator/CoordinatedCommitsUtils.java
@@ -31,7 +31,7 @@ public class CoordinatedCommitsUtils {
 
     /** The configuration key for the coordinated commits owner. */
     private static final String COORDINATED_COMMITS_COORDINATOR_CONF_KEY =
-            "delta.coordinatedCommits.commitCoordinator-preview";
+            "delta.coordinatedCommits.commitCoordinator";
 
     /**
      * Creates a new unbackfilled delta file path for the given commit version.

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -380,7 +380,7 @@
   },
   "DELTA_CLONE_MUST_OVERRIDE_ALL_COORDINATED_COMMITS_CONFS" : {
     "message" : [
-      "During CLONE, either all coordinated commits configurations i.e.\"delta.coordinatedCommits.commitCoordinator-preview\", \"delta.coordinatedCommits.commitCoordinatorConf-preview\" must be overridden or none of them."
+      "During CLONE, either all coordinated commits configurations i.e.\"delta.coordinatedCommits.commitCoordinator\", \"delta.coordinatedCommits.commitCoordinatorConf\" must be overridden or none of them."
     ],
     "sqlState" : "42616"
   },

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -740,7 +740,7 @@ trait DeltaConfigsBase extends DeltaLogging {
     helpMessage = "needs to be a boolean.")
 
   val COORDINATED_COMMITS_COORDINATOR_NAME = buildConfig[Option[String]](
-    "coordinatedCommits.commitCoordinator-preview",
+    "coordinatedCommits.commitCoordinator",
     null,
     v => Option(v),
     _ => true,
@@ -751,14 +751,14 @@ trait DeltaConfigsBase extends DeltaLogging {
       |""".stripMargin)
 
   val COORDINATED_COMMITS_COORDINATOR_CONF = buildConfig[Map[String, String]](
-    "coordinatedCommits.commitCoordinatorConf-preview",
+    "coordinatedCommits.commitCoordinatorConf",
     null,
     v => JsonUtils.fromJson[Map[String, String]](Option(v).getOrElse("{}")),
     _ => true,
     "A string-to-string map of configuration properties for the coordinated commits-coordinator.")
 
   val COORDINATED_COMMITS_TABLE_CONF = buildConfig[Map[String, String]](
-    "coordinatedCommits.tableConf-preview",
+    "coordinatedCommits.tableConf",
     null,
     v => JsonUtils.fromJson[Map[String, String]](Option(v).getOrElse("{}")),
     _ => true,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableSuiteBase.scala
@@ -954,8 +954,8 @@ trait CloneTableSuiteBase extends QueryTest
           tableProperties = properties)
       }
       assert(e1.getMessage.contains("During CLONE, either all coordinated commits " +
-        "configurations i.e.\"delta.coordinatedCommits.commitCoordinator-preview\", " +
-        "\"delta.coordinatedCommits.commitCoordinatorConf-preview\" must be overridden or none " +
+        "configurations i.e.\"delta.coordinatedCommits.commitCoordinator\", " +
+        "\"delta.coordinatedCommits.commitCoordinatorConf\" must be overridden or none " +
         "of them."))
 
       val e2 = intercept[IllegalArgumentException] {
@@ -970,7 +970,7 @@ trait CloneTableSuiteBase extends QueryTest
           isReplace = true,
           tableProperties = properties)
       }
-      assert(e2.getMessage.contains("Configuration \"delta.coordinatedCommits.tableConf-preview\"" +
+      assert(e2.getMessage.contains("Configuration \"delta.coordinatedCommits.tableConf\"" +
         " cannot be overridden with CLONE command."))
 
       val properties = Map(

--- a/storage/src/test/scala/io/delta/storage/commit/CoordinatedCommitsUtils.java
+++ b/storage/src/test/scala/io/delta/storage/commit/CoordinatedCommitsUtils.java
@@ -37,7 +37,7 @@ public class CoordinatedCommitsUtils {
 
     /** The configuration key for the coordinated commits owner. */
     private static final String COORDINATED_COMMITS_COORDINATOR_CONF_KEY =
-            "delta.coordinatedCommits.commitCoordinator-preview";
+            "delta.coordinatedCommits.commitCoordinator";
 
     /**
      * Returns the path to the backfilled delta file for the given commit version.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Removes the -preview suffix from CC configs. Note that this does not remove the -preview suffix from the table feature name.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Existing tests should cover this change.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No