### PR TITLE
[Kernel] Ignore non-conforming commit files in Delta log directory

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/DeltaLogFile.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/DeltaLogFile.java
@@ -34,12 +34,13 @@ public class DeltaLogFile {
   }
 
   public static DeltaLogFile forCommitOrCheckpoint(FileStatus file) {
+    String filePath = file.getPath();
     String fileName = new Path(file.getPath()).getName();
     LogType logType = null;
     long version = -1;
-    if (FileNames.isCommitFile(fileName)) {
+    if (FileNames.isCommitFile(filePath)) {
       logType = LogType.COMMIT;
-      version = FileNames.deltaVersion(fileName);
+      version = FileNames.deltaVersion(filePath);
     } else if (FileNames.isClassicCheckpointFile(fileName)) {
       logType = LogType.CHECKPOINT_CLASSIC;
       version = FileNames.checkpointVersion(fileName);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/DeltaLogFile.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/DeltaLogFile.java
@@ -36,14 +36,14 @@ public class DeltaLogFile {
   public static DeltaLogFile forCommitOrCheckpoint(FileStatus file) {
     String filePath = file.getPath();
     String fileName = new Path(file.getPath()).getName();
-    LogType logType = null;
+    LogType logType;
     long version = -1;
     if (FileNames.isCommitFile(filePath)) {
       logType = LogType.COMMIT;
       version = FileNames.deltaVersion(filePath);
     } else if (FileNames.isClassicCheckpointFile(fileName)) {
       logType = LogType.CHECKPOINT_CLASSIC;
-      version = FileNames.checkpointVersion(fileName);
+      version = FileNames.checkpointVersion(filePath);
     } else if (FileNames.isMultiPartCheckpointFile(fileName)) {
       logType = LogType.MULTIPART_CHECKPOINT;
       version = FileNames.checkpointVersion(fileName);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/DeltaLogFile.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/DeltaLogFile.java
@@ -43,7 +43,7 @@ public class DeltaLogFile {
     } else if (FileNames.isClassicCheckpointFile(fileName)) {
       logType = LogType.CHECKPOINT_CLASSIC;
       version = FileNames.checkpointVersion(fileName);
-    } else if (FileNames.isMulitPartCheckpointFile(fileName)) {
+    } else if (FileNames.isMultiPartCheckpointFile(fileName)) {
       logType = LogType.MULTIPART_CHECKPOINT;
       version = FileNames.checkpointVersion(fileName);
     } else if (FileNames.isV2CheckpointFile(fileName)) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
@@ -44,9 +44,28 @@ public final class FileNames {
 
   public static final String SIDECAR_DIRECTORY = "_sidecars";
 
+  /**
+   * The subdirectory in the delta log directory where un-backfilled commits are stored as part of
+   * the coordinated commits table feature.
+   */
+  public static final String COMMIT_SUBDIR = "_commits";
+
   /** Returns the delta (json format) path for a given delta file. */
   public static String deltaFile(Path path, long version) {
     return String.format("%s/%020d.json", path, version);
+  }
+
+  /**
+   * Returns the un-backfilled uuid formatted delta (json format) path for a given version.
+   *
+   * @param logPath The root path of the delta log.
+   * @param version The version of the delta file.
+   * @param uuidString An optional UUID string.
+   * @return The path to the un-backfilled delta file: <logPath>/_commits/<version>.<uuid>.json
+   */
+  public static String unbackfilledDeltaFile(Path logPath, long version, String uuidString) {
+    Path commitsPath = commitDirPath(logPath);
+    return new Path(commitsPath, String.format("%020d.%s.json", version, uuidString)).toString();
   }
 
   /** Returns the version for the given delta path. */
@@ -136,7 +155,7 @@ public final class FileNames {
     return CLASSIC_CHECKPOINT_FILE_PATTERN.matcher(fileName).matches();
   }
 
-  public static boolean isMulitPartCheckpointFile(String fileName) {
+  public static boolean isMultiPartCheckpointFile(String fileName) {
     return MULTI_PART_CHECKPOINT_FILE_PATTERN.matcher(fileName).matches();
   }
 
@@ -144,10 +163,14 @@ public final class FileNames {
     return V2_CHECKPOINT_FILE_PATTERN.matcher(fileName).matches();
   }
 
-  public static boolean isCommitFile(String fileName) {
-    String filename = new Path(fileName).getName();
-    return DELTA_FILE_PATTERN.matcher(filename).matches()
-        || UUID_DELTA_FILE_REGEX.matcher(filename).matches();
+  public static boolean isCommitFile(String filePathStr) {
+    Path filePath = new Path(filePathStr);
+    String fileName = filePath.getName();
+    String fileParentName = filePath.getParent().getName();
+    return DELTA_FILE_PATTERN.matcher(fileName).matches()
+        // If parent is _commits dir, then match against un-backfilled commit file name pattern.
+        || (COMMIT_SUBDIR.equals(fileParentName)
+            && UUID_DELTA_FILE_REGEX.matcher(fileName).matches());
   }
 
   /**
@@ -167,5 +190,10 @@ public final class FileNames {
       throw new IllegalArgumentException(
           String.format("Unexpected file type found in transaction log: %s", path));
     }
+  }
+
+  /** Returns path to the sidecar directory */
+  public static Path commitDirPath(Path logPath) {
+    return new Path(logPath, COMMIT_SUBDIR);
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
@@ -166,11 +166,14 @@ public final class FileNames {
   public static boolean isCommitFile(String filePathStr) {
     Path filePath = new Path(filePathStr);
     String fileName = filePath.getName();
-    String fileParentName = filePath.getParent().getName();
-    return DELTA_FILE_PATTERN.matcher(fileName).matches()
-        // If parent is _commits dir, then match against un-backfilled commit file name pattern.
-        || (COMMIT_SUBDIR.equals(fileParentName)
-            && UUID_DELTA_FILE_REGEX.matcher(fileName).matches());
+    if (DELTA_FILE_PATTERN.matcher(fileName).matches()) {
+      return true;
+    } else {
+      String fileParentName = filePath.getParent().getName();
+      // If parent is _commits dir, then match against un-backfilled commit file name pattern.
+      return COMMIT_SUBDIR.equals(fileParentName)
+          && UUID_DELTA_FILE_REGEX.matcher(fileName).matches();
+    }
   }
 
   /**

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockFileSystemClientUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockFileSystemClientUtils.scala
@@ -42,6 +42,15 @@ trait MockFileSystemClientUtils extends MockEngineUtils {
     deltaVersions.map(v => FileStatus.of(FileNames.deltaFile(logPath, v), v, v*10))
   }
 
+  /* non-conforming name: name that is not "%020d.json" format */
+  def nonConformingDeltaFileStatuses(deltaVersions: Seq[Long]): Seq[FileStatus] = {
+    deltaVersions.map(v => FileStatus.of(
+      new Path(logPath, f"$v%020d.${UUID.randomUUID.toString}.json").toString,
+      v, /* size */
+      v*10 /* modTime */
+    ))
+  }
+
   /** Checkpoint file statuses where the timestamp = 10*version */
   def singularCheckpointFileStatuses(checkpointVersions: Seq[Long]): Seq[FileStatus] = {
     assert(checkpointVersions.size == checkpointVersions.toSet.size)


### PR DESCRIPTION
## Description
Support for coordinated commit introduced an issue where a Delta file in `_delta_log` that doesn't conform to the expected file name format (`%020d.json`) is considered part of the Delta history. 

We use the following method to test whether a file is a `commit` file.

Before coordinated commit support:

```
  public static boolean isCommitFile(String filePath) {
    String fileName = ..
    return Pattern.compile("\\d+\\.json").matcher(fileName).matches();
  }
```

After the coordinated commit support:
```
  public static boolean isCommitFile(String filePath) {
    String fileName = ..
    return Pattern.compile("\\d+\\.json").matcher(fileName).matches() || // backfilled commit file
        Pattern.compile("(\\d+)\\.([^\\.]+)\\.json").matcher(fileName).matches() // un-backfilled commit file
  }
```

For example, if the `_delta_log` has a file with name `0000x.uuid.json`, it will be considered to be part of the delta file, but it is not. The commit files of format `%20d.uuid.json` are considered part of the table history only if the parent directory name is `_commit`.

Update the above method as follows (this is in line with the Delta-Spark)

```
  public static boolean isCommitFile(String filePath) {
    String fileName = ...
    String parentDirName = ...
    return Pattern.compile("\\d+\\.json").matcher(fileName).matches() || // backfilled commit file
        (parentDirName == "_commit" &&
            Pattern.compile("(\\d+)\\.([^\\.]+)\\.json").matcher(fileName).matches()) // un-backfilled commit file
  }
```


## How was this patch tested?
Unit test that reproes the issue without the fix
