### PR TITLE
Use getCondition instead of the deprecated getErrorClass from SparkThrowable

### DIFF
--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/CloneIcebergSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/CloneIcebergSuite.scala
@@ -436,7 +436,7 @@ class CloneIcebergByNameSuite extends CloneIcebergSuiteBase
           val e = intercept[DeltaIllegalStateException] {
             runCreateOrReplace("SHALLOW", sourceIdentifier)
           }
-          assert(e.getErrorClass == "DELTA_MISSING_ICEBERG_CLASS")
+          assert(e.getCondition == "DELTA_MISSING_ICEBERG_CLASS")
         }
       } finally {
         ConvertUtils.icebergSparkTableClassPath = validIcebergSparkTableClassPath

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/ConvertIcebergToDeltaSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/ConvertIcebergToDeltaSuite.scala
@@ -196,7 +196,7 @@ trait ConvertIcebergToDeltaSuiteBase
           val e = intercept[DeltaIllegalStateException] {
             convert(s"iceberg.`$tablePath`")
           }
-          assert(e.getErrorClass == "DELTA_MISSING_ICEBERG_CLASS")
+          assert(e.getCondition == "DELTA_MISSING_ICEBERG_CLASS")
         }
       } finally {
         ConvertUtils.icebergSparkTableClassPath = validIcebergSparkTableClassPath

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaFormatSharingSourceSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaFormatSharingSourceSuite.scala
@@ -1167,7 +1167,7 @@ class DeltaFormatSharingSourceSuite
             var e = intercept[StreamingQueryException] {
               processAllAvailableInStream(0)
             }
-            assert(e.getCause.asInstanceOf[DeltaIllegalStateException].getErrorClass
+            assert(e.getCause.asInstanceOf[DeltaIllegalStateException].getCondition
               == "DELTA_SCHEMA_CHANGED_WITH_STARTING_OPTIONS")
             assert(e.getMessage.contains("Detected schema change in version 3"))
 

--- a/spark/src/main/scala/io/delta/exceptions/DeltaConcurrentExceptions.scala
+++ b/spark/src/main/scala/io/delta/exceptions/DeltaConcurrentExceptions.scala
@@ -46,7 +46,7 @@ class ConcurrentWriteException(message: String)
   def this(messageParameters: Array[String]) = {
     this(DeltaThrowableHelper.getMessage("DELTA_CONCURRENT_WRITE", messageParameters))
   }
-  override def getErrorClass: String = "DELTA_CONCURRENT_WRITE"
+  override def getCondition: String = "DELTA_CONCURRENT_WRITE"
   override def getMessage: String = message
 }
 
@@ -65,7 +65,7 @@ class MetadataChangedException(message: String)
   def this(messageParameters: Array[String]) = {
     this(DeltaThrowableHelper.getMessage("DELTA_METADATA_CHANGED", messageParameters))
   }
-  override def getErrorClass: String = "DELTA_METADATA_CHANGED"
+  override def getCondition: String = "DELTA_METADATA_CHANGED"
   override def getMessage: String = message
 }
 
@@ -84,7 +84,7 @@ class ProtocolChangedException(message: String)
   def this(messageParameters: Array[String]) = {
     this(DeltaThrowableHelper.getMessage("DELTA_PROTOCOL_CHANGED", messageParameters))
   }
-  override def getErrorClass: String = "DELTA_PROTOCOL_CHANGED"
+  override def getCondition: String = "DELTA_PROTOCOL_CHANGED"
   override def getMessage: String = message
 }
 
@@ -102,7 +102,7 @@ class ConcurrentAppendException(message: String)
   def this(messageParameters: Array[String]) = {
     this(DeltaThrowableHelper.getMessage("DELTA_CONCURRENT_APPEND", messageParameters))
   }
-  override def getErrorClass: String = "DELTA_CONCURRENT_APPEND"
+  override def getCondition: String = "DELTA_CONCURRENT_APPEND"
   override def getMessage: String = message
 }
 
@@ -120,7 +120,7 @@ class ConcurrentDeleteReadException(message: String)
   def this(messageParameters: Array[String]) = {
     this(DeltaThrowableHelper.getMessage("DELTA_CONCURRENT_DELETE_READ", messageParameters))
   }
-  override def getErrorClass: String = "DELTA_CONCURRENT_DELETE_READ"
+  override def getCondition: String = "DELTA_CONCURRENT_DELETE_READ"
   override def getMessage: String = message
 }
 
@@ -138,7 +138,7 @@ class ConcurrentDeleteDeleteException(message: String)
   def this(messageParameters: Array[String]) = {
     this(DeltaThrowableHelper.getMessage("DELTA_CONCURRENT_DELETE_DELETE", messageParameters))
   }
-  override def getErrorClass: String = "DELTA_CONCURRENT_DELETE_DELETE"
+  override def getCondition: String = "DELTA_CONCURRENT_DELETE_DELETE"
   override def getMessage: String = message
 }
 
@@ -156,6 +156,6 @@ class ConcurrentTransactionException(message: String)
   def this(messageParameters: Array[String]) = {
     this(DeltaThrowableHelper.getMessage("DELTA_CONCURRENT_TRANSACTION", messageParameters))
   }
-  override def getErrorClass: String = "DELTA_CONCURRENT_TRANSACTION"
+  override def getCondition: String = "DELTA_CONCURRENT_TRANSACTION"
   override def getMessage: String = message
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3693,7 +3693,7 @@ class DeltaColumnMappingUnsupportedException(
   extends ColumnMappingUnsupportedException(
     DeltaThrowableHelper.getMessage(errorClass, messageParameters))
     with DeltaThrowable {
-  override def getErrorClass: String = errorClass
+  override def getCondition: String = errorClass
 }
 
 class DeltaFileNotFoundException(
@@ -3702,7 +3702,7 @@ class DeltaFileNotFoundException(
   extends FileNotFoundException(
     DeltaThrowableHelper.getMessage(errorClass, messageParameters))
     with DeltaThrowable {
-  override def getErrorClass: String = errorClass
+  override def getCondition: String = errorClass
 }
 
 class DeltaFileAlreadyExistsException(
@@ -3711,7 +3711,7 @@ class DeltaFileAlreadyExistsException(
   extends FileAlreadyExistsException(
     DeltaThrowableHelper.getMessage(errorClass, messageParameters))
     with DeltaThrowable {
-  override def getErrorClass: String = errorClass
+  override def getCondition: String = errorClass
 }
 
 class DeltaIOException(
@@ -3721,7 +3721,7 @@ class DeltaIOException(
   extends IOException(
     DeltaThrowableHelper.getMessage(errorClass, messageParameters), cause)
     with DeltaThrowable {
-  override def getErrorClass: String = errorClass
+  override def getCondition: String = errorClass
 }
 
 class DeltaIllegalStateException(
@@ -3731,7 +3731,7 @@ class DeltaIllegalStateException(
   extends IllegalStateException(
     DeltaThrowableHelper.getMessage(errorClass, messageParameters), cause)
     with DeltaThrowable {
-  override def getErrorClass: String = errorClass
+  override def getCondition: String = errorClass
 
   override def getMessageParameters: java.util.Map[String, String] = {
     DeltaThrowableHelper.getParameterNames(errorClass, null)
@@ -3745,7 +3745,7 @@ class DeltaIndexOutOfBoundsException(
   extends IndexOutOfBoundsException(
     DeltaThrowableHelper.getMessage(errorClass, messageParameters))
     with DeltaThrowable {
-  override def getErrorClass: String = errorClass
+  override def getCondition: String = errorClass
 }
 
 /** Thrown when the protocol version of a table is greater than supported by this client. */
@@ -3765,7 +3765,7 @@ case class InvalidProtocolVersionException(
       supportedReaderVersions.sorted.mkString(", "),
       supportedWriterVersions.sorted.mkString(", "))))
   with DeltaThrowable {
-  override def getErrorClass: String = "DELTA_INVALID_PROTOCOL_VERSION"
+  override def getCondition: String = "DELTA_INVALID_PROTOCOL_VERSION"
 }
 
 class ProtocolDowngradeException(oldProtocol: Protocol, newProtocol: Protocol)
@@ -3773,7 +3773,7 @@ class ProtocolDowngradeException(oldProtocol: Protocol, newProtocol: Protocol)
     errorClass = "DELTA_INVALID_PROTOCOL_DOWNGRADE",
     messageParameters = Array(s"(${oldProtocol.simpleString})", s"(${newProtocol.simpleString})")
   )) with DeltaThrowable {
-  override def getErrorClass: String = "DELTA_INVALID_PROTOCOL_DOWNGRADE"
+  override def getCondition: String = "DELTA_INVALID_PROTOCOL_DOWNGRADE"
 }
 
 class DeltaTableFeatureException(
@@ -3795,7 +3795,7 @@ class DeltaRuntimeException(
   extends RuntimeException(
     DeltaThrowableHelper.getMessage(errorClass, messageParameters))
     with DeltaThrowable {
-  override def getErrorClass: String = errorClass
+  override def getCondition: String = errorClass
 
   override def getMessageParameters: java.util.Map[String, String] =
     DeltaThrowableHelper.getParameterNames(errorClass, null)
@@ -3809,7 +3809,7 @@ class DeltaSparkException(
   extends SparkException(
     DeltaThrowableHelper.getMessage(errorClass, messageParameters), cause)
     with DeltaThrowable {
-  override def getErrorClass: String = errorClass
+  override def getCondition: String = errorClass
 }
 
 class DeltaNoSuchTableException(
@@ -3818,7 +3818,7 @@ class DeltaNoSuchTableException(
   extends AnalysisException(
     DeltaThrowableHelper.getMessage(errorClass, messageParameters))
     with DeltaThrowable {
-  override def getErrorClass: String = errorClass
+  override def getCondition: String = errorClass
 }
 
 class DeltaCommandUnsupportedWithDeletionVectorsException(
@@ -3827,7 +3827,7 @@ class DeltaCommandUnsupportedWithDeletionVectorsException(
   extends UnsupportedOperationException(
     DeltaThrowableHelper.getMessage(errorClass, messageParameters))
     with DeltaThrowable {
-  override def getErrorClass: String = errorClass
+  override def getCondition: String = errorClass
 }
 
 sealed trait DeltaTablePropertyValidationFailedSubClass {
@@ -3867,7 +3867,7 @@ class DeltaTablePropertyValidationFailedException(
       subClass.tag).zip(subClass.messageParameters(table)).toMap.asJava
   }
 
-  override def getErrorClass: String =
+  override def getCondition: String =
     "DELTA_VIOLATE_TABLE_PROPERTY_VALIDATION_FAILED." + subClass.tag
 }
 
@@ -3884,7 +3884,7 @@ class DeltaChecksumException(
   extends ChecksumException(
     DeltaThrowableHelper.getMessage(errorClass, messageParameters), pos)
     with DeltaThrowable {
-  override def getErrorClass: String = errorClass
+  override def getCondition: String = errorClass
 }
 
 /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaSharedExceptions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaSharedExceptions.scala
@@ -51,7 +51,7 @@ class DeltaIllegalArgumentException(
   extends IllegalArgumentException(
       DeltaThrowableHelper.getMessage(errorClass, messageParameters), cause)
     with DeltaThrowable {
-    override def getErrorClass: String = errorClass
+    override def getCondition: String = errorClass
   def getMessageParametersArray: Array[String] = messageParameters
 
   override def getMessageParameters: java.util.Map[String, String] = {
@@ -66,7 +66,7 @@ class DeltaUnsupportedOperationException(
   extends UnsupportedOperationException(
       DeltaThrowableHelper.getMessage(errorClass, messageParameters))
     with DeltaThrowable {
-  override def getErrorClass: String = errorClass
+  override def getCondition: String = errorClass
   def getMessageParametersArray: Array[String] = messageParameters
 
   override def getMessageParameters: java.util.Map[String, String] = {
@@ -93,7 +93,7 @@ class DeltaArithmeticException(
   extends ArithmeticException(
       DeltaThrowableHelper.getMessage(errorClass, messageParameters))
     with DeltaThrowable {
-  override def getErrorClass: String = errorClass
+  override def getCondition: String = errorClass
 
   override def getMessageParameters: java.util.Map[String, String] = {
     DeltaThrowableHelper.getParameterNames(errorClass, errorSubClass = null)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaThrowable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaThrowable.scala
@@ -25,8 +25,8 @@ trait DeltaThrowable extends SparkThrowable {
   // Portable error identifier across SQL engines
   // If null, error class or SQLSTATE is not set
   override def getSqlState: String =
-    DeltaThrowableHelper.getSqlState(this.getErrorClass.split('.').head)
+    DeltaThrowableHelper.getSqlState(this.getCondition.split('.').head)
 
   // True if this error is an internal error.
-  override def isInternalError: Boolean = DeltaThrowableHelper.isInternalError(this.getErrorClass)
+  override def isInternalError: Boolean = DeltaThrowableHelper.isInternalError(this.getCondition)
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/GeneratedColumn.scala
@@ -187,7 +187,7 @@ object GeneratedColumn extends DeltaLogging with AnalysisHelper {
     } catch {
       case ex: AnalysisException =>
         // Improve error message if possible
-        if (ex.getErrorClass == "UNRESOLVED_COLUMN.WITH_SUGGESTION") {
+        if (ex.getCondition == "UNRESOLVED_COLUMN.WITH_SUGGESTION") {
           throw DeltaErrors.generatedColumnsReferToWrongColumns(ex)
         }
         throw ex

--- a/spark/src/main/scala/org/apache/spark/sql/delta/metering/DeltaLogging.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/metering/DeltaLogging.scala
@@ -194,9 +194,9 @@ trait DeltaLogging
     var data = Map[String, Any]("exceptionMessage" -> e.getMessage)
     e condDo {
       case sparkEx: SparkThrowable
-        if sparkEx.getErrorClass != null && sparkEx.getErrorClass.nonEmpty =>
+        if sparkEx.getCondition != null && sparkEx.getCondition.nonEmpty =>
         data ++= Map(
-          "errorClass" -> sparkEx.getErrorClass,
+          "errorClass" -> sparkEx.getCondition,
           "sqlState" -> sparkEx.getSqlState
         )
       case NonFatal(e) if e.getCause != null =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/InvariantViolationException.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/InvariantViolationException.scala
@@ -123,7 +123,7 @@ class DeltaInvariantViolationException(
     messageParameters: Array[String])
   extends InvariantViolationException(
     DeltaThrowableHelper.getMessage(errorClass, messageParameters)) with DeltaThrowable {
-  override def getErrorClass: String = errorClass
+  override def getCondition: String = errorClass
 
   override def getMessageParameters: util.Map[String, String] = {
     DeltaThrowableHelper.getParameterNames(errorClass, errorSubClass = null)

--- a/spark/src/test/scala/io/delta/sql/DeltaExtensionAndCatalogSuite.scala
+++ b/spark/src/test/scala/io/delta/sql/DeltaExtensionAndCatalogSuite.scala
@@ -108,7 +108,7 @@ class DeltaExtensionAndCatalogSuite extends SparkFunSuite {
           DeltaLog.forTable(spark, path)
         }
         assert(e.isInstanceOf[DeltaAnalysisException])
-        assert(e.getErrorClass() == "DELTA_CONFIGURE_SPARK_SESSION_WITH_EXTENSION_AND_CATALOG")
+        assert(e.getCondition() == "DELTA_CONFIGURE_SPARK_SESSION_WITH_EXTENSION_AND_CATALOG")
       }
     }
   }

--- a/spark/src/test/scala/io/delta/tables/DeltaTableSuite.scala
+++ b/spark/src/test/scala/io/delta/tables/DeltaTableSuite.scala
@@ -666,7 +666,7 @@ class DeltaTableHadoopOptionsSuite extends QueryTest
       // update the protocol again with invalid feature name.
       assert(intercept[DeltaTableFeatureException] {
         table.addFeatureSupport("__invalid_feature__")
-      }.getErrorClass === "DELTA_UNSUPPORTED_FEATURES_IN_CONFIG")
+      }.getCondition === "DELTA_UNSUPPORTED_FEATURES_IN_CONFIG")
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableSuiteBase.scala
@@ -758,7 +758,7 @@ trait CloneTableSuiteBase extends QueryTest
         target,
         isShallow,
         tableProperties = Map(DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.key -> "false"))()
-    }.getErrorClass === "DELTA_ADDING_DELETION_VECTORS_DISALLOWED"
+    }.getCondition === "DELTA_ADDING_DELETION_VECTORS_DISALLOWED"
   }
 
   for(targetExists <- BOOLEAN_DOMAIN)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaAlterTableTests.scala
@@ -1934,7 +1934,7 @@ trait DeltaAlterTableByPathTests extends DeltaAlterTableTestBase {
         val e = intercept[DeltaAnalysisException] {
           sql(s"alter table $identifier set location '$path'")
         }
-        assert(e.getErrorClass == "DELTA_CANNOT_SET_LOCATION_ON_PATH_IDENTIFIER")
+        assert(e.getCondition == "DELTA_CANNOT_SET_LOCATION_ON_PATH_IDENTIFIER")
         assert(e.getSqlState == "42613")
         assert(e.getMessage == "[DELTA_CANNOT_SET_LOCATION_ON_PATH_IDENTIFIER] " +
           "Cannot change the location of a path based table.")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCColumnMappingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCColumnMappingSuite.scala
@@ -553,14 +553,14 @@ trait DeltaCDCColumnMappingSuiteBase extends DeltaCDCSuiteBase
       f
     }
     val (end, readSchemaJson) = if (bySchemaChange) {
-      assert(e.getErrorClass == "DELTA_CHANGE_DATA_FEED_INCOMPATIBLE_SCHEMA_CHANGE")
+      assert(e.getCondition == "DELTA_CHANGE_DATA_FEED_INCOMPATIBLE_SCHEMA_CHANGE")
       val Seq(_, end, readSchemaJson, readSchemaVersion, incompatibleVersion, _, _, _, _) =
         e.getMessageParametersArray.toSeq
       assert(incompatibleVersion.toLong == expectedIncompatSchemaVersion)
       assert(readSchemaVersion.toLong == expectedReadSchemaVersion)
       (end, readSchemaJson)
     } else {
-      assert(e.getErrorClass == "DELTA_CHANGE_DATA_FEED_INCOMPATIBLE_DATA_SCHEMA")
+      assert(e.getCondition == "DELTA_CHANGE_DATA_FEED_INCOMPATIBLE_DATA_SCHEMA")
       val Seq(_, end, readSchemaJson, readSchemaVersion, incompatibleVersion, config) =
         e.getMessageParametersArray.toSeq
       assert(incompatibleVersion.toLong == expectedIncompatSchemaVersion)
@@ -688,7 +688,7 @@ trait DeltaCDCColumnMappingScalaSuiteBase extends DeltaCDCColumnMappingSuiteBase
           EndingVersion("1"),
           readerOptions = Map(DeltaOptions.VERSION_AS_OF -> "0")).collect()
       }
-      assert(e.getErrorClass == "DELTA_UNSUPPORTED_TIME_TRAVEL_VIEWS")
+      assert(e.getCondition == "DELTA_UNSUPPORTED_TIME_TRAVEL_VIEWS")
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSQLSuite.scala
@@ -272,7 +272,7 @@ class DeltaCDCSQLSuite extends DeltaCDCSuiteBase with DeltaColumnMappingTestUtil
     e = intercept[AnalysisException] {
       sql(s"SELECT * FROM table_changes('invalidtable', 1, 1)")
     }
-    assert(e.getErrorClass === "TABLE_OR_VIEW_NOT_FOUND")
+    assert(e.getCondition === "TABLE_OR_VIEW_NOT_FOUND")
 
     withTable ("tbl") {
       spark.range(1).write.format("delta").saveAsTable("tbl")
@@ -332,13 +332,13 @@ class DeltaCDCSQLSuite extends DeltaCDCSuiteBase with DeltaColumnMappingTestUtil
         var e = intercept[AnalysisException] {
           spark.sql(s"SELECT * FROM table_changes('tbl', 0, 1)")
         }
-        assert(e.getErrorClass == "DELTA_TABLE_ONLY_OPERATION")
+        assert(e.getCondition == "DELTA_TABLE_ONLY_OPERATION")
         assert(e.getMessage.contains("table_changes"))
 
         e = intercept[AnalysisException] {
           spark.sql(s"SELECT * FROM table_changes_by_path('${dir.getAbsolutePath}', 0, 1)")
         }
-        assert(e.getErrorClass == "DELTA_MISSING_DELTA_TABLE")
+        assert(e.getCondition == "DELTA_MISSING_DELTA_TABLE")
         assert(e.getMessage.contains("not a Delta table"))
       }
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSuite.scala
@@ -397,7 +397,7 @@ abstract class DeltaCDCSuiteBase
           StartingTimestamp(ts0),
           EndingTimestamp(ts1))
           .collect()
-      }.getErrorClass === "DELTA_INVALID_CDC_RANGE"
+      }.getCondition === "DELTA_INVALID_CDC_RANGE"
     }
   }
 
@@ -418,7 +418,7 @@ abstract class DeltaCDCSuiteBase
           StartingTimestamp(ts0),
           EndingTimestamp(ts1))
           .collect()
-      }.getErrorClass === "DELTA_INVALID_CDC_RANGE"
+      }.getCondition === "DELTA_INVALID_CDC_RANGE"
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
@@ -743,7 +743,7 @@ class DeltaColumnMappingSuite extends QueryTest
               existingMetadata.configuration - DeltaConfigs.COLUMN_MAPPING_MAX_ID.key) :: Nil,
               DeltaOperations.ManualUpdate)
           }
-        }.getErrorClass == "DELTA_COLUMN_MAPPING_MAX_COLUMN_ID_NOT_SET"
+        }.getCondition == "DELTA_COLUMN_MAPPING_MAX_COLUMN_ID_NOT_SET"
       }
       // Use an invalid max column id prop
       assert {
@@ -757,7 +757,7 @@ class DeltaColumnMappingSuite extends QueryTest
               )) :: Nil,
               DeltaOperations.ManualUpdate)
           }
-        }.getErrorClass == "DELTA_COLUMN_MAPPING_MAX_COLUMN_ID_NOT_SET_CORRECTLY"
+        }.getCondition == "DELTA_COLUMN_MAPPING_MAX_COLUMN_ID_NOT_SET_CORRECTLY"
       }
     }
   }
@@ -1147,7 +1147,7 @@ class DeltaColumnMappingSuite extends QueryTest
       assert {
         intercept[DeltaAnalysisException] {
           df1.collect()
-        }.getErrorClass == "DELTA_SCHEMA_CHANGE_SINCE_ANALYSIS"
+        }.getCondition == "DELTA_SCHEMA_CHANGE_SINCE_ANALYSIS"
       }
       // See we can't read back the same data any more
       // Note: We need to use separate dataframe, because the error in df1 will be cached.
@@ -1820,7 +1820,7 @@ class DeltaColumnMappingSuite extends QueryTest
             assert {
               intercept[DeltaAnalysisException] {
                 oldDf.select("value").collect()
-              }.getErrorClass == "DELTA_SCHEMA_CHANGE_SINCE_ANALYSIS"
+              }.getCondition == "DELTA_SCHEMA_CHANGE_SINCE_ANALYSIS"
             }
           }
         }
@@ -1829,7 +1829,7 @@ class DeltaColumnMappingSuite extends QueryTest
         assert {
           intercept[DeltaAnalysisException] {
             oldDf.select("value").collect()
-          }.getErrorClass == "DELTA_SCHEMA_CHANGE_SINCE_ANALYSIS"
+          }.getCondition == "DELTA_SCHEMA_CHANGE_SINCE_ANALYSIS"
         }
       }
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnRenameSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnRenameSuite.scala
@@ -62,8 +62,8 @@ class DeltaColumnRenameSuite extends QueryTest
         spark.table("t1").select("b").collect()
       }
       // The error class is renamed in Spark 3.4
-      assert(e.getErrorClass == "UNRESOLVED_COLUMN.WITH_SUGGESTION"
-        || e.getErrorClass == "MISSING_COLUMN" )
+      assert(e.getCondition == "UNRESOLVED_COLUMN.WITH_SUGGESTION"
+        || e.getCondition == "MISSING_COLUMN" )
 
       // rename partition column
       spark.sql(s"Alter table t1 RENAME COLUMN a to a1")
@@ -97,8 +97,8 @@ class DeltaColumnRenameSuite extends QueryTest
         spark.table("t1").select("a").collect()
       }
       // The error class is renamed in Spark 3.4
-      assert(e2.getErrorClass == "UNRESOLVED_COLUMN.WITH_SUGGESTION"
-        || e2.getErrorClass == "MISSING_COLUMN" )
+      assert(e2.getCondition == "UNRESOLVED_COLUMN.WITH_SUGGESTION"
+        || e2.getCondition == "MISSING_COLUMN" )
 
       // b1.c is no longer visible
       val e3 = intercept[AnalysisException] {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameWriterV2Suite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaDataFrameWriterV2Suite.scala
@@ -148,7 +148,7 @@ trait OpenSourceDataFrameWriterV2Tests
     val e = intercept[AnalysisException] {
       spark.table("source2").writeTo("table_name").overwrite($"id" === 3)
     }
-    assert(e.getErrorClass == "DELTA_REPLACE_WHERE_MISMATCH")
+    assert(e.getCondition == "DELTA_REPLACE_WHERE_MISMATCH")
     assert(e.getMessage.startsWith(
       "[DELTA_REPLACE_WHERE_MISMATCH] Written data does not conform to partial table overwrite " +
         "condition or constraint"))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -183,9 +183,9 @@ trait DeltaErrorsSuiteBase
       startWith: Boolean = false): Unit = {
     val prefix = errClassOpt match {
       case Some(exist) =>
-        assert(e.getErrorClass == exist)
+        assert(e.getCondition == exist)
         exist
-      case _ => e.getErrorClass
+      case _ => e.getCondition
     }
     sqlStateOpt match {
       case Some(sqlState) => assert(e.getSqlState == sqlState)
@@ -682,7 +682,7 @@ trait DeltaErrorsSuiteBase
           throw DeltaErrors.schemaChangedException(oldSchema, newSchema, retryable, None, false)
         }
         assert(expectedClass.isAssignableFrom(e.getClass))
-        assert(e.getErrorClass == "DELTA_SCHEMA_CHANGED")
+        assert(e.getCondition == "DELTA_SCHEMA_CHANGED")
         assert(e.getSqlState == "KD007")
         // Use '#' as stripMargin interpolator to get around formatSchema having '|' in it
         var msg =
@@ -707,7 +707,7 @@ trait DeltaErrorsSuiteBase
           throw DeltaErrors.schemaChangedException(oldSchema, newSchema, retryable, Some(10), false)
         }
         assert(expectedClass.isAssignableFrom(e.getClass))
-        assert(e.getErrorClass == "DELTA_SCHEMA_CHANGED_WITH_VERSION")
+        assert(e.getCondition == "DELTA_SCHEMA_CHANGED_WITH_VERSION")
         assert(e.getSqlState == "KD007")
         // Use '#' as stripMargin interpolator to get around formatSchema having '|' in it
         msg =
@@ -727,7 +727,7 @@ trait DeltaErrorsSuiteBase
           throw DeltaErrors.schemaChangedException(oldSchema, newSchema, retryable, Some(10), true)
         }
         assert(expectedClass.isAssignableFrom(e.getClass))
-        assert(e.getErrorClass == "DELTA_SCHEMA_CHANGED_WITH_STARTING_OPTIONS")
+        assert(e.getCondition == "DELTA_SCHEMA_CHANGED_WITH_STARTING_OPTIONS")
         assert(e.getSqlState == "KD007")
         // Use '#' as stripMargin interpolator to get around formatSchema having '|' in it
         msg =
@@ -2781,7 +2781,7 @@ trait DeltaErrorsSuiteBase
           val e = intercept[AnalysisException] {
             sql(s"SELECT * FROM ${fnName}()").collect()
           }
-          assert(e.getErrorClass == "INCORRECT_NUMBER_OF_ARGUMENTS")
+          assert(e.getCondition == "INCORRECT_NUMBER_OF_ARGUMENTS")
           assert(e.getMessage.contains(
             s"not enough args, $fnName requires at least 2 arguments " +
               "and at most 3 arguments."))
@@ -2790,7 +2790,7 @@ trait DeltaErrorsSuiteBase
           val e = intercept[AnalysisException] {
             sql(s"SELECT * FROM ${fnName}(1, 2, 3, 4, 5)").collect()
           }
-          assert(e.getErrorClass == "INCORRECT_NUMBER_OF_ARGUMENTS")
+          assert(e.getCondition == "INCORRECT_NUMBER_OF_ARGUMENTS")
           assert(e.getMessage.contains(
             s"too many args, $fnName requires at least 2 arguments " +
               "and at most 3 arguments."))
@@ -3041,7 +3041,7 @@ trait DeltaErrorsSuiteBase
       val e = intercept[DeltaAnalysisException] {
         errorBuilder.finalizeAndThrow(spark.sessionState.conf)
       }
-      assert(e.getErrorClass == "_LEGACY_ERROR_TEMP_DELTA_0007")
+      assert(e.getCondition == "_LEGACY_ERROR_TEMP_DELTA_0007")
     }
     {
       val e = intercept[DeltaAnalysisException] {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaGenerateSymlinkManifestSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaGenerateSymlinkManifestSuite.scala
@@ -649,7 +649,7 @@ trait DeltaGenerateSymlinkManifestSuiteBase extends QueryTest
       exception: SparkThrowable,
       errorClass: String
   ): Unit = {
-    assert(exception.getErrorClass === errorClass,
+    assert(exception.getCondition === errorClass,
       s"Expected errorClass $errorClass, but got $exception")
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTableSuite.scala
@@ -161,7 +161,7 @@ class DeltaInsertIntoSQLSuite
         val e = intercept[AnalysisException] {
           sql(s"INSERT INTO $targetTableName BY NAME SELECT * FROM $sourceTableName")
         }
-        assert(e.getErrorClass === expectedErrorClass)
+        assert(e.getCondition === expectedErrorClass)
       }
     }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaOptionSuite.scala
@@ -302,7 +302,7 @@ class DeltaOptionSuite extends QueryTest
             .save(tempDir.getAbsolutePath)
         }
       }
-      assert(e.getErrorClass == "DELTA_OVERWRITE_SCHEMA_WITH_DYNAMIC_PARTITION_OVERWRITE")
+      assert(e.getCondition == "DELTA_OVERWRITE_SCHEMA_WITH_DYNAMIC_PARTITION_OVERWRITE")
     }
   }
 
@@ -322,7 +322,7 @@ class DeltaOptionSuite extends QueryTest
             .saveAsTable("temp")
         }
       }
-      assert(e.getErrorClass == "DELTA_OVERWRITE_SCHEMA_WITH_DYNAMIC_PARTITION_OVERWRITE")
+      assert(e.getCondition == "DELTA_OVERWRITE_SCHEMA_WITH_DYNAMIC_PARTITION_OVERWRITE")
     }
   }
 
@@ -339,7 +339,7 @@ class DeltaOptionSuite extends QueryTest
             .option("partitionOverwriteMode", "dynamic")
             .save(tempDir.getAbsolutePath)
         }
-        assert(e.getErrorClass == "DELTA_DYNAMIC_PARTITION_OVERWRITE_DISABLED")
+        assert(e.getCondition == "DELTA_DYNAMIC_PARTITION_OVERWRITE_DISABLED")
         withSQLConf(PARTITION_OVERWRITE_MODE.key -> "dynamic") {
           e = intercept[DeltaIllegalArgumentException] {
             Seq(1, 2, 3).toDF
@@ -350,7 +350,7 @@ class DeltaOptionSuite extends QueryTest
               .save(tempDir.getAbsolutePath)
           }
         }
-        assert(e.getErrorClass == "DELTA_DYNAMIC_PARTITION_OVERWRITE_DISABLED")
+        assert(e.getCondition == "DELTA_DYNAMIC_PARTITION_OVERWRITE_DISABLED")
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -573,7 +573,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       tableNameOrPath: String,
       readerRequiredVersion: Int,
       writerRequiredVersion: Int): Unit = {
-    assert(exception.getErrorClass == "DELTA_INVALID_PROTOCOL_VERSION")
+    assert(exception.getCondition == "DELTA_INVALID_PROTOCOL_VERSION")
     assert(exception.tableNameOrPath == tableNameOrPath)
     assert(exception.readerRequiredVersion == readerRequiredVersion)
     assert(exception.writerRequiredVersion == writerRequiredVersion)
@@ -762,7 +762,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       errorClass: String,
       tableNameOrPath: String,
       unsupportedFeatures: Iterable[String]): Unit = {
-    assert(exception.getErrorClass == errorClass)
+    assert(exception.getCondition == errorClass)
     assert(exception.tableNameOrPath == tableNameOrPath)
     assert(exception.unsupported.toSeq.sorted == unsupportedFeatures.toSeq.sorted)
   }
@@ -778,7 +778,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
           log.upgradeProtocol(Protocol(1, 2))
         }
         assert(log.update().protocol == Protocol(2, 5))
-        assert(e.getErrorClass.contains("DELTA_INVALID_PROTOCOL_DOWNGRADE"))
+        assert(e.getCondition.contains("DELTA_INVALID_PROTOCOL_DOWNGRADE"))
       }
       { // DeltaTable API
         val table = io.delta.tables.DeltaTable.forPath(spark, path.getCanonicalPath)
@@ -1173,13 +1173,13 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
 
       assert(intercept[DeltaIllegalStateException] {
         log.update()
-      }.getErrorClass == "DELTA_STATE_RECOVER_ERROR")
+      }.getCondition == "DELTA_STATE_RECOVER_ERROR")
       assert(intercept[DeltaIllegalStateException] {
         spark.read.format("delta").load(path.getCanonicalPath)
-      }.getErrorClass == "DELTA_STATE_RECOVER_ERROR")
+      }.getCondition == "DELTA_STATE_RECOVER_ERROR")
       assert(intercept[DeltaIllegalStateException] {
         spark.range(1).write.format("delta").mode(SaveMode.Overwrite).save(path.getCanonicalPath)
-      }.getErrorClass == "DELTA_STATE_RECOVER_ERROR")
+      }.getCondition == "DELTA_STATE_RECOVER_ERROR")
     }
   }
 
@@ -1434,7 +1434,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
             sql(
               s"CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta " +
                 s"TBLPROPERTIES ($propString)")
-          }.getErrorClass === expectedExceptionClass.get)
+          }.getCondition === expectedExceptionClass.get)
         } else {
           sql(
             s"CREATE TABLE delta.`${dir.getCanonicalPath}` (id bigint) USING delta " +
@@ -1647,7 +1647,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         if (expectedExceptionClass.isDefined) {
           assert(intercept[DeltaTableFeatureException] {
             sql(s"ALTER TABLE delta.`${dir.getCanonicalPath}` SET TBLPROPERTIES ($propString)")
-          }.getErrorClass === expectedExceptionClass.get)
+          }.getCondition === expectedExceptionClass.get)
         } else {
           sql(s"ALTER TABLE delta.`${dir.getCanonicalPath}` SET TBLPROPERTIES ($propString)")
         }
@@ -1905,7 +1905,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
             s"ALTER TABLE delta.`${dir.getCanonicalPath}` SET TBLPROPERTIES (" +
               s"  '${TestWriterMetadataNoAutoUpdateFeature.TABLE_PROP_KEY}' = 'true')")
         }
-      }.getErrorClass === "DELTA_FEATURES_REQUIRE_MANUAL_ENABLEMENT",
+      }.getCondition === "DELTA_FEATURES_REQUIRE_MANUAL_ENABLEMENT",
       "existing tables should ignore session defaults.")
 
       sql(
@@ -1950,7 +1950,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
           (protocolOfNewTable.implicitlyAndExplicitlySupportedFeatures +
             ChangeDataFeedTableFeature +
             TestReaderWriterMetadataAutoUpdateFeature).map(_.name).toSeq.sorted.mkString(", ")
-        assert(e.getErrorClass === "DELTA_FEATURES_REQUIRE_MANUAL_ENABLEMENT")
+        assert(e.getCondition === "DELTA_FEATURES_REQUIRE_MANUAL_ENABLEMENT")
 
         // `getMessageParameters` is available starting from Spark 3.4.
         // For now we have to check for substrings.
@@ -3699,7 +3699,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
             AlterTableDropFeatureDeltaCommand(DeltaTableV2(spark, deltaLog.dataPath), featureName)
               .run(spark)
           }
-          assert(e.getErrorClass == exceptionClass)
+          assert(e.getCondition == exceptionClass)
         case None =>
           AlterTableDropFeatureDeltaCommand(DeltaTableV2(spark, deltaLog.dataPath), featureName)
             .run(spark)
@@ -3789,7 +3789,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
             featurePropertyKey)
           .run(spark)
       }
-      assert(e.getErrorClass == "DELTA_FEATURE_DROP_FEATURE_NOT_PRESENT")
+      assert(e.getCondition == "DELTA_FEATURE_DROP_FEATURE_NOT_PRESENT")
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
@@ -84,7 +84,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
   protected val ExpectSchemaLogInitializationFailedException =
     ExpectFailure[DeltaRuntimeException](e =>
       assert(
-        e.asInstanceOf[DeltaRuntimeException].getErrorClass ==
+        e.asInstanceOf[DeltaRuntimeException].getCondition ==
           "DELTA_STREAMING_SCHEMA_LOG_INIT_FAILED_INCOMPATIBLE_METADATA" &&
           // Does NOT come from the stream start check which is for lazy initialization ...
           !e.getStackTrace.exists(
@@ -98,7 +98,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
   protected val ExpectMetadataEvolutionException =
     ExpectFailure[DeltaRuntimeException](e =>
       assert(
-        e.asInstanceOf[DeltaRuntimeException].getErrorClass ==
+        e.asInstanceOf[DeltaRuntimeException].getCondition ==
           "DELTA_STREAMING_METADATA_EVOLUTION" &&
           e.getStackTrace.exists(
             _.toString.contains("updateMetadataTrackingLogAndFailTheStreamIfNeeded"))
@@ -108,7 +108,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
   protected val ExpectMetadataEvolutionExceptionFromInitialization =
     ExpectFailure[DeltaRuntimeException](e =>
       assert(
-        e.asInstanceOf[DeltaRuntimeException].getErrorClass ==
+        e.asInstanceOf[DeltaRuntimeException].getCondition ==
           "DELTA_STREAMING_METADATA_EVOLUTION" &&
           !e.getStackTrace.exists(_.toString.contains("checkReadIncompatibleSchemaChanges")) &&
           e.getStackTrace.exists(_.toString.contains("initializeMetadataTrackingAndExitStream"))
@@ -282,7 +282,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
       readStream(schemaLocation = Some(invalidSchemaLocation))
         .writeStream.option("checkpointLocation", ckpt).start(dest)
     }
-    assert(e.getErrorClass == "DELTA_STREAMING_SCHEMA_LOCATION_NOT_UNDER_CHECKPOINT")
+    assert(e.getCondition == "DELTA_STREAMING_SCHEMA_LOCATION_NOT_UNDER_CHECKPOINT")
 
     // But can be lifted with the flag
     allowSchemaLocationOutsideCheckpoint {
@@ -312,7 +312,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
       val e = intercept[DeltaAnalysisException] {
         sdf.writeStream.option("checkpointLocation", ckpt).start(dest)
       }
-      assert(e.getErrorClass == "DELTA_STREAMING_SCHEMA_LOCATION_CONFLICT")
+      assert(e.getCondition == "DELTA_STREAMING_SCHEMA_LOCATION_CONFLICT")
 
 
       // But providing an additional source name can differentiate
@@ -394,7 +394,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
           q.stop()
         }
         ExceptionUtils.getRootCause(e).asInstanceOf[DeltaAnalysisException]
-          .getErrorClass == "DELTA_STREAMING_SCHEMA_LOG_INCOMPATIBLE_DELTA_TABLE_ID"
+          .getCondition == "DELTA_STREAMING_SCHEMA_LOG_INCOMPATIBLE_DELTA_TABLE_ID"
       }
     }
   }
@@ -417,7 +417,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
       val e = intercept[DeltaAnalysisException] {
         schemaLog2.writeNewMetadata(newSchema)
       }
-      assert(e.getErrorClass == "DELTA_STREAMING_SCHEMA_LOCATION_CONFLICT")
+      assert(e.getCondition == "DELTA_STREAMING_SCHEMA_LOCATION_CONFLICT")
     }
   }
 
@@ -1664,7 +1664,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
     ExpectFailure[DeltaRuntimeException] { e =>
       val se = e.asInstanceOf[DeltaRuntimeException]
       assert {
-        se.getErrorClass == "DELTA_STREAMING_CANNOT_CONTINUE_PROCESSING_POST_SCHEMA_EVOLUTION" &&
+        se.getCondition == "DELTA_STREAMING_CANNOT_CONTINUE_PROCESSING_POST_SCHEMA_EVOLUTION" &&
           se.messageParameters(0) == opType && se.messageParameters(2) == ver.toString &&
           se.messageParameters.exists(_.contains(checkpointHash.toString))
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -81,7 +81,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
           val e = intercept[StreamingQueryException] {
             runStream()
           }
-          assert(e.getErrorClass == "STREAM_FAILED")
+          assert(e.getCondition == "STREAM_FAILED")
           // This assertion checks the schema of the source did not change while processing a batch.
           assert(e.getMessage.contains("assertion failed: Invalid batch: nullTypeCol"))
         } else {
@@ -821,7 +821,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         SerializedOffset(json)
       )
     }
-    assert(e.getErrorClass == "DELTA_INVALID_FORMAT_FROM_SOURCE_VERSION")
+    assert(e.getCondition == "DELTA_INVALID_FORMAT_FROM_SOURCE_VERSION")
     assert(e.toString.contains("Please upgrade to newer version of Delta"))
   }
 
@@ -842,7 +842,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         SerializedOffset(json)
       )
     }
-    assert(e.getErrorClass == "DELTA_INVALID_SOURCE_OFFSET_FORMAT")
+    assert(e.getCondition == "DELTA_INVALID_SOURCE_OFFSET_FORMAT")
     assert(e.toString.contains("source offset format is invalid"))
   }
 
@@ -862,7 +862,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         SerializedOffset(json)
       )
     }
-    assert(e.getErrorClass == "DELTA_INVALID_SOURCE_VERSION")
+    assert(e.getCondition == "DELTA_INVALID_SOURCE_VERSION")
     for (msg <- "is invalid") {
       assert(e.toString.contains(msg))
     }
@@ -886,7 +886,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         SerializedOffset(json)
       )
     }
-    assert(e.getErrorClass == "DIFFERENT_DELTA_TABLE_READ_BY_STREAMING_SOURCE")
+    assert(e.getCondition == "DIFFERENT_DELTA_TABLE_READ_BY_STREAMING_SOURCE")
     for (msg <- Seq("delete", "checkpoint", "restart")) {
       assert(e.toString.contains(msg))
     }
@@ -998,7 +998,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
     val e = intercept[SparkThrowable] {
       JsonUtils.fromJson[DeltaSourceOffset](jsonV1)
     }
-    assert(e.getErrorClass == "DELTA_INVALID_SOURCE_OFFSET_FORMAT")
+    assert(e.getCondition == "DELTA_INVALID_SOURCE_OFFSET_FORMAT")
   }
 
   test("DeltaSourceOffset serialization") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableCreationTests.scala
@@ -1891,7 +1891,7 @@ class DeltaTableCreationSuite
           val e = intercept[AnalysisException] {
             sql(s"CREATE TABLE $emptySchemaTableName USING delta LOCATION '${dir.getAbsolutePath}'")
           }
-          assert(e.getErrorClass == "DELTA_CREATE_EXTERNAL_TABLE_WITHOUT_TXN_LOG")
+          assert(e.getCondition == "DELTA_CREATE_EXTERNAL_TABLE_WITHOUT_TXN_LOG")
         }
       }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -477,14 +477,14 @@ trait DeltaTestUtilsForTempViews
         errorContains(ex.getMessage, expectedErrorMsgForSQLTempView)
       }
       if (expectedErrorClassForSQLTempView != null) {
-        assert(ex.getErrorClass == expectedErrorClassForSQLTempView)
+        assert(ex.getCondition == expectedErrorClassForSQLTempView)
       }
     } else {
       if (expectedErrorMsgForDataSetTempView != null) {
         errorContains(ex.getMessage, expectedErrorMsgForDataSetTempView)
       }
       if (expectedErrorClassForDataSetTempView != null) {
-        assert(ex.getErrorClass == expectedErrorClassForDataSetTempView, ex.getMessage)
+        assert(ex.getCondition == expectedErrorClassForDataSetTempView, ex.getMessage)
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/HiveConvertToDeltaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/HiveConvertToDeltaSuite.scala
@@ -174,7 +174,7 @@ abstract class HiveConvertToDeltaSuiteBase
           convertToDelta(tbl, Some("part string"))
         }
 
-        assert(ae.getErrorClass == "DELTA_CONVERSION_NO_PARTITION_FOUND")
+        assert(ae.getCondition == "DELTA_CONVERSION_NO_PARTITION_FOUND")
         assert(ae.getSqlState == "42KD6")
         assert(ae.getMessage.contains(tbl))
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnAdmissionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnAdmissionSuite.scala
@@ -58,14 +58,14 @@ trait IdentityColumnAdmissionSuiteBase
             val ex = intercept[AnalysisException] {
               sql(s"ALTER TABLE $tblName $keyword COLUMN id TYPE ${targetType.sql}")
             }
-            assert(ex.getErrorClass === "NOT_SUPPORTED_CHANGE_COLUMN")
+            assert(ex.getCondition === "NOT_SUPPORTED_CHANGE_COLUMN")
           case DoubleType =>
             // Long -> Double (upcast) is rejected in Delta when altering data type of an
             // identity column.
             val ex = intercept[DeltaAnalysisException] {
               sql(s"ALTER TABLE $tblName $keyword COLUMN id TYPE ${targetType.sql}")
             }
-            assert(ex.getErrorClass === "DELTA_IDENTITY_COLUMNS_ALTER_COLUMN_NOT_SUPPORTED")
+            assert(ex.getCondition === "DELTA_IDENTITY_COLUMNS_ALTER_COLUMN_NOT_SUPPORTED")
           case _ => fail("unexpected targetType")
         }
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnSuite.scala
@@ -503,7 +503,7 @@ class IdentityColumnScalaSuite
             )
           )
         }
-        assert(ex.getErrorClass === "DELTA_IDENTITY_COLUMNS_UNSUPPORTED_DATA_TYPE")
+        assert(ex.getCondition === "DELTA_IDENTITY_COLUMNS_UNSUPPORTED_DATA_TYPE")
         assert(ex.getMessage.contains("is not supported for IDENTITY columns"))
       }
     }
@@ -520,7 +520,7 @@ class IdentityColumnScalaSuite
           createTableWithIdColAndIntValueCol(
             tblName, generatedAsIdentityType, startsWith, incrementBy = Some(0))
         }
-        assert(ex.getErrorClass === "DELTA_IDENTITY_COLUMNS_ILLEGAL_STEP")
+        assert(ex.getCondition === "DELTA_IDENTITY_COLUMNS_ILLEGAL_STEP")
         assert(ex.getMessage.contains("step cannot be 0."))
       }
     }
@@ -531,7 +531,7 @@ class IdentityColumnScalaSuite
       val ex = intercept[DeltaAnalysisException] {
         f
       }
-      assert(ex.getErrorClass === "DELTA_IDENTITY_COLUMNS_WITH_GENERATED_EXPRESSION")
+      assert(ex.getCondition === "DELTA_IDENTITY_COLUMNS_WITH_GENERATED_EXPRESSION")
       ex.getMessage.contains(
         "Identity column cannot be specified with a generated column expression.")
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/ImplicitDMLCastingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/ImplicitDMLCastingSuite.scala
@@ -149,14 +149,14 @@ abstract class ImplicitDMLCastingSuite extends QueryTest
 
         val sparkThrowable = failureCause.asInstanceOf[SparkThrowable]
         assert(Seq("CAST_OVERFLOW", NUMERIC_VALUE_OUT_OF_RANGE_ERROR_MSG, "CAST_INVALID_INPUT")
-          .contains(sparkThrowable.getErrorClass))
+          .contains(sparkThrowable.getCondition))
       case Some(failureCause) if !sqlConfig.followAnsiEnabled =>
         assert(sqlConfig.storeAssignmentPolicy === SQLConf.StoreAssignmentPolicy.ANSI)
 
         val sparkThrowable = failureCause.asInstanceOf[SparkThrowable]
         // Only arithmetic exceptions get a custom error message.
         if (testConfig.exceptionAnsiCast == "SparkArithmeticException") {
-          assert(sparkThrowable.getErrorClass == "DELTA_CAST_OVERFLOW_IN_TABLE_WRITE")
+          assert(sparkThrowable.getCondition == "DELTA_CAST_OVERFLOW_IN_TABLE_WRITE")
           assert(sparkThrowable.getMessageParameters ==
             Map("sourceType" -> ("\"" + testConfig.sourceTypeInErrorMessage + "\""),
                 "targetType" -> ("\"" + testConfig.targetTypeInErrorMessage + "\""),
@@ -166,7 +166,7 @@ abstract class ImplicitDMLCastingSuite extends QueryTest
                   DeltaSQLConf.UPDATE_AND_MERGE_CASTING_FOLLOWS_ANSI_ENABLED_FLAG.key,
                 "ansiEnabledFlag" -> SQLConf.ANSI_ENABLED.key).asJava)
         } else {
-          assert(sparkThrowable.getErrorClass == "CAST_INVALID_INPUT")
+          assert(sparkThrowable.getCondition == "CAST_INVALID_INPUT")
           assert(sparkThrowable.getMessageParameters.get("sourceType") == "\"STRING\"")
         }
       case None => assert(false, s"No arithmetic exception thrown: $exception")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSchemaEvolutionSuite.scala
@@ -1045,7 +1045,7 @@ trait MergeIntoSchemaEvolutionBaseTests {
             "target.key = source.key",
             update("extra = -1"), insert("*"))
         }
-        assert(e.getErrorClass === "DELTA_MERGE_UNRESOLVED_EXPRESSION")
+        assert(e.getCondition === "DELTA_MERGE_UNRESOLVED_EXPRESSION")
         assert(e.getMessage.contains("resolve extra in UPDATE clause"))
 
         // Should succeed with schema evolution

--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoSuiteBase.scala
@@ -3014,7 +3014,7 @@ abstract class MergeIntoSuiteBase
 
             def extractErrorClass(e: Throwable): String =
               e match {
-                case dt: DeltaThrowable => s"\\[${dt.getErrorClass}\\] "
+                case dt: DeltaThrowable => s"\\[${dt.getCondition}\\] "
                 case _ => ""
               }
 
@@ -3168,7 +3168,7 @@ abstract class MergeIntoSuiteBase
     text = "SELECT key FROM tab",
     mergeCondition = "src.a = v.key AND src.b = v.value",
     expectedResult = ExpectedResult.Failure { ex =>
-      assert(ex.getErrorClass === "UNRESOLVED_COLUMN.WITH_SUGGESTION")
+      assert(ex.getCondition === "UNRESOLVED_COLUMN.WITH_SUGGESTION")
     }
   )
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/OptimisticTransactionSuite.scala
@@ -766,7 +766,7 @@ class OptimisticTransactionSuite
       val addFileWithDVWithoutStats = addFileWithDV.copy(stats = null)
       testRuntimeErrorOnCommit(Seq(addFileWithDVWithoutStats, removeFile), deltaLog) { e =>
         val expErrorClass = "DELTA_DELETION_VECTOR_MISSING_NUM_RECORDS"
-        assert(e.getErrorClass == expErrorClass)
+        assert(e.getCondition == expErrorClass)
         assert(e.getSqlState == "2D521")
       }
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/TightBoundsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/TightBoundsSuite.scala
@@ -117,7 +117,7 @@ class TightBoundsSuite
       val exception = intercept[DeltaIllegalStateException] {
         txn.commitActions(DeltaOperations.TestOperation(), addFiles: _*)
       }
-      assert(exception.getErrorClass ===
+      assert(exception.getCondition ===
         "DELTA_ADDING_DELETION_VECTORS_WITH_TIGHT_BOUNDS_DISALLOWED")
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UpdateSuiteBase.scala
@@ -398,8 +398,8 @@ abstract class UpdateSuiteBase
         executeUpdate("table", set = "column_doesnt_exist = 'San Francisco'", where = "t = 'a'")
       }
       // The error class is renamed from MISSING_COLUMN to UNRESOLVED_COLUMN in Spark 3.4
-      assert(ae.getErrorClass == "UNRESOLVED_COLUMN.WITH_SUGGESTION"
-        || ae.getErrorClass == "MISSING_COLUMN" )
+      assert(ae.getCondition == "UNRESOLVED_COLUMN.WITH_SUGGESTION"
+        || ae.getCondition == "MISSING_COLUMN" )
 
       withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
         executeUpdate(target = "table", set = "S = 1, T = 'b'", where = "T = 'a'")
@@ -414,23 +414,23 @@ abstract class UpdateSuiteBase
           executeUpdate(target = "table", set = "S = 1", where = "t = 'a'")
         }
         // The error class is renamed from MISSING_COLUMN to UNRESOLVED_COLUMN in Spark 3.4
-        assert(ae.getErrorClass == "UNRESOLVED_COLUMN.WITH_SUGGESTION"
-          || ae.getErrorClass == "MISSING_COLUMN" )
+        assert(ae.getCondition == "UNRESOLVED_COLUMN.WITH_SUGGESTION"
+          || ae.getCondition == "MISSING_COLUMN" )
 
         ae = intercept[AnalysisException] {
           executeUpdate(target = "table", set = "S = 1, s = 'b'", where = "s = 1")
         }
         // The error class is renamed from MISSING_COLUMN to UNRESOLVED_COLUMN in Spark 3.4
-        assert(ae.getErrorClass == "UNRESOLVED_COLUMN.WITH_SUGGESTION"
-          || ae.getErrorClass == "MISSING_COLUMN" )
+        assert(ae.getCondition == "UNRESOLVED_COLUMN.WITH_SUGGESTION"
+          || ae.getCondition == "MISSING_COLUMN" )
 
         // unresolved column in condition
         ae = intercept[AnalysisException] {
           executeUpdate(target = "table", set = "s = 1", where = "T = 'a'")
         }
         // The error class is renamed from MISSING_COLUMN to UNRESOLVED_COLUMN in Spark 3.4
-        assert(ae.getErrorClass == "UNRESOLVED_COLUMN.WITH_SUGGESTION"
-          || ae.getErrorClass == "MISSING_COLUMN" )
+        assert(ae.getCondition == "UNRESOLVED_COLUMN.WITH_SUGGESTION"
+          || ae.getCondition == "MISSING_COLUMN" )
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/DropColumnMappingFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/DropColumnMappingFeatureSuite.scala
@@ -58,7 +58,7 @@ class DropColumnMappingFeatureSuite extends RemoveColumnMappingSuiteUtils {
       dropColumnMappingTableFeature()
     }
     checkError(e,
-      DeltaErrors.dropTableFeatureFeatureNotSupportedByProtocol(".").getErrorClass,
+      DeltaErrors.dropTableFeatureFeatureNotSupportedByProtocol(".").getCondition,
       parameters = Map("feature" -> "columnMapping"))
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/RemoveColumnMappingCDCSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/RemoveColumnMappingCDCSuite.scala
@@ -218,7 +218,7 @@ class RemoveColumnMappingCDCSuite extends RemoveColumnMappingSuiteUtils {
     val e = intercept[DeltaUnsupportedOperationException] {
       getChanges(startVersion, endVersion)
     }
-    assert(e.getErrorClass === "DELTA_CHANGE_DATA_FEED_INCOMPATIBLE_SCHEMA_CHANGE")
+    assert(e.getCondition === "DELTA_CHANGE_DATA_FEED_INCOMPATIBLE_SCHEMA_CHANGE")
   }
 
   private def getCDCAndFailIncompatibleDataSchema(
@@ -227,7 +227,7 @@ class RemoveColumnMappingCDCSuite extends RemoveColumnMappingSuiteUtils {
     val e = intercept[DeltaUnsupportedOperationException] {
       getChanges(startVersion, endVersion)
     }
-    assert(e.getErrorClass === "DELTA_CHANGE_DATA_FEED_INCOMPATIBLE_DATA_SCHEMA")
+    assert(e.getCondition === "DELTA_CHANGE_DATA_FEED_INCOMPATIBLE_DATA_SCHEMA")
   }
 
   private def getChanges(startVersion: Long, endVersion: Option[Long]): Array[Row] = {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/RemoveColumnMappingStreamingReadSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/columnmapping/RemoveColumnMappingStreamingReadSuite.scala
@@ -198,7 +198,7 @@ class RemoveColumnMappingStreamingReadSuite
   protected val ExpectMetadataEvolutionException =
     ExpectFailure[DeltaRuntimeException](e =>
       assert(
-        e.asInstanceOf[DeltaRuntimeException].getErrorClass ==
+        e.asInstanceOf[DeltaRuntimeException].getCondition ==
           "DELTA_STREAMING_METADATA_EVOLUTION" &&
           e.getStackTrace.exists(
             _.toString.contains("updateMetadataTrackingLogAndFailTheStreamIfNeeded"))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtilsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtilsSuite.scala
@@ -86,7 +86,7 @@ class CoordinatedCommitsUtilsSuite extends QueryTest
           }
           checkError(
             e,
-            errorOpt.get.getErrorClass,
+            errorOpt.get.getCondition,
             sqlState = errorOpt.get.getSqlState,
             parameters = errorOpt.get.getMessageParameters.asScala.toMap)
         } else {
@@ -261,7 +261,7 @@ class CoordinatedCommitsUtilsSuite extends QueryTest
       }
       checkError(
         e,
-        errorOpt.get.getErrorClass,
+        errorOpt.get.getCondition,
         sqlState = errorOpt.get.getSqlState,
         parameters = errorOpt.get.getMessageParameters.asScala.toMap)
     } else {
@@ -329,7 +329,7 @@ class CoordinatedCommitsUtilsSuite extends QueryTest
       }
       checkError(
         e,
-        errorOpt.get.getErrorClass,
+        errorOpt.get.getCondition,
         sqlState = errorOpt.get.getSqlState,
         parameters = errorOpt.get.getMessageParameters.asScala.toMap)
     } else {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdCloneSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowid/RowIdCloneSuite.scala
@@ -233,7 +233,7 @@ class RowIdCloneSuite
         rowIdsEnabled = true, tableState = TableState.NON_EMPTY)) {
       assert(intercept[DeltaIllegalStateException] {
         cloneTable(targetTableName = "target", sourceTableName = "source")
-      }.getErrorClass === "DELTA_UNSUPPORTED_NON_EMPTY_CLONE")
+      }.getCondition === "DELTA_UNSUPPORTED_NON_EMPTY_CLONE")
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/MaterializedColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/rowtracking/MaterializedColumnSuite.scala
@@ -254,7 +254,7 @@ class MaterializedColumnSuite extends RowIdTestUtils
 
           assert(intercept[DeltaIllegalStateException] {
             sql(s"CREATE OR REPLACE TABLE $targetTableName SHALLOW CLONE $sourceTableName")
-          }.getErrorClass === "DELTA_UNSUPPORTED_NON_EMPTY_CLONE")
+          }.getCondition === "DELTA_UNSUPPORTED_NON_EMPTY_CLONE")
         }
       }
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/schema/CaseSensitivitySuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/schema/CaseSensitivitySuite.scala
@@ -198,9 +198,9 @@ class CaseSensitivitySuite extends QueryTest
             .option("replaceWhere", "key = 2") // note the different case
             .save(path)
         }
-        assert(e.getErrorClass == "UNRESOLVED_COLUMN.WITHOUT_SUGGESTION"
-          || e.getErrorClass == "MISSING_COLUMN"
-          || e.getErrorClass == "UNRESOLVED_COLUMN.WITH_SUGGESTION")
+        assert(e.getCondition == "UNRESOLVED_COLUMN.WITHOUT_SUGGESTION"
+          || e.getCondition == "MISSING_COLUMN"
+          || e.getCondition == "UNRESOLVED_COLUMN.WITH_SUGGESTION")
       }
 
       checkAnswer(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/schema/CheckConstraintsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/schema/CheckConstraintsSuite.scala
@@ -172,7 +172,7 @@ class CheckConstraintsSuite extends QueryTest
         val e = intercept[AnalysisException] {
           sql(s"ALTER TABLE $table DROP CONSTRAINT myConstraint")
         }
-        assert(e.getErrorClass == "DELTA_CONSTRAINT_DOES_NOT_EXIST")
+        assert(e.getCondition == "DELTA_CONSTRAINT_DOES_NOT_EXIST")
         errorContains(e.getMessage,
           "nonexistent constraint myconstraint from table `default`.`checkconstraintstest`")
         errorContains(e.getMessage,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
@@ -79,7 +79,7 @@ class SchemaUtilsSuite extends QueryTest
 
     @tailrec
     def getError(ex: Throwable): Option[DeltaAnalysisException] = ex match {
-      case e: DeltaAnalysisException if e.getErrorClass() == errorClass => Some(e)
+      case e: DeltaAnalysisException if e.getCondition() == errorClass => Some(e)
       case e: AnalysisException => getError(e.getCause)
       case _ => None
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/skipping/clustering/ClusteredTableDDLSuite.scala
@@ -708,7 +708,7 @@ trait ClusteredTableDDLSuiteBase
       val e2 = intercept[DeltaAnalysisException] {
         sql(s"ALTER TABLE $testTable CLUSTER BY (id, id)")
       }
-      assert(e2.getErrorClass == "DELTA_DUPLICATE_COLUMNS_FOUND")
+      assert(e2.getCondition == "DELTA_DUPLICATE_COLUMNS_FOUND")
       assert(e2.getSqlState == "42711")
       assert(e2.getMessageParametersArray === Array("in CLUSTER BY", "`id`"))
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/StatsCollectionSuite.scala
@@ -117,7 +117,7 @@ class StatsCollectionSuite
           val deltaLog = DeltaLog.forTable(spark, dir)
           StatisticsCollection.recompute(spark, deltaLog)
         }
-        assert(e.getErrorClass == "DELTA_UNSUPPORTED_STATS_RECOMPUTE_WITH_DELETION_VECTORS")
+        assert(e.getCondition == "DELTA_UNSUPPORTED_STATS_RECOMPUTE_WITH_DELETION_VECTORS")
         assert(e.getSqlState == "0AKDD")
         assert(e.getMessage ==
           "[DELTA_UNSUPPORTED_STATS_RECOMPUTE_WITH_DELETION_VECTORS] " +
@@ -514,7 +514,7 @@ class StatsCollectionSuite
           )
         }
         assert(
-          exceptOne.getErrorClass == "DELTA_COLUMN_DATA_SKIPPING_NOT_SUPPORTED_TYPE" &&
+          exceptOne.getCondition == "DELTA_COLUMN_DATA_SKIPPING_NOT_SUPPORTED_TYPE" &&
           exceptOne.getMessageParametersArray.toSeq == Seq(columnName, typename)
         )
         sql(s"create table $tableName2 (c1 long, c2 $invalidType) using delta")
@@ -522,7 +522,7 @@ class StatsCollectionSuite
           sql(s"ALTER TABLE $tableName2 SET TBLPROPERTIES('delta.dataSkippingStatsColumns' = 'c2')")
         }
         assert(
-          exceptTwo.getErrorClass == "DELTA_COLUMN_DATA_SKIPPING_NOT_SUPPORTED_TYPE" &&
+          exceptTwo.getCondition == "DELTA_COLUMN_DATA_SKIPPING_NOT_SUPPORTED_TYPE" &&
           exceptTwo.getMessageParametersArray.toSeq == Seq(columnName, typename)
         )
       }
@@ -538,7 +538,7 @@ class StatsCollectionSuite
           )
         }
         assert(
-          exceptOne.getErrorClass == "DELTA_COLUMN_DATA_SKIPPING_NOT_SUPPORTED_TYPE" &&
+          exceptOne.getCondition == "DELTA_COLUMN_DATA_SKIPPING_NOT_SUPPORTED_TYPE" &&
             exceptOne.getMessageParametersArray.toSeq == Seq(columnName, typename)
         )
         val exceptTwo = intercept[DeltaIllegalArgumentException] {
@@ -548,7 +548,7 @@ class StatsCollectionSuite
           )
         }
         assert(
-          exceptTwo.getErrorClass == "DELTA_COLUMN_DATA_SKIPPING_NOT_SUPPORTED_TYPE" &&
+          exceptTwo.getCondition == "DELTA_COLUMN_DATA_SKIPPING_NOT_SUPPORTED_TYPE" &&
           exceptTwo.getMessageParametersArray.toSeq == Seq(columnName, typename)
         )
         sql(s"create table $tableName2 (c1 long, c2 STRUCT<c20:INT, c21:$invalidType>) using delta")
@@ -558,14 +558,14 @@ class StatsCollectionSuite
           )
         }
         assert(
-          exceptThree.getErrorClass == "DELTA_COLUMN_DATA_SKIPPING_NOT_SUPPORTED_TYPE" &&
+          exceptThree.getCondition == "DELTA_COLUMN_DATA_SKIPPING_NOT_SUPPORTED_TYPE" &&
           exceptThree.getMessageParametersArray.toSeq == Seq(columnName, typename)
         )
         val exceptFour = interceptWithUnwrapping[DeltaIllegalArgumentException] {
           sql(s"ALTER TABLE $tableName2 SET TBLPROPERTIES('delta.dataSkippingStatsColumns'='c2')")
         }
         assert(
-          exceptFour.getErrorClass == "DELTA_COLUMN_DATA_SKIPPING_NOT_SUPPORTED_TYPE" &&
+          exceptFour.getCondition == "DELTA_COLUMN_DATA_SKIPPING_NOT_SUPPORTED_TYPE" &&
           exceptFour.getMessageParametersArray.toSeq == Seq(columnName, typename)
         )
       }
@@ -656,7 +656,7 @@ class StatsCollectionSuite
             )
           }
           assert(
-            except.getErrorClass == "DELTA_COLUMN_DATA_SKIPPING_NOT_SUPPORTED_PARTITIONED_COLUMN" &&
+            except.getCondition == "DELTA_COLUMN_DATA_SKIPPING_NOT_SUPPORTED_PARTITIONED_COLUMN" &&
             except.getMessageParametersArray.toSeq == Seq("c1")
           )
         } else {
@@ -667,7 +667,7 @@ class StatsCollectionSuite
             )
           }
           assert(
-            except.getErrorClass == "DELTA_COLUMN_DATA_SKIPPING_NOT_SUPPORTED_PARTITIONED_COLUMN" &&
+            except.getCondition == "DELTA_COLUMN_DATA_SKIPPING_NOT_SUPPORTED_PARTITIONED_COLUMN" &&
             except.getMessageParametersArray.toSeq == Seq("c1")
           )
         }
@@ -845,7 +845,7 @@ class StatsCollectionSuite
         )
       }
       assert(
-        exception.getErrorClass == "DELTA_DUPLICATE_DATA_SKIPPING_COLUMNS" &&
+        exception.getCondition == "DELTA_DUPLICATE_DATA_SKIPPING_COLUMNS" &&
         exception.getMessageParametersArray.toSeq == Seq(duplicatedColumns)
       )
     }
@@ -869,7 +869,7 @@ class StatsCollectionSuite
         )
       }
       assert(
-        exception.getErrorClass == "DELTA_DUPLICATE_DATA_SKIPPING_COLUMNS" &&
+        exception.getCondition == "DELTA_DUPLICATE_DATA_SKIPPING_COLUMNS" &&
         exception.getMessageParametersArray.toSeq == Seq(duplicatedColumns)
       )
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorStoreSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorStoreSuite.scala
@@ -98,7 +98,7 @@ trait DeletionVectorStoreSuiteBase
         dvStore.read(dvPath.path, dvRange.offset, dvRange.length)
       }
       // make sure this is our exception not ChecksumFileSystem's
-      assert(e.getErrorClass == "DELTA_DELETION_VECTOR_CHECKSUM_MISMATCH")
+      assert(e.getCondition == "DELTA_DELETION_VECTOR_CHECKSUM_MISMATCH")
       assert(e.getSqlState == "XXKDS")
       assert(e.getMessage == "[DELTA_DELETION_VECTOR_CHECKSUM_MISMATCH] " +
         "Could not verify deletion vector integrity, CRC checksum verification failed.")
@@ -122,7 +122,7 @@ trait DeletionVectorStoreSuiteBase
       val e = intercept[DeltaChecksumException] {
         dvStore.read(dvPath.path, dvRange.offset, dvRange.length)
       }
-      assert(e.getErrorClass == "DELTA_DELETION_VECTOR_SIZE_MISMATCH")
+      assert(e.getCondition == "DELTA_DELETION_VECTOR_SIZE_MISMATCH")
       assert(e.getSqlState == "XXKDS")
       assert(e.getMessage == "[DELTA_DELETION_VECTOR_SIZE_MISMATCH] " +
         "Deletion vector integrity check failed. Encountered a size mismatch.")
@@ -173,7 +173,7 @@ trait DeletionVectorStoreSuiteBase
             updateStats = false
           )
         }
-        assert(e.getErrorClass == "DELTA_DELETION_VECTOR_INVALID_ROW_INDEX")
+        assert(e.getCondition == "DELTA_DELETION_VECTOR_INVALID_ROW_INDEX")
         assert(e.getSqlState == "XXKDS")
         assert(e.getMessage == "[DELTA_DELETION_VECTOR_INVALID_ROW_INDEX] " +
             "Deletion vector integrity check failed. Encountered an invalid row index.")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/uniform/IcebergCompatV2EnableUniformByAlterTableSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/uniform/IcebergCompatV2EnableUniformByAlterTableSuiteBase.scala
@@ -581,7 +581,7 @@ trait IcebergCompatV2EnableUniformByAlterTableSuiteBase extends QueryTest {
       )
       assertResult(
         "DELTA_ICEBERG_COMPAT_VIOLATION.VERSION_MUTUAL_EXCLUSIVE"
-      )(ex.getErrorClass)
+      )(ex.getCondition)
     }
   }
 
@@ -606,7 +606,7 @@ trait IcebergCompatV2EnableUniformByAlterTableSuiteBase extends QueryTest {
       )
       assertResult(
         "DELTA_ICEBERG_COMPAT_VIOLATION.VERSION_MUTUAL_EXCLUSIVE"
-      )(ex.getErrorClass)
+      )(ex.getCondition)
     }
   }
 
@@ -633,7 +633,7 @@ trait IcebergCompatV2EnableUniformByAlterTableSuiteBase extends QueryTest {
       )
       assertResult(
         "DELTA_ICEBERG_COMPAT_VIOLATION.WRONG_REQUIRED_TABLE_PROPERTY"
-      )(ex.getErrorClass)
+      )(ex.getCondition)
     }
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

The PR https://github.com/apache/spark/pull/48196 deprecated the `getErrorClass` method of `SparkThrowable` and added new one `getCondition`. In the PR, I propose to migrate Delta exception onto new method `getCondition`.
 
## How was this patch tested?
By compiling and running the existing tests.

## Does this PR introduce _any_ user-facing changes?
No.
