### PR TITLE
Implement parser changes for Lite Vacuum

### DIFF
--- a/spark/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
+++ b/spark/src/main/antlr4/io/delta/sql/parser/DeltaSqlBase.g4
@@ -73,8 +73,7 @@ singleStatement
 // If you add keywords here that should not be reserved, add them to 'nonReserved' list.
 statement
     : VACUUM (path=STRING | table=qualifiedName)
-        (USING INVENTORY (inventoryTable=qualifiedName | LEFT_PAREN inventoryQuery=subQuery RIGHT_PAREN))?
-        (RETAIN number HOURS)? (DRY RUN)?                               #vacuumTable
+        vacuumModifiers                                                 #vacuumTable
     | (DESC | DESCRIBE) DETAIL (path=STRING | table=qualifiedName)      #describeDeltaDetail
     | GENERATE modeName=identifier FOR TABLE table=qualifiedName        #generate
     | (DESC | DESCRIBE) HISTORY (path=STRING | table=qualifiedName)
@@ -196,6 +195,29 @@ dataType
     : identifier ('(' INTEGER_VALUE (',' INTEGER_VALUE)* ')')?         #primitiveDataType
     ;
 
+vacuumModifiers
+    : (vacuumType
+    | inventory
+    | retain
+    | dryRun)*
+    ;
+
+vacuumType
+    : LITE|FULL
+    ;
+
+inventory
+    : USING INVENTORY (inventoryTable=qualifiedName | LEFT_PAREN inventoryQuery=subQuery RIGHT_PAREN)
+    ;
+
+retain
+    : RETAIN number HOURS
+    ;
+
+dryRun
+    : DRY RUN
+    ;
+
 number
     : MINUS? DECIMAL_VALUE            #decimalLiteral
     | MINUS? INTEGER_VALUE            #integerLiteral
@@ -234,7 +256,7 @@ exprToken
 // Add keywords here so that people's queries don't break if they have a column name as one of
 // these tokens
 nonReserved
-    : VACUUM | USING | INVENTORY | RETAIN | HOURS | DRY | RUN
+    : VACUUM | FULL | LITE | USING | INVENTORY | RETAIN | HOURS | DRY | RUN
     | CONVERT | TO | DELTA | PARTITIONED | BY
     | DESC | DESCRIBE | LIMIT | DETAIL
     | GENERATE | FOR | TABLE | CHECK | EXISTS | OPTIMIZE | FULL
@@ -285,6 +307,7 @@ IF: 'IF';
 INVENTORY: 'INVENTORY';
 LEFT_PAREN: '(';
 LIMIT: 'LIMIT';
+LITE: 'LITE';
 LOCATION: 'LOCATION';
 MINUS: '-';
 NO: 'NO';

--- a/spark/src/main/scala/io/delta/tables/execution/VacuumTableCommand.scala
+++ b/spark/src/main/scala/io/delta/tables/execution/VacuumTableCommand.scala
@@ -43,7 +43,8 @@ case class VacuumTableCommand(
     horizonHours: Option[Double],
     inventoryTable: Option[LogicalPlan],
     inventoryQuery: Option[String],
-    dryRun: Boolean) extends RunnableCommand with UnaryNode with DeltaCommand {
+    dryRun: Boolean,
+    vacuumType: Option[String]) extends RunnableCommand with UnaryNode with DeltaCommand {
 
   override val output: Seq[Attribute] =
     Seq(AttributeReference("path", StringType, nullable = true)())
@@ -64,7 +65,7 @@ case class VacuumTableCommand(
         .map(p => Some(getDeltaTable(p, "VACUUM").toDf(sparkSession)))
         .getOrElse(inventoryQuery.map(sparkSession.sql))
     VacuumCommand.gc(sparkSession, deltaTable.deltaLog, dryRun, horizonHours,
-      inventory).collect()
+      inventory, vacuumType).collect()
   }
 }
 
@@ -75,9 +76,11 @@ object VacuumTableCommand {
       inventoryTable: Option[TableIdentifier],
       inventoryQuery: Option[String],
       horizonHours: Option[Double],
-      dryRun: Boolean): VacuumTableCommand = {
+      dryRun: Boolean,
+      vacuumType: Option[String]): VacuumTableCommand = {
     val child = UnresolvedDeltaPathOrIdentifier(path, table, "VACUUM")
     val unresolvedInventoryTable = inventoryTable.map(rt => UnresolvedTable(rt.nameParts, "VACUUM"))
-    VacuumTableCommand(child, horizonHours, unresolvedInventoryTable, inventoryQuery, dryRun)
+    VacuumTableCommand(child, horizonHours, unresolvedInventoryTable, inventoryQuery, dryRun,
+      vacuumType)
   }
 }

--- a/spark/src/test/scala/io/delta/sql/parser/DeltaSqlParserSuite.scala
+++ b/spark/src/test/scala/io/delta/sql/parser/DeltaSqlParserSuite.scala
@@ -41,26 +41,29 @@ class DeltaSqlParserSuite extends SparkFunSuite with SQLHelper {
     // Setting `delegate` to `null` is fine. The following tests don't need to touch `delegate`.
     val parser = new DeltaSqlParser(null)
     assert(parser.parsePlan("vacuum 123_") ===
-      VacuumTableCommand(UnresolvedTable(Seq("123_"), "VACUUM"), None, None, None, false))
+      VacuumTableCommand(UnresolvedTable(Seq("123_"), "VACUUM"), None, None, None, false, None))
     assert(parser.parsePlan("vacuum 1a.123_") ===
-      VacuumTableCommand(UnresolvedTable(Seq("1a", "123_"), "VACUUM"), None, None, None, false))
+      VacuumTableCommand(UnresolvedTable(Seq("1a", "123_"), "VACUUM"), None, None, None, false,
+        None))
     assert(parser.parsePlan("vacuum a.123A") ===
-      VacuumTableCommand(UnresolvedTable(Seq("a", "123A"), "VACUUM"), None, None, None, false))
+      VacuumTableCommand(UnresolvedTable(Seq("a", "123A"), "VACUUM"), None, None, None, false,
+        None))
     assert(parser.parsePlan("vacuum a.123E3_column") ===
       VacuumTableCommand(UnresolvedTable(Seq("a", "123E3_column"), "VACUUM"),
-        None, None, None, false))
+        None, None, None, false, None))
     assert(parser.parsePlan("vacuum a.123D_column") ===
       VacuumTableCommand(UnresolvedTable(Seq("a", "123D_column"), "VACUUM"),
-        None, None, None, false))
+        None, None, None, false, None))
     assert(parser.parsePlan("vacuum a.123BD_column") ===
       VacuumTableCommand(UnresolvedTable(Seq("a", "123BD_column"), "VACUUM"),
-        None, None, None, false))
+        None, None, None, false, None))
     assert(parser.parsePlan("vacuum delta.`/tmp/table`") ===
       VacuumTableCommand(UnresolvedTable(Seq("delta", "/tmp/table"), "VACUUM"),
-        None, None, None, false))
+        None, None, None, false, None))
     assert(parser.parsePlan("vacuum \"/tmp/table\"") ===
       VacuumTableCommand(
-        UnresolvedPathBasedDeltaTable("/tmp/table", Map.empty, "VACUUM"), None, None, None, false))
+        UnresolvedPathBasedDeltaTable("/tmp/table", Map.empty, "VACUUM"), None, None, None, false,
+        None))
   }
 
   test("Restore command is parsed as expected") {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaVacuumSuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
 import org.apache.spark.sql.delta.test.DeltaSQLTestUtils
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
-import org.apache.spark.sql.delta.util.{DeltaFileOperations, FileNames}
+import org.apache.spark.sql.delta.util.{DeltaFileOperations, DeltaCommitFileProvider, FileNames}
 import org.apache.spark.sql.util.ScalaExtensions._
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.fs.FileSystem
@@ -359,7 +359,7 @@ trait DeltaVacuumSuiteBase extends QueryTest
   }
 
   protected def deleteCommitFile(deltaLog: DeltaLog, version: Long) = {
-    new File(FileNames.unsafeDeltaFile(deltaLog.logPath, version).toUri).delete()
+    new File(DeltaCommitFileProvider(deltaLog.update()).deltaFile(version).toUri).delete()
   }
 
   /**
@@ -371,7 +371,7 @@ trait DeltaVacuumSuiteBase extends QueryTest
   }
 
   protected def setCommitClock(deltaLog: DeltaLog, version: Long, clock: ManualClock) = {
-    val f = new File(FileNames.unsafeDeltaFile(deltaLog.logPath, version).toUri)
+    val f = new File(DeltaCommitFileProvider(deltaLog.update()).deltaFile(version).toUri)
     f.setLastModified(clock.getTimeMillis())
   }
 
@@ -1315,8 +1315,8 @@ class DeltaVacuumSuite
     test(s"vacuum event logging dryRun=$isDryRun loggingEnabled=$loggingEnabled" +
       s" retentionHours=$retentionHours timeGap=$timeGapHours") {
       withSQLConf(DeltaSQLConf.DELTA_VACUUM_LOGGING_ENABLED.key -> loggingEnabled.toString) {
-
         withEnvironment { (dir, clock) =>
+          clock.setTime(System.currentTimeMillis())
           spark.range(2).write.format("delta").save(dir.getAbsolutePath)
           val deltaLog = DeltaLog.forTable(spark, dir, clock)
           setCommitClock(deltaLog, 0L, clock)
@@ -1395,6 +1395,86 @@ class DeltaVacuumSuite
     retentionHours = 20, // vacuum will not delete any files
     timeGapHours = 10
   )
+
+  test(s"vacuum sql syntax checks") {
+    val tableName = "testTable"
+    withDeletionVectorsEnabled() {
+    withTable(tableName) {
+      withSQLConf(
+        DeltaSQLConf.DELTA_VACUUM_RETENTION_CHECK_ENABLED.key -> "false",
+        DeltaSQLConf.LITE_VACUUM_ENABLED.key -> "false"
+      ) {
+        spark.range(0, 50, step = 1, numPartitions = 5).write.format("delta")
+.saveAsTable(tableName)
+        var e = intercept[AnalysisException] {
+          spark.sql(s"Vacuum $tableName DRY RUN DRY RUN")
+        }
+        assert(e.getMessage.contains("Found duplicate clauses: DRY RUN"))
+
+        e = intercept[AnalysisException] {
+          spark.sql(s"Vacuum $tableName RETAIN 200 HOURS RETAIN 200 HOURS")
+        }
+        assert(e.getMessage.contains("Found duplicate clauses: RETAIN"))
+
+        e = intercept[AnalysisException] {
+          spark.sql(s"Vacuum $tableName FULL LITE")
+        }
+        assert(e.getMessage.contains("Found duplicate clauses: LITE/FULL"))
+
+        e = intercept[AnalysisException] {
+          spark.sql(s"Vacuum $tableName USING INVENTORY $tableName INVENTORY $tableName")
+        }
+        assert(e.getMessage.contains("Syntax error at or near"), e.getMessage)
+
+        e = intercept[AnalysisException] {
+          spark.sql(s"Vacuum $tableName USING INVENTORY $tableName LITE")
+        }
+        assert(e.getMessage.contains("Inventory option is not compatible with LITE"))
+
+        // create an uncommitted file. Presence or lack of this file will help us
+        // validate that we ran the right type of Vacuum.
+        val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tableName))
+        val basePath = deltaLog.dataPath.toString
+        val clock = new ManualClock()
+        val fs = new Path(basePath).getFileSystem(deltaLog.newDeltaHadoopConf())
+        val sanitizedPath = new Path("UnCommittedFile.parquet").toUri.toString
+        val file = new File(
+          fs.makeQualified(DeltaFileOperations.absolutePath(basePath, sanitizedPath)).toUri)
+        createFile(basePath, sanitizedPath, file, clock)
+
+        spark.sql(s"DELETE from $tableName WHERE ID % 2 = 0 and ID < 40")
+        assertNumFiles(deltaLog, addFiles = 5, addFilesWithDVs = 4, dvFiles = 1, dataFiles = 6)
+        purgeDVs(tableName)
+
+        assertNumFiles(deltaLog, addFiles = 5, addFilesWithDVs = 0, dvFiles = 1,
+          dataFiles = 10) // 9 file actions + one  uncommitted file
+
+        spark.sql(s"Vacuum $tableName LITE DRY RUN RETAIN 0 HOURS")
+        // DRY RUN option doesn't change anything.
+        assertNumFiles(deltaLog, addFiles = 5, addFilesWithDVs = 0, dvFiles = 1,
+          dataFiles = 10)
+
+        // LITE will be able to GC 4 files removed by DELETE.
+        spark.sql(s"Vacuum $tableName LITE RETAIN 0 HOURS")
+        assertNumFiles(deltaLog, addFiles = 5, addFilesWithDVs = 0, dvFiles = 0,
+          dataFiles = 6)
+
+        // Default is full and it's able to delete the 'notCommittedFile.parquet'
+        spark.sql(s"Vacuum $tableName RETAIN 0 HOURS")
+        assertNumFiles(deltaLog, addFiles = 5, addFilesWithDVs = 0, dvFiles = 0,
+          dataFiles = 5)
+        // Create the uncommittedFile file again to make sure explicit vacuum full works as
+        // expected.
+        createFile(basePath, sanitizedPath, file, clock)
+        assertNumFiles(deltaLog, addFiles = 5, addFilesWithDVs = 0, dvFiles = 0,
+          dataFiles = 6)
+        spark.sql(s"Vacuum $tableName FULL RETAIN 0 HOURS")
+        assertNumFiles(deltaLog, addFiles = 5, addFilesWithDVs = 0, dvFiles = 0,
+          dataFiles = 5)
+      }
+     }
+    }
+  }
 }
 
 class DeltaVacuumWithCoordinatedCommitsBatch100Suite extends DeltaVacuumSuite {
@@ -1436,12 +1516,15 @@ class DeltaLiteVacuumSuite
         val deltaTable = io.delta.tables.DeltaTable.forPath(dir.getAbsolutePath)
         val deltaLog = DeltaLog.forTable(spark, dir.getAbsolutePath)
         deltaTable.delete()
-        // Checkpoint will allow us to construct the table snapshot
-        deltaLog.createCheckpointAtVersion(0L)
+        // Checkpoints will allow us to construct the table snapshot
+        deltaLog.createCheckpointAtVersion(2L)
         deleteCommitFile(deltaLog, 0L) // delete version 0
-        intercept[DeltaIllegalStateException] {
+
+        val e = intercept[DeltaIllegalStateException] {
           VacuumCommand.gc(spark, deltaLog, dryRun = true, retentionHours = Some(0))
         }
+        assert(e.getMessage.contains("VACUUM LITE cannot delete all eligible files as some files" +
+          " are not referenced by the Delta log. Please run VACUUM FULL."))
       }
     }
   }
@@ -1478,9 +1561,12 @@ class DeltaLiteVacuumSuite
         for (i <- 1 to 2) {
           deleteCommitFile(deltaLog, i)
         }
-        intercept[DeltaIllegalStateException] {
+
+        val e = intercept[DeltaIllegalStateException] {
           VacuumCommand.gc(spark, deltaLog, dryRun = true, retentionHours = Some(0))
         }
+        assert(e.getMessage.contains("VACUUM LITE cannot delete all eligible files as some files" +
+          " are not referenced by the Delta log. Please run VACUUM FULL."))
       }
     }
   }
@@ -1511,4 +1597,8 @@ class DeltaLiteVacuumSuite
       )
     }
   }
+}
+
+class DeltaLiteVacuumWithCoordinatedCommitsBatch100Suite extends DeltaLiteVacuumSuite {
+  override val coordinatedCommitsBackfillBatchSize: Option[Int] = Some(100)
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR implements parser related changes for Lite Vacuum. As part of this, Vacuum overall syntax has been changed to accept vacuum parameters in any order unlike a fixed order before. This was one of the recommendations from the SQL committee.
Additionally, PR contains some test related changes.

## How was this patch tested?

Added new tests

## Does this PR introduce _any_ user-facing changes?

No
