### PR TITLE
[Kernel] Add editable property to TableConfig

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -201,7 +201,7 @@ public final class DeltaErrors {
 
   public static KernelException cannotModifyTableProperty(String key) {
     String msg = format("The Delta table property '%s' is an internal property " +
-      "and cannot be updated.", key);
+            "and cannot be updated.", key);
     return new KernelException(msg);
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -200,8 +200,8 @@ public final class DeltaErrors {
   }
 
   public static KernelException cannotModifyTableProperty(String key) {
-    String msg = format("The Delta table property '%s' is an internal property " +
-            "and cannot be updated.", key);
+    String msg = format("The Delta table property '%s' is an internal " +
+        "property and cannot be updated.", key);
     return new KernelException(msg);
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -200,7 +200,8 @@ public final class DeltaErrors {
   }
 
   public static KernelException cannotModifyTableProperty(String key) {
-    String msg = format("Delta cannot modify table property: %s", key);
+    String msg = format("The Delta table property '%s' is an internal property " +
+            "and cannot be updated.", key);
     return new KernelException(msg);
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -200,7 +200,7 @@ public final class DeltaErrors {
   }
 
   public static KernelException cannotModifyTableProperty(String key) {
-    String msg = format("Delta can not modify table property: %s", key);
+    String msg = format("Delta cannot modify table property: %s", key);
     return new KernelException(msg);
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -201,9 +201,7 @@ public final class DeltaErrors {
 
   public static KernelException cannotModifyTableProperty(String key) {
     String msg =
-        format(
-            "The Delta table property '%s' is an internal property and cannot be updated.",
-            key);
+        format("The Delta table property '%s' is an internal property and cannot be updated.", key);
     return new KernelException(msg);
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -199,6 +199,11 @@ public final class DeltaErrors {
         "Failed to parse the schema. Encountered unsupported Delta data type: VOID");
   }
 
+  public static KernelException cannotModifyTableProperty(String key) {
+    String msg = format("Delta can not modify table property: %s", key);
+    return new KernelException(msg);
+  }
+
   public static KernelException unknownConfigurationException(String confKey) {
     return new UnknownConfigurationException(confKey);
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -202,7 +202,7 @@ public final class DeltaErrors {
   public static KernelException cannotModifyTableProperty(String key) {
     String msg =
         format(
-            "The Delta table property '%s' is an internal " + "property and cannot be updated.",
+            "The Delta table property '%s' is an internal property and cannot be updated.",
             key);
     return new KernelException(msg);
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -201,7 +201,7 @@ public final class DeltaErrors {
 
   public static KernelException cannotModifyTableProperty(String key) {
     String msg = format("The Delta table property '%s' is an internal property " +
-            "and cannot be updated.", key);
+        "and cannot be updated.", key);
     return new KernelException(msg);
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -201,7 +201,7 @@ public final class DeltaErrors {
 
   public static KernelException cannotModifyTableProperty(String key) {
     String msg = format("The Delta table property '%s' is an internal property " +
-        "and cannot be updated.", key);
+      "and cannot be updated.", key);
     return new KernelException(msg);
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -200,8 +200,8 @@ public final class DeltaErrors {
   }
 
   public static KernelException cannotModifyTableProperty(String key) {
-    String msg = format("The Delta table property '%s' is an internal " +
-        "property and cannot be updated.", key);
+    String msg = format("The Delta table property '%s' is an internal "
+        + "property and cannot be updated.", key);
     return new KernelException(msg);
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -200,8 +200,10 @@ public final class DeltaErrors {
   }
 
   public static KernelException cannotModifyTableProperty(String key) {
-    String msg = format("The Delta table property '%s' is an internal "
-        + "property and cannot be updated.", key);
+    String msg =
+        format(
+            "The Delta table property '%s' is an internal " + "property and cannot be updated.",
+            key);
     return new KernelException(msg);
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -62,7 +62,8 @@ public class TableConfig<T> {
           (engineOpt, v) -> IntervalParserUtils.safeParseIntervalAsMillis(v),
           value -> value >= 0,
           "needs to be provided as a calendar interval such as '2 weeks'. Months"
-              + " and years are not accepted. You may specify '365 days' for a year instead.");
+              + " and years are not accepted. You may specify '365 days' for a year instead.",
+          true);
 
   /**
    * How often to checkpoint the delta log? For every N (this config) commits to the log, we will
@@ -74,7 +75,8 @@ public class TableConfig<T> {
           "10",
           (engineOpt, v) -> Integer.valueOf(v),
           value -> value > 0,
-          "needs to be a positive integer.");
+          "needs to be a positive integer.",
+          true);
 
   /**
    * This table property is used to track the enablement of the {@code inCommitTimestamps}.
@@ -89,7 +91,8 @@ public class TableConfig<T> {
           "false", /* default values */
           (engineOpt, v) -> Boolean.valueOf(v),
           value -> true,
-          "needs to be a boolean.");
+          "needs to be a boolean.",
+          true);
 
   /**
    * This table property is used to track the version of the table at which {@code
@@ -101,7 +104,8 @@ public class TableConfig<T> {
           null, /* default values */
           (engineOpt, v) -> Optional.ofNullable(v).map(Long::valueOf),
           value -> true,
-          "needs to be a long.");
+          "needs to be a long.",
+          true);
 
   /**
    * This table property is used to track the timestamp at which {@code inCommitTimestamps} were
@@ -114,7 +118,8 @@ public class TableConfig<T> {
           null, /* default values */
           (engineOpt, v) -> Optional.ofNullable(v).map(Long::valueOf),
           value -> true,
-          "needs to be a long.");
+          "needs to be a long.",
+          true);
 
   /*
    * This table property is used to track the commit-coordinator name for this table. If this
@@ -131,7 +136,8 @@ public class TableConfig<T> {
               + "which implementation of commit-coordinator to use when committing "
               + "to this table. If this property is not set, the table will be "
               + "considered as file system table and commits will be done via "
-              + "atomically publishing the commit file.");
+              + "atomically publishing the commit file.",
+          true);
 
   /*
    * This table property is used to track the configuration properties for the commit coordinator
@@ -144,7 +150,8 @@ public class TableConfig<T> {
           TableConfig::parseJSONKeyValueMap,
           value -> true,
           "A string-to-string map of configuration properties for the"
-              + " coordinated commits-coordinator.");
+              + " coordinated commits-coordinator.",
+          true);
 
   /*
    * This property is used by the commit coordinator to uniquely identify and manage the table
@@ -157,7 +164,8 @@ public class TableConfig<T> {
           TableConfig::parseJSONKeyValueMap,
           value -> true,
           "A string-to-string map of configuration properties for"
-              + "  describing the table to commit-coordinator.");
+              + "  describing the table to commit-coordinator.",
+          true);
 
   /** This table property is used to control the column mapping mode. */
   public static final TableConfig<ColumnMappingMode> COLUMN_MAPPING_MODE =
@@ -166,7 +174,8 @@ public class TableConfig<T> {
           "none", /* default values */
           (engineOpt, v) -> ColumnMappingMode.fromTableConfig(v),
           value -> true,
-          "Needs to be one of none, id, name.");
+          "Needs to be one of none, id, name.",
+          true);
 
   /**
    * Table property that enables modifying the table in accordance with the Delta-Iceberg
@@ -182,7 +191,8 @@ public class TableConfig<T> {
           "false",
           (engineOpt, v) -> Boolean.valueOf(v),
           value -> true,
-          "needs to be a boolean.");
+          "needs to be a boolean.",
+          true);
 
   /** All the valid properties that can be set on the table. */
   private static final Map<String, TableConfig<?>> VALID_PROPERTIES =
@@ -206,6 +216,7 @@ public class TableConfig<T> {
   private final String defaultValue;
   private final BiFunction<Engine, String, T> fromString;
   private final Predicate<T> validator;
+  private final boolean editable;
   private final String helpMessage;
 
   private TableConfig(
@@ -213,12 +224,14 @@ public class TableConfig<T> {
       String defaultValue,
       BiFunction<Engine, String, T> fromString,
       Predicate<T> validator,
-      String helpMessage) {
+      String helpMessage,
+      boolean editable) {
     this.key = key;
     this.defaultValue = defaultValue;
     this.fromString = fromString;
     this.validator = validator;
     this.helpMessage = helpMessage;
+    this.editable = editable;
   }
 
   /**
@@ -319,6 +332,9 @@ public class TableConfig<T> {
   }
 
   private void validate(Engine engine, String value) {
+    if (!editable) {
+      throw DeltaErrors.cannotModifyTableProperty(key);
+    }
     T parsedValue = fromString.apply(engine, value);
     if (!validator.test(parsedValue)) {
       throw DeltaErrors.invalidConfigurationValueException(key, value, helpMessage);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -280,19 +280,19 @@ public class TableConfig<T> {
       Engine engine, Map<String, String> configurations) {
     Map<String, String> validatedConfigurations = new HashMap<>();
     for (Map.Entry<String, String> kv : configurations.entrySet()) {
-        String key = kv.getKey().toLowerCase(Locale.ROOT);
-        String value = kv.getValue();
-        if (key.startsWith("delta.")) {
-            TableConfig<?> tableConfig = VALID_PROPERTIES.get(key);
-            if (tableConfig.editable) {
-                tableConfig.validate(engine, value);
-                validatedConfigurations.put(tableConfig.getKey(), value);
-            } else {
-                throw DeltaErrors.cannotModifyTableProperty(key);
-            }
+      String key = kv.getKey().toLowerCase(Locale.ROOT);
+      String value = kv.getValue();
+      if (key.startsWith("delta.")) {
+        TableConfig<?> tableConfig = VALID_PROPERTIES.get(key);
+        if (tableConfig.editable) {
+          tableConfig.validate(engine, value);
+          validatedConfigurations.put(tableConfig.getKey(), value);
         } else {
-            throw DeltaErrors.unknownConfigurationException(key);
+          throw DeltaErrors.cannotModifyTableProperty(key);
         }
+      } else {
+        throw DeltaErrors.unknownConfigurationException(key);
+      }
     }
     return validatedConfigurations;
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -179,13 +179,13 @@ public class TableConfig<T> {
 
   /** This table property is used to control the maximum column mapping ID. */
   public static final TableConfig<Long> COLUMN_MAPPING_MAX_COLUMN_ID =
-          new TableConfig<>(
-                  "delta.columnMapping.maxColumnId",
-                  "0",
-                  (engineOpt, v) -> Long.valueOf(v),
-                  value -> value >= 0,
-                  "",
-                  false);
+      new TableConfig<>(
+          "delta.columnMapping.maxColumnId",
+          "0",
+          (engineOpt, v) -> Long.valueOf(v),
+          value -> value >= 0,
+          "",
+          false);
 
   /**
    * Table property that enables modifying the table in accordance with the Delta-Iceberg

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -194,6 +194,16 @@ public class TableConfig<T> {
           "needs to be a boolean.",
           true);
 
+  /** This table property is used to control the maximum column mapping ID. */
+  public static final TableConfig<Long> MAX_COLUMN_ID =
+      new TableConfig<>(
+          "delta.columnMapping.maxColumnId",
+          "0",
+          (engineOpt, v) -> Long.valueOf(v),
+          value -> value >= 0,
+          "",
+          false);
+
   /** All the valid properties that can be set on the table. */
   private static final Map<String, TableConfig<?>> VALID_PROPERTIES =
       Collections.unmodifiableMap(
@@ -209,6 +219,7 @@ public class TableConfig<T> {
               addConfig(this, COORDINATED_COMMITS_TABLE_CONF);
               addConfig(this, COLUMN_MAPPING_MODE);
               addConfig(this, ICEBERG_COMPAT_V2_ENABLED);
+              addConfig(this, MAX_COLUMN_ID);
             }
           });
 
@@ -271,16 +282,16 @@ public class TableConfig<T> {
     for (Map.Entry<String, String> kv : configurations.entrySet()) {
         String key = kv.getKey().toLowerCase(Locale.ROOT);
         String value = kv.getValue();
-        if (key.startsWith("delta.") && VALID_PROPERTIES.containsKey(key)) {
-          TableConfig<?> tableConfig = VALID_PROPERTIES.get(key);
-          if (tableConfig.editable) {
-              tableConfig.validate(engine, value);
-              validatedConfigurations.put(tableConfig.getKey(), value);
-          } else {
-            throw DeltaErrors.cannotModifyTableProperty(key);
-          }
+        if (key.startsWith("delta.")) {
+            TableConfig<?> tableConfig = VALID_PROPERTIES.get(key);
+            if (tableConfig.editable) {
+                tableConfig.validate(engine, value);
+                validatedConfigurations.put(tableConfig.getKey(), value);
+            } else {
+                throw DeltaErrors.cannotModifyTableProperty(key);
+            }
         } else {
-          throw DeltaErrors.unknownConfigurationException(key);
+            throw DeltaErrors.unknownConfigurationException(key);
         }
     }
     return validatedConfigurations;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -277,10 +277,10 @@ public class TableConfig<T> {
               tableConfig.validate(engine, value);
               validatedConfigurations.put(tableConfig.getKey(), value);
           } else {
-              throw DeltaErrors.cannotModifyTableProperty(key);
+            throw DeltaErrors.cannotModifyTableProperty(key);
           }
         } else {
-            throw DeltaErrors.unknownConfigurationException(key);
+          throw DeltaErrors.unknownConfigurationException(key);
         }
     }
     return validatedConfigurations;

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableConfigSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableConfigSuite.scala
@@ -92,10 +92,10 @@ class TableConfigSuite extends AnyFunSuite with MockEngineUtils {
     }
 
     assert(e.isInstanceOf[KernelException])
-    assert(e.getMessage.toLowerCase() ==
-      s"The Delta table property ".toLowerCase() +
-      s"'${TableConfig.COLUMN_MAPPING_MAX_COLUMN_ID.getKey}'".toLowerCase() +
-      s" is an internal property and cannot be updated.".toLowerCase())
+    assert(e.getMessage ===
+      s"The Delta table property " +
+      s"'${TableConfig.COLUMN_MAPPING_MAX_COLUMN_ID.getKey}'" +
+      s" is an internal property and cannot be updated.")
   }
 }
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableConfigSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableConfigSuite.scala
@@ -61,6 +61,24 @@ class TableConfigSuite extends AnyFunSuite with MockEngineUtils {
     }
     assert(e4.getMessage === null)
   }
+
+  test("check TableConfig.editable is true") {
+    val expMap = Map("key1" -> "string_value", "key2Int" -> "2")
+    val engine = mockEngine(jsonHandler = new KeyValueJsonHandler(expMap))
+
+    TableConfig.validateProperties(engine,
+      Map(
+        TableConfig.TOMBSTONE_RETENTION.getKey -> "interval 2 week",
+        TableConfig.CHECKPOINT_INTERVAL.getKey -> "20",
+        TableConfig.IN_COMMIT_TIMESTAMPS_ENABLED.getKey -> "true",
+        TableConfig.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.getKey -> "1",
+        TableConfig.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.getKey -> "1",
+        TableConfig.COORDINATED_COMMITS_COORDINATOR_NAME.getKey -> "{in-memory}",
+        TableConfig.COORDINATED_COMMITS_COORDINATOR_CONF.getKey -> "{\"1\": \"1\"}",
+        TableConfig.COORDINATED_COMMITS_TABLE_CONF.getKey -> "{\"1\": \"1\"}",
+        TableConfig.COLUMN_MAPPING_MODE.getKey -> "name",
+        TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true").asJava)
+  }
 }
 
 /**

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableConfigSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableConfigSuite.scala
@@ -63,7 +63,7 @@ class TableConfigSuite extends AnyFunSuite with MockEngineUtils {
   }
 
   test("check TableConfig.editable is true") {
-    val expMap = Map("key1" -> "string_value", "key2Int" -> "2")
+    val expMap: Map[String, String] = Map()
     val engine = mockEngine(jsonHandler = new KeyValueJsonHandler(expMap))
 
     TableConfig.validateProperties(engine,

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableConfigSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableConfigSuite.scala
@@ -88,12 +88,13 @@ class TableConfigSuite extends AnyFunSuite with MockEngineUtils {
           TableConfig.TOMBSTONE_RETENTION.getKey -> "interval 2 week",
           TableConfig.CHECKPOINT_INTERVAL.getKey -> "20",
           TableConfig.IN_COMMIT_TIMESTAMPS_ENABLED.getKey -> "true",
-          TableConfig.MAX_COLUMN_ID.getKey -> "10").asJava)
+          TableConfig.COLUMN_MAPPING_MAX_COLUMN_ID.getKey -> "10").asJava)
     }
 
     assert(e.isInstanceOf[KernelException])
     assert(e.getMessage.toLowerCase() ==
-      s"The Delta table property '${TableConfig.MAX_COLUMN_ID.getKey}'".toLowerCase() +
+      s"The Delta table property ".toLowerCase() +
+      s"'${TableConfig.COLUMN_MAPPING_MAX_COLUMN_ID.getKey}'".toLowerCase() +
       s" is an internal property and cannot be updated.".toLowerCase())
   }
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableConfigSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableConfigSuite.scala
@@ -78,6 +78,24 @@ class TableConfigSuite extends AnyFunSuite with MockEngineUtils {
         TableConfig.COLUMN_MAPPING_MODE.getKey -> "name",
         TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true").asJava)
   }
+
+  test("check TableConfig.MAX_COLUMN_ID.editable is false") {
+    val engine = mockEngine(jsonHandler = new KeyValueJsonHandler(Map()))
+
+    val e = intercept[KernelException] {
+      TableConfig.validateProperties(engine,
+        Map(
+          TableConfig.TOMBSTONE_RETENTION.getKey -> "interval 2 week",
+          TableConfig.CHECKPOINT_INTERVAL.getKey -> "20",
+          TableConfig.IN_COMMIT_TIMESTAMPS_ENABLED.getKey -> "true",
+          TableConfig.MAX_COLUMN_ID.getKey -> "10").asJava)
+    }
+
+    assert(e.isInstanceOf[KernelException])
+    assert(e.getMessage.toLowerCase() ==
+      s"The Delta table property '${TableConfig.MAX_COLUMN_ID.getKey}'".toLowerCase() +
+      s" is an internal property and cannot be updated.".toLowerCase())
+  }
 }
 
 /**

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableConfigSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableConfigSuite.scala
@@ -63,8 +63,7 @@ class TableConfigSuite extends AnyFunSuite with MockEngineUtils {
   }
 
   test("check TableConfig.editable is true") {
-    val expMap: Map[String, String] = Map()
-    val engine = mockEngine(jsonHandler = new KeyValueJsonHandler(expMap))
+    val engine = mockEngine(jsonHandler = new KeyValueJsonHandler(Map()))
 
     TableConfig.validateProperties(engine,
       Map(


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description
Resolves #3455. 
Added editable property to TableConfig. Changed TableConfig#validateProperties to check if property is editable.

## How was this patch tested?
Test added to `TableConfigSuite.scala`.

## Does this PR introduce _any_ user-facing changes?
No.
