### PR TITLE
[Standalone] Safer checkpointing and better logging

### DIFF
--- a/connectors/standalone/src/main/scala/io/delta/standalone/internal/SnapshotImpl.scala
+++ b/connectors/standalone/src/main/scala/io/delta/standalone/internal/SnapshotImpl.scala
@@ -83,7 +83,7 @@ private[internal] class SnapshotImpl(
 
   import SnapshotImpl._
 
-  private var loadedState = false
+  @volatile private var loadedState = false
 
   private val memoryOptimizedLogReplay =
     new MemoryOptimizedLogReplay(files, deltaLog.store, hadoopConf, deltaLog.timezone)


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [X] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR

- adds better logging throughout Delta Standalone (improves debuggability)
- fixes an issue in the Delta Standalone Checkpoint code path where we would incorrectly close an incomplete checkpoint upon error

## How was this patch tested?

Existing UTs + tested and verified locally

## Does this PR introduce _any_ user-facing changes?

No
