### PR TITLE
Upgrade delta-sharing-client to 1.2.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -547,7 +547,7 @@ lazy val sharing = (project in file("sharing"))
     libraryDependencies ++= Seq(
       "org.apache.spark" %% "spark-sql" % sparkVersion.value % "provided",
 
-      "io.delta" %% "delta-sharing-client" % "1.2.0",
+      "io.delta" %% "delta-sharing-client" % "1.2.1",
 
       // Test deps
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test",

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingCDFUtilsSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingCDFUtilsSuite.scala
@@ -81,6 +81,7 @@ class TestDeltaSharingClientForCDFUtils(
     readerFeatures: String = "",
     queryTablePaginationEnabled: Boolean = false,
     maxFilesPerReq: Int = 100000,
+    endStreamActionEnabled: Boolean = false,
     enableAsyncQuery: Boolean = false,
     asyncQueryPollIntervalMillis: Long = 10000L,
     asyncQueryMaxDuration: Long = 600000L,

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingDataSourceDeltaSuite.scala
@@ -1510,5 +1510,4 @@ trait DeltaSharingDataSourceDeltaSuiteBase
   }
 }
 
-@org.scalatest.Ignore
 class DeltaSharingDataSourceDeltaSuite extends DeltaSharingDataSourceDeltaSuiteBase {}

--- a/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingFileIndexSuite.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/DeltaSharingFileIndexSuite.scala
@@ -93,6 +93,7 @@ class TestDeltaSharingClientForFileIndex(
     readerFeatures: String = "",
     queryTablePaginationEnabled: Boolean = false,
     maxFilesPerReq: Int = 100000,
+    endStreamActionEnabled: Boolean = false,
     enableAsyncQuery: Boolean = false,
     asyncQueryPollIntervalMillis: Long = 10000L,
     asyncQueryMaxDuration: Long = 600000L,

--- a/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
@@ -51,6 +51,7 @@ private[spark] class TestClientForDeltaFormatSharing(
     readerFeatures: String = "",
     queryTablePaginationEnabled: Boolean = false,
     maxFilesPerReq: Int = 100000,
+    endStreamActionEnabled: Boolean = false,
     enableAsyncQuery: Boolean = false,
     asyncQueryPollIntervalMillis: Long = 10000L,
     asyncQueryMaxDuration: Long = 600000L,


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [X] Other (Sharing)

## Description
Upgrade delta-sharing-client to 1.2.1 in DBR master, see the changes in https://github.com/delta-io/delta-sharing/releases/tag/v1.2.1, supporting EndStreamAction, and additional logging.

## How was this patch tested?
Unit Tests

## Does this PR introduce _any_ user-facing changes?
No
