### PR TITLE
[Spark][TEST-ONLY] Identity Column high watermark and replace tests

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnSyncSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnSyncSuite.scala
@@ -93,7 +93,7 @@ trait IdentityColumnSyncSuiteBase
 
       sql(s"ALTER TABLE $tblName ALTER COLUMN id SYNC IDENTITY")
       assert(getHighWaterMark(deltaLog.update(), "id").isEmpty,
-        "sync identity must not add a the high watermark that is lower " +
+        "sync identity must not add a high watermark that is lower " +
         "than the start value when it has positive increment")
 
       sql(s"INSERT INTO $tblName (value) VALUES ('d'), ('e'), ('f')")
@@ -182,7 +182,7 @@ trait IdentityColumnSyncSuiteBase
 
       sql(s"ALTER TABLE $tblName ALTER COLUMN id SYNC IDENTITY")
       assert(getHighWaterMark(deltaLog.update(), "id").isEmpty,
-        "sync identity must not add a the high watermark that is higher " +
+        "sync identity must not add a high watermark that is higher " +
         "than the start value when it has negative increment")
 
       sql(s"INSERT INTO $tblName (value) VALUES ('d'), ('e'), ('f')")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnTestUtils.scala
@@ -99,12 +99,26 @@ trait IdentityColumnTestUtils
     checkAnswer(sql(s"SELECT * FROM $tableName ORDER BY value ASC"), expectedAnswer)
   }
 
+
+  /**
+   * Retrieves the high watermark information for the given `colName` in the metadata of
+   * given `snapshot`, if it's present. Returns None if the high watermark has not been set yet.
+   */
+  protected def getHighWaterMark(snapshot: Snapshot, colName: String): Option[Long] = {
+    val metadata = snapshot.schema(colName).metadata
+    if (metadata.contains(DeltaSourceUtils.IDENTITY_INFO_HIGHWATERMARK)) {
+      Some(metadata.getLong(DeltaSourceUtils.IDENTITY_INFO_HIGHWATERMARK))
+    } else {
+      None
+    }
+  }
+
   /**
    * Retrieves the high watermark information for the given `colName` in the metadata of
    * given `snapshot`
    */
   protected def highWaterMark(snapshot: Snapshot, colName: String): Long = {
-    snapshot.schema(colName).metadata.getLong(DeltaSourceUtils.IDENTITY_INFO_HIGHWATERMARK)
+    getHighWaterMark(snapshot, colName).get
   }
 
   /**


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
In this PR, we expand the test coverage for identity columns. Specifically, we add more assertions for the high watermarks and cover more test scenarios with replacing tables.

## How was this patch tested?

Test-only PR. We expand test coverage.

## Does this PR introduce _any_ user-facing changes?
No.