### PR TITLE
Update checkError calls in DeltaInsertIntoTableSuite to compile against spark master

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTableSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTableSuite.scala
@@ -333,7 +333,7 @@ class DeltaInsertIntoSQLSuite
       }
       checkErrorMatchPVals(
         exception = err,
-        errorClass = "_LEGACY_ERROR_TEMP_DELTA_0007",
+        "_LEGACY_ERROR_TEMP_DELTA_0007",
         parameters = Map(
           "message" -> "A schema mismatch detected when writing to the Delta table(.|\\n)*"
         )
@@ -377,7 +377,7 @@ class DeltaInsertIntoSQLSuite
       }
       checkError(
         exception = e,
-        errorClass = "DELTA_INSERT_COLUMN_ARITY_MISMATCH",
+        "DELTA_INSERT_COLUMN_ARITY_MISMATCH",
         parameters = Map(
           "tableName" -> "spark_catalog.default.target",
           "columnName" -> "not enough nested fields in value",
@@ -410,7 +410,7 @@ class DeltaInsertIntoSQLSuite
       }
       checkErrorMatchPVals(
         exception = e,
-        errorClass = "_LEGACY_ERROR_TEMP_DELTA_0007",
+        "_LEGACY_ERROR_TEMP_DELTA_0007",
         parameters = Map(
           "message" -> "A schema mismatch detected when writing to the Delta table(.|\\n)*"
         )
@@ -451,7 +451,7 @@ class DeltaInsertIntoSQLSuite
       }
       checkErrorMatchPVals(
         exception = e,
-        errorClass = "_LEGACY_ERROR_TEMP_DELTA_0007",
+        "_LEGACY_ERROR_TEMP_DELTA_0007",
         parameters = Map(
           "message" -> "A schema mismatch detected when writing to the Delta table(.|\\n)*"
         )


### PR DESCRIPTION
## Description
Small test fix to get https://github.com/delta-io/delta/commit/ca118d189591a98082e7bfa5014bf9264918c0a2 to compile against spark master

The `errorClass` argument of `checkError` was renamed to `condition` in recent spark release. To work with both, the named argument is changed to be unnamed.

## How was this patch tested?
N/A, test-only

## Does this PR introduce _any_ user-facing changes?
No