### PR TITLE
[SPARK] Use StateCache to manage DatasetRefCache instances

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DatasetRefCache.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DatasetRefCache.scala
@@ -42,9 +42,11 @@ import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
  *
  * @param creator a function to create [[Dataset]].
  */
-class DatasetRefCache[T](creator: () => Dataset[T]) {
+class DatasetRefCache[T] private[util](creator: () => Dataset[T]) {
 
   private val holder = new AtomicReference[Dataset[T]]
+
+  private[delta] def invalidate() = holder.set(null)
 
   def get: Dataset[T] = Option(holder.get())
     .filter(_.sparkSession eq SparkSession.active)
@@ -54,4 +56,3 @@ class DatasetRefCache[T](creator: () => Dataset[T]) {
       df
     }
 }
-


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

`DatasetRefCache` instances are currently untracked, making it hard to discard or invalidate them when no longer needed. We start to address that issue by using `StateCache` to track them, so that `Snapshot.uncache()` can clean them up -- the same way `CachedDS` instances are already tracked and cleaned up.

## How was this patch tested?

Existing unit tests exercise `Snapshot.uncache` path.

## Does this PR introduce _any_ user-facing changes?

No
