### PR TITLE
[Kernel] Reduce deprecate Path class usage

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaLogActionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaLogActionUtils.java
@@ -206,7 +206,7 @@ public class DeltaLogActionUtils {
 
     List<Long> commitVersions =
         commitFiles.stream()
-            .map(fs -> FileNames.deltaVersion(new Path(fs.getPath())))
+            .map(fs -> FileNames.deltaVersion(fs.getPath()))
             .collect(Collectors.toList());
 
     for (int i = 1; i < commitVersions.size(); i++) {
@@ -280,7 +280,7 @@ public class DeltaLogActionUtils {
           logger.debug("Ignoring non-commit file {}", fs.getPath());
           continue;
         }
-        if (FileNames.getFileVersion(new Path(fs.getPath())) > endVersion) {
+        if (FileNames.getFileVersion(fs.getPath()) > endVersion) {
           logger.debug(
               "Stopping listing found file {} with version > {}=endVersion",
               fs.getPath(),

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -146,8 +146,8 @@ public class TransactionBuilderImpl implements TransactionBuilder {
 
     return new TransactionImpl(
         isNewTable,
-        table.getDataPath(),
-        table.getLogPath(),
+        table.getDataPath().toString(),
+        table.getLogPath().toString(),
         snapshot,
         engineInfo,
         operation,

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -29,7 +29,6 @@ import io.delta.kernel.exceptions.ConcurrentWriteException;
 import io.delta.kernel.expressions.Column;
 import io.delta.kernel.internal.actions.*;
 import io.delta.kernel.internal.data.TransactionStateRow;
-import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.replay.ConflictChecker;
 import io.delta.kernel.internal.replay.ConflictChecker.TransactionRebaseState;
 import io.delta.kernel.internal.util.*;
@@ -62,8 +61,8 @@ public class TransactionImpl implements Transaction {
   private final boolean isNewTable; // the transaction is creating a new table
   private final String engineInfo;
   private final Operation operation;
-  private final Path dataPath;
-  private final Path logPath;
+  private final String dataPath;
+  private final String logPath;
   private final Protocol protocol;
   private final SnapshotImpl readSnapshot;
   private final Optional<SetTransaction> setTxnOpt;
@@ -77,8 +76,8 @@ public class TransactionImpl implements Transaction {
 
   public TransactionImpl(
       boolean isNewTable,
-      Path dataPath,
-      Path logPath,
+      String dataPath,
+      String logPath,
       SnapshotImpl readSnapshot,
       String engineInfo,
       Operation operation,
@@ -104,7 +103,7 @@ public class TransactionImpl implements Transaction {
 
   @Override
   public Row getTransactionState(Engine engine) {
-    return TransactionStateRow.of(metadata, dataPath.toString());
+    return TransactionStateRow.of(metadata, dataPath);
   }
 
   @Override
@@ -250,7 +249,7 @@ public class TransactionImpl implements Transaction {
       if (commitAsVersion == 0) {
         // New table, create a delta log directory
         if (!wrapEngineExceptionThrowsIO(
-            () -> engine.getFileSystemClient().mkdirs(logPath.toString()),
+            () -> engine.getFileSystemClient().mkdirs(logPath),
             "Creating directories for path %s",
             logPath)) {
           throw new RuntimeException("Failed to create delta log directory: " + logPath);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/CommitInfo.java
@@ -206,7 +206,7 @@ public class CommitInfo {
   }
 
   /** Get the persisted commit info (if available) for the given delta file. */
-  public static Optional<CommitInfo> getCommitInfoOpt(Engine engine, Path logPath, long version) {
+  public static Optional<CommitInfo> getCommitInfoOpt(Engine engine, String logPath, long version) {
     final FileStatus file =
         FileStatus.of(
             FileNames.deltaFile(logPath, version), /* path */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActionsIterator.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ActionsIterator.java
@@ -271,7 +271,7 @@ public class ActionsIterator implements CloseableIterator<ActionWrapper> {
       }
       FileStatus sideCarFileStatus =
           FileStatus.of(
-              FileNames.sidecarFile(deltaLogPath, sidecarFile.getPath()),
+              FileNames.sidecarFile(deltaLogPath.toString(), sidecarFile.getPath()),
               sidecarFile.getSizeInBytes(),
               sidecarFile.getModificationTime());
 
@@ -297,7 +297,7 @@ public class ActionsIterator implements CloseableIterator<ActionWrapper> {
       switch (nextLogFile.getLogType()) {
         case COMMIT:
           {
-            final long fileVersion = FileNames.deltaVersion(nextFilePath);
+            final long fileVersion = FileNames.deltaVersion(nextFilePath.toString());
             // We can not read multiple JSON files in parallel (like the checkpoint files),
             // because each one has a different version, and we need to associate the
             // version with actions read from the JSON file for further optimizations later
@@ -328,7 +328,7 @@ public class ActionsIterator implements CloseableIterator<ActionWrapper> {
             // parts of the current multipart checkpoint.
             CloseableIterator<ColumnarBatch> dataIter =
                 getActionsIterFromSinglePartOrV2Checkpoint(nextFile, fileName);
-            long version = checkpointVersion(nextFilePath);
+            long version = checkpointVersion(nextFilePath.toString());
             return combine(dataIter, true /* isFromCheckpoint */, version, Optional.empty());
           }
         case MULTIPART_CHECKPOINT:
@@ -350,7 +350,7 @@ public class ActionsIterator implements CloseableIterator<ActionWrapper> {
                     readSchema,
                     checkpointPredicate);
 
-            long version = checkpointVersion(nextFilePath);
+            long version = checkpointVersion(nextFilePath.toString());
             return combine(dataIter, true /* isFromCheckpoint */, version, Optional.empty());
           }
         default:

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ConflictChecker.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ConflictChecker.java
@@ -266,7 +266,7 @@ public class ConflictChecker {
 
   private List<FileStatus> getWinningCommitFiles(Engine engine) {
     String firstWinningCommitFile =
-        deltaFile(snapshot.getLogPath(), snapshot.getVersion(engine) + 1);
+        deltaFile(snapshot.getLogPath().toString(), snapshot.getVersion(engine) + 1);
 
     try (CloseableIterator<FileStatus> files =
         wrapEngineExceptionThrowsIO(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -391,7 +391,7 @@ public class SnapshotManager {
                 // Take files until the version we want to load
                 final boolean versionWithinRange =
                     versionToLoad
-                        .map(v -> FileNames.getFileVersion(new Path(fileStatus.getPath())) <= v)
+                        .map(v -> FileNames.getFileVersion(fileStatus.getPath()) <= v)
                         .orElse(true);
 
                 if (!versionWithinRange) {
@@ -737,7 +737,7 @@ public class SnapshotManager {
                             versionToLoadOpt.orElseGet(
                                 () -> {
                                   final FileStatus lastDelta = deltas.get(deltas.size() - 1);
-                                  return FileNames.deltaVersion(new Path(lastDelta.getPath()));
+                                  return FileNames.deltaVersion(lastDelta.getPath());
                                 });
 
                         return getLogSegmentWithMaxExclusiveCheckpointVersion(
@@ -762,8 +762,7 @@ public class SnapshotManager {
     final List<FileStatus> deltasAfterCheckpoint =
         deltas.stream()
             .filter(
-                fileStatus ->
-                    FileNames.deltaVersion(new Path(fileStatus.getPath())) > newCheckpointVersion)
+                fileStatus -> FileNames.deltaVersion(fileStatus.getPath()) > newCheckpointVersion)
             .collect(Collectors.toList());
 
     logDebug(
@@ -777,7 +776,7 @@ public class SnapshotManager {
 
     final LinkedList<Long> deltaVersionsAfterCheckpoint =
         deltasAfterCheckpoint.stream()
-            .map(fileStatus -> FileNames.deltaVersion(new Path(fileStatus.getPath())))
+            .map(fileStatus -> FileNames.deltaVersion(fileStatus.getPath()))
             .collect(Collectors.toCollection(LinkedList::new));
 
     logDebug(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
@@ -16,6 +16,8 @@
 
 package io.delta.kernel.internal.util;
 
+import static io.delta.kernel.internal.fs.Path.getName;
+
 import io.delta.kernel.internal.fs.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,15 +47,11 @@ public final class FileNames {
   public static final String SIDECAR_DIRECTORY = "_sidecars";
 
   /** Returns the delta (json format) path for a given delta file. */
-  public static String deltaFile(Path path, long version) {
+  public static String deltaFile(String path, long version) {
     return String.format("%s/%020d.json", path, version);
   }
 
   /** Returns the version for the given delta path. */
-  public static long deltaVersion(Path path) {
-    return Long.parseLong(path.getName().split("\\.")[0]);
-  }
-
   public static long deltaVersion(String path) {
     final int slashIdx = path.lastIndexOf(Path.SEPARATOR);
     final String name = path.substring(slashIdx + 1);
@@ -61,18 +59,14 @@ public final class FileNames {
   }
 
   /** Returns the version for the given checkpoint path. */
-  public static long checkpointVersion(Path path) {
-    return Long.parseLong(path.getName().split("\\.")[0]);
-  }
-
   public static long checkpointVersion(String path) {
     final int slashIdx = path.lastIndexOf(Path.SEPARATOR);
     final String name = path.substring(slashIdx + 1);
     return Long.parseLong(name.split("\\.")[0]);
   }
 
-  public static String sidecarFile(Path path, String sidecar) {
-    return String.format("%s/%s/%s", path.toString(), SIDECAR_DIRECTORY, sidecar);
+  public static String sidecarFile(String path, String sidecar) {
+    return String.format("%s/%s/%s", path, SIDECAR_DIRECTORY, sidecar);
   }
 
   /**
@@ -105,8 +99,8 @@ public final class FileNames {
   }
 
   /** Returns the path for a V2 sidecar file with a given UUID. */
-  public static Path v2CheckpointSidecarFile(Path path, String uuid) {
-    return new Path(String.format("%s/_sidecars/%s.parquet", path.toString(), uuid));
+  public static String v2CheckpointSidecarFile(String path, String uuid) {
+    return String.format("%s/_sidecars/%s.parquet", path, uuid);
   }
 
   /**
@@ -128,8 +122,9 @@ public final class FileNames {
     return output;
   }
 
-  public static boolean isCheckpointFile(String fileName) {
-    return CHECKPOINT_FILE_PATTERN.matcher(new Path(fileName).getName()).matches();
+  public static boolean isCheckpointFile(String path) {
+    String fileName = getName(path);
+    return CHECKPOINT_FILE_PATTERN.matcher(fileName).matches();
   }
 
   public static boolean isClassicCheckpointFile(String fileName) {
@@ -144,10 +139,10 @@ public final class FileNames {
     return V2_CHECKPOINT_FILE_PATTERN.matcher(fileName).matches();
   }
 
-  public static boolean isCommitFile(String fileName) {
-    String filename = new Path(fileName).getName();
-    return DELTA_FILE_PATTERN.matcher(filename).matches()
-        || UUID_DELTA_FILE_REGEX.matcher(filename).matches();
+  public static boolean isCommitFile(String path) {
+    String fileName = getName(path);
+    return DELTA_FILE_PATTERN.matcher(fileName).matches()
+        || UUID_DELTA_FILE_REGEX.matcher(fileName).matches();
   }
 
   /**
@@ -156,10 +151,11 @@ public final class FileNames {
    * compatibility in cases where new file types are added, but without an explicit protocol
    * upgrade.
    */
-  public static long getFileVersion(Path path) {
-    if (isCheckpointFile(path.getName())) {
+  public static long getFileVersion(String path) {
+    String fileName = getName(path);
+    if (isCheckpointFile(fileName)) {
       return checkpointVersion(path);
-    } else if (isCommitFile(path.getName())) {
+    } else if (isCommitFile(fileName)) {
       return deltaVersion(path);
       // } else if (isChecksumFile(path)) {
       //    checksumVersion(path);

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/DeltaLogActionUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/DeltaLogActionUtilsSuite.scala
@@ -35,7 +35,7 @@ class DeltaLogActionUtilsSuite extends AnyFunSuite with MockFileSystemClientUtil
 
   def getCommitFiles(versions: Seq[Long]): java.util.List[FileStatus] = {
     versions
-      .map(v => FileStatus.of(FileNames.deltaFile(logPath, v), 0, 0))
+      .map(v => FileStatus.of(FileNames.deltaFile(logPath.toString, v), 0, 0))
       .asJava
   }
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
@@ -227,7 +227,7 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
         Optional.empty(),
         versionToLoad,
         Optional.of(
-          new MockTableCommitCoordinatorClientHandler(logPath, unbackfilledDeltaVersions))
+          new MockTableCommitCoordinatorClientHandler(logPath.toString, unbackfilledDeltaVersions))
       )
       assert(logSegmentOpt.isPresent())
 
@@ -907,7 +907,7 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
       expectedErrorMessageContains = errMsg,
       tableCommitCoordinatorClientHandlerOpt =
         Optional.of(new MockTableCommitCoordinatorClientHandler(
-          logPath, e = new RuntimeException(errMsg)))
+          logPath.toString, e = new RuntimeException(errMsg)))
     )
   }
 }
@@ -951,7 +951,7 @@ class MockSidecarJsonHandler(sidecars: Seq[FileStatus])
 }
 
 class MockTableCommitCoordinatorClientHandler(
-  logPath: Path, versions: Seq[Long] = Seq.empty, e: Throwable = null)
+  logPath: String, versions: Seq[Long] = Seq.empty, e: Throwable = null)
   extends TableCommitCoordinatorClientHandler(null, null, null) {
   override def getCommits(
     startVersion: javaLang.Long, endVersion: javaLang.Long): GetCommitsResponse = {

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/FileNamesSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/util/FileNamesSuite.scala
@@ -33,12 +33,12 @@ class FileNamesSuite extends AnyFunSuite {
   }
 
   test("checkpointVersion") {
-    assert(checkpointVersion(new Path("/a/123.checkpoint.parquet")) == 123)
-    assert(checkpointVersion(new Path("/a/0.checkpoint.parquet")) == 0)
+    assert(checkpointVersion("/a/123.checkpoint.parquet") == 123)
+    assert(checkpointVersion("/a/0.checkpoint.parquet") == 0)
     assert(checkpointVersion(
-      new Path("/a/00000000000000000151.checkpoint.parquet")) == 151)
+      "/a/00000000000000000151.checkpoint.parquet") == 151)
     assert(checkpointVersion(
-      new Path("/a/999.checkpoint.0000000090.0000000099.parquet")) == 999)
+      "/a/999.checkpoint.0000000090.0000000099.parquet") == 999)
     assert(checkpointVersion("/a/000000010.checkpoint.80a083e8-7026.json") == 10)
   }
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockFileSystemClientUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/MockFileSystemClientUtils.scala
@@ -39,7 +39,7 @@ trait MockFileSystemClientUtils extends MockEngineUtils {
   /** Delta file statuses where the timestamp = 10*version */
   def deltaFileStatuses(deltaVersions: Seq[Long]): Seq[FileStatus] = {
     assert(deltaVersions.size == deltaVersions.toSet.size)
-    deltaVersions.map(v => FileStatus.of(FileNames.deltaFile(logPath, v), v, v*10))
+    deltaVersions.map(v => FileStatus.of(FileNames.deltaFile(logPath.toString, v), v, v*10))
   }
 
   /** Checkpoint file statuses where the timestamp = 10*version */
@@ -79,7 +79,7 @@ trait MockFileSystemClientUtils extends MockEngineUtils {
       }
       val sidecars = (0 until numSidecars).map { _ =>
         FileStatus.of(
-          FileNames.v2CheckpointSidecarFile(logPath, UUID.randomUUID().toString).toString,
+          FileNames.v2CheckpointSidecarFile(logPath.toString, UUID.randomUUID().toString),
           v, v * 10)
       }
       (topLevelFile, sidecars)

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
@@ -851,7 +851,7 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
   private def generateCommits(path: String, commits: Long*): Unit = {
     commits.zipWithIndex.foreach { case (ts, i) =>
       spark.range(i*10, i*10 + 10).write.format("delta").mode("append").save(path)
-      val file = new File(FileNames.deltaFile(new Path(path, "_delta_log"), i))
+      val file = new File(FileNames.deltaFile(path + "/_delta_log", i))
       file.setLastModified(ts)
     }
   }
@@ -974,7 +974,7 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
       }
 
       // Setup part 2 of 2: edit lastModified times
-      val logPath = new Path(dir.getCanonicalPath, "_delta_log")
+      val logPath = dir.getCanonicalPath + "/_delta_log"
 
       val delta0 = new File(FileNames.deltaFile(logPath, 0))
       val delta1 = new File(FileNames.deltaFile(logPath, 1))
@@ -1039,7 +1039,7 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
       }
 
       (0 to 35).foreach { i =>
-        val delta = new File(FileNames.deltaFile(logPath, i))
+        val delta = new File(FileNames.deltaFile(logPath.toString, i))
         if (i >= 25) {
           delta.setLastModified(nowEpochMs + i * 1000)
         } else {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWriteSuiteBase.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWriteSuiteBase.scala
@@ -154,7 +154,7 @@ trait DeltaTableWriteSuiteBase extends AnyFunSuite with TestUtils {
     tablePath: String,
     version: Long, consumer: Row => Option[Any]): Option[Any] = {
     val table = Table.forPath(engine, tablePath)
-    val logPath = new DeltaPath(table.getPath(engine), "_delta_log")
+    val logPath = table.getPath(engine) + "/_delta_log"
     val file = FileStatus.of(FileNames.deltaFile(logPath, version), 0, 0)
     val columnarBatches = engine.getJsonHandler.readJsonFiles(
       singletonCloseableIterator(file),

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/InCommitTimestampSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/InCommitTimestampSuite.scala
@@ -40,7 +40,7 @@ import io.delta.kernel.internal.actions.SingleAction.createCommitInfoSingleActio
 
 class InCommitTimestampSuite extends DeltaTableWriteSuiteBase {
 
-  private def removeCommitInfoFromCommit(engine: Engine, version: Long, logPath: Path): Unit = {
+  private def removeCommitInfoFromCommit(engine: Engine, version: Long, logPath: String): Unit = {
     val file = FileStatus.of(FileNames.deltaFile(logPath, version), 0, 0)
     val columnarBatches =
       engine.getJsonHandler.readJsonFiles(
@@ -159,7 +159,7 @@ class InCommitTimestampSuite extends DeltaTableWriteSuiteBase {
         value = "true",
         expectedValue = true)
       // Remove CommitInfo from the commit.
-      val logPath = new Path(table.getPath(engine), "_delta_log")
+      val logPath = table.getPath(engine) + "/_delta_log";
       removeCommitInfoFromCommit(engine, 0, logPath)
 
       val ex = intercept[InvalidTableException] {
@@ -180,7 +180,7 @@ class InCommitTimestampSuite extends DeltaTableWriteSuiteBase {
       setTablePropAndVerify(
         engine, tablePath, isNewTable = true, IN_COMMIT_TIMESTAMPS_ENABLED, "true", true)
       // Remove CommitInfo.inCommitTimestamp from the commit.
-      val logPath = new Path(table.getPath(engine), "_delta_log")
+      val logPath = table.getPath(engine) + "/_delta_log"
       val file = FileStatus.of(FileNames.deltaFile(logPath, 0), 0, 0)
       val columnarBatches =
         engine.getJsonHandler.readJsonFiles(
@@ -405,7 +405,7 @@ class InCommitTimestampSuite extends DeltaTableWriteSuiteBase {
    *  is not null, otherwise return null.
    */
   private def getInCommitTimestamp(engine: Engine, table: Table, version: Long): Option[Long] = {
-    val logPath = new Path(table.getPath(engine), "_delta_log")
+    val logPath = table.getPath(engine) + "/_delta_log"
     val commitInfoOpt = CommitInfo.getCommitInfoOpt(engine, logPath, version)
     if (commitInfoOpt.isPresent && commitInfoOpt.get.getInCommitTimestamp.isPresent) {
       Some(commitInfoOpt.get.getInCommitTimestamp.get)
@@ -526,7 +526,7 @@ class InCommitTimestampSuite extends DeltaTableWriteSuiteBase {
       )
 
       // Remove CommitInfo from the commit.
-      val logPath = new Path(table.getPath(engine), "_delta_log")
+      val logPath = table.getPath(engine) + "/_delta_log"
       removeCommitInfoFromCommit(engine, 2, logPath)
 
       clock.setTime(startTime - 1000)

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LogReplayEngineMetricsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LogReplayEngineMetricsSuite.scala
@@ -387,7 +387,7 @@ trait FileReadMetrics { self: Object =>
   private def updateVersionsRead(fileStatus: FileStatus): Unit = {
     val path = new Path(fileStatus.getPath)
     if (FileNames.isCommitFile(path.getName) || FileNames.isCheckpointFile(path.getName)) {
-      val version = FileNames.getFileVersion(path)
+      val version = FileNames.getFileVersion(fileStatus.getPath)
 
       // We may split json/parquet reads, so don't record the same file multiple times
       if (!versionsRead.contains(version)) {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/TableChangesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/TableChangesSuite.scala
@@ -124,7 +124,7 @@ class TableChangesSuite extends AnyFunSuite with TestUtils {
       def generateCommits(path: String, commits: Long*): Unit = {
         commits.zipWithIndex.foreach { case (ts, i) =>
           spark.range(i*10, i*10 + 10).write.format("delta").mode("append").save(path)
-          val file = new File(FileNames.deltaFile(new Path(path, "_delta_log"), i))
+          val file = new File(FileNames.deltaFile(path + "/_delta_log", i))
           file.setLastModified(ts)
         }
       }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/coordinatedcommits/CoordinatedCommitsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/coordinatedcommits/CoordinatedCommitsSuite.scala
@@ -85,7 +85,7 @@ class CoordinatedCommitsSuite extends DeltaTableWriteSuiteBase
 
     /** Rewrite the FS to CC conversion commit and move coordinated commits to _commits folder */
     (0L until totalCommitNum).foreach{ version =>
-      val commitFilePath = getHadoopDeltaFile(logPath, version)
+      val commitFilePath = getHadoopDeltaFile(logPath.toString, version)
 
       if (version == versionConvertToCC) {
         tableConf = handler.registerTable(

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/coordinatedcommits/CoordinatedCommitsTestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/coordinatedcommits/CoordinatedCommitsTestUtils.scala
@@ -93,15 +93,15 @@ trait CoordinatedCommitsTestUtils {
       updatedActions).getCommit
   }
 
-  def getHadoopDeltaFile(logPath: Path, version: Long): Path = {
-    new Path(FileNames.deltaFile(new io.delta.kernel.internal.fs.Path(logPath.toString), version))
+  def getHadoopDeltaFile(logPath: String, version: Long): Path = {
+    new Path(FileNames.deltaFile(new io.delta.kernel.internal.fs.Path(logPath).toString, version))
   }
 
   def writeConvertToCCCommit(
     engine: Engine, logPath: Path, commit: CloseableIterator[Row], version: Long): Unit = {
     createLogPath(engine, logPath)
     engine.getJsonHandler.writeJsonFileAtomically(
-      getHadoopDeltaFile(logPath, version).toString,
+      getHadoopDeltaFile(logPath.toString, version).toString,
       commit,
       true)
   }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

Reduce deprecate `Path` class usage. 

## How was this patch tested?

N/A

## Does this PR introduce _any_ user-facing changes?

No