### PR TITLE
[3.3 Release] Update SBT to not publish delta connect artifacts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -242,7 +242,7 @@ lazy val connectCommon = (project in file("spark-connect/common"))
     name := "delta-connect-common",
     commonSettings,
     crossSparkSettings(),
-    releaseSettings,
+    skipReleaseSettings,
     Compile / compile := runTaskOnlyOnSparkMaster(
       task = Compile / compile,
       taskName = "compile",
@@ -281,7 +281,7 @@ lazy val connectClient = (project in file("spark-connect/client"))
   .settings(
     name := "delta-connect-client",
     commonSettings,
-    releaseSettings,
+    skipReleaseSettings,
     Compile / compile := runTaskOnlyOnSparkMaster(
       task = Compile / compile,
       taskName = "compile",
@@ -369,7 +369,7 @@ lazy val connectServer = (project in file("spark-connect/server"))
   .settings(
     name := "delta-connect-server",
     commonSettings,
-    releaseSettings,
+    skipReleaseSettings,
     Compile / compile := runTaskOnlyOnSparkMaster(
       task = Compile / compile,
       taskName = "compile",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Skips release for delta connect projects for 3.3 release. These artifacts are only compiled with Spark 4 / Spark master but currently our release process includes them (likely empty since compile is skipped?).

## How was this patch tested?

Tested release from this branch and checked the artifacts are not included.

## Does this PR introduce _any_ user-facing changes?

No.