### PR TITLE
[Spark] CheckpointProtectionTableFeature base implementation

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/MetadataCleanup.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.delta.actions.{Action, Metadata}
 import org.apache.spark.sql.delta.logging.DeltaLogKeys
 import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.util.FileNames
-import org.apache.spark.sql.delta.util.FileNames.{checkpointVersion, listingPrefix, CheckpointFile, DeltaFile, UnbackfilledDeltaFile}
+import org.apache.spark.sql.delta.util.FileNames._
 import org.apache.commons.lang3.time.DateUtils
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
 
@@ -73,6 +73,12 @@ trait MetadataCleanup extends DeltaLogging {
       val formattedDate = fileCutOffTime.toGMTString
       logInfo(log"Starting the deletion of log files older than " +
         log"${MDC(DeltaLogKeys.DATE, formattedDate)}")
+
+      if (!metadataCleanupAllowed(snapshotToCleanup, fileCutOffTime.getTime)) {
+        logInfo("Metadata cleanup was skipped due to not satisfying the requirements " +
+          "of CheckpointProtectionTableFeature.")
+        return
+      }
 
       val fs = logPath.getFileSystem(newDeltaHadoopConf())
       var numDeleted = 0
@@ -134,6 +140,12 @@ trait MetadataCleanup extends DeltaLogging {
     }
   }
 
+  /** Helper function for getting the version of a checkpoint or a commit. */
+  def getDeltaFileOrCheckpointVersion(filePath: Path): Long = {
+    require(isCheckpointFile(filePath) || isDeltaFile(filePath))
+    getFileVersion(filePath)
+  }
+
   /**
    * Returns an iterator of expired delta logs that can be cleaned up. For a delta log to be
    * considered as expired, it must:
@@ -141,22 +153,34 @@ trait MetadataCleanup extends DeltaLogging {
    *  - be older than `fileCutOffTime`
    */
   private def listExpiredDeltaLogs(fileCutOffTime: Long): Iterator[FileStatus] = {
-    import org.apache.spark.sql.delta.util.FileNames._
-
     val latestCheckpoint = readLastCheckpointFile()
     if (latestCheckpoint.isEmpty) return Iterator.empty
     val threshold = latestCheckpoint.get.version - 1L
     val files = store.listFrom(listingPrefix(logPath, 0), newDeltaHadoopConf())
       .filter(f => isCheckpointFile(f) || isDeltaFile(f))
-    def getVersion(filePath: Path): Long = {
-      if (isCheckpointFile(filePath)) {
-        checkpointVersion(filePath)
-      } else {
-        deltaVersion(filePath)
-      }
-    }
 
-    new BufferingLogDeletionIterator(files, fileCutOffTime, threshold, getVersion)
+    new BufferingLogDeletionIterator(
+      files, fileCutOffTime, threshold, getDeltaFileOrCheckpointVersion)
+  }
+
+  /**
+   * Validates whether the metadata cleanup adheres to the CheckpointProtectionTableFeature
+   * requirements. Metadata cleanup is only allowed if we can clean up everything before
+   * requireCheckpointProtectionBeforeVersion. The implementation below scans the history
+   * until it finds a commit that satisfies the invariant.
+   */
+  private def metadataCleanupAllowed(
+      snapshot: Snapshot,
+      fileCutOffTime: Long): Boolean = {
+    val checkpointProtectionVersion =
+      CheckpointProtectionTableFeature.getCheckpointProtectionVersion(snapshot)
+    if (checkpointProtectionVersion <= 0) return true
+
+    def versionGreaterOrEqualToThreshold(file: FileStatus): Boolean =
+      getDeltaFileOrCheckpointVersion(file.getPath) >= checkpointProtectionVersion - 1
+
+    val expiredDeltaLogs = listExpiredDeltaLogs(fileCutOffTime)
+    expiredDeltaLogs.isEmpty || expiredDeltaLogs.exists(versionGreaterOrEqualToThreshold)
   }
 
   /**

--- a/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointProtectionTestUtilsMixin.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CheckpointProtectionTestUtilsMixin.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta
+
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
+
+import org.apache.spark.util.ManualClock
+
+trait CheckpointProtectionTestUtilsMixin
+    extends DeltaSQLCommandTest { self: DeltaRetentionSuiteBase =>
+
+  def testRequireCheckpointProtectionBeforeVersion(
+      createNumCommitsOutsideRetentionPeriod: Int,
+      createNumCommitsWithinRetentionPeriod: Int,
+      createCheckpoints: Set[Int],
+      requireCheckpointProtectionBeforeVersion: Int,
+      additionalFeatureToEnable: Option[TableFeature] = None,
+      expectedCommitsAfterCleanup: Set[Int],
+      expectedCheckpointsAfterCleanup: Set[Int]): Unit = {
+    withTempDir { dir =>
+      val currentTime = System.currentTimeMillis()
+      val clock = new ManualClock(currentTime)
+      val deltaLog = DeltaLog.forTable(spark, dir, clock)
+      val fs = deltaLog.logPath.getFileSystem(deltaLog.newDeltaHadoopConf())
+      val propertyKey = DeltaConfigs.REQUIRE_CHECKPOINT_PROTECTION_BEFORE_VERSION.key
+      val additionalFeatureEnablement =
+        additionalFeatureToEnable.map(f => s"delta.feature.${f.name} = 'supported',")
+          .getOrElse("")
+
+      // Commit 0.
+      sql(
+        s"""CREATE TABLE delta.`${deltaLog.dataPath}` (id bigint) USING delta
+           |TBLPROPERTIES (
+           |delta.feature.${CheckpointProtectionTableFeature.name} = 'supported',
+           |$additionalFeatureEnablement
+           |$propertyKey = $requireCheckpointProtectionBeforeVersion
+           |)""".stripMargin)
+      if (createCheckpoints.contains(0)) deltaLog.checkpoint(deltaLog.update())
+
+      // Rest createNumCommitsOutsideRetentionPeriod - 1 commits.
+      (1 to createNumCommitsOutsideRetentionPeriod - 1).foreach { n =>
+        spark.range(n, n + 1).write.format("delta").mode("append").save(dir.getCanonicalPath)
+        if (createCheckpoints.contains(n)) deltaLog.checkpoint(deltaLog.update())
+
+        setModificationTime(deltaLog, startTime = currentTime, version = n, dayNum = 0, fs)
+      }
+
+      val millisToAdvance =
+        intervalStringToMillis(DeltaConfigs.LOG_RETENTION.defaultValue) + TimeUnit.DAYS.toMillis(3)
+      clock.advance(millisToAdvance)
+
+      // Commits within retention period.
+      val daysToAdvance = TimeUnit.MILLISECONDS.toDays(millisToAdvance).toInt
+      (0 to createNumCommitsWithinRetentionPeriod - 1)
+        .foreach { n =>
+          val m = createNumCommitsOutsideRetentionPeriod + n
+          spark.range(m, m + 1).write.format("delta").mode("append").save(dir.getCanonicalPath)
+          if (createCheckpoints.contains(m)) deltaLog.checkpoint(deltaLog.update())
+
+          // Advance the timestamp of the commit/checkpoint we just created.
+          setModificationTime(
+            deltaLog,
+            startTime = currentTime,
+            version = m,
+            // The files were created somewhere between day 32 and day 33.
+            dayNum = daysToAdvance - 1,
+            fs)
+        }
+
+      deltaLog.cleanUpExpiredLogs(deltaLog.update())
+
+      val logPath = new File(deltaLog.logPath.toUri)
+      assert(getDeltaVersions(logPath) === expectedCommitsAfterCleanup)
+      assert(getCheckpointVersions(logPath) === expectedCheckpointsAfterCleanup)
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Base implementation of `CheckpointProtectionTableFeature`. Writers are only allowed to cleanup metadata as long as the can truncate history up to `requireCheckpointProtectionBeforeVersion` in one go.

As a second step, the feature can be improved by allowing metadata cleanup even when the invariant above does not hold. Metadata cleanup could be allowed if the client verifies it supports all writer features contained in the history it intends to truncate. This improvement is important to support for providing GDPR compliance.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Added tests in `DeltaRetentionSuite`.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.
