### PR TITLE
[Spark] Add Catalog Type to Spark Structured Logging MDC framework for Delta

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/logging/DeltaLogKeys.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/logging/DeltaLogKeys.scala
@@ -49,6 +49,7 @@ trait DeltaLogKeysBase {
   case object ATTEMPT extends LogKeyShims
   case object BATCH_ID extends LogKeyShims
   case object BATCH_SIZE extends LogKeyShims
+  case object CATALOG extends LogKeyShims
   case object CLASS_NAME extends LogKeyShims
   case object COLUMN_NAME extends LogKeyShims
   case object COMPACTION_INFO_NEW extends LogKeyShims


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Add a new `Catalog` type to be used in Spark Structured Logging within delta-spark

## How was this patch tested?

Build

## Does this PR introduce _any_ user-facing changes?

No
