### PR TITLE
[SPARK] Use better TahoeLogFileIndex constructor

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingFileIndex.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingFileIndex.scala
@@ -212,12 +212,7 @@ case class DeltaSharingFileIndex(
       partitionFilters: Seq[Expression],
       dataFilters: Seq[Expression]): TahoeLogFileIndex = {
     val deltaLog = fetchFilesAndConstructDeltaLog(partitionFilters, dataFilters, None)
-    new TahoeLogFileIndex(
-      params.spark,
-      deltaLog,
-      deltaLog.dataPath,
-      deltaLog.unsafeVolatileSnapshot
-    )
+    TahoeLogFileIndex(params.spark, deltaLog)
   }
 
   override def listFiles(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Tiny bit of code hygiene: Remove some redundant code from `DeltaSharingFileIndex` by invoking the existing alternate constructor for `TahoeLogFileIndex` that does the same thing.

## How was this patch tested?

Existing tests cover this code.

## Does this PR introduce _any_ user-facing changes?

No.