### PR TITLE
[Uniform] Add support for Timestamp partition values, and move away from using partition string paths to using StructLike partition values in Iceberg..

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConversionTransaction.scala
@@ -97,9 +97,8 @@ class IcebergConversionTransaction(
           tablePath,
           partitionSpec,
           logicalToPhysicalPartitionNames,
-          postCommitSnapshot.statsSchema,
           statsParser,
-          postCommitSnapshot.deltaLog
+          postCommitSnapshot
         )
       )
     }
@@ -138,9 +137,8 @@ class IcebergConversionTransaction(
           tablePath,
           partitionSpec,
           logicalToPhysicalPartitionNames,
-          postCommitSnapshot.statsSchema,
           statsParser,
-          postCommitSnapshot.deltaLog
+          postCommitSnapshot
         )
       )
     }
@@ -148,7 +146,11 @@ class IcebergConversionTransaction(
     def remove(remove: RemoveFile): Unit = {
       overwriter.deleteFile(
         convertDeltaRemoveFileToIcebergDataFile(
-          remove, tablePath, partitionSpec, logicalToPhysicalPartitionNames)
+          remove,
+          tablePath,
+          partitionSpec,
+          logicalToPhysicalPartitionNames,
+          postCommitSnapshot)
       )
     }
   }
@@ -167,7 +169,11 @@ class IcebergConversionTransaction(
       val dataFilesToDelete = removes.map { f =>
         assert(!f.dataChange, "Rewrite operation should not add data")
         convertDeltaRemoveFileToIcebergDataFile(
-          f, tablePath, partitionSpec, logicalToPhysicalPartitionNames)
+          f,
+          tablePath,
+          partitionSpec,
+          logicalToPhysicalPartitionNames,
+          postCommitSnapshot)
       }.toSet.asJava
 
       val dataFilesToAdd = adds.map { f =>
@@ -177,9 +183,8 @@ class IcebergConversionTransaction(
           tablePath,
           partitionSpec,
           logicalToPhysicalPartitionNames,
-          postCommitSnapshot.statsSchema,
           statsParser,
-          postCommitSnapshot.deltaLog
+          postCommitSnapshot
         )
       }.toSet.asJava
 

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergTransactionUtils.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergTransactionUtils.scala
@@ -16,10 +16,13 @@
 
 package org.apache.spark.sql.delta.icebergShaded
 
+import java.nio.ByteBuffer
+import java.time.Instant
+
 import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 
-import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaConfig, DeltaConfigs, DeltaErrors, DeltaLog, DeltaRuntimeException}
+import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaConfig, DeltaConfigs, DeltaErrors, DeltaLog, Snapshot}
 import org.apache.spark.sql.delta.DeltaConfigs.parseCalendarInterval
 import org.apache.spark.sql.delta.actions.{AddFile, FileAction, RemoveFile}
 import org.apache.spark.sql.delta.metering.DeltaLogging
@@ -27,6 +30,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import shadedForDelta.org.apache.iceberg.{DataFile, DataFiles, FileFormat, PartitionSpec, Schema => IcebergSchema}
 import shadedForDelta.org.apache.iceberg.Metrics
+import shadedForDelta.org.apache.iceberg.StructLike
 import shadedForDelta.org.apache.iceberg.TableProperties
 
 // scalastyle:off import.ordering.noEmptyLine
@@ -35,7 +39,7 @@ import shadedForDelta.org.apache.iceberg.catalog.{Namespace, TableIdentifier => 
 import shadedForDelta.org.apache.iceberg.hive.HiveCatalog
 
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier => SparkTableIdentifier}
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{BinaryType, BooleanType, ByteType, DataType, DateType, DecimalType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, StructType, TimestampNTZType, TimestampType}
 import org.apache.spark.unsafe.types.CalendarInterval
 
 object IcebergTransactionUtils
@@ -58,66 +62,6 @@ object IcebergTransactionUtils
       }
       builder.build()
     }
-  }
-
-  def convertDeltaAddFileToIcebergDataFile(
-      add: AddFile,
-      tablePath: Path,
-      partitionSpec: PartitionSpec,
-      logicalToPhysicalPartitionNames: Map[String, String],
-      statsSchema: StructType,
-      statsParser: String => InternalRow,
-      deltaLog: DeltaLog): DataFile = {
-    if (add.deletionVector != null) {
-      throw new UnsupportedOperationException("No support yet for DVs")
-    }
-
-    var dataFileBuilder =
-      convertFileAction(add, tablePath, partitionSpec, logicalToPhysicalPartitionNames)
-        // Attempt to attach the number of records metric regardless of whether the Delta stats
-        // string is null/empty or not because this metric is required by Iceberg. If the number
-        // of records is both unavailable here and unavailable in the Delta stats, Iceberg will
-        // throw an exception when building the data file.
-        .withRecordCount(add.numLogicalRecords.getOrElse(-1L))
-
-    if (add.stats != null && add.stats.nonEmpty) {
-      try {
-        val statsRow = statsParser(add.stats)
-
-        val metricsConverter = IcebergStatsConverter(statsRow, statsSchema)
-        val metrics = new Metrics(
-          metricsConverter.numRecordsStat, // rowCount
-          null, // columnSizes
-          null, // valueCounts
-          metricsConverter.nullValueCountsStat.getOrElse(null).asJava, // nullValueCounts
-          null, // nanValueCounts
-          metricsConverter.lowerBoundsStat.getOrElse(null).asJava, // lowerBounds
-          metricsConverter.upperBoundsStat.getOrElse(null).asJava // upperBounds
-        )
-
-        dataFileBuilder = dataFileBuilder.withMetrics(metrics)
-      } catch {
-        case NonFatal(e) =>
-          logWarning("Failed to convert Delta stats to Iceberg stats. Iceberg conversion will " +
-          "attempt to proceed without stats.", e)
-      }
-    }
-
-    dataFileBuilder.build()
-  }
-
-  /**
-   * Note that APIs like [[shadedForDelta.org.apache.iceberg.OverwriteFiles#deleteFile]] take
-   * a DataFile, and not a DeleteFile as you might have expected.
-   */
-  def convertDeltaRemoveFileToIcebergDataFile(
-      remove: RemoveFile,
-      tablePath: Path,
-      partitionSpec: PartitionSpec,
-      logicalToPhysicalPartitionNames: Map[String, String]): DataFile = {
-    convertFileAction(remove, tablePath, partitionSpec, logicalToPhysicalPartitionNames)
-      .withRecordCount(remove.numLogicalRecords.getOrElse(0L))
-      .build()
   }
 
   /**
@@ -168,46 +112,151 @@ object IcebergTransactionUtils
     partitionSchema.fields.map(f => f.name -> DeltaColumnMapping.getPhysicalName(f)).toMap
   }
 
+  class Row (val values: Array[Any]) extends StructLike {
+    override def size: Int = values.length
+    override def get[T <: Any](pos: Int, javaClass: Class[T]): T = javaClass.cast(values(pos))
+    override def set[T <: Any](pos: Int, value: T): Unit = {
+      values(pos) = value
+    }
+  }
+
   ////////////////////
   // Helper Methods //
   ////////////////////
 
   /** Visible for testing. */
+  private[delta] def convertDeltaAddFileToIcebergDataFile(
+      add: AddFile,
+      tablePath: Path,
+      partitionSpec: PartitionSpec,
+      logicalToPhysicalPartitionNames: Map[String, String],
+      statsParser: String => InternalRow,
+      snapshot: Snapshot): DataFile = {
+    if (add.deletionVector != null) {
+      throw new UnsupportedOperationException("No support yet for DVs")
+    }
+
+    var dataFileBuilder =
+      convertFileAction(
+        add, tablePath, partitionSpec, logicalToPhysicalPartitionNames, snapshot)
+        // Attempt to attach the number of records metric regardless of whether the Delta stats
+        // string is null/empty or not because this metric is required by Iceberg. If the number
+        // of records is both unavailable here and unavailable in the Delta stats, Iceberg will
+        // throw an exception when building the data file.
+        .withRecordCount(add.numLogicalRecords.getOrElse(-1L))
+
+    try {
+      if (add.stats != null && add.stats.nonEmpty) {
+        dataFileBuilder = dataFileBuilder.withMetrics(
+          getMetricsForIcebergDataFile(statsParser, add.stats, snapshot.statsSchema))
+      }
+    } catch {
+      case NonFatal(e) =>
+        logWarning("Failed to convert Delta stats to Iceberg stats. Iceberg conversion will " +
+          "attempt to proceed without stats.", e)
+    }
+
+    dataFileBuilder.build()
+  }
+
+  private[delta] def convertDeltaRemoveFileToIcebergDataFile(
+      remove: RemoveFile,
+      tablePath: Path,
+      partitionSpec: PartitionSpec,
+      logicalToPhysicalPartitionNames: Map[String, String],
+      snapshot: Snapshot): DataFile = {
+    convertFileAction(
+      remove, tablePath, partitionSpec, logicalToPhysicalPartitionNames, snapshot)
+      .withRecordCount(remove.numLogicalRecords.getOrElse(0L))
+      .build()
+  }
+
   private[delta] def convertFileAction(
       f: FileAction,
       tablePath: Path,
       partitionSpec: PartitionSpec,
-      logicalToPhysicalPartitionNames: Map[String, String]): DataFiles.Builder = {
+      logicalToPhysicalPartitionNames: Map[String, String],
+      snapshot: Snapshot): DataFiles.Builder = {
     val absPath = canonicalizeFilePath(f, tablePath)
-
+    val schema = snapshot.schema
     var builder = DataFiles
       .builder(partitionSpec)
       .withPath(absPath)
       .withFileSizeInBytes(f.getFileSize)
       .withFormat(FileFormat.PARQUET)
+    val nameToDataTypes = schema.fields.map(f => f.name -> f.dataType).toMap
 
     if (partitionSpec.isPartitioned) {
       val ICEBERG_NULL_PARTITION_VALUE = "__HIVE_DEFAULT_PARTITION__"
-      val partitionPath = partitionSpec
-        .fields()
-        .asScala
-        .map(_.name)
-        .map { logicalPartCol =>
-          // The Iceberg Schema and PartitionSpec all use the column logical names.
-          // Delta FileAction::partitionValues, however, uses physical names.
-          val physicalPartKey = logicalToPhysicalPartitionNames(logicalPartCol)
+      val partitionPath = partitionSpec.fields()
+      val partitionVals = new Array[Any](partitionSpec.fields().size())
+      for (i <- partitionVals.indices) {
+        val logicalPartCol = partitionPath.get(i).name()
+        val physicalPartKey = logicalToPhysicalPartitionNames(logicalPartCol)
+        // ICEBERG_NULL_PARTITION_VALUE is referred in Iceberg lib to mark NULL partition value
+        val partValue = Option(f.partitionValues(physicalPartKey))
+          .getOrElse(ICEBERG_NULL_PARTITION_VALUE)
+        val partitionColumnDataType = nameToDataTypes(logicalPartCol)
+        val icebergPartitionValue =
+          stringToIcebergPartitionValue(partitionColumnDataType, partValue, snapshot.version)
+        partitionVals(i) = icebergPartitionValue
+      }
 
-          // ICEBERG_NULL_PARTITION_VALUE is referred in Iceberg lib to mark NULL partition value
-          val partValue = Option(f.partitionValues(physicalPartKey))
-            .getOrElse(ICEBERG_NULL_PARTITION_VALUE)
-          s"$logicalPartCol=$partValue"
-        }
-        .mkString("/")
+      builder = builder.withPartition(new Row(partitionVals))
+    }
+    builder
+  }
 
-      builder = builder.withPartitionPath(partitionPath)
+  /**
+   * Follows deserialization as specified here
+   * https://github.com/delta-io/delta/blob/master/PROTOCOL.md#Partition-Value-Serialization
+   */
+  private def stringToIcebergPartitionValue(
+      elemType: DataType,
+      partitionVal: String,
+      version: Long): Any = {
+    if (partitionVal == null || partitionVal == "__HIVE_DEFAULT_PARTITION__") {
+      return null
     }
 
-    builder
+    elemType match {
+      case _: StringType => partitionVal
+      case _: DateType =>
+        java.sql.Date.valueOf(partitionVal).toLocalDate.toEpochDay.asInstanceOf[Int]
+      case _: IntegerType => partitionVal.toInt.asInstanceOf[Integer]
+      case _: ShortType => partitionVal.toInt.asInstanceOf[Integer]
+      case _: ByteType => partitionVal.toInt.asInstanceOf[Integer]
+      case _: LongType => partitionVal.toLong
+      case _: BooleanType => partitionVal.toBoolean
+      case _: FloatType => partitionVal.toFloat
+      case _: DoubleType => partitionVal.toDouble
+      case _: DecimalType => new java.math.BigDecimal(partitionVal)
+      case _: BinaryType => ByteBuffer.wrap(partitionVal.getBytes("UTF-8"))
+      case _: TimestampNTZType =>
+        java.sql.Timestamp.valueOf(partitionVal).getNanos/1000.asInstanceOf[Long]
+      case _: TimestampType =>
+        Instant.parse(partitionVal).getNano/1000.asInstanceOf[Long]
+      case _ =>
+        throw DeltaErrors.universalFormatConversionFailedException(
+          version, "iceberg", "Unexpected partition data type " + elemType)
+    }
+  }
+
+  private def getMetricsForIcebergDataFile(
+      statsParser: String => InternalRow,
+      stats: String,
+      statsSchema: StructType): Metrics = {
+    val statsRow = statsParser(stats)
+    val metricsConverter = IcebergStatsConverter(statsRow, statsSchema)
+    new Metrics(
+      metricsConverter.numRecordsStat, // rowCount
+      null, // columnSizes
+      null, // valueCounts
+      metricsConverter.nullValueCountsStat.getOrElse(null).asJava, // nullValueCounts
+      null, // nanValueCounts
+      metricsConverter.lowerBoundsStat.getOrElse(null).asJava, // lowerBounds
+      metricsConverter.upperBoundsStat.getOrElse(null).asJava // upperBounds
+    )
   }
 
   /**

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -1156,6 +1156,12 @@
           "<schema>"
         ]
       },
+      "UNSUPPORTED_PARTITION_DATA_TYPE" : {
+        "message" : [
+          "IcebergCompatV<version> does not support the data type <dataType> for partition columns in your schema. Your partition schema:",
+          "<schema>"
+        ]
+      },
       "VERSION_MUTUAL_EXCLUSIVE" : {
         "message" : [
           "Only one IcebergCompat version can be enabled, please explicitly disable all other IcebergCompat versions that are not needed."

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3250,6 +3250,15 @@ trait DeltaErrorsBase
     )
   }
 
+  def icebergCompatUnsupportedPartitionDataTypeException(
+      version: Int, dataType: DataType, schema: StructType): Throwable = {
+    new DeltaUnsupportedOperationException(
+      errorClass = "DELTA_ICEBERG_COMPAT_VIOLATION.UNSUPPORTED_PARTITION_DATA_TYPE",
+      messageParameters = Array(version.toString, version.toString,
+        dataType.typeName, schema.treeString)
+    )
+  }
+
   def icebergCompatMissingRequiredTableFeatureException(
       version: Int, tf: TableFeature): Throwable = {
     new DeltaUnsupportedOperationException(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2ESuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uniform/UniFormE2ESuite.scala
@@ -37,6 +37,77 @@ abstract class UniFormE2EIcebergSuiteBase extends UniFormE2ETest {
     }
   }
 
+  test("Insert Partitioned Table") {
+    val partitionColumns = Array(
+      "str STRING",
+      "i INTEGER",
+      "l LONG",
+      "s SHORT",
+      "b BYTE",
+      "dt DATE",
+      "bin BINARY",
+      "bool BOOLEAN",
+      "ts_ntz TIMESTAMP_NTZ",
+      "ts TIMESTAMP")
+
+    val partitionValues: Array[Any] = Array(
+      "'some_value'",
+      1,
+      1234567L,
+      1000,
+      119,
+      "to_date('2016-12-31', 'yyyy-MM-dd')",
+      "'asdf'",
+      true,
+      "TIMESTAMP_NTZ'2021-12-06 00:00:00'",
+      "TIMESTAMP'2023-08-18 05:00:00UTC-7'"
+    )
+
+    partitionColumns zip partitionValues map {
+      partitionColumnsAndValues =>
+        val partitionColumnName =
+          partitionColumnsAndValues._1.split(" ")(0)
+        val tableName = testTableName + "_" + partitionColumnName
+        withTable(tableName) {
+          write(
+            s"""CREATE TABLE $tableName (${partitionColumnsAndValues._1}, col1 INT)
+               | USING DELTA
+               | PARTITIONED BY ($partitionColumnName)
+               | TBLPROPERTIES (
+               |  'delta.columnMapping.mode' = 'name',
+               |  'delta.enableIcebergCompatV2' = 'true',
+               |  'delta.universalFormat.enabledFormats' = 'iceberg'
+               |)""".stripMargin)
+          write(s"INSERT INTO $tableName VALUES (${partitionColumnsAndValues._2}, 123)")
+          val verificationQuery = s"SELECT col1 FROM $tableName " +
+            s"where ${partitionColumnName}=${partitionColumnsAndValues._2}"
+          // Verify against Delta read and Iceberg read
+          checkAnswer(spark.sql(verificationQuery), Seq(Row(123)))
+          checkAnswer(createReaderSparkSession.sql(verificationQuery), Seq(Row(123)))
+        }
+    }
+  }
+
+  test("Insert Partitioned Table - Multiple Partitions") {
+    withTable(testTableName) {
+      write(
+        s"""CREATE TABLE $testTableName (id int, ts timestamp, col1 INT)
+           | USING DELTA
+           | PARTITIONED BY (id, ts)
+           | TBLPROPERTIES (
+           |  'delta.columnMapping.mode' = 'name',
+           |  'delta.enableIcebergCompatV2' = 'true',
+           |  'delta.universalFormat.enabledFormats' = 'iceberg'
+           |)""".stripMargin)
+      write(s"INSERT INTO $testTableName VALUES (1, TIMESTAMP'2023-08-18 05:00:00UTC-7', 123)")
+      val verificationQuery = s"SELECT col1 FROM $testTableName " +
+        s"where id=1 and ts=TIMESTAMP'2023-08-18 05:00:00UTC-7'"
+      // Verify against Delta read and Iceberg read
+      checkAnswer(spark.sql(verificationQuery), Seq(Row(123)))
+      checkAnswer(createReaderSparkSession.sql(verificationQuery), Seq(Row(123)))
+    }
+  }
+
   test("CIUD") {
     withTable(testTableName) {
       write(


### PR DESCRIPTION
Uniform: Add support for Timestamp partition values, and move away from using partition string paths to using StructLike partition values in Iceberg..

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ X] Other Uniform

## Description
This change adds support for timestamp partition values in Delta Uniform and refactors to avoid using partition strings during partition value conversion from Delta->Iceberg. Instead, Delta partition values are deserialized and then converted Iceberg partition values which are stored in StructLike and passed to the DataFile builder during metadata conversion.

## How was this patch tested?

Added unit test which tests different partition data types in addition to the new support for timestamp partitions.

## Does this PR introduce _any_ user-facing changes?

Before this change, the table could successfully be created but writes to the table with timestamp partition would fail. Now, writes to the table with the timestamp partition value will succeed.
