### PR TITLE
allow user-specified schema in read if it's consistent

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2859,7 +2859,7 @@
   },
   "DELTA_UNSUPPORTED_SCHEMA_DURING_READ" : {
     "message" : [
-      "Delta does not support specifying the schema at read time."
+      "Delta does not support specifying the schema at read time, unless it's the same as the actual table schema."
     ],
     "sqlState" : "0AKDC"
   },

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2859,7 +2859,7 @@
   },
   "DELTA_UNSUPPORTED_SCHEMA_DURING_READ" : {
     "message" : [
-      "Delta does not support specifying the schema at read time, unless it's the same as the actual table schema."
+      "Delta does not support specifying the schema at read time."
     ],
     "sqlState" : "0AKDC"
   },

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaDataSource.scala
@@ -105,7 +105,8 @@ class DeltaDataSource
         .getOrElse(snapshot.schema)
     }
 
-    if (schema.nonEmpty && !DataType.equalsIgnoreCompatibleNullability(readSchema, schema.get)) {
+    if (schema.nonEmpty && schema.get.nonEmpty &&
+      !DataType.equalsIgnoreCompatibleNullability(readSchema, schema.get)) {
       throw DeltaErrors.specifySchemaAtReadTimeException
     }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -157,13 +157,13 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         assert(e.getMessage.contains(msg))
       }
 
-      val e = intercept[SparkThrowable] {
+      val e2 = intercept[SparkThrowable] {
         spark.readStream
           .schema(StructType.fromDDL("value STRING"))
           .format("delta")
           .load(inputDir.getCanonicalPath)
       }
-      assert(e.getMessage.contains("does not support user-specified schema"))
+      assert(e2.getMessage.contains("does not support user-specified schema"))
     }
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -157,7 +157,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         assert(e.getMessage.contains(msg))
       }
 
-      val e2 = intercept[SparkThrowable] {
+      val e2 = intercept[Exception] {
         spark.readStream
           .schema(StructType.fromDDL("value STRING"))
           .format("delta")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

User-specified schema may come from the catalog if the Delta table is stored in an external catalog that syncs the table schema with the Delta log. We should allow it if it's the same as the real Delta table schema.

This is already the case for batch read, see https://github.com/apache/spark/pull/15046

This PR changes the Delta streaming read to allow it as well.

Note: since Delta uses DS v2 (`TableProvider`) and explicitly claims that user-specified schema is not supported (`TableProvider#supportsExternalMetadata` returns false by default), end users still can't specify schema in `spark.read/readStream.schema`. This change is only for advanced Spark plugins that can construct logical plans to triggers Delta v1 source stream scan.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
a new test
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No