### PR TITLE
[Spark] Inject special chars in temp dirs of all Delta tests

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/ConvertToDeltaSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ConvertToDeltaSuiteBase.scala
@@ -188,7 +188,7 @@ trait ConvertToDeltaSuiteBase extends ConvertToDeltaSuiteBaseCommons
   }
 
   test("filter non-parquet file for schema inference when not using catalog schema") {
-    withTempDir { dir =>
+    withTempDir(prefix = "spark") { dir =>
       val tempDir = dir.getCanonicalPath
       writeFiles(tempDir + "/part=1/", Seq(1).toDF("corrupted_id"), format = "orc")
       writeFiles(tempDir + "/part=2/", Seq(2).toDF("id"))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDDLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDDLSuite.scala
@@ -134,7 +134,7 @@ abstract class DeltaDDLTestBase extends QueryTest with DeltaSQLTestUtils {
 
         intercept[InvariantViolationException] {
           Seq((2L, null)).toDF("a", "b")
-            .write.format("delta").mode("append").save(table.location.toString)
+            .write.format("delta").mode("append").save(table.location.getPath)
         }
       }
     }
@@ -286,7 +286,7 @@ abstract class DeltaDDLTestBase extends QueryTest with DeltaSQLTestUtils {
           spark.createDataFrame(
             Seq(Row(Row(2L, null), 2L)).asJava,
             schema
-          ).write.format("delta").mode("append").save(table.location.toString)
+          ).write.format("delta").mode("append").save(table.location.getPath)
         }
         verifyInvariantViolationException(e)
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -301,12 +301,12 @@ class DeltaLogSuite extends QueryTest
     withTempDir { dir =>
       val log = DeltaLog.forTable(spark, dir)
       assert(new File(log.logPath.toUri).mkdirs())
-      val path = new File(dir, "a/b/c").getCanonicalPath
+      val path = new File(dir, "a/b%c/d").toURI.toString
       val rm = RemoveFile(path, Some(System.currentTimeMillis()), dataChange = true)
       log.startTransaction().commitManually(rm)
 
-      val committedRemove = log.update(stalenessAcceptable = false).tombstones.collect()
-      assert(committedRemove.head.path === s"file://$path")
+      val committedRemove = log.update(stalenessAcceptable = false).tombstones.collect().head
+      assert(committedRemove.path === path)
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -537,7 +537,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
 
   test("Trigger.AvailableNow with an empty table") {
     withTempDirs { (inputDir, outputDir, checkpointDir) =>
-      sql(s"CREATE TABLE delta.`${inputDir.toURI}` (value STRING) USING delta")
+      sql(s"CREATE TABLE delta.`${inputDir.getCanonicalPath}` (value STRING) USING delta")
 
       val stream = spark.readStream
         .format("delta")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
@@ -2427,6 +2427,9 @@ trait DeltaTableCreationColumnMappingSuiteBase extends DeltaColumnMappingSelecte
 
 class DeltaTableCreationIdColumnMappingSuite extends DeltaTableCreationSuite
   with DeltaColumnMappingEnableIdMode {
+
+  override val defaultTempDirPrefix = "spark"
+
   override protected def getTableProperties(tableName: String): Map[String, String] = {
     // ignore comparing column mapping properties
     dropColumnMappingConfigurations(super.getTableProperties(tableName))
@@ -2435,6 +2438,8 @@ class DeltaTableCreationIdColumnMappingSuite extends DeltaTableCreationSuite
 
 class DeltaTableCreationNameColumnMappingSuite extends DeltaTableCreationSuite
   with DeltaColumnMappingEnableNameMode {
+  override val defaultTempDirPrefix = "spark"
+
   override protected def getTableProperties(tableName: String): Map[String, String] = {
     // ignore comparing column mapping properties
     dropColumnMappingConfigurations(super.getTableProperties(tableName))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/HiveConvertToDeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/HiveConvertToDeltaSuite.scala
@@ -130,7 +130,7 @@ abstract class HiveConvertToDeltaSuiteBase
 
   test("convert a Hive based external parquet table") {
     val tbl = "hive_parquet"
-    withTempDir { dir =>
+    withTempDir(prefix = "spark") { dir =>
       withTable(tbl) {
         sql(
           s"""

--- a/spark/src/test/scala/org/apache/spark/sql/delta/test/DeltaSQLTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/test/DeltaSQLTestUtils.scala
@@ -28,16 +28,19 @@ trait DeltaSQLTestUtils extends SQLTestUtils {
    *    without clear benefits.
    * 2. Allow creating paths with special characters for better test coverage.
    */
+
+  protected val defaultTempDirPrefix: String = "spark%dir%prefix"
+
   override protected def withTempDir(f: File => Unit): Unit = {
-    withTempDir(prefix = "spark")(f)
+    withTempDir(prefix = defaultTempDirPrefix)(f)
   }
 
   override protected def withTempPaths(numPaths: Int)(f: Seq[File] => Unit): Unit = {
-    withTempPaths(numPaths, prefix = "spark")(f)
+    withTempPaths(numPaths, prefix = defaultTempDirPrefix)(f)
   }
 
   override def withTempPath(f: File => Unit): Unit = {
-    withTempPath(prefix = "spark")(f)
+    withTempPath(prefix = defaultTempDirPrefix)(f)
   }
 
   /**


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Make DeltaSQLTestUtils use a default prefix for temporary directories that contains special chars and provides test coverage for URL-encoding of paths. In addition, update all Delta suites to inherit from DeltaSQLTestUtils instead of SQLTestUtils to use the temp dir overrides.

Finally, update a bunch of tests to correctly handle tests with special chars. A number of tests require further investigation and potential code fixes and will be handled in follow-up commits.

## How was this patch tested?

Test-only PR.

## Does this PR introduce _any_ user-facing changes?

No