### PR TITLE
[Spark] Detect opaque URIs and throw proper exception

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -590,7 +590,15 @@ sealed trait FileAction extends Action {
   @JsonIgnore
   val tags: Map[String, String]
   @JsonIgnore
-  lazy val pathAsUri: URI = new URI(path)
+  lazy val pathAsUri: URI = {
+    // Paths like http:example.com are opaque URIs that have schema and scheme-specific parts, but
+    // path is not defined. We do not support such paths, so we throw an exception.
+    val uri = new URI(path)
+    if (uri.getPath == null) {
+      throw DeltaErrors.cannotReconstructPathFromURI(path)
+    }
+    uri
+  }
   @JsonIgnore
   def numLogicalRecords: Option[Long]
   @JsonIgnore


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

An opaque URI is an absolute URI whose scheme-specific part does not begin with a slash character ('/'), and are not further parsed by `java.net.URI` library (see https://docs.oracle.com/javase/7/docs/api/java/net/URI.html):
```
val uri = new URI("http:example.com")
uri.isOpaque -> true
uri.isAbsolute -> true
uri.getPath -> null
```

This causes issues when we try to call path-related methods in the URIs, e.g.:
```
val filePath = new Path(uri)
filePath.toString -> "http:"
filePath.isAbsolute -> NullPointerException
```

This commit fixes this issue by detecting such URIs in Delta file actions and throwing a proper exception.


## How was this patch tested?

Add new UT.

## Does this PR introduce _any_ user-facing changes?

No