### PR TITLE
[SPARK] Stringify the delta optimize 'auto' operationalParameter in CommitInfo

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -699,7 +699,7 @@ object DeltaOperations {
       // When clustering columns are specified, set the zOrderBy key to empty.
       ZORDER_PARAMETER_KEY -> JsonUtils.toJson(if (clusterBy.isEmpty) zOrderBy else Seq.empty),
       CLUSTERING_PARAMETER_KEY -> JsonUtils.toJson(clusterBy.getOrElse(Seq.empty)),
-      AUTO_COMPACTION_PARAMETER_KEY -> auto
+      AUTO_COMPACTION_PARAMETER_KEY -> auto.toString
     )
     // `isFull` is not relevant for non-clustering tables, so skip it.
     .++(clusterBy.filter(_.nonEmpty).map(_ => CLUSTERING_IS_FULL_KEY -> isFull))


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

The `inCommitTimestamp` feature of Delta Kernel API expects the `operationalParameters` of `CommitInfo` to be a `MapType<StringType, StringType>`.  

The newly added `autoCompact` feature added the `auto` flag to `operationalParamaters` as a boolean, which is incompatible.

This PR restores that expectation of the `inCommitTimestamp` feature for the `OPTIMIZE` operation in the Spark Connector.

Resolves #3888.

## How was this patch tested?

I've attached a test-case.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
We change format of the field `commitInfo.operationalParameters.auto` field from boolean to string.
