### PR TITLE
[Spark] Align supported type changes in type widening preview with Iceberg

### DIFF
--- a/spark/src/main/scala-spark-3.5/shims/TypeWideningShims.scala
+++ b/spark/src/main/scala-spark-3.5/shims/TypeWideningShims.scala
@@ -42,12 +42,7 @@ object TypeWideningShims {
       case _ => false
     }
 
-  /**
-   * Returns whether the given type change can be applied during schema evolution. Only a
-   * subset of supported type changes are considered for schema evolution.
-   */
-  def isTypeChangeSupportedForSchemaEvolution(fromType: AtomicType, toType: AtomicType): Boolean = {
-    // All supported type changes are eligible for schema evolution.
+  /** Whether we support reading the given type change. */
+  def canReadTypeChange(fromType: AtomicType, toType: AtomicType): Boolean =
     isTypeChangeSupported(fromType, toType)
-  }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -921,7 +921,7 @@ class DeltaAnalysis(session: SparkSession)
           if s != t && sNull == tNull =>
         addCastsToArrayStructs(tblName, attr, s, t, sNull, allowTypeWidening)
       case (s: AtomicType, t: AtomicType)
-        if allowTypeWidening && TypeWidening.isTypeChangeSupportedForSchemaEvolution(t, s) =>
+        if allowTypeWidening && TypeWidening.isTypeChangeSupported(t, s) =>
         // Keep the type from the query, the target schema will be updated to widen the existing
         // type to match it.
         attr
@@ -1069,8 +1069,7 @@ class DeltaAnalysis(session: SparkSession)
         }
 
       case (StructField(name, dt: AtomicType, _, _), i) if i < target.length && allowTypeWidening &&
-        TypeWidening.isTypeChangeSupportedForSchemaEvolution(
-          target(i).dataType.asInstanceOf[AtomicType], dt) =>
+        TypeWidening.isTypeChangeSupported(target(i).dataType.asInstanceOf[AtomicType], dt) =>
         val targetAttr = target(i)
         Alias(
           GetStructField(parent, i, Option(name)),

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TypeWidening.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TypeWidening.scala
@@ -16,9 +16,8 @@
 
 package org.apache.spark.sql.delta
 
-import org.apache.spark.sql.delta.actions.{AddFile, Metadata, Protocol, TableFeatureProtocolUtils}
+import org.apache.spark.sql.delta.actions.{Metadata, Protocol, TableFeatureProtocolUtils}
 
-import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.types._
 
 object TypeWidening {
@@ -69,13 +68,6 @@ object TypeWidening {
     TypeWideningShims.isTypeChangeSupported(fromType, toType)
 
   /**
-   * Returns whether the given type change can be applied during schema evolution. Only a
-   * subset of supported type changes are considered for schema evolution.
-   */
-  def isTypeChangeSupportedForSchemaEvolution(fromType: AtomicType, toType: AtomicType): Boolean =
-    TypeWideningShims.isTypeChangeSupportedForSchemaEvolution(fromType, toType)
-
-  /**
    * Asserts that the given table doesn't contain any unsupported type changes. This should never
    * happen unless a non-compliant writer applied a type change that is not part of the feature
    * specification.
@@ -88,7 +80,7 @@ object TypeWidening {
 
     TypeWideningMetadata.getAllTypeChanges(metadata.schema).foreach {
       case (_, TypeChange(_, from: AtomicType, to: AtomicType, _))
-        if isTypeChangeSupported(from, to) =>
+        if TypeWideningShims.canReadTypeChange(from, to) =>
       case (fieldPath, invalidChange) =>
         throw DeltaErrors.unsupportedTypeChangeInSchema(
           fieldPath ++ invalidChange.fieldPath,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaMergingUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaMergingUtils.scala
@@ -216,7 +216,7 @@ object SchemaMergingUtils {
         case (current, update) if keepExistingType => current
 
         case (current: AtomicType, update: AtomicType) if allowTypeWidening &&
-          TypeWidening.isTypeChangeSupportedForSchemaEvolution(current, update) => update
+          TypeWidening.isTypeChangeSupported(current, update) => update
 
         // If implicit conversions are allowed, that means we can use any valid implicit cast to
         // perform the merge.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -428,7 +428,7 @@ def normalizeColumnNamesInDataType(
             isDatatypeReadCompatible(e.keyType, n.keyType) &&
             isDatatypeReadCompatible(e.valueType, n.valueType)
         case (e: AtomicType, n: AtomicType) if allowTypeWidening =>
-          TypeWidening.isTypeChangeSupportedForSchemaEvolution(e, n)
+          TypeWidening.isTypeChangeSupported(e, n)
         case (a, b) => a == b
       }
     }

--- a/spark/src/test/scala-spark-3.5/shims/TypeWideningTestCasesShims.scala
+++ b/spark/src/test/scala-spark-3.5/shims/TypeWideningTestCasesShims.scala
@@ -43,9 +43,9 @@ trait TypeWideningTestCasesShims {
       Seq(4, -4, Int.MinValue, Int.MaxValue, null.asInstanceOf[Int]))
   )
 
-  // Type changes that are only supported in ALTER TABLE CHANGE COLUMN TYPE but are not considered
-  // for automatic type widening.
-  protected val alterTableOnlySupportedTestCases: Seq[TypeEvolutionTestCase] = Seq.empty
+  // Type changes that were only supported during the preview and were removed in the stable version
+  // of the feature.
+  protected val previewOnlySupportedTestCases: Seq[TypeEvolutionTestCase] = Seq.empty
 
   // Test type changes that aren't supported.
   protected val unsupportedTestCases: Seq[TypeEvolutionTestCase] = Seq(

--- a/spark/src/test/scala-spark-master/shims/TypeWideningTestCasesShims.scala
+++ b/spark/src/test/scala-spark-master/shims/TypeWideningTestCasesShims.scala
@@ -56,29 +56,23 @@ trait TypeWideningTestCasesShims {
     SupportedTypeEvolutionTestCase(DateType, TimestampNTZType,
       Seq("2020-01-01", "2024-02-29", "1312-02-27"),
       Seq("2020-03-17 15:23:15.123456", "2058-12-31 23:59:59.999", "0001-01-01 00:00:00")),
-    // Larger precision.
+    // Larger precision, same physical type.
+    SupportedTypeEvolutionTestCase(DecimalType(Decimal.MAX_INT_DIGITS - 2, 2),
+      DecimalType(Decimal.MAX_INT_DIGITS, 2),
+      Seq(BigDecimal("1.23"), BigDecimal("10.34"), null.asInstanceOf[BigDecimal]),
+      Seq(BigDecimal("-67.89"), BigDecimal("9" * (Decimal.MAX_INT_DIGITS - 2) + ".99"),
+        null.asInstanceOf[BigDecimal])),
+    // Larger precision, different physical type.
     SupportedTypeEvolutionTestCase(DecimalType(Decimal.MAX_INT_DIGITS, 2),
       DecimalType(Decimal.MAX_LONG_DIGITS, 2),
-      Seq(BigDecimal("1.23"), BigDecimal("10.34"), null.asInstanceOf[BigDecimal]),
-      Seq(BigDecimal("-67.89"), BigDecimal("9" * (Decimal.MAX_LONG_DIGITS - 2) + ".99"),
-        null.asInstanceOf[BigDecimal])),
-    // Larger precision and scale, same physical type.
-    SupportedTypeEvolutionTestCase(DecimalType(Decimal.MAX_INT_DIGITS - 1, 2),
-      DecimalType(Decimal.MAX_INT_DIGITS, 3),
-      Seq(BigDecimal("1.23"), BigDecimal("10.34"), null.asInstanceOf[BigDecimal]),
-      Seq(BigDecimal("-67.89"), BigDecimal("9" * (Decimal.MAX_INT_DIGITS - 3) + ".99"),
-        null.asInstanceOf[BigDecimal])),
-    // Larger precision and scale, different physical types.
-    SupportedTypeEvolutionTestCase(DecimalType(Decimal.MAX_INT_DIGITS, 2),
-      DecimalType(Decimal.MAX_LONG_DIGITS + 1, 3),
       Seq(BigDecimal("1.23"), BigDecimal("10.34"), null.asInstanceOf[BigDecimal]),
       Seq(BigDecimal("-67.89"), BigDecimal("9" * (Decimal.MAX_LONG_DIGITS - 2) + ".99"),
         null.asInstanceOf[BigDecimal]))
   )
 
-  // Type changes that are only supported in ALTER TABLE CHANGE COLUMN TYPE but are not considered
-  // for automatic type widening.
-  protected val alterTableOnlySupportedTestCases: Seq[TypeEvolutionTestCase] = Seq(
+  // Type changes that were only supported during the preview and were removed in the stable version
+  // of the feature.
+  protected val previewOnlySupportedTestCases: Seq[TypeEvolutionTestCase] = Seq(
     SupportedTypeEvolutionTestCase(IntegerType, DoubleType,
       Seq(1, -1, Int.MinValue, Int.MaxValue, null.asInstanceOf[Int]),
       Seq(987654321.987654321d, -0d, 0d, Double.NaN, Double.NegativeInfinity,
@@ -95,7 +89,13 @@ trait TypeWideningTestCasesShims {
       Seq(BigDecimal("1.23"), BigDecimal("9" * 10), null.asInstanceOf[BigDecimal])),
     SupportedTypeEvolutionTestCase(LongType, DecimalType(20, 0),
       Seq(1L, -1L, Long.MinValue, Long.MaxValue, null.asInstanceOf[Int]),
-      Seq(BigDecimal("1.23"), BigDecimal("9" * 20), null.asInstanceOf[BigDecimal]))
+      Seq(BigDecimal("1.23"), BigDecimal("9" * 20), null.asInstanceOf[BigDecimal])),
+    // Larger precision and scale.
+    SupportedTypeEvolutionTestCase(DecimalType(Decimal.MAX_INT_DIGITS - 1, 2),
+      DecimalType(Decimal.MAX_INT_DIGITS, 3),
+      Seq(BigDecimal("1.23"), BigDecimal("10.34"), null.asInstanceOf[BigDecimal]),
+      Seq(BigDecimal("-67.89"), BigDecimal("9" * (Decimal.MAX_INT_DIGITS - 3) + ".99"),
+        null.asInstanceOf[BigDecimal]))
   )
 
   // Test type changes that aren't supported.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningAlterTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningAlterTableSuite.scala
@@ -46,7 +46,7 @@ trait TypeWideningAlterTableTests
   import testImplicits._
 
   for {
-    testCase <- supportedTestCases ++ alterTableOnlySupportedTestCases
+    testCase <- supportedTestCases
     partitioned <- BOOLEAN_DOMAIN
   } {
     test(s"type widening ${testCase.fromType.sql} -> ${testCase.toType.sql}, " +
@@ -80,7 +80,7 @@ trait TypeWideningAlterTableTests
   }
 
   for {
-    testCase <- unsupportedTestCases
+    testCase <- unsupportedTestCases ++ previewOnlySupportedTestCases
     partitioned <- BOOLEAN_DOMAIN
   } {
     test(s"unsupported type changes ${testCase.fromType.sql} -> ${testCase.toType.sql}, " +

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningInsertSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningInsertSchemaEvolutionSuite.scala
@@ -78,7 +78,7 @@ trait TypeWideningInsertSchemaEvolutionTests
   }
 
   for {
-    testCase <- unsupportedTestCases ++ alterTableOnlySupportedTestCases
+    testCase <- unsupportedTestCases ++ previewOnlySupportedTestCases
   } {
     test(s"INSERT - unsupported automatic type widening " +
       s"${testCase.fromType.sql} -> ${testCase.toType.sql}") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningMergeIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningMergeIntoSchemaEvolutionSuite.scala
@@ -79,7 +79,7 @@ trait TypeWideningMergeIntoSchemaEvolutionTests
   }
 
   for {
-    testCase <- unsupportedTestCases ++ alterTableOnlySupportedTestCases
+    testCase <- unsupportedTestCases ++ previewOnlySupportedTestCases
   } {
     test(s"MERGE - unsupported automatic type widening " +
       s"${testCase.fromType.sql} -> ${testCase.toType.sql}") {


### PR DESCRIPTION
## Description
The following type changes available in the preview of type widening aren't supported by Iceberg and it will be very hard to support them - mainly due to the [Binary single-value serialization](https://iceberg.apache.org/spec/#binary-single-value-serialization) part of the spec:
- (byte,short,int,long) → decimals
- (byte,short,int) → double
- decimal scale increase, e.g. decimal(12,2) → decimal(14,4)

These type changes will get in the way of interoperability with Iceberg. To prevent issues in the future, we won't allow applying these types changes in the stable version of the type widening feature. We can add these back once Iceberg supports them. Reading a table that had such a type change applied will still be allowed though.

## How was this patch tested?
Moved existing test cases for these type changes to the 'unsuported' list.
Added a dedicated test to ensure we can still read back data if such a type change was applied in the past.

## Does this PR introduce _any_ user-facing changes?
Running `ALTER TABLE <table> CHANGE COLUMN <col> TYPE <type>` to apply one of the deprecated type changes will fail with:
```
[DELTA_UNSUPPORTED_ALTER_TABLE_CHANGE_COL_OP] ALTER TABLE CHANGE COLUMN is not supported for changing column <fieldPath> from <oldField> to <newField>
```
