### PR TITLE
[Spark] Add RowTrackingBackfill and Clone conflicts tests

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillCloneConflictsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillCloneConflictsSuite.scala
@@ -1,0 +1,201 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands.backfill
+
+import org.apache.spark.sql.delta.{MetadataChangedException, RowTracking}
+import org.apache.spark.sql.delta.fuzzer.{OptimisticTransactionPhases, PhaseLockingTransactionExecutionObserver => TransactionObserver}
+
+import org.apache.spark.SparkException
+import org.apache.spark.util.ThreadUtils
+
+/**
+ * Clone uses commitLarge which does not do conflict checking nor retry. So when there is
+ * a concurrent conflict, either Clone will fail from concurrent modification or
+ * Backfill will fail from the metadata change.
+ */
+
+/*
+ * Tests for conflict detection with Backfill and Clone. Note that each backfill in this case has
+ * 2 stages:
+ * - Upgrade the protocol to support the Row Tracking Table Feature
+ * - Mark Row Tracking active by updating the table metadata
+ *
+ * -------------------------------------------> TIME -------------------------------------------->
+ *
+ * Backfill         Row Tracking              Row Tracking               Row Tracking
+ * Command          Protocol upgrade -------- metadata update ---------- metadata update
+ * Thread           prepare + commit          prepare                    commit
+ *
+ *
+ * Clone
+ *
+ * Scenario 1                        prepare ----------------- commit
+ * Scenario 2                        prepare -------------------------------------------- commit
+ *
+ * -------------------------------------------> TIME -------------------------------------------->
+ */
+class RowTrackingBackfillCloneConflictsSuite extends RowTrackingBackfillConflictsTestBase {
+  override val testTableName = "BackfillCloneTarget"
+
+  val sourceTableName = "CloneSource"
+
+  private def withSourceTable(testBlock: => Unit): Unit = {
+    withTable(sourceTableName) {
+      withRowTrackingEnabled(enabled = false) {
+        tableCreationAfterInsert().write.format("delta").saveAsTable(sourceTableName)
+        testBlock
+      }
+    }
+  }
+
+  private def createAndChainBackfillObservers(): (TransactionObserver, TransactionObserver) = {
+    // This observes the transaction in [[BackfillCommand]] that does manual state
+    // transitions to make the concurrency testing framework happy in other Suites.
+    val manualTransitionsBackfillObserver = new TransactionObserver(
+      OptimisticTransactionPhases.forName("manual-transitions-backfill-observer"))
+
+    // This observes the transaction in [[alterDeltaTableCommands]] after the backfill
+    // that tries to update the table's metadata.
+    val updateMetadataBackfillObserver = new TransactionObserver(
+      OptimisticTransactionPhases.forName("update-metadata-backfill-observer"))
+
+    // Chain observers
+    manualTransitionsBackfillObserver.setNextObserver(
+      updateMetadataBackfillObserver, autoAdvance = true)
+
+    (manualTransitionsBackfillObserver, updateMetadataBackfillObserver)
+  }
+
+  test("Backfill fails from conflict with CLONE") {
+    val cloneTransaction =
+      () => sql(s"CREATE OR REPLACE TABLE " +
+        s"$testTableName SHALLOW CLONE $sourceTableName").collect()
+
+    withTrackedBackfillCommits {
+      withSourceTable {
+        withEmptyTestTable {
+          // Row tracking will be enabled by the backfill.
+          validateSuccessfulBackfillMetrics(expectedNumSuccessfulBatches = 0) {
+            val Seq(backfillFuture) =
+              runFunctionsWithOrderingFromObserver(Seq(backfillTransaction)) {
+                // The upgradeProtocolBackfillObserver observes the transaction in
+                // [[RowTrackingBackfillCommands]] that adds the Row tracking table feature support.
+                case (upgradeProtocolBackfillObserver :: Nil) =>
+                  val (manualTransitionsBackfillObserver, updateMetadataBackfillObserver) =
+                    createAndChainBackfillObservers()
+                  upgradeProtocolBackfillObserver.setNextObserver(
+                    manualTransitionsBackfillObserver, autoAdvance = true)
+
+                  // Prepare and commit Row Tracking table feature support transaction.
+                  prepareAndCommitWithNextObserverSet(upgradeProtocolBackfillObserver)
+
+                  // Prepare and commit Manual State Transitions transaction.
+                  prepareAndCommitWithNextObserverSet(manualTransitionsBackfillObserver)
+
+                  val Seq(cloneFuture) =
+                    runFunctionsWithOrderingFromObserver(Seq(cloneTransaction)) {
+                      case (cloneTransactionObserver :: Nil) =>
+                        // Prepare Clone commit.
+                        unblockUntilPreCommit(cloneTransactionObserver)
+                        waitForPrecommit(cloneTransactionObserver)
+
+                        // Prepare Row Tracking metadata update commit.
+                        unblockUntilPreCommit(updateMetadataBackfillObserver)
+                        waitForPrecommit(updateMetadataBackfillObserver)
+
+                        // Commit Clone.
+                        unblockCommit(cloneTransactionObserver)
+                        waitForCommit(cloneTransactionObserver)
+
+                        // Commit Row Tracking metadata update.
+                        unblockCommit(updateMetadataBackfillObserver)
+                        waitForCommit(updateMetadataBackfillObserver)
+                    }
+
+                  ThreadUtils.awaitResult(cloneFuture, timeout)
+                  checkAnswer(spark.table(testTableName), spark.table(sourceTableName))
+              }
+
+            val ex = intercept[SparkException] {
+              ThreadUtils.awaitResult(backfillFuture, timeout)
+            }
+            assertAbortedBecauseOfMetadataChange(ex)
+            assert(ex.getMessage.contains("\"operation\":\"CLONE\""))
+            assert(!RowTracking.isEnabled(latestSnapshot.protocol, latestSnapshot.metadata))
+          }
+        }
+      }
+    }
+  }
+
+  test("Clone fails from conflict with Backfill") {
+    val cloneTransaction =
+      () => sql(s"CREATE OR REPLACE TABLE " +
+        s"$testTableName SHALLOW CLONE $sourceTableName").collect()
+
+    withTrackedBackfillCommits {
+      withSourceTable {
+        withEmptyTestTable {
+          // Row tracking will be enabled by the backfill.
+          validateSuccessfulBackfillMetrics(expectedNumSuccessfulBatches = 0) {
+            val Seq(backfillFuture) =
+              runFunctionsWithOrderingFromObserver(Seq(backfillTransaction)) {
+                // The upgradeProtocolBackfillObserver observes the transaction in
+                // [[RowTrackingBackfillCommands]] that adds the Row tracking table feature support.
+                case (upgradeProtocolBackfillObserver :: Nil) =>
+                  val (manualTransitionsBackfillObserver, updateMetadataBackfillObserver) =
+                    createAndChainBackfillObservers()
+                  upgradeProtocolBackfillObserver.setNextObserver(
+                    manualTransitionsBackfillObserver, autoAdvance = true)
+
+                  // Prepare and commit Row Tracking table feature support transaction.
+                  prepareAndCommitWithNextObserverSet(upgradeProtocolBackfillObserver)
+
+                  // Prepare and commit Manual State Transitions transaction.
+                  prepareAndCommitWithNextObserverSet(manualTransitionsBackfillObserver)
+
+                  val Seq(cloneFuture) =
+                    runFunctionsWithOrderingFromObserver(Seq(cloneTransaction)) {
+                      case (cloneTransactionObserver :: Nil) =>
+                        // Prepare Clone commit.
+                        unblockUntilPreCommit(cloneTransactionObserver)
+                        waitForPrecommit(cloneTransactionObserver)
+
+                        // Prepare and commit Row Tracking metadata update commit.
+                        prepareAndCommit(updateMetadataBackfillObserver)
+
+                        // Commit Clone.
+                        unblockCommit(cloneTransactionObserver)
+                        waitForCommit(cloneTransactionObserver)
+                  }
+
+                  val ex = intercept[SparkException] {
+                    ThreadUtils.awaitResult(cloneFuture, timeout)
+                  }
+                  assertAbortedBecauseOfConcurrentWrite(ex)
+                  assert(ex.getMessage.contains("\"operation\":\"SET TBLPROPERTIES\""))
+              }
+
+            ThreadUtils.awaitResult(backfillFuture, timeout)
+            assert(RowTracking.isEnabled(latestSnapshot.protocol, latestSnapshot.metadata))
+            checkAnswer(spark.table(testTableName), Seq.empty)
+          }
+        }
+      }
+    }
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillCloneConflictsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/commands/backfill/RowTrackingBackfillCloneConflictsSuite.scala
@@ -134,7 +134,6 @@ class RowTrackingBackfillCloneConflictsSuite extends RowTrackingBackfillConflict
               ThreadUtils.awaitResult(backfillFuture, timeout)
             }
             assertAbortedBecauseOfMetadataChange(ex)
-            assert(ex.getMessage.contains("\"operation\":\"CLONE\""))
             assert(!RowTracking.isEnabled(latestSnapshot.protocol, latestSnapshot.metadata))
           }
         }
@@ -187,7 +186,6 @@ class RowTrackingBackfillCloneConflictsSuite extends RowTrackingBackfillConflict
                     ThreadUtils.awaitResult(cloneFuture, timeout)
                   }
                   assertAbortedBecauseOfConcurrentWrite(ex)
-                  assert(ex.getMessage.contains("\"operation\":\"SET TBLPROPERTIES\""))
               }
 
             ThreadUtils.awaitResult(backfillFuture, timeout)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/TransactionExecutionTestMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/concurrency/TransactionExecutionTestMixin.scala
@@ -148,6 +148,36 @@ trait TransactionExecutionTestMixin {
   }
 
   /**
+   * Prepare and commit the transaction managed by the given observer.
+   * If nextObserver is set, we need to manually call backfillPhase.leave() to advance to the
+   * nextObserver. Details in [[TransactionObserver.waitForCommitPhaseAndAdvanceToNextObserver]].
+   */
+  private def prepareAndCommitBase(
+      observer: TransactionObserver, hasNextObserver: Boolean): Unit = {
+    unblockUntilPreCommit(observer)
+    waitForPrecommit(observer)
+    unblockCommit(observer)
+    if (hasNextObserver) {
+      observer.phases.backfillPhase.leave()
+    }
+    waitForCommit(observer)
+  }
+
+  /**
+   * Prepare and commit the transaction managed by the given observer.
+   */
+  def prepareAndCommit(observer: TransactionObserver): Unit = {
+    prepareAndCommitBase(observer, hasNextObserver = false)
+  }
+
+  /**
+   * Prepare and commit the transaction managed by the given observer which has nextObserver set.
+   */
+  def prepareAndCommitWithNextObserverSet(observer: TransactionObserver): Unit = {
+    prepareAndCommitBase(observer, hasNextObserver = true)
+  }
+
+  /**
    * Run 2 transactions A, B with following order:
    *
    * t1 -------------------------------------- TxnA starts


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Add some `RowTrackingBackfill` and Clone conflicts tests.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Added UTs.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
