### PR TITLE
[Kernel] [CC Refactor] Make Protocol implement AbstractProtocol

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -25,6 +25,7 @@ import io.delta.kernel.utils.DataFileStatus;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -146,11 +147,17 @@ public final class DeltaErrors {
       int tableFeatureVersion,
       int minRequiredVersion,
       Set<String> tableFeatures) {
+    final String featureTypeStr = featureType.toString().toLowerCase(Locale.ROOT);
     final String message =
         String.format(
-            "Found %s Features %s in protocol version %s but these are only supported in "
-                + "protocol version %s and above.",
-            featureType, tableFeatureVersion, minRequiredVersion, tableFeatures);
+            "Found %s features %s in %s protocol version %s but these are only supported in "
+                + "%s protocol version %s and above.",
+            featureTypeStr,
+            tableFeatures,
+            featureTypeStr,
+            tableFeatureVersion,
+            featureTypeStr,
+            minRequiredVersion);
     return new KernelException(message);
   }
 
@@ -158,9 +165,9 @@ public final class DeltaErrors {
       int tableReaderVersion, int tableWriterVersion) {
     final String message =
         String.format(
-            "Table Reader Features are supported (current reader protocol version is %s) yet "
-                + "table Writer Features are not (current writer protocol version is %s). Writer "
-                + "protocol version must be at least %s to proceed",
+            "Table reader features are supported (current reader protocol version is %s) yet "
+                + "table writer features are not (current writer protocol version is %s). Writer "
+                + "protocol version must be at least %s to proceed.",
             tableReaderVersion,
             tableWriterVersion,
             TableFeatures.TABLE_FEATURES_MIN_WRITER_VERSION);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -18,6 +18,7 @@ package io.delta.kernel.internal;
 import static java.lang.String.format;
 
 import io.delta.kernel.exceptions.*;
+import io.delta.kernel.internal.TableFeatures.TableFeatureType;
 import io.delta.kernel.types.DataType;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.DataFileStatus;
@@ -138,7 +139,33 @@ public final class DeltaErrors {
     return new KernelException(message);
   }
 
-  /* ------------------------ PROTOCOL EXCEPTIONS ----------------------------- */
+  /* ------------------------ PROTOCOL EXCEPTIONS - START ----------------------------- */
+
+  public static KernelException mismatchedProtocolVersionFeatureSet(
+      TableFeatureType featureType,
+      int tableFeatureVersion,
+      int minRequiredVersion,
+      Set<String> tableFeatures) {
+    final String message =
+        String.format(
+            "Found %s Features %s in protocol version %s but these are only supported in "
+                + "protocol version %s and above.",
+            featureType, tableFeatureVersion, minRequiredVersion, tableFeatures);
+    return new KernelException(message);
+  }
+
+  public static KernelException tableFeatureReadRequiresWrite(
+      int tableReaderVersion, int tableWriterVersion) {
+    final String message =
+        String.format(
+            "Table Reader Features are supported (current reader protocol version is %s) yet "
+                + "table Writer Features are not (current writer protocol version is %s). Writer "
+                + "protocol version must be at least %s to proceed",
+            tableReaderVersion,
+            tableWriterVersion,
+            TableFeatures.TABLE_FEATURES_MIN_WRITER_VERSION);
+    return new KernelException(message);
+  }
 
   public static KernelException unsupportedReaderProtocol(
       String tablePath, int tableReaderVersion) {
@@ -185,6 +212,8 @@ public final class DeltaErrors {
             + "column invariants present.";
     return new KernelException(message);
   }
+
+  /* ------------------------ PROTOCOL EXCEPTIONS - END ----------------------------- */
 
   public static KernelException unsupportedDataType(DataType dataType) {
     return new KernelException("Kernel doesn't support writing data of type: " + dataType);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableFeatures.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableFeatures.java
@@ -30,6 +30,22 @@ import java.util.stream.Collectors;
 /** Contains utility methods related to the Delta table feature support in protocol. */
 public class TableFeatures {
 
+  public enum TableFeatureType {
+    READER,
+    WRITER;
+
+    @Override
+    public String toString() {
+      return name().charAt(0) + name().substring(1).toLowerCase();
+    }
+  }
+
+  /** Min reader version that supports reader features. */
+  public static final int TABLE_FEATURES_MIN_READER_VERSION = 3;
+
+  /** Min writer version that supports writer features. */
+  public static final int TABLE_FEATURES_MIN_WRITER_VERSION = 7;
+
   private static final Set<String> SUPPORTED_WRITER_FEATURES =
       Collections.unmodifiableSet(
           new HashSet<String>() {
@@ -58,7 +74,7 @@ public class TableFeatures {
           });
 
   ////////////////////
-  // Helper Methods //
+  // Public Methods //
   ////////////////////
 
   public static void validateReadSupportedTable(
@@ -70,7 +86,7 @@ public class TableFeatures {
         metadata.ifPresent(ColumnMapping::throwOnUnsupportedColumnMappingMode);
         break;
       case 3:
-        List<String> readerFeatures = protocol.getReaderFeatures();
+        final Set<String> readerFeatures = protocol.getReaderFeatures();
         if (!SUPPORTED_READER_FEATURES.containsAll(readerFeatures)) {
           Set<String> unsupportedFeatures = new HashSet<>(readerFeatures);
           unsupportedFeatures.removeAll(SUPPORTED_READER_FEATURES);
@@ -186,6 +202,10 @@ public class TableFeatures {
             f -> protocol.getWriterFeatures() == null || !protocol.getWriterFeatures().contains(f))
         .collect(Collectors.toSet());
   }
+
+  ////////////////////
+  // Helper Methods //
+  ////////////////////
 
   /**
    * Get the minimum reader version required for a feature.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableFeatures.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableFeatures.java
@@ -33,11 +33,6 @@ public class TableFeatures {
   public enum TableFeatureType {
     READER,
     WRITER;
-
-    @Override
-    public String toString() {
-      return name().charAt(0) + name().substring(1).toLowerCase();
-    }
   }
 
   /** Min reader version that supports reader features. */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -135,9 +135,9 @@ public class TransactionBuilderImpl implements TransactionBuilder {
       if (!newWriterFeatures.isEmpty()) {
         logger.info("Automatically enabling writer features: {}", newWriterFeatures);
         shouldUpdateProtocol = true;
-        List<String> oldWriterFeatures = protocol.getWriterFeatures();
-        protocol = protocol.withNewWriterFeatures(newWriterFeatures);
-        List<String> curWriterFeatures = protocol.getWriterFeatures();
+        final Set<String> oldWriterFeatures = protocol.getWriterFeatures();
+        protocol = protocol.withAdditionalWriterFeatures(newWriterFeatures);
+        final Set<String> curWriterFeatures = protocol.getWriterFeatures();
         checkArgument(!Objects.equals(oldWriterFeatures, curWriterFeatures));
         TableFeatures.validateWriteSupportedTable(
             protocol, metadata, metadata.getSchema(), table.getPath(engine));
@@ -257,7 +257,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
     return new Protocol(
         DEFAULT_READ_VERSION,
         DEFAULT_WRITE_VERSION,
-        null /* readerFeatures */,
-        null /* writerFeatures */);
+        Collections.emptySet() /* readerFeatures */,
+        Collections.emptySet() /* writerFeatures */);
   }
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableFeaturesSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableFeaturesSuite.scala
@@ -106,8 +106,8 @@ class TableFeaturesSuite extends AnyFunSuite {
       0,
       minWriterVersion,
       // reader features - it doesn't matter as the read fails anyway before the writer check
-      Collections.emptyList(),
-      writerFeatures.toSeq.asJava
+      Collections.emptySet(),
+      writerFeatures.toSet.asJava
     )
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ActionSerializerSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ActionSerializerSuite.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel.defaults;
+
+import io.delta.kernel.defaults.internal.json.JsonUtils
+import io.delta.kernel.internal.actions.Protocol
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.util.Collections
+import scala.collection.JavaConverters._
+
+// TODO: this class should actually write the actions to a json file and read them back
+// TODO: do this for all action types
+class ActionSerializerSuite extends AnyFunSuite {
+  test("protocol to json") {
+    {
+      val protocol = new Protocol(1, 2, Collections.emptySet(), Collections.emptySet())
+      val json = JsonUtils.rowToJson(protocol.toRow)
+      assert(json === """{"minReaderVersion":1,"minWriterVersion":2}""")
+    }
+    {
+      val protocol = new Protocol(3, 7, Collections.emptySet(), Collections.emptySet())
+      val json = JsonUtils.rowToJson(protocol.toRow)
+      // scalastyle:off line.size.limit
+      assert(json === """{"minReaderVersion":3,"minWriterVersion":7,"readerFeatures":[],"writerFeatures":[]}""")
+      // scalastyle:on line.size.limit
+    }
+    {
+      val protocol = new Protocol(3, 7, Set("columnMapping").asJava, Set("appendOnly").asJava)
+      val json = JsonUtils.rowToJson(protocol.toRow)
+      // scalastyle:off line.size.limit
+      assert(json === """{"minReaderVersion":3,"minWriterVersion":7,"readerFeatures":["columnMapping"],"writerFeatures":["appendOnly"]}""")
+      // scalastyle:on line.size.limit
+    }
+  }
+}

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/coordinatedcommits/CoordinatedCommitsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/coordinatedcommits/CoordinatedCommitsSuite.scala
@@ -92,7 +92,7 @@ class CoordinatedCommitsSuite extends DeltaTableWriteSuiteBase
           logPath.toString,
           version - 1L,
           CoordinatedCommitsUtils.convertMetadataToAbstractMetadata(getEmptyMetadata),
-          CoordinatedCommitsUtils.convertProtocolToAbstractProtocol(getProtocol(1, 1)))
+          getProtocol(1, 1))
         val tableConfString = if (tableConfToOverwrite != null) {
           tableConfToOverwrite
         } else {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/coordinatedcommits/CoordinatedCommitsTestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/coordinatedcommits/CoordinatedCommitsTestUtils.scala
@@ -56,7 +56,7 @@ trait CoordinatedCommitsTestUtils {
 
   def getProtocol(minReaderVersion: Int, minWriterVersion: Int): Protocol = {
     new Protocol(
-      minReaderVersion, minWriterVersion, Collections.emptyList(), Collections.emptyList())
+      minReaderVersion, minWriterVersion, Collections.emptySet(), Collections.emptySet())
   }
 
   def getCommitInfo(newTimestamp: Long): CommitInfo = {
@@ -123,9 +123,9 @@ trait CoordinatedCommitsTestUtils {
     new UpdatedActions(
       CoordinatedCommitsUtils.convertCommitInfoToAbstractCommitInfo(commitInfo),
       CoordinatedCommitsUtils.convertMetadataToAbstractMetadata(newMetadata),
-      CoordinatedCommitsUtils.convertProtocolToAbstractProtocol(getProtocol(3, 7)),
+      getProtocol(3, 7),
       CoordinatedCommitsUtils.convertMetadataToAbstractMetadata(oldMetadata),
-      CoordinatedCommitsUtils.convertProtocolToAbstractProtocol(getProtocol(3, 7)))
+      getProtocol(3, 7))
   }
 
   def getUpdatedActionsForNonZerothCommit(commitInfo: CommitInfo): UpdatedActions = {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Make `Protocol` implement `AbstractProtocol`.

Add some better validation of constructor params, too.

Add a simple ActionSerializerSuite, that is not fully fleshed out, that makes sure we are writing good protocol json.

## How was this patch tested?

Existing + new UTs.

## Does this PR introduce _any_ user-facing changes?

No.