### PR TITLE
Remove snapshotAnalysis from TahoeLogFileIndex

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
@@ -107,7 +107,7 @@ object GeneratedColumn extends DeltaLogging with AnalysisHelper {
    * - The table writer protocol >= GeneratedColumn.MIN_WRITER_VERSION;
    * - It has a generation expression in the column metadata.
    */
-  def getGeneratedColumns(snapshot: Snapshot): Seq[StructField] = {
+  def getGeneratedColumns(snapshot: SnapshotDescriptor): Seq[StructField] = {
     if (satisfyGeneratedColumnProtocol(snapshot.protocol)) {
       snapshot.metadata.schema.partition(isGeneratedColumn)._1
     } else {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableUpdate.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableUpdate.scala
@@ -57,7 +57,7 @@ case class PreprocessTableUpdate(sqlConf: SQLConf)
         throw DeltaErrors.notADeltaSourceException("UPDATE", Some(o))
     }
 
-    val generatedColumns = GeneratedColumn.getGeneratedColumns(index.snapshotAtAnalysis)
+    val generatedColumns = GeneratedColumn.getGeneratedColumns(index)
     if (generatedColumns.nonEmpty && !deltaLogicalNode.isInstanceOf[LogicalRelation]) {
       // Disallow temp views referring to a Delta table that contains generated columns. When the
       // user doesn't provide expressions for generated columns, we need to create update

--- a/spark/src/main/scala/org/apache/spark/sql/delta/files/TahoeFileIndex.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/files/TahoeFileIndex.scala
@@ -216,6 +216,19 @@ abstract class TahoeFileIndexWithSnapshotDescriptor(
   protected[delta] def sizeInBytesIfKnown: Option[Long] = snapshot.sizeInBytesIfKnown
 }
 
+/**
+ * A lightweight [[SnapshotDescriptor]] implementation that points to an actual [[Snapshot]].
+ *
+ * @param snapshot the [[Snapshot]] this pointer points to
+ */
+class ShallowSnapshotDescriptor(snapshot: Snapshot) extends SnapshotDescriptor {
+  override val deltaLog: DeltaLog = snapshot.deltaLog
+  override val version: Long = snapshot.version
+  override val metadata: Metadata = snapshot.metadata
+  override val protocol: Protocol = snapshot.protocol
+  override protected[delta] val numOfFilesIfKnown: Option[Long] = snapshot.numOfFilesIfKnown
+  override protected[delta] val sizeInBytesIfKnown: Option[Long] = snapshot.sizeInBytesIfKnown
+}
 
 /**
  * A [[TahoeFileIndex]] that generates the list of files from DeltaLog with given partition filters.
@@ -227,10 +240,28 @@ case class TahoeLogFileIndex(
     override val spark: SparkSession,
     override val deltaLog: DeltaLog,
     override val path: Path,
+    snapshotAtAnalysis: SnapshotDescriptor,
+    partitionFilters: Seq[Expression],
+    isTimeTravelQuery: Boolean)
+  extends TahoeFileIndex(spark, deltaLog, path) {
+
+  def this(
+    spark: SparkSession,
+    deltaLog: DeltaLog,
+    path: Path,
     snapshotAtAnalysis: Snapshot,
     partitionFilters: Seq[Expression] = Nil,
-    isTimeTravelQuery: Boolean = false)
-  extends TahoeFileIndex(spark, deltaLog, path) {
+    isTimeTravelQuery: Boolean = false
+  ) = this (
+    spark,
+    deltaLog,
+    path,
+    if (isTimeTravelQuery) snapshotAtAnalysis
+    else new ShallowSnapshotDescriptor(snapshotAtAnalysis),
+    partitionFilters,
+    isTimeTravelQuery)
+
+  require(!isTimeTravelQuery || snapshotAtAnalysis.isInstanceOf[Snapshot])
 
 
   // WARNING: Stability of this method is _NOT_ guaranteed!
@@ -252,7 +283,7 @@ case class TahoeLogFileIndex(
 
   protected def getSnapshotToScan: Snapshot = {
     if (isTimeTravelQuery) {
-      snapshotAtAnalysis
+      snapshotAtAnalysis.asInstanceOf[Snapshot]
     } else {
       deltaLog.update(stalenessAcceptable = true)
     }
@@ -333,7 +364,18 @@ case class TahoeLogFileIndex(
 
 object TahoeLogFileIndex {
   def apply(spark: SparkSession, deltaLog: DeltaLog): TahoeLogFileIndex =
-    TahoeLogFileIndex(spark, deltaLog, deltaLog.dataPath, deltaLog.unsafeVolatileSnapshot)
+    new TahoeLogFileIndex(spark, deltaLog, deltaLog.dataPath, deltaLog.unsafeVolatileSnapshot)
+
+  def apply(
+    spark: SparkSession,
+    deltaLog: DeltaLog,
+    path: Path,
+    snapshotAtAnalysis: Snapshot,
+    partitionFilters: Seq[Expression] = Nil,
+    isTimeTravelQuery: Boolean = false): TahoeLogFileIndex
+  = new TahoeLogFileIndex(
+    spark, deltaLog, path, snapshotAtAnalysis, partitionFilters, isTimeTravelQuery
+  )
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR fixes the OOM caused by SparkSession.cloneSession and TemporaryView. It replaces the reference of `Snapshot`  in `TahoeLogFileIndex` using `SnapshotDescriptor`, thus remove the reference to `SparkSession` from `TahoeLogFileIndex`.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
UT
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
