### PR TITLE
[Spark] Update tests in ConvertToDeltaSuite

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/ConvertToDeltaSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ConvertToDeltaSuiteBase.scala
@@ -188,7 +188,7 @@ trait ConvertToDeltaSuiteBase extends ConvertToDeltaSuiteBaseCommons
   }
 
   test("filter non-parquet file for schema inference when not using catalog schema") {
-    withTempDir(prefix = "spark") { dir =>
+    withTempDir { dir =>
       val tempDir = dir.getCanonicalPath
       writeFiles(tempDir + "/part=1/", Seq(1).toDF("corrupted_id"), format = "orc")
       writeFiles(tempDir + "/part=2/", Seq(2).toDF("id"))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/HiveConvertToDeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/HiveConvertToDeltaSuite.scala
@@ -130,7 +130,7 @@ abstract class HiveConvertToDeltaSuiteBase
 
   test("convert a Hive based external parquet table") {
     val tbl = "hive_parquet"
-    withTempDir(prefix = "spark") { dir =>
+    withTempDir { dir =>
       withTable(tbl) {
         sql(
           s"""


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?


- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Enable injection of special chars in temporary directories in two tests in ConvertToDeltaSuite. The previous issues have been resolved in 90c1b2a26a86ce0c16e8218ec4188c81b9f7a21c.


## How was this patch tested?

Test-only change.

## Does this PR introduce _any_ user-facing changes?

No
