### PR TITLE
[KERNEL][VARIANT] Basic read variant

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,6 +59,9 @@ spark / sparkVersion := getSparkVersion()
 connectCommon / sparkVersion := getSparkVersion()
 connectClient / sparkVersion := getSparkVersion()
 connectServer / sparkVersion := getSparkVersion()
+kernelDefaults / sparkVersion := getSparkVersion()
+storage / sparkVersion := getSparkVersion()
+goldenTables / sparkVersion := getSparkVersion()
 
 // Dependent library versions
 val defaultSparkVersion = LATEST_RELEASED_SPARK_VERSION
@@ -162,6 +165,25 @@ def javafmtCheckSettings() = Seq(
 )
 
 /**
+ * Java-/Scala-/Uni-Doc settings aren't working yet against Spark Master.
+    1) delta-spark on Spark Master uses JDK 17. delta-iceberg uses JDK 8 or 11. For some reason,
+       generating delta-spark unidoc compiles delta-iceberg
+    2) delta-spark unidoc fails to compile. spark 3.5 is on its classpath. likely due to iceberg
+       issue above.
+ */
+def crossSparkUniDocSettings(): Seq[Setting[_]] = getSparkVersion() match {
+  case LATEST_RELEASED_SPARK_VERSION => Seq(
+    // Java-/Scala-/Uni-Doc Settings
+    scalacOptions ++= Seq(
+      "-P:genjavadoc:strictVisibility=true" // hide package private types and methods in javadoc
+    ),
+    unidocSourceFilePatterns := Seq(SourceFilePattern("io/delta/tables/", "io/delta/exceptions/"))
+  )
+
+  case SPARK_MASTER_VERSION => Seq()
+}
+
+/**
  * Note: we cannot access sparkVersion.value here, since that can only be used within a task or
  *       setting macro.
  */
@@ -175,12 +197,6 @@ def crossSparkSettings(): Seq[Setting[_]] = getSparkVersion() match {
     Compile / unmanagedSourceDirectories += (Compile / baseDirectory).value / "src" / "main" / "scala-spark-3.5",
     Test / unmanagedSourceDirectories += (Test / baseDirectory).value / "src" / "test" / "scala-spark-3.5",
     Antlr4 / antlr4Version := "4.9.3",
-
-    // Java-/Scala-/Uni-Doc Settings
-    scalacOptions ++= Seq(
-      "-P:genjavadoc:strictVisibility=true" // hide package private types and methods in javadoc
-    ),
-    unidocSourceFilePatterns := Seq(SourceFilePattern("io/delta/tables/", "io/delta/exceptions/"))
   )
 
   case SPARK_MASTER_VERSION => Seq(
@@ -205,13 +221,6 @@ def crossSparkSettings(): Seq[Setting[_]] = getSparkVersion() match {
       "--add-opens=java.base/sun.security.action=ALL-UNNAMED",
       "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED"
     )
-
-    // Java-/Scala-/Uni-Doc Settings
-    // This isn't working yet against Spark Master.
-    // 1) delta-spark on Spark Master uses JDK 17. delta-iceberg uses JDK 8 or 11. For some reason,
-    //    generating delta-spark unidoc compiles delta-iceberg
-    // 2) delta-spark unidoc fails to compile. spark 3.5 is on its classpath. likely due to iceberg
-    //    issue above.
   )
 }
 
@@ -239,6 +248,7 @@ lazy val connectCommon = (project in file("spark-connect/common"))
     name := "delta-connect-common",
     commonSettings,
     crossSparkSettings(),
+    crossSparkUniDocSettings(),
     releaseSettings,
     Compile / compile := runTaskOnlyOnSparkMaster(
       task = Compile / compile,
@@ -386,6 +396,7 @@ lazy val connectServer = (project in file("spark-connect/server"))
       emptyValue = ()
     ).value,
     crossSparkSettings(),
+    crossSparkUniDocSettings(),
     libraryDependencies ++= Seq(
       "com.google.protobuf" % "protobuf-java" % protoVersion % "protobuf",
 
@@ -414,6 +425,7 @@ lazy val spark = (project in file("spark"))
     sparkMimaSettings,
     releaseSettings,
     crossSparkSettings(),
+    crossSparkUniDocSettings(),
     libraryDependencies ++= Seq(
       // Adding test classifier seems to break transitive resolution of the core dependencies
       "org.apache.spark" %% "spark-hive" % sparkVersion.value % "provided",
@@ -565,6 +577,7 @@ lazy val kernelApi = (project in file("kernel/kernel-api"))
     javaOnlyReleaseSettings,
     javafmtCheckSettings,
     Test / javaOptions ++= Seq("-ea"),
+    crossSparkSettings(),
     libraryDependencies ++= Seq(
       "org.roaringbitmap" % "RoaringBitmap" % "0.9.25",
       "org.slf4j" % "slf4j-api" % "1.7.36",
@@ -622,6 +635,7 @@ lazy val kernelDefaults = (project in file("kernel/kernel-defaults"))
     javaOnlyReleaseSettings,
     javafmtCheckSettings,
     Test / javaOptions ++= Seq("-ea"),
+    crossSparkSettings(),
     libraryDependencies ++= Seq(
       "org.apache.hadoop" % "hadoop-client-runtime" % hadoopVersion,
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.5",
@@ -638,10 +652,10 @@ lazy val kernelDefaults = (project in file("kernel/kernel-defaults"))
       "org.openjdk.jmh" % "jmh-core" % "1.37" % "test",
       "org.openjdk.jmh" % "jmh-generator-annprocess" % "1.37" % "test",
 
-      "org.apache.spark" %% "spark-hive" % defaultSparkVersion % "test" classifier "tests",
-      "org.apache.spark" %% "spark-sql" % defaultSparkVersion % "test" classifier "tests",
-      "org.apache.spark" %% "spark-core" % defaultSparkVersion % "test" classifier "tests",
-      "org.apache.spark" %% "spark-catalyst" % defaultSparkVersion % "test" classifier "tests",
+      "org.apache.spark" %% "spark-hive" % sparkVersion.value % "test" classifier "tests",
+      "org.apache.spark" %% "spark-sql" % sparkVersion.value % "test" classifier "tests",
+      "org.apache.spark" %% "spark-core" % sparkVersion.value % "test" classifier "tests",
+      "org.apache.spark" %% "spark-catalyst" % sparkVersion.value % "test" classifier "tests",
     ),
     javaCheckstyleSettings("dev/kernel-checkstyle.xml"),
       // Unidoc settings
@@ -657,6 +671,8 @@ lazy val storage = (project in file("storage"))
     name := "delta-storage",
     commonSettings,
     javaOnlyReleaseSettings,
+    crossSparkSettings(),
+
     libraryDependencies ++= Seq(
       // User can provide any 2.x or 3.x version. We don't use any new fancy APIs. Watch out for
       // versions with known vulnerabilities.
@@ -1356,14 +1372,15 @@ lazy val goldenTables = (project in file("connectors/golden-tables"))
     name := "golden-tables",
     commonSettings,
     skipReleaseSettings,
+    crossSparkSettings(),
     libraryDependencies ++= Seq(
       // Test Dependencies
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
       "commons-io" % "commons-io" % "2.8.0" % "test",
-      "org.apache.spark" %% "spark-sql" % defaultSparkVersion % "test",
-      "org.apache.spark" %% "spark-catalyst" % defaultSparkVersion % "test" classifier "tests",
-      "org.apache.spark" %% "spark-core" % defaultSparkVersion % "test" classifier "tests",
-      "org.apache.spark" %% "spark-sql" % defaultSparkVersion % "test" classifier "tests"
+      "org.apache.spark" %% "spark-sql" % sparkVersion.value % "test",
+      "org.apache.spark" %% "spark-catalyst" % sparkVersion.value % "test" classifier "tests",
+      "org.apache.spark" %% "spark-core" % sparkVersion.value % "test" classifier "tests",
+      "org.apache.spark" %% "spark-sql" % sparkVersion.value % "test" classifier "tests"
     )
   )
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/data/ColumnVector.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/data/ColumnVector.java
@@ -170,6 +170,14 @@ public interface ColumnVector extends AutoCloseable {
   }
 
   /**
+   * Return the variant value located at {@code rowId}. Returns null if the slot for {@code rowId}
+   * is null
+   */
+  default VariantValue getVariant(int rowId) {
+    throw new UnsupportedOperationException("Invalid value request for data type");
+  }
+
+  /**
    * Get the child vector associated with the given ordinal. This method is applicable only to the
    * {@code struct} type columns.
    *

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/data/Row.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/data/Row.java
@@ -114,4 +114,10 @@ public interface Row {
    * given ordinal is not of map type,
    */
   MapValue getMap(int ordinal);
+
+  /**
+   * Return variant value of the column located at the given ordinal. Throws error if the column at
+   * given ordinal is not of variant type.
+   */
+  VariantValue getVariant(int ordinal);
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/data/VariantValue.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/data/VariantValue.java
@@ -16,6 +16,7 @@
 package io.delta.kernel.data;
 
 import io.delta.kernel.annotation.Evolving;
+import java.time.ZoneId;
 
 /**
  * Abstraction to represent a single Variant value in a {@link ColumnVector}.
@@ -27,4 +28,6 @@ public interface VariantValue {
   byte[] getValue();
 
   byte[] getMetadata();
+
+  String toJson(ZoneId zoneId);
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/data/VariantValue.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/data/VariantValue.java
@@ -15,7 +15,14 @@
  */
 package io.delta.kernel.data;
 
-/** Abstraction to represent a single Variant value in a {@link ColumnVector}. */
+import io.delta.kernel.annotation.Evolving;
+
+/**
+ * Abstraction to represent a single Variant value in a {@link ColumnVector}.
+ *
+ * @since 4.0.0
+ */
+@Evolving
 public interface VariantValue {
   byte[] getValue();
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/data/VariantValue.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/data/VariantValue.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.data;
+
+/** Abstraction to represent a single Variant value in a {@link ColumnVector}. */
+public interface VariantValue {
+  byte[] getValue();
+
+  byte[] getMetadata();
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableFeatures.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableFeatures.java
@@ -65,6 +65,7 @@ public class TableFeatures {
             case "deletionVectors": // fall through
             case "timestampNtz": // fall through
             case "vacuumProtocolCheck": // fall through
+            case "variantType-preview": // fall through
             case "v2Checkpoint":
               break;
             default:

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ChildVectorBasedRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ChildVectorBasedRow.java
@@ -19,6 +19,7 @@ import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.MapValue;
 import io.delta.kernel.data.Row;
+import io.delta.kernel.data.VariantValue;
 import io.delta.kernel.types.StructType;
 import java.math.BigDecimal;
 
@@ -106,6 +107,11 @@ public abstract class ChildVectorBasedRow implements Row {
   @Override
   public MapValue getMap(int ordinal) {
     return getChild(ordinal).getMap(rowId);
+  }
+
+  @Override
+  public VariantValue getVariant(int ordinal) {
+    return getChild(ordinal).getVariant(rowId);
   }
 
   protected abstract ColumnVector getChild(int ordinal);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/GenericRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/GenericRow.java
@@ -21,6 +21,7 @@ import static java.util.Objects.requireNonNull;
 import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.MapValue;
 import io.delta.kernel.data.Row;
+import io.delta.kernel.data.VariantValue;
 import io.delta.kernel.types.*;
 import java.math.BigDecimal;
 import java.util.Map;
@@ -132,6 +133,12 @@ public class GenericRow implements Row {
 
   private Object getValue(int ordinal) {
     return ordinalToValue.get(ordinal);
+  }
+
+  @Override
+  public VariantValue getVariant(int ordinal) {
+    throwIfUnsafeAccess(ordinal, VariantType.class, "variant");
+    return (VariantValue) getValue(ordinal);
   }
 
   private void throwIfUnsafeAccess(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/VectorUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/VectorUtils.java
@@ -202,6 +202,8 @@ public final class VectorUtils {
       return toJavaList(columnVector.getArray(rowId));
     } else if (dataType instanceof MapType) {
       return toJavaMap(columnVector.getMap(rowId));
+    } else if (dataType instanceof VariantType) {
+      return columnVector.getVariant(rowId);
     } else {
       throw new UnsupportedOperationException("unsupported data type");
     }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/BasePrimitiveType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/BasePrimitiveType.java
@@ -60,6 +60,7 @@ public abstract class BasePrimitiveType extends DataType {
                   put("timestamp_ntz", TimestampNTZType.TIMESTAMP_NTZ);
                   put("binary", BinaryType.BINARY);
                   put("string", StringType.STRING);
+                  put("variant", VariantType.VARIANT);
                 }
               });
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/VariantType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/VariantType.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.types;
+
+import io.delta.kernel.annotation.Evolving;
+
+/**
+ * A logical variant type.
+ *
+ * @since 4.0.0
+ */
+@Evolving
+public class VariantType extends BasePrimitiveType {
+  public static final VariantType VARIANT = new VariantType();
+
+  private VariantType() {
+    super("variant");
+  }
+}

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/TransactionSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/TransactionSuite.scala
@@ -129,7 +129,7 @@ object TransactionSuite extends VectorTestUtils with MockEngineUtils {
         // Update the vectors
         val newColumnVectors = vectors.toBuffer
         newColumnVectors.remove(ordinal)
-        columnarBatch(newSchema, newColumnVectors)
+        columnarBatch(newSchema, newColumnVectors.toSeq)
       }
 
       override def getSize: Int = vectors.head.getSize

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
@@ -756,7 +756,7 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
     // corrupt incomplete multi-part checkpoint
     val corruptedCheckpointStatuses = FileNames.checkpointFileWithParts(logPath, 10, 5).asScala
       .map(p => FileStatus.of(p.toString, 10, 10))
-      .take(4)
+      .take(4).toSeq
     val deltas = deltaFileStatuses(10L to 13L)
     testExpectedError[InvalidTableException](
       corruptedCheckpointStatuses ++ deltas,
@@ -805,7 +805,7 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
     // _last_checkpoint refers to incomplete multi-part checkpoint
     val corruptedCheckpointStatuses = FileNames.checkpointFileWithParts(logPath, 20, 5).asScala
       .map(p => FileStatus.of(p.toString, 10, 10))
-      .take(4)
+      .take(4).toSeq
     testExpectedError[RuntimeException](
       files = corruptedCheckpointStatuses ++ deltaFileStatuses(10L to 20L) ++
         singularCheckpointFileStatuses(Seq(10L)),

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/DefaultJsonRow.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/DefaultJsonRow.java
@@ -22,6 +22,7 @@ import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.MapValue;
 import io.delta.kernel.data.Row;
+import io.delta.kernel.data.VariantValue;
 import io.delta.kernel.defaults.internal.DefaultKernelUtils;
 import io.delta.kernel.defaults.internal.data.vector.DefaultGenericVector;
 import io.delta.kernel.internal.util.InternalUtils;
@@ -124,6 +125,11 @@ public class DefaultJsonRow implements Row {
   @Override
   public MapValue getMap(int ordinal) {
     return (MapValue) parsedValues[ordinal];
+  }
+
+  @Override
+  public VariantValue getVariant(int ordinal) {
+    throw new UnsupportedOperationException("not yet implemented");
   }
 
   private static void throwIfTypeMismatch(String expType, boolean hasExpType, JsonNode jsonNode) {

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/value/DefaultVariantValue.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/value/DefaultVariantValue.java
@@ -16,6 +16,7 @@
 package io.delta.kernel.defaults.internal.data.value;
 
 import io.delta.kernel.data.VariantValue;
+import java.time.ZoneId;
 import java.util.Arrays;
 
 /** Default implementation of a Delta kernel VariantValue. */
@@ -36,6 +37,11 @@ public class DefaultVariantValue implements VariantValue {
   @Override
   public byte[] getMetadata() {
     return metadata;
+  }
+
+  @Override
+  public String toJson(ZoneId zoneId) {
+    throw new UnsupportedOperationException("The 'toJson' method has not been implemented yet.");
   }
 
   @Override

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/value/DefaultVariantValue.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/value/DefaultVariantValue.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults.internal.data.value;
+
+import io.delta.kernel.data.VariantValue;
+import java.util.Arrays;
+
+/** Default implementation of a Delta kernel VariantValue. */
+public class DefaultVariantValue implements VariantValue {
+  private final byte[] value;
+  private final byte[] metadata;
+
+  public DefaultVariantValue(byte[] value, byte[] metadata) {
+    this.value = value;
+    this.metadata = metadata;
+  }
+
+  @Override
+  public byte[] getValue() {
+    return value;
+  }
+
+  @Override
+  public byte[] getMetadata() {
+    return metadata;
+  }
+
+  @Override
+  public String toString() {
+    return "VariantValue{value="
+        + Arrays.toString(value)
+        + ", metadata="
+        + Arrays.toString(metadata)
+        + '}';
+  }
+
+  /**
+   * Compare two variants in bytes. The variant equality is more complex than it, and we haven't
+   * supported it in the user surface yet. This method is only intended for tests.
+   */
+  @Override
+  public boolean equals(Object other) {
+    if (other instanceof DefaultVariantValue) {
+      return Arrays.equals(value, ((DefaultVariantValue) other).getValue())
+          && Arrays.equals(metadata, ((DefaultVariantValue) other).getMetadata());
+    } else {
+      return false;
+    }
+  }
+}

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/AbstractColumnVector.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/AbstractColumnVector.java
@@ -21,6 +21,7 @@ import static java.util.Objects.requireNonNull;
 import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.MapValue;
+import io.delta.kernel.data.VariantValue;
 import io.delta.kernel.types.DataType;
 import java.math.BigDecimal;
 import java.util.Optional;
@@ -137,6 +138,11 @@ public abstract class AbstractColumnVector implements ColumnVector {
   @Override
   public ArrayValue getArray(int rowId) {
     throw unsupportedDataAccessException("array");
+  }
+
+  @Override
+  public VariantValue getVariant(int rowId) {
+    throw unsupportedDataAccessException("variant");
   }
 
   // TODO no need to override these here; update default implementations in `ColumnVector`

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultGenericVector.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultGenericVector.java
@@ -152,6 +152,13 @@ public class DefaultGenericVector implements ColumnVector {
   }
 
   @Override
+  public VariantValue getVariant(int rowId) {
+    assertValidRowId(rowId);
+    throwIfUnsafeAccess(VariantType.class, "variant");
+    return (VariantValue) rowIdToValueAccessor.apply(rowId);
+  }
+
+  @Override
   public ColumnVector getChild(int ordinal) {
     throwIfUnsafeAccess(StructType.class, "struct");
     StructType structType = (StructType) dataType;

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultSubFieldVector.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultSubFieldVector.java
@@ -22,6 +22,7 @@ import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.MapValue;
 import io.delta.kernel.data.Row;
+import io.delta.kernel.data.VariantValue;
 import io.delta.kernel.types.DataType;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
@@ -149,6 +150,12 @@ public class DefaultSubFieldVector implements ColumnVector {
   public ArrayValue getArray(int rowId) {
     assertValidRowId(rowId);
     return rowIdToRowAccessor.apply(rowId).getArray(columnOrdinal);
+  }
+
+  @Override
+  public VariantValue getVariant(int rowId) {
+    assertValidRowId(rowId);
+    return rowIdToRowAccessor.apply(rowId).getVariant(columnOrdinal);
   }
 
   @Override

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultVariantVector.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultVariantVector.java
@@ -30,7 +30,7 @@ public class DefaultVariantVector extends AbstractColumnVector {
   private final ColumnVector metadataVector;
 
   /**
-   * Create an instance of {@link io.delta.kernel.data.ColumnVector} for array type.
+   * Create an instance of {@link io.delta.kernel.data.ColumnVector} for variant type.
    *
    * @param size number of elements in the vector.
    * @param type {@code variant} datatype definition.

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultVariantVector.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultVariantVector.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults.internal.data.vector;
+
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.data.VariantValue;
+import io.delta.kernel.defaults.internal.data.value.DefaultVariantValue;
+import io.delta.kernel.types.DataType;
+import java.util.Optional;
+
+/** {@link io.delta.kernel.data.ColumnVector} implementation for variant type data. */
+public class DefaultVariantVector extends AbstractColumnVector {
+  private final ColumnVector valueVector;
+  private final ColumnVector metadataVector;
+
+  /**
+   * Create an instance of {@link io.delta.kernel.data.ColumnVector} for array type.
+   *
+   * @param size number of elements in the vector.
+   * @param type {@code variant} datatype definition.
+   * @param nullability Optional array of nullability value for each element in the vector. All
+   *     values in the vector are considered non-null when parameter is empty.
+   * @param value The child binary column vector representing each variant's values.
+   * @param metadata The child binary column vector representing each variant's metadata.
+   */
+  public DefaultVariantVector(
+      int size,
+      DataType type,
+      Optional<boolean[]> nullability,
+      ColumnVector value,
+      ColumnVector metadata) {
+    super(size, type, nullability);
+    this.valueVector = requireNonNull(value, "value is null");
+    this.metadataVector = requireNonNull(metadata, "metadata is null");
+  }
+
+  /**
+   * Get the value at given {@code rowId}. The return value is undefined and can be anything, if the
+   * slot for {@code rowId} is null.
+   *
+   * @param rowId
+   * @return
+   */
+  @Override
+  public VariantValue getVariant(int rowId) {
+    checkValidRowId(rowId);
+    if (isNullAt(rowId)) {
+      return null;
+    }
+
+    return new DefaultVariantValue(valueVector.getBinary(rowId), metadataVector.getBinary(rowId));
+  }
+
+  /**
+   * Get the child column vector at the given {@code ordinal}. Variants should only have two child
+   * vectors, one for value and one for metadata.
+   *
+   * @param ordinal
+   * @return
+   */
+  @Override
+  public ColumnVector getChild(int ordinal) {
+    checkArgument(ordinal >= 0 && ordinal < 2, "Invalid ordinal " + ordinal);
+    if (ordinal == 0) {
+      return valueVector;
+    } else {
+      return metadataVector;
+    }
+  }
+}

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultViewVector.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/data/vector/DefaultViewVector.java
@@ -20,6 +20,7 @@ import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.MapValue;
+import io.delta.kernel.data.VariantValue;
 import io.delta.kernel.types.DataType;
 import java.math.BigDecimal;
 
@@ -132,6 +133,12 @@ public class DefaultViewVector implements ColumnVector {
   public ArrayValue getArray(int rowId) {
     checkValidRowId(rowId);
     return underlyingVector.getArray(offset + rowId);
+  }
+
+  @Override
+  public VariantValue getVariant(int rowId) {
+    checkValidRowId(rowId);
+    return underlyingVector.getVariant(offset + rowId);
   }
 
   @Override

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetColumnReaders.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetColumnReaders.java
@@ -70,6 +70,13 @@ class ParquetColumnReaders {
     } else if (typeFromClient instanceof TimestampNTZType) {
       return createTimestampConverter(
           initialBatchSize, typeFromFile, TimestampNTZType.TIMESTAMP_NTZ);
+    } else if (typeFromClient instanceof VariantType) {
+      return new RowColumnReader(
+          initialBatchSize,
+          new StructType()
+              .add("value", BinaryType.BINARY, false)
+              .add("metadata", BinaryType.BINARY, false),
+          (GroupType) typeFromFile);
     }
 
     throw new UnsupportedOperationException(typeFromClient + " is not supported");

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetColumnReaders.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/ParquetColumnReaders.java
@@ -71,12 +71,7 @@ class ParquetColumnReaders {
       return createTimestampConverter(
           initialBatchSize, typeFromFile, TimestampNTZType.TIMESTAMP_NTZ);
     } else if (typeFromClient instanceof VariantType) {
-      return new RowColumnReader(
-          initialBatchSize,
-          new StructType()
-              .add("value", BinaryType.BINARY, false)
-              .add("metadata", BinaryType.BINARY, false),
-          (GroupType) typeFromFile);
+      return new VariantColumnReader(initialBatchSize, (GroupType) typeFromFile);
     }
 
     throw new UnsupportedOperationException(typeFromClient + " is not supported");

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/VariantColumnReader.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/parquet/VariantColumnReader.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults.internal.parquet;
+
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.*;
+
+import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.defaults.internal.data.vector.DefaultVariantVector;
+import io.delta.kernel.defaults.internal.parquet.ParquetColumnReaders.BaseColumnReader;
+import io.delta.kernel.defaults.internal.parquet.ParquetColumnReaders.BinaryColumnReader;
+import io.delta.kernel.types.BinaryType;
+import io.delta.kernel.types.VariantType;
+import java.util.*;
+import org.apache.parquet.io.api.Converter;
+import org.apache.parquet.io.api.GroupConverter;
+import org.apache.parquet.schema.*;
+
+class VariantColumnReader extends GroupConverter implements BaseColumnReader {
+  private final BinaryColumnReader valueConverter;
+  private final BinaryColumnReader metadataConverter;
+
+  // working state
+  private int currentRowIndex;
+  private boolean[] nullability;
+  // If the value is null, start/end never get called which is a signal for null
+  // Set the initial state to true and when start() is called set it to false.
+  private boolean isCurrentValueNull = true;
+  // The field index of the "value" field in the struct backing the variant.
+  private int valueIndex;
+
+  /**
+   * Create converter for {@link VariantType} column.
+   *
+   * @param initialBatchSize Estimate of initial row batch size. Used in memory allocations.
+   */
+  VariantColumnReader(int initialBatchSize, GroupType typeFromFile) {
+    checkArgument(initialBatchSize > 0, "invalid initialBatchSize: %s", initialBatchSize);
+    this.nullability = ParquetColumnReaders.initNullabilityVector(initialBatchSize);
+
+    this.valueConverter = new BinaryColumnReader(BinaryType.BINARY, initialBatchSize);
+    this.metadataConverter = new BinaryColumnReader(BinaryType.BINARY, initialBatchSize);
+
+    List<Type> parquetFields = typeFromFile.getFields();
+
+    checkArgument(
+        parquetFields.size() == 2
+            && parquetFields.get(0).isPrimitive()
+            && parquetFields.get(0).asPrimitiveType().getPrimitiveTypeName() == BINARY
+            && parquetFields.get(1).isPrimitive()
+            && parquetFields.get(1).asPrimitiveType().getPrimitiveTypeName() == BINARY
+            && ((parquetFields.get(0).getName() == "value"
+                    && parquetFields.get(1).getName() == "metadata")
+                || (parquetFields.get(0).getName() == "metadata"
+                    && parquetFields.get(1).getName() == "value")),
+        "the struct representing a variant must contain two binary fields, with one named "
+            + "\"value\" and the other named \"metadata\".");
+
+    valueIndex = parquetFields.get(0).getName() == "value" ? 0 : 1;
+  }
+
+  @Override
+  public Converter getConverter(int fieldIndex) {
+    checkArgument(
+        fieldIndex >= 0 && fieldIndex < 2, "variant type is represented by a struct with 2 fields");
+    if (fieldIndex == 0) {
+      return valueIndex == 0 ? valueConverter : metadataConverter;
+    } else {
+      return valueIndex == 0 ? metadataConverter : valueConverter;
+    }
+  }
+
+  @Override
+  public void start() {
+    isCurrentValueNull = false;
+  }
+
+  @Override
+  public void end() {}
+
+  @Override
+  public void finalizeCurrentRow(long currentRowIndex) {
+    resizeIfNeeded();
+    finalizeLastRowInConverters(currentRowIndex);
+    nullability[this.currentRowIndex] = isCurrentValueNull;
+    isCurrentValueNull = true;
+
+    this.currentRowIndex++;
+  }
+
+  public ColumnVector getDataColumnVector(int batchSize) {
+    ColumnVector vector =
+        new DefaultVariantVector(
+            batchSize,
+            VariantType.VARIANT,
+            Optional.of(nullability),
+            valueConverter.getDataColumnVector(batchSize),
+            metadataConverter.getDataColumnVector(batchSize));
+    resetWorkingState();
+    return vector;
+  }
+
+  @Override
+  public void resizeIfNeeded() {
+    if (nullability.length == currentRowIndex) {
+      int newSize = nullability.length * 2;
+      this.nullability = Arrays.copyOf(this.nullability, newSize);
+      ParquetColumnReaders.setNullabilityToTrue(this.nullability, newSize / 2, newSize);
+    }
+  }
+
+  @Override
+  public void resetWorkingState() {
+    this.currentRowIndex = 0;
+    this.isCurrentValueNull = true;
+    this.nullability = ParquetColumnReaders.initNullabilityVector(this.nullability.length);
+  }
+
+  private void finalizeLastRowInConverters(long prevRowIndex) {
+    valueConverter.finalizeCurrentRow(prevRowIndex);
+    metadataConverter.finalizeCurrentRow(prevRowIndex);
+  }
+}

--- a/kernel/kernel-defaults/src/test/java/io/delta/kernel/defaults/integration/DataBuilderUtils.java
+++ b/kernel/kernel-defaults/src/test/java/io/delta/kernel/defaults/integration/DataBuilderUtils.java
@@ -21,6 +21,7 @@ import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.ColumnarBatch;
 import io.delta.kernel.data.MapValue;
 import io.delta.kernel.data.Row;
+import io.delta.kernel.data.VariantValue;
 import io.delta.kernel.defaults.internal.data.DefaultRowBasedColumnarBatch;
 import io.delta.kernel.types.StructType;
 import java.math.BigDecimal;
@@ -163,6 +164,11 @@ public class DataBuilderUtils {
     public MapValue getMap(int ordinal) {
       throw new UnsupportedOperationException(
           "map type unsupported for TestColumnBatchBuilder; use scala test utilities");
+    }
+
+    @Override
+    public VariantValue getVariant(int ordinal) {
+      return (VariantValue) values.get(ordinal);
     }
   }
 }

--- a/kernel/kernel-defaults/src/test/scala-spark-3.5/DeltaExcludedBySparkVersionTestMixinShims.scala
+++ b/kernel/kernel-defaults/src/test/scala-spark-3.5/DeltaExcludedBySparkVersionTestMixinShims.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.defaults
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import io.delta.kernel.defaults.utils.TestUtils
+
+trait DeltaExcludedBySparkVersionTestMixinShims extends AnyFunSuite with TestUtils {
+  /**
+   * Tests that are meant for Delta compiled against Spark Latest Release only. Executed since this
+   * is the Spark Latest Release shim.
+   */
+  protected def testSparkLatestOnly(
+      testName: String, testTags: org.scalatest.Tag*)
+      (testFun: => Any)
+      (implicit pos: org.scalactic.source.Position): Unit = {
+    test(testName, testTags: _*)(testFun)(pos)
+  }
+
+  /**
+   * Tests that are meant for Delta compiled against Spark Master Release only. Ignored since this
+   * is the Spark Latest Release shim.
+   */
+  protected def testSparkMasterOnly(
+      testName: String, testTags: org.scalatest.Tag*)
+      (testFun: => Any)
+      (implicit pos: org.scalactic.source.Position): Unit = {
+    ignore(testName, testTags: _*)(testFun)(pos)
+  }
+}

--- a/kernel/kernel-defaults/src/test/scala-spark-3.5/shims/VariantShims.scala
+++ b/kernel/kernel-defaults/src/test/scala-spark-3.5/shims/VariantShims.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.defaults
+
+import io.delta.kernel.defaults.internal.data.value.DefaultVariantValue
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.DataType
+
+object VariantShims {
+
+  /**
+   * Spark's variant type is implemented for Spark 4.0 and is not implemented in Spark 3.5. Thus,
+   * any Spark 3.5 DataType cannot be a variant type.
+   */
+  def isVariantType(dt: DataType): Boolean = false
+
+  /**
+   * Converts Spark's variant value to Kernel Default's variant value for testing.
+   * This method should not be called when depending on Spark 3.5 because Spark 3.5 cannot create
+   * variants.
+   */
+  def convertToKernelVariant(v: Any): DefaultVariantValue =
+    throw new UnsupportedOperationException("Not supported")
+
+  /**
+   * Retrieves a Spark variant from a Spark row and converts it to Kernel Default's variant value
+   * for testing.
+   *
+   * Should not be called when testing using Spark 3.5.
+   */
+  def getVariantAndConvertToKernel(r: Row, ordinal: Int): DefaultVariantValue =
+    throw new UnsupportedOperationException("Not supported")
+
+  /**
+   * Returns Spark's variant type singleton. This should not be called when testing with Spark 3.5.
+   */
+  def getSparkVariantType(): DataType = throw new UnsupportedOperationException("Not supported")
+}

--- a/kernel/kernel-defaults/src/test/scala-spark-master/DeltaExcludedBySparkVersionTestMixinShims.scala
+++ b/kernel/kernel-defaults/src/test/scala-spark-master/DeltaExcludedBySparkVersionTestMixinShims.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.defaults
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import io.delta.kernel.defaults.utils.TestUtils
+
+trait DeltaExcludedBySparkVersionTestMixinShims extends AnyFunSuite with TestUtils {
+
+  /**
+   * Tests that are meant for Delta compiled against Spark Latest Release only. Ignored since this
+   * is the Spark Master shim.
+   */
+  protected def testSparkLatestOnly(
+      testName: String, testTags: org.scalatest.Tag*)
+      (testFun: => Any)
+      (implicit pos: org.scalactic.source.Position): Unit = {
+    ignore(testName + " (Spark Latest Release Only)", testTags: _*)(testFun)(pos)
+  }
+
+  /**
+   * Tests that are meant for Delta compiled against Spark Master (4.0+). Executed since this is the
+   * Spark Master shim.
+   */
+  protected def testSparkMasterOnly(
+      testName: String, testTags: org.scalatest.Tag*)
+      (testFun: => Any)
+      (implicit pos: org.scalactic.source.Position): Unit = {
+    test(testName, testTags: _*)(testFun)(pos)
+  }
+
+}

--- a/kernel/kernel-defaults/src/test/scala-spark-master/shims/VariantShims.scala
+++ b/kernel/kernel-defaults/src/test/scala-spark-master/shims/VariantShims.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.defaults
+
+import io.delta.kernel.defaults.internal.data.value.DefaultVariantValue
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{DataType, VariantType}
+import org.apache.spark.unsafe.types.VariantVal
+
+object VariantShims {
+
+  /** Spark's variant type is only implemented in Spark 4.0 and above. */
+  def isVariantType(dt: DataType): Boolean = dt.isInstanceOf[VariantType]
+
+  /** Converts Spark's variant value to Kernel Default's variant value for testing. */
+  def convertToKernelVariant(v: Any): DefaultVariantValue = {
+    val sparkVariant = v.asInstanceOf[VariantVal]
+    new DefaultVariantValue(sparkVariant.getValue(), sparkVariant.getMetadata())
+  }
+
+  /** 
+   * Retrieves a Spark variant from a Spark row and converts it to Kernel Default's variant value
+   * for testing.
+   */
+  def getVariantAndConvertToKernel(r: Row, ordinal: Int): DefaultVariantValue = {
+    val sparkVariant = r.getAs[VariantVal](ordinal)
+    new DefaultVariantValue(sparkVariant.getValue(), sparkVariant.getMetadata())
+  }
+
+  def getSparkVariantType(): DataType = VariantType
+}

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
@@ -316,12 +316,12 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
       Seq(TestRow(2), TestRow(2), TestRow(2)),
       TestRow("2", "2", TestRow(2, 2L)),
       "2"
-    ) :: Nil)
+    ) :: Nil).toSeq
 
     checkTable(
       path = path,
       expectedAnswer = expectedAnswer,
-      readCols = readCols
+      readCols = readCols.toSeq
     )
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWriteSuiteBase.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWriteSuiteBase.scala
@@ -49,7 +49,7 @@ import java.io.File
 import java.nio.file.{Files, Paths}
 import java.util.Optional
 import scala.collection.JavaConverters._
-import scala.collection.immutable.{ListMap, Seq}
+import scala.collection.immutable.ListMap
 
 /**
  * Common utility methods for write test suites.

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
@@ -41,7 +41,6 @@ import io.delta.kernel.utils.CloseableIterable
 
 import java.util.{Locale, Optional}
 import scala.collection.JavaConverters._
-import scala.collection.immutable.Seq
 
 class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
 
@@ -622,8 +621,8 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
       val parquetAllTypes = goldenTablePath("parquet-all-types")
       val schema = removeUnsupportedTypes(tableSchema(parquetAllTypes))
 
-      val data = readTableUsingKernel(engine, parquetAllTypes, schema).to[Seq]
-      val dataWithPartInfo = Seq(Map.empty[String, Literal] -> data)
+      val data = readTableUsingKernel(engine, parquetAllTypes, schema)
+      val dataWithPartInfo = Seq(Map[String, Literal]() -> data)
 
       appendData(engine, tblPath, isNewTable = true, schema, Seq.empty, dataWithPartInfo)
       var expData = dataWithPartInfo.flatMap(_._2).flatMap(_.toTestRows)
@@ -665,7 +664,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
         "timestampType"
       )
       val casePreservingPartCols =
-        casePreservingPartitionColNames(schema, partCols.asJava).asScala.to[Seq]
+        casePreservingPartitionColNames(schema, partCols.asJava).asScala.toSeq
 
       // get the partition values from the data batch at the given rowId
       def getPartitionValues(batch: ColumnarBatch, rowId: Int): Map[String, Literal] = {
@@ -698,7 +697,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
         }.toMap
       }
 
-      val data = readTableUsingKernel(engine, parquetAllTypes, schema).to[Seq]
+      val data = readTableUsingKernel(engine, parquetAllTypes, schema)
 
       // From the above table read data, convert each row as a new batch with partition info
       // Take the values of the partitionCols from the data and create a new batch with the

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LogReplayEngineMetricsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LogReplayEngineMetricsSuite.scala
@@ -398,7 +398,7 @@ trait FileReadMetrics { self: Object =>
     }
   }
 
-  def getVersionsRead: Seq[Long] = versionsRead
+  def getVersionsRead: Seq[Long] = versionsRead.toSeq
 
   def getLastCheckpointMetadataReadCalls: Int = lastCheckpointMetadataReadCalls
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
@@ -18,12 +18,14 @@ package io.delta.kernel.defaults
 import io.delta.golden.GoldenTableUtils.goldenTablePath
 import io.delta.kernel.data.{ColumnVector, ColumnarBatch, FilteredColumnarBatch, Row}
 import io.delta.kernel.defaults.engine.{DefaultEngine, DefaultJsonHandler, DefaultParquetHandler}
-import io.delta.kernel.defaults.utils.{ExpressionTestUtils, TestUtils}
+import io.delta.kernel.defaults.utils.{ExpressionTestUtils, TestRow, TestUtils}
 import io.delta.kernel.engine.{Engine, JsonHandler, ParquetHandler}
 import io.delta.kernel.expressions.Literal._
 import io.delta.kernel.expressions._
 import io.delta.kernel.internal.util.InternalUtils
+import io.delta.kernel.internal.util.Utils.singletonCloseableIterator
 import io.delta.kernel.internal.{InternalScanFileUtils, ScanImpl}
+import io.delta.kernel.internal.data.ScanStateRow
 import io.delta.kernel.types.IntegerType.INTEGER
 import io.delta.kernel.types.StringType.STRING
 import io.delta.kernel.types._
@@ -33,7 +35,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog}
 import org.apache.spark.sql.types.{IntegerType => SparkIntegerType, StructField => SparkStructField, StructType => SparkStructType}
-import org.apache.spark.sql.{Row => SparkRow}
+import org.apache.spark.sql.{DataFrame, Row => SparkRow}
 import org.scalatest.funsuite.AnyFunSuite
 
 import java.math.{BigDecimal => JBigDecimal}
@@ -41,6 +43,7 @@ import java.sql.Date
 import java.time.temporal.ChronoUnit
 import java.time.{Instant, OffsetDateTime}
 import java.util.Optional
+import scala.collection.mutable.ArrayBuffer
 import scala.collection.JavaConverters._
 
 class ScanSuite extends AnyFunSuite

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
@@ -26,7 +26,7 @@ import io.delta.kernel.internal.util.InternalUtils
 import io.delta.kernel.internal.{InternalScanFileUtils, ScanImpl}
 import io.delta.kernel.types.IntegerType.INTEGER
 import io.delta.kernel.types.StringType.STRING
-import io.delta.kernel.types.StructType
+import io.delta.kernel.types._
 import io.delta.kernel.utils.{CloseableIterator, FileStatus}
 import io.delta.kernel.{Scan, Snapshot, Table}
 import org.apache.hadoop.conf.Configuration
@@ -43,7 +43,10 @@ import java.time.{Instant, OffsetDateTime}
 import java.util.Optional
 import scala.collection.JavaConverters._
 
-class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with SQLHelper {
+class ScanSuite extends AnyFunSuite
+  with ExpressionTestUtils
+  with SQLHelper
+  with DeltaExcludedBySparkVersionTestMixinShims {
 
   import io.delta.kernel.defaults.ScanSuite._
 
@@ -1593,6 +1596,98 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
           ).build()
       )
     }
+  }
+
+  private def testReadWithVariant(testName: String)(df: => DataFrame): Unit = {
+    testSparkMasterOnly(testName) {
+      withTable("test_table") {
+        df.write
+          .format("delta")
+          .mode("overwrite")
+          .saveAsTable("test_table")
+        val path = spark.sql("describe table extended `test_table`")
+          .where("col_name = 'Location'")
+          .collect()(0)
+          .getString(1)
+          .replace("file:", "")
+
+        val kernelSchema = tableSchema(path)
+
+        val snapshot = latestSnapshot(path)
+        val scan = snapshot.getScanBuilder(defaultEngine).build()
+        val scanState = scan.getScanState(defaultEngine)
+        val physicalReadSchema =
+          ScanStateRow.getPhysicalDataReadSchema(defaultEngine, scanState)
+        val scanFilesIter = scan.getScanFiles(defaultEngine)
+
+        val readRows = ArrayBuffer[Row]()
+        while (scanFilesIter.hasNext()) {
+          val scanFilesBatch = scanFilesIter.next()
+          val scanFileRows = scanFilesBatch.getRows()
+          while (scanFileRows.hasNext()) {
+            val scanFileRow = scanFileRows.next()
+            val fileStatus = InternalScanFileUtils.getAddFileStatus(scanFileRow)
+
+            val physicalDataIter = defaultEngine.getParquetHandler.readParquetFiles(
+              singletonCloseableIterator(fileStatus),
+              physicalReadSchema,
+              Optional.empty())
+
+            val transformedRowsIter = Scan.transformPhysicalData(
+              defaultEngine,
+              scanState,
+              scanFileRow,
+              physicalDataIter
+            )
+
+            val transformedRows = transformedRowsIter.asScala.toSeq.map(_.getRows).flatMap(_.toSeq)
+            readRows.appendAll(transformedRows)
+          }
+        }
+
+        checkAnswer(readRows.toSeq, df.collect().map(TestRow(_)))
+      }
+    }
+  }
+
+  testReadWithVariant("basic variant") {
+    spark.range(0, 1, 1, 1).selectExpr(
+      "parse_json(cast(id as string)) as basic_v",
+      "named_struct('v', parse_json(cast(id as string))) as struct_v",
+      "named_struct('v', array(parse_json(cast(id as string)))) as struct_array_v",
+      "named_struct('v', map('key', parse_json(cast(id as string)))) as struct_map_v",
+      "named_struct('top', named_struct('v', parse_json(cast(id as string)))) as struct_struct_v",
+      """array(
+        parse_json(cast(id as string)),
+        parse_json(cast(id as string)),
+        parse_json(cast(id as string))
+      ) as array_v""",
+      """array(
+        named_struct('v', parse_json(cast(id as string))),
+        named_struct('v', parse_json(cast(id as string))),
+        named_struct('v', parse_json(cast(id as string)))
+      ) as array_struct_v""",
+      """array(
+        map('v', parse_json(cast(id as string))),
+        map('k1', parse_json(cast(id as string)), 'k2',  parse_json(cast(id as string))),
+        map('v', parse_json(cast(id as string)))
+      ) as array_map_v""",
+      "map('test', parse_json(cast(id as string))) as map_value_v",
+      "map('test', named_struct('v', parse_json(cast(id as string)))) as map_struct_v"
+    )
+  }
+
+  testReadWithVariant("basic null variant") {
+    spark.range(0, 10, 1, 1).selectExpr(
+      "cast(null as variant) basic_v",
+      "named_struct('v', cast(null as variant)) as struct_v",
+      """array(
+        parse_json(cast(id as string)),
+        parse_json(cast(id as string)),
+        null
+      ) as array_v""",
+      "map('test', cast(null as variant)) as map_value_v"
+    )
   }
 }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -396,7 +396,7 @@ trait TestUtils extends Assertions with SQLHelper {
 
   /**
    * Reads the results of the Spark dataframe with Kernel and verifies that the results are
-   * identical. 
+   * identical.
    */
   def checkTableVsSpark(df: DataFrame): Unit = {
     withTempDir { dir =>

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -24,6 +24,7 @@ import scala.collection.mutable.ArrayBuffer
 import io.delta.golden.GoldenTableUtils
 import io.delta.kernel.{Scan, Snapshot, Table}
 import io.delta.kernel.data.{ColumnVector, ColumnarBatch, FilteredColumnarBatch, MapValue, Row}
+import io.delta.kernel.defaults.VariantShims
 import io.delta.kernel.defaults.engine.DefaultEngine
 import io.delta.kernel.defaults.internal.data.vector.DefaultGenericVector
 import io.delta.kernel.engine.Engine
@@ -71,7 +72,7 @@ trait TestUtils extends Assertions with SQLHelper {
         while (iter.hasNext) {
           result.append(iter.next())
         }
-        result
+        result.toSeq
       } finally {
         iter.close()
       }
@@ -173,7 +174,7 @@ trait TestUtils extends Assertions with SQLHelper {
         // for all primitive types
         Seq(new Column((basePath :+ field.getName).asJava.toArray(new Array[String](0))));
       case _ => Seq.empty
-    }
+    }.toSeq
   }
 
   def collectScanFileRows(scan: Scan, engine: Engine = defaultEngine): Seq[Row] = {
@@ -251,7 +252,7 @@ trait TestUtils extends Assertions with SQLHelper {
         }
       }
     }
-    result
+    result.toSeq
   }
 
   def readTableUsingKernel(
@@ -700,7 +701,8 @@ trait TestUtils extends Assertions with SQLHelper {
             toSparkType(field.getDataType),
             field.isNullable
           )
-        })
+        }.toSeq)
+      case VariantType.VARIANT => VariantShims.getSparkVariantType()
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Adds new `VariantValue` interface and `getVariant` methods to `ColumnVector` interface so column vectors consisting of `VariantValue`s can be created.

In kernel-defaults, we implementthe default implementation such that it understands variants completely for now and can directly scan variants with its own `VariantColumnReader`. This is subject to change in the future to remove the `VariantColumnReader` and instead return structs from the scan.

This PR also does the following

* Cross compiles kernel defaults with Spark 3.5 and Spark 4.0. This is done so the tests can write variants using spark 4.0 rather than needing to manually creating and comparing against variant values
* Allows compilation on Java 8 and Java 17 for the above.

## How was this patch tested?

added UTs against Spark

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
