### PR TITLE
[SPARK] Refactor StatsCollectionUtils.computeStats

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotManagement.scala
@@ -1179,7 +1179,7 @@ trait SnapshotManagement { self: DeltaLog =>
       }
     }.getOrElse {
       logInfo("Creating initial snapshot without metadata, because the directory is empty")
-      new InitialSnapshot(logPath, this)
+      new DummySnapshot(logPath, this)
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotState.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SnapshotState.scala
@@ -168,9 +168,8 @@ trait SnapshotStateManager extends DeltaLogging { self: Snapshot =>
   protected[delta] def numOfFilesIfKnown: Option[Long] = Some(numOfFiles)
   protected[delta] def domainMetadatasIfKnown: Option[Seq[DomainMetadata]] = Some(domainMetadata)
 
-  /** Generate a default SnapshotState of a new table, given the table metadata */
-  protected def initialState(metadata: Metadata): SnapshotState = {
-    val protocol = Protocol.forNewTable(spark, Some(metadata))
+  /** Generate a default SnapshotState of a new table given the table metadata and the protocol. */
+  protected def initialState(metadata: Metadata, protocol: Protocol): SnapshotState = {
 
     SnapshotState(
       sizeInBytes = 0L,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
@@ -282,8 +282,8 @@ abstract class ConvertToDeltaCommandBase(
       spark: SparkSession,
       txn: OptimisticTransaction,
       addFiles: Seq[AddFile]): Iterator[AddFile] = {
-    val initialSnapshot = new InitialSnapshot(txn.deltaLog.logPath, txn.deltaLog, txn.metadata)
-    ConvertToDeltaCommand.computeStats(txn.deltaLog, initialSnapshot, addFiles)
+    val dummySnapshot = new DummySnapshot(txn.deltaLog.logPath, txn.deltaLog, txn.metadata)
+    ConvertToDeltaCommand.computeStats(txn.deltaLog, dummySnapshot, addFiles)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DMLWithDeletionVectorsHelper.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DMLWithDeletionVectorsHelper.scala
@@ -272,12 +272,10 @@ object DMLWithDeletionVectorsHelper extends DeltaCommand {
       if (filesWithNoStats.nonEmpty) {
         StatsCollectionUtils.computeStats(spark,
           conf = snapshot.deltaLog.newDeltaHadoopConf(),
-          dataPath = snapshot.deltaLog.dataPath,
+          deltaLog = snapshot.deltaLog,
+          snapshot = snapshot,
           addFiles = filesWithNoStats.toDS(spark),
           numFilesOpt = Some(filesWithNoStats.size),
-          columnMappingMode = snapshot.metadata.columnMappingMode,
-          dataSchema = snapshot.dataSchema,
-          statsSchema = snapshot.statsSchema,
           setBoundsToWide = true)
           .collect()
           .toSeq

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatsCollectionUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatsCollectionUtils.scala
@@ -23,7 +23,7 @@ import scala.language.existentials
 import scala.util.control.NonFatal
 
 // scalastyle:off import.ordering.noEmptyLine
-import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaColumnMappingMode, DeltaErrors, IdMapping, NameMapping, NoMapping}
+import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaColumnMappingMode, DeltaErrors, DeltaLog, IdMapping, NameMapping, NoMapping, Snapshot}
 import org.apache.spark.sql.delta.actions.AddFile
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.DeltaStatistics._
@@ -51,16 +51,16 @@ object StatsCollectionUtils
   extends Logging
 {
 
-  /** A helper function to compute stats of addFiles using StatsCollector.
+  /**
+   * A helper function to compute stats of addFiles using StatsCollector.
    *
    * @param spark The SparkSession used to process data.
    * @param conf The Hadoop configuration used to access file system.
-   * @param dataPath The data path of table, to which these AddFile(s) belong.
+   * @param deltaLog The delta log of table, to which these AddFile(s) belong.
+   * @param snapshot The snapshot of the table used to derive table schema information. We do not
+   *                 derive it from deltaLog because a snapshot may not exist yet.
    * @param addFiles The list of target AddFile(s) to be processed.
    * @param numFilesOpt The number of AddFile(s) to process if known. Speeds up the query.
-   * @param columnMappingMode The column mapping mode of table.
-   * @param dataSchema The data schema of table.
-   * @param statsSchema The stats schema to be collected.
    * @param ignoreMissingStats Whether to ignore missing stats during computation.
    * @param setBoundsToWide Whether to set bounds to wide independently of whether or not
    *                        the files have DVs.
@@ -71,12 +71,10 @@ object StatsCollectionUtils
   def computeStats(
       spark: SparkSession,
       conf: Configuration,
-      dataPath: Path,
+      deltaLog: DeltaLog,
+      snapshot: Snapshot,
       addFiles: Dataset[AddFile],
       numFilesOpt: Option[Long],
-      columnMappingMode: DeltaColumnMappingMode,
-      dataSchema: StructType,
-      statsSchema: StructType,
       ignoreMissingStats: Boolean = true,
       setBoundsToWide: Boolean = false): Dataset[AddFile] = {
 
@@ -94,13 +92,18 @@ object StatsCollectionUtils
     val stringTruncateLength =
       spark.sessionState.conf.getConf(DeltaSQLConf.DATA_SKIPPING_STRING_PREFIX_LENGTH)
 
-    val statsCollector = StatsCollector(columnMappingMode, dataSchema, statsSchema,
-      parquetRebaseMode, ignoreMissingStats, Some(stringTruncateLength))
+    val statsCollector = StatsCollector(
+      snapshot.columnMappingMode,
+      snapshot.dataSchema,
+      snapshot.statsSchema,
+      parquetRebaseMode,
+      ignoreMissingStats,
+      Some(stringTruncateLength))
 
     val serializableConf = new SerializableConfiguration(conf)
     val broadcastConf = spark.sparkContext.broadcast(serializableConf)
 
-    val dataRootDir = dataPath.toString
+    val dataRootDir = deltaLog.dataPath.toString
 
     import org.apache.spark.sql.delta.implicits._
     preparedAddFiles.mapPartitions { addFileIter =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.delta.CoordinatedCommitType._
 import org.apache.spark.sql.delta.DeltaConfigs.{CHECKPOINT_INTERVAL, COORDINATED_COMMITS_COORDINATOR_CONF, COORDINATED_COMMITS_COORDINATOR_NAME, COORDINATED_COMMITS_TABLE_CONF, IN_COMMIT_TIMESTAMPS_ENABLED}
 import org.apache.spark.sql.delta.DeltaLog
 import org.apache.spark.sql.delta.DeltaTestUtils.createTestAddFile
-import org.apache.spark.sql.delta.InitialSnapshot
+import org.apache.spark.sql.delta.DummySnapshot
 import org.apache.spark.sql.delta.LogSegment
 import org.apache.spark.sql.delta.Snapshot
 import org.apache.spark.sql.delta.actions._
@@ -242,12 +242,12 @@ class CoordinatedCommitsSuite
       val tablePath = tempDir.getAbsolutePath
       val clock = new ManualClock(System.currentTimeMillis())
       val log = DeltaLog.forTable(spark, new Path(tablePath), clock)
-      assert(log.unsafeVolatileSnapshot.isInstanceOf[InitialSnapshot])
+      assert(log.unsafeVolatileSnapshot.isInstanceOf[DummySnapshot])
       assert(log.unsafeVolatileSnapshot.tableCommitCoordinatorClientOpt.isEmpty)
       assert(log.getCapturedSnapshot().updateTimestamp == clock.getTimeMillis())
       clock.advance(500)
       log.update()
-      assert(log.unsafeVolatileSnapshot.isInstanceOf[InitialSnapshot])
+      assert(log.unsafeVolatileSnapshot.isInstanceOf[DummySnapshot])
       assert(log.getCapturedSnapshot().updateTimestamp == clock.getTimeMillis())
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
The PR refactors `StatsCollectionUtils.computeStats`:

- Replaces parameter `dataPath` with `deltaLog`
- Replaces parameter `columnMappingMode` and `dataSchema` with `snapshot`

The old fields can be accessed from the newly added fields, so it's better to not have parameters more than necessary.

In order to achieve this, the PR adds a new parameter `protocolOpt` in the constructor of `InitialSnapshot` to make the `statsSchema` derived from the snapshot consistent with the desired protocol rather than the default protocol computed from the metadata in the snapshot. 

We also changed the name `InitialSnapshot` to `DummySnapshot` to fit its semantics more.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
It's a refactor change. Existing tests should cover this.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
