### PR TITLE
[3.3] Fix scala examples to run with Java 8 for the 3.3 release

### DIFF
--- a/examples/scala/build.sbt
+++ b/examples/scala/build.sbt
@@ -169,6 +169,5 @@ lazy val root = (project in file("."))
     scalacOptions ++= Seq(
       "-deprecation",
       "-feature"
-    ),
-    java17Settings
+    )
   )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

In preparation for the 4.0 preview release which uses java 17 for Delta Spark we added `java17settings` to the scala examples build. This breaks when running with Java 8.

## How was this patch tested?

Ran tests locally.

## Does this PR introduce _any_ user-facing changes?

No.