### PR TITLE
[Spark] Fix delta-spark test log4j

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -176,6 +176,7 @@ def crossSparkSettings(): Seq[Setting[_]] = getSparkVersion() match {
     Compile / unmanagedSourceDirectories += (Compile / baseDirectory).value / "src" / "main" / "scala-spark-3.5",
     Test / unmanagedSourceDirectories += (Test / baseDirectory).value / "src" / "test" / "scala-spark-3.5",
     Antlr4 / antlr4Version := "4.9.3",
+    Test / javaOptions ++= Seq("-Dlog4j.configurationFile=log4j2.properties"),
 
     // Java-/Scala-/Uni-Doc Settings
     scalacOptions ++= Seq(
@@ -204,8 +205,9 @@ def crossSparkSettings(): Seq[Setting[_]] = getSparkVersion() match {
       "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
       "--add-opens=java.base/sun.nio.cs=ALL-UNNAMED",
       "--add-opens=java.base/sun.security.action=ALL-UNNAMED",
-      "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED"
-    )
+      "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED",
+      "-Dlog4j.configurationFile=log4j2_spark_master.properties"
+    ),
 
     // Java-/Scala-/Uni-Doc Settings
     // This isn't working yet against Spark Master.

--- a/spark/src/test/resources/log4j2_spark_master.properties
+++ b/spark/src/test/resources/log4j2_spark_master.properties
@@ -38,18 +38,18 @@ appender.file.append = true
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n
 
-# Pattern Logging Appender
-appender.pattern.type = File
-appender.pattern.name = pattern
-appender.pattern.fileName = target/pattern.log
-appender.pattern.layout.type = PatternLayout
-appender.pattern.layout.pattern = %d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n%ex
+# Structured Logging Appender
+appender.structured.type = File
+appender.structured.name = structured
+appender.structured.fileName = target/structured.log
+appender.structured.layout.type = JsonTemplateLayout
+appender.structured.layout.eventTemplateUri = classpath:org/apache/spark/SparkLayout.json
 
-# Custom logger for testing structured logging with Spark 3.5 shims
-logger.pattern_logging.name = org.apache.spark.sql.delta.logging.DeltaPatternLoggingSuite
-logger.pattern_logging.level = trace
-logger.pattern_logging.appenderRefs = pattern
-logger.pattern_logging.appenderRef.pattern.ref = pattern
+# Custom logger for testing structured logging with Spark master
+logger.structured_logging.name = org.apache.spark.sql.delta.logging.DeltaStructuredLoggingSuite
+logger.structured_logging.level = trace
+logger.structured_logging.appenderRefs = structured
+logger.structured_logging.appenderRef.structured.ref = structured
 
 # Tests that launch java subprocesses can set the "test.appender" system property to
 # "console" to avoid having the child process's logs overwrite the unit test's


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

https://github.com/delta-io/delta/pull/3146 added support for spark master structured logging, but broke the test logging for delta-spark against spark 3.5. This PR fixes that.

The broken logging looked like this (https://github.com/delta-io/delta/actions/runs/10856009436/job/30129811815):

```
ERROR StatusConsoleListener Unable to locate plugin type for JsonTemplateLayout
ERROR StatusConsoleListener Unable to locate plugin for JsonTemplateLayout
ERROR StatusConsoleListener Could not create plugin of type class org.apache.logging.log4j.core.appender.FileAppender for element File: java.lang.NullPointerException
 java.lang.NullPointerException
	at org.apache.logging.log4j.core.config.plugins.visitors.PluginElementVisitor.findNamedNode(PluginElementVisitor.java:104)
```

## How was this patch tested?

GitHub CI tests.

## Does this PR introduce _any_ user-facing changes?

No.