### PR TITLE
[Kernel] [CC Refactor] Make Metadata implement AbstractMetadata; fix Metadata partition col APIs

### DIFF
--- a/connectors/flink/src/main/scala/io/delta/flink/internal/KernelSnapshotWrapper.java
+++ b/connectors/flink/src/main/scala/io/delta/flink/internal/KernelSnapshotWrapper.java
@@ -140,7 +140,7 @@ public class KernelSnapshotWrapper implements io.delta.standalone.Snapshot {
         );
 
         // Convert the partition columns from a ColumnVector to a List<String>
-        ColumnVector partitionsVec = kernelMetadata.getPartitionColumnsRaw().getElements();
+        ColumnVector partitionsVec = kernelMetadata.getPartitionColumnsArrayValue().getElements();
         ArrayList<String> partitionColumns = new ArrayList<String>(partitionsVec.getSize());
         for(int i = 0; i < partitionsVec.getSize(); i++) {
             partitionColumns.add(partitionsVec.getString(i));
@@ -186,12 +186,12 @@ public class KernelSnapshotWrapper implements io.delta.standalone.Snapshot {
 
         return new Metadata(
             kernelMetadata.getId(),
-            kernelMetadata.getName().orElse(null),
-            kernelMetadata.getDescription().orElse(null),
+            kernelMetadata.getName(),
+            kernelMetadata.getDescription(),
             format,
             partitionColumns,
             kernelMetadata.getConfiguration(),
-            kernelMetadata.getCreatedTime(),
+            Optional.ofNullable(kernelMetadata.getCreatedTime()),
             schema
         );
     }

--- a/connectors/flink/src/main/scala/io/delta/flink/internal/KernelSnapshotWrapper.java
+++ b/connectors/flink/src/main/scala/io/delta/flink/internal/KernelSnapshotWrapper.java
@@ -140,7 +140,7 @@ public class KernelSnapshotWrapper implements io.delta.standalone.Snapshot {
         );
 
         // Convert the partition columns from a ColumnVector to a List<String>
-        ColumnVector partitionsVec = kernelMetadata.getPartitionColumns().getElements();
+        ColumnVector partitionsVec = kernelMetadata.getPartitionColumnsRaw().getElements();
         ArrayList<String> partitionColumns = new ArrayList<String>(partitionsVec.getSize());
         for(int i = 0; i < partitionsVec.getSize(); i++) {
             partitionColumns.add(partitionsVec.getString(i));

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/annotation/Nullable.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/annotation/Nullable.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Annotation to indicate that a field, method parameter, method return value, or local variable may
+ * be null.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE})
+public @interface Nullable {}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/engine/coordinatedcommits/actions/AbstractMetadata.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/engine/coordinatedcommits/actions/AbstractMetadata.java
@@ -17,9 +17,9 @@
 package io.delta.kernel.engine.coordinatedcommits.actions;
 
 import io.delta.kernel.annotation.Evolving;
+import io.delta.kernel.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * Interface for metadata actions in Delta. The metadata defines the metadata of the table.
@@ -33,9 +33,11 @@ public interface AbstractMetadata {
   String getId();
 
   /** User-specified table identifier. */
+  @Nullable
   String getName();
 
   /** User-specified table description. */
+  @Nullable
   String getDescription();
 
   /** The table provider format. */
@@ -54,5 +56,6 @@ public interface AbstractMetadata {
   Map<String, String> getConfiguration();
 
   /** Timestamp for the creation of this metadata. */
-  Optional<Long> getCreatedTime();
+  @Nullable
+  Long getCreatedTime();
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -78,7 +78,7 @@ public class ScanImpl implements Scan {
     this.partitionColToStructFieldMap =
         () -> {
           final Set<String> partitionColNames =
-              PartitionUtils.arrayValueToLowerCaseSet(metadata.getPartitionColumnsRaw());
+              PartitionUtils.arrayValueToLowerCaseSet(metadata.getPartitionColumnsArrayValue());
           return metadata.getSchema().fields().stream()
               .filter(field -> partitionColNames.contains(field.getName().toLowerCase(Locale.ROOT)))
               .collect(toMap(field -> field.getName().toLowerCase(Locale.ROOT), identity()));
@@ -157,7 +157,8 @@ public class ScanImpl implements Scan {
     // Compute the physical data read schema, basically the list of columns to read
     // from a Parquet data file. It should exclude partition columns and include
     // row_index metadata columns (in case DVs are present)
-    List<String> partitionColumns = VectorUtils.toJavaList(metadata.getPartitionColumnsRaw());
+    List<String> partitionColumns =
+        VectorUtils.toJavaList(metadata.getPartitionColumnsArrayValue());
     StructType physicalDataReadSchema =
         PartitionUtils.physicalSchemaWithoutPartitionColumns(
             readSchema, /* logical read schema */
@@ -187,7 +188,7 @@ public class ScanImpl implements Scan {
         predicate ->
             PartitionUtils.splitMetadataAndDataPredicates(
                 predicate,
-                PartitionUtils.arrayValueToLowerCaseSet(metadata.getPartitionColumnsRaw())));
+                PartitionUtils.arrayValueToLowerCaseSet(metadata.getPartitionColumnsArrayValue())));
   }
 
   private Optional<Predicate> getDataFilters() {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanImpl.java
@@ -77,7 +77,8 @@ public class ScanImpl implements Scan {
     this.dataPath = dataPath;
     this.partitionColToStructFieldMap =
         () -> {
-          Set<String> partitionColNames = metadata.getPartitionColNames();
+          final Set<String> partitionColNames =
+              PartitionUtils.arrayValueToLowerCaseSet(metadata.getPartitionColumnsRaw());
           return metadata.getSchema().fields().stream()
               .filter(field -> partitionColNames.contains(field.getName().toLowerCase(Locale.ROOT)))
               .collect(toMap(field -> field.getName().toLowerCase(Locale.ROOT), identity()));
@@ -156,7 +157,7 @@ public class ScanImpl implements Scan {
     // Compute the physical data read schema, basically the list of columns to read
     // from a Parquet data file. It should exclude partition columns and include
     // row_index metadata columns (in case DVs are present)
-    List<String> partitionColumns = VectorUtils.toJavaList(metadata.getPartitionColumns());
+    List<String> partitionColumns = VectorUtils.toJavaList(metadata.getPartitionColumnsRaw());
     StructType physicalDataReadSchema =
         PartitionUtils.physicalSchemaWithoutPartitionColumns(
             readSchema, /* logical read schema */
@@ -185,7 +186,8 @@ public class ScanImpl implements Scan {
     return filter.map(
         predicate ->
             PartitionUtils.splitMetadataAndDataPredicates(
-                predicate, metadata.getPartitionColNames()));
+                predicate,
+                PartitionUtils.arrayValueToLowerCaseSet(metadata.getPartitionColumnsRaw())));
   }
 
   private Optional<Predicate> getDataFilters() {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -112,7 +112,7 @@ public class TransactionImpl implements Transaction {
 
   @Override
   public List<String> getPartitionColumns(Engine engine) {
-    return VectorUtils.toJavaList(metadata.getPartitionColumns());
+    return VectorUtils.toJavaList(metadata.getPartitionColumnsRaw());
   }
 
   @Override
@@ -303,7 +303,7 @@ public class TransactionImpl implements Transaction {
 
   private Map<String, String> getOperationParameters() {
     if (isNewTable) {
-      List<String> partitionCols = VectorUtils.toJavaList(metadata.getPartitionColumns());
+      List<String> partitionCols = VectorUtils.toJavaList(metadata.getPartitionColumnsRaw());
       String partitionBy =
           partitionCols.stream()
               .map(col -> "\"" + col + "\"")

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -112,7 +112,7 @@ public class TransactionImpl implements Transaction {
 
   @Override
   public List<String> getPartitionColumns(Engine engine) {
-    return VectorUtils.toJavaList(metadata.getPartitionColumnsRaw());
+    return VectorUtils.toJavaList(metadata.getPartitionColumnsArrayValue());
   }
 
   @Override
@@ -303,7 +303,7 @@ public class TransactionImpl implements Transaction {
 
   private Map<String, String> getOperationParameters() {
     if (isNewTable) {
-      List<String> partitionCols = VectorUtils.toJavaList(metadata.getPartitionColumnsRaw());
+      List<String> partitionCols = VectorUtils.toJavaList(metadata.getPartitionColumnsArrayValue());
       String partitionBy =
           partitionCols.stream()
               .map(col -> "\"" + col + "\"")

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ScanStateRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ScanStateRow.java
@@ -61,7 +61,8 @@ public class ScanStateRow extends GenericRow {
     valueMap.put(COL_NAME_TO_ORDINAL.get("physicalSchemaString"), readSchemaPhysicalJson);
     valueMap.put(
         COL_NAME_TO_ORDINAL.get("physicalDataReadSchemaString"), readPhysicalDataSchemaJson);
-    valueMap.put(COL_NAME_TO_ORDINAL.get("partitionColumns"), metadata.getPartitionColumnsRaw());
+    valueMap.put(
+        COL_NAME_TO_ORDINAL.get("partitionColumns"), metadata.getPartitionColumnsArrayValue());
     valueMap.put(COL_NAME_TO_ORDINAL.get("minReaderVersion"), protocol.getMinReaderVersion());
     valueMap.put(COL_NAME_TO_ORDINAL.get("minWriterVersion"), protocol.getMinWriterVersion());
     valueMap.put(COL_NAME_TO_ORDINAL.get("tablePath"), tablePath);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ScanStateRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/ScanStateRow.java
@@ -61,7 +61,7 @@ public class ScanStateRow extends GenericRow {
     valueMap.put(COL_NAME_TO_ORDINAL.get("physicalSchemaString"), readSchemaPhysicalJson);
     valueMap.put(
         COL_NAME_TO_ORDINAL.get("physicalDataReadSchemaString"), readPhysicalDataSchemaJson);
-    valueMap.put(COL_NAME_TO_ORDINAL.get("partitionColumns"), metadata.getPartitionColumns());
+    valueMap.put(COL_NAME_TO_ORDINAL.get("partitionColumns"), metadata.getPartitionColumnsRaw());
     valueMap.put(COL_NAME_TO_ORDINAL.get("minReaderVersion"), protocol.getMinReaderVersion());
     valueMap.put(COL_NAME_TO_ORDINAL.get("minWriterVersion"), protocol.getMinWriterVersion());
     valueMap.put(COL_NAME_TO_ORDINAL.get("tablePath"), tablePath);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/TransactionStateRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/TransactionStateRow.java
@@ -46,7 +46,7 @@ public class TransactionStateRow extends GenericRow {
   public static TransactionStateRow of(Metadata metadata, String tablePath) {
     HashMap<Integer, Object> valueMap = new HashMap<>();
     valueMap.put(COL_NAME_TO_ORDINAL.get("logicalSchemaString"), metadata.getSchemaString());
-    valueMap.put(COL_NAME_TO_ORDINAL.get("partitionColumns"), metadata.getPartitionColumns());
+    valueMap.put(COL_NAME_TO_ORDINAL.get("partitionColumns"), metadata.getPartitionColumnsRaw());
     valueMap.put(COL_NAME_TO_ORDINAL.get("configuration"), metadata.getConfigurationMapValue());
     valueMap.put(COL_NAME_TO_ORDINAL.get("tablePath"), tablePath);
     return new TransactionStateRow(valueMap);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/TransactionStateRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/TransactionStateRow.java
@@ -46,7 +46,8 @@ public class TransactionStateRow extends GenericRow {
   public static TransactionStateRow of(Metadata metadata, String tablePath) {
     HashMap<Integer, Object> valueMap = new HashMap<>();
     valueMap.put(COL_NAME_TO_ORDINAL.get("logicalSchemaString"), metadata.getSchemaString());
-    valueMap.put(COL_NAME_TO_ORDINAL.get("partitionColumns"), metadata.getPartitionColumnsRaw());
+    valueMap.put(
+        COL_NAME_TO_ORDINAL.get("partitionColumns"), metadata.getPartitionColumnsArrayValue());
     valueMap.put(COL_NAME_TO_ORDINAL.get("configuration"), metadata.getConfigurationMapValue());
     valueMap.put(COL_NAME_TO_ORDINAL.get("tablePath"), tablePath);
     return new TransactionStateRow(valueMap);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/CoordinatedCommitsUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/CoordinatedCommitsUtils.java
@@ -16,66 +16,12 @@
 package io.delta.kernel.internal.util;
 
 import io.delta.kernel.engine.coordinatedcommits.actions.AbstractCommitInfo;
-import io.delta.kernel.engine.coordinatedcommits.actions.AbstractMetadata;
 import io.delta.kernel.engine.coordinatedcommits.actions.AbstractProtocol;
 import io.delta.kernel.internal.actions.CommitInfo;
-import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
 import java.util.*;
 
 public class CoordinatedCommitsUtils {
-  public static AbstractMetadata convertMetadataToAbstractMetadata(Metadata metadata) {
-    return new AbstractMetadata() {
-      @Override
-      public String getId() {
-        return metadata.getId();
-      }
-
-      @Override
-      public String getName() {
-        return metadata.getName().orElse(null);
-      }
-
-      @Override
-      public String getDescription() {
-        return metadata.getDescription().orElse(null);
-      }
-
-      @Override
-      public String getProvider() {
-        return metadata.getFormat().getProvider();
-      }
-
-      @Override
-      public Map<String, String> getFormatOptions() {
-        // Assuming Format class has a method to get format options
-        return metadata.getFormat().getOptions();
-      }
-
-      @Override
-      public String getSchemaString() {
-        // Assuming Metadata class has a method to get schema string
-        return metadata.getSchemaString();
-      }
-
-      @Override
-      public List<String> getPartitionColumns() {
-        // Assuming Metadata class has a method to get partition columns
-        return VectorUtils.toJavaList(metadata.getPartitionColumnsRaw());
-      }
-
-      @Override
-      public Map<String, String> getConfiguration() {
-        return metadata.getConfiguration();
-      }
-
-      @Override
-      public Optional<Long> getCreatedTime() {
-        return metadata.getCreatedTime();
-      }
-    };
-  }
-
   public static AbstractProtocol convertProtocolToAbstractProtocol(Protocol protocol) {
     return new AbstractProtocol() {
       @Override

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/CoordinatedCommitsUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/CoordinatedCommitsUtils.java
@@ -61,7 +61,7 @@ public class CoordinatedCommitsUtils {
       @Override
       public List<String> getPartitionColumns() {
         // Assuming Metadata class has a method to get partition columns
-        return VectorUtils.toJavaList(metadata.getPartitionColumns());
+        return VectorUtils.toJavaList(metadata.getPartitionColumnsRaw());
       }
 
       @Override

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/PartitionUtils.java
@@ -26,6 +26,7 @@ import static java.util.Arrays.asList;
 import io.delta.kernel.data.*;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.engine.ExpressionHandler;
+import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.expressions.*;
 import io.delta.kernel.internal.InternalScanFileUtils;
 import io.delta.kernel.internal.fs.Path;
@@ -45,6 +46,28 @@ public class PartitionUtils {
       DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS");
 
   private PartitionUtils() {}
+
+  /**
+   * Converts an {@link ArrayValue} of partition columns name to a {@link Set} of lowercase strings.
+   *
+   * @param partitionColumnsVector an {@code ArrayValue} containing the partition column names.
+   * @return a {@code Set<String>} with each partition column name in lowercase.
+   */
+  public static Set<String> arrayValueToLowerCaseSet(ArrayValue partitionColumnsVector) {
+    final Set<String> result =
+        VectorUtils.<String>toJavaList(partitionColumnsVector).stream()
+            .map(s -> s.toLowerCase(Locale.ROOT))
+            .collect(Collectors.toSet());
+
+    if (result.size() != partitionColumnsVector.getSize()) {
+      throw new KernelException(
+          String.format(
+              "partitionColumnsVector contains duplicate partition column names: %s",
+              partitionColumnsVector));
+    }
+
+    return result;
+  }
 
   /**
    * Utility method to remove the given columns (as {@code columnsToRemove}) from the given {@code

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/coordinatedcommits/StorageKernelAPIAdapter.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/coordinatedcommits/StorageKernelAPIAdapter.java
@@ -121,7 +121,7 @@ public class StorageKernelAPIAdapter {
 
       @Override
       public Long getCreatedTime() {
-        return metadata.getCreatedTime().orElse(null);
+        return metadata.getCreatedTime();
       }
     };
   }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/InCommitTimestampSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/InCommitTimestampSuite.scala
@@ -349,7 +349,7 @@ class InCommitTimestampSuite extends DeltaTableWriteSuiteBase {
           "delta.enableInCommitTimestamps=true, " +
           "delta.inCommitTimestampEnablementVersion=1}}",
         metadata.getId,
-        metadata.getCreatedTime.get,
+        metadata.getCreatedTime,
         inCommitTimestamp.toString))
     }
   }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/coordinatedcommits/CoordinatedCommitsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/coordinatedcommits/CoordinatedCommitsSuite.scala
@@ -91,7 +91,7 @@ class CoordinatedCommitsSuite extends DeltaTableWriteSuiteBase
         tableConf = handler.registerTable(
           logPath.toString,
           version - 1L,
-          CoordinatedCommitsUtils.convertMetadataToAbstractMetadata(getEmptyMetadata),
+          getEmptyMetadata,
           CoordinatedCommitsUtils.convertProtocolToAbstractProtocol(getProtocol(1, 1)))
         val tableConfString = if (tableConfToOverwrite != null) {
           tableConfToOverwrite

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/coordinatedcommits/CoordinatedCommitsTestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/coordinatedcommits/CoordinatedCommitsTestUtils.scala
@@ -43,11 +43,11 @@ trait CoordinatedCommitsTestUtils {
   def getEmptyMetadata: Metadata = {
     new Metadata(
       util.UUID.randomUUID().toString,
-      Optional.empty(),
-      Optional.empty(),
+      Optional.empty(), /* name */
+      Optional.empty(), /* description */
       new Format(),
       "",
-      null,
+      new StructType(),
       stringArrayValue(Collections.emptyList()),
       Optional.empty(),
       VectorUtils.stringStringMapValue(Collections.emptyMap())
@@ -122,9 +122,9 @@ trait CoordinatedCommitsTestUtils {
     val newMetadata = oldMetadata.withNewConfiguration(newMetadataConfiguration.asJava)
     new UpdatedActions(
       CoordinatedCommitsUtils.convertCommitInfoToAbstractCommitInfo(commitInfo),
-      CoordinatedCommitsUtils.convertMetadataToAbstractMetadata(newMetadata),
+      newMetadata,
       CoordinatedCommitsUtils.convertProtocolToAbstractProtocol(getProtocol(3, 7)),
-      CoordinatedCommitsUtils.convertMetadataToAbstractMetadata(oldMetadata),
+      oldMetadata,
       CoordinatedCommitsUtils.convertProtocolToAbstractProtocol(getProtocol(3, 7)))
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

- Make Metadata implement AbstractMetadata
- Update kernel's AbstractMetadata to align it with delta-storage's AbstractMetadata (storage uses Long for createdTime, kerenel used Optional<Long>).
- Update kernel's AbstractMetadata to all `@Nulalble` annotations to make it clear the expected return values.
- Consolidate Metadata's getPartitionColumn APIs (there were two APIs, with different return types and different case-sensitivities; now there's only 1 API)

## How was this patch tested?

Just a refactor. Existing UTs.

## Does this PR introduce _any_ user-facing changes?

No.
