### PR TITLE
[Spark] Move some ICT test helper utils to InCommitTimestampTestUtils.scala

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/InCommitTimestampSuite.scala
@@ -46,28 +46,11 @@ class InCommitTimestampSuite
     with DeltaTestUtilsBase
     with CoordinatedCommitsTestUtils
     with StreamTest {
+  import InCommitTimestampTestUtils._
 
   override def beforeAll(): Unit = {
     super.beforeAll()
     spark.conf.set(DeltaConfigs.IN_COMMIT_TIMESTAMPS_ENABLED.defaultTablePropertyKey, "true")
-  }
-
-  private def getInCommitTimestamp(deltaLog: DeltaLog, version: Long): Long = {
-    val deltaFile = DeltaCommitFileProvider(deltaLog.unsafeVolatileSnapshot).deltaFile(version)
-    val commitInfo = DeltaHistoryManager.getCommitInfoOpt(
-      deltaLog.store,
-      deltaFile,
-      deltaLog.newDeltaHadoopConf())
-    commitInfo.get.inCommitTimestamp.get
-  }
-
-  private def getFileModificationTimesMap(
-      deltaLog: DeltaLog, start: Long, end: Long): Map[Long, Long] = {
-    deltaLog.store.listFrom(
-        FileNames.listingPrefix(deltaLog.logPath, start), deltaLog.newDeltaHadoopConf())
-      .collect { case FileNames.DeltaFile(fs, v) => v -> fs.getModificationTime }
-      .takeWhile(_._1 <= end)
-      .toMap
   }
 
   test("Enable ICT on commit 0") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
For code hygiene, we move some ICT test helper utils from the `ICTSuite` to the object `InCommitTimestampTestUtils`, which is dedicated to contain the ICT test utils.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Existing UTs.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
