### PR TITLE
[Spark][Kernel] Pass table identifier in Coordinated Commits

### DIFF
--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultCommitCoordinatorClientHandler.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/engine/DefaultCommitCoordinatorClientHandler.java
@@ -95,7 +95,7 @@ public class DefaultCommitCoordinatorClientHandler implements CommitCoordinatorC
     //  table identifier into `CommitCoordinatorClient` in all APIs.
     return commitCoordinatorClient.registerTable(
         new Path(logPath),
-        Optional.empty(),
+        Optional.empty() /* table identfier */,
         currentVersion,
         StorageKernelAPIAdapter.toStorageAbstractMetadata(currentMetadata),
         StorageKernelAPIAdapter.toStorageAbstractProtocol(currentProtocol));
@@ -116,7 +116,7 @@ public class DefaultCommitCoordinatorClientHandler implements CommitCoordinatorC
           commitCoordinatorClient.commit(
               logStore,
               hadoopConf,
-              new TableDescriptor(path, Optional.empty(), tableConf),
+              new TableDescriptor(path, Optional.empty() /* table identfier */, tableConf),
               commitVersion,
               new Iterator<String>() {
                 @Override
@@ -149,7 +149,8 @@ public class DefaultCommitCoordinatorClientHandler implements CommitCoordinatorC
       throws IOException {
     Path path = new Path(logPath);
     LogStore logStore = LogStoreProvider.getLogStore(hadoopConf, path.toUri().getScheme());
-    TableDescriptor tableDesc = new TableDescriptor(path, Optional.empty(), tableConf);
+    TableDescriptor tableDesc =
+        new TableDescriptor(path, Optional.empty() /* table identfier */, tableConf);
     commitCoordinatorClient.backfillToVersion(
         logStore, hadoopConf, tableDesc, version, lastKnownBackfilledVersion);
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -361,7 +361,9 @@ trait Checkpoints extends DeltaLogging {
     //   00015.json
     //   00016.json
     //   00018.checkpoint.parquet
-    snapshotToCheckpoint.ensureCommitFilesBackfilled()
+    // TODO(table-identifier-plumbing): Plumb the right tableIdentifier from the Checkpoint Hook
+    //  and pass it to `ensureCommitFilesBackfilled`.
+    snapshotToCheckpoint.ensureCommitFilesBackfilled(tableIdentifierOpt = None)
     Checkpoints.writeCheckpoint(spark, this, snapshotToCheckpoint)
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -38,6 +38,7 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 
 import org.apache.spark.internal.{MDC, MessageWithContext}
 import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.Utils
@@ -572,7 +573,7 @@ class Snapshot(
    * @throws IllegalStateException
    *   if the delta file for the current version is not found after backfilling.
    */
-  def ensureCommitFilesBackfilled(): Unit = {
+  def ensureCommitFilesBackfilled(tableIdentifierOpt: Option[TableIdentifier]): Unit = {
     val tableCommitCoordinatorClient = getTableCommitCoordinatorForWrites.getOrElse {
       return
     }
@@ -580,6 +581,7 @@ class Snapshot(
     if (minUnbackfilledVersion <= version) {
       val hadoopConf = deltaLog.newDeltaHadoopConf()
       tableCommitCoordinatorClient.backfillToVersion(
+        tableIdentifierOpt,
         version,
         lastKnownBackfilledVersion = Some(minUnbackfilledVersion - 1))
       val fs = deltaLog.logPath.getFileSystem(hadoopConf)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -174,9 +174,13 @@ trait SnapshotManagement { self: DeltaLog =>
 
     // Submit a potential async call to get commits from commit coordinator if available
     val threadPool = SnapshotManagement.commitCoordinatorGetCommitsThreadPool
+    // TODO(table-identifier-plumbing): Plumb the right tableIdentifier from the deltaLog.update and
+    // Cold deltaLog initialization codepath.
+    val tableIdentifierOpt = None
     def getCommitsTask(isAsyncRequest: Boolean): GetCommitsResponse = {
       CoordinatedCommitsUtils.getCommitsFromCommitCoordinatorWithUsageLogs(
-        this, tableCommitCoordinatorClient, startVersion, versionToLoad, isAsyncRequest)
+        this, tableCommitCoordinatorClient, tableIdentifierOpt,
+        startVersion, versionToLoad, isAsyncRequest)
     }
     val unbackfilledCommitsResponseFuture =
       if (threadPool.getActiveCount < threadPool.getMaximumPoolSize) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/TableCommitCoordinatorClient.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/TableCommitCoordinatorClient.scala
@@ -16,8 +16,6 @@
 
 package org.apache.spark.sql.delta.coordinatedcommits
 
-import java.util.Optional
-
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.delta.DeltaLog

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogMinorCompactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogMinorCompactionSuite.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsBaseSuite
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, FileNames}
 import org.apache.hadoop.fs.Path
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta
 
 import java.io.{BufferedReader, File, InputStreamReader, IOException}
 import java.nio.charset.StandardCharsets
-import java.util.Locale
+import java.util.{Locale, Optional}
 
 import scala.collection.JavaConverters._
 import scala.language.postfixOps
@@ -34,6 +34,7 @@ import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import io.delta.storage.commit.TableDescriptor
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.fs.permission.FsPermission
 
@@ -506,8 +507,9 @@ class DeltaLogSuite extends QueryTest
         // file.
         val oc = CommitCoordinatorProvider.getCommitCoordinatorClient(
           "tracking-in-memory", Map.empty[String, String], spark)
-        val commitResponse = oc.getCommits(
-          deltaLog.logPath, Map.empty[String, String].asJava, 2, null)
+        val tableDesc =
+          new TableDescriptor(deltaLog.logPath, Optional.empty(), Map.empty[String, String].asJava)
+        val commitResponse = oc.getCommits(tableDesc, 2, null)
         if (!commitResponse.getCommits.isEmpty) {
           val path = commitResponse.getCommits.asScala.last.getFileStatus.getPath
           fs.delete(path, true)
@@ -619,8 +621,9 @@ class DeltaLogSuite extends QueryTest
         // file.
         val oc = CommitCoordinatorProvider.getCommitCoordinatorClient(
           "tracking-in-memory", Map.empty[String, String], spark)
-        val commitResponse = oc.getCommits(
-          log.logPath, Map.empty[String, String].asJava, 1, null)
+        val tableDesc =
+          new TableDescriptor(log.logPath, Optional.empty(), Map.empty[String, String].asJava)
+        val commitResponse = oc.getCommits(tableDesc, 1, null)
         if (!commitResponse.getCommits.isEmpty) {
           commitFilePath = commitResponse.getCommits.asScala.head.getFileStatus.getPath
         }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.delta.actions.{Action, CommitInfo}
 import org.apache.spark.sql.delta.coordinatedcommits.{CommitCoordinatorProvider, CoordinatedCommitsBaseSuite, CoordinatedCommitsTestUtils, TrackingInMemoryCommitCoordinatorBuilder}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, FileNames, JsonUtils}
 import org.apache.hadoop.fs.Path
 
@@ -1016,7 +1017,7 @@ class InCommitTimestampWithCoordinatedCommitsSuite
       val commitFileProvider = DeltaCommitFileProvider(deltaLog.update())
       val unbackfilledCommits =
         tableCommitCoordinatorClient
-          .getCommits(Some(1))
+          .getCommits(Some(1L))
           .getCommits.asScala
           .map { commit => DeltaHistoryManager.Commit(commit.getVersion, commit.getCommitTimestamp)}
       val commits = (Seq(commit0) ++ unbackfilledCommits).toList

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -18,7 +18,6 @@ package org.apache.spark.sql.delta
 
 // scalastyle:off import.ordering.noEmptyLine
 import java.nio.file.FileAlreadyExistsException
-import java.util.Optional
 
 import com.databricks.spark.util.Log4jUsageLogger
 import org.apache.spark.sql.delta.DeltaOperations.ManualUpdate

--- a/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, FileNames, JsonUtils}
 import io.delta.storage.LogStore
-import io.delta.storage.commit.{Commit, CommitCoordinatorClient, GetCommitsResponse}
+import io.delta.storage.commit.{Commit, CommitCoordinatorClient, GetCommitsResponse, TableDescriptor}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.FileStatus
 import org.apache.hadoop.fs.Path
@@ -546,8 +546,7 @@ case class ConcurrentBackfillCommitCoordinatorClient(
 ) extends InMemoryCommitCoordinator(batchSize) {
   private val deferredBackfills: mutable.Map[Long, () => Unit] = mutable.Map.empty
   override def getCommits(
-      logPath: Path,
-      coordinatedCommitsTableConf: java.util.Map[String, String],
+      tableDesc: TableDescriptor,
       startVersion: java.lang.Long,
       endVersion: java.lang.Long): GetCommitsResponse = {
     if (ConcurrentBackfillCommitCoordinatorClient.beginConcurrentBackfills) {
@@ -556,7 +555,7 @@ case class ConcurrentBackfillCommitCoordinatorClient(
       deferredBackfills.keys.toSeq.sorted.foreach((version: Long) => deferredBackfills(version)())
       deferredBackfills.clear()
     }
-    super.getCommits(logPath, coordinatedCommitsTableConf, startVersion, endVersion)
+    super.getCommits(tableDesc, startVersion, endVersion)
   }
   override def backfill(
       logStore: LogStore,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CommitCoordinatorClientImplSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CommitCoordinatorClientImplSuiteBase.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.actions.{CommitInfo, Metadata, Protocol}
 import org.apache.spark.sql.delta.storage.{LogStore, LogStoreProvider}
 import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.FileNames
 import org.apache.spark.sql.delta.util.threads.DeltaThreadPool
 import io.delta.dynamodbcommitcoordinator.DynamoDBCommitCoordinatorClient

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CommitCoordinatorClientSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CommitCoordinatorClientSuite.scala
@@ -16,6 +16,8 @@
 
 package org.apache.spark.sql.delta.coordinatedcommits
 
+import java.util.Optional
+
 import scala.collection.JavaConverters._
 import scala.reflect.runtime.universe._
 
@@ -24,7 +26,7 @@ import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
 import io.delta.storage.LogStore
-import io.delta.storage.commit.{CommitCoordinatorClient, CommitResponse, GetCommitsResponse => JGetCommitsResponse, UpdatedActions}
+import io.delta.storage.commit.{CommitCoordinatorClient, CommitResponse, GetCommitsResponse => JGetCommitsResponse, TableDescriptor, TableIdentifier, UpdatedActions}
 import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
@@ -39,8 +41,7 @@ class CommitCoordinatorClientSuite extends QueryTest with DeltaSQLTestUtils with
     override def commit(
         logStore: LogStore,
         hadoopConf: Configuration,
-        logPath: Path,
-        coordinatedCommitsTableConf: java.util.Map[String, String],
+        tableDesc: TableDescriptor,
         commitVersion: Long,
         actions: java.util.Iterator[String],
         updatedActions: UpdatedActions): CommitResponse = {
@@ -48,8 +49,7 @@ class CommitCoordinatorClientSuite extends QueryTest with DeltaSQLTestUtils with
     }
 
     override def getCommits(
-        logPath: Path,
-        coordinatedCommitsTableConf: java.util.Map[String, String],
+        tableDesc: TableDescriptor,
         startVersion: java.lang.Long,
         endVersion: java.lang.Long): JGetCommitsResponse =
       new JGetCommitsResponse(Seq.empty.asJava, -1)
@@ -57,13 +57,13 @@ class CommitCoordinatorClientSuite extends QueryTest with DeltaSQLTestUtils with
     override def backfillToVersion(
         logStore: LogStore,
         hadoopConf: Configuration,
-        logPath: Path,
-        coordinatedCommitsTableConf: java.util.Map[String, String],
+        tableDesc: TableDescriptor,
         version: Long,
         lastKnownBackfilledVersion: java.lang.Long): Unit = {}
 
     override def registerTable(
         logPath: Path,
+        tableIdentifier: Optional[TableIdentifier],
         currentVersion: Long,
         currentMetadata: AbstractMetadata,
         currentProtocol: AbstractProtocol): java.util.Map[String, String] =

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsTestUtils.scala
@@ -16,6 +16,7 @@
 
 package org.apache.spark.sql.delta.coordinatedcommits
 
+import java.util.Optional
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.apache.spark.sql.delta.{DeltaConfigs, DeltaLog, DeltaTestUtilsBase}
@@ -23,7 +24,7 @@ import org.apache.spark.sql.delta.DeltaConfigs.COORDINATED_COMMITS_COORDINATOR_N
 import org.apache.spark.sql.delta.actions.{Action, CommitInfo, Metadata, Protocol}
 import org.apache.spark.sql.delta.util.JsonUtils
 import io.delta.storage.LogStore
-import io.delta.storage.commit.{CommitCoordinatorClient, CommitResponse, GetCommitsResponse => JGetCommitsResponse, UpdatedActions}
+import io.delta.storage.commit.{CommitCoordinatorClient, CommitResponse, GetCommitsResponse => JGetCommitsResponse, TableDescriptor, TableIdentifier, UpdatedActions}
 import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
@@ -246,42 +247,36 @@ class TrackingCommitCoordinatorClient(
   override def commit(
       logStore: LogStore,
       hadoopConf: Configuration,
-      logPath: Path,
-      coordinatedCommitsTableConf: java.util.Map[String, String],
+      tableDesc: TableDescriptor,
       commitVersion: Long,
       actions: java.util.Iterator[String],
       updatedActions: UpdatedActions): CommitResponse = recordOperation("commit") {
     delegatingCommitCoordinatorClient.commit(
       logStore,
       hadoopConf,
-      logPath,
-      coordinatedCommitsTableConf,
+      tableDesc,
       commitVersion,
       actions,
       updatedActions)
   }
 
   override def getCommits(
-      logPath: Path,
-      coordinatedCommitsTableConf: java.util.Map[String, String],
+      tableDesc: TableDescriptor,
       startVersion: java.lang.Long,
       endVersion: java.lang.Long): JGetCommitsResponse = recordOperation("getCommits") {
-    delegatingCommitCoordinatorClient.getCommits(
-      logPath, coordinatedCommitsTableConf, startVersion, endVersion)
+    delegatingCommitCoordinatorClient.getCommits(tableDesc, startVersion, endVersion)
   }
 
   override def backfillToVersion(
       logStore: LogStore,
       hadoopConf: Configuration,
-      logPath: Path,
-      coordinatedCommitsTableConf: java.util.Map[String, String],
+      tableDesc: TableDescriptor,
       version: Long,
       lastKnownBackfilledVersion: java.lang.Long): Unit = recordOperation("backfillToVersion") {
     delegatingCommitCoordinatorClient.backfillToVersion(
       logStore,
       hadoopConf,
-      logPath,
-      coordinatedCommitsTableConf,
+      tableDesc,
       version,
       lastKnownBackfilledVersion)
   }
@@ -304,12 +299,13 @@ class TrackingCommitCoordinatorClient(
 
   override def registerTable(
       logPath: Path,
+      tableIdentifier: Optional[TableIdentifier],
       currentVersion: Long,
       currentMetadata: AbstractMetadata,
       currentProtocol: AbstractProtocol): java.util.Map[String, String] =
     recordOperation("registerTable") {
       delegatingCommitCoordinatorClient.registerTable(
-        logPath, currentVersion, currentMetadata, currentProtocol)
+        logPath, tableIdentifier, currentVersion, currentMetadata, currentProtocol)
     }
 }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryCommitCoordinatorSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/InMemoryCommitCoordinatorSuite.scala
@@ -16,10 +16,13 @@
 
 package org.apache.spark.sql.delta.coordinatedcommits
 
+import java.util.Optional
+
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.actions.Protocol
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import io.delta.storage.commit.{GetCommitsResponse => JGetCommitsResponse}
 import org.apache.hadoop.fs.Path
 
@@ -29,7 +32,8 @@ abstract class InMemoryCommitCoordinatorSuite(batchSize: Int)
   override protected def createTableCommitCoordinatorClient(
       deltaLog: DeltaLog): TableCommitCoordinatorClient = {
     val cs = InMemoryCommitCoordinatorBuilder(batchSize).build(spark, Map.empty)
-    val conf = cs.registerTable(deltaLog.logPath, -1L, initMetadata, Protocol(1, 1))
+    val conf = cs.registerTable(
+      deltaLog.logPath, Optional.empty(), -1L, initMetadata, Protocol(1, 1))
     TableCommitCoordinatorClient(cs, deltaLog, conf.asScala.toMap)
   }
 

--- a/storage/src/main/java/io/delta/storage/commit/CommitCoordinatorClient.java
+++ b/storage/src/main/java/io/delta/storage/commit/CommitCoordinatorClient.java
@@ -19,6 +19,7 @@ package io.delta.storage.commit;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 
 import io.delta.storage.commit.actions.AbstractMetadata;
 import io.delta.storage.commit.actions.AbstractProtocol;
@@ -51,13 +52,15 @@ public interface CommitCoordinatorClient {
    * the upgrade commit needs to be a file system commit which will write the backfilled file
    * directly.
    *
-   * @param logPath The path to the delta log of the table that should be converted
-   * @param currentVersion The currentTableVersion is the version of the table just before
-   *                       conversion. currentTableVersion + 1 represents the commit that
-   *                       will do the conversion. This must be backfilled atomically.
-   *                       currentTableVersion + 2 represents the first commit after conversion.
-   *                       This will go through the CommitCoordinatorClient and the client is
-   *                       free to choose when it wants to backfill this commit.
+   * @param logPath         The path to the delta log of the table that should be converted
+   * @param tableIdentifier The optional tableIdentifier for the table. Some commit coordinators may
+   *                         choose to make this compulsory and error out if this is not provided.
+   * @param currentVersion  The currentTableVersion is the version of the table just before
+   *                        conversion. currentTableVersion + 1 represents the commit that
+   *                        will do the conversion. This must be backfilled atomically.
+   *                        currentTableVersion + 2 represents the first commit after conversion.
+   *                        This will go through the CommitCoordinatorClient and the client is
+   *                        free to choose when it wants to backfill this commit.
    * @param currentMetadata The metadata of the table at currentTableVersion
    * @param currentProtocol The protocol of the table at currentTableVersion
    * @return A map of key-value pairs which is issued by the commit coordinator to identify the
@@ -67,6 +70,7 @@ public interface CommitCoordinatorClient {
    */
   Map<String, String> registerTable(
     Path logPath,
+    Optional<TableIdentifier> tableIdentifier,
     long currentVersion,
     AbstractMetadata currentMetadata,
     AbstractProtocol currentProtocol);
@@ -75,15 +79,13 @@ public interface CommitCoordinatorClient {
    * API to commit the given set of actions to the table represented by logPath at the
    * given commitVersion.
    *
-   * @param logStore The log store to use for writing the commit file.
-   * @param hadoopConf The Hadoop configuration required to access the file system.
-   * @param logPath The path to the delta log of the table that should be committed to.
-   * @param tableConf The table configuration that was returned by the commit coordinator
-   *                  client during registration.
-   * @param commitVersion The version of the commit that is being committed.
-   * @param actions The actions that need to be committed.
-   * @param updatedActions The commit info and any metadata or protocol changes that are made
-   *                       as part of this commit.
+   * @param logStore        The log store to use for writing the commit file.
+   * @param hadoopConf      The Hadoop configuration required to access the file system.
+   * @param tableDescriptor The descriptor for the table.
+   * @param commitVersion   The version of the commit that is being committed.
+   * @param actions         The actions that need to be committed.
+   * @param updatedActions  The commit info and any metadata or protocol changes that are made
+   *                        as part of this commit.
    * @return CommitResponse which contains the file status of the committed commit file. If the
    *         commit is already backfilled, then the file status could be omitted from the response
    *         and the client could retrieve the information by itself.
@@ -92,8 +94,7 @@ public interface CommitCoordinatorClient {
   CommitResponse commit(
     LogStore logStore,
     Configuration hadoopConf,
-    Path logPath,
-    Map<String, String> tableConf,
+    TableDescriptor tableDescriptor,
     long commitVersion,
     Iterator<String> actions,
     UpdatedActions updatedActions) throws CommitFailedException;
@@ -111,18 +112,14 @@ public interface CommitCoordinatorClient {
    * coordinator. Note that returning latestTableVersion as -1 is acceptable only if the commit
    * coordinator never ratified any version, i.e. it never accepted any unbackfilled commit.
    *
-   * @param logPath The path to the delta log of the table for which the unbackfilled
-   *                  commits should be retrieved.
-   * @param tableConf The table configuration that was returned by the commit coordinator
-   *                  during registration.
-   * @param startVersion The minimum version of the commit that should be returned. Can be null.
-   * @param endVersion The maximum version of the commit that should be returned. Can be null.
-   * @return GetCommitsResponse which has a list of {@link Commit}s and the latestTableVersion which is
-   *         tracked by {@link CommitCoordinatorClient}.
+   * @param tableDescriptor The descriptor for the table.
+   * @param startVersion    The minimum version of the commit that should be returned. Can be null.
+   * @param endVersion      The maximum version of the commit that should be returned. Can be null.
+   * @return GetCommitsResponse which has a list of {@link Commit}s and the latestTableVersion which
+   *         is tracked by {@link CommitCoordinatorClient}.
    */
   GetCommitsResponse getCommits(
-    Path logPath,
-    Map<String, String> tableConf,
+    TableDescriptor tableDescriptor,
     Long startVersion,
     Long endVersion);
 
@@ -133,12 +130,11 @@ public interface CommitCoordinatorClient {
    * If this API returns successfully, that means the backfill must have been completed, although
    * the commit coordinator may not be aware of it yet.
    *
-   * @param logStore The log store to use for writing the backfilled commits.
-   * @param hadoopConf The Hadoop configuration required to access the file system.
-   * @param logPath The path to the delta log of the table that should be backfilled.
-   * @param tableConf The table configuration that was returned by the commit coordinator
-   *                  during registration.
-   * @param version The version till which the commit coordinator client should backfill.
+   * @param logStore                   The log store to use for writing the backfilled commits.
+   * @param hadoopConf                 The Hadoop configuration required to access the file system.
+   * @param tableDescriptor            The descriptor for the table.
+   * @param version                    The version till which the commit coordinator client should
+   *                                   backfill.
    * @param lastKnownBackfilledVersion The last known version that was backfilled before this API
    *                                   was called. If it is None or invalid, then the commit
    *                                   coordinator client should backfill from the beginning of
@@ -148,8 +144,7 @@ public interface CommitCoordinatorClient {
   void backfillToVersion(
     LogStore logStore,
     Configuration hadoopConf,
-    Path logPath,
-    Map<String, String> tableConf,
+    TableDescriptor tableDescriptor,
     long version,
     Long lastKnownBackfilledVersion) throws IOException;
 

--- a/storage/src/main/java/io/delta/storage/commit/CommitFailedException.java
+++ b/storage/src/main/java/io/delta/storage/commit/CommitFailedException.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.fs.Path;
 
 /**
  * Exception raised by
- * {@link io.delta.storage.commit.CommitCoordinatorClient#commit(LogStore, Configuration, Path, Map, long, Iterator, UpdatedActions)}
+ * {@link CommitCoordinatorClient#commit(LogStore, Configuration, TableDescriptor, long, Iterator, UpdatedActions)}
  *
  * <pre>
  *  | retryable | conflict  | meaning                                                         |

--- a/storage/src/main/java/io/delta/storage/commit/CommitResponse.java
+++ b/storage/src/main/java/io/delta/storage/commit/CommitResponse.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.fs.Path;
 
 /**
  * Response container for
- * {@link io.delta.storage.commit.CommitCoordinatorClient#commit(LogStore, Configuration, Path, Map, long, Iterator, UpdatedActions)}.
+ * {@link CommitCoordinatorClient#commit(LogStore, Configuration, TableDescriptor, long, Iterator, UpdatedActions)}.
  */
 public class CommitResponse {
 

--- a/storage/src/main/java/io/delta/storage/commit/GetCommitsResponse.java
+++ b/storage/src/main/java/io/delta/storage/commit/GetCommitsResponse.java
@@ -23,7 +23,7 @@ import org.apache.hadoop.fs.Path;
 
 /**
  * Response container for
- * {@link io.delta.storage.commit.CommitCoordinatorClient#getCommits(Path, Map, Long, Long)}.
+ * {@link CommitCoordinatorClient#getCommits(TableDescriptor, Long, Long)}.
  */
 public class GetCommitsResponse {
 

--- a/storage/src/main/java/io/delta/storage/commit/TableDescriptor.java
+++ b/storage/src/main/java/io/delta/storage/commit/TableDescriptor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.hadoop.fs.Path;
+
+/**
+ * Container for all the info to uniquely identify the table
+ */
+public class TableDescriptor {
+
+    private Path logPath;
+    private Optional<TableIdentifier> tableIdentifier;
+
+    private Map<String, String> tableConf;
+
+    public TableDescriptor(Path logPath, Optional<TableIdentifier> tableIdentifier, Map<String, String> tableConf) {
+        this.logPath = logPath;
+        this.tableIdentifier = tableIdentifier;
+        this.tableConf = tableConf;
+    }
+
+    public Optional<TableIdentifier> getTableIdentifier() {
+        return tableIdentifier;
+    }
+
+    public Path getLogPath() {
+        return logPath;
+    }
+
+    public Map<String, String> getTableConf() {
+        return tableConf;
+    }
+}

--- a/storage/src/main/java/io/delta/storage/commit/TableIdentifier.java
+++ b/storage/src/main/java/io/delta/storage/commit/TableIdentifier.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.storage.commit;
+
+/**
+ * Identifier for a table.
+ */
+public class TableIdentifier {
+
+    // The name of the table.
+    private String name;
+
+    // The namespace of the table. e.g. <catalog> / <schema>
+    private String[] namespace;
+
+    public TableIdentifier(String[] namespace, String name) {
+        this.namespace = namespace;
+        this.name = name;
+    }
+
+    public TableIdentifier(String firstName, String... rest) {
+        String[] namespace = new String[rest.length];
+        String name;
+        if (rest.length > 0) {
+            name = rest[rest.length-1];
+            namespace[0] = firstName;
+            System.arraycopy(rest, 0, namespace, 1, rest.length-1);
+        } else {
+            name = firstName;
+        }
+        this.namespace = namespace;
+        this.name = name;
+    }
+
+    /**
+     * Returns the namespace of the table.
+     */
+    public String[] getNamespace() {
+        return namespace;
+    }
+
+    /**
+     * Returns the name of the table.
+     */
+    public String getName() {
+        return name;
+    }
+}


### PR DESCRIPTION

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

This PR adds TableIdentifier in the Coordinated Commit Interface.

There will be a separate change to pass the tableName reliably to the Commit Coordinator in delta-spark.

## How was this patch tested?

Existing UTs

## Does this PR introduce _any_ user-facing changes?

No