### PR TITLE
[Spark] Reject unsupported type changes with Uniform

### DIFF
--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/TypeWideningUniformSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/TypeWideningUniformSuite.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.uniform
+
+import org.apache.spark.sql.delta.typewidening.TypeWideningUniformTests
+
+class TypeWideningUniformSuite extends TypeWideningUniformTests with WriteDeltaHMSReadIceberg

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/TypeWideningUniformSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/uniform/TypeWideningUniformSuite.scala
@@ -18,4 +18,7 @@ package org.apache.spark.sql.delta.uniform
 
 import org.apache.spark.sql.delta.typewidening.TypeWideningUniformTests
 
+/**
+ * Suite running Uniform Iceberg + type widening tests against HMS.
+ */
 class TypeWideningUniformSuite extends TypeWideningUniformTests with WriteDeltaHMSReadIceberg

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -1221,6 +1221,12 @@
           "<schema>"
         ]
       },
+      "UNSUPPORTED_TYPE_WIDENING" : {
+        "message" : [
+          "IcebergCompatV<version> is incompatible with a type change applied to this table:",
+          "Field <fieldPath> was changed from <prevType> to <newType>."
+        ]
+      },
       "VERSION_MUTUAL_EXCLUSIVE" : {
         "message" : [
           "Only one IcebergCompat version can be enabled, please explicitly disable all other IcebergCompat versions that are not needed."

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaAnalysis.scala
@@ -949,10 +949,11 @@ class DeltaAnalysis(session: SparkSession)
   }
 
   /**
-   * Returns a mapping of (fromType, toType) to Boolean indicating whether `fromType` is eligible to
-   * be automatically widened to `toType` when ingesting data. If it is, the table schema is updated
-   * to `toType` before ingestion and values are written using their origin `toType` type.
-   * Otherwise, the table type `fromType` is retained and values are downcasted on write.
+   * Returns the type widening mode to use for the given delta table. A type widening mode indicates
+   * for (fromType, toType) tuples whether `fromType` is eligible to be automatically widened to
+   * `toType` when ingesting data. If it is, the table schema is updated to `toType` before
+   * ingestion and values are written using their original `toType` type. Otherwise, the table type
+   * `fromType` is retained and values are downcasted on write.
    */
   private def getTypeWideningMode(
       deltaTable: DeltaTableV2,
@@ -964,7 +965,7 @@ class DeltaAnalysis(session: SparkSession)
 
     if (typeWideningEnabled && schemaEvolutionEnabled) {
       TypeWideningMode.TypeEvolution(
-        uniformIcebergEnabled = UniversalFormat.icebergEnabled(snapshot.metadata))
+        uniformIcebergCompatibleOnly = UniversalFormat.icebergEnabled(snapshot.metadata))
     } else {
       TypeWideningMode.NoTypeWidening
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -3402,6 +3402,23 @@ trait DeltaErrorsBase
     )
   }
 
+  def icebergCompatUnsupportedTypeWideningException(
+      version: Int,
+      fieldPath: Seq[String],
+      oldType: DataType,
+      newType: DataType): Throwable = {
+    new DeltaUnsupportedOperationException(
+      errorClass = "DELTA_ICEBERG_COMPAT_VIOLATION.UNSUPPORTED_TYPE_WIDENING",
+      messageParameters = Array(
+        version.toString,
+        version.toString,
+        SchemaUtils.prettyFieldName(fieldPath),
+        toSQLType(oldType),
+        toSQLType(newType)
+      )
+    )
+  }
+
   def universalFormatConversionFailedException(
       failedOnCommitVersion: Long,
       format: String,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/IcebergCompat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/IcebergCompat.scala
@@ -474,9 +474,8 @@ object CheckDeletionVectorDisabled extends IcebergCompatCheck {
  */
 object CheckTypeWideningSupported extends IcebergCompatCheck {
   override def apply(context: IcebergCompatContext): Unit = {
-    val skipCheck = context.spark.conf
-      .get(DeltaSQLConf.DELTA_TYPE_WIDENING_ALLOW_UNSUPPORTED_ICEBERG_TYPE_CHANGES.key)
-      .toBoolean
+    val skipCheck = context.spark.sessionState.conf
+      .getConf(DeltaSQLConf.DELTA_TYPE_WIDENING_ALLOW_UNSUPPORTED_ICEBERG_TYPE_CHANGES)
 
     if (skipCheck || !TypeWidening.isSupported(context.newestProtocol)) return
 
@@ -489,7 +488,7 @@ object CheckTypeWideningSupported extends IcebergCompatCheck {
           !TypeWidening.isTypeChangeSupportedByIceberg(fromType, toType) =>
         throw DeltaErrors.icebergCompatUnsupportedTypeWideningException(
           context.version, fieldPath, fromType, toType)
-      case _ =>
+      case _ => () // ignore
     }
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1969,6 +1969,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
 
     val (protocolUpdate1, metadataUpdate1) =
       UniversalFormat.enforceInvariantsAndDependencies(
+        spark,
         // Note: if this txn has no protocol or metadata updates, then `prev` will equal `newest`.
         snapshot,
         newestProtocol = protocol, // Note: this will try to use `newProtocol`

--- a/spark/src/main/scala/org/apache/spark/sql/delta/ResolveDeltaMergeInto.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/ResolveDeltaMergeInto.scala
@@ -297,7 +297,7 @@ object ResolveDeltaMergeInto {
         target.collectFirst {
           case DeltaTable(index) if TypeWidening.isEnabled(index.protocol, index.metadata) =>
             TypeWideningMode.TypeEvolution(
-              uniformIcebergEnabled = UniversalFormat.icebergEnabled(index.metadata))
+              uniformIcebergCompatibleOnly = UniversalFormat.icebergEnabled(index.metadata))
         }.getOrElse(TypeWideningMode.NoTypeWidening)
 
       // The implicit conversions flag allows any type to be merged from source to target if Spark

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TypeWidening.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TypeWidening.scala
@@ -68,7 +68,7 @@ object TypeWidening {
    * It is the responsibility of the caller to recurse into structs, maps and arrays.
    */
   def isTypeChangeSupported(fromType: AtomicType, toType: AtomicType): Boolean =
-    TypeWideningShims.isTypeChangeSupported(fromType, toType)
+    TypeWideningShims.isTypeChangeSupported(fromType = fromType, toType = toType)
 
   /**
    * Returns whether the given type change can be applied during schema evolution. Only a
@@ -78,18 +78,13 @@ object TypeWidening {
       fromType: AtomicType,
       toType: AtomicType,
       uniformIcebergEnabled: Boolean): Boolean =
-    TypeWideningShims.isTypeChangeSupportedForSchemaEvolution(fromType, toType) &&
-      (!uniformIcebergEnabled || isTypeChangeSupportedByIceberg(fromType, toType))
-
-  /**
-   * Alias for the above method extracting `uniformIcebergEnabled` value from the table metadata.
-   */
-  def isTypeChangeSupportedForSchemaEvolution(
-      fromType: AtomicType,
-      toType: AtomicType,
-      metadata: Metadata): Boolean =
-    isTypeChangeSupportedForSchemaEvolution(
-      fromType, toType, uniformIcebergEnabled = UniversalFormat.icebergEnabled(metadata))
+    TypeWideningShims.isTypeChangeSupportedForSchemaEvolution(
+      fromType = fromType,
+      toType = toType
+    ) && (
+      !uniformIcebergEnabled ||
+        isTypeChangeSupportedByIceberg(fromType = fromType, toType = toType)
+    )
 
   /**
    * Returns whether the given type change is supported by Iceberg, and by extension can be read

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TypeWidening.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TypeWidening.scala
@@ -77,12 +77,12 @@ object TypeWidening {
   def isTypeChangeSupportedForSchemaEvolution(
       fromType: AtomicType,
       toType: AtomicType,
-      uniformIcebergEnabled: Boolean): Boolean =
+      uniformIcebergCompatibleOnly: Boolean): Boolean =
     TypeWideningShims.isTypeChangeSupportedForSchemaEvolution(
       fromType = fromType,
       toType = toType
     ) && (
-      !uniformIcebergEnabled ||
+      !uniformIcebergCompatibleOnly ||
         isTypeChangeSupportedByIceberg(fromType = fromType, toType = toType)
     )
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TypeWideningMode.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TypeWideningMode.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.types.AtomicType

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TypeWideningMode.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TypeWideningMode.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.spark.sql.delta
 
 import org.apache.spark.sql.types.AtomicType
@@ -21,12 +22,13 @@ import org.apache.spark.sql.types.AtomicType
  * A type widening mode captures a specific set of type changes that are allowed to be applied.
  * Currently:
  *  - NoTypeWidening: No type change is allowed.
- *  - TypeEvolution(uniformIcebergEnabled = true): Type changes that are eligible to be applied
- *    automatically during schema evolution and that are supported by Iceberg are allowed.
- *  - TypeEvolution(uniformIcebergEnabled = false): Type changes that are eligible to be applied
- *    automatically during schema evolution are allowed, even if they are not supported by Iceberg.
+ *  - TypeEvolution(uniformIcebergCompatibleOnly = true): Type changes that are eligible to be
+ *    applied automatically during schema evolution and that are supported by Iceberg are allowed.
+ *  - TypeEvolution(uniformIcebergCompatibleOnly = false): Type changes that are eligible to be
+ *    applied automatically during schema evolution are allowed, even if they are not supported by
+ *    Iceberg.
  */
-trait TypeWideningMode {
+sealed trait TypeWideningMode {
   def shouldWidenType(fromType: AtomicType, toType: AtomicType): Boolean
 }
 
@@ -34,7 +36,7 @@ object TypeWideningMode {
   /**
    * No type change allowed. Typically because type widening and/or schema evolution isn't enabled.
    */
-  object NoTypeWidening extends TypeWideningMode {
+  case object NoTypeWidening extends TypeWideningMode {
     override def shouldWidenType(fromType: AtomicType, toType: AtomicType): Boolean = false
   }
 
@@ -42,9 +44,9 @@ object TypeWideningMode {
    * Type changes that are eligible to be applied automatically during schema evolution are allowed.
    * Can be restricted to only type changes supported by Iceberg.
    */
-  case class TypeEvolution(uniformIcebergEnabled: Boolean) extends TypeWideningMode {
+  case class TypeEvolution(uniformIcebergCompatibleOnly: Boolean) extends TypeWideningMode {
     override def shouldWidenType(fromType: AtomicType, toType: AtomicType): Boolean =
         TypeWidening.isTypeChangeSupportedForSchemaEvolution(
-          fromType = fromType, toType = toType, uniformIcebergEnabled)
+          fromType = fromType, toType = toType, uniformIcebergCompatibleOnly)
   }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TypeWideningMode.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TypeWideningMode.scala
@@ -1,0 +1,35 @@
+package org.apache.spark.sql.delta
+
+import org.apache.spark.sql.types.AtomicType
+
+/**
+ * A type widening mode captures a specific set of type changes that are allowed to be applied.
+ * Currently:
+ *  - NoTypeWidening: No type change is allowed.
+ *  - TypeEvolution(uniformIcebergEnabled = true): Type changes that are eligible to be applied
+ *    automatically during schema evolution and that are supported by Iceberg are allowed.
+ *  - TypeEvolution(uniformIcebergEnabled = false): Type changes that are eligible to be applied
+ *    automatically during schema evolution are allowed, even if they are not supported by Iceberg.
+ */
+trait TypeWideningMode {
+  def shouldWidenType(fromType: AtomicType, toType: AtomicType): Boolean
+}
+
+object TypeWideningMode {
+  /**
+   * No type change allowed. Typically because type widening and/or schema evolution isn't enabled.
+   */
+  object NoTypeWidening extends TypeWideningMode {
+    override def shouldWidenType(fromType: AtomicType, toType: AtomicType): Boolean = false
+  }
+
+  /**
+   * Type changes that are eligible to be applied automatically during schema evolution are allowed.
+   * Can be restricted to only type changes supported by Iceberg.
+   */
+  case class TypeEvolution(uniformIcebergEnabled: Boolean) extends TypeWideningMode {
+    override def shouldWidenType(fromType: AtomicType, toType: AtomicType): Boolean =
+        TypeWidening.isTypeChangeSupportedForSchemaEvolution(
+          fromType = fromType, toType = toType, uniformIcebergEnabled)
+  }
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/UniversalFormat.scala
@@ -109,6 +109,7 @@ object UniversalFormat extends DeltaLogging {
    *         updates need to be applied, will return None.
    */
   def enforceInvariantsAndDependencies(
+      spark: SparkSession,
       snapshot: Snapshot,
       newestProtocol: Protocol,
       newestMetadata: Metadata,
@@ -116,7 +117,7 @@ object UniversalFormat extends DeltaLogging {
       actions: Seq[Action]): (Option[Protocol], Option[Metadata]) = {
     enforceHudiDependencies(newestMetadata, snapshot)
     enforceIcebergInvariantsAndDependencies(
-      snapshot, newestProtocol, newestMetadata, operation, actions)
+      spark, snapshot, newestProtocol, newestMetadata, operation, actions)
   }
 
   /**
@@ -151,6 +152,7 @@ object UniversalFormat extends DeltaLogging {
    *         updates need to be applied, will return None.
    */
   def enforceIcebergInvariantsAndDependencies(
+      spark: SparkSession,
       snapshot: Snapshot,
       newestProtocol: Protocol,
       newestMetadata: Metadata,
@@ -200,6 +202,7 @@ object UniversalFormat extends DeltaLogging {
     changed = uniformProtocol.nonEmpty || uniformMetadata.nonEmpty
 
     val (v1protocolUpdate, v1metadataUpdate) = IcebergCompatV1.enforceInvariantsAndDependencies(
+      spark,
       snapshot,
       newestProtocol = protocolToCheck,
       newestMetadata = metadataToCheck,
@@ -211,6 +214,7 @@ object UniversalFormat extends DeltaLogging {
     changed ||= v1protocolUpdate.nonEmpty || v1metadataUpdate.nonEmpty
 
     val (v2protocolUpdate, v2metadataUpdate) = IcebergCompatV2.enforceInvariantsAndDependencies(
+      spark,
       snapshot,
       newestProtocol = protocolToCheck,
       newestMetadata = metadataToCheck,
@@ -238,12 +242,14 @@ object UniversalFormat extends DeltaLogging {
    *         otherwise the original configuration.
    */
   def enforceDependenciesInConfiguration(
+      spark: SparkSession,
       configuration: Map[String, String],
       snapshot: Snapshot): Map[String, String] = {
     var metadata = snapshot.metadata.copy(configuration = configuration)
 
     // Check UniversalFormat related property dependencies
     val (_, universalMetadata) = UniversalFormat.enforceInvariantsAndDependencies(
+      spark,
       snapshot,
       newestProtocol = snapshot.protocol,
       newestMetadata = metadata,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/ImplicitMetadataOperation.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/ImplicitMetadataOperation.scala
@@ -220,14 +220,17 @@ object ImplicitMetadataOperation {
     } else {
       checkDependentExpressions(spark, txn.protocol, txn.metadata, dataSchema)
 
-      def shouldWidenType(from: AtomicType, to: AtomicType): Boolean =
-        TypeWidening.isEnabled(txn.protocol, txn.metadata) &&
-          TypeWidening.isTypeChangeSupportedForSchemaEvolution(from, to, txn.metadata)
+      val typeWideningMode = if (TypeWidening.isEnabled(txn.protocol, txn.metadata)) {
+        TypeWideningMode.TypeEvolution(
+          uniformIcebergEnabled = UniversalFormat.icebergEnabled(txn.metadata))
+      } else {
+        TypeWideningMode.NoTypeWidening
+      }
 
       SchemaMergingUtils.mergeSchemas(
         txn.metadata.schema,
         dataSchema,
-        shouldWidenType = shouldWidenType)
+        typeWideningMode = typeWideningMode)
     }
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/ImplicitMetadataOperation.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/ImplicitMetadataOperation.scala
@@ -222,7 +222,7 @@ object ImplicitMetadataOperation {
 
       val typeWideningMode = if (TypeWidening.isEnabled(txn.protocol, txn.metadata)) {
         TypeWideningMode.TypeEvolution(
-          uniformIcebergEnabled = UniversalFormat.icebergEnabled(txn.metadata))
+          uniformIcebergCompatibleOnly = UniversalFormat.icebergEnabled(txn.metadata))
       } else {
         TypeWideningMode.NoTypeWidening
       }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaMergingUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaMergingUtils.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.delta.schema
 
 import scala.util.control.NonFatal
 
-import org.apache.spark.sql.delta.{DeltaAnalysisException, TypeWidening}
+import org.apache.spark.sql.delta.{DeltaAnalysisException, TypeWideningMode}
 
 import org.apache.spark.sql.catalyst.analysis.{Resolver, TypeCoercion, UnresolvedAttribute}
 import org.apache.spark.sql.catalyst.expressions.Literal
@@ -153,7 +153,7 @@ object SchemaMergingUtils {
       dataSchema: StructType,
       allowImplicitConversions: Boolean = false,
       keepExistingType: Boolean = false,
-      shouldWidenType: (AtomicType, AtomicType) => Boolean = (_, _) => false,
+      typeWideningMode: TypeWideningMode = TypeWideningMode.NoTypeWidening,
       caseSensitive: Boolean = false): StructType = {
     checkColumnNameDuplication(dataSchema, "in the data to save", caseSensitive)
     mergeDataTypes(
@@ -161,7 +161,7 @@ object SchemaMergingUtils {
       dataSchema,
       allowImplicitConversions,
       keepExistingType,
-      shouldWidenType,
+      typeWideningMode,
       caseSensitive,
       allowOverride = false
     ).asInstanceOf[StructType]
@@ -178,8 +178,9 @@ object SchemaMergingUtils {
    *                                 merge will succeed, because once we get to write time Spark SQL
    *                                 will support implicitly converting the int to a string.
    * @param keepExistingType Whether to keep existing types instead of trying to merge types.
-   * @param shouldWidenType Identifies the (current, update) type tuples where `current` can be
-   *                        widened to `update`, in which case `update` is used.
+   * @param typeWideningMode Identifies the (current, update) type tuples where `current` can be
+   *                        widened to `update`, in which case `update` is used. See
+   *                        [[TypeWideningMode]].
    * @param caseSensitive Whether we should keep field mapping case-sensitively.
    *                      This should default to false for Delta, which is case insensitive.
    * @param allowOverride Whether to let incoming type override the existing type if unmatched.
@@ -189,7 +190,7 @@ object SchemaMergingUtils {
       update: DataType,
       allowImplicitConversions: Boolean,
       keepExistingType: Boolean,
-      shouldWidenType: (AtomicType, AtomicType) => Boolean,
+      typeWideningMode: TypeWideningMode,
       caseSensitive: Boolean,
       allowOverride: Boolean): DataType = {
     def merge(current: DataType, update: DataType): DataType = {
@@ -240,7 +241,8 @@ object SchemaMergingUtils {
 
         // If type widening is enabled and the type can be widened, it takes precedence over
         // keepExistingType.
-        case (current: AtomicType, update: AtomicType) if shouldWidenType(current, update) => update
+        case (current: AtomicType, update: AtomicType)
+          if typeWideningMode.shouldWidenType(fromType = current, toType = update) => update
 
         // Simply keeps the existing type for primitive types
         case (current, _) if keepExistingType => current

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -20,7 +20,7 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
 
-import org.apache.spark.sql.delta.{DeltaAnalysisException, DeltaColumnMappingMode, DeltaErrors, DeltaLog, GeneratedColumn, NoMapping, TypeWidening}
+import org.apache.spark.sql.delta.{DeltaAnalysisException, DeltaColumnMappingMode, DeltaErrors, DeltaLog, GeneratedColumn, NoMapping, TypeWidening, TypeWideningMode}
 import org.apache.spark.sql.delta.{RowCommitVersion, RowId}
 import org.apache.spark.sql.delta.actions.Protocol
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
@@ -382,7 +382,7 @@ def normalizeColumnNamesInDataType(
    * rules are to return false if:
    *   - Dropping any column that was present in the existing schema, if not allowMissingColumns
    *   - Any change of datatype, unless eligible for widening. The caller specifies eligible type
-   *     changes via `shouldWidenType`.
+   *     changes via `typeWideningMode`.
    *   - Change of partition columns. Although analyzed LogicalPlan is not changed,
    *     physical structure of data is changed and thus is considered not read compatible.
    *   - If `forbidTightenNullability` = true:
@@ -403,7 +403,7 @@ def normalizeColumnNamesInDataType(
       readSchema: StructType,
       forbidTightenNullability: Boolean = false,
       allowMissingColumns: Boolean = false,
-      shouldWidenType: (AtomicType, AtomicType) => Boolean = (_, _) => false,
+      typeWideningMode: TypeWideningMode = TypeWideningMode.NoTypeWidening,
       newPartitionColumns: Seq[String] = Seq.empty,
       oldPartitionColumns: Seq[String] = Seq.empty): Boolean = {
 
@@ -418,7 +418,7 @@ def normalizeColumnNamesInDataType(
     def isDatatypeReadCompatible(existing: DataType, newtype: DataType): Boolean = {
       (existing, newtype) match {
         case (e: StructType, n: StructType) =>
-          isReadCompatible(e, n, forbidTightenNullability, shouldWidenType = shouldWidenType)
+          isReadCompatible(e, n, forbidTightenNullability, typeWideningMode = typeWideningMode)
         case (e: ArrayType, n: ArrayType) =>
           // if existing elements are non-nullable, so should be the new element
           isNullabilityCompatible(e.containsNull, n.containsNull) &&
@@ -428,7 +428,8 @@ def normalizeColumnNamesInDataType(
           isNullabilityCompatible(e.valueContainsNull, n.valueContainsNull) &&
             isDatatypeReadCompatible(e.keyType, n.keyType) &&
             isDatatypeReadCompatible(e.valueType, n.valueType)
-        case (e: AtomicType, n: AtomicType) if shouldWidenType(e, n) => true
+        case (e: AtomicType, n: AtomicType)
+          if typeWideningMode.shouldWidenType(fromType = e, toType = n) => true
         case (a, b) => a == b
       }
     }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1205,6 +1205,22 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(false)
 
+  /**
+   * Internal config to bypass check that prevents applying type changes that are not supported by
+   * Iceberg when Uniform is enabled with Iceberg compatibility.
+   */
+  val DELTA_TYPE_WIDENING_ALLOW_UNSUPPORTED_ICEBERG_TYPE_CHANGES =
+    buildConf("typeWidening.allowUnsupportedIcebergTypeChanges")
+      .internal()
+      .doc(
+        """
+          |By default, type changes that aren't supported by Iceberg are rejected when Uniform is
+          |enabled with Iceberg compatibility. This config allows bypassing this restriction, but
+          |reading the affected column with Iceberg clients will likely fail or behave erratically.
+          |""".stripMargin)
+      .booleanConf
+      .createWithDefault(false)
+
   val DELTA_IS_DELTA_TABLE_THROW_ON_ERROR =
     buildConf("isDeltaTable.throwOnError")
       .internal()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
@@ -178,7 +178,7 @@ case class DeltaSink(
 
     val typeWideningMode = if (canMergeSchema && TypeWidening.isEnabled(protocol, metadata)) {
         TypeWideningMode.TypeEvolution(
-          uniformIcebergEnabled = UniversalFormat.icebergEnabled(metadata))
+          uniformIcebergCompatibleOnly = UniversalFormat.icebergEnabled(metadata))
       } else {
         TypeWideningMode.NoTypeWidening
       }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
@@ -180,7 +180,9 @@ case class DeltaSink(
       metadata.schema,
       dataSchema,
       allowImplicitConversions = true,
-      allowTypeWidening = canMergeSchema && TypeWidening.isEnabled(protocol, metadata)
+      shouldWidenType =
+        canMergeSchema && TypeWidening.isEnabled(protocol, metadata) &&
+          TypeWidening.isTypeChangeSupportedForSchemaEvolution(_, _, metadata)
     )
   }
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSink.scala
@@ -176,13 +176,17 @@ case class DeltaSink(
 
     if (canOverwriteSchema) return dataSchema
 
+    val typeWideningMode = if (canMergeSchema && TypeWidening.isEnabled(protocol, metadata)) {
+        TypeWideningMode.TypeEvolution(
+          uniformIcebergEnabled = UniversalFormat.icebergEnabled(metadata))
+      } else {
+        TypeWideningMode.NoTypeWidening
+      }
     SchemaMergingUtils.mergeSchemas(
       metadata.schema,
       dataSchema,
       allowImplicitConversions = true,
-      shouldWidenType =
-        canMergeSchema && TypeWidening.isEnabled(protocol, metadata) &&
-          TypeWidening.isTypeChangeSupportedForSchemaEvolution(_, _, metadata)
+      typeWideningMode = typeWideningMode
     )
   }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaInsertIntoTest.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.delta
 import scala.collection.mutable
 
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.hadoop.fs.Path
 
 import org.apache.spark.{DebugFilesystem, SparkThrowable}
 import org.apache.spark.sql.{DataFrame, QueryTest, SaveMode}
@@ -221,10 +222,11 @@ trait DeltaInsertIntoTest extends QueryTest with DeltaDMLTestUtils with DeltaSQL
     val isSQL: Boolean = false
     def runInsert(columns: Seq[String], whereCol: String, whereValue: Int): Unit = {
       val tablePath = DeltaLog.forTable(spark, TableIdentifier("target")).dataPath
+      val checkpointLocation = new Path(tablePath, "_checkpoint")
       val query = spark.readStream
         .table("source")
         .writeStream
-        .option("checkpointLocation", tablePath.toString)
+        .option("checkpointLocation", checkpointLocation.toString)
         .format("delta")
         .trigger(Trigger.AvailableNow())
         .toTable("target")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/UniversalFormatSuiteBase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/UniversalFormatSuiteBase.scala
@@ -450,7 +450,7 @@ trait UniversalFormatMiscSuiteBase extends IcebergCompatUtilsBase {
       // The enforce is not lossy. It will do nothing if there is no Universal related key.
 
       def getUpdatedConfiguration(conf: Map[String, String]): Map[String, String] =
-        UniversalFormat.enforceDependenciesInConfiguration(conf, snapshot)
+        UniversalFormat.enforceDependenciesInConfiguration(spark, conf, snapshot)
 
       var updatedConfiguration = getUpdatedConfiguration(configurationUnderTest)
       assert(configurationUnderTest == configurationUnderTest)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/schema/SchemaUtilsSuite.scala
@@ -2533,7 +2533,7 @@ class SchemaUtilsSuite extends QueryTest
       mergeSchemas(
         base,
         update,
-        typeWideningMode = TypeWideningMode.TypeEvolution(uniformIcebergEnabled = false),
+        typeWideningMode = TypeWideningMode.TypeEvolution(uniformIcebergCompatibleOnly = false),
         keepExistingType = true
       )
     assert(mergedSchema === expected)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningUniformTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningUniformTests.scala
@@ -191,12 +191,12 @@ trait TypeWideningUniformTests extends QueryTest
 
 
   for (insert <- Set(
-    // Cover only a subset of all INSERTs. There's little value in testing all of them and it
-    // quickly gets expensive.
-    SQLInsertByPosition(SaveMode.Append),
-    SQLInsertByName(SaveMode.Append),
-    DFv1InsertInto(SaveMode.Append),
-    StreamingInsert)) {
+      // Cover only a subset of all INSERTs. There's little value in testing all of them and it
+      // quickly gets expensive.
+      SQLInsertByPosition(SaveMode.Append),
+      SQLInsertByName(SaveMode.Append),
+      DFv1InsertInto(SaveMode.Append),
+      StreamingInsert)) {
     test(s"enable uniform then apply supported type change - ${insert.name}") {
       for (testCase <- icebergSupportedTestCases) {
         Given(s"changing ${testCase.fromType.sql} -> ${testCase.toType.sql}")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningUniformTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningUniformTests.scala
@@ -1,0 +1,247 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.typewidening
+
+import org.apache.spark.sql.delta.{DeltaInsertIntoTest, DeltaUnsupportedOperationException, IcebergCompat, IcebergCompatV1, IcebergCompatV2}
+import org.apache.spark.sql.delta.DeltaErrors.toSQLType
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
+import org.scalatest.GivenWhenThen
+
+import org.apache.spark.sql.{QueryTest, SaveMode}
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types.{DataType, DateType, DecimalType}
+
+/** Trait collecting tests covering type widening + Uniform Iceberg compatibility. */
+trait TypeWideningUniformTests extends QueryTest
+  with TypeWideningTestMixin
+  with TypeWideningTestCases
+  with DeltaInsertIntoTest
+  with GivenWhenThen {
+
+  // Iceberg supports all base type changes eligible for widening during schema evolution except
+  // for date -> timestampNtz and decimal scale changes.
+  private val icebergSupportedTestCases = supportedTestCases.filter {
+    case SupportedTypeEvolutionTestCase(_ : DateType, _, _, _) => false
+    case SupportedTypeEvolutionTestCase(from: DecimalType, to: DecimalType, _, _) =>
+      from.scale == to.scale
+    case _ => true
+  }
+
+  // Unsupported type changes are all base changes that aren't supported above and all changes that
+  // are not eligible for schema evolution: int -> double, int -> decimal
+  private val icebergUnsupportedTestCases =
+    supportedTestCases.diff(icebergSupportedTestCases) ++ alterTableOnlySupportedTestCases
+
+  /** Helper to enable Uniform with Iceberg compatibility on the given table. */
+  private def enableIcebergUniform(tableName: String, compat: IcebergCompat): Unit =
+    sql(
+      s"""
+         |ALTER TABLE $tableName SET TBLPROPERTIES (
+         |  'delta.columnMapping.mode' = 'name',
+         |  '${compat.config.key}' = 'true',
+         |  'delta.universalFormat.enabledFormats' = 'iceberg'
+         |)
+       """.stripMargin)
+
+  /** Helper to check that the given function violates Uniform compatibility with type widening. */
+  private def checkIcebergCompatViolation(
+      compat: IcebergCompat,
+      fromType: DataType,
+      toType: DataType)(f: => Unit): Unit = {
+    Given(s"iceberg compat ${compat.getClass.getSimpleName}")
+    checkError(
+      exception = intercept[DeltaUnsupportedOperationException] {
+        f
+      },
+      "DELTA_ICEBERG_COMPAT_VIOLATION.UNSUPPORTED_TYPE_WIDENING",
+      parameters = Map(
+        "version" -> compat.version.toString,
+        "prevType" -> toSQLType(fromType),
+        "newType" -> toSQLType(toType),
+        "fieldPath" -> "a"
+      )
+    )
+  }
+
+  test("apply supported type change then enable uniform") {
+    for (testCase <- icebergSupportedTestCases) {
+      Given(s"changing ${testCase.fromType.sql} -> ${testCase.toType.sql}")
+      val tableName = "type_widening_uniform_supported_table"
+      withTable(tableName) {
+        sql(s"CREATE TABLE $tableName (a ${testCase.fromType.sql}) USING DELTA")
+        sql(s"ALTER TABLE $tableName CHANGE COLUMN a TYPE ${testCase.toType.sql}")
+        enableIcebergUniform(tableName, IcebergCompatV2)
+      }
+    }
+  }
+
+  test("apply unsupported type change then enable uniform") {
+    for (testCase <- icebergUnsupportedTestCases) {
+      val tableName = "type_widening_uniform_unsupported_table"
+      withTable(tableName) {
+        Given(s"changing ${testCase.fromType.sql} -> ${testCase.toType.sql}")
+        sql(s"CREATE TABLE $tableName (a ${testCase.fromType.sql}) USING DELTA")
+        sql(s"ALTER TABLE $tableName CHANGE COLUMN a TYPE ${testCase.toType.sql}")
+        checkIcebergCompatViolation(IcebergCompatV1, testCase.fromType, testCase.toType) {
+          enableIcebergUniform(tableName, IcebergCompatV1)
+        }
+        checkIcebergCompatViolation(IcebergCompatV2, testCase.fromType, testCase.toType) {
+          enableIcebergUniform(tableName, IcebergCompatV2)
+        }
+      }
+    }
+  }
+
+  test("enable uniform then apply supported type change - ALTER TABLE") {
+    for (testCase <- icebergSupportedTestCases) {
+      Given(s"changing ${testCase.fromType.sql} -> ${testCase.toType.sql}")
+      val tableName = "type_widening_uniform_manual_supported_table"
+      withTable(tableName) {
+        sql(s"CREATE TABLE $tableName (a ${testCase.fromType.sql}) USING DELTA")
+        enableIcebergUniform(tableName, IcebergCompatV2)
+        sql(s"ALTER TABLE $tableName CHANGE COLUMN a TYPE ${testCase.toType.sql}")
+      }
+    }
+  }
+
+  test("enable uniform then apply unsupported type change - ALTER TABLE") {
+    for (testCase <- icebergUnsupportedTestCases) {
+      val tableName = "type_widening_uniform_manual_unsupported_table"
+      withTable(tableName) {
+        Given(s"changing ${testCase.fromType.sql} -> ${testCase.toType.sql}")
+        sql(s"CREATE TABLE $tableName (a ${testCase.fromType.sql}) USING DELTA")
+        enableIcebergUniform(tableName, IcebergCompatV2)
+        checkIcebergCompatViolation(IcebergCompatV2, testCase.fromType, testCase.toType) {
+          sql(s"ALTER TABLE $tableName CHANGE COLUMN a TYPE ${testCase.toType.sql}")
+        }
+      }
+    }
+  }
+
+
+  test("enable uniform then apply supported type change - MERGE") {
+    for (testCase <- icebergSupportedTestCases) {
+      Given(s"changing ${testCase.fromType.sql} -> ${testCase.toType.sql}")
+      withTable("source", "target") {
+        testCase.initialValuesDF.write.format("delta").saveAsTable("target")
+        testCase.additionalValuesDF.write.format("delta").saveAsTable("source")
+        enableIcebergUniform("target", IcebergCompatV2)
+        withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true") {
+          sql(
+            s"""
+               |MERGE INTO target
+               |USING source
+               |ON 0 = 1
+               |WHEN NOT MATCHED THEN INSERT *
+           """.stripMargin)
+        }
+        val result = sql(s"SELECT * FROM target")
+        assert(result.schema("value").dataType === testCase.toType)
+        checkAnswer(result, testCase.expectedResult)
+      }
+    }
+  }
+
+  test("enable uniform then apply unsupported type change - MERGE") {
+    for (testCase <- icebergUnsupportedTestCases) {
+      Given(s"changing ${testCase.fromType.sql} -> ${testCase.toType.sql}")
+      withTable("source", "target") {
+        testCase.initialValuesDF.write.format("delta").saveAsTable("target")
+        // Here we use a source for MERGE that contains the same data that is already present in the
+        // target, except that it uses a wider type. Since Uniform is enabled and Iceberg doesn't
+        // support the given type change, we will keep the existing narrower type and downcast
+        // values. `testCase.additionalValueDF` contains values that would overflow, which would
+        // just fail, hence why we use `testCase.initialValueDF` instead.
+        testCase.initialValuesDF
+          .select(col("value").cast(testCase.toType))
+          .write
+          .format("delta")
+          .saveAsTable("source")
+        enableIcebergUniform("target", IcebergCompatV2)
+        withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true") {
+          sql(
+            s"""
+               |MERGE INTO target
+               |USING source
+               |ON 0 = 1
+               |WHEN NOT MATCHED THEN INSERT *
+          """.stripMargin)
+        }
+        val result = sql(s"SELECT * FROM target")
+        val expected = testCase.initialValuesDF.union(testCase.initialValuesDF)
+        assert(result.schema("value").dataType === testCase.fromType)
+        checkAnswer(result, expected)
+      }
+    }
+  }
+
+
+  for (insert <- Set(
+    // Cover only a subset of all INSERTs. There's little value in testing all of them and it
+    // quickly gets expensive.
+    SQLInsertByPosition(SaveMode.Append),
+    SQLInsertByName(SaveMode.Append),
+    DFv1InsertInto(SaveMode.Append),
+    StreamingInsert)) {
+    test(s"enable uniform then apply supported type change - ${insert.name}") {
+      for (testCase <- icebergSupportedTestCases) {
+        Given(s"changing ${testCase.fromType.sql} -> ${testCase.toType.sql}")
+        withTable("source", "target") {
+          testCase.initialValuesDF.write.format("delta").saveAsTable("target")
+          testCase.additionalValuesDF.write.format("delta").saveAsTable("source")
+          enableIcebergUniform("target", IcebergCompatV2)
+          withSQLConf(DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true") {
+            insert.runInsert(columns = Seq("value"), whereCol = "value", whereValue = 1)
+          }
+          val result = sql(s"SELECT * FROM target")
+          assert(result.schema("value").dataType === testCase.toType)
+          checkAnswer(result, testCase.expectedResult)
+        }
+      }
+    }
+
+    test(s"enable uniform then apply unsupported type change - ${insert.name}") {
+      for (testCase <- icebergUnsupportedTestCases) {
+        Given(s"changing ${testCase.fromType.sql} -> ${testCase.toType.sql}")
+        withTable("source", "target") {
+          testCase.initialValuesDF.write.format("delta").saveAsTable("target")
+          // Here we use a source for INSERT that contains the same data that is already present in
+          // the target, except that it uses a wider type. Since Uniform is enabled and Iceberg
+          // doesn't support the given type change, we will keep the existing narrower type and
+          // downcast values. `testCase.additionalValueDF` contains values that would overflow,
+          // which would just fail, hence why we use `testCase.initialValueDF` instead.
+          testCase.initialValuesDF
+            .select(col("value").cast(testCase.toType))
+            .write
+            .format("delta")
+            .saveAsTable("source")
+          enableIcebergUniform("target", IcebergCompatV2)
+          withSQLConf(
+            DeltaSQLConf.DELTA_SCHEMA_AUTO_MIGRATE.key -> "true",
+            DeltaSQLConf.DELTA_STREAMING_SINK_ALLOW_IMPLICIT_CASTS.key -> "true"
+          ) {
+            insert.runInsert(columns = Seq("value"), whereCol = "value", whereValue = 1)
+          }
+          val result = sql(s"SELECT * FROM target")
+          val expected = testCase.initialValuesDF.union(testCase.initialValuesDF)
+          assert(result.schema("value").dataType === testCase.fromType)
+          checkAnswer(result, expected)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description
Iceberg only supports a subset of the type changes that Delta's type widening feature covers.
See https://iceberg.apache.org/spec/#schema-evolution.
Unsupported type changes areL
- integers -> decimal
- integers -> double
- decimal scale increase
- date -> timestamp_ntz

This change makes using Uniform with Iceberg compatibility mutually exclusive with using one of these unsupported type changes, e.p.:
- Fail when trying to apply an unsupported type change if Uniform with Iceberg compatibility enabled.
- Fail when trying to enable Uniform with Iceberg compatibility if an unsupported type change was applied in the past.
- Don't automatically widen type during schema evolution if Uniform with Iceberg compatibility is enabled and the type promotion isn't supported by Iceberg.

## How was this patch tested?
- Added suite `TypeWideningUniformSuite` covering all cases listed above. E.p. for schema evolution, covers MERGE and a sample of INSERTs, including streaming writes.

## Does this PR introduce _any_ user-facing changes?
Note: all the unsupported Iceberg type changes covered here will only be supported in Delta starting with Delta 4.0, so this doesn't impact any released Delta version except for 4.0 preview.

Applying a type change not supported by Iceberg when Uniform with Iceberg compatibility now fails with:
```
CREATE TABLE t (a DECIMAL(10, 2)) TBLPROPERTIES (
  'delta.enableTypeWidening' = 'true',
  'delta.IcebergCompatV2' = 'true',
  'delta.universalFormat.enabledFormats' = 'iceberg'
);

ALTER TABLE t CHANGE COLUMN a TYPE DECIMAL(12, 4);
[DELTA_ICEBERG_COMPAT_VIOLATION.UNSUPPORTED_TYPE_WIDENING] 
IcebergCompatV2 is incompatible with a type change applied to this table: Field a was changed from DECIMAL(10, 2) to DECIMAL(12, 4)."
```

Enabling Uniform with Iceberg compatibility on a table that had an unsupported type change applied in the past now fails with:
```
CREATE TABLE t (a DECIMAL(10, 2)) TBLPROPERTIES ('delta.enableTypeWidening' = 'true');
ALTER TABLE t CHANGE COLUMN a TYPE DECIMAL(12, 4);


ALTER TABLE t SET TBLPROPERTIES (
  'delta.IcebergCompatV2' = 'true',
  'delta.universalFormat.enabledFormats' = 'iceberg'
);
[DELTA_ICEBERG_COMPAT_VIOLATION.UNSUPPORTED_TYPE_WIDENING] 
IcebergCompatV2 is incompatible with a type change applied to this table: Field a was changed from DECIMAL(10, 2) to DECIMAL(12, 4)."
```

Type changes not supported by Iceberg aren't eligible anymore for automatic type widening with schema evolution in MERGE/INSERT operation when Uniform with Iceberg compatibility is enabled.
