### PR TITLE
[Kernel] Add `Snapshot::getTimestamp` public API

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
@@ -30,8 +30,7 @@ import java.util.List;
 public interface Snapshot {
 
   /**
-   * Get the version of this snapshot in the table. Returns -1 if the table is empty and so has no
-   * commits.
+   * Get the version of this snapshot in the table.
    *
    * @param engine {@link Engine} instance to use in Delta Kernel.
    * @return version of this snapshot in the Delta table
@@ -50,14 +49,7 @@ public interface Snapshot {
   List<String> getPartitionColumnNames(Engine engine);
 
   /**
-   * Get the timestamp (in milliseconds since the Unix epoch) of the latest commit of this snapshot.
-   * Returns -1 if the table is empty and so has no commits.
-   *
-   * <p>When InCommitTimestampTableFeature is enabled, the timestamp is retrieved from the
-   * CommitInfo of the latest commit which can result in an IO operation.
-   *
-   * <p>For non-ICT tables, this is the same as the file modification time of the latest commit in
-   * the snapshot.
+   * Get the timestamp (in milliseconds since the Unix epoch) of the latest commit in this snapshot.
    *
    * @param engine the engine to use for IO operations
    * @return the timestamp of the latest commit

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
@@ -47,6 +47,22 @@ public interface Snapshot {
    * @return a list of partition column names, or an empty list if the table is not partitioned.
    */
   List<String> getPartitionColumnNames(Engine engine);
+
+  /**
+   * Get the timestamp (in milliseconds since the Unix epoch) of the latest commit of this snapshot.
+   * For an uninitialized snapshot, this returns -1.
+   *
+   * <p>When InCommitTimestampTableFeature is enabled, the timestamp is retrieved from the
+   * CommitInfo of the latest commit which can result in an IO operation.
+   *
+   * <p>For non-ICT tables, this is the same as the file modification time of the latest commit in
+   * the snapshot.
+   *
+   * @param engine the engine to use for IO operations
+   * @return the timestamp of the latest commit
+   */
+  long getTimestamp(Engine engine);
+
   /**
    * Get the schema of the table at this snapshot.
    *

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
@@ -30,7 +30,8 @@ import java.util.List;
 public interface Snapshot {
 
   /**
-   * Get the version of this snapshot in the table.
+   * Get the version of this snapshot in the table. Returns -1 if the table is empty and so has no
+   * commits.
    *
    * @param engine {@link Engine} instance to use in Delta Kernel.
    * @return version of this snapshot in the Delta table
@@ -50,7 +51,7 @@ public interface Snapshot {
 
   /**
    * Get the timestamp (in milliseconds since the Unix epoch) of the latest commit of this snapshot.
-   * For an uninitialized snapshot, this returns -1.
+   * Returns -1 if the table is empty and so has no commits.
    *
    * <p>When InCommitTimestampTableFeature is enabled, the timestamp is retrieved from the
    * CommitInfo of the latest commit which can result in an IO operation.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -75,6 +75,9 @@ public class SnapshotImpl implements Snapshot {
 
   /**
    * Get the timestamp (in milliseconds since the Unix epoch) of the latest commit in this Snapshot.
+   * If the table does not yet exist (i.e. this Snapshot is being used to create the new table),
+   * this method returns -1. Note that this -1 value will never be exposed to users - either they
+   * get a valid snapshot for a table or they get an exception.
    *
    * <p>When InCommitTimestampTableFeature is enabled, the timestamp is retrieved from the
    * CommitInfo of the latest commit in this Snapshot, which can result in an IO operation.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -75,7 +75,7 @@ public class SnapshotImpl implements Snapshot {
 
   @Override
   public long getTimestamp(Engine engine) {
-    if (TableConfig.isICTEnabled(engine, metadata)) {
+    if (IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(metadata)) {
       if (!inCommitTimestampOpt.isPresent()) {
         Optional<CommitInfo> commitInfoOpt =
             CommitInfo.getCommitInfoOpt(engine, logPath, logSegment.version);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -64,9 +64,30 @@ public class SnapshotImpl implements Snapshot {
     this.inCommitTimestampOpt = Optional.empty();
   }
 
+  /////////////////
+  // Public APIs //
+  /////////////////
+
   @Override
   public long getVersion(Engine engine) {
     return version;
+  }
+
+  @Override
+  public long getTimestamp(Engine engine) {
+    if (TableConfig.isICTEnabled(engine, metadata)) {
+      if (!inCommitTimestampOpt.isPresent()) {
+        Optional<CommitInfo> commitInfoOpt =
+            CommitInfo.getCommitInfoOpt(engine, logPath, logSegment.version);
+        inCommitTimestampOpt =
+            Optional.of(
+                CommitInfo.getRequiredInCommitTimestamp(
+                    commitInfoOpt, String.valueOf(logSegment.version), dataPath));
+      }
+      return inCommitTimestampOpt.get();
+    } else {
+      return logSegment.lastCommitTimestamp;
+    }
   }
 
   @Override
@@ -79,8 +100,16 @@ public class SnapshotImpl implements Snapshot {
     return new ScanBuilderImpl(dataPath, protocol, metadata, getSchema(engine), logReplay, engine);
   }
 
-  public Metadata getMetadata() {
-    return metadata;
+  ///////////////////
+  // Internal APIs //
+  ///////////////////
+
+  public Path getLogPath() {
+    return logPath;
+  }
+
+  public Path getDataPath() {
+    return dataPath;
   }
 
   public Protocol getProtocol() {
@@ -102,6 +131,14 @@ public class SnapshotImpl implements Snapshot {
     return logReplay.getDomainMetadataMap();
   }
 
+  public Metadata getMetadata() {
+    return metadata;
+  }
+
+  public LogSegment getLogSegment() {
+    return logSegment;
+  }
+
   public CreateCheckpointIterator getCreateCheckpointIterator(Engine engine) {
     long minFileRetentionTimestampMillis =
         System.currentTimeMillis() - TOMBSTONE_RETENTION.fromMetadata(metadata);
@@ -120,47 +157,6 @@ public class SnapshotImpl implements Snapshot {
    */
   public Optional<Long> getLatestTransactionVersion(Engine engine, String applicationId) {
     return logReplay.getLatestTransactionIdentifier(engine, applicationId);
-  }
-
-  public LogSegment getLogSegment() {
-    return logSegment;
-  }
-
-  public Path getLogPath() {
-    return logPath;
-  }
-
-  public Path getDataPath() {
-    return dataPath;
-  }
-
-  /**
-   * Returns the timestamp of the latest commit of this snapshot. For an uninitialized snapshot,
-   * this returns -1.
-   *
-   * <p>When InCommitTimestampTableFeature is enabled, the timestamp is retrieved from the
-   * CommitInfo of the latest commit which can result in an IO operation.
-   *
-   * <p>For non-ICT tables, this is the same as the file modification time of the latest commit in
-   * the snapshot.
-   *
-   * @param engine the engine to use for IO operations
-   * @return the timestamp of the latest commit
-   */
-  public long getTimestamp(Engine engine) {
-    if (IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(metadata)) {
-      if (!inCommitTimestampOpt.isPresent()) {
-        Optional<CommitInfo> commitInfoOpt =
-            CommitInfo.getCommitInfoOpt(engine, logPath, logSegment.version);
-        inCommitTimestampOpt =
-            Optional.of(
-                CommitInfo.getRequiredInCommitTimestamp(
-                    commitInfoOpt, String.valueOf(logSegment.version), dataPath));
-      }
-      return inCommitTimestampOpt.get();
-    } else {
-      return logSegment.lastCommitTimestamp;
-    }
   }
 
   /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -73,6 +73,15 @@ public class SnapshotImpl implements Snapshot {
     return version;
   }
 
+  /**
+   * Get the timestamp (in milliseconds since the Unix epoch) of the latest commit in this Snapshot.
+   *
+   * <p>When InCommitTimestampTableFeature is enabled, the timestamp is retrieved from the
+   * CommitInfo of the latest commit in this Snapshot, which can result in an IO operation.
+   *
+   * <p>For non-ICT tables, this is the same as the file modification time of the latest commit in
+   * this Snapshot.
+   */
   @Override
   public long getTimestamp(Engine engine) {
     if (IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(metadata)) {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Add a new `Snapshot::getTimestamp` public API.

## How was this patch tested?

N/A. Trivial.

## Does this PR introduce _any_ user-facing changes?

Yes. Adds a new `Snapshot::getTimestamp` public API.
