### PR TITLE
[Spark][Master] Fix compilation issues on Spark master

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -1140,7 +1140,7 @@ object Checkpoints
     val partitionValues = partitionSchema.map { field =>
       val physicalName = DeltaColumnMapping.getPhysicalName(field)
       val attribute = UnresolvedAttribute.quotedString(partitionValuesColName)
-      new Column(Cast(
+      Column(Cast(
         ElementAt(
           attribute,
           Literal(physicalName),

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ColumnWithDefaultExprUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ColumnWithDefaultExprUtils.scala
@@ -128,7 +128,7 @@ object ColumnWithDefaultExprUtils extends DeltaLogging {
             constraints += Constraints.Check(s"Generated Column", EqualNullSafe(column.expr, expr))
             Some(column)
           } else {
-            Some(new Column(expr).alias(f.name))
+            Some(Column(expr).alias(f.name))
           }
         case _ =>
           if (isIdentityColumn(f)) {
@@ -147,7 +147,7 @@ object ColumnWithDefaultExprUtils extends DeltaLogging {
               // we only want to consider columns that are in the data's schema or are generated
               // to allow DataFrame with null columns to be written.
               // The actual check for nullability on data is done in the DeltaInvariantCheckerExec
-              getDefaultValueExprOrNullLit(f, nullAsDefault).map(new Column(_))
+              getDefaultValueExprOrNullLit(f, nullAsDefault).map(Column(_))
             }
           }
       }
@@ -169,12 +169,12 @@ object ColumnWithDefaultExprUtils extends DeltaLogging {
 
     val rowIdExprs = data.queryExecution.analyzed.output
       .filter(RowId.RowIdMetadataAttribute.isRowIdColumn)
-      .map(new Column(_))
+      .map(Column(_))
     selectExprs = selectExprs ++ rowIdExprs
 
     val rowCommitVersionExprs = data.queryExecution.analyzed.output
       .filter(RowCommitVersion.MetadataAttribute.isRowCommitVersionColumn)
-      .map(new Column(_))
+      .map(Column(_))
     selectExprs = selectExprs ++ rowCommitVersionExprs
 
     val newData = queryExecution match {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -970,7 +970,7 @@ object DeltaLog extends DeltaLogging {
       partitionFilters
     }
     val expr = rewrittenFilters.reduceLeftOption(And).getOrElse(Literal.TrueLiteral)
-    val columnFilter = new Column(expr)
+    val columnFilter = Column(expr)
     files.filter(columnFilter)
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
@@ -222,7 +222,7 @@ object GeneratedColumn extends DeltaLogging with AnalysisHelper {
         case Some(exprString) =>
           val expr = parseGenerationExpression(spark, exprString)
           validateColumnReferences(spark, f.name, expr, schema)
-          new Column(expr).alias(f.name)
+          Column(expr).alias(f.name)
         case None =>
           // Should not happen
           throw DeltaErrors.expressionsNotFoundInGeneratedColumn(f.name)
@@ -278,7 +278,7 @@ object GeneratedColumn extends DeltaLogging with AnalysisHelper {
     val generationExprs = schema.flatMap { col =>
       getGenerationExpressionStr(col).map { exprStr =>
         val expr = parseGenerationExpression(SparkSession.active, exprStr)
-        new Column(expr).alias(col.name)
+        Column(expr).alias(col.name)
       }
     }
     if (generationExprs.isEmpty) {
@@ -327,7 +327,7 @@ object GeneratedColumn extends DeltaLogging with AnalysisHelper {
     val partitionGenerationExprs = partitionSchema.flatMap { col =>
       getGenerationExpressionStr(col).map { exprStr =>
         val expr = parseGenerationExpression(SparkSession.active, exprStr)
-        new Column(expr).alias(col.name)
+        Column(expr).alias(col.name)
       }
     }
     if (partitionGenerationExprs.isEmpty) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/IdentityColumn.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/IdentityColumn.scala
@@ -71,7 +71,7 @@ object IdentityColumn extends DeltaLogging {
 
   // Create a column to generate IDENTITY values for the column `field`.
   def createIdentityColumnGenerationExprAsColumn(field: StructField): Column = {
-    new Column(createIdentityColumnGenerationExpr(field)).alias(field.name)
+    Column(createIdentityColumnGenerationExpr(field)).alias(field.name)
   }
 
   /**
@@ -117,7 +117,7 @@ object IdentityColumn extends DeltaLogging {
     // The expression will be: to_json(array(max(id1), min(id2)))
     val aggregates = identityColumnInfo.map {
       case (name, positiveStep) =>
-        val col = new Column(UnresolvedAttribute.quoted(name))
+        val col = Column(UnresolvedAttribute.quoted(name))
         if (positiveStep) max(col) else min(col)
     }
     val unresolvedExpr = to_json(array(aggregates: _*))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -1423,13 +1423,13 @@ object SingleAction extends Logging {
     org.apache.spark.sql.delta.implicits.addFileEncoder
 
   lazy val nullLitForRemoveFile: Column =
-    new Column(Literal(null, ScalaReflection.schemaFor[RemoveFile].dataType))
+    Column(Literal(null, ScalaReflection.schemaFor[RemoveFile].dataType))
 
   lazy val nullLitForAddCDCFile: Column =
-    new Column(Literal(null, ScalaReflection.schemaFor[AddCDCFile].dataType))
+    Column(Literal(null, ScalaReflection.schemaFor[AddCDCFile].dataType))
 
   lazy val nullLitForMetadataAction: Column =
-    new Column(Literal(null, ScalaReflection.schemaFor[Metadata].dataType))
+    Column(Literal(null, ScalaReflection.schemaFor[Metadata].dataType))
 }
 
 /** Serializes Maps containing JSON strings without extra escaping. */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DMLWithDeletionVectorsHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DMLWithDeletionVectorsHelper.scala
@@ -338,7 +338,7 @@ object DeletionVectorBitmapGenerator {
     /** Create a bitmap set aggregator over the given column */
     private def createBitmapSetAggregator(indexColumn: Column): Column = {
       val func = new BitmapAggregator(indexColumn.expr, RoaringBitmapArrayFormat.Portable)
-      new Column(func.toAggregateExpression(isDistinct = false))
+      Column(func.toAggregateExpression(isDistinct = false))
     }
 
     protected def outputColumns: Seq[Column] =

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeleteCommand.scala
@@ -306,9 +306,9 @@ case class DeleteCommand(
                 if (candidateFiles.isEmpty) {
                   Array.empty[String]
                 } else {
-                  data.filter(new Column(cond))
+                  data.filter(Column(cond))
                     .select(input_file_name())
-                    .filter(new Column(incrDeletedCountExpr))
+                    .filter(Column(incrDeletedCountExpr))
                     .distinct()
                     .as[String]
                     .collect()
@@ -451,15 +451,15 @@ case class DeleteCommand(
         // as table data, while all rows which don't match are removed from the rewritten table data
         // but do get included in the output as CDC events.
         baseData
-          .filter(new Column(incrTouchedCountExpr))
+          .filter(Column(incrTouchedCountExpr))
           .withColumn(
             CDC_TYPE_COLUMN_NAME,
-            new Column(If(filterCondition, CDC_TYPE_NOT_CDC, CDC_TYPE_DELETE))
+            Column(If(filterCondition, CDC_TYPE_NOT_CDC, CDC_TYPE_DELETE))
           )
       } else {
         baseData
-          .filter(new Column(incrTouchedCountExpr))
-          .filter(new Column(filterCondition))
+          .filter(Column(incrTouchedCountExpr))
+          .filter(Column(filterCondition))
       }
 
       txn.writeFiles(dfToWrite)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/UpdateCommand.scala
@@ -183,9 +183,9 @@ case class UpdateCommand(
         val incrUpdatedCountExpr = IncrementMetric(TrueLiteral, metrics("numUpdatedRows"))
         val pathsToRewrite =
           withStatusCode("DELTA", UpdateCommand.FINDING_TOUCHED_FILES_MSG) {
-            data.filter(new Column(updateCondition))
+            data.filter(Column(updateCondition))
               .select(input_file_name())
-              .filter(new Column(incrUpdatedCountExpr))
+              .filter(Column(incrUpdatedCountExpr))
               .distinct()
               .as[String]
               .collect()
@@ -357,13 +357,13 @@ case class UpdateCommand(
       updateExpressions)
 
     val targetDfWithEvaluatedCondition = {
-      val evalDf = targetDf.withColumn(UpdateCommand.CONDITION_COLUMN_NAME, new Column(condition))
+      val evalDf = targetDf.withColumn(UpdateCommand.CONDITION_COLUMN_NAME, Column(condition))
       val copyAndUpdateRowsDf = if (copyUnmodifiedRows) {
         evalDf
       } else {
-        evalDf.filter(new Column(UpdateCommand.CONDITION_COLUMN_NAME))
+        evalDf.filter(Column(UpdateCommand.CONDITION_COLUMN_NAME))
       }
-      copyAndUpdateRowsDf.filter(new Column(incrTouchedCountExpr))
+      copyAndUpdateRowsDf.filter(Column(incrTouchedCountExpr))
     }
 
     val updatedDataFrame = UpdateCommand.withUpdatedColumns(
@@ -432,19 +432,19 @@ object UpdateCommand {
       shouldOutputCdc: Boolean): DataFrame = {
     val resultDf = if (shouldOutputCdc) {
       val namedUpdateCols = updateExpressions.zip(originalExpressions).map {
-        case (expr, targetCol) => new Column(expr).as(targetCol.name, targetCol.metadata)
+        case (expr, targetCol) => Column(expr).as(targetCol.name, targetCol.metadata)
       }
 
       // Build an array of output rows to be unpacked later. If the condition is matched, we
       // generate CDC pre and postimages in addition to the final output row; if the condition
       // isn't matched, we just generate a rewritten no-op row without any CDC events.
-      val preimageCols = originalExpressions.map(new Column(_)) :+
+      val preimageCols = originalExpressions.map(Column(_)) :+
         lit(CDC_TYPE_UPDATE_PREIMAGE).as(CDC_TYPE_COLUMN_NAME)
       val postimageCols = namedUpdateCols :+
         lit(CDC_TYPE_UPDATE_POSTIMAGE).as(CDC_TYPE_COLUMN_NAME)
-      val notCdcCol = new Column(CDC_TYPE_NOT_CDC).as(CDC_TYPE_COLUMN_NAME)
+      val notCdcCol = Column(CDC_TYPE_NOT_CDC).as(CDC_TYPE_COLUMN_NAME)
       val updatedDataCols = namedUpdateCols :+ notCdcCol
-      val noopRewriteCols = originalExpressions.map(new Column(_)) :+ notCdcCol
+      val noopRewriteCols = originalExpressions.map(Column(_)) :+ notCdcCol
       val packedUpdates = array(
         struct(preimageCols: _*),
         struct(postimageCols: _*),
@@ -465,7 +465,7 @@ object UpdateCommand {
         a => col(s"packedData.`${a.name}`").as(a.name, a.metadata)
       }
       dfWithEvaluatedCondition
-        .select(explode(new Column(packedData)).as("packedData"))
+        .select(explode(Column(packedData)).as("packedData"))
         .select(finalColumns: _*)
     } else {
       val finalCols = updateExpressions.zip(originalExpressions).map { case (update, original) =>
@@ -474,7 +474,7 @@ object UpdateCommand {
         } else {
           If(UnresolvedAttribute(CONDITION_COLUMN_NAME), update, original)
         }
-        new Column(updated).as(original.name, original.metadata)
+        Column(updated).as(original.name, original.metadata)
       }
 
       dfWithEvaluatedCondition.select(finalCols: _*)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -295,7 +295,7 @@ case class WriteIntoDelta(
             val insertCols = outputCols :+
               lit(CDCReader.CDC_TYPE_INSERT).as(CDCReader.CDC_TYPE_COLUMN_NAME)
             val insertDataCols = outputCols :+
-              new Column(CDCReader.CDC_TYPE_NOT_CDC)
+              Column(CDCReader.CDC_TYPE_NOT_CDC)
                 .as(CDCReader.CDC_TYPE_COLUMN_NAME)
             val packedInserts = array(
               struct(insertCols: _*),
@@ -303,7 +303,7 @@ case class WriteIntoDelta(
             ).expr
 
             dataWithDefaultExprs
-              .select(explode(new Column(packedInserts)).as("packedData"))
+              .select(explode(Column(packedInserts)).as("packedData"))
               .select(
                 (dataWithDefaultExprs.schema.map(_.name) :+ CDCReader.CDC_TYPE_COLUMN_NAME)
                   .map { n => col(s"packedData.`$n`").as(n) }: _*)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -1055,7 +1055,7 @@ case class AlterTableAddConstraintDeltaCommand(
       val unresolvedExpr = sparkSession.sessionState.sqlParser.parseExpression(exprText)
 
       try {
-        df.where(new Column(unresolvedExpr)).queryExecution.analyzed
+        df.where(Column(unresolvedExpr)).queryExecution.analyzed
       } catch {
         case a: AnalysisException
             if a.errorClass.contains("DATATYPE_MISMATCH.FILTER_NOT_BOOLEAN") =>
@@ -1070,7 +1070,7 @@ case class AlterTableAddConstraintDeltaCommand(
       recordDeltaOperation(
           txn.snapshot.deltaLog,
           "delta.ddl.alter.addConstraint.checkExisting") {
-        val n = df.where(new Column(Or(Not(unresolvedExpr), IsUnknown(unresolvedExpr)))).count()
+        val n = df.where(Column(Or(Not(unresolvedExpr), IsUnknown(unresolvedExpr)))).count()
 
         if (n > 0) {
           throw DeltaErrors.newCheckConstraintViolated(n, table.name(), exprText)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
@@ -162,7 +162,7 @@ object CDCReader extends CDCReaderImpl
         sqlContext.sparkSession,
         readSchemaSnapshot = Some(snapshotForBatchSchema))
 
-      val filter = new Column(DeltaSourceUtils.translateFilters(filters))
+      val filter = Column(DeltaSourceUtils.translateFilters(filters))
       val projections = requiredColumns.map(SchemaUtils.fieldNameToColumn)
       df.filter(filter).select(projections: _*).rdd
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/InsertOnlyMergeExecutor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/InsertOnlyMergeExecutor.scala
@@ -193,7 +193,7 @@ trait InsertOnlyMergeExecutor extends MergeOutputGeneration {
       } else {
         expr
       }
-      new Column(Alias(exprAfterPassthru, name)())
+      Column(Alias(exprAfterPassthru, name)())
     }
   }
 
@@ -263,7 +263,7 @@ trait InsertOnlyMergeExecutor extends MergeOutputGeneration {
       seqToString(outputExprs))
 
     outputExprs.zip(outputColNames).map { case (expr, name) =>
-      new Column(Alias(expr, name)())
+      Column(Alias(expr, name)())
     }
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
@@ -376,7 +376,7 @@ trait GenerateSymlinkManifestImpl extends PostCommitHook with DeltaLogging with 
       colNameToAttribs,
       spark.sessionState.conf.sessionLocalTimeZone)
 
-    df.withColumn("relativePartitionDir", new Column(relativePartitionDirExpression))
+    df.withColumn("relativePartitionDir", Column(relativePartitionDirExpression))
       .drop(colToRenamedCols.map(_._2): _*)
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/optimizablePartitionExpressions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/optimizablePartitionExpressions.scala
@@ -78,7 +78,7 @@ object OptimizablePartitionExpression {
   /** Provide a convenient method to convert a string to a column expression */
   implicit class ColumnExpression(val colName: String) extends AnyVal {
     // This will always be a top level column so quote it if necessary
-    def toPartCol: Expression = new Column(quoteIfNeeded(colName)).expr
+    def toPartCol: Expression = Column(quoteIfNeeded(colName)).expr
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -1239,7 +1239,7 @@ def normalizeColumnNamesInDataType(
   }
 
   def fieldToColumn(field: StructField): Column = {
-    new Column(UnresolvedAttribute.quoted(field.name))
+    Column(UnresolvedAttribute.quoted(field.name))
   }
 
   /**  converting field name to column type with quoted back-ticks */

--- a/spark/src/main/scala/org/apache/spark/sql/delta/skipping/MultiDimClusteringFunctions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/skipping/MultiDimClusteringFunctions.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.types.StringType
 
 /** Functions for multi-dimensional clustering of the data */
 object MultiDimClusteringFunctions {
-  private def withExpr(expr: Expression): Column = new Column(expr)
+  private def withExpr(expr: Expression): Column = Column(expr)
 
   /**
    * Conceptually range-partitions the domain of values of the given column into `numPartitions`

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
@@ -146,7 +146,7 @@ object SkippingEligibleColumn {
  */
 object SkippingEligibleLiteral {
   def unapply(arg: Literal): Option[Column] = {
-    if (SkippingEligibleDataType(arg.dataType)) Some(new Column(arg)) else None
+    if (SkippingEligibleDataType(arg.dataType)) Some(Column(arg)) else None
   }
 }
 
@@ -170,7 +170,7 @@ private[delta] object DataSkippingReader {
   /** Default number of cols for which we should collect stats */
   val DATA_SKIPPING_NUM_INDEXED_COLS_DEFAULT_VALUE = 32
 
-  private[this] def col(e: Expression): Column = new Column(e)
+  private[this] def col(e: Expression): Column = Column(e)
   def fold(e: Expression): Column = col(new Literal(e.eval(), e.dataType))
 
   // Literals often used in the data skipping reader expressions.
@@ -686,11 +686,11 @@ trait DataSkippingReaderBase
           //
           // There is a longer term task SC-22825 to fix the serialization problem that caused this.
           // But we need the adjustment in any case to correctly read stats written by old versions.
-          new Column(Cast(TimeAdd(statCol.expr, oneMillisecondLiteralExpr), TimestampType))
+          Column(Cast(TimeAdd(statCol.expr, oneMillisecondLiteralExpr), TimestampType))
         case (statCol, TimestampNTZType, _) if pathToStatType.head == MAX =>
           // We also apply the same adjustment of max stats that was applied to Timestamp
           // for TimestampNTZ because these 2 types have the same precision in terms of time.
-          new Column(Cast(TimeAdd(statCol.expr, oneMillisecondLiteralExpr), TimestampNTZType))
+          Column(Cast(TimeAdd(statCol.expr, oneMillisecondLiteralExpr), TimestampNTZType))
         case (statCol, _, _) =>
           statCol
       }
@@ -827,7 +827,7 @@ trait DataSkippingReaderBase
     recordFrameProfile("Delta", "DataSkippingReader.constructPartitionFilters") {
       val rewritten = DeltaLog.rewritePartitionFilters(
         metadata.partitionSchema, spark.sessionState.conf.resolver, filters)
-      rewritten.reduceOption(And).map { expr => new Column(expr) }.getOrElse(trueLiteral)
+      rewritten.reduceOption(And).map { expr => Column(expr) }.getOrElse(trueLiteral)
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
@@ -359,7 +359,7 @@ trait StatisticsCollection extends DeltaLogging {
       schema.flatMap {
         case f @ StructField(name, s: StructType, _, _) =>
           val column = parent.map(_.getItem(name))
-            .getOrElse(new Column(UnresolvedAttribute.quoted(name)))
+            .getOrElse(Column(UnresolvedAttribute.quoted(name)))
           val stats = collectStats(s, Some(column), parentFields :+ name, function)
           if (stats.nonEmpty) {
             Some(struct(stats: _*) as DeltaColumnMapping.getPhysicalName(f))
@@ -369,7 +369,7 @@ trait StatisticsCollection extends DeltaLogging {
         case f @ StructField(name, _, _, _) =>
           val fieldPath = UnresolvedAttribute(parentFields :+ name).name
           val column = parent.map(_.getItem(name))
-            .getOrElse(new Column(UnresolvedAttribute.quoted(name)))
+            .getOrElse(Column(UnresolvedAttribute.quoted(name)))
           // alias the column with its physical name
           // Note: explodedDataSchemaNames comes from dataSchema. In the read path, dataSchema comes
           // from the table's metadata.dataSchema, which is the same as tableSchema. In the

--- a/spark/src/test/scala/org/apache/spark/sql/delta/AutoCompactSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/AutoCompactSuite.scala
@@ -314,8 +314,8 @@ class AutoCompactSuite extends
     "partition values") { dir =>
       Seq(null, "", " ").map(UTF8String.fromString).zipWithIndex.foreach { case (partValue, i) =>
         val path = new File(dir, i.toString).getCanonicalPath
-        val df1 = spark.range(5).withColumn("part", new Column(Literal(partValue, StringType)))
-        val df2 = spark.range(5, 10).withColumn("part", new Column(Literal("1")))
+        val df1 = spark.range(5).withColumn("part", Column(Literal(partValue, StringType)))
+        val df2 = spark.range(5, 10).withColumn("part", Column(Literal("1")))
         val isLogged = checkAutoOptimizeLogging {
           // repartition to increase number of files written
           df1.union(df2).repartition(4)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ConflictCheckerPredicateEliminationUnitSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ConflictCheckerPredicateEliminationUnitSuite.scala
@@ -38,7 +38,7 @@ class ConflictCheckerPredicateEliminationUnitSuite
   val simpleExpressionB: Expression = (col("b") === "test").expr
 
   val deterministicExpression: Expression = (col("c") > 5L).expr
-  val nonDeterministicExpression: Expression = (col("c") > new Column(Rand(0))).expr
+  val nonDeterministicExpression: Expression = (col("c") > Column(Rand(0))).expr
   lazy val deterministicSubquery: Expression = {
     val df = spark.sql("SELECT 5")
     df.collect()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingTestUtils.scala
@@ -372,7 +372,7 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
         case a: Attribute =>
           convertColumnNameToAttributeWithPhysicalName(a.name, schema)
       }
-      new Column(newExpr)
+      Column(newExpr)
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/EvolvabilitySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/EvolvabilitySuite.scala
@@ -46,8 +46,8 @@ class EvolvabilitySuite extends EvolvabilitySuiteBase with DeltaSQLCommandTest {
 
   test("serialized partition values must contain null values") {
     val tempDir = Utils.createTempDir().toString
-    val df1 = spark.range(5).withColumn("part", new Column(Literal(null, StringType)))
-    val df2 = spark.range(5).withColumn("part", new Column(Literal("1")))
+    val df1 = spark.range(5).withColumn("part", Column(Literal(null, StringType)))
+    val df2 = spark.range(5).withColumn("part", Column(Literal("1")))
     df1.union(df2).coalesce(1).write.partitionBy("part").format("delta").save(tempDir)
 
     // Clear the cache

--- a/spark/src/test/scala/org/apache/spark/sql/delta/GenerateIdentityValuesSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/GenerateIdentityValuesSuite.scala
@@ -44,7 +44,7 @@ class GenerateIdentityValuesSuite extends QueryTest with SharedSparkSession {
     checkAnswer(df.select(count(col(colName))), Row(rowCount))
 
     // Check there is no duplicate.
-    checkAnswer(df.select(count_distinct(new Column(colName))), Row(rowCount))
+    checkAnswer(df.select(count_distinct(Column(colName))), Row(rowCount))
 
     // Check every value follows start and step configuration
     val condViolateConfig = s"($colName - ${identityInfo.start}) % ${identityInfo.step} != 0"
@@ -57,7 +57,7 @@ class GenerateIdentityValuesSuite extends QueryTest with SharedSparkSession {
 
     // When high watermark is empty, the first value should be start.
     if (identityInfo.highWaterMark.isEmpty) {
-      val agg = if (identityInfo.step > 0) min(new Column(colName)) else max(new Column(colName))
+      val agg = if (identityInfo.step > 0) min(Column(colName)) else max(Column(colName))
       checkAnswer(df.select(agg), Row(identityInfo.start))
     }
   }
@@ -72,7 +72,7 @@ class GenerateIdentityValuesSuite extends QueryTest with SharedSparkSession {
       val df = spark.range(1, size + 1, 1, slice).toDF(colName)
       highWaterMarks.foreach { highWaterMark =>
         verifyIdentityValues(
-          df.select(new Column(GenerateIdentityValues(start, step, highWaterMark)).alias(colName)),
+          df.select(Column(GenerateIdentityValues(start, step, highWaterMark)).alias(colName)),
           IdentityInfo(start, step, highWaterMark),
           size
         )
@@ -93,7 +93,7 @@ class GenerateIdentityValuesSuite extends QueryTest with SharedSparkSession {
       val gev = GenerateIdentityValues(start, step, highWaterMark)
       val gev2 = gev.copy()
       verifyIdentityValues(
-        df.select(new Column(
+        df.select(Column(
             If(GreaterThan(col(colName).expr, right = Literal(10)), gev, gev2)).alias(colName)),
         IdentityInfo(start, step, highWaterMark),
         size
@@ -110,7 +110,7 @@ class GenerateIdentityValuesSuite extends QueryTest with SharedSparkSession {
     val df = spark.range(1, size + 1, 1, slice).toDF(colName)
     verifyIdentityValues(
       df.select(
-        new Column(GenerateIdentityValues(start, step, Some(highWaterMark))).alias(colName)),
+        Column(GenerateIdentityValues(start, step, Some(highWaterMark))).alias(colName)),
       IdentityInfo(start, step, Some(highWaterMark)),
       size
     )
@@ -119,7 +119,7 @@ class GenerateIdentityValuesSuite extends QueryTest with SharedSparkSession {
   test("overflow initial value") {
     val events = Log4jUsageLogger.track {
       val df = spark.range(1, 10, 1, 5).toDF(colName)
-        .select(new Column(GenerateIdentityValues(
+        .select(Column(GenerateIdentityValues(
           start = 2,
           step = Long.MaxValue,
           highWaterMarkOpt = Some(2 - Long.MaxValue))))
@@ -137,7 +137,7 @@ class GenerateIdentityValuesSuite extends QueryTest with SharedSparkSession {
   test("overflow next") {
     val events = Log4jUsageLogger.track {
       val df = spark.range(1, 10, 1, 5).toDF(colName)
-        .select(new Column(GenerateIdentityValues(
+        .select(Column(GenerateIdentityValues(
           start = Long.MaxValue - 1,
           step = 2,
           highWaterMarkOpt = Some(Long.MaxValue - 3))))
@@ -155,7 +155,7 @@ class GenerateIdentityValuesSuite extends QueryTest with SharedSparkSession {
   test("invalid high water mark") {
     val df = spark.range(1, 10, 1, 5).toDF(colName)
     intercept[IllegalArgumentException] {
-      df.select(new Column(GenerateIdentityValues(
+      df.select(Column(GenerateIdentityValues(
         start = 1,
         step = 2,
         highWaterMarkOpt = Some(4)))
@@ -166,7 +166,7 @@ class GenerateIdentityValuesSuite extends QueryTest with SharedSparkSession {
   test("invalid step") {
     val df = spark.range(1, 10, 1, 5).toDF(colName)
     intercept[IllegalArgumentException] {
-      df.select(new Column(GenerateIdentityValues(
+      df.select(Column(GenerateIdentityValues(
         start = 1,
         step = 0,
         highWaterMarkOpt = Some(4)))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/metric/IncrementMetricSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/metric/IncrementMetricSuite.scala
@@ -51,10 +51,10 @@ abstract class IncrementMetricSuiteBase extends QueryTest with SharedSparkSessio
     val havingIncrement = IncrementMetric(
       GreaterThan(UnresolvedAttribute("s"), Literal(10)), metric)
     val df = testDf
-      .filter(new Column(increment))
-      .groupBy(new Column(groupByKey).as("gby"))
+      .filter(Column(increment))
+      .groupBy(Column(groupByKey).as("gby"))
       .agg(sum("a").as("s"))
-      .filter(new Column(havingIncrement))
+      .filter(Column(havingIncrement))
     val numGroups = df.collect().size
     validatePlan(df.queryExecution.executedPlan)
 
@@ -73,10 +73,10 @@ abstract class IncrementMetricSuiteBase extends QueryTest with SharedSparkSessio
     val ifCondition: Expression = ('a < Literal(20)).expr
     val conditional = If(ifCondition, incrementTrueBranch, incrementFalseBranch)
     val df = testDf
-      .filter(new Column(incrementPreFilter))
+      .filter(Column(incrementPreFilter))
       .filter('a < 25)
-      .filter(new Column(increment))
-      .filter(new Column(conditional))
+      .filter(Column(increment))
+      .filter(Column(conditional))
     val numRows = df.collect().size
     validatePlan(df.queryExecution.executedPlan)
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/util/BitmapAggregatorE2ESuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/util/BitmapAggregatorE2ESuite.scala
@@ -199,6 +199,6 @@ object BitmapAggregatorE2ESuite {
       column: Column,
       format: RoaringBitmapArrayFormat.Value): Column = {
     val func = new BitmapAggregator(column.expr, format);
-    new Column(func.toAggregateExpression(isDistinct = false))
+    Column(func.toAggregateExpression(isDistinct = false))
   }
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Spark master compilation is currently broken due to this commit in Spark
https://github.com/apache/spark/commit/a767f5cb1704075ee249169e8faf2ab3610b9dbc#diff-81eca9f7af2e9b23b13904131c3d32b0af9e9e1dcc7ddb5efba13201b00066c4 which changes the `Column` constructor. 

To fix, change any instances of `new Column(...)` to `Column(...)` so that we can use the constructors in `object Column`.

## How was this patch tested?

Existing tests suffice.