### PR TITLE
[Spark] Add tests for DML commands on partitioned tables with special chars

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.datasources.FileFormat
-import org.apache.spark.sql.functions.struct
+import org.apache.spark.sql.functions.{lit, struct}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.StoreAssignmentPolicy
 import org.apache.spark.sql.test.SharedSparkSession
@@ -967,5 +967,27 @@ abstract class UpdateSuiteBase
         where = "to_json(v) = '1'", set = "i = 10, v = parse_json('123')")
     checkAnswer(readDeltaTable(tempPath).selectExpr("i", "to_json(v)"),
         Seq(Row(0, "0"), Row(10, "123")))
+  }
+
+  test("update on partitioned table with special chars") {
+    val partA = "part%one"
+    val partB = "part%two"
+    spark.range(0, 3, 1, 1).toDF("key").withColumn("value", lit(partA))
+      .write.format("delta").partitionBy("value").save(tempPath)
+    checkUpdate(
+      condition = Some(s"value = '$partA' AND key = 1"),
+      setClauses = s"value = '$partB'",
+      expectedResults = Row(0, partA) :: Row(1, partB) :: Row(2, partA) :: Nil
+    )
+    checkUpdate(
+      condition = Some(s"value = '$partA' AND key = 2"),
+      setClauses = s"value = '$partB'",
+      expectedResults = Row(0, partA) :: Row(1, partB) :: Row(2, partB) :: Nil
+    )
+    checkUpdate(
+      condition = Some(s"value = '$partA'"),
+      setClauses = s"value = '$partB'",
+      expectedResults = Row(0, partB) :: Row(1, partB) :: Row(2, partB) :: Nil
+    )
   }
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

The paths of partitioned tables contain the partition values in escaped form that follows the Hive-style partitioning. This PR introduces a basic test for DML operations on such tables.

## How was this patch tested?

Test-only PR.

## Does this PR introduce _any_ user-facing changes?

No