### PR TITLE
[3.2] always include CatalogTable#storage#properties into data source options

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -89,7 +89,21 @@ case class DeltaTableV2(
   // in cases where we will fallback to the V1 behavior.
   lazy val deltaLog: DeltaLog = {
     DeltaTableV2.withEnrichedUnsupportedTableException(catalogTable, tableIdentifier) {
-      DeltaLog.forTable(spark, rootPath, options)
+      // Ideally the table storage properties should always be the same as the options load from
+      // the Delta log, as Delta CREATE TABLE command guarantees it. However, custom catalogs such
+      // as Unity Catalog may add more table storage properties on the fly. We should respect it
+      // and merge the table storage properties and Delta options.
+      val dataSourceOptions = if (catalogTable.isDefined) {
+        // To be safe, here we only extra file system options from table storage properties and
+        // the original `options` has higher priority than the table storage properties.
+        val fileSystemOptions = catalogTable.get.storage.properties.filter { case (k, _) =>
+          DeltaTableUtils.validDeltaTableHadoopPrefixes.exists(k.startsWith)
+        }
+        fileSystemOptions ++ options
+      } else {
+        options
+      }
+      DeltaLog.forTable(spark, rootPath, dataSourceOptions)
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CustomCatalogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CustomCatalogSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.delta
 import scala.collection.JavaConverters._
 
 // scalastyle:off import.ordering.noEmptyLine
-import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.catalog.{DeltaCatalog, DeltaTableV2}
 import org.apache.spark.sql.delta.commands._
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.hadoop.fs.{FileSystem, Path}
@@ -34,7 +34,6 @@ import org.apache.spark.sql.catalyst.plans.logical.{AppendData, LogicalPlan, Set
 import org.apache.spark.sql.catalyst.trees.UnaryLike
 import org.apache.spark.sql.connector.catalog.{DelegatingCatalogExtension, Identifier, InMemoryTable, InMemoryTableCatalog, Table, TableCatalog, TableChange, V1Table}
 import org.apache.spark.sql.connector.expressions.Transform
-import org.apache.spark.sql.delta.catalog.DeltaCatalog
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, V2SessionCatalog}
 import org.apache.spark.sql.test.SharedSparkSession

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CustomCatalogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CustomCatalogSuite.scala
@@ -32,10 +32,11 @@ import org.apache.spark.sql.catalyst.analysis.ResolvedTable
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTable, CatalogTableType}
 import org.apache.spark.sql.catalyst.plans.logical.{AppendData, LogicalPlan, SetTableProperties, UnaryNode, UnsetTableProperties}
 import org.apache.spark.sql.catalyst.trees.UnaryLike
-import org.apache.spark.sql.connector.catalog.{Identifier, Table, TableCatalog, TableChange}
+import org.apache.spark.sql.connector.catalog.{DelegatingCatalogExtension, Identifier, InMemoryTable, InMemoryTableCatalog, Table, TableCatalog, TableChange, V1Table}
 import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.delta.catalog.DeltaCatalog
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
-import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, V2SessionCatalog}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
@@ -281,6 +282,21 @@ class CustomCatalogSuite extends QueryTest with SharedSparkSession
     }
   }
 
+  test("custom catalog that adds additional table storage properties") {
+    // Reset catalog manager so that the new `spark_catalog` implementation can apply.
+    spark.sessionState.catalogManager.reset()
+    withSQLConf("spark.sql.catalog.spark_catalog" -> classOf[DummySessionCatalog].getName) {
+      withTable("t") {
+        withTempPath { path =>
+          spark.range(10).write.format("delta").save(path.getCanonicalPath)
+          sql(s"CREATE TABLE t (id LONG) USING delta LOCATION '${path.getCanonicalPath}'")
+          val t = spark.sessionState.catalogManager.v2SessionCatalog.asInstanceOf[TableCatalog]
+            .loadTable(Identifier.of(Array("default"), "t")).asInstanceOf[DeltaTableV2]
+          assert(t.deltaLog.options("fs.myKey") == "val")
+        }
+      }
+    }
+  }
 }
 
 class DummyCatalog extends TableCatalog {
@@ -364,5 +380,58 @@ class DummyCatalog extends TableCatalog {
       storage = CatalogStorageFormat(Some(tablePath.toUri), None, None, None, false, Map.empty),
       schema = spark.range(0).schema
     )
+  }
+}
+
+// A dummy catalog that adds additional table storage properties after the table is loaded.
+// It's only used inside `DummySessionCatalog`.
+class DummySessionCatalogInner extends DelegatingCatalogExtension {
+  override def loadTable(ident: Identifier): Table = {
+    val t = super.loadTable(ident).asInstanceOf[V1Table]
+    V1Table(t.v1Table.copy(
+      storage = t.v1Table.storage.copy(
+        properties = t.v1Table.storage.properties ++ Map("fs.myKey" -> "val")
+      )
+    ))
+  }
+}
+
+// A dummy catalog that adds a layer between DeltaCatalog and the Spark SessionCatalog,
+// to attach additional table storage properties after the table is loaded.
+class DummySessionCatalog extends TableCatalog {
+  private var deltaCatalog: DelegatingCatalogExtension = null
+
+  override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
+    val inner = new DummySessionCatalogInner()
+    inner.setDelegateCatalog(new V2SessionCatalog(
+      SparkSession.active.sessionState.catalogManager.v1SessionCatalog))
+    deltaCatalog = new DeltaCatalog()
+    deltaCatalog.setDelegateCatalog(inner)
+  }
+
+  override def name(): String = deltaCatalog.name()
+
+  override def listTables(namespace: Array[String]): Array[Identifier] = {
+    deltaCatalog.listTables(namespace)
+  }
+
+  override def loadTable(ident: Identifier): Table = deltaCatalog.loadTable(ident)
+
+  override def createTable(
+      ident: Identifier,
+      schema: StructType,
+      partitions: Array[Transform],
+      properties: java.util.Map[String, String]): Table = {
+    deltaCatalog.createTable(ident, schema, partitions, properties)
+  }
+
+  override def alterTable(ident: Identifier, changes: TableChange*): Table = {
+    deltaCatalog.alterTable(ident, changes: _*)
+  }
+
+  override def dropTable(ident: Identifier): Boolean = deltaCatalog.dropTable(ident)
+
+  override def renameTable(oldIdent: Identifier, newIdent: Identifier): Unit = {
+    deltaCatalog.renameTable(oldIdent, newIdent)
   }
 }


### PR DESCRIPTION
backport https://github.com/delta-io/delta/pull/3536 . It's a clean cherry-pick

<!--
Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
5. If possible, provide a concise example to reproduce the issue for a faster review.
6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

`DeltaTableV2` uses the options to create `DeltaLog`, assuming that the options should always be consistent with the one in `CatalogTable#storage#properties`. This may not be true as custom catalogs may add more table storage properties on the fly, like Unity Catalog.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why. -->

Tested locally with UC. It's not an issue for HMS.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no