### PR TITLE
[Kernel] Support beforeOrAt and atOrAfter semantics for getting a commit version from a timestamp

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaHistoryManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaHistoryManager.java
@@ -43,22 +43,22 @@ public final class DeltaHistoryManager {
   /**
    * Returns the latest commit that happened at or before {@code timestamp}.
    *
-   * If the timestamp is outside the range of [earliestCommit, latestCommit] then use
-   * parameters {@code canReturnLastCommit} and {@code canReturnEarliestCommit} to control whether
-   * an exception is thrown or the corresponding earliest/latest commit is returned.
+   * <p>If the timestamp is outside the range of [earliestCommit, latestCommit] then use parameters
+   * {@code canReturnLastCommit} and {@code canReturnEarliestCommit} to control whether an exception
+   * is thrown or the corresponding earliest/latest commit is returned.
    *
    * @param engine instance of {@link Engine} to use
    * @param logPath the _delta_log path of the table
    * @param timestamp the timestamp find the version for in milliseconds since the unix epoch
    * @param mustBeRecreatable whether the state at the returned commit should be recreatable
    * @param canReturnLastCommit whether we can return the latest version of the table if the
-   *                            provided timestamp is after the latest commit
+   *     provided timestamp is after the latest commit
    * @param canReturnEarliestCommit whether we can return the earliest version of the table if the
-   *                                provided timestamp is before the earliest commit
+   *     provided timestamp is before the earliest commit
    * @throws KernelException if the provided timestamp is before the earliest commit and
-   *                         canReturnEarliestCommit is false
+   *     canReturnEarliestCommit is false
    * @throws KernelException if the provided timestamp is after the latest commit and
-   *                         canReturnLastCommit is false
+   *     canReturnLastCommit is false
    * @throws TableNotFoundException when there is no Delta table at the given path
    */
   public static Commit getActiveCommitAtTimestamp(
@@ -67,8 +67,8 @@ public final class DeltaHistoryManager {
       long timestamp,
       boolean mustBeRecreatable,
       boolean canReturnLastCommit,
-      boolean canReturnEarliestCommit
-      ) throws TableNotFoundException {
+      boolean canReturnEarliestCommit)
+      throws TableNotFoundException {
 
     long earliestVersion =
         (mustBeRecreatable)

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaHistoryManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaHistoryManager.java
@@ -291,12 +291,20 @@ public final class DeltaHistoryManager {
 
   public static class Commit {
 
-    public final long version;
-    public final long timestamp;
+    private final long version;
+    private final long timestamp;
 
     Commit(long version, long timestamp) {
       this.version = version;
       this.timestamp = timestamp;
+    }
+
+    public long getVersion() {
+      return version;
+    }
+
+    public long getTimestamp() {
+      return timestamp;
     }
 
     @Override

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaHistoryManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaHistoryManager.java
@@ -19,6 +19,7 @@ import static io.delta.kernel.internal.DeltaErrors.wrapEngineExceptionThrowsIO;
 import static io.delta.kernel.internal.fs.Path.getName;
 
 import io.delta.kernel.engine.Engine;
+import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.exceptions.TableNotFoundException;
 import io.delta.kernel.internal.checkpoints.CheckpointInstance;
 import io.delta.kernel.internal.fs.Path;
@@ -40,36 +41,58 @@ public final class DeltaHistoryManager {
   private static final Logger logger = LoggerFactory.getLogger(DeltaHistoryManager.class);
 
   /**
-   * Returns the latest recreatable commit that happened at or before {@code timestamp}. If the
-   * provided timestamp is after the timestamp of the latest version of the table throws an
-   * exception. If the provided timestamp is before the timestamp of the earliest version of the
-   * table throws an exception.
+   * Returns the latest commit that happened at or before {@code timestamp}.
+   *
+   * If the timestamp is outside the range of [earliestCommit, latestCommit] then use
+   * parameters {@code canReturnLastCommit} and {@code canReturnEarliestCommit} to control whether
+   * an exception is thrown or the corresponding earliest/latest commit is returned.
    *
    * @param engine instance of {@link Engine} to use
    * @param logPath the _delta_log path of the table
    * @param timestamp the timestamp find the version for in milliseconds since the unix epoch
-   * @return the active recreatable commit version at the provided timestamp
+   * @param mustBeRecreatable whether the state at the returned commit should be recreatable
+   * @param canReturnLastCommit whether we can return the latest version of the table if the
+   *                            provided timestamp is after the latest commit
+   * @param canReturnEarliestCommit whether we can return the earliest version of the table if the
+   *                                provided timestamp is before the earliest commit
+   * @throws KernelException if the provided timestamp is before the earliest commit and
+   *                         canReturnEarliestCommit is false
+   * @throws KernelException if the provided timestamp is after the latest commit and
+   *                         canReturnLastCommit is false
    * @throws TableNotFoundException when there is no Delta table at the given path
    */
-  public static long getActiveCommitAtTimestamp(Engine engine, Path logPath, long timestamp)
-      throws TableNotFoundException {
+  public static Commit getActiveCommitAtTimestamp(
+      Engine engine,
+      Path logPath,
+      long timestamp,
+      boolean mustBeRecreatable,
+      boolean canReturnLastCommit,
+      boolean canReturnEarliestCommit
+      ) throws TableNotFoundException {
 
-    long earliestRecreatableCommit = getEarliestRecreatableCommit(engine, logPath);
+    long earliestVersion =
+        (mustBeRecreatable)
+            ? getEarliestRecreatableCommit(engine, logPath)
+            : getEarliestDeltaFile(engine, logPath);
 
     // Search for the commit
-    List<Commit> commits = getCommits(engine, logPath, earliestRecreatableCommit);
+    List<Commit> commits = getCommits(engine, logPath, earliestVersion);
     Commit commit =
         lastCommitBeforeOrAtTimestamp(commits, timestamp)
-            .orElseThrow(
-                () ->
-                    DeltaErrors.timestampBeforeFirstAvailableCommit(
-                        logPath.getParent().toString(), /* use dataPath */
-                        timestamp,
-                        commits.get(0).timestamp,
-                        commits.get(0).version));
+            .orElse(commits.get(0)); // This is only returned if canReturnEarliestCommit (see below)
 
+    // If timestamp is before the earliest commit
+    if (commit.timestamp > timestamp && !canReturnEarliestCommit) {
+      throw DeltaErrors.timestampBeforeFirstAvailableCommit(
+          logPath.getParent().toString(), /* use dataPath */
+          timestamp,
+          commits.get(0).timestamp,
+          commits.get(0).version);
+    }
     // If timestamp is after the last commit of the table
-    if (commit == commits.get(commits.size() - 1) && commit.timestamp < timestamp) {
+    if (commit == commits.get(commits.size() - 1)
+        && commit.timestamp < timestamp
+        && !canReturnLastCommit) {
       throw DeltaErrors.timestampAfterLatestCommit(
           logPath.getParent().toString(), /* use dataPath */
           timestamp,
@@ -77,7 +100,7 @@ public final class DeltaHistoryManager {
           commit.version);
     }
 
-    return commit.version;
+    return commit;
   }
 
   /**
@@ -155,6 +178,30 @@ public final class DeltaHistoryManager {
         throw new RuntimeException(String.format("No recreatable commits found at %s", logPath));
       } else {
         throw new RuntimeException(String.format("No commits found at %s", logPath));
+      }
+    } catch (IOException e) {
+      throw new RuntimeException("Could not close iterator", e);
+    }
+  }
+
+  /**
+   * Get the earliest commit available for this table. Note that this version isn't guaranteed to
+   * exist when performing an action as a concurrent operation can delete the file during cleanup.
+   * This value must be used as a lower bound.
+   */
+  public static long getEarliestDeltaFile(Engine engine, Path logPath)
+      throws TableNotFoundException {
+
+    try (CloseableIterator<FileStatus> files =
+        listFrom(engine, logPath, 0).filter(fs -> FileNames.isCommitFile(getName(fs.getPath())))) {
+
+      if (files.hasNext()) {
+        return FileNames.deltaVersion(files.next().getPath());
+      } else {
+        // listFrom already throws an error if the directory is truly empty, thus this must
+        // be because no files are delta files
+        throw new RuntimeException(
+            String.format("No delta files found in the directory: %s", logPath));
       }
     } catch (IOException e) {
       throw new RuntimeException("Could not close iterator", e);
@@ -242,10 +289,10 @@ public final class DeltaHistoryManager {
     return Optional.ofNullable((i < 0) ? null : commits.get(i));
   }
 
-  private static class Commit {
+  public static class Commit {
 
-    final long version;
-    final long timestamp;
+    public final long version;
+    public final long timestamp;
 
     Commit(long version, long timestamp) {
       this.version = version;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
@@ -151,7 +151,7 @@ public class TableImpl implements Table {
             // e.g. we give time T-1 and first commit has time T, then do NOT want that earliest
             // commit
             false /* canReturnEarliestCommit */)
-        .version;
+        .getVersion();
   }
 
   /**
@@ -189,14 +189,14 @@ public class TableImpl implements Table {
             // commit
             true /* canReturnEarliestCommit */);
 
-    if (commit.timestamp >= millisSinceEpochUTC) {
-      return commit.version;
+    if (commit.getTimestamp() >= millisSinceEpochUTC) {
+      return commit.getVersion();
     } else {
       // this commit.timestamp is before the input timestamp. if this is the last commit, then
-      // the input timestamp is after the last commit and `getActiveCommitAtTime` would have thrown
-      // an KernelException. So, clearly, this can't be the last commit, so we can safely
+      // the input timestamp is after the last commit and `getActiveCommitAtTimestamp` would have
+      // thrown an KernelException. So, clearly, this can't be the last commit, so we can safely
       // return commit.version + 1 as the version that is at or after the input timestamp.
-      return commit.version + 1;
+      return commit.getVersion() + 1;
     }
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
@@ -121,22 +121,23 @@ public class TableImpl implements Table {
   }
 
   /**
-   * Returns the latest version that was committed before or at {@code millisSinceEpochUTC}.
-   * If no version exists, throws a {@link KernelException}
+   * Returns the latest version that was committed before or at {@code millisSinceEpochUTC}. If no
+   * version exists, throws a {@link KernelException}
    *
-   * Specifically:
+   * <p>Specifically:
+   *
    * <ul>
-   *     <li>if a commit version exactly matches the provided timestamp, we return it</li>
-   *     <li>else, we return the latest commit version with a timestamp less than the
-   *         provided one</li>
-   *     <li>If the provided timestamp is less than the timestamp of any committed version,
-   *         we throw an error.</li>
-   * </ul>.
+   *   <li>if a commit version exactly matches the provided timestamp, we return it
+   *   <li>else, we return the latest commit version with a timestamp less than the provided one
+   *   <li>If the provided timestamp is less than the timestamp of any committed version, we throw
+   *       an error.
+   * </ul>
+   *
+   * .
    *
    * @param millisSinceEpochUTC the number of milliseconds since midnight, January 1, 1970 UTC
    * @return latest commit that happened before or at {@code timestamp}.
-   * @throws KernelException if the timestamp is less than the timestamp of any committed
-   *                         version
+   * @throws KernelException if the timestamp is less than the timestamp of any committed version
    * @throws TableNotFoundException if no delta table is found
    */
   public long getVersionBeforeOrAtTimestamp(Engine engine, long millisSinceEpochUTC) {
@@ -154,42 +155,49 @@ public class TableImpl implements Table {
   }
 
   /**
-   * Returns the latest version that was committed at or after {@code millisSinceEpochUTC}.
-   * If no version exists, throws a {@link KernelException}
+   * Returns the latest version that was committed at or after {@code millisSinceEpochUTC}. If no
+   * version exists, throws a {@link KernelException}
    *
-   * Specifically:
+   * <p>Specifically:
+   *
    * <ul>
-   *     <li>if a commit version exactly matches the provided timestamp, we return it</li>
-   *     <li>else, we return the earliest commit version with a timestamp greater than the
-   *         provided one</li>
-   *     <li>If the provided timestamp is larger than the timestamp of any committed version,
-   *         we throw an error.</li>
-   * </ul>.
+   *   <li>if a commit version exactly matches the provided timestamp, we return it
+   *   <li>else, we return the earliest commit version with a timestamp greater than the provided
+   *       one
+   *   <li>If the provided timestamp is larger than the timestamp of any committed version, we throw
+   *       an error.
+   * </ul>
+   *
+   * .
    *
    * @param millisSinceEpochUTC the number of milliseconds since midnight, January 1, 1970 UTC
    * @return latest commit that happened at or before {@code timestamp}.
-   * @throws KernelException if the timestamp is more than the timestamp of any committed
-   *                         version
+   * @throws KernelException if the timestamp is more than the timestamp of any committed version
    * @throws TableNotFoundException if no delta table is found
    */
   public long getVersionAtOrAfterTimestamp(Engine engine, long millisSinceEpochUTC) {
-      DeltaHistoryManager.Commit commit = DeltaHistoryManager.getActiveCommitAtTimestamp(engine, getLogPath(), millisSinceEpochUTC, false, /* mustBeRecreatable */
-          // e.g. if we give time T+2 and last commit has time T, then we do NOT want that last
-          // commit
-          false, /* canReturnLastCommit */
-          // e.g. we give time T-1 and first commit has time T, then we DO want that earliest
-          // commit
-          true /* canReturnEarliestCommit */);
+    DeltaHistoryManager.Commit commit =
+        DeltaHistoryManager.getActiveCommitAtTimestamp(
+            engine,
+            getLogPath(),
+            millisSinceEpochUTC,
+            false, /* mustBeRecreatable */
+            // e.g. if we give time T+2 and last commit has time T, then we do NOT want that last
+            // commit
+            false, /* canReturnLastCommit */
+            // e.g. we give time T-1 and first commit has time T, then we DO want that earliest
+            // commit
+            true /* canReturnEarliestCommit */);
 
-      if (commit.timestamp >= millisSinceEpochUTC) {
-          return commit.version;
-      } else {
-          // this commit.timestamp is before the input timestamp. if this is the last commit, then the
-          // input timestamp is after the last commit and `getActiveCommitAtTime` would have thrown
-          // an KernelException. So, clearly, this can't be the last commit, so we can safely
-          // return commit.version + 1 as the version that is at or after the input timestamp.
-          return commit.version + 1;
-      }
+    if (commit.timestamp >= millisSinceEpochUTC) {
+      return commit.version;
+    } else {
+      // this commit.timestamp is before the input timestamp. if this is the last commit, then
+      // the input timestamp is after the last commit and `getActiveCommitAtTime` would have thrown
+      // an KernelException. So, clearly, this can't be the last commit, so we can safely
+      // return commit.version + 1 as the version that is at or after the input timestamp.
+      return commit.version + 1;
+    }
   }
 
   /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -175,8 +175,8 @@ public class SnapshotManager {
                 millisSinceEpochUTC,
                 true /* mustBeRecreatable */,
                 false /* canReturnLastCommit */,
-                false /* canReturnEarliestCommit */
-        ).version;
+                false /* canReturnEarliestCommit */)
+            .version;
     logger.info(
         "{}: Took {}ms to fetch version at timestamp {}",
         tablePath,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -176,7 +176,7 @@ public class SnapshotManager {
                 true /* mustBeRecreatable */,
                 false /* canReturnLastCommit */,
                 false /* canReturnEarliestCommit */)
-            .version;
+            .getVersion();
     logger.info(
         "{}: Took {}ms to fetch version at timestamp {}",
         tablePath,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -169,7 +169,14 @@ public class SnapshotManager {
       throws TableNotFoundException {
     long startTimeMillis = System.currentTimeMillis();
     long versionToRead =
-        DeltaHistoryManager.getActiveCommitAtTimestamp(engine, logPath, millisSinceEpochUTC);
+        DeltaHistoryManager.getActiveCommitAtTimestamp(
+                engine,
+                logPath,
+                millisSinceEpochUTC,
+                true /* mustBeRecreatable */,
+                false /* canReturnLastCommit */,
+                false /* canReturnEarliestCommit */
+        ).version;
     logger.info(
         "{}: Took {}ms to fetch version at timestamp {}",
         tablePath,

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/DeltaHistoryManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/DeltaHistoryManagerSuite.scala
@@ -29,25 +29,52 @@ class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtil
   def checkGetActiveCommitAtTimestamp(
     fileList: Seq[FileStatus],
     timestamp: Long,
-    expectedVersion: Long): Unit = {
+    expectedVersion: Long,
+    mustBeRecreatable: Boolean = true,
+    canReturnLastCommit: Boolean = false,
+    canReturnEarliestCommit: Boolean = false): Unit = {
     val activeCommit = DeltaHistoryManager.getActiveCommitAtTimestamp(
       createMockFSListFromEngine(fileList),
       logPath,
-      timestamp
+      timestamp,
+      mustBeRecreatable,
+      canReturnLastCommit,
+      canReturnEarliestCommit
     )
-    assert(activeCommit == expectedVersion,
+    assert(activeCommit.version == expectedVersion,
       s"Expected version $expectedVersion but got $activeCommit for timestamp=$timestamp")
+
+    if (mustBeRecreatable) {
+      // When mustBeRecreatable=true, we should have the same answer as mustBeRecreatable=false
+      // for valid queries that do not throw an error
+      val activeCommit = DeltaHistoryManager.getActiveCommitAtTimestamp(
+        createMockFSListFromEngine(fileList),
+        logPath,
+        timestamp,
+        false, // mustBeRecreatable
+        canReturnLastCommit,
+        canReturnEarliestCommit
+      )
+      assert(activeCommit.version == expectedVersion,
+        s"Expected version $expectedVersion but got $activeCommit for timestamp=$timestamp")
+    }
   }
 
   def checkGetActiveCommitAtTimestampError[T <: Throwable](
     fileList: Seq[FileStatus],
     timestamp: Long,
-    expectedErrorMessageContains: String)(implicit classTag: ClassTag[T]): Unit = {
+    expectedErrorMessageContains: String,
+    mustBeRecreatable: Boolean = true,
+    canReturnLastCommit: Boolean = false,
+    canReturnEarliestCommit: Boolean = false)(implicit classTag: ClassTag[T]): Unit = {
     val e = intercept[T] {
       DeltaHistoryManager.getActiveCommitAtTimestamp(
         createMockFSListFromEngine(fileList),
         logPath,
-        timestamp
+        timestamp,
+        mustBeRecreatable,
+        canReturnLastCommit,
+        canReturnEarliestCommit
       )
     }
     assert(e.getMessage.contains(expectedErrorMessageContains))
@@ -72,6 +99,9 @@ class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtil
       21,
       DeltaErrors.timestampAfterLatestCommit(dataPath.toString, 21, 20, 2).getMessage
     )
+    // Valid queries with canReturnLastCommit=true and canReturnEarliestCommit=true
+    checkGetActiveCommitAtTimestamp(deltaFiles, -1, 0, canReturnEarliestCommit = true)
+    checkGetActiveCommitAtTimestamp(deltaFiles, 21, 2, canReturnLastCommit = true)
   }
 
   test("getActiveCommitAtTimestamp: basic listing from 0 with a checkpoint") {
@@ -93,6 +123,9 @@ class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtil
       21,
       DeltaErrors.timestampAfterLatestCommit(dataPath.toString, 21, 20, 2).getMessage
     )
+    // Valid queries with canReturnLastCommit=true and canReturnEarliestCommit=true
+    checkGetActiveCommitAtTimestamp(deltaFiles, -1, 0, canReturnEarliestCommit = true)
+    checkGetActiveCommitAtTimestamp(deltaFiles, 21, 2, canReturnLastCommit = true)
   }
 
   test("getActiveCommitAtTimestamp: truncated delta log") {
@@ -112,6 +145,9 @@ class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtil
       31,
       DeltaErrors.timestampAfterLatestCommit(dataPath.toString, 31, 30, 3).getMessage
     )
+    // Valid queries with canReturnLastCommit=true and canReturnEarliestCommit=true
+    checkGetActiveCommitAtTimestamp(deltaFiles, 8, 2, canReturnEarliestCommit = true)
+    checkGetActiveCommitAtTimestamp(deltaFiles, 31, 3, canReturnLastCommit = true)
   }
 
   test("getActiveCommitAtTimestamp: truncated delta log only checkpoint version") {
@@ -129,6 +165,9 @@ class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtil
       21,
       DeltaErrors.timestampAfterLatestCommit(dataPath.toString, 21, 20, 2).getMessage
     )
+    // Valid queries with canReturnLastCommit=true and canReturnEarliestCommit=true
+    checkGetActiveCommitAtTimestamp(deltaFiles, 8, 2, canReturnEarliestCommit = true)
+    checkGetActiveCommitAtTimestamp(deltaFiles, 21, 2, canReturnLastCommit = true)
   }
 
   test("getActiveCommitAtTimestamp: truncated delta log with multi-part checkpoint") {
@@ -148,6 +187,9 @@ class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtil
       31,
       DeltaErrors.timestampAfterLatestCommit(dataPath.toString, 31, 30, 3).getMessage
     )
+    // Valid queries with canReturnLastCommit=true and canReturnEarliestCommit=true
+    checkGetActiveCommitAtTimestamp(deltaFiles, 8, 2, canReturnEarliestCommit = true)
+    checkGetActiveCommitAtTimestamp(deltaFiles, 31, 3, canReturnLastCommit = true)
   }
 
   test("getActiveCommitAtTimestamp: throws table not found exception") {
@@ -156,7 +198,10 @@ class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtil
       DeltaHistoryManager.getActiveCommitAtTimestamp(
         createMockFSListFromEngine(p => throw new FileNotFoundException(p)),
         logPath,
-        0
+        0,
+        true, // mustBeRecreatable
+        false, // canReturnLastCommit
+        false // canReturnEarliestCommit
       )
     )
     // Empty _delta_log directory
@@ -164,7 +209,10 @@ class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtil
       DeltaHistoryManager.getActiveCommitAtTimestamp(
         createMockFSListFromEngine(p => Seq()),
         logPath,
-        0
+        0,
+        true, // mustBeRecreatable
+        false, // canReturnLastCommit
+        false // canReturnEarliestCommit
       )
     )
   }
@@ -203,6 +251,79 @@ class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtil
       deltaFileStatuses(Seq(2L, 3L)) ++ multiCheckpointFileStatuses(Seq(2L), 3).take(2),
       25,
       "No recreatable commits found"
+    )
+  }
+
+  test("getActiveCommitAtTimestamp: when mustBeRecreatable=false") {
+    Seq(deltaFileStatuses(Seq(1L, 2L, 3L)), // w/o checkpoint
+      singularCheckpointFileStatuses(Seq(2L)) ++ deltaFileStatuses(Seq(1L, 2L, 3L)) // w/checkpoint
+    ).foreach { deltaFiles =>
+      // Valid queries
+      checkGetActiveCommitAtTimestamp(deltaFiles, 10, 1, mustBeRecreatable = false)
+      checkGetActiveCommitAtTimestamp(deltaFiles, 11, 1, mustBeRecreatable = false)
+      checkGetActiveCommitAtTimestamp(deltaFiles, 20, 2, mustBeRecreatable = false)
+      checkGetActiveCommitAtTimestamp(deltaFiles, 21, 2, mustBeRecreatable = false)
+      checkGetActiveCommitAtTimestamp(deltaFiles, 30, 3, mustBeRecreatable = false)
+      // Invalid queries
+      checkGetActiveCommitAtTimestampError[RuntimeException](
+        deltaFiles,
+        -1,
+        DeltaErrors.timestampBeforeFirstAvailableCommit(dataPath.toString, -1, 10, 1).getMessage,
+        mustBeRecreatable = false
+      )
+      checkGetActiveCommitAtTimestampError[RuntimeException](
+        deltaFiles,
+        31,
+        DeltaErrors.timestampAfterLatestCommit(dataPath.toString, 31, 30, 3).getMessage,
+        mustBeRecreatable = false
+      )
+      // Valid queries with canReturnLastCommit=true and canReturnEarliestCommit=true
+      checkGetActiveCommitAtTimestamp(
+        deltaFiles, 0, 1, mustBeRecreatable = false, canReturnEarliestCommit = true)
+      checkGetActiveCommitAtTimestamp(
+        deltaFiles, 31, 3, mustBeRecreatable = false, canReturnLastCommit = true)
+    }
+  }
+
+  test("getActiveCommitAtTimestamp: mustBeRecreatable=false error cases") {
+    /* ---------- TABLE NOT FOUND --------- */
+    // Non-existent path
+    intercept[TableNotFoundException](
+      DeltaHistoryManager.getActiveCommitAtTimestamp(
+        createMockFSListFromEngine(p => throw new FileNotFoundException(p)),
+        logPath,
+        0,
+        false, // mustBeRecreatable
+        false, // canReturnLastCommit
+        false // canReturnEarliestCommit
+      )
+    )
+    // Empty _delta_log directory
+    intercept[TableNotFoundException](
+      DeltaHistoryManager.getActiveCommitAtTimestamp(
+        createMockFSListFromEngine(p => Seq()),
+        logPath,
+        0,
+        true, // mustBeRecreatable
+        false, // canReturnLastCommit
+        false // canReturnEarliestCommit
+      )
+    )
+    /* ---------- CORRUPT LISTINGS --------- */
+    // No commit files at all (only checkpoint files)
+    checkGetActiveCommitAtTimestampError[RuntimeException](
+      singularCheckpointFileStatuses(Seq(1L)),
+      25,
+      "No delta files found in the directory",
+      mustBeRecreatable = false
+    )
+    // No delta files
+    checkGetActiveCommitAtTimestampError[RuntimeException](
+      Seq("foo", "notdelta.parquet", "foo.json", "001.checkpoint.00f.oo0.parquet")
+        .map(FileStatus.of(_, 10, 10)),
+      25,
+      "No delta files found in the directory",
+      mustBeRecreatable = false
     )
   }
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/DeltaHistoryManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/DeltaHistoryManagerSuite.scala
@@ -41,7 +41,7 @@ class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtil
       canReturnLastCommit,
       canReturnEarliestCommit
     )
-    assert(activeCommit.version == expectedVersion,
+    assert(activeCommit.getVersion == expectedVersion,
       s"Expected version $expectedVersion but got $activeCommit for timestamp=$timestamp")
 
     if (mustBeRecreatable) {
@@ -55,7 +55,7 @@ class DeltaHistoryManagerSuite extends AnyFunSuite with MockFileSystemClientUtil
         canReturnLastCommit,
         canReturnEarliestCommit
       )
-      assert(activeCommit.version == expectedVersion,
+      assert(activeCommit.getVersion == expectedVersion,
         s"Expected version $expectedVersion but got $activeCommit for timestamp=$timestamp")
     }
   }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableImplSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableImplSuite.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.delta.kernel.internal
 
 import io.delta.kernel.test.{MockFileSystemClientUtils, MockListFromResolvePathFileSystemClient}

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableImplSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableImplSuite.scala
@@ -1,0 +1,108 @@
+package io.delta.kernel.internal
+
+import io.delta.kernel.test.{MockFileSystemClientUtils, MockListFromResolvePathFileSystemClient}
+import io.delta.kernel.utils.FileStatus
+import io.delta.kernel.Table
+import io.delta.kernel.exceptions.KernelException
+import org.scalatest.funsuite.AnyFunSuite
+
+class TableImplSuite extends AnyFunSuite with MockFileSystemClientUtils {
+
+  def checkGetVersionBeforeOrAtTimestamp(
+    fileList: Seq[FileStatus],
+    timestamp: Long,
+    expectedVersion: Option[Long] = None,
+    expectedErrorMessageContains: Option[String] = None): Unit = {
+    // Check our inputs are as expected
+    assert(expectedVersion.isEmpty || expectedErrorMessageContains.isEmpty)
+    assert(expectedVersion.nonEmpty || expectedErrorMessageContains.nonEmpty)
+
+    val engine = mockEngine(fileSystemClient =
+      new MockListFromResolvePathFileSystemClient(listFromProvider(fileList)))
+    val table = Table.forPath(engine, dataPath.toString)
+
+    expectedVersion.foreach { v =>
+      assert(table.asInstanceOf[TableImpl].getVersionBeforeOrAtTimestamp(engine, timestamp) == v)
+    }
+    expectedErrorMessageContains.foreach { s =>
+      assert(intercept[KernelException] {
+        table.asInstanceOf[TableImpl].getVersionBeforeOrAtTimestamp(engine, timestamp)
+      }.getMessage.contains(s))
+    }
+  }
+
+  def checkGetVersionAtOrAfterTimestamp(
+    fileList: Seq[FileStatus],
+    timestamp: Long,
+    expectedVersion: Option[Long] = None,
+    expectedErrorMessageContains: Option[String] = None): Unit = {
+    // Check our inputs are as expected
+    assert(expectedVersion.isEmpty || expectedErrorMessageContains.isEmpty)
+    assert(expectedVersion.nonEmpty || expectedErrorMessageContains.nonEmpty)
+
+    val engine = mockEngine(fileSystemClient =
+      new MockListFromResolvePathFileSystemClient(listFromProvider(fileList)))
+    val table = Table.forPath(engine, dataPath.toString)
+
+    expectedVersion.foreach { v =>
+      assert(table.asInstanceOf[TableImpl].getVersionAtOrAfterTimestamp(engine, timestamp) == v)
+    }
+    expectedErrorMessageContains.foreach { s =>
+      assert(intercept[KernelException] {
+        table.asInstanceOf[TableImpl].getVersionAtOrAfterTimestamp(engine, timestamp)
+      }.getMessage.contains(s))
+    }
+  }
+
+  test("getVersionBeforeOrAtTimestamp: basic case from 0") {
+    val deltaFiles = deltaFileStatuses(Seq(0L, 1L))
+    checkGetVersionBeforeOrAtTimestamp(deltaFiles, -1,
+      expectedErrorMessageContains = Some("is before the earliest available version 0")) // before 0
+    checkGetVersionBeforeOrAtTimestamp(deltaFiles, 0, expectedVersion = Some(0)) // at 0
+    checkGetVersionBeforeOrAtTimestamp(deltaFiles, 5, expectedVersion = Some(0)) // btw 0, 1
+    checkGetVersionBeforeOrAtTimestamp(deltaFiles, 10, expectedVersion = Some(1)) // at 1
+    checkGetVersionBeforeOrAtTimestamp(deltaFiles, 11, expectedVersion = Some(1)) // after 1
+  }
+
+  test("getVersionAtOrAfterTimestamp: basic case from 0") {
+    val deltaFiles = deltaFileStatuses(Seq(0L, 1L))
+    checkGetVersionAtOrAfterTimestamp(deltaFiles, -1, expectedVersion = Some(0)) // before 0
+    checkGetVersionAtOrAfterTimestamp(deltaFiles, 0, expectedVersion = Some(0)) // at 0
+    checkGetVersionAtOrAfterTimestamp(deltaFiles, 5, expectedVersion = Some(1)) // btw 0, 1
+    checkGetVersionAtOrAfterTimestamp(deltaFiles, 10, expectedVersion = Some(1)) // at 1
+    checkGetVersionAtOrAfterTimestamp(deltaFiles, 11,
+      expectedErrorMessageContains = Some("is after the latest available version 1")) // after 1
+  }
+
+  test("getVersionBeforeOrAtTimestamp: w/ checkpoint + w/o checkpoint") {
+    Seq(
+      deltaFileStatuses(Seq(10L, 11L, 12L)) ++ singularCheckpointFileStatuses(Seq(10L)),
+      deltaFileStatuses(Seq(10L, 11L, 12L)) // checks that does not need to be recreatable
+    ).foreach { deltaFiles =>
+      checkGetVersionBeforeOrAtTimestamp(deltaFiles, 99, // before 10
+        expectedErrorMessageContains = Some("is before the earliest available version 10"))
+      checkGetVersionBeforeOrAtTimestamp(deltaFiles, 100, expectedVersion = Some(10)) // at 10
+      checkGetVersionBeforeOrAtTimestamp(deltaFiles, 105, expectedVersion = Some(10)) // btw 10, 11
+      checkGetVersionBeforeOrAtTimestamp(deltaFiles, 110, expectedVersion = Some(11)) // at 11
+      checkGetVersionBeforeOrAtTimestamp(deltaFiles, 115, expectedVersion = Some(11)) // btw 11, 12
+      checkGetVersionBeforeOrAtTimestamp(deltaFiles, 120, expectedVersion = Some(12)) // at 12
+      checkGetVersionBeforeOrAtTimestamp(deltaFiles, 125, expectedVersion = Some(12)) // after 12
+    }
+  }
+
+  test("getVersionAtOrAfterTimestamp: w/ checkpoint + w/o checkpoint") {
+    Seq(
+      deltaFileStatuses(Seq(10L, 11L, 12L)) ++ singularCheckpointFileStatuses(Seq(10L)),
+      deltaFileStatuses(Seq(10L, 11L, 12L)) // checks that does not need to be recreatable
+    ).foreach { deltaFiles =>
+      checkGetVersionAtOrAfterTimestamp(deltaFiles, 99, expectedVersion = Some(10)) // before 10
+      checkGetVersionAtOrAfterTimestamp(deltaFiles, 100, expectedVersion = Some(10)) // at 10
+      checkGetVersionAtOrAfterTimestamp(deltaFiles, 105, expectedVersion = Some(11)) // btw 10, 11
+      checkGetVersionAtOrAfterTimestamp(deltaFiles, 110, expectedVersion = Some(11)) // at 11
+      checkGetVersionAtOrAfterTimestamp(deltaFiles, 115, expectedVersion = Some(12)) // btw 11, 12
+      checkGetVersionAtOrAfterTimestamp(deltaFiles, 120, expectedVersion = Some(12)) // at 12
+      checkGetVersionAtOrAfterTimestamp(deltaFiles, 125,
+        expectedErrorMessageContains = Some("is after the latest available version 12")) // after 12
+    }
+  }
+}

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockFileSystemClientUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockFileSystemClientUtils.scala
@@ -141,3 +141,23 @@ class MockListFromFileSystemClient(listFromProvider: String => Seq[FileStatus])
 
   def getListFromCalls: Seq[String] = listFromCalls
 }
+
+/**
+ * A mock [[FileSystemClient]] that answers `listFrom` calls from a given content provider and
+ * implements the identity function for `resolvePath` calls.
+ *
+ * It also maintains metrics on number of times `listFrom` is called and arguments for each call.
+ */
+class MockListFromResolvePathFileSystemClient(listFromProvider: String => Seq[FileStatus])
+  extends BaseMockFileSystemClient {
+  private var listFromCalls: Seq[String] = Seq.empty
+
+  override def listFrom(filePath: String): CloseableIterator[FileStatus] = {
+    listFromCalls = listFromCalls :+ filePath
+    toCloseableIterator(listFromProvider(filePath).iterator.asJava)
+  }
+
+  override def resolvePath(path: String): String = path
+
+  def getListFromCalls: Seq[String] = listFromCalls
+}

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
@@ -18,12 +18,15 @@ package io.delta.kernel.defaults
 import io.delta.golden.GoldenTableUtils.goldenTablePath
 import io.delta.kernel.exceptions.{InvalidTableException, KernelException, TableNotFoundException}
 import io.delta.kernel.defaults.utils.{TestRow, TestUtils}
+import io.delta.kernel.internal.TableImpl
 import io.delta.kernel.internal.fs.Path
 import io.delta.kernel.internal.util.InternalUtils.daysSinceEpoch
 import io.delta.kernel.internal.util.{DateTimeConstants, FileNames}
 import io.delta.kernel.types.{LongType, StructType}
 import io.delta.kernel.Table
 import org.apache.hadoop.shaded.org.apache.commons.io.FileUtils
+import org.apache.spark.sql.delta.{DeltaLog, DeltaOperations}
+import org.apache.spark.sql.delta.actions.{AddFile, Metadata}
 import org.apache.spark.sql.functions.col
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -856,6 +859,143 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
       intercept[TableNotFoundException] {
         Table.forPath(defaultEngine, dir.getCanonicalPath)
           .getSnapshotAsOfTimestamp(defaultEngine, 0L)
+      }
+    }
+  }
+
+  ///////////////////////////////////////////////////////////////////////////////////////////////
+  // getVersionBeforeOrAtTimestamp + getVersionAtOrAfterTimestamp tests
+  // (more in TableImplSuite and DeltaHistoryManagerSuite)
+  //////////////////////////////////////////////////////////////////////////////////////////////
+
+  // Copied from Standalone DeltaLogSuite
+  test("getVersionBeforeOrAtTimestamp and getVersionAtOrAfterTimestamp") {
+    // Note:
+    // - all Xa test cases will test getVersionBeforeOrAtTimestamp
+    // - all Xb test cases will test getVersionAtOrAfterTimestamp
+    withTempDir { dir =>
+      val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
+      val tableImpl = Table.forPath(defaultEngine, dir.getCanonicalPath).asInstanceOf[TableImpl]
+
+      // ========== case 0: delta table does not exist ==========
+      intercept[TableNotFoundException] {
+        tableImpl.getVersionBeforeOrAtTimestamp(defaultEngine, System.currentTimeMillis())
+      }
+      intercept[TableNotFoundException] {
+        tableImpl.getVersionAtOrAfterTimestamp(defaultEngine, System.currentTimeMillis())
+      }
+
+      // Setup part 1 of 2: create log files
+      (0 to 2).foreach { i =>
+        val files = AddFile(i.toString, Map.empty, 1, 1, true) :: Nil
+        val metadata = if (i == 0) Metadata() :: Nil else Nil
+        log.startTransaction().commit( metadata ++ files, DeltaOperations.ManualUpdate)
+      }
+
+      // Setup part 2 of 2: edit lastModified times
+      val logPath = new Path(dir.getCanonicalPath, "_delta_log")
+
+      val delta0 = new File(FileNames.deltaFile(logPath, 0))
+      val delta1 = new File(FileNames.deltaFile(logPath, 1))
+      val delta2 = new File(FileNames.deltaFile(logPath, 2))
+      delta0.setLastModified(1000)
+      delta1.setLastModified(2000)
+      delta2.setLastModified(3000)
+
+      // ========== case 1: before first commit ==========
+      // case 1a
+      val e1 = intercept[KernelException] {
+        tableImpl.getVersionBeforeOrAtTimestamp(defaultEngine, 500)
+      }.getMessage
+      assert(e1.contains("is before the earliest available version 0"))
+      // case 1b
+      assert(tableImpl.getVersionAtOrAfterTimestamp(defaultEngine, 500) == 0)
+
+      // ========== case 2: at first commit ==========
+      // case 2a
+      assert(tableImpl.getVersionBeforeOrAtTimestamp(defaultEngine, 1000) == 0)
+      // case 2b
+      assert(tableImpl.getVersionAtOrAfterTimestamp(defaultEngine, 1000) == 0)
+
+      // ========== case 3: between two normal commits ==========
+      // case 3a
+      assert(tableImpl.getVersionBeforeOrAtTimestamp(defaultEngine, 1500) == 0) // round down to v0
+      // case 3b
+      assert(tableImpl.getVersionAtOrAfterTimestamp(defaultEngine, 1500) == 1) // round up to v1
+
+      // ========== case 4: at last commit ==========
+      // case 4a
+      assert(tableImpl.getVersionBeforeOrAtTimestamp(defaultEngine, 3000) == 2)
+      // case 4b
+      assert(tableImpl.getVersionAtOrAfterTimestamp(defaultEngine, 3000) == 2)
+
+      // ========== case 5: after last commit ==========
+      // case 5a
+      assert(tableImpl.getVersionBeforeOrAtTimestamp(defaultEngine, 4000) == 2)
+      // case 5b
+      val e2 = intercept[KernelException] {
+        tableImpl.getVersionAtOrAfterTimestamp(defaultEngine, 4000)
+      }.getMessage
+      assert(e2.contains("is after the latest available version 2"))
+    }
+  }
+
+  // Copied from Standalone DeltaLogSuite
+  test("getVersionBeforeOrAtTimestamp and getVersionAtOrAfterTimestamp - recoverability") {
+    withTempDir { dir =>
+      // local file system truncates to seconds
+      val nowEpochMs = System.currentTimeMillis() / 1000 * 1000
+
+      val logPath = new Path(dir.getCanonicalPath, "_delta_log")
+
+      val log = DeltaLog.forTable(spark, dir.getCanonicalPath)
+      val tableImpl = Table.forPath(defaultEngine, dir.getCanonicalPath).asInstanceOf[TableImpl]
+
+      (0 to 35).foreach { i =>
+        val files = AddFile(i.toString, Map.empty, 1, 1, true) :: Nil
+        val metadata = if (i == 0) Metadata() :: Nil else Nil
+        log.startTransaction().commit(metadata ++ files, DeltaOperations.ManualUpdate)
+      }
+
+      (0 to 35).foreach { i =>
+        val delta = new File(FileNames.deltaFile(logPath, i))
+        if (i >= 25) {
+          delta.setLastModified(nowEpochMs + i * 1000)
+        } else {
+          assert(delta.delete())
+        }
+      }
+
+      // A checkpoint exists at version 30, so all versions [30, 35] are recoverable.
+      // Nonetheless, getVersionBeforeOrAtTimestamp and getVersionAtOrAfterTimestamp do not
+      // require that the version is recoverable, so we should still be able to get back versions
+      // [25-29]
+
+      (25 to 34).foreach { i =>
+        if (i == 25) {
+          assertThrows[KernelException] {
+            tableImpl.getVersionBeforeOrAtTimestamp(defaultEngine, nowEpochMs + i * 1000 - 1)
+          }
+        } else {
+          assert(tableImpl.getVersionBeforeOrAtTimestamp(defaultEngine, nowEpochMs + i * 1000 - 1)
+            == i - 1)
+        }
+
+        assert(
+          tableImpl.getVersionAtOrAfterTimestamp(defaultEngine, nowEpochMs + i * 1000 - 1) == i)
+
+        assert(tableImpl.getVersionBeforeOrAtTimestamp(defaultEngine, nowEpochMs + i * 1000) == i)
+        assert(tableImpl.getVersionAtOrAfterTimestamp(defaultEngine, nowEpochMs + i * 1000) == i)
+
+        assert(
+          tableImpl.getVersionBeforeOrAtTimestamp(defaultEngine, nowEpochMs + i * 1000 + 1)== i)
+
+        if (i == 35) {
+          tableImpl.getVersionAtOrAfterTimestamp(defaultEngine, nowEpochMs + i * 1000 + 1)
+        } else {
+          assert(tableImpl.getVersionAtOrAfterTimestamp(defaultEngine, nowEpochMs + i * 1000 + 1)
+            == i + 1)
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Adds the functions `getVersionBeforeOrAtTimestamp` and `getVersionAtOrAfterTimestamp` to `TableImpl` for use with the `getChangesByVersion` API to enable querying changes between two timestamps. 

## How was this patch tested?

Adds unit tests.