### PR TITLE
[Kernel] Fix RoaringBitmapArray create/add methods. Closes issue #3881

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/deletionvectors/RoaringBitmapArray.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/deletionvectors/RoaringBitmapArray.java
@@ -100,7 +100,7 @@ public final class RoaringBitmapArray {
   // Instance Fields / Methods
   ////////////////////////////////////////////////////////////////////////////////
 
-  private RoaringBitmap[] bitmaps;
+  private RoaringBitmap[] bitmaps = new RoaringBitmap[0];
 
   /**
    * Deserialize the contents of `buffer` into this [[RoaringBitmapArray]].
@@ -267,7 +267,6 @@ public final class RoaringBitmapArray {
 
   public static RoaringBitmapArray create(long... values) {
     RoaringBitmapArray bitmap = new RoaringBitmapArray();
-    bitmap.bitmaps = new RoaringBitmap[0];
     for (long value : values) {
       bitmap.add(value);
     }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/deletionvectors/RoaringBitmapArraySuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/deletionvectors/RoaringBitmapArraySuite.scala
@@ -21,18 +21,48 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class RoaringBitmapArraySuite extends AnyFunSuite {
 
-  test("RoaringBitmapArray create and contains methods") {
-    val bitmap = RoaringBitmapArray.create(1L, 100L, 10000000000L)
+
+  test("RoaringBitmapArray create empty map") {
+    val bitmap = RoaringBitmapArray.create()
+    assert(bitmap.toArray.isEmpty)
+  }
+
+  test("RoaringBitmapArray create map with values only in first bitmap") {
+    // Values <= max unsigned integer (4,294,967,295) will be in the first bitmap
+    val bitmap = RoaringBitmapArray.create(1L, 100L)
 
     assert(bitmap.contains(1L))
     assert(bitmap.contains(100L))
-    assert(bitmap.contains(10000000000L))
 
     assert(!bitmap.contains(2L))
     assert(!bitmap.contains(99L))
-    assert(!bitmap.contains(10000000001L))
 
-    assert(bitmap.toArray.sorted sameElements Array(1L, 100L, 10000000000L))
+    assert(bitmap.toArray sameElements Array(1L, 100L))
+  }
+
+  test("RoaringBitmapArray create map with values only in second bitmap") {
+    // Values > max unsigned integer (4,294,967,295) will be in the second bitmap
+    val bitmap = RoaringBitmapArray.create(5000000000L, 5000000100L)
+
+    assert(bitmap.contains(5000000000L))
+    assert(bitmap.contains(5000000100L))
+
+    assert(!bitmap.contains(5000000001L))
+    assert(!bitmap.contains(5000000099L))
+
+    assert(bitmap.toArray sameElements Array(5000000000L, 5000000100L))
+  }
+
+  test("RoaringBitmapArray create map with values in first and second bitmap") {
+    val bitmap = RoaringBitmapArray.create(100L, 5000000000L)
+
+    assert(bitmap.contains(100L))
+    assert(bitmap.contains(5000000000L))
+
+    assert(!bitmap.contains(101L))
+    assert(!bitmap.contains(5000000001L))
+
+    assert(bitmap.toArray sameElements Array(100L, 5000000000L))
   }
 
   // TODO need to implement serialize to copy over tests

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/deletionvectors/RoaringBitmapArraySuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/deletionvectors/RoaringBitmapArraySuite.scala
@@ -16,9 +16,24 @@
 
 package io.delta.kernel.deletionvectors
 
+import io.delta.kernel.internal.deletionvectors.RoaringBitmapArray
 import org.scalatest.funsuite.AnyFunSuite
 
 class RoaringBitmapArraySuite extends AnyFunSuite {
+
+  test("RoaringBitmapArray create and contains methods") {
+    val bitmap = RoaringBitmapArray.create(1L, 100L, 10000000000L)
+
+    assert(bitmap.contains(1L))
+    assert(bitmap.contains(100L))
+    assert(bitmap.contains(10000000000L))
+
+    assert(!bitmap.contains(2L))
+    assert(!bitmap.contains(99L))
+    assert(!bitmap.contains(10000000001L))
+
+    assert(bitmap.toArray.sorted sameElements Array(1L, 100L, 10000000000L))
+  }
 
   // TODO need to implement serialize to copy over tests
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/deletionvectors/RoaringBitmapArraySuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/deletionvectors/RoaringBitmapArraySuite.scala
@@ -21,14 +21,13 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class RoaringBitmapArraySuite extends AnyFunSuite {
 
-
   test("RoaringBitmapArray create empty map") {
     val bitmap = RoaringBitmapArray.create()
     assert(bitmap.toArray.isEmpty)
   }
 
   test("RoaringBitmapArray create map with values only in first bitmap") {
-    // Values <= max unsigned integer (4,294,967,295) will be in the first bitmap
+    // Values <= max unsigned int (4,294,967,295) will be in the first bitmap
     val bitmap = RoaringBitmapArray.create(1L, 100L)
 
     assert(bitmap.contains(1L))
@@ -41,7 +40,7 @@ class RoaringBitmapArraySuite extends AnyFunSuite {
   }
 
   test("RoaringBitmapArray create map with values only in second bitmap") {
-    // Values > max unsigned integer (4,294,967,295) will be in the second bitmap
+    // Values between max unsigned int and 2*(max unsigned int) will be in the second bitmap
     val bitmap = RoaringBitmapArray.create(5000000000L, 5000000100L)
 
     assert(bitmap.contains(5000000000L))

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/deletionvectors/RoaringBitmapArraySuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/deletionvectors/RoaringBitmapArraySuite.scala
@@ -52,16 +52,17 @@ class RoaringBitmapArraySuite extends AnyFunSuite {
     assert(bitmap.toArray sameElements Array(5000000000L, 5000000100L))
   }
 
-  test("RoaringBitmapArray create map with values in first and second bitmap") {
-    val bitmap = RoaringBitmapArray.create(100L, 5000000000L)
+  test("RoaringBitmapArray create map with values in first and third bitmap") {
+    // Values between 2*(max unsigned int) and 3*(max unsigned int) will be in the third bitmap
+    val bitmap = RoaringBitmapArray.create(100L, 10000000000L)
 
     assert(bitmap.contains(100L))
-    assert(bitmap.contains(5000000000L))
+    assert(bitmap.contains(10000000000L))
 
     assert(!bitmap.contains(101L))
-    assert(!bitmap.contains(5000000001L))
+    assert(!bitmap.contains(10000000001L))
 
-    assert(bitmap.toArray sameElements Array(100L, 5000000000L))
+    assert(bitmap.toArray sameElements Array(100L, 10000000000L))
   }
 
   // TODO need to implement serialize to copy over tests


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Resolves #3881 
 - The bitmaps array should be initialized in the `create` path.
 - The `expandBitMaps` method should set new bitmaps from the old length up to the new length, instead of overwriting the old ones.

Also adds a `toArray` method mimicking the one provided by the scala version which the class is based on.

## How was this patch tested?

Added unit tests.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
