### PR TITLE
Implementation for Lite Vacuum without parser changes

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -327,6 +327,12 @@
     ],
     "sqlState" : "428FT"
   },
+  "DELTA_CANNOT_VACUUM_LITE" : {
+    "message" : [
+      "VACUUM LITE cannot delete all eligible files as some files are not referenced by the Delta log. Please run VACUUM FULL."
+    ],
+    "sqlState" : "55000"
+  },
   "DELTA_CANNOT_WRITE_INTO_VIEW" : {
     "message" : [
       "<table> is a view. Writes to a view are not supported."

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -1676,6 +1676,11 @@ trait DeltaErrorsBase
       messageParameters = Array(tableName, tablePath, tableName))
   }
 
+  def deltaCannotVacuumLite(): Throwable = {
+    new DeltaIllegalStateException(
+      errorClass = "DELTA_CANNOT_VACUUM_LITE")
+  }
+
   def updateSchemaMismatchExpression(from: StructType, to: StructType): Throwable = {
     new DeltaAnalysisException(
       errorClass = "DELTA_UPDATE_SCHEMA_MISMATCH_EXPRESSION",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -481,6 +481,12 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createOptional
 
+  val LITE_VACUUM_ENABLED =
+    buildConf("vacuum.lite.enabled")
+      .doc("Allows Vacuum to be run in Lite mode")
+      .booleanConf
+      .createWithDefault(false)
+
   val DELTA_VACUUM_RETENTION_CHECK_ENABLED =
     buildConf("retentionDurationCheck.enabled")
       .doc("Adds a check preventing users from running vacuum with a very short retention " +

--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaEncoders.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaEncoders.scala
@@ -74,6 +74,9 @@ private[delta] trait DeltaEncoders {
   private lazy val _removeFileEncoder = new DeltaEncoder[RemoveFile]
   implicit def removeFileEncoder: Encoder[RemoveFile] = _removeFileEncoder.get
 
+  private lazy val _addCdcFileEncoder = new DeltaEncoder[AddCDCFile]
+  implicit def addCdcFileEncoder: Encoder[AddCDCFile] = _addCdcFileEncoder.get
+
   private lazy val _pmtvEncoder = new DeltaEncoder[(Protocol, Metadata, Option[Long], Long)]
   implicit def pmtvEncoder: Encoder[(Protocol, Metadata, Option[Long], Long)] = _pmtvEncoder.get
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR implements the logic of Lite Vacuum. Since the user surface is not defined yet, all of the code is behind a spark conf which is set to false by default.

## How was this patch tested?

Modified existing tests to run in both Lite and full mode. Additionally, added new tests cases specific to Lite vacuum.

## Does this PR introduce _any_ user-facing changes?

NO
