### PR TITLE
[Kernel] Remove `JsonHandler.deserializeStructType` and add `DataType` JSON SerDe in API module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -571,13 +571,42 @@ lazy val kernelApi = (project in file("kernel/kernel-api"))
       "org.roaringbitmap" % "RoaringBitmap" % "0.9.25",
       "org.slf4j" % "slf4j-api" % "1.7.36",
 
-      "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.5" % "test",
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.5",
+      "com.fasterxml.jackson.core" % "jackson-core" % "2.13.5",
+      "com.fasterxml.jackson.core" % "jackson-annotations" % "2.13.5",
+
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
       "junit" % "junit" % "4.13.2" % "test",
       "com.novocode" % "junit-interface" % "0.11" % "test",
       "org.slf4j" % "slf4j-log4j12" % "1.7.36" % "test",
       "org.assertj" % "assertj-core" % "3.26.3" % "test"
     ),
+    // Shade jackson libraries so that connector developers don't have to worry
+    // about jackson version conflicts.
+    Compile / packageBin := assembly.value,
+    assembly / assemblyJarName := s"${name.value}-${version.value}.jar",
+    assembly / logLevel := Level.Info,
+    assembly / test := {},
+    assembly / assemblyExcludedJars := {
+      val cp = (assembly / fullClasspath).value
+      val allowedPrefixes = Set("META_INF", "io", "jackson")
+      cp.filter { f =>
+        !allowedPrefixes.exists(prefix => f.data.getName.startsWith(prefix))
+      }
+    },
+     assembly / assemblyShadeRules := Seq(
+      ShadeRule.rename("com.fasterxml.jackson.**" -> "io.delta.kernel.shaded.com.fasterxml.jackson.@1").inAll
+    ),
+    assembly / assemblyMergeStrategy := {
+      // Discard `module-info.class` to fix the `different file contents found` error.
+      // TODO Upgrade SBT to 1.5 which will do this automatically
+      case "module-info.class" => MergeStrategy.discard
+      // Discard unused `parquet.thrift` so that we don't conflict the file used by the user
+      case PathList("META-INF", "services", xs @ _*) => MergeStrategy.discard
+      case x =>
+        val oldStrategy = (assembly / assemblyMergeStrategy).value
+        oldStrategy(x)
+    },
     // Generate the package object to provide the version information in runtime.
     Compile / sourceGenerators += Def.task {
       val file = (Compile / sourceManaged).value / "io" / "delta" / "kernel" / "Meta.java"

--- a/connectors/flink/src/main/scala/io/delta/flink/internal/KernelSnapshotWrapper.java
+++ b/connectors/flink/src/main/scala/io/delta/flink/internal/KernelSnapshotWrapper.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 
 import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.internal.types.DataTypeJsonSerDe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -173,7 +174,7 @@ public class KernelSnapshotWrapper implements io.delta.standalone.Snapshot {
             fields[index] = new io.delta.standalone.types.StructField(
                 kernelField.getName(),
                 io.delta.standalone.types.DataType.fromJson(
-                    kernelField.getDataType().toJson()
+                    DataTypeJsonSerDe.serializeDataType(kernelField.getDataType())
                 ),
                 kernelField.isNullable(),
                 fieldMetadata

--- a/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/MultiThreadedTableReader.java
+++ b/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/MultiThreadedTableReader.java
@@ -144,14 +144,14 @@ public class MultiThreadedTableReader
          * Get the deserialized scan state as {@link Row} object
          */
         Row getScanRow(Engine engine) {
-            return RowSerDe.deserializeRowFromJson(engine, stateJson);
+            return RowSerDe.deserializeRowFromJson(stateJson);
         }
 
         /**
          * Get the deserialized scan file as {@link Row} object
          */
         Row getScanFileRow(Engine engine) {
-            return RowSerDe.deserializeRowFromJson(engine, fileJson);
+            return RowSerDe.deserializeRowFromJson(fileJson);
         }
     }
 

--- a/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/utils/RowSerDe.java
+++ b/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/utils/RowSerDe.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.types.*;
+import io.delta.kernel.internal.types.DataTypeJsonSerDe;
 
 import io.delta.kernel.internal.util.VectorUtils;
 
@@ -59,12 +60,11 @@ public class RowSerDe {
     /**
      * Utility method to deserialize a {@link Row} object from the JSON form.
      */
-    public static Row deserializeRowFromJson(Engine engine, String jsonRowWithSchema) {
+    public static Row deserializeRowFromJson(String jsonRowWithSchema) {
         try {
             JsonNode jsonNode = OBJECT_MAPPER.readTree(jsonRowWithSchema);
             JsonNode schemaNode = jsonNode.get("schema");
-            StructType schema =
-                engine.getJsonHandler().deserializeStructType(schemaNode.asText());
+            StructType schema = DataTypeJsonSerDe.deserializeStructType(schemaNode.asText());
             return parseRowFromJsonWithSchema((ObjectNode) jsonNode.get("row"), schema);
         } catch (JsonProcessingException ex) {
             throw new UncheckedIOException(ex);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Scan.java
@@ -150,8 +150,8 @@ public interface Scan {
         if (inited) {
           return;
         }
-        physicalReadSchema = ScanStateRow.getPhysicalSchema(engine, scanState);
-        logicalReadSchema = ScanStateRow.getLogicalSchema(engine, scanState);
+        physicalReadSchema = ScanStateRow.getPhysicalSchema(scanState);
+        logicalReadSchema = ScanStateRow.getLogicalSchema(scanState);
 
         tablePath = ScanStateRow.getTableRoot(scanState);
         inited = true;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/engine/JsonHandler.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/engine/JsonHandler.java
@@ -71,16 +71,6 @@ public interface JsonHandler {
       Optional<ColumnVector> selectionVector);
 
   /**
-   * Deserialize the Delta schema from {@code structTypeJson} according to the Delta Protocol <a
-   * href="https://github.com/delta-io/delta/blob/master/PROTOCOL.md#primitive-types">schema
-   * serialization rules </a>.
-   *
-   * @param structTypeJson the JSON formatted schema string to parse
-   * @return the parsed {@link StructType}
-   */
-  StructType deserializeStructType(String structTypeJson);
-
-  /**
    * Read and parse the JSON format file at given locations and return the data as a {@link
    * ColumnarBatch} with the columns requested by {@code physicalSchema}.
    *

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/Metadata.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/Metadata.java
@@ -15,15 +15,14 @@
  */
 package io.delta.kernel.internal.actions;
 
-import static io.delta.kernel.internal.DeltaErrors.wrapEngineException;
 import static io.delta.kernel.internal.util.InternalUtils.requireNonNull;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import io.delta.kernel.data.*;
-import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.data.GenericRow;
 import io.delta.kernel.internal.lang.Lazy;
+import io.delta.kernel.internal.types.DataTypeJsonSerDe;
 import io.delta.kernel.internal.util.VectorUtils;
 import io.delta.kernel.types.*;
 import java.util.*;
@@ -31,18 +30,14 @@ import java.util.stream.Collectors;
 
 public class Metadata {
 
-  public static Metadata fromColumnVector(ColumnVector vector, int rowId, Engine engine) {
+  public static Metadata fromColumnVector(ColumnVector vector, int rowId) {
     if (vector.isNullAt(rowId)) {
       return null;
     }
 
     final String schemaJson =
         requireNonNull(vector.getChild(4), rowId, "schemaString").getString(rowId);
-    StructType schema =
-        wrapEngineException(
-            () -> engine.getJsonHandler().deserializeStructType(schemaJson),
-            "Parsing the schema from the metadata. Schema JSON:\n%s",
-            schemaJson);
+    StructType schema = DataTypeJsonSerDe.deserializeStructType(schemaJson);
 
     return new Metadata(
         requireNonNull(vector.getChild(0), rowId, "id").getString(rowId),

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/TransactionStateRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/TransactionStateRow.java
@@ -15,7 +15,6 @@
  */
 package io.delta.kernel.internal.data;
 
-import static io.delta.kernel.internal.DeltaErrors.wrapEngineException;
 import static java.util.stream.Collectors.toMap;
 
 import io.delta.kernel.Transaction;
@@ -23,6 +22,7 @@ import io.delta.kernel.data.Row;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.TableConfig;
 import io.delta.kernel.internal.actions.Metadata;
+import io.delta.kernel.internal.types.DataTypeJsonSerDe;
 import io.delta.kernel.internal.util.VectorUtils;
 import io.delta.kernel.types.*;
 import java.util.*;
@@ -67,10 +67,7 @@ public class TransactionStateRow extends GenericRow {
   public static StructType getLogicalSchema(Engine engine, Row transactionState) {
     String serializedSchema =
         transactionState.getString(COL_NAME_TO_ORDINAL.get("logicalSchemaString"));
-    return wrapEngineException(
-        () -> engine.getJsonHandler().deserializeStructType(serializedSchema),
-        "Parsing the schema from the scan state. Schema JSON:\n%s",
-        serializedSchema);
+    return DataTypeJsonSerDe.deserializeStructType(serializedSchema);
   }
 
   /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
@@ -229,7 +229,7 @@ public class LogReplay {
 
           for (int i = 0; i < metadataVector.getSize(); i++) {
             if (!metadataVector.isNullAt(i)) {
-              metadata = Metadata.fromColumnVector(metadataVector, i, engine);
+              metadata = Metadata.fromColumnVector(metadataVector, i);
 
               if (protocol != null) {
                 // Stop since we have found the latest Protocol and Metadata.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/types/DataTypeJsonSerDe.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/types/DataTypeJsonSerDe.java
@@ -13,34 +13,86 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.delta.kernel.defaults.internal.types;
+package io.delta.kernel.internal.types;
 
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+import static java.lang.String.format;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.internal.DeltaErrors;
+import io.delta.kernel.internal.util.Preconditions;
 import io.delta.kernel.types.*;
+import java.io.IOException;
 import java.util.*;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Parses JSON serialized Delta data types to their {@link DataType} class based on the <a
+ * Serialize and deserialize Delta data types {@link DataType} to JSON and from JSON class based on
+ * the <a
  * href="https://github.com/delta-io/delta/blob/master/PROTOCOL.md#primitive-types">serialization
  * rules </a> outlined in the Delta Protocol.
  */
-public class DataTypeParser {
+public class DataTypeJsonSerDe {
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper()
+          .registerModule(
+              new SimpleModule().addSerializer(StructType.class, new DataTypeSerializer()));
 
-  private DataTypeParser() {}
+  private DataTypeJsonSerDe() {}
 
-  public static StructType parseSchema(JsonNode json) {
-    DataType parsedType = parseDataType(json);
-    if (parsedType instanceof StructType) {
-      return (StructType) parsedType;
-    } else {
-      throw new IllegalArgumentException(
-          String.format("Could not parse the following JSON as a valid StructType:\n%s", json));
+  /**
+   * Serializes a {@link StructType} to a JSON string
+   *
+   * @param structType
+   * @return
+   */
+  public static String serializeStructType(StructType structType) {
+    try {
+      return OBJECT_MAPPER.writeValueAsString(structType);
+    } catch (JsonProcessingException ex) {
+      throw new KernelException("Could not serialize StructType to JSON", ex);
+    }
+  }
+
+  /**
+   * Serializes a {@link DataType} to a JSON string according to the Delta Protocol.
+   *
+   * @param dataType
+   * @return
+   */
+  public static String serializeDataType(DataType dataType) {
+    try {
+      return OBJECT_MAPPER.writeValueAsString(dataType);
+    } catch (JsonProcessingException ex) {
+      throw new KernelException("Could not serialize DataType to JSON", ex);
+    }
+  }
+
+  /**
+   * Deserializes a JSON string representing a Delta data type to a {@link DataType}.
+   *
+   * @param structTypeJson JSON string representing a {@link StructType} data type
+   */
+  public static StructType deserializeStructType(String structTypeJson) {
+    try {
+      DataType parsedType = parseDataType(OBJECT_MAPPER.reader().readTree(structTypeJson));
+      if (parsedType instanceof StructType) {
+        return (StructType) parsedType;
+      } else {
+        throw new IllegalArgumentException(
+            String.format(
+                "Could not parse the following JSON as a valid StructType:\n%s", structTypeJson));
+      }
+    } catch (JsonProcessingException ex) {
+      throw new KernelException(
+          format("Could not parse schema given as JSON string: %s", structTypeJson), ex);
     }
   }
 
@@ -134,7 +186,7 @@ public class DataTypeParser {
         String.format(
             "Expected JSON object with 2 fields for struct data type but got:\n%s", json));
     JsonNode fieldsNode = getNonNullField(json, "fields");
-    checkArgument(
+    Preconditions.checkArgument(
         fieldsNode.isArray(),
         String.format("Expected array for fieldName=%s in:\n%s", "fields", json));
     Iterator<JsonNode> fields = fieldsNode.elements();
@@ -150,7 +202,7 @@ public class DataTypeParser {
    * struct field </a>
    */
   private static StructField parseStructField(JsonNode json) {
-    checkArgument(json.isObject(), "Expected JSON object for struct field");
+    Preconditions.checkArgument(json.isObject(), "Expected JSON object for struct field");
     String name = getStringField(json, "name");
     DataType type = parseDataType(getNonNullField(json, "type"));
     boolean nullable = getBooleanField(json, "nullable");
@@ -164,7 +216,7 @@ public class DataTypeParser {
       return FieldMetadata.empty();
     }
 
-    checkArgument(json.isObject(), "Expected JSON object for struct field metadata");
+    Preconditions.checkArgument(json.isObject(), "Expected JSON object for struct field metadata");
     final Iterator<Map.Entry<String, JsonNode>> iterator = json.fields();
     final FieldMetadata.Builder builder = FieldMetadata.builder();
     while (iterator.hasNext()) {
@@ -207,7 +259,8 @@ public class DataTypeParser {
           } else if (head.isObject()) {
             builder.putFieldMetadataArray(
                 key,
-                buildList(value, DataTypeParser::parseFieldMetadata).toArray(new FieldMetadata[0]));
+                buildList(value, DataTypeJsonSerDe::parseFieldMetadata)
+                    .toArray(new FieldMetadata[0]));
           } else {
             throw new IllegalArgumentException(
                 String.format("Unsupported type for Array as field metadata value: %s", value));
@@ -275,7 +328,7 @@ public class DataTypeParser {
 
   private static String getStringField(JsonNode rootNode, String fieldName) {
     JsonNode node = getNonNullField(rootNode, fieldName);
-    checkArgument(
+    Preconditions.checkArgument(
         node.isTextual(),
         String.format("Expected string for fieldName=%s in:\n%s", fieldName, rootNode));
     return node.textValue(); // double check this only works for string values! and isTextual()!
@@ -283,9 +336,134 @@ public class DataTypeParser {
 
   private static boolean getBooleanField(JsonNode rootNode, String fieldName) {
     JsonNode node = getNonNullField(rootNode, fieldName);
-    checkArgument(
+    Preconditions.checkArgument(
         node.isBoolean(),
         String.format("Expected boolean for fieldName=%s in:\n%s", fieldName, rootNode));
     return node.booleanValue();
+  }
+
+  protected static class DataTypeSerializer extends StdSerializer<DataType> {
+    public DataTypeSerializer() {
+      super(DataType.class);
+    }
+
+    @Override
+    public void serialize(DataType dataType, JsonGenerator gen, SerializerProvider provider)
+        throws IOException {
+      writeDataType(gen, dataType);
+    }
+  }
+
+  protected static void writeDataType(JsonGenerator gen, DataType dataType) throws IOException {
+    if (dataType instanceof StructType) {
+      writeStructType(gen, (StructType) dataType);
+    } else if (dataType instanceof ArrayType) {
+      writeArrayType(gen, (ArrayType) dataType);
+    } else if (dataType instanceof MapType) {
+      writeMapType(gen, (MapType) dataType);
+    } else if (dataType instanceof DecimalType) {
+      DecimalType decimalType = (DecimalType) dataType;
+      gen.writeString(format("decimal(%d,%d)", decimalType.getPrecision(), decimalType.getScale()));
+    } else {
+      gen.writeString(dataType.toString());
+    }
+  }
+
+  private static void writeArrayType(JsonGenerator gen, ArrayType arrayType) throws IOException {
+    gen.writeStartObject();
+    gen.writeStringField("type", "array");
+    gen.writeFieldName("elementType");
+    writeDataType(gen, arrayType.getElementType());
+    gen.writeBooleanField("containsNull", arrayType.containsNull());
+    gen.writeEndObject();
+  }
+
+  private static void writeMapType(JsonGenerator gen, MapType mapType) throws IOException {
+    gen.writeStartObject();
+    gen.writeStringField("type", "map");
+    gen.writeFieldName("keyType");
+    writeDataType(gen, mapType.getKeyType());
+    gen.writeFieldName("valueType");
+    writeDataType(gen, mapType.getValueType());
+    gen.writeBooleanField("valueContainsNull", mapType.isValueContainsNull());
+    gen.writeEndObject();
+  }
+
+  private static void writeStructType(JsonGenerator gen, StructType structType) throws IOException {
+    gen.writeStartObject();
+    gen.writeStringField("type", "struct");
+    gen.writeArrayFieldStart("fields");
+    for (StructField field : structType.fields()) {
+      writeStructField(gen, field);
+    }
+    gen.writeEndArray();
+    gen.writeEndObject();
+  }
+
+  private static void writeStructField(JsonGenerator gen, StructField field) throws IOException {
+    gen.writeStartObject();
+    gen.writeStringField("name", field.getName());
+    gen.writeFieldName("type");
+    writeDataType(gen, field.getDataType());
+    gen.writeBooleanField("nullable", field.isNullable());
+    gen.writeFieldName("metadata");
+    writeFieldMetadata(gen, field.getMetadata());
+    gen.writeEndObject();
+  }
+
+  private static void writeFieldMetadata(JsonGenerator gen, FieldMetadata metadata)
+      throws IOException {
+    gen.writeStartObject();
+    for (Map.Entry<String, Object> entry : metadata.getEntries().entrySet()) {
+      gen.writeFieldName(entry.getKey());
+      Object value = entry.getValue();
+      if (value instanceof Long) {
+        gen.writeNumber((Long) value);
+      } else if (value instanceof Double) {
+        gen.writeNumber((Double) value);
+      } else if (value instanceof Boolean) {
+        gen.writeBoolean((Boolean) value);
+      } else if (value instanceof String) {
+        gen.writeString((String) value);
+      } else if (value instanceof FieldMetadata) {
+        writeFieldMetadata(gen, (FieldMetadata) value);
+      } else if (value instanceof Long[]) {
+        gen.writeStartArray();
+        for (Long v : (Long[]) value) {
+          gen.writeNumber(v);
+        }
+        gen.writeEndArray();
+      } else if (value instanceof Double[]) {
+        gen.writeStartArray();
+        for (Double v : (Double[]) value) {
+          gen.writeNumber(v);
+        }
+        gen.writeEndArray();
+      } else if (value instanceof Boolean[]) {
+        gen.writeStartArray();
+        for (Boolean v : (Boolean[]) value) {
+          gen.writeBoolean(v);
+        }
+        gen.writeEndArray();
+      } else if (value instanceof String[]) {
+        gen.writeStartArray();
+        for (String v : (String[]) value) {
+          gen.writeString(v);
+        }
+        gen.writeEndArray();
+      } else if (value instanceof FieldMetadata[]) {
+        gen.writeStartArray();
+        for (FieldMetadata v : (FieldMetadata[]) value) {
+          writeFieldMetadata(gen, v);
+        }
+        gen.writeEndArray();
+      } else if (value == null) {
+        gen.writeNull();
+      } else {
+        throw new IllegalArgumentException(
+            format("Unsupported type for field metadata value: %s", value));
+      }
+    }
+    gen.writeEndObject();
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/ArrayType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/ArrayType.java
@@ -72,13 +72,6 @@ public class ArrayType extends DataType {
   }
 
   @Override
-  public String toJson() {
-    return String.format(
-        "{" + "\"type\": \"array\"," + "\"elementType\": %s," + "\"containsNull\": %s" + "}",
-        getElementType().toJson(), containsNull());
-  }
-
-  @Override
   public String toString() {
     return "array[" + getElementType() + "]";
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/BasePrimitiveType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/BasePrimitiveType.java
@@ -91,9 +91,4 @@ public abstract class BasePrimitiveType extends DataType {
   public String toString() {
     return primitiveTypeName;
   }
-
-  @Override
-  public String toJson() {
-    return String.format("\"%s\"", primitiveTypeName);
-  }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/DataType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/DataType.java
@@ -25,12 +25,6 @@ import io.delta.kernel.annotation.Evolving;
  */
 @Evolving
 public abstract class DataType {
-  /**
-   * Convert the data type to Delta protocol specified serialization format.
-   *
-   * @return Data type serialized in JSON format.
-   */
-  public abstract String toJson();
 
   /**
    * Are the data types same? The metadata or column names could be different.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/DecimalType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/DecimalType.java
@@ -58,11 +58,6 @@ public final class DecimalType extends DataType {
   }
 
   @Override
-  public String toJson() {
-    return String.format("\"decimal(%d, %d)\"", precision, scale);
-  }
-
-  @Override
   public String toString() {
     return String.format("Decimal(%d, %d)", precision, scale);
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/FieldMetadata.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/FieldMetadata.java
@@ -111,15 +111,17 @@ public final class FieldMetadata {
     return get(key, FieldMetadata[].class);
   }
 
-  public String toJson() {
-    return metadata.entrySet().stream()
-        .map(e -> String.format("\"%s\" : %s", e.getKey(), valueToJson(e.getValue())))
-        .collect(Collectors.joining(",\n", "{", "}"));
-  }
-
   @Override
   public String toString() {
-    return toJson();
+    return metadata.entrySet().stream()
+        .map(
+            entry ->
+                entry.getKey()
+                    + "="
+                    + (entry.getValue().getClass().isArray()
+                        ? Arrays.toString((Object[]) entry.getValue())
+                        : entry.getValue().toString()))
+        .collect(Collectors.joining(", ", "{", "}"));
   }
 
   @Override
@@ -180,18 +182,6 @@ public final class FieldMetadata {
         type,
         value.getClass());
     return type.cast(value);
-  }
-
-  // TODO this is a hack for now until we have real serialization as part of the JsonHandler
-  /** Wraps string objects in quotations, otherwise converts using toString() */
-  private String valueToJson(Object value) {
-    if (value == null) {
-      return "null";
-    } else if (value instanceof String) {
-      return String.format("\"%s\"", value);
-    } else {
-      return value.toString();
-    }
   }
 
   /** Builder class for {@link FieldMetadata}. */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/MapType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/MapType.java
@@ -86,18 +86,6 @@ public class MapType extends DataType {
   }
 
   @Override
-  public String toJson() {
-    return String.format(
-        "{"
-            + "\"type\": \"map\","
-            + "\"keyType\": %s,"
-            + "\"valueType\": %s,"
-            + "\"valueContainsNull\": %s"
-            + "}",
-        getKeyType().toJson(), getValueType().toJson(), isValueContainsNull());
-  }
-
-  @Override
   public String toString() {
     return String.format("map[%s, %s]", getKeyType(), getValueType());
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructField.java
@@ -99,19 +99,7 @@ public class StructField {
   @Override
   public String toString() {
     return String.format(
-        "StructField(name=%s,type=%s,nullable=%s,metadata=%s)",
-        name, dataType, nullable, metadata.toJson());
-  }
-
-  public String toJson() {
-    return String.format(
-        "{\n"
-            + "  \"name\" : \"%s\",\n"
-            + "  \"type\" : %s,\n"
-            + "  \"nullable\" : %s, \n"
-            + "  \"metadata\" : %s\n"
-            + "}",
-        name, dataType.toJson(), nullable, metadata.toJson());
+        "StructField(name=%s,type=%s,nullable=%s,metadata=%s)", name, dataType, nullable, metadata);
   }
 
   @Override

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructType.java
@@ -17,6 +17,7 @@ package io.delta.kernel.types;
 
 import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.expressions.Column;
+import io.delta.kernel.internal.types.DataTypeJsonSerDe;
 import io.delta.kernel.internal.util.Tuple2;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -109,6 +110,15 @@ public final class StructType extends DataType {
     return new Column(field.getName());
   }
 
+  /**
+   * Convert the struct type to Delta protocol specified serialization format.
+   *
+   * @return serialized in JSON format.
+   */
+  public String toJson() {
+    return DataTypeJsonSerDe.serializeStructType(this);
+  }
+
   @Override
   public boolean equivalent(DataType dataType) {
     if (!(dataType instanceof StructType)) {
@@ -126,14 +136,6 @@ public final class StructType extends DataType {
   public String toString() {
     return String.format(
         "struct(%s)", fields.stream().map(StructField::toString).collect(Collectors.joining(", ")));
-  }
-
-  @Override
-  public String toJson() {
-    String fieldsAsJson = fields.stream().map(e -> e.toJson()).collect(Collectors.joining(",\n"));
-
-    return String.format(
-        "{\n" + "  \"type\" : \"struct\",\n" + "  \"fields\" : [ %s ]\n" + "}", fieldsAsJson);
   }
 
   @Override

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/TransactionSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/TransactionSuite.scala
@@ -17,17 +17,17 @@ package io.delta.kernel
 
 import io.delta.kernel.Transaction.{generateAppendActions, transformLogicalData}
 import io.delta.kernel.data._
-import io.delta.kernel.engine.Engine
 import io.delta.kernel.exceptions.KernelException
 import io.delta.kernel.expressions.{Column, Literal}
 import io.delta.kernel.internal.DataWriteContextImpl
 import io.delta.kernel.internal.TableConfig.ICEBERG_COMPAT_V2_ENABLED
 import io.delta.kernel.internal.actions.{Format, Metadata}
 import io.delta.kernel.internal.data.TransactionStateRow
+import io.delta.kernel.internal.types.DataTypeJsonSerDe
 import io.delta.kernel.internal.util.Utils.toCloseableIterator
 import io.delta.kernel.internal.util.VectorUtils
 import io.delta.kernel.internal.util.VectorUtils.stringStringMapValue
-import io.delta.kernel.test.{BaseMockJsonHandler, MockEngineUtils, VectorTestUtils}
+import io.delta.kernel.test.{MockEngineUtils, VectorTestUtils}
 import io.delta.kernel.types.{LongType, StringType, StructType}
 import io.delta.kernel.utils.{CloseableIterator, DataFileStatistics, DataFileStatus}
 import org.scalatest.funsuite.AnyFunSuite
@@ -45,7 +45,7 @@ class TransactionSuite extends AnyFunSuite with VectorTestUtils with MockEngineU
     test("transformLogicalData: un-partitioned table, " +
       s"icebergCompatV2Enabled=$icebergCompatV2Enabled") {
       val transformedDateIter = transformLogicalData(
-        testMockEngine(testSchema),
+        mockEngine(),
         testTxnState(testSchema, enableIcebergCompatV2 = icebergCompatV2Enabled),
         testData(includePartitionCols = false),
         Map.empty[String, Literal].asJava /* partition values */)
@@ -59,7 +59,7 @@ class TransactionSuite extends AnyFunSuite with VectorTestUtils with MockEngineU
     test("transformLogicalData: partitioned table, " +
       s"icebergCompatV2Enabled=$icebergCompatV2Enabled") {
       val transformedDateIter = transformLogicalData(
-        testMockEngine(testSchemaWithPartitions),
+        mockEngine(),
         testTxnState(
           testSchemaWithPartitions,
           testPartitionColNames,
@@ -83,7 +83,7 @@ class TransactionSuite extends AnyFunSuite with VectorTestUtils with MockEngineU
     test(s"generateAppendActions: iceberg comaptibily checks, " +
       s"icebergCompatV2Enabled=$icebergCompatV2Enabled") {
       val txnState = testTxnState(testSchema, enableIcebergCompatV2 = icebergCompatV2Enabled)
-      val engine = testMockEngine(testSchema)
+      val engine = mockEngine()
 
       Seq(
         // missing stats
@@ -196,24 +196,13 @@ object TransactionSuite extends VectorTestUtils with MockEngineUtils {
       Optional.empty(), /* name */
       Optional.empty(), /* description */
       new Format(),
-      "", // schemaString,
+      DataTypeJsonSerDe.serializeDataType(schema),
       schema,
       VectorUtils.stringArrayValue(partitionCols.asJava), // partitionColumns
       Optional.empty(), // createdTime
       stringStringMapValue(configurationMap.asJava) // configurationMap
     )
     TransactionStateRow.of(metadata, "table path")
-  }
-
-  /**
-   * Create a mock [[Engine]] with the given schema which is returned by the mock [[JsonHandler]].
-   */
-  def testMockEngine(schema: StructType): Engine = {
-    mockEngine(
-      jsonHandler = new BaseMockJsonHandler {
-        override def deserializeStructType(structTypeJson: String): StructType = schema
-      }
-    )
   }
 
   def testStats(numRowsOpt: Option[Long]): Option[DataFileStatistics] = {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/types/DataTypeJsonSerDeSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/types/DataTypeJsonSerDeSuite.scala
@@ -179,7 +179,7 @@ class DataTypeJsonSerDeSuite extends AnyFunSuite {
         |  "long-2" : 16070400023423400,
         |  "double" : 2.22,
         |  "boolean" : true,
-        |  "string" : "10",
+        |  "string" : "10\"@",
         |  "metadata" : { "nestedInt" : 200 },
         |  "empty_arr" : [],
         |  "int_arr" : [1, 2, 0],
@@ -196,7 +196,7 @@ class DataTypeJsonSerDeSuite extends AnyFunSuite {
       .putLong("long-2", 16070400023423400L)
       .putDouble("double", 2.22)
       .putBoolean("boolean", true)
-      .putString("string", "10")
+      .putString("string", "10\"@") // special characters
       .putFieldMetadata("metadata", FieldMetadata.builder().putLong("nestedInt", 200).build())
       .putLongArray("empty_arr", Array())
       .putLongArray("int_arr", Array(1, 2, 0))

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/types/DataTypeJsonSerDeSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/types/DataTypeJsonSerDeSuite.scala
@@ -16,31 +16,23 @@
 package io.delta.kernel.internal.types
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.module.SimpleModule
 import io.delta.kernel.types._
 import org.scalatest.funsuite.AnyFunSuite
 
-import java.io.StringWriter
 import scala.reflect.ClassTag
 
 class DataTypeJsonSerDeSuite extends AnyFunSuite {
 
   import DataTypeJsonSerDeSuite._
 
-  private val objectMapper = new ObjectMapper().registerModule(
-    new SimpleModule()
-      .addSerializer(classOf[StructType], new DataTypeJsonSerDe.DataTypeSerializer))
+  private val objectMapper = new ObjectMapper()
 
   private def parse(json: String): DataType = {
     DataTypeJsonSerDe.parseDataType(objectMapper.readTree(json))
   }
 
   private def serialize(dataType: DataType): String = {
-    val writer = new StringWriter()
-    val generator = objectMapper.createGenerator(writer)
-    DataTypeJsonSerDe.writeDataType(generator, dataType)
-    generator.flush()
-    writer.toString
+    DataTypeJsonSerDe.serializeDataType(dataType)
   }
 
   private def testRoundTrip(dataTypeJsonString: String, dataType: DataType): Unit = {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/types/DataTypeJsonSerDeSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/types/DataTypeJsonSerDeSuite.scala
@@ -13,33 +13,47 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.delta.kernel.defaults.internal.types
-
-import scala.reflect.ClassTag
+package io.delta.kernel.internal.types
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.module.SimpleModule
+import io.delta.kernel.types._
 import org.scalatest.funsuite.AnyFunSuite
 
-import io.delta.kernel.types._
+import java.io.StringWriter
+import scala.reflect.ClassTag
 
-class DataTypeParserSuite extends AnyFunSuite {
+class DataTypeJsonSerDeSuite extends AnyFunSuite {
 
-  import DataTypeParserSuite._
+  import DataTypeJsonSerDeSuite._
 
-  private val objectMapper = new ObjectMapper()
+  private val objectMapper = new ObjectMapper().registerModule(
+    new SimpleModule()
+      .addSerializer(classOf[StructType], new DataTypeJsonSerDe.DataTypeSerializer))
 
   private def parse(json: String): DataType = {
-    DataTypeParser.parseDataType(objectMapper.readTree(json))
+    DataTypeJsonSerDe.parseDataType(objectMapper.readTree(json))
   }
 
-  private def checkDataType(dataTypeString: String, expectedDataType: DataType): Unit = {
-    test(s"parseDataType: parse ${dataTypeString.replace("\n", "")}") {
-      assert(parse(dataTypeString) === expectedDataType)
-    }
+  private def serialize(dataType: DataType): String = {
+    val writer = new StringWriter()
+    val generator = objectMapper.createGenerator(writer)
+    DataTypeJsonSerDe.writeDataType(generator, dataType)
+    generator.flush()
+    writer.toString
+  }
+
+  private def testRoundTrip(dataTypeJsonString: String, dataType: DataType): Unit = {
+    // test deserialization
+    assert(parse(dataTypeJsonString) === dataType)
+
+    // test serialization
+    val serializedJson = serialize(dataType)
+    assert(parse(serializedJson) === dataType)
   }
 
   private def checkError[T <: Throwable](json: String, expectedErrorContains: String)
-      (implicit classTag: ClassTag[T]): Unit = {
+    (implicit classTag: ClassTag[T]): Unit = {
     val e = intercept[T] {
       parse(json)
     }
@@ -48,20 +62,26 @@ class DataTypeParserSuite extends AnyFunSuite {
 
   /* --------------- Primitive data types (stored as a string) ----------------- */
 
-  checkDataType("\"string\"", StringType.STRING)
-  checkDataType("\"long\"", LongType.LONG)
-  checkDataType("\"short\"", ShortType.SHORT)
-  checkDataType("\"integer\"", IntegerType.INTEGER)
-  checkDataType("\"boolean\"", BooleanType.BOOLEAN)
-  checkDataType("\"byte\"", ByteType.BYTE)
-  checkDataType("\"float\"", FloatType.FLOAT)
-  checkDataType("\"double\"", DoubleType.DOUBLE)
-  checkDataType("\"binary\"", BinaryType.BINARY)
-  checkDataType("\"date\"", DateType.DATE)
-  checkDataType("\"timestamp\"", TimestampType.TIMESTAMP)
-  checkDataType("\"decimal\"", DecimalType.USER_DEFAULT)
-  checkDataType("\"decimal(10, 5)\"", new DecimalType(10, 5))
-  checkDataType("\"variant\"", VariantType.VARIANT)
+  Seq(
+    ("\"string\"", StringType.STRING),
+    ("\"long\"", LongType.LONG),
+    ("\"short\"", ShortType.SHORT),
+    ("\"integer\"", IntegerType.INTEGER),
+    ("\"boolean\"", BooleanType.BOOLEAN),
+    ("\"byte\"", ByteType.BYTE),
+    ("\"float\"", FloatType.FLOAT),
+    ("\"double\"", DoubleType.DOUBLE),
+    ("\"binary\"", BinaryType.BINARY),
+    ("\"date\"", DateType.DATE),
+    ("\"timestamp\"", TimestampType.TIMESTAMP),
+    ("\"decimal\"", DecimalType.USER_DEFAULT),
+    ("\"decimal(10, 5)\"", new DecimalType(10, 5)),
+    ("\"variant\"", VariantType.VARIANT)
+  ).foreach { case (json, dataType) =>
+    test("serialize/deserialize: " + dataType) {
+      testRoundTrip(json, dataType)
+    }
+  }
 
   test("parseDataType: invalid primitive string data type") {
     checkError[IllegalArgumentException]("\"foo\"", "foo is not a supported delta data type")
@@ -75,54 +95,60 @@ class DataTypeParserSuite extends AnyFunSuite {
 
   /* ---------------  Complex types ----------------- */
 
-  test("parseDataType: array type") {
+  test("serialize/deserialize: array type") {
     for (containsNull <- Seq(true, false)) {
       for ((elementJson, elementType) <- SAMPLE_JSON_TO_TYPES) {
-        val parsedType = parse(arrayTypeJson(elementJson, containsNull))
+        // test deserialization
+        val json = arrayTypeJson(elementJson, containsNull)
         val expectedType = new ArrayType(elementType, containsNull)
-        assert(parsedType == expectedType)
+
+        testRoundTrip(json, expectedType)
       }
     }
   }
 
-  test("parseDataType: map type") {
+  test("serialize/deserialize: map type") {
     for (valueContainsNull <- Seq(true, false)) {
       for ((keyJson, keyType) <- SAMPLE_JSON_TO_TYPES) {
         for ((valueJson, valueType) <- SAMPLE_JSON_TO_TYPES) {
-          val parsedType = parse(mapTypeJson(keyJson, valueJson, valueContainsNull))
+          val json = mapTypeJson(keyJson, valueJson, valueContainsNull)
           val expectedType = new MapType(keyType, valueType, valueContainsNull)
-          assert(parsedType == expectedType)
+
+          testRoundTrip(json, expectedType)
         }
       }
     }
   }
 
-  test("parseDataType: struct type") {
+  test("serialize/deserialize: struct type") {
     for ((col1Json, col1Type) <- SAMPLE_JSON_TO_TYPES) {
       for ((col2Json, col2Type) <- SAMPLE_JSON_TO_TYPES) {
         val fieldsJson = Seq(
           structFieldJson("col1", col1Json, false),
           structFieldJson("col2", col2Json, true, Some("{ \"int\" : 0 }"))
         )
-        val parsedType = parse(structTypeJson(fieldsJson))
+
+        val json = structTypeJson(fieldsJson)
         val expectedType = new StructType()
           .add("col1", col1Type, false)
           .add("col2", col2Type, true, FieldMetadata.builder().putLong("int", 0).build())
-        assert(parsedType == expectedType)
+
+        testRoundTrip(json, expectedType)
       }
     }
   }
 
-  test("parseDataType: special characters for column name") {
-    val parsedType = parse(structTypeJson(Seq(
+  test("serialize/deserialize: special characters for column name") {
+    val json = structTypeJson(Seq(
       structFieldJson("@_! *c", "\"string\"", true)
-    )))
+    ))
     val expectedType = new StructType()
       .add("@_! *c", StringType.STRING, true)
-    assert(parsedType == expectedType)
+
+    testRoundTrip(json, expectedType)
   }
 
-  test("parseDataType: empty struct type") {
+  test("serialize/deserialize: empty struct type") {
     val str =
       """
         |{
@@ -130,16 +156,18 @@ class DataTypeParserSuite extends AnyFunSuite {
         |  "fields": []
         |}
         |""".stripMargin
-    assert(parse(str) == new StructType())
+    testRoundTrip(str, new StructType())
   }
 
-  test("parseDataType: parsing FieldMetadata") {
+  test("serialize/deserialize: parsing FieldMetadata") {
     def testFieldMetadata(fieldMetadataJson: String, expectedFieldMetadata: FieldMetadata): Unit = {
-      val parsedMetadata = parse(structTypeJson(
-        Seq(structFieldJson("testCol", "\"string\"", true, Some(fieldMetadataJson)))
-      )).asInstanceOf[StructType].get("testCol").getMetadata
+      val json = structTypeJson(Seq(
+        structFieldJson("testCol", "\"string\"", true, Some(fieldMetadataJson))
+      ))
 
-      assert(parsedMetadata == expectedFieldMetadata)
+      val dataType = new StructType().add("testCol", StringType.STRING, true, expectedFieldMetadata)
+
+      testRoundTrip(json, dataType)
     }
 
     val fieldMetadataAllTypesJson =
@@ -205,7 +233,7 @@ class DataTypeParserSuite extends AnyFunSuite {
   }
 }
 
-object DataTypeParserSuite {
+object DataTypeJsonSerDeSuite {
 
   val SAMPLE_JSON_TO_TYPES = Seq(
     ("\"string\"", StringType.STRING),
@@ -247,10 +275,10 @@ object DataTypeParserSuite {
   }
 
   def structFieldJson(
-      name: String,
-      typeJson: String,
-      nullable: Boolean,
-      metadataJson: Option[String] = None): String = {
+    name: String,
+    typeJson: String,
+    nullable: Boolean,
+    metadataJson: Option[String] = None): String = {
     metadataJson match {
       case Some(metadata) =>
         s"""
@@ -274,10 +302,10 @@ object DataTypeParserSuite {
 
   def structTypeJson(fieldsJsons: Seq[String]): String = {
     s"""
-      |{
-      |  "type" : "struct",
-      |  "fields": ${fieldsJsons.mkString("[\n", ",\n", "]\n")}
-      |}
-      |""".stripMargin
+       |{
+       |  "type" : "struct",
+       |  "fields": ${fieldsJsons.mkString("[\n", ",\n", "]\n")}
+       |}
+       |""".stripMargin
   }
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockEngineUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockEngineUtils.scala
@@ -89,9 +89,6 @@ trait BaseMockJsonHandler extends JsonHandler {
       selectionVector: Optional[ColumnVector]): ColumnarBatch =
     throw new UnsupportedOperationException("not supported in this test suite")
 
-  override def deserializeStructType(structTypeJson: String): StructType =
-    throw new UnsupportedOperationException("not supported in this test suite")
-
   override def readJsonFiles(
       fileIter: CloseableIterator[FileStatus],
       physicalSchema: StructType,

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultJsonHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultJsonHandler.java
@@ -26,10 +26,8 @@ import io.delta.kernel.defaults.internal.data.DefaultJsonRow;
 import io.delta.kernel.defaults.internal.data.DefaultRowBasedColumnarBatch;
 import io.delta.kernel.defaults.internal.json.JsonUtils;
 import io.delta.kernel.defaults.internal.logstore.LogStoreProvider;
-import io.delta.kernel.defaults.internal.types.DataTypeParser;
 import io.delta.kernel.engine.JsonHandler;
 import io.delta.kernel.exceptions.KernelEngineException;
-import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.internal.util.Utils;
 import io.delta.kernel.types.*;
@@ -45,10 +43,9 @@ import org.apache.hadoop.fs.*;
 /** Default implementation of {@link JsonHandler} based on Hadoop APIs. */
 public class DefaultJsonHandler implements JsonHandler {
   private static final ObjectMapper mapper = new ObjectMapper();
-  private static final ObjectReader defaultObjectReader = mapper.reader();
   // by default BigDecimals are truncated and read as floats
   private static final ObjectReader objectReaderReadBigDecimals =
-      mapper.reader(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
+      new ObjectMapper().reader(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
 
   private final Configuration hadoopConf;
   private final int maxBatchSize;
@@ -76,18 +73,6 @@ public class DefaultJsonHandler implements JsonHandler {
       }
     }
     return new DefaultRowBasedColumnarBatch(outputSchema, rows);
-  }
-
-  @Override
-  public StructType deserializeStructType(String structTypeJson) {
-    try {
-      // We don't expect Java BigDecimal anywhere in a Delta schema so we use the default
-      // JSON reader
-      return DataTypeParser.parseSchema(defaultObjectReader.readTree(structTypeJson));
-    } catch (JsonProcessingException ex) {
-      throw new KernelException(
-          format("Could not parse schema given as JSON string: %s", structTypeJson), ex);
-    }
   }
 
   @Override

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/InCommitTimestampSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/InCommitTimestampSuite.scala
@@ -345,9 +345,9 @@ class InCommitTimestampSuite extends DeltaTableWriteSuiteBase {
       assert(metadata.toString == String.format(
         "Metadata{id='%s', name=Optional.empty, description=Optional.empty, " +
           "format=Format{provider='parquet', options={}}, " +
-          "schemaString='{\n  \"type\" : \"struct\",\n  \"fields\" : [ {\n" +
-          "  \"name\" : \"id\",\n  \"type\" : \"integer\",\n  \"nullable\" : true, \n" +
-          "  \"metadata\" : {}\n} ]\n}', " +
+          "schemaString='{\"type\":\"struct\",\"fields\":[{" +
+          "\"name\":\"id\",\"type\":\"integer\",\"nullable\":true," +
+          "\"metadata\":{}}]}', " +
           "partitionColumns=List(), createdTime=Optional[%s], " +
           "configuration={delta.inCommitTimestampEnablementTimestamp=%s, " +
           "delta.enableInCommitTimestamps=true, " +

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LogReplaySuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LogReplaySuite.scala
@@ -113,7 +113,7 @@ class LogReplaySuite extends AnyFunSuite with TestUtils {
       .getScanState(defaultEngine)
 
     // schema is updated
-    assert(ScanStateRow.getLogicalSchema(defaultEngine, scanStateRow)
+    assert(ScanStateRow.getLogicalSchema(scanStateRow)
       .fieldNames().asScala.toSet == Set("col1", "col2")
     )
 


### PR DESCRIPTION
## Description
Given now Kernel-API module contains Jackson libs:
1) Remove `JsonHandler.deserializeStructType` and its usages
2) Rename `DataTypeParser` to `DataTypeJSONSerDe` (similarly the test suite)
3) Add `StructType` serialization utilities to `DataTypeJSONSerDe`

## How was this patch tested?
Unit tests

## Does this PR introduce _any_ user-facing changes?
For connectors that implement custom `JsonHandler`, don't need to implement `deserializeStructType` API.
