### PR TITLE
[Spark] Fix time travel utility method for ICT

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaHistoryManagerSuite.scala
@@ -70,6 +70,14 @@ trait DeltaTimeTravelTests extends QueryTest
     val crc = new File(FileNames.checksumFile(deltaLog.logPath, version).toUri)
     if (isICTEnabledForNewTables) {
       InCommitTimestampTestUtils.overwriteICTInDeltaFile(deltaLog, filePath, Some(ts))
+      if (FileNames.isUnbackfilledDeltaFile(filePath)) {
+        // Also change the ICT in the backfilled file if it exists.
+        val backfilledFilePath = FileNames.unsafeDeltaFile(deltaLog.logPath, version)
+        val fs = backfilledFilePath.getFileSystem(deltaLog.newDeltaHadoopConf())
+        if (fs.exists(backfilledFilePath)) {
+          InCommitTimestampTestUtils.overwriteICTInDeltaFile(deltaLog, backfilledFilePath, Some(ts))
+        }
+      }
       if (crc.exists()) {
         InCommitTimestampTestUtils.overwriteICTInCrc(deltaLog, version, Some(ts))
       }


### PR DESCRIPTION


#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Fix time travel utility method for ICT.

DeltaHistoryManager modified the in-commit-timestamp to custom values for testing specific scenarios. This is done by getting the delta file from the snapshot's logsegment and modifying its content.

Sometimes the Snapshot might be pointing to UUID files - in such cases we should also modify the timestamp in backfilled commit.json file.

## How was this patch tested?

Existing UTs

## Does this PR introduce _any_ user-facing changes?

No