### PR TITLE
[Spark] Fix dependent constraints/generated columns checker for type widening

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -78,7 +78,7 @@ trait AlterDeltaTableCommand extends DeltaCommand {
   protected def checkDependentExpressions(
       sparkSession: SparkSession,
       columnParts: Seq[String],
-      newMetadata: actions.Metadata,
+      oldMetadata: actions.Metadata,
       protocol: Protocol): Unit = {
     if (!sparkSession.sessionState.conf.getConf(
       DeltaSQLConf.DELTA_ALTER_TABLE_CHANGE_COLUMN_CHECK_EXPRESSIONS)) {
@@ -86,14 +86,14 @@ trait AlterDeltaTableCommand extends DeltaCommand {
     }
     // check if the column to change is referenced by check constraints
     val dependentConstraints =
-      Constraints.findDependentConstraints(sparkSession, columnParts, newMetadata)
+      Constraints.findDependentConstraints(sparkSession, columnParts, oldMetadata)
     if (dependentConstraints.nonEmpty) {
       throw DeltaErrors.foundViolatingConstraintsForColumnChange(
         UnresolvedAttribute(columnParts).name, dependentConstraints)
     }
     // check if the column to change is referenced by any generated columns
     val dependentGenCols = SchemaUtils.findDependentGeneratedColumns(
-      sparkSession, columnParts, protocol, newMetadata.schema)
+      sparkSession, columnParts, protocol, oldMetadata.schema)
     if (dependentGenCols.nonEmpty) {
       throw DeltaErrors.foundViolatingGeneratedColumnsForColumnChange(
         UnresolvedAttribute(columnParts).name, dependentGenCols)
@@ -768,7 +768,7 @@ case class AlterTableDropColumnsDeltaCommand(
         configuration = newConfiguration
       )
       columnsToDrop.foreach { columnParts =>
-        checkDependentExpressions(sparkSession, columnParts, newMetadata, txn.protocol)
+        checkDependentExpressions(sparkSession, columnParts, metadata, txn.protocol)
       }
 
       txn.updateMetadata(newMetadata)
@@ -927,7 +927,7 @@ case class AlterTableChangeColumnDeltaCommand(
       if (newColumn.name != columnName) {
         // need to validate the changes if the column is renamed
         checkDependentExpressions(
-          sparkSession, columnPath :+ columnName, newMetadata, txn.protocol)
+          sparkSession, columnPath :+ columnName, metadata, txn.protocol)
       }
 
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/constraints/Constraints.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/constraints/Constraints.scala
@@ -106,7 +106,11 @@ object Constraints {
     metadata.configuration.filter {
       case (key, constraint) if key.toLowerCase(Locale.ROOT).startsWith("delta.constraints.") =>
         SchemaUtils.containsDependentExpression(
-          sparkSession, columnName, constraint, sparkSession.sessionState.conf.resolver)
+          sparkSession,
+          columnName,
+          constraint,
+          metadata.schema,
+          sparkSession.sessionState.conf.resolver)
       case _ => false
     }
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1580,6 +1580,21 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
+  val DELTA_CHANGE_COLUMN_CHECK_DEPENDENT_EXPRESSIONS_USE_V2 =
+    buildConf("changeColumn.checkDependentExpressionsUseV2")
+      .internal()
+      .doc(
+        """
+          |More accurate implementation of checker for altering/renaming/dropping columns
+          |that might be referenced by constraints or generation rules.
+          |It respects nested arrays and maps, unlike the V1 checker.
+          |
+          |This is a safety switch - we should only turn this off when there is an issue with
+          |expression checking logic that prevents a valid column change from going through.
+          |""".stripMargin)
+      .booleanConf
+      .createWithDefault(true)
+
   val DELTA_ALTER_TABLE_DROP_COLUMN_ENABLED =
     buildConf("alterTable.dropColumn.enabled")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningConstraintsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningConstraintsSuite.scala
@@ -20,6 +20,7 @@ import org.apache.spark.sql.delta.DeltaAnalysisException
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 
 import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types._
 
 /**
@@ -93,6 +94,39 @@ trait TypeWideningConstraintsTests { self: QueryTest with TypeWideningTestMixin 
       // Changing the type of a.y is allowed since it's not referenced by the CHECK constraint.
       sql("ALTER TABLE t CHANGE COLUMN a.y TYPE SMALLINT")
       checkAnswer(sql("SELECT * FROM t"), Row(Row(2, 3)))
+    }
+  }
+
+  test("check constraint on arrays and maps with type change") {
+    withTable("t") {
+      sql("CREATE TABLE t (m map<byte, byte>, a array<byte>) USING DELTA")
+      sql("INSERT INTO t VALUES (map(1, 2, 7, -3), array(1, -2, 3))")
+
+      sql("ALTER TABLE t CHANGE COLUMN a.element TYPE SMALLINT")
+      sql("ALTER TABLE t ADD CONSTRAINT ch1 CHECK (hash(a[1]) = -1160545675)")
+      checkError(
+        intercept[DeltaAnalysisException] {
+          sql("ALTER TABLE t CHANGE COLUMN a.element TYPE INTEGER")
+        },
+        "DELTA_CONSTRAINT_DEPENDENT_COLUMN_CHANGE",
+        parameters = Map(
+          "columnName" -> "a.element",
+          "constraints" -> "delta.constraints.ch1 -> hash ( a [ 1 ] ) = - 1160545675"
+        )
+      )
+
+      sql("ALTER TABLE t CHANGE COLUMN m.value TYPE SMALLINT")
+      sql("ALTER TABLE t ADD CONSTRAINT ch2 CHECK (sign(m[7]) < 0)")
+      checkError(
+        intercept[DeltaAnalysisException] {
+          sql("ALTER TABLE t CHANGE COLUMN m.value TYPE INTEGER")
+        },
+        "DELTA_CONSTRAINT_DEPENDENT_COLUMN_CHANGE",
+        parameters = Map(
+          "columnName" -> "m.value",
+          "constraints" -> "delta.constraints.ch2 -> sign ( m [ 7 ] ) < 0"
+        )
+      )
     }
   }
 
@@ -185,6 +219,49 @@ trait TypeWideningConstraintsTests { self: QueryTest with TypeWideningTestMixin 
             |""".stripMargin
         )
         checkAnswer(sql("SELECT hash(a.x.z) FROM t"), Seq(Row(1765031574), Row(1765031574)))
+      }
+    }
+  }
+
+  test("check constraint on arrays and maps with type evolution") {
+    withTable("t") {
+      sql("CREATE TABLE t (s struct<arr array<map<byte, byte>>>) USING DELTA")
+      sql("ALTER TABLE t ADD CONSTRAINT ck CHECK (s.arr[0][3] = 3)")
+      sql("INSERT INTO t(s) VALUES (struct(struct(array(map(1, 1, 3, 3)))))")
+      checkAnswer(sql("SELECT s.arr[0][3] FROM t"), Row(3))
+
+      withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true") {
+        // Insert by name is not supported by type evolution.
+        checkError(
+          intercept[DeltaAnalysisException] {
+            // Migrate map's key to int type.
+            spark.createDataFrame(Seq(Tuple1(Tuple1(Array(Map(999999 -> 1, 3 -> 3))))))
+              .toDF("s").withColumn("s", col("s").cast("struct<arr:array<map<int,tinyint>>>"))
+              .write.format("delta").mode("append").saveAsTable("t")
+          },
+          "DELTA_CONSTRAINT_DATA_TYPE_MISMATCH",
+          parameters = Map(
+            "columnName" -> "s.arr.element.key",
+            "columnType" -> "TINYINT",
+            "dataType" -> "INT",
+            "constraints" -> "delta.constraints.ck -> s . arr [ 0 ] [ 3 ] = 3"
+          )
+        )
+        checkError(
+          intercept[DeltaAnalysisException] {
+            // Migrate map's value to int type.
+            spark.createDataFrame(Seq(Tuple1(Tuple1(Array(Map(1 -> 999999, 3 -> 3))))))
+              .toDF("s").withColumn("s", col("s").cast("struct<arr:array<map<tinyint,int>>>"))
+              .write.format("delta").mode("append").saveAsTable("t")
+          },
+          "DELTA_CONSTRAINT_DATA_TYPE_MISMATCH",
+          parameters = Map(
+            "columnName" -> "s.arr.element.value",
+            "columnType" -> "TINYINT",
+            "dataType" -> "INT",
+            "constraints" -> "delta.constraints.ck -> s . arr [ 0 ] [ 3 ] = 3"
+          )
+        )
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
The current checker of dependent expressions doesn't validate changes for array and map types. For example, usage of type widening could lead to constraints breaks:
```
scala> sql("CREATE TABLE table (a array<byte>) USING DELTA")
scala> sql("INSERT INTO table VALUES (array(1, -2, 3))")
scala> sql("SELECT hash(a[1]) FROM table").show()
+-----------+
| hash(a[1])|
+-----------+
|-1160545675|
+-----------+

scala> sql("ALTER TABLE table ADD CONSTRAINT ch1 CHECK (hash(a[1]) = -1160545675)")
scala> sql("ALTER TABLE table SET TBLPROPERTIES('delta.enableTypeWidening' = true)")
scala> sql("ALTER TABLE table CHANGE COLUMN a.element TYPE BIGINT")
scala> sql("SELECT hash(a[1]) FROM table").show()
+----------+
|hash(a[1])|
+----------+
|-981642528|
+----------+

scala> sql("INSERT INTO table VALUES (array(1, -2, 3))")
24/11/15 12:53:23 ERROR Utils: Aborting task
com.databricks.sql.transaction.tahoe.schema.DeltaInvariantViolationException: [DELTA_VIOLATE_CONSTRAINT_WITH_VALUES] CHECK constraint ch1 (hash(a[1]) = -1160545675) violated by row with values:
```
The proposed algorithm is more strict and regards maps, arrays and structs during constraints/generated columns dependencies.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Added new tests for constraints and generated columns used with type widening feature.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
Due to strictness of the algorithm new potential dangerous type changes will be prohibited. An exception will be thrown in the example above.
But such changes are called in the schema evolution feature mostly that was introduced recently, so it should not affect many users.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
