### PR TITLE
docs: Add default value for Delta Lake auto compaction configuration

### DIFF
--- a/docs/source/optimizations-oss.md
+++ b/docs/source/optimizations-oss.md
@@ -80,7 +80,7 @@ Auto compaction combines small files within Delta table partitions to automatica
 
 You can control the output file size by setting the configuration `spark.databricks.delta.autoCompact.maxFileSize`.
 
-Auto compaction is only triggered for partitions or tables that have at least a certain number of small files. You can optionally change the minimum number of files required to trigger auto compaction by setting `spark.databricks.delta.autoCompact.minNumFiles`.
+Auto compaction is only triggered for partitions or tables that have at least a certain number of small files. You can optionally change the minimum number of files required to trigger auto compaction by setting `spark.databricks.delta.autoCompact.minNumFiles` (default=50).
 
 Auto compaction can be enabled at the table or session level using the following settings:
 


### PR DESCRIPTION
## Description
Added the default value (50) for the `spark.databricks.delta.autoCompact.minNumFiles` configuration parameter in the auto compaction documentation. This helps users better understand the default behavior without having to check the source code or experiment.

## Changes
* Added default value in parentheses to the `minNumFiles` configuration description

## Testing
* Verified the accuracy of the default value in the codebase
* Reviewed documentation formatting

## Additional Notes
This is a documentation-only change that improves clarity for users configuring auto compaction settings.