### PR TITLE
always include CatalogTable#storage#properties into data source options

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/CustomCatalogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CustomCatalogSuite.scala
@@ -383,6 +383,8 @@ class DummyCatalog extends TableCatalog {
   }
 }
 
+// A dummy catalog that adds additional table storage properties after the table is loaded.
+// It's only used inside `DummySessionCatalog`.
 class DummySessionCatalogInner extends DelegatingCatalogExtension {
   override def loadTable(ident: Identifier): Table = {
     val t = super.loadTable(ident).asInstanceOf[V1Table]
@@ -394,6 +396,8 @@ class DummySessionCatalogInner extends DelegatingCatalogExtension {
   }
 }
 
+// A dummy catalog that adds a layer between DeltaCatalog and the Spark SessionCatalog,
+// to attach additional table storage properties after the table is loaded.
 class DummySessionCatalog extends TableCatalog {
   private var deltaCatalog: DelegatingCatalogExtension = null
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CustomCatalogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CustomCatalogSuite.scala
@@ -283,6 +283,8 @@ class CustomCatalogSuite extends QueryTest with SharedSparkSession
   }
 
   test("custom catalog that adds additional table storage properties") {
+    // Reset catalog manager so that the new `spark_catalog` implementation can apply.
+    spark.sessionState.catalogManager.reset()
     withSQLConf("spark.sql.catalog.spark_catalog" -> classOf[DummySessionCatalog].getName) {
       withTable("t") {
         withTempPath { path =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

`DeltaTableV2` uses the options to create `DeltaLog`, assuming that the options should always be consistent with the one in `CatalogTable#storage#properties`. This may not be true as custom catalogs may add more table storage properties on the fly, like Unity Catalog.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Tested locally with UC. It's not an issue for HMS.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no