### PR TITLE
[Spark] Fix for pushing down filters referencing attributes with special characters in name into CDF

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
@@ -42,13 +42,13 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Literal}
+import org.apache.spark.sql.catalyst.expressions.{And, Attribute, AttributeReference, Expression, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.Statistics
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
 import org.apache.spark.sql.execution.LogicalRDD
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.sources.{BaseRelation, Filter, PrunedFilteredScan}
+import org.apache.spark.sql.sources.{BaseRelation, CatalystScan, Filter}
 import org.apache.spark.sql.types.{LongType, StringType, StructType, TimestampType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
@@ -119,7 +119,7 @@ object CDCReader extends CDCReaderImpl
       snapshotWithSchemaMode: SnapshotWithSchemaMode,
       sqlContext: SQLContext,
       startingVersion: Option[Long],
-      endingVersion: Option[Long]) extends BaseRelation with PrunedFilteredScan {
+      endingVersion: Option[Long]) extends BaseRelation with CatalystScan {
 
     private val deltaLog = snapshotWithSchemaMode.snapshot.deltaLog
 
@@ -158,7 +158,7 @@ object CDCReader extends CDCReaderImpl
 
     override def unhandledFilters(filters: Array[Filter]): Array[Filter] = Array.empty
 
-    override def buildScan(requiredColumns: Array[String], filters: Array[Filter]): RDD[Row] = {
+    override def buildScan(requiredColumns: Seq[Attribute], filters: Seq[Expression]): RDD[Row] = {
       val df = changesToBatchDF(
         deltaLog,
         startingVersion.get,
@@ -169,8 +169,18 @@ object CDCReader extends CDCReaderImpl
         sqlContext.sparkSession,
         readSchemaSnapshot = Some(snapshotForBatchSchema))
 
-      val filter = Column(DeltaSourceUtils.translateFilters(filters))
-      val projections = requiredColumns.map(SchemaUtils.fieldNameToColumn)
+      // Rewrite the attributes in the required columns and pushed down filters to match the output
+      // of the internal DataFrame.
+      val outputMap = df.queryExecution.analyzed.output.map(a => a.name -> a).toMap
+      val projections =
+        requiredColumns.map(a => Column(a.withExprId(outputMap(a.name).exprId)))
+      val filter = Column(
+        filters
+          .map(_.transform { case a: Attribute => a.withExprId(outputMap(a.name).exprId) })
+          .reduceOption(And)
+          .getOrElse(Literal.TrueLiteral)
+      )
+
       df.filter(filter).select(projections: _*).rdd
     }
   }
@@ -412,7 +422,7 @@ trait CDCReaderImpl extends DeltaLogging {
       spark.sqlContext,
       startingVersion = None,
       endingVersion = None) {
-      override def buildScan(requiredColumns: Array[String], filters: Array[Filter]): RDD[Row] =
+      override def buildScan(requiredColumns: Seq[Attribute], filters: Seq[Expression]): RDD[Row] =
         sqlContext.sparkSession.sparkContext.emptyRDD[Row]
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCColumnMappingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCColumnMappingSuite.scala
@@ -539,7 +539,8 @@ trait DeltaCDCColumnMappingSuiteBase extends DeltaCDCSuiteBase
     "add column batch cdc read not blocked",
     "data type and nullability change batch cdc read blocked",
     "drop column batch cdc read blocked",
-    "rename column batch cdc read blocked"
+    "rename column batch cdc read blocked",
+    "filters with special characters in name should be pushed down"
   )
 
   protected def assertBlocked(
@@ -648,6 +649,28 @@ trait DeltaCDCColumnMappingSuiteBase extends DeltaCDCSuiteBase
         StartingVersion("0"),
         EndingVersion(deltaLog.update().version.toString)).dropCDCFields,
       (0 until 10).map(_.toString).toDF("id").withColumn("value", col("id")))
+  }
+
+  test("filters with special characters in name should be pushed down") {
+    val tblName = "tbl"
+    withTable(tblName) {
+      spark.range(end = 10).withColumn("id with space", col("id"))
+          .write.format("delta").saveAsTable(tblName)
+
+      val plans = DeltaTestUtils.withAllPlansCaptured(spark) {
+        val res = cdcRead(new TableName(tblName), StartingVersion("0"), EndingVersion("1"))
+          .select("id with space", "_change_type")
+          .where(col("id with space") < lit(5))
+
+        assert(res.columns === Seq("id with space", "_change_type"))
+        checkAnswer(
+          res,
+          spark.range(end = 5)
+            .withColumn("_change_type", lit("insert")))
+      }
+      assert(plans.map(_.executedPlan).toString
+        .contains("PushedFilters: [*IsNotNull(id with space), *LessThan(id with space,5)]"))
+    }
   }
 }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR fixes the push down of filters into CDF. Previously this would cause a parsing exception to be thrown if the filter referenced an attribute with at least one special character in the name. This is due to having to turn the `Filter`s back into `Expression`s. We avoid this by extending `CatalystScan` instead, which avoids the `Expression` to `Filter` to `Expression` roundtrip.

## How was this patch tested?

Added a new test

## Does this PR introduce _any_ user-facing changes?

No
