### PR TITLE
[Spark] Nicer error when failing to read table due to type change not support…

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2832,13 +2832,13 @@
     ],
     "sqlState" : "0AKDC"
   },
-  "DELTA_UNSUPPORTED_TYPE_CHANGE_IN_PREVIEW": {
-    "message": [
+  "DELTA_UNSUPPORTED_TYPE_CHANGE_IN_PREVIEW" : {
+    "message" : [
       "This table can't be read by this version of Delta because an unsupported type change was applied. Field <fieldPath> was changed from <fromType> to <toType>.",
       "Please upgrade to Delta 4.0 or higher to read this table, or drop the Type Widening table feature using a client that supports reading this table:",
       "  ALTER TABLE tableName DROP FEATURE <typeWideningFeatureName>"
     ],
-    "sqlState": "0AKDC"
+    "sqlState" : "0AKDC"
   },
   "DELTA_UNSUPPORTED_TYPE_CHANGE_IN_SCHEMA" : {
     "message" : [

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2832,6 +2832,14 @@
     ],
     "sqlState" : "0AKDC"
   },
+  "DELTA_UNSUPPORTED_TYPE_CHANGE_IN_PREVIEW": {
+    "message": [
+      "This table can't be read by this version of Delta because an unsupported type change was applied. Field <fieldPath> was changed from <fromType> to <toType>.",
+      "Please upgrade to Delta 4.0 or higher to read this table, or drop the Type Widening table feature using a client that supports reading this table:",
+      "  ALTER TABLE tableName DROP FEATURE <typeWideningFeatureName>"
+    ],
+    "sqlState": "0AKDC"
+  },
   "DELTA_UNSUPPORTED_TYPE_CHANGE_IN_SCHEMA" : {
     "message" : [
       "Unable to operate on this table because an unsupported type change was applied. Field <fieldName> was changed from <fromType> to <toType>."

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -667,6 +667,20 @@ trait DeltaErrorsBase
     )
   }
 
+  def unsupportedTypeChangeInPreview(
+      fieldPath: Seq[String],
+      fromType: DataType,
+      toType: DataType,
+      feature: TypeWideningTableFeatureBase): Throwable =
+    new DeltaUnsupportedOperationException(
+      errorClass = "DELTA_UNSUPPORTED_TYPE_CHANGE_IN_PREVIEW",
+      messageParameters = Array(
+        SchemaUtils.prettyFieldName(fieldPath),
+        fromType.sql,
+        toType.sql,
+        feature.name
+    ))
+
   def unsupportedTypeChangeInSchema(
       fieldPath: Seq[String],
       fromType: DataType,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -1031,6 +1031,24 @@ trait DeltaErrorsSuiteBase
       ))
     }
     {
+      checkError(
+        exception = intercept[DeltaUnsupportedOperationException] {
+          throw DeltaErrors.unsupportedTypeChangeInPreview(
+            fieldPath = Seq("origin", "country"),
+            fromType = IntegerType,
+            toType = LongType,
+            feature = TypeWideningPreviewTableFeature
+          )
+        },
+        "DELTA_UNSUPPORTED_TYPE_CHANGE_IN_PREVIEW",
+        parameters = Map(
+          "fieldPath" -> "origin.country",
+          "fromType" -> "INT",
+          "toType" -> "BIGINT",
+          "typeWideningFeatureName" -> "typeWidening-preview"
+        ))
+    }
+    {
       val e = intercept[DeltaIllegalStateException] {
         throw DeltaErrors.unsupportedTypeChangeInSchema(Seq("s", "a"), IntegerType, StringType)
       }


### PR DESCRIPTION
## Description
Delta 3.2/3.3 only supports a limited subset of type changes that will become available with Delta 4.0 / Spark 4.0.
This changes improves the error returned when reading a table with an unsupported type change to tell user to upgrade to Delta 4.0 in case the type change will be supported in that version.

## How was this patch tested?
Added tests to cover the error path.

## Does this PR introduce _any_ user-facing changes?
Updates error thrown on unsupported type change when reading a table.
