### PR TITLE
[Spark] Always enable all legacy preceding features when a legacy feature is enabled

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -684,11 +684,13 @@ trait OptimisticTransactionImpl extends TransactionalWrite
     }
     val existingFeatureNames = newProtocolBeforeAddingFeatures.readerAndWriterFeatureNames
     if (!newFeaturesFromTableConf.map(_.name).subsetOf(existingFeatureNames)) {
+      // When enabling legacy features, include all preceding legacy features.
+      val implicitFeatures = TableFeatureProtocolUtils.implicitFeatures(newFeaturesFromTableConf)
       newProtocol = Some(
         Protocol(
           readerVersionForNewProtocol,
           TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION)
-          .withFeatures(newFeaturesFromTableConf)
+          .withFeatures(newFeaturesFromTableConf ++ implicitFeatures)
           .merge(newProtocolBeforeAddingFeatures))
     }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -685,7 +685,8 @@ trait OptimisticTransactionImpl extends TransactionalWrite
     val existingFeatureNames = newProtocolBeforeAddingFeatures.readerAndWriterFeatureNames
     if (!newFeaturesFromTableConf.map(_.name).subsetOf(existingFeatureNames)) {
       // When enabling legacy features, include all preceding legacy features.
-      val implicitFeatures = TableFeatureProtocolUtils.implicitlySupportedFeatures(newFeaturesFromTableConf)
+      val implicitFeatures =
+        TableFeatureProtocolUtils.implicitlySupportedFeatures(newFeaturesFromTableConf)
       newProtocol = Some(
         Protocol(
           readerVersionForNewProtocol,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -685,7 +685,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
     val existingFeatureNames = newProtocolBeforeAddingFeatures.readerAndWriterFeatureNames
     if (!newFeaturesFromTableConf.map(_.name).subsetOf(existingFeatureNames)) {
       // When enabling legacy features, include all preceding legacy features.
-      val implicitFeatures = TableFeatureProtocolUtils.implicitFeatures(newFeaturesFromTableConf)
+      val implicitFeatures = TableFeatureProtocolUtils.implicitlySupportedFeatures(newFeaturesFromTableConf)
       newProtocol = Some(
         Protocol(
           readerVersionForNewProtocol,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -498,4 +498,12 @@ object TableFeatureProtocolUtils {
    */
   def minimumRequiredVersions(features: Seq[TableFeature]): (Int, Int) =
     ((features.map(_.minReaderVersion) :+ 1).max, (features.map(_.minWriterVersion) :+ 1).max)
+
+  /**
+   * Return a set with the implicit features of the provided feature set.
+   */
+  def implicitFeatures(features: Set[TableFeature]): Set[TableFeature] =
+    features.flatMap { f =>
+      Protocol(f.minReaderVersion, f.minWriterVersion).implicitlySupportedFeatures
+    }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -500,9 +500,15 @@ object TableFeatureProtocolUtils {
     ((features.map(_.minReaderVersion) :+ 1).max, (features.map(_.minWriterVersion) :+ 1).max)
 
   /**
-   * Return a set with the implicit features of the provided feature set.
+   * Returns a set of legacy features that contains the input features as well as the
+   * features that will be supported by the protocol as a "byproduct" of supporting the
+   * given legacy `features`.
+   *
+   * As an example, the legacy protocol for supporting ColumnMapping also supports
+   * AppendOnly, Invariants, CheckConstraints, CDF, GeneratedColumns as byproducts and there is
+   * no way to not support them.
    */
-  def implicitFeatures(features: Set[TableFeature]): Set[TableFeature] =
+  def implicitlySupportedFeatures(features: Set[TableFeature]): Set[TableFeature] =
     features.flatMap { f =>
       Protocol(f.minReaderVersion, f.minWriterVersion).implicitlySupportedFeatures
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -342,11 +342,6 @@ object Protocol {
         spark, metadata, Protocol().withFeatures(tablePropEnabledFeatures))
     val allEnabledFeatures = tablePropEnabledFeatures ++ metaEnabledFeatures
 
-    // When enabling legacy features, include all preceding legacy features.
-    val implicitFeatures = allEnabledFeatures.flatMap { f =>
-      Protocol(f.minReaderVersion, f.minWriterVersion).implicitlySupportedFeatures
-    }
-
     // Determine the min reader and writer version required by features in table properties or
     // metadata.
     // If any table property is specified:
@@ -403,6 +398,9 @@ object Protocol {
         case _ => Set.empty
       }
 
+    // When enabling legacy features, include all preceding legacy features.
+    val implicitFeatures = TableFeatureProtocolUtils.implicitFeatures(allEnabledFeatures)
+
     (finalReaderVersion, finalWriterVersion,
       allEnabledFeatures ++ implicitFeatures ++ implicitFeaturesFromTableConf)
   }
@@ -430,10 +428,9 @@ object Protocol {
       readerVersion = math.max(readerVersion, feature.minReaderVersion)
       writerVersion = math.max(writerVersion, feature.minWriterVersion)
     }
+
     // When enabling legacy features, include all preceding legacy features.
-    val implicitFeatures = enabledFeatures.flatMap { f =>
-      Protocol(f.minReaderVersion, f.minWriterVersion).implicitlySupportedFeatures
-    }
+    val implicitFeatures = TableFeatureProtocolUtils.implicitFeatures(enabledFeatures)
 
     (readerVersion, writerVersion, enabledFeatures ++ implicitFeatures)
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -399,7 +399,8 @@ object Protocol {
       }
 
     // When enabling legacy features, include all preceding legacy features.
-    val implicitFeatures = TableFeatureProtocolUtils.implicitlySupportedFeatures(allEnabledFeatures)
+    val implicitFeatures =
+      TableFeatureProtocolUtils.implicitlySupportedFeatures(allEnabledFeatures)
 
     (finalReaderVersion, finalWriterVersion,
       allEnabledFeatures ++ implicitFeatures ++ implicitFeaturesFromTableConf)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -399,7 +399,7 @@ object Protocol {
       }
 
     // When enabling legacy features, include all preceding legacy features.
-    val implicitFeatures = TableFeatureProtocolUtils.implicitFeatures(allEnabledFeatures)
+    val implicitFeatures = TableFeatureProtocolUtils.implicitlySupportedFeatures(allEnabledFeatures)
 
     (finalReaderVersion, finalWriterVersion,
       allEnabledFeatures ++ implicitFeatures ++ implicitFeaturesFromTableConf)
@@ -430,7 +430,7 @@ object Protocol {
     }
 
     // When enabling legacy features, include all preceding legacy features.
-    val implicitFeatures = TableFeatureProtocolUtils.implicitFeatures(enabledFeatures)
+    val implicitFeatures = TableFeatureProtocolUtils.implicitlySupportedFeatures(enabledFeatures)
 
     (readerVersion, writerVersion, enabledFeatures ++ implicitFeatures)
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -393,7 +393,7 @@ case class AlterTableDropFeatureDeltaCommand(
         }
       }
 
-      txn.updateProtocol(txn.protocol.denormalized.removeFeature(removableFeature))
+      txn.updateProtocol(txn.protocol.removeFeature(removableFeature))
       txn.commit(Nil, DeltaOperations.DropTableFeature(featureName, truncateHistory))
       Nil
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
@@ -1892,8 +1892,6 @@ class DeltaColumnMappingSuite extends QueryTest
   test("column mapping upgrade with table features") {
     val testTableName = "columnMappingTestTable"
     withTable(testTableName) {
-      val minReaderKey = DeltaConfigs.MIN_READER_VERSION.key
-      val minWriterKey = DeltaConfigs.MIN_WRITER_VERSION.key
       sql(
         s"""CREATE TABLE $testTableName
            |USING DELTA
@@ -1915,7 +1913,15 @@ class DeltaColumnMappingSuite extends QueryTest
       assert(deltaLog.update().protocol === Protocol(2, 7).withFeatures(Seq(
         AppendOnlyTableFeature,
         InvariantsTableFeature,
+        CheckConstraintsTableFeature,
+        GeneratedColumnsTableFeature,
+        ChangeDataFeedTableFeature,
         ColumnMappingTableFeature,
+        TestLegacyWriterFeature,
+        TestLegacyReaderWriterFeature,
+        TestRemovableLegacyWriterFeature,
+        TestRemovableLegacyReaderWriterFeature,
+        DomainMetadataTableFeature,
         RowTrackingFeature
       )))
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolTransitionsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolTransitionsSuite.scala
@@ -391,8 +391,8 @@ class DeltaProtocolTransitionsSuite extends DeltaProtocolTransitionsBaseSuite {
         createTableProperties = Seq(
           (s"delta.feature.${ColumnMappingTableFeature.name}", "supported"),
           (s"delta.feature.${DomainMetadataTableFeature.name}", "supported"),
-          (s"delta.feature.${DeletionVectorsTableFeature.name}", "supported")),
-        dropFeatures = Seq(DeletionVectorsTableFeature),
+          (s"delta.feature.${V2CheckpointTableFeature.name}", "supported")),
+        dropFeatures = Seq(V2CheckpointTableFeature),
         expectedProtocol = Protocol(2, 7).withFeatures(Seq(
           InvariantsTableFeature,
           AppendOnlyTableFeature,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -4194,4 +4194,3 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
 }
 
 class DeltaProtocolVersionSuite extends DeltaProtocolVersionSuiteBase
-  with DeltaProtocolVersionSuiteEdge

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -4205,12 +4205,3 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
 }
 
 class DeltaProtocolVersionSuite extends DeltaProtocolVersionSuiteBase
-  with DeltaProtocolVersionSuiteEdge {
-
-  test("TEST") {
-    testWriterFeatureRemoval(
-      TestRemovableLegacyWriterFeature,
-      TestRemovableLegacyWriterFeature.TABLE_PROP_KEY)
-  }
-
-}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -2407,25 +2407,14 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
            |$featureProperty = "true"
            |)""".stripMargin)
 
-    /*
-    val expectedReaderVersion = Math.max(feature.minReaderVersion, 1)
+    val expectedReaderVersion = Math.max(1, feature.minReaderVersion)
     val expectProtocol = if (feature.isLegacyFeature) {
       Protocol(expectedReaderVersion, feature.minWriterVersion)
     } else {
-     Protocol(
-       expectedReaderVersion,
-       TABLE_FEATURES_MIN_WRITER_VERSION,
-       if (supportsReaderFeatures(expectedReaderVersion)) Some(Set(feature.name)) else None,
-       Some(Set(feature.name, InvariantsTableFeature.name, AppendOnlyTableFeature.name)))
-    }
-    */
-    val expectProtocol = if (feature.isLegacyFeature) {
-      Protocol(Math.max(1, feature.minReaderVersion), feature.minWriterVersion)
-    } else {
-      Protocol(3, 7).withFeatures(Seq(
+      Protocol(expectedReaderVersion, 7).withFeatures(Seq(
         InvariantsTableFeature,
         AppendOnlyTableFeature,
-        feature)).normalized
+        feature))
     }
 
     assert(deltaLog.update().protocol === expectProtocol)
@@ -4205,3 +4194,4 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
 }
 
 class DeltaProtocolVersionSuite extends DeltaProtocolVersionSuiteBase
+  with DeltaProtocolVersionSuiteEdge

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
@@ -335,17 +335,17 @@ class DeltaTableFeatureSuite
         val log = DeltaLog.forTable(spark, TableIdentifier("tbl"))
         val protocol = log.update().protocol
         assert(protocol.readerAndWriterFeatureNames === Set(
-          AppendOnlyTableFeature.name,
-          InvariantsTableFeature.name,
-          CheckConstraintsTableFeature.name,
-          GeneratedColumnsTableFeature.name,
-          ChangeDataFeedTableFeature.name,
-          ColumnMappingTableFeature.name,
-          TestLegacyWriterFeature.name,
-          TestRemovableLegacyReaderWriterFeature.name,
-          TestLegacyReaderWriterFeature.name,
-          TestRemovableLegacyWriterFeature.name,
-          TestWriterFeature.name))
+          AppendOnlyTableFeature,
+          InvariantsTableFeature,
+          CheckConstraintsTableFeature,
+          GeneratedColumnsTableFeature,
+          ChangeDataFeedTableFeature,
+          ColumnMappingTableFeature,
+          TestLegacyWriterFeature,
+          TestRemovableLegacyReaderWriterFeature,
+          TestLegacyReaderWriterFeature,
+          TestRemovableLegacyWriterFeature,
+          TestWriterFeature).map(_.name))
       }
     }
   }
@@ -396,12 +396,12 @@ class DeltaTableFeatureSuite
             commandName, targetTableName = "tbl", sourceTableName = "tbl", tblProperties))
           val protocol = log.update().protocol
           assert(protocol.readerAndWriterFeatureNames === Set(
-            AppendOnlyTableFeature.name,
-            InvariantsTableFeature.name,
-            CheckConstraintsTableFeature.name,
-            GeneratedColumnsTableFeature.name,
-            ChangeDataFeedTableFeature.name,
-            TestWriterFeature.name))
+            AppendOnlyTableFeature,
+            InvariantsTableFeature,
+            CheckConstraintsTableFeature,
+            GeneratedColumnsTableFeature,
+            ChangeDataFeedTableFeature,
+            TestWriterFeature).map(_.name))
         }
       }
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
@@ -337,7 +337,14 @@ class DeltaTableFeatureSuite
         assert(protocol.readerAndWriterFeatureNames === Set(
           AppendOnlyTableFeature.name,
           InvariantsTableFeature.name,
+          CheckConstraintsTableFeature.name,
+          GeneratedColumnsTableFeature.name,
+          ChangeDataFeedTableFeature.name,
           ColumnMappingTableFeature.name,
+          TestLegacyWriterFeature.name,
+          TestRemovableLegacyReaderWriterFeature.name,
+          TestLegacyReaderWriterFeature.name,
+          TestRemovableLegacyWriterFeature.name,
           TestWriterFeature.name))
       }
     }
@@ -372,8 +379,7 @@ class DeltaTableFeatureSuite
         commandName = "CLONE", targetTableName = "target", sourceTableName = "src"))
       val targetLog = DeltaLog.forTable(spark, TableIdentifier("target"))
       val protocol = targetLog.update().protocol
-      assert(protocol.readerAndWriterFeatureNames === Set(
-        ColumnMappingTableFeature.name))
+      assert(protocol === Protocol(2, 5))
     }
   }
 
@@ -392,6 +398,8 @@ class DeltaTableFeatureSuite
           assert(protocol.readerAndWriterFeatureNames === Set(
             AppendOnlyTableFeature.name,
             InvariantsTableFeature.name,
+            CheckConstraintsTableFeature.name,
+            GeneratedColumnsTableFeature.name,
             ChangeDataFeedTableFeature.name,
             TestWriterFeature.name))
         }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/DropColumnMappingFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/DropColumnMappingFeatureSuite.scala
@@ -209,9 +209,8 @@ class DropColumnMappingFeatureSuite extends RemoveColumnMappingSuiteUtils {
          |ALTER TABLE $testTableName DROP FEATURE ${ColumnMappingTableFeature.name} TRUNCATE HISTORY
          |""".stripMargin)
     val newSnapshot = deltaLog.update()
-    assert(newSnapshot.protocol.readerAndWriterFeatures.isEmpty, "Should drop the feature.")
-    assert(newSnapshot.protocol.minWriterVersion == 1)
-    assert(newSnapshot.protocol.minReaderVersion == 1)
+    assert(!newSnapshot.protocol.readerAndWriterFeatures.contains(ColumnMappingTableFeature),
+      "Should drop the feature.")
   }
 
   protected def dropColumnMappingTableFeature(): Unit = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Currently, enabling a legacy feature on a table features protocol enables only the requested feature. On the other hand, when enabling a legacy feature on a legacy protocol we enable all preceding legacy features as well. For example, enabling `CDF` on protocol `(1, 2)` results to protocol `(1, 4)`. This means, that apart from `CDF` we also enabled `CheckConstraints` and `GeneratedColumns`.

In this PR, we fix this inconsistency by always adding preceding legacy features in all cases.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Adapted tests in `DeltaProtocolVersionSuite`, `DeltaProtocolTransitionsSuite` as well as tests in miscellaneous suites.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.