### PR TITLE
[Kernel][IcebergCompatV2] Validate `add` actions have `numRecords` in statistics

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
@@ -30,6 +30,7 @@ import io.delta.kernel.engine.Engine;
 import io.delta.kernel.exceptions.ConcurrentWriteException;
 import io.delta.kernel.expressions.Literal;
 import io.delta.kernel.internal.DataWriteContextImpl;
+import io.delta.kernel.internal.IcebergCompatV2Utils;
 import io.delta.kernel.internal.actions.AddFile;
 import io.delta.kernel.internal.actions.SingleAction;
 import io.delta.kernel.internal.fs.Path;
@@ -186,7 +187,9 @@ public interface Transaction {
    *
    * @param engine {@link Engine} instance.
    * @param transactionState State of the transaction.
-   * @param fileStatusIter Iterator of row objects representing each data file written.
+   * @param fileStatusIter Iterator of row objects representing each data file written. When {@code
+   *     delta.icebergCompatV2} is enabled, each data file status should contain {@link
+   *     DataFileStatistics} with at least the {@link DataFileStatistics#getNumRecords()} field set.
    * @param dataWriteContext The context used when writing the data files given in {@code
    *     fileStatusIter}
    * @return {@link CloseableIterator} of {@link Row} representing the actions to commit using
@@ -201,9 +204,13 @@ public interface Transaction {
         dataWriteContext instanceof DataWriteContextImpl,
         "DataWriteContext is not created by the `Transaction.getWriteContext()`");
 
+    boolean isIcebergCompatV2Enabled = isIcebergCompatV2Enabled(transactionState);
     URI tableRoot = new Path(getTablePath(transactionState)).toUri();
     return fileStatusIter.map(
         dataFileStatus -> {
+          if (isIcebergCompatV2Enabled) {
+            IcebergCompatV2Utils.validDataFileStatus(dataFileStatus);
+          }
           Row addFileRow =
               AddFile.convertDataFileStatus(
                   tableRoot,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -20,6 +20,7 @@ import static java.lang.String.format;
 import io.delta.kernel.exceptions.*;
 import io.delta.kernel.types.DataType;
 import io.delta.kernel.types.StructType;
+import io.delta.kernel.utils.DataFileStatus;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.List;
@@ -173,6 +174,13 @@ public final class DeltaErrors {
         "The schema of the data to be written to the table doesn't match "
             + "the table schema. \nTable: %s\nTable schema: %s, \nData schema: %s";
     return new KernelException(format(msgT, tablePath, tableSchema, dataSchema));
+  }
+
+  public static KernelException missingNumRecordsStatsForIcebergCompatV2(
+      DataFileStatus dataFileStatus) {
+    throw new KernelException(
+        format(
+            "Iceberg V2 compatibility requires statistics.\n DataFileStatus: %s", dataFileStatus));
   }
 
   public static KernelException partitionColumnMissingInData(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/IcebergCompatV2Utils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/IcebergCompatV2Utils.java
@@ -15,9 +15,6 @@
  */
 package io.delta.kernel.internal;
 
-import static java.lang.String.format;
-
-import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.utils.DataFileStatus;
 
 /** Utility methods for validation and compatibility checks for Iceberg V2. */
@@ -32,10 +29,8 @@ public class IcebergCompatV2Utils {
    */
   public static void validDataFileStatus(DataFileStatus dataFileStatus) {
     if (!dataFileStatus.getStatistics().isPresent()) {
-      throw new KernelException(
-          format(
-              "Iceberg V2 compatibility requires statistics.\n DataFileStatus: %s",
-              dataFileStatus));
+      // presence of stats means always has a non-null `numRecords`
+      throw DeltaErrors.missingNumRecordsStatsForIcebergCompatV2(dataFileStatus);
     }
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/IcebergCompatV2Utils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/IcebergCompatV2Utils.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal;
+
+import static java.lang.String.format;
+
+import io.delta.kernel.exceptions.KernelException;
+import io.delta.kernel.utils.DataFileStatus;
+
+/** Utility methods for validation and compatibility checks for Iceberg V2. */
+public class IcebergCompatV2Utils {
+  private IcebergCompatV2Utils() {}
+
+  /**
+   * Validate the given {@link DataFileStatus} that is being added as a {@code add} action to Delta
+   * Log. Currently, it checks that the statistics are not empty.
+   *
+   * @param dataFileStatus The {@link DataFileStatus} to validate.
+   */
+  public static void validDataFileStatus(DataFileStatus dataFileStatus) {
+    if (!dataFileStatus.getStatistics().isPresent()) {
+      throw new KernelException(
+          format(
+              "Iceberg V2 compatibility requires statistics.\n DataFileStatus: %s",
+              dataFileStatus));
+    }
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/utils/DataFileStatistics.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/utils/DataFileStatistics.java
@@ -15,6 +15,8 @@
  */
 package io.delta.kernel.utils;
 
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+
 import io.delta.kernel.expressions.Column;
 import io.delta.kernel.expressions.Literal;
 import java.util.Collections;
@@ -42,6 +44,7 @@ public class DataFileStatistics {
       Map<Column, Literal> minValues,
       Map<Column, Literal> maxValues,
       Map<Column, Long> nullCounts) {
+    checkArgument(numRecords >= 0, "numRecords should be non-negative");
     this.numRecords = numRecords;
     this.minValues = Collections.unmodifiableMap(minValues);
     this.maxValues = Collections.unmodifiableMap(maxValues);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/utils/DataFileStatistics.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/utils/DataFileStatistics.java
@@ -87,8 +87,15 @@ public class DataFileStatistics {
     return nullCounts;
   }
 
+  @Override
+  public String toString() {
+    return serializeAsJson();
+  }
+
   public String serializeAsJson() {
-    // TODO: implement this
-    return "{}";
+    // TODO: implement this. Full statistics serialization will be added as part of
+    // https://github.com/delta-io/delta/pull/3342. The PR is pending on a decision.
+    // For now just serialize the number of records.
+    return "{\"numRecords\":" + numRecords + "}";
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/utils/DataFileStatus.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/utils/DataFileStatus.java
@@ -48,4 +48,19 @@ public class DataFileStatus extends FileStatus {
   public Optional<DataFileStatistics> getStatistics() {
     return statistics;
   }
+
+  @Override
+  public String toString() {
+    return "DataFileStatus{"
+        + "path='"
+        + getPath()
+        + '\''
+        + ", size="
+        + getSize()
+        + ", modificationTime="
+        + getModificationTime()
+        + ", statistics="
+        + statistics
+        + '}';
+  }
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/TransactionSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/TransactionSuite.scala
@@ -85,7 +85,6 @@ class TransactionSuite extends AnyFunSuite with VectorTestUtils with MockEngineU
       val txnState = testTxnState(testSchema, enableIcebergCompatV2 = icebergCompatV2Enabled)
       val engine = testMockEngine(testSchema)
 
-
       Seq(
         // missing stats
         (
@@ -223,7 +222,7 @@ object TransactionSuite extends VectorTestUtils with MockEngineUtils {
         numRows,
         Map.empty[Column, Literal].asJava, // minValues - empty value as this is just for tests.
         Map.empty[Column, Literal].asJava, // maxValues - empty value as this is just for tests.
-        Map.empty[Column, JLong].asJava, // nullCount - empty value as this is just for tests.
+        Map.empty[Column, JLong].asJava // nullCount - empty value as this is just for tests.
       )
     })
   }


### PR DESCRIPTION
## Description
Delta [IcebergCompatV2](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#iceberg-compatibility-v2) requires each `add` action added to the Delta Log contain `numRecords` in statistics. This PR adds the change to enforce the check as part of `Transaction.generateAppendActions`. 

## How was this patch tested?
Unit tests.