### PR TITLE
Replace spark.implicits import

### DIFF
--- a/connectors/sql-delta-import/src/main/scala/JDBCImport.scala
+++ b/connectors/sql-delta-import/src/main/scala/JDBCImport.scala
@@ -51,7 +51,7 @@ class JDBCImport(jdbcUrl: String,
                  dataTransform: DataTransforms)
                 (implicit val spark: SparkSession) {
 
-  import org.apache.spark.sql.delta.implicits._
+  import com.databricks.sql.transaction.tahoe.implicits._
 
   implicit def mapToProperties(m: Map[String, String]): Properties = {
     val properties = new Properties()

--- a/connectors/sql-delta-import/src/main/scala/JDBCImport.scala
+++ b/connectors/sql-delta-import/src/main/scala/JDBCImport.scala
@@ -51,7 +51,7 @@ class JDBCImport(jdbcUrl: String,
                  dataTransform: DataTransforms)
                 (implicit val spark: SparkSession) {
 
-  import spark.implicits._
+  import org.apache.spark.sql.delta.implicits._
 
   implicit def mapToProperties(m: Map[String, String]): Properties = {
     val properties = new Properties()


### PR DESCRIPTION

#### Which Delta project/connector is this regarding?

- [X ] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

This PR replaces the import of `spark.implicits._` with that from `org.apache.spark.sql.delta.implicits._`
This change is to confirm with best practice.

## How was this patch tested?

Existing tests should suffice.

## Does this PR introduce _any_ user-facing changes?

No.