### PR TITLE
[Spark] Make MERGE source materialize depend on checkpointRDDBlockIdNotFoundError error class, not message

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/merge/MergeIntoMaterializeSource.scala
@@ -163,8 +163,8 @@ trait MergeIntoMaterializeSource extends DeltaLogging with DeltaSparkPlanUtils {
     // SparkCoreErrors.checkpointRDDBlockIdNotFoundError from LocalCheckpointRDD.compute.
     case s: SparkException
       if materializedSourceRDD.nonEmpty &&
-        s.getMessage.matches(
-          mergeMaterializedSourceRddBlockLostErrorRegex(materializedSourceRDD.get.id)) =>
+        s.getErrorClass() == "CHECKPOINT_RDD_BLOCK_ID_NOT_FOUND" &&
+        s.getMessageParameters().get("blockId") == materializedSourceRDD.get.id.toString =>
       log.warn("Materialized Merge source RDD block lost. Merge needs to be restarted. " +
         s"This was attempt number $attempt.")
       if (!isLastAttempt) {
@@ -400,10 +400,6 @@ object MergeIntoMaterializeSource {
     assert(!isMaterialized ||
       MergeIntoMaterializeSourceReason.MATERIALIZED_REASONS.contains(materializeReason))
   }
-
-  // This depends on SparkCoreErrors.checkpointRDDBlockIdNotFoundError msg
-  def mergeMaterializedSourceRddBlockLostErrorRegex(rddId: Int): String =
-    s"(?s).*Checkpoint block rdd_${rddId}_[0-9]+ not found!.*"
 
   /**
    * @return The columns of the source plan that are used in this MERGE

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoMaterializeSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoMaterializeSourceSuite.scala
@@ -72,9 +72,8 @@ trait MergeIntoMaterializeSourceTests
       checkpointedDf.collect()
     }
     assert(ex.isInstanceOf[SparkException], ex)
-    assert(
-      ex.getMessage().matches(mergeMaterializedSourceRddBlockLostErrorRegex(rdd.id)),
-      s"RDD id ${rdd.id}: Message: ${ex.getMessage}")
+    assert(ex.asInstanceOf[SparkException].getErrorClass() == "CHECKPOINT_RDD_BLOCK_ID_NOT_FOUND")
+    assert(ex.asInstanceOf[SparkException].getMessageParameters().get("blockId") == rdd.id.toString)
   }
 
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

In Spark master, there is now an error code for checkpointRDDBlockIdNotFoundError. Depend on that instead of regexing against a message.

## How was this patch tested?

Test adapted.

## Does this PR introduce _any_ user-facing changes?

No.
