### PR TITLE
[Spark] Followup to #3633: update some comments to checkAddFileWithDeletionVectorStatsAreNotTightBounds

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -153,7 +153,7 @@ object DeltaOperations {
     }
     override def changesData: Boolean = true
 
-    // This operation shouldn't be introducing AddFile actions with DVs and non tight bounds stats.
+    // This operation shouldn't be introducing AddFile actions with DVs and tight bounds stats.
     // DVs can be introduced by the replaceWhere operation.
     override def checkAddFileWithDeletionVectorStatsAreNotTightBounds: Boolean = true
   }
@@ -181,7 +181,7 @@ object DeltaOperations {
     override val operationMetrics: Set[String] = DeltaOperationMetrics.STREAMING_UPDATE
     override def changesData: Boolean = true
 
-    // This operation shouldn't be introducing AddFile actions with DVs and non tight bounds stats.
+    // This operation shouldn't be introducing AddFile actions with DVs and tight bounds stats.
     override def checkAddFileWithDeletionVectorStatsAreNotTightBounds: Boolean = true
   }
   /** Recorded while deleting certain partitions. */
@@ -205,7 +205,7 @@ object DeltaOperations {
     }
     override def changesData: Boolean = true
 
-    // This operation shouldn't be introducing AddFile actions with DVs and non tight bounds stats.
+    // This operation shouldn't be introducing AddFile actions with DVs and tight bounds stats.
     override def checkAddFileWithDeletionVectorStatsAreNotTightBounds: Boolean = true
   }
   /** Recorded when truncating the table. */
@@ -214,7 +214,7 @@ object DeltaOperations {
     override val operationMetrics: Set[String] = DeltaOperationMetrics.TRUNCATE
     override def changesData: Boolean = true
 
-    // This operation shouldn't be introducing AddFile actions with DVs and non-tight bounds stats.
+    // This operation shouldn't be introducing AddFile actions at all. This check should be trivial.
     override def checkAddFileWithDeletionVectorStatsAreNotTightBounds: Boolean = true
   }
 
@@ -399,6 +399,8 @@ object DeltaOperations {
     override val parameters: Map[String, Any] = Map("properties" -> JsonUtils.toJson(properties))
 
     // This operation shouldn't be introducing AddFile actions at all. This check should be trivial.
+    // Note: This operation may trigger additional actions and additional commits. For example
+    // RowTrackingBackfill. These are separate transactions, and this check is performed separately.
     override def checkAddFileWithDeletionVectorStatsAreNotTightBounds: Boolean = true
   }
   /** Recorded when the table properties are unset. */
@@ -421,6 +423,8 @@ object DeltaOperations {
       "truncateHistory" -> truncateHistory)
 
     // This operation shouldn't be introducing AddFile actions at all. This check should be trivial.
+    // Note: this operation may trigger additional actions and additional commits. These would be
+    // separate transactions, and this check is performed separately.
     override def checkAddFileWithDeletionVectorStatsAreNotTightBounds: Boolean = true
   }
   /** Recorded when columns are added. */
@@ -622,7 +626,7 @@ object DeltaOperations {
 
     override val operationMetrics: Set[String] = DeltaOperationMetrics.OPTIMIZE
 
-    // This operation shouldn't be introducing AddFile actions with DVs and non tight bounds stats.
+    // This operation shouldn't be introducing AddFile actions with DVs and tight bounds stats.
     override def checkAddFileWithDeletionVectorStatsAreNotTightBounds: Boolean = true
   }
 
@@ -688,7 +692,7 @@ object DeltaOperations {
 
     override val operationMetrics: Set[String] = DeltaOperationMetrics.OPTIMIZE
 
-    // This operation shouldn't be introducing AddFile actions with DVs and non tight bounds stats.
+    // This operation shouldn't be introducing AddFile actions with DVs and tight bounds stats.
     override def checkAddFileWithDeletionVectorStatsAreNotTightBounds: Boolean = true
   }
 
@@ -761,7 +765,7 @@ object DeltaOperations {
       OP_UPGRADE_UNIFORM_BY_REORG) {
     override val parameters: Map[String, Any] = Map("properties" -> JsonUtils.toJson(properties))
 
-    // This operation shouldn't be introducing AddFile actions with DVs and non tight bounds stats.
+    // This operation shouldn't be introducing AddFile actions with DVs and tight bounds stats.
     override def checkAddFileWithDeletionVectorStatsAreNotTightBounds: Boolean = true
   }
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Post merge review followup: update and fix some comments.

## How was this patch tested?

N/A

## Does this PR introduce _any_ user-facing changes?

No.
