### PR TITLE
[Spark] Reflect a new parameter in the constructor of LogicalRelation for Spark 4.0

### DIFF
--- a/spark/src/main/scala-spark-master/shims/LogicalRelationShims.scala
+++ b/spark/src/main/scala-spark-master/shims/LogicalRelationShims.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.execution.datasources
 
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.sources.BaseRelation
 
 object LogicalRelationShims {
@@ -32,21 +31,6 @@ object LogicalRelationShims {
       output: Seq[AttributeReference],
       catalogTable: Option[CatalogTable],
       isStreaming: Boolean): LogicalRelation = {
-    LogicalRelation(relation, output, catalogTable, isStreaming)
-  }
-}
-
-// Handles a breaking change between Spark 3.5 and Spark Master (4.0).
-// `LogicalRelationWithTable` is a new object in Spark 4.0.
-
-/**
- * Extract the [[BaseRelation]] and [[CatalogTable]] from [[LogicalRelation]]. You can also
- * retrieve the instance of LogicalRelation like following:
- *
- * case l @ LogicalRelationWithTable(relation, catalogTable) => ...
- */
-object LogicalRelationWithTable {
-  def unapply(plan: LogicalRelation): Option[(BaseRelation, Option[CatalogTable])] = {
-    Some(plan.relation, plan.catalogTable)
+    LogicalRelation(relation, output, catalogTable, isStreaming, stream = None)
   }
 }

--- a/spark/src/main/scala-spark-master/shims/LogicalRelationShims.scala
+++ b/spark/src/main/scala-spark-master/shims/LogicalRelationShims.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.execution.datasources
 
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.sources.BaseRelation
 
 object LogicalRelationShims {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -61,7 +61,7 @@ import org.apache.spark.sql.connector.expressions.{FieldReference, IdentityTrans
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.command.CreateTableLikeCommand
 import org.apache.spark.sql.execution.command.RunnableCommand
-import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation, LogicalRelationWithTable}
+import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation, LogicalRelationShims, LogicalRelationWithTable}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.execution.streaming.StreamingRelation
@@ -1228,7 +1228,7 @@ object DeltaRelation extends DeltaLogging {
       } else {
         v2Relation.output
       }
-      LogicalRelation(relation, output, d.ttSafeCatalogTable, isStreaming = false)
+      LogicalRelationShims.newInstance(relation, output, d.ttSafeCatalogTable, isStreaming = false)
     }
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -46,7 +46,7 @@ import org.apache.spark.sql.connector.catalog.V1Table
 import org.apache.spark.sql.connector.expressions._
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, SupportsDynamicOverwrite, SupportsOverwrite, SupportsTruncate, V1Write, WriteBuilder}
 import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.execution.datasources.{LogicalRelation, LogicalRelationShims}
 import org.apache.spark.sql.sources.{BaseRelation, Filter, InsertableRelation}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
@@ -280,7 +280,7 @@ case class DeltaTableV2(
   /** Creates a [[LogicalRelation]] that represents this table */
   lazy val toLogicalRelation: LogicalRelation = {
     val relation = this.toBaseRelation
-    LogicalRelation(
+    LogicalRelationShims.newInstance(
       relation, toAttributes(relation.schema), ttSafeCatalogTable, isStreaming = false)
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR proposes to reflect a new parameter in the constructor of LogicalRelation for Spark 4.0. This PR deals with it via creating a shim object like we have done with IncrementalExecution for parameters difference.

There are overloaded methods to create a LogicalRelation instance and Spark community tried to provide the new method to avoid this change, but Spark couldn't just add a new overloaded method to workaround as it was ambiguous with existing method with default param.

## How was this patch tested?

Existing tests.

## Does this PR introduce _any_ user-facing changes?

No.