### PR TITLE
[SPARK] Relax metadata conflict for identity column

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/IdentityColumn.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/IdentityColumn.scala
@@ -44,6 +44,8 @@ object IdentityColumn extends DeltaLogging {
   val opTypeDefinition = "delta.identityColumn.definition"
   // When table with IDENTITY columns are written into.
   val opTypeWrite = "delta.identityColumn.write"
+  // When IDENTITY column update causes transaction to abort.
+  val opTypeAbort = "delta.identityColumn.abort"
 
   // Return true if `field` is an identity column that allows explicit insert. Caller must ensure
   // `isIdentityColumn(field)` is true.
@@ -242,6 +244,10 @@ object IdentityColumn extends DeltaLogging {
         )
       )
     }
+  }
+
+  def logTransactionAbort(deltaLog: DeltaLog): Unit = {
+    recordDeltaEvent(deltaLog, opTypeAbort)
   }
 
   // Calculate the sync'ed IDENTITY high water mark based on actual data and returns a

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -400,9 +400,16 @@ trait OptimisticTransactionImpl extends TransactionalWrite
   // writes.
   protected var trackHighWaterMarks: Option[Set[String]] = None
 
+  // Set to true if this transaction is ALTER TABLE ALTER COLUMN SYNC IDENTITY.
+  protected var syncIdentity: Boolean = false
+
   def setTrackHighWaterMarks(track: Set[String]): Unit = {
     assert(trackHighWaterMarks.isEmpty, "The tracking set shouldn't have been set")
     trackHighWaterMarks = Some(track)
+  }
+
+  def setSyncIdentity(): Unit = {
+    syncIdentity = true
   }
 
   /**
@@ -420,6 +427,15 @@ trait OptimisticTransactionImpl extends TransactionalWrite
   private def updateMetadataAfterWrite(updatedMetadata: Metadata): Unit = {
     updateMetadataInternal(updatedMetadata, ignoreDefaultProperties = false)
   }
+
+  // Returns whether this transaction updates metadata solely for IDENTITY high water marks (this
+  // can be either a write that generates IDENTITY values or an ALTER TABLE ALTER COLUMN SYNC
+  // IDENTITY command). This must be called before precommitUpdateSchemaWithIdentityHighWaterMarks
+  // as it might update `newMetadata`.
+  def isIdentityOnlyMetadataUpdate(): Boolean = {
+    syncIdentity || (updatedIdentityHighWaterMarks.nonEmpty && newMetadata.isEmpty)
+  }
+
 
   // Called before commit to update table schema with collected IDENTITY column high water marks
   // so that the change can be committed to delta log.
@@ -1206,6 +1222,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       // Check for internal SetTransaction conflicts and dedup.
       val finalActions = checkForSetTransactionConflictAndDedup(actions ++ this.actions.toSeq)
 
+      val identityOnlyMetadataUpdate = isIdentityOnlyMetadataUpdate()
       // Update schema for IDENTITY column writes if necessary. This has to be called before
       // `prepareCommit` because it might change metadata and `prepareCommit` is responsible for
       // converting updated metadata into a `Metadata` action.
@@ -1235,6 +1252,12 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       val readRowIdHighWatermark =
         RowId.extractHighWatermark(snapshot).getOrElse(RowId.MISSING_HIGH_WATER_MARK)
 
+      val autoTags = mutable.HashMap.empty[String, String]
+      if (identityOnlyMetadataUpdate) {
+        autoTags += (DeltaSourceUtils.IDENTITY_COMMITINFO_TAG -> "true")
+      }
+      val allTags = tags ++ autoTags
+
       commitAttemptStartTimeMillis = clock.getTimeMillis()
       commitInfo = CommitInfo(
         time = commitAttemptStartTimeMillis,
@@ -1248,7 +1271,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
         isBlindAppend = Some(isBlindAppend),
         operationMetrics = getOperationMetrics(op),
         userMetadata = getUserMetadata(op),
-        tags = if (tags.nonEmpty) Some(tags) else None,
+        tags = if (allTags.nonEmpty) Some(allTags) else None,
         txnId = Some(txnId))
 
       val firstAttemptVersion = getFirstAttemptVersion

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -436,7 +436,6 @@ trait OptimisticTransactionImpl extends TransactionalWrite
     syncIdentity || (updatedIdentityHighWaterMarks.nonEmpty && newMetadata.isEmpty)
   }
 
-
   // Called before commit to update table schema with collected IDENTITY column high water marks
   // so that the change can be committed to delta log.
   def precommitUpdateSchemaWithIdentityHighWaterMarks(): Unit = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -634,6 +634,7 @@ case class AlterTableChangeColumnDeltaCommand(
               assert(oldColumn == newColumn)
               val df = txn.snapshot.deltaLog.createDataFrame(txn.snapshot, txn.filterFiles())
               val field = IdentityColumn.syncIdentity(newColumn, df)
+              txn.setSyncIdentity()
               txn.readWholeTable()
               field
             } else {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceUtils.scala
@@ -41,6 +41,7 @@ object DeltaSourceUtils {
   val IDENTITY_INFO_START = "delta.identity.start"
   val IDENTITY_INFO_STEP = "delta.identity.step"
   val IDENTITY_INFO_HIGHWATERMARK = "delta.identity.highWaterMark"
+  val IDENTITY_COMMITINFO_TAG = "delta.identity.schemaUpdate"
 
   def isDeltaDataSourceName(name: String): Boolean = {
     name.toLowerCase(Locale.ROOT) == NAME || name.toLowerCase(Locale.ROOT) == ALT_NAME

--- a/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnConflictSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnConflictSuite.scala
@@ -269,13 +269,14 @@ trait IdentityColumnConflictSuiteBase
     }
   }
 
-  test(s"ALTER TABLE SYNC IDENTITY Serializable") {
+  test("ALTER TABLE SYNC IDENTITY conflict on serializable table") {
     transactionIdentityConflictHelper(
       syncIdentityTestCase,
       noMetadataUpdateTestCase,
       tblIsoLevel = Some(Serializable)
     )
   }
+
 }
 
 class IdentityColumnConflictScalaSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnConflictSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnConflictSuite.scala
@@ -1,0 +1,283 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import scala.concurrent.duration.Duration
+import scala.util.control.NonFatal
+
+import com.databricks.spark.util.Log4jUsageLogger
+import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils
+import org.apache.spark.sql.delta.concurrency.{PhaseLockingTestMixin, TransactionExecutionTestMixin}
+import org.apache.spark.sql.delta.fuzzer.{OptimisticTransactionPhases, PhaseLockingTransactionExecutionObserver}
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.execution.QueryExecution
+import org.apache.spark.util.ThreadUtils
+
+/**
+ * Helper class used in this test suite for describing different transaction conflict scenarios.
+ */
+sealed trait TransactionConflictTestCase {
+  /** label for this transaction scenario. */
+  def name: String
+  /** SQL command to be executed. */
+  def sqlCommand: String
+  /** Boolean indicating whether this transaction does a metadata update. */
+  def hasMetadataUpdate: Boolean
+  /** Boolean indicating whether the SQL command appends data (add files) to the table. */
+  def isAppend: Boolean
+}
+
+case class NoMetadataUpdateTestCase(
+    name: String,
+    sqlCommand: String,
+    isAppend: Boolean) extends TransactionConflictTestCase {
+  val hasMetadataUpdate = false
+}
+
+/**
+ * A transaction that will do a metadata update but will not be tagged as identity column only nor
+ * row tracking enablement only.
+ */
+case class GenericMetadataUpdateTestCase(
+    name: String,
+    sqlCommand: String,
+    isAppend: Boolean) extends TransactionConflictTestCase {
+  val hasMetadataUpdate = true
+}
+
+/** A transaction that will be tagged as a metadata update only for identity column. */
+case class IdentityOnlyMetadataUpdateTestCase(
+    name: String,
+    sqlCommand: String,
+    isAppend: Boolean) extends TransactionConflictTestCase {
+  val hasMetadataUpdate = true
+}
+
+/** A transaction that will be tagged as a metadata update only for row tracking enablement. */
+case class RowTrackingEnablementOnlyTestCase(
+    name: String,
+    sqlCommand: String,
+    isAppend: Boolean) extends TransactionConflictTestCase {
+  val hasMetadataUpdate = true
+}
+
+trait IdentityColumnConflictSuiteBase
+    extends IdentityColumnTestUtils
+    with TransactionExecutionTestMixin
+    with PhaseLockingTestMixin {
+  override def sparkConf: SparkConf = super.sparkConf
+    .set(DeltaSQLConf.DELTA_ROW_TRACKING_BACKFILL_ENABLED.key, "true")
+
+  val tblName = "identity_conflict_test"
+  val colName = "id"
+
+  private def setupEmptyTableWithRowTrackingTableFeature(
+      tblIsoLevel: Option[IsolationLevel]): Unit = {
+    val tblPropertiesMap: Map[String, String] = Map(
+      TableFeatureProtocolUtils.propertyKey(RowTrackingFeature) -> "supported",
+      DeltaConfigs.ROW_TRACKING_ENABLED.key -> "false",
+      DeltaConfigs.ISOLATION_LEVEL.key ->
+        tblIsoLevel.map(_.toString).getOrElse(DeltaConfigs.ISOLATION_LEVEL.defaultValue)
+    )
+
+    createTableWithIdColAndIntValueCol(
+      tableName = tblName,
+      generatedAsIdentityType = GeneratedAsIdentityType.GeneratedByDefault,
+      startsWith = Some(1),
+      incrementBy = Some(1),
+      tblProperties = tblPropertiesMap
+    )
+  }
+
+  /**
+   * Returns the expected exception class for the test case.
+   * Returns None if no exception is expected.
+   */
+  private def expectedExceptionClass(
+      currentTxn: TransactionConflictTestCase,
+      winningTxn: TransactionConflictTestCase): Option[Class[_ <: RuntimeException]] = {
+    val currentTxnShouldAbortDueToMetadataUpdate = winningTxn match {
+      case _: NoMetadataUpdateTestCase => false
+      case _: IdentityOnlyMetadataUpdateTestCase if !currentTxn.hasMetadataUpdate => false
+      case _: RowTrackingEnablementOnlyTestCase if !currentTxn.hasMetadataUpdate => false
+      case _ => true
+    }
+
+    // Metadata update is checked before concurrent append in ConflictChecker.
+    if (currentTxnShouldAbortDueToMetadataUpdate) {
+      return Some(classOf[io.delta.exceptions.MetadataChangedException])
+    }
+
+    val currentTxnShouldAbortDueToConcurrentAppend = winningTxn.isAppend &&
+      currentTxn.isInstanceOf[IdentityOnlyMetadataUpdateTestCase] && !currentTxn.isAppend
+
+    if (currentTxnShouldAbortDueToConcurrentAppend) {
+        return Some(classOf[io.delta.exceptions.ConcurrentAppendException])
+    }
+
+    None
+  }
+
+  /**
+   * Helper function to test two concurrently running commands. Winning transaction commits before
+   * current transaction commits.
+   */
+  private def transactionIdentityConflictHelper(
+      currentTxn: TransactionConflictTestCase,
+      winningTxn: TransactionConflictTestCase,
+      tblIsoLevel: Option[IsolationLevel]): Unit = {
+    withTable(tblName) {
+      // We start with an empty table that has row tracking table feature support and row tracking
+      // table property disabled. This way, when we set the table property to true, it will not
+      // also do a protocol upgrade and we don't need any backfill commit.
+      setupEmptyTableWithRowTrackingTableFeature(tblIsoLevel)
+
+      val threadPool =
+        ThreadUtils.newDaemonSingleThreadExecutor(threadName = "identity-column-thread-pool")
+      var (txnObserver, future) = runQueryWithObserver(
+        name = "current", threadPool, currentTxn.sqlCommand)
+
+      // If the current txn is enabling row tracking on an existing table, the first txn is
+      // a NOOP since there are no files in the table initially. No commit will be made.
+      // Let's "skip" this txn obj. Replace the observer after the first commit.
+      // We want to observe the metadata update in this test, which happens after backfill.
+      val metadataUpdateObserver = new PhaseLockingTransactionExecutionObserver(
+        OptimisticTransactionPhases.forName("late-txn"))
+      if (currentTxn.isInstanceOf[RowTrackingEnablementOnlyTestCase]) {
+        txnObserver.setNextObserver(metadataUpdateObserver, autoAdvance = true)
+        unblockAllPhases(txnObserver)
+        txnObserver.phases.backfillPhase.exitBarrier.unblock()
+        txnObserver = metadataUpdateObserver
+      }
+
+      unblockUntilPreCommit(txnObserver)
+      busyWaitFor(txnObserver.phases.preparePhase.hasEntered, timeout)
+
+      sql(winningTxn.sqlCommand)
+
+      val expectedException = expectedExceptionClass(currentTxn, winningTxn)
+      val events = Log4jUsageLogger.track {
+        try {
+          unblockCommit(txnObserver)
+          ThreadUtils.awaitResult(future, Duration.Inf)
+          assert(expectedException.isEmpty, "Expected txn to fail, but no exception was thrown")
+        } catch {
+          case NonFatal(e) =>
+            assert(expectedException.isDefined, "Unexpected failure")
+            assert(e.getCause.getClass === expectedException.get)
+        }
+      }
+
+      // We should log if the txn is aborted due to identity column only metadata update.
+      if (currentTxn.hasMetadataUpdate
+          && winningTxn.isInstanceOf[IdentityOnlyMetadataUpdateTestCase]) {
+        val identityColumnAbortEvents = events
+            .filter(_.tags.get("opType").contains(IdentityColumn.opTypeAbort))
+        assert(identityColumnAbortEvents.size === 1)
+      }
+    }
+  }
+
+  // scalastyle:off line.size.limit
+  /**
+   * We are testing the following combinations (see [[ConflictChecker.checkNoMetadataUpdates]]
+   * for details).
+   *
+   * |                                               | Winning Metadata (id) | Winning Metadata Row Tracking Enablement Only | Winning Metadata (other) | Winning No Metadata |
+   * | --------------------------------------------- | --------------------- | --------------------------------------------- | ------------------------ | ------------------- |
+   * | Current Metadata (id)                         | Conflict              | Conflict                                      | Conflict                 | No conflict         |
+   * | Current Metadata Row Tracking Enablement Only | Conflict              | Conflict                                      | Conflict                 | No conflict         |
+   * | Current Metadata (other)                      | Conflict              | Conflict                                      | Conflict                 | No conflict         |
+   * | Current No Metadata                           | No conflict           | No conflict                                   | Conflict                 | No conflict         |
+   */
+  // scalastyle:on line.size.limit
+
+  // System generated IDENTITY value will have a metadata update for IDENTITY high water marks.
+  private val generatedIdTestCase = IdentityOnlyMetadataUpdateTestCase(
+    name = "generatedId",
+    sqlCommand = s"INSERT INTO $tblName(value) VALUES (1)",
+    isAppend = true
+  )
+
+  // SYNC IDENTITY updates the high water mark based on the values in the IDENTITY column.
+  private val syncIdentityTestCase = IdentityOnlyMetadataUpdateTestCase(
+    name = "syncIdentity",
+    sqlCommand = s"ALTER TABLE $tblName ALTER COLUMN $colName SYNC IDENTITY",
+    isAppend = false
+  )
+
+  // Explicitly provided IDENTITY value will not generate a metadata update.
+  private val noMetadataUpdateTestCase =
+    NoMetadataUpdateTestCase(
+      name = "noMetadataUpdate",
+      sqlCommand = s"INSERT INTO $tblName VALUES (1, 1)",
+      isAppend = true
+    )
+
+  private val rowTrackingEnablementTestCase = RowTrackingEnablementOnlyTestCase(
+      name = "rowTrackingEnablement",
+      sqlCommand =
+        s"""ALTER TABLE $tblName
+           |SET TBLPROPERTIES(
+           |'${DeltaConfigs.ROW_TRACKING_ENABLED.key}' = 'true'
+           |)""".stripMargin,
+      isAppend = false
+    )
+
+  private val otherMetadataUpdateTestCase = GenericMetadataUpdateTestCase(
+      name = "otherMetadataUpdate",
+      sqlCommand = s"ALTER TABLE $tblName ADD COLUMN value2 STRING",
+      isAppend = false
+    )
+
+  private val conflictTestCases: Seq[TransactionConflictTestCase] = Seq(
+    generatedIdTestCase,
+    syncIdentityTestCase,
+    noMetadataUpdateTestCase,
+    rowTrackingEnablementTestCase,
+    otherMetadataUpdateTestCase
+  )
+
+  for {
+    currentTxn <- conflictTestCases
+    winningTxn <- conflictTestCases
+  } {
+    val testName =
+      s"identity conflict test: [currentTxn: ${currentTxn.name}, winningTxn: ${winningTxn.name}]"
+    test(testName) {
+      transactionIdentityConflictHelper(
+        currentTxn,
+        winningTxn,
+        tblIsoLevel = None
+      )
+    }
+  }
+
+  test(s"ALTER TABLE SYNC IDENTITY Serializable") {
+    transactionIdentityConflictHelper(
+      syncIdentityTestCase,
+      noMetadataUpdateTestCase,
+      tblIsoLevel = Some(Serializable)
+    )
+  }
+}
+
+class IdentityColumnConflictScalaSuite
+  extends IdentityColumnConflictSuiteBase
+  with ScalaDDLTestUtils

--- a/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnConflictSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnConflictSuite.scala
@@ -276,7 +276,6 @@ trait IdentityColumnConflictSuiteBase
       tblIsoLevel = Some(Serializable)
     )
   }
-
 }
 
 class IdentityColumnConflictScalaSuite

--- a/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/TransactionExecutionTestMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/TransactionExecutionTestMixin.scala
@@ -118,6 +118,14 @@ trait TransactionExecutionTestMixin {
     observer.phases.preparePhase.entryBarrier.unblock()
   }
 
+  /**
+   * Unblocks the `commitPhase` and `backfillPhase` for [[TransactionObserver]].
+   */
+  def unblockCommit(observer: TransactionObserver): Unit = {
+    observer.phases.commitPhase.entryBarrier.unblock()
+    observer.phases.backfillPhase.entryBarrier.unblock()
+  }
+
   /** Unblocks all phases for [[TransactionObserver]] so that corresponding query can finish. */
   def unblockAllPhases(observer: TransactionObserver): Unit = {
     observer.phases.initialPhase.entryBarrier.unblock()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR is part of https://github.com/delta-io/delta/issues/1959.
The PR relaxes metadata conflict for identity column SYNC high water mark operation. When winning transaction contains identity column metadata change and the current transaction does not contain metadata change, we mark the current transaction as no metadata conflict.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
A new test suite.
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.