### PR TITLE
[Kernel] Add `Snapshot::getPartitionColumnNames` public API

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
@@ -19,6 +19,7 @@ package io.delta.kernel;
 import io.delta.kernel.annotation.Evolving;
 import io.delta.kernel.engine.Engine;
 import io.delta.kernel.types.StructType;
+import java.util.List;
 
 /**
  * Represents the snapshot of a Delta table.
@@ -36,6 +37,16 @@ public interface Snapshot {
    */
   long getVersion(Engine engine);
 
+  /**
+   * Get the names of the partition columns in the Delta table at this snapshot.
+   *
+   * <p>The partition column names are returned in the order they are defined in the Delta table
+   * schema. If the table does not define any partition columns, this method returns an empty list.
+   *
+   * @param engine {@link Engine} instance to use in Delta Kernel.
+   * @return a list of partition column names, or an empty list if the table is not partitioned.
+   */
+  List<String> getPartitionColumnNames(Engine engine);
   /**
    * Get the schema of the table at this snapshot.
    *

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -31,7 +31,9 @@ import io.delta.kernel.internal.replay.CreateCheckpointIterator;
 import io.delta.kernel.internal.replay.LogReplay;
 import io.delta.kernel.internal.snapshot.LogSegment;
 import io.delta.kernel.internal.snapshot.TableCommitCoordinatorClientHandler;
+import io.delta.kernel.internal.util.VectorUtils;
 import io.delta.kernel.types.StructType;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -83,6 +85,10 @@ public class SnapshotImpl implements Snapshot {
 
   public Protocol getProtocol() {
     return protocol;
+  }
+
+  public List<String> getPartitionColumnNames(Engine engine) {
+    return VectorUtils.toJavaList(getMetadata().getPartitionColumns());
   }
 
   /**

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/SnapshotSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/SnapshotSuite.scala
@@ -1,0 +1,49 @@
+package io.delta.kernel.defaults
+
+import io.delta.kernel.{Operation, Table}
+import io.delta.kernel.defaults.utils.TestUtils
+import io.delta.kernel.types.{IntegerType, StructField, StructType}
+import io.delta.kernel.utils.CloseableIterable
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.collection.JavaConverters._
+
+class SnapshotSuite extends AnyFunSuite with TestUtils {
+
+  Seq(
+    Seq("part1"), // simple case
+    Seq("part1", "part2", "part3"), // multiple partition columns
+    Seq(), // non-partitioned
+    Seq("PART1", "part2") // case-sensitive
+  ).foreach { partCols =>
+    test(s"Snapshot getPartitionColumnNames - partCols=$partCols") {
+      withTempDir { dir =>
+        // Step 1: Create a table with the given partition columns
+        val table = Table.forPath(defaultEngine, dir.getCanonicalPath)
+
+        val columns = (partCols ++ Seq("col1", "col2")).map { colName =>
+          new StructField(colName, IntegerType.INTEGER, true /* nullable */)
+        }
+
+        val schema = new StructType(columns.asJava)
+
+        var txnBuilder = table
+          .createTransactionBuilder(defaultEngine, "engineInfo", Operation.CREATE_TABLE)
+          .withSchema(defaultEngine, schema)
+
+        if (partCols.nonEmpty) {
+          txnBuilder = txnBuilder.withPartitionColumns(defaultEngine, partCols.asJava)
+        }
+
+        txnBuilder.build(defaultEngine).commit(defaultEngine, CloseableIterable.emptyIterable())
+
+        // Step 2: Check the partition columns
+        val tablePartCols =
+          table.getLatestSnapshot(defaultEngine).getPartitionColumnNames(defaultEngine)
+
+        assert(partCols.asJava === tablePartCols)
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Add new `Snapshot::getPartitionColumnNames` public API

## How was this patch tested?

Simple UTs.

## Does this PR introduce _any_ user-facing changes?

Yes.