### PR TITLE
[Kernel] Assign base row ID and default row commit version to AddFile

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -295,7 +295,7 @@ public final class DeltaErrors {
 
   public static KernelException missingNumRecordsStatsForRowTracking() {
     return new KernelException(
-        "Cannot write to a rowTracking-supported table without 'numRecord' statistics. "
+        "Cannot write to a rowTracking-supported table without 'numRecords' statistics. "
             + "Connectors are expected to populate the number of records statistics when "
             + "writing to a Delta table with 'rowTracking' table feature supported.");
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -293,6 +293,19 @@ public final class DeltaErrors {
     return new ConcurrentWriteException(message);
   }
 
+  public static KernelException missingNumRecordsStatsForRowTracking() {
+    return new KernelException(
+        "Cannot write to a rowTracking-supported table without 'numRecord' statistics. "
+            + "Connectors are expected to populate the number of records statistics when "
+            + "writing to a Delta table with 'rowTracking' table feature supported.");
+  }
+
+  public static KernelException rowTrackingSupportedWithDomainMetadataUnsupported() {
+    return new KernelException(
+        "Feature 'rowTracking' is supported and depends on feature 'domainMetadata',"
+            + " but 'domainMetadata' is unsupported");
+  }
+
   /* ------------------------ HELPER METHODS ----------------------------- */
   private static String formatTimestamp(long millisSinceEpochUTC) {
     return new Timestamp(millisSinceEpochUTC).toInstant().toString();

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/InternalScanFileUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/InternalScanFileUtils.java
@@ -32,6 +32,7 @@ import io.delta.kernel.utils.FileStatus;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Utilities to extract information out of the scan file rows returned by {@link
@@ -42,6 +43,7 @@ public class InternalScanFileUtils {
 
   private static final String TABLE_ROOT_COL_NAME = "tableRoot";
   private static final DataType TABLE_ROOT_DATA_TYPE = StringType.STRING;
+
   /** {@link Column} expression referring to the `partitionValues` in scan `add` file. */
   public static final Column ADD_FILE_PARTITION_COL_REF =
       new Column(new String[] {"add", "partitionValues"});
@@ -86,6 +88,11 @@ public class InternalScanFileUtils {
   private static final int ADD_FILE_DATA_CHANGE_ORDINAL = ADD_FILE_SCHEMA.indexOf("dataChange");
 
   private static final int ADD_FILE_DV_ORDINAL = ADD_FILE_SCHEMA.indexOf("deletionVector");
+
+  private static final int ADD_FILE_BASE_ROW_ID_ORDINAL = ADD_FILE_SCHEMA.indexOf("baseRowId");
+
+  private static final int ADD_FILE_DEFAULT_ROW_COMMIT_VERSION_ORDINAL =
+      ADD_FILE_SCHEMA.indexOf("defaultRowCommitVersion");
 
   private static final int TABLE_ROOT_ORDINAL = SCAN_FILE_SCHEMA.indexOf(TABLE_ROOT_COL_NAME);
 
@@ -189,5 +196,21 @@ public class InternalScanFileUtils {
    */
   public static Column getPartitionValuesParsedRefInAddFile(String partitionColName) {
     return new Column(new String[] {"add", "partitionValues_parsed", partitionColName});
+  }
+
+  /** Get the base row id from the given scan file row. */
+  public static Optional<Long> getBaseRowId(Row scanFile) {
+    Row addFile = getAddFileEntry(scanFile);
+    return addFile.isNullAt(ADD_FILE_BASE_ROW_ID_ORDINAL)
+        ? Optional.empty()
+        : Optional.of(addFile.getLong(ADD_FILE_BASE_ROW_ID_ORDINAL));
+  }
+
+  /** Get the default row commit version from the given scan file row. */
+  public static Optional<Long> getDefaultRowCommitVersion(Row scanFile) {
+    Row addFile = getAddFileEntry(scanFile);
+    return addFile.isNullAt(ADD_FILE_DEFAULT_ROW_COMMIT_VERSION_ORDINAL)
+        ? Optional.empty()
+        : Optional.of(addFile.getLong(ADD_FILE_DEFAULT_ROW_COMMIT_VERSION_ORDINAL));
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/InternalScanFileUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/InternalScanFileUtils.java
@@ -198,7 +198,6 @@ public class InternalScanFileUtils {
     return new Column(new String[] {"add", "partitionValues_parsed", partitionColName});
   }
 
-  /** Get the base row id from the given scan file row. */
   public static Optional<Long> getBaseRowId(Row scanFile) {
     Row addFile = getAddFileEntry(scanFile);
     return addFile.isNullAt(ADD_FILE_BASE_ROW_ID_ORDINAL)
@@ -206,7 +205,6 @@ public class InternalScanFileUtils {
         : Optional.of(addFile.getLong(ADD_FILE_BASE_ROW_ID_ORDINAL));
   }
 
-  /** Get the default row commit version from the given scan file row. */
   public static Optional<Long> getDefaultRowCommitVersion(Row scanFile) {
     Row addFile = getAddFileEntry(scanFile);
     return addFile.isNullAt(ADD_FILE_DEFAULT_ROW_COMMIT_VERSION_ORDINAL)

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/InternalScanFileUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/InternalScanFileUtils.java
@@ -89,11 +89,6 @@ public class InternalScanFileUtils {
 
   private static final int ADD_FILE_DV_ORDINAL = ADD_FILE_SCHEMA.indexOf("deletionVector");
 
-  private static final int ADD_FILE_BASE_ROW_ID_ORDINAL = ADD_FILE_SCHEMA.indexOf("baseRowId");
-
-  private static final int ADD_FILE_DEFAULT_ROW_COMMIT_VERSION_ORDINAL =
-      ADD_FILE_SCHEMA.indexOf("defaultRowCommitVersion");
-
   private static final int TABLE_ROOT_ORDINAL = SCAN_FILE_SCHEMA.indexOf(TABLE_ROOT_COL_NAME);
 
   public static final int ADD_FILE_STATS_ORDINAL = AddFile.SCHEMA_WITH_STATS.indexOf("stats");
@@ -199,16 +194,12 @@ public class InternalScanFileUtils {
   }
 
   public static Optional<Long> getBaseRowId(Row scanFile) {
-    Row addFile = getAddFileEntry(scanFile);
-    return addFile.isNullAt(ADD_FILE_BASE_ROW_ID_ORDINAL)
-        ? Optional.empty()
-        : Optional.of(addFile.getLong(ADD_FILE_BASE_ROW_ID_ORDINAL));
+    Row addFileRow = getAddFileEntry(scanFile);
+    return new AddFile(addFileRow).getBaseRowId();
   }
 
   public static Optional<Long> getDefaultRowCommitVersion(Row scanFile) {
-    Row addFile = getAddFileEntry(scanFile);
-    return addFile.isNullAt(ADD_FILE_DEFAULT_ROW_COMMIT_VERSION_ORDINAL)
-        ? Optional.empty()
-        : Optional.of(addFile.getLong(ADD_FILE_DEFAULT_ROW_COMMIT_VERSION_ORDINAL));
+    Row addFileRow = getAddFileEntry(scanFile);
+    return new AddFile(addFileRow).getDefaultRowCommitVersion();
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableFeatures.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableFeatures.java
@@ -40,6 +40,7 @@ public class TableFeatures {
               add("typeWidening-preview");
               add("typeWidening");
               add(DOMAIN_METADATA_FEATURE_NAME);
+              add(ROW_TRACKING_FEATURE_NAME);
             }
           });
 
@@ -58,8 +59,9 @@ public class TableFeatures {
             }
           });
 
-  /** The feature name for domain metadata. */
   public static final String DOMAIN_METADATA_FEATURE_NAME = "domainMetadata";
+
+  public static final String ROW_TRACKING_FEATURE_NAME = "rowTracking";
 
   /** The minimum writer version required to support table features. */
   public static final int TABLE_FEATURES_MIN_WRITER_VERSION = 7;
@@ -100,7 +102,8 @@ public class TableFeatures {
    *   <li>protocol writer version 1.
    *   <li>protocol writer version 2 only with appendOnly feature enabled.
    *   <li>protocol writer version 7 with {@code appendOnly}, {@code inCommitTimestamp}, {@code
-   *       columnMapping}, {@code typeWidening}, {@code domainMetadata} feature enabled.
+   *       columnMapping}, {@code typeWidening}, {@code domainMetadata}, {@code rowTracking} feature
+   *       enabled.
    * </ul>
    *
    * @param protocol Table protocol
@@ -135,6 +138,12 @@ public class TableFeatures {
           if (!SUPPORTED_WRITER_FEATURES.contains(writerFeature)) {
             throw unsupportedWriterFeature(tablePath, writerFeature);
           }
+        }
+        // Eventually we may have a way to declare and enforce dependencies between features.
+        // By putting this check for row tracking here, it makes it easier to spot that row
+        // tracking defines such a dependency that can be implicitly checked.
+        if (isRowTrackingSupported(protocol) && !isDomainMetadataSupported(protocol)) {
+          throw DeltaErrors.rowTrackingSupportedWithDomainMetadataUnsupported();
         }
         break;
       default:
@@ -189,12 +198,17 @@ public class TableFeatures {
    * @return true if the "domainMetadata" feature is supported, false otherwise
    */
   public static boolean isDomainMetadataSupported(Protocol protocol) {
-    List<String> writerFeatures = protocol.getWriterFeatures();
-    if (writerFeatures == null) {
-      return false;
-    }
-    return writerFeatures.contains(DOMAIN_METADATA_FEATURE_NAME)
-        && protocol.getMinWriterVersion() >= TABLE_FEATURES_MIN_WRITER_VERSION;
+    return isWriterFeatureSupported(protocol, DOMAIN_METADATA_FEATURE_NAME);
+  }
+
+  /**
+   * Check if the table protocol supports the "rowTracking" writer feature.
+   *
+   * @param protocol the protocol to check
+   * @return true if the protocol supports row tracking, false otherwise
+   */
+  public static boolean isRowTrackingSupported(Protocol protocol) {
+    return isWriterFeatureSupported(protocol, ROW_TRACKING_FEATURE_NAME);
   }
 
   /**
@@ -252,5 +266,14 @@ public class TableFeatures {
     if (hasInvariants) {
       throw columnInvariantsNotSupported();
     }
+  }
+
+  private static boolean isWriterFeatureSupported(Protocol protocol, String featureName) {
+    List<String> writerFeatures = protocol.getWriterFeatures();
+    if (writerFeatures == null) {
+      return false;
+    }
+    return writerFeatures.contains(featureName)
+        && protocol.getMinWriterVersion() >= TABLE_FEATURES_MIN_WRITER_VERSION;
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/AddFile.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/AddFile.java
@@ -136,7 +136,7 @@ public class AddFile extends RowBackedAction {
 
   /** Constructs an {@link AddFile} action from the given 'AddFile' {@link Row}. */
   public AddFile(Row row) {
-    super(row, FULL_SCHEMA);
+    super(row);
   }
 
   public String getPath() {
@@ -181,10 +181,12 @@ public class AddFile extends RowBackedAction {
   }
 
   public Optional<DataFileStatistics> getStats() {
-    int index = getFieldIndex("stats");
-    return row.isNullAt(index)
-        ? Optional.empty()
-        : DataFileStatistics.deserializeFromJson(row.getString(index));
+    return getFieldIndexOpt("stats")
+        .flatMap(
+            index ->
+                row.isNullAt(index)
+                    ? Optional.empty()
+                    : DataFileStatistics.deserializeFromJson(row.getString(index)));
   }
 
   public Optional<Long> getNumRecords() {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/RowBackedAction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/RowBackedAction.java
@@ -40,8 +40,8 @@ public abstract class RowBackedAction {
   }
 
   /**
-   * Returns the index of the field with the given name in the full schema of the row. Throws an
-   * {@link IllegalArgumentException} if the field is not found.
+   * Returns the index of the field with the given name in the schema of the row. Throws an {@link
+   * IllegalArgumentException} if the field is not found.
    */
   protected int getFieldIndex(String fieldName) {
     int index = row.getSchema().indexOf(fieldName);
@@ -50,7 +50,7 @@ public abstract class RowBackedAction {
   }
 
   /**
-   * Returns the index of the field with the given name in the full schema of the row, or {@link
+   * Returns the index of the field with the given name in the schema of the row, or {@link
    * Optional#empty()} if the field is not found. This should be used when the underlying row may or
    * may not contain that field.
    */

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/RowBackedAction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/RowBackedAction.java
@@ -22,6 +22,7 @@ import io.delta.kernel.internal.data.DelegateRow;
 import io.delta.kernel.types.*;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * An abstract base class for Delta Log actions that are backed by a {@link Row}. This design is to
@@ -34,13 +35,7 @@ public abstract class RowBackedAction {
   /** The underlying {@link Row} that represents an action and contains all its field values. */
   protected final Row row;
 
-  protected RowBackedAction(Row row, StructType expectedSchema) {
-    checkArgument(
-        row.getSchema().equals(expectedSchema),
-        "Expected row schema: %s, found: %s",
-        expectedSchema,
-        row.getSchema());
-
+  protected RowBackedAction(Row row) {
     this.row = row;
   }
 
@@ -52,6 +47,16 @@ public abstract class RowBackedAction {
     int index = row.getSchema().indexOf(fieldName);
     checkArgument(index >= 0, "Field '%s' not found in schema: %s", fieldName, row.getSchema());
     return index;
+  }
+
+  /**
+   * Returns the index of the field with the given name in the full schema of the row, or {@link
+   * Optional#empty()} if the field is not found. This should be used when the underlying row may or
+   * may not contain that field.
+   */
+  protected Optional<Integer> getFieldIndexOpt(String fieldName) {
+    int index = row.getSchema().indexOf(fieldName);
+    return index >= 0 ? Optional.of(index) : Optional.empty();
   }
 
   /**

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/SingleAction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/SingleAction.java
@@ -72,7 +72,7 @@ public class SingleAction {
   // schema for those fields here.
 
   private static final int TXN_ORDINAL = FULL_SCHEMA.indexOf("txn");
-  private static final int ADD_FILE_ORDINAL = FULL_SCHEMA.indexOf("add");
+  public static final int ADD_FILE_ORDINAL = FULL_SCHEMA.indexOf("add");
   private static final int REMOVE_FILE_ORDINAL = FULL_SCHEMA.indexOf("remove");
   private static final int METADATA_ORDINAL = FULL_SCHEMA.indexOf("metaData");
   private static final int PROTOCOL_ORDINAL = FULL_SCHEMA.indexOf("protocol");

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/RowTracking.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/RowTracking.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.rowtracking;
+
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+
+import io.delta.kernel.data.Row;
+import io.delta.kernel.internal.DeltaErrors;
+import io.delta.kernel.internal.SnapshotImpl;
+import io.delta.kernel.internal.TableFeatures;
+import io.delta.kernel.internal.actions.*;
+import io.delta.kernel.utils.CloseableIterable;
+import io.delta.kernel.utils.CloseableIterator;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+/** A collection of helper methods for working with row tracking. */
+public class RowTracking {
+  private RowTracking() {
+    // Empty constructor to prevent instantiation of this class
+  }
+
+  private static final int ADD_FILE_ORDINAL = SingleAction.FULL_SCHEMA.indexOf("add");
+
+  /**
+   * Assigns base row IDs and default row commit versions to {@link AddFile} actions prior to
+   * commit. This method should only be called when the 'rowTracking' feature is supported.
+   *
+   * <p>For {@link AddFile} actions missing a base row ID, assigns the current row ID high watermark
+   * plus 1. The high watermark is then incremented by the number of records in the file. For
+   * actions missing a default row commit version, assigns the specified commit version.
+   *
+   * @param snapshot the current snapshot of the table
+   * @param commitVersion the version of the commit for default row commit version assignment
+   * @param dataActions the {@link CloseableIterable} of data actions to process
+   * @return an {@link CloseableIterable} of data actions with base row IDs and default row commit
+   *     versions assigned
+   */
+  public static CloseableIterable<Row> assignBaseRowIdAndDefaultRowCommitVersion(
+      SnapshotImpl snapshot, long commitVersion, CloseableIterable<Row> dataActions) {
+    checkArgument(
+        TableFeatures.isRowTrackingSupported(snapshot.getProtocol()),
+        "Base row ID and default row commit version are assigned "
+            + "only when feature 'rowTracking' is supported.");
+
+    return new CloseableIterable<Row>() {
+      @Override
+      public void close() throws IOException {
+        dataActions.close();
+      }
+
+      @Override
+      public CloseableIterator<Row> iterator() {
+        // Used to keep track of the current high watermark as we iterate through the data actions.
+        // Use an AtomicLong to allow for updating the high watermark in the lambda.
+        final AtomicLong currRowIdHighWatermark = new AtomicLong(readRowIdHighWaterMark(snapshot));
+        return dataActions
+            .iterator()
+            .map(
+                row -> {
+                  // Non-AddFile actions are returned unchanged
+                  if (row.isNullAt(ADD_FILE_ORDINAL)) {
+                    return row;
+                  }
+
+                  AddFile addFile = new AddFile(row.getStruct(ADD_FILE_ORDINAL));
+
+                  // Assign base row ID if missing
+                  if (!addFile.getBaseRowId().isPresent()) {
+                    final long numRecords = getNumRecordsOrThrow(addFile);
+                    addFile = addFile.withNewBaseRowId(currRowIdHighWatermark.get() + 1L);
+                    currRowIdHighWatermark.addAndGet(numRecords);
+                  }
+
+                  // Assign default row commit version if missing
+                  if (!addFile.getDefaultRowCommitVersion().isPresent()) {
+                    addFile = addFile.withNewDefaultRowCommitVersion(commitVersion);
+                  }
+
+                  return SingleAction.createAddFileSingleAction(addFile.toRow());
+                });
+      }
+    };
+  }
+
+  /**
+   * Returns a {@link DomainMetadata} action if the row ID high watermark has changed due to newly
+   * processed {@link AddFile} actions. This method should be called only when the 'rowTracking'
+   * feature is supported.
+   *
+   * @param snapshot the current snapshot of the table
+   * @param dataActions the iterable of data actions that may update the high watermark
+   */
+  public static Optional<DomainMetadata> createNewHighWaterMarkIfNeeded(
+      SnapshotImpl snapshot, CloseableIterable<Row> dataActions) {
+    checkArgument(
+        TableFeatures.isRowTrackingSupported(snapshot.getProtocol()),
+        "Row ID high watermark is updated only when feature 'rowTracking' is supported.");
+
+    final long prevRowIdHighWatermark = readRowIdHighWaterMark(snapshot);
+    // Use an AtomicLong to allow for updating the high watermark in the lambda
+    final AtomicLong newRowIdHighWatermark = new AtomicLong(prevRowIdHighWatermark);
+
+    dataActions.forEach(
+        row -> {
+          if (!row.isNullAt(ADD_FILE_ORDINAL)) {
+            AddFile addFile = new AddFile(row.getStruct(ADD_FILE_ORDINAL));
+            if (!addFile.getBaseRowId().isPresent()) {
+              newRowIdHighWatermark.addAndGet(getNumRecordsOrThrow(addFile));
+            }
+          }
+        });
+
+    return (newRowIdHighWatermark.get() != prevRowIdHighWatermark)
+        ? Optional.of(new RowTrackingMetadataDomain(newRowIdHighWatermark.get()).toDomainMetadata())
+        : Optional.empty();
+  }
+
+  /**
+   * Reads the current row ID high watermark from the snapshot, or returns a default value if
+   * missing.
+   */
+  public static long readRowIdHighWaterMark(SnapshotImpl snapshot) {
+    return RowTrackingMetadataDomain.fromSnapshot(snapshot)
+        .map(RowTrackingMetadataDomain::getRowIdHighWaterMark)
+        .orElse(RowTrackingMetadataDomain.MISSING_ROW_ID_HIGH_WATERMARK);
+  }
+
+  /**
+   * Get the number of records from the AddFile's statistics. It errors out if statistics are
+   * missing.
+   */
+  private static long getNumRecordsOrThrow(AddFile addFile) {
+    return addFile.getNumRecords().orElseThrow(DeltaErrors::missingNumRecordsStatsForRowTracking);
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/RowTrackingMetadataDomain.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/rowtracking/RowTrackingMetadataDomain.java
@@ -26,6 +26,8 @@ public final class RowTrackingMetadataDomain extends JsonMetadataDomain {
 
   public static final String DOMAIN_NAME = "delta.rowTracking";
 
+  public static final long MISSING_ROW_ID_HIGH_WATERMARK = -1L;
+
   /**
    * Creates an instance of {@link RowTrackingMetadataDomain} from a JSON configuration string.
    *

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableFeaturesSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableFeaturesSuite.scala
@@ -69,16 +69,20 @@ class TableFeaturesSuite extends AnyFunSuite {
   }
 
   Seq("appendOnly", "inCommitTimestamp", "columnMapping", "typeWidening-preview", "typeWidening",
-    "domainMetadata")
-    .foreach { supportedWriterFeature =>
+    "domainMetadata", "rowTracking").foreach { supportedWriterFeature =>
     test(s"validateWriteSupported: protocol 7 with $supportedWriterFeature") {
-      checkSupported(createTestProtocol(minWriterVersion = 7, supportedWriterFeature))
+      val protocol = if (supportedWriterFeature == "rowTracking") {
+        createTestProtocol(minWriterVersion = 7, supportedWriterFeature, "domainMetadata")
+      } else {
+        createTestProtocol(minWriterVersion = 7, supportedWriterFeature)
+      }
+      checkSupported(protocol)
     }
   }
 
   Seq("invariants", "checkConstraints", "generatedColumns", "allowColumnDefaults", "changeDataFeed",
-      "identityColumns", "deletionVectors", "rowTracking", "timestampNtz",
-      "v2Checkpoint", "icebergCompatV1", "icebergCompatV2", "clustering",
+    "identityColumns", "deletionVectors", "timestampNtz", "v2Checkpoint", "icebergCompatV1",
+    "icebergCompatV2", "clustering",
       "vacuumProtocolCheck").foreach { unsupportedWriterFeature =>
     test(s"validateWriteSupported: protocol 7 with $unsupportedWriterFeature") {
       checkUnsupported(createTestProtocol(minWriterVersion = 7, unsupportedWriterFeature))

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/RowTrackingSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/RowTrackingSuite.scala
@@ -225,7 +225,7 @@ class RowTrackingSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
       }
       assert(
         e.getMessage.contains(
-          "Cannot write to a rowTracking-supported table without 'numRecord' statistics. "
+          "Cannot write to a rowTracking-supported table without 'numRecords' statistics. "
           + "Connectors are expected to populate the number of records statistics when "
           + "writing to a Delta table with 'rowTracking' table feature supported."
         )

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/RowTrackingSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/RowTrackingSuite.scala
@@ -1,0 +1,302 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults
+
+import io.delta.kernel.data.Row
+import io.delta.kernel.defaults.internal.parquet.ParquetSuiteBase
+import io.delta.kernel.engine.Engine
+import io.delta.kernel.exceptions.KernelException
+import io.delta.kernel.expressions.Literal
+import io.delta.kernel.internal.{InternalScanFileUtils, SnapshotImpl, TableImpl}
+import io.delta.kernel.internal.actions.{AddFile, Protocol, SingleAction}
+import io.delta.kernel.internal.util.Utils.toCloseableIterator
+import io.delta.kernel.internal.rowtracking.RowTrackingMetadataDomain
+import io.delta.kernel.internal.util.VectorUtils
+import io.delta.kernel.types.StructType
+import io.delta.kernel.types.LongType.LONG
+import io.delta.kernel.utils.CloseableIterable
+import io.delta.kernel.utils.CloseableIterable.{emptyIterable, inMemoryIterable}
+
+import java.util
+import java.util.{Collections, Optional}
+import scala.collection.JavaConverters._
+import scala.collection.immutable.Seq
+
+class RowTrackingSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
+  private def prepareActionsForCommit(actions: Row*): CloseableIterable[Row] = {
+    inMemoryIterable(toCloseableIterator(actions.asJava.iterator()))
+  }
+
+  private def setWriterFeatureSupported(
+      engine: Engine,
+      tablePath: String,
+      schema: StructType,
+      writerFeatures: Seq[String]): Unit = {
+    val protocol = new Protocol(
+      3, // minReaderVersion
+      7, // minWriterVersion
+      Collections.emptyList(), // readerFeatures
+      writerFeatures.asJava // writerFeatures
+    )
+    val protocolAction = SingleAction.createProtocolSingleAction(protocol.toRow)
+    val txn = createTxn(engine, tablePath, isNewTable = false, schema, Seq.empty)
+    txn.commit(engine, prepareActionsForCommit(protocolAction))
+  }
+
+  private def createTableWithRowTrackingSupported(
+      engine: Engine,
+      tablePath: String,
+      schema: StructType = testSchema): Unit = {
+    createTxn(engine, tablePath, isNewTable = true, schema, Seq.empty)
+      .commit(engine, emptyIterable())
+    setWriterFeatureSupported(engine, tablePath, schema, Seq("domainMetadata", "rowTracking"))
+  }
+
+  private def verifyBaseRowIDs(
+      engine: Engine,
+      tablePath: String,
+      expectedValue: Seq[Long]): Unit = {
+    val table = TableImpl.forPath(engine, tablePath)
+    val snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
+
+    val scanFileRows = collectScanFileRows(
+      snapshot.getScanBuilder(engine).build()
+    )
+    val sortedBaseRowIds = scanFileRows
+      .map(InternalScanFileUtils.getBaseRowId)
+      .map(_.orElse(-1))
+      .sorted
+
+    assert(sortedBaseRowIds === expectedValue)
+  }
+
+  private def verifyDefaultRowCommitVersion(
+      engine: Engine,
+      tablePath: String,
+      expectedValue: Seq[Long]) = {
+    val table = TableImpl.forPath(engine, tablePath)
+    val snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
+
+    val scanFileRows = collectScanFileRows(
+      snapshot.getScanBuilder(engine).build()
+    )
+    val sortedAddFileDefaultRowCommitVersions = scanFileRows
+      .map(InternalScanFileUtils.getDefaultRowCommitVersion)
+      .map(_.orElse(-1))
+      .sorted
+
+    assert(sortedAddFileDefaultRowCommitVersions === expectedValue)
+  }
+
+  private def verifyHighWatermark(engine: Engine, tablePath: String, expectedValue: Long): Unit = {
+    val table = TableImpl.forPath(engine, tablePath)
+    val snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
+    val rowTrackingMetadataDomain = RowTrackingMetadataDomain.fromSnapshot(snapshot)
+
+    assert(rowTrackingMetadataDomain.isPresent)
+    assert(rowTrackingMetadataDomain.get().getRowIdHighWaterMark === expectedValue)
+  }
+
+  test("Base row IDs/default row commit versions are assigned to AddFile actions") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      createTableWithRowTrackingSupported(engine, tablePath)
+
+      val dataBatch1 = generateData(testSchema, Seq.empty, Map.empty, 100, 1) // 100 rows
+      val dataBatch2 = generateData(testSchema, Seq.empty, Map.empty, 200, 1) // 200 rows
+      val dataBatch3 = generateData(testSchema, Seq.empty, Map.empty, 400, 1) // 400 rows
+
+      // Commit three files in one transaction
+      val commitVersion = appendData(
+        engine,
+        tablePath,
+        data = Seq(dataBatch1, dataBatch2, dataBatch3).map(Map.empty[String, Literal] -> _)
+      ).getVersion
+
+      verifyBaseRowIDs(engine, tablePath, Seq(0, 100, 300))
+      verifyDefaultRowCommitVersion(engine, tablePath, Seq.fill(3)(commitVersion))
+      verifyHighWatermark(engine, tablePath, 699)
+    }
+  }
+
+  test("Previous Row ID high watermark can be picked up to assign base row IDs") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      createTableWithRowTrackingSupported(engine, tablePath)
+
+      val dataBatch1 = generateData(testSchema, Seq.empty, Map.empty, 100, 1)
+      val commitVersion1 = appendData(
+        engine,
+        tablePath,
+        data = Seq(dataBatch1).map(Map.empty[String, Literal] -> _)
+      ).getVersion
+
+      verifyBaseRowIDs(engine, tablePath, Seq(0))
+      verifyDefaultRowCommitVersion(engine, tablePath, Seq(commitVersion1))
+      verifyHighWatermark(engine, tablePath, 99)
+
+      val dataBatch2 = generateData(testSchema, Seq.empty, Map.empty, 200, 1)
+      val commitVersion2 = appendData(
+        engine,
+        tablePath,
+        data = Seq(dataBatch2).map(Map.empty[String, Literal] -> _)
+      ).getVersion
+
+      verifyBaseRowIDs(engine, tablePath, Seq(0, 100))
+      verifyDefaultRowCommitVersion(engine, tablePath, Seq(commitVersion1, commitVersion2))
+      verifyHighWatermark(engine, tablePath, 299)
+    }
+  }
+
+  test("Base row IDs/default row commit versions are preserved in checkpoint") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      createTableWithRowTrackingSupported(engine, tablePath)
+
+      val dataBatch1 = generateData(testSchema, Seq.empty, Map.empty, 100, 1)
+      val dataBatch2 = generateData(testSchema, Seq.empty, Map.empty, 200, 1)
+      val dataBatch3 = generateData(testSchema, Seq.empty, Map.empty, 400, 1)
+
+      val commitVersion1 = appendData(
+        engine,
+        tablePath,
+        data = Seq(dataBatch1).map(Map.empty[String, Literal] -> _)
+      ).getVersion
+
+      val commitVersion2 = appendData(
+        engine,
+        tablePath,
+        data = Seq(dataBatch2).map(Map.empty[String, Literal] -> _)
+      ).getVersion
+
+      // Checkpoint the table
+      val table = TableImpl.forPath(engine, tablePath)
+      val latestVersion = table.getLatestSnapshot(engine).getVersion(engine)
+      table.checkpoint(engine, latestVersion)
+
+      val commitVersion3 = appendData(
+        engine,
+        tablePath,
+        data = Seq(dataBatch3).map(Map.empty[String, Literal] -> _)
+      ).getVersion
+
+      verifyBaseRowIDs(engine, tablePath, Seq(0, 100, 300))
+      verifyDefaultRowCommitVersion(
+        engine,
+        tablePath,
+        Seq(commitVersion1, commitVersion2, commitVersion3)
+      )
+      verifyHighWatermark(engine, tablePath, 699)
+    }
+  }
+
+  test("Fail if row tracking is supported but AddFile actions are missing stats") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      createTableWithRowTrackingSupported(engine, tablePath)
+
+      val addFileRow = AddFile.createAddFileRow(
+        "fakePath",
+        VectorUtils.stringStringMapValue(new util.HashMap[String, String]()),
+        0L,
+        0L,
+        false,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty() // No stats
+      )
+      val action = SingleAction.createAddFileSingleAction(addFileRow)
+      val txn = createTxn(engine, tablePath, isNewTable = false, testSchema, Seq.empty)
+
+      // KernelException thrown inside a lambda is wrapped in a RuntimeException
+      val e = intercept[RuntimeException] {
+        txn.commit(engine, prepareActionsForCommit(action))
+      }
+      assert(
+        e.getMessage.contains(
+          "Cannot write to a rowTracking-supported table without 'numRecord' statistics. "
+          + "Connectors are expected to populate the number of records statistics when "
+          + "writing to a Delta table with 'rowTracking' table feature supported."
+        )
+      )
+    }
+  }
+
+  test("Fail if row tracking is supported but domain metadata is not supported") {
+    withTempDirAndEngine((tablePath, engine) => {
+      createTxn(engine, tablePath, isNewTable = true, testSchema, Seq.empty)
+        .commit(engine, emptyIterable())
+
+      // Only 'rowTracking' is supported, not 'domainMetadata'
+      setWriterFeatureSupported(engine, tablePath, testSchema, Seq("rowTracking"))
+
+      val dataBatch1 = generateData(testSchema, Seq.empty, Map.empty, 100, 1)
+      val e = intercept[KernelException] {
+        appendData(
+          engine,
+          tablePath,
+          data = Seq(dataBatch1).map(Map.empty[String, Literal] -> _)
+        ).getVersion
+      }
+
+      assert(
+        e.getMessage
+          .contains(
+            "Feature 'rowTracking' is supported and depends on feature 'domainMetadata',"
+            + " but 'domainMetadata' is unsupported"
+          )
+      )
+    })
+  }
+
+  test("Integration test - Write table with Kernel then write with Spark") {
+    withTempDirAndEngine((tablePath, engine) => {
+      val tbl = "tbl"
+      withTable(tbl) {
+        val schema = new StructType().add("id", LONG)
+        createTableWithRowTrackingSupported(engine, tablePath, schema = schema)
+
+        // Write table using Kernel
+        val dataBatch1 = generateData(schema, Seq.empty, Map.empty, 100, 1) // 100 rows
+        val dataBatch2 = generateData(schema, Seq.empty, Map.empty, 200, 1) // 200 rows
+        val dataBatch3 = generateData(schema, Seq.empty, Map.empty, 400, 1) // 400 rows
+        appendData(
+          engine,
+          tablePath,
+          schema = schema,
+          data = Seq(dataBatch1, dataBatch2, dataBatch3).map(Map.empty[String, Literal] -> _)
+        ).getVersion // version 2
+
+        // Verify the table state
+        verifyBaseRowIDs(engine, tablePath, Seq(0, 100, 300))
+        verifyDefaultRowCommitVersion(engine, tablePath, Seq(2, 2, 2))
+        verifyHighWatermark(engine, tablePath, 699)
+
+        // Write 20, 80 rows to the table using Spark
+        spark.range(0, 20).write.format("delta").mode("append").save(tablePath) // version 3
+        spark.range(20, 100).write.format("delta").mode("append").save(tablePath) // version 4
+
+        // Verify the table state
+        verifyBaseRowIDs(engine, tablePath, Seq(0, 100, 300, 700, 720))
+        verifyDefaultRowCommitVersion(engine, tablePath, Seq(2, 2, 2, 3, 4))
+        verifyHighWatermark(engine, tablePath, 799)
+      }
+    })
+  }
+
+  test("Integration test - Write table with Spark then write with Kernel") {
+    // TODO: Implement this test. Creating and writing a table using Spark with row tracking also
+    //  enables the 'invariants' feature, which is not yet supported by the Kernel.
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


This PR implements the row tracking _support_ requirements in Delta Kernel, according to the [Delta Protocol](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#row-tracking). Specifically, it includes:

- assigning `baseRowId` and `defaultRowCommitVersion` to `AddFile` actions prior to committing them
- maintaining the `rowIdHighWaterMark` of the `delta.rowTracking` metadata domain during the base row ID assignment, which is the highest assigned fresh row id for the table

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Added tests in `RowTrackingSuite.scala`. This includes unit tests and integration tests with Delta-Spark.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.