### PR TITLE
[Infra] [WIP] Add test report listener to delta-spark and bucket test suites by estimated runtime

### DIFF
--- a/.github/workflows/spark_test.yaml
+++ b/.github/workflows/spark_test.yaml
@@ -85,3 +85,10 @@ jobs:
         run: |
           TEST_PARALLELISM_COUNT=4 pipenv run python run-tests.py --group spark --shard ${{ matrix.shard }}
         if: steps.git-diff.outputs.diff
+      - name: Upload test result artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-DSL-${{ matrix.scala }}-shard-${{ matrix.shard }}-run-${{ github.run_id }}-attempt-${{ github.run_attempt }}
+          path: |
+            test_results_*.csv

--- a/build.sbt
+++ b/build.sbt
@@ -444,7 +444,7 @@ lazy val spark = (project in file("spark"))
 
     Test / testOptions += Tests.Argument("-oDF"),
     Test / testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
-    testListeners += TestTimeListener,
+    Test / testListeners += TestTimeListener,
 
     // Don't execute in parallel since we can't have multiple Sparks in the same JVM
     Test / parallelExecution := false,

--- a/build.sbt
+++ b/build.sbt
@@ -444,6 +444,7 @@ lazy val spark = (project in file("spark"))
 
     Test / testOptions += Tests.Argument("-oDF"),
     Test / testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
+    testListeners += TestTimeListener,
 
     // Don't execute in parallel since we can't have multiple Sparks in the same JVM
     Test / parallelExecution := false,

--- a/project/TestTimeListener.scala
+++ b/project/TestTimeListener.scala
@@ -36,8 +36,8 @@ object TestTimeListener extends TestReportListener {
   private val testResults = new ConcurrentHashMap[String, Seq[(String, Long, String)]]()
 
   /** Generate a unique file name per JVM using process ID and timestamp */
-  private val jvmId: String = ManagementFactory.getRuntimeMXBean().getName.split("@")(0)
-  private val individualTestCsvPath = s"test_results_jvm_${jvmId}.csv"
+  private val jvmId = ManagementFactory.getRuntimeMXBean().getName.split("@")(0)
+  private val individualTestCsvPath = s"test_results_${jvmId}_${System.currentTimeMillis()}.csv"
 
   /** Lock to ensure only one thread writes to a file at a time within this JVM */
   private val writeLock = new ReentrantLock()

--- a/project/TestTimeListener.scala
+++ b/project/TestTimeListener.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright (2024-present) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import sbt._
+import sbt.testing._
+import java.io.{FileWriter, IOException}
+import java.nio.file.{Files, Paths}
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.ReentrantLock
+import java.lang.management.ManagementFactory
+import scala.util.Using
+
+/**
+ * This class implements a custom Test Report Listener that logs detailed test execution
+ * information, including test suite name, test case name, test duration, and test result.
+ *
+ * Each JVM writes its test results to a uniquely named CSV file based on the JVM's process ID,
+ * ensuring no conflicts between concurrent JVMs.
+ */
+object TestTimeListener extends TestReportListener {
+
+  /** testSuite -> Seq[(testName, duration, result)] */
+  private val testResults = new ConcurrentHashMap[String, Seq[(String, Long, String)]]()
+
+  /** Generate a unique file name per JVM using process ID and timestamp */
+  private val jvmId: String = ManagementFactory.getRuntimeMXBean().getName.split("@")(0)
+  private val individualTestCsvPath = s"test_results_jvm_${jvmId}.csv"
+
+  /** Lock to ensure only one thread writes to a file at a time within this JVM */
+  private val writeLock = new ReentrantLock()
+
+  initialize()
+
+  /** Clears the CSV file at the start of the test run. */
+  private def initialize(): Unit = {
+    clearCsvFile(individualTestCsvPath)
+  }
+
+  /////////////////
+  // Public APIs //
+  /////////////////
+
+  /** Called when individual tests end. Records test suite, name, duration, and result. */
+  override def testEvent(event: TestEvent): Unit = {
+    event.detail.foreach { detail =>
+      val suiteName = detail.fullyQualifiedName()
+      val testName = detail.selector() match {
+        case s: TestSelector => s.testName()
+        case _ => "Unknown Test"
+      }
+      val testDuration = detail.duration()
+      val testStatus = detail.status().toString
+
+      println(s"Test suite: $suiteName, Test: $testName, Duration: $testDuration ms, Result: $testStatus")
+
+      testResults.merge(suiteName, Seq((testName, testDuration, testStatus)), _ ++ _)
+    }
+  }
+
+  /**
+   * Called when a test suite ends. Writes the results to the JVM-specific CSV file and clears the
+   * suite's data from the concurrent hash map.
+   */
+  override def endGroup(suiteName: String, result: TestResult): Unit = {
+    println(s"Test suite $suiteName ended with result: $result")
+
+    if (testResults.containsKey(suiteName)) {
+      writeTestResultsToCsv(suiteName)
+      testResults.remove(suiteName)
+    } else {
+      println(s"No test result data for test suite: $suiteName")
+    }
+  }
+
+  override def startGroup(suiteName: String): Unit = {
+    println(s"Test suite started: $suiteName")
+  }
+
+  override def endGroup(suiteName: String, t: Throwable): Unit = {
+    println(s"Test suite $suiteName ended with error: ${t.getMessage}")
+  }
+
+  ////////////////////
+  // Helper methods //
+  ////////////////////
+
+  /** Escapes a CSV field by enclosing it in quotes if necessary and doubling internal quotes. */
+  private def escapeCsvField(field: String): String = {
+    if (field.contains(",") || field.contains("\"") || field.contains("\n")) {
+      "\"" + field.replace("\"", "\"\"") + "\""
+    } else {
+      field
+    }
+  }
+
+  /** Clears the given CSV file before writing. Ensures no data from previous runs is appended. */
+  private def clearCsvFile(path: String): Unit = {
+    try {
+      Files.deleteIfExists(Paths.get(path))  // The file will be created automatically by FileWriter
+    } catch {
+      case e: IOException => println(s"Failed to clear CSV file: ${e.getMessage}")
+    }
+  }
+
+  /**
+   * Writes the test results for a specific suite to the JVM-specific CSV file. Expects that
+   * [[testResults]] contains [[suiteName]].
+   */
+  private def writeTestResultsToCsv(suiteName: String): Unit = {
+    writeLock.lock()
+    try {
+      Using.resource(new FileWriter(individualTestCsvPath, true)) { writer =>
+        testResults.get(suiteName).foreach { case (testName, duration, result) =>
+          val escapedSuiteName = escapeCsvField(suiteName)
+          val escapedTestName = escapeCsvField(testName)
+          val escapedResult = escapeCsvField(result)
+
+          writer.write(s"$escapedSuiteName,$escapedTestName,$duration,$escapedResult\n")
+        }
+      }
+    } catch {
+      case e: IOException => println(s"Failed to write test results to file: ${e.getMessage}")
+    } finally {
+      writeLock.unlock()
+    }
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [X] Other (Infra)

## Description

Adds a test report listener to delta-spark to record test runtimes. This listener logs test runtime metrics and writes metrics to a csv file (per CI shard, per attempt, per jvm, per thread) and uploads it as a test artifact.

We can use the output of this job to learn how to better bucket our slowest + largest tests.

https://github.com/delta-io/delta/actions/runs/11002528077?pr=3694

![image](https://github.com/user-attachments/assets/ca87779f-6e2a-4cf2-8044-45cfa996bbf7)

## How was this patch tested?

Locally and GitHub CI.

## Does this PR introduce _any_ user-facing changes?

No.