### PR TITLE
[Spark] Update sbt testing task of Delta Connect Client to automatically use the Spark latest jars

### DIFF
--- a/.github/workflows/spark_master_test.yaml
+++ b/.github/workflows/spark_master_test.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Run Spark Master tests
         # when changing TEST_PARALLELISM_COUNT make sure to also change it in spark_test.yaml
         run: |
-          TEST_PARALLELISM_COUNT=4 SHARD_ID=${{matrix.shard}} build/sbt -DsparkVersion=master "++ ${{ matrix.scala }}" clean spark/test
-          TEST_PARALLELISM_COUNT=4 build/sbt -DsparkVersion=master "++ ${{ matrix.scala }}" clean connectServer/test
           TEST_PARALLELISM_COUNT=4 build/sbt -DsparkVersion=master "++ ${{ matrix.scala }}" clean connectServer/assembly connectClient/test
+          TEST_PARALLELISM_COUNT=4 build/sbt -DsparkVersion=master "++ ${{ matrix.scala }}" clean connectServer/test
+          TEST_PARALLELISM_COUNT=4 SHARD_ID=${{matrix.shard}} build/sbt -DsparkVersion=master "++ ${{ matrix.scala }}" clean spark/test
         if: steps.git-diff.outputs.diff

--- a/build.sbt
+++ b/build.sbt
@@ -417,10 +417,11 @@ lazy val connectClient = (project in file("spark-connect/client"))
       }
     }.taskValue,
     (Test / resourceGenerators) += Def.task {
-      val dest = (Test / resourceManaged).value / "spark-connect.jar"
+      val sparkConnectComponentName = "spark-connect_2.13"
+      val dest = (Test / resourceManaged).value / s"$sparkConnectComponentName.jar"
 
       if (!dest.exists()) {
-        downloadLatestSparkReleaseJar("spark-connect_2.13", (Test / resourceManaged).value)
+        downloadLatestSparkReleaseJar(sparkConnectComponentName, (Test / resourceManaged).value)
       }
 
       Seq(dest)

--- a/build.sbt
+++ b/build.sbt
@@ -297,25 +297,25 @@ def downloadLatestSparkReleaseJar(
   // https://repository.apache.org/content/groups/snapshots/org/apache/spark/
   // spark-catalyst_2.13/4.0.0-SNAPSHOT/
   val latestSparkComponentJarDir = sparkMasterSnapshotsURL +
-    s"$componentName/$SPARK_MASTER_VERSION/"
+    s"$sparkComponentName/$SPARK_MASTER_VERSION/"
   val metadataUrl = new URL(latestSparkComponentJarDir + "maven-metadata.xml")
 
   // Fetch and parse the maven-metadata.xml file.
   val metadataXml = XML.load(metadataUrl)
 
   // Extract the latest snapshot jar version's metadata information.
-  val version = (metadataXml \ "version").text.replace("-SNAPSHOT", "")
+  val sparkVersion = SPARK_MASTER_VERSION.replace("-SNAPSHOT", "")
   val timestamp = (metadataXml \\ "snapshot" \ "timestamp").text
   val buildNumber = (metadataXml \\ "snapshot" \ "buildNumber").text
 
   // Ensure the metadata information is properly extracted.
-  if (version.isEmpty || timestamp.isEmpty || buildNumber.isEmpty) {
+  if (sparkVersion.isEmpty || timestamp.isEmpty || buildNumber.isEmpty) {
     throw new RuntimeException("Could not extract the required metadata " +
       "from maven-metadata.xml")
   }
 
   // Construct the URL for the latest snapshot JAR.
-  val latestSparkJarName = s"$componentName-$version-$timestamp-$buildNumber.jar"
+  val latestSparkJarName = s"$sparkComponentName-$sparkVersion-$timestamp-$buildNumber.jar"
   val latestSparkJarUrl = latestSparkComponentJarDir + latestSparkJarName
   val latestSparkJarPath = destDir / latestSparkJarName
 

--- a/build.sbt
+++ b/build.sbt
@@ -367,7 +367,7 @@ lazy val connectClient = (project in file("spark-connect/client"))
           // https://repository.apache.org/content/groups/snapshots/org/apache/spark/
           // spark-catalyst_2.13/4.0.0-SNAPSHOT/
           val latestSparkComponentJarDir = "https://repository.apache.org/content/groups/snapshots/" +
-            s"org/apache/spark/$sparkJarName/$SPARK_MASTER_VERSION/"
+            s"org/apache/spark/$sparkComponentName/$SPARK_MASTER_VERSION/"
           val metadataUrl = latestSparkComponentJarDir + "maven-metadata.xml"
 
           // Fetch and parse the maven-metadata.xml file.
@@ -384,12 +384,12 @@ lazy val connectClient = (project in file("spark-connect/client"))
               "information of the latest snapshot jar.")
           }
 
-          val latestSparkJarName = s"$sparkJarName-$version-$timestamp-$buildNumber.jar"
+          val latestSparkJarName = s"$sparkComponentName-$version-$timestamp-$buildNumber.jar"
           // Construct the URL for the latest snapshot JAR.
           val latestSparkJarUrl = latestSparkComponentJarDir + latestSparkJarName
 
           // Download the latest snapshot JAR and delete the outdated one.
-          val latestSparkJarPath = SparkJarsDir / latestSparkJarName
+          val latestSparkJarPath = sparkJarsDir / latestSparkJarName
           new URL(latestSparkJarUrl) #> latestSparkJarPath!
           outdatedJar.delete()
         }

--- a/build.sbt
+++ b/build.sbt
@@ -317,7 +317,7 @@ def downloadLatestSparkReleaseJar(
   // Construct the URL for the latest snapshot JAR.
   val latestSparkJarName = s"$sparkComponentName-$sparkVersion-$timestamp-$buildNumber.jar"
   val latestSparkJarUrl = latestSparkComponentJarDir + latestSparkJarName
-  val latestSparkJarPath = destDir / latestSparkJarName
+  val latestSparkJarPath = destDir / sparkComponentName
 
   // Download the latest snapshot JAR.
   new URL(latestSparkJarUrl) #> latestSparkJarPath!

--- a/build.sbt
+++ b/build.sbt
@@ -277,7 +277,7 @@ lazy val connectCommon = (project in file("spark-connect/common"))
   )
 
 /**
- * Downloads the latest snapshot JAR for a given Spark component and saves it to
+ * Downloads the latest nightly release JAR of a given Spark component and saves it to
  * the specified directory.
  *
  * @param sparkComponentName The name of the Spark component.
@@ -290,7 +290,7 @@ def downloadLatestSparkReleaseJar(
     "org/apache/spark/"
 
   // Construct the URL to the maven-metadata.xml file, the maven-metadata.xml has
-  // metadata information about the latest snapshot version of the jar, since the
+  // metadata information about the latest nightly release of the jar, since the
   // jar directory also retains slightly older jar versions.
   //
   // An example folder is:
@@ -303,7 +303,7 @@ def downloadLatestSparkReleaseJar(
   // Fetch and parse the maven-metadata.xml file.
   val metadataXml = XML.load(metadataUrl)
 
-  // Extract the metadata information about the latest jar release.
+  // Extract the metadata information about the latest nightly release JAR.
   val sparkVersion = SPARK_MASTER_VERSION.replace("-SNAPSHOT", "")
   val timestamp = (metadataXml \\ "snapshot" \ "timestamp").text
   val buildNumber = (metadataXml \\ "snapshot" \ "buildNumber").text
@@ -314,12 +314,12 @@ def downloadLatestSparkReleaseJar(
       "from maven-metadata.xml")
   }
 
-  // Construct the URL for the latest snapshot JAR.
+  // Construct the URL for the latest nightly release JAR.
   val latestSparkJarName = s"$sparkComponentName-$sparkVersion-$timestamp-$buildNumber.jar"
   val latestSparkJarUrl = latestSparkComponentJarDir + latestSparkJarName
   val latestSparkJarPath = destDir / sparkComponentName
 
-  // Download the latest snapshot JAR.
+  // Download the latest nightly release JAR.
   new URL(latestSparkJarUrl) #> latestSparkJarPath!
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -317,7 +317,7 @@ def downloadLatestSparkReleaseJar(
   // Construct the URL for the latest nightly release JAR.
   val latestSparkJarName = s"$sparkComponentName-$sparkVersion-$timestamp-$buildNumber.jar"
   val latestSparkJarUrl = latestSparkComponentJarDir + latestSparkJarName
-  val latestSparkJarPath = destDir / sparkComponentName
+  val latestSparkJarPath = destDir / s"$sparkComponentName.jar"
 
   // Download the latest nightly release JAR.
   new URL(latestSparkJarUrl) #> latestSparkJarPath!

--- a/build.sbt
+++ b/build.sbt
@@ -298,7 +298,7 @@ def downloadLatestSparkReleaseJar(
   // spark-catalyst_2.13/4.0.0-SNAPSHOT/
   val latestSparkComponentJarDir = sparkMasterSnapshotsURL +
     s"$componentName/$SPARK_MASTER_VERSION/"
-  val metadataUrl = new URL(latestComponentJarDir + "maven-metadata.xml")
+  val metadataUrl = new URL(latestSparkComponentJarDir + "maven-metadata.xml")
 
   // Fetch and parse the maven-metadata.xml file.
   val metadataXml = XML.load(metadataUrl)

--- a/build.sbt
+++ b/build.sbt
@@ -303,7 +303,7 @@ def downloadLatestSparkReleaseJar(
   // Fetch and parse the maven-metadata.xml file.
   val metadataXml = XML.load(metadataUrl)
 
-  // Extract the latest snapshot jar version's metadata information.
+  // Extract the metadata information about the latest jar release.
   val sparkVersion = SPARK_MASTER_VERSION.replace("-SNAPSHOT", "")
   val timestamp = (metadataXml \\ "snapshot" \ "timestamp").text
   val buildNumber = (metadataXml \\ "snapshot" \ "buildNumber").text

--- a/build.sbt
+++ b/build.sbt
@@ -376,6 +376,7 @@ lazy val connectClient = (project in file("spark-connect/client"))
                 if (entry.isDirectory) {
                   dest.mkdirs()
                 } else {
+                  // Ensure parent directories exist.
                   dest.getParentFile.mkdirs()
 
                   Using(Files.newOutputStream(dest.toPath)) { os =>

--- a/build.sbt
+++ b/build.sbt
@@ -376,7 +376,7 @@ lazy val connectClient = (project in file("spark-connect/client"))
                 if (entry.isDirectory) {
                   dest.mkdirs()
                 } else {
-                  // Ensure parent directories exist.
+                  // Ensure the parent directories exist.
                   dest.getParentFile.mkdirs()
 
                   Using(Files.newOutputStream(dest.toPath)) { os =>
@@ -410,10 +410,7 @@ lazy val connectClient = (project in file("spark-connect/client"))
           val sparkComponentName = outdatedJar.getName.stripSuffix("-4.0.0-preview1.jar")
           downloadLatestSparkReleaseJar(sparkComponentName, sparkJarsDir)
         }
-
-        outdatedJars.foreach { outdatedJar =>
-          outdatedJar.delete()
-        }
+        outdatedJars.foreach(_.delete())
       }
 
       Seq(destDir)

--- a/spark-connect/client/src/test/scala-spark-master/io/delta/connect/tables/RemoteSparkSession.scala
+++ b/spark-connect/client/src/test/scala-spark-master/io/delta/connect/tables/RemoteSparkSession.scala
@@ -72,7 +72,7 @@ trait RemoteSparkSession extends BeforeAndAfterAll { self: Suite =>
     "spark-connect/server/target/scala-2.13/delta-connect-server-assembly-3.3.0-SNAPSHOT.jar"
 
   private val resources = s"$buildLocation/spark-connect/client/target/scala-2.13/resource_managed/test"
-  private val sparkConnectJar = s"$resources/spark-connect.jar"
+  private val sparkConnectJar = s"$resources/spark-connect_2.13.jar"
   private val sparkSubmit = s"$resources/spark/spark-4.0.0-preview1-bin-hadoop3/sbin/start-connect-server.sh"
 
   private lazy val server = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Currently, in order to test Delta Connect Client with Spark Connect, we always fetch the [Spark 4.0 First Preview jars](https://github.com/delta-io/delta/commit/455dbacaf456158644bcbe8b0b13bd4eae65c974#diff-5634c415cd8c8504fdb973a3ed092300b43c4b8fc1e184f7249eb29a55511f91R308), which were created in May 2024.

Since then, lots of things have changed in [Spark](https://github.com/apache/spark), so the jars are outdated and the testing no longer works due to binary incompatibility between the latest version of Delta and Spark 4.0 First Preview version.

Therefore, **we are updating the `sbt` testing task of the Delta Connect Client project to automatically fetch and use the latest jars from [Spark nightly releases](https://repository.apache.org/content/groups/snapshots/org/apache/spark/)**.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Ran `build/sbt -DsparkVersion=master clean connectServer/assembly connectClient/test`.

Observed that the [latest jar releases](https://repository.apache.org/content/groups/snapshots/org/apache/spark/) of Spark are downloaded and the Delta Connect Client test suite's (`DeltaTableSuite`) ran successfully.

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
