### PR TITLE
[Delta] Exclude default coordinated commits properties during replace

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/CreateDeltaTableCommand.scala
@@ -724,7 +724,7 @@ case class CreateDeltaTableCommand(
       // When a table already exists, and we're using the DataFrameWriterV2 API to replace
       // or createOrReplace a table, we blindly overwrite the metadata.
       val newMetadata = getProvidedMetadata(table, schema.json)
-      txn.updateMetadataForNewTable(newMetadata)
+      txn.updateMetadataForNewTableInReplace(newMetadata)
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
@@ -279,10 +279,20 @@ object CoordinatedCommitsUtils extends DeltaLogging {
     DeltaConfigs.COORDINATED_COMMITS_COORDINATOR_CONF,
     DeltaConfigs.COORDINATED_COMMITS_TABLE_CONF)
 
+  val ICT_TABLE_PROPERTY_CONFS = Seq(
+    DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED,
+    DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION,
+    DeltaConfigs.IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP)
+
   /**
    * The main table properties used to instantiate a TableCommitCoordinatorClient.
    */
   val TABLE_PROPERTY_KEYS: Seq[String] = TABLE_PROPERTY_CONFS.map(_.key)
+
+  /**
+   * The main ICT table properties used as dependencies for Coordinated Commits.
+   */
+  val ICT_TABLE_PROPERTY_KEYS: Seq[String] = ICT_TABLE_PROPERTY_CONFS.map(_.key)
 
   /**
    * Returns true if any CoordinatedCommits-related table properties is present in the metadata.
@@ -374,9 +384,14 @@ object CoordinatedCommitsUtils extends DeltaLogging {
    */
   def extractCoordinatedCommitsConfigurations(
       properties: Map[String, String]): Map[String, String] = {
-    properties.filter { case (k, _) =>
-      CoordinatedCommitsUtils.TABLE_PROPERTY_KEYS.contains(k)
-    }
+    properties.filter { case (k, _) => TABLE_PROPERTY_KEYS.contains(k) }
+  }
+
+  /**
+   * Extracts the ICT configurations from the provided properties.
+   */
+  def extractICTConfigurations(properties: Map[String, String]): Map[String, String] = {
+    properties.filter { case (k, _) => ICT_TABLE_PROPERTY_KEYS.contains(k) }
   }
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
@@ -28,7 +28,7 @@ import com.databricks.spark.util.UsageRecord
 import org.apache.spark.sql.delta.{CommitStats, CoordinatedCommitsStats, CoordinatedCommitsTableFeature, DeltaOperations, DeltaUnsupportedOperationException, V2CheckpointTableFeature}
 import org.apache.spark.sql.delta.{CommitCoordinatorGetCommitsFailedException, DeltaIllegalArgumentException}
 import org.apache.spark.sql.delta.CoordinatedCommitType._
-import org.apache.spark.sql.delta.DeltaConfigs.{CHECKPOINT_INTERVAL, COORDINATED_COMMITS_COORDINATOR_CONF, COORDINATED_COMMITS_COORDINATOR_NAME, COORDINATED_COMMITS_TABLE_CONF}
+import org.apache.spark.sql.delta.DeltaConfigs.{CHECKPOINT_INTERVAL, COORDINATED_COMMITS_COORDINATOR_CONF, COORDINATED_COMMITS_COORDINATOR_NAME, COORDINATED_COMMITS_TABLE_CONF, IN_COMMIT_TIMESTAMPS_ENABLED}
 import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
 import org.apache.spark.sql.delta.InitialSnapshot
@@ -1608,6 +1608,56 @@ class CoordinatedCommitsSuite
         errorClass = "DELTA_CANNOT_UNSET_COORDINATED_COMMITS_CONFS",
         sqlState = "42616",
         parameters = Map[String, String]())
+    }
+  }
+
+  test("During REPLACE, for non-CC tables, default CC configurations are ignored, but default " +
+      "ICT confs are retained, and existing ICT confs are discarded") {
+    // Non-CC table, REPLACE with default CC and ICT confs => Non-CC, but with ICT confs.
+    withTempDir { tempDir =>
+      withoutCoordinatedCommitsDefaultTableProperties {
+        sql(s"CREATE TABLE delta.`${tempDir.getAbsolutePath}` (id LONG) USING delta")
+      }
+      withSQLConf(IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> "true") {
+        sql(s"REPLACE TABLE delta.`${tempDir.getAbsolutePath}` (id STRING) USING delta")
+      }
+      assert(DeltaLog.forTable(spark, tempDir).snapshot.tableCommitCoordinatorClientOpt.isEmpty)
+      assert(DeltaLog.forTable(spark, tempDir).snapshot.metadata.configuration.contains(
+        IN_COMMIT_TIMESTAMPS_ENABLED.key))
+    }
+
+    // Non-CC table with ICT confs, REPLACE with only default CC confs => Non-CC, also no ICT confs.
+    withTempDir { tempDir =>
+      withoutCoordinatedCommitsDefaultTableProperties {
+        withSQLConf(IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey -> "true") {
+          sql(s"CREATE TABLE delta.`${tempDir.getAbsolutePath}` (id LONG) USING delta")
+        }
+      }
+      sql(s"REPLACE TABLE delta.`${tempDir.getAbsolutePath}` (id STRING) USING delta")
+      assert(DeltaLog.forTable(spark, tempDir).snapshot.tableCommitCoordinatorClientOpt.isEmpty)
+      assert(!DeltaLog.forTable(spark, tempDir).snapshot.metadata.configuration.contains(
+        IN_COMMIT_TIMESTAMPS_ENABLED.key))
+    }
+  }
+
+  test("During REPLACE, for CC tables, existing CC and ICT configurations are both retained.") {
+    CommitCoordinatorProvider.registerBuilder(TrackingInMemoryCommitCoordinatorBuilder(1))
+
+    withTempDir { tempDir =>
+      withoutCoordinatedCommitsDefaultTableProperties {
+        sql(s"CREATE TABLE delta.`${tempDir.getAbsolutePath}` (id LONG) USING delta")
+        sql(s"INSERT INTO delta.`${tempDir.getAbsolutePath}` VALUES (0)")
+        sql(s"ALTER TABLE delta.`${tempDir.getAbsolutePath}` SET TBLPROPERTIES " +
+          s"('${COORDINATED_COMMITS_COORDINATOR_NAME.key}' = 'tracking-in-memory', " +
+          s"'${COORDINATED_COMMITS_COORDINATOR_CONF.key}' = '${JsonUtils.toJson(Map())}')")
+        // All three ICT configurations should be set because Coordinated Commits is enabled later.
+        // REPLACE with default CC confs => CC, and all ICT confs.
+        sql(s"REPLACE TABLE delta.`${tempDir.getAbsolutePath}` (id STRING) USING delta")
+        assert(DeltaLog.forTable(spark, tempDir).snapshot.tableCommitCoordinatorClientOpt.nonEmpty)
+        CoordinatedCommitsUtils.ICT_TABLE_PROPERTY_KEYS.foreach { key =>
+          assert(DeltaLog.forTable(spark, tempDir).snapshot.metadata.configuration.contains(key))
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

1. Exclude default CC properties during REPLACE command. Before, all default properties are merged at some later stage of REPLACE; now, we exclude the CC ones. If an existing commit coordinator is retained, the existing ICT properties are also retained; otherwise, default ICT properties are included.
2. Added UTs.

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

UTs.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.