### PR TITLE
[Sharing] Add timestamp_ntz to Delta Sharing reader feature header

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala
@@ -27,7 +27,8 @@ import org.apache.spark.sql.delta.{
   DeletionVectorsTableFeature,
   DeltaLog,
   DeltaParquetFileFormat,
-  SnapshotDescriptor
+  SnapshotDescriptor,
+  TimestampNTZTableFeature
 }
 import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
 import com.google.common.hash.Hashing
@@ -45,9 +46,17 @@ import org.apache.spark.storage.{BlockId, StorageLevel}
 object DeltaSharingUtils extends Logging {
 
   val STREAMING_SUPPORTED_READER_FEATURES: Seq[String] =
-    Seq(DeletionVectorsTableFeature.name, ColumnMappingTableFeature.name)
+    Seq(
+      DeletionVectorsTableFeature.name,
+      ColumnMappingTableFeature.name,
+      TimestampNTZTableFeature.name
+    )
   val SUPPORTED_READER_FEATURES: Seq[String] =
-    Seq(DeletionVectorsTableFeature.name, ColumnMappingTableFeature.name)
+    Seq(
+      DeletionVectorsTableFeature.name,
+      ColumnMappingTableFeature.name,
+      TimestampNTZTableFeature.name
+    )
 
   // The prefix will be used for block ids of all blocks that store the delta log in BlockManager.
   // It's used to ensure delta sharing queries don't mess up with blocks with other applications.

--- a/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
@@ -58,8 +58,12 @@ private[spark] class TestClientForDeltaFormatSharing(
 
   assert(
     responseFormat == DeltaSharingRestClient.RESPONSE_FORMAT_PARQUET ||
-    (readerFeatures.contains("deletionVectors") && readerFeatures.contains("columnMapping")),
-    "deletionVectors and columnMapping should be supported in all types of queries."
+    (
+      readerFeatures.contains("deletionVectors") &&
+      readerFeatures.contains("columnMapping") &&
+      readerFeatures.contains("timestampNtz")
+    ),
+    "deletionVectors, columnMapping, timestampNtz should be supported in all types of queries."
   )
 
   import TestClientForDeltaFormatSharing._


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Sharing)

## Description

Add timestamp_ntz to Delta Sharing reader feature header.

## How was this patch tested?

Unit test

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
