### PR TITLE
[Spark] Writing of UUID commits should not use put-if-absent semantics

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
@@ -43,7 +43,7 @@ import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 import org.apache.spark.sql.delta.util.{FileNames, JsonUtils}
 import org.apache.spark.sql.delta.util.FileNames.{CompactedDeltaFile, DeltaFile, UnbackfilledDeltaFile}
 import io.delta.storage.LogStore
-import io.delta.storage.commit.{CommitCoordinatorClient, CommitResponse, GetCommitsResponse => JGetCommitsResponse, TableDescriptor, TableIdentifier, UpdatedActions}
+import io.delta.storage.commit.{CommitCoordinatorClient, CommitResponse, CoordinatedCommitsUtils => JCoordinatedCommitsUtils, GetCommitsResponse => JGetCommitsResponse, TableDescriptor, TableIdentifier, UpdatedActions}
 import io.delta.storage.commit.actions.{AbstractMetadata, AbstractProtocol}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
@@ -79,27 +79,23 @@ class CoordinatedCommitsSuite
     val m1 = Metadata(
       configuration = Map(COORDINATED_COMMITS_COORDINATOR_NAME.key -> "string_value")
     )
-    assert(CoordinatedCommitsUtils.fromAbstractMetadataAndDeltaConfig(
-      m1, COORDINATED_COMMITS_COORDINATOR_NAME) === Some("string_value"))
+    assert(JCoordinatedCommitsUtils.getCoordinatorName(m1) === Optional.of("string_value"))
 
     val m2 = Metadata(
       configuration = Map(COORDINATED_COMMITS_COORDINATOR_NAME.key -> "")
     )
-    assert(CoordinatedCommitsUtils.fromAbstractMetadataAndDeltaConfig(
-      m2, COORDINATED_COMMITS_COORDINATOR_NAME) === Some(""))
+    assert(JCoordinatedCommitsUtils.getCoordinatorName(m2)=== Optional.of(""))
 
     val m3 = Metadata(
       configuration = Map(
         COORDINATED_COMMITS_COORDINATOR_CONF.key ->
           """{"key1": "string_value", "key2Int": 2, "key3ComplexStr": "\"hello\""}""")
     )
-    assert(CoordinatedCommitsUtils.fromAbstractMetadataAndDeltaConfig(
-      m3, COORDINATED_COMMITS_COORDINATOR_CONF) ===
-      Map("key1" -> "string_value", "key2Int" -> "2", "key3ComplexStr" -> "\"hello\""))
+    assert(JCoordinatedCommitsUtils.getCoordinatorConf(m3) ===
+      Map("key1" -> "string_value", "key2Int" -> "2", "key3ComplexStr" -> "\"hello\"").asJava)
 
     val m4 = Metadata()
-    assert(CoordinatedCommitsUtils.fromAbstractMetadataAndDeltaConfig(
-      m4, COORDINATED_COMMITS_TABLE_CONF) === Map.empty)
+    assert(JCoordinatedCommitsUtils.getCoordinatorConf(m4) === Map.empty.asJava)
   }
 
 

--- a/storage/src/test/scala/io/delta/storage/commit/InMemoryCommitCoordinator.scala
+++ b/storage/src/test/scala/io/delta/storage/commit/InMemoryCommitCoordinator.scala
@@ -122,7 +122,7 @@ class InMemoryCommitCoordinator(val batchSize: Long) extends CommitCoordinatorCl
       backfillToVersion(logStore, hadoopConf, tableDesc, commitVersion - 1, null)
     }
     // Write new commit file in _commits directory
-    val fileStatus = CoordinatedCommitsUtils.writeCommitFile(
+    val fileStatus = CoordinatedCommitsUtils.writeUnbackfilledCommitFile(
       logStore, hadoopConf, logPath.toString, commitVersion, actions, generateUUID())
     // Do the actual commit
     val commitTimestamp = updatedActions.getCommitInfo.getCommitTimestamp


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR fixes the coordinated commits utils to not write UUID-based commit files with put-if-absent semantics. This is not necessary because we assume that UUID-based commit files are globally unique so we will never have concurrent writers attempting to write the same commit file.

DynamoDBCommitCoordinator also now uses the utils for writing backfilled files.

## How was this patch tested?

Existing tests are sufficient as this only affects how a commit is
written in the underlying storage layer but does not change any logic in
Delta Spark.

## Does this PR introduce _any_ user-facing changes?

No
