### PR TITLE
[SPARK] Clean up vacuum-related code

### DIFF
--- a/project/SparkMimaExcludes.scala
+++ b/project/SparkMimaExcludes.scala
@@ -30,6 +30,7 @@ object SparkMimaExcludes {
       ProblemFilters.exclude[DirectMissingMethodProblem]("io.delta.tables.DeltaTable.executeGenerate"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("io.delta.tables.DeltaTable.executeHistory"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("io.delta.tables.DeltaTable.executeVacuum"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("io.delta.tables.DeltaTable.executeVacuum$default$3"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("io.delta.tables.DeltaTable.this"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("io.delta.tables.DeltaTable.deltaLog"),
 

--- a/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
+++ b/spark/src/main/scala/io/delta/sql/parser/DeltaSqlParser.scala
@@ -349,10 +349,11 @@ class DeltaSqlAstBuilder extends DeltaSqlBaseBaseVisitor[AnyRef] {
       horizonHours =
         ctx.vacuumModifiers().retain().asScala.headOption.map(_.number.getText.toDouble),
       dryRun =
-        ctx.vacuumModifiers().dryRun().asScala.headOption.map(_.RUN != null).getOrElse(false),
+        ctx.vacuumModifiers().dryRun().asScala.headOption.exists(_.RUN != null),
       vacuumType = ctx.vacuumModifiers().vacuumType().asScala.headOption.map {
         t => if (t.LITE != null) "LITE" else "FULL"
-      }
+      },
+      options = Map.empty
     )
   }
 

--- a/spark/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/spark/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -98,7 +98,7 @@ class DeltaTable private[tables](
    * @since 0.3.0
    */
   def vacuum(retentionHours: Double): DataFrame = {
-    executeVacuum(deltaLog, Some(retentionHours), table.getTableIdentifierIfExists)
+    executeVacuum(table, Some(retentionHours))
   }
 
   /**
@@ -111,7 +111,7 @@ class DeltaTable private[tables](
    * @since 0.3.0
    */
   def vacuum(): DataFrame = {
-    executeVacuum(deltaLog, None, table.getTableIdentifierIfExists)
+    executeVacuum(table, retentionHours = None)
   }
 
   /**

--- a/spark/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
+++ b/spark/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.delta.DeltaTableUtils.withActiveSession
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.{DeltaGenerateCommand, DescribeDeltaDetailCommand, VacuumCommand}
 import org.apache.spark.sql.delta.util.AnalysisHelper
+import org.apache.spark.sql.util.ScalaExtensions._
 import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.{functions, Column, DataFrame}
@@ -86,10 +87,20 @@ trait DeltaTableOperations extends AnalysisHelper { self: io.delta.tables.DeltaT
   }
 
   protected def executeVacuum(
-      deltaLog: DeltaLog,
-      retentionHours: Option[Double],
-      tableId: Option[TableIdentifier] = None): DataFrame = withActiveSession(sparkSession) {
-    VacuumCommand.gc(sparkSession, deltaLog, false, retentionHours)
+      table: DeltaTableV2,
+      retentionHours: Option[Double]): DataFrame = withActiveSession(sparkSession) {
+    val tableId = table.getTableIdentifierIfExists
+    val path = Option.when(tableId.isEmpty)(deltaLog.dataPath.toString)
+    val vacuum = VacuumTableCommand(
+      path,
+      tableId,
+      inventoryTable = None,
+      inventoryQuery = None,
+      retentionHours,
+      dryRun = false,
+      vacuumType = None,
+      deltaLog.options)
+    toDataset(sparkSession, vacuum)
     sparkSession.emptyDataFrame
   }
 

--- a/spark/src/main/scala/io/delta/tables/execution/VacuumTableCommand.scala
+++ b/spark/src/main/scala/io/delta/tables/execution/VacuumTableCommand.scala
@@ -64,7 +64,7 @@ case class VacuumTableCommand(
     val inventory = inventoryTable.map(sparkSession.sessionState.analyzer.execute)
         .map(p => Some(getDeltaTable(p, "VACUUM").toDf(sparkSession)))
         .getOrElse(inventoryQuery.map(sparkSession.sql))
-    VacuumCommand.gc(sparkSession, deltaTable.deltaLog, dryRun, horizonHours,
+    VacuumCommand.gc(sparkSession, deltaTable, dryRun, horizonHours,
       inventory, vacuumType).collect()
   }
 }
@@ -77,8 +77,9 @@ object VacuumTableCommand {
       inventoryQuery: Option[String],
       horizonHours: Option[Double],
       dryRun: Boolean,
-      vacuumType: Option[String]): VacuumTableCommand = {
-    val child = UnresolvedDeltaPathOrIdentifier(path, table, "VACUUM")
+      vacuumType: Option[String],
+      options: Map[String, String]): VacuumTableCommand = {
+    val child = UnresolvedDeltaPathOrIdentifier(path, table, options, "VACUUM")
     val unresolvedInventoryTable = inventoryTable.map(rt => UnresolvedTable(rt.nameParts, "VACUUM"))
     VacuumTableCommand(child, horizonHours, unresolvedInventoryTable, inventoryQuery, dryRun,
       vacuumType)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -729,10 +729,11 @@ object UnresolvedPathOrIdentifier {
   def apply(
       path: Option[String],
       tableIdentifier: Option[TableIdentifier],
+      options: Map[String, String],
       cmd: String): LogicalPlan = {
     (path, tableIdentifier) match {
       case (_, Some(t)) => UnresolvedTable(t.nameParts, cmd)
-      case (Some(p), None) => UnresolvedPathBasedTable(p, Map.empty, cmd)
+      case (Some(p), None) => UnresolvedPathBasedTable(p, options, cmd)
       case _ => throw new IllegalArgumentException(
         s"At least one of path or tableIdentifier must be provided to $cmd")
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/DescribeDeltaDetailsCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/DescribeDeltaDetailsCommand.scala
@@ -199,6 +199,7 @@ object DescribeDeltaDetailCommand {
     val plan = UnresolvedPathOrIdentifier(
       path,
       tableIdentifier,
+      hadoopConf,
       CMD_NAME
     )
     DescribeDeltaDetailCommand(plan, hadoopConf)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsSuite.scala
@@ -51,7 +51,7 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{QueryTest, Row, SparkSession}
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.util.ManualClock
+import org.apache.spark.util.{ManualClock, SystemClock}
 
 class CoordinatedCommitsSuite
     extends QueryTest

--- a/spark/src/test/scala/org/apache/spark/sql/delta/test/DeltaTestImplicits.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/test/DeltaTestImplicits.scala
@@ -164,6 +164,13 @@ object DeltaTestImplicits {
     /** Convenience overload that omits the cmd arg (which is not helpful in tests). */
     def apply(spark: SparkSession, id: TableIdentifier): DeltaTableV2 =
       dt.apply(spark, id, "test")
+
+    def apply(spark: SparkSession, tableDir: File, clock: Clock): DeltaTableV2 = {
+      val tablePath = new Path(tableDir.getAbsolutePath)
+      new DeltaTableV2(spark, tablePath) {
+        override lazy val deltaLog: DeltaLog = DeltaLog.forTable(spark, tablePath, clock)
+      }
+    }
   }
 
   implicit class DeltaTableV2TestHelper(deltaTable: DeltaTableV2) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR cleans up a few things
+ In scala API, use the `VacuumTableCommand` instead of calling `VacuumCommand.gc` directly,
+ Pass `DeltaTableV2` to `VacuumCommand.gc` instead of `DeltaLog`.
+ Use `DeltaTableV2` in tests instead of `DeltaLog`.

## How was this patch tested?
Unit tests
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No