### PR TITLE
[Spark][Kernel] Add isFatal detection to LogStoreErors

### DIFF
--- a/storage/src/main/java/io/delta/storage/internal/LogStoreErrors.java
+++ b/storage/src/main/java/io/delta/storage/internal/LogStoreErrors.java
@@ -36,6 +36,14 @@ public class LogStoreErrors {
         return true;
     }
 
+    /**
+     * Returns true if the provided Throwable is to be considered fatal, or false if it is to be
+     * considered non-fatal
+     */
+    public static boolean isFatal(Throwable t) {
+        return !isNonFatal(t);
+    }
+
     public static IOException incorrectLogStoreImplementationException(Throwable cause) {
         return new IOException(
             String.join("\n",


### PR DESCRIPTION

#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

Simple PR that adds `isFatal` utility that can be used in `delta-storage`

## How was this patch tested?

Build

## Does this PR introduce _any_ user-facing changes?

No