### PR TITLE
[SPARK] Add metric for DV-related errors

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeletionVectorUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeletionVectorUtils.scala
@@ -18,16 +18,19 @@ package org.apache.spark.sql.delta.commands
 
 import org.apache.spark.sql.delta.{DeletionVectorsTableFeature, DeltaConfigs, Snapshot, SnapshotDescriptor}
 import org.apache.spark.sql.delta.actions.{Metadata, Protocol}
+import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
 import org.apache.spark.sql.delta.files.SupportsRowIndexFilters
 import org.apache.spark.sql.delta.files.TahoeFileIndex
+import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.datasources.FileIndex
 import org.apache.spark.sql.functions.col
 import org.apache.spark.util.Utils
 
-trait DeletionVectorUtils {
+trait DeletionVectorUtils extends DeltaLogging {
 
   /**
    * Run a query on the delta log to determine if the given snapshot contains no deletion vectors.
@@ -84,6 +87,55 @@ trait DeletionVectorUtils {
       metadata: Metadata): Boolean = {
     protocol.isFeatureSupported(DeletionVectorsTableFeature) &&
       metadata.format.provider == "parquet" // DVs are only supported on parquet tables.
+  }
+
+  /**
+   * Serializes `bitmap` into a byte array using `serializationFormat`. If it fails, it records a
+   * delta event and re-throws the exception.
+   */
+  def serialize(
+      bitmap: RoaringBitmapArray,
+      serializationFormat: RoaringBitmapArrayFormat.Value,
+      tablePath: Option[Path] = None,
+      debugInfo: Map[String, Any] = Map.empty): Array[Byte] = {
+    try {
+      bitmap.serializeAsByteArray(serializationFormat)
+    } catch {
+      case e: Exception =>
+        recordDeltaEvent(
+          deltaLog = null,
+          opType = "delta.assertions.deletionVectorSerializationError",
+          data = debugInfo ++ Map(
+            "serializationFormat" -> serializationFormat,
+            "cardinality" -> bitmap.cardinality,
+            "errorMsg" -> e.getMessage,
+            "errorStackTrace" -> e.getStackTrace),
+          path = tablePath)
+        throw e
+    }
+  }
+
+  /**
+   * Deserializes a RoaringBitmapArray from `bytes`. If it fails, it records a delta event and
+   * re-throws the exception.
+   */
+  def deserialize(
+      bytes: Array[Byte],
+      tablePath: Option[Path] = None,
+      debugInfo: Map[String, Any] = Map.empty): RoaringBitmapArray = {
+    try {
+      RoaringBitmapArray.readFrom(bytes)
+    } catch {
+      case e: Exception =>
+        recordDeltaEvent(
+          deltaLog = null,
+          "delta.assertions.deletionVectorDeserializationError",
+          data = debugInfo ++ Map(
+            "errorMsg" -> e.getMessage,
+            "errorStackTrace" -> e.getStackTrace),
+          path = tablePath)
+        throw e
+    }
   }
 }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/cdc/CDCReader.scala
@@ -23,6 +23,7 @@ import scala.util.Try
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions._
+import org.apache.spark.sql.delta.commands.DeletionVectorUtils
 import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, RoaringBitmapArrayFormat}
 import org.apache.spark.sql.delta.files.{CdcAddFileIndex, TahoeChangeFileIndex, TahoeFileIndexWithSnapshotDescriptor, TahoeRemoveFileIndex}
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
@@ -1073,10 +1074,12 @@ trait CDCReaderImpl extends DeltaLogging {
         val finalReAddedRowsBitmap = getDeletionVectorsDiff(removeBitmap, addBitmap)
 
         val finalRemovedRowsDv = DeletionVectorDescriptor.inlineInLog(
-          finalRemovedRowsBitmap.serializeAsByteArray(RoaringBitmapArrayFormat.Portable),
+          DeletionVectorUtils.serialize(
+            finalRemovedRowsBitmap, RoaringBitmapArrayFormat.Portable, Some(deltaLog.dataPath)),
           finalRemovedRowsBitmap.cardinality)
         val finalReAddedRowsDv = DeletionVectorDescriptor.inlineInLog(
-          finalReAddedRowsBitmap.serializeAsByteArray(RoaringBitmapArrayFormat.Portable),
+          DeletionVectorUtils.serialize(
+            finalReAddedRowsBitmap, RoaringBitmapArrayFormat.Portable, Some(deltaLog.dataPath)),
           finalReAddedRowsBitmap.cardinality)
 
         newActions += remove.copy(deletionVector = finalRemovedRowsDv)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/deletionvectors/StoredBitmap.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/deletionvectors/StoredBitmap.scala
@@ -20,6 +20,7 @@ import java.io.{IOException, ObjectInputStream}
 
 import org.apache.spark.sql.delta.DeltaErrors
 import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor
+import org.apache.spark.sql.delta.commands.DeletionVectorUtils
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.storage.dv.DeletionVectorStore
 import org.apache.hadoop.fs.Path
@@ -70,7 +71,10 @@ case class DeletionVectorStoredBitmap(
     val bitmap = if (isEmpty) {
       new RoaringBitmapArray()
     } else if (isInline) {
-      RoaringBitmapArray.readFrom(dvDescriptor.inlineData)
+      DeletionVectorUtils.deserialize(
+        dvDescriptor.inlineData,
+        tableDataPath,
+        debugInfo = Map("dvDescriptor" -> dvDescriptor))
     } else {
       assert(isOnDisk)
       dvStore.read(onDiskPath.get, dvDescriptor.offset.getOrElse(0), dvDescriptor.sizeInBytes)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorStore.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/storage/dv/DeletionVectorStore.scala
@@ -24,6 +24,7 @@ import java.util.zip.CRC32
 
 import org.apache.spark.sql.delta.DeltaErrors
 import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor
+import org.apache.spark.sql.delta.commands.DeletionVectorUtils
 import org.apache.spark.sql.delta.deletionvectors.{RoaringBitmapArray, StoredBitmap}
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.util.PathWithFileSystem
@@ -197,7 +198,9 @@ class HadoopFileSystemDVStore(hadoopConf: Configuration)
       reader.seek(offset)
       DeletionVectorStore.readRangeFromStream(reader, size)
     }
-    RoaringBitmapArray.readFrom(buffer)
+    DeletionVectorUtils.deserialize(
+      buffer,
+      debugInfo = Map("path" -> path, "offset" -> offset, "size" -> size))
   }
 
   override def createWriter(path: PathWithFileSystem): DeletionVectorStore.Writer = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
It wraps two `RoaringBitmapArray` APIs `readFrom` and `serializeAsByteArray` with two utils function `DeletionVectorUtils.serialize` and `DeletionVectorUtils.deserialize`, which will log a delta event when it fails during (de-)serialization to enable monitoring and debugging the error.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Log-only change.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
