### PR TITLE
[Spark] Add support for dropping the CheckpointProtection table feature

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -967,10 +967,32 @@
     ],
     "sqlState" : "0AKDE"
   },
+  "DELTA_FEATURE_CAN_ONLY_DROP_CHECKPOINT_PROTECTION_WITH_HISTORY_TRUNCATION" : {
+    "message" : [
+      "Could not drop the Checkpoint Protection feature.",
+      "This feature can only be dropped by truncating history.",
+      "Please try again with the TRUNCATE HISTORY option:",
+      "",
+      "    ALTER TABLE table_name DROP FEATURE checkpointProtection TRUNCATE HISTORY"
+    ],
+    "sqlState" : "55000"
+  },
   "DELTA_FEATURE_DROP_CHECKPOINT_FAILED" : {
     "message" : [
       "Dropping <featureName> failed due to a failure in checkpoint creation.",
       "Please try again later. It the issue persists, contact support."
+    ],
+    "sqlState" : "22KD0"
+  },
+  "DELTA_FEATURE_DROP_CHECKPOINT_PROTECTION_WAIT_FOR_RETENTION_PERIOD" : {
+    "message" : [
+      "The operation did not succeed because there are still traces of dropped features ",
+      "in the table history. CheckpointProtection cannot be dropped until these historical",
+      "versions have expired.",
+      "",
+      "To drop CheckpointProtection, please wait for the historical versions to",
+      "expire, and then repeat this command. The retention period for historical versions is",
+      "currently configured to <truncateHistoryLogRetentionPeriod>."
     ],
     "sqlState" : "22KD0"
   },

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ConflictChecker.scala
@@ -272,7 +272,7 @@ private[delta] class ConflictChecker(
           case m: Metadata if m != currentTransactionInfo.metadata =>
             recordDeltaEvent(
               deltaLog = currentTransactionInfo.readSnapshot.deltaLog,
-              opType = "dropFeature.conflictCheck.metadataMissmatch",
+              opType = "dropFeature.conflictCheck.metadataMismatch",
               data = Map(
                 "transactionInfoMetadata" -> currentTransactionInfo.metadata,
                 "actionMetadata" -> m))

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -2385,6 +2385,14 @@ trait DeltaErrorsBase
     )
   }
 
+  def dropCheckpointProtectionWaitForRetentionPeriod(
+      metadata: Metadata): DeltaTableFeatureException = {
+    val config = logRetentionConfig(metadata)
+    new DeltaTableFeatureException(
+      errorClass = "DELTA_FEATURE_DROP_CHECKPOINT_PROTECTION_WAIT_FOR_RETENTION_PERIOD",
+      messageParameters = Array(config.truncateHistoryRetention))
+  }
+
   def tableFeatureDropHistoryTruncationNotAllowed(): DeltaTableFeatureException = {
     new DeltaTableFeatureException(
       errorClass = "DELTA_FEATURE_DROP_HISTORY_TRUNCATION_NOT_ALLOWED",
@@ -2441,6 +2449,11 @@ trait DeltaErrorsBase
       messageParameters = Array(featureName))
   }
 
+  def canOnlyDropCheckpointProtectionWithHistoryTruncationException: DeltaTableFeatureException = {
+    new DeltaTableFeatureException(
+      errorClass = "DELTA_FEATURE_CAN_ONLY_DROP_CHECKPOINT_PROTECTION_WITH_HISTORY_TRUNCATION",
+      messageParameters = Array.empty)
+  }
   def concurrentAppendException(
       conflictingCommit: Option[CommitInfo],
       partition: String,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -19,10 +19,13 @@ package org.apache.spark.sql.delta.actions
 import java.util.Locale
 
 import scala.collection.mutable
+import scala.util.control.NonFatal
 
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.DeltaOperations.Operation
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils.TABLE_FEATURES_MIN_WRITER_VERSION
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
+import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import com.fasterxml.jackson.annotation.JsonIgnore
 
@@ -504,4 +507,73 @@ object TableFeatureProtocolUtils {
    */
   def minimumRequiredVersions(features: Seq[TableFeature]): (Int, Int) =
     ((features.map(_.minReaderVersion) :+ 1).max, (features.map(_.minWriterVersion) :+ 1).max)
+}
+
+object DropTableFeatureUtils extends DeltaLogging {
+  private val MAX_CHECKPOINT_RETRIES = 3
+
+  /**
+   * Helper function for creating checkpoints. If checkpoint creation fails we retry up
+   * to [[MAX_CHECKPOINT_RETRIES]] times.
+   *
+   * @param snapshotRefreshStartTimeTs The timestamp to use as a starting point for refreshing
+   *                                   the snapshot. This value is used to improve the performance
+   *                                   of the snapshot refresh operation.
+   */
+  def createCheckpointWithRetries(
+      table: DeltaTableV2,
+      snapshotRefreshStartTimeTs: Long): Boolean = {
+    val log = table.deltaLog
+    val snapshot = log.update(checkIfUpdatedSinceTs = Some(snapshotRefreshStartTimeTs))
+
+    def checkpointAndVerify(snapshot: Snapshot): Boolean = {
+      try {
+        log.checkpoint(snapshot)
+        val upperBoundVersion = Some(CheckpointInstance(version = snapshot.version + 1))
+        val lastVerifiedCheckpoint = log.findLastCompleteCheckpointBefore(upperBoundVersion)
+        lastVerifiedCheckpoint.exists(_.version == snapshot.version)
+      } catch {
+        case NonFatal(e) =>
+          recordDeltaEvent(
+            deltaLog = log,
+            opType = "dropFeature.checkpointAndVerify.error",
+            data = Map(
+              "message" -> e.getMessage,
+              "stackTrace" -> e.getStackTrace().mkString("\n")))
+          false
+      }
+    }
+
+    (1 to MAX_CHECKPOINT_RETRIES).collectFirst {
+      case _ if checkpointAndVerify(snapshot) => true
+    }.getOrElse(false)
+  }
+
+  def createEmptyCommitAndCheckpoint(
+      table: DeltaTableV2,
+      snapshotRefreshStartTs: Long,
+      retryOnFailure: Boolean = false): Boolean = {
+    val log = table.deltaLog
+    val snapshot = log.update(checkIfUpdatedSinceTs = Some(snapshotRefreshStartTs))
+    val emptyCommitTS = System.nanoTime()
+    log.startTransaction(table.catalogTable, Some(snapshot))
+      .commit(Nil, DeltaOperations.EmptyCommit)
+
+    // retryOnFailure is temporary to avoid affecting the behavior of the legacy Drop Feature
+    // command behavior.
+    if (retryOnFailure) {
+      createCheckpointWithRetries(table, emptyCommitTS)
+    } else {
+      log.checkpoint(log.update(checkIfUpdatedSinceTs = Some(emptyCommitTS)))
+      true
+    }
+  }
+
+  def truncateHistoryLogRetentionMillis(metadata: Metadata): Long = {
+    val truncateHistoryLogRetention = DeltaConfigs
+      .TABLE_FEATURE_DROP_TRUNCATE_HISTORY_LOG_RETENTION
+      .fromMetaData(metadata)
+
+    DeltaConfigs.getMilliSeconds(truncateHistoryLogRetention)
+  }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -308,80 +308,9 @@ case class AlterTableDropFeatureDeltaCommand(
   extends LeafRunnableCommand
   with AlterDeltaTableCommand
   with IgnoreCachedData {
+  import org.apache.spark.sql.delta.actions.DropTableFeatureUtils._
 
-
-  val MAX_CHECKPOINT_RETRIES = 3
-  val NUMBER_OF_BARRIER_CHECKPOINTS = 3
-
-  /**
-   * Helper function for creating checkpoints. If checkpoint creation fails we retry up
-   * to [[MAX_CHECKPOINT_RETRIES]] times.
-   *
-   * @param snapshotRefreshStartTimeTs The timestamp to use as a starting point for refreshing
-   *                                   the snapshot. This value is used to improve the performance
-   *                                   of the snapshot refresh operation.
-   */
-  private def createCheckpointWithRetries(snapshotRefreshStartTimeTs: Long): Boolean = {
-    val log = table.deltaLog
-    val snapshot = log.update(
-      checkIfUpdatedSinceTs = Some(snapshotRefreshStartTimeTs),
-      catalogTableOpt = table.catalogTable)
-
-    def checkpointAndVerify(snapshot: Snapshot): Boolean = {
-      try {
-        log.checkpoint(snapshot)
-        val upperBoundVersion = Some(CheckpointInstance(version = snapshot.version + 1))
-        val lastVerifiedCheckpoint = log.findLastCompleteCheckpointBefore(upperBoundVersion)
-        lastVerifiedCheckpoint.exists(_.version == snapshot.version)
-      } catch {
-        case NonFatal(e) =>
-          recordDeltaEvent(
-            deltaLog = log,
-            opType = "dropFeature.checkpointAndVerify.error",
-            data = Map(
-              "message" -> e.getMessage,
-              "stackTrace" -> e.getStackTrace().mkString("\n")))
-          false
-      }
-    }
-
-    (1 to MAX_CHECKPOINT_RETRIES).collectFirst {
-      case _ if checkpointAndVerify(snapshot) => true
-    }.getOrElse(false)
-  }
-
-  private def createEmptyCommitAndCheckpoint(
-      snapshotRefreshStartTs: Long,
-      retryOnFailure: Boolean = false): Boolean = {
-    val log = table.deltaLog
-    val snapshot = log.update(
-      checkIfUpdatedSinceTs = Some(snapshotRefreshStartTs),
-      catalogTableOpt = table.catalogTable)
-    val emptyCommitTS = System.nanoTime()
-    table.startTransaction(Some(snapshot))
-      .commit(Nil, DeltaOperations.EmptyCommit)
-
-    // retryOnFailure is temporary to avoid affecting the behavior of the legacy Drop Feature
-    // command behavior.
-    if (retryOnFailure) {
-      createCheckpointWithRetries(emptyCommitTS)
-    } else {
-      log.checkpoint(log.update(
-        checkIfUpdatedSinceTs = Some(emptyCommitTS),
-        catalogTableOpt = table.catalogTable))
-      true
-    }
-  }
-
-  def truncateHistoryLogRetentionMillis(txn: OptimisticTransaction): Option[Long] = {
-    if (!truncateHistory) return None
-
-    val truncateHistoryLogRetention = DeltaConfigs
-      .TABLE_FEATURE_DROP_TRUNCATE_HISTORY_LOG_RETENTION
-      .fromMetaData(txn.metadata)
-
-    Some(DeltaConfigs.getMilliSeconds(truncateHistoryLogRetention))
-  }
+  private val NUMBER_OF_BARRIER_CHECKPOINTS = 3
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
     val removableFeature = TableFeature.featureNameToFeature(featureName) match {
@@ -400,8 +329,14 @@ case class AlterTableDropFeatureDeltaCommand(
       throw DeltaErrors.dropTableFeatureFeatureNotSupportedByProtocol(featureName)
     }
 
-    if (truncateHistory && !removableFeature.requiresHistoryProtection) {
+    val historyTruncationEligibleFeature = removableFeature.requiresHistoryProtection ||
+      removableFeature == CheckpointProtectionTableFeature
+    if (truncateHistory && !historyTruncationEligibleFeature) {
       throw DeltaErrors.tableFeatureDropHistoryTruncationNotAllowed()
+    }
+
+    if (removableFeature == CheckpointProtectionTableFeature && !truncateHistory) {
+      throw DeltaErrors.canOnlyDropCheckpointProtectionWithHistoryTruncationException
     }
 
     // Validate that the `removableFeature` is not a dependency of any other feature that is
@@ -458,7 +393,7 @@ case class AlterTableDropFeatureDeltaCommand(
         // asap. The checkpoint is based on a new commit to avoid creating a checkpoint
         // on a commit that still contains traces of the removed feature.
         // Note, the checkpoint is created in both executions of DROP FEATURE command.
-        createEmptyCommitAndCheckpoint(startTimeNs)
+        createEmptyCommitAndCheckpoint(table, startTimeNs)
 
         // If the pre-downgrade command made changes, then the table's historical versions
         // certainly still contain traces of the feature. We don't have to run an expensive
@@ -490,9 +425,11 @@ case class AlterTableDropFeatureDeltaCommand(
         // concurrent metadataCleanup during findEarliestReliableCheckpoint. Note, this
         // cleanUpExpiredLogs call truncates the cutoff at a minute granularity.
         deltaLog.cleanUpExpiredLogs(
-          snapshot,
-          truncateHistoryLogRetentionMillis(txn),
-          TruncationGranularity.MINUTE)
+          snapshotToCleanup = snapshot,
+          deltaRetentionMillisOpt =
+            if (truncateHistory) Some(truncateHistoryLogRetentionMillis(txn.metadata)) else None,
+          cutoffTruncationGranularity =
+            if (truncateHistory) TruncationGranularity.MINUTE else TruncationGranularity.DAY)
 
         val historyContainsFeature = removableFeature.historyContainsFeature(
           spark = sparkSession,
@@ -560,7 +497,7 @@ case class AlterTableDropFeatureDeltaCommand(
         (1 to NUMBER_OF_BARRIER_CHECKPOINTS).foreach { _ =>
           // This call also cleans up the logs. In most of the cases we should be able to truncate
           // the history of a previous drop feature operation.
-          if (!createEmptyCommitAndCheckpoint(startTimeNs, retryOnFailure = true)) {
+          if (!createEmptyCommitAndCheckpoint(table, startTimeNs, retryOnFailure = true)) {
             throw DeltaErrors.dropTableFeatureCheckpointFailedException(removableFeature.name)
           }
           startTimeNs = System.nanoTime()
@@ -595,7 +532,7 @@ case class AlterTableDropFeatureDeltaCommand(
       txn.commit(Nil, DeltaOperations.DropTableFeature(featureName, false))
 
       // This is a protected checkpoint.
-      if (historyBarrierIsRequired) createCheckpointWithRetries(System.nanoTime())
+      if (historyBarrierIsRequired) createCheckpointWithRetries(table, System.nanoTime())
       Nil
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -2535,7 +2535,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       // Pretend retention period has passed.
       if (advanceClockPastRetentionPeriod) {
         val clockAdvanceMillis = if (truncateHistory) {
-          DeltaConfigs.getMilliSeconds(truncateHistoryRetention) + TimeUnit.HOURS.toMillis(3)
+          DeltaConfigs.getMilliSeconds(truncateHistoryRetention) + TimeUnit.HOURS.toMillis(24)
         } else {
           deltaLog.deltaRetentionMillis(deltaLog.update().metadata) + TimeUnit.DAYS.toMillis(3)
         }
@@ -2912,7 +2912,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
           "truncateHistoryLogRetentionPeriod" -> truncateHistoryDefaultLogRetention.toString))
 
       // Advance clock.
-      clock.advance(TimeUnit.DAYS.toMillis(1) + TimeUnit.HOURS.toMillis(3))
+      clock.advance(TimeUnit.DAYS.toMillis(1) + TimeUnit.HOURS.toMillis(24))
 
       // Generate commit.
       spark.range(120, 140).write.format("delta").mode("append").save(dir.getCanonicalPath)
@@ -3224,7 +3224,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         }
 
         // Move past retention period.
-        clock.advance(TimeUnit.HOURS.toMillis(3))
+        clock.advance(TimeUnit.HOURS.toMillis(24))
 
         sql(s"ALTER TABLE $table DROP FEATURE $featureName TRUNCATE HISTORY")
         assert(deltaLog.update().protocol === Protocol(1, 2))
@@ -3425,7 +3425,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
 
       // Pretend retention period has passed.
       val clockAdvanceMillis = DeltaConfigs.getMilliSeconds(truncateHistoryDefaultLogRetention)
-      clock.advance(clockAdvanceMillis + TimeUnit.HOURS.toMillis(3))
+      clock.advance(clockAdvanceMillis + TimeUnit.HOURS.toMillis(24))
 
       // History is now clean. We should be able to remove the feature.
       AlterTableDropFeatureDeltaCommand(
@@ -3512,7 +3512,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       // Pretend retention period has passed.
       val clockAdvanceMillis = if (truncateHistory) {
         DeltaConfigs.getMilliSeconds(truncateHistoryDefaultLogRetention) +
-          TimeUnit.HOURS.toMillis(3)
+          TimeUnit.HOURS.toMillis(24)
       } else {
         deltaLog.deltaRetentionMillis(deltaLog.update().metadata) + TimeUnit.DAYS.toMillis(3)
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -2535,11 +2535,11 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       // Pretend retention period has passed.
       if (advanceClockPastRetentionPeriod) {
         val clockAdvanceMillis = if (truncateHistory) {
-          DeltaConfigs.getMilliSeconds(truncateHistoryRetention)
+          DeltaConfigs.getMilliSeconds(truncateHistoryRetention) + TimeUnit.HOURS.toMillis(3)
         } else {
-          deltaLog.deltaRetentionMillis(deltaLog.update().metadata)
+          deltaLog.deltaRetentionMillis(deltaLog.update().metadata) + TimeUnit.DAYS.toMillis(3)
         }
-        clock.advance(clockAdvanceMillis + TimeUnit.MINUTES.toMillis(5))
+        clock.advance(clockAdvanceMillis)
       }
 
       val dropCommand = AlterTableDropFeatureDeltaCommand(
@@ -2912,7 +2912,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
           "truncateHistoryLogRetentionPeriod" -> truncateHistoryDefaultLogRetention.toString))
 
       // Advance clock.
-      clock.advance(TimeUnit.DAYS.toMillis(1) + TimeUnit.MINUTES.toMillis(5))
+      clock.advance(TimeUnit.DAYS.toMillis(1) + TimeUnit.HOURS.toMillis(3))
 
       // Generate commit.
       spark.range(120, 140).write.format("delta").mode("append").save(dir.getCanonicalPath)
@@ -2994,8 +2994,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
 
       // Pretend retention period has passed.
       clock.advance(
-        deltaLog.deltaRetentionMillis(deltaLog.update().metadata) +
-        TimeUnit.MINUTES.toMillis(5))
+        deltaLog.deltaRetentionMillis(deltaLog.update().metadata) + TimeUnit.DAYS.toMillis(3))
 
       // History is now clean. We should be able to remove the feature.
       AlterTableDropFeatureDeltaCommand(
@@ -3098,8 +3097,8 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
       spark.range(100, 120).write.format("delta").mode("append").save(dir.getCanonicalPath)
 
       // Pretend retention period has passed.
-      clock.advance(deltaLog.deltaRetentionMillis(deltaLog.update().metadata) +
-        TimeUnit.MINUTES.toMillis(5))
+      clock.advance(
+        deltaLog.deltaRetentionMillis(deltaLog.update().metadata) + TimeUnit.DAYS.toMillis(3))
 
       // Perform an unrelated metadata change.
       sql(s"ALTER TABLE delta.`${deltaLog.dataPath}` ADD COLUMN (value INT)")
@@ -3225,7 +3224,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         }
 
         // Move past retention period.
-        clock.advance(TimeUnit.HOURS.toMillis(1))
+        clock.advance(TimeUnit.HOURS.toMillis(3))
 
         sql(s"ALTER TABLE $table DROP FEATURE $featureName TRUNCATE HISTORY")
         assert(deltaLog.update().protocol === Protocol(1, 2))
@@ -3426,7 +3425,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
 
       // Pretend retention period has passed.
       val clockAdvanceMillis = DeltaConfigs.getMilliSeconds(truncateHistoryDefaultLogRetention)
-      clock.advance(clockAdvanceMillis + TimeUnit.MINUTES.toMillis(5))
+      clock.advance(clockAdvanceMillis + TimeUnit.HOURS.toMillis(3))
 
       // History is now clean. We should be able to remove the feature.
       AlterTableDropFeatureDeltaCommand(
@@ -3512,11 +3511,12 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
 
       // Pretend retention period has passed.
       val clockAdvanceMillis = if (truncateHistory) {
-        DeltaConfigs.getMilliSeconds(truncateHistoryDefaultLogRetention)
+        DeltaConfigs.getMilliSeconds(truncateHistoryDefaultLogRetention) +
+          TimeUnit.HOURS.toMillis(3)
       } else {
-        deltaLog.deltaRetentionMillis(deltaLog.update().metadata)
+        deltaLog.deltaRetentionMillis(deltaLog.update().metadata) + TimeUnit.DAYS.toMillis(3)
       }
-      clock.advance(clockAdvanceMillis + TimeUnit.MINUTES.toMillis(5))
+      clock.advance(clockAdvanceMillis)
 
       AlterTableDropFeatureDeltaCommand(
         table = DeltaTableV2(spark, deltaLog.dataPath),
@@ -3626,8 +3626,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
 
         // Pretend retention period has passed.
         clock.advance(
-          targetLog.deltaRetentionMillis(targetLog.update().metadata) +
-            TimeUnit.MINUTES.toMillis(5))
+          targetLog.deltaRetentionMillis(targetLog.update().metadata) + TimeUnit.DAYS.toMillis(3))
 
         // History is now clean. We should be able to remove the feature.
         dropV2CheckpointsTableFeature(spark, targetLog)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaProtocolVersionSuite.scala
@@ -3224,7 +3224,7 @@ trait DeltaProtocolVersionSuiteBase extends QueryTest
         }
 
         // Move past retention period.
-        clock.advance(TimeUnit.HOURS.toMillis(24))
+        clock.advance(TimeUnit.HOURS.toMillis(48))
 
         sql(s"ALTER TABLE $table DROP FEATURE $featureName TRUNCATE HISTORY")
         assert(deltaLog.update().protocol === Protocol(1, 2))

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
@@ -507,7 +507,7 @@ class DeltaRetentionSuite extends QueryTest
   }
 }
 
-class DeltaRetentionWithCoordinatedComm`itsBatch1Suite extends DeltaRetentionSuite {
+class DeltaRetentionWithCoordinatedCommitsBatch1Suite extends DeltaRetentionSuite {
   override val coordinatedCommitsBackfillBatchSize: Option[Int] = Some(1)
 }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuite.scala
@@ -507,7 +507,7 @@ class DeltaRetentionSuite extends QueryTest
   }
 }
 
-class DeltaRetentionWithCoordinatedCommitsBatch1Suite extends DeltaRetentionSuite {
+class DeltaRetentionWithCoordinatedComm`itsBatch1Suite extends DeltaRetentionSuite {
   override val coordinatedCommitsBackfillBatchSize: Option[Int] = Some(1)
 }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaRetentionSuiteBase.scala
@@ -161,7 +161,6 @@ trait DeltaRetentionSuiteBase extends QueryTest
       dayNum: Int,
       fs: FileSystem,
       checkpointOnly: Boolean = false): Unit = {
-    val logDir = log.logPath.toUri.toString
     val paths = log
       .listFrom(version)
       .collect { case FileNames.CheckpointFile(f, v) if v == version => f.getPath }
@@ -171,7 +170,7 @@ trait DeltaRetentionSuiteBase extends QueryTest
       fs.setTimes(cpPath, day(startTime, dayNum) + version * 1000, 0)
     }
     if (!checkpointOnly) {
-      val deltaPath = new Path(logDir + f"/$version%020d.json")
+      val deltaPath = new Path(log.logPath, new Path(f"$version%020d.json"))
       if (fs.exists(deltaPath)) {
         // Add some second offset so that we don't have files with same timestamps
         fs.setTimes(deltaPath, day(startTime, dayNum) + version * 1000, 0)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTableFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningTableFeatureSuite.scala
@@ -73,7 +73,7 @@ trait TypeWideningTableFeatureTests
     assert(clock != null, "Must call setupManualClock in tests that are using this method.")
     clock.advance(
       deltaLog.deltaRetentionMillis(deltaLog.update().metadata) +
-        TimeUnit.MINUTES.toMillis(5))
+        TimeUnit.DAYS.toMillis(3))
   }
 
   test("enable type widening at table creation then disable it") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Adds support for dropping the `CheckpointProtection` table feature. To drop the feature, we need to truncate all history prior to the CheckpointProtection version. For this cleanup operation we use a shorter retention period of 24 hours. This is configured in `delta.dropFeatureTruncateHistory.retentionDuration` and is the same config we use in the drop feature with History Truncation implementation.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Added tests in `DeltaFastDropFeatureSuite`.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.