### PR TITLE
[Kernel] Remove `engine` from `TableConfig` APIs

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -85,7 +85,7 @@ public class SnapshotImpl implements Snapshot {
 
   public CreateCheckpointIterator getCreateCheckpointIterator(Engine engine) {
     long minFileRetentionTimestampMillis =
-        System.currentTimeMillis() - TOMBSTONE_RETENTION.fromMetadata(engine, metadata);
+        System.currentTimeMillis() - TOMBSTONE_RETENTION.fromMetadata(metadata);
     return new CreateCheckpointIterator(engine, logSegment, minFileRetentionTimestampMillis);
   }
 
@@ -129,7 +129,7 @@ public class SnapshotImpl implements Snapshot {
    * @return the timestamp of the latest commit
    */
   public long getTimestamp(Engine engine) {
-    if (TableConfig.isICTEnabled(engine, metadata)) {
+    if (IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(metadata)) {
       if (!inCommitTimestampOpt.isPresent()) {
         Optional<CommitInfo> commitInfoOpt =
             CommitInfo.getCommitInfoOpt(engine, logPath, logSegment.version);
@@ -154,17 +154,17 @@ public class SnapshotImpl implements Snapshot {
   public Optional<TableCommitCoordinatorClientHandler> getTableCommitCoordinatorClientHandlerOpt(
       Engine engine) {
     return COORDINATED_COMMITS_COORDINATOR_NAME
-        .fromMetadata(engine, metadata)
+        .fromMetadata(metadata)
         .map(
             commitCoordinatorStr -> {
               CommitCoordinatorClientHandler handler =
                   engine.getCommitCoordinatorClientHandler(
                       commitCoordinatorStr,
-                      COORDINATED_COMMITS_COORDINATOR_CONF.fromMetadata(engine, metadata));
+                      COORDINATED_COMMITS_COORDINATOR_CONF.fromMetadata(metadata));
               return new TableCommitCoordinatorClientHandler(
                   handler,
                   logPath.toString(),
-                  COORDINATED_COMMITS_TABLE_CONF.fromMetadata(engine, metadata));
+                  COORDINATED_COMMITS_TABLE_CONF.fromMetadata(metadata));
             });
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -18,6 +18,7 @@ package io.delta.kernel.internal;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.delta.kernel.exceptions.InvalidConfigurationValueException;
+import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.exceptions.UnknownConfigurationException;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.util.*;
@@ -291,7 +292,7 @@ public class TableConfig<T> {
       ObjectMapper mapper = new ObjectMapper();
       return mapper.readValue(jsonString, new TypeReference<Map<String, String>>() {});
     } catch (Exception e) {
-      throw new RuntimeException("Failed to parse JSON string", e);
+      throw new KernelException(String.format("Failed to parse JSON string: %s", jsonString), e);
     }
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -15,25 +15,15 @@
  */
 package io.delta.kernel.internal;
 
-import static io.delta.kernel.internal.util.InternalUtils.getSingularElement;
-import static io.delta.kernel.internal.util.InternalUtils.singletonStringColumnVector;
-import static io.delta.kernel.internal.util.Preconditions.checkArgument;
-
-import io.delta.kernel.data.Row;
-import io.delta.kernel.engine.Engine;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.delta.kernel.exceptions.InvalidConfigurationValueException;
-import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.exceptions.UnknownConfigurationException;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.util.*;
 import io.delta.kernel.internal.util.ColumnMapping.ColumnMappingMode;
-import io.delta.kernel.types.MapType;
-import io.delta.kernel.types.StringType;
-import io.delta.kernel.types.StructType;
-import io.delta.kernel.utils.CloseableIterator;
-import java.io.IOException;
 import java.util.*;
-import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 /**
@@ -41,6 +31,11 @@ import java.util.function.Predicate;
  * table metadata.
  */
 public class TableConfig<T> {
+
+  //////////////////
+  // TableConfigs //
+  //////////////////
+
   /**
    * The shortest duration we have to keep logically deleted data files around before deleting them
    * physically.
@@ -59,7 +54,7 @@ public class TableConfig<T> {
       new TableConfig<>(
           "delta.deletedFileRetentionDuration",
           "interval 1 week",
-          (engineOpt, v) -> IntervalParserUtils.safeParseIntervalAsMillis(v),
+          IntervalParserUtils::safeParseIntervalAsMillis,
           value -> value >= 0,
           "needs to be provided as a calendar interval such as '2 weeks'. Months"
               + " and years are not accepted. You may specify '365 days' for a year instead.",
@@ -73,7 +68,7 @@ public class TableConfig<T> {
       new TableConfig<>(
           "delta.checkpointInterval",
           "10",
-          (engineOpt, v) -> Integer.valueOf(v),
+          Integer::valueOf,
           value -> value > 0,
           "needs to be a positive integer.",
           true);
@@ -86,7 +81,7 @@ public class TableConfig<T> {
       new TableConfig<>(
           "delta.logRetentionDuration",
           "interval 30 days",
-          (engineOpt, v) -> IntervalParserUtils.safeParseIntervalAsMillis(v),
+          IntervalParserUtils::safeParseIntervalAsMillis,
           value -> true,
           "needs to be provided as a calendar interval such as '2 weeks'. Months "
               + "and years are not accepted. You may specify '365 days' for a year instead.",
@@ -97,7 +92,7 @@ public class TableConfig<T> {
       new TableConfig<>(
           "delta.enableExpiredLogCleanup",
           "true",
-          (engineOpt, v) -> Boolean.valueOf(v),
+          v -> Boolean.valueOf(v),
           value -> true,
           "needs to be a boolean.",
           true /* editable */);
@@ -113,7 +108,7 @@ public class TableConfig<T> {
       new TableConfig<>(
           "delta.enableInCommitTimestamps",
           "false", /* default values */
-          (engineOpt, v) -> Boolean.valueOf(v),
+          v -> Boolean.valueOf(v),
           value -> true,
           "needs to be a boolean.",
           true);
@@ -126,7 +121,7 @@ public class TableConfig<T> {
       new TableConfig<>(
           "delta.inCommitTimestampEnablementVersion",
           null, /* default values */
-          (engineOpt, v) -> Optional.ofNullable(v).map(Long::valueOf),
+          v -> Optional.ofNullable(v).map(Long::valueOf),
           value -> true,
           "needs to be a long.",
           true);
@@ -140,7 +135,7 @@ public class TableConfig<T> {
       new TableConfig<>(
           "delta.inCommitTimestampEnablementTimestamp",
           null, /* default values */
-          (engineOpt, v) -> Optional.ofNullable(v).map(Long::valueOf),
+          v -> Optional.ofNullable(v).map(Long::valueOf),
           value -> true,
           "needs to be a long.",
           true);
@@ -154,7 +149,7 @@ public class TableConfig<T> {
       new TableConfig<>(
           "delta.coordinatedCommits.commitCoordinator-preview",
           null, /* default values */
-          (engineOpt, v) -> Optional.ofNullable(v),
+          Optional::ofNullable,
           value -> true,
           "The commit-coordinator name for this table. This is used to determine "
               + "which implementation of commit-coordinator to use when committing "
@@ -196,7 +191,7 @@ public class TableConfig<T> {
       new TableConfig<>(
           "delta.columnMapping.mode",
           "none", /* default values */
-          (engineOpt, v) -> ColumnMappingMode.fromTableConfig(v),
+          ColumnMappingMode::fromTableConfig,
           value -> true,
           "Needs to be one of none, id, name.",
           true);
@@ -204,12 +199,7 @@ public class TableConfig<T> {
   /** This table property is used to control the maximum column mapping ID. */
   public static final TableConfig<Long> COLUMN_MAPPING_MAX_COLUMN_ID =
       new TableConfig<>(
-          "delta.columnMapping.maxColumnId",
-          "0",
-          (engineOpt, v) -> Long.valueOf(v),
-          value -> value >= 0,
-          "",
-          false);
+          "delta.columnMapping.maxColumnId", "0", Long::valueOf, value -> value >= 0, "", false);
 
   /**
    * Table property that enables modifying the table in accordance with the Delta-Iceberg
@@ -223,7 +213,7 @@ public class TableConfig<T> {
       new TableConfig<>(
           "delta.enableIcebergCompatV2",
           "false",
-          (engineOpt, v) -> Boolean.valueOf(v),
+          Boolean::valueOf,
           value -> true,
           "needs to be a boolean.",
           true);
@@ -247,9 +237,75 @@ public class TableConfig<T> {
             }
           });
 
+  ///////////////////////////
+  // Static Helper Methods //
+  ///////////////////////////
+
+  /**
+   * Validates that the given properties have the delta prefix in the key name, and they are in the
+   * set of valid properties. The caller should get the validated configurations and store the case
+   * of the property name defined in TableConfig.
+   *
+   * @param configurations the properties to validate
+   * @throws InvalidConfigurationValueException if any of the properties are invalid
+   * @throws UnknownConfigurationException if any of the properties are unknown
+   */
+  public static Map<String, String> validateProperties(Map<String, String> configurations) {
+    Map<String, String> validatedConfigurations = new HashMap<>();
+    for (Map.Entry<String, String> kv : configurations.entrySet()) {
+      String key = kv.getKey().toLowerCase(Locale.ROOT);
+      String value = kv.getValue();
+      if (key.startsWith("delta.") && VALID_PROPERTIES.containsKey(key)) {
+        TableConfig<?> tableConfig = VALID_PROPERTIES.get(key);
+        if (tableConfig.editable) {
+          tableConfig.validate(value);
+          validatedConfigurations.put(tableConfig.getKey(), value);
+        } else {
+          throw DeltaErrors.cannotModifyTableProperty(kv.getKey());
+        }
+      } else {
+        throw DeltaErrors.unknownConfigurationException(kv.getKey());
+      }
+    }
+    return validatedConfigurations;
+  }
+
+  /**
+   * Parses the given JSON string into a map of key-value pairs.
+   *
+   * <p>The JSON string should be in the format:
+   *
+   * <pre>{@code {"key1": "value1", "key2": "value2", ...}}</pre>
+   *
+   * where both keys and values are strings.
+   *
+   * @param jsonString The JSON string to parse
+   * @return A map containing the key-value pairs extracted from the JSON string
+   */
+  public static Map<String, String> parseJSONKeyValueMap(String jsonString) {
+    if (jsonString == null || jsonString.trim().isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      return mapper.readValue(jsonString, new TypeReference<Map<String, String>>() {});
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to parse JSON string", e);
+    }
+  }
+
+  private static void addConfig(HashMap<String, TableConfig<?>> configs, TableConfig<?> config) {
+    configs.put(config.getKey().toLowerCase(Locale.ROOT), config);
+  }
+
+  /////////////////////////////
+  // Member Fields / Methods //
+  /////////////////////////////
+
   private final String key;
   private final String defaultValue;
-  private final BiFunction<Engine, String, T> fromString;
+  private final Function<String, T> fromString;
   private final Predicate<T> validator;
   private final boolean editable;
   private final String helpMessage;
@@ -257,7 +313,7 @@ public class TableConfig<T> {
   private TableConfig(
       String key,
       String defaultValue,
-      BiFunction<Engine, String, T> fromString,
+      Function<String, T> fromString,
       Predicate<T> validator,
       String helpMessage,
       boolean editable) {
@@ -272,25 +328,23 @@ public class TableConfig<T> {
   /**
    * Returns the value of the table property from the given metadata.
    *
-   * @param engine {@link Engine} instance.
    * @param metadata the table metadata
    * @return the value of the table property
    */
-  public T fromMetadata(Engine engine, Metadata metadata) {
-    return fromMetadata(engine, metadata.getConfiguration());
+  public T fromMetadata(Metadata metadata) {
+    return fromMetadata(metadata.getConfiguration());
   }
 
   /**
    * Returns the value of the table property from the given configuration.
    *
-   * @param engine {@link Engine} instance.
    * @param configuration the table configuration
    * @return the value of the table property
    */
-  public T fromMetadata(Engine engine, Map<String, String> configuration) {
+  public T fromMetadata(Map<String, String> configuration) {
     String value = configuration.getOrDefault(key, defaultValue);
-    validate(engine, value);
-    return fromString.apply(engine, value);
+    validate(value);
+    return fromString.apply(value);
   }
 
   /**
@@ -302,89 +356,10 @@ public class TableConfig<T> {
     return key;
   }
 
-  /**
-   * Validates that the given properties have the delta prefix in the key name, and they are in the
-   * set of valid properties. The caller should get the validated configurations and store the case
-   * of the property name defined in TableConfig.
-   *
-   * @param configurations the properties to validate
-   * @throws InvalidConfigurationValueException if any of the properties are invalid
-   * @throws UnknownConfigurationException if any of the properties are unknown
-   */
-  public static Map<String, String> validateProperties(
-      Engine engine, Map<String, String> configurations) {
-    Map<String, String> validatedConfigurations = new HashMap<>();
-    for (Map.Entry<String, String> kv : configurations.entrySet()) {
-      String key = kv.getKey().toLowerCase(Locale.ROOT);
-      String value = kv.getValue();
-      if (key.startsWith("delta.") && VALID_PROPERTIES.containsKey(key)) {
-        TableConfig<?> tableConfig = VALID_PROPERTIES.get(key);
-        if (tableConfig.editable) {
-          tableConfig.validate(engine, value);
-          validatedConfigurations.put(tableConfig.getKey(), value);
-        } else {
-          throw DeltaErrors.cannotModifyTableProperty(kv.getKey());
-        }
-      } else {
-        throw DeltaErrors.unknownConfigurationException(kv.getKey());
-      }
-    }
-    return validatedConfigurations;
-  }
-
-  public static Boolean isICTEnabled(Engine engine, Metadata metadata) {
-    return IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(engine, metadata);
-  }
-
-  /**
-   * Parses the given JSON string into a map of key-value pairs.
-   *
-   * <p>The JSON string should be in the format:
-   *
-   * <pre>{@code {"key1": "value1", "key2": "value2", ...}}</pre>
-   *
-   * where both keys and values are strings.
-   *
-   * @param engine the {@link Engine} instance used for parsing
-   * @param jsonString The JSON string to parse
-   * @return A map containing the key-value pairs extracted from the JSON string
-   */
-  protected static Map<String, String> parseJSONKeyValueMap(Engine engine, String jsonString) {
-    if (jsonString == null) {
-      return Collections.emptyMap();
-    }
-    // By adding the top-level key "config", the schema is fixed with a single column "config"
-    // of type MapType(StringType, StringType). In this way, we can parse the JSON string into
-    // MapType(StringType, StringType) using existing engine.getJsonHandler().parseJson API.
-    StructType schema =
-        new StructType().add("config", new MapType(StringType.STRING, StringType.STRING, true));
-    try (CloseableIterator<Row> batchRows =
-        engine
-            .getJsonHandler()
-            .parseJson(
-                singletonStringColumnVector(String.format("{\"config\": %s}", jsonString)),
-                schema,
-                Optional.empty())
-            .getRows()) {
-      Row row =
-          getSingularElement(batchRows)
-              .orElseThrow(
-                  () -> new IllegalStateException(String.format("Unable to parse %s", jsonString)));
-      checkArgument(!row.isNullAt(0));
-      return VectorUtils.toJavaMap(row.getMap(0));
-    } catch (IOException e) {
-      throw new KernelException(e);
-    }
-  }
-
-  private void validate(Engine engine, String value) {
-    T parsedValue = fromString.apply(engine, value);
+  private void validate(String value) {
+    T parsedValue = fromString.apply(value);
     if (!validator.test(parsedValue)) {
       throw DeltaErrors.invalidConfigurationValueException(key, value, helpMessage);
     }
-  }
-
-  private static void addConfig(HashMap<String, TableConfig<?>> configs, TableConfig<?> config) {
-    configs.put(config.getKey().toLowerCase(Locale.ROOT), config);
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -93,7 +93,7 @@ public class TableConfig<T> {
       new TableConfig<>(
           "delta.enableExpiredLogCleanup",
           "true",
-          v -> Boolean.valueOf(v),
+          Boolean::valueOf,
           value -> true,
           "needs to be a boolean.",
           true /* editable */);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableConfig.java
@@ -15,10 +15,7 @@
  */
 package io.delta.kernel.internal;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.delta.kernel.exceptions.InvalidConfigurationValueException;
-import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.exceptions.UnknownConfigurationException;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.util.*;
@@ -167,7 +164,7 @@ public class TableConfig<T> {
       new TableConfig<>(
           "delta.coordinatedCommits.commitCoordinatorConf-preview",
           null, /* default values */
-          TableConfig::parseJSONKeyValueMap,
+          JsonUtils::parseJSONKeyValueMap,
           value -> true,
           "A string-to-string map of configuration properties for the"
               + " coordinated commits-coordinator.",
@@ -181,7 +178,7 @@ public class TableConfig<T> {
       new TableConfig<>(
           "delta.coordinatedCommits.tableConf-preview",
           null, /* default values */
-          TableConfig::parseJSONKeyValueMap,
+          JsonUtils::parseJSONKeyValueMap,
           value -> true,
           "A string-to-string map of configuration properties for"
               + "  describing the table to commit-coordinator.",
@@ -269,31 +266,6 @@ public class TableConfig<T> {
       }
     }
     return validatedConfigurations;
-  }
-
-  /**
-   * Parses the given JSON string into a map of key-value pairs.
-   *
-   * <p>The JSON string should be in the format:
-   *
-   * <pre>{@code {"key1": "value1", "key2": "value2", ...}}</pre>
-   *
-   * where both keys and values are strings.
-   *
-   * @param jsonString The JSON string to parse
-   * @return A map containing the key-value pairs extracted from the JSON string
-   */
-  public static Map<String, String> parseJSONKeyValueMap(String jsonString) {
-    if (jsonString == null || jsonString.trim().isEmpty()) {
-      return Collections.emptyMap();
-    }
-
-    try {
-      ObjectMapper mapper = new ObjectMapper();
-      return mapper.readValue(jsonString, new TypeReference<Map<String, String>>() {});
-    } catch (Exception e) {
-      throw new KernelException(String.format("Failed to parse JSON string: %s", jsonString), e);
-    }
   }
 
   private static void addConfig(HashMap<String, TableConfig<?>> configs, TableConfig<?> config) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableFeatures.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableFeatures.java
@@ -17,8 +17,8 @@
 package io.delta.kernel.internal;
 
 import static io.delta.kernel.internal.DeltaErrors.*;
+import static io.delta.kernel.internal.TableConfig.IN_COMMIT_TIMESTAMPS_ENABLED;
 
-import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import io.delta.kernel.internal.util.ColumnMapping;
@@ -174,15 +174,14 @@ public class TableFeatures {
    * when the delta property name (delta.enableInCommitTimestamps) is set to true in the metadata if
    * it is not already enabled.
    *
-   * @param engine the engine to use for IO operations
    * @param metadata the metadata of the table
    * @param protocol the protocol of the table
    * @return the writer features that should be enabled automatically
    */
   public static Set<String> extractAutomaticallyEnabledWriterFeatures(
-      Engine engine, Metadata metadata, Protocol protocol) {
+      Metadata metadata, Protocol protocol) {
     return TableFeatures.SUPPORTED_WRITER_FEATURES.stream()
-        .filter(f -> metadataRequiresWriterFeatureToBeEnabled(engine, metadata, f))
+        .filter(f -> metadataRequiresWriterFeatureToBeEnabled(metadata, f))
         .filter(
             f -> protocol.getWriterFeatures() == null || !protocol.getWriterFeatures().contains(f))
         .collect(Collectors.toSet());
@@ -222,16 +221,15 @@ public class TableFeatures {
    * Determine whether a writer feature must be supported and enabled to satisfy the metadata
    * requirements.
    *
-   * @param engine the engine to use for IO operations
    * @param metadata the table metadata
    * @param feature the writer feature to check
    * @return whether the writer feature must be enabled
    */
   private static boolean metadataRequiresWriterFeatureToBeEnabled(
-      Engine engine, Metadata metadata, String feature) {
+      Metadata metadata, String feature) {
     switch (feature) {
       case "inCommitTimestamp":
-        return TableConfig.isICTEnabled(engine, metadata);
+        return IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(metadata);
       default:
         return false;
     }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -118,7 +118,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
     Protocol protocol = snapshot.getProtocol();
     if (tableProperties.isPresent()) {
       Map<String, String> validatedProperties =
-          TableConfig.validateProperties(engine, tableProperties.get());
+          TableConfig.validateProperties(tableProperties.get());
       Map<String, String> newProperties =
           metadata.filterOutUnchangedProperties(validatedProperties);
 
@@ -131,7 +131,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
       }
 
       Set<String> newWriterFeatures =
-          TableFeatures.extractAutomaticallyEnabledWriterFeatures(engine, metadata, protocol);
+          TableFeatures.extractAutomaticallyEnabledWriterFeatures(metadata, protocol);
       if (!newWriterFeatures.isEmpty()) {
         logger.info("Automatically enabling writer features: {}", newWriterFeatures);
         shouldUpdateProtocol = true;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -251,8 +251,7 @@ public class TransactionImpl implements Transaction {
           "Write file actions to JSON log file `%s`",
           FileNames.deltaFile(logPath, commitAsVersion));
 
-      return new TransactionCommitResult(
-          commitAsVersion, isReadyForCheckpoint(engine, commitAsVersion));
+      return new TransactionCommitResult(commitAsVersion, isReadyForCheckpoint(commitAsVersion));
     } catch (FileAlreadyExistsException e) {
       throw e;
     } catch (IOException ioe) {
@@ -276,7 +275,7 @@ public class TransactionImpl implements Transaction {
    */
   private Optional<Long> generateInCommitTimestampForFirstCommitAttempt(
       Engine engine, long currentTimestamp) {
-    if (isICTEnabled(engine, metadata)) {
+    if (IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(metadata)) {
       long lastCommitTimestamp = readSnapshot.getTimestamp(engine);
       return Optional.of(Math.max(currentTimestamp, lastCommitTimestamp + 1));
     } else {
@@ -297,8 +296,8 @@ public class TransactionImpl implements Transaction {
         Collections.emptyMap() /* operationMetrics */);
   }
 
-  private boolean isReadyForCheckpoint(Engine engine, long newVersion) {
-    int checkpointInterval = CHECKPOINT_INTERVAL.fromMetadata(engine, metadata);
+  private boolean isReadyForCheckpoint(long newVersion) {
+    int checkpointInterval = CHECKPOINT_INTERVAL.fromMetadata(metadata);
     return newVersion > 0 && newVersion % checkpointInterval == 0;
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -242,8 +242,8 @@ public class SnapshotManager {
 
     // Clean up delta log files if enabled.
     Metadata metadata = snapshot.getMetadata();
-    if (EXPIRED_LOG_CLEANUP_ENABLED.fromMetadata(engine, metadata)) {
-      cleanupExpiredLogs(engine, clock, tablePath, LOG_RETENTION.fromMetadata(engine, metadata));
+    if (EXPIRED_LOG_CLEANUP_ENABLED.fromMetadata(metadata)) {
+      cleanupExpiredLogs(engine, clock, tablePath, LOG_RETENTION.fromMetadata(metadata));
     } else {
       logger.info(
           "{}: Log cleanup is disabled. Skipping the deletion of expired log files", tablePath);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/InCommitTimestampUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/InCommitTimestampUtils.java
@@ -15,7 +15,7 @@
  */
 package io.delta.kernel.internal.util;
 
-import static io.delta.kernel.internal.TableConfig.isICTEnabled;
+import static io.delta.kernel.internal.TableConfig.IN_COMMIT_TIMESTAMPS_ENABLED;
 
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.internal.SnapshotImpl;
@@ -68,9 +68,11 @@ public class InCommitTimestampUtils {
     //
     // WARNING: To ensure that this function returns true if ICT is enabled during the first
     // commit, we explicitly handle the case where the readSnapshot.version is -1.
-    boolean isICTCurrentlyEnabled = isICTEnabled(engine, currentTransactionMetadata);
+    boolean isICTCurrentlyEnabled =
+        IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(currentTransactionMetadata);
     boolean wasICTEnabledInReadSnapshot =
-        readSnapshot.getVersion(engine) != -1 && isICTEnabled(engine, readSnapshot.getMetadata());
+        readSnapshot.getVersion(engine) != -1
+            && IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(readSnapshot.getMetadata());
     return isICTCurrentlyEnabled && !wasICTEnabledInReadSnapshot;
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/JsonUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/JsonUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.internal.util;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.delta.kernel.exceptions.KernelException;
+import java.util.Collections;
+import java.util.Map;
+
+public class JsonUtils {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private JsonUtils() {}
+
+  /**
+   * Parses the given JSON string into a map of key-value pairs.
+   *
+   * <p>The JSON string should be in the format:
+   *
+   * <pre>{@code {"key1": "value1", "key2": "value2", ...}}</pre>
+   *
+   * where both keys and values are strings.
+   *
+   * @param jsonString The JSON string to parse
+   * @return A map containing the key-value pairs extracted from the JSON string
+   */
+  public static Map<String, String> parseJSONKeyValueMap(String jsonString) {
+    if (jsonString == null || jsonString.trim().isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    try {
+      return MAPPER.readValue(jsonString, new TypeReference<Map<String, String>>() {});
+    } catch (Exception e) {
+      throw new KernelException(String.format("Failed to parse JSON string: %s", jsonString), e);
+    }
+  }
+}

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableConfigSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableConfigSuite.scala
@@ -15,57 +15,21 @@
  */
 package io.delta.kernel.internal
 
-import io.delta.kernel.data.{ColumnarBatch, ColumnVector, MapValue, Row}
 import io.delta.kernel.exceptions.KernelException
-import io.delta.kernel.internal.util.VectorUtils.{stringArrayValue, stringVector}
-import io.delta.kernel.test.VectorTestUtils
-import io.delta.kernel.test.{BaseMockJsonHandler, MockEngineUtils}
-import io.delta.kernel.types.{DataType, MapType, StringType, StructType}
-import io.delta.kernel.utils.CloseableIterator
 import org.scalatest.funsuite.AnyFunSuite
 
-import java.io.IOException
-import java.util.{Collections, Optional}
 import scala.collection.JavaConverters._
 
-class TableConfigSuite extends AnyFunSuite with MockEngineUtils {
+class TableConfigSuite extends AnyFunSuite {
 
   test("Parse Map[String, String] type table config") {
     val expMap = Map("key1" -> "string_value", "key2Int" -> "2", "key3ComplexStr" -> "\"hello\"")
-    val engine = mockEngine(jsonHandler = new KeyValueJsonHandler(expMap))
     val input = """{"key1": "string_value", "key2Int": "2", "key3ComplexStr": "\"hello\""}"""
-    assert(TableConfig.parseJSONKeyValueMap(engine, input) === expMap.asJava)
-
-    val engine1 = mockEngine(jsonHandler = new ReturnNullRowsJsonHandler(nRow = 0))
-    val e1 = intercept[IllegalStateException] {
-      TableConfig.parseJSONKeyValueMap(engine1, """{"key": "value"}""")
-    }
-    assert(e1.getMessage.contains("""Unable to parse {"key": "value"}"""))
-
-    val engine2 = mockEngine(jsonHandler = new ReturnNullRowsJsonHandler(nRow = 2))
-    val e2 = intercept[IllegalArgumentException] {
-      TableConfig.parseJSONKeyValueMap(engine2, """{"key": "value"}""")
-    }
-    assert(e2.getMessage.contains("Iterator contains more than one element"))
-
-    val errMsg = "Close called failed"
-    val engine3 = mockEngine(jsonHandler = new ReturnCloseFailIteratorJsonHandler(errMsg = errMsg))
-    val e3 = intercept[KernelException] {
-      TableConfig.parseJSONKeyValueMap(engine3, """{"key": "value"}""")
-    }
-    assert(e3.getMessage.contains(s"java.io.IOException: $errMsg"))
-
-    val engine4 = mockEngine(jsonHandler = new ReturnNullRowsJsonHandler(nRow = 1))
-    val e4 = intercept[IllegalArgumentException] {
-      TableConfig.parseJSONKeyValueMap(engine4, """{"key": "value"}""")
-    }
-    assert(e4.getMessage === null)
+    assert(TableConfig.parseJSONKeyValueMap(input) === expMap.asJava)
   }
 
   test("check TableConfig.editable is true") {
-    val engine = mockEngine(jsonHandler = new KeyValueJsonHandler(Map()))
-
-    TableConfig.validateProperties(engine,
+    TableConfig.validateProperties(
       Map(
         TableConfig.TOMBSTONE_RETENTION.getKey -> "interval 2 week",
         TableConfig.CHECKPOINT_INTERVAL.getKey -> "20",
@@ -80,10 +44,8 @@ class TableConfigSuite extends AnyFunSuite with MockEngineUtils {
   }
 
   test("check TableConfig.MAX_COLUMN_ID.editable is false") {
-    val engine = mockEngine(jsonHandler = new KeyValueJsonHandler(Map()))
-
     val e = intercept[KernelException] {
-      TableConfig.validateProperties(engine,
+      TableConfig.validateProperties(
         Map(
           TableConfig.TOMBSTONE_RETENTION.getKey -> "interval 2 week",
           TableConfig.CHECKPOINT_INTERVAL.getKey -> "20",
@@ -96,88 +58,5 @@ class TableConfigSuite extends AnyFunSuite with MockEngineUtils {
       s"The Delta table property " +
       s"'${TableConfig.COLUMN_MAPPING_MAX_COLUMN_ID.getKey}'" +
       s" is an internal property and cannot be updated.")
-  }
-}
-
-/**
- * Mock JsonHandler which returns a ColumnarBatch with a single row containing a Map[String, String]
- * column.
- */
-class KeyValueJsonHandler(
-  map: Map[String, String]) extends BaseMockJsonHandler with VectorTestUtils {
-  val expSchema: StructType =
-    new StructType().add("config", new MapType(StringType.STRING, StringType.STRING, true))
-  override def parseJson(
-    jsonStringVector: ColumnVector,
-    outputSchema: StructType,
-    selectionVector: Optional[ColumnVector]): ColumnarBatch = {
-    assert(outputSchema == expSchema)
-    new ColumnarBatch {
-      override def getSchema: StructType = outputSchema
-
-      override def getColumnVector(ordinal: Int): ColumnVector = {
-        ordinal match {
-          case 0 => mapTypeVector(Seq(map))
-        }
-      }
-
-      override def getSize: Int = 1
-    }
-  }
-}
-
-/**
- * Mock JsonHandler which returns a ColumnarBatch with nRow rows containing a single null column.
- */
-class ReturnNullRowsJsonHandler(nRow: Int) extends BaseMockJsonHandler {
-  override def parseJson(
-    jsonStringVector: ColumnVector,
-    outputSchema: StructType,
-    selectionVector: Optional[ColumnVector]): ColumnarBatch = {
-    new ColumnarBatch {
-      override def getSchema: StructType = outputSchema
-
-      override def getColumnVector(ordinal: Int): ColumnVector = {
-        stringVector(List.fill(nRow)(null).asInstanceOf[List[String]].asJava)
-      }
-
-      override def getSize: Int = nRow
-    }
-  }
-}
-
-/**
- * Mock JsonHandler which returns a ColumnarBatch with an iterator that throws an IOException when
- * close is called.
- */
-class ReturnCloseFailIteratorJsonHandler(errMsg: String) extends BaseMockJsonHandler {
-  override def parseJson(
-    jsonStringVector: ColumnVector,
-    outputSchema: StructType,
-    selectionVector: Optional[ColumnVector]): ColumnarBatch = {
-    new ColumnarBatch {
-      override def getSchema: StructType = outputSchema
-
-      override def getColumnVector(ordinal: Int): ColumnVector = null
-
-      override def getSize: Int = 1
-
-      override def getRows: CloseableIterator[Row] = {
-        new CloseableIterator[Row] {
-          var rowId = 0
-
-          override def hasNext: Boolean = rowId < 1
-
-          override def next(): Row = {
-            rowId += 1
-            null
-          }
-
-          override def close(): Unit = {
-            throw new IOException(errMsg)
-          }
-        }
-      }
-    }
   }
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableConfigSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableConfigSuite.scala
@@ -22,19 +22,6 @@ import scala.collection.JavaConverters._
 
 class TableConfigSuite extends AnyFunSuite {
 
-  test("Parse Map[String, String] type table config - positive case") {
-    val expMap = Map("key1" -> "string_value", "key2Int" -> "2", "key3ComplexStr" -> "\"hello\"")
-    val input = """{"key1": "string_value", "key2Int": "2", "key3ComplexStr": "\"hello\""}"""
-    assert(TableConfig.parseJSONKeyValueMap(input) === expMap.asJava)
-  }
-
-  test("Parse Map[String, String] type table config - negative case") {
-    val e = intercept[KernelException] {
-      TableConfig.parseJSONKeyValueMap("""{"key1": "string_value", asdf"}""")
-    }
-    assert(e.getMessage.contains("Failed to parse JSON string:"))
-  }
-
   test("check TableConfig.editable is true") {
     TableConfig.validateProperties(
       Map(

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableConfigSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableConfigSuite.scala
@@ -22,10 +22,17 @@ import scala.collection.JavaConverters._
 
 class TableConfigSuite extends AnyFunSuite {
 
-  test("Parse Map[String, String] type table config") {
+  test("Parse Map[String, String] type table config - positive case") {
     val expMap = Map("key1" -> "string_value", "key2Int" -> "2", "key3ComplexStr" -> "\"hello\"")
     val input = """{"key1": "string_value", "key2Int": "2", "key3ComplexStr": "\"hello\""}"""
     assert(TableConfig.parseJSONKeyValueMap(input) === expMap.asJava)
+  }
+
+  test("Parse Map[String, String] type table config - negative case") {
+    val e = intercept[KernelException] {
+      TableConfig.parseJSONKeyValueMap("""{"key1": "string_value", asdf"}""")
+    }
+    assert(e.getMessage.contains("Failed to parse JSON string:"))
   }
 
   test("check TableConfig.editable is true") {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/JsonUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/JsonUtilsSuite.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.internal.util
+
+import io.delta.kernel.exceptions.KernelException
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.collection.JavaConverters._
+
+class JsonUtilsSuite extends AnyFunSuite {
+  test("Parse Map[String, String] JSON - positive case") {
+    val expMap = Map("key1" -> "string_value", "key2Int" -> "2", "key3ComplexStr" -> "\"hello\"")
+    val input = """{"key1": "string_value", "key2Int": "2", "key3ComplexStr": "\"hello\""}"""
+    assert(JsonUtils.parseJSONKeyValueMap(input) === expMap.asJava)
+
+    assert(JsonUtils.parseJSONKeyValueMap("").isEmpty)
+    assert(JsonUtils.parseJSONKeyValueMap(null).isEmpty)
+  }
+
+  test("Parse Map[String, String] JSON - negative case") {
+    val e = intercept[KernelException] {
+      JsonUtils.parseJSONKeyValueMap("""{"key1": "string_value", asdf"}""")
+    }
+    assert(e.getMessage.contains("Failed to parse JSON string:"))
+  }
+}

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWriteSuiteBase.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWriteSuiteBase.scala
@@ -316,16 +316,14 @@ trait DeltaTableWriteSuiteBase extends AnyFunSuite with TestUtils {
   }
 
   def assertMetadataProp(
-    engine: Engine,
     snapshot: SnapshotImpl,
     key: TableConfig[_ <: Any],
     expectedValue: Any): Unit = {
-    assert(key.fromMetadata(engine, snapshot.getMetadata) == expectedValue)
+    assert(key.fromMetadata(snapshot.getMetadata) == expectedValue)
   }
 
-  def assertHasNoMetadataProp(
-    engine: Engine, snapshot: SnapshotImpl, key: TableConfig[_ <: Any]): Unit = {
-    assertMetadataProp(engine, snapshot, key, Optional.empty())
+  def assertHasNoMetadataProp(snapshot: SnapshotImpl, key: TableConfig[_ <: Any]): Unit = {
+    assertMetadataProp(snapshot, key, Optional.empty())
   }
 
   def assertHasWriterFeature(snapshot: SnapshotImpl, writerFeature: String): Unit = {
@@ -352,7 +350,7 @@ trait DeltaTableWriteSuiteBase extends AnyFunSuite with TestUtils {
       .commit(engine, emptyIterable())
 
     val snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
-    assertMetadataProp(engine, snapshot, key, expectedValue)
+    assertMetadataProp(snapshot, key, expectedValue)
   }
 
   def verifyWrittenContent(path: String, expSchema: StructType, expData: Seq[TestRow]): Unit = {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
@@ -146,7 +146,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
       txn1.commit(engine, emptyIterable())
 
       val ver0Snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
-      assertMetadataProp(engine, ver0Snapshot, TableConfig.CHECKPOINT_INTERVAL, 10)
+      assertMetadataProp(ver0Snapshot, TableConfig.CHECKPOINT_INTERVAL, 10)
 
       setTablePropAndVerify(
         engine = engine,
@@ -174,7 +174,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
         data = Seq(Map.empty[String, Literal] -> dataBatches1)
       )
       val ver1Snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
-      assertMetadataProp(engine, ver1Snapshot, TableConfig.CHECKPOINT_INTERVAL, 2)
+      assertMetadataProp(ver1Snapshot, TableConfig.CHECKPOINT_INTERVAL, 2)
     }
   }
 
@@ -197,13 +197,13 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
       )
 
       val ver1Snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
-      assertMetadataProp(engine, ver1Snapshot, TableConfig.CHECKPOINT_INTERVAL, 10)
+      assertMetadataProp(ver1Snapshot, TableConfig.CHECKPOINT_INTERVAL, 10)
 
       // Try to commit txn1
       txn1.commit(engine, emptyIterable())
 
       val ver2Snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
-      assertMetadataProp(engine, ver2Snapshot, TableConfig.CHECKPOINT_INTERVAL, 2)
+      assertMetadataProp(ver2Snapshot, TableConfig.CHECKPOINT_INTERVAL, 2)
     }
   }
 
@@ -225,7 +225,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
         tableProperties =
           Map(TableConfig.CHECKPOINT_INTERVAL.getKey.toLowerCase(Locale.ROOT) -> "2"))
       val ver1Snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
-      assertMetadataProp(engine, ver1Snapshot, TableConfig.CHECKPOINT_INTERVAL, 2)
+      assertMetadataProp(ver1Snapshot, TableConfig.CHECKPOINT_INTERVAL, 2)
       assert(getMetadataActionFromCommit(engine, table, 1).isEmpty)
     }
   }
@@ -246,7 +246,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
           Map(TableConfig.CHECKPOINT_INTERVAL.getKey.toLowerCase(Locale.ROOT) -> "2"))
 
       val ver0Snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
-      assertMetadataProp(engine, ver0Snapshot, TableConfig.CHECKPOINT_INTERVAL, 2)
+      assertMetadataProp(ver0Snapshot, TableConfig.CHECKPOINT_INTERVAL, 2)
 
       val configurations = ver0Snapshot.getMetadata.getConfiguration
       assert(configurations.containsKey(TableConfig.CHECKPOINT_INTERVAL.getKey))

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/InCommitTimestampSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/InCommitTimestampSuite.scala
@@ -93,7 +93,7 @@ class InCommitTimestampSuite extends DeltaTableWriteSuiteBase {
       txn1.commit(engine, emptyIterable())
 
       val ver0Snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
-      assertMetadataProp(engine, ver0Snapshot, IN_COMMIT_TIMESTAMPS_ENABLED, false)
+      assertMetadataProp(ver0Snapshot, IN_COMMIT_TIMESTAMPS_ENABLED, false)
       assertHasNoWriterFeature(ver0Snapshot, "inCommitTimestamp")
       assert(getInCommitTimestamp(engine, table, version = 0).isEmpty)
 
@@ -132,7 +132,7 @@ class InCommitTimestampSuite extends DeltaTableWriteSuiteBase {
 
       val ver1Snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
       val ver1Timestamp = ver1Snapshot.getTimestamp(engine)
-      assert(isICTEnabled(engine, ver1Snapshot.getMetadata))
+      assert(IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(ver1Snapshot.getMetadata))
 
       clock.setTime(startTime - 10000)
       appendData(
@@ -229,8 +229,8 @@ class InCommitTimestampSuite extends DeltaTableWriteSuiteBase {
 
       val ver0Snapshot =
         Table.forPath(engine, tablePath).getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
-      assertHasNoMetadataProp(engine, ver0Snapshot, IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP)
-      assertHasNoMetadataProp(engine, ver0Snapshot, IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION)
+      assertHasNoMetadataProp(ver0Snapshot, IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP)
+      assertHasNoMetadataProp(ver0Snapshot, IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION)
     }
   }
 
@@ -254,14 +254,12 @@ class InCommitTimestampSuite extends DeltaTableWriteSuiteBase {
         tableProperties = Map(IN_COMMIT_TIMESTAMPS_ENABLED.getKey -> "true"))
 
       val ver1Snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
-      assertMetadataProp(engine, ver1Snapshot, IN_COMMIT_TIMESTAMPS_ENABLED, true)
+      assertMetadataProp(ver1Snapshot, IN_COMMIT_TIMESTAMPS_ENABLED, true)
       assertMetadataProp(
-        engine,
         ver1Snapshot,
         IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP,
         Optional.of(ver1Snapshot.getTimestamp(engine)))
       assertMetadataProp(
-        engine,
         ver1Snapshot,
         IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION,
         Optional.of(1L))
@@ -274,14 +272,12 @@ class InCommitTimestampSuite extends DeltaTableWriteSuiteBase {
         data = Seq(Map.empty[String, Literal] -> dataBatches2))
 
       val ver2Snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
-      assertMetadataProp(engine, ver2Snapshot, IN_COMMIT_TIMESTAMPS_ENABLED, true)
+      assertMetadataProp(ver2Snapshot, IN_COMMIT_TIMESTAMPS_ENABLED, true)
       assertMetadataProp(
-        engine,
         ver2Snapshot,
         IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP,
         Optional.of(ver1Snapshot.getTimestamp(engine)))
       assertMetadataProp(
-        engine,
         ver2Snapshot,
         IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION,
         Optional.of(1L))
@@ -378,14 +374,12 @@ class InCommitTimestampSuite extends DeltaTableWriteSuiteBase {
         tableProperties = Map(IN_COMMIT_TIMESTAMPS_ENABLED.getKey -> "true"))
 
       val ver1Snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
-      assertMetadataProp(engine, ver1Snapshot, IN_COMMIT_TIMESTAMPS_ENABLED, true)
+      assertMetadataProp(ver1Snapshot, IN_COMMIT_TIMESTAMPS_ENABLED, true)
       assertMetadataProp(
-        engine,
         ver1Snapshot,
         IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP,
         Optional.of(getInCommitTimestamp(engine, table, version = 1).get))
       assertMetadataProp(
-        engine,
         ver1Snapshot,
         IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION,
         Optional.of(1L))
@@ -489,9 +483,9 @@ class InCommitTimestampSuite extends DeltaTableWriteSuiteBase {
           engine, winningCommitCount).asInstanceOf[SnapshotImpl]
         val curSnapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
         val observedEnablementTimestamp =
-          IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.fromMetadata(engine, curSnapshot.getMetadata)
+          IN_COMMIT_TIMESTAMP_ENABLEMENT_TIMESTAMP.fromMetadata(curSnapshot.getMetadata)
         val observedEnablementVersion =
-          IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.fromMetadata(engine, curSnapshot.getMetadata)
+          IN_COMMIT_TIMESTAMP_ENABLEMENT_VERSION.fromMetadata(curSnapshot.getMetadata)
         assert(observedEnablementTimestamp.get === lastSnapshot.getTimestamp(engine) + 1)
         assert(
           observedEnablementTimestamp.get ===


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Remove `engine` references from `TableConfig` APIs. We don't actually need it, and it muddles our APIs, making us pass `engine` references everywhere. Clean up code along the way.

## How was this patch tested?

Existing UTs.

## Does this PR introduce _any_ user-facing changes?

No.