### PR TITLE
[Spark] Fix a bug where MERGE command can fail to run with AnalysisException

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/MergeIntoScalaSuite.scala
@@ -721,8 +721,7 @@ class MergeIntoScalaSuite extends MergeIntoSuiteBase
     withTable("mytab") {
       spark.sql("create table mytab (id int) using delta")
 
-      // This test is intended to check if the following query compilation
-      // succeeds or not. https://github.com/delta-io/delta/issues/3099
+      // Without the fix, the following SQL fails with AnalysisException
       spark.sql("""
         merge into mytab as target
         using (


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Resolves #3099 by cloning the merge command before setting a tag.

This could be also solved on the Spark side, by fixing the relation cache logic to return a copy of the cached relation instead of returning the same instance, which can cause this issue. However, that can take some time, and it doesn't change the fact that current and old Spark versions have the issue.

## How was this patch tested?

Added a test that fails without the fix with the error "org.apache.spark.sql.AnalysisException: Table does not support reads", and passes with the fix.

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

It is unlikely a user will notice any change with this PR. The fix copies a query plan tree and this happens all the time in the analysis/optimization/planning phases of Spark.