### PR TITLE
path rewrite from wasbs to abfss when converting Iceberg table

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergFileManifest.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergFileManifest.scala
@@ -47,7 +47,7 @@ class IcebergFileManifest(
 
   private var _numFiles: Option[Long] = None
 
-  val basePath = table.location()
+  val basePath = IcebergTable.rewritePath(table.location())
 
   val icebergSchema = table.schema()
 
@@ -115,7 +115,7 @@ class IcebergFileManifest(
         log"finished ${MDC(DeltaLogKeys.NUM_FILES, numFiles)} files so far")
       numFiles += batch.length
       val filePathWithPartValues = batch.map { fileScanTask =>
-        val filePath = fileScanTask.file().path().toString
+        val filePath = IcebergTable.rewritePath(fileScanTask.file().path().toString)
         // If an Iceberg table has deletion file associated with the data file (Supported in
         // Iceberg V2, either position deletes or equality deletes), we could not convert directly.
         val hasMergeOnReadDeletionFiles = fileScanTask.deletes().size() > 0

--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergTable.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergTable.scala
@@ -155,4 +155,13 @@ object IcebergTable {
        |$conflictingColumns. Delta does not support case sensitive column names.
        |Please rename these columns before converting to Delta.
        """.stripMargin
+
+  /**
+   * Convert a wasbs URI to an abfss URI when reading an iceberg table
+   */
+  def rewritePath(path: String) : String = {
+    if (path.startsWith("wasbs://")) path.replace("wasbs://", "abfss://")
+      .replace("blob.core.windows.net", "dfs.core.windows.net")
+    else path
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

path rewrite from wasbs to abfss when converting Iceberg table

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Exist UTs
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
