### PR TITLE
[Spark] Fast Drop Feature Command

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -967,6 +967,13 @@
     ],
     "sqlState" : "0AKDE"
   },
+  "DELTA_FEATURE_DROP_CHECKPOINT_FAILED" : {
+    "message" : [
+      "Dropping <featureName> failed due to a failure in checkpoint creation.",
+      "Please try again later. It the issue persists, contact support."
+    ],
+    "sqlState" : "22KD0"
+  },
   "DELTA_FEATURE_DROP_CONFLICT_REVALIDATION_FAIL" : {
     "message" : [
       "Cannot drop feature because a concurrent transaction modified the table.",

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -272,7 +272,7 @@ private[delta] class ConflictChecker(
           case m: Metadata if m != currentTransactionInfo.metadata =>
             recordDeltaEvent(
               deltaLog = currentTransactionInfo.readSnapshot.deltaLog,
-              opType = "dropFeature.conflictCheck.metadataMismatch",
+              opType = "dropFeature.conflictCheck.metadataMissmatch",
               data = Map(
                 "transactionInfoMetadata" -> currentTransactionInfo.metadata,
                 "actionMetadata" -> m))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -272,7 +272,7 @@ private[delta] class ConflictChecker(
           case m: Metadata if m != currentTransactionInfo.metadata =>
             recordDeltaEvent(
               deltaLog = currentTransactionInfo.readSnapshot.deltaLog,
-              opType = "dropFeature.conflictCheck.metadataMissmatch",
+              opType = "dropFeature.conflictCheck.metadataMismatch",
               data = Map(
                 "transactionInfoMetadata" -> currentTransactionInfo.metadata,
                 "actionMetadata" -> m))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala
@@ -835,6 +835,24 @@ trait DeltaConfigsBase extends DeltaLogging {
     v => Option(v).map(_.toLong),
     validationFunction = _ => true,
     "needs to be a long.")
+
+  /**
+   * This property is used by CheckpointProtectionTableFeature and denotes the
+   * version up to which the checkpoints are required to be cleaned up only together with the
+   * corresponding commits. If this is not possible, and metadata cleanup creates a new checkpoint
+   * prior to requireCheckpointProtectionBeforeVersion, it should validate write support against
+   * all protocols included in the commits that are being removed, or else abort. This is needed
+   * to make sure that the writer understands how to correctly create a checkpoint for the
+   * historic commit.
+   *
+   * Note, this is an internal config and should never be manually altered.
+   */
+  val REQUIRE_CHECKPOINT_PROTECTION_BEFORE_VERSION = buildConfig[Long](
+    "requireCheckpointProtectionBeforeVersion",
+    "0",
+    _.toLong,
+    _ >= 0,
+    "needs to be greater or equal to zero.")
 }
 
 object DeltaConfigs extends DeltaConfigsBase

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2435,6 +2435,12 @@ trait DeltaErrorsBase
     )
   }
 
+  def dropTableFeatureCheckpointFailedException(featureName: String): Throwable = {
+    new DeltaTableFeatureException(
+      errorClass = "DELTA_FEATURE_DROP_CHECKPOINT_FAILED",
+      messageParameters = Array(featureName))
+  }
+
   def concurrentAppendException(
       conflictingCommit: Option[CommitInfo],
       partition: String,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -431,6 +431,16 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
+  val FAST_DROP_FEATURE_ENABLED =
+    buildConf("tableFeatures.dev.fastDropFeature.enabled")
+      .internal()
+      .doc(
+        """Whether to enable the fast drop feature feature functionality.
+          |This feature is currently in development and this config is only intended to be enabled
+          |for testing purposes.""".stripMargin)
+      .booleanConf
+      .createWithDefault(false)
+
   val DELTA_MAX_SNAPSHOT_LINEAGE_LENGTH =
     buildConf("maxSnapshotLineageLength")
       .internal()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This is base PR for Fast Drop feature. This is a new implementation of the DROP FEATURE command that requires no waiting time and no history truncation.

The main difficulty when dropping a feature is that after the operation is complete the history of the table still contains traces of the feature. This may cause the following problems:

1. Reconstructing the state of the latest version may require replaying log records prior to feature removal. Log replay is based on checkpoints, an auxiliary data structure, which is used by clients as a starting point for replaying history. Any actions before the checkpoint do not need to be replayed. However, checkpoints are not permanent and may be deleted any time.
2. Clients may create checkpoints in historical versions when do not support the required features.

The proposed solution is `CheckpointProtectionTableFeature`. This is a new writer feature that ensures that the entire history until a certain table version, V, can only be cleaned up in its entirety or not at all. Alternatively, the writer can delete commits and associated checkpoints up to any version (less than V) as long as it validates against all protocols included in the commits/checkpoints planing to remove. We protect against the anomalies above as follows:

-  All checkpoints before the transition table version are protected. This prevents anomaly (1) by turning checkpoints into reliable barriers that can hide unsupported log records behind them.
- Because log cleanup is disabled for the older versions, this also removes the only reason why writers would create new checkpoints, preventing anomaly (2).


This still uses a writer feature, but is a step forward compared to previous solutions because it allows the table to be readable by older clients immediately, instead of after 24 hours. Compatibility with older writers can subsequently be achieved by truncating the history after a 24-hour waiting period.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Added `DeltaFastDropFeatureSuite` as well as tests in `DeltaProtocolTransitionsSuite`.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.
