### PR TITLE
[Kernel] [CC Refactor #2] Add new Kernel CommitCoordinatorClient interface

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Table.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Table.java
@@ -20,7 +20,7 @@ import io.delta.kernel.engine.Engine;
 import io.delta.kernel.exceptions.CheckpointAlreadyExistsException;
 import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.exceptions.TableNotFoundException;
-import io.delta.kernel.internal.TableImpl;
+import io.delta.kernel.internal.TableBuilderImpl;
 import java.io.IOException;
 
 /**
@@ -54,7 +54,19 @@ public interface Table {
    * @return an instance of {@link Table} representing the Delta table at the given path
    */
   static Table forPath(Engine engine, String path) {
-    return TableImpl.forPath(engine, path);
+    return new TableBuilderImpl(engine, path).build();
+  }
+
+  /**
+   * Create a {@link TableBuilder} to build a {@link Table} instance.
+   *
+   * @param engine
+   * @param path
+   * @return
+   * @since 3.3.0
+   */
+  static TableBuilder builder(Engine engine, String path) {
+    return new TableBuilderImpl(engine, path);
   }
 
   /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Table.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Table.java
@@ -33,20 +33,8 @@ public interface Table {
   /**
    * Instantiate a table object for the Delta Lake table at the given path.
    *
-   * <ul>
-   *   <li>Behavior when the table location doesn't exist:
-   *       <ul>
-   *         <li>Reads will fail with a {@link TableNotFoundException}
-   *         <li>Writes will create the location
-   *       </ul>
-   *   <li>Behavior when the table location exists (with contents or not) but not a Delta table:
-   *       <ul>
-   *         <li>Reads will fail with a {@link TableNotFoundException}
-   *         <li>Writes will create a Delta table at the given location. If there are any existing
-   *             files in the location that are not already part of the Delta table, they will
-   *             remain excluded from the Delta table.
-   *       </ul>
-   * </ul>
+   * <p>For detailed behavior when creating, reading from, or writing to the table, see {@link
+   * TableBuilder#build()}.
    *
    * @param engine {@link Engine} instance to use in Delta Kernel.
    * @param path location of the table. Path is resolved to fully qualified path using the given
@@ -54,15 +42,16 @@ public interface Table {
    * @return an instance of {@link Table} representing the Delta table at the given path
    */
   static Table forPath(Engine engine, String path) {
-    return new TableBuilderImpl(engine, path).build();
+    return builder(engine, path).build();
   }
 
   /**
    * Create a {@link TableBuilder} to build a {@link Table} instance.
    *
-   * @param engine
-   * @param path
-   * @return
+   * @param engine {@link Engine} instance to use in Delta Kernel.
+   * @param path location of the table. Path is resolved to fully qualified path using the given
+   *     {@code engine}.
+   * @return a {@link TableBuilder} instance
    * @since 3.3.0
    */
   static TableBuilder builder(Engine engine, String path) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/TableBuilder.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/TableBuilder.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel;
+
+import io.delta.kernel.config.ConfigurationProvider;
+
+public interface TableBuilder {
+  TableBuilder withConfigurationProvider(ConfigurationProvider configProvider);
+
+  TableBuilder withTableId(TableIdentifier tableId);
+
+  Table build();
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/TableBuilder.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/TableBuilder.java
@@ -16,12 +16,61 @@
 
 package io.delta.kernel;
 
+import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.config.ConfigurationProvider;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.exceptions.TableNotFoundException;
 
+/**
+ * Builder for creating a {@link Table} instance.
+ *
+ * <p>Required parameters for building a {@link TableBuilder} instance include:
+ *
+ * <ul>
+ *   <li>{@code Engine}: The {@link Engine} instance required to interact with Delta Kernel.
+ *   <li>{@code Path}: The location of the table, resolved by the provided {@code Engine}.
+ * </ul>
+ *
+ * @since 3.3.0
+ */
+@Evolving
 public interface TableBuilder {
+
+  /**
+   * Set the {@link ConfigurationProvider} to use for the table.
+   *
+   * @param configProvider {@link ConfigurationProvider} to use for the table
+   * @return this updated {@link TableBuilder} instance
+   */
   TableBuilder withConfigurationProvider(ConfigurationProvider configProvider);
 
+  /**
+   * Set the {@link TableIdentifier} for the table.
+   *
+   * @param tableId {@link TableIdentifier} for the table
+   * @return this updated {@link TableBuilder} instance
+   */
   TableBuilder withTableId(TableIdentifier tableId);
 
+  /**
+   * Builds the table object for the Delta Lake table at the given path.
+   *
+   * <ul>
+   *   <li>Behavior when the table location doesn't exist:
+   *       <ul>
+   *         <li>Reads will fail with a {@link TableNotFoundException}
+   *         <li>Writes will create the location
+   *       </ul>
+   *   <li>Behavior when the table location exists (with contents or not) but is not a Delta table:
+   *       <ul>
+   *         <li>Reads will fail with a {@link TableNotFoundException}
+   *         <li>Writes will create a Delta table at the given location. If there are any existing
+   *             files in the location that are not already part of the Delta table, they will
+   *             remain excluded from the Delta table.
+   *       </ul>
+   * </ul>
+   *
+   * @return the new {@link Table} instance
+   */
   Table build();
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/TableIdentifier.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/TableIdentifier.java
@@ -1,0 +1,25 @@
+package io.delta.kernel;
+
+/** Identifier for a table. e.g. <catalog> / <schema> / <tableName> */
+public class TableIdentifier {
+  /** The name of the table. */
+  private final String name;
+
+  /** The namespace of the table. e.g. <catalog> / <schema> */
+  private final String[] namespace;
+
+  public TableIdentifier(String[] namespace, String name) {
+    this.namespace = namespace;
+    this.name = name;
+  }
+
+  /** Returns the namespace of the table. */
+  public String[] getNamespace() {
+    return namespace;
+  }
+
+  /** Returns the name of the table. */
+  public String getName() {
+    return name;
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/TableIdentifier.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/TableIdentifier.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.delta.kernel;
 
 /** Identifier for a table. e.g. <catalog> / <schema> / <tableName> */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/annotation/Nullable.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/annotation/Nullable.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Annotation to indicate that a field, method parameter, method return value, or local variable may
+ * be null.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE})
+public @interface Nullable {}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/config/ConfigurationProvider.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/config/ConfigurationProvider.java
@@ -16,12 +16,46 @@
 
 package io.delta.kernel.config;
 
+import io.delta.kernel.annotation.Evolving;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
+/**
+ * Provides per-session configuration values for Delta Kernel, specific to the current execution.
+ *
+ * <p>These values are not Delta table properties. Delta table properties are stored in the Delta
+ * log metadata and apply globally to all readers and writers interacting with the table.
+ *
+ * <p>Instead, the configuration values provided by this interface are scoped to a single instance
+ * of Delta Kernel during its execution.
+ *
+ * @since 3.3.0
+ */
+@Evolving
 public interface ConfigurationProvider {
+  /**
+   * Retrieves the configuration value for the given key.
+   *
+   * @param key the configuration key
+   * @return the configuration value associated with the key
+   * @throws NoSuchElementException if the key is not found
+   */
   String get(String key);
 
+  /**
+   * Retrieves the configuration value for the given key. If it doesn't exist, returns {@link
+   * Optional#empty}.
+   *
+   * @param key the configuration key
+   * @return the configuration value associated with the key, if it exists
+   */
   Optional<String> getOptional(String key);
 
+  /**
+   * Checks if the configuration provider contains the given key.
+   *
+   * @param key the configuration key
+   * @return {@code true} if the key exists, else {@code false}
+   */
   boolean contains(String key);
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/config/ConfigurationProvider.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/config/ConfigurationProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.delta.kernel.config;
 
 import java.util.Optional;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/config/ConfigurationProvider.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/config/ConfigurationProvider.java
@@ -1,0 +1,11 @@
+package io.delta.kernel.config;
+
+import java.util.Optional;
+
+public interface ConfigurationProvider {
+  String get(String key);
+
+  Optional<String> getOptional(String key);
+
+  boolean contains(String key);
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/coordinatedcommits/TableDescriptor.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/coordinatedcommits/TableDescriptor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.coordinatedcommits;
+
+import static java.util.Objects.requireNonNull;
+
+import io.delta.kernel.TableIdentifier;
+import io.delta.kernel.annotation.Evolving;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * The complete descriptor of a Coordinated Commits (CC) Delta table, including its logPath, table
+ * identifier, and table CC table configuration.
+ *
+ * @since 3.3.0
+ */
+@Evolving
+public class TableDescriptor {
+
+  private final String logPath;
+  private final Optional<TableIdentifier> tableIdOpt;
+  private final Map<String, String> tableConf;
+
+  public TableDescriptor(
+      String logPath, Optional<TableIdentifier> tableIdOpt, Map<String, String> tableConf) {
+    requireNonNull(logPath, "Expected non-null value for 'logPath'");
+    requireNonNull(tableIdOpt, "Expected non-null value for 'tableIdOpt'");
+    requireNonNull(tableConf, "Expected non-null value for 'tableConf'");
+
+    this.logPath = logPath;
+    this.tableIdOpt = tableIdOpt;
+    this.tableConf = tableConf;
+  }
+
+  /** Returns the Delta log path of the table. */
+  public String getLogPath() {
+    return logPath;
+  }
+
+  /** Returns the optional table identifier of the table, e.g. <catalog> / <schema> / <tableName> */
+  public Optional<TableIdentifier> getTableIdentifierOpt() {
+    return tableIdOpt;
+  }
+
+  /**
+   * Returns the Coordinated Commits table configuration.
+   *
+   * <p>This is the parsed value of the Delta table property {@link
+   * io.delta.kernel.internal.TableConfig#COORDINATED_COMMITS_TABLE_CONF} and represents the
+   * configuration properties for describing the Delta table to commit-coordinator.
+   */
+  public Map<String, String> getTableConf() {
+    return tableConf;
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/engine/CommitCoordinatorClient.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/engine/CommitCoordinatorClient.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.engine;
+
+import io.delta.kernel.TableIdentifier;
+import io.delta.kernel.annotation.Evolving;
+import io.delta.kernel.annotation.Nullable;
+import io.delta.kernel.coordinatedcommits.TableDescriptor;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.engine.coordinatedcommits.CommitFailedException;
+import io.delta.kernel.engine.coordinatedcommits.CommitResponse;
+import io.delta.kernel.engine.coordinatedcommits.GetCommitsResponse;
+import io.delta.kernel.engine.coordinatedcommits.UpdatedActions;
+import io.delta.kernel.engine.coordinatedcommits.actions.AbstractMetadata;
+import io.delta.kernel.engine.coordinatedcommits.actions.AbstractProtocol;
+import io.delta.kernel.utils.CloseableIterator;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * The CommitCoordinatorClient is responsible for communicating with the commit coordinator and
+ * backfilling commits. It has four main APIs that need to be implemented:
+ *
+ * <ul>
+ *   <li>{@link #registerTable}: Determine the table config during commit coordinator registration.
+ *   <li>{@link #commit}: Commit a new version of the table.
+ *   <li>{@link #getUnbackfilledCommits}: Tracks and returns unbackfilled commits.
+ *   <li>{@link #backfillToVersion}: Ensure that commits are backfilled if/when needed.
+ * </ul>
+ *
+ * @since 3.3.0
+ */
+@Evolving
+public interface CommitCoordinatorClient {
+
+  /**
+   * API to register the table represented by the given {@code logPath} at the provided {@code
+   * currentVersion} with the commit coordinator this commit coordinator client represents.
+   *
+   * <p>This API is called when the table is being converted from an existing file system table to a
+   * coordinated-commit table.
+   *
+   * <p>When a new coordinated-commit table is being created, the {@code currentVersion} will be -1
+   * and the upgrade commit needs to be a file system commit which will write the backfilled file
+   * directly.
+   *
+   * @param engine The {@link Engine} instance to use.
+   * @param logPath The path to the delta log of the table that should be converted.
+   * @param tableIdentifier The table identifier for the table, or {@code null} if the table doesn't
+   *     use any identifier (i.e. it is path-based).
+   * @param currentVersion The version of the table just before conversion. currentVersion + 1
+   *     represents the commit that will do the conversion. This must be backfilled atomically.
+   *     currentVersion + 2 represents the first commit after conversion. This will go through the
+   *     CommitCoordinatorClient and the client is free to choose when it wants to backfill this
+   *     commit.
+   * @param currentMetadata The metadata of the table at currentVersion
+   * @param currentProtocol The protocol of the table at currentVersion
+   * @return A map of key-value pairs which is issued by the commit coordinator to uniquely identify
+   *     the table. This should be stored in the table's metadata for table property {@link *
+   *     io.delta.kernel.internal.TableConfig#COORDINATED_COMMITS_TABLE_CONF}. This information
+   *     needs to be passed to the {@link #commit}, {@link #getUnbackfilledCommits}, and {@link
+   *     #backfillToVersion} APIs to identify the table.
+   */
+  Map<String, String> registerTable(
+      Engine engine,
+      String logPath,
+      @Nullable TableIdentifier tableIdentifier,
+      long currentVersion,
+      AbstractMetadata currentMetadata,
+      AbstractProtocol currentProtocol);
+
+  /**
+   * API to commit the given set of actions to the table represented by {@code tableDescriptor}.
+   *
+   * @param engine The {@link Engine} instance to use.
+   * @param tableDescriptor The descriptor for the table.
+   * @param commitVersion The version of the commit that is being committed.
+   * @param actions The set of actions to be committed
+   * @param updatedActions Additional information for the commit, including:
+   *     <ul>
+   *       <li>Commit info
+   *       <li>Metadata changes
+   *       <li>Protocol changes
+   *     </ul>
+   *
+   * @return {@link CommitResponse} containing the file status of the committed file. Note: If the
+   *     commit is already backfilled, the file status may be omitted, and the client can retrieve
+   *     this information independently.
+   * @throws CommitFailedException if the commit operation fails
+   */
+  CommitResponse commit(
+      Engine engine,
+      TableDescriptor tableDescriptor,
+      long commitVersion,
+      CloseableIterator<Row> actions,
+      UpdatedActions updatedActions)
+      throws CommitFailedException;
+
+  /**
+   * API to get the unbackfilled commits for the table represented by the given tableDescriptor.
+   * Commits older than startVersion (if given) or newer than endVersion (if given) are ignored. The
+   * returned commits are contiguous and in ascending version order.
+   *
+   * <p>Note that the first version returned by this API may not be equal to startVersion. This
+   * happens when some versions starting from startVersion have already been backfilled and so the
+   * commit coordinator may have stopped tracking them.
+   *
+   * <p>The returned latestTableVersion is the maximum commit version ratified by the commit
+   * coordinator. Note that returning latestTableVersion as -1 is acceptable only if the commit
+   * coordinator never ratified any version, i.e. it never accepted any unbackfilled commit.
+   *
+   * @param engine The {@link Engine} instance to use.
+   * @param tableDescriptor The descriptor for the table.
+   * @param startVersion The minimum version of the commit that should be returned, or {@code null}
+   *     if there is no minimum.
+   * @param endVersion The maximum version of the commit that should be returned, or {@code null} if
+   *     there is no maximum.
+   * @return {@link GetCommitsResponse} which has a list of {@link
+   *     io.delta.kernel.engine.coordinatedcommits.Commit}s and the latestTableVersion which is
+   *     tracked by the {@link CommitCoordinatorClient}.
+   */
+  GetCommitsResponse getUnbackfilledCommits(
+      Engine engine,
+      TableDescriptor tableDescriptor,
+      @Nullable Long startVersion,
+      @Nullable Long endVersion);
+
+  /**
+   * API to ask the commit coordinator client to backfill all commits up to {@code version} and
+   * notify the commit coordinator.
+   *
+   * <p>If this API returns successfully, that means the backfill must have been completed, although
+   * the commit coordinator may not be aware of it yet.
+   *
+   * @param engine The {@link Engine} instance to use.
+   * @param tableDescriptor The descriptor for the table.
+   * @param version The version until which the commit coordinator client should backfill.
+   * @param lastKnownBackfilledVersion The last known version that was backfilled before this API
+   *     was called. If it is {@code null}, then the commit coordinator client should backfill from
+   *     the beginning of the table.
+   * @throws IOException if there is an IO error while backfilling the commits.
+   */
+  void backfillToVersion(
+      Engine engine,
+      TableDescriptor tableDescriptor,
+      long version,
+      @Nullable Long lastKnownBackfilledVersion)
+      throws IOException;
+
+  /**
+   * Checks if this CommitCoordinatorClient is semantically equal to another
+   * CommitCoordinatorClient.
+   */
+  boolean semanticEquals(CommitCoordinatorClient other);
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/engine/Engine.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/engine/Engine.java
@@ -17,6 +17,7 @@
 package io.delta.kernel.engine;
 
 import io.delta.kernel.annotation.Evolving;
+import io.delta.kernel.config.ConfigurationProvider;
 import java.util.Map;
 
 /**
@@ -55,6 +56,26 @@ public interface Engine {
    * @return An implementation of {@link ParquetHandler}.
    */
   ParquetHandler getParquetHandler();
+
+  /**
+   * Retrieves a {@link CommitCoordinatorClient} for the specified commit coordinator name.
+   *
+   * @param commitCoordinatorName The name (identifier) of the underlying commit coordinator client
+   *     to instantiate
+   * @param sessionConfig The current per-session configuration values for Delta Kernel
+   * @param commitCoordinatorConf The configuration settings for the underlying commit coordinator
+   *     client, taken directly from the Delta table property {@link
+   *     io.delta.kernel.internal.TableConfig#COORDINATED_COMMITS_TABLE_CONF}
+   * @return A {@link CommitCoordinatorClient} implementation corresponding to the specified commit
+   *     coordinator name
+   * @since 3.3.0
+   */
+  default CommitCoordinatorClient getCommitCoordinatorClient(
+      String commitCoordinatorName,
+      ConfigurationProvider sessionConfig,
+      Map<String, String> commitCoordinatorConf) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
 
   /**
    * Retrieves a {@link CommitCoordinatorClientHandler} for the specified commit coordinator client.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/engine/coordinatedcommits/UpdatedActions.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/engine/coordinatedcommits/UpdatedActions.java
@@ -23,7 +23,7 @@ import io.delta.kernel.engine.coordinatedcommits.actions.AbstractProtocol;
 
 /**
  * A container class to inform the {@link io.delta.kernel.engine.CommitCoordinatorClientHandler}
- * about any changes in Protocol/Metadata
+ * about any changes in Protocol/Metadata/CommitInfo.
  *
  * @since 3.3.0
  */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/EmptyConfigurationProvider.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/EmptyConfigurationProvider.java
@@ -1,0 +1,22 @@
+package io.delta.kernel.internal;
+
+import io.delta.kernel.config.ConfigurationProvider;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+public class EmptyConfigurationProvider implements ConfigurationProvider {
+  @Override
+  public String get(String key) {
+    throw new NoSuchElementException();
+  }
+
+  @Override
+  public Optional<String> getOptional(String key) {
+    return Optional.empty();
+  }
+
+  @Override
+  public boolean contains(String key) {
+    return false;
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/EmptyConfigurationProvider.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/EmptyConfigurationProvider.java
@@ -20,6 +20,11 @@ import io.delta.kernel.config.ConfigurationProvider;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
+/**
+ * An implementation of {@link ConfigurationProvider} that always returns empty results or throws
+ * exceptions for configuration values. This class is intended to be used in cases where no
+ * configuration is provided or expected.
+ */
 public class EmptyConfigurationProvider implements ConfigurationProvider {
   @Override
   public String get(String key) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/EmptyConfigurationProvider.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/EmptyConfigurationProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.delta.kernel.internal;
 
 import io.delta.kernel.config.ConfigurationProvider;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableBuilderImpl.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.internal;
+
+import static java.util.Objects.requireNonNull;
+
+import io.delta.kernel.Table;
+import io.delta.kernel.TableBuilder;
+import io.delta.kernel.TableIdentifier;
+import io.delta.kernel.config.ConfigurationProvider;
+import io.delta.kernel.engine.Engine;
+import io.delta.kernel.internal.util.Clock;
+import java.util.Optional;
+
+public class TableBuilderImpl implements TableBuilder {
+  private final Engine engine;
+  private final String path;
+
+  private Optional<ConfigurationProvider> configProviderOpt = Optional.empty();
+  private Optional<TableIdentifier> tableIdOpt = Optional.empty();
+
+  /** Note: This is not for a public API. It's for internal testing use only. */
+  private Optional<Clock> clockOpt = Optional.empty();
+
+  public TableBuilderImpl(Engine engine, String path) {
+    requireNonNull(engine, "Expected non-null value for 'engine'");
+    requireNonNull(path, "Expected non-null value for 'path'");
+
+    this.engine = engine;
+    this.path = path;
+  }
+
+  @Override
+  public TableBuilder withConfigurationProvider(ConfigurationProvider configProvider) {
+    requireNonNull(configProvider, "Expected non-null value for 'configProvider'");
+    this.configProviderOpt = Optional.of(configProvider);
+    return this;
+  }
+
+  @Override
+  public TableBuilder withTableId(TableIdentifier tableId) {
+    requireNonNull(tableId, "Expected non-null value for 'tableId'");
+    this.tableIdOpt = Optional.of(tableId);
+    return null;
+  }
+
+  /** Note: This is not a public API. It's for internal testing use only. */
+  public TableBuilder withClock(Clock clock) {
+    requireNonNull(clock, "Expected non-null value for 'clock'");
+    this.clockOpt = Optional.of(clock);
+    return this;
+  }
+
+  @Override
+  public Table build() {
+    return TableImpl.create(
+        engine,
+        path,
+        clockOpt.orElse(System::currentTimeMillis),
+        configProviderOpt.orElse(new EmptyConfigurationProvider()),
+        tableIdOpt);
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableImpl.java
@@ -55,6 +55,7 @@ public class TableImpl implements Table {
     return new TableBuilderImpl(engine, path);
   }
 
+  /** Package-private method */
   static Table create(
       Engine engine,
       String unresolvedPath,

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWriteSuiteBase.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWriteSuiteBase.scala
@@ -272,7 +272,7 @@ trait DeltaTableWriteSuiteBase extends AnyFunSuite with TestUtils {
     clock: Clock = () => System.currentTimeMillis): Transaction = {
 
     var txnBuilder = createWriteTxnBuilder(
-      TableImpl.forPath(engine, tablePath, clock))
+      TableImpl.builder(engine, tablePath).withClock(clock).build())
 
     if (isNewTable) {
       txnBuilder = txnBuilder.withSchema(engine, schema)

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/InCommitTimestampSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/InCommitTimestampSuite.scala
@@ -236,7 +236,7 @@ class InCommitTimestampSuite extends DeltaTableWriteSuiteBase {
 
   test("Enablement tracking works when ICT is enabled post commit 0") {
     withTempDirAndEngine { (tablePath, engine) =>
-      val table = TableImpl.forPath(engine, tablePath)
+      val table = Table.forPath(engine, tablePath)
       val txnBuilder = table.createTransactionBuilder(engine, testEngineInfo, CREATE_TABLE)
 
       val txn = txnBuilder
@@ -323,7 +323,7 @@ class InCommitTimestampSuite extends DeltaTableWriteSuiteBase {
 
   test("Metadata toString should work with ICT enabled") {
     withTempDirAndEngine { (tablePath, engine) =>
-      val table = TableImpl.forPath(engine, tablePath)
+      val table = Table.forPath(engine, tablePath)
       val txnBuilder = table.createTransactionBuilder(engine, testEngineInfo, CREATE_TABLE)
 
       val txn = txnBuilder
@@ -360,7 +360,7 @@ class InCommitTimestampSuite extends DeltaTableWriteSuiteBase {
 
   test("Table with ICT enabled is readable") {
     withTempDirAndEngine { (tablePath, engine) =>
-      val table = TableImpl.forPath(engine, tablePath)
+      val table = Table.forPath(engine, tablePath)
       val txnBuilder = table.createTransactionBuilder(engine, testEngineInfo, CREATE_TABLE)
 
       val txn = txnBuilder
@@ -422,7 +422,7 @@ class InCommitTimestampSuite extends DeltaTableWriteSuiteBase {
 
   test("Conflict resolution of timestamps") {
     withTempDirAndEngine { (tablePath, engine) =>
-      val table = TableImpl.forPath(engine, tablePath, () => System.currentTimeMillis)
+      val table = Table.forPath(engine, tablePath)
       setTablePropAndVerify(
         engine, tablePath, isNewTable = true, IN_COMMIT_TIMESTAMPS_ENABLED, "true", true)
 
@@ -453,7 +453,7 @@ class InCommitTimestampSuite extends DeltaTableWriteSuiteBase {
   Seq(10, 2).foreach { winningCommitCount =>
     test(s"Conflict resolution of enablement version(Winning Commit Count=$winningCommitCount)") {
       withTempDirAndEngine { (tablePath, engine) =>
-        val table = TableImpl.forPath(engine, tablePath, () => System.currentTimeMillis)
+        val table = Table.forPath(engine, tablePath)
         val txnBuilder = table.createTransactionBuilder(engine, testEngineInfo, CREATE_TABLE)
 
         val txn = txnBuilder
@@ -504,7 +504,7 @@ class InCommitTimestampSuite extends DeltaTableWriteSuiteBase {
   test("Missing CommitInfo in last winning commit in conflict resolution should result in a " +
     "DELTA_MISSING_COMMIT_INFO exception") {
     withTempDirAndEngine { (tablePath, engine) =>
-      val table = TableImpl.forPath(engine, tablePath, () => System.currentTimeMillis)
+      val table = Table.forPath(engine, tablePath)
       setTablePropAndVerify(
         engine, tablePath, isNewTable = true, IN_COMMIT_TIMESTAMPS_ENABLED, "true", true)
 
@@ -549,7 +549,7 @@ class InCommitTimestampSuite extends DeltaTableWriteSuiteBase {
   test("Throw an error where the winning txn enables the ICT and losing txn prepares txn with " +
     "ICT enabled") {
     withTempDirAndEngine { (tablePath, engine) =>
-      val table = TableImpl.forPath(engine, tablePath, () => System.currentTimeMillis)
+      val table = Table.forPath(engine, tablePath)
       val txnBuilder = table.createTransactionBuilder(engine, testEngineInfo, CREATE_TABLE)
 
       val txn = txnBuilder


### PR DESCRIPTION
**NOTE: I won't be merging any of these PRs until the entire e2e implementation is complete and all PRs are approved**

This is part of some stacked PRs:
1. https://github.com/delta-io/delta/pull/3781
2. https://github.com/delta-io/delta/pull/3782

To see the diff of only this PR: click [here](https://github.com/scottsand-db/delta/compare/delta_kernel_commit_coordinator_refactor_1...delta_kernel_commit_coordinator_refactor_2)

#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

This PR adds the new `CommitCoordinatorClient` interface into `delta-kernel-api`. Notably I use `#getUnbackfilledCommits` instead of `#getCommits`.

This PR does NOT delete the existing `CommitCoordinatorClientHandler` interface in `delta-kernel-api`.

That will come in the next PR.

## How was this patch tested?

N/A

## Does this PR introduce _any_ user-facing changes?

New `CommitCoordinatorClient` interface into.
