### PR TITLE
[Spark] Ignore internal metadata when detecting schema changes in Delta source

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingDataSource.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingDataSource.scala
@@ -151,7 +151,7 @@ private[sharing] class DeltaSharingDataSource
           .getOrElse(snapshotDescriptor.schema)
       }
 
-      val schemaToUse = TahoeDeltaTableUtils.removeInternalMetadata(
+      val schemaToUse = TahoeDeltaTableUtils.removeInternalWriterMetadata(
         sqlContext.sparkSession,
         readSchema
       )
@@ -416,7 +416,7 @@ private[sharing] class DeltaSharingDataSource
       // column locations. Otherwise, for any partition columns not in `dataSchema`, Spark would
       // just append them to the end of `dataSchema`.
       dataSchema = DeltaColumnMapping.dropColumnMappingMetadata(
-        TahoeDeltaTableUtils.removeInternalMetadata(
+        TahoeDeltaTableUtils.removeInternalWriterMetadata(
           spark,
           SchemaUtils.dropNullTypeColumns(deltaSharingTableMetadata.metadata.schema)
         )

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -607,7 +607,7 @@ class DeltaLog private(
       // column locations. Otherwise, for any partition columns not in `dataSchema`, Spark would
       // just append them to the end of `dataSchema`.
       dataSchema = DeltaColumnMapping.dropColumnMappingMetadata(
-        DeltaTableUtils.removeInternalMetadata(spark, dataSchema)
+        DeltaTableUtils.removeInternalWriterMetadata(spark, dataSchema)
       ),
       bucketSpec = bucketSpec,
       fileFormat(snapshot.protocol, snapshot.metadata),

--- a/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/catalog/DeltaTableV2.scala
@@ -181,7 +181,7 @@ case class DeltaTableV2(
 
   private lazy val tableSchema: StructType = {
     val baseSchema = cdcRelation.map(_.schema).getOrElse {
-      DeltaTableUtils.removeInternalMetadata(spark, initialSnapshot.schema)
+      DeltaTableUtils.removeInternalWriterMetadata(spark, initialSnapshot.schema)
     }
     DeltaColumnMapping.dropColumnMappingMetadata(baseSchema)
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
@@ -109,7 +109,7 @@ class DeltaDataSource
     }
 
     val schemaToUse = DeltaColumnMapping.dropColumnMappingMetadata(
-      DeltaTableUtils.removeInternalMetadata(sqlContext.sparkSession, readSchema)
+      DeltaTableUtils.removeInternalWriterMetadata(sqlContext.sparkSession, readSchema)
     )
     if (schemaToUse.isEmpty) {
       throw DeltaErrors.schemaNotSetException

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1503,6 +1503,15 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(false)
 
+  val DELTA_STREAMING_IGNORE_INTERNAL_METADATA_FOR_SCHEMA_CHANGE =
+    buildConf("streaming.ignoreInternalMetadataForSchemaChange.enabled")
+      .doc(
+        "Whether to ignore internal metadata attached to struct fields when detecting schema " +
+        "changes in Delta sources, e.g. identity columns internal high-water mark tracking.")
+      .internal()
+      .booleanConf
+      .createWithDefault(true)
+
   val DELTA_STREAMING_ENABLE_SCHEMA_TRACKING =
     buildConf("streaming.schemaTracking.enabled")
       .doc(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSource.scala
@@ -216,7 +216,7 @@ trait DeltaSourceBase extends Source
   @volatile protected var hasCheckedReadIncompatibleSchemaChangesOnStreamStart: Boolean = false
 
   override val schema: StructType = {
-    val readSchema = DeltaTableUtils.removeInternalMetadata(spark, readSchemaAtSourceInit)
+    val readSchema = DeltaTableUtils.removeInternalWriterMetadata(spark, readSchemaAtSourceInit)
     val readSchemaWithCdc = if (options.readChangeFeed) {
       CDCReader.cdcReadSchema(readSchema)
     } else {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceMetadataEvolutionSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceMetadataEvolutionSupport.scala
@@ -125,9 +125,9 @@ trait DeltaSourceMetadataEvolutionSupport extends DeltaSourceBase { base: DeltaS
   }
 
   /**
-   * Check if a schema change is different from the stream read schema. We make sure:
-   * 1. A strict equality check on the schemas to capture all schema changes, OR
-   * 2. A strict equality check on the delta related table configurations, AND
+   * Check the table metadata or protocol changed since the initial read snapshot. We make sure:
+   * 1. The schema is the same, except for internal metadata, AND
+   * 2. The delta related table configurations are strictly equal, AND
    * 3. The incoming metadata change should not be considered a failure-causing change if we have
    *    marked the persisted schema and the stream progress is behind that schema version.
    *    This could happen when we've already merged consecutive schema changes during the analysis
@@ -143,13 +143,24 @@ trait DeltaSourceMetadataEvolutionSupport extends DeltaSourceBase { base: DeltaS
     } else {
       protocolChangeOpt.exists(_ != readProtocolAtSourceInit) ||
       metadataChangeOpt.exists { newMetadata =>
-         newMetadata.schema != readSchemaAtSourceInit ||
+         hasSchemaChangeComparedToStreamMetadata(newMetadata.schema) ||
            newMetadata.partitionSchema != readPartitionSchemaAtSourceInit ||
            newMetadata.configuration.filterKeys(_.startsWith("delta.")).toMap !=
              readConfigurationsAtSourceInit.filterKeys(_.startsWith("delta.")).toMap
       }
     }
   }
+
+  /**
+   * Check that the give schema is the same as the schema from the initial read snapshot.
+   */
+  private def hasSchemaChangeComparedToStreamMetadata(newSchema: StructType): Boolean =
+    if (spark.conf.get(DeltaSQLConf.DELTA_STREAMING_IGNORE_INTERNAL_METADATA_FOR_SCHEMA_CHANGE)) {
+      DeltaTableUtils.removeInternalMetadata(spark, newSchema) !=
+        DeltaTableUtils.removeInternalMetadata(spark, readSchemaAtSourceInit)
+    } else {
+      newSchema != readSchemaAtSourceInit
+    }
 
   /**
    * If the current stream metadata is not equal to the metadata change in [[metadataChangeOpt]],

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceMetadataEvolutionSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSourceMetadataEvolutionSupport.scala
@@ -156,8 +156,8 @@ trait DeltaSourceMetadataEvolutionSupport extends DeltaSourceBase { base: DeltaS
    */
   private def hasSchemaChangeComparedToStreamMetadata(newSchema: StructType): Boolean =
     if (spark.conf.get(DeltaSQLConf.DELTA_STREAMING_IGNORE_INTERNAL_METADATA_FOR_SCHEMA_CHANGE)) {
-      DeltaTableUtils.removeInternalMetadata(spark, newSchema) !=
-        DeltaTableUtils.removeInternalMetadata(spark, readSchemaAtSourceInit)
+      DeltaTableUtils.removeInternalWriterMetadata(spark, newSchema) !=
+        DeltaTableUtils.removeInternalWriterMetadata(spark, readSchemaAtSourceInit)
     } else {
       newSchema != readSchemaAtSourceInit
     }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
@@ -705,7 +705,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
 
   test("identity columns shouldn't cause schema mismatches") {
     withTable("source") {
-      spark.sql(
+      sql(
         s"""
           |CREATE TABLE source (key INT, id LONG GENERATED ALWAYS AS IDENTITY)
           |USING DELTA
@@ -752,6 +752,10 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
           Execute { _ => addData(values = 20 until 25) },
           ProcessAllAvailable()
         )
+        // No schema change detected. Note that the identity column metadata is still present in the
+        // tracked schema
+        val field = getDefaultSchemaLog()(deltaLog).getLatestMetadata.get.dataSchema("id")
+        assert(field.metadata.contains(DeltaSourceUtils.IDENTITY_INFO_HIGHWATERMARK))
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableUtilsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTableUtilsSuite.scala
@@ -74,7 +74,7 @@ class DeltaTableUtilsSuite extends SharedSparkSession with DeltaSQLCommandTest {
     }
   }
 
-  test("removeInternalMetadata") {
+  test("removeInternalWriterMetadata") {
     for (flag <- BOOLEAN_DOMAIN) {
       withSQLConf(DeltaSQLConf.DELTA_SCHEMA_REMOVE_SPARK_INTERNAL_METADATA.key -> flag.toString) {
         for (internalMetadataKey <- DeltaTableUtils.SPARK_INTERNAL_METADATA_KEYS) {
@@ -83,7 +83,7 @@ class DeltaTableUtilsSuite extends SharedSparkSession with DeltaSQLCommandTest {
             .putString("other", "bar")
             .build()
           val schema = StructType(Seq(StructField("foo", StringType, metadata = metadata)))
-          val newSchema = DeltaTableUtils.removeInternalMetadata(spark, schema)
+          val newSchema = DeltaTableUtils.removeInternalWriterMetadata(spark, schema)
           newSchema.foreach { f =>
             if (flag) {
               // Flag on: should remove internal metadata


### PR DESCRIPTION

## Description
When reading from a Delta streaming source with schema tracking enabled - by specifying `schemaTrackingLocation` - internal metadata in the table schema causes a schema change to be detected.

This is especially problematic for identity columns that track the current high-water mark for ids as metadata in the table schema and update it on every write, causing streams to repeatedly fail and requiring a restart.

This change addresses the issue by ignoring internal metadata fields when detecting schema changes.

A flag is added to revert to the old behavior if needed.

## How was this patch tested?
Added test case covering problematic use case with both fix enabled and disabled.
