### PR TITLE
[Spark] Pass table identifier through DeltaLog API to commit coordinator

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -69,6 +69,7 @@ import org.apache.spark.util._
  * @param options Filesystem options filtered from `allOptions`.
  * @param allOptions All options provided by the user, for example via `df.write.option()`. This
  *                   includes but not limited to filesystem and table properties.
+ * @param initialTableIdentifier Identifier of the table when the log is initialized.
  * @param clock Clock to be used when starting a new transaction.
  */
 class DeltaLog private(
@@ -76,6 +77,7 @@ class DeltaLog private(
     val dataPath: Path,
     val options: Map[String, String],
     val allOptions: Map[String, String],
+    val initialTableIdentifier: Option[TableIdentifier],
     val clock: Clock
   ) extends Checkpoints
   with MetadataCleanup
@@ -750,22 +752,27 @@ object DeltaLog extends DeltaLogging {
 
   /** Helper for creating a log when it stored at the root of the data. */
   def forTable(spark: SparkSession, dataPath: String): DeltaLog = {
-    apply(spark, logPathFor(dataPath), Map.empty, new SystemClock)
+    apply(
+      spark,
+      logPathFor(dataPath),
+      options = Map.empty,
+      initialTableIdentifier = None,
+      new SystemClock)
   }
 
   /** Helper for creating a log when it stored at the root of the data. */
   def forTable(spark: SparkSession, dataPath: Path): DeltaLog = {
-    apply(spark, logPathFor(dataPath), new SystemClock)
+    apply(spark, logPathFor(dataPath), initialTableIdentifier = None, new SystemClock)
   }
 
   /** Helper for creating a log when it stored at the root of the data. */
   def forTable(spark: SparkSession, dataPath: Path, options: Map[String, String]): DeltaLog = {
-    apply(spark, logPathFor(dataPath), options, new SystemClock)
+    apply(spark, logPathFor(dataPath), options, initialTableIdentifier = None, new SystemClock)
   }
 
   /** Helper for creating a log when it stored at the root of the data. */
   def forTable(spark: SparkSession, dataPath: Path, clock: Clock): DeltaLog = {
-    apply(spark, logPathFor(dataPath), clock)
+    apply(spark, logPathFor(dataPath), initialTableIdentifier = None, clock)
   }
 
   /** Helper for creating a log for the table. */
@@ -789,11 +796,15 @@ object DeltaLog extends DeltaLogging {
 
   /** Helper for creating a log for the table. */
   def forTable(spark: SparkSession, table: CatalogTable, clock: Clock): DeltaLog = {
-    apply(spark, logPathFor(new Path(table.location)), clock)
+    apply(spark, logPathFor(new Path(table.location)), Some(table.identifier), clock)
   }
 
-  private def apply(spark: SparkSession, rawPath: Path, clock: Clock = new SystemClock): DeltaLog =
-    apply(spark, rawPath, Map.empty, clock)
+  private def apply(
+      spark: SparkSession,
+      rawPath: Path,
+      initialTableIdentifier: Option[TableIdentifier],
+      clock: Clock): DeltaLog =
+    apply(spark, rawPath, options = Map.empty, initialTableIdentifier, clock)
 
 
   /** Helper for getting a log, as well as the latest snapshot, of the table */
@@ -815,7 +826,9 @@ object DeltaLog extends DeltaLogging {
       spark: SparkSession,
       dataPath: Path,
       options: Map[String, String]): (DeltaLog, Snapshot) =
-    withFreshSnapshot { apply(spark, logPathFor(dataPath), options, _) }
+    withFreshSnapshot {
+      apply(spark, logPathFor(dataPath), options, initialTableIdentifier = None, _)
+    }
 
   /**
    * Helper function to be used with the forTableWithSnapshot calls. Thunk is a
@@ -834,6 +847,7 @@ object DeltaLog extends DeltaLogging {
       spark: SparkSession,
       rawPath: Path,
       options: Map[String, String],
+      initialTableIdentifier: Option[TableIdentifier],
       clock: Clock
   ): DeltaLog = {
     val fileSystemOptions: Map[String, String] =
@@ -862,6 +876,7 @@ object DeltaLog extends DeltaLogging {
             dataPath = path.getParent,
             options = fileSystemOptions,
             allOptions = options,
+            initialTableIdentifier = initialTableIdentifier,
             clock = clock
           )
         }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1796,7 +1796,8 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       attemptVersion,
       commit,
       newChecksumOpt = None,
-      preCommitLogSegment = preCommitLogSegment)
+      preCommitLogSegment = preCommitLogSegment,
+      catalogTable.map(_.identifier))
     if (currentSnapshot.version != attemptVersion) {
       throw DeltaErrors.invalidCommittedVersion(attemptVersion, currentSnapshot.version)
     }
@@ -2236,8 +2237,8 @@ trait OptimisticTransactionImpl extends TransactionalWrite
       attemptVersion,
       commit,
       newChecksumOpt,
-      preCommitLogSegment
-    )
+      preCommitLogSegment,
+      catalogTable.map(_.identifier))
     val postCommitReconstructionTime = System.nanoTime()
 
     // Post stats
@@ -2534,7 +2535,8 @@ trait OptimisticTransactionImpl extends TransactionalWrite
     assert(previousAttemptVersion == preCommitLogSegment.version + 1)
     val (newPreCommitLogSegment, newCommitFileStatuses) = deltaLog.getUpdatedLogSegment(
       preCommitLogSegment,
-      readSnapshotTableCommitCoordinatorClientOpt)
+      readSnapshotTableCommitCoordinatorClientOpt,
+      catalogTable.map(_.identifier))
     assert(preCommitLogSegment.version + newCommitFileStatuses.size ==
       newPreCommitLogSegment.version)
     preCommitLogSegment = newPreCommitLogSegment

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/CheckpointHook.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/CheckpointHook.scala
@@ -39,7 +39,8 @@ object CheckpointHook extends PostCommitHook {
     val snapshotToCheckpoint = txn.deltaLog.getSnapshotAt(
       committedVersion,
       lastCheckpointHint = None,
-      lastCheckpointProvider = Some(cp))
+      lastCheckpointProvider = Some(cp),
+      tableIdentifierOpt = txn.catalogTable.map(_.identifier))
     txn.deltaLog.checkpoint(snapshotToCheckpoint, txn.catalogTable.map(_.identifier))
   }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/SnapshotManagementSuite.scala
@@ -469,6 +469,7 @@ class SnapshotManagementSuite extends QueryTest with DeltaSQLTestUtils with Shar
       val newLogSegment = log.snapshot.logSegment
       assert(log.getLogSegmentAfterCommit(
         log.snapshot.tableCommitCoordinatorClientOpt,
+        tableIdentifierOpt = None,
         oldLogSegment.checkpointProvider) === newLogSegment)
       spark.range(10).write.format("delta").mode("append").save(path)
       val fs = log.logPath.getFileSystem(log.newDeltaHadoopConf())
@@ -477,17 +478,20 @@ class SnapshotManagementSuite extends QueryTest with DeltaSQLTestUtils with Shar
         val commitFile = fs.getFileStatus(commitFileProvider.deltaFile(1))
         val commit = new Commit(1, commitFile, 0)
         // Version exists, but not contiguous with old logSegment
-        log.getLogSegmentAfterCommit(1, None, oldLogSegment, commit, None, EmptyCheckpointProvider)
+        log.getLogSegmentAfterCommit(
+          1, None, oldLogSegment, commit, None, None, EmptyCheckpointProvider)
       }
       intercept[IllegalArgumentException] {
         val commitFile = fs.getFileStatus(commitFileProvider.deltaFile(0))
         val commit = new Commit(0, commitFile, 0)
 
         // Version exists, but newLogSegment already contains it
-        log.getLogSegmentAfterCommit(0, None, newLogSegment, commit, None, EmptyCheckpointProvider)
+        log.getLogSegmentAfterCommit(
+          0, None, newLogSegment, commit, None, None, EmptyCheckpointProvider)
       }
       assert(log.getLogSegmentAfterCommit(
         log.snapshot.tableCommitCoordinatorClientOpt,
+        tableIdentifierOpt = None,
         oldLogSegment.checkpointProvider) === log.snapshot.logSegment)
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Change all relevant APIs of `DeltaLog` to take in a table identifier and pass this identifier all the way to the commit coordinator. Update `OptimisticTransaction` to use the new API. 

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
New unit tests
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
