### PR TITLE
[KERNEL] Support for CollatedPredicate

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/CollatedPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/CollatedPredicate.java
@@ -16,15 +16,14 @@
 package io.delta.kernel.expressions;
 
 import io.delta.kernel.types.CollationIdentifier;
-
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Defines collated predicate which is an extension of {@link Predicate} that
- * is used for comparing string in collated fashion.
+ * Defines collated predicate which is an extension of {@link Predicate} that is used for comparing
+ * string in collated fashion.
  *
  * @since 3.3.0
  */
@@ -32,13 +31,15 @@ public class CollatedPredicate extends Predicate {
 
   private final CollationIdentifier collationIdentifier;
 
-  public CollatedPredicate(String name, List<Expression> children, CollationIdentifier collationIdentifier) {
+  public CollatedPredicate(
+      String name, List<Expression> children, CollationIdentifier collationIdentifier) {
     super(name, children);
     this.collationIdentifier = collationIdentifier;
   }
 
   /** Constructor for a binary CollatedPredicate expression */
-  public CollatedPredicate(String name, Expression left, Expression right, CollationIdentifier collationIdentifier) {
+  public CollatedPredicate(
+      String name, Expression left, Expression right, CollationIdentifier collationIdentifier) {
     super(name, left, right);
     this.collationIdentifier = collationIdentifier;
   }
@@ -51,11 +52,12 @@ public class CollatedPredicate extends Predicate {
   @Override
   public String toString() {
     if (BINARY_OPERATORS.contains(name)) {
-      return String.format("(%s %s %s %s)", children.get(0), name, children.get(1), collationIdentifier);
+      return String.format(
+          "(%s %s %s %s)", children.get(0), name, children.get(1), collationIdentifier);
     }
     return super.toString();
   }
 
   private static final Set<String> BINARY_OPERATORS =
-          Stream.of("<", "<=", ">", ">=", "=", "AND", "OR").collect(Collectors.toSet());
+      Stream.of("<", "<=", ">", ">=", "=", "AND", "OR").collect(Collectors.toSet());
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/CollatedPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/CollatedPredicate.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.expressions;
+
+import io.delta.kernel.types.CollationIdentifier;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Defines collated predicate which is an extension of {@link Predicate} that
+ * is used for comparing string in collated fashion.
+ *
+ * @since 3.3.0
+ */
+public class CollatedPredicate extends Predicate {
+
+  private final CollationIdentifier collationIdentifier;
+
+  public CollatedPredicate(String name, List<Expression> children, CollationIdentifier collationIdentifier) {
+    super(name, children);
+    this.collationIdentifier = collationIdentifier;
+  }
+
+  /** Constructor for a binary CollatedPredicate expression */
+  public CollatedPredicate(String name, Expression left, Expression right, CollationIdentifier collationIdentifier) {
+    super(name, left, right);
+    this.collationIdentifier = collationIdentifier;
+  }
+
+  /** @return the {@link CollationIdentifier} used for this {@link CollatedPredicate} */
+  public CollationIdentifier getCollationIdentifier() {
+    return collationIdentifier;
+  }
+
+  @Override
+  public String toString() {
+    if (BINARY_OPERATORS.contains(name)) {
+      return String.format("(%s %s %s %s)", children.get(0), name, children.get(1), collationIdentifier);
+    }
+    return super.toString();
+  }
+
+  private static final Set<String> BINARY_OPERATORS =
+          Stream.of("<", "<=", ">", ">=", "=", "AND", "OR").collect(Collectors.toSet());
+}

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
@@ -329,7 +329,11 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
           throw unsupportedExpressionException(predicate, msg);
         }
       }
-      return new Predicate(predicate.getName(), left, right);
+      if (predicate instanceof CollatedPredicate) {
+        return new CollatedPredicate(predicate.getName(), left, right, ((CollatedPredicate) predicate).getCollationIdentifier());
+      } else {
+        return new Predicate(predicate.getName(), left, right);
+      }
     }
   }
 
@@ -427,35 +431,19 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
       PredicateChildrenEvalResult argResults = evalBinaryExpressionChildren(predicate);
       switch (predicate.getName()) {
         case "=":
-          return comparatorVector(
-              argResults.leftResult,
-              argResults.rightResult,
-              (compareResult) -> (compareResult == 0));
         case ">":
-          return comparatorVector(
-              argResults.leftResult,
-              argResults.rightResult,
-              (compareResult) -> (compareResult > 0));
         case ">=":
-          return comparatorVector(
-              argResults.leftResult,
-              argResults.rightResult,
-              (compareResult) -> (compareResult >= 0));
         case "<":
-          return comparatorVector(
-              argResults.leftResult,
-              argResults.rightResult,
-              (compareResult) -> (compareResult < 0));
         case "<=":
           return comparatorVector(
               argResults.leftResult,
               argResults.rightResult,
-              (compareResult) -> (compareResult <= 0));
+              predicate);
         case "IS NOT DISTINCT FROM":
           return nullSafeComparatorVector(
               argResults.leftResult,
               argResults.rightResult,
-              (compareResult) -> (compareResult == 0));
+              predicate);
         default:
           // We should never reach this based on the ExpressionVisitor
           throw new IllegalStateException(

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
@@ -330,7 +330,11 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
         }
       }
       if (predicate instanceof CollatedPredicate) {
-        return new CollatedPredicate(predicate.getName(), left, right, ((CollatedPredicate) predicate).getCollationIdentifier());
+        return new CollatedPredicate(
+            predicate.getName(),
+            left,
+            right,
+            ((CollatedPredicate) predicate).getCollationIdentifier());
       } else {
         return new Predicate(predicate.getName(), left, right);
       }
@@ -435,15 +439,9 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
         case ">=":
         case "<":
         case "<=":
-          return comparatorVector(
-              argResults.leftResult,
-              argResults.rightResult,
-              predicate);
+          return comparatorVector(argResults.leftResult, argResults.rightResult, predicate);
         case "IS NOT DISTINCT FROM":
-          return nullSafeComparatorVector(
-              argResults.leftResult,
-              argResults.rightResult,
-              predicate);
+          return nullSafeComparatorVector(argResults.leftResult, argResults.rightResult, predicate);
         default:
           // We should never reach this based on the ExpressionVisitor
           throw new IllegalStateException(

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
@@ -128,6 +128,7 @@ class DefaultExpressionUtils {
     }
   }
 
+  /** Identifies default/binary collation */
   private static CollationIdentifier defaultCollationIdentifier =
       CollationIdentifier.fromString("SPARK.UTF8_BINARY");
 

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
@@ -20,13 +20,17 @@ import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.MapValue;
+import io.delta.kernel.expressions.CollatedPredicate;
 import io.delta.kernel.expressions.Expression;
+import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.internal.util.Utils;
 import io.delta.kernel.types.*;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.function.IntPredicate;
 import java.util.stream.Collectors;
@@ -107,18 +111,43 @@ class DefaultExpressionUtils {
   }
 
   /**
+   * Matches predicate name to comparison function.
+   */
+  static IntPredicate getBooleanPredicate(Predicate predicate) {
+    switch(predicate.getName()) {
+      case "=":
+      case "IS NOT DISTINCT FROM":
+        return x -> x == 0;
+      case "<":
+        return x -> x < 0;
+      case "<=":
+        return x -> x <= 0;
+      case ">":
+        return x -> x > 0;
+      case ">=":
+        return x -> x >= 0;
+      default:
+        throw new IllegalArgumentException(String.format("Unsupported predicate '%s'", predicate.getName()));
+    }
+  }
+
+  private static CollationIdentifier defaultCollationIdentifier =
+          CollationIdentifier.fromString("SPARK.UTF8_BINARY");
+
+  /**
    * Utility method for getting value comparator
    *
    * @param left
    * @param right
-   * @param booleanComparator
+   * @param predicate
    * @return
    */
   static IntPredicate getComparator(
-      ColumnVector left, ColumnVector right, IntPredicate booleanComparator) {
+      ColumnVector left, ColumnVector right, Predicate predicate) {
     checkArgument(
         left.getSize() == right.getSize(), "Left and right operand have different vector sizes.");
 
+    IntPredicate booleanComparator = getBooleanPredicate(predicate);
     DataType dataType = left.getDataType();
     IntPredicate vectorValueComparator;
     if (dataType instanceof BooleanType) {
@@ -155,10 +184,25 @@ class DefaultExpressionUtils {
               booleanComparator.test(
                   BIGDECIMAL_COMPARATOR.compare(left.getDecimal(rowId), right.getDecimal(rowId)));
     } else if (dataType instanceof StringType) {
-      vectorValueComparator =
-          rowId ->
-              booleanComparator.test(
-                  STRING_COMPARATOR.compare(left.getString(rowId), right.getString(rowId)));
+      if (predicate instanceof CollatedPredicate) {
+        CollatedPredicate collatedPredicate = (CollatedPredicate) predicate;
+        CollationIdentifier collationIdentifier = collatedPredicate.getCollationIdentifier();
+        if (collationIdentifier.equals(defaultCollationIdentifier)) {
+          vectorValueComparator =
+                  rowId ->
+                          booleanComparator.test(
+                                  STRING_COMPARATOR
+                                          .compare(left.getString(rowId), right.getString(rowId)));
+        } else {
+          throw new IllegalArgumentException(
+                  String.format("Invalid collation identifier: \"%s\"", collationIdentifier));
+        }
+      } else {
+        vectorValueComparator =
+                rowId ->
+                        booleanComparator.test(
+                                STRING_COMPARATOR.compare(left.getString(rowId), right.getString(rowId)));
+      }
     } else if (dataType instanceof BinaryType) {
       vectorValueComparator =
           rowId ->
@@ -178,8 +222,8 @@ class DefaultExpressionUtils {
    * <p>Only primitive data types are supported.
    */
   static ColumnVector comparatorVector(
-      ColumnVector left, ColumnVector right, IntPredicate booleanComparator) {
-    IntPredicate vectorValueComparator = getComparator(left, right, booleanComparator);
+      ColumnVector left, ColumnVector right, Predicate predicate) {
+    IntPredicate vectorValueComparator = getComparator(left, right, predicate);
 
     return new ColumnVector() {
 
@@ -220,8 +264,8 @@ class DefaultExpressionUtils {
    * <p>Only primitive data types are supported.
    */
   static ColumnVector nullSafeComparatorVector(
-      ColumnVector left, ColumnVector right, IntPredicate booleanComparator) {
-    IntPredicate vectorValueComparator = getComparator(left, right, booleanComparator);
+        ColumnVector left, ColumnVector right, Predicate predicate) {
+    IntPredicate vectorValueComparator = getComparator(left, right, predicate);
     return new ColumnVector() {
       @Override
       public DataType getDataType() {

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
@@ -28,9 +28,7 @@ import io.delta.kernel.types.*;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
 import java.util.function.IntPredicate;
 import java.util.stream.Collectors;
@@ -110,11 +108,9 @@ class DefaultExpressionUtils {
     };
   }
 
-  /**
-   * Matches predicate name to comparison function.
-   */
+  /** Matches predicate name to comparison function. */
   static IntPredicate getBooleanPredicate(Predicate predicate) {
-    switch(predicate.getName()) {
+    switch (predicate.getName()) {
       case "=":
       case "IS NOT DISTINCT FROM":
         return x -> x == 0;
@@ -127,12 +123,13 @@ class DefaultExpressionUtils {
       case ">=":
         return x -> x >= 0;
       default:
-        throw new IllegalArgumentException(String.format("Unsupported predicate '%s'", predicate.getName()));
+        throw new IllegalArgumentException(
+            String.format("Unsupported predicate '%s'", predicate.getName()));
     }
   }
 
   private static CollationIdentifier defaultCollationIdentifier =
-          CollationIdentifier.fromString("SPARK.UTF8_BINARY");
+      CollationIdentifier.fromString("SPARK.UTF8_BINARY");
 
   /**
    * Utility method for getting value comparator
@@ -142,8 +139,7 @@ class DefaultExpressionUtils {
    * @param predicate
    * @return
    */
-  static IntPredicate getComparator(
-      ColumnVector left, ColumnVector right, Predicate predicate) {
+  static IntPredicate getComparator(ColumnVector left, ColumnVector right, Predicate predicate) {
     checkArgument(
         left.getSize() == right.getSize(), "Left and right operand have different vector sizes.");
 
@@ -189,19 +185,18 @@ class DefaultExpressionUtils {
         CollationIdentifier collationIdentifier = collatedPredicate.getCollationIdentifier();
         if (collationIdentifier.equals(defaultCollationIdentifier)) {
           vectorValueComparator =
-                  rowId ->
-                          booleanComparator.test(
-                                  STRING_COMPARATOR
-                                          .compare(left.getString(rowId), right.getString(rowId)));
+              rowId ->
+                  booleanComparator.test(
+                      STRING_COMPARATOR.compare(left.getString(rowId), right.getString(rowId)));
         } else {
           throw new IllegalArgumentException(
-                  String.format("Invalid collation identifier: \"%s\"", collationIdentifier));
+              String.format("Invalid collation identifier: \"%s\"", collationIdentifier));
         }
       } else {
         vectorValueComparator =
-                rowId ->
-                        booleanComparator.test(
-                                STRING_COMPARATOR.compare(left.getString(rowId), right.getString(rowId)));
+            rowId ->
+                booleanComparator.test(
+                    STRING_COMPARATOR.compare(left.getString(rowId), right.getString(rowId)));
       }
     } else if (dataType instanceof BinaryType) {
       vectorValueComparator =
@@ -221,8 +216,7 @@ class DefaultExpressionUtils {
    *
    * <p>Only primitive data types are supported.
    */
-  static ColumnVector comparatorVector(
-      ColumnVector left, ColumnVector right, Predicate predicate) {
+  static ColumnVector comparatorVector(ColumnVector left, ColumnVector right, Predicate predicate) {
     IntPredicate vectorValueComparator = getComparator(left, right, predicate);
 
     return new ColumnVector() {
@@ -264,7 +258,7 @@ class DefaultExpressionUtils {
    * <p>Only primitive data types are supported.
    */
   static ColumnVector nullSafeComparatorVector(
-        ColumnVector left, ColumnVector right, Predicate predicate) {
+      ColumnVector left, ColumnVector right, Predicate predicate) {
     IntPredicate vectorValueComparator = getComparator(left, right, predicate);
     return new ColumnVector() {
       @Override

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionVisitor.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionVisitor.java
@@ -100,7 +100,8 @@ abstract class ExpressionVisitor<R> {
       case "IS NOT DISTINCT FROM":
         if (expression instanceof CollatedPredicate) {
           return visitComparator(
-                  new CollatedPredicate(name, children, ((CollatedPredicate) expression).getCollationIdentifier()));
+              new CollatedPredicate(
+                  name, children, ((CollatedPredicate) expression).getCollationIdentifier()));
         }
         return visitComparator(new Predicate(name, children));
       case "ELEMENT_AT":

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionVisitor.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionVisitor.java
@@ -98,6 +98,10 @@ abstract class ExpressionVisitor<R> {
       case ">":
       case ">=":
       case "IS NOT DISTINCT FROM":
+        if (expression instanceof CollatedPredicate) {
+          return visitComparator(
+                  new CollatedPredicate(name, children, ((CollatedPredicate) expression).getCollationIdentifier()));
+        }
         return visitComparator(new Predicate(name, children));
       case "ELEMENT_AT":
         return visitElementAt(expression);

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ImplicitCastExpression.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ImplicitCastExpression.java
@@ -24,7 +24,6 @@ import io.delta.kernel.defaults.engine.DefaultExpressionHandler;
 import io.delta.kernel.expressions.Expression;
 import io.delta.kernel.types.DataType;
 import io.delta.kernel.types.StringType;
-
 import java.util.*;
 
 /**

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ImplicitCastExpression.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ImplicitCastExpression.java
@@ -23,6 +23,8 @@ import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.defaults.engine.DefaultExpressionHandler;
 import io.delta.kernel.expressions.Expression;
 import io.delta.kernel.types.DataType;
+import io.delta.kernel.types.StringType;
+
 import java.util.*;
 
 /**
@@ -110,7 +112,6 @@ final class ImplicitCastExpression implements Expression {
               this.put("integer", Arrays.asList("long", "float", "double"));
               this.put("long", Arrays.asList("float", "double"));
               this.put("float", Arrays.asList("double"));
-              this.put("string", Arrays.asList("string"));
             }
           });
 
@@ -120,6 +121,11 @@ final class ImplicitCastExpression implements Expression {
    */
   static boolean canCastTo(DataType from, DataType to) {
     // TODO: The type name should be a first class method on `DataType` instead of getting it
+    // This separate check is needed since both collated and non-collated StringTypes
+    // have same toString ("string")
+    if (from instanceof StringType && to instanceof StringType) {
+      return true;
+    }
     // using the `toString`.
     String fromStr = from.toString();
     String toStr = to.toString();

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ImplicitCastExpression.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ImplicitCastExpression.java
@@ -92,6 +92,8 @@ final class ImplicitCastExpression implements Expression {
         return new LongUpConverter(outputType, input);
       case "float":
         return new FloatUpConverter(outputType, input);
+      case "string":
+        return new StringUpConverter(outputType, input);
       default:
         throw new UnsupportedOperationException(
             format("Cast from %s is not supported", fromTypeStr));
@@ -108,6 +110,7 @@ final class ImplicitCastExpression implements Expression {
               this.put("integer", Arrays.asList("long", "float", "double"));
               this.put("long", Arrays.asList("float", "double"));
               this.put("float", Arrays.asList("double"));
+              this.put("string", Arrays.asList("string"));
             }
           });
 
@@ -257,6 +260,17 @@ final class ImplicitCastExpression implements Expression {
     @Override
     public double getDouble(int rowId) {
       return inputVector.getFloat(rowId);
+    }
+  }
+
+  private static class StringUpConverter extends UpConverter {
+    StringUpConverter(DataType targetType, ColumnVector inputVector) {
+      super(targetType, inputVector);
+    }
+
+    @Override
+    public String getString(int rowId) {
+      return inputVector.getString(rowId);
     }
   }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
@@ -94,7 +94,13 @@ class DefaultExpressionEvaluatorSuite extends AnyFunSuite with ExpressionSuiteBa
   }
 
   SIMPLE_TYPES.foreach { dataType =>
-    test(s"evaluate expression: column of type $dataType") {
+    val toString = dataType match {
+      case st: StringType =>
+        String.format("%s %s", dataType.toString, st.getCollationIdentifier)
+      case _ =>
+        dataType.toString
+    }
+    test(s"evaluate expression: column of type $toString") {
       val batchSize = 78;
       val batchSchema = new StructType().add("col1", dataType)
       val batch = new DefaultColumnarBatch(
@@ -773,6 +779,81 @@ class DefaultExpressionEvaluatorSuite extends AnyFunSuite with ExpressionSuiteBa
     ofNull(DoubleType.DOUBLE)
   )
 
+  test("evaluate expression: compare collated strings") {
+    // scalastyle:off nonascii
+    // TODO: add UTF8_LCASE when supported
+    Seq(
+      "UTF8_BINARY"
+    ).foreach {
+      collationName =>
+        // Empty strings.
+        assertCompare("", "", collationName, 0)
+        assertCompare("a", "", collationName, 1)
+        assertCompare("", "a", collationName, -1)
+        // Basic tests.
+        assertCompare("a", "a", collationName, 0)
+        assertCompare("a", "b", collationName, -1)
+        assertCompare("b", "a", collationName, 1)
+        assertCompare("A", "A", collationName, 0)
+        assertCompare("A", "B", collationName, -1)
+        assertCompare("B", "A", collationName, 1)
+        assertCompare("aa", "a", collationName, 1)
+        assertCompare("b", "bb", collationName, -1)
+        assertCompare("abc", "a", collationName, 1)
+        assertCompare("abc", "b", collationName, -1)
+        assertCompare("abc", "ab", collationName, 1)
+        assertCompare("abc", "abc", collationName, 0)
+        assertCompare("aaaa", "aaa", collationName, 1)
+        assertCompare("hello", "world", collationName, -1)
+        assertCompare("Spark", "Spark", collationName, 0)
+        assertCompare("ü", "ü", collationName, 0)
+        assertCompare("ü", "", collationName, 1)
+        assertCompare("", "ü", collationName, -1)
+        assertCompare("äü", "äü", collationName, 0)
+        assertCompare("äxx", "äx", collationName, 1)
+        assertCompare("a", "ä", collationName, -1)
+    }
+
+    // Advanced tests.
+    assertCompare("äü", "bü", "UTF8_BINARY", 1)
+    assertCompare("bxx", "bü", "UTF8_BINARY", -1)
+    // Case variation.
+    assertCompare("AbCd", "aBcD", "UTF8_BINARY", -1)
+    // Accent variation.
+    assertCompare("aBćD", "ABĆD", "UTF8_BINARY", 1)
+    // One-to-many case mapping (e.g. Turkish dotted I).
+    assertCompare("i\u0307", "İ", "UTF8_BINARY", -1)
+    assertCompare("İ", "i\u0307", "UTF8_BINARY", 1)
+    // Conditional case mapping (e.g. Greek sigmas).
+    assertCompare("ς", "σ", "UTF8_BINARY", -1)
+    assertCompare("ς", "Σ", "UTF8_BINARY", 1)
+    assertCompare("σ", "Σ", "UTF8_BINARY", 1)
+    // Surrogate pairs.
+    assertCompare("a🙃b🙃c", "aaaaa", "UTF8_BINARY", 1)
+    assertCompare("a🙃b🙃c", "a🙃b🙃c", "UTF8_BINARY", 0)
+    assertCompare("a🙃b🙃c", "a🙃b🙃d", "UTF8_BINARY", -1)
+    // scalastyle:on nonascii
+
+    // Maximum code point.
+    val maxCodePoint = Character.MAX_CODE_POINT
+    val maxCodePointStr = new String(Character.toChars(maxCodePoint))
+    var i = 0
+    while (i < maxCodePoint && Character.isValidCodePoint(i)) {
+      assertCompare(new String(Character.toChars(i)), maxCodePointStr, "UTF8_BINARY", -1)
+
+      i += 1
+    }
+    // Minimum code point.// Minimum code point.
+    val minCodePoint = Character.MIN_CODE_POINT
+    val minCodePointStr = new String(Character.toChars(minCodePoint))
+    i = minCodePoint + 1
+    while (i <= maxCodePoint && Character.isValidCodePoint(i)) {
+      assertCompare(new String(Character.toChars(i)), minCodePointStr, "UTF8_BINARY", 1)
+
+      i += 1
+    }
+  }
+
   test("evaluate expression: comparators `byte` with other implicit types") {
     // Mapping of comparator to expected results for:
     // (byte, short), (byte, int), (byte, long), (byte, float), (byte, double)
@@ -1021,9 +1102,42 @@ class DefaultExpressionEvaluatorSuite extends AnyFunSuite with ExpressionSuiteBa
     new DefaultExpressionEvaluator(inputSchema, expression, outputType)
   }
 
+  private def assertCompare(s1: String, s2: String, collationName: String, expResult: Int): Unit = {
+    val l1 = ofString(s1)
+    val l2 = ofString(s2)
+    if (expResult == -1) {
+      testComparator("<", l1, l2, true, Some(collationName))
+    } else if (expResult == 1) {
+      testComparator("<", l2, l1, true, Some(collationName))
+    } else if (expResult == 0) {
+      testComparator("=", l1, l2, true, Some(collationName))
+    } else {
+      throw new IllegalArgumentException(
+        String.format("Invalid expected result: %s.", expResult.toString))
+    }
+  }
+
   private def testComparator(
-    comparator: String, left: Expression, right: Expression, expResult: BooleanJ): Unit = {
-    val expression = new Predicate(comparator, left, right)
+    comparator: String,
+    left: Expression,
+    right: Expression,
+    expResult: BooleanJ,
+    collationName: Option[String] = Option.empty): Unit = {
+    val expression =
+      if (collationName.isEmpty) {
+        new Predicate(comparator, left, right)
+      } else {
+        val collationIdentifier =
+          if (collationName.get.startsWith("UTF8")) {
+            CollationIdentifier.fromString(
+              String.format("%s.%s", "SPARK", collationName.get))
+          } else {
+            throw new IllegalArgumentException(
+              String.format("Invalid collation name: %s.", collationName));
+          }
+        new CollatedPredicate(
+          comparator, left, right, collationIdentifier)
+      }
     val batch = zeroColumnBatch(rowCount = 1)
     val outputVector = evaluator(batch.getSchema, expression, BooleanType.BOOLEAN).eval(batch)
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
@@ -839,7 +839,6 @@ class DefaultExpressionEvaluatorSuite extends AnyFunSuite with ExpressionSuiteBa
     var i = 0
     while (i < maxCodePoint && Character.isValidCodePoint(i)) {
       assertCompare(new String(Character.toChars(i)), maxCodePointStr, "UTF8_BINARY", -1)
-
       i += 1
     }
     // Minimum code point.// Minimum code point.

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -315,6 +315,7 @@ trait TestUtils extends Assertions with SQLHelper {
     TimestampType.TIMESTAMP,
     TimestampNTZType.TIMESTAMP_NTZ,
     StringType.STRING,
+    new StringType(CollationIdentifier.fromString("SPARK.UTF8_LCASE")),
     BinaryType.BINARY,
     new DecimalType(10, 5)
   )
@@ -589,7 +590,7 @@ trait TestUtils extends Assertions with SQLHelper {
       case LongType.LONG => rowId % 25 == 0
       case FloatType.FLOAT => rowId % 5 == 0
       case DoubleType.DOUBLE => rowId % 10 == 0
-      case StringType.STRING => rowId % 2 == 0
+      case _: StringType => rowId % 2 == 0
       case BinaryType.BINARY => rowId % 3 == 0
       case DateType.DATE => rowId % 5 == 0
       case TimestampType.TIMESTAMP => rowId % 3 == 0
@@ -610,7 +611,7 @@ trait TestUtils extends Assertions with SQLHelper {
       case LongType.LONG => rowId * 287623L / 91
       case FloatType.FLOAT => rowId * 7651.2323f / 91
       case DoubleType.DOUBLE => rowId * 23423.23d / 17
-      case StringType.STRING => (rowId % 19).toString
+      case _: StringType => (rowId % 19).toString
       case BinaryType.BINARY => Array[Byte]((rowId % 21).toByte, (rowId % 7 - 1).toByte)
       case DateType.DATE => (rowId * 28234) % 2876
       case TimestampType.TIMESTAMP => (rowId * 2342342L) % 23


### PR DESCRIPTION


#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description
Added CollatedPredicate, which extends Predicate and it should be used for comparing strings in collated fashion.

## How was this patch tested?
Tests added to `DefaultExpressionEvaluatorSuite` and `ImplicitCastExpressionSuite`.

## Does this PR introduce _any_ user-facing changes?
Yes, it introduce new type of Predicate, CollatedPredicate.
