### PR TITLE
[Storage] Add Javadoc for CoordinatedCommitsUtils::getCoordinatorName

### DIFF
--- a/storage/src/main/java/io/delta/storage/commit/CoordinatedCommitsUtils.java
+++ b/storage/src/main/java/io/delta/storage/commit/CoordinatedCommitsUtils.java
@@ -68,9 +68,9 @@ public class CoordinatedCommitsUtils {
             Long commitVersion,
             UpdatedActions updatedActions) {
         boolean oldMetadataHasCoordinatedCommits =
-                !getCoordinator(updatedActions.getOldMetadata()).isEmpty();
+                getCoordinatorName(updatedActions.getOldMetadata()).isPresent();
         boolean newMetadataHasCoordinatedCommits =
-                !getCoordinator(updatedActions.getNewMetadata()).isEmpty();
+                getCoordinatorName(updatedActions.getNewMetadata()).isPresent();
         return oldMetadataHasCoordinatedCommits && !newMetadataHasCoordinatedCommits && commitVersion > 0;
     }
 
@@ -120,10 +120,17 @@ public class CoordinatedCommitsUtils {
         return new Path(logPath, COMMIT_SUBDIR);
     }
 
-    public static String getCoordinator(AbstractMetadata metadata) {
+    /**
+     * Retrieves the coordinator name from the provided abstract metadata.
+     * If no coordinator is set, an empty string is returned.
+     *
+     * @param metadata The abstract metadata from which to retrieve the coordinator name.
+     * @return The coordinator name if set, otherwise an empty string.
+     */
+    public static Optional<String> getCoordinatorName(AbstractMetadata metadata) {
         String coordinator = metadata
                 .getConfiguration()
                 .get(COORDINATED_COMMITS_COORDINATOR_NAME_KEY);
-        return coordinator != null ? coordinator : "";
+        return Optional.ofNullable(coordinator);
     }
 }

--- a/storage/src/main/java/io/delta/storage/commit/CoordinatedCommitsUtils.java
+++ b/storage/src/main/java/io/delta/storage/commit/CoordinatedCommitsUtils.java
@@ -122,10 +122,10 @@ public class CoordinatedCommitsUtils {
 
     /**
      * Retrieves the coordinator name from the provided abstract metadata.
-     * If no coordinator is set, an empty string is returned.
+     * If no coordinator is set, an empty optional is returned.
      *
      * @param metadata The abstract metadata from which to retrieve the coordinator name.
-     * @return The coordinator name if set, otherwise an empty string.
+     * @return The coordinator name if set, otherwise an empty optional.
      */
     public static Optional<String> getCoordinatorName(AbstractMetadata metadata) {
         String coordinator = metadata


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Storage)

## Description
This is a simple cleanup PR for improving documentation of getCoordinatorName

1. Return an Optional<String> to indicate the method may return null if no coordinator is set
2. Rename the method from getCoordinator -> getCoordinatorName

## How was this patch tested?

Build

## Does this PR introduce _any_ user-facing changes?

No
