### PR TITLE
[Kernel] Adds protocol checks to the public getChanges API on TableImpl

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /** Contains methods to create user-facing Delta exceptions. */
@@ -149,12 +150,13 @@ public final class DeltaErrors {
     return new KernelException(message);
   }
 
-  public static KernelException unsupportedReaderFeature(String tablePath, String readerFeature) {
+  public static KernelException unsupportedReaderFeature(
+      String tablePath, Set<String> unsupportedFeatures) {
     String message =
         String.format(
-            "Unsupported Delta reader feature: table `%s` requires reader table feature \"%s\" "
+            "Unsupported Delta reader features: table `%s` requires reader table features [%s] "
                 + "which is unsupported by this version of Delta Kernel.",
-            tablePath, readerFeature);
+            tablePath, String.join(", ", unsupportedFeatures));
     return new KernelException(message);
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaLogActionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaLogActionUtils.java
@@ -53,7 +53,7 @@ public class DeltaLogActionUtils {
 
   /**
    * Represents a Delta action. This is used to request which actions to read from the commit files
-   * in {@link TableImpl#getChangesByVersion(Engine, long, long, Set)}.
+   * in {@link TableImpl#getChanges(Engine, long, long, Set)}.
    *
    * <p>See the Delta protocol for more details
    * https://github.com/delta-io/delta/blob/master/PROTOCOL.md#actions

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableFeatures.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableFeatures.java
@@ -24,10 +24,7 @@ import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.util.ColumnMapping;
 import io.delta.kernel.internal.util.Tuple2;
 import io.delta.kernel.types.StructType;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /** Contains utility methods related to the Delta table feature support in protocol. */
@@ -48,19 +45,19 @@ public class TableFeatures {
   ////////////////////
 
   public static void validateReadSupportedTable(
-      Protocol protocol, Metadata metadata, String tablePath) {
+      Protocol protocol, Optional<Metadata> metadata, String tablePath) {
     switch (protocol.getMinReaderVersion()) {
       case 1:
         break;
       case 2:
-        ColumnMapping.throwOnUnsupportedColumnMappingMode(metadata);
+        metadata.ifPresent(ColumnMapping::throwOnUnsupportedColumnMappingMode);
         break;
       case 3:
         List<String> readerFeatures = protocol.getReaderFeatures();
         for (String readerFeature : readerFeatures) {
           switch (readerFeature) {
             case "columnMapping":
-              ColumnMapping.throwOnUnsupportedColumnMappingMode(metadata);
+              metadata.ifPresent(ColumnMapping::throwOnUnsupportedColumnMappingMode);
               break;
             case "deletionVectors": // fall through
             case "timestampNtz": // fall through

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableFeatures.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableFeatures.java
@@ -58,7 +58,7 @@ public class TableFeatures {
   ////////////////////
 
   public static void validateReadSupportedTable(
-      Protocol protocol, Optional<Metadata> metadata, String tablePath) {
+      Protocol protocol, String tablePath, Optional<Metadata> metadata) {
     switch (protocol.getMinReaderVersion()) {
       case 1:
         break;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
@@ -149,7 +149,7 @@ public class TableImpl implements Table {
    *     range
    * @throws KernelException if provided an invalid version range
    */
-  private CloseableIterator<ColumnarBatch> getChangesByVersion(
+  private CloseableIterator<ColumnarBatch> getRawChanges(
       Engine engine,
       long startVersion,
       long endVersion,
@@ -204,7 +204,7 @@ public class TableImpl implements Table {
       long endVersion,
       Set<DeltaLogActionUtils.DeltaAction> actionSet) {
     if (actionSet.contains(DeltaLogActionUtils.DeltaAction.PROTOCOL)) {
-      return getChangesByVersion(engine, startVersion, endVersion, actionSet)
+      return getRawChanges(engine, startVersion, endVersion, actionSet)
           .map(
               batch -> {
                 int protocolIdx =
@@ -220,7 +220,7 @@ public class TableImpl implements Table {
                 return batch;
               });
     } else {
-      return getChangesByVersion(engine, startVersion, endVersion, actionSet);
+      return getRawChanges(engine, startVersion, endVersion, actionSet);
     }
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
@@ -170,9 +170,9 @@ public class TableImpl implements Table {
 
   /**
    * Returns the raw delta actions for each version between startVersion and endVersion. Only reads
-   * the actions requested in actionSet from the JSON log files. When
-   * {@link DeltaLogActionUtils.DeltaAction#PROTOCOL} is present in {@code actionSet} Kernel also
-   * performs read protocol checks on any protocol actions read.
+   * the actions requested in actionSet from the JSON log files. When {@link
+   * DeltaLogActionUtils.DeltaAction#PROTOCOL} is present in {@code actionSet} Kernel also performs
+   * read protocol checks on any protocol actions read.
    *
    * <p>For the returned columnar batches:
    *
@@ -195,8 +195,8 @@ public class TableImpl implements Table {
    * @throws KernelException if a commit file does not exist for any of the versions in the provided
    *     range
    * @throws KernelException if provided an invalid version range
-   * @throws KernelException if {@link DeltaLogActionUtils.DeltaAction#PROTOCOL} is in actionSet
-   *                         and a Protocol action that is not read supported by Kernel is read
+   * @throws KernelException if {@link DeltaLogActionUtils.DeltaAction#PROTOCOL} is in actionSet and
+   *     a Protocol action that is not read supported by Kernel is read
    */
   public CloseableIterator<ColumnarBatch> getChanges(
       Engine engine,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
@@ -195,7 +195,7 @@ public class TableImpl implements Table {
    *     range
    * @throws KernelException if provided an invalid version range
    * @throws KernelException if the version range contains a version with reader protocol that is
-   *                         unsupported by Kernel
+   *     unsupported by Kernel
    */
   public CloseableIterator<ColumnarBatch> getChanges(
       Engine engine,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
@@ -233,7 +233,8 @@ public class LogReplay {
 
               if (protocol != null) {
                 // Stop since we have found the latest Protocol and Metadata.
-                TableFeatures.validateReadSupportedTable(protocol, metadata, dataPath.toString());
+                TableFeatures.validateReadSupportedTable(
+                    protocol, Optional.of(metadata), dataPath.toString());
                 return new Tuple2<>(protocol, metadata);
               }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/LogReplay.java
@@ -234,7 +234,7 @@ public class LogReplay {
               if (protocol != null) {
                 // Stop since we have found the latest Protocol and Metadata.
                 TableFeatures.validateReadSupportedTable(
-                    protocol, Optional.of(metadata), dataPath.toString());
+                    protocol, dataPath.toString(), Optional.of(metadata));
                 return new Tuple2<>(protocol, metadata);
               }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/TableChangesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/TableChangesSuite.scala
@@ -351,6 +351,7 @@ class TableChangesSuite extends AnyFunSuite with TestUtils {
   }
 
   test("getChanges - fails when protocol is not readable by Kernel") {
+    // Existing tests suffice to check if the protocol column is present/dropped correctly
     // We test our protocol checks for table features in TableFeaturesSuite
     // Min reader version is too high
     assert(intercept[KernelException] {
@@ -359,10 +360,12 @@ class TableChangesSuite extends AnyFunSuite with TestUtils {
         .asInstanceOf[TableImpl]
         .getChanges(defaultEngine, 0, 0, FULL_ACTION_SET.asJava).toSeq
     }.getMessage.contains("Unsupported Delta protocol reader version"))
-    // No error if we don't request the protocol file action
-    Table.forPath(defaultEngine, goldenTablePath("deltalog-invalid-protocol-version"))
-      .asInstanceOf[TableImpl]
-      .getChanges(defaultEngine, 0, 0, Set(DeltaAction.ADD).asJava).toSeq
+    // We still get an error if we don't request the protocol file action
+    assert(intercept[KernelException] {
+      Table.forPath(defaultEngine, goldenTablePath("deltalog-invalid-protocol-version"))
+        .asInstanceOf[TableImpl]
+        .getChanges(defaultEngine, 0, 0, Set(DeltaAction.ADD).asJava).toSeq
+    }.getMessage.contains("Unsupported Delta protocol reader version"))
   }
 
   //////////////////////////////////////////////////////////////////////////////////

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/TableChangesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/TableChangesSuite.scala
@@ -354,17 +354,15 @@ class TableChangesSuite extends AnyFunSuite with TestUtils {
     // We test our protocol checks for table features in TableFeaturesSuite
     // Min reader version is too high
     assert(intercept[KernelException] {
+      // Use toSeq because we need to consume the iterator to force the exception
       Table.forPath(defaultEngine, goldenTablePath("deltalog-invalid-protocol-version"))
         .asInstanceOf[TableImpl]
-        .getChanges(defaultEngine, 0, 0, FULL_ACTION_SET.asJava)
+        .getChanges(defaultEngine, 0, 0, FULL_ACTION_SET.asJava).toSeq
     }.getMessage.contains("Unsupported Delta protocol reader version"))
     // No error if we don't request the protocol file action
-    testGetChangesVsSpark(
-      goldenTablePath("deltalog-invalid-protocol-version"),
-      0,
-      0,
-      Set(DeltaAction.ADD)
-    )
+    Table.forPath(defaultEngine, goldenTablePath("deltalog-invalid-protocol-version"))
+      .asInstanceOf[TableImpl]
+      .getChanges(defaultEngine, 0, 0, Set(DeltaAction.ADD).asJava).toSeq
   }
 
   //////////////////////////////////////////////////////////////////////////////////

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/TableChangesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/TableChangesSuite.scala
@@ -75,7 +75,7 @@ class TableChangesSuite extends AnyFunSuite with TestUtils {
   }
 
   // Golden table from Delta Standalone test
-  test("getChangesByVersion - golden table deltalog-getChanges valid queries") {
+  test("getChanges - golden table deltalog-getChanges valid queries") {
     withGoldenTable("deltalog-getChanges") { tablePath =>
       // request subset of actions
       testGetChangesVsSpark(
@@ -118,7 +118,7 @@ class TableChangesSuite extends AnyFunSuite with TestUtils {
     }
   }
 
-  test("getChangesByVersion - returns correct timestamps") {
+  test("getChanges - returns correct timestamps") {
     withTempDir { tempDir =>
 
       def generateCommits(path: String, commits: Long*): Unit = {
@@ -163,7 +163,7 @@ class TableChangesSuite extends AnyFunSuite with TestUtils {
     }
   }
 
-  test("getChangesByVersion - empty _delta_log folder") {
+  test("getChanges - empty _delta_log folder") {
     withTempDir { tempDir =>
       new File(tempDir, "delta_log").mkdirs()
       intercept[TableNotFoundException] {
@@ -174,7 +174,7 @@ class TableChangesSuite extends AnyFunSuite with TestUtils {
     }
   }
 
-  test("getChangesByVersion - empty folder no _delta_log dir") {
+  test("getChanges - empty folder no _delta_log dir") {
     withTempDir { tempDir =>
       intercept[TableNotFoundException] {
         Table.forPath(defaultEngine, tempDir.getCanonicalPath)
@@ -184,7 +184,7 @@ class TableChangesSuite extends AnyFunSuite with TestUtils {
     }
   }
 
-  test("getChangesByVersion - non-empty folder not a delta table") {
+  test("getChanges - non-empty folder not a delta table") {
     withTempDir { tempDir =>
       spark.range(20).write.format("parquet").mode("overwrite").save(tempDir.getCanonicalPath)
       intercept[TableNotFoundException] {
@@ -195,7 +195,7 @@ class TableChangesSuite extends AnyFunSuite with TestUtils {
     }
   }
 
-  test("getChangesByVersion - directory does not exist") {
+  test("getChanges - directory does not exist") {
     intercept[TableNotFoundException] {
       Table.forPath(defaultEngine, "/fake/table/path")
         .asInstanceOf[TableImpl]
@@ -203,7 +203,7 @@ class TableChangesSuite extends AnyFunSuite with TestUtils {
     }
   }
 
-  test("getChangesByVersion - golden table deltalog-getChanges invalid queries") {
+  test("getChanges - golden table deltalog-getChanges invalid queries") {
     withGoldenTable("deltalog-getChanges") { tablePath =>
       def getChangesByVersion(
         startVersion: Long, endVersion: Long): CloseableIterator[ColumnarBatch] = {
@@ -234,7 +234,7 @@ class TableChangesSuite extends AnyFunSuite with TestUtils {
     }
   }
 
-  test("getChangesByVersion - with truncated log") {
+  test("getChanges - with truncated log") {
     withTempDir { tempDir =>
       // PREPARE TEST TABLE
       val tablePath = tempDir.getCanonicalPath
@@ -296,7 +296,7 @@ class TableChangesSuite extends AnyFunSuite with TestUtils {
     }
   }
 
-  test("getChangesByVersion - table with a lot of changes") {
+  test("getChanges - table with a lot of changes") {
     withTempDir { tempDir =>
       spark.sql(
         f"""


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

To avoid reading invalid tables, Kernel should check that any read protocol actions are supported by Kernel. This PR makes the current API private, and adds a public API around it that does this check when the `Protocol` is included in the list of actions to be read from the file.

Also removes the "byVersion" part of the API name since we are adding separate timestamp APIs in https://github.com/delta-io/delta/pull/3650.

## How was this patch tested?

Adds unit tests.