### PR TITLE
[INFRA] Fix the pip version in the dockerfile as well to accomodate for versions with "-" in it 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,13 @@ RUN apt-get install -y git
 # cryptography. Otherwise, building wheels for these packages fails.
 RUN pip3 install --upgrade pip
 
+# Update the pip version to 24.0. By default `pyenv.run` installs the latest pip version
+# available. From version 24.1, `pip` doesn't allow installing python packages
+# with version string containing `-`. In Delta-Spark case, the pypi package generated has
+# `-SNAPSHOT` in version (e.g. `3.3.0-SNAPSHOT`) as the version is picked up from
+# the`version.sbt` file.
+RUN pip install pip==24.0 setuptools==69.5.1 wheel==0.43.0
+
 RUN pip3 install pyspark==3.5.2
 
 RUN pip3 install mypy==0.982


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [X] Other (INFRA)

## Description

Later versions of pip doesn't allow installing python packages with "-" in the name but we use version with "-SNAPSHOT" in it. Instead fix the pip version to 24.0.

## How was this patch tested?

Copied from our other CI.