### PR TITLE
[Spark] Allow missing fields with implicit casting during streaming write

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableMerge.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableMerge.scala
@@ -185,7 +185,7 @@ case class PreprocessTableMerge(override val conf: SQLConf)
             castIfNeeded(
               a.expr,
               targetAttrib.dataType,
-              castingBehavior = CastingBehavior.forMergeOrUpdate(withSchemaEvolution),
+              castingBehavior = MergeOrUpdateCastingBehavior(withSchemaEvolution),
               targetAttrib.name),
             targetColNameResolved = true)
         }.getOrElse {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableMerge.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableMerge.scala
@@ -42,8 +42,6 @@ import org.apache.spark.sql.types.{DataType, DateType, StringType, StructField, 
 case class PreprocessTableMerge(override val conf: SQLConf)
   extends Rule[LogicalPlan] with UpdateExpressionsSupport {
 
-  override protected val supportMergeAndUpdateLegacyCastBehavior: Boolean = true
-
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperators {
     case m: DeltaMergeInto if m.resolved => apply(m, true)
@@ -187,7 +185,7 @@ case class PreprocessTableMerge(override val conf: SQLConf)
             castIfNeeded(
               a.expr,
               targetAttrib.dataType,
-              allowStructEvolution = withSchemaEvolution,
+              castingBehavior = CastingBehavior.forMergeOrUpdate(withSchemaEvolution),
               targetAttrib.name),
             targetColNameResolved = true)
         }.getOrElse {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableUpdate.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreprocessTableUpdate.scala
@@ -37,8 +37,6 @@ case class PreprocessTableUpdate(sqlConf: SQLConf)
 
   override def conf: SQLConf = sqlConf
 
-  override protected val supportMergeAndUpdateLegacyCastBehavior: Boolean = true
-
   override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperators {
     case u: DeltaUpdateTable if u.resolved =>
       u.condition.foreach { cond =>

--- a/spark/src/main/scala/org/apache/spark/sql/delta/UpdateExpressionsSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/UpdateExpressionsSupport.scala
@@ -78,9 +78,7 @@ trait UpdateExpressionsSupport extends SQLConfHelper with AnalysisHelper with De
    *
    * @param fromExpression the expression to cast
    * @param dataType The data type to cast to.
-   * @param allowStructEvolution Whether to allow structs to evolve. When this is false (default),
-   *                             struct casting will throw an error if the target struct type
-   *                             contains more fields than the expression to cast.
+   * @param castingBehavior Configures the casting behavior to use, see [[CastingBehavior]].
    * @param columnName The name of the column written to. It is used for the error message.
    */
   protected def castIfNeeded(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
@@ -119,7 +119,7 @@ trait MergeIntoCommandBase extends LeafRunnableCommand
             castIfNeeded(
               attr.withNullability(attr.nullable || makeNullable),
               col.dataType,
-              castingBehavior = CastingBehavior.forMergeOrUpdate(canMergeSchema),
+              castingBehavior = MergeOrUpdateCastingBehavior(canMergeSchema),
               col.name),
             col.name
           )()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/MergeIntoCommandBase.scala
@@ -65,8 +65,6 @@ trait MergeIntoCommandBase extends LeafRunnableCommand
       DeletionVectorUtils.deletionVectorsWritable(txn.snapshot)
   }
 
-  override protected val supportMergeAndUpdateLegacyCastBehavior: Boolean = true
-
   override val (canMergeSchema, canOverwriteSchema) = {
     // Delta options can't be passed to MERGE INTO currently, so they'll always be empty.
     // The methods in options check if user has instructed to turn on schema evolution for this
@@ -121,7 +119,7 @@ trait MergeIntoCommandBase extends LeafRunnableCommand
             castIfNeeded(
               attr.withNullability(attr.nullable || makeNullable),
               col.dataType,
-              allowStructEvolution = canMergeSchema,
+              castingBehavior = CastingBehavior.forMergeOrUpdate(canMergeSchema),
               col.name),
             col.name
           )()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1581,9 +1581,7 @@ trait DeltaSQLConfBase {
           |The casting behavior is governed by 'spark.sql.storeAssignmentPolicy'.
           |""".stripMargin)
       .booleanConf
-      // This feature doesn't properly support structs with missing fields and is disabled until a
-      // fix is implemented.
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   val DELTA_CDF_UNSAFE_BATCH_READ_ON_INCOMPATIBLE_SCHEMA_CHANGES =
     buildConf("changeDataFeed.unsafeBatchReadOnIncompatibleSchemaChanges.enabled")

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
@@ -202,7 +202,11 @@ case class DeltaSink(
       val castExpr = castIfNeeded(
         fromExpression = data.col(columnName).expr,
         dataType = targetTypes(columnName),
-        allowStructEvolution = canMergeSchema,
+        castingBehavior = CastingBehavior(
+          allowMissingStructField = true,
+          resolveStructsByName = true,
+          isMergeOrUpdate = false
+        ),
         columnName = columnName
       )
       Column(Alias(castExpr, columnName)())

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
@@ -202,11 +202,7 @@ case class DeltaSink(
       val castExpr = castIfNeeded(
         fromExpression = data.col(columnName).expr,
         dataType = targetTypes(columnName),
-        castingBehavior = CastingBehavior(
-          allowMissingStructField = true,
-          resolveStructsByName = true,
-          isMergeOrUpdate = false
-        ),
+        castingBehavior = CastByName(allowMissingStructField = true),
         columnName = columnName
       )
       Column(Alias(castExpr, columnName)())

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoColumnOrderSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoColumnOrderSuite.scala
@@ -125,14 +125,17 @@ class DeltaInsertIntoColumnOrderSuite extends DeltaInsertIntoTest {
 
   for { (inserts: Set[Insert], expectedAnswer) <- Seq(
     // When there's a type mismatch and an implicit cast is required, then all inserts use position
-    // based resolution for struct fields, except for `INSERT OVERWRITE PARTITION (partition)` which
-    // uses name based resolution, and dataframe inserts by name which don't support implicit cast
-    // and fail - see negative test below.
+    // based resolution for struct fields, except for `INSERT OVERWRITE PARTITION (partition)` and
+    // streaming insert which use name based resolution, and dataframe inserts by name which don't
+    // support implicit cast and fail - see negative test below.
     insertsAppend - StreamingInsert ->
       TestData("a int, s struct <x int, y: int>",
         Seq("""{ "a": 1, "s": { "x": 2, "y": 3 } }""", """{ "a": 1, "s": { "x": 5, "y": 4 } }""")),
     insertsOverwrite - SQLInsertOverwritePartitionByPosition ->
       TestData("a int, s struct <x int, y: int>", Seq("""{ "a": 1, "s": { "x": 5, "y": 4 } }""")),
+    Set(StreamingInsert) ->
+      TestData("a int, s struct <x int, y: int>",
+        Seq("""{ "a": 1, "s": { "x": 2, "y": 3 } }""", """{ "a": 1, "s": { "x": 4, "y": 5 } }""")),
     Set(SQLInsertOverwritePartitionByPosition) ->
       TestData("a int, s struct <x int, y: int>", Seq("""{ "a": 1, "s": { "x": 4, "y": 5 } }"""))
     )

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoMissingColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoMissingColumnSuite.scala
@@ -31,7 +31,7 @@ class DeltaInsertIntoMissingColumnSuite extends DeltaInsertIntoTest {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    spark.conf.set(DeltaSQLConf.DELTA_STREAMING_SINK_ALLOW_IMPLICIT_CASTS.key, "false")
+    spark.conf.set(DeltaSQLConf.DELTA_STREAMING_SINK_ALLOW_IMPLICIT_CASTS.key, "true")
     spark.conf.set(SQLConf.ANSI_ENABLED.key, "true")
   }
 
@@ -89,7 +89,7 @@ class DeltaInsertIntoMissingColumnSuite extends DeltaInsertIntoTest {
           .add("a", LongType)
           .add("b", IntegerType)
           .add("c", IntegerType)),
-      includeInserts = insertsByName.intersect(insertsSQL),
+      includeInserts = insertsByName.intersect(insertsSQL) + StreamingInsert,
       confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
     )
 
@@ -100,8 +100,8 @@ class DeltaInsertIntoMissingColumnSuite extends DeltaInsertIntoTest {
       overwriteWhere = "a" -> 1,
       insertData = TestData("a int, b long", Seq("""{ "a": 1, "b": 4 }""")),
       expectedResult = ExpectedResult.Failure(ex => {
-        // The missing column isn't an issue, but dataframe insert by name doesn't support implicit
-        // casting to reconcile the type mismatch.
+        // The missing column isn't an issue, but dataframe inserts by name (except streaming) don't
+        // support implicit casting to reconcile the type mismatch.
         checkError(
           ex,
           "DELTA_FAILED_TO_MERGE_FIELDS",
@@ -110,7 +110,7 @@ class DeltaInsertIntoMissingColumnSuite extends DeltaInsertIntoTest {
             "updateField" -> "a"
           ))
       }),
-      includeInserts = insertsByName.intersect(insertsDataframe),
+      includeInserts = insertsByName.intersect(insertsDataframe) - StreamingInsert,
       confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
     )
 
@@ -123,8 +123,8 @@ class DeltaInsertIntoMissingColumnSuite extends DeltaInsertIntoTest {
       insertData =
         TestData("a int, s struct<y: long>", Seq("""{ "a": 1, "s": { "y": 5 } }""")),
       expectedResult = ExpectedResult.Failure(ex => {
-        // The missing field isn't an issue, but dataframe insert by name doesn't support implicit
-        // casting to reconcile the type mismatch.
+        // The missing column isn't an issue, but dataframe inserts by name (except streaming) don't
+        // support implicit casting to reconcile the type mismatch.
         checkError(
           ex,
           "DELTA_FAILED_TO_MERGE_FIELDS",
@@ -133,7 +133,7 @@ class DeltaInsertIntoMissingColumnSuite extends DeltaInsertIntoTest {
             "updateField" -> "s"
           ))
       }),
-      includeInserts = insertsByName.intersect(insertsDataframe),
+      includeInserts = insertsByName.intersect(insertsDataframe) - StreamingInsert,
       confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
     )
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoSchemaEvolutionSuite.scala
@@ -32,7 +32,7 @@ class DeltaInsertIntoSchemaEvolutionSuite extends DeltaInsertIntoTest {
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    spark.conf.set(DeltaSQLConf.DELTA_STREAMING_SINK_ALLOW_IMPLICIT_CASTS.key, "false")
+    spark.conf.set(DeltaSQLConf.DELTA_STREAMING_SINK_ALLOW_IMPLICIT_CASTS.key, "true")
     spark.conf.set(SQLConf.ANSI_ENABLED.key, "true")
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoSchemaEvolutionSuite.scala
@@ -105,7 +105,7 @@ class DeltaInsertIntoSchemaEvolutionSuite extends DeltaInsertIntoTest {
             ))
         })
       },
-      includeInserts = insertsByPosition,
+      includeInserts = insertsByPosition + StreamingInsert,
       confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
     )
 
@@ -124,7 +124,7 @@ class DeltaInsertIntoSchemaEvolutionSuite extends DeltaInsertIntoTest {
             "updateField" -> "b"
           ))
       }),
-      includeInserts = insertsDataframe.intersect(insertsByName),
+      includeInserts = insertsDataframe.intersect(insertsByName) - StreamingInsert,
       confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
     )
 
@@ -210,7 +210,7 @@ class DeltaInsertIntoSchemaEvolutionSuite extends DeltaInsertIntoTest {
             ))
         })
       },
-      includeInserts = insertsSQL ++ insertsByPosition -- Seq(
+      includeInserts = insertsSQL ++ insertsByPosition + StreamingInsert -- Seq(
         // It's not possible to specify a column that doesn't exist in the target using SQL with an
         // explicit column list.
         SQLInsertColList(SaveMode.Append),
@@ -236,7 +236,7 @@ class DeltaInsertIntoSchemaEvolutionSuite extends DeltaInsertIntoTest {
             "updateField" -> "s"
           ))
       }),
-      includeInserts = insertsDataframe.intersect(insertsByName),
+      includeInserts = insertsDataframe.intersect(insertsByName) - StreamingInsert,
       confs = Seq(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> schemaEvolution.toString)
     )
   }


### PR DESCRIPTION
## Description
Follow-up on https://github.com/delta-io/delta/pull/3443 that introduced implicit casting during streaming write to delta tables.

The feature was shipped disabled due to a regression found in testing where writing data with missing struct fields start being rejected. Streaming writes are one of the few inserts that allows missing struct fields.

This change allows configuring the casting behavior used in MERGE, UPDATE and streaming writes wrt to missing struct fields.

## How was this patch tested?
Extensive tests were added in https://github.com/delta-io/delta/pull/3762 in preparation for this changes, covering for all inserts (SQL, dataframe, append/overwrite, ..):
- Missing top-level columns and nested struct fields.
- Extra top-level columns and nested struct fields with schema evolution.
- Position vs. name based resolution for top-level columns and nested struct fields.
with e.p. the goal of ensuring that enabling implicit casting in stream writes here doesn't cause any other unwanted behavior change.

## This PR introduces the following *user-facing* changes
From the initial PR: https://github.com/delta-io/delta/pull/3443

Previously, writing to a Delta sink using a type that doesn't match the column type in the Delta table failed with `DELTA_FAILED_TO_MERGE_FIELDS`:
```
spark.readStream
    .table("delta_source")
    # Column 'a' has type INT in 'delta_sink'.
    .select(col("a").cast("long").alias("a"))
    .writeStream
    .format("delta")
    .option("checkpointLocation", "<location>")
    .toTable("delta_sink")

DeltaAnalysisException: [DELTA_FAILED_TO_MERGE_FIELDS] Failed to merge fields 'a' and 'a'
```
With this change, writing to the sink now succeeds and data is cast from `LONG` to `INT`. If any value overflows, the stream fails with (assuming default `storeAssignmentPolicy=ANSI`):
```
SparkArithmeticException: [CAST_OVERFLOW_IN_TABLE_INSERT] Fail to assign a value of 'LONG' type to the 'INT' type column or variable 'a' due to an overflow. Use `try_cast` on the input value to tolerate overflow and return NULL instead."
```
