### PR TITLE
Pass table identifiers/table catalogs to DeltaLog API call sites

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/icebergShaded/IcebergConverter.scala
@@ -267,7 +267,7 @@ class IcebergConverter(spark: SparkSession)
         try {
           // TODO: We can optimize this by providing a checkpointHint to getSnapshotAt. Check if
           //  txn.snapshot.version < version. If true, use txn.snapshot's checkpoint as a hint.
-          Some(log.getSnapshotAt(version))
+          Some(log.getSnapshotAt(version, tableIdentifierOpt = Some(catalogTable.identifier)))
         } catch {
           // If we can't load the file since the last time Iceberg was converted, it's likely that
           // the commit file expired. Treat this like a new Iceberg table conversion.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -1145,7 +1145,10 @@ class DeltaAnalysis(session: SparkSession)
             session, dataSourceV1.options
           ).foreach { rootSchemaTrackingLocation =>
             assert(dataSourceV1.options.contains("path"), "Path for Delta table must be defined")
-            val log = DeltaLog.forTable(session, new Path(dataSourceV1.options("path")))
+            val log = dataSourceV1.catalogTable match {
+                case Some(catalogTable) => DeltaLog.forTable(session, catalogTable)
+                case None => DeltaLog.forTable(session, new Path(dataSourceV1.options("path")))
+            }
             val sourceIdOpt = dataSourceV1.options.get(DeltaOptions.STREAMING_SOURCE_TRACKING_ID)
             val schemaTrackingLocation =
               DeltaSourceMetadataTrackingLog.fullMetadataTrackingLocation(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -156,11 +156,12 @@ case class DeltaTableV2(
         "queriedVersion" -> version,
         "accessType" -> accessType
       ))
-      deltaLog.getSnapshotAt(version)
+      deltaLog.getSnapshotAt(version, tableIdentifierOpt = getTableIdentifierIfExists)
     }.getOrElse(
       deltaLog.update(
         stalenessAcceptable = true,
-        checkIfUpdatedSinceTs = Some(creationTimeMs)
+        checkIfUpdatedSinceTs = Some(creationTimeMs),
+        tableIdentifierOpt = getTableIdentifierIfExists
       )
     )
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaGenerateCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaGenerateCommand.scala
@@ -39,14 +39,16 @@ case class DeltaGenerateCommand(
       throw DeltaErrors.unsupportedGenerateModeException(modeName)
     }
 
-    val tablePath = DeltaTableIdentifier(sparkSession, tableId) match {
+    val deltaLog = DeltaTableIdentifier(sparkSession, tableId) match {
       case Some(id) if id.path.isDefined =>
-        new Path(id.path.get)
+        DeltaLog.forTable(sparkSession, new Path(id.path.get), options)
       case _ =>
-        new Path(sparkSession.sessionState.catalog.getTableMetadata(tableId).location)
+        DeltaLog.forTable(
+          sparkSession,
+          sparkSession.sessionState.catalog.getTableMetadata(tableId),
+          options)
     }
 
-    val deltaLog = DeltaLog.forTable(sparkSession, tablePath, options)
     if (!deltaLog.tableExists) {
       throw DeltaErrors.notADeltaTableException("GENERATE")
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/RestoreTableCommand.scala
@@ -92,6 +92,7 @@ case class RestoreTableCommand(sourceTable: DeltaTableV2)
 
   override def run(spark: SparkSession): Seq[Row] = {
     val deltaLog = sourceTable.deltaLog
+    val catalogTable = sourceTable.catalogTable
     val version = sourceTable.timeTravelOpt.get.version
     val timestamp = getTimestamp()
     recordDeltaOperation(deltaLog, "delta.restore") {
@@ -105,14 +106,18 @@ case class RestoreTableCommand(sourceTable: DeltaTableV2)
           .version
       }
 
-      val latestVersion = deltaLog.update().version
+      val latestVersion = deltaLog
+        .update(tableIdentifierOpt = catalogTable.map(_.identifier))
+        .version
 
       require(versionToRestore < latestVersion, s"Version to restore ($versionToRestore)" +
         s"should be less then last available version ($latestVersion)")
 
-      deltaLog.withNewTransaction(sourceTable.catalogTable) { txn =>
+      deltaLog.withNewTransaction(catalogTable) { txn =>
         val latestSnapshot = txn.snapshot
-        val snapshotToRestore = deltaLog.getSnapshotAt(versionToRestore)
+        val snapshotToRestore = deltaLog.getSnapshotAt(
+          versionToRestore,
+          tableIdentifierOpt = catalogTable.map(_.identifier))
         val latestSnapshotFiles = latestSnapshot.allFiles
         val snapshotToRestoreFiles = snapshotToRestore.allFiles
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
@@ -56,7 +56,10 @@ case class DeltaSink(
     with UpdateExpressionsSupport
     with DeltaLogging {
 
-  private val deltaLog = DeltaLog.forTable(sqlContext.sparkSession, path)
+  private val deltaLog = catalogTable match {
+    case Some(table) => DeltaLog.forTable(sqlContext.sparkSession, table)
+    case None => DeltaLog.forTable(sqlContext.sparkSession, path)
+  }
 
   private val sqlConf = sqlContext.sparkSession.sessionState.conf
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
@@ -56,6 +56,8 @@ case class DeltaSink(
     with UpdateExpressionsSupport
     with DeltaLogging {
 
+  // Use the catalog table to get the delta log if available so that the code in delta log,
+  // can differentiate between path-based and name-based table access.
   private val deltaLog = catalogTable match {
     case Some(table) => DeltaLog.forTable(sqlContext.sparkSession, table)
     case None => DeltaLog.forTable(sqlContext.sparkSession, path)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaLogSuite.scala
@@ -582,7 +582,7 @@ class DeltaLogSuite extends QueryTest
       val deltaLog = DeltaLog.forTable(spark, path)
       assert(deltaLog.snapshot.version === 0)
 
-      val (_, snapshot) = DeltaLog.withFreshSnapshot { _ =>
+      val (_, snapshot) = DeltaLog.withFreshSnapshot() { _ =>
         // This update is necessary to advance the lastUpdatedTs beyond the start time of
         // withFreshSnapshot call.
         deltaLog.update()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

- Added `forTable(SparkSession, CatalogTable, Map[String, String])`
- Added `forTableWithSnapshot(SparkSession, CatalogTable, Map[String, String])`
- Modified `withFreshSnapshot` to take in a table identifier.
- Passed table identifier or table catalog to call sites of DeltaLog API so that the table identifier becomes available and eventually passed to the commit coordinator. 
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
unit tests
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
