### PR TITLE
[KERNEL] Additional Delta action support (Metadata, Protocol, CommitInfo and AddCDCFile) for LogImpl::getChangesByVersion

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaLogActionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaLogActionUtils.java
@@ -26,8 +26,7 @@ import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.exceptions.TableNotFoundException;
 import io.delta.kernel.expressions.ExpressionEvaluator;
 import io.delta.kernel.expressions.Literal;
-import io.delta.kernel.internal.actions.AddFile;
-import io.delta.kernel.internal.actions.RemoveFile;
+import io.delta.kernel.internal.actions.*;
 import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.replay.ActionsIterator;
 import io.delta.kernel.internal.util.FileNames;
@@ -61,8 +60,11 @@ public class DeltaLogActionUtils {
    */
   public enum DeltaAction {
     REMOVE("remove", RemoveFile.FULL_SCHEMA),
-    ADD("add", AddFile.FULL_SCHEMA);
-    // Remaining actions coming in follow-up PR
+    ADD("add", AddFile.FULL_SCHEMA),
+    METADATA("metaData", Metadata.FULL_SCHEMA),
+    PROTOCOL("protocol", Protocol.FULL_SCHEMA),
+    COMMITINFO("commitInfo", CommitInfo.FULL_SCHEMA);
+    // TODO AddCDC
 
     public final String colName;
     public final StructType schema;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaLogActionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaLogActionUtils.java
@@ -63,8 +63,8 @@ public class DeltaLogActionUtils {
     ADD("add", AddFile.FULL_SCHEMA),
     METADATA("metaData", Metadata.FULL_SCHEMA),
     PROTOCOL("protocol", Protocol.FULL_SCHEMA),
-    COMMITINFO("commitInfo", CommitInfo.FULL_SCHEMA);
-    // TODO AddCDC
+    COMMITINFO("commitInfo", CommitInfo.FULL_SCHEMA),
+    CDC("cdc", AddCDCFile.FULL_SCHEMA);
 
     public final String colName;
     public final StructType schema;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -293,7 +293,8 @@ public class TransactionImpl implements Transaction {
         operation.getDescription(), /* description */
         getOperationParameters(), /* operationParameters */
         isBlindAppend(), /* isBlindAppend */
-        txnId.toString() /* txnId */);
+        txnId.toString(), /* txnId */
+        Collections.emptyMap() /* operationMetrics */);
   }
 
   private boolean isReadyForCheckpoint(Engine engine, long newVersion) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/AddCDCFile.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/AddCDCFile.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.actions;
+
+import io.delta.kernel.types.*;
+
+/** Metadata about {@code cdc} action in the Delta Log. */
+public class AddCDCFile {
+  /** Full schema of the {@code cdc} action in the Delta Log. */
+  public static final StructType FULL_SCHEMA =
+      new StructType()
+          .add("path", StringType.STRING, false /* nullable */)
+          .add(
+              "partitionValues",
+              new MapType(StringType.STRING, StringType.STRING, true),
+              false /* nullable*/)
+          .add("size", LongType.LONG, false /* nullable*/)
+          .add(
+              "tags", new MapType(StringType.STRING, StringType.STRING, true), true /* nullable */);
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
@@ -66,7 +66,7 @@ public class CommitInfo {
     }
 
     ColumnVector[] children = new ColumnVector[8];
-    for (int i = 0; i < 8; i++) {
+    for (int i = 0; i < children.length; i++) {
       children[i] = vector.getChild(i);
     }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
@@ -65,8 +65,8 @@ public class CommitInfo {
       return null;
     }
 
-    ColumnVector[] children = new ColumnVector[7];
-    for (int i = 0; i < 7; i++) {
+    ColumnVector[] children = new ColumnVector[8];
+    for (int i = 0; i < 8; i++) {
       children[i] = vector.getChild(i);
     }
 
@@ -79,7 +79,10 @@ public class CommitInfo {
             ? Collections.emptyMap()
             : VectorUtils.toJavaMap(children[4].getMap(rowId)),
         children[5].isNullAt(rowId) ? null : children[5].getBoolean(rowId),
-        children[6].isNullAt(rowId) ? null : children[6].getString(rowId));
+        children[6].isNullAt(rowId) ? null : children[6].getString(rowId),
+        children[7].isNullAt(rowId)
+            ? Collections.emptyMap()
+            : VectorUtils.toJavaMap(children[7].getMap(rowId)));
   }
 
   public static StructType FULL_SCHEMA =
@@ -92,7 +95,10 @@ public class CommitInfo {
               "operationParameters",
               new MapType(StringType.STRING, StringType.STRING, true /* nullable */))
           .add("isBlindAppend", BooleanType.BOOLEAN, true /* nullable */)
-          .add("txnId", StringType.STRING);
+          .add("txnId", StringType.STRING)
+          .add(
+              "operationMetrics",
+              new MapType(StringType.STRING, StringType.STRING, true /* nullable */));
 
   private static final Map<String, Integer> COL_NAME_TO_ORDINAL =
       IntStream.range(0, FULL_SCHEMA.length())
@@ -108,6 +114,7 @@ public class CommitInfo {
   private final boolean isBlindAppend;
   private final String txnId;
   private Optional<Long> inCommitTimestamp;
+  private final Map<String, String> operationMetrics;
 
   public CommitInfo(
       Optional<Long> inCommitTimestamp,
@@ -116,7 +123,8 @@ public class CommitInfo {
       String operation,
       Map<String, String> operationParameters,
       boolean isBlindAppend,
-      String txnId) {
+      String txnId,
+      Map<String, String> operationMetrics) {
     this.inCommitTimestamp = inCommitTimestamp;
     this.timestamp = timestamp;
     this.engineInfo = engineInfo;
@@ -124,6 +132,7 @@ public class CommitInfo {
     this.operationParameters = Collections.unmodifiableMap(operationParameters);
     this.isBlindAppend = isBlindAppend;
     this.txnId = txnId;
+    this.operationMetrics = operationMetrics;
   }
 
   public Optional<Long> getInCommitTimestamp() {
@@ -161,6 +170,8 @@ public class CommitInfo {
         COL_NAME_TO_ORDINAL.get("operationParameters"), stringStringMapValue(operationParameters));
     commitInfo.put(COL_NAME_TO_ORDINAL.get("isBlindAppend"), isBlindAppend);
     commitInfo.put(COL_NAME_TO_ORDINAL.get("txnId"), txnId);
+    commitInfo.put(
+        COL_NAME_TO_ORDINAL.get("operationMetrics"), stringStringMapValue(operationMetrics));
 
     return new GenericRow(CommitInfo.FULL_SCHEMA, commitInfo);
   }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/TableChangesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/TableChangesSuite.scala
@@ -431,7 +431,7 @@ class TableChangesSuite extends AnyFunSuite with TestUtils {
           VectorUtils.toJavaList(
             metadataRow.getArray(Metadata.FULL_SCHEMA.indexOf("partitionColumns"))).asScala,
           VectorUtils.toJavaMap[String, String](
-            metadataRow.getMap(Metadata.FULL_SCHEMA.indexOf("configuration"))).asScala.toMap,
+            metadataRow.getMap(Metadata.FULL_SCHEMA.indexOf("configuration"))).asScala.toMap
         ))
 
       case DeltaAction.PROTOCOL.colName =>
@@ -465,9 +465,12 @@ class TableChangesSuite extends AnyFunSuite with TestUtils {
 
         Some(StandardCommitInfo(
           if (commitInfoRow.isNullAt(operationIdx)) null else commitInfoRow.getString(operationIdx),
-          if (commitInfoRow.isNullAt(operationMetricsIdx)) Map.empty else
+          if (commitInfoRow.isNullAt(operationMetricsIdx)) {
+            Map.empty
+          } else {
             VectorUtils.toJavaMap[String, String](
               commitInfoRow.getMap(operationMetricsIdx)).asScala.toMap
+          }
         ))
 
       case DeltaAction.CDC.colName =>

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/coordinatedcommits/CoordinatedCommitsTestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/coordinatedcommits/CoordinatedCommitsTestUtils.scala
@@ -67,7 +67,9 @@ trait CoordinatedCommitsTestUtils {
       null,
       Collections.emptyMap(),
       true,
-      null)
+      null,
+      Collections.emptyMap()
+    )
   }
 
   def commit(


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

https://github.com/delta-io/delta/pull/3531 added support for reading the add and remove file actions using the LogImpl::getChangesByVersion API. This PR adds support for additional actions metadata, protocol, commitInfo and cdc.

## How was this patch tested?

Adds unit tests.