### PR TITLE
Introducing Delta Lake Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![License](https://img.shields.io/badge/license-Apache%202-brightgreen.svg)](https://github.com/delta-io/delta/blob/master/LICENSE.txt)
 [![PyPI](https://img.shields.io/pypi/v/delta-spark.svg)](https://pypi.org/project/delta-spark/)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/delta-spark)](https://pypistats.org/packages/delta-spark)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Delta%20Lake%20Guru-006BFF)](https://gurubase.io/g/delta-lake)
 
 Delta Lake is an open-source storage framework that enables building a [Lakehouse architecture](http://cidrdb.org/cidr2021/papers/cidr2021_paper17.pdf) with compute engines including Spark, PrestoDB, Flink, Trino, and Hive and APIs for Scala, Java, Rust, Ruby, and Python. 
 * See the [Delta Lake Documentation](https://docs.delta.io) for details.


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Delta Lake Guru](https://gurubase.io/g/delta-lake) to Gurubase. Delta Lake Guru uses the data from this repo and data from the [docs](https://docs.delta.io) to answer questions by leveraging the LLM.

In this PR, I showcased the "Delta Lake Guru", which highlights that Delta Lake now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Delta Lake Guru in Gurubase, just let me know that's totally fine.
