### PR TITLE
[Spark] Fix schema evolution issue with nested struct (within a map) and column renamed

### DIFF
--- a/examples/scala/src/main/scala/example/EvolutionWithMap.scala
+++ b/examples/scala/src/main/scala/example/EvolutionWithMap.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package example
+
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.SparkSession
+
+object EvolutionWithMap {
+  def main(args: Array[String]): Unit = {
+    val spark = SparkSession.builder()
+      .appName("EvolutionWithMap")
+      .master("local[*]")
+      .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+      .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+      .getOrCreate()
+
+    import spark.implicits._
+
+    val tableName = "insert_map_schema_evolution"
+
+    try {
+      // Define initial schema
+      val initialSchema = StructType(Seq(
+          StructField("key", IntegerType, nullable = false),
+          StructField("metrics", MapType(StringType, StructType(Seq(
+              StructField("id", IntegerType, nullable = false),
+              StructField("value", IntegerType, nullable = false)
+          ))))
+          ))
+
+      val data = Seq(
+      Row(1, Map("event" -> Row(1, 1)))
+      )
+
+      val rdd = spark.sparkContext.parallelize(data)
+
+      val initialDf = spark.createDataFrame(rdd, initialSchema)
+
+      initialDf.write
+        .option("overwriteSchema", "true")
+        .mode("overwrite")
+        .format("delta")
+        .saveAsTable(s"$tableName")
+
+      // Define the schema with simulteneous change in a StructField name
+      // And additional field in a map column
+      val evolvedSchema = StructType(Seq(
+      StructField("renamed_key", IntegerType, nullable = false),
+      StructField("metrics", MapType(StringType, StructType(Seq(
+          StructField("id", IntegerType, nullable = false),
+          StructField("value", IntegerType, nullable = false),
+          StructField("comment", StringType, nullable = true)
+      ))))
+      ))
+
+      val evolvedData = Seq(
+      Row(1, Map("event" -> Row(1, 1, "deprecated")))
+      )
+
+      val evolvedRDD = spark.sparkContext.parallelize(evolvedData)
+
+      val modifiedDf = spark.createDataFrame(evolvedRDD, evolvedSchema)
+
+      // The below would fail without schema evolution for map types
+      modifiedDf.write
+        .mode("append")
+        .option("mergeSchema", "true")
+        .format("delta")
+        .insertInto(s"$tableName")
+
+      spark.sql(s"SELECT * FROM $tableName").show(false)
+
+    } finally {
+
+      // Cleanup
+      spark.sql(s"DROP TABLE IF EXISTS $tableName")
+
+      spark.stop()
+    }
+
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -933,7 +933,7 @@ class DeltaAnalysis(session: SparkSession)
         attr
       case (s: MapType, t: MapType)
         if !DataType.equalsStructurally(s, t, ignoreNullability = true) || allowTypeWidening =>
-        // only trigger addCastsToMaps if exits differences like extra fields, renaming
+        // only trigger addCastsToMaps if exists differences like extra fields, renaming
         // Or allowTypeWidening is enabled
         addCastsToMaps(tblName, attr, s, t, allowTypeWidening)
       case _ =>
@@ -1138,24 +1138,23 @@ class DeltaAnalysis(session: SparkSession)
       sourceMapType: MapType,
       targetMapType: MapType,
       allowTypeWidening: Boolean): Expression = {
-
     val transformedKeys =
       if (sourceMapType.keyType != targetMapType.keyType) {
         // Create a transformation for the keys
         ArrayTransform(MapKeys(parent), {
           val key = NamedLambdaVariable(
-                  "key", sourceMapType.keyType, nullable = false)
+            "key", sourceMapType.keyType, nullable = false)
 
           val keyAttr = AttributeReference(
-              "key", targetMapType.keyType, nullable = false)()
+            "key", targetMapType.keyType, nullable = false)()
 
           val castedKey =
-              addCastToColumn(
-                key,
-                keyAttr,
-                tableName,
-                allowTypeWidening
-              )
+            addCastToColumn(
+              key,
+              keyAttr,
+              tableName,
+              allowTypeWidening
+            )
           LambdaFunction(castedKey, Seq(key))
         })
       } else {
@@ -1167,18 +1166,18 @@ class DeltaAnalysis(session: SparkSession)
         // Create a transformation for the values
         ArrayTransform(MapValues(parent), {
           val value = NamedLambdaVariable(
-              "value", sourceMapType.valueType, sourceMapType.valueContainsNull)
+            "value", sourceMapType.valueType, sourceMapType.valueContainsNull)
 
           val valueAttr = AttributeReference(
-              "value", targetMapType.valueType, sourceMapType.valueContainsNull)()
+            "value", targetMapType.valueType, sourceMapType.valueContainsNull)()
 
           val castedValue =
-              addCastToColumn(
-                value,
-                valueAttr,
-                tableName,
-                allowTypeWidening
-              )
+            addCastToColumn(
+              value,
+              valueAttr,
+              tableName,
+              allowTypeWidening
+            )
           LambdaFunction(castedValue, Seq(value))
         })
       } else {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTableSuite.scala
@@ -281,6 +281,245 @@ class DeltaInsertIntoSQLSuite
     }
   }
 
+  // Schema evolution for complex map type
+  test("insertInto schema evolution with map type - append mode: field renaming + new field") {
+    withTable("map_schema_evolution") {
+      val tableName = "map_schema_evolution"
+      val initialSchema = StructType(Seq(
+        StructField("key", IntegerType, nullable = false),
+        StructField("metrics", MapType(StringType, StructType(Seq(
+          StructField("id", IntegerType, nullable = false),
+          StructField("value", IntegerType, nullable = false)
+        ))))
+      ))
+
+      val initialData = Seq(
+        Row(1, Map("event" -> Row(1, 1)))
+      )
+
+      val initialRdd = spark.sparkContext.parallelize(initialData)
+      val initialDf = spark.createDataFrame(initialRdd, initialSchema)
+
+      // Write initial data
+      initialDf.write
+        .option("overwriteSchema", "true")
+        .mode("overwrite")
+        .format("delta")
+        .saveAsTable(tableName)
+
+      // Evolved schema with field renamed and additional field in map struct
+      val evolvedSchema = StructType(Seq(
+        StructField("renamed_key", IntegerType, nullable = false),
+        StructField("metrics", MapType(StringType, StructType(Seq(
+          StructField("id", IntegerType, nullable = false),
+          StructField("value", IntegerType, nullable = false),
+          StructField("comment", StringType, nullable = true)
+        ))))
+      ))
+
+      val evolvedData = Seq(
+        Row(1, Map("event" -> Row(1, 1, "deprecated")))
+      )
+
+      val evolvedRdd = spark.sparkContext.parallelize(evolvedData)
+      val evolvedDf = spark.createDataFrame(evolvedRdd, evolvedSchema)
+
+      // insert data without schema evolution
+      val err = intercept[AnalysisException] {
+        evolvedDf.write
+          .mode("append")
+          .format("delta")
+          .insertInto(tableName)
+      }
+      checkErrorMatchPVals(
+        exception = err,
+        errorClass = "_LEGACY_ERROR_TEMP_DELTA_0007",
+        parameters = Map(
+          "message" -> "A schema mismatch detected when writing to the Delta table(.|\\n)*"
+        )
+      )
+
+      // insert data with schema evolution
+      withSQLConf("spark.databricks.delta.schema.autoMerge.enabled" -> "true") {
+        evolvedDf.write
+          .mode("append")
+          .format("delta")
+          .insertInto(tableName)
+
+        val result = spark.sql(s"SELECT * FROM $tableName").collect()
+        val expected = Seq(
+          Row(1, Map("event" -> Row(1, 1, null))),
+          Row(1, Map("event" -> Row(1, 1, "deprecated")))
+        )
+
+        assert(result.toSet == expected.toSet)
+      }
+    }
+  }
+
+  test("not enough column in source to insert in nested map types") {
+    withTable("source", "target") {
+      sql(
+        """CREATE TABLE source (
+          |  id INT,
+          |  metrics MAP<STRING, STRUCT<id: INT, value: INT>>
+          |) USING delta""".stripMargin)
+
+      sql(
+        """CREATE TABLE target (
+          |  id INT,
+          |  metrics MAP<STRING, STRUCT<id: INT, value: INT, comment: STRING>>
+          |) USING delta""".stripMargin)
+
+      sql("INSERT INTO source VALUES (1, map('event', struct(1, 1)))")
+
+      val e = intercept[AnalysisException] {
+        sql("INSERT INTO target SELECT * FROM source")
+      }
+      checkError(
+        exception = e,
+        errorClass = "DELTA_INSERT_COLUMN_ARITY_MISMATCH",
+        parameters = Map(
+          "tableName" -> "spark_catalog.default.target",
+          "columnName" -> "not enough nested fields in value",
+          "numColumns" -> "3",
+          "insertColumns" -> "2"
+        )
+      )
+    }
+  }
+
+  // not enough nested fields in value
+  test("more columns in source to insert in nested map types") {
+    withTable("source", "target") {
+      sql(
+        """CREATE TABLE source (
+          |  id INT,
+          |  metrics MAP<STRING, STRUCT<id: INT, value: INT, comment: STRING>>
+          |) USING delta""".stripMargin)
+
+      sql(
+        """CREATE TABLE target (
+          |  id INT,
+          |  metrics MAP<STRING, STRUCT<id: INT, value: INT>>
+          |) USING delta""".stripMargin)
+
+      sql("INSERT INTO source VALUES (1, map('event', struct(1, 1, 'deprecated')))")
+
+      val e = intercept[AnalysisException] {
+        sql("INSERT INTO target SELECT * FROM source")
+      }
+      checkErrorMatchPVals(
+        exception = e,
+        errorClass = "_LEGACY_ERROR_TEMP_DELTA_0007",
+        parameters = Map(
+          "message" -> "A schema mismatch detected when writing to the Delta table(.|\\n)*"
+        )
+      )
+
+      withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true") {
+        sql("INSERT INTO target SELECT * FROM source")
+        val result = spark.sql(s"SELECT * FROM source").collect()
+        val expected = Seq(
+          Row(1, Map("event" -> Row(1, 1, "deprecated")))
+        )
+
+        assert(result.toSet == expected.toSet)
+      }
+    }
+  }
+
+  test("more columns in source to insert in nested 2-level deep map types") {
+    withTable("source", "target") {
+      sql(
+        """CREATE TABLE source (
+          |  id INT,
+          |  metrics MAP<STRING, MAP<STRING, STRUCT<id: INT, value: INT, comment: STRING>>>
+          |) USING delta""".stripMargin)
+
+      sql(
+        """CREATE TABLE target (
+          |  id INT,
+          |  metrics MAP<STRING, MAP<STRING, STRUCT<id: INT, value: INT>>>
+          |) USING delta""".stripMargin)
+
+      sql(
+        """INSERT INTO source VALUES
+         | (1, map('event', map('subEvent', struct(1, 1, 'deprecated'))))
+         """.stripMargin)
+
+      val e = intercept[AnalysisException] {
+        sql("INSERT INTO target SELECT * FROM source")
+      }
+      checkErrorMatchPVals(
+        exception = e,
+        errorClass = "_LEGACY_ERROR_TEMP_DELTA_0007",
+        parameters = Map(
+          "message" -> "A schema mismatch detected when writing to the Delta table(.|\\n)*"
+        )
+      )
+
+      withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true") {
+        sql("INSERT INTO target SELECT * FROM source")
+        val result = spark.sql(s"SELECT * FROM source").collect()
+        val expected = Seq(
+          Row(1, Map("event" -> Map("subEvent" -> Row(1, 1, "deprecated"))))
+        )
+
+        assert(result.toSet == expected.toSet)
+      }
+    }
+  }
+
+  test("insert map type with different data type in key") {
+    withTable("source", "target") {
+      sql(
+        """CREATE TABLE source (
+          |  id INT,
+          |  metrics MAP<STRING, STRUCT<id: INT, value: INT>>
+          |) USING delta""".stripMargin)
+
+      sql(
+        """CREATE TABLE target (
+          |  id INT,
+          |  metrics MAP<INT, STRUCT<id: INT, value: INT>>
+          |) USING delta""".stripMargin)
+
+      sql("INSERT INTO source VALUES (1, map('1', struct(2, 3)))")
+
+      sql("INSERT INTO target SELECT * FROM source")
+
+      val result = spark.sql("SELECT * FROM target").collect()
+      val expected = Seq(Row(1, Map(1 -> Row(2, 3))))
+      assert(result.toSet == expected.toSet)
+    }
+  }
+
+  test("insert map type with different data type in value") {
+    withTable("source", "target") {
+      sql(
+        """CREATE TABLE source (
+          |  id INT,
+          |  metrics MAP<STRING, STRUCT<id: INT, value: LONG>>
+          |) USING delta""".stripMargin)
+
+      sql(
+        """CREATE TABLE target (
+          |  id INT,
+          |  metrics MAP<STRING, STRUCT<id: INT, value: INT>>
+          |) USING delta""".stripMargin)
+
+      sql("INSERT INTO source VALUES (1, map('m1', struct(2, 3L)))")
+
+      sql("INSERT INTO target SELECT * FROM source")
+
+      val result = spark.sql("SELECT * FROM target").collect()
+      val expected = Seq(Row(1, Map("m1" -> Row(2, 3))))
+      assert(result.toSet == expected.toSet)
+    }
+  }
+
+
   def runInsertOverwrite(
       sourceSchema: String,
       sourceRecord: String,

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTableSuite.scala
@@ -346,13 +346,12 @@ class DeltaInsertIntoSQLSuite
           .format("delta")
           .insertInto(tableName)
 
-        val result = spark.sql(s"SELECT * FROM $tableName").collect()
-        val expected = Seq(
-          Row(1, Map("event" -> Row(1, 1, null))),
-          Row(1, Map("event" -> Row(1, 1, "deprecated")))
-        )
-
-        assert(result.toSet == expected.toSet)
+        checkAnswer(
+          spark.sql(s"SELECT * FROM $tableName"),
+          Seq(
+            Row(1, Map("event" -> Row(1, 1, null))),
+            Row(1, Map("event" -> Row(1, 1, "deprecated")))
+        ))
       }
     }
   }
@@ -419,12 +418,11 @@ class DeltaInsertIntoSQLSuite
 
       withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true") {
         sql("INSERT INTO target SELECT * FROM source")
-        val result = spark.sql(s"SELECT * FROM source").collect()
-        val expected = Seq(
-          Row(1, Map("event" -> Row(1, 1, "deprecated")))
-        )
-
-        assert(result.toSet == expected.toSet)
+        checkAnswer(
+          spark.sql(s"SELECT * FROM source"),
+          Seq(
+            Row(1, Map("event" -> Row(1, 1, "deprecated")))
+        ))
       }
     }
   }
@@ -461,12 +459,11 @@ class DeltaInsertIntoSQLSuite
 
       withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true") {
         sql("INSERT INTO target SELECT * FROM source")
-        val result = spark.sql(s"SELECT * FROM source").collect()
-        val expected = Seq(
-          Row(1, Map("event" -> Map("subEvent" -> Row(1, 1, "deprecated"))))
-        )
-
-        assert(result.toSet == expected.toSet)
+        checkAnswer(
+          spark.sql(s"SELECT * FROM source"),
+          Seq(
+            Row(1, Map("event" -> Map("subEvent" -> Row(1, 1, "deprecated"))))
+        ))
       }
     }
   }
@@ -489,9 +486,11 @@ class DeltaInsertIntoSQLSuite
 
       sql("INSERT INTO target SELECT * FROM source")
 
-      val result = spark.sql("SELECT * FROM target").collect()
-      val expected = Seq(Row(1, Map(1 -> Row(2, 3))))
-      assert(result.toSet == expected.toSet)
+      checkAnswer(
+        spark.sql("SELECT * FROM target"),
+        Seq(
+          Row(1, Map(1 -> Row(2, 3)))
+      ))
     }
   }
 
@@ -513,9 +512,11 @@ class DeltaInsertIntoSQLSuite
 
       sql("INSERT INTO target SELECT * FROM source")
 
-      val result = spark.sql("SELECT * FROM target").collect()
-      val expected = Seq(Row(1, Map("m1" -> Row(2, 3))))
-      assert(result.toSet == expected.toSet)
+      checkAnswer(
+        spark.sql("SELECT * FROM target"),
+        Seq(
+          Row(1, Map("m1" -> Row(2, 3)))
+      ))
     }
   }
 


### PR DESCRIPTION
This PR fixes an issue with schema evolution in Delta Lake where adding a new field to a struct within a map and renaming an existing top level field caused the operation to fail.

The fix includes logic to handle these transformations properly, ensuring that new fields are added without conflicts.

It also resolved a ToDo of casting map types in the [DeltaAnalysis.scala](https://github.com/Richard-code-gig/delta/blob/feature/schema-evolution-with-map-fix/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala) module.

### Changes:
- Updated schema evolution logic to support complex map transformations.
- Enabled schema evolution for both map keys, simple and nested values
- Added additional case statements to handle MapTypes in addCastToColumn method in DeltaAnalysis.scala module.
- Modified TypeWideningInsertSchemaEvolutionSuite test to support schema evolution of maps.
- Added an additional method (addCastsToMaps) to DeltaAnalysis.scala module.
- Changed argument type of addCastToColumn from attributes to namedExpression
- Added [EvolutionWithMap](https://github.com/Richard-code-gig/delta/blob/feature/schema-evolution-with-map-fix/examples/scala/src/main/scala/example/EvolutionWithMap.scala) in the example modules to demonstrate use case.
- Modified nested struct type evolution with field upcast test in map in TypeWideningInsertSchemaEvolutionSuite.scala
- Added new tests cases for maps to DeltaInsertIntoTableSuite.scala

### Related Issues:
- Resolves: #3227 


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [✓] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Tested through:
- Integration Tests: Validated changes with Delta Lake and Spark integration. See [EvolutionWithMap](https://github.com/Richard-code-gig/delta/blob/feature/schema-evolution-with-map-fix/examples/scala/src/main/scala/example/EvolutionWithMap.scala).
- Validated the test suites passed and [TypeWideningInsertSchemaEvolutionSuite](https://github.com/Richard-code-gig/delta/blob/feature/schema-evolution-with-map-fix/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningInsertSchemaEvolutionSuite.scala) to add support for maps.
- Added additional tests cases in [DeltaInsertIntoTableSuite](https://github.com/Richard-code-gig/delta/blob/feature/schema-evolution-with-map-fix/spark/src/test/scala/org/apache/spark/sql/DeltaInsertIntoTableSuite.scala) to cover complex map transformations


<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No, it doesn't introduce any user-facing changes. It only resolved an issue even in the released versions of Delta Lake.

The previous behaviour was an error message when attempting operations involving adding extra fields to StructField in maps:
[[DATATYPE_MISMATCH.CAST_WITHOUT_SUGGESTION](https://docs.databricks.com/error-messages/error-classes.html#datatype_mismatch.cast_without_suggestion)] Cannot resolve "metrics" due to data type mismatch: cannot cast "MAP<STRING, STRUCT<id: INT, value: INT, comment: STRING>>" to "MAP<STRING, STRUCT<id: INT, value: INT>>". 


<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
