### PR TITLE
use logical column name as physical name for Iceberg clone source tables

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergTable.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergTable.scala
@@ -65,7 +65,7 @@ class IcebergTable(
       fieldPathToPhysicalName)
 
     // Assign physical names to new columns.
-    DeltaColumnMapping.assignPhysicalNames(mergedSchema)
+    DeltaColumnMapping.assignPhysicalNames(mergedSchema, reuseLogicalName = true)
   }
 
   override val requiredColumnMappingMode: DeltaColumnMappingMode = IdMapping
@@ -82,7 +82,7 @@ class IcebergTable(
       fieldPathToPhysicalName)
 
     // Assign physical names to new partition columns.
-    DeltaColumnMapping.assignPhysicalNames(mergedPartitionSchema)
+    DeltaColumnMapping.assignPhysicalNames(mergedPartitionSchema, reuseLogicalName = true)
   }
 
   val tableSchema: StructType = PartitioningUtils.mergeDataAndPartitionSchema(

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergTable.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergTable.scala
@@ -65,7 +65,7 @@ class IcebergTable(
       fieldPathToPhysicalName)
 
     // Assign physical names to new columns.
-    DeltaColumnMapping.assignPhysicalNames(mergedSchema, reuseLogicalName = true)
+    DeltaColumnMapping.assignPhysicalNames(mergedSchema)
   }
 
   override val requiredColumnMappingMode: DeltaColumnMappingMode = IdMapping
@@ -82,7 +82,7 @@ class IcebergTable(
       fieldPathToPhysicalName)
 
     // Assign physical names to new partition columns.
-    DeltaColumnMapping.assignPhysicalNames(mergedPartitionSchema, reuseLogicalName = true)
+    DeltaColumnMapping.assignPhysicalNames(mergedPartitionSchema)
   }
 
   val tableSchema: StructType = PartitioningUtils.mergeDataAndPartitionSchema(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -807,20 +807,13 @@ class DeltaAnalysis(session: SparkSession)
           case Some(existingCatalog) => existingCatalog.identifier
           case None => TableIdentifier(path.toString, Some("delta"))
         }
-        // Reuse the existing schema so that the physical name of columns are consistent
-        val cloneSourceTable = sourceTbl match {
-          case source: CloneIcebergSource =>
-            // Reuse the existing schema so that the physical name of columns are consistent
-            source.copy(tableSchema = Some(deltaTableV2.initialSnapshot.metadata.schema))
-          case other => other
-        }
         val catalogTable = createCatalogTableForCloneCommand(
           path,
           byPath = existingTable.isEmpty,
           tblIdent,
           targetLocation,
           sourceCatalogTable,
-          cloneSourceTable,
+          sourceTbl,
           statement.tablePropertyOverrides)
 
         CreateDeltaTableCommand(
@@ -828,7 +821,7 @@ class DeltaAnalysis(session: SparkSession)
           existingTable,
           saveMode,
           Some(CloneTableCommand(
-            cloneSourceTable,
+            sourceTbl,
             tblIdent,
             statement.tablePropertyOverrides,
             path)),

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
@@ -233,12 +233,9 @@ trait DeltaColumnMappingBase extends DeltaLogging {
       .build())
   }
 
-  def assignPhysicalNames(schema: StructType, reuseLogicalName: Boolean = false): StructType = {
+  def assignPhysicalNames(schema: StructType): StructType = {
     SchemaMergingUtils.transformColumns(schema) { (_, field, _) =>
-      if (hasPhysicalName(field)) field else {
-        if (reuseLogicalName) assignPhysicalName(field, field.name)
-        else assignPhysicalName(field, generatePhysicalName)
-      }
+      if (hasPhysicalName(field)) field else assignPhysicalName(field, generatePhysicalName)
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
@@ -233,9 +233,12 @@ trait DeltaColumnMappingBase extends DeltaLogging {
       .build())
   }
 
-  def assignPhysicalNames(schema: StructType): StructType = {
+  def assignPhysicalNames(schema: StructType, reuseLogicalName: Boolean = false): StructType = {
     SchemaMergingUtils.transformColumns(schema) { (_, field, _) =>
-      if (hasPhysicalName(field)) field else assignPhysicalName(field, generatePhysicalName)
+      if (hasPhysicalName(field)) field else {
+        if (reuseLogicalName) assignPhysicalName(field, field.name)
+        else assignPhysicalName(field, generatePhysicalName)
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

The current randomly assigned physical names do not match with anything in parquet file in source iceberg table, and caused it cannot convert type widened iceberg tables; 


## How was this patch tested?

manually tested the fix to convert a type widened iceberg table. 

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
