### PR TITLE
[SPARK] Refactor IdentityColumnTestUtils

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnSuite.scala
@@ -384,9 +384,9 @@ trait IdentityColumnSuiteBase extends IdentityColumnTestUtils {
     withTable(tableName) {
       generateTableWithIdentityColumn(tableName)
       sql(s"RESTORE TABLE $tableName TO VERSION AS OF 3")
-      sql(s"INSERT INTO $tableName (val) VALUES (6)")
+      sql(s"INSERT INTO $tableName (value) VALUES (6)")
       checkAnswer(
-        sql(s"SELECT key, val FROM $tableName ORDER BY val ASC"),
+        sql(s"SELECT id, value FROM $tableName ORDER BY value ASC"),
         Seq(Row(0, 0), Row(1, 1), Row(2, 2), Row(6, 6))
       )
     }
@@ -397,9 +397,9 @@ trait IdentityColumnSuiteBase extends IdentityColumnTestUtils {
     withTable(tableName) {
       generateTableWithIdentityColumn(tableName, step = -1)
       sql(s"RESTORE TABLE $tableName TO VERSION AS OF 3")
-      sql(s"INSERT INTO $tableName (val) VALUES (6)")
+      sql(s"INSERT INTO $tableName (value) VALUES (6)")
       checkAnswer(
-        sql(s"SELECT key, val FROM $tableName ORDER BY val ASC"),
+        sql(s"SELECT id, value FROM $tableName ORDER BY value ASC"),
         Seq(Row(0, 0), Row(-1, 1), Row(-2, 2), Row(-6, 6))
       )
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnTestUtils.scala
@@ -78,26 +78,20 @@ trait IdentityColumnTestUtils
   }
 
   protected def generateTableWithIdentityColumn(tableName: String, step: Long = 1): Unit = {
-    createTable(
+    createTableWithIdColAndIntValueCol(
       tableName,
-      Seq(
-        IdentityColumnSpec(
-          GeneratedAlways,
-          startsWith = Some(0),
-          incrementBy = Some(step),
-          colName = "key"
-        ),
-        TestColumnSpec(colName = "val", dataType = LongType)
-      )
+      GeneratedAlways,
+      startsWith = Some(0),
+      incrementBy = Some(step)
     )
 
     // Insert numRows and make sure they assigned sequential IDs
     val numRows = 6
     for (i <- 0 until numRows) {
-      sql(s"INSERT INTO $tableName (val) VALUES ($i)")
+      sql(s"INSERT INTO $tableName (value) VALUES ($i)")
     }
     val expectedAnswer = for (i <- 0 until numRows) yield Row(i * step, i)
-    checkAnswer(sql(s"SELECT * FROM $tableName ORDER BY val ASC"), expectedAnswer)
+    checkAnswer(sql(s"SELECT * FROM $tableName ORDER BY value ASC"), expectedAnswer)
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR is part of https://github.com/delta-io/delta/issues/1959 .
The change refactors `IdentityColumnTestUtils` to reuse `createTableWithIdColAndIntValueCol` to create tables and to unify the column names in identity column tests.
## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
This is test only change.
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.