### PR TITLE
Infra: Shard spark and spark master tests across 3 actions

### DIFF
--- a/.github/workflows/spark_master_test.yaml
+++ b/.github/workflows/spark_master_test.yaml
@@ -7,8 +7,12 @@ jobs:
       matrix:
         # These Scala versions must match those in the build.sbt
         scala: [2.13.13]
+        # Important: This list of shards must be [0..NUM_SHARDS - 1]
+        shard: [0, 1, 2]
     env:
       SCALA_VERSION: ${{ matrix.scala }}
+      # Important: This must be the same as the length of shards in matrix
+      NUM_SHARDS: 3
     steps:
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v4
@@ -46,7 +50,7 @@ jobs:
       - name: Run Spark Master tests
         # when changing TEST_PARALLELISM_COUNT make sure to also change it in spark_test.yaml
         run: |
-          TEST_PARALLELISM_COUNT=2 build/sbt -DsparkVersion=master "++ ${{ matrix.scala }}" clean spark/test
+          TEST_PARALLELISM_COUNT=2 SHARD_ID=${{matrix.shard}} build/sbt -DsparkVersion=master "++ ${{ matrix.scala }}" clean spark/test
           TEST_PARALLELISM_COUNT=2 build/sbt -DsparkVersion=master "++ ${{ matrix.scala }}" clean connectServer/test
           TEST_PARALLELISM_COUNT=2 build/sbt -DsparkVersion=master "++ ${{ matrix.scala }}" clean connectServer/assembly connectClient/test
         if: steps.git-diff.outputs.diff

--- a/.github/workflows/spark_test.yaml
+++ b/.github/workflows/spark_test.yaml
@@ -7,8 +7,12 @@ jobs:
       matrix:
         # These Scala versions must match those in the build.sbt
         scala: [2.12.18, 2.13.13]
+        # Important: This list of shards must be [0..NUM_SHARDS - 1]
+        shard: [0, 1, 2]
     env:
       SCALA_VERSION: ${{ matrix.scala }}
+      # Important: This must be the same as the length of shards in matrix
+      NUM_SHARDS: 3
     steps:
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v4
@@ -78,5 +82,5 @@ jobs:
       - name: Run Scala/Java and Python tests
         # when changing TEST_PARALLELISM_COUNT make sure to also change it in spark_master_test.yaml
         run: |
-          TEST_PARALLELISM_COUNT=2 pipenv run python run-tests.py --group spark
+          TEST_PARALLELISM_COUNT=2 pipenv run python run-tests.py --group spark --shard ${{ matrix.shard }}
         if: steps.git-diff.outputs.diff

--- a/build.sbt
+++ b/build.sbt
@@ -1506,7 +1506,8 @@ val createTargetClassesDir = taskKey[Unit]("create target classes dir")
 
 // Don't use these groups for any other projects
 lazy val sparkGroup = project
-  .aggregate(contribs, storage, storageS3DynamoDB, iceberg, testDeltaIcebergJar, sharing, hudi)  .settings(
+  .aggregate(spark, contribs, storage, storageS3DynamoDB, iceberg, testDeltaIcebergJar, sharing, hudi)
+  .settings(
     // crossScalaVersions must be set to Nil on the aggregating project
     crossScalaVersions := Nil,
     publishArtifact := false,

--- a/build.sbt
+++ b/build.sbt
@@ -1506,8 +1506,7 @@ val createTargetClassesDir = taskKey[Unit]("create target classes dir")
 
 // Don't use these groups for any other projects
 lazy val sparkGroup = project
-  .aggregate(spark, contribs, storage, storageS3DynamoDB, iceberg, testDeltaIcebergJar, sharing, hudi)
-  .settings(
+  .aggregate(contribs, storage, storageS3DynamoDB, iceberg, testDeltaIcebergJar, sharing, hudi)  .settings(
     // crossScalaVersions must be set to Nil on the aggregating project
     crossScalaVersions := Nil,
     publishArtifact := false,

--- a/run-tests.py
+++ b/run-tests.py
@@ -43,16 +43,23 @@ def get_args():
         default=False,
         action="store_true",
         help="Enables test coverage and generates an aggregate report for all subprojects")
+    parser.add_argument(
+        "--shard",
+        required=False,
+        default=None,
+        help="some shard")
     return parser.parse_args()
 
 
-def run_sbt_tests(root_dir, test_group, coverage, scala_version=None):
+def run_sbt_tests(root_dir, test_group, coverage, scala_version=None, shard=None):
     print("##### Running SBT tests #####")
 
     sbt_path = path.join(root_dir, path.join("build", "sbt"))
     cmd = [sbt_path, "clean"]
 
     test_cmd = "test"
+    if shard:
+        os.environ["SHARD_ID"] = str(shard)
 
     if test_group:
         # if test group is specified, then run tests only on that test group
@@ -223,7 +230,7 @@ if __name__ == "__main__":
         run_tests_in_docker(test_env_image_tag, args.group)
     else:
         scala_version = os.getenv("SCALA_VERSION")
-        run_sbt_tests(root_dir, args.group, args.coverage, scala_version)
+        run_sbt_tests(root_dir, args.group, args.coverage, scala_version, args.shard)
 
         # Python tests are run only when spark group of projects are being tested.
         is_testing_spark_group = args.group is None or args.group == "spark"


### PR DESCRIPTION
This change adds a matrix of 3 shards to github CI for the delta spark/spark master tests and plumbs those through to our parallelization strategy which will then select tests to run if they are assigned to that shard. This brings down CI times from ~4 hours to 2 hours.

3 shards seemsd to be the point of diminishing returns, and we should look at the actual tests and possibly higher instance types if we really want to get those down further.

No sharding: 4 hours
2 shards: 3 hours
3 shards:  ~2 hours
4 shards: ~2 hours


### How to revert

To undo this change without a full revert commit there are a few ways (in order of recommendation)

1. Remove/comment out *both* 
the shard row in the GH matrix https://github.com/delta-io/delta/pull/3517/files#diff-b77047dc65c62d814f7f67eec57c23c4cf9d9796e6a8a018558e0e935739d8d8R10-R11

AND

the NUM_SHARDS env variable
https://github.com/delta-io/delta/pull/3517/files#diff-b77047dc65c62d814f7f67eec57c23c4cf9d9796e6a8a018558e0e935739d8d8R15

2. Comment out this block https://github.com/delta-io/delta/pull/3517/files#diff-00b77d52981e1ba8cc5ac9b80b22d8f7bb9814222121b714269e14e139daaae0R141-R152 in TestParallelization

