### PR TITLE
[Delta] Extend signature for checkpoint function

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/Checkpoints.scala
@@ -43,6 +43,7 @@ import org.apache.spark.paths.SparkPath
 import org.apache.spark.sql.{Column, DataFrame, Dataset, Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions.{Cast, ElementAt, Literal}
 import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.datasources.FileFormat
@@ -300,12 +301,13 @@ trait Checkpoints extends DeltaLogging {
    */
   def checkpoint(
       snapshotToCheckpoint: Snapshot,
-      tableIdentifierOpt: Option[TableIdentifier] = None): Unit =
+      catalogTable: Option[CatalogTable] = None): Unit =
     recordDeltaOperation(this, "delta.checkpoint") {
     withCheckpointExceptionHandling(snapshotToCheckpoint.deltaLog, "delta.checkpoint.sync.error") {
       if (snapshotToCheckpoint.version < 0) {
         throw DeltaErrors.checkpointNonExistTable(dataPath)
       }
+      val tableIdentifierOpt = catalogTable.map(_.identifier)
       checkpointAndCleanUpDeltaLog(snapshotToCheckpoint, tableIdentifierOpt)
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/CheckpointHook.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/CheckpointHook.scala
@@ -41,6 +41,6 @@ object CheckpointHook extends PostCommitHook {
       lastCheckpointHint = None,
       lastCheckpointProvider = Some(cp),
       tableIdentifierOpt = txn.catalogTable.map(_.identifier))
-    txn.deltaLog.checkpoint(snapshotToCheckpoint, txn.catalogTable.map(_.identifier))
+    txn.deltaLog.checkpoint(snapshotToCheckpoint, txn.catalogTable)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
 A minor refactor for checkpoint function
* Change the signature from `checkpoint(snapshotToCheckpoint, tableIdentifierOpt: Option[TableIdentifier] = None)` to `checkpoint(snapshotToCheckpoint, catalogTable: Option[CatalogTable] = None)`

## How was this patch tested?
Existing UTs

## Does this PR introduce _any_ user-facing changes?
No
