### PR TITLE
[Spark] Improve missing stats column message for unsupported data skipping types

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -379,6 +379,12 @@
     ],
     "sqlState" : "0AKDC"
   },
+  "DELTA_CLUSTERING_COLUMNS_DATATYPE_NOT_SUPPORTED" : {
+    "message" : [
+      "Clustering requires the data types of clustering columns to support data skipping. However the following column(s) '<columnsWithDataTypes>' have unsupported data types for data skipping in Delta."
+    ],
+    "sqlState" : "22000"
+  },
   "DELTA_CLUSTERING_COLUMNS_MISMATCH" : {
     "message" : [
       "The provided clustering columns do not match the existing table's.",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3334,6 +3334,13 @@ trait DeltaErrorsBase
     )
   }
 
+  def clusteringColumnUnsupportedDataTypes(clusteringColumnsWithDataTypes: String): Throwable = {
+    new DeltaAnalysisException(
+      errorClass = "DELTA_CLUSTERING_COLUMNS_DATATYPE_NOT_SUPPORTED",
+      messageParameters = Array(clusteringColumnsWithDataTypes)
+    )
+  }
+
   def clusteringColumnsMismatchException(
       providedClusteringColumns: String,
       existingClusteringColumns: String): Throwable = {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableUtils.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.delta.clustering.ClusteringMetadataDomain
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.delta.stats.{DeltaStatistics, StatisticsCollection}
+import org.apache.spark.sql.delta.stats.{DeltaStatistics, SkippingEligibleDataType, StatisticsCollection}
 import org.apache.spark.sql.delta.util.{Utils => DeltaUtils}
 
 import org.apache.spark.sql.{AnalysisException, SparkSession}
@@ -355,11 +355,26 @@ trait ClusteredTableUtilsBase extends DeltaLogging {
   private def validateClusteringColumnsInStatsSchema(
       statsCollection: StatisticsCollection,
       clusteringColumnInfos: Seq[ClusteringColumnInfo]): Unit = {
-    val missingColumn = getClusteringColumnsNotInStatsSchema(statsCollection, clusteringColumnInfos)
-    if (missingColumn.nonEmpty) {
-      // Convert back to logical names.
+    val missingColumns =
+      getClusteringColumnsNotInStatsSchema(statsCollection, clusteringColumnInfos)
+    if (missingColumns.nonEmpty) {
+      // Check DataType eligibility.
+      val missingColumnSet = missingColumns.toSet
+      val missingColumnInfos = clusteringColumnInfos.filter(
+        info => missingColumnSet.contains(info.logicalName))
+      // This assertion must hold since missingColumns are subset of clusteringColumnInfos.
+      assert(missingColumnInfos.length == missingColumns.length)
+      val nonSkippingEligibleMissingColumnInfos =
+        missingColumnInfos.filter(info => !SkippingEligibleDataType(info.dataType))
+      if (nonSkippingEligibleMissingColumnInfos.nonEmpty) {
+        val columnNameWithDataTypes = nonSkippingEligibleMissingColumnInfos
+          .map(info => s"${info.logicalName} : ${info.dataType.sql}")
+          .mkString(", ")
+        throw DeltaErrors.clusteringColumnUnsupportedDataTypes(columnNameWithDataTypes)
+      }
+
       throw DeltaErrors.clusteringColumnMissingStats(
-        missingColumn.mkString(", "),
+        missingColumnSet.mkString(", "),
         statsCollection.statCollectionLogicalSchema.treeString)
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableUtils.scala
@@ -359,9 +359,8 @@ trait ClusteredTableUtilsBase extends DeltaLogging {
       getClusteringColumnsNotInStatsSchema(statsCollection, clusteringColumnInfos)
     if (missingColumns.nonEmpty) {
       // Check DataType eligibility.
-      val missingColumnSet = missingColumns.toSet
       val missingColumnInfos = clusteringColumnInfos.filter(
-        info => missingColumnSet.contains(info.logicalName))
+        info => missingColumns.contains(info.logicalName))
       // This assertion must hold since missingColumns are subset of clusteringColumnInfos.
       assert(missingColumnInfos.length == missingColumns.length)
       val nonSkippingEligibleMissingColumnInfos =
@@ -374,7 +373,7 @@ trait ClusteredTableUtilsBase extends DeltaLogging {
       }
 
       throw DeltaErrors.clusteringColumnMissingStats(
-        missingColumnSet.mkString(", "),
+        missingColumns.mkString(", "),
         statsCollection.statCollectionLogicalSchema.treeString)
     }
   }

--- a/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantSuite.scala
+++ b/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantSuite.scala
@@ -243,13 +243,8 @@ class DeltaVariantSuite
       }
       checkError(
         e,
-        "DELTA_CLUSTERING_COLUMN_MISSING_STATS",
-        parameters = Map(
-          "columns" -> "v",
-          "schema" -> """#root
-                         # |-- v: variant (nullable = true)
-                         #""".stripMargin('#')
-        )
+        "DELTA_CLUSTERING_COLUMNS_DATATYPE_NOT_SUPPORTED",
+        parameters = Map("columnsWithDataTypes" -> "v : VARIANT")
       )
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
@@ -20,7 +20,7 @@ import java.io.File
 
 import com.databricks.spark.util.{Log4jUsageLogger, MetricDefinitions}
 import org.apache.spark.sql.delta.skipping.ClusteredTableTestUtils
-import org.apache.spark.sql.delta.{DeltaAnalysisException, DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode, DeltaConfigs, DeltaExcludedBySparkVersionTestMixinShims, DeltaLog, DeltaUnsupportedOperationException}
+import org.apache.spark.sql.delta.{DeltaAnalysisException, DeltaColumnMappingEnableIdMode, DeltaColumnMappingEnableNameMode, DeltaConfigs, DeltaExcludedBySparkVersionTestMixinShims, DeltaLog, DeltaUnsupportedOperationException, NoMapping}
 import org.apache.spark.sql.delta.clustering.ClusteringMetadataDomain
 import org.apache.spark.sql.delta.hooks.UpdateCatalog
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -30,9 +30,11 @@ import org.apache.spark.sql.delta.util.JsonUtils
 
 import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.connector.expressions.FieldReference
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{ArrayType, IntegerType, StructField, StructType}
+import org.apache.spark.util.Utils
 
 trait ClusteredTableCreateOrReplaceDDLSuiteBase extends QueryTest
   with SharedSparkSession
@@ -184,9 +186,28 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase extends QueryTest
     test(s"validate column datatype checking on $clause table") {
       withTable("srcTbl", "dstTbl") {
         // Create reference table for CTAS/RTAS.
-        sql(s"CREATE table srcTbl (a STRUCT<b INT, c INT>, d BOOLEAN, e MAP<INT, INT>) USING delta")
+        val columnMappingMode =
+          sparkConf
+            .getOption(DeltaConfigs.COLUMN_MAPPING_MODE.defaultTablePropertyKey)
+            .getOrElse("none")
+        val columnMappingEnabled = columnMappingMode != NoMapping.name
+        val specialColName = "`f@q`"
+        val commaColSql = if (columnMappingEnabled) {
+          s",$specialColName INT"
+        } else {
+          ""
+        }
+        val schemaStr =
+          s"""
+            |a STRUCT<b INT, c INT>
+            |,d BOOLEAN
+            |,e MAP<INT, INT>
+            |$commaColSql
+            |""".stripMargin
+        sql(s"CREATE table srcTbl ($schemaStr) USING delta")
 
-        val data = (0 to 1000).map(i => Row(Row(i + 1, i * 10), i % 2 == 0, Map(i -> i)))
+        val data = (0 to 1000)
+          .map(i => Row(Row(i + 1, i * 10), i % 2 == 0, Map(i -> i), i % 2 == 1))
         val schema = StructType(List(
           StructField("a", StructType(
             Array(
@@ -199,7 +220,12 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase extends QueryTest
 
         val (_, snapshot) = DeltaLog.forTableWithSnapshot(spark, new TableIdentifier("srcTbl"))
         // Test multiple data types.
-        Seq("a", "d", "e").foreach { colName =>
+        // Columns "a", "d" and "e" are all unsupported data skipping types.
+        // Columns "a.b" and "`f@q`" are eligible data skipping types.
+        val commaClusterColOpt = if (columnMappingEnabled) {
+          Some(specialColName)
+        } else None
+        (Seq("a", "d", "e", "a.b") ++ commaClusterColOpt).foreach { colName =>
           withTempDir { tmpDir =>
             // Since validation happens both on create and replace, validate for both cases to
             // ensure that datatype validation behaves consistently between the two.
@@ -211,33 +237,41 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase extends QueryTest
             Seq(
               // Scenario 1: Standard CREATE/REPLACE TABLE.
               () => {
-                val schema = "a STRUCT<b INT, c INT>, d BOOLEAN, e MAP<INT, INT>"
+                val schema = s"a STRUCT<b INT, c INT>, d BOOLEAN, e MAP<INT, INT>, `f,q` INT"
                 createOrReplaceClusteredTable(
-                  clause, "dstTbl", schema, colName, location = Some(tmpDir.getAbsolutePath))
+                  clause, "dstTbl", schemaStr, colName, location = Some(tmpDir.getAbsolutePath))
               },
               // Scenario 2: CTAS/RTAS.
               () =>
                 createOrReplaceAsSelectClusteredTable(
                 clause, "dstTbl", "srcTbl", colName, location = Some(tmpDir.getAbsolutePath)))
               .foreach { f =>
-                val e = intercept[DeltaAnalysisException] {
+                if (colName == "a.b" || colName == specialColName) {
+                  if (clause == "CREATE") {
+                    // Drop the table and delete the _delta_log directory to allow
+                    // external delta table creation.
+                    sql("DROP TABLE IF EXISTS dstTbl")
+                    Utils.deleteRecursively(new File(tmpDir, "_delta_log"))
+                  }
+                  // Qualified data types and no exception is epxected.
                   f()
+                } else {
+                  val e = intercept[DeltaAnalysisException] {
+                    f()
+                  }
+                  val tableSchema =
+                    DeltaLog.forTable(spark, TableIdentifier("srcTbl")).update().metadata.schema
+                  val dataTypeOpt = tableSchema
+                    .findNestedField(FieldReference(colName).fieldNames())
+                    .map(_._2.dataType)
+                  assert(dataTypeOpt.nonEmpty, s"Can't find column $colName " +
+                    s"in schema ${tableSchema.treeString}")
+                  checkError(
+                    exception = e,
+                    errorClass = "DELTA_CLUSTERING_COLUMNS_DATATYPE_NOT_SUPPORTED",
+                    parameters = Map("columnsWithDataTypes" -> s"$colName : ${dataTypeOpt.get.sql}")
+                  )
                 }
-                checkError(
-                  exception = e,
-                  errorClass = "DELTA_CLUSTERING_COLUMN_MISSING_STATS",
-                  parameters = Map(
-                    "columns" -> colName,
-                    "schema" -> """root
-                      | |-- a: struct (nullable = true)
-                      | |    |-- b: integer (nullable = true)
-                      | |    |-- c: integer (nullable = true)
-                      | |-- d: boolean (nullable = true)
-                      | |-- e: map (nullable = true)
-                      | |    |-- key: integer
-                      | |    |-- value: integer (valueContainsNull = true)
-                      |""".stripMargin)
-                )
               }
           }
         }
@@ -423,16 +457,8 @@ trait ClusteredTableCreateOrReplaceDDLSuiteBase extends QueryTest
             Some(nonEligibleTableSchema)))
         checkError(
           exception = e,
-          errorClass = "DELTA_CLUSTERING_COLUMN_MISSING_STATS",
-          parameters = Map(
-            "columns" -> "col1.col11",
-            "schema" -> """root
-              | |-- col0: integer (nullable = true)
-              | |-- col1: struct (nullable = true)
-              | |    |-- col11: array (nullable = true)
-              | |    |    |-- element: integer (containsNull = true)
-              | |    |-- col12: string (nullable = true)
-              |""".stripMargin)
+          errorClass = "DELTA_CLUSTERING_COLUMNS_DATATYPE_NOT_SUPPORTED",
+          parameters = Map("columnsWithDataTypes" -> "col1.col11 : ARRAY<INT>")
         )
       }
     }
@@ -962,13 +988,8 @@ trait ClusteredTableDDLSuiteBase
     }
     checkError(
       e,
-      "DELTA_CLUSTERING_COLUMN_MISSING_STATS",
-      parameters = Map(
-        "columns" -> "v",
-        "schema" -> """root
-                      | |-- id: long (nullable = true)
-                      | |-- v: variant (nullable = true)
-                      |""".stripMargin)
+      "DELTA_CLUSTERING_COLUMNS_DATATYPE_NOT_SUPPORTED",
+      parameters = Map("columnsWithDataTypes" -> "v : VARIANT")
     )
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Today when either the clustering column data type is unsupported for data skipping or clustering column is not in the first 32 columns, it shows the following message

[DELTA_CLUSTERING_COLUMN_MISSING_STATS] Liquid clustering requires clustering columns to have stats. Couldn't find clustering column(s) 'current_version' in stats schema:

This is confusing to users when the column data type is not supported for data skipping. To improve this scenario this PR introduces a new error class DELTA_CLUSTERING_COLUMNS_NOT_SUPPORTED_DATATYPE  when cluster by non data skipping data type such as cluster by Boolean column

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Existing unit tests.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
