### PR TITLE
[Kernel][Default Parquet Writer] Always return the row count in returned file statistics

### DIFF
--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetFileWriterSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/parquet/ParquetFileWriterSuite.scala
@@ -332,8 +332,6 @@ class ParquetFileWriterSuite extends AnyFunSuite
     statsColumns: Seq[Column],
     expStatsColCount: Int): Unit = {
 
-    if (statsColumns.isEmpty) return
-
     val actualStatsOutput = actualFileStatuses
       .map { fileStatus =>
         // validate there are no more the expected number of stats columns
@@ -345,8 +343,6 @@ class ParquetFileWriterSuite extends AnyFunSuite
         // Convert to TestRow for comparison with the actual values computing using Spark.
         fileStatus.toTestRow(statsColumns)
       }
-
-    if (expStatsColCount == 0) return
 
     // Use spark to fetch the stats from the parquet files use them as the expected statistics
     // Compare them with the actual stats returned by the Kernel's Parquet writer.


### PR DESCRIPTION
## Description
Currently, the default Parquet writer returnes `numRows` statistics only if one or more column statistics are requested. This changes to always return the `numRows` in `DataFileStatus`. It is easy to compute the number of rows written without reading the Parquet footer. Reading parquet footer is needed for finding the column stats for written file.

The `numRows` stat is needed for supporting writing into Uniform enabled tables.

## How was this patch tested?
Modify existing tests.