### PR TITLE
[Spark] Do not use the same variable name in the coordinator registration code

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CommitCoordinatorClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CommitCoordinatorClient.scala
@@ -57,10 +57,10 @@ object CommitCoordinatorProvider {
   /** Registers a new [[CommitCoordinatorBuilder]] with the [[CommitCoordinatorProvider]] */
   def registerBuilder(commitCoordinatorBuilder: CommitCoordinatorBuilder): Unit = synchronized {
     nameToBuilderMapping.get(commitCoordinatorBuilder.getName) match {
-      case Some(commitCoordinatorBuilder: CommitCoordinatorBuilder) =>
+      case Some(existingBuilder: CommitCoordinatorBuilder) =>
         throw new IllegalArgumentException(
-          s"commit-coordinator: ${commitCoordinatorBuilder.getName} already" +
-          s" registered with builder ${commitCoordinatorBuilder.getClass.getName}")
+          s"commit-coordinator: ${existingBuilder.getName} already" +
+          s" registered with builder ${existingBuilder.getClass.getName}")
       case None =>
         nameToBuilderMapping.put(commitCoordinatorBuilder.getName, commitCoordinatorBuilder)
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
In commit coordinator registration, we use the same variable name from the method and case use case which are bad practice. This PR simply fixes it.


## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Simple variable renaming change + existing unit tests will cover them

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
