### PR TITLE
[SPARK] Rewrite GENERATE SYMLINK MANIFEST command to use Spark table resolution

### DIFF
--- a/project/SparkMimaExcludes.scala
+++ b/project/SparkMimaExcludes.scala
@@ -27,6 +27,7 @@ object SparkMimaExcludes {
       ProblemFilters.exclude[Problem]("io.delta.sql.parser.*"),
       ProblemFilters.exclude[Problem]("io.delta.tables.execution.*"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("io.delta.tables.DeltaTable.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("io.delta.tables.DeltaTable.executeGenerate"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("io.delta.tables.DeltaTable.executeHistory"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("io.delta.tables.DeltaTable.executeVacuum"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("io.delta.tables.DeltaTable.this"),

--- a/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
+++ b/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
@@ -453,9 +453,8 @@ class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
 
   override def visitGenerate(ctx: GenerateContext): LogicalPlan = withOrigin(ctx) {
     DeltaGenerateCommand(
-      modeName = ctx.modeName.getText,
-      tableId = visitTableIdentifier(ctx.table),
-      Map.empty)
+      UnresolvedTable(visitTableIdentifier(ctx.table).nameParts, DeltaGenerateCommand.COMMAND_NAME),
+      modeName = ctx.modeName.getText)
   }
 
   override def visitConvert(ctx: ConvertContext): LogicalPlan = withOrigin(ctx) {

--- a/spark/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/spark/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -159,8 +159,7 @@ class DeltaTable private[tables](
    * @since 0.5.0
    */
   def generate(mode: String): Unit = {
-    val tableId = table.tableIdentifier.getOrElse(s"delta.`${deltaLog.dataPath.toString}`")
-    executeGenerate(tableId, mode)
+    executeGenerate(deltaLog.dataPath.toString, table.getTableIdentifierIfExists, mode)
   }
 
   /**

--- a/spark/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
+++ b/spark/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
@@ -28,7 +28,8 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.{functions, Column, DataFrame}
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedRelation}
+import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedRelation, UnresolvedTable}
+import org.apache.spark.sql.catalyst.analysis.UnresolvedTableImplicits._
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.connector.catalog.Identifier
@@ -63,15 +64,13 @@ trait DeltaTableOperations extends AnalysisHelper { self: io.delta.tables.DeltaT
     toDataset(sparkSession, details)
   }
 
-  protected def executeGenerate(tblIdentifier: String, mode: String): Unit =
-    withActiveSession(sparkSession) {
-      val tableId: TableIdentifier = sparkSession
-        .sessionState
-        .sqlParser
-        .parseTableIdentifier(tblIdentifier)
-      val generate = DeltaGenerateCommand(mode, tableId, self.deltaLog.options)
-      toDataset(sparkSession, generate)
-    }
+  protected def executeGenerate(
+      path: String,
+      tableIdentifier: Option[TableIdentifier],
+      mode: String): Unit = withActiveSession(sparkSession) {
+    val generate = DeltaGenerateCommand(Option(path), tableIdentifier, mode, self.deltaLog.options)
+    toDataset(sparkSession, generate)
+  }
 
   protected def executeUpdate(
       set: Map[String, Column],

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -700,14 +700,21 @@ object UnresolvedDeltaPathOrIdentifier {
   def apply(
       path: Option[String],
       tableIdentifier: Option[TableIdentifier],
+      options: Map[String, String],
       cmd: String): LogicalPlan = {
     (path, tableIdentifier) match {
-      case (Some(p), None) => UnresolvedPathBasedDeltaTable(p, Map.empty, cmd)
+      case (Some(p), None) => UnresolvedPathBasedDeltaTable(p, options, cmd)
       case (None, Some(t)) => UnresolvedTable(t.nameParts, cmd)
       case _ => throw new IllegalArgumentException(
         s"Exactly one of path or tableIdentifier must be provided to $cmd")
     }
   }
+
+  def apply(
+      path: Option[String],
+      tableIdentifier: Option[TableIdentifier],
+      cmd: String): LogicalPlan =
+    this(path, tableIdentifier, Map.empty, cmd)
 }
 
 /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaGenerateCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DeltaGenerateCommand.scala
@@ -17,50 +17,59 @@
 package org.apache.spark.sql.delta.commands
 
 // scalastyle:off import.ordering.noEmptyLine
-import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, DeltaTableIdentifier}
+import org.apache.spark.sql.delta.{DeltaErrors, DeltaLog, UnresolvedDeltaPathOrIdentifier}
 import org.apache.spark.sql.delta.hooks.GenerateSymlinkManifest
-import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, UnaryNode}
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
-import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.command.RunnableCommand
 
-case class DeltaGenerateCommand(
-    modeName: String,
-    tableId: TableIdentifier,
-    options: Map[String, String])
-  extends LeafRunnableCommand {
+case class DeltaGenerateCommand(override val child: LogicalPlan, modeName: String)
+  extends RunnableCommand
+  with UnaryNode
+  with DeltaCommand {
 
   import DeltaGenerateCommand._
+
+  override def withNewChildInternal(newChild: LogicalPlan): LogicalPlan = copy(child = newChild)
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     if (!modeNameToGenerationFunc.contains(modeName)) {
       throw DeltaErrors.unsupportedGenerateModeException(modeName)
     }
-
-    val deltaLog = DeltaTableIdentifier(sparkSession, tableId) match {
-      case Some(id) if id.path.isDefined =>
-        DeltaLog.forTable(sparkSession, new Path(id.path.get), options)
-      case _ =>
-        DeltaLog.forTable(
-          sparkSession,
-          sparkSession.sessionState.catalog.getTableMetadata(tableId),
-          options)
-    }
-
-    if (!deltaLog.tableExists) {
-      throw DeltaErrors.notADeltaTableException("GENERATE")
-    }
     val generationFunc = modeNameToGenerationFunc(modeName)
-    generationFunc(sparkSession, deltaLog)
+    val table = getDeltaTable(child, COMMAND_NAME)
+    generationFunc(sparkSession, table.deltaLog, table.catalogTable)
     Seq.empty
   }
 }
 
 object DeltaGenerateCommand {
-  val modeNameToGenerationFunc = CaseInsensitiveMap(
-    Map[String, (SparkSession, DeltaLog) => Unit](
-    "symlink_format_manifest" -> GenerateSymlinkManifest.generateFullManifest
-  ))
+  val modeNameToGenerationFunc
+      : CaseInsensitiveMap[(SparkSession, DeltaLog, Option[CatalogTable]) => Unit] =
+    CaseInsensitiveMap(
+      Map[String, (SparkSession, DeltaLog, Option[CatalogTable]) => Unit](
+        "symlink_format_manifest" -> GenerateSymlinkManifest.generateFullManifest
+      )
+    )
+
+  val COMMAND_NAME = "GENERATE"
+
+  def apply(
+    path: Option[String],
+    tableIdentifier: Option[TableIdentifier],
+    modeName: String,
+    options: Map[String, String]
+  ): DeltaGenerateCommand = {
+    // Exactly one of path or tableIdentifier should be specified
+    val plan = UnresolvedDeltaPathOrIdentifier(
+      path.filter(_ => tableIdentifier.isEmpty),
+      tableIdentifier,
+      options,
+      COMMAND_NAME)
+    DeltaGenerateCommand(plan, modeName)
+  }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/hooks/GenerateSymlinkManifest.scala
@@ -32,7 +32,7 @@ import org.apache.spark.SparkEnv
 import org.apache.spark.internal.MDC
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
-import org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils
+import org.apache.spark.sql.catalyst.catalog.{CatalogTable, ExternalCatalogUtils}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Cast, Concat, Expression, Literal, ScalaUDF}
 import org.apache.spark.sql.execution.datasources.InMemoryFileIndex
@@ -74,8 +74,7 @@ trait GenerateSymlinkManifestImpl extends PostCommitHook with DeltaLogging with 
       committedVersion: Long,
       postCommitSnapshot: Snapshot,
       committedActions: Seq[Action]): Unit = {
-    generateIncrementalManifest(
-      spark, txn.deltaLog, txn.snapshot, postCommitSnapshot, committedActions)
+    generateIncrementalManifest(spark, txn, postCommitSnapshot, committedActions)
   }
 
   override def handleError(spark: SparkSession, error: Throwable, version: Long): Unit = {
@@ -93,21 +92,21 @@ trait GenerateSymlinkManifestImpl extends PostCommitHook with DeltaLogging with 
    */
   protected def generateIncrementalManifest(
       spark: SparkSession,
-      deltaLog: DeltaLog,
-      txnReadSnapshot: Snapshot,
+      txn: OptimisticTransactionImpl,
       currentSnapshot: Snapshot,
-      actions: Seq[Action]): Unit = recordManifestGeneration(deltaLog, full = false) {
+      actions: Seq[Action]): Unit = recordManifestGeneration(txn.deltaLog, full = false) {
 
     import org.apache.spark.sql.delta.implicits._
 
     checkColumnMappingMode(currentSnapshot.metadata)
 
+    val deltaLog = txn.deltaLog
     val partitionCols = currentSnapshot.metadata.partitionColumns
     val manifestRootDirPath = new Path(deltaLog.dataPath, MANIFEST_LOCATION)
     val hadoopConf = new SerializableConfiguration(deltaLog.newDeltaHadoopConf())
     val fs = deltaLog.dataPath.getFileSystem(hadoopConf.value)
     if (!fs.exists(manifestRootDirPath)) {
-      generateFullManifest(spark, deltaLog)
+      generateFullManifest(spark, deltaLog, txn.catalogTable)
       return
     }
 
@@ -120,7 +119,7 @@ trait GenerateSymlinkManifestImpl extends PostCommitHook with DeltaLogging with 
       val removedFileNames =
         spark.createDataset(actions.collect { case r: RemoveFile => r.path }).toDF("path")
       val partitionValuesOfRemovedFiles =
-        txnReadSnapshot.allFiles.join(removedFileNames, "path").select("partitionValues").persist()
+        txn.snapshot.allFiles.join(removedFileNames, "path").select("partitionValues").persist()
       try {
         val partitionsOfRemovedFiles = partitionValuesOfRemovedFiles
           .as[Map[String, String]](GenerateSymlinkManifestUtils.mapEncoder).collect().toSet
@@ -180,8 +179,9 @@ trait GenerateSymlinkManifestImpl extends PostCommitHook with DeltaLogging with 
    */
   def generateFullManifest(
       spark: SparkSession,
-      deltaLog: DeltaLog): Unit = {
-    val snapshot = deltaLog.update(stalenessAcceptable = false)
+      deltaLog: DeltaLog,
+      catalogTableOpt: Option[CatalogTable]): Unit = {
+    val snapshot = deltaLog.update(catalogTableOpt = catalogTableOpt)
     assertTableIsDVFree(spark, snapshot)
     generateFullManifestWithSnapshot(spark, deltaLog, snapshot)
   }

--- a/spark/src/test/scala-spark-3.5/shims/DeltaGenerateSymlinkManifestSuiteShims.scala
+++ b/spark/src/test/scala-spark-3.5/shims/DeltaGenerateSymlinkManifestSuiteShims.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+object DeltaGenerateSymlinkManifestSuiteShims {
+  val FAILS_ON_TEMP_VIEWS_ERROR_MSG = "v is a temp view. 'GENERATE' expects a table"
+}

--- a/spark/src/test/scala-spark-master/shims/DeltaGenerateSymlinkManifestSuiteShims.scala
+++ b/spark/src/test/scala-spark-master/shims/DeltaGenerateSymlinkManifestSuiteShims.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+object DeltaGenerateSymlinkManifestSuiteShims {
+  val FAILS_ON_TEMP_VIEWS_ERROR_MSG = "'GENERATE' expects a table but `v` is a view."
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaGenerateSymlinkManifestSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaGenerateSymlinkManifestSuite.scala
@@ -20,6 +20,7 @@ import java.io.File
 import java.net.URI
 
 // scalastyle:off import.ordering.noEmptyLine
+import org.apache.spark.sql.delta.DeltaGenerateSymlinkManifestSuiteShims._
 import org.apache.spark.sql.delta.DeltaOperations.Delete
 import org.apache.spark.sql.delta.commands.DeltaGenerateCommand
 import org.apache.spark.sql.delta.hooks.GenerateSymlinkManifest
@@ -100,16 +101,14 @@ trait DeltaGenerateSymlinkManifestSuiteBase extends QueryTest
         spark.sql(s"GENERATE symlink_format_manifest FOR TABLE delta.`$dir`")
       }
 
-      assert(e.getMessage.contains("not found") ||
-        e.getMessage.contains("only supported for Delta"))
+      assert(e.getMessage.contains("is not a Delta table"))
 
       spark.range(2).write.format("parquet").mode("overwrite").save(dir.toString)
 
       e = intercept[AnalysisException] {
         spark.sql(s"GENERATE symlink_format_manifest FOR TABLE delta.`$dir`")
       }
-      assert(e.getMessage.contains("table not found") ||
-        e.getMessage.contains("only supported for Delta"))
+      assert(e.getMessage.contains("is not a Delta table"))
 
       e = intercept[AnalysisException] {
         spark.sql(s"GENERATE symlink_format_manifest FOR TABLE parquet.`$dir`")
@@ -125,7 +124,7 @@ trait DeltaGenerateSymlinkManifestSuiteBase extends QueryTest
       val e = intercept[AnalysisException] {
         spark.sql(s"GENERATE symlink_format_manifest FOR TABLE v")
       }
-      assert(e.getMessage.contains("not found") || e.getMessage.contains("cannot be found"))
+      assert(e.getMessage.contains(FAILS_ON_TEMP_VIEWS_ERROR_MSG))
     }
   }
 
@@ -771,7 +770,7 @@ trait DeltaGenerateSymlinkManifestSuiteBase extends QueryTest
 
   protected def generateSymlinkManifest(tablePath: String): Unit = {
     val deltaLog = DeltaLog.forTable(spark, tablePath)
-    GenerateSymlinkManifest.generateFullManifest(spark, deltaLog)
+    GenerateSymlinkManifest.generateFullManifest(spark, deltaLog, catalogTableOpt = None)
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR rewrites the GENERATE SYMLINK MANIFEST command (`DeltaGenerateCommand`) to use Spark's table resolution mechanism. It is replaced to be a `UnaryRunnableCommand` that takes in a child logical plan, which is initially an unresolved table. The table is then resolved by Spark's resolution mechanism, resulting in a `DeltaTableV2` object.

With this object, we also have a catalog table which is passed down into `generateFulllManifest` as part of the effort to pass the catalog table to DeltaLog API's call sites.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

unit tests

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No
