### PR TITLE
[Doc] Update supported type changes for type widening preview to align with Iceberg

### DIFF
--- a/docs/source/delta-type-widening.md
+++ b/docs/source/delta-type-widening.md
@@ -10,29 +10,17 @@ The type widening feature allows changing the type of columns in a Delta table t
 
 ## Supported type changes
 
-The feature introduces a limited set of supported type changes in <Delta> 3.2 and expandes it in <Delta> 4.0 and above.
+The feature introduces a limited set of supported type changes in <Delta> 3.2 and expands it in <Delta> 4.0 and above.
 
 .. csv-table::
   :header: "Source type", "Supported wider types - Delta 3.2", "Supported wider types - Delta 4.0"
 
-  "`byte`","`short`, `int`","`short`,`int`,`long`, `decimal`, `double`"
-  "`short`","`int`", "`int`,`long`, `decimal`, `double`"
-  "`int`"," ","`long`, `decimal`, `double`"
-  "`long`", ,"`decimal`"
+  "`byte`","`short`, `int`","`short`,`int`,`long`"
+  "`short`","`int`", "`int`,`long`"
+  "`int`"," ","`long`"
   "`float`", ,"`double`"
-  "`decimal`", ,"`decimal` with greater precision and scale"
+  "`decimal`", ,"`decimal` with greater precision and same scale"
   "`date`", ,"`timestampNTZ`"
-
-To avoid accidental promotion of integer values to decimals, type changes from `byte`, `short`, `int`, or `long` to `decimal` or `double` are not eligible to be applied automatically during schema evolution. You must manually alter the type in that case.
-
-.. note::
-
-  When changing an integer or decimal type to decimal, the total precision must be equal to or greater than the starting precision. If you also increase the scale, the total precision must increase by a corresponding amount.
-  That is, `decimal(p, s)` can be changed to `decimal(p + k1, s + k2)` iff `k1 >= k2 >= 0`.
-
-  For example, if you want to add two decimal places to a field with `decimal(10,1)`, the minimum target is `decimal(12,3)`.
-
-  The minimum target for `byte`, `short`, and `int` types is `decimal(10,0)`. The minimum target for `long` is `decimal(20,0)`.
 
 Type changes are supported for top-level columns as well as fields nested inside structs, maps and arrays.
 


### PR DESCRIPTION
## Description
The following type changes available in the preview of type widening aren't supported by Iceberg and it will be very hard to support them - mainly due to the [Binary single-value serialization](https://iceberg.apache.org/spec/#binary-single-value-serialization) part of the spec:
- (byte,short,int,long) → decimals
- (byte,short,int) → double
- decimal scale increase, e.g. decimal(12,2) → decimal(14,4)

These type changes will get in the way of interoperability with Iceberg. To prevent issues in the future, we won't allow applying these types changes in the stable version of the type widening feature. We can add these back once Iceberg supports them. Reading a table that had such a type change applied will still be allowed though.

The documentation is updated to remove these type changes from the list of supported type changes for the upcoming Delta 4.0 version