### PR TITLE
Get rid of duplicated replaceCharWithVarchar function

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDelta.scala
@@ -154,7 +154,8 @@ case class WriteIntoDelta(
       // If READ_SIDE_CHAR_PADDING is not enabled, CHAR type is the same as VARCHAR. The change
       // below makes DESC TABLE to show VARCHAR instead of CHAR.
       CharVarcharUtils.replaceCharVarcharWithStringInSchema(
-        replaceCharWithVarchar(CharVarcharUtils.getRawSchema(data.schema)).asInstanceOf[StructType])
+        CharVarcharUtils.replaceCharWithVarchar(CharVarcharUtils.getRawSchema(data.schema))
+          .asInstanceOf[StructType])
     }
     val finalSchema = schemaInCatalog.getOrElse(dataSchema)
     if (txn.metadata.schemaString != null) {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDeltaLike.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/WriteIntoDeltaLike.scala
@@ -153,20 +153,6 @@ trait WriteIntoDeltaLike {
     txn.registerSQLMetrics(spark, sqlMetrics)
   }
 
-  import org.apache.spark.sql.types.{ArrayType, CharType, DataType, MapType, VarcharType}
-  protected def replaceCharWithVarchar(dt: DataType): DataType = dt match {
-    case ArrayType(et, nullable) =>
-      ArrayType(replaceCharWithVarchar(et), nullable)
-    case MapType(kt, vt, nullable) =>
-      MapType(replaceCharWithVarchar(kt), replaceCharWithVarchar(vt), nullable)
-    case StructType(fields) =>
-      StructType(fields.map { field =>
-        field.copy(dataType = replaceCharWithVarchar(field.dataType))
-      })
-    case CharType(length) => VarcharType(length)
-    case _ => dt
-  }
-
   protected def extractConstraints(
       sparkSession: SparkSession,
       expr: Seq[Expression]): Seq[Constraint] = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
It removes duplicated function (CharVarcharUtils#replaceCharWithVarchar).
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
It gets compiled. Changes doesn't require new tests.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
