### PR TITLE
[Spark] Add isShallow argument to Clone Scala APIs

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2647,7 +2647,7 @@
   },
   "DELTA_UNSUPPORTED_DEEP_CLONE" : {
     "message" : [
-      "Deep clone is not supported for this Delta version."
+      "Deep clone is not supported by this Delta version."
     ],
     "sqlState" : "0A000"
   },

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2645,6 +2645,12 @@
     ],
     "sqlState" : "42621"
   },
+  "DELTA_UNSUPPORTED_DEEP_CLONE" : {
+    "message" : [
+      "Deep clone is not supported for this Delta version."
+    ],
+    "sqlState" : "0A000"
+  },
   "DELTA_UNSUPPORTED_DESCRIBE_DETAIL_VIEW" : {
     "message" : [
       "<view> is a view. DESCRIBE DETAIL is only supported for tables."

--- a/spark/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/spark/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -574,17 +574,30 @@ class DeltaTable private[tables](
    *  io.delta.tables.DeltaTable.clone(
    *   "/some/path/to/table",
    *   true,
+   *   true,
    *   Map("foo" -> "bar"))
    * }}}
    *
    * @param target The path or table name to create the clone.
+   * @param isShallow Whether to create a shallow clone or a deep clone.
    * @param replace Whether to replace the destination with the clone command.
    * @param properties The table properties to override in the clone.
    *
    * @since 3.3.0
    */
-  def clone(target: String, replace: Boolean, properties: Map[String, String]): DeltaTable = {
-    executeClone(table, target, replace, properties)
+  def clone(
+      target: String,
+      isShallow: Boolean,
+      replace: Boolean,
+      properties: Map[String, String]): DeltaTable = {
+    executeClone(
+      table,
+      target,
+      isShallow,
+      replace,
+      properties,
+      versionAsOf = None,
+      timestampAsOf = None)
   }
 
   /**
@@ -592,16 +605,20 @@ class DeltaTable private[tables](
    *
    * An example would be
    * {{{
-   *  io.delta.tables.DeltaTable.clone("/some/path/to/table", true)
+   *   io.delta.tables.DeltaTable.clone(
+   *     "/some/path/to/table",
+   *     true,
+   *     true)
    * }}}
    *
    * @param target The path or table name to create the clone.
+   * @param isShallow Whether to create a shallow clone or a deep clone.
    * @param replace Whether to replace the destination with the clone command.
    *
    * @since 3.3.0
    */
-  def clone(target: String, replace: Boolean): DeltaTable = {
-    clone(target, replace, properties = Map.empty)
+  def clone(target: String, isShallow: Boolean, replace: Boolean): DeltaTable = {
+    clone(target, isShallow, replace, properties = Map.empty[String, String])
   }
 
   /**
@@ -609,15 +626,18 @@ class DeltaTable private[tables](
    *
    * An example would be
    * {{{
-   *  io.delta.tables.DeltaTable.clone("/some/path/to/table")
+   *   io.delta.tables.DeltaTable.clone(
+   *     "/some/path/to/table",
+   *     true)
    * }}}
    *
    * @param target The path or table name to create the clone.
+   * @param isShallow Whether to create a shallow clone or a deep clone.
    *
    * @since 3.3.0
    */
-  def clone(target: String): DeltaTable = {
-    clone(target, replace = false)
+  def clone(target: String, isShallow: Boolean): DeltaTable = {
+    clone(target, isShallow, replace = false)
   }
 
   /**
@@ -629,15 +649,17 @@ class DeltaTable private[tables](
    *
    * An example would be
    * {{{
-   *  io.delta.tables.DeltaTable.cloneAtVersion(
-   *   5,
-   *   "/some/path/to/table",
-   *   true,
-   *   Map("foo" -> "bar"))
+   *   io.delta.tables.DeltaTable.cloneAtVersion(
+   *     5,
+   *     "/some/path/to/table",
+   *     true,
+   *     true,
+   *     Map("foo" -> "bar"))
    * }}}
    *
    * @param version The version of this table to clone from.
    * @param target The path or table name to create the clone.
+   * @param isShallow Whether to create a shallow clone or a deep clone.
    * @param replace Whether to replace the destination with the clone command.
    * @param properties The table properties to override in the clone.
    *
@@ -646,9 +668,17 @@ class DeltaTable private[tables](
   def cloneAtVersion(
       version: Long,
       target: String,
+      isShallow: Boolean,
       replace: Boolean,
       properties: Map[String, String]): DeltaTable = {
-    executeClone(table, target, replace, properties, versionAsOf = Some(version))
+    executeClone(
+      table,
+      target,
+      isShallow,
+      replace,
+      properties,
+      versionAsOf = Some(version),
+      timestampAsOf = None)
   }
 
   /**
@@ -657,17 +687,26 @@ class DeltaTable private[tables](
    *
    * An example would be
    * {{{
-   *  io.delta.tables.DeltaTable.cloneAtVersion(5, "/some/path/to/table", true)
+   *   io.delta.tables.DeltaTable.cloneAtVersion(
+   *     5,
+   *     "/some/path/to/table",
+   *     true,
+   *     true)
    * }}}
    *
    * @param version The version of this table to clone from.
    * @param target The path or table name to create the clone.
+   * @param isShallow Whether to create a shallow clone or a deep clone.
    * @param replace Whether to replace the destination with the clone command.
    *
    * @since 3.3.0
    */
-  def cloneAtVersion(version: Long, target: String, replace: Boolean): DeltaTable = {
-    cloneAtVersion(version, target, replace, properties = Map.empty)
+  def cloneAtVersion(
+      version: Long,
+      target: String,
+      isShallow: Boolean,
+      replace: Boolean): DeltaTable = {
+    cloneAtVersion(version, target, isShallow, replace, properties = Map.empty[String, String])
   }
 
   /**
@@ -676,19 +715,23 @@ class DeltaTable private[tables](
    *
    * An example would be
    * {{{
-   *  io.delta.tables.DeltaTable.cloneAtVersion(5, "/some/path/to/table")
+   *   io.delta.tables.DeltaTable.cloneAtVersion(
+   *     5,
+   *     "/some/path/to/table",
+   *     true)
    * }}}
    *
    * @param version The version of this table to clone from.
    * @param target The path or table name to create the clone.
+   * @param isShallow Whether to create a shallow clone or a deep clone.
    *
    * @since 3.3.0
    */
-  def cloneAtVersion(version: Long, target: String): DeltaTable = {
-    cloneAtVersion(version, target, replace = false)
+  def cloneAtVersion(version: Long, target: String, isShallow: Boolean): DeltaTable = {
+    cloneAtVersion(version, target, isShallow, replace = false)
   }
 
-   /**
+  /**
    * Clone a DeltaTable at a specific timestamp to a given destination to mirror the existing
    * table's data and metadata at that timestamp.
    *
@@ -699,15 +742,17 @@ class DeltaTable private[tables](
    *
    * An example would be
    * {{{
-   *  io.delta.tables.DeltaTable.cloneAtTimestamp(
-   *   "2019-01-01",
-   *   "/some/path/to/table",
-   *   true,
-   *   Map("foo" -> "bar"))
+   *   io.delta.tables.DeltaTable.cloneAtTimestamp(
+   *     "2019-01-01",
+   *     "/some/path/to/table",
+   *     true,
+   *     true,
+   *     Map("foo" -> "bar"))
    * }}}
    *
    * @param timestamp The timestamp of this table to clone from.
    * @param target The path or table name to create the clone.
+   * @param isShallow Whether to create a shallow clone or a deep clone.
    * @param replace Whether to replace the destination with the clone command.
    * @param properties The table properties to override in the clone.
    *
@@ -716,9 +761,18 @@ class DeltaTable private[tables](
   def cloneAtTimestamp(
       timestamp: String,
       target: String,
+      isShallow: Boolean,
       replace: Boolean,
       properties: Map[String, String]): DeltaTable = {
-    executeClone(table, target, replace, properties, timestampAsOf = Some(timestamp))
+    executeClone(
+      table,
+      target,
+      isShallow,
+      replace,
+      properties,
+      versionAsOf = None,
+      timestampAsOf = Some(timestamp)
+    )
   }
 
   /**
@@ -729,17 +783,26 @@ class DeltaTable private[tables](
    *
    * An example would be
    * {{{
-   *  io.delta.tables.DeltaTable.cloneAtTimestamp("2019-01-01", "/some/path/to/table", true)
+   *   io.delta.tables.DeltaTable.cloneAtTimestamp(
+   *     "2019-01-01",
+   *     "/some/path/to/table",
+   *     true,
+   *     true)
    * }}}
    *
    * @param timestamp The timestamp of this table to clone from.
    * @param target The path or table name to create the clone.
+   * @param isShallow Whether to create a shallow clone or a deep clone.
    * @param replace Whether to replace the destination with the clone command.
    *
    * @since 3.3.0
    */
-  def cloneAtTimestamp(timestamp: String, target: String, replace: Boolean): DeltaTable = {
-    cloneAtTimestamp(timestamp, target, replace, properties = Map.empty)
+  def cloneAtTimestamp(
+      timestamp: String,
+      target: String,
+      isShallow: Boolean,
+      replace: Boolean): DeltaTable = {
+    cloneAtTimestamp(timestamp, target, isShallow, replace, properties = Map.empty[String, String])
   }
 
   /**
@@ -750,16 +813,20 @@ class DeltaTable private[tables](
    *
    * An example would be
    * {{{
-   *  io.delta.tables.DeltaTable.cloneAtTimestamp("2019-01-01", "/some/path/to/table")
+   *   io.delta.tables.DeltaTable.cloneAtTimestamp(
+   *     "2019-01-01",
+   *     "/some/path/to/table",
+   *     true)
    * }}}
    *
    * @param timestamp The timestamp of this table to clone from.
    * @param target The path or table name to create the clone.
+   * @param isShallow Whether to create a shallow clone or a deep clone.
    *
    * @since 3.3.0
    */
-  def cloneAtTimestamp(timestamp: String, target: String): DeltaTable = {
-    cloneAtTimestamp(timestamp, target, replace = false)
+  def cloneAtTimestamp(timestamp: String, target: String, isShallow: Boolean): DeltaTable = {
+    cloneAtTimestamp(timestamp, target, isShallow, replace = false)
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -627,6 +627,13 @@ trait DeltaErrorsBase
     )
   }
 
+  def unsupportedDeepCloneException(): Throwable = {
+    new DeltaIllegalArgumentException(
+      errorClass = "DELTA_UNSUPPORTED_DEEP_CLONE",
+      messageParameters = Array.empty
+    )
+  }
+
   def viewInDescribeDetailException(view: TableIdentifier): Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_UNSUPPORTED_DESCRIBE_DETAIL_VIEW",

--- a/spark/src/test/scala/io/delta/tables/DeltaTableSuite.scala
+++ b/spark/src/test/scala/io/delta/tables/DeltaTableSuite.scala
@@ -436,7 +436,7 @@ class DeltaTableHadoopOptionsSuite extends QueryTest
 
       val srcTable =
         io.delta.tables.DeltaTable.forPath(spark, srcDir, fakeFileSystemOptions)
-      srcTable.clone(dstDir)
+      srcTable.clone(dstDir, isShallow = true)
 
       val srcLog = DeltaLog.forTable(spark, new Path(srcDir), fakeFileSystemOptions)
       val dstLog = DeltaLog.forTable(spark, new Path(dstDir), fakeFileSystemOptions)
@@ -474,7 +474,7 @@ class DeltaTableHadoopOptionsSuite extends QueryTest
           io.delta.tables.DeltaTable.forPath(spark, srcDir, fakeFileSystemOptions)
 
         if (cloneWithVersion) {
-          srcTable.cloneAtVersion(0, dstDir)
+          srcTable.cloneAtVersion(0, dstDir, isShallow = true)
         } else {
           // clone with timestamp.
           //
@@ -487,7 +487,7 @@ class DeltaTableHadoopOptionsSuite extends QueryTest
           val logPath = new Path(srcDir, "_delta_log")
           val file = new File(FileNames.unsafeDeltaFile(logPath, 0).toString)
           assert(file.setLastModified(time))
-          srcTable.cloneAtTimestamp(desiredTime, dstDir)
+          srcTable.cloneAtTimestamp(desiredTime, dstDir, isShallow = true)
         }
 
         val dstLog = DeltaLog.forTable(spark, new Path(dstDir), fakeFileSystemOptions)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableScalaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableScalaSuite.scala
@@ -16,13 +16,20 @@
 
 package org.apache.spark.sql.delta
 
+import org.apache.spark.sql.delta.util.AnalysisHelper
+import org.apache.hadoop.fs.Path
+
 class CloneTableScalaSuite extends CloneTableSuiteBase
-  with DeltaColumnMappingTestUtils {
+    with AnalysisHelper
+    with DeltaColumnMappingTestUtils {
+
+  import testImplicits._
 
   // scalastyle:off argcount
   override protected def cloneTable(
       source: String,
       target: String,
+      isShallow: Boolean,
       sourceIsTable: Boolean = false,
       targetIsTable: Boolean = false,
       targetLocation: Option[String] = None,
@@ -38,12 +45,113 @@ class CloneTableScalaSuite extends CloneTableSuiteBase
     }
 
     if (versionAsOf.isDefined) {
-      table.cloneAtVersion(versionAsOf.get, target, isReplace, tableProperties)
+      table.cloneAtVersion(versionAsOf.get,
+        target, isShallow, replace = isReplace, tableProperties)
     } else if (timestampAsOf.isDefined) {
-      table.cloneAtTimestamp(timestampAsOf.get, target, isReplace, tableProperties)
+      table.cloneAtTimestamp(timestampAsOf.get,
+        target, isShallow, replace = isReplace, tableProperties)
     } else {
-      table.clone(target, isReplace, tableProperties)
+      table.clone(target, isShallow, replace = isReplace, tableProperties)
     }
   }
   // scalastyle:on argcount
+
+  testAllClones("cloneAtVersion API") { (source, target, isShallow) =>
+    spark.range(5).write.format("delta").save(source)
+    spark.range(5).write.format("delta").mode("append").save(source)
+    spark.range(5).write.format("delta").mode("append").save(source)
+
+    val sourceTbl = io.delta.tables.DeltaTable.forPath(source)
+    assert(spark.read.format("delta").load(source).count() === 15)
+
+    runAndValidateClone(source, target, isShallow, sourceVersion = Some(0)) {
+      () => {
+        sourceTbl.cloneAtVersion(0, target, isShallow)
+      }
+    }
+  }
+
+  test("deep clone not supported yet") {
+    withSourceTargetDir { (source, clone) =>
+      assert(intercept[DeltaIllegalArgumentException] {
+        val df1 = Seq(1, 2, 3, 4, 5).toDF("id").withColumn("part", 'id % 2)
+        val df2 = Seq(8, 9, 10).toDF("id").withColumn("part", 'id % 2)
+        df1.write.format("delta").partitionBy("part").mode("append").save(source)
+        df2.write.format("delta").mode("append").save(source)
+
+        runAndValidateClone(source, clone, isShallow = false)()
+      }.getErrorClass === "DELTA_UNSUPPORTED_DEEP_CLONE")
+    }
+  }
+
+  testAllClones("clone API") { (source, target, isShallow) =>
+    spark.range(5).write.format("delta").save(source)
+    spark.range(5).write.format("delta").mode("append").save(source)
+    spark.range(5).write.format("delta").mode("append").save(source)
+
+    val sourceTbl = io.delta.tables.DeltaTable.forPath(source)
+    assert(spark.read.format("delta").load(source).count() === 15)
+
+    runAndValidateClone(source, target, isShallow) {
+      () => {
+        sourceTbl.clone(target, isShallow)
+      }
+    }
+  }
+
+  testAllClones("cloneAtTimestamp API") { (source, target, isShallow) =>
+    spark.range(5).write.format("delta").save(source)
+    spark.range(5).write.format("delta").mode("append").save(source)
+    spark.range(5).write.format("delta").mode("append").save(source)
+
+    val sourceTbl = io.delta.tables.DeltaTable.forPath(source)
+    assert(spark.read.format("delta").load(source).count() === 15)
+
+    val desiredTime = "1996-01-12"
+
+    val format = new java.text.SimpleDateFormat("yyyy-MM-dd")
+    val time = format.parse(desiredTime).getTime
+
+    val path = new Path(source + "/_delta_log/00000000000000000000.json")
+    // scalastyle:off deltahadoopconfiguration
+    val fs = path.getFileSystem(spark.sessionState.newHadoopConf())
+    // scalastyle:on deltahadoopconfiguration
+    fs.setTimes(path, time, 0)
+    if (coordinatedCommitsEnabledInTests) {
+      InCommitTimestampTestUtils.overwriteICTInDeltaFile(
+        DeltaLog.forTable(spark, source),
+        path,
+        Some(time))
+    }
+
+    runAndValidateClone(source, target, isShallow, sourceTimestamp = Some(desiredTime)) {
+      () => {
+        sourceTbl.cloneAtTimestamp(desiredTime, target, isShallow)
+      }
+    }
+  }
+}
+
+class CloneTableScalaIdColumnMappingSuite
+    extends CloneTableScalaSuite
+    with CloneTableColumnMappingSuiteBase
+    with DeltaColumnMappingEnableIdMode {
+
+  override protected def runOnlyTests: Seq[String] = super.runOnlyTests ++ Seq(
+    "cloneAtVersion API",
+    "clone API",
+    "cloneAtTimestamp API"
+  )
+}
+
+class CloneTableScalaNameColumnMappingSuite
+    extends CloneTableScalaSuite
+    with CloneTableColumnMappingNameSuiteBase
+    with DeltaColumnMappingEnableNameMode {
+
+  override protected def runOnlyTests: Seq[String] = super.runOnlyTests ++ Seq(
+    "cloneAtVersion API",
+    "clone API",
+    "cloneAtTimestamp API"
+  )
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableScalaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableScalaSuite.scala
@@ -46,12 +46,12 @@ class CloneTableScalaSuite extends CloneTableSuiteBase
 
     if (versionAsOf.isDefined) {
       table.cloneAtVersion(versionAsOf.get,
-        target, isShallow, replace = isReplace, tableProperties)
+        target, isShallow = isShallow, replace = isReplace, tableProperties)
     } else if (timestampAsOf.isDefined) {
       table.cloneAtTimestamp(timestampAsOf.get,
-        target, isShallow, replace = isReplace, tableProperties)
+        target, isShallow = isShallow, replace = isReplace, tableProperties)
     } else {
-      table.clone(target, isShallow, replace = isReplace, tableProperties)
+      table.clone(target, isShallow = isShallow, replace = isReplace, tableProperties)
     }
   }
   // scalastyle:on argcount
@@ -73,14 +73,17 @@ class CloneTableScalaSuite extends CloneTableSuiteBase
 
   test("deep clone not supported yet") {
     withSourceTargetDir { (source, clone) =>
-      assert(intercept[DeltaIllegalArgumentException] {
-        val df1 = Seq(1, 2, 3, 4, 5).toDF("id").withColumn("part", 'id % 2)
-        val df2 = Seq(8, 9, 10).toDF("id").withColumn("part", 'id % 2)
-        df1.write.format("delta").partitionBy("part").mode("append").save(source)
-        df2.write.format("delta").mode("append").save(source)
+      checkError(
+        intercept[DeltaIllegalArgumentException] {
+          val df1 = Seq(1, 2, 3, 4, 5).toDF("id").withColumn("part", 'id % 2)
+          val df2 = Seq(8, 9, 10).toDF("id").withColumn("part", 'id % 2)
+          df1.write.format("delta").partitionBy("part").mode("append").save(source)
+          df2.write.format("delta").mode("append").save(source)
 
-        runAndValidateClone(source, clone, isShallow = false)()
-      }.getErrorClass === "DELTA_UNSUPPORTED_DEEP_CLONE")
+          runAndValidateClone(source, clone, isShallow = false)()
+        },
+        "DELTA_UNSUPPORTED_DEEP_CLONE"
+      )
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2493,6 +2493,13 @@ trait DeltaErrorsSuiteBase
           "Did you manually delete files in the _delta_log directory?"))
     }
     {
+      val e = intercept[DeltaIllegalArgumentException] {
+        throw DeltaErrors.unsupportedDeepCloneException()
+      }
+      checkErrorMessage(e, Some("DELTA_UNSUPPORTED_DEEP_CLONE"), Some("0A000"),
+        Some("Deep clone is not supported for this Delta version."))
+    }
+    {
       val e = intercept[DeltaAnalysisException] {
         throw DeltaErrors.viewInDescribeDetailException(TableIdentifier("customer"))
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2497,7 +2497,7 @@ trait DeltaErrorsSuiteBase
         throw DeltaErrors.unsupportedDeepCloneException()
       }
       checkErrorMessage(e, Some("DELTA_UNSUPPORTED_DEEP_CLONE"), Some("0A000"),
-        Some("Deep clone is not supported for this Delta version."))
+        Some("Deep clone is not supported by this Delta version."))
     }
     {
       val e = intercept[DeltaAnalysisException] {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
- Add the `isShallow` argument to the Clone Scala APIs (`clone`, `cloneAtVersion`, and `cloneAtTimestamp`).
- This enables users to be able to decide the type of clone they would like from the API call.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Added UTs.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
Yes, modified the Clone Scala APIs of `DeltaTable`
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
