### PR TITLE
[Spark] Add INSERT tests with missing, extra, reordered columns/fields

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoColumnOrderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoColumnOrderSuite.scala
@@ -1,0 +1,170 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * Test suite covering INSERT operations with columns or struct fields ordered differently than in
+ * the table schema.
+ */
+class DeltaInsertIntoColumnOrderSuite extends DeltaInsertIntoTest {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    spark.conf.set(DeltaSQLConf.DELTA_STREAMING_SINK_ALLOW_IMPLICIT_CASTS.key, "false")
+    spark.conf.set(SQLConf.ANSI_ENABLED.key, "true")
+  }
+
+  test("all test cases are implemented") {
+    checkAllTestCasesImplemented()
+  }
+
+  // Inserting using a different ordering for top-level columns behaves as one would expect:
+  // inserts by position resolve columns based on position, inserts by name resolve based on name.
+  // Whether additional handling is required to add implicit casts doesn't impact this behavior.
+  for { (inserts, expectedAnswer) <- Seq(
+      insertsByPosition.intersect(insertsAppend) ->
+        TestData("a int, b int, c int",
+          Seq("""{ "a": 1, "b": 2, "c": 3 }""", """{ "a": 1, "b": 4, "c": 5 }""")),
+      insertsByPosition.intersect(insertsOverwrite) ->
+        TestData("a int, b int, c int", Seq("""{ "a": 1, "b": 4, "c": 5 }""")),
+      insertsByName.intersect(insertsAppend) ->
+        TestData("a int, b int, c int",
+          Seq("""{ "a": 1, "b": 2, "c": 3 }""", """{ "a": 1, "b": 5, "c": 4 }""")),
+      insertsByName.intersect(insertsOverwrite) ->
+        TestData("a int, b int, c int", Seq("""{ "a": 1, "b": 5, "c": 4 }"""))
+    )
+  } {
+    testInserts(s"insert with different top-level column ordering")(
+      initialData = TestData("a int, b int, c int", Seq("""{ "a": 1, "b": 2, "c": 3 }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData("a int, c int, b int", Seq("""{ "a": 1, "c": 4, "b": 5 }""")),
+      expectedResult = ExpectedResult.Success(expectedAnswer),
+      includeInserts = inserts
+    )
+
+    testInserts(s"insert with implicit cast and different top-level column ordering")(
+      initialData = TestData("a int, b int, c int", Seq("""{ "a": 1, "b": 2, "c": 3 }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData("a long, c int, b int", Seq("""{ "a": 1, "c": 4, "b": 5 }""")),
+      expectedResult = ExpectedResult.Success(expectedAnswer),
+      // Dataframe insert by name don't support implicit cast, see negative test below.
+      includeInserts = inserts -- insertsByName.intersect(insertsDataframe)
+    )
+  }
+
+  testInserts(s"insert with implicit cast and different top-level column ordering")(
+    initialData = TestData("a int, b int, c int", Seq("""{ "a": 1, "b": 2, "c": 3 }""")),
+    partitionBy = Seq("a"),
+    overwriteWhere = "a" -> 1,
+    insertData = TestData("a long, c int, b int", Seq("""{ "a": 1, "c": 4, "b": 4 }""")),
+    expectedResult = ExpectedResult.Failure(ex => {
+      checkError(
+        ex,
+        "DELTA_FAILED_TO_MERGE_FIELDS",
+        parameters = Map(
+          "currentField" -> "a",
+          "updateField" -> "a"
+        ))}),
+    includeInserts = insertsByName.intersect(insertsDataframe)
+  )
+
+  // Inserting using a different ordering for struct fields is full of surprises...
+  for { (inserts: Set[Insert], expectedAnswer) <- Seq(
+    // Most inserts use name based resolution for struct fields when there's no implicit cast
+    // required due to mismatching data types, except for `INSERT INTO/OVERWRITE (columns)` and
+    // `INSERT OVERWRITE PARTITION (partition) (columns)` which use position based resolution - even
+    // though these are by name inserts.
+    insertsAppend -
+      SQLInsertColList(SaveMode.Append) ->
+      TestData("a int, s struct <x int, y: int>",
+        Seq("""{ "a": 1, "s": { "x": 2, "y": 3 } }""", """{ "a": 1, "s": { "x": 4, "y": 5 } }""")),
+    insertsOverwrite -
+      SQLInsertColList(SaveMode.Overwrite) - SQLInsertOverwritePartitionColList ->
+      TestData("a int, s struct <x int, y: int>", Seq("""{ "a": 1, "s": { "x": 4, "y": 5 } }""")),
+    Set(SQLInsertColList(SaveMode.Append)) ->
+      TestData("a int, s struct <x int, y: int>",
+        Seq("""{ "a": 1, "s": { "x": 2, "y": 3 } }""", """{ "a": 1, "s": { "x": 5, "y": 4 } }""")),
+    Set(SQLInsertColList(SaveMode.Overwrite), SQLInsertOverwritePartitionColList) ->
+      TestData("a int, s struct <x int, y: int>", Seq("""{ "a": 1, "s": { "x": 5, "y": 4 } }"""))
+    )
+  } {
+    testInserts(s"insert with different struct fields ordering")(
+      initialData = TestData(
+        "a int, s struct <x: int, y int>",
+        Seq("""{ "a": 1, "s": { "x": 2, "y": 3 } }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData("a int, s struct <y int, x: int>",
+        Seq("""{ "a": 1, "s": { "y": 5, "x": 4 } }""")),
+      expectedResult = ExpectedResult.Success(expectedAnswer),
+      includeInserts = inserts
+    )
+  }
+
+  for { (inserts: Set[Insert], expectedAnswer) <- Seq(
+    // When there's a type mismatch and an implicit cast is required, then all inserts use position
+    // based resolution for struct fields, except for `INSERT OVERWRITE PARTITION (partition)` which
+    // uses name based resolution, and dataframe inserts by name which don't support implicit cast
+    // and fail - see negative test below.
+    insertsAppend - StreamingInsert ->
+      TestData("a int, s struct <x int, y: int>",
+        Seq("""{ "a": 1, "s": { "x": 2, "y": 3 } }""", """{ "a": 1, "s": { "x": 5, "y": 4 } }""")),
+    insertsOverwrite - SQLInsertOverwritePartitionByPosition ->
+      TestData("a int, s struct <x int, y: int>", Seq("""{ "a": 1, "s": { "x": 5, "y": 4 } }""")),
+    Set(SQLInsertOverwritePartitionByPosition) ->
+      TestData("a int, s struct <x int, y: int>", Seq("""{ "a": 1, "s": { "x": 4, "y": 5 } }"""))
+    )
+  } {
+    testInserts(s"insert with implicit cast and different struct fields ordering")(
+      initialData = TestData(
+        "a int, s struct <x: int, y int>",
+        Seq("""{ "a": 1, "s": { "x": 2, "y": 3 } }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData("a long, s struct <y int, x: int>",
+        Seq("""{ "a": 1, "s": { "y": 5, "x": 4 } }""")),
+      expectedResult = ExpectedResult.Success(expectedAnswer),
+      includeInserts = inserts -- insertsDataframe.intersect(insertsByName)
+    )
+  }
+
+  testInserts(s"insert with implicit cast and different struct fields ordering")(
+    initialData = TestData(
+      "a int, s struct <x: int, y int>",
+      Seq("""{ "a": 1, "s": { "x": 2, "y": 3 } }""")),
+    partitionBy = Seq("a"),
+    overwriteWhere = "a" -> 1,
+    insertData = TestData("a long, s struct <y int, x: int>",
+      Seq("""{ "a": 1, "s": { "y": 5, "x": 4 } }""")),
+    expectedResult = ExpectedResult.Failure(ex => {
+      checkError(
+        ex,
+        "DELTA_FAILED_TO_MERGE_FIELDS",
+        parameters = Map(
+          "currentField" -> "a",
+          "updateField" -> "a"
+        ))}),
+    includeInserts = insertsDataframe.intersect(insertsByName)
+  )
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoImplicitCastSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoImplicitCastSuite.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
-import org.apache.spark.sql.SaveMode
+
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
@@ -38,15 +38,17 @@ class DeltaInsertIntoImplicitCastSuite extends DeltaInsertIntoTest {
     spark.conf.set(SQLConf.ANSI_ENABLED.key, "true")
   }
 
+  test("all test cases are implemented") {
+    checkAllTestCasesImplemented()
+  }
+
   for (schemaEvolution <- BOOLEAN_DOMAIN) {
     testInserts("insert with implicit up and down cast on top-level fields, " +
       s"schemaEvolution=$schemaEvolution")(
-      initialSchemaDDL = "a long, b int",
-      initialJsonData = Seq("""{ "a": 1, "b": 2 }"""),
+      initialData = TestData("a long, b int", Seq("""{ "a": 1, "b": 2 }""")),
       partitionBy = Seq("a"),
       overwriteWhere = "a" -> 1,
-      insertSchemaDDL = "a int, b long",
-      insertJsonData = Seq("""{ "a": 1, "b": 4 }"""),
+      insertData = TestData("a int, b long", Seq("""{ "a": 1, "b": 4 }""")),
       expectedResult = ExpectedResult.Success(
         expected = new StructType()
           .add("a", LongType)
@@ -54,26 +56,16 @@ class DeltaInsertIntoImplicitCastSuite extends DeltaInsertIntoTest {
       // The following insert operations don't implicitly cast the data but fail instead - see
       // following test covering failure for these cases. We should change this to offer consistent
       // behavior across all inserts.
-      excludeInserts = Seq(
-        DFv1SaveAsTable(SaveMode.Append),
-        DFv1SaveAsTable(SaveMode.Overwrite),
-        DFv1Save(SaveMode.Append),
-        DFv1Save(SaveMode.Overwrite),
-        DFv2Append,
-        DFv2Overwrite,
-        DFv2OverwritePartition
-      ),
+      excludeInserts = insertsDataframe.intersect(insertsByName) - StreamingInsert,
       confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
     )
 
     testInserts("insert with implicit up and down cast on top-level fields, " +
       s"schemaEvolution=$schemaEvolution")(
-      initialSchemaDDL = "a long, b int",
-      initialJsonData = Seq("""{ "a": 1, "b": 2 }"""),
+      initialData = TestData("a long, b int", Seq("""{ "a": 1, "b": 2 }""")),
       partitionBy = Seq("a"),
       overwriteWhere = "a" -> 1,
-      insertSchemaDDL = "a int, b long",
-      insertJsonData = Seq("""{ "a": 1, "b": 4 }"""),
+      insertData = TestData("a int, b long", Seq("""{ "a": 1, "b": 4 }""")),
       expectedResult = ExpectedResult.Failure { ex =>
         checkError(
           ex,
@@ -83,26 +75,18 @@ class DeltaInsertIntoImplicitCastSuite extends DeltaInsertIntoTest {
             "updateField" -> "a"
         ))
       },
-      includeInserts = Seq(
-        DFv1SaveAsTable(SaveMode.Append),
-        DFv1SaveAsTable(SaveMode.Overwrite),
-        DFv1Save(SaveMode.Append),
-        DFv1Save(SaveMode.Overwrite),
-        DFv2Append,
-        DFv2Overwrite,
-        DFv2OverwritePartition
-      ),
+      includeInserts = insertsDataframe.intersect(insertsByName) - StreamingInsert,
       confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
     )
 
     testInserts("insert with implicit up and down cast on fields nested in array, " +
       s"schemaEvolution=$schemaEvolution")(
-      initialSchemaDDL = "key int, a array<struct<x: long, y: int>>",
-      initialJsonData = Seq("""{ "key": 1, "a": [ { "x": 1, "y": 2 } ] }"""),
+      initialData = TestData("key int, a array<struct<x: long, y: int>>",
+        Seq("""{ "key": 1, "a": [ { "x": 1, "y": 2 } ] }""")),
       partitionBy = Seq("key"),
       overwriteWhere = "key" -> 1,
-      insertSchemaDDL = "key int, a array<struct<x: int, y: long>>",
-      insertJsonData = Seq("""{ "key": 1, "a": [ { "x": 3, "y": 4 } ] }"""),
+      insertData = TestData("key int, a array<struct<x: int, y: long>>",
+        Seq("""{ "key": 1, "a": [ { "x": 3, "y": 4 } ] }""")),
       expectedResult = ExpectedResult.Success(
         expected = new StructType()
           .add("key", IntegerType)
@@ -112,26 +96,18 @@ class DeltaInsertIntoImplicitCastSuite extends DeltaInsertIntoTest {
       // The following insert operations don't implicitly cast the data but fail instead - see
       // following test covering failure for these cases. We should change this to offer consistent
       // behavior across all inserts.
-      excludeInserts = Seq(
-        DFv1SaveAsTable(SaveMode.Append),
-        DFv1SaveAsTable(SaveMode.Overwrite),
-        DFv1Save(SaveMode.Append),
-        DFv1Save(SaveMode.Overwrite),
-        DFv2Append,
-        DFv2Overwrite,
-        DFv2OverwritePartition
-      ),
+      excludeInserts = insertsDataframe.intersect(insertsByName) - StreamingInsert,
       confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
     )
 
     testInserts("insert with implicit up and down cast on fields nested in array, " +
       s"schemaEvolution=$schemaEvolution")(
-      initialSchemaDDL = "key int, a array<struct<x: long, y: int>>",
-      initialJsonData = Seq("""{ "key": 1, "a": [ { "x": 1, "y": 2 } ] }"""),
+      initialData = TestData("key int, a array<struct<x: long, y: int>>",
+        Seq("""{ "key": 1, "a": [ { "x": 1, "y": 2 } ] }""")),
       partitionBy = Seq("key"),
       overwriteWhere = "key" -> 1,
-      insertSchemaDDL = "key int, a array<struct<x: int, y: long>>",
-      insertJsonData = Seq("""{ "key": 1, "a": [ { "x": 3, "y": 4 } ] }"""),
+      insertData = TestData("key int, a array<struct<x: int, y: long>>",
+        Seq("""{ "key": 1, "a": [ { "x": 3, "y": 4 } ] }""")),
       expectedResult = ExpectedResult.Failure { ex =>
         checkError(
           ex,
@@ -141,26 +117,18 @@ class DeltaInsertIntoImplicitCastSuite extends DeltaInsertIntoTest {
             "updateField" -> "a"
         ))
       },
-      includeInserts = Seq(
-        DFv1SaveAsTable(SaveMode.Append),
-        DFv1SaveAsTable(SaveMode.Overwrite),
-        DFv1Save(SaveMode.Append),
-        DFv1Save(SaveMode.Overwrite),
-        DFv2Append,
-        DFv2Overwrite,
-        DFv2OverwritePartition
-      ),
+      includeInserts = insertsDataframe.intersect(insertsByName) - StreamingInsert,
       confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
     )
 
     testInserts("insert with implicit up and down cast on fields nested in map, " +
       s"schemaEvolution=$schemaEvolution")(
-      initialSchemaDDL = "key int, m map<string, struct<x: long, y: int>>",
-      initialJsonData = Seq("""{ "key": 1, "m": { "a": { "x": 1, "y": 2 } } }"""),
+      initialData = TestData("key int, m map<string, struct<x: long, y: int>>",
+        Seq("""{ "key": 1, "m": { "a": { "x": 1, "y": 2 } } }""")),
       partitionBy = Seq("key"),
       overwriteWhere = "key" -> 1,
-      insertSchemaDDL = "key int, m map<string, struct<x: int, y: long>>",
-      insertJsonData = Seq("""{ "key": 1, "m": { "a": { "x": 3, "y": 4 } } }"""),
+      insertData = TestData("key int, m map<string, struct<x: int, y: long>>",
+        Seq("""{ "key": 1, "m": { "a": { "x": 3, "y": 4 } } }""")),
       expectedResult = ExpectedResult.Success(
         expected = new StructType()
           .add("key", IntegerType)
@@ -170,26 +138,18 @@ class DeltaInsertIntoImplicitCastSuite extends DeltaInsertIntoTest {
       // The following insert operations don't implicitly cast the data but fail instead - see
       // following test covering failure for these cases. We should change this to offer consistent
       // behavior across all inserts.
-      excludeInserts = Seq(
-        DFv1SaveAsTable(SaveMode.Append),
-        DFv1SaveAsTable(SaveMode.Overwrite),
-        DFv1Save(SaveMode.Append),
-        DFv1Save(SaveMode.Overwrite),
-        DFv2Append,
-        DFv2Overwrite,
-        DFv2OverwritePartition
-      ),
+      excludeInserts = insertsDataframe.intersect(insertsByName) - StreamingInsert,
       confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
     )
 
     testInserts("insert with implicit up and down cast on fields nested in map, " +
       s"schemaEvolution=$schemaEvolution")(
-      initialSchemaDDL = "key int, m map<string, struct<x: long, y: int>>",
-      initialJsonData = Seq("""{ "key": 1, "m": { "a": { "x": 1, "y": 2 } } }"""),
+      initialData = TestData("key int, m map<string, struct<x: long, y: int>>",
+        Seq("""{ "key": 1, "m": { "a": { "x": 1, "y": 2 } } }""")),
       partitionBy = Seq("key"),
       overwriteWhere = "key" -> 1,
-      insertSchemaDDL = "key int, m map<string, struct<x: int, y: long>>",
-      insertJsonData = Seq("""{ "key": 1, "m": { "a": { "x": 3, "y": 4 } } }"""),
+      insertData = TestData("key int, m map<string, struct<x: int, y: long>>",
+        Seq("""{ "key": 1, "m": { "a": { "x": 3, "y": 4 } } }""")),
       expectedResult = ExpectedResult.Failure { ex =>
         checkError(
           ex,
@@ -199,15 +159,7 @@ class DeltaInsertIntoImplicitCastSuite extends DeltaInsertIntoTest {
             "updateField" -> "m"
         ))
       },
-      includeInserts = Seq(
-        DFv1SaveAsTable(SaveMode.Append),
-        DFv1SaveAsTable(SaveMode.Overwrite),
-        DFv1Save(SaveMode.Append),
-        DFv1Save(SaveMode.Overwrite),
-        DFv2Append,
-        DFv2Overwrite,
-        DFv2OverwritePartition
-      ),
+      includeInserts = insertsDataframe.intersect(insertsByName) - StreamingInsert,
       confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
     )
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoMissingColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoMissingColumnSuite.scala
@@ -1,0 +1,229 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types._
+
+/**
+ * Test suite covering behavior of INSERT operations with missing top-level columns or nested struct
+ * fields.
+ * This suite intends to exhaustively cover all the ways INSERT can be run on a Delta table. See
+ * [[DeltaInsertIntoTest]] for a list of these INSERT operations covered.
+ */
+class DeltaInsertIntoMissingColumnSuite extends DeltaInsertIntoTest {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    spark.conf.set(DeltaSQLConf.DELTA_STREAMING_SINK_ALLOW_IMPLICIT_CASTS.key, "false")
+    spark.conf.set(SQLConf.ANSI_ENABLED.key, "true")
+  }
+
+  test("all test cases are implemented") {
+    checkAllTestCasesImplemented()
+  }
+
+  for (schemaEvolution <- BOOLEAN_DOMAIN) {
+    // Missing top-level columns are allowed for all inserts by name (SQL+dataframe) but missing
+    // nested fields are only allowed for dataframe inserts by name.
+    testInserts(s"insert with missing top-level column, schemaEvolution=$schemaEvolution")(
+      initialData = TestData("a int, b int, c int", Seq("""{ "a": 1, "b": 2, "c": 3 }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData("a int, b int", Seq("""{ "a": 1, "b": 4 }""")),
+      expectedResult = ExpectedResult.Success(
+        expected = new StructType()
+          .add("a", IntegerType)
+          .add("b", IntegerType)
+          .add("c", IntegerType)),
+      includeInserts = insertsByName,
+      confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
+    )
+
+    testInserts(s"insert with missing nested field, schemaEvolution=$schemaEvolution")(
+      initialData =
+        TestData("a int, s struct<x: int, y: int>", Seq("""{ "a": 1, "s": { "x": 2, "y": 3 } }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData =
+        TestData("a int, s struct<y: int>", Seq("""{ "a": 1, "s": { "y": 5 } }""")),
+      expectedResult = ExpectedResult.Success(
+        expected = new StructType()
+          .add("a", IntegerType)
+          .add("s", new StructType()
+            .add("x", IntegerType)
+            .add("y", IntegerType)
+          )),
+      includeInserts = insertsByName.intersect(insertsDataframe),
+      confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
+    )
+
+    // Missing columns for all inserts by name and missing nested fields for dataframe inserts by
+    // name are also allowed when the insert includes type mismatches, with the difference that
+    // dataframe inserts by name don't support implicit casting and will fail due to the type
+    // mismatch (but not the missing column/field per se).
+    testInserts(s"insert with implicit cast and missing top-level column," +
+      s"schemaEvolution=$schemaEvolution")(
+      initialData = TestData("a long, b int, c int", Seq("""{ "a": 1, "b": 2, "c": 3 }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData("a int, b long", Seq("""{ "a": 1, "b": 4 }""")),
+      expectedResult = ExpectedResult.Success(
+        expected = new StructType()
+          .add("a", LongType)
+          .add("b", IntegerType)
+          .add("c", IntegerType)),
+      includeInserts = insertsByName.intersect(insertsSQL),
+      confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
+    )
+
+    testInserts(s"insert with implicit cast and missing top-level column," +
+      s"schemaEvolution=$schemaEvolution")(
+      initialData = TestData("a long, b int, c int", Seq("""{ "a": 1, "b": 2, "c": 3 }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData("a int, b long", Seq("""{ "a": 1, "b": 4 }""")),
+      expectedResult = ExpectedResult.Failure(ex => {
+        // The missing column isn't an issue, but dataframe insert by name doesn't support implicit
+        // casting to reconcile the type mismatch.
+        checkError(
+          ex,
+          "DELTA_FAILED_TO_MERGE_FIELDS",
+          parameters = Map(
+            "currentField" -> "a",
+            "updateField" -> "a"
+          ))
+      }),
+      includeInserts = insertsByName.intersect(insertsDataframe),
+      confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
+    )
+
+    testInserts(s"insert with implicit cast and missing nested field," +
+      s"schemaEvolution=$schemaEvolution")(
+      initialData =
+        TestData("a int, s struct<x: int, y: int>", Seq("""{ "a": 1, "s": { "x": 2, "y": 3 } }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData =
+        TestData("a int, s struct<y: long>", Seq("""{ "a": 1, "s": { "y": 5 } }""")),
+      expectedResult = ExpectedResult.Failure(ex => {
+        // The missing field isn't an issue, but dataframe insert by name doesn't support implicit
+        // casting to reconcile the type mismatch.
+        checkError(
+          ex,
+          "DELTA_FAILED_TO_MERGE_FIELDS",
+          parameters = Map(
+            "currentField" -> "s",
+            "updateField" -> "s"
+          ))
+      }),
+      includeInserts = insertsByName.intersect(insertsDataframe),
+      confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
+    )
+
+    // Missing columns for all inserts by position and missing nested fields for all inserts by
+    // position or SQL inserts are rejected. Whether the insert also includes a type mismatch
+    // doesn't play a role.
+    testInserts(s"insert with missing top-level column, schemaEvolution=$schemaEvolution")(
+      initialData = TestData("a int, b int, c int", Seq("""{ "a": 1, "b": 2, "c": 3 }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData("a int, b int", Seq("""{ "a": 1, "b": 4 }""")),
+      expectedResult = ExpectedResult.Failure(ex => {
+        checkError(
+          ex,
+          "DELTA_INSERT_COLUMN_ARITY_MISMATCH",
+          parameters = Map(
+            "tableName" -> "spark_catalog.default.target",
+            "columnName" -> "not enough data columns",
+            "numColumns" -> "3",
+            "insertColumns" -> "2"
+          ))
+      }),
+      includeInserts = insertsByPosition,
+      confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
+    )
+
+    testInserts(s"insert with implicit cast and missing top-level column," +
+      s"schemaEvolution=$schemaEvolution")(
+      initialData = TestData("a long, b int, c int", Seq("""{ "a": 1, "b": 2, "c": 3 }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData("a int, b long", Seq("""{ "a": 1, "b": 4 }""")),
+      expectedResult = ExpectedResult.Failure(ex => {
+        checkError(
+          ex,
+          "DELTA_INSERT_COLUMN_ARITY_MISMATCH",
+          parameters = Map(
+            "tableName" -> "spark_catalog.default.target",
+            "columnName" -> "not enough data columns",
+            "numColumns" -> "3",
+            "insertColumns" -> "2"
+          ))
+      }),
+      includeInserts = insertsByPosition,
+      confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
+    )
+
+    testInserts(s"insert with missing nested field, schemaEvolution=$schemaEvolution")(
+      initialData =
+        TestData("a int, s struct<x: int, y: int>", Seq("""{ "a": 1, "s": { "x": 2, "y": 3 } }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData =
+        TestData("a int, s struct<y: int>", Seq("""{ "a": 1, "s": { "y": 5 } }""")),
+      expectedResult = ExpectedResult.Failure(ex => {
+        checkErrorMatchPVals(
+          ex,
+          "DELTA_INSERT_COLUMN_ARITY_MISMATCH",
+          parameters = Map(
+            "tableName" -> "spark_catalog\\.default\\.target",
+            "columnName" -> "not enough nested fields in (spark_catalog\\.default\\.source\\.)?s",
+            "numColumns" -> "2",
+            "insertColumns" -> "1"
+          ))
+      }),
+      includeInserts = insertsByPosition ++ insertsSQL,
+      confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
+    )
+
+    testInserts(s"insert with implicit cast and missing nested field," +
+      s"schemaEvolution=$schemaEvolution")(
+      initialData =
+        TestData("a int, s struct<x: int, y: int>", Seq("""{ "a": 1, "s": { "x": 2, "y": 3 } }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData =
+        TestData("a int, s struct<y: long>", Seq("""{ "a": 1, "s": { "y": 5 } }""")),
+      expectedResult = ExpectedResult.Failure(ex => {
+        checkErrorMatchPVals(
+          ex,
+          "DELTA_INSERT_COLUMN_ARITY_MISMATCH",
+          parameters = Map(
+            "tableName" -> "spark_catalog\\.default\\.target",
+            "columnName" -> "not enough nested fields in (spark_catalog\\.default\\.source\\.)?s",
+            "numColumns" -> "2",
+            "insertColumns" -> "1"
+          ))
+      }),
+      includeInserts = insertsByPosition ++ insertsSQL,
+      confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
+    )
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoSchemaEvolutionSuite.scala
@@ -1,0 +1,243 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+
+import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types._
+
+/**
+ * Test suite covering behavior of INSERT operations with extra top-level columns or nested struct
+ * fields in the input data.
+ * This suite intends to exhaustively cover all the ways INSERT can be run on a Delta table. See
+ * [[DeltaInsertIntoTest]] for a list of these INSERT operations covered.
+ */
+class DeltaInsertIntoSchemaEvolutionSuite extends DeltaInsertIntoTest {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    spark.conf.set(DeltaSQLConf.DELTA_STREAMING_SINK_ALLOW_IMPLICIT_CASTS.key, "false")
+    spark.conf.set(SQLConf.ANSI_ENABLED.key, "true")
+  }
+
+  test("all test cases are implemented") {
+    // we don't cover SQL INSERT with an explicit column list in this suite as it's not possible to
+    // specify a column that doesn't exist in the target table that way.
+    val ignoredTestCases = testCases.map { case (name, _) =>
+      name -> Set(
+        SQLInsertColList(SaveMode.Append),
+        SQLInsertColList(SaveMode.Overwrite),
+        SQLInsertOverwritePartitionColList)
+    }.toMap
+    checkAllTestCasesImplemented(ignoredTestCases)
+  }
+
+  for (schemaEvolution <- BOOLEAN_DOMAIN) {
+    // We allow adding new top-level columns with schema evolution for all inserts.
+    testInserts(s"insert with extra top-level column, schemaEvolution=$schemaEvolution")(
+      initialData = TestData("a int, b int", Seq("""{ "a": 1, "b": 2 }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData("a int, b int, c int", Seq("""{ "a": 1, "b": 4, "c": 5  }""")),
+      expectedResult = if (schemaEvolution) {
+        ExpectedResult.Success(
+          expected = new StructType()
+            .add("a", IntegerType)
+            .add("b", IntegerType)
+            .add("c", IntegerType))
+      } else {
+        ExpectedResult.Failure(ex => {
+          checkErrorMatchPVals(
+            ex,
+            "_LEGACY_ERROR_TEMP_DELTA_0007",
+            parameters = Map(
+              "message" -> "A schema mismatch detected when writing to the Delta table(.|\\n)*"
+            ))
+        })
+      },
+      excludeInserts = Set(
+        SQLInsertColList(SaveMode.Append),
+        SQLInsertColList(SaveMode.Overwrite),
+        SQLInsertOverwritePartitionColList
+      ),
+      confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
+    )
+
+
+    // Adding new top-level columns with schema evolution is allowed for all inserts except SQL
+    // inserts by name, but dataframe inserts by name don't support implicit casting and will fail
+    // due to the type mismatch.
+    testInserts(s"insert with extra top-level column and implicit cast," +
+      s"schemaEvolution=$schemaEvolution")(
+      initialData = TestData("a int, b int", Seq("""{ "a": 1, "b": 2 }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData("a int, b long, c int", Seq("""{ "a": 1, "b": 4, "c": 5  }""")),
+      expectedResult = if (schemaEvolution) {
+        ExpectedResult.Success(
+          expected = new StructType()
+            .add("a", IntegerType)
+            .add("b", IntegerType)
+            .add("c", IntegerType))
+      } else {
+        ExpectedResult.Failure(ex => {
+          checkErrorMatchPVals(
+            ex,
+            "_LEGACY_ERROR_TEMP_DELTA_0007",
+            parameters = Map(
+              "message" -> "A schema mismatch detected when writing to the Delta table(.|\\n)*"
+            ))
+        })
+      },
+      includeInserts = insertsByPosition,
+      confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
+    )
+
+    testInserts(s"insert with extra top-level column and implicit cast," +
+      s"schemaEvolution=$schemaEvolution")(
+      initialData = TestData("a int, b int", Seq("""{ "a": 1, "b": 2 }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData("a int, b long, c int", Seq("""{ "a": 1, "b": 4, "c": 5  }""")),
+      expectedResult = ExpectedResult.Failure(ex => {
+        checkError(
+          ex,
+          "DELTA_FAILED_TO_MERGE_FIELDS",
+          parameters = Map(
+            "currentField" -> "b",
+            "updateField" -> "b"
+          ))
+      }),
+      includeInserts = insertsDataframe.intersect(insertsByName),
+      confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
+    )
+
+    testInserts(s"insert with extra top-level column and implicit cast," +
+      s"schemaEvolution=$schemaEvolution")(
+      initialData = TestData("a int, b int", Seq("""{ "a": 1, "b": 2 }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData("a int, b long, c int", Seq("""{ "a": 1, "b": 4, "c": 5  }""")),
+      expectedResult = ExpectedResult.Failure(ex => {
+        checkError(
+          ex,
+          "INSERT_COLUMN_ARITY_MISMATCH.TOO_MANY_DATA_COLUMNS",
+          parameters = Map(
+            "tableName" -> "`spark_catalog`.`default`.`target`",
+            "tableColumns" -> "`a`, `b`",
+            "dataColumns" -> "`a`, `b`, `c`"
+          ))
+      }),
+      includeInserts = insertsSQL.intersect(insertsByName) -- Set(
+        // It's not possible to specify a column that doesn't exist in the target using SQL with an
+        // explicit column list.
+        SQLInsertColList(SaveMode.Append),
+        SQLInsertColList(SaveMode.Overwrite),
+        SQLInsertOverwritePartitionColList
+      ),
+      confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
+    )
+
+    // We allow adding new nested struct fields for all inserts, including SQL inserts by name.
+    testInserts(s"insert with extra nested field, schemaEvolution=$schemaEvolution")(
+      initialData = TestData("a int, s struct <x: int>", Seq("""{ "a": 1, "s": { "x": 2 } }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData("a int, s struct <x: int, y: int>",
+        Seq("""{ "a": 1, "s": { "x": 4, "y": 5 } }""")),
+      expectedResult = if (schemaEvolution) {
+        ExpectedResult.Success(
+          expected = new StructType()
+            .add("a", IntegerType)
+            .add("s", new StructType()
+              .add("x", IntegerType)
+              .add("y", IntegerType)
+            ))
+      } else {
+        ExpectedResult.Failure(ex => {
+          checkErrorMatchPVals(
+            ex,
+            "_LEGACY_ERROR_TEMP_DELTA_0007",
+            parameters = Map(
+              "message" -> "A schema mismatch detected when writing to the Delta table(.|\\n)*"
+            ))
+        })
+      },
+      confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
+    )
+
+    // Adding new nested struct fields with schema evolution is allowed for all inserts, but
+    // dataframe inserts by name don't support implicit casting and will fail due to the type
+    // mismatch.
+    testInserts(s"insert with extra nested field and implicit cast," +
+      s"schemaEvolution=$schemaEvolution")(
+      initialData = TestData("a int, s struct <x: int>", Seq("""{ "a": 1, "s": { "x": 2 } }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData("a int, s struct <x: long, y: int>",
+        Seq("""{ "a": 1, "s": { "x": 4, "y": 5 } }""")),
+      expectedResult = if (schemaEvolution) {
+        ExpectedResult.Success(
+          expected = new StructType()
+            .add("a", IntegerType)
+            .add("s", new StructType()
+              .add("x", IntegerType)
+              .add("y", IntegerType)
+            ))
+      } else {
+        ExpectedResult.Failure(ex => {
+          checkErrorMatchPVals(
+            ex,
+            "_LEGACY_ERROR_TEMP_DELTA_0007",
+            parameters = Map(
+              "message" -> "A schema mismatch detected when writing to the Delta table(.|\\n)*"
+            ))
+        })
+      },
+      includeInserts = insertsSQL ++ insertsByPosition -- Seq(
+        // It's not possible to specify a column that doesn't exist in the target using SQL with an
+        // explicit column list.
+        SQLInsertColList(SaveMode.Append),
+        SQLInsertColList(SaveMode.Overwrite),
+        SQLInsertOverwritePartitionColList
+      ),
+      confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
+    )
+
+    testInserts(s"insert with extra nested field and implicit cast," +
+      s"schemaEvolution=$schemaEvolution")(
+      initialData = TestData("a int, s struct <x: int>", Seq("""{ "a": 1, "s": { "x": 2 } }""")),
+      partitionBy = Seq("a"),
+      overwriteWhere = "a" -> 1,
+      insertData = TestData("a int, s struct <x: long, y: int>",
+        Seq("""{ "a": 1, "s": { "x": 4, "y": 5 } }""")),
+      expectedResult = ExpectedResult.Failure(ex => {
+        checkError(
+          ex,
+          "DELTA_FAILED_TO_MERGE_FIELDS",
+          parameters = Map(
+            "currentField" -> "s",
+            "updateField" -> "s"
+          ))
+      }),
+      includeInserts = insertsDataframe.intersect(insertsByName),
+      confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
+    )
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
@@ -16,13 +16,15 @@
 
 package org.apache.spark.sql.delta
 
+import scala.collection.mutable
+
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 
 import org.apache.spark.{DebugFilesystem, SparkThrowable}
 import org.apache.spark.sql.{DataFrame, QueryTest, SaveMode}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.functions.{col, lit}
-import org.apache.spark.sql.streaming.Trigger
+import org.apache.spark.sql.streaming.{StreamingQueryException, Trigger}
 import org.apache.spark.sql.types.StructType
 
 /**
@@ -38,13 +40,18 @@ trait DeltaInsertIntoTest extends QueryTest with DeltaDMLTestUtils with DeltaSQL
 
   /**
    * Represents one way of inserting data into a Delta table.
+   * @param name A human-readable name for the insert type displayed in the test names.
    * @param mode Append or Overwrite. This dictates in particular what the expected result after the
    *             insert should be.
-   * @param name A human-readable name for the insert type displayed in the test names.
+   * @param byName Whether the insert uses name-based resolution or position-based resolution.
+   * @param isSQL Whether the insert is done using SQL or the dataframe API (includes streaming
+   *              write).
    */
   trait Insert {
-    val mode: SaveMode
     val name: String
+    val mode: SaveMode
+    val byName: Boolean
+    val isSQL: Boolean
 
     /**
      * The method that tests will call to run the insert. Each type of insert must implement its
@@ -56,14 +63,19 @@ trait DeltaInsertIntoTest extends QueryTest with DeltaDMLTestUtils with DeltaSQL
     def intoOrOverwrite: String = if (mode == SaveMode.Append) "INTO" else "OVERWRITE"
 
     /** The expected content of the table after the insert. */
-    def expectedResult(initialDF: DataFrame, insertedDF: DataFrame): DataFrame =
-      if (mode == SaveMode.Overwrite) insertedDF
-      else initialDF.unionByName(insertedDF, allowMissingColumns = true)
+    def expectedResult(initialDF: DataFrame, insertedDF: DataFrame): DataFrame = {
+      // Always union with the initial data even if we're overwriting it to ensure the resulting
+      // schema contains all columns from the table in case some are missing in `insertedDF`.
+      val initial = if (mode == SaveMode.Overwrite) initialDF.limit(0) else initialDF
+      initial.unionByName(insertedDF, allowMissingColumns = true)
+    }
   }
 
   /** INSERT INTO/OVERWRITE */
   case class SQLInsertByPosition(mode: SaveMode) extends Insert {
     val name: String = s"INSERT $intoOrOverwrite"
+    val byName: Boolean = false
+    val isSQL: Boolean = true
     def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit =
       sql(s"INSERT $intoOrOverwrite target SELECT * FROM source")
   }
@@ -71,6 +83,8 @@ trait DeltaInsertIntoTest extends QueryTest with DeltaDMLTestUtils with DeltaSQL
   /** INSERT INTO/OVERWRITE (a, b) */
   case class SQLInsertColList(mode: SaveMode) extends Insert {
     val name: String = s"INSERT $intoOrOverwrite (columns) - $mode"
+    val byName: Boolean = true
+    val isSQL: Boolean = true
     def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit = {
       val colList = columns.mkString(", ")
       sql(s"INSERT $intoOrOverwrite target ($colList) SELECT $colList FROM source")
@@ -80,14 +94,18 @@ trait DeltaInsertIntoTest extends QueryTest with DeltaDMLTestUtils with DeltaSQL
   /** INSERT INTO/OVERWRITE BY NAME */
   case class SQLInsertByName(mode: SaveMode) extends Insert {
     val name: String = s"INSERT $intoOrOverwrite BY NAME - $mode"
+    val byName: Boolean = true
+    val isSQL: Boolean = true
     def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit =
-      sql(s"INSERT $intoOrOverwrite target SELECT ${columns.mkString(", ")} FROM source")
+      sql(s"INSERT $intoOrOverwrite target BY NAME SELECT ${columns.mkString(", ")} FROM source")
   }
 
   /** INSERT INTO REPLACE WHERE */
   object SQLInsertOverwriteReplaceWhere extends Insert {
-    val mode: SaveMode = SaveMode.Overwrite
     val name: String = s"INSERT INTO REPLACE WHERE"
+    val mode: SaveMode = SaveMode.Overwrite
+    val byName: Boolean = false
+    val isSQL: Boolean = true
     def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit =
       sql(s"INSERT INTO target REPLACE WHERE $whereCol = $whereValue " +
           s"SELECT ${columns.mkString(", ")} FROM source")
@@ -95,8 +113,10 @@ trait DeltaInsertIntoTest extends QueryTest with DeltaDMLTestUtils with DeltaSQL
 
   /** INSERT OVERWRITE PARTITION (part = 1) */
   object SQLInsertOverwritePartitionByPosition extends Insert {
-    val mode: SaveMode = SaveMode.Overwrite
     val name: String = s"INSERT OVERWRITE PARTITION (partition)"
+    val mode: SaveMode = SaveMode.Overwrite
+    val byName: Boolean = false
+    val isSQL: Boolean = true
     def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit = {
       val assignments = columns.filterNot(_ == whereCol).mkString(", ")
       sql(s"INSERT OVERWRITE target PARTITION ($whereCol = $whereValue) " +
@@ -106,8 +126,10 @@ trait DeltaInsertIntoTest extends QueryTest with DeltaDMLTestUtils with DeltaSQL
 
   /** INSERT OVERWRITE PARTITION (part = 1) (a, b) */
   object SQLInsertOverwritePartitionColList extends Insert {
-    val mode: SaveMode = SaveMode.Overwrite
     val name: String = s"INSERT OVERWRITE PARTITION (partition) (columns)"
+    val mode: SaveMode = SaveMode.Overwrite
+    val byName: Boolean = true
+    val isSQL: Boolean = true
     def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit = {
       val assignments = columns.filterNot(_ == whereCol).mkString(", ")
       sql(s"INSERT OVERWRITE target PARTITION ($whereCol = $whereValue) ($assignments) " +
@@ -118,6 +140,8 @@ trait DeltaInsertIntoTest extends QueryTest with DeltaDMLTestUtils with DeltaSQL
   /** df.write.mode(mode).insertInto() */
   case class DFv1InsertInto(mode: SaveMode) extends Insert {
     val name: String = s"DFv1 insertInto() - $mode"
+    val byName: Boolean = false
+    val isSQL: Boolean = false
     def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit =
       spark.read.table("source").write.mode(mode).insertInto("target")
   }
@@ -125,6 +149,8 @@ trait DeltaInsertIntoTest extends QueryTest with DeltaDMLTestUtils with DeltaSQL
   /** df.write.mode(mode).saveAsTable() */
   case class DFv1SaveAsTable(mode: SaveMode) extends Insert {
     val name: String = s"DFv1 saveAsTable() - $mode"
+    val byName: Boolean = true
+    val isSQL: Boolean = false
     def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit = {
       spark.read.table("source").write.mode(mode).format("delta").saveAsTable("target")
     }
@@ -133,16 +159,33 @@ trait DeltaInsertIntoTest extends QueryTest with DeltaDMLTestUtils with DeltaSQL
   /** df.write.mode(mode).save() */
   case class DFv1Save(mode: SaveMode) extends Insert {
     val name: String = s"DFv1 save() - $mode"
+    val byName: Boolean = true
+    val isSQL: Boolean = false
     def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit = {
       val deltaLog = DeltaLog.forTable(spark, TableIdentifier("target"))
       spark.read.table("source").write.mode(mode).format("delta").save(deltaLog.dataPath.toString)
     }
   }
 
+  /** df.write.mode(mode).option("partitionOverwriteMode", "dynamic").insertInto() */
+  object DFv1InsertIntoDynamicPartitionOverwrite extends Insert {
+    val name: String = s"DFv1 insertInto() - dynamic partition overwrite"
+    val mode: SaveMode = SaveMode.Overwrite
+    val byName: Boolean = false
+    val isSQL: Boolean = false
+    def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit =
+      spark.read.table("source").write
+        .mode(mode)
+        .option("partitionOverwriteMode", "dynamic")
+        .insertInto("target")
+  }
+
   /** df.writeTo.append() */
   object DFv2Append extends Insert { self: Insert =>
-    val mode: SaveMode = SaveMode.Append
     val name: String = "DFv2 append()"
+    val mode: SaveMode = SaveMode.Append
+    val byName: Boolean = true
+    val isSQL: Boolean = false
     def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit = {
       spark.read.table("source").writeTo("target").append()
     }
@@ -150,8 +193,10 @@ trait DeltaInsertIntoTest extends QueryTest with DeltaDMLTestUtils with DeltaSQL
 
   /** df.writeTo.overwrite() */
   object DFv2Overwrite extends Insert { self: Insert =>
-    val mode: SaveMode = SaveMode.Overwrite
     val name: String = s"DFv2 overwrite()"
+    val mode: SaveMode = SaveMode.Overwrite
+    val byName: Boolean = true
+    val isSQL: Boolean = false
     def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit = {
       spark.read.table("source").writeTo("target").overwrite(col(whereCol) === lit(whereValue))
     }
@@ -159,8 +204,10 @@ trait DeltaInsertIntoTest extends QueryTest with DeltaDMLTestUtils with DeltaSQL
 
   /** df.writeTo.overwritePartitions() */
   object DFv2OverwritePartition extends Insert { self: Insert =>
-    override val mode: SaveMode = SaveMode.Overwrite
     val name: String = s"DFv2 overwritePartitions()"
+    override val mode: SaveMode = SaveMode.Overwrite
+    val byName: Boolean = true
+    val isSQL: Boolean = false
     def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit = {
       spark.read.table("source").writeTo("target").overwritePartitions()
     }
@@ -168,8 +215,10 @@ trait DeltaInsertIntoTest extends QueryTest with DeltaDMLTestUtils with DeltaSQL
 
   /** df.writeStream.toTable() */
   object StreamingInsert extends Insert { self: Insert =>
-    override val mode: SaveMode = SaveMode.Append
     val name: String = s"Streaming toTable()"
+    override val mode: SaveMode = SaveMode.Append
+    val byName: Boolean = true
+    val isSQL: Boolean = false
     def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit = {
       val tablePath = DeltaLog.forTable(spark, TableIdentifier("target")).dataPath
       val query = spark.readStream
@@ -184,10 +233,11 @@ trait DeltaInsertIntoTest extends QueryTest with DeltaDMLTestUtils with DeltaSQL
   }
 
   /** Collects all the types of insert previously defined. */
-  protected lazy val allInsertTypes: Seq[Insert] = Seq(
+  protected lazy val allInsertTypes: Set[Insert] = Set(
         SQLInsertOverwriteReplaceWhere,
         SQLInsertOverwritePartitionByPosition,
         SQLInsertOverwritePartitionColList,
+        DFv1InsertIntoDynamicPartitionOverwrite,
         DFv2Append,
         DFv2Overwrite,
         DFv2OverwritePartition,
@@ -202,68 +252,117 @@ trait DeltaInsertIntoTest extends QueryTest with DeltaDMLTestUtils with DeltaSQL
         DFv1SaveAsTable(mode),
         DFv1Save(mode)
       )
-    } yield insert)
+    } yield insert).toSet
+
+  /** Collects inserts using resolution by name and by position respectively. */
+  protected lazy val (insertsByName, insertsByPosition): (Set[Insert], Set[Insert]) =
+    allInsertTypes.partition(_.byName)
+
+  /** Collects inserts run through SQL and the dataframe API respectively. */
+  protected lazy val (insertsSQL, insertsDataframe): (Set[Insert], Set[Insert]) =
+    allInsertTypes.partition(_.isSQL)
+
+  /** Collects append inserts vs. overwrite. */
+  protected lazy val (insertsAppend, insertsOverwrite): (Set[Insert], Set[Insert]) =
+    allInsertTypes.partition(_.mode == SaveMode.Append)
+
+  /** Collects all test cases defined, aggregated by test name. Used in
+   * [[checkAllTestCasesImplemented]] below to ensure each test covers all existing insert types.
+   */
+  protected val testCases: mutable.Map[String, Set[Insert]] =
+    mutable.HashMap.empty.withDefaultValue(Set.empty)
+
+  /** Tests should cover all insert types but it's easy to miss some cases. This method checks
+   * that each test cover all insert types.
+   */
+  def checkAllTestCasesImplemented(ignoredTestCases: Map[String, Set[Insert]] = Map.empty): Unit = {
+    val ignoredTests = ignoredTestCases.withDefaultValue(Set.empty)
+    val missingTests = testCases.map {
+      case (name, inserts) => name -> (allInsertTypes -- inserts -- ignoredTests(name))
+    }.collect {
+      case (name, missingInserts) if missingInserts.nonEmpty =>
+        s"Test '$name' is not covering all insert types, missing: $missingInserts"
+    }
+
+    if (missingTests.nonEmpty) {
+      fail("Missing test cases:\n" + missingTests)
+    }
+  }
+
+  /** Convenience wrapper define test data using a SQL schema and a JSON string for each row. */
+  case class TestData(schemaDDL: String, data: Seq[String]) {
+    val schema: StructType = StructType.fromDDL(schemaDDL)
+    def toDF: DataFrame = readFromJSON(data, schema)
+  }
 
   /**
    * Test runner to cover INSERT operations defined above.
-   * @param name             Test name
-   * @param initialSchemaDDL Initial schema of the table to be inserted into (as a DDL string).
-   * @param initialJsonData  Initial data present in the table to be inserted into (as a JSON
-   *                         string).
-   * @param partitionBy      Partition columns for the initial table.
-   * @param insertSchemaDDL  Schema of the data to be inserted (as a DDL string).
-   * @param insertJsonData   Data to be inserted (as a JSON string)
-   * @param overwriteWhere   Where clause for overwrite PARTITION / REPLACE WHERE (as
-   *                         colName -> value)
-   * @param expectedResult   Expected result, see [[ExpectedResult]] above.
-   * @param includeInserts   List of insert types to run the test with. Defaults to all inserts.
-   * @param excludeInserts   List of insert types to exclude when running the test. Defaults to no
-   *                         inserts excluded.
-   * @param confs            Custom spark confs to set before running the insert operation.
+   * @param name           Test name
+   * @param initialData    Initial data used to create the table.
+   * @param partitionBy    Partition columns for the initial table.
+   * @param insertData     Additional data to be inserted.
+   * @param overwriteWhere Where clause for overwrite PARTITION / REPLACE WHERE (as
+   *                       colName -> value)
+   * @param expectedResult Expected result, see [[ExpectedResult]] above.
+   * @param includeInserts List of insert types to run the test with. Defaults to all inserts.
+   * @param excludeInserts List of insert types to exclude when running the test. Defaults to no
+   *                       inserts excluded.
+   * @param confs          Custom spark confs to set before running the insert operation.
    */
-  // scalastyle:off argcount
-  def testInserts(name: String)(
-      initialSchemaDDL: String,
-      initialJsonData: Seq[String],
+  def testInserts[T](name: String)(
+      initialData: TestData,
       partitionBy: Seq[String] = Seq.empty,
-      insertSchemaDDL: String,
-      insertJsonData: Seq[String],
+      insertData: TestData,
       overwriteWhere: (String, Int),
-      expectedResult: ExpectedResult[StructType],
-      includeInserts: Seq[Insert] = allInsertTypes,
-      excludeInserts: Seq[Insert] = Seq.empty,
+      expectedResult: ExpectedResult[T],
+      includeInserts: Set[Insert] = allInsertTypes,
+      excludeInserts: Set[Insert] = Set.empty,
       confs: Seq[(String, String)] = Seq.empty): Unit = {
-    for (insert <- includeInserts.filterNot(excludeInserts.toSet)) {
+    val inserts = includeInserts.filterNot(excludeInserts)
+    assert(inserts.nonEmpty, s"Test '$name' doesn't cover any inserts. Please check the " +
+      "includeInserts/excludeInserts sets and ensure at least one insert is included.")
+    testCases(name) ++= inserts
+
+    for (insert <- inserts) {
       test(s"${insert.name} - $name") {
         withTable("source", "target") {
-          val initialDF = readFromJSON(initialJsonData, StructType.fromDDL(initialSchemaDDL))
-          val writer = initialDF.write.format("delta")
+          val writer = initialData.toDF.write.format("delta")
           if (partitionBy.nonEmpty) {
             writer.partitionBy(partitionBy: _*)
           }
           writer.saveAsTable("target")
           // Write the data to insert to a table so that we can use it in both SQL and dataframe
           // writer inserts.
-          val insertDF = readFromJSON(insertJsonData, StructType.fromDDL(insertSchemaDDL))
-          insertDF.write.format("delta").saveAsTable("source")
+          insertData.toDF.write.format("delta").saveAsTable("source")
 
           def runInsert(): Unit =
             insert.runInsert(
-              columns = insertDF.schema.map(_.name),
+              columns = insertData.schema.map(_.name),
               whereCol = overwriteWhere._1,
               whereValue = overwriteWhere._2
             )
 
           withSQLConf(confs: _*) {
             expectedResult match {
-              case ExpectedResult.Success(expectedSchema) =>
+              case ExpectedResult.Success(expectedSchema: StructType) =>
                 runInsert()
                 val target = spark.read.table("target")
                 assert(target.schema === expectedSchema)
-                checkAnswer(target, insert.expectedResult(initialDF, insertDF))
+                checkAnswer(target, insert.expectedResult(initialData.toDF, insertData.toDF))
+              case ExpectedResult.Success(expectedData: TestData) =>
+                runInsert()
+                val target = spark.read.table("target")
+                assert(target.schema === expectedData.schema)
+                checkAnswer(spark.read.table("target"), expectedData.toDF)
               case ExpectedResult.Failure(checkError) =>
-                val ex = intercept[SparkThrowable] {
-                  runInsert()
+                val ex = if (insert == StreamingInsert) {
+                  intercept[StreamingQueryException] {
+                    runInsert()
+                  }.getCause.asInstanceOf[SparkThrowable]
+                } else {
+                  intercept[SparkThrowable] {
+                    runInsert()
+                  }
                 }
                 checkError(ex)
             }
@@ -272,5 +371,4 @@ trait DeltaInsertIntoTest extends QueryTest with DeltaDMLTestUtils with DeltaSQL
       }
     }
   }
-  // scalastyle:on argcount
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -246,7 +246,7 @@ trait DeltaTestUtilsBase {
    * - Failure: an exception is thrown and the caller passes a function to check that it matches an
    *     expected error, typ. `checkError()` or `checkErrorMatchPVals()`.
    */
-  sealed trait ExpectedResult[T]
+  sealed trait ExpectedResult[-T]
   object ExpectedResult {
     case class Success[T](expected: T) extends ExpectedResult[T]
     case class Failure[T](checkError: SparkThrowable => Unit) extends ExpectedResult[T]

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
@@ -3140,7 +3140,7 @@ abstract class MergeIntoSuiteBase
                 runMerge()
               }
               checkError(ex)
-            case ExpectedResult.Success(expectedRows) =>
+            case ExpectedResult.Success(expectedRows: Seq[Row]) =>
               if (checkViewStripped) {
                 checkStripViewFromTarget(target = "v")
               }


### PR DESCRIPTION
## Description
Follow on https://github.com/delta-io/delta/pull/3605

Adds more tests covering behavior for all ways of running insert with:
- an extra column or struct field in the input, in `DeltaInsertIntoSchemaEvolutionSuite`
- a missing column or struct field in the input, in `DeltaInsertIntoImplicitCastSuite`
- a different column or field ordering than the table schema, in `DeltaInsertIntoColumnOrderSuite`

Note: tests are spread across multiple suites as each test case covers 20 different ways to run inserts, quickly leading to large test suites.

This change includes improvements to `DeltaInsertIntoTest`:
- Group all types of inserts into categories that are easier to reference in tests:
  - SQL vs. Dataframe inserts
  - Position-based vs. name-based inserts
  - Append vs. overwrite
- Provide a mechanism to ensure that each test covers all existing insert types.

## How was this patch tested?
N/A: test only
