### PR TITLE
[Kernel] [CC Refactor] Make CommitInfo implement AbstractCommitInfo

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -138,6 +138,26 @@ public final class DeltaErrors {
     return new KernelException(message);
   }
 
+  public static KernelException missingCommitInfo(String version) {
+    final String message =
+        String.format(
+            "This table has the feature inCommitTimestamp enabled which requires the "
+                + "presence of the CommitInfo action in every commit. However, the CommitInfo "
+                + "action is missing from commit version %s.",
+            version);
+    return new KernelException(message);
+  }
+
+  public static KernelException missingCommitTimestamp(String version) {
+    final String message =
+        String.format(
+            "This table has the feature inCommitTimestamp enabled which requires the presence of "
+                + "inCommitTimestamp in the CommitInfo action. However, this field has not been "
+                + "set in commit version %s.",
+            version);
+    return new KernelException(message);
+  }
+
   /* ------------------------ PROTOCOL EXCEPTIONS ----------------------------- */
 
   public static KernelException unsupportedReaderProtocol(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -132,11 +132,9 @@ public class SnapshotImpl implements Snapshot {
     if (IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(metadata)) {
       if (!inCommitTimestampOpt.isPresent()) {
         Optional<CommitInfo> commitInfoOpt =
-            CommitInfo.getCommitInfoOpt(engine, logPath, logSegment.version);
+            CommitInfo.loadCommitInfoAtVersion(engine, logPath, logSegment.version);
         inCommitTimestampOpt =
-            Optional.of(
-                CommitInfo.getRequiredInCommitTimestamp(
-                    commitInfoOpt, String.valueOf(logSegment.version), dataPath));
+            Optional.of(CommitInfo.getRequiredInCommitTimestamp(commitInfoOpt, logSegment.version));
       }
       return inCommitTimestampOpt.get();
     } else {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ConflictChecker.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ConflictChecker.java
@@ -102,7 +102,8 @@ public class ConflictChecker {
             ColumnarBatch batch = actionBatch.getColumnarBatch();
             if (actionBatch.getVersion() == lastWinningVersion) {
               Optional<CommitInfo> commitInfo =
-                  getCommitInfo(batch.getColumnVector(COMMITINFO_ORDINAL));
+                  getCommitInfo(
+                      batch.getColumnVector(COMMITINFO_ORDINAL), actionBatch.getVersion());
               winningCommitInfoOpt.set(commitInfo);
             }
 
@@ -195,12 +196,13 @@ public class ConflictChecker {
    * Get the commit info from the winning transactions.
    *
    * @param commitInfoVector commit info rows from the winning transactions
+   * @param version version of the winning transaction
    * @return the commit info
    */
-  private Optional<CommitInfo> getCommitInfo(ColumnVector commitInfoVector) {
+  private Optional<CommitInfo> getCommitInfo(ColumnVector commitInfoVector, long version) {
     for (int rowId = 0; rowId < commitInfoVector.getSize(); rowId++) {
       if (!commitInfoVector.isNullAt(rowId)) {
-        return Optional.of(CommitInfo.fromColumnVector(commitInfoVector, rowId));
+        return Optional.of(CommitInfo.fromColumnVector(commitInfoVector, rowId, version));
       }
     }
     return Optional.empty();
@@ -272,8 +274,7 @@ public class ConflictChecker {
         || !IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(snapshot.getMetadata())) {
       return lastWinningTxn.getModificationTime();
     } else {
-      return CommitInfo.getRequiredInCommitTimestamp(
-          winningCommitInfoOpt, String.valueOf(lastWinningVersion), snapshot.getDataPath());
+      return CommitInfo.getRequiredInCommitTimestamp(winningCommitInfoOpt, lastWinningVersion);
     }
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/CoordinatedCommitsUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/CoordinatedCommitsUtils.java
@@ -15,10 +15,8 @@
  */
 package io.delta.kernel.internal.util;
 
-import io.delta.kernel.engine.coordinatedcommits.actions.AbstractCommitInfo;
 import io.delta.kernel.engine.coordinatedcommits.actions.AbstractMetadata;
 import io.delta.kernel.engine.coordinatedcommits.actions.AbstractProtocol;
-import io.delta.kernel.internal.actions.CommitInfo;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import java.util.*;
@@ -98,9 +96,5 @@ public class CoordinatedCommitsUtils {
         return new HashSet<>(protocol.getWriterFeatures());
       }
     };
-  }
-
-  public static AbstractCommitInfo convertCommitInfoToAbstractCommitInfo(CommitInfo commitInfo) {
-    return () -> commitInfo.getInCommitTimestamp().orElse(commitInfo.getTimestamp());
   }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/coordinatedcommits/CoordinatedCommitsTestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/coordinatedcommits/CoordinatedCommitsTestUtils.scala
@@ -59,8 +59,9 @@ trait CoordinatedCommitsTestUtils {
       minReaderVersion, minWriterVersion, Collections.emptyList(), Collections.emptyList())
   }
 
-  def getCommitInfo(newTimestamp: Long): CommitInfo = {
+  def getCommitInfo(version: Long, newTimestamp: Long): CommitInfo = {
     new CommitInfo(
+      version,
       Optional.of(newTimestamp),
       -1,
       null,
@@ -79,7 +80,7 @@ trait CoordinatedCommitsTestUtils {
     timestamp: Long,
     commit: CloseableIterator[Row],
     commitCoordinatorClientHandler: CommitCoordinatorClientHandler): Commit = {
-    val updatedCommitInfo = getCommitInfo(timestamp)
+    val updatedCommitInfo = getCommitInfo(version, timestamp)
     val updatedActions = if (version == 0) {
       getUpdatedActionsForZerothCommit(updatedCommitInfo)
     } else {
@@ -121,7 +122,7 @@ trait CoordinatedCommitsTestUtils {
         TableConfig.COORDINATED_COMMITS_COORDINATOR_CONF.getKey -> "{}")
     val newMetadata = oldMetadata.withNewConfiguration(newMetadataConfiguration.asJava)
     new UpdatedActions(
-      CoordinatedCommitsUtils.convertCommitInfoToAbstractCommitInfo(commitInfo),
+      commitInfo,
       CoordinatedCommitsUtils.convertMetadataToAbstractMetadata(newMetadata),
       CoordinatedCommitsUtils.convertProtocolToAbstractProtocol(getProtocol(3, 7)),
       CoordinatedCommitsUtils.convertMetadataToAbstractMetadata(oldMetadata),


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR makes CommitInfo depend on AbstractCommitInfo. This lets us remove the `CoordinatedCommitsUtils.convertCommitInfoToAbstractCommitInfo` method.

Also cleans up code along the way, and adds `version` (read from the file name) to CommitInfo.

## How was this patch tested?

Existing UTs.

## Does this PR introduce _any_ user-facing changes?

No.