### PR TITLE
[Protocol] Amend Row Tracking Protocol to explicitly require domainMetadata

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1063,7 +1063,7 @@ Row Tracking is defined to be **supported** or **enabled** on a table as follows
 
 Enablement:
 - The table must be on Writer Version 7.
-- The feature `rowTracking` must exist in the table `protocol`'s `writerFeatures`.
+- The feature `rowTracking` must exist in the table `protocol`'s `writerFeatures`. The feature `domainMetadata` is required in the table `protocol`'s `writerFeatures`.
 - The table property `delta.enableRowTracking` must be set to `true`.
 
 ## Row IDs


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (Protocol changes)

## Description
Right now, the Delta protocol for Row tracking references the DomainMetadata table feature, but does not explicitly state domainMetadata as one of its required table feature like e.g. Clusteredtable.  The code in `TableFeature.scala` accurately lists domainMetadata as one of the required table feature. 

This PR amends the Protocol to accurately reflect the state of the system and the remainder of the Row tracking proposition. Row Tracking cannot require writers to write DomainMetadata if it is not listing domainMetadata as one of its required feature. This is also to be consistent with how other table features handle listing their required table features.

## How was this patch tested?
N/A

## Does this PR introduce _any_ user-facing changes?
'No'