### PR TITLE
Change default engine to ignore collated data skipping predicate

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/CollatedPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/CollatedPredicate.java
@@ -16,15 +16,14 @@
 package io.delta.kernel.expressions;
 
 import io.delta.kernel.types.CollationIdentifier;
-
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Defines collated predicate which is an extension of {@link Predicate} that
- * is used for comparing string in collated fashion.
+ * Defines collated predicate which is an extension of {@link Predicate} that is used for comparing
+ * string in collated fashion.
  *
  * @since 3.3.0
  */
@@ -32,13 +31,15 @@ public class CollatedPredicate extends Predicate {
 
   private final CollationIdentifier collationIdentifier;
 
-  public CollatedPredicate(String name, List<Expression> children, CollationIdentifier collationIdentifier) {
+  public CollatedPredicate(
+      String name, List<Expression> children, CollationIdentifier collationIdentifier) {
     super(name, children);
     this.collationIdentifier = collationIdentifier;
   }
 
   /** Constructor for a binary CollatedPredicate expression */
-  public CollatedPredicate(String name, Expression left, Expression right, CollationIdentifier collationIdentifier) {
+  public CollatedPredicate(
+      String name, Expression left, Expression right, CollationIdentifier collationIdentifier) {
     super(name, left, right);
     this.collationIdentifier = collationIdentifier;
   }
@@ -51,11 +52,12 @@ public class CollatedPredicate extends Predicate {
   @Override
   public String toString() {
     if (BINARY_OPERATORS.contains(name)) {
-      return String.format("(%s %s %s %s)", children.get(0), name, children.get(1), collationIdentifier);
+      return String.format(
+          "(%s %s %s %s)", children.get(0), name, children.get(1), collationIdentifier);
     }
     return super.toString();
   }
 
   private static final Set<String> BINARY_OPERATORS =
-          Stream.of("<", "<=", ">", ">=", "=", "AND", "OR").collect(Collectors.toSet());
+      Stream.of("<", "<=", ">", ">=", "=", "AND", "OR").collect(Collectors.toSet());
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/CollatedPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/CollatedPredicate.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.expressions;
+
+import io.delta.kernel.types.CollationIdentifier;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Defines collated predicate which is an extension of {@link Predicate} that
+ * is used for comparing string in collated fashion.
+ *
+ * @since 3.3.0
+ */
+public class CollatedPredicate extends Predicate {
+
+  private final CollationIdentifier collationIdentifier;
+
+  public CollatedPredicate(String name, List<Expression> children, CollationIdentifier collationIdentifier) {
+    super(name, children);
+    this.collationIdentifier = collationIdentifier;
+  }
+
+  /** Constructor for a binary CollatedPredicate expression */
+  public CollatedPredicate(String name, Expression left, Expression right, CollationIdentifier collationIdentifier) {
+    super(name, left, right);
+    this.collationIdentifier = collationIdentifier;
+  }
+
+  /** @return the {@link CollationIdentifier} used for this {@link CollatedPredicate} */
+  public CollationIdentifier getCollationIdentifier() {
+    return collationIdentifier;
+  }
+
+  @Override
+  public String toString() {
+    if (BINARY_OPERATORS.contains(name)) {
+      return String.format("(%s %s %s %s)", children.get(0), name, children.get(1), collationIdentifier);
+    }
+    return super.toString();
+  }
+
+  private static final Set<String> BINARY_OPERATORS =
+          Stream.of("<", "<=", ">", ">=", "=", "AND", "OR").collect(Collectors.toSet());
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -271,7 +271,7 @@ public class ScanImpl implements Scan {
     StructType prunedStatsSchema =
         DataSkippingUtils.pruneStatsSchema(
             getStatsSchema(metadata.getDataSchema()), dataSkippingFilter.getReferencedCols());
-    StructType totalStatsSchema = appendCollatedStatsSchema(prunedStatsSchema, dataSkippingFilter.getCollatedReferencedCols());
+    StructType totalStatsSchema = appendCollatedStatsSchema(prunedStatsSchema, dataSkippingFilter.getReferencedCollatedCols());
 
     // Skipping happens in two steps:
     // 1. The predicate produces false for any file whose stats prove we can safely skip it. A

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -280,7 +280,7 @@ public class ScanImpl implements Scan {
         new Predicate(
             "=",
             new ScalarExpression(
-                "COALESCE", Arrays.asList(dataSkippingFilter, Literal.ofBoolean(true))),
+                "COALESCE", Arrays.asList(dataSkippingFilter.asPredicate(), Literal.ofBoolean(true))),
             AlwaysTrue.ALWAYS_TRUE);
 
     PredicateEvaluator predicateEvaluator =

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -271,7 +271,9 @@ public class ScanImpl implements Scan {
     StructType prunedStatsSchema =
         DataSkippingUtils.pruneStatsSchema(
             getStatsSchema(metadata.getDataSchema()), dataSkippingFilter.getReferencedCols());
-    StructType totalStatsSchema = appendCollatedStatsSchema(prunedStatsSchema, dataSkippingFilter.getReferencedCollatedCols());
+    StructType totalStatsSchema =
+        appendCollatedStatsSchema(
+            prunedStatsSchema, dataSkippingFilter.getReferencedCollatedCols());
 
     // Skipping happens in two steps:
     // 1. The predicate produces false for any file whose stats prove we can safely skip it. A
@@ -282,15 +284,14 @@ public class ScanImpl implements Scan {
         new Predicate(
             "=",
             new ScalarExpression(
-                "COALESCE", Arrays.asList(dataSkippingFilter.asPredicate(), Literal.ofBoolean(true))),
+                "COALESCE",
+                Arrays.asList(dataSkippingFilter.asPredicate(), Literal.ofBoolean(true))),
             AlwaysTrue.ALWAYS_TRUE);
 
     PredicateEvaluator predicateEvaluator =
         wrapEngineException(
             () ->
-                engine
-                    .getExpressionHandler()
-                    .getPredicateEvaluator(totalStatsSchema, filterToEval),
+                engine.getExpressionHandler().getPredicateEvaluator(totalStatsSchema, filterToEval),
             "Get the predicate evaluator for data skipping with schema=%s and filter=%s",
             prunedStatsSchema,
             filterToEval);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/CollatedDataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/CollatedDataSkippingPredicate.java
@@ -2,20 +2,22 @@ package io.delta.kernel.internal.skipping;
 
 import io.delta.kernel.expressions.*;
 import io.delta.kernel.types.CollationIdentifier;
-
 import java.util.*;
 
-public class CollatedDataSkippingPredicate extends CollatedPredicate implements DataSkippingPredicate {
+public class CollatedDataSkippingPredicate extends CollatedPredicate
+    implements DataSkippingPredicate {
 
   private final Set<Column> referencedCols;
 
   /** Set of collated {@link Column}s referenced by the predicate or any of its child expressions */
   private final Map<CollationIdentifier, Set<Column>> referencedCollatedCols;
 
-  CollatedDataSkippingPredicate(String name, Column column, Literal literal, CollationIdentifier collationIdentifier) {
+  CollatedDataSkippingPredicate(
+      String name, Column column, Literal literal, CollationIdentifier collationIdentifier) {
     super(name, Arrays.asList(column, literal), collationIdentifier);
     this.referencedCols = Collections.singleton(column);
-    this.referencedCollatedCols = Collections.singletonMap(collationIdentifier, Collections.singleton(column));
+    this.referencedCollatedCols =
+        Collections.singletonMap(collationIdentifier, Collections.singleton(column));
   }
 
   @Override

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/CollatedDataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/CollatedDataSkippingPredicate.java
@@ -1,0 +1,35 @@
+package io.delta.kernel.internal.skipping;
+
+import io.delta.kernel.expressions.CollatedPredicate;
+import io.delta.kernel.expressions.Column;
+import io.delta.kernel.expressions.Expression;
+import io.delta.kernel.expressions.Predicate;
+import io.delta.kernel.types.CollationIdentifier;
+
+import java.util.*;
+
+public class CollatedDataSkippingPredicate extends CollatedPredicate implements DataSkippingPredicate {
+
+  /** Set of collated {@link Column}s referenced by the predicate or any of its child expressions */
+  private final Set<Column> collatedReferencedCols;
+
+  CollatedDataSkippingPredicate(String name, List<Expression> children, Set<Column> collatedReferencedCols, CollationIdentifier collationIdentifier) {
+    super(name, children, collationIdentifier);
+    this.collatedReferencedCols = Collections.unmodifiableSet(collatedReferencedCols);
+  }
+
+  @Override
+  public Set<Column> getReferencedCols() {
+    return collatedReferencedCols;
+  }
+
+  @Override
+  public Set<Column> getCollatedReferencedCols() {
+    return collatedReferencedCols;
+  }
+
+  @Override
+  public Predicate asPredicate() {
+    return this;
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/CollatedDataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/CollatedDataSkippingPredicate.java
@@ -1,30 +1,31 @@
 package io.delta.kernel.internal.skipping;
 
-import io.delta.kernel.expressions.CollatedPredicate;
-import io.delta.kernel.expressions.Column;
-import io.delta.kernel.expressions.Expression;
-import io.delta.kernel.expressions.Predicate;
+import io.delta.kernel.expressions.*;
+import io.delta.kernel.internal.util.Tuple2;
 import io.delta.kernel.types.CollationIdentifier;
 
 import java.util.*;
 
 public class CollatedDataSkippingPredicate extends CollatedPredicate implements DataSkippingPredicate {
 
-  /** Set of collated {@link Column}s referenced by the predicate or any of its child expressions */
-  private final Set<Column> collatedReferencedCols;
+  private final Set<Column> referencedCols;
 
-  CollatedDataSkippingPredicate(String name, List<Expression> children, Set<Column> collatedReferencedCols, CollationIdentifier collationIdentifier) {
-    super(name, children, collationIdentifier);
-    this.collatedReferencedCols = Collections.unmodifiableSet(collatedReferencedCols);
+  /** Set of collated {@link Column}s referenced by the predicate or any of its child expressions */
+  private final Set<Tuple2<CollationIdentifier, Column>> collatedReferencedCols;
+
+  CollatedDataSkippingPredicate(String name, Column column, Literal literal, CollationIdentifier collationIdentifier) {
+    super(name, Arrays.asList(column, literal), collationIdentifier);
+    this.referencedCols = Collections.singleton(column);
+    this.collatedReferencedCols = Collections.singleton(new Tuple2<>(collationIdentifier, column));
   }
 
   @Override
   public Set<Column> getReferencedCols() {
-    return collatedReferencedCols;
+    return referencedCols;
   }
 
   @Override
-  public Set<Column> getCollatedReferencedCols() {
+  public Set<Tuple2<CollationIdentifier, Column>> getCollatedReferencedCols() {
     return collatedReferencedCols;
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/CollatedDataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/CollatedDataSkippingPredicate.java
@@ -1,17 +1,45 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.delta.kernel.internal.skipping;
 
 import io.delta.kernel.expressions.*;
 import io.delta.kernel.types.CollationIdentifier;
 import java.util.*;
 
+/** A {@link Predicate} with a set of columns referenced by the expression. */
 public class CollatedDataSkippingPredicate extends CollatedPredicate
     implements DataSkippingPredicate {
 
+  /**
+   * Set of {@link Column}s referenced by the predicate or any of its child expressions.
+   * For a {@link CollatedDataSkippingPredicate}, set of referenced {@link Column}s is same as
+   * set of referenced collated {@link Column}s.
+   */
   private final Set<Column> referencedCols;
 
   /** Set of collated {@link Column}s referenced by the predicate or any of its child expressions */
   private final Map<CollationIdentifier, Set<Column>> referencedCollatedCols;
 
+  /**
+   *
+   * @param name the predicate name
+   * @param column the column referenced by this predicate
+   * @param literal
+   * @param collationIdentifier identifies collation for data skipping
+   */
   public CollatedDataSkippingPredicate(
       String name, Column column, Literal literal, CollationIdentifier collationIdentifier) {
     super(name, Arrays.asList(column, literal), collationIdentifier);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/CollatedDataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/CollatedDataSkippingPredicate.java
@@ -11,12 +11,12 @@ public class CollatedDataSkippingPredicate extends CollatedPredicate implements 
   private final Set<Column> referencedCols;
 
   /** Set of collated {@link Column}s referenced by the predicate or any of its child expressions */
-  private final Set<Tuple2<CollationIdentifier, Column>> collatedReferencedCols;
+  private final Map<CollationIdentifier, Set<Column>> collatedReferencedCols;
 
   CollatedDataSkippingPredicate(String name, Column column, Literal literal, CollationIdentifier collationIdentifier) {
     super(name, Arrays.asList(column, literal), collationIdentifier);
     this.referencedCols = Collections.singleton(column);
-    this.collatedReferencedCols = Collections.singleton(new Tuple2<>(collationIdentifier, column));
+    this.collatedReferencedCols = Collections.singletonMap(collationIdentifier, Collections.singleton(column));
   }
 
   @Override
@@ -25,7 +25,7 @@ public class CollatedDataSkippingPredicate extends CollatedPredicate implements 
   }
 
   @Override
-  public Set<Tuple2<CollationIdentifier, Column>> getCollatedReferencedCols() {
+  public Map<CollationIdentifier, Set<Column>> getCollatedReferencedCols() {
     return collatedReferencedCols;
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/CollatedDataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/CollatedDataSkippingPredicate.java
@@ -1,7 +1,6 @@
 package io.delta.kernel.internal.skipping;
 
 import io.delta.kernel.expressions.*;
-import io.delta.kernel.internal.util.Tuple2;
 import io.delta.kernel.types.CollationIdentifier;
 
 import java.util.*;
@@ -11,12 +10,12 @@ public class CollatedDataSkippingPredicate extends CollatedPredicate implements 
   private final Set<Column> referencedCols;
 
   /** Set of collated {@link Column}s referenced by the predicate or any of its child expressions */
-  private final Map<CollationIdentifier, Set<Column>> collatedReferencedCols;
+  private final Map<CollationIdentifier, Set<Column>> referencedCollatedCols;
 
   CollatedDataSkippingPredicate(String name, Column column, Literal literal, CollationIdentifier collationIdentifier) {
     super(name, Arrays.asList(column, literal), collationIdentifier);
     this.referencedCols = Collections.singleton(column);
-    this.collatedReferencedCols = Collections.singletonMap(collationIdentifier, Collections.singleton(column));
+    this.referencedCollatedCols = Collections.singletonMap(collationIdentifier, Collections.singleton(column));
   }
 
   @Override
@@ -25,8 +24,8 @@ public class CollatedDataSkippingPredicate extends CollatedPredicate implements 
   }
 
   @Override
-  public Map<CollationIdentifier, Set<Column>> getCollatedReferencedCols() {
-    return collatedReferencedCols;
+  public Map<CollationIdentifier, Set<Column>> getReferencedCollatedCols() {
+    return referencedCollatedCols;
   }
 
   @Override

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/CollatedDataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/CollatedDataSkippingPredicate.java
@@ -17,7 +17,7 @@ public class CollatedDataSkippingPredicate extends CollatedPredicate
     super(name, Arrays.asList(column, literal), collationIdentifier);
     this.referencedCols = Collections.singleton(column);
     this.referencedCollatedCols =
-        Collections.singletonMap(collationIdentifier, Collections.singleton(column));
+        new HashMap<>(Collections.singletonMap(collationIdentifier, new HashSet<>(Collections.singleton(column))));
   }
 
   @Override

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/CollatedDataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/CollatedDataSkippingPredicate.java
@@ -24,9 +24,9 @@ public class CollatedDataSkippingPredicate extends CollatedPredicate
     implements DataSkippingPredicate {
 
   /**
-   * Set of {@link Column}s referenced by the predicate or any of its child expressions.
-   * For a {@link CollatedDataSkippingPredicate}, set of referenced {@link Column}s is same as
-   * set of referenced collated {@link Column}s.
+   * Set of {@link Column}s referenced by the predicate or any of its child expressions. For a
+   * {@link CollatedDataSkippingPredicate}, set of referenced {@link Column}s is same as set of
+   * referenced collated {@link Column}s.
    */
   private final Set<Column> referencedCols;
 
@@ -34,7 +34,6 @@ public class CollatedDataSkippingPredicate extends CollatedPredicate
   private final Map<CollationIdentifier, Set<Column>> referencedCollatedCols;
 
   /**
-   *
    * @param name the predicate name
    * @param column the column referenced by this predicate
    * @param literal
@@ -45,7 +44,9 @@ public class CollatedDataSkippingPredicate extends CollatedPredicate
     super(name, Arrays.asList(column, literal), collationIdentifier);
     this.referencedCols = Collections.singleton(column);
     this.referencedCollatedCols =
-        new HashMap<>(Collections.singletonMap(collationIdentifier, new HashSet<>(Collections.singleton(column))));
+        new HashMap<>(
+            Collections.singletonMap(
+                collationIdentifier, new HashSet<>(Collections.singleton(column))));
   }
 
   @Override

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/CollatedDataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/CollatedDataSkippingPredicate.java
@@ -12,7 +12,7 @@ public class CollatedDataSkippingPredicate extends CollatedPredicate
   /** Set of collated {@link Column}s referenced by the predicate or any of its child expressions */
   private final Map<CollationIdentifier, Set<Column>> referencedCollatedCols;
 
-  CollatedDataSkippingPredicate(
+  public CollatedDataSkippingPredicate(
       String name, Column column, Literal literal, CollationIdentifier collationIdentifier) {
     super(name, Arrays.asList(column, literal), collationIdentifier);
     this.referencedCols = Collections.singleton(column);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingPredicate.java
@@ -3,7 +3,6 @@ package io.delta.kernel.internal.skipping;
 import io.delta.kernel.expressions.Column;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.types.CollationIdentifier;
-
 import java.util.Map;
 import java.util.Set;
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingPredicate.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.delta.kernel.internal.skipping;
 
 import io.delta.kernel.expressions.Column;
@@ -6,10 +21,16 @@ import io.delta.kernel.types.CollationIdentifier;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Base interface for all file pruning predicates.
+ */
 public interface DataSkippingPredicate {
+  /** @return set of {@link Column}s referenced by the predicate or any of its child expressions */
   Set<Column> getReferencedCols();
 
+  /** @return set of collated {@link Column}s referenced by the predicate or any of its child expressions */
   Map<CollationIdentifier, Set<Column>> getReferencedCollatedCols();
 
+  /** @return {@link DataSkippingPredicate} as {@link Predicate} */
   Predicate asPredicate();
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (2024) The Delta Lake Project Authors.
+ * Copyright (2023) The Delta Lake Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingPredicate.java
@@ -2,13 +2,15 @@ package io.delta.kernel.internal.skipping;
 
 import io.delta.kernel.expressions.Column;
 import io.delta.kernel.expressions.Predicate;
+import io.delta.kernel.internal.util.Tuple2;
+import io.delta.kernel.types.CollationIdentifier;
 
 import java.util.Set;
 
 public interface DataSkippingPredicate {
   Set<Column> getReferencedCols();
 
-  Set<Column> getCollatedReferencedCols();
+  Set<Tuple2<CollationIdentifier, Column>> getCollatedReferencedCols();
 
   Predicate asPredicate();
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingPredicate.java
@@ -1,63 +1,14 @@
-/*
- * Copyright (2023) The Delta Lake Project Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.delta.kernel.internal.skipping;
 
 import io.delta.kernel.expressions.Column;
-import io.delta.kernel.expressions.Expression;
 import io.delta.kernel.expressions.Predicate;
-import java.util.*;
 
-/** A {@link Predicate} with a set of columns referenced by the expression. */
-public class DataSkippingPredicate extends Predicate {
+import java.util.Set;
 
-  /** Set of {@link Column}s referenced by the predicate or any of its child expressions */
-  private final Set<Column> referencedCols;
+public interface DataSkippingPredicate {
+  Set<Column> getReferencedCols();
 
-  /**
-   * @param name the predicate name
-   * @param children list of expressions that are input to this predicate.
-   * @param referencedCols set of columns referenced by this predicate or any of its child
-   *     expressions
-   */
-  DataSkippingPredicate(String name, List<Expression> children, Set<Column> referencedCols) {
-    super(name, children);
-    this.referencedCols = Collections.unmodifiableSet(referencedCols);
-  }
+  Set<Column> getCollatedReferencedCols();
 
-  /**
-   * Constructor for a binary {@link DataSkippingPredicate} where both children are instances of
-   * {@link DataSkippingPredicate}.
-   *
-   * @param name the predicate name
-   * @param left left input to this predicate
-   * @param right right input to this predicate
-   */
-  DataSkippingPredicate(String name, DataSkippingPredicate left, DataSkippingPredicate right) {
-    this(
-        name,
-        Arrays.asList(left, right),
-        new HashSet<Column>() {
-          {
-            addAll(left.getReferencedCols());
-            addAll(right.getReferencedCols());
-          }
-        });
-  }
-
-  public Set<Column> getReferencedCols() {
-    return referencedCols;
-  }
+  Predicate asPredicate();
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingPredicate.java
@@ -21,14 +21,15 @@ import io.delta.kernel.types.CollationIdentifier;
 import java.util.Map;
 import java.util.Set;
 
-/**
- * Base interface for all file pruning predicates.
- */
+/** Base interface for all file pruning predicates. */
 public interface DataSkippingPredicate {
   /** @return set of {@link Column}s referenced by the predicate or any of its child expressions */
   Set<Column> getReferencedCols();
 
-  /** @return set of collated {@link Column}s referenced by the predicate or any of its child expressions */
+  /**
+   * @return set of collated {@link Column}s referenced by the predicate or any of its child
+   *     expressions
+   */
   Map<CollationIdentifier, Set<Column>> getReferencedCollatedCols();
 
   /** @return {@link DataSkippingPredicate} as {@link Predicate} */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingPredicate.java
@@ -10,7 +10,7 @@ import java.util.Set;
 public interface DataSkippingPredicate {
   Set<Column> getReferencedCols();
 
-  Map<CollationIdentifier, Set<Column>> getCollatedReferencedCols();
+  Map<CollationIdentifier, Set<Column>> getReferencedCollatedCols();
 
   Predicate asPredicate();
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingPredicate.java
@@ -2,15 +2,15 @@ package io.delta.kernel.internal.skipping;
 
 import io.delta.kernel.expressions.Column;
 import io.delta.kernel.expressions.Predicate;
-import io.delta.kernel.internal.util.Tuple2;
 import io.delta.kernel.types.CollationIdentifier;
 
+import java.util.Map;
 import java.util.Set;
 
 public interface DataSkippingPredicate {
   Set<Column> getReferencedCols();
 
-  Set<Tuple2<CollationIdentifier, Column>> getCollatedReferencedCols();
+  Map<CollationIdentifier, Set<Column>> getCollatedReferencedCols();
 
   Predicate asPredicate();
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
@@ -313,29 +313,17 @@ public class DataSkippingUtils {
         return new DefaultDataSkippingPredicate(
             "AND",
             constructCollatedDataSkippingPredicate(
-                "<=",
-                schemaHelper.getMinColumn(leftCol)._1,
-                rightLit,
-                collationIdentifier),
+                "<=", schemaHelper.getMinColumn(leftCol)._1, rightLit, collationIdentifier),
             constructCollatedDataSkippingPredicate(
-                ">=",
-                schemaHelper.getMaxColumn(leftCol)._1,
-                rightLit,
-                collationIdentifier));
+                ">=", schemaHelper.getMaxColumn(leftCol)._1, rightLit, collationIdentifier));
       case "<":
       case "<=":
         return constructCollatedDataSkippingPredicate(
-            name,
-            schemaHelper.getMinColumn(leftCol)._1,
-            rightLit,
-            collationIdentifier);
+            name, schemaHelper.getMinColumn(leftCol)._1, rightLit, collationIdentifier);
       case ">":
       case ">=":
         return constructCollatedDataSkippingPredicate(
-            name,
-            schemaHelper.getMaxColumn(leftCol)._1,
-            rightLit,
-            collationIdentifier);
+            name, schemaHelper.getMaxColumn(leftCol)._1, rightLit, collationIdentifier);
       default:
         throw new IllegalArgumentException(
             String.format("Unsupported comparator expression %s", comparator));
@@ -391,7 +379,8 @@ public class DataSkippingUtils {
   private static DataSkippingPredicate constructCollatedDataSkippingPredicate(
       String exprName, Column col, Literal lit, CollationIdentifier collationIdentifier) {
     if (collationIdentifier.equals(CollationIdentifier.fromString("SPARK.UTF8_BINARY"))) {
-      return new DefaultDataSkippingPredicate(exprName, Arrays.asList(col, lit), Collections.singleton(col), Collections.emptyMap());
+      return new DefaultDataSkippingPredicate(
+          exprName, Arrays.asList(col, lit), Collections.singleton(col), Collections.emptyMap());
     }
     return new CollatedDataSkippingPredicate(exprName, col, lit, collationIdentifier);
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
@@ -300,6 +300,7 @@ public class DataSkippingUtils {
     return Optional.empty();
   }
 
+  /** Construct the skipping collated predicate for a given comparator */
   private static DataSkippingPredicate constructCollatedComparatorDataSkippingFilters(
       String comparator,
       Column leftCol,
@@ -382,6 +383,11 @@ public class DataSkippingUtils {
     }
   }
 
+  /**
+   * Constructs a {@link DataSkippingPredicate} for a binary predicate expression with a left
+   * column, a right expression of type {@link Literal}, and a collated comparison using
+   * {@link CollationIdentifier}.
+   */
   private static DataSkippingPredicate constructCollatedDataSkippingPredicate(
       String exprName, Column col, Literal lit, CollationIdentifier collationIdentifier) {
     return new CollatedDataSkippingPredicate(exprName, col, lit, collationIdentifier);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
@@ -492,13 +492,13 @@ public class DataSkippingUtils {
                     "OR",
                     constructCollatedComparatorDataSkippingFilters(
                         "<",
-                        schemaHelper.getMinColumn(leftCol)._1,
+                        leftCol,
                         rightLit,
                         schemaHelper,
                         collationIdentifier),
                     constructCollatedComparatorDataSkippingFilters(
                         ">",
-                        schemaHelper.getMaxColumn(leftCol)._1,
+                        leftCol,
                         rightLit,
                         schemaHelper,
                         collationIdentifier)));
@@ -518,8 +518,13 @@ public class DataSkippingUtils {
                         ">", schemaHelper.getMaxColumn(leftCol), rightLit)));
           }
         } else if (right instanceof Column && left instanceof Literal) {
+          Predicate reversed = new Predicate("=", right, left);
+          if (childPredicate instanceof CollatedPredicate) {
+            CollationIdentifier collationIdentifier = ((CollatedPredicate) childPredicate).getCollationIdentifier();
+            reversed = new CollatedPredicate("=", right, left, collationIdentifier);
+          }
           return constructDataSkippingFilter(
-              new Predicate("NOT", new Predicate("=", right, left)), schemaHelper);
+              new Predicate("NOT", reversed), schemaHelper);
         }
         break;
       case "<":

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
@@ -385,8 +385,8 @@ public class DataSkippingUtils {
 
   /**
    * Constructs a {@link DataSkippingPredicate} for a binary predicate expression with a left
-   * column, a right expression of type {@link Literal}, and a collated comparison using
-   * {@link CollationIdentifier}.
+   * column, a right expression of type {@link Literal}, and a collated comparison using {@link
+   * CollationIdentifier}.
    */
   private static DataSkippingPredicate constructCollatedDataSkippingPredicate(
       String exprName, Column col, Literal lit, CollationIdentifier collationIdentifier) {
@@ -420,10 +420,10 @@ public class DataSkippingUtils {
   private static Predicate reverseComparatorFilter(Predicate predicate) {
     if (predicate instanceof CollatedPredicate) {
       return new CollatedPredicate(
-              REVERSE_COMPARATORS.get(predicate.getName().toUpperCase(Locale.ROOT)),
-              getRight(predicate),
-              getLeft(predicate),
-              ((CollatedPredicate) predicate).getCollationIdentifier());
+          REVERSE_COMPARATORS.get(predicate.getName().toUpperCase(Locale.ROOT)),
+          getRight(predicate),
+          getLeft(predicate),
+          ((CollatedPredicate) predicate).getCollationIdentifier());
     }
     return new Predicate(
         REVERSE_COMPARATORS.get(predicate.getName().toUpperCase(Locale.ROOT)),

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
@@ -231,7 +231,7 @@ public class DataSkippingUtils {
                         add(numRecordsCol);
                       }
                     },
-                    new HashSet<>()));
+                    new HashMap<>()));
           }
         }
         break;
@@ -248,7 +248,7 @@ public class DataSkippingUtils {
             Literal zero = Literal.ofLong(0);
             return Optional.of(
                 new DefaultDataSkippingPredicate(
-                    ">", Arrays.asList(nullCountCol, zero), Collections.singleton(nullCountCol), new HashSet<>()));
+                    ">", Arrays.asList(nullCountCol, zero), Collections.singleton(nullCountCol), new HashMap<>()));
           }
         }
         break;
@@ -374,7 +374,7 @@ public class DataSkippingUtils {
     Column column = colExpr._1;
     Expression adjColExpr = colExpr._2.isPresent() ? colExpr._2.get() : column;
     return new DefaultDataSkippingPredicate(
-        exprName, Arrays.asList(adjColExpr, lit), Collections.singleton(column), new HashSet<>());
+        exprName, Arrays.asList(adjColExpr, lit), Collections.singleton(column), new HashMap<>());
   }
 
   private static final Map<String, String> REVERSE_COMPARATORS =

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
@@ -15,6 +15,7 @@
  */
 package io.delta.kernel.internal.skipping;
 
+import static io.delta.kernel.internal.DeltaErrors.protocolChangedException;
 import static io.delta.kernel.internal.DeltaErrors.wrapEngineException;
 import static io.delta.kernel.internal.InternalScanFileUtils.ADD_FILE_ORDINAL;
 import static io.delta.kernel.internal.InternalScanFileUtils.ADD_FILE_STATS_ORDINAL;
@@ -26,6 +27,8 @@ import io.delta.kernel.data.FilteredColumnarBatch;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.expressions.*;
 import io.delta.kernel.internal.util.Tuple2;
+import io.delta.kernel.types.CollationIdentifier;
+import io.delta.kernel.types.StringType;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
 import java.util.*;
@@ -180,7 +183,7 @@ public class DataSkippingUtils {
             constructDataSkippingFilter(asPredicate(getRight(dataFilters)), schemaHelper);
         if (e1AndFilter.isPresent() && e2AndFilter.isPresent()) {
           return Optional.of(
-              new DataSkippingPredicate("AND", e1AndFilter.get(), e2AndFilter.get()));
+              new DefaultDataSkippingPredicate("AND", e1AndFilter.get(), e2AndFilter.get()));
         } else if (e1AndFilter.isPresent()) {
           return e1AndFilter;
         } else {
@@ -205,7 +208,7 @@ public class DataSkippingUtils {
         Optional<DataSkippingPredicate> e2OrFilter =
             constructDataSkippingFilter(asPredicate(getRight(dataFilters)), schemaHelper);
         if (e1OrFilter.isPresent() && e2OrFilter.isPresent()) {
-          return Optional.of(new DataSkippingPredicate("OR", e1OrFilter.get(), e2OrFilter.get()));
+          return Optional.of(new DefaultDataSkippingPredicate("OR", e1OrFilter.get(), e2OrFilter.get()));
         } else {
           return Optional.empty();
         }
@@ -219,7 +222,7 @@ public class DataSkippingUtils {
             Column nullCountCol = schemaHelper.getNullCountColumn(childColumn);
             Column numRecordsCol = schemaHelper.getNumRecordsColumn();
             return Optional.of(
-                new DataSkippingPredicate(
+                new DefaultDataSkippingPredicate(
                     "<",
                     Arrays.asList(nullCountCol, numRecordsCol),
                     new HashSet<Column>() {
@@ -227,7 +230,8 @@ public class DataSkippingUtils {
                         add(nullCountCol);
                         add(numRecordsCol);
                       }
-                    }));
+                    },
+                    new HashSet<>()));
           }
         }
         break;
@@ -243,8 +247,8 @@ public class DataSkippingUtils {
             Column nullCountCol = schemaHelper.getNullCountColumn(childColumn);
             Literal zero = Literal.ofLong(0);
             return Optional.of(
-                new DataSkippingPredicate(
-                    ">", Arrays.asList(nullCountCol, zero), Collections.singleton(nullCountCol)));
+                new DefaultDataSkippingPredicate(
+                    ">", Arrays.asList(nullCountCol, zero), Collections.singleton(nullCountCol), new HashSet<>()));
           }
         }
         break;
@@ -260,6 +264,15 @@ public class DataSkippingUtils {
         if (left instanceof Column && right instanceof Literal) {
           Column leftCol = (Column) left;
           Literal rightLit = (Literal) right;
+
+          if (dataFilters instanceof CollatedPredicate
+          && schemaHelper.isCollatedSkippingEligibleMinMaxColumn(leftCol)
+          && rightLit.getDataType() instanceof StringType) {
+            return Optional.of(
+                    constructCollatedComparatorDataSkippingFilters(dataFilters.getName(),
+                            leftCol, rightLit, schemaHelper, ((CollatedPredicate) dataFilters).getCollationIdentifier()));
+          }
+
           if (schemaHelper.isSkippingEligibleMinMaxColumn(leftCol)
               && schemaHelper.isSkippingEligibleLiteral(rightLit)) {
             return Optional.of(
@@ -280,6 +293,31 @@ public class DataSkippingUtils {
     return Optional.empty();
   }
 
+  private static DataSkippingPredicate constructCollatedComparatorDataSkippingFilters(
+          String comparator, Column leftCol, Literal rightLit, StatsSchemaHelper schemaHelper, CollationIdentifier collationIdentifier) {
+    String name = comparator.toUpperCase(Locale.ROOT);
+    switch (name) {
+     case "=":
+      return new DefaultDataSkippingPredicate(
+              "AND",
+              constructCollatedDataSkippingPredicate(
+                      "<=", schemaHelper.getCollatedMinColumn(leftCol, collationIdentifier), rightLit, collationIdentifier),
+              constructCollatedDataSkippingPredicate(
+                      ">=", schemaHelper.getCollatedMaxColumn(leftCol, collationIdentifier), rightLit, collationIdentifier));
+     case "<":
+     case "<=":
+       return constructCollatedDataSkippingPredicate(
+               name, schemaHelper.getCollatedMinColumn(leftCol, collationIdentifier), rightLit, collationIdentifier);
+     case ">":
+     case ">=":
+       return constructCollatedDataSkippingPredicate(
+               name, schemaHelper.getCollatedMaxColumn(leftCol, collationIdentifier), rightLit, collationIdentifier);
+      default:
+        throw new IllegalArgumentException(
+                String.format("Unsupported comparator expression %s", comparator));
+   }
+  }
+
   /** Construct the skipping predicate for a given comparator */
   private static DataSkippingPredicate constructComparatorDataSkippingFilters(
       String comparator, Column leftCol, Literal rightLit, StatsSchemaHelper schemaHelper) {
@@ -289,7 +327,7 @@ public class DataSkippingUtils {
         // Match any file whose min/max range contains the requested point.
       case "=":
         // For example a = 1 --> minValue.a <= 1 AND maxValue.a >= 1
-        return new DataSkippingPredicate(
+        return new DefaultDataSkippingPredicate(
             "AND",
             constructBinaryDataSkippingPredicate(
                 "<=", schemaHelper.getMinColumn(leftCol), rightLit),
@@ -321,6 +359,11 @@ public class DataSkippingUtils {
     }
   }
 
+  private static DataSkippingPredicate constructCollatedDataSkippingPredicate(
+          String exprName, Column col, Literal lit, CollationIdentifier collationIdentifier) {
+    return new CollatedDataSkippingPredicate(exprName, Arrays.asList(col, lit), Collections.singleton(col), collationIdentifier);
+  }
+
   /**
    * Constructs a {@link DataSkippingPredicate} for a binary predicate expression with a left
    * column, an optional column adjustment expression and a right expression of type {@link
@@ -330,8 +373,8 @@ public class DataSkippingUtils {
       String exprName, Tuple2<Column, Optional<Expression>> colExpr, Literal lit) {
     Column column = colExpr._1;
     Expression adjColExpr = colExpr._2.isPresent() ? colExpr._2.get() : column;
-    return new DataSkippingPredicate(
-        exprName, Arrays.asList(adjColExpr, lit), Collections.singleton(column));
+    return new DefaultDataSkippingPredicate(
+        exprName, Arrays.asList(adjColExpr, lit), Collections.singleton(column), new HashSet<>());
   }
 
   private static final Map<String, String> REVERSE_COMPARATORS =
@@ -413,7 +456,7 @@ public class DataSkippingUtils {
             // rejected point.
             // For example a != 1 --> minValue.a < 1 OR maxValue.a > 1
             return Optional.of(
-                new DataSkippingPredicate(
+                new DefaultDataSkippingPredicate(
                     "OR",
                     constructBinaryDataSkippingPredicate(
                         "<", schemaHelper.getMinColumn(leftCol), rightLit),

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
@@ -361,7 +361,7 @@ public class DataSkippingUtils {
 
   private static DataSkippingPredicate constructCollatedDataSkippingPredicate(
           String exprName, Column col, Literal lit, CollationIdentifier collationIdentifier) {
-    return new CollatedDataSkippingPredicate(exprName, Arrays.asList(col, lit), Collections.singleton(col), collationIdentifier);
+    return new CollatedDataSkippingPredicate(exprName, col, lit, collationIdentifier);
   }
 
   /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
@@ -314,26 +314,26 @@ public class DataSkippingUtils {
             "AND",
             constructCollatedDataSkippingPredicate(
                 "<=",
-                schemaHelper.getCollatedMinColumn(leftCol, collationIdentifier),
+                schemaHelper.getMinColumn(leftCol)._1,
                 rightLit,
                 collationIdentifier),
             constructCollatedDataSkippingPredicate(
                 ">=",
-                schemaHelper.getCollatedMaxColumn(leftCol, collationIdentifier),
+                schemaHelper.getMaxColumn(leftCol)._1,
                 rightLit,
                 collationIdentifier));
       case "<":
       case "<=":
         return constructCollatedDataSkippingPredicate(
             name,
-            schemaHelper.getCollatedMinColumn(leftCol, collationIdentifier),
+            schemaHelper.getMinColumn(leftCol)._1,
             rightLit,
             collationIdentifier);
       case ">":
       case ">=":
         return constructCollatedDataSkippingPredicate(
             name,
-            schemaHelper.getCollatedMaxColumn(leftCol, collationIdentifier),
+            schemaHelper.getMaxColumn(leftCol)._1,
             rightLit,
             collationIdentifier);
       default:
@@ -500,13 +500,13 @@ public class DataSkippingUtils {
                     "OR",
                     constructCollatedComparatorDataSkippingFilters(
                         "<",
-                        schemaHelper.getCollatedMinColumn(leftCol, collationIdentifier),
+                        schemaHelper.getMinColumn(leftCol)._1,
                         rightLit,
                         schemaHelper,
                         collationIdentifier),
                     constructCollatedComparatorDataSkippingFilters(
                         ">",
-                        schemaHelper.getCollatedMaxColumn(leftCol, collationIdentifier),
+                        schemaHelper.getMaxColumn(leftCol)._1,
                         rightLit,
                         schemaHelper,
                         collationIdentifier)));

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
@@ -15,7 +15,6 @@
  */
 package io.delta.kernel.internal.skipping;
 
-import static io.delta.kernel.internal.DeltaErrors.protocolChangedException;
 import static io.delta.kernel.internal.DeltaErrors.wrapEngineException;
 import static io.delta.kernel.internal.InternalScanFileUtils.ADD_FILE_ORDINAL;
 import static io.delta.kernel.internal.InternalScanFileUtils.ADD_FILE_STATS_ORDINAL;
@@ -266,7 +265,7 @@ public class DataSkippingUtils {
           Literal rightLit = (Literal) right;
 
           if (dataFilters instanceof CollatedPredicate
-          && schemaHelper.isCollatedSkippingEligibleMinMaxColumn(leftCol)
+          && schemaHelper.isSkippingEligibleCollatedMinMaxColumn(leftCol)
           && rightLit.getDataType() instanceof StringType) {
             return Optional.of(
                     constructCollatedComparatorDataSkippingFilters(dataFilters.getName(),

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
@@ -390,6 +390,9 @@ public class DataSkippingUtils {
    */
   private static DataSkippingPredicate constructCollatedDataSkippingPredicate(
       String exprName, Column col, Literal lit, CollationIdentifier collationIdentifier) {
+    if (collationIdentifier.equals(CollationIdentifier.fromString("SPARK.UTF8_BINARY"))) {
+      return new DefaultDataSkippingPredicate(exprName, Arrays.asList(col, lit), Collections.singleton(col), Collections.emptyMap());
+    }
     return new CollatedDataSkippingPredicate(exprName, col, lit, collationIdentifier);
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
@@ -412,6 +412,13 @@ public class DataSkippingUtils {
       };
 
   private static Predicate reverseComparatorFilter(Predicate predicate) {
+    if (predicate instanceof CollatedPredicate) {
+      return new CollatedPredicate(
+              REVERSE_COMPARATORS.get(predicate.getName().toUpperCase(Locale.ROOT)),
+              getRight(predicate),
+              getLeft(predicate),
+              ((CollatedPredicate) predicate).getCollationIdentifier());
+    }
     return new Predicate(
         REVERSE_COMPARATORS.get(predicate.getName().toUpperCase(Locale.ROOT)),
         getRight(predicate),

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DataSkippingUtils.java
@@ -207,7 +207,8 @@ public class DataSkippingUtils {
         Optional<DataSkippingPredicate> e2OrFilter =
             constructDataSkippingFilter(asPredicate(getRight(dataFilters)), schemaHelper);
         if (e1OrFilter.isPresent() && e2OrFilter.isPresent()) {
-          return Optional.of(new DefaultDataSkippingPredicate("OR", e1OrFilter.get(), e2OrFilter.get()));
+          return Optional.of(
+              new DefaultDataSkippingPredicate("OR", e1OrFilter.get(), e2OrFilter.get()));
         } else {
           return Optional.empty();
         }
@@ -247,7 +248,10 @@ public class DataSkippingUtils {
             Literal zero = Literal.ofLong(0);
             return Optional.of(
                 new DefaultDataSkippingPredicate(
-                    ">", Arrays.asList(nullCountCol, zero), Collections.singleton(nullCountCol), new HashMap<>()));
+                    ">",
+                    Arrays.asList(nullCountCol, zero),
+                    Collections.singleton(nullCountCol),
+                    new HashMap<>()));
           }
         }
         break;
@@ -265,11 +269,15 @@ public class DataSkippingUtils {
           Literal rightLit = (Literal) right;
 
           if (dataFilters instanceof CollatedPredicate
-          && schemaHelper.isSkippingEligibleCollatedMinMaxColumn(leftCol)
-          && rightLit.getDataType() instanceof StringType) {
+              && schemaHelper.isSkippingEligibleCollatedMinMaxColumn(leftCol)
+              && rightLit.getDataType() instanceof StringType) {
             return Optional.of(
-                    constructCollatedComparatorDataSkippingFilters(dataFilters.getName(),
-                            leftCol, rightLit, schemaHelper, ((CollatedPredicate) dataFilters).getCollationIdentifier()));
+                constructCollatedComparatorDataSkippingFilters(
+                    dataFilters.getName(),
+                    leftCol,
+                    rightLit,
+                    schemaHelper,
+                    ((CollatedPredicate) dataFilters).getCollationIdentifier()));
           }
 
           if (schemaHelper.isSkippingEligibleMinMaxColumn(leftCol)
@@ -293,28 +301,44 @@ public class DataSkippingUtils {
   }
 
   private static DataSkippingPredicate constructCollatedComparatorDataSkippingFilters(
-          String comparator, Column leftCol, Literal rightLit, StatsSchemaHelper schemaHelper, CollationIdentifier collationIdentifier) {
+      String comparator,
+      Column leftCol,
+      Literal rightLit,
+      StatsSchemaHelper schemaHelper,
+      CollationIdentifier collationIdentifier) {
     String name = comparator.toUpperCase(Locale.ROOT);
     switch (name) {
-     case "=":
-      return new DefaultDataSkippingPredicate(
-              "AND",
-              constructCollatedDataSkippingPredicate(
-                      "<=", schemaHelper.getCollatedMinColumn(leftCol, collationIdentifier), rightLit, collationIdentifier),
-              constructCollatedDataSkippingPredicate(
-                      ">=", schemaHelper.getCollatedMaxColumn(leftCol, collationIdentifier), rightLit, collationIdentifier));
-     case "<":
-     case "<=":
-       return constructCollatedDataSkippingPredicate(
-               name, schemaHelper.getCollatedMinColumn(leftCol, collationIdentifier), rightLit, collationIdentifier);
-     case ">":
-     case ">=":
-       return constructCollatedDataSkippingPredicate(
-               name, schemaHelper.getCollatedMaxColumn(leftCol, collationIdentifier), rightLit, collationIdentifier);
+      case "=":
+        return new DefaultDataSkippingPredicate(
+            "AND",
+            constructCollatedDataSkippingPredicate(
+                "<=",
+                schemaHelper.getCollatedMinColumn(leftCol, collationIdentifier),
+                rightLit,
+                collationIdentifier),
+            constructCollatedDataSkippingPredicate(
+                ">=",
+                schemaHelper.getCollatedMaxColumn(leftCol, collationIdentifier),
+                rightLit,
+                collationIdentifier));
+      case "<":
+      case "<=":
+        return constructCollatedDataSkippingPredicate(
+            name,
+            schemaHelper.getCollatedMinColumn(leftCol, collationIdentifier),
+            rightLit,
+            collationIdentifier);
+      case ">":
+      case ">=":
+        return constructCollatedDataSkippingPredicate(
+            name,
+            schemaHelper.getCollatedMaxColumn(leftCol, collationIdentifier),
+            rightLit,
+            collationIdentifier);
       default:
         throw new IllegalArgumentException(
-                String.format("Unsupported comparator expression %s", comparator));
-   }
+            String.format("Unsupported comparator expression %s", comparator));
+    }
   }
 
   /** Construct the skipping predicate for a given comparator */
@@ -359,7 +383,7 @@ public class DataSkippingUtils {
   }
 
   private static DataSkippingPredicate constructCollatedDataSkippingPredicate(
-          String exprName, Column col, Literal lit, CollationIdentifier collationIdentifier) {
+      String exprName, Column col, Literal lit, CollationIdentifier collationIdentifier) {
     return new CollatedDataSkippingPredicate(exprName, col, lit, collationIdentifier);
   }
 
@@ -451,20 +475,28 @@ public class DataSkippingUtils {
           Literal rightLit = (Literal) right;
 
           if (childPredicate instanceof CollatedPredicate
-          && schemaHelper.isSkippingEligibleCollatedMinMaxColumn(leftCol)
-          && rightLit.getDataType() instanceof StringType) {
+              && schemaHelper.isSkippingEligibleCollatedMinMaxColumn(leftCol)
+              && rightLit.getDataType() instanceof StringType) {
             // Match any file whose min/max range contains anything other than the
             // rejected point.
             // For example a != "a" --> minValue.a < "a" OR maxValue.a > "a"
             CollationIdentifier collationIdentifier =
-                    ((CollatedPredicate) childPredicate).getCollationIdentifier();
+                ((CollatedPredicate) childPredicate).getCollationIdentifier();
             return Optional.of(
-                    new DefaultDataSkippingPredicate(
-                            "OR",
-                            constructCollatedComparatorDataSkippingFilters(
-                                    "<", schemaHelper.getCollatedMinColumn(leftCol, collationIdentifier), rightLit, schemaHelper, collationIdentifier),
-                            constructCollatedComparatorDataSkippingFilters(
-                                    ">", schemaHelper.getCollatedMaxColumn(leftCol, collationIdentifier), rightLit, schemaHelper, collationIdentifier)));
+                new DefaultDataSkippingPredicate(
+                    "OR",
+                    constructCollatedComparatorDataSkippingFilters(
+                        "<",
+                        schemaHelper.getCollatedMinColumn(leftCol, collationIdentifier),
+                        rightLit,
+                        schemaHelper,
+                        collationIdentifier),
+                    constructCollatedComparatorDataSkippingFilters(
+                        ">",
+                        schemaHelper.getCollatedMaxColumn(leftCol, collationIdentifier),
+                        rightLit,
+                        schemaHelper,
+                        collationIdentifier)));
           }
 
           if (schemaHelper.isSkippingEligibleMinMaxColumn(leftCol)
@@ -488,32 +520,44 @@ public class DataSkippingUtils {
       case "<":
         if (childPredicate instanceof CollatedPredicate) {
           return constructDataSkippingFilter(
-                  new CollatedPredicate(">=", childPredicate.getChildren(), ((CollatedPredicate) childPredicate).getCollationIdentifier()),
-                  schemaHelper);
+              new CollatedPredicate(
+                  ">=",
+                  childPredicate.getChildren(),
+                  ((CollatedPredicate) childPredicate).getCollationIdentifier()),
+              schemaHelper);
         }
         return constructDataSkippingFilter(
             new Predicate(">=", childPredicate.getChildren()), schemaHelper);
       case "<=":
         if (childPredicate instanceof CollatedPredicate) {
           return constructDataSkippingFilter(
-                  new CollatedPredicate(">", childPredicate.getChildren(), ((CollatedPredicate) childPredicate).getCollationIdentifier()),
-                  schemaHelper);
+              new CollatedPredicate(
+                  ">",
+                  childPredicate.getChildren(),
+                  ((CollatedPredicate) childPredicate).getCollationIdentifier()),
+              schemaHelper);
         }
         return constructDataSkippingFilter(
             new Predicate(">", childPredicate.getChildren()), schemaHelper);
       case ">":
         if (childPredicate instanceof CollatedPredicate) {
           return constructDataSkippingFilter(
-                  new CollatedPredicate("<=", childPredicate.getChildren(), ((CollatedPredicate) childPredicate).getCollationIdentifier()),
-                  schemaHelper);
+              new CollatedPredicate(
+                  "<=",
+                  childPredicate.getChildren(),
+                  ((CollatedPredicate) childPredicate).getCollationIdentifier()),
+              schemaHelper);
         }
         return constructDataSkippingFilter(
             new Predicate("<=", childPredicate.getChildren()), schemaHelper);
       case ">=":
         if (childPredicate instanceof CollatedPredicate) {
           return constructDataSkippingFilter(
-                  new CollatedPredicate("<", childPredicate.getChildren(), ((CollatedPredicate) childPredicate).getCollationIdentifier()),
-                  schemaHelper);
+              new CollatedPredicate(
+                  "<",
+                  childPredicate.getChildren(),
+                  ((CollatedPredicate) childPredicate).getCollationIdentifier()),
+              schemaHelper);
         }
         return constructDataSkippingFilter(
             new Predicate("<", childPredicate.getChildren()), schemaHelper);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DefaultDataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DefaultDataSkippingPredicate.java
@@ -18,7 +18,6 @@ package io.delta.kernel.internal.skipping;
 import io.delta.kernel.expressions.Column;
 import io.delta.kernel.expressions.Expression;
 import io.delta.kernel.expressions.Predicate;
-import io.delta.kernel.internal.util.Tuple2;
 import io.delta.kernel.types.CollationIdentifier;
 
 import java.util.*;
@@ -30,7 +29,7 @@ public class DefaultDataSkippingPredicate extends Predicate implements DataSkipp
   private final Set<Column> referencedCols;
 
   /** Set of collated {@link Column}s referenced by the predicate or any of its child expressions */
-  private final Map<CollationIdentifier, Set<Column>> collatedReferencedCols;
+  private final Map<CollationIdentifier, Set<Column>> referencedCollatedCols;
 
   /**
    * @param name the predicate name
@@ -41,7 +40,7 @@ public class DefaultDataSkippingPredicate extends Predicate implements DataSkipp
   DefaultDataSkippingPredicate(String name, List<Expression> children, Set<Column> referencedCols, Map<CollationIdentifier, Set<Column>> collatedReferencedCols) {
     super(name, children);
     this.referencedCols = Collections.unmodifiableSet(referencedCols);
-    this.collatedReferencedCols = Collections.unmodifiableMap(collatedReferencedCols);
+    this.referencedCollatedCols = Collections.unmodifiableMap(collatedReferencedCols);
   }
 
   /**
@@ -64,8 +63,8 @@ public class DefaultDataSkippingPredicate extends Predicate implements DataSkipp
         },
         new HashMap<CollationIdentifier, Set<Column>>() {
           {
-            putAll(left.getCollatedReferencedCols());
-            putAll(right.getCollatedReferencedCols());
+            putAll(left.getReferencedCollatedCols());
+            putAll(right.getReferencedCollatedCols());
           }
         });
   }
@@ -75,8 +74,8 @@ public class DefaultDataSkippingPredicate extends Predicate implements DataSkipp
   }
 
   @Override
-  public Map<CollationIdentifier, Set<Column>> getCollatedReferencedCols() {
-    return collatedReferencedCols;
+  public Map<CollationIdentifier, Set<Column>> getReferencedCollatedCols() {
+    return referencedCollatedCols;
   }
 
   @Override

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DefaultDataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DefaultDataSkippingPredicate.java
@@ -36,7 +36,7 @@ public class DefaultDataSkippingPredicate extends Predicate implements DataSkipp
    * @param referencedCols set of columns referenced by this predicate or any of its child
    *     expressions
    */
-  DefaultDataSkippingPredicate(
+  public DefaultDataSkippingPredicate(
       String name,
       List<Expression> children,
       Set<Column> referencedCols,
@@ -54,7 +54,7 @@ public class DefaultDataSkippingPredicate extends Predicate implements DataSkipp
    * @param left left input to this predicate
    * @param right right input to this predicate
    */
-  DefaultDataSkippingPredicate(
+  public DefaultDataSkippingPredicate(
       String name, DataSkippingPredicate left, DataSkippingPredicate right) {
     this(
         name,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DefaultDataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DefaultDataSkippingPredicate.java
@@ -19,7 +19,6 @@ import io.delta.kernel.expressions.Column;
 import io.delta.kernel.expressions.Expression;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.types.CollationIdentifier;
-
 import java.util.*;
 
 /** A {@link Predicate} with a set of columns referenced by the expression. */
@@ -37,7 +36,11 @@ public class DefaultDataSkippingPredicate extends Predicate implements DataSkipp
    * @param referencedCols set of columns referenced by this predicate or any of its child
    *     expressions
    */
-  DefaultDataSkippingPredicate(String name, List<Expression> children, Set<Column> referencedCols, Map<CollationIdentifier, Set<Column>> collatedReferencedCols) {
+  DefaultDataSkippingPredicate(
+      String name,
+      List<Expression> children,
+      Set<Column> referencedCols,
+      Map<CollationIdentifier, Set<Column>> collatedReferencedCols) {
     super(name, children);
     this.referencedCols = Collections.unmodifiableSet(referencedCols);
     this.referencedCollatedCols = Collections.unmodifiableMap(collatedReferencedCols);
@@ -51,7 +54,8 @@ public class DefaultDataSkippingPredicate extends Predicate implements DataSkipp
    * @param left left input to this predicate
    * @param right right input to this predicate
    */
-  DefaultDataSkippingPredicate(String name, DataSkippingPredicate left, DataSkippingPredicate right) {
+  DefaultDataSkippingPredicate(
+      String name, DataSkippingPredicate left, DataSkippingPredicate right) {
     this(
         name,
         Arrays.asList(left.asPredicate(), right.asPredicate()),
@@ -63,14 +67,16 @@ public class DefaultDataSkippingPredicate extends Predicate implements DataSkipp
         },
         new HashMap<CollationIdentifier, Set<Column>>() {
           {
-            for (Map.Entry<CollationIdentifier, Set<Column>> entry : left.getReferencedCollatedCols().entrySet()) {
+            for (Map.Entry<CollationIdentifier, Set<Column>> entry :
+                left.getReferencedCollatedCols().entrySet()) {
               if (!containsKey(entry.getKey())) {
                 put(entry.getKey(), entry.getValue());
               } else {
                 get(entry.getKey()).addAll(entry.getValue());
               }
             }
-            for (Map.Entry<CollationIdentifier, Set<Column>> entry : right.getReferencedCollatedCols().entrySet()) {
+            for (Map.Entry<CollationIdentifier, Set<Column>> entry :
+                right.getReferencedCollatedCols().entrySet()) {
               if (!containsKey(entry.getKey())) {
                 put(entry.getKey(), entry.getValue());
               } else {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DefaultDataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DefaultDataSkippingPredicate.java
@@ -30,7 +30,7 @@ public class DefaultDataSkippingPredicate extends Predicate implements DataSkipp
   private final Set<Column> referencedCols;
 
   /** Set of collated {@link Column}s referenced by the predicate or any of its child expressions */
-  private final Set<Tuple2<CollationIdentifier, Column>> collatedReferencedCols;
+  private final Map<CollationIdentifier, Set<Column>> collatedReferencedCols;
 
   /**
    * @param name the predicate name
@@ -38,10 +38,10 @@ public class DefaultDataSkippingPredicate extends Predicate implements DataSkipp
    * @param referencedCols set of columns referenced by this predicate or any of its child
    *     expressions
    */
-  DefaultDataSkippingPredicate(String name, List<Expression> children, Set<Column> referencedCols, Set<Tuple2<CollationIdentifier, Column>> collatedReferencedCols) {
+  DefaultDataSkippingPredicate(String name, List<Expression> children, Set<Column> referencedCols, Map<CollationIdentifier, Set<Column>> collatedReferencedCols) {
     super(name, children);
     this.referencedCols = Collections.unmodifiableSet(referencedCols);
-    this.collatedReferencedCols = Collections.unmodifiableSet(collatedReferencedCols);
+    this.collatedReferencedCols = Collections.unmodifiableMap(collatedReferencedCols);
   }
 
   /**
@@ -62,10 +62,10 @@ public class DefaultDataSkippingPredicate extends Predicate implements DataSkipp
             addAll(right.getReferencedCols());
           }
         },
-        new HashSet<Tuple2<CollationIdentifier, Column>>() {
+        new HashMap<CollationIdentifier, Set<Column>>() {
           {
-            addAll(left.getCollatedReferencedCols());
-            addAll(right.getCollatedReferencedCols());
+            putAll(left.getCollatedReferencedCols());
+            putAll(right.getCollatedReferencedCols());
           }
         });
   }
@@ -75,7 +75,7 @@ public class DefaultDataSkippingPredicate extends Predicate implements DataSkipp
   }
 
   @Override
-  public Set<Tuple2<CollationIdentifier, Column>> getCollatedReferencedCols() {
+  public Map<CollationIdentifier, Set<Column>> getCollatedReferencedCols() {
     return collatedReferencedCols;
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DefaultDataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DefaultDataSkippingPredicate.java
@@ -35,8 +35,8 @@ public class DefaultDataSkippingPredicate extends Predicate implements DataSkipp
    * @param children list of expressions that are input to this predicate.
    * @param referencedCols set of columns referenced by this predicate or any of its child
    *     expressions
-   * @param collatedReferencedCols set of collated columns referenced by this predicate or
-   *                               any ot its child expressions
+   * @param collatedReferencedCols set of collated columns referenced by this predicate or any ot
+   *     its child expressions
    */
   public DefaultDataSkippingPredicate(
       String name,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DefaultDataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DefaultDataSkippingPredicate.java
@@ -35,6 +35,8 @@ public class DefaultDataSkippingPredicate extends Predicate implements DataSkipp
    * @param children list of expressions that are input to this predicate.
    * @param referencedCols set of columns referenced by this predicate or any of its child
    *     expressions
+   * @param collatedReferencedCols set of collated columns referenced by this predicate or
+   *                               any ot its child expressions
    */
   public DefaultDataSkippingPredicate(
       String name,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DefaultDataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DefaultDataSkippingPredicate.java
@@ -63,8 +63,20 @@ public class DefaultDataSkippingPredicate extends Predicate implements DataSkipp
         },
         new HashMap<CollationIdentifier, Set<Column>>() {
           {
-            putAll(left.getReferencedCollatedCols());
-            putAll(right.getReferencedCollatedCols());
+            for (Map.Entry<CollationIdentifier, Set<Column>> entry : left.getReferencedCollatedCols().entrySet()) {
+              if (!containsKey(entry.getKey())) {
+                put(entry.getKey(), entry.getValue());
+              } else {
+                get(entry.getKey()).addAll(entry.getValue());
+              }
+            }
+            for (Map.Entry<CollationIdentifier, Set<Column>> entry : right.getReferencedCollatedCols().entrySet()) {
+              if (!containsKey(entry.getKey())) {
+                put(entry.getKey(), entry.getValue());
+              } else {
+                get(entry.getKey()).addAll(entry.getValue());
+              }
+            }
           }
         });
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DefaultDataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DefaultDataSkippingPredicate.java
@@ -43,7 +43,7 @@ public class DefaultDataSkippingPredicate extends Predicate implements DataSkipp
       Map<CollationIdentifier, Set<Column>> collatedReferencedCols) {
     super(name, children);
     this.referencedCols = Collections.unmodifiableSet(referencedCols);
-    this.referencedCollatedCols = Collections.unmodifiableMap(collatedReferencedCols);
+    this.referencedCollatedCols = collatedReferencedCols;
   }
 
   /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DefaultDataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DefaultDataSkippingPredicate.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.skipping;
+
+import io.delta.kernel.expressions.Column;
+import io.delta.kernel.expressions.Expression;
+import io.delta.kernel.expressions.Predicate;
+import java.util.*;
+
+/** A {@link Predicate} with a set of columns referenced by the expression. */
+public class DefaultDataSkippingPredicate extends Predicate implements DataSkippingPredicate {
+
+  /** Set of {@link Column}s referenced by the predicate or any of its child expressions */
+  private final Set<Column> referencedCols;
+
+  /** Set of collated {@link Column}s referenced by the predicate or any of its child expressions */
+  private final Set<Column> collatedReferencedCols;
+
+  /**
+   * @param name the predicate name
+   * @param children list of expressions that are input to this predicate.
+   * @param referencedCols set of columns referenced by this predicate or any of its child
+   *     expressions
+   */
+  DefaultDataSkippingPredicate(String name, List<Expression> children, Set<Column> referencedCols, Set<Column> collatedReferencedCols) {
+    super(name, children);
+    this.referencedCols = Collections.unmodifiableSet(referencedCols);
+    this.collatedReferencedCols = Collections.unmodifiableSet(collatedReferencedCols);
+  }
+
+  /**
+   * Constructor for a binary {@link DataSkippingPredicate} where both children are instances of
+   * {@link DataSkippingPredicate}.
+   *
+   * @param name the predicate name
+   * @param left left input to this predicate
+   * @param right right input to this predicate
+   */
+  DefaultDataSkippingPredicate(String name, DataSkippingPredicate left, DataSkippingPredicate right) {
+    this(
+        name,
+        Arrays.asList(left.asPredicate(), right.asPredicate()),
+        new HashSet<Column>() {
+          {
+            addAll(left.getReferencedCols());
+            addAll(right.getReferencedCols());
+          }
+        },
+        new HashSet<Column>() {
+          {
+            addAll(left.getCollatedReferencedCols());
+            addAll(right.getCollatedReferencedCols());
+          }
+        });
+  }
+
+  public Set<Column> getReferencedCols() {
+    return referencedCols;
+  }
+
+  @Override
+  public Set<Column> getCollatedReferencedCols() {
+    return collatedReferencedCols;
+  }
+
+  @Override
+  public Predicate asPredicate() {
+    return this;
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DefaultDataSkippingPredicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/DefaultDataSkippingPredicate.java
@@ -18,6 +18,9 @@ package io.delta.kernel.internal.skipping;
 import io.delta.kernel.expressions.Column;
 import io.delta.kernel.expressions.Expression;
 import io.delta.kernel.expressions.Predicate;
+import io.delta.kernel.internal.util.Tuple2;
+import io.delta.kernel.types.CollationIdentifier;
+
 import java.util.*;
 
 /** A {@link Predicate} with a set of columns referenced by the expression. */
@@ -27,7 +30,7 @@ public class DefaultDataSkippingPredicate extends Predicate implements DataSkipp
   private final Set<Column> referencedCols;
 
   /** Set of collated {@link Column}s referenced by the predicate or any of its child expressions */
-  private final Set<Column> collatedReferencedCols;
+  private final Set<Tuple2<CollationIdentifier, Column>> collatedReferencedCols;
 
   /**
    * @param name the predicate name
@@ -35,7 +38,7 @@ public class DefaultDataSkippingPredicate extends Predicate implements DataSkipp
    * @param referencedCols set of columns referenced by this predicate or any of its child
    *     expressions
    */
-  DefaultDataSkippingPredicate(String name, List<Expression> children, Set<Column> referencedCols, Set<Column> collatedReferencedCols) {
+  DefaultDataSkippingPredicate(String name, List<Expression> children, Set<Column> referencedCols, Set<Tuple2<CollationIdentifier, Column>> collatedReferencedCols) {
     super(name, children);
     this.referencedCols = Collections.unmodifiableSet(referencedCols);
     this.collatedReferencedCols = Collections.unmodifiableSet(collatedReferencedCols);
@@ -59,7 +62,7 @@ public class DefaultDataSkippingPredicate extends Predicate implements DataSkipp
             addAll(right.getReferencedCols());
           }
         },
-        new HashSet<Column>() {
+        new HashSet<Tuple2<CollationIdentifier, Column>>() {
           {
             addAll(left.getCollatedReferencedCols());
             addAll(right.getCollatedReferencedCols());
@@ -72,7 +75,7 @@ public class DefaultDataSkippingPredicate extends Predicate implements DataSkipp
   }
 
   @Override
-  public Set<Column> getCollatedReferencedCols() {
+  public Set<Tuple2<CollationIdentifier, Column>> getCollatedReferencedCols() {
     return collatedReferencedCols;
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
@@ -106,13 +106,18 @@ public class StatsSchemaHelper {
     for (Map.Entry<CollationIdentifier, Set<Column>> entry : collatedReferencedCols.entrySet()) {
       StructType statsSchema =
           DataSkippingUtils.pruneStatsSchema(getMinMaxStatsSchema(dataSchema), entry.getValue());
-      collatedStatsSchema =
-          collatedStatsSchema.add(
-              entry.getKey().toString(),
-              new StructType().add(MIN, statsSchema, true).add(MAX, statsSchema, true),
-              true);
+      if (statsSchema.length() > 0) {
+        collatedStatsSchema =
+            collatedStatsSchema.add(
+                entry.getKey().toString(),
+                new StructType().add(MIN, statsSchema, true).add(MAX, statsSchema, true),
+                true);
+      }
     }
-    return dataSchema.add(STATS_WITH_COLLATION, collatedStatsSchema, true);
+    if (collatedStatsSchema.length() > 0) {
+      return dataSchema.add(STATS_WITH_COLLATION, collatedStatsSchema, true);
+    }
+    return dataSchema;
   }
 
   //////////////////////////////////////////////////////////////////////////////////

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
@@ -84,16 +84,17 @@ public class StatsSchemaHelper {
     return statsSchema;
   }
 
-  public static StructType appendCollatedStatsSchema(StructType dataSchema,
-                                                     Map<CollationIdentifier, Set<Column>> collatedReferencedCols) {
+  public static StructType appendCollatedStatsSchema(
+      StructType dataSchema, Map<CollationIdentifier, Set<Column>> collatedReferencedCols) {
     StructType collatedStatsSchema = new StructType();
     for (Map.Entry<CollationIdentifier, Set<Column>> entry : collatedReferencedCols.entrySet()) {
-      StructType statsSchema = DataSkippingUtils.pruneStatsSchema(getMinMaxStatsSchema(dataSchema), entry.getValue());
-      collatedStatsSchema = collatedStatsSchema
-              .add(entry.getKey().toString(),
-                      new StructType()
-                      .add(MIN, statsSchema, true)
-                      .add(MAX, statsSchema, true), true);
+      StructType statsSchema =
+          DataSkippingUtils.pruneStatsSchema(getMinMaxStatsSchema(dataSchema), entry.getValue());
+      collatedStatsSchema =
+          collatedStatsSchema.add(
+              entry.getKey().toString(),
+              new StructType().add(MIN, statsSchema, true).add(MAX, statsSchema, true),
+              true);
     }
     return dataSchema.add(STATS_WITH_COLLATION, collatedStatsSchema, true);
   }
@@ -128,15 +129,17 @@ public class StatsSchemaHelper {
 
   public Column getCollatedMinColumn(Column column, CollationIdentifier collationIdentifier) {
     checkArgument(
-            isSkippingEligibleCollatedMinMaxColumn(column),
-            String.format("%s is not a valid collated min column for data schema %s", column, dataSchema));
+        isSkippingEligibleCollatedMinMaxColumn(column),
+        String.format(
+            "%s is not a valid collated min column for data schema %s", column, dataSchema));
     return getCollatedStatsColumn(column, MIN, collationIdentifier);
   }
 
   public Column getCollatedMaxColumn(Column column, CollationIdentifier collationIdentifier) {
     checkArgument(
-            isSkippingEligibleCollatedMinMaxColumn(column),
-            String.format("%s is not a valid collated max column for data schema %s", column, dataSchema));
+        isSkippingEligibleCollatedMinMaxColumn(column),
+        String.format(
+            "%s is not a valid collated max column for data schema %s", column, dataSchema));
     return getCollatedStatsColumn(column, MAX, collationIdentifier);
   }
 
@@ -212,7 +215,8 @@ public class StatsSchemaHelper {
   }
 
   public boolean isSkippingEligibleCollatedMinMaxColumn(Column column) {
-    return logicalToDataType.containsKey(column) && logicalToDataType.get(column) instanceof StringType;
+    return logicalToDataType.containsKey(column)
+        && logicalToDataType.get(column) instanceof StringType;
   }
 
   /**
@@ -316,10 +320,11 @@ public class StatsSchemaHelper {
     return getChildColumn(logicalToPhysicalColumn.get(column), statType);
   }
 
-  private Column getCollatedStatsColumn(Column column, String statType, CollationIdentifier collatedIdentifier) {
+  private Column getCollatedStatsColumn(
+      Column column, String statType, CollationIdentifier collatedIdentifier) {
     checkArgument(
-            logicalToPhysicalColumn.containsKey(column),
-            String.format("%s is not a valid leaf column for data schema", column, dataSchema));
+        logicalToPhysicalColumn.containsKey(column),
+        String.format("%s is not a valid leaf column for data schema", column, dataSchema));
     return getChildColumn(getChildColumn(column, statType), collatedIdentifier.toString());
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
@@ -325,7 +325,12 @@ public class StatsSchemaHelper {
     checkArgument(
         logicalToPhysicalColumn.containsKey(column),
         String.format("%s is not a valid leaf column for data schema", column, dataSchema));
-    return getChildColumn(getChildColumn(column, statType), collatedIdentifier.toString());
+    return getChildColumn(
+              getChildColumn(
+                    getChildColumn(
+                            logicalToPhysicalColumn.get(column), statType),
+                      collatedIdentifier.toString()),
+          STATS_WITH_COLLATION);
   }
 
   /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
@@ -84,6 +84,20 @@ public class StatsSchemaHelper {
     return statsSchema;
   }
 
+  public static StructType appendCollatedStatsSchema(StructType dataSchema,
+                                                     Map<CollationIdentifier, Set<Column>> collatedReferencedCols) {
+    StructType collatedStatsSchema = new StructType();
+    for (Map.Entry<CollationIdentifier, Set<Column>> entry : collatedReferencedCols.entrySet()) {
+      StructType statsSchema = DataSkippingUtils.pruneStatsSchema(getMinMaxStatsSchema(dataSchema), entry.getValue());
+      collatedStatsSchema
+              .add(entry.getKey().toString(),
+                      new StructType()
+                      .add(MIN, statsSchema, true)
+                      .add(MAX, statsSchema, true), true);
+    }
+    return dataSchema.add(STATS_WITH_COLLATION, collatedStatsSchema, true);
+  }
+
   //////////////////////////////////////////////////////////////////////////////////
   // Instance fields and public methods
   //////////////////////////////////////////////////////////////////////////////////

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
@@ -89,7 +89,7 @@ public class StatsSchemaHelper {
     StructType collatedStatsSchema = new StructType();
     for (Map.Entry<CollationIdentifier, Set<Column>> entry : collatedReferencedCols.entrySet()) {
       StructType statsSchema = DataSkippingUtils.pruneStatsSchema(getMinMaxStatsSchema(dataSchema), entry.getValue());
-      collatedStatsSchema
+      collatedStatsSchema = collatedStatsSchema
               .add(entry.getKey().toString(),
                       new StructType()
                       .add(MIN, statsSchema, true)

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
@@ -87,18 +87,18 @@ public class StatsSchemaHelper {
   /**
    * Appends collated stats schema for referenced columns.
    *
-   * <p>Here is an example of a data schema, referenced columns, and the schema of the statistics that would be
-   * collected.
+   * <p>Here is an example of a data schema, referenced columns, and the schema of the statistics
+   * that would be collected.
    *
    * <p>Data Schema: {{{ |-- a: string (nullable = true) | |-- b: string (nullable = true) | | |--
    * c: long (nullable = true) }}}
    *
-   * <p> Referenced {@link Column} is just a {@link Column} "a" with "SPARK.UTF8_LCASE" collation.
+   * <p>Referenced {@link Column} is just a {@link Column} "a" with "SPARK.UTF8_LCASE" collation.
    *
    * <p>Collected Collated Statistics: {{{ |-- statsWithCollation: struct (nullable = true) | |--
-   * SPARK_UTF8_LCASE: struct (nullable = true) | | |-- minValues: struct (nullable = true) | | | |--
-   * a: StringType (nullable = true) | | |-- maxValues: struct (nullable = true) | | | |--
-   * a: StringType (nullable = true) }}}
+   * SPARK_UTF8_LCASE: struct (nullable = true) | | |-- minValues: struct (nullable = true) | | |
+   * |-- a: StringType (nullable = true) | | |-- maxValues: struct (nullable = true) | | | |-- a:
+   * StringType (nullable = true) }}}
    */
   public static StructType appendCollatedStatsSchema(
       StructType dataSchema, Map<CollationIdentifier, Set<Column>> collatedReferencedCols) {
@@ -247,8 +247,8 @@ public class StatsSchemaHelper {
   }
 
   /**
-   * Returns true if the given column is skipping-eligible using collated min/max statistics. This means the
-   * column exists, is a leaf column, and is of a StringType.
+   * Returns true if the given column is skipping-eligible using collated min/max statistics. This
+   * means the column exists, is a leaf column, and is of a StringType.
    */
   public boolean isSkippingEligibleCollatedMinMaxColumn(Column column) {
     return logicalToDataType.containsKey(column)
@@ -357,8 +357,8 @@ public class StatsSchemaHelper {
   }
 
   /**
-   * Given a logical column, a stats type, and a {@link CollationIdentifier}
-   * returns the corresponding column in the collated statistics schema
+   * Given a logical column, a stats type, and a {@link CollationIdentifier} returns the
+   * corresponding column in the collated statistics schema
    */
   private Column getCollatedStatsColumn(
       Column column, String statType, CollationIdentifier collatedIdentifier) {
@@ -366,11 +366,10 @@ public class StatsSchemaHelper {
         logicalToPhysicalColumn.containsKey(column),
         String.format("%s is not a valid leaf column for data schema", column, dataSchema));
     return getChildColumn(
-              getChildColumn(
-                    getChildColumn(
-                            logicalToPhysicalColumn.get(column), statType),
-                      collatedIdentifier.toString()),
-          STATS_WITH_COLLATION);
+        getChildColumn(
+            getChildColumn(logicalToPhysicalColumn.get(column), statType),
+            collatedIdentifier.toString()),
+        STATS_WITH_COLLATION);
   }
 
   /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
@@ -128,14 +128,14 @@ public class StatsSchemaHelper {
 
   public Column getCollatedMinColumn(Column column, CollationIdentifier collationIdentifier) {
     checkArgument(
-            isCollatedSkippingEligibleMinMaxColumn(column),
+            isSkippingEligibleCollatedMinMaxColumn(column),
             String.format("%s is not a valid collated min column for data schema %s", column, dataSchema));
     return getCollatedStatsColumn(column, MIN, collationIdentifier);
   }
 
   public Column getCollatedMaxColumn(Column column, CollationIdentifier collationIdentifier) {
     checkArgument(
-            isCollatedSkippingEligibleMinMaxColumn(column),
+            isSkippingEligibleCollatedMinMaxColumn(column),
             String.format("%s is not a valid collated max column for data schema %s", column, dataSchema));
     return getCollatedStatsColumn(column, MAX, collationIdentifier);
   }
@@ -211,7 +211,7 @@ public class StatsSchemaHelper {
         && isSkippingEligibleDataType(logicalToDataType.get(column));
   }
 
-  public boolean isCollatedSkippingEligibleMinMaxColumn(Column column) {
+  public boolean isSkippingEligibleCollatedMinMaxColumn(Column column) {
     return logicalToDataType.containsKey(column) && logicalToDataType.get(column) instanceof StringType;
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/skipping/StatsSchemaHelper.java
@@ -150,38 +150,6 @@ public class StatsSchemaHelper {
 
   /**
    * Given a logical column in the data schema provided when creating {@code this}, return the
-   * corresponding collated MIN column.
-   *
-   * @param column the logical column name.
-   * @param collationIdentifier identifier collation stats to use for data skipping
-   * @return the collated MIN column
-   */
-  public Column getCollatedMinColumn(Column column, CollationIdentifier collationIdentifier) {
-    checkArgument(
-        isSkippingEligibleCollatedMinMaxColumn(column),
-        String.format(
-            "%s is not a valid collated min column for data schema %s", column, dataSchema));
-    return getCollatedStatsColumn(column, MIN, collationIdentifier);
-  }
-
-  /**
-   * Given a logical column in the data schema provided when creating {@code this}, return the
-   * corresponding collated MAX column.
-   *
-   * @param column the logical column name.
-   * @param collationIdentifier identifier collation stats to use for data skipping
-   * @return the collated MAX column
-   */
-  public Column getCollatedMaxColumn(Column column, CollationIdentifier collationIdentifier) {
-    checkArgument(
-        isSkippingEligibleCollatedMinMaxColumn(column),
-        String.format(
-            "%s is not a valid collated max column for data schema %s", column, dataSchema));
-    return getCollatedStatsColumn(column, MAX, collationIdentifier);
-  }
-
-  /**
-   * Given a logical column in the data schema provided when creating {@code this}, return the
    * corresponding MIN column and an optional column adjustment expression from the statistic schema
    * that stores the MIN values for the provided logical column.
    *
@@ -359,22 +327,6 @@ public class StatsSchemaHelper {
         logicalToPhysicalColumn.containsKey(column),
         String.format("%s is not a valid leaf column for data schema", column, dataSchema));
     return getChildColumn(logicalToPhysicalColumn.get(column), statType);
-  }
-
-  /**
-   * Given a logical column, a stats type, and a {@link CollationIdentifier} returns the
-   * corresponding column in the collated statistics schema
-   */
-  private Column getCollatedStatsColumn(
-      Column column, String statType, CollationIdentifier collatedIdentifier) {
-    checkArgument(
-        logicalToPhysicalColumn.containsKey(column),
-        String.format("%s is not a valid leaf column for data schema", column, dataSchema));
-    return getChildColumn(
-        getChildColumn(
-            getChildColumn(logicalToPhysicalColumn.get(column), statType),
-            collatedIdentifier.toString()),
-        STATS_WITH_COLLATION);
   }
 
   /**

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/skipping/StatsSchemaHelperSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/skipping/StatsSchemaHelperSuite.scala
@@ -130,8 +130,8 @@ class StatsSchemaHelperSuite extends AnyFunSuite {
       )
     ).foreach {
       case (startingDataSchema, referencedCollatedCols, finalDataSchema) =>
-        assert(finalDataSchema
-          .equals(StatsSchemaHelper.appendCollatedStatsSchema(startingDataSchema, referencedCollatedCols)))
+        assert(finalDataSchema.equals(
+            StatsSchemaHelper.appendCollatedStatsSchema(startingDataSchema, referencedCollatedCols)))
     }
   }
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/skipping/StatsSchemaHelperSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/skipping/StatsSchemaHelperSuite.scala
@@ -1,0 +1,137 @@
+package io.delta.kernel.internal.skipping
+
+import io.delta.kernel.expressions.Column
+import io.delta.kernel.types.{CollationIdentifier, IntegerType, StringType, StructType}
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.util
+import java.util.Collections
+
+class StatsSchemaHelperSuite extends AnyFunSuite {
+  test("check appendCollatedStatsSchema") {
+    val STATS_WITH_COLLATION = "statsWithCollation"
+    val defaultCollationIdentifier = CollationIdentifier.fromString("SPARK.UTF8_BINARY")
+    val MIN = "minValues"
+    val MAX = "maxValues"
+
+    Seq(
+      // (startingDataSchema, referencedCollatedCols, finalDataSchema)
+      (
+        new StructType()
+          .add("a1", StringType.STRING, true)
+          .add("a2", IntegerType.INTEGER, false)
+          .add("a3", new StructType()
+            .add("b1", StringType.STRING, false), true),
+        new util.HashMap[CollationIdentifier, util.Set[Column]](),
+        new StructType()
+          .add("a1", StringType.STRING, true)
+          .add("a2", IntegerType.INTEGER, false)
+          .add("a3", new StructType()
+            .add("b1", StringType.STRING, false), true)
+          .add(STATS_WITH_COLLATION, new StructType(), true)
+      ),
+      (
+        new StructType()
+          .add("a1", StringType.STRING, true)
+          .add("a2", IntegerType.INTEGER, false)
+          .add("a3", new StructType()
+            .add("b1", StringType.STRING, false), true),
+        new util.HashMap[CollationIdentifier, util.Set[Column]]() {
+          {
+            put(
+              defaultCollationIdentifier,
+              Collections.singleton(new Column(Array("a3", "b1"))))
+          }
+        },
+        new StructType()
+          .add("a1", StringType.STRING, true)
+          .add("a2", IntegerType.INTEGER, false)
+          .add("a3", new StructType()
+            .add("b1", StringType.STRING, false), true)
+          .add(STATS_WITH_COLLATION, new StructType()
+            .add(defaultCollationIdentifier.toString, new StructType()
+              .add(MIN, new StructType()
+                .add("a3", new StructType()
+                  .add("b1", StringType.STRING, true), true), true)
+              .add(MAX, new StructType()
+                .add("a3", new StructType()
+                  .add("b1", StringType.STRING, true), true), true), true), true)
+      ),
+      (
+        new StructType()
+          .add("a1", StringType.STRING, true)
+          .add("a2", IntegerType.INTEGER, false)
+          .add("a3", new StructType()
+            .add("b1", StringType.STRING, false), true),
+        new util.HashMap[CollationIdentifier, util.Set[Column]]() {
+          {
+            put(
+              defaultCollationIdentifier,
+              scala.collection.JavaConverters.setAsJavaSet(
+                Set(new Column(Array("a3", "b1")), new Column("a1"))))
+          }
+        },
+        new StructType()
+          .add("a1", StringType.STRING, true)
+          .add("a2", IntegerType.INTEGER, false)
+          .add("a3", new StructType()
+            .add("b1", StringType.STRING, false), true)
+          .add(STATS_WITH_COLLATION, new StructType()
+            .add(defaultCollationIdentifier.toString, new StructType()
+              .add(MIN, new StructType()
+                .add("a1", StringType.STRING, true)
+                .add("a3", new StructType()
+                  .add("b1", StringType.STRING, true), true), true)
+              .add(MAX, new StructType()
+                .add("a1", StringType.STRING, true)
+                .add("a3", new StructType()
+                  .add("b1", StringType.STRING, true), true), true), true), true)
+      ),
+      (
+        new StructType()
+          .add("a1", StringType.STRING, true)
+          .add("a2", IntegerType.INTEGER, false)
+          .add("a3", new StructType()
+            .add("b1", StringType.STRING, false)
+            .add("b2", StringType.STRING, false), true),
+        new util.HashMap[CollationIdentifier, util.Set[Column]]() {
+          {
+            put(
+              defaultCollationIdentifier,
+              scala.collection.JavaConverters.setAsJavaSet(
+                Set(new Column(Array("a3", "b1")), new Column("a1"))))
+            put(CollationIdentifier.fromString("SPARK.UTF8_LCASE"),
+              Collections.singleton(new Column(Array("a3", "b2"))))
+          }
+        },
+        new StructType()
+          .add("a1", StringType.STRING, true)
+          .add("a2", IntegerType.INTEGER, false)
+          .add("a3", new StructType()
+            .add("b1", StringType.STRING, false)
+            .add("b2", StringType.STRING, false), true)
+          .add(STATS_WITH_COLLATION, new StructType()
+            .add("SPARK.UTF8_LCASE", new StructType()
+              .add(MIN, new StructType()
+                .add("a3", new StructType()
+                  .add("b2", StringType.STRING, true), true), true)
+              .add(MAX, new StructType()
+                .add("a3", new StructType()
+                  .add("b2", StringType.STRING, true), true), true), true)
+            .add(defaultCollationIdentifier.toString, new StructType()
+              .add(MIN, new StructType()
+                .add("a1", StringType.STRING, true)
+                .add("a3", new StructType()
+                  .add("b1", StringType.STRING, true), true), true)
+              .add(MAX, new StructType()
+                .add("a1", StringType.STRING, true)
+                .add("a3", new StructType()
+                  .add("b1", StringType.STRING, true), true), true), true), true)
+      )
+    ).foreach {
+      case (startingDataSchema, referencedCollatedCols, finalDataSchema) =>
+        assert(finalDataSchema
+          .equals(StatsSchemaHelper.appendCollatedStatsSchema(startingDataSchema, referencedCollatedCols)))
+    }
+  }
+}

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/skipping/StatsSchemaHelperSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/skipping/StatsSchemaHelperSuite.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.delta.kernel.internal.skipping
 
 import io.delta.kernel.expressions.Column
@@ -129,8 +144,8 @@ class StatsSchemaHelperSuite extends AnyFunSuite {
       )
     ).foreach {
       case (startingDataSchema, referencedCollatedCols, finalDataSchema) =>
-        assert(finalDataSchema.equals(
-            StatsSchemaHelper.appendCollatedStatsSchema(startingDataSchema, referencedCollatedCols)))
+        assert(finalDataSchema.equals(StatsSchemaHelper
+          .appendCollatedStatsSchema(startingDataSchema, referencedCollatedCols)))
     }
   }
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/skipping/StatsSchemaHelperSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/skipping/StatsSchemaHelperSuite.scala
@@ -28,7 +28,6 @@ class StatsSchemaHelperSuite extends AnyFunSuite {
           .add("a2", IntegerType.INTEGER, false)
           .add("a3", new StructType()
             .add("b1", StringType.STRING, false), true)
-          .add(STATS_WITH_COLLATION, new StructType(), true)
       ),
       (
         new StructType()

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/DataSkippingUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/DataSkippingUtilsSuite.scala
@@ -187,6 +187,39 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
         new StructType()
           .add("a1", StringType.STRING)
           .add("a2", StringType.STRING)
+      ),
+      (
+        new Or(
+          new CollatedPredicate(
+            "<",
+            new Column("a1"),
+            new Column("a2"),
+            defaultCollationIdentifier),
+          new CollatedPredicate(
+            "<",
+            Literal.ofString("a"),
+            new Column("a2"),
+            defaultCollationIdentifier)),
+        new StructType()
+          .add("a1", StringType.STRING)
+          .add("a2", StringType.STRING)
+      ),
+      (
+        new And(
+          new CollatedPredicate(
+            "<",
+            new Column("a1"),
+            new Column("a2"),
+            defaultCollationIdentifier),
+          new CollatedPredicate(
+            "<",
+            new Column("a1"),
+            new Column("a3"),
+            defaultCollationIdentifier)),
+        new StructType()
+          .add("a1", StringType.STRING)
+          .add("a2", StringType.STRING)
+          .add("a3", StringType.STRING)
       )
     ).foreach {
       case (predicate, schema) =>
@@ -356,6 +389,28 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
               Literal.ofString("a")).asJava,
             new util.HashSet(),
             new util.HashMap()))
+      ),
+      (
+        new And(
+          new CollatedPredicate(
+            "<",
+            new Column("a1"),
+            Literal.ofString("a"),
+            defaultCollationIdentifier),
+          new Predicate("<",
+            new Column("a1"),
+            new Column("a2"))),
+        new StructType()
+          .add("a1", StringType.STRING)
+          .add("a2", StringType.STRING),
+        new CollatedDataSkippingPredicate(
+          "<",
+          new Column(Array(STATS_WITH_COLLATION,
+            defaultCollationIdentifier.toString,
+            MIN,
+            "a1")),
+          Literal.ofString("a"),
+          defaultCollationIdentifier)
       )
     ).foreach {
       case (predicate, schema, dataSkippingPredicate) =>

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/DataSkippingUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/DataSkippingUtilsSuite.scala
@@ -16,11 +16,10 @@
 package io.delta.kernel.internal.util
 
 import scala.collection.JavaConverters._
-
-import io.delta.kernel.expressions.Column
+import io.delta.kernel.expressions.{CollatedPredicate, Column, Literal}
 import io.delta.kernel.internal.skipping.DataSkippingUtils
 import io.delta.kernel.types.IntegerType.INTEGER
-import io.delta.kernel.types.{DataType, StructField, StructType}
+import io.delta.kernel.types.{CollationIdentifier, DataType, StringType, StructField, StructType}
 import org.scalatest.funsuite.AnyFunSuite
 
 class DataSkippingUtilsSuite extends AnyFunSuite {
@@ -166,5 +165,27 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
       Set(),
       new StructType()
     )
+  }
+
+  test("constructDataSkippingFilter - with collated predicates") {
+    val defaultCollationIdentifier =
+      CollationIdentifier.fromString("SPARK.UTF8_BINARY")
+
+    Seq(
+      // (predicate, schema)
+      (
+        new CollatedPredicate(
+          "<",
+          new Column("a1"),
+          Literal.ofString("a"),
+          defaultCollationIdentifier),
+        new StructType()
+          .add("a1", StringType.STRING)
+      )
+    ).foreach {
+      case (predicate, schema) =>
+        assert(DataSkippingUtils.constructDataSkippingFilter(predicate, schema).toString
+        .equals())
+    }
   }
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/DataSkippingUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/DataSkippingUtilsSuite.scala
@@ -217,8 +217,8 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
       (
         new CollatedPredicate(
           "=",
-          new Column("a1"),
           Literal.ofString("a"),
+          new Column("a1"),
           defaultCollationIdentifier),
         new StructType()
           .add("a1", StringType.STRING),

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/DataSkippingUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/DataSkippingUtilsSuite.scala
@@ -196,6 +196,33 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
           defaultCollationIdentifier)
       ),
       (
+        new CollatedPredicate(
+          "=",
+          new Column("a1"),
+          Literal.ofString("a"),
+          defaultCollationIdentifier),
+        new StructType()
+          .add("a1", StringType.STRING),
+        new DefaultDataSkippingPredicate(
+          "AND",
+          new CollatedDataSkippingPredicate(
+            "<=",
+            new Column(Array(STATS_WITH_COLLATION,
+              defaultCollationIdentifier.toString,
+              MIN,
+              "a1")),
+            Literal.ofString("a"),
+            defaultCollationIdentifier),
+          new CollatedDataSkippingPredicate(
+            ">=",
+            new Column(Array(STATS_WITH_COLLATION,
+              defaultCollationIdentifier.toString,
+              MAX,
+              "a1")),
+            Literal.ofString("a"),
+            defaultCollationIdentifier))
+      ),
+      (
         new And(
           new CollatedPredicate(
             "<",
@@ -226,7 +253,7 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
               Literal.ofString("a")).asJava,
             new util.HashSet(),
             new util.HashMap()))
-      )
+      ),
     ).foreach {
       case (predicate, schema, dataSkippingPredicate) =>
         assert(DataSkippingUtils.constructDataSkippingFilter(predicate, schema).get().toString

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/DataSkippingUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/DataSkippingUtilsSuite.scala
@@ -171,6 +171,8 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
 
   val defaultCollationIdentifier =
     CollationIdentifier.fromString("SPARK.UTF8_BINARY")
+  val unicodeCollationIdentifier =
+    CollationIdentifier.fromString("ICU.UNICODE")
   val MIN = "minValues"
   val MAX = "maxValues"
 
@@ -237,11 +239,26 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
           defaultCollationIdentifier),
         new StructType()
           .add("a1", StringType.STRING),
+        new DefaultDataSkippingPredicate(
+          "<",
+          List(new Column(Array(MIN, "a1")),
+          Literal.ofString("a")).asJava,
+          new util.HashSet(),
+          new util.HashMap())
+      ),
+      (
+        new CollatedPredicate(
+          ">",
+          Literal.ofString("a"),
+          new Column("a1"),
+          unicodeCollationIdentifier),
+        new StructType()
+          .add("a1", StringType.STRING),
         new CollatedDataSkippingPredicate(
           "<",
           new Column(Array(MIN, "a1")),
           Literal.ofString("a"),
-          defaultCollationIdentifier)
+          unicodeCollationIdentifier)
       ),
       (
         new CollatedPredicate(
@@ -253,16 +270,39 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
           .add("a1", StringType.STRING),
         new DefaultDataSkippingPredicate(
           "AND",
+          new DefaultDataSkippingPredicate(
+            "<=",
+            List(new Column(Array(MIN, "a1")),
+            Literal.ofString("a")).asJava,
+            new util.HashSet(),
+            new util.HashMap()),
+          new DefaultDataSkippingPredicate(
+            ">=",
+            List(new Column(Array(MAX, "a1")),
+            Literal.ofString("a")).asJava,
+            new util.HashSet(),
+            new util.HashMap()))
+      ),
+      (
+        new CollatedPredicate(
+          "=",
+          Literal.ofString("a"),
+          new Column("a1"),
+          unicodeCollationIdentifier),
+        new StructType()
+          .add("a1", StringType.STRING),
+        new DefaultDataSkippingPredicate(
+          "AND",
           new CollatedDataSkippingPredicate(
             "<=",
             new Column(Array(MIN, "a1")),
             Literal.ofString("a"),
-            defaultCollationIdentifier),
+            unicodeCollationIdentifier),
           new CollatedDataSkippingPredicate(
             ">=",
             new Column(Array(MAX, "a1")),
             Literal.ofString("a"),
-            defaultCollationIdentifier))
+            unicodeCollationIdentifier))
       ),
       (
         new And(
@@ -270,7 +310,7 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
             "<",
             new Column("a1"),
             Literal.ofString("a"),
-            defaultCollationIdentifier),
+            unicodeCollationIdentifier),
           new Predicate("<",
             new Column("a1"),
             Literal.ofString("a"))),
@@ -282,7 +322,7 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
             "<",
             new Column(Array(MIN, "a1")),
             Literal.ofString("a"),
-            defaultCollationIdentifier),
+            unicodeCollationIdentifier),
           new DefaultDataSkippingPredicate(
             "<",
             List(
@@ -299,7 +339,7 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
             "<",
             new Column("a1"),
             Literal.ofString("a"),
-            defaultCollationIdentifier),
+            unicodeCollationIdentifier),
           new Predicate("<",
             new Column("a1"),
             Literal.ofString("a"))),
@@ -311,7 +351,7 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
             "<",
             new Column(Array(MIN, "a1")),
             Literal.ofString("a"),
-            defaultCollationIdentifier),
+            unicodeCollationIdentifier),
           new DefaultDataSkippingPredicate(
             "<",
             List(
@@ -329,14 +369,14 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
             "<",
             new Column("a1"),
             Literal.ofString("a"),
-            defaultCollationIdentifier)),
+            unicodeCollationIdentifier)),
         new StructType()
           .add("a1", StringType.STRING),
         new CollatedDataSkippingPredicate(
           ">=",
           new Column(Array(MAX, "a1")),
           Literal.ofString("a"),
-          defaultCollationIdentifier)
+          unicodeCollationIdentifier)
       ),
       (
         new Predicate(
@@ -346,7 +386,7 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
               "<",
               new Column("a1"),
               Literal.ofString("a"),
-              defaultCollationIdentifier),
+              unicodeCollationIdentifier),
             new Predicate("<",
               new Column("a1"),
               Literal.ofString("a")))),
@@ -357,7 +397,7 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
             ">=",
             new Column(Array(MAX, "a1")),
             Literal.ofString("a"),
-            defaultCollationIdentifier),
+            unicodeCollationIdentifier),
           new DefaultDataSkippingPredicate(
             ">=",
             List(
@@ -374,7 +414,7 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
             "<",
             new Column("a1"),
             Literal.ofString("a"),
-            defaultCollationIdentifier),
+            unicodeCollationIdentifier),
           new Predicate("<",
             new Column("a1"),
             new Column("a2"))),
@@ -385,7 +425,7 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
           "<",
           new Column(Array(MIN, "a1")),
           Literal.ofString("a"),
-          defaultCollationIdentifier)
+          unicodeCollationIdentifier)
       )
     ).foreach {
       case (predicate, schema, dataSkippingPredicate) =>

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/DataSkippingUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/DataSkippingUtilsSuite.scala
@@ -381,6 +381,29 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
       (
         new Predicate(
           "NOT",
+          new CollatedPredicate(
+            "=",
+            Literal.ofString("a"),
+            new Column("a1"),
+            unicodeCollationIdentifier)),
+        new StructType()
+          .add("a1", StringType.STRING),
+        new DefaultDataSkippingPredicate(
+          "OR",
+          new CollatedDataSkippingPredicate(
+            "<",
+            new Column(Array(MIN, "a1")),
+            Literal.ofString("a"),
+            unicodeCollationIdentifier),
+          new CollatedDataSkippingPredicate(
+            ">",
+            new Column(Array(MAX, "a1")),
+            Literal.ofString("a"),
+            unicodeCollationIdentifier))
+      ),
+      (
+        new Predicate(
+          "NOT",
           new And(
             new CollatedPredicate(
               "<",

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/DataSkippingUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/DataSkippingUtilsSuite.scala
@@ -171,7 +171,6 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
 
   val defaultCollationIdentifier =
     CollationIdentifier.fromString("SPARK.UTF8_BINARY")
-  val STATS_WITH_COLLATION = "statsWithCollation"
   val MIN = "minValues"
   val MAX = "maxValues"
 
@@ -240,10 +239,7 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
           .add("a1", StringType.STRING),
         new CollatedDataSkippingPredicate(
           "<",
-          new Column(Array(STATS_WITH_COLLATION,
-            defaultCollationIdentifier.toString,
-            MIN,
-            "a1")),
+          new Column(Array(MIN, "a1")),
           Literal.ofString("a"),
           defaultCollationIdentifier)
       ),
@@ -259,18 +255,12 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
           "AND",
           new CollatedDataSkippingPredicate(
             "<=",
-            new Column(Array(STATS_WITH_COLLATION,
-              defaultCollationIdentifier.toString,
-              MIN,
-              "a1")),
+            new Column(Array(MIN, "a1")),
             Literal.ofString("a"),
             defaultCollationIdentifier),
           new CollatedDataSkippingPredicate(
             ">=",
-            new Column(Array(STATS_WITH_COLLATION,
-              defaultCollationIdentifier.toString,
-              MAX,
-              "a1")),
+            new Column(Array(MAX, "a1")),
             Literal.ofString("a"),
             defaultCollationIdentifier))
       ),
@@ -290,10 +280,7 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
           "AND",
           new CollatedDataSkippingPredicate(
             "<",
-            new Column(Array(STATS_WITH_COLLATION,
-              defaultCollationIdentifier.toString,
-              MIN,
-              "a1")),
+            new Column(Array(MIN, "a1")),
             Literal.ofString("a"),
             defaultCollationIdentifier),
           new DefaultDataSkippingPredicate(
@@ -322,10 +309,7 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
           "OR",
           new CollatedDataSkippingPredicate(
             "<",
-            new Column(Array(STATS_WITH_COLLATION,
-              defaultCollationIdentifier.toString,
-              MIN,
-              "a1")),
+            new Column(Array(MIN, "a1")),
             Literal.ofString("a"),
             defaultCollationIdentifier),
           new DefaultDataSkippingPredicate(
@@ -350,10 +334,7 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
           .add("a1", StringType.STRING),
         new CollatedDataSkippingPredicate(
           ">=",
-          new Column(Array(STATS_WITH_COLLATION,
-            defaultCollationIdentifier.toString,
-            MAX,
-            "a1")),
+          new Column(Array(MAX, "a1")),
           Literal.ofString("a"),
           defaultCollationIdentifier)
       ),
@@ -374,10 +355,7 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
         new Or(
           new CollatedDataSkippingPredicate(
             ">=",
-            new Column(Array(STATS_WITH_COLLATION,
-              defaultCollationIdentifier.toString,
-              MAX,
-              "a1")),
+            new Column(Array(MAX, "a1")),
             Literal.ofString("a"),
             defaultCollationIdentifier),
           new DefaultDataSkippingPredicate(
@@ -405,10 +383,7 @@ class DataSkippingUtilsSuite extends AnyFunSuite {
           .add("a2", StringType.STRING),
         new CollatedDataSkippingPredicate(
           "<",
-          new Column(Array(STATS_WITH_COLLATION,
-            defaultCollationIdentifier.toString,
-            MIN,
-            "a1")),
+          new Column(Array(MIN, "a1")),
           Literal.ofString("a"),
           defaultCollationIdentifier)
       )

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
@@ -329,7 +329,11 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
           throw unsupportedExpressionException(predicate, msg);
         }
       }
-      return new Predicate(predicate.getName(), left, right);
+      if (predicate instanceof CollatedPredicate) {
+        return new CollatedPredicate(predicate.getName(), left, right, ((CollatedPredicate) predicate).getCollationIdentifier());
+      } else {
+        return new Predicate(predicate.getName(), left, right);
+      }
     }
   }
 
@@ -427,35 +431,19 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
       PredicateChildrenEvalResult argResults = evalBinaryExpressionChildren(predicate);
       switch (predicate.getName()) {
         case "=":
-          return comparatorVector(
-              argResults.leftResult,
-              argResults.rightResult,
-              (compareResult) -> (compareResult == 0));
         case ">":
-          return comparatorVector(
-              argResults.leftResult,
-              argResults.rightResult,
-              (compareResult) -> (compareResult > 0));
         case ">=":
-          return comparatorVector(
-              argResults.leftResult,
-              argResults.rightResult,
-              (compareResult) -> (compareResult >= 0));
         case "<":
-          return comparatorVector(
-              argResults.leftResult,
-              argResults.rightResult,
-              (compareResult) -> (compareResult < 0));
         case "<=":
           return comparatorVector(
               argResults.leftResult,
               argResults.rightResult,
-              (compareResult) -> (compareResult <= 0));
+              predicate);
         case "IS NOT DISTINCT FROM":
           return nullSafeComparatorVector(
               argResults.leftResult,
               argResults.rightResult,
-              (compareResult) -> (compareResult == 0));
+              predicate);
         default:
           // We should never reach this based on the ExpressionVisitor
           throw new IllegalStateException(

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
@@ -330,7 +330,11 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
         }
       }
       if (predicate instanceof CollatedPredicate) {
-        return new CollatedPredicate(predicate.getName(), left, right, ((CollatedPredicate) predicate).getCollationIdentifier());
+        return new CollatedPredicate(
+            predicate.getName(),
+            left,
+            right,
+            ((CollatedPredicate) predicate).getCollationIdentifier());
       } else {
         return new Predicate(predicate.getName(), left, right);
       }
@@ -435,15 +439,9 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
         case ">=":
         case "<":
         case "<=":
-          return comparatorVector(
-              argResults.leftResult,
-              argResults.rightResult,
-              predicate);
+          return comparatorVector(argResults.leftResult, argResults.rightResult, predicate);
         case "IS NOT DISTINCT FROM":
-          return nullSafeComparatorVector(
-              argResults.leftResult,
-              argResults.rightResult,
-              predicate);
+          return nullSafeComparatorVector(argResults.leftResult, argResults.rightResult, predicate);
         default:
           // We should never reach this based on the ExpressionVisitor
           throw new IllegalStateException(

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
@@ -20,13 +20,17 @@ import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.MapValue;
+import io.delta.kernel.expressions.CollatedPredicate;
 import io.delta.kernel.expressions.Expression;
+import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.internal.util.Utils;
 import io.delta.kernel.types.*;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.function.IntPredicate;
 import java.util.stream.Collectors;
@@ -107,18 +111,43 @@ class DefaultExpressionUtils {
   }
 
   /**
+   * Matches predicate name to comparison function.
+   */
+  static IntPredicate getBooleanPredicate(Predicate predicate) {
+    switch(predicate.getName()) {
+      case "=":
+      case "IS NOT DISTINCT FROM":
+        return x -> x == 0;
+      case "<":
+        return x -> x < 0;
+      case "<=":
+        return x -> x <= 0;
+      case ">":
+        return x -> x > 0;
+      case ">=":
+        return x -> x >= 0;
+      default:
+        throw new IllegalArgumentException(String.format("Unsupported predicate '%s'", predicate.getName()));
+    }
+  }
+
+  private static CollationIdentifier defaultCollationIdentifier =
+          CollationIdentifier.fromString("SPARK.UTF8_BINARY");
+
+  /**
    * Utility method for getting value comparator
    *
    * @param left
    * @param right
-   * @param booleanComparator
+   * @param predicate
    * @return
    */
   static IntPredicate getComparator(
-      ColumnVector left, ColumnVector right, IntPredicate booleanComparator) {
+      ColumnVector left, ColumnVector right, Predicate predicate) {
     checkArgument(
         left.getSize() == right.getSize(), "Left and right operand have different vector sizes.");
 
+    IntPredicate booleanComparator = getBooleanPredicate(predicate);
     DataType dataType = left.getDataType();
     IntPredicate vectorValueComparator;
     if (dataType instanceof BooleanType) {
@@ -155,10 +184,25 @@ class DefaultExpressionUtils {
               booleanComparator.test(
                   BIGDECIMAL_COMPARATOR.compare(left.getDecimal(rowId), right.getDecimal(rowId)));
     } else if (dataType instanceof StringType) {
-      vectorValueComparator =
-          rowId ->
-              booleanComparator.test(
-                  STRING_COMPARATOR.compare(left.getString(rowId), right.getString(rowId)));
+      if (predicate instanceof CollatedPredicate) {
+        CollatedPredicate collatedPredicate = (CollatedPredicate) predicate;
+        CollationIdentifier collationIdentifier = collatedPredicate.getCollationIdentifier();
+        if (collationIdentifier.equals(defaultCollationIdentifier)) {
+          vectorValueComparator =
+                  rowId ->
+                          booleanComparator.test(
+                                  STRING_COMPARATOR
+                                          .compare(left.getString(rowId), right.getString(rowId)));
+        } else {
+          throw new IllegalArgumentException(
+                  String.format("Invalid collation identifier: \"%s\"", collationIdentifier));
+        }
+      } else {
+        vectorValueComparator =
+                rowId ->
+                        booleanComparator.test(
+                                STRING_COMPARATOR.compare(left.getString(rowId), right.getString(rowId)));
+      }
     } else if (dataType instanceof BinaryType) {
       vectorValueComparator =
           rowId ->
@@ -178,8 +222,8 @@ class DefaultExpressionUtils {
    * <p>Only primitive data types are supported.
    */
   static ColumnVector comparatorVector(
-      ColumnVector left, ColumnVector right, IntPredicate booleanComparator) {
-    IntPredicate vectorValueComparator = getComparator(left, right, booleanComparator);
+      ColumnVector left, ColumnVector right, Predicate predicate) {
+    IntPredicate vectorValueComparator = getComparator(left, right, predicate);
 
     return new ColumnVector() {
 
@@ -220,8 +264,8 @@ class DefaultExpressionUtils {
    * <p>Only primitive data types are supported.
    */
   static ColumnVector nullSafeComparatorVector(
-      ColumnVector left, ColumnVector right, IntPredicate booleanComparator) {
-    IntPredicate vectorValueComparator = getComparator(left, right, booleanComparator);
+        ColumnVector left, ColumnVector right, Predicate predicate) {
+    IntPredicate vectorValueComparator = getComparator(left, right, predicate);
     return new ColumnVector() {
       @Override
       public DataType getDataType() {

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
@@ -28,9 +28,7 @@ import io.delta.kernel.types.*;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
 import java.util.function.IntPredicate;
 import java.util.stream.Collectors;
@@ -110,11 +108,9 @@ class DefaultExpressionUtils {
     };
   }
 
-  /**
-   * Matches predicate name to comparison function.
-   */
+  /** Matches predicate name to comparison function. */
   static IntPredicate getBooleanPredicate(Predicate predicate) {
-    switch(predicate.getName()) {
+    switch (predicate.getName()) {
       case "=":
       case "IS NOT DISTINCT FROM":
         return x -> x == 0;
@@ -127,12 +123,13 @@ class DefaultExpressionUtils {
       case ">=":
         return x -> x >= 0;
       default:
-        throw new IllegalArgumentException(String.format("Unsupported predicate '%s'", predicate.getName()));
+        throw new IllegalArgumentException(
+            String.format("Unsupported predicate '%s'", predicate.getName()));
     }
   }
 
   private static CollationIdentifier defaultCollationIdentifier =
-          CollationIdentifier.fromString("SPARK.UTF8_BINARY");
+      CollationIdentifier.fromString("SPARK.UTF8_BINARY");
 
   /**
    * Utility method for getting value comparator
@@ -142,8 +139,7 @@ class DefaultExpressionUtils {
    * @param predicate
    * @return
    */
-  static IntPredicate getComparator(
-      ColumnVector left, ColumnVector right, Predicate predicate) {
+  static IntPredicate getComparator(ColumnVector left, ColumnVector right, Predicate predicate) {
     checkArgument(
         left.getSize() == right.getSize(), "Left and right operand have different vector sizes.");
 
@@ -189,19 +185,18 @@ class DefaultExpressionUtils {
         CollationIdentifier collationIdentifier = collatedPredicate.getCollationIdentifier();
         if (collationIdentifier.equals(defaultCollationIdentifier)) {
           vectorValueComparator =
-                  rowId ->
-                          booleanComparator.test(
-                                  STRING_COMPARATOR
-                                          .compare(left.getString(rowId), right.getString(rowId)));
+              rowId ->
+                  booleanComparator.test(
+                      STRING_COMPARATOR.compare(left.getString(rowId), right.getString(rowId)));
         } else {
           throw new IllegalArgumentException(
-                  String.format("Invalid collation identifier: \"%s\"", collationIdentifier));
+              String.format("Invalid collation identifier: \"%s\"", collationIdentifier));
         }
       } else {
         vectorValueComparator =
-                rowId ->
-                        booleanComparator.test(
-                                STRING_COMPARATOR.compare(left.getString(rowId), right.getString(rowId)));
+            rowId ->
+                booleanComparator.test(
+                    STRING_COMPARATOR.compare(left.getString(rowId), right.getString(rowId)));
       }
     } else if (dataType instanceof BinaryType) {
       vectorValueComparator =
@@ -221,8 +216,7 @@ class DefaultExpressionUtils {
    *
    * <p>Only primitive data types are supported.
    */
-  static ColumnVector comparatorVector(
-      ColumnVector left, ColumnVector right, Predicate predicate) {
+  static ColumnVector comparatorVector(ColumnVector left, ColumnVector right, Predicate predicate) {
     IntPredicate vectorValueComparator = getComparator(left, right, predicate);
 
     return new ColumnVector() {
@@ -264,7 +258,7 @@ class DefaultExpressionUtils {
    * <p>Only primitive data types are supported.
    */
   static ColumnVector nullSafeComparatorVector(
-        ColumnVector left, ColumnVector right, Predicate predicate) {
+      ColumnVector left, ColumnVector right, Predicate predicate) {
     IntPredicate vectorValueComparator = getComparator(left, right, predicate);
     return new ColumnVector() {
       @Override

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionVisitor.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionVisitor.java
@@ -100,7 +100,8 @@ abstract class ExpressionVisitor<R> {
       case "IS NOT DISTINCT FROM":
         if (expression instanceof CollatedPredicate) {
           return visitComparator(
-                  new CollatedPredicate(name, children, ((CollatedPredicate) expression).getCollationIdentifier()));
+              new CollatedPredicate(
+                  name, children, ((CollatedPredicate) expression).getCollationIdentifier()));
         }
         return visitComparator(new Predicate(name, children));
       case "ELEMENT_AT":

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionVisitor.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionVisitor.java
@@ -98,6 +98,10 @@ abstract class ExpressionVisitor<R> {
       case ">":
       case ">=":
       case "IS NOT DISTINCT FROM":
+        if (expression instanceof CollatedPredicate) {
+          return visitComparator(
+                  new CollatedPredicate(name, children, ((CollatedPredicate) expression).getCollationIdentifier()));
+        }
         return visitComparator(new Predicate(name, children));
       case "ELEMENT_AT":
         return visitElementAt(expression);

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ImplicitCastExpression.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ImplicitCastExpression.java
@@ -92,6 +92,8 @@ final class ImplicitCastExpression implements Expression {
         return new LongUpConverter(outputType, input);
       case "float":
         return new FloatUpConverter(outputType, input);
+      case "string":
+        return new StringUpConverter(outputType, input);
       default:
         throw new UnsupportedOperationException(
             format("Cast from %s is not supported", fromTypeStr));
@@ -108,6 +110,7 @@ final class ImplicitCastExpression implements Expression {
               this.put("integer", Arrays.asList("long", "float", "double"));
               this.put("long", Arrays.asList("float", "double"));
               this.put("float", Arrays.asList("double"));
+              this.put("string", Arrays.asList("string"));
             }
           });
 
@@ -257,6 +260,17 @@ final class ImplicitCastExpression implements Expression {
     @Override
     public double getDouble(int rowId) {
       return inputVector.getFloat(rowId);
+    }
+  }
+
+  private static class StringUpConverter extends UpConverter {
+    StringUpConverter(DataType targetType, ColumnVector inputVector) {
+      super(targetType, inputVector);
+    }
+
+    @Override
+    public String getString(int rowId) {
+      return inputVector.getString(rowId);
     }
   }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
@@ -1371,7 +1371,7 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
         new Column("as_string"),
         Literal.ofString("0"),
         CollationIdentifier.fromString("SPARK.UTF8_LCASE")),
-      2)
+      1)
   }
 
   test("data skipping - non-eligible min/max data skipping types all nulls in file") {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
@@ -1355,8 +1355,7 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
         "<",
         new Column("as_string"),
         Literal.ofString("0")),
-      0
-    )
+      0)
 
     checkResults(
       new CollatedPredicate(
@@ -1364,8 +1363,15 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
         new Column("as_string"),
         Literal.ofString("0"),
         defaultCollationIdentifier),
-      0
-    )
+      0)
+
+    checkResults(
+      new CollatedPredicate(
+        "<",
+        new Column("as_string"),
+        Literal.ofString("0"),
+        CollationIdentifier.fromString("SPARK.UTF8_LCASE")),
+      2)
   }
 
   test("data skipping - non-eligible min/max data skipping types all nulls in file") {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
@@ -1385,6 +1385,43 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
           Literal.ofString("0"),
           CollationIdentifier.fromString("SPARK.UTF8_LCASE"))),
       0)
+
+    checkResults(
+      new Or(
+        new Predicate(
+          "<",
+          new Column("as_string"),
+          Literal.ofString("0")),
+        new CollatedPredicate(
+          "<",
+          new Column("as_string"),
+          Literal.ofString("0"),
+          CollationIdentifier.fromString("SPARK.UTF8_LCASE"))),
+      1)
+
+    checkResults(
+      new Or(
+        new Predicate(
+          "<",
+          new Column("as_string"),
+          Literal.ofString("0")),
+        new CollatedPredicate(
+          ">",
+          new Column("as_string"),
+          Literal.ofString("0"),
+          defaultCollationIdentifier)),
+      0)
+
+    checkResults(
+      new Predicate(
+        "NOT",
+        new CollatedPredicate(
+          "=",
+          new Column("as_string"),
+          Literal.ofString("0"),
+          defaultCollationIdentifier)),
+      0
+    )
   }
 
   test("data skipping - non-eligible min/max data skipping types all nulls in file") {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
@@ -1348,8 +1348,8 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
 
     val defaultCollationIdentifier = CollationIdentifier.fromString("SPARK.UTF8_BINARY");
 
-    // DefaultEngine should ignore collated predicates but still perform file
-    // pruning with the remaining predicates
+    // DefaultEngine should ignore collated predicates (except for UTF8_BINARY collation),
+    // but still perform file pruning with the remaining predicates
     checkResults(
       new Predicate(
         "<",
@@ -1372,6 +1372,19 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
         Literal.ofString("0"),
         CollationIdentifier.fromString("SPARK.UTF8_LCASE")),
       1)
+
+    checkResults(
+      new And(
+        new Predicate(
+          "<",
+          new Column("as_string"),
+          Literal.ofString("0")),
+        new CollatedPredicate(
+          "<",
+          new Column("as_string"),
+          Literal.ofString("0"),
+          CollationIdentifier.fromString("SPARK.UTF8_LCASE"))),
+      0)
   }
 
   test("data skipping - non-eligible min/max data skipping types all nulls in file") {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
@@ -1346,7 +1346,8 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
         s"Expected $expNumFiles but found ${scanFiles.length} for $predicate")
     }
 
-    val defaultCollationIdentifier = CollationIdentifier.fromString("SPARK.UTF8_BINARY");
+    val defaultCollationIdentifier = CollationIdentifier.fromString("SPARK.UTF8_BINARY")
+    val unicodeCollationIdentifier = CollationIdentifier.fromString("ICU.UNICODE")
 
     // DefaultEngine should ignore collated predicates (except for UTF8_BINARY collation),
     // but still perform file pruning with the remaining predicates
@@ -1370,7 +1371,7 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
         "<",
         new Column("as_string"),
         Literal.ofString("0"),
-        CollationIdentifier.fromString("SPARK.UTF8_LCASE")),
+        unicodeCollationIdentifier),
       1)
 
     checkResults(
@@ -1383,7 +1384,7 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
           "<",
           new Column("as_string"),
           Literal.ofString("0"),
-          CollationIdentifier.fromString("SPARK.UTF8_LCASE"))),
+          unicodeCollationIdentifier)),
       0)
 
     checkResults(
@@ -1396,7 +1397,7 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
           "<",
           new Column("as_string"),
           Literal.ofString("0"),
-          CollationIdentifier.fromString("SPARK.UTF8_LCASE"))),
+          unicodeCollationIdentifier)),
       1)
 
     checkResults(
@@ -1420,8 +1421,47 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
           new Column("as_string"),
           Literal.ofString("0"),
           defaultCollationIdentifier)),
-      0
-    )
+      0)
+
+    checkResults(
+      new Predicate(
+        "NOT",
+        new CollatedPredicate(
+          "=",
+          Literal.ofString("0"),
+          new Column("as_string"),
+          defaultCollationIdentifier)),
+      0)
+
+    checkResults(
+      new Predicate(
+        "NOT",
+        new CollatedPredicate(
+          "=",
+          Literal.ofString("0"),
+          new Column("as_string"),
+          unicodeCollationIdentifier)),
+      1)
+
+    checkResults(
+      new Predicate(
+        "NOT",
+        new CollatedPredicate(
+          ">",
+          Literal.ofString("0"),
+          new Column("as_string"),
+          defaultCollationIdentifier)),
+      1)
+
+    checkResults(
+      new Predicate(
+        "NOT",
+        new CollatedPredicate(
+          ">",
+          Literal.ofString("0"),
+          new Column("as_string"),
+          unicodeCollationIdentifier)),
+      1)
   }
 
   test("data skipping - non-eligible min/max data skipping types all nulls in file") {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
@@ -94,7 +94,13 @@ class DefaultExpressionEvaluatorSuite extends AnyFunSuite with ExpressionSuiteBa
   }
 
   SIMPLE_TYPES.foreach { dataType =>
-    test(s"evaluate expression: column of type $dataType") {
+    val toString = dataType match {
+      case st: StringType =>
+        String.format("%s %s", dataType.toString, st.getCollationIdentifier)
+      case _ =>
+        dataType.toString
+    }
+    test(s"evaluate expression: column of type $toString") {
       val batchSize = 78;
       val batchSchema = new StructType().add("col1", dataType)
       val batch = new DefaultColumnarBatch(
@@ -773,6 +779,81 @@ class DefaultExpressionEvaluatorSuite extends AnyFunSuite with ExpressionSuiteBa
     ofNull(DoubleType.DOUBLE)
   )
 
+  test("evaluate expression: compare collated strings") {
+    // scalastyle:off nonascii
+    // TODO: add UTF8_LCASE when supported
+    Seq(
+      "UTF8_BINARY"
+    ).foreach {
+      collationName =>
+        // Empty strings.
+        assertCompare("", "", collationName, 0)
+        assertCompare("a", "", collationName, 1)
+        assertCompare("", "a", collationName, -1)
+        // Basic tests.
+        assertCompare("a", "a", collationName, 0)
+        assertCompare("a", "b", collationName, -1)
+        assertCompare("b", "a", collationName, 1)
+        assertCompare("A", "A", collationName, 0)
+        assertCompare("A", "B", collationName, -1)
+        assertCompare("B", "A", collationName, 1)
+        assertCompare("aa", "a", collationName, 1)
+        assertCompare("b", "bb", collationName, -1)
+        assertCompare("abc", "a", collationName, 1)
+        assertCompare("abc", "b", collationName, -1)
+        assertCompare("abc", "ab", collationName, 1)
+        assertCompare("abc", "abc", collationName, 0)
+        assertCompare("aaaa", "aaa", collationName, 1)
+        assertCompare("hello", "world", collationName, -1)
+        assertCompare("Spark", "Spark", collationName, 0)
+        assertCompare("ü", "ü", collationName, 0)
+        assertCompare("ü", "", collationName, 1)
+        assertCompare("", "ü", collationName, -1)
+        assertCompare("äü", "äü", collationName, 0)
+        assertCompare("äxx", "äx", collationName, 1)
+        assertCompare("a", "ä", collationName, -1)
+    }
+
+    // Advanced tests.
+    assertCompare("äü", "bü", "UTF8_BINARY", 1)
+    assertCompare("bxx", "bü", "UTF8_BINARY", -1)
+    // Case variation.
+    assertCompare("AbCd", "aBcD", "UTF8_BINARY", -1)
+    // Accent variation.
+    assertCompare("aBćD", "ABĆD", "UTF8_BINARY", 1)
+    // One-to-many case mapping (e.g. Turkish dotted I).
+    assertCompare("i\u0307", "İ", "UTF8_BINARY", -1)
+    assertCompare("İ", "i\u0307", "UTF8_BINARY", 1)
+    // Conditional case mapping (e.g. Greek sigmas).
+    assertCompare("ς", "σ", "UTF8_BINARY", -1)
+    assertCompare("ς", "Σ", "UTF8_BINARY", 1)
+    assertCompare("σ", "Σ", "UTF8_BINARY", 1)
+    // Surrogate pairs.
+    assertCompare("a🙃b🙃c", "aaaaa", "UTF8_BINARY", 1)
+    assertCompare("a🙃b🙃c", "a🙃b🙃c", "UTF8_BINARY", 0)
+    assertCompare("a🙃b🙃c", "a🙃b🙃d", "UTF8_BINARY", -1)
+    // scalastyle:on nonascii
+
+    // Maximum code point.
+    val maxCodePoint = Character.MAX_CODE_POINT
+    val maxCodePointStr = new String(Character.toChars(maxCodePoint))
+    var i = 0
+    while (i < maxCodePoint && Character.isValidCodePoint(i)) {
+      assertCompare(new String(Character.toChars(i)), maxCodePointStr, "UTF8_BINARY", -1)
+
+      i += 1
+    }
+    // Minimum code point.// Minimum code point.
+    val minCodePoint = Character.MIN_CODE_POINT
+    val minCodePointStr = new String(Character.toChars(minCodePoint))
+    i = minCodePoint + 1
+    while (i <= maxCodePoint && Character.isValidCodePoint(i)) {
+      assertCompare(new String(Character.toChars(i)), minCodePointStr, "UTF8_BINARY", 1)
+
+      i += 1
+    }
+  }
+
   test("evaluate expression: comparators `byte` with other implicit types") {
     // Mapping of comparator to expected results for:
     // (byte, short), (byte, int), (byte, long), (byte, float), (byte, double)
@@ -1021,9 +1102,42 @@ class DefaultExpressionEvaluatorSuite extends AnyFunSuite with ExpressionSuiteBa
     new DefaultExpressionEvaluator(inputSchema, expression, outputType)
   }
 
+  private def assertCompare(s1: String, s2: String, collationName: String, expResult: Int): Unit = {
+    val l1 = ofString(s1)
+    val l2 = ofString(s2)
+    if (expResult == -1) {
+      testComparator("<", l1, l2, true, Some(collationName))
+    } else if (expResult == 1) {
+      testComparator("<", l2, l1, true, Some(collationName))
+    } else if (expResult == 0) {
+      testComparator("=", l1, l2, true, Some(collationName))
+    } else {
+      throw new IllegalArgumentException(
+        String.format("Invalid expected result: %s.", expResult.toString))
+    }
+  }
+
   private def testComparator(
-    comparator: String, left: Expression, right: Expression, expResult: BooleanJ): Unit = {
-    val expression = new Predicate(comparator, left, right)
+    comparator: String,
+    left: Expression,
+    right: Expression,
+    expResult: BooleanJ,
+    collationName: Option[String] = Option.empty): Unit = {
+    val expression =
+      if (collationName.isEmpty) {
+        new Predicate(comparator, left, right)
+      } else {
+        val collationIdentifier =
+          if (collationName.get.startsWith("UTF8")) {
+            CollationIdentifier.fromString(
+              String.format("%s.%s", "SPARK", collationName.get))
+          } else {
+            throw new IllegalArgumentException(
+              String.format("Invalid collation name: %s.", collationName));
+          }
+        new CollatedPredicate(
+          comparator, left, right, collationIdentifier)
+      }
     val batch = zeroColumnBatch(rowCount = 1)
     val outputVector = evaluator(batch.getSchema, expression, BooleanType.BOOLEAN).eval(batch)
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -315,6 +315,7 @@ trait TestUtils extends Assertions with SQLHelper {
     TimestampType.TIMESTAMP,
     TimestampNTZType.TIMESTAMP_NTZ,
     StringType.STRING,
+    new StringType(CollationIdentifier.fromString("SPARK.UTF8_LCASE")),
     BinaryType.BINARY,
     new DecimalType(10, 5)
   )
@@ -589,7 +590,7 @@ trait TestUtils extends Assertions with SQLHelper {
       case LongType.LONG => rowId % 25 == 0
       case FloatType.FLOAT => rowId % 5 == 0
       case DoubleType.DOUBLE => rowId % 10 == 0
-      case StringType.STRING => rowId % 2 == 0
+      case _: StringType => rowId % 2 == 0
       case BinaryType.BINARY => rowId % 3 == 0
       case DateType.DATE => rowId % 5 == 0
       case TimestampType.TIMESTAMP => rowId % 3 == 0
@@ -610,7 +611,7 @@ trait TestUtils extends Assertions with SQLHelper {
       case LongType.LONG => rowId * 287623L / 91
       case FloatType.FLOAT => rowId * 7651.2323f / 91
       case DoubleType.DOUBLE => rowId * 23423.23d / 17
-      case StringType.STRING => (rowId % 19).toString
+      case _: StringType => (rowId % 19).toString
       case BinaryType.BINARY => Array[Byte]((rowId % 21).toByte, (rowId % 7 - 1).toByte)
       case DateType.DATE => (rowId * 28234) % 2876
       case TimestampType.TIMESTAMP => (rowId * 2342342L) % 23


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description
Adapts DefaultEngine to ignore CollatedPredicate for file pruning.

## How was this patch tested?
Tests added to `ScanSuite`.

## Does this PR introduce _any_ user-facing changes?
No.
