### PR TITLE
[3.2] invoke Spark catalog plugin API to create tables

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaCatalog.scala
@@ -38,6 +38,7 @@ import org.apache.spark.sql.delta.sources.{DeltaDataSource, DeltaSourceUtils, De
 import org.apache.spark.sql.delta.stats.StatisticsCollection
 import org.apache.spark.sql.delta.tablefeatures.DropFeature
 import org.apache.spark.sql.delta.util.PartitionUtils
+import org.apache.spark.sql.util.ScalaExtensions._
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.SparkException
@@ -69,6 +70,12 @@ class DeltaCatalog extends DelegatingCatalogExtension
 
 
   val spark = SparkSession.active
+
+  private lazy val isUnityCatalog: Boolean = {
+    val delegateField = classOf[DelegatingCatalogExtension].getDeclaredField("delegate")
+    delegateField.setAccessible(true)
+    delegateField.get(this).getClass.getCanonicalName.startsWith("io.unitycatalog.")
+  }
 
   /**
    * Creates a Delta table
@@ -181,7 +188,19 @@ class DeltaCatalog extends DelegatingCatalogExtension
       operation.mode,
       writer,
       operation,
-      tableByPath = isByPath).run(spark)
+      tableByPath = isByPath,
+      // We should invoke the Spark catalog plugin API to create the table, to
+      // respect third party catalogs. Note: only handle CREATE TABLE for now, we
+      // should support CTAS later.
+      // TODO: Spark `V2SessionCatalog` mistakenly treat tables with location as EXTERNAL table.
+      //       Before this bug is fixed, we should only call the catalog plugin API to create tables
+      //       if UC is enabled to replace `V2SessionCatalog`.
+      createTableFunc = Option.when(isUnityCatalog && sourceQuery.isEmpty) {
+        v1Table => {
+          val t = V1Table(v1Table)
+          super.createTable(ident, t.columns(), t.partitioning, t.properties)
+        }
+      }).run(spark)
 
     loadTable(ident)
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Today, `DeltaCatalog` takes care of the Spark CREATE TABLE command and calls `CreateDeltaTableCommand#run` at the end. Within this command, `spark.sessionState.catalog.createTable` is called, which bypasses any custom catalog that overwrites `spark_catalog`. `DeltaCatalog` always creates tables in the Hive Metastore.

This PR fixes this issue by calling the Spark catalog plugin API to create the table, to respect custom catalog that overwrites `spark_catalog`, such as Unity Catalog.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Locally tested it with Spark + Unity Catalog.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no