### PR TITLE
[Table Redirect] Introduce Redirect ReaderWriter Feature

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2371,6 +2371,19 @@
     ],
     "sqlState" : "XXKDS"
   },
+  "DELTA_TABLE_INVALID_REDIRECT_STATE_TRANSITION" : {
+    "message" : [
+      "Unable to update table redirection state: Invalid state transition attempted.",
+      "The Delta table '<table>' cannot change from '<oldState>' to '<newState>'."
+    ],
+    "sqlState" : "KD007"
+  },
+  "DELTA_TABLE_INVALID_REMOVE_TABLE_REDIRECT" : {
+    "message" : [
+      "Unable to remove table redirection for <table> due to its invalid state: <currentState>."
+    ],
+    "sqlState" : "KD007"
+  },
   "DELTA_TABLE_LOCATION_MISMATCH" : {
     "message" : [
       "The location of the existing table <tableName> is <existingTableLocation>. It doesn't match the specified location <tableLocation>."

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -407,6 +407,26 @@ trait DeltaConfigsBase extends DeltaLogging {
     "needs to be a positive integer.")
 
   /**
+   * This is the property that describes the table redirection detail. It is a JSON string format
+   * of the `TableRedirectConfiguration` class, which includes following attributes:
+   * - type(String): The type of redirection.
+   * - state(String): The current state of the redirection:
+   *                  ENABLE-REDIRECT-IN-PROGRESS, REDIRECT-READY, DROP-REDIRECT-IN-PROGRESS.
+   * - spec(JSON String): The specification of accessing redirect destination table. This is free
+   *                      form json object. Each delta service provider can customize its own
+   *                      implementation. In Databricks, it is an object that contains a
+   *                      attribute named `Table` with Map[String, String] type.
+   */
+  val REDIRECT_READER_WRITER: DeltaConfig[Option[String]] =
+    buildConfig[Option[String]](
+      "redirectReaderWriter-preview",
+      null,
+      v => Option(v),
+      _ => true,
+      "A JSON representation of the TableRedirectConfiguration class, which contains all " +
+        "information of redirect reader writer feature.")
+
+  /**
    * Enable auto compaction for a Delta table. When enabled, we will check if files already
    * written to a Delta table can leverage compaction after a commit. If so, we run a post-commit
    * hook to compact the files.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -31,6 +31,7 @@ import org.apache.spark.sql.delta.constraints.Constraints
 import org.apache.spark.sql.delta.hooks.AutoCompactType
 import org.apache.spark.sql.delta.hooks.PostCommitHook
 import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.redirect.RedirectState
 import org.apache.spark.sql.delta.schema.{DeltaInvariantViolationException, InvariantViolationException, SchemaUtils, UnsupportedDataTypeInfo}
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.JsonUtils
@@ -340,6 +341,24 @@ trait DeltaErrorsBase
     new DeltaAnalysisException(
       errorClass = "DELTA_CANNOT_DROP_CHECK_CONSTRAINT_FEATURE",
       messageParameters = Array(constraintNames.map(formatColumn).mkString(", "))
+    )
+  }
+
+  def invalidRedirectStateTransition(
+      table: String,
+      oldState: RedirectState,
+      newState: RedirectState): Unit = {
+    new DeltaIllegalStateException(
+      errorClass = "DELTA_TABLE_INVALID_REDIRECT_STATE_TRANSITION",
+      messageParameters = Array(
+        table, table, oldState.name, newState.name)
+    )
+  }
+
+  def invalidRemoveTableRedirect(table: String, currentState: RedirectState): Unit = {
+    new DeltaIllegalStateException(
+      errorClass = "DELTA_TABLE_INVALID_REMOVE_TABLE_REDIRECT",
+      messageParameters = Array(table, table, currentState.name)
     )
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.constraints.{Constraints, Invariants}
 import org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsUtils
+import org.apache.spark.sql.delta.redirect.RedirectReaderWriter
 import org.apache.spark.sql.delta.schema.SchemaMergingUtils
 import org.apache.spark.sql.delta.schema.SchemaUtils
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -367,6 +368,7 @@ object TableFeature {
       CoordinatedCommitsTableFeature)
     if (DeltaUtils.isTesting && testingFeaturesEnabled) {
       features ++= Set(
+        RedirectReaderWriterFeature,
         TestLegacyWriterFeature,
         TestLegacyReaderWriterFeature,
         TestWriterFeature,
@@ -574,6 +576,18 @@ object TimestampNTZTableFeature extends ReaderWriterFeature(name = "timestampNtz
       protocol: Protocol, metadata: Metadata, spark: SparkSession): Boolean = {
     SchemaUtils.checkForTimestampNTZColumnsRecursively(metadata.schema)
   }
+}
+
+object RedirectReaderWriterFeature
+  extends ReaderWriterFeature(name = "redirectReaderWriter-preview")
+  with FeatureAutomaticallyEnabledByMetadata {
+  override def metadataRequiresFeatureToBeEnabled(
+    protocol: Protocol,
+    metadata: Metadata,
+    spark: SparkSession
+  ): Boolean = RedirectReaderWriter.isFeatureSet(metadata)
+
+  override def automaticallyUpdateProtocolOfExistingTables: Boolean = true
 }
 
 object VariantTypeTableFeature extends ReaderWriterFeature(name = "variantType-preview")

--- a/spark/src/main/scala/org/apache/spark/sql/delta/redirect/TableRedirect.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/redirect/TableRedirect.scala
@@ -1,0 +1,311 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.redirect
+
+import scala.reflect.ClassTag
+
+import org.apache.spark.sql.delta.{DeltaConfig, DeltaConfigs, DeltaErrors, DeltaLog, DeltaOperations}
+import org.apache.spark.sql.delta.actions.Metadata
+import org.apache.spark.sql.delta.util.JsonUtils
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+
+/**
+ * The table redirection feature includes specific states that manage the behavior of Delta clients
+ * during various stages of redirection. These states ensure query result consistency and prevent
+ * data loss. There are four states:
+ *   0. NO-REDIRECT: Indicates that table redirection is not enabled.
+ *   1. ENABLE-REDIRECT-IN-PROGRESS: Table redirection is being enabled. Only read-only queries are
+ *                                   allowed on the source table, while all write and metadata
+ *                                   transactions are aborted.
+ *   2. REDIRECT-READY: The redirection setup is complete, and all queries on the source table are
+ *                      routed to the destination table.
+ *   3. DROP-REDIRECT-IN-PROGRESS: Table redirection is being disabled. Only read-only queries are
+ *                                 allowed on the destination table, with all write and metadata
+ *                                 transactions aborted.
+ * The valid procedures of state transition are:
+ *   0. NO-REDIRECT -> ENABLE-REDIRECT-IN-PROGRESS: Begins the table redirection process by
+ *                                                  transitioning the table to
+ *                                                  'ENABLE-REDIRECT-IN-PROGRESS.' During this setup
+ *                                                  phase, all concurrent DML and DDL operations are
+ *                                                  temporarily blocked..
+ *   1. ENABLE-REDIRECT-IN-PROGRESS -> REDIRECT-READY: Completes the setup for the table redirection
+ *                                                     feature. The table starts redirecting all
+ *                                                     queries to the destination location.
+ *   2. REDIRECT-READY -> DROP-REDIRECT-IN-PROGRESS: Initiates the process of removing table
+ *                                                   redirection by setting the table to
+ *                                                   'DROP-REDIRECT-IN-PROGRESS.' This ensures that
+ *                                                   concurrent DML/DDL operations do not interfere
+ *                                                   with the cancellation process.
+ *   3. DROP-REDIRECT-IN-PROGRESS -> NO-REDIRECT: Completes the removal of table redirection. As a
+ *                                                result, all DML, DDL, and read-only queries are no
+ *                                                longer redirected to the previous destination.
+ *   4. ENABLE-REDIRECT-IN-PROGRESS -> NO-REDIRECT: This transition involves canceling table
+ *                                                  redirection while it is still in the process of
+ *                                                  being enabled.
+ */
+sealed trait RedirectState {
+  val name: String
+}
+
+/** This state indicates that redirect is not enabled on the table. */
+case object NoRedirect extends RedirectState {
+  override val name = "NO-REDIRECT"
+}
+
+/** This state indicates that the redirect process is still going on. */
+case object EnableRedirectInProgress extends RedirectState {
+  override val name = "ENABLE-REDIRECT-IN-PROGRESS"
+}
+
+/**
+ * This state indicates that the redirect process is completed. All types of queries would be
+ * redirected to the table specified inside RedirectSpec object.
+ */
+case object RedirectReady extends RedirectState { override val name = "REDIRECT-READY" }
+
+/**
+ * The table redirection is under withdrawal and the redirection property is going to be removed
+ * from the delta table. In this state, the delta client stops redirecting new queries to redirect
+ * destination tables, and only accepts read-only queries to access the redirect source table.
+ * The on-going redirected write or metadata transactions, which are visiting redirect
+ * destinations, can not commit.
+ */
+case object DropRedirectInProgress extends RedirectState {
+  override val name = "DROP-REDIRECT-IN-PROGRESS"
+}
+
+/**
+ * This is the abstract class of the redirect specification, which stores the information
+ * of accessing the redirect destination table.
+ */
+abstract class RedirectSpec()
+
+/**
+ * The default redirect spec that is used for OSS delta.
+ * This is the specification about how to access the redirect destination table.
+ * One example of its JSON presentation is:
+ *   {
+ *     ......
+ *     "spec": {
+ *       "tablePath": "s3://<bucket-1>/tables/<table-name>"
+ *     }
+ *   }
+ * @param tablePath this is the path where stores the redirect destination table's location.
+ */
+class PathBasedRedirectSpec(val tablePath: String) extends RedirectSpec
+
+object PathBasedRedirectSpec {
+  /**
+   * This is the path based redirection. Delta client uses the `tablePath` of PathBasedRedirectSpec
+   * to access the delta log files on the redirect destination location.
+   */
+  final val REDIRECT_TYPE = "PathBasedRedirect"
+}
+
+/**
+ * The customized JSON deserializer that parses the redirect specification's content into
+ * RedirectSpec object. This class is passed to the JSON execution time object mapper.
+ */
+class RedirectSpecDeserializer[T <: RedirectSpec : ClassTag] {
+  def deserialize(specValue: String): T = {
+    val mapper = new ObjectMapper()
+    mapper.registerModule(DefaultScalaModule)
+    val clazz = implicitly[ClassTag[T]].runtimeClass.asInstanceOf[Class[T]]
+    mapper.readValue(specValue, clazz)
+  }
+}
+
+object RedirectSpec {
+  def getDeserializeModule(redirectType: String): RedirectSpecDeserializer[_ <: RedirectSpec] = {
+      new RedirectSpecDeserializer[PathBasedRedirectSpec]()
+  }
+}
+
+/**
+ * This class stores all values defined inside table redirection property.
+ * @param type: The type of redirection.
+ * @param state: The current state of the redirection:
+ *               ENABLE-REDIRECT-IN-PROGRESS, REDIRECT-READY, DROP-REDIRECT-IN-PROGRESS.
+ * @param specValue: The specification of accessing redirect destination table.
+ *
+ * This class would be serialized into a JSON string during commit. One example of its JSON
+ * presentation is:
+ * PathBasedRedirect:
+ *   {
+ *     "type": "PathBasedRedirect",
+ *     "state": "DROP-REDIRECT-IN-PROGRESS",
+ *     "spec": {
+ *       "tablePath": "s3://<bucket-1>/tables/<table-name>"
+ *     }
+ *   }
+ */
+case class TableRedirectConfiguration(
+    `type`: String,
+    state: String,
+    @JsonProperty("spec")
+    specValue: String) {
+  @JsonIgnore
+  val spec: RedirectSpec = RedirectSpec.getDeserializeModule(`type`).deserialize(specValue)
+  @JsonIgnore
+  val redirectState: RedirectState = state match {
+    case EnableRedirectInProgress.name => EnableRedirectInProgress
+    case RedirectReady.name => RedirectReady
+    case DropRedirectInProgress.name => DropRedirectInProgress
+    case _ => throw new IllegalArgumentException(s"Unrecognizable Table Redirect State: $state")
+  }
+}
+
+/**
+ * This is the main class of the table redirect that interacts with other components.
+ */
+class TableRedirect(config: DeltaConfig[Option[String]]) {
+  /**
+   * Determine whether the property of table redirect feature is set.
+   */
+  def isFeatureSet(metadata: Metadata): Boolean = config.fromMetaData(metadata).nonEmpty
+
+  /**
+   * Parse the property of table redirect feature to be an in-memory object of
+   * TableRedirectConfiguration.
+   */
+  def getRedirectConfiguration(deltaLogMetadata: Metadata): Option[TableRedirectConfiguration] = {
+    config.fromMetaData(deltaLogMetadata).map { propertyValue =>
+      val mapper = new ObjectMapper()
+      mapper.registerModule(DefaultScalaModule)
+      mapper.readValue(propertyValue, classOf[TableRedirectConfiguration])
+    }
+  }
+
+  /**
+   * Generate the key-value pair of the table redirect property. Its key is the table redirect
+   * property name and its name is the JSON string of TableRedirectConfiguration.
+   */
+  private def generateRedirectMetadata(
+    redirectType: String,
+    state: RedirectState,
+    redirectSpec: RedirectSpec
+  ): Map[String, String] = {
+    val redirectConfiguration = TableRedirectConfiguration(
+      redirectType,
+      state.name,
+      JsonUtils.toJson(redirectSpec)
+    )
+    val redirectJson = JsonUtils.toJson(redirectConfiguration)
+    Map(config.key -> redirectJson)
+  }
+
+  /**
+   * Issues a commit to update the table redirect property on the `catalogTableOpt`.
+   * For the commits update the `state`, a validation is applied to ensure the state
+   * transition is valid.
+   * @param deltaLog The deltaLog object of the table to be redirected.
+   * @param catalogTableOpt The CatalogTable object of the table to be redirected.
+   * @param state The new state of redirection.
+   * @param spec The specification of redirection contains all necessary detail of looking up the
+   *             redirect destination table.
+   */
+  def update(
+    deltaLog: DeltaLog,
+    catalogTableOpt: Option[CatalogTable],
+    state: RedirectState,
+    spec: RedirectSpec
+  ): Unit = {
+    val txn = deltaLog.startTransaction(catalogTableOpt)
+    val deltaMetadata = txn.snapshot.metadata
+    val currentConfigOpt = getRedirectConfiguration(deltaMetadata)
+    val tableIdent = catalogTableOpt.get.identifier.quotedString
+    // There should be an existing table redirect configuration.
+    if (currentConfigOpt.isEmpty) {
+      DeltaErrors.invalidRedirectStateTransition(tableIdent, NoRedirect, state)
+    }
+
+    val currentConfig = currentConfigOpt.get
+    state match {
+      case RedirectReady =>
+        if (currentConfig.redirectState != EnableRedirectInProgress) {
+          DeltaErrors.invalidRedirectStateTransition(tableIdent, currentConfig.redirectState, state)
+        }
+      case DropRedirectInProgress =>
+        if (currentConfig.redirectState != RedirectReady) {
+          DeltaErrors.invalidRedirectStateTransition(tableIdent, currentConfig.redirectState, state)
+        }
+      case _ =>
+        DeltaErrors.invalidRedirectStateTransition(tableIdent, currentConfig.redirectState, state)
+    }
+    val properties = generateRedirectMetadata(currentConfig.`type`, state, spec)
+    val newConfigs = txn.metadata.configuration ++ properties
+    val newMetadata = txn.metadata.copy(configuration = newConfigs)
+    txn.updateMetadata(newMetadata)
+    txn.commit(Nil, DeltaOperations.SetTableProperties(properties))
+  }
+
+  /**
+   * Issues a commit to add the redirect property with state `EnableRedirectInProgress`
+   * to the `catalogTableOpt`.
+   * @param deltaLog The deltaLog object of the table to be redirected.
+   * @param catalogTableOpt The CatalogTable object of the table to be redirected.
+   * @param redirectType The type of redirection is used as an identifier to deserialize the content
+   *                     of `spec`.
+   * @param spec The specification of redirection contains all necessary detail of looking up the
+   *             redirect destination table.
+   */
+  def add(
+     deltaLog: DeltaLog,
+     catalogTableOpt: Option[CatalogTable],
+     redirectType: String,
+     spec: RedirectSpec
+  ): Unit = {
+    val txn = deltaLog.startTransaction(catalogTableOpt)
+    val snapshot = txn.snapshot
+    getRedirectConfiguration(snapshot.metadata).foreach { currentConfig =>
+      DeltaErrors.invalidRedirectStateTransition(
+        catalogTableOpt.get.identifier.quotedString,
+        currentConfig.redirectState,
+        EnableRedirectInProgress
+      )
+    }
+    val properties = generateRedirectMetadata(redirectType, EnableRedirectInProgress, spec)
+    val newConfigs = txn.metadata.configuration ++ properties
+    val newMetadata = txn.metadata.copy(configuration = newConfigs)
+    txn.updateMetadata(newMetadata)
+    txn.commit(Nil, DeltaOperations.SetTableProperties(properties))
+  }
+
+  /** Issues a commit to remove the redirect property from the `catalogTableOpt`. */
+  def remove(deltaLog: DeltaLog, catalogTableOpt: Option[CatalogTable]): Unit = {
+    val txn = deltaLog.startTransaction(catalogTableOpt)
+    val currentConfigOpt = getRedirectConfiguration(txn.snapshot.metadata)
+    val tableIdent = catalogTableOpt.get.identifier.quotedString
+    if (currentConfigOpt.isEmpty) {
+      DeltaErrors.invalidRemoveTableRedirect(tableIdent, NoRedirect)
+    }
+    val redirectState = currentConfigOpt.get.redirectState
+    if (redirectState != DropRedirectInProgress && redirectState != EnableRedirectInProgress) {
+      DeltaErrors.invalidRemoveTableRedirect(tableIdent, redirectState)
+    }
+    val newConfigs = txn.metadata.configuration.filterNot { case (key, _) => key == config.key }
+    txn.updateMetadata(txn.metadata.copy(configuration = newConfigs))
+    txn.commit(Nil, DeltaOperations.UnsetTableProperties(Seq(config.key), ifExists = true))
+  }
+}
+
+object RedirectReaderWriter extends TableRedirect(config = DeltaConfigs.REDIRECT_READER_WRITER)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/TableRedirectSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/TableRedirectSuite.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.io.File
+
+import org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsBaseSuite
+import org.apache.spark.sql.delta.redirect.{
+  DropRedirectInProgress,
+  EnableRedirectInProgress,
+  PathBasedRedirectSpec,
+  RedirectReaderWriter,
+  RedirectReady,
+  RedirectState,
+  TableRedirect
+}
+import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.test.SharedSparkSession
+
+class TableRedirectSuite extends QueryTest
+  with SharedSparkSession
+  with DeltaSQLCommandTest
+  with CoordinatedCommitsBaseSuite
+  with DeltaCheckpointTestUtils
+  with DeltaSQLTestUtils {
+
+  private def validateState(
+      deltaLog: DeltaLog,
+      redirectState: RedirectState,
+      destTablePath: File
+  ): Unit = {
+    val snapshot = deltaLog.update()
+    assert(RedirectReaderWriter.isFeatureSet(snapshot.metadata))
+    val redirectConfig = RedirectReaderWriter.getRedirectConfiguration(snapshot.metadata).get
+    assert(snapshot.protocol.supportsReaderFeatures && snapshot.protocol.supportsWriterFeatures)
+    assert(snapshot.protocol.readerFeatureNames.contains(RedirectReaderWriterFeature.name))
+    assert(snapshot.protocol.writerFeatureNames.contains(RedirectReaderWriterFeature.name))
+    assert(redirectConfig.redirectState == redirectState)
+    assert(redirectConfig.`type` == PathBasedRedirectSpec.REDIRECT_TYPE)
+    val expectedSpecValue = s"""{"tablePath":"${destTablePath.getCanonicalPath}"}"""
+    assert(redirectConfig.specValue == expectedSpecValue)
+    val redirectSpec = redirectConfig.spec.asInstanceOf[PathBasedRedirectSpec]
+    assert(redirectSpec.tablePath == destTablePath.getCanonicalPath)
+  }
+
+  private def validateRemovedState(deltaLog: DeltaLog, feature: TableRedirect): Unit = {
+    val snapshot = deltaLog.update()
+    val protocol = snapshot.protocol
+    assert(!feature.isFeatureSet(snapshot.metadata))
+    assert(protocol.supportsReaderFeatures && protocol.supportsWriterFeatures)
+    assert(protocol.readerFeatureNames.contains(RedirectReaderWriterFeature.name))
+    assert(protocol.writerFeatureNames.contains(RedirectReaderWriterFeature.name))
+  }
+
+  test("basic table redirect") {
+    withTempDir { sourceTablePath =>
+      withTempDir { destTablePath =>
+        val feature = RedirectReaderWriter
+        sql(s"CREATE external TABLE t1(c0 long, c1 long) USING delta LOCATION '$sourceTablePath';")
+        val catalogTable = spark.sessionState.catalog.getTableMetadata(TableIdentifier("t1"))
+        val deltaLog = DeltaLog.forTable(spark, new Path(sourceTablePath.getCanonicalPath))
+        assert(!feature.isFeatureSet(deltaLog.update().metadata))
+        val redirectSpec = new PathBasedRedirectSpec(destTablePath.getCanonicalPath)
+        val catalogTableOpt = Some(catalogTable)
+        val redirectType = PathBasedRedirectSpec.REDIRECT_TYPE
+        // Step-1: Initiate table redirection and set to EnableRedirectInProgress state.
+        feature.add(deltaLog, catalogTableOpt, redirectType, redirectSpec)
+        validateState(deltaLog, EnableRedirectInProgress, destTablePath)
+        // Step-2: Complete table redirection and set to RedirectReady state.
+        feature.update(deltaLog, catalogTableOpt, RedirectReady, redirectSpec)
+        validateState(deltaLog, RedirectReady, destTablePath)
+        // Step-3: Start dropping table redirection and set to DropRedirectInProgress state.
+        feature.update(deltaLog, catalogTableOpt, DropRedirectInProgress, redirectSpec)
+        validateState(deltaLog, DropRedirectInProgress, destTablePath)
+        // Step-4: Finish dropping table redirection and remove the property completely.
+        feature.remove(deltaLog, Some(catalogTable))
+        validateRemovedState(deltaLog, feature)
+        // Step-5: Initiate table redirection and set to EnableRedirectInProgress state one
+        // more time.
+        withTempDir { destTablePath2 =>
+          val redirectSpec = new PathBasedRedirectSpec(destTablePath2.getCanonicalPath)
+          feature.add(deltaLog, catalogTableOpt, redirectType, redirectSpec)
+          validateState(deltaLog, EnableRedirectInProgress, destTablePath2)
+          // Step-6: Finish dropping table redirection and remove the property completely.
+          feature.remove(deltaLog, Some(catalogTable))
+          validateRemovedState(deltaLog, feature)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description


This PR introduces a new reader-writer table feature "redirection". This table feature would redirect the read and write query from the current storage location to a new storage location  described inside the value of table feature.

The redirection has several phases to ensure no anomaly. To label these phases, we introduces four states:

0. NO-REDIRECT: This state indicates that redirect is not enabled on the table.
1. ENABLE-REDIRECT-IN-PROGRESS: This state indicates that the redirect process is still going on. No DML or DDL transaction can be committed to the table when the table is in this state.
2. REDIRECT-READY: This state indicates that the redirect process is completed. All types of queries would be redirected to the table specified inside RedirectSpec object.
3. DROP-REDIRECT-IN-PROGRESS: The table redirection is under withdrawal and the redirection property is going to be removed from the delta table. In this state, the delta client stops redirecting new queries to redirect destination tables, and only accepts read-only queries to access the redirect source table.

To ensure no undefined behavior, the valid procedures of state transition are:

0. NO-REDIRECT -> ENABLE-REDIRECT-IN-PROGRESS
1. ENABLE-REDIRECT-IN-PROGRESS -> REDIRECT-READY
2. REDIRECT-READY -> DROP-REDIRECT-IN-PROGRESS
3. DROP-REDIRECT-IN-PROGRESS -> NO-REDIRECT
4. ENABLE-REDIRECT-IN-PROGRESS -> NO-REDIRECT


The protocol RFC document is on: https://github.com/delta-io/delta/issues/3702

## How was this patch tested?

Unit Test of transition between different states of redirection.


## Does this PR introduce _any_ user-facing changes?
No
