### PR TITLE
[Spark] Relax protocol reader feature requirements to allow backward compatibility

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -139,10 +139,15 @@ case class Protocol private (
   extends Action
   with AbstractProtocol
   with TableFeatureSupport {
-  // Correctness check
-  // Reader and writer versions must match the status of reader and writer features
+  // Correctness check.
+  // Reader and writer versions must match the status of reader and writer features.
+  // For the reader features requirement we exclude the column mapping reader version (2)
+  // to allow backward compatibility with older writers. The correct behavior is when
+  // column mapping exists it should be included in the reader features. However, there used
+  // to be a bug where the reader features would not be set in that case.
   require(
-    (supportsReaderFeatures || canSupportColumnMappingFeature) == readerFeatures.isDefined,
+    supportsReaderFeatures == readerFeatures.isDefined ||
+      minReaderVersion == ColumnMappingTableFeature.minReaderVersion,
     "Mismatched minReaderVersion and readerFeatures.")
   require(
     supportsWriterFeatures == writerFeatures.isDefined,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -2406,8 +2406,20 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
     Protocol(
       minReaderVersion = 2,
       minWriterVersion = 7,
+      readerFeatures = None,
+      writerFeatures = Some(Set(ColumnMappingTableFeature.name)))
+
+    Protocol(
+      minReaderVersion = 2,
+      minWriterVersion = 7,
       readerFeatures = Some(Set.empty),
       writerFeatures = Some(Set(ColumnMappingTableFeature.name)))
+
+    Protocol(
+      minReaderVersion = 2,
+      minWriterVersion = 7,
+      readerFeatures = None,
+      writerFeatures = Some(Set(ColumnMappingTableFeature.name, TestWriterFeature.name)))
 
     Protocol(
       minReaderVersion = 2,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This is a followup of https://github.com/delta-io/delta/commit/920f185a04382ff466e47e75240dfda48efe40d3. We relax the protocol reader feature requirements to allow backward compatibility with older writers. This is because before https://github.com/delta-io/delta/commit/920f185a04382ff466e47e75240dfda48efe40d3 was possible to serialize invalid (2, 7) protocols without the reader features set.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Added new UTs.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.