### PR TITLE
[Spark] Mark DeltaConfig.DATA_SKIPPING_NUM_INDEXED_COLS lazy

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -535,7 +535,10 @@ trait DeltaConfigsBase extends DeltaLogging {
    * (e.g., in append and OPTIMIZE) as well as data skipping (e.g., the column stats beyond this
    * number will be ignored even when they exist).
    */
-  val DATA_SKIPPING_NUM_INDEXED_COLS = buildConfig[Int](
+  lazy val DATA_SKIPPING_NUM_INDEXED_COLS = buildConfig[Int](
+    // This is lazy because of the initialization order.
+    // DeltaConfig -> DataSkippingReader -> Column.apply -> SQLConf.get
+    // -> SparkSession -> SqlGatewayConfig -> DeltaConfig
     "dataSkippingNumIndexedCols",
     DataSkippingReader.DATA_SKIPPING_NUM_INDEXED_COLS_DEFAULT_VALUE.toString,
     _.toInt,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -536,9 +536,8 @@ trait DeltaConfigsBase extends DeltaLogging {
    * number will be ignored even when they exist).
    */
   lazy val DATA_SKIPPING_NUM_INDEXED_COLS = buildConfig[Int](
-    // This is lazy because of the initialization order.
-    // DeltaConfig -> DataSkippingReader -> Column.apply -> SQLConf.get
-    // -> SparkSession -> SqlGatewayConfig -> DeltaConfig
+    // It involves loading additional context in DataSkippingReader so
+    // delay its initialization as much as possible
     "dataSkippingNumIndexedCols",
     DataSkippingReader.DATA_SKIPPING_NUM_INDEXED_COLS_DEFAULT_VALUE.toString,
     _.toInt,


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR proposes to mark DeltaConfig.DATA_SKIPPING_NUM_INDEXED_COLS lazy. Otherwise, it might ending up with `null` because of the initialization order. See the stacktrace below:

## How was this patch tested?

Existing Ci should test it out.

## Does this PR introduce _any_ user-facing changes?

No.