### PR TITLE
[Spark] Table features protocols should handle legacy reader features as reader features

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -426,7 +426,7 @@ class DeltaLog private(
   def assertTableFeaturesMatchMetadata(
       targetProtocol: Protocol,
       targetMetadata: Metadata): Unit = {
-    if (!targetProtocol.supportsReaderFeatures && !targetProtocol.supportsWriterFeatures) return
+    if (!targetProtocol.supportsTableFeatures) return
 
     val protocolEnabledFeatures = targetProtocol.writerFeatureNames
       .flatMap(TableFeature.featureNameToFeature)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Snapshot.scala
@@ -542,7 +542,7 @@ class Snapshot(
     }
     base.put(Protocol.MIN_READER_VERSION_PROP, protocol.minReaderVersion.toString)
     base.put(Protocol.MIN_WRITER_VERSION_PROP, protocol.minWriterVersion.toString)
-    if (protocol.supportsReaderFeatures || protocol.supportsWriterFeatures) {
+    if (protocol.supportsTableFeatures) {
       val features = protocol.readerAndWriterFeatureNames.map(name =>
         s"${TableFeatureProtocolUtils.FEATURE_PROP_PREFIX}$name" ->
           TableFeatureProtocolUtils.FEATURE_PROP_SUPPORTED)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ActionSerializerSuite.scala
@@ -235,7 +235,7 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
     expectedJson =
       s"""{"protocol":{"minReaderVersion":$TABLE_FEATURES_MIN_READER_VERSION,""" +
         s""""minWriterVersion":$TABLE_FEATURES_MIN_WRITER_VERSION,""" +
-        """"readerFeatures":["testLegacyReaderWriter"],""" +
+        """"readerFeatures":[],""" +
         """"writerFeatures":["testLegacyReaderWriter"]}}""")
 
   testActionSerDe(
@@ -248,7 +248,7 @@ class ActionSerializerSuite extends QueryTest with SharedSparkSession with Delta
     expectedJson =
       s"""{"protocol":{"minReaderVersion":$TABLE_FEATURES_MIN_READER_VERSION,""" +
         s""""minWriterVersion":$TABLE_FEATURES_MIN_WRITER_VERSION,""" +
-        """"readerFeatures":["testLegacyReaderWriter","testReaderWriter"],""" +
+        """"readerFeatures":["testReaderWriter"],""" +
         """"writerFeatures":["testLegacyReaderWriter","testReaderWriter"]}}""")
 
   testActionSerDe(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCColumnMappingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCColumnMappingSuite.scala
@@ -618,7 +618,7 @@ trait DeltaCDCColumnMappingSuiteBase extends DeltaCDCSuiteBase
       }
       // upgrade to name mode
       val protocol = deltaLog.snapshot.protocol
-      val (r, w) = if (protocol.supportsReaderFeatures || protocol.supportsWriterFeatures) {
+      val (r, w) = if (protocol.supportsTableFeatures) {
         (TableFeatureProtocolUtils.TABLE_FEATURES_MIN_READER_VERSION,
           TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION)
       } else {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingTestUtils.scala
@@ -271,7 +271,7 @@ trait DeltaColumnMappingTestUtilsBase extends SharedSparkSession {
         Protocol.forNewTable(spark, Some(metadata)).minReaderVersion.toString),
       (Protocol.MIN_WRITER_VERSION_PROP,
         Protocol.forNewTable(spark, Some(metadata)).minWriterVersion.toString))
-    if (snapshot.protocol.supportsReaderFeatures || snapshot.protocol.supportsWriterFeatures) {
+    if (snapshot.protocol.supportsTableFeatures) {
       props ++=
         Protocol.minProtocolComponentsFromAutomaticallyEnabledFeatures(
           spark, metadata, snapshot.protocol)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceColumnMappingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceColumnMappingSuite.scala
@@ -303,7 +303,7 @@ trait ColumnMappingStreamingBlockedWorkflowSuiteBase extends ColumnMappingStream
 
       // upgrade to name mode
       val protocol = deltaLog.snapshot.protocol
-        val (r, w) = if (protocol.supportsReaderFeatures || protocol.supportsWriterFeatures) {
+        val (r, w) = if (protocol.supportsTableFeatures) {
         (TableFeatureProtocolUtils.TABLE_FEATURES_MIN_READER_VERSION,
           TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION)
       } else {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSuite.scala
@@ -3000,7 +3000,7 @@ class DeltaNameColumnMappingSuite extends DeltaSuite
           .save(tempDir.getCanonicalPath)
 
         val protocol = DeltaLog.forTable(spark, tempDir).snapshot.protocol
-        val (r, w) = if (protocol.supportsReaderFeatures || protocol.supportsWriterFeatures) {
+        val (r, w) = if (protocol.supportsTableFeatures) {
           (TableFeatureProtocolUtils.TABLE_FEATURES_MIN_READER_VERSION,
             TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION)
         } else {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableFeatureSuite.scala
@@ -197,9 +197,8 @@ class DeltaTableFeatureSuite
 
     val protocol =
       Protocol(2, TABLE_FEATURES_MIN_WRITER_VERSION).withFeature(TestLegacyReaderWriterFeature)
-    assert(!protocol.readerFeatures.isDefined)
-    assert(
-      protocol.writerFeatures.get === Set(TestLegacyReaderWriterFeature.name))
+    assert(protocol.readerFeatures.get === Set.empty)
+    assert(protocol.writerFeatures.get === Set(TestLegacyReaderWriterFeature.name))
   }
 
   test("merge protocols") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DescribeDeltaHistorySuite.scala
@@ -424,7 +424,7 @@ trait DescribeDeltaHistorySuiteBase
         Seq("UPGRADE PROTOCOL",
           s"""{"minReaderVersion":$readerVersion,""" +
             s""""minWriterVersion":$writerVersion,""" +
-            s""""readerFeatures":["${TestLegacyReaderWriterFeature.name}"],""" +
+            s""""readerFeatures":[],""" +
             s""""writerFeatures":["${TestLegacyReaderWriterFeature.name}"]}"""),
         Seq($"operation", $"operationParameters.newProtocol"))
       // scalastyle:on line.size.limit

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingBackfillSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowTrackingBackfillSuite.scala
@@ -460,7 +460,8 @@ class RowTrackingBackfillSuite
       assert(
         afterProtocol.minWriterVersion ===
           TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION)
-      assert(afterProtocol.readerFeatures === None)
+      assert(afterProtocol.readerFeatures === Some(Set(
+        ColumnMappingTableFeature.name)))
       assert(
         afterProtocol.writerFeatures === Some((
           prevProtocol.implicitlyAndExplicitlySupportedFeatures ++


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR fixes a bug where protocol (2, 7) is not considered to support reader features. This issue could manifest in several places. For example, it would result in hiding (2, x) features in the reader features list when it was the only reader feature present. For example, Protocol(2, 7, None, Set(ColumnMapping, RowTracking).
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Added new test and adapted existing tests.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
