### PR TITLE
Fix schema tracking location check condition against checkpoint location

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/S3LikeLocalFileSystem.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/S3LikeLocalFileSystem.scala
@@ -22,7 +22,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.RawLocalFileSystem
 
 /**
- * A local filesystem on scheme s3. Useful for testing paths on non-defualt schemes.
+ * A local filesystem on scheme s3. Useful for testing paths on non-default schemes.
  */
 class S3LikeLocalFileSystem extends RawLocalFileSystem {
   private var uri: URI = _


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
This PR introduces a better way to check if the schema tracking location is under the checkpoint location that would work with arbitrary file systems and paths.

## How was this patch tested?
New UT.

## Does this PR introduce _any_ user-facing changes?
No
