### PR TITLE
[Kernel] Change string comparing from UTF16 to UTF8

### DIFF
--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
@@ -35,12 +35,25 @@ import java.util.stream.Collectors;
 class DefaultExpressionUtils {
 
   static final Comparator<BigDecimal> BIGDECIMAL_COMPARATOR = Comparator.naturalOrder();
+  static final Comparator<String> STRING_COMPARATOR =
+      (leftOp, rightOp) -> {
+        byte[] leftBytes = leftOp.getBytes(StandardCharsets.UTF_8);
+        byte[] rightBytes = rightOp.getBytes(StandardCharsets.UTF_8);
+        int i = 0;
+        while (i < leftBytes.length && i < rightBytes.length) {
+          if (leftBytes[i] != rightBytes[i]) {
+            return Byte.toUnsignedInt(leftBytes[i]) - Byte.toUnsignedInt(rightBytes[i]);
+          }
+          i++;
+        }
+        return Integer.compare(leftBytes.length, rightBytes.length);
+      };
   static final Comparator<byte[]> BINARY_COMPARTOR =
       (leftOp, rightOp) -> {
         int i = 0;
         while (i < leftOp.length && i < rightOp.length) {
           if (leftOp[i] != rightOp[i]) {
-            return Byte.toUnsignedInt(leftOp[i]) - Byte.toUnsignedInt(rightOp[i]);
+            return Byte.compare(leftOp[i], rightOp[i]);
           }
           i++;
         }
@@ -152,9 +165,9 @@ class DefaultExpressionUtils {
       vectorValueComparator =
           rowId ->
               booleanComparator.test(
-                  BINARY_COMPARTOR.compare(
-                      left.getString(rowId).getBytes(StandardCharsets.UTF_8),
-                      right.getString(rowId).getBytes(StandardCharsets.UTF_8)));
+                  STRING_COMPARATOR.compare(
+                      left.getString(rowId),
+                      right.getString(rowId)));
     } else if (dataType instanceof BinaryType) {
       vectorValueComparator =
           rowId ->

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
@@ -153,7 +153,7 @@ class DefaultExpressionUtils {
       vectorValueComparator =
           rowId ->
               booleanComparator.test(
-                  -BINARY_COMPARTOR.compare(
+                  BINARY_COMPARTOR.compare(
                       left.getString(rowId).getBytes(StandardCharsets.UTF_8),
                       right.getString(rowId).getBytes(StandardCharsets.UTF_8)));
     } else if (dataType instanceof BinaryType) {

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
@@ -24,6 +24,7 @@ import io.delta.kernel.expressions.Expression;
 import io.delta.kernel.internal.util.Utils;
 import io.delta.kernel.types.*;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
@@ -152,7 +153,7 @@ class DefaultExpressionUtils {
       vectorValueComparator =
           rowId ->
               booleanComparator.test(
-                  STRING_COMPARATOR.compare(left.getString(rowId), right.getString(rowId)));
+                  -BINARY_COMPARTOR.compare(left.getString(rowId).getBytes(StandardCharsets.UTF_8), right.getString(rowId).getBytes(StandardCharsets.UTF_8)));
     } else if (dataType instanceof BinaryType) {
       vectorValueComparator =
           rowId ->

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
@@ -165,9 +165,7 @@ class DefaultExpressionUtils {
       vectorValueComparator =
           rowId ->
               booleanComparator.test(
-                  STRING_COMPARATOR.compare(
-                      left.getString(rowId),
-                      right.getString(rowId)));
+                  STRING_COMPARATOR.compare(left.getString(rowId), right.getString(rowId)));
     } else if (dataType instanceof BinaryType) {
       vectorValueComparator =
           rowId ->

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
@@ -35,13 +35,12 @@ import java.util.stream.Collectors;
 class DefaultExpressionUtils {
 
   static final Comparator<BigDecimal> BIGDECIMAL_COMPARATOR = Comparator.naturalOrder();
-  static final Comparator<String> STRING_COMPARATOR = Comparator.naturalOrder();
   static final Comparator<byte[]> BINARY_COMPARTOR =
       (leftOp, rightOp) -> {
         int i = 0;
         while (i < leftOp.length && i < rightOp.length) {
           if (leftOp[i] != rightOp[i]) {
-            return Byte.compare(leftOp[i], rightOp[i]);
+            return Byte.toUnsignedInt(leftOp[i]) - Byte.toUnsignedInt(rightOp[i]);
           }
           i++;
         }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
@@ -153,7 +153,9 @@ class DefaultExpressionUtils {
       vectorValueComparator =
           rowId ->
               booleanComparator.test(
-                  -BINARY_COMPARTOR.compare(left.getString(rowId).getBytes(StandardCharsets.UTF_8), right.getString(rowId).getBytes(StandardCharsets.UTF_8)));
+                  -BINARY_COMPARTOR.compare(
+                      left.getString(rowId).getBytes(StandardCharsets.UTF_8),
+                      right.getString(rowId).getBytes(StandardCharsets.UTF_8)));
     } else if (dataType instanceof BinaryType) {
       vectorValueComparator =
           rowId ->

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
@@ -221,7 +221,6 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
 
     val res = x.eval(new DefaultColumnarBatch(1, schema,
       columnarArray.asJava.toArray(Array.empty[ColumnVector])))
-    println(res.getBoolean(0))
   }
 
   //////////////////////////////////////////////////////////////////////////////////

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
@@ -17,16 +17,12 @@ package io.delta.kernel.defaults
 
 import io.delta.golden.GoldenTableUtils.goldenTablePath
 import io.delta.kernel.exceptions.{InvalidTableException, KernelException, TableNotFoundException}
-import io.delta.kernel.expressions.{Literal, ScalarExpression}
 import io.delta.kernel.defaults.utils.{TestRow, TestUtils}
 import io.delta.kernel.internal.fs.Path
 import io.delta.kernel.internal.util.InternalUtils.daysSinceEpoch
 import io.delta.kernel.internal.util.{DateTimeConstants, FileNames}
-import io.delta.kernel.types.{BooleanType, LongType, StringType, StructType}
+import io.delta.kernel.types.{LongType, StructType}
 import io.delta.kernel.Table
-import io.delta.kernel.data.ColumnVector
-import io.delta.kernel.defaults.internal.data.DefaultColumnarBatch
-import io.delta.kernel.defaults.internal.expressions.DefaultExpressionEvaluator
 import org.apache.hadoop.shaded.org.apache.commons.io.FileUtils
 import org.apache.spark.sql.functions.col
 import org.scalatest.funsuite.AnyFunSuite
@@ -34,7 +30,6 @@ import org.scalatest.funsuite.AnyFunSuite
 import java.io.File
 import java.math.BigDecimal
 import java.sql.Date
-import java.util.Optional
 import scala.collection.JavaConverters._
 
 class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
@@ -26,7 +26,6 @@ import io.delta.kernel.types.{BooleanType, LongType, StringType, StructType}
 import io.delta.kernel.Table
 import io.delta.kernel.data.ColumnVector
 import io.delta.kernel.defaults.internal.data.DefaultColumnarBatch
-import io.delta.kernel.defaults.internal.data.vector.DefaultStringVector
 import io.delta.kernel.defaults.internal.expressions.DefaultExpressionEvaluator
 import org.apache.hadoop.shaded.org.apache.commons.io.FileUtils
 import org.apache.spark.sql.functions.col

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
@@ -202,27 +202,6 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
     )
   }
 
-  test("compare random") {
-    val schema = new StructType()
-      .add("c1", new StringType("UTF8_BINARY"), true)
-
-    val s1 = List("�", "\uD83C\uDF3C")
-    val s2 = List("\uD83C\uDF3C")
-    val columnar1 = new DefaultStringVector(1, Optional.empty(),
-      s1.asJava.toArray(Array.empty[String]), "UTF8_BINARY")
-    val columnar2 = new DefaultStringVector(1, Optional.empty(),
-      s2.asJava.toArray(Array.empty[String]), "UTF8_BINARY")
-    val x = new DefaultExpressionEvaluator(schema, new ScalarExpression("<",
-      scala.collection.JavaConverters
-        .seqAsJavaList(Seq(Literal.ofString("�", "UTF8_BINARY"),
-          Literal.ofString("\uD83C\uDF3C", "UTF8_BINARY")))), BooleanType.BOOLEAN)
-
-    val columnarArray = Seq(columnar1)
-
-    val res = x.eval(new DefaultColumnarBatch(1, schema,
-      columnarArray.asJava.toArray(Array.empty[ColumnVector])))
-  }
-
   //////////////////////////////////////////////////////////////////////////////////
   // Table/Snapshot tests
   //////////////////////////////////////////////////////////////////////////////////

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
@@ -658,9 +658,9 @@ class DefaultExpressionEvaluatorSuite extends AnyFunSuite with ExpressionSuiteBa
         ofNull(StringType.STRING)
       ),
       (
+        ofString(s"a${UTF8_MAX_CHARACTER}d"),
         ofString(s"a$UTF8_MAX_CHARACTER$ASCII_MAX_CHARACTER"),
-        ofString(s"a${UTF8_MAX_CHARACTER}d)"),
-        ofString(s"a$UTF8_MAX_CHARACTER$ASCII_MAX_CHARACTER"),
+        ofString(s"a${UTF8_MAX_CHARACTER}d"),
         ofNull(StringType.STRING)
       ),
       (

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
@@ -583,6 +583,9 @@ class DefaultExpressionEvaluatorSuite extends AnyFunSuite with ExpressionSuiteBa
   }
 
   test("evaluate expression: comparators (=, <, <=, >, >=)") {
+    val ASCII_MAX_CHARACTER = '\u007F'
+    val UTF8_MAX_CHARACTER = new String(Character.toChars(Character.MAX_CODE_POINT))
+
     // Literals for each data type from the data type value range, used as inputs to comparator
     // (small, big, small, null)
     val literals = Seq(
@@ -627,9 +630,45 @@ class DefaultExpressionEvaluatorSuite extends AnyFunSuite with ExpressionSuiteBa
       (ofString("abc"), ofString("世界"), ofString("abc"), ofNull(StringType.STRING)),
       (ofString("世界"), ofString("你好"), ofString("世界"), ofNull(StringType.STRING)),
       (ofString("你好122"), ofString("你好123"), ofString("你好122"), ofNull(StringType.STRING)),
-      (ofString("A"), ofString("\u0100"), ofString("A"), ofNull(StringType.STRING)),
-      (ofString("\00BB"), ofString("\u00EE"), ofString("\00BB"), ofNull(StringType.STRING)),
-      (ofString("\uFFFD"), ofString("\uD83C\uDF3C"), ofString("\uFFFD"), ofNull(StringType.STRING)),
+      (ofString("A"), ofString("Ā"), ofString("A"), ofNull(StringType.STRING)),
+      (ofString("»"), ofString("î"), ofString("»"), ofNull(StringType.STRING)),
+      (ofString("�"), ofString("🌼"), ofString("�"), ofNull(StringType.STRING)),
+      (
+        ofString("abcdef🚀"),
+        ofString(s"abcdef$UTF8_MAX_CHARACTER"),
+        ofString("abcdef🚀"),
+        ofNull(StringType.STRING)
+      ),
+      (
+        ofString("abcde�abcdef�abcdef�abcdef"),
+        ofString(s"abcde�$ASCII_MAX_CHARACTER"),
+        ofString("abcde�abcdef�abcdef�abcdef"),
+        ofNull(StringType.STRING)
+      ),
+      (
+        ofString("abcde�abcdef�abcdef�abcdef"),
+        ofString(s"abcde�$ASCII_MAX_CHARACTER"),
+        ofString("abcde�abcdef�abcdef�abcdef"),
+        ofNull(StringType.STRING)
+      ),
+      (
+        ofString("����"),
+        ofString(s"��$UTF8_MAX_CHARACTER"),
+        ofString("����"),
+        ofNull(StringType.STRING)
+      ),
+      (
+        ofString(s"a$UTF8_MAX_CHARACTER$ASCII_MAX_CHARACTER"),
+        ofString(s"a${UTF8_MAX_CHARACTER}d)"),
+        ofString(s"a$UTF8_MAX_CHARACTER$ASCII_MAX_CHARACTER"),
+        ofNull(StringType.STRING)
+      ),
+      (
+        ofString("abcdefghijklm💞😉💕\n🥀🌹💐🌺🌷🌼🌻🌷🥀"),
+        ofString(s"abcdefghijklm💞😉💕\n🥀🌹💐🌺🌷🌼$UTF8_MAX_CHARACTER"),
+        ofString("abcdefghijklm💞😉💕\n🥀🌹💐🌺🌷🌼🌻🌷🥀"),
+        ofNull(StringType.STRING)
+      ),
       // scalastyle:on nonascii
       (
         ofBinary("apples".getBytes()),

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
@@ -607,44 +607,30 @@ class DefaultExpressionEvaluatorSuite extends AnyFunSuite with ExpressionSuiteBa
       ),
       (ofDate(-12123), ofDate(123123), ofDate(-12123), ofNull(DateType.DATE)),
       (ofString("apples"), ofString("oranges"), ofString("apples"), ofNull(StringType.STRING)),
+      (ofString(""), ofString("a"), ofString(""), ofNull(StringType.STRING)),
+      (ofString("abc"), ofString("abc0"), ofString("abc"), ofNull(StringType.STRING)),
+      (ofString("abc"), ofString("abcd"), ofString("abc"), ofNull(StringType.STRING)),
+      (ofString("abc"), ofString("abd"), ofString("abc"), ofNull(StringType.STRING)),
       (
-        ofString("apples"),
-        ofString("oranges"),
-        ofString("apples"),
+        ofString("Abcabcabc"),
+        ofString("aBcabcabc"),
+        ofString("Abcabcabc"),
         ofNull(StringType.STRING)
       ),
       (
-        ofString("abc"),
-        ofString("abcd"),
-        ofString("abc"),
+        ofString("abcabcabC"),
+        ofString("abcabcabc"),
+        ofString("abcabcabC"),
         ofNull(StringType.STRING)
       ),
-      (
-        ofString("abc"),
-        ofString("abd"),
-        ofString("abc"),
-        ofNull(StringType.STRING)
-      ),
-      (
-        // scalastyle:off nonascii
-        ofString("A"),
-        ofString("\u0100"),
-        ofString("A"),
-        ofNull(StringType.STRING)
-      ),
-      (
-        ofString("\00BB"),
-        ofString("\u00EE"),
-        ofString("\00BB"),
-        ofNull(StringType.STRING)
-      ),
-      (
-        ofString("\uFFFD"),
-        ofString("\uD83C\uDF3C"),
-        ofString("\uFFFD"),
-        ofNull(StringType.STRING)
-        // scalastyle:on nonascii
-      ),
+      // scalastyle:off nonascii
+      (ofString("abc"), ofString("世界"), ofString("abc"), ofNull(StringType.STRING)),
+      (ofString("世界"), ofString("你好"), ofString("世界"), ofNull(StringType.STRING)),
+      (ofString("你好122"), ofString("你好123"), ofString("你好122"), ofNull(StringType.STRING)),
+      (ofString("A"), ofString("\u0100"), ofString("A"), ofNull(StringType.STRING)),
+      (ofString("\00BB"), ofString("\u00EE"), ofString("\00BB"), ofNull(StringType.STRING)),
+      (ofString("\uFFFD"), ofString("\uD83C\uDF3C"), ofString("\uFFFD"), ofNull(StringType.STRING)),
+      // scalastyle:on nonascii
       (
         ofBinary("apples".getBytes()),
         ofBinary("oranges".getBytes()),

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
@@ -608,6 +608,44 @@ class DefaultExpressionEvaluatorSuite extends AnyFunSuite with ExpressionSuiteBa
       (ofDate(-12123), ofDate(123123), ofDate(-12123), ofNull(DateType.DATE)),
       (ofString("apples"), ofString("oranges"), ofString("apples"), ofNull(StringType.STRING)),
       (
+        ofString("apples"),
+        ofString("oranges"),
+        ofString("apples"),
+        ofNull(StringType.STRING)
+      ),
+      (
+        ofString("abc"),
+        ofString("abcd"),
+        ofString("abc"),
+        ofNull(StringType.STRING)
+      ),
+      (
+        ofString("abc"),
+        ofString("abd"),
+        ofString("abc"),
+        ofNull(StringType.STRING)
+      ),
+      (
+        // scalastyle:off nonascii
+        ofString("A"),
+        ofString("\u0100"),
+        ofString("A"),
+        ofNull(StringType.STRING)
+      ),
+      (
+        ofString("\00BB"),
+        ofString("\u00EE"),
+        ofString("\00BB"),
+        ofNull(StringType.STRING)
+      ),
+      (
+        ofString("\uFFFD"),
+        ofString("\uD83C\uDF3C"),
+        ofString("\uFFFD"),
+        ofNull(StringType.STRING)
+        // scalastyle:on nonascii
+      ),
+      (
         ofBinary("apples".getBytes()),
         ofBinary("oranges".getBytes()),
         ofBinary("apples".getBytes()),


### PR DESCRIPTION
## Description
Changed string comparing from UTF16 to UTF8. This fixes comparison issues around the characters with surrogate pairs.

## How was this patch tested?
Tests added to `DefaultExpressionEvaluatorSuite.scala`
