### PR TITLE
[Spark] Fix `addFeatureSupport` test for Delta Connect

### DIFF
--- a/python/delta/tests/test_deltatable.py
+++ b/python/delta/tests/test_deltatable.py
@@ -23,7 +23,6 @@ import os
 from multiprocessing.pool import ThreadPool
 from typing import List, Set, Dict, Optional, Any, Callable, Union, Tuple
 
-from py4j.protocol import Py4JJavaError
 from pyspark.errors.exceptions.base import UnsupportedOperationException
 from pyspark.sql import DataFrame, Row
 from pyspark.sql.functions import col, lit, expr, floor
@@ -1199,7 +1198,7 @@ class DeltaTableTestsMixin:
             self.spark.conf.unset('spark.databricks.delta.minWriterVersion')
 
         # bad args
-        with self.assertRaisesRegex(Py4JJavaError, "DELTA_UNSUPPORTED_FEATURES_IN_CONFIG"):
+        with self.assertRaisesRegex(Exception, "DELTA_UNSUPPORTED_FEATURES_IN_CONFIG"):
             dt.addFeatureSupport("abc")
         with self.assertRaisesRegex(ValueError, "featureName needs to be a string"):
             dt.addFeatureSupport(12345)  # type: ignore[arg-type]


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR follows https://github.com/delta-io/delta/pull/3786 to fix an error running the test in Delta Connect mode, in which the "DELTA_UNSUPPORTED_FEATURES_IN_CONFIG" exception is wrapped by `SparkConnectGrpcException` rather than being a `Py4JJavaError`.

## How was this patch tested?

Locally.

## Does this PR introduce _any_ user-facing changes?

No.