### PR TITLE
[SPARK] Add new config to disable implicit not null invariants

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -862,6 +862,15 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(false)
 
+  val IMPLICIT_NOT_NULL_CONSTRAINT_ENABLED =
+    buildConf("constraints.implicitNotNull.enabled")
+      .internal()
+      .doc("If enabled, NOT NULL constraints will be automatically added for non-nullable " +
+        "fields. Note that nullability is determined independently at each level of a nested " +
+        "struct, so non-nullable children of a nullable struct must always be non-null.")
+      .booleanConf
+      .createWithDefault(true)
+
   val CHECKPOINT_SCHEMA_WRITE_THRESHOLD_LENGTH =
     buildConf("checkpointSchema.writeThresholdLength")
       .internal()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Resolves #860 

Adds a new config that can disable implicit not null constraints that are added for non-nullable fields. This is to get around the fact that Delta does not properly respect the struct nullability semantics of Spark. The discussion of why this is true is in the issue. There is currently no workaround for this issue, so this new config at least lets users opt-in to say "I know what I'm doing" and prevent the unwanted default behavior.

An original attempt to address this issue is https://github.com/delta-io/delta/pull/1296. This is an alternative in the hopes that _something_ can be done to fix this issue that more users are reporting, and has frustrated my team for a long time.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
New UT

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Allows users to opt-in to skipping potential erroneous not null constraints.