### PR TITLE
[Delta] Centralize checks for coordinated commits property via different code paths

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -1714,7 +1714,7 @@
   },
   "DELTA_MUST_SET_ALL_COORDINATED_COMMITS_CONFS_IN_SESSION" : {
     "message" : [
-      "During <command>, either both coordinated commits configurations (\"spark.databricks.delta.properties.defaults.coordinatedCommits.commitCoordinator-preview\", \"spark.databricks.delta.properties.defaults.coordinatedCommits.commitCoordinatorConf-preview\") are set in the SparkSession configurations or neither of them. Missing: \"<configuration>\". Please set this configuration in the SparkSession or unset the other configuration, and then retry the command again."
+      "During <command>, either both coordinated commits configurations (\"coordinatedCommits.commitCoordinator-preview\", \"coordinatedCommits.commitCoordinatorConf-preview\") are set in the SparkSession configurations or neither of them. Missing: \"<configuration>\". Please set this configuration in the SparkSession or unset the other configuration, and then retry the command again."
     ],
     "sqlState" : "42616"
   },

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -213,6 +213,12 @@
     ],
     "sqlState" : "42939"
   },
+  "DELTA_CANNOT_OVERRIDE_COORDINATED_COMMITS_CONFS" : {
+    "message" : [
+      "<Command> cannot override coordinated commits configurations for an existing target table. Please remove them (\"delta.coordinatedCommits.commitCoordinator-preview\", \"delta.coordinatedCommits.commitCoordinatorConf-preview\", \"delta.coordinatedCommits.tableConf-preview\") from the TBLPROPERTIES clause and then retry the command again."
+    ],
+    "sqlState" : "42616"
+  },
   "DELTA_CANNOT_RECONSTRUCT_PATH_FROM_URI" : {
     "message" : [
       "A uri (<uri>) which cannot be turned into a relative path was found in the transaction log."
@@ -365,24 +371,6 @@
       "<targetIdentifier>."
     ],
     "sqlState" : "42613"
-  },
-  "DELTA_CLONE_CANNOT_OVERRIDE_COORDINATED_COMMITS" : {
-    "message" : [
-      "Cannot override coordinated commits configurations for an existing target table that already has coordinated commits enabled during CLONE."
-    ],
-    "sqlState" : "42616"
-  },
-  "DELTA_CLONE_CONF_OVERRIDE_NOT_SUPPORTED" : {
-    "message" : [
-      "Configuration \"<configuration>\" cannot be overridden with CLONE command."
-    ],
-    "sqlState" : "42616"
-  },
-  "DELTA_CLONE_MUST_OVERRIDE_ALL_COORDINATED_COMMITS_CONFS" : {
-    "message" : [
-      "During CLONE, either all coordinated commits configurations i.e.\"delta.coordinatedCommits.commitCoordinator-preview\", \"delta.coordinatedCommits.commitCoordinatorConf-preview\" must be overridden or none of them."
-    ],
-    "sqlState" : "42616"
   },
   "DELTA_CLONE_UNSUPPORTED_SOURCE" : {
     "message" : [
@@ -557,6 +545,18 @@
       "There is a conflict from these SET columns: <columnList>."
     ],
     "sqlState" : "42701"
+  },
+  "DELTA_CONF_OVERRIDE_NOT_SUPPORTED_IN_COMMAND" : {
+    "message" : [
+      "During <command>, configuration \"<configuration>\" cannot be set from the command. Please remove it from the TBLPROPERTIES clause and then retry the command again."
+    ],
+    "sqlState" : "42616"
+  },
+  "DELTA_CONF_OVERRIDE_NOT_SUPPORTED_IN_SESSION" : {
+    "message" : [
+      "During <command>, configuration \"<configuration>\" cannot be set from the SparkSession configurations. Please unset it by running `spark.conf.unset(\"<configuration>\")` and then retry the command again."
+    ],
+    "sqlState" : "42616"
   },
   "DELTA_CONSTRAINT_ALREADY_EXISTS" : {
     "message" : [
@@ -1705,6 +1705,18 @@
       "<usageReference>"
     ],
     "sqlState" : "21506"
+  },
+  "DELTA_MUST_SET_ALL_COORDINATED_COMMITS_CONFS_IN_COMMAND" : {
+    "message" : [
+      "During <command>, either both coordinated commits configurations (\"delta.coordinatedCommits.commitCoordinator-preview\", \"delta.coordinatedCommits.commitCoordinatorConf-preview\") are set in the command or neither of them. Missing: \"<configuration>\". Please specify this configuration in the TBLPROPERTIES clause or remove the other configuration, and then retry the command again."
+    ],
+    "sqlState" : "42616"
+  },
+  "DELTA_MUST_SET_ALL_COORDINATED_COMMITS_CONFS_IN_SESSION" : {
+    "message" : [
+      "During <command>, either both coordinated commits configurations (\"spark.databricks.delta.properties.defaults.coordinatedCommits.commitCoordinator-preview\", \"spark.databricks.delta.properties.defaults.coordinatedCommits.commitCoordinatorConf-preview\") are set in the SparkSession configurations or neither of them. Missing: \"<configuration>\". Please set this configuration in the SparkSession or unset the other configuration, and then retry the command again."
+    ],
+    "sqlState" : "42616"
   },
   "DELTA_NESTED_NOT_NULL_CONSTRAINT" : {
     "message" : [

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.delta.DeltaColumnMapping.{dropColumnMappingMetadata,
 import org.apache.spark.sql.delta.actions.{Action, Metadata, Protocol}
 import org.apache.spark.sql.delta.actions.DomainMetadata
 import org.apache.spark.sql.delta.commands.DMLUtils.TaggedCommitData
+import org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsUtils
 import org.apache.spark.sql.delta.hooks.{HudiConverterHook, IcebergConverterHook, UpdateCatalog, UpdateCatalogFactory}
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
@@ -131,6 +132,8 @@ case class CreateDeltaTableCommand(
 
     val tableLocation = getDeltaTablePath(tableWithLocation)
     val deltaLog = DeltaLog.forTable(sparkSession, tableLocation)
+    CoordinatedCommitsUtils.validateCoordinatedCommitsConfigurations(
+      sparkSession, deltaLog, query, tableWithLocation.properties)
 
     recordDeltaOperation(deltaLog, "delta.ddl.createTable") {
       val result = handleCommit(sparkSession, deltaLog, tableWithLocation)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
@@ -19,8 +19,9 @@ package org.apache.spark.sql.delta.coordinatedcommits
 import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 
-import org.apache.spark.sql.delta.{CoordinatedCommitsTableFeature, DeltaConfig, DeltaConfigs, DeltaLog, Snapshot, SnapshotDescriptor}
+import org.apache.spark.sql.delta.{CoordinatedCommitsTableFeature, DeltaConfig, DeltaConfigs, DeltaIllegalArgumentException, DeltaLog, Snapshot, SnapshotDescriptor}
 import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
+import org.apache.spark.sql.delta.commands.CloneTableCommand
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
@@ -33,6 +34,7 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 
 import org.apache.spark.internal.MDC
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.util.Utils
 
 object CoordinatedCommitsUtils extends DeltaLogging {
@@ -360,5 +362,139 @@ object CoordinatedCommitsUtils extends DeltaLogging {
       case _ => // do nothing
     }
     maxFile
+  }
+
+  /**
+   * Extracts the Coordinated Commits configurations from the provided properties.
+   */
+  def extractCoordinatedCommitsConfigurations(
+      properties: Map[String, String]): Map[String, String] = {
+    properties.filter { case (k, _) =>
+      CoordinatedCommitsUtils.TABLE_PROPERTY_KEYS.contains(k)
+    }
+  }
+
+  /**
+   * Fetches the SparkSession default configurations for Coordinated Commits. The `withDefaultKey`
+   * flag controls whether the keys in the returned map should have the default prefix or not.
+   * For example, if property 'coordinatedCommits.commitCoordinator-preview' is set to 'dynamodb'
+   * in SparkSession default, then
+   *
+   *   - fetchDefaultCoordinatedCommitsConfigurations(spark) =>
+   *       Map("delta.coordinatedCommits.commitCoordinator-preview" -> "dynamodb")
+   *
+   *   - fetchDefaultCoordinatedCommitsConfigurations(spark, withDefaultKey = true) =>
+   *       Map("spark.databricks.delta.properties.defaults
+   *            .coordinatedCommits.commitCoordinator-preview" -> "dynamodb")
+   */
+  def fetchDefaultCoordinatedCommitsConfigurations(
+      spark: SparkSession, withDefaultKey: Boolean = false): Map[String, String] = {
+    TABLE_PROPERTY_CONFS.flatMap { conf =>
+      spark.conf.getOption(conf.defaultTablePropertyKey).map { value =>
+        val finalKey = if (withDefaultKey) conf.defaultTablePropertyKey else conf.key
+        finalKey -> value
+      }
+    }.toMap
+  }
+
+  /**
+   * Verifies that the properties contain exactly the Coordinator Name and Coordinator Conf.
+   * If `fromDefault` is true, then the properties have keys with the default prefix.
+   */
+  private def verifyContainsOnlyCoordinatorNameAndConf(
+      properties: Map[String, String],
+      command: String,
+      fromDefault: Boolean): Unit = {
+    Seq(DeltaConfigs.COORDINATED_COMMITS_TABLE_CONF).foreach { conf =>
+      if (fromDefault) {
+        if (properties.contains(conf.defaultTablePropertyKey)) {
+          throw new DeltaIllegalArgumentException(
+            errorClass = "DELTA_CONF_OVERRIDE_NOT_SUPPORTED_IN_SESSION",
+            messageParameters = Array(
+              command, conf.defaultTablePropertyKey, conf.defaultTablePropertyKey))
+        }
+      } else {
+        if (properties.contains(conf.key)) {
+          throw new DeltaIllegalArgumentException(
+            errorClass = "DELTA_CONF_OVERRIDE_NOT_SUPPORTED_IN_COMMAND",
+            messageParameters = Array(command, conf.key))
+        }
+      }
+    }
+    Seq(
+      DeltaConfigs.COORDINATED_COMMITS_COORDINATOR_NAME,
+      DeltaConfigs.COORDINATED_COMMITS_COORDINATOR_CONF).foreach { conf =>
+      if (fromDefault) {
+        if (!properties.contains(conf.defaultTablePropertyKey)) {
+          throw new DeltaIllegalArgumentException(
+            errorClass = "DELTA_MUST_SET_ALL_COORDINATED_COMMITS_CONFS_IN_SESSION",
+            messageParameters = Array(command, conf.defaultTablePropertyKey))
+        }
+      } else {
+        if (!properties.contains(conf.key)) {
+          throw new DeltaIllegalArgumentException(
+            errorClass = "DELTA_MUST_SET_ALL_COORDINATED_COMMITS_CONFS_IN_COMMAND",
+            messageParameters = Array(command, conf.key))
+        }
+      }
+    }
+  }
+
+  /**
+   * Validates the Coordinated Commits configurations in explicit command overrides and default
+   * SparkSession properties. See `validateCoordinatedCommitsConfigurationsImpl` for details.
+   */
+  def validateCoordinatedCommitsConfigurations(
+      spark: SparkSession,
+      deltaLog: DeltaLog,
+      query: Option[LogicalPlan],
+      catalogTableProperties: Map[String, String]): Unit = {
+    val tableExists = deltaLog.tableExists
+    val (command, propertyOverrides) = query match {
+      // For CLONE, we cannot use the properties from the catalog table, because they are already
+      // the result of merging the source table properties with the overrides, but we do not
+      // consider the source table properties for Coordinated Commits.
+      case Some(cmd: CloneTableCommand) =>
+        (if (tableExists) "REPLACE with CLONE" else "CREATE with CLONE",
+          cmd.tablePropertyOverrides)
+      case _ => (if (tableExists) "REPLACE" else "CREATE", catalogTableProperties)
+    }
+    validateCoordinatedCommitsConfigurationsImpl(
+      spark, propertyOverrides, tableExists, command)
+  }
+
+  /**
+   * Validates the Coordinated Commits configurations for the table.
+   *   - If the table already exists, the explicit command property overrides must not contain any
+   *     Coordinated Commits configurations.
+   *   - If the table does not exist, the explicit command property overrides must contain exactly
+   *     the Coordinator Name and Coordinator Conf, and no Table Conf. Default configurations are
+   *     checked similarly if non of the three properties is present in explicit overrides.
+   */
+  private[delta] def validateCoordinatedCommitsConfigurationsImpl(
+      spark: SparkSession,
+      propertyOverrides: Map[String, String],
+      tableExists: Boolean,
+      command: String): Unit = {
+    val coordinatedCommitsConfs = extractCoordinatedCommitsConfigurations(propertyOverrides)
+    if (tableExists) {
+      if (coordinatedCommitsConfs.nonEmpty) {
+        throw new DeltaIllegalArgumentException(
+          "DELTA_CANNOT_OVERRIDE_COORDINATED_COMMITS_CONFS",
+          Array(command))
+      }
+    } else {
+      if (coordinatedCommitsConfs.nonEmpty) {
+        verifyContainsOnlyCoordinatorNameAndConf(
+          coordinatedCommitsConfs, command, fromDefault = false)
+      } else {
+        val defaultCoordinatedCommitsConfs = fetchDefaultCoordinatedCommitsConfigurations(
+          spark, withDefaultKey = true)
+        if (defaultCoordinatedCommitsConfs.nonEmpty) {
+          verifyContainsOnlyCoordinatorNameAndConf(
+            defaultCoordinatedCommitsConfs, command, fromDefault = true)
+        }
+      }
+    }
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableSuiteBase.scala
@@ -953,10 +953,10 @@ trait CloneTableSuiteBase extends QueryTest
           isReplace = true,
           tableProperties = properties)
       }
-      assert(e1.getMessage.contains("During CLONE, either all coordinated commits " +
-        "configurations i.e.\"delta.coordinatedCommits.commitCoordinator-preview\", " +
-        "\"delta.coordinatedCommits.commitCoordinatorConf-preview\" must be overridden or none " +
-        "of them."))
+      assert(e1.getMessage.contains("During CREATE with CLONE, either both coordinated commits " +
+        "configurations (\"delta.coordinatedCommits.commitCoordinator-preview\", \"delta." +
+        "coordinatedCommits.commitCoordinatorConf-preview\") are set in the command or neither " +
+        "of them. Missing: \"delta.coordinatedCommits.commitCoordinatorConf-preview\"."))
 
       val e2 = intercept[IllegalArgumentException] {
         val properties = Map(
@@ -970,8 +970,8 @@ trait CloneTableSuiteBase extends QueryTest
           isReplace = true,
           tableProperties = properties)
       }
-      assert(e2.getMessage.contains("Configuration \"delta.coordinatedCommits.tableConf-preview\"" +
-        " cannot be overridden with CLONE command."))
+      assert(e2.getMessage.contains("During CREATE with CLONE, configuration \"delta." +
+        "coordinatedCommits.tableConf-preview\" cannot be set from the command."))
 
       val properties = Map(
         DeltaConfigs.COORDINATED_COMMITS_COORDINATOR_NAME.key ->

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsEnablementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsEnablementSuite.scala
@@ -97,21 +97,5 @@ class CoordinatedCommitsEnablementSuite
       validateCoordinatedCommitsCompleteEnablement(log.update(), expectEnabled = true)
     }
   }
-
-  testWithDefaultCommitCoordinatorUnset(
-    "enablement after commit 0: CC should enable ICT and VacuumProtocolCheck" +
-      " --- replace table") {
-    withTempDir { tempDir =>
-      val tablePath = tempDir.getAbsolutePath
-      Seq(1).toDF().write.format("delta").mode("overwrite").save(tablePath) // commit 0
-      Seq(1).toDF().write.format("delta").mode("append").save(tablePath) // commit 1
-      val log = DeltaLog.forTable(spark, tablePath)
-      validateCoordinatedCommitsCompleteEnablement(log.snapshot, expectEnabled = false)
-      sql(s"REPLACE TABLE delta.`$tablePath` (value int) USING delta TBLPROPERTIES " + // Enable CC
-        s"('${DeltaConfigs.COORDINATED_COMMITS_COORDINATOR_NAME.key}' = 'tracking-in-memory')")
-      Seq(1).toDF().write.format("delta").mode("overwrite").save(tablePath) // commit 3
-      validateCoordinatedCommitsCompleteEnablement(log.update(), expectEnabled = true)
-    }
-  }
   // ---- Tests END: Enablement after commit 0 ----
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
@@ -1705,7 +1705,7 @@ class CoordinatedCommitsSuite
       (Map(tableConf), Seq(cNameDefault)),
       (Map(tableConf), Seq(cNameDefault, cConfDefault)),
       (Map(tableConf), Seq(cNameDefault, cConfDefault, tableConfDefault)),
-      (Map(tableConf), Seq(tableConfDefault)),
+      (Map(tableConf), Seq(tableConfDefault))
     )
   ) { case (
       propertyOverrides: Map[String, String],
@@ -1724,7 +1724,7 @@ class CoordinatedCommitsSuite
       (Seq(cNameDefault), Some(errMissingConfInSession(cConfDefaultKey))),
       (Seq(cNameDefault, cConfDefault), None),
       (Seq(cNameDefault, cConfDefault, tableConfDefault), Some(errTableConfInSession)),
-      (Seq(tableConfDefault), Some(errTableConfInSession)),
+      (Seq(tableConfDefault), Some(errTableConfInSession))
     )
   ) { case (
       defaultConfs: Seq[(String, String)],
@@ -1781,7 +1781,7 @@ class CoordinatedCommitsSuite
       Seq(cNameDefault),
       Seq(cNameDefault, cConfDefault),
       Seq(cNameDefault, cConfDefault, tableConfDefault),
-      Seq(tableConfDefault),
+      Seq(tableConfDefault)
     )
   ) { defaultConfs: Seq[(String, String)] =>
     testValidation(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
@@ -24,7 +24,7 @@ import scala.collection.mutable.ArrayBuffer
 import com.databricks.spark.util.Log4jUsageLogger
 import com.databricks.spark.util.UsageRecord
 import org.apache.spark.sql.delta.{CommitStats, CoordinatedCommitsStats, CoordinatedCommitsTableFeature, DeltaOperations, DeltaUnsupportedOperationException, V2CheckpointTableFeature}
-import org.apache.spark.sql.delta.CommitCoordinatorGetCommitsFailedException
+import org.apache.spark.sql.delta.{CommitCoordinatorGetCommitsFailedException, DeltaIllegalArgumentException}
 import org.apache.spark.sql.delta.CoordinatedCommitType._
 import org.apache.spark.sql.delta.DeltaConfigs.{CHECKPOINT_INTERVAL, COORDINATED_COMMITS_COORDINATOR_CONF, COORDINATED_COMMITS_COORDINATOR_NAME, COORDINATED_COMMITS_TABLE_CONF}
 import org.apache.spark.sql.delta.DeltaLog
@@ -44,6 +44,7 @@ import io.delta.storage.commit.{CommitCoordinatorClient, CommitResponse, GetComm
 import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
+import org.scalatest.Tag
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{QueryTest, Row, SparkSession}
@@ -1571,5 +1572,226 @@ class CoordinatedCommitsSuite
 
   /////////////////////////////////////////////////////////////////////////////////////////////
   //           Test coordinated-commits with DeltaLog.getChangeLogFile API ENDS                  //
+  /////////////////////////////////////////////////////////////////////////////////////////////
+
+  /////////////////////////////////////////////////////////////////////////////////////////////
+  //     Test CoordinatedCommitsUtils.validateCoordinatedCommitsConfigurationsImpl STARTS    //
+  /////////////////////////////////////////////////////////////////////////////////////////////
+
+  def gridTest[A](testNamePrefix: String, testTags: Tag*)(params: Seq[A])(
+    testFun: A => Unit): Unit = {
+    for (param <- params) {
+      test(testNamePrefix + s" ($param)", testTags: _*)(testFun(param))
+    }
+  }
+
+  private val cNameKey = COORDINATED_COMMITS_COORDINATOR_NAME.key
+  private val cConfKey = COORDINATED_COMMITS_COORDINATOR_CONF.key
+  private val tableConfKey = COORDINATED_COMMITS_TABLE_CONF.key
+  private val cName = cNameKey -> "some-cc-name"
+  private val cConf = cConfKey -> "some-cc-conf"
+  private val tableConf = tableConfKey -> "some-table-conf"
+
+  private val cNameDefaultKey = COORDINATED_COMMITS_COORDINATOR_NAME.defaultTablePropertyKey
+  private val cConfDefaultKey = COORDINATED_COMMITS_COORDINATOR_CONF.defaultTablePropertyKey
+  private val tableConfDefaultKey = COORDINATED_COMMITS_TABLE_CONF.defaultTablePropertyKey
+  private val cNameDefault = cNameDefaultKey -> "some-cc-name"
+  private val cConfDefault = cConfDefaultKey -> "some-cc-conf"
+  private val tableConfDefault = tableConfDefaultKey -> "some-table-conf"
+
+  private val command = "CLONE"
+
+  private val errCannotOverride = new DeltaIllegalArgumentException(
+    "DELTA_CANNOT_OVERRIDE_COORDINATED_COMMITS_CONFS", Array(command))
+
+  private def errMissingConfInCommand(key: String) = new DeltaIllegalArgumentException(
+      "DELTA_MUST_SET_ALL_COORDINATED_COMMITS_CONFS_IN_COMMAND", Array(command, key))
+
+  private def errMissingConfInSession(key: String) = new DeltaIllegalArgumentException(
+    "DELTA_MUST_SET_ALL_COORDINATED_COMMITS_CONFS_IN_SESSION", Array(command, key))
+
+  private def errTableConfInCommand = new DeltaIllegalArgumentException(
+    "DELTA_CONF_OVERRIDE_NOT_SUPPORTED_IN_COMMAND", Array(command, tableConfKey))
+
+  private def errTableConfInSession = new DeltaIllegalArgumentException(
+    "DELTA_CONF_OVERRIDE_NOT_SUPPORTED_IN_SESSION",
+    Array(command, tableConfDefaultKey, tableConfDefaultKey))
+
+  private def testValidation(
+      tableExists: Boolean,
+      propertyOverrides: Map[String, String],
+      defaultConfs: Seq[(String, String)],
+      errorOpt: Option[DeltaIllegalArgumentException]): Unit = {
+    withoutCoordinatedCommitsDefaultTableProperties {
+      withSQLConf(defaultConfs: _*) {
+        if (errorOpt.isDefined) {
+          val e = intercept[DeltaIllegalArgumentException] {
+            CoordinatedCommitsUtils.validateCoordinatedCommitsConfigurationsImpl(
+              spark, propertyOverrides, tableExists, command)
+          }
+          assert(e.getMessage.contains(errorOpt.get.getMessage))
+        } else {
+          CoordinatedCommitsUtils.validateCoordinatedCommitsConfigurationsImpl(
+            spark, propertyOverrides, tableExists, command)
+        }
+      }
+    }
+  }
+
+  // tableExists: True
+  //            | False
+  //
+  // propertyOverrides: Map.empty
+  //                  | Map(cName)
+  //                  | Map(cName, cConf)
+  //                  | Map(cName, cConf, tableConf)
+  //                  | Map(tableConf)
+  //
+  // defaultConf: Seq.empty
+  //            | Seq(cNameDefault)
+  //            | Seq(cNameDefault, cConfDefault)
+  //            | Seq(cNameDefault, cConfDefault, tableConfDefault)
+  //            | Seq(tableConfDefault)
+  //
+  // errorOpt: None
+  //         | Some(errCannotOverride)
+  //         | Some(errMissingConfInCommand(cConfKey))
+  //         | Some(errMissingConfInSession(cConfKey))
+  //         | Some(errTableConfInCommand)
+  //         | Some(errTableConfInSession)
+
+  gridTest("During CLONE, CoordinatedCommitsUtils.validateCoordinatedCommitsConfigurationsImpl " +
+      "passes for existing target tables with no explicit Coordinated Commits Configurations.") (
+    Seq(
+      Seq.empty,
+      // Not having any explicit Coordinated Commits configurations, but having an illegal
+      // combination of Coordinated Commits configurations in default: pass.
+      // This is because we don't consider default configurations when the table exists.
+      Seq(cNameDefault),
+      Seq(cNameDefault, cConfDefault),
+      Seq(cNameDefault, cConfDefault, tableConfDefault),
+      Seq(tableConfDefault)
+    )
+  ) { defaultConfs: Seq[(String, String)] =>
+    testValidation(
+      tableExists = true,
+      propertyOverrides = Map.empty,
+      defaultConfs,
+      errorOpt = None)
+  }
+
+  gridTest("During CLONE, CoordinatedCommitsUtils.validateCoordinatedCommitsConfigurationsImpl " +
+      "fails for existing target tables with any explicit Coordinated Commits Configurations.") (
+    Seq(
+      (Map(cName), Seq.empty),
+      (Map(cName), Seq(cNameDefault)),
+      (Map(cName), Seq(cNameDefault, cConfDefault)),
+      (Map(cName), Seq(cNameDefault, cConfDefault, tableConfDefault)),
+      (Map(cName), Seq(tableConfDefault)),
+
+      (Map(cName, cConf), Seq.empty),
+      (Map(cName, cConf), Seq(cNameDefault)),
+      (Map(cName, cConf), Seq(cNameDefault, cConfDefault)),
+      (Map(cName, cConf), Seq(cNameDefault, cConfDefault, tableConfDefault)),
+      (Map(cName, cConf), Seq(tableConfDefault)),
+
+      (Map(cName, cConf, tableConf), Seq.empty),
+      (Map(cName, cConf, tableConf), Seq(cNameDefault)),
+      (Map(cName, cConf, tableConf), Seq(cNameDefault, cConfDefault)),
+      (Map(cName, cConf, tableConf), Seq(cNameDefault, cConfDefault, tableConfDefault)),
+      (Map(cName, cConf, tableConf), Seq(tableConfDefault)),
+
+      (Map(tableConf), Seq.empty),
+      (Map(tableConf), Seq(cNameDefault)),
+      (Map(tableConf), Seq(cNameDefault, cConfDefault)),
+      (Map(tableConf), Seq(cNameDefault, cConfDefault, tableConfDefault)),
+      (Map(tableConf), Seq(tableConfDefault)),
+    )
+  ) { case (
+      propertyOverrides: Map[String, String],
+      defaultConfs: Seq[(String, String)]) =>
+    testValidation(
+      tableExists = true,
+      propertyOverrides,
+      defaultConfs,
+      errorOpt = Some(errCannotOverride))
+  }
+
+  gridTest("During CLONE, CoordinatedCommitsUtils.validateCoordinatedCommitsConfigurationsImpl " +
+      "works correctly for new target tables with default Coordinated Commits Configurations.") (
+    Seq(
+      (Seq.empty, None),
+      (Seq(cNameDefault), Some(errMissingConfInSession(cConfDefaultKey))),
+      (Seq(cNameDefault, cConfDefault), None),
+      (Seq(cNameDefault, cConfDefault, tableConfDefault), Some(errTableConfInSession)),
+      (Seq(tableConfDefault), Some(errTableConfInSession)),
+    )
+  ) { case (
+      defaultConfs: Seq[(String, String)],
+      errorOpt: Option[DeltaIllegalArgumentException]) =>
+    testValidation(
+      tableExists = false,
+      propertyOverrides = Map.empty,
+      defaultConfs,
+      errorOpt)
+  }
+
+  gridTest("During CLONE, CoordinatedCommitsUtils.validateCoordinatedCommitsConfigurationsImpl " +
+      "fails for new target tables with any illegal explicit Coordinated Commits Configurations.") (
+    Seq(
+      (Map(cName), Seq.empty, Some(errMissingConfInCommand(cConfKey))),
+      (Map(cName), Seq(cNameDefault), Some(errMissingConfInCommand(cConfKey))),
+      (Map(cName), Seq(cNameDefault, cConfDefault), Some(errMissingConfInCommand(cConfKey))),
+      (Map(cName), Seq(cNameDefault, cConfDefault, tableConfDefault),
+        Some(errMissingConfInCommand(cConfKey))),
+      (Map(cName), Seq(tableConfDefault), Some(errMissingConfInCommand(cConfKey))),
+
+      (Map(cName, cConf, tableConf), Seq.empty, Some(errTableConfInCommand)),
+      (Map(cName, cConf, tableConf), Seq(cNameDefault), Some(errTableConfInCommand)),
+      (Map(cName, cConf, tableConf), Seq(cNameDefault, cConfDefault), Some(errTableConfInCommand)),
+      (Map(cName, cConf, tableConf), Seq(cNameDefault, cConfDefault, tableConfDefault),
+        Some(errTableConfInCommand)),
+      (Map(cName, cConf, tableConf), Seq(tableConfDefault), Some(errTableConfInCommand)),
+
+      (Map(tableConf), Seq.empty, Some(errTableConfInCommand)),
+      (Map(tableConf), Seq(cNameDefault), Some(errTableConfInCommand)),
+      (Map(tableConf), Seq(cNameDefault, cConfDefault), Some(errTableConfInCommand)),
+      (Map(tableConf), Seq(cNameDefault, cConfDefault, tableConfDefault),
+        Some(errTableConfInCommand)),
+      (Map(tableConf), Seq(tableConfDefault), Some(errTableConfInCommand))
+    )
+  ) { case (
+      propertyOverrides: Map[String, String],
+      defaultConfs: Seq[(String, String)],
+      errorOpt: Option[DeltaIllegalArgumentException]) =>
+    testValidation(
+      tableExists = false,
+      propertyOverrides,
+      defaultConfs,
+      errorOpt)
+  }
+
+  gridTest("During CLONE, CoordinatedCommitsUtils.validateCoordinatedCommitsConfigurationsImpl " +
+      "passes for new target tables with legal explicit Coordinated Commits Configurations.") (
+    Seq(
+      // Having exactly Coordinator Name and Coordinator Conf explicitly, but having an illegal
+      // combination of Coordinated Commits configurations in default: pass.
+      // This is because we don't consider default configurations when explicit ones are provided.
+      Seq.empty,
+      Seq(cNameDefault),
+      Seq(cNameDefault, cConfDefault),
+      Seq(cNameDefault, cConfDefault, tableConfDefault),
+      Seq(tableConfDefault),
+    )
+  ) { defaultConfs: Seq[(String, String)] =>
+    testValidation(
+      tableExists = false,
+      propertyOverrides = Map(cName, cConf),
+      defaultConfs,
+      errorOpt = None)
+  }
+
+  /////////////////////////////////////////////////////////////////////////////////////////////
+  //      Test CoordinatedCommitsUtils.validateCoordinatedCommitsConfigurationsImpl ENDS     //
   /////////////////////////////////////////////////////////////////////////////////////////////
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
@@ -65,15 +65,17 @@ trait CoordinatedCommitsTestUtils
 
   /**
    * Runs the function `f` with coordinated commits default properties unset.
-   * Any table created in function `f`` won't have coordinated commits enabled by default.
+   * Any table created in function `f` won't have coordinated commits enabled by default.
    */
   def withoutCoordinatedCommitsDefaultTableProperties[T](f: => T): T = {
-    val commitCoordinatorKey = COORDINATED_COMMITS_COORDINATOR_NAME.defaultTablePropertyKey
-    val oldCommitCoordinatorValue = spark.conf.getOption(commitCoordinatorKey)
-    spark.conf.unset(commitCoordinatorKey)
+    val defaultCoordinatedCommitsConfs = CoordinatedCommitsUtils
+      .fetchDefaultCoordinatedCommitsConfigurations(spark, withDefaultKey = true)
+    defaultCoordinatedCommitsConfs.foreach { case (defaultKey, _) =>
+      spark.conf.unset(defaultKey)
+    }
     try { f } finally {
-      oldCommitCoordinatorValue.foreach {
-        spark.conf.set(commitCoordinatorKey, _)
+      defaultCoordinatedCommitsConfs.foreach { case (defaultKey, oldValue) =>
+        spark.conf.set(defaultKey, oldValue)
       }
     }
   }


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

1. Moves the checks for Coordinated Commits configurations for CLONE early to `CreateDeltaTableCommand.scala`. This also affects CREATE and REPLACE code paths; the same checks are placed on all three commands.
2. Modified the precedence of Coordinated Commits configurations for CLONE. Now for existing tables, it blocks Coordinated Commits overrides completely, even if the existing table had no commit coordinator before. We want the users to upgrade a table with Coordinated Commits only with ALTER command, and not piggyback in other commands like CLONE.
4. Updated the error messages to better reflect the exceptions.
5. Added UTs and modified existing UTs for the new logic.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

UTs.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.