### PR TITLE
[Spark] Adding ConcurrentDomainMetadataException to correctly indicate conflicting domains.

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -542,7 +542,7 @@
   },
   "DELTA_CONCURRENT_DOMAIN_METADATA" : {
     "message" : [
-      "ConcurrentDomainMetadataException: This error occurs when multiple streaming queries have a conflicting domain. Please try the operation again. <conflictingCommit>\nRefer to <docLink> for more details."
+      "ConcurrentDomainMetadataException: This error occurs when multiple queries have a conflicting domain. Please try the operation again. <conflictingCommit>\nRefer to <docLink> for more details."
     ],
     "sqlState" : "2D521"
   },

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -540,6 +540,12 @@
     ],
     "sqlState" : "2D521"
   },
+  "DELTA_CONCURRENT_DOMAIN_METADATA" : {
+    "message" : [
+      "ConcurrentDomainMetadataException: This error occurs when multiple streaming queries have a conflicting domain. Please try the operation again. <conflictingCommit>\nRefer to <docLink> for more details."
+    ],
+    "sqlState" : "2D521"
+  },
   "DELTA_CONCURRENT_WRITE" : {
     "message" : [
       "ConcurrentWriteException: A concurrent transaction has written new data since the current transaction read the table. Please try the operation again.\nRefer to <docLink> for more details."

--- a/spark/src/main/scala/io/delta/exceptions/DeltaConcurrentExceptions.scala
+++ b/spark/src/main/scala/io/delta/exceptions/DeltaConcurrentExceptions.scala
@@ -72,6 +72,23 @@ class MetadataChangedException(message: String)
 /**
  * :: Evolving ::
  *
+ * Thrown when a conflicting metadata domain is added.
+ *
+ */
+@Evolving
+class ConcurrentDomainMetadataException(message: String)
+  extends org.apache.spark.sql.delta.ConcurrentWriteException(message)
+    with DeltaThrowable {
+  def this(messageParameters: Array[String]) = {
+    this(DeltaThrowableHelper.getMessage("DELTA_CONCURRENT_DOMAIN_METADATA", messageParameters))
+  }
+  override def getErrorClass: String = "DELTA_CONCURRENT_DOMAIN_METADATA"
+  override def getMessage: String = message
+}
+
+/**
+ * :: Evolving ::
+ *
  * Thrown when the protocol version has changed between the time of read
  * and the time of commit.
  *
@@ -158,4 +175,5 @@ class ConcurrentTransactionException(message: String)
   }
   override def getErrorClass: String = "DELTA_CONCURRENT_TRANSACTION"
   override def getMessage: String = message
+
 }

--- a/spark/src/main/scala/io/delta/exceptions/DeltaConcurrentExceptions.scala
+++ b/spark/src/main/scala/io/delta/exceptions/DeltaConcurrentExceptions.scala
@@ -175,5 +175,4 @@ class ConcurrentTransactionException(message: String)
   }
   override def getErrorClass: String = "DELTA_CONCURRENT_TRANSACTION"
   override def getMessage: String = message
-
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -17,24 +17,26 @@
 package org.apache.spark.sql.delta
 
 // scalastyle:off import.ordering.noEmptyLine
+import java.util.concurrent.TimeUnit
 
-import io.delta.storage.commit.UpdatedActions
-import org.apache.hadoop.fs.FileStatus
-import org.apache.spark.internal.{MDC, MessageWithContext}
-import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionSet}
+import scala.collection.mutable
+
 import org.apache.spark.sql.delta.DeltaOperations.ROW_TRACKING_BACKFILL_OPERATION_NAME
 import org.apache.spark.sql.delta.RowId.RowTrackingMetadataDomain
 import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
-import org.apache.spark.sql.delta.sources.{DeltaSQLConf, DeltaSourceUtils}
+import org.apache.spark.sql.delta.sources.DeltaSourceUtils
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.DeltaSparkPlanUtils.CheckDeterministicOptions
 import org.apache.spark.sql.delta.util.FileNames
-import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import io.delta.storage.commit.UpdatedActions
+import org.apache.hadoop.fs.FileStatus
 
-import java.util.concurrent.TimeUnit
-import scala.collection.mutable
+import org.apache.spark.internal.{MDC, MessageWithContext}
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionSet, Or}
+import org.apache.spark.sql.types.StructType
 
 /**
  * A class representing different attributes of current transaction needed for conflict detection.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3547,6 +3547,19 @@ class MetadataChangedException(message: String)
 
 /**
  * This class is kept for backward compatibility.
+ * Use [[io.delta.exceptions.ConcurrentDomainMetadataException]] instead.
+ */
+class ConcurrentDomainMetadataException(message: String)
+  extends io.delta.exceptions.DeltaConcurrentModificationException(message) {
+  def this(conflictingCommit: Option[CommitInfo], domain: String) = this(
+    DeltaErrors.concurrentModificationExceptionMsg(
+      SparkEnv.get.conf,
+      s"A conflicting domain '${domain}' has been added. Please try the operation again.",
+      conflictingCommit))
+}
+
+/**
+ * This class is kept for backward compatibility.
  * Use [[io.delta.exceptions.ProtocolChangedException]] instead.
  */
 class ProtocolChangedException(message: String)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3554,7 +3554,7 @@ class ConcurrentDomainMetadataException(message: String)
   def this(conflictingCommit: Option[CommitInfo], domain: String) = this(
     DeltaErrors.concurrentModificationExceptionMsg(
       SparkEnv.get.conf,
-      s"A conflicting domain '${domain}' has been added. Please try the operation again.",
+      s"A conflicting metadata domain ${domain} is added.",
       conflictingCommit))
 }
 


### PR DESCRIPTION
Adding ConcurrentDomainMetadataException to correctly indicate conflicting domains as compared to ConcurrentTransactionException.

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
ConcurrentTransactionException did not correctly indicate the problem as it was intended to be used during SetTransaction. By making a new typed error we collect additional information about the conflicting operation in the context of the exception.

## How was this patch tested?
`build/sbt compile && build/sbt test`

## Does this PR introduce _any_ user-facing changes?

Exceptions will now indicate ConcurrentDomainMetadataException rather than ConcurrentTransactionException with domain info in the string message. 
