### PR TITLE
[Infra] Include GitHub workflow name in each task

### DIFF
--- a/.github/workflows/connectors_test.yaml
+++ b/.github/workflows/connectors_test.yaml
@@ -2,7 +2,7 @@ name: "Delta Connectors Tests"
 on: [push, pull_request]
 jobs:
   build:
-    name: "Run tests"
+    name: "Delta Connectors: Scala ${{ matrix.scala }}"
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/connectors_test.yaml
+++ b/.github/workflows/connectors_test.yaml
@@ -1,8 +1,8 @@
-name: "Delta Connectors Tests"
+name: "Delta Connectors"
 on: [push, pull_request]
 jobs:
   build:
-    name: "Delta Connectors: Scala ${{ matrix.scala }}"
+    name: "DC: Scala ${{ matrix.scala }}"
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/kernel_test.yaml
+++ b/.github/workflows/kernel_test.yaml
@@ -1,8 +1,8 @@
-name: "Delta Kernel Tests"
+name: "Delta Kernel"
 on: [push, pull_request]
 jobs:
   test:
-    name: "Delta Kernel"
+    name: "DK"
     runs-on: ubuntu-20.04
     env:
       SCALA_VERSION: 2.12.18

--- a/.github/workflows/kernel_test.yaml
+++ b/.github/workflows/kernel_test.yaml
@@ -2,6 +2,7 @@ name: "Delta Kernel Tests"
 on: [push, pull_request]
 jobs:
   test:
+    name: "Delta Kernel"
     runs-on: ubuntu-20.04
     env:
       SCALA_VERSION: 2.12.18

--- a/.github/workflows/spark_examples_test.yaml
+++ b/.github/workflows/spark_examples_test.yaml
@@ -1,8 +1,8 @@
-name: "Delta Spark Local Publishing and Examples Compilation"
+name: "Delta Spark Publishing and Examples"
 on: [push, pull_request]
 jobs:
   test:
-    name: "Delta Spark Local Publishing and Examples Compilation: Scala ${{ matrix.scala }}"
+    name: "DSP&E: Scala ${{ matrix.scala }}"
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/spark_examples_test.yaml
+++ b/.github/workflows/spark_examples_test.yaml
@@ -2,6 +2,7 @@ name: "Delta Spark Local Publishing and Examples Compilation"
 on: [push, pull_request]
 jobs:
   test:
+    name: "Delta Spark Local Publishing and Examples Compilation: Scala ${{ matrix.scala }}"
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/spark_master_test.yaml
+++ b/.github/workflows/spark_master_test.yaml
@@ -2,6 +2,7 @@ name: "Delta Spark Master Tests"
 on: [push, pull_request]
 jobs:
   test:
+    name: "Delta Spark Master: Scala ${{ matrix.scala }}, Shard ${{ matrix.shard }}"
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/spark_master_test.yaml
+++ b/.github/workflows/spark_master_test.yaml
@@ -1,8 +1,8 @@
-name: "Delta Spark Master Tests"
+name: "Delta Spark Master"
 on: [push, pull_request]
 jobs:
   test:
-    name: "Delta Spark Master: Scala ${{ matrix.scala }}, Shard ${{ matrix.shard }}"
+    name: "DSM: Scala ${{ matrix.scala }}, Shard ${{ matrix.shard }}"
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/spark_python_test.yaml
+++ b/.github/workflows/spark_python_test.yaml
@@ -1,8 +1,8 @@
-name: "Delta Spark Python Tests"
+name: "Delta Spark Python"
 on: [push, pull_request]
 jobs:
   test:
-    name: "Delta Spark Python"
+    name: "DSP"
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/spark_python_test.yaml
+++ b/.github/workflows/spark_python_test.yaml
@@ -2,6 +2,7 @@ name: "Delta Spark Python Tests"
 on: [push, pull_request]
 jobs:
   test:
+    name: "Delta Spark Python"
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/spark_test.yaml
+++ b/.github/workflows/spark_test.yaml
@@ -1,8 +1,8 @@
-name: "Delta Spark Tests"
+name: "Delta Spark Latest"
 on: [push, pull_request]
 jobs:
   test:
-    name: "Delta Spark Latest: Scala ${{ matrix.scala }}, Shard ${{ matrix.shard }}"
+    name: "DSL: Scala ${{ matrix.scala }}, Shard ${{ matrix.shard }}"
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/spark_test.yaml
+++ b/.github/workflows/spark_test.yaml
@@ -2,6 +2,7 @@ name: "Delta Spark Tests"
 on: [push, pull_request]
 jobs:
   test:
+    name: "Delta Spark Latest: Scala ${{ matrix.scala }}, Shard ${{ matrix.shard }}"
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/unidoc.yaml
+++ b/.github/workflows/unidoc.yaml
@@ -1,12 +1,12 @@
-  name: "Unidoc generation"
+  name: "Unidoc"
   on: [push, pull_request]
   jobs:
     build:
-      name: "Generate unidoc"
+      name: "U: Scala ${{ matrix.scala }}"
       runs-on: ubuntu-20.04
       strategy:
         matrix:
-        # These Scala versions must match those in the build.sbt
+          # These Scala versions must match those in the build.sbt
           scala: [2.13.13, 2.12.18]
       steps:
         - name: install java


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [X] Other (Infra)

## Description

I'd like to do some data science using the GitHub REST API on our PR runtimes.

Unfortunately, using the GitHub CHECKs API (https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#list-check-runs-for-a-git-reference), I only get the name of the individual job. Getting the name of the parent workflow requires an additional API call.

This is because our job names are the default job names right now for most of our GitHub workflows. This doesn't give us any info as to which workflow it is for. For example, today I'd get result `test (2.13.13, 0)` but I am unable to determine if this is for Delta Spark Latest or Delta Spark Master.

This PR updates the workflow job name to include the workflow name so now we can uniquely identify the jobs.

## How was this patch tested?

CI tests.

## Does this PR introduce _any_ user-facing changes?

No