### PR TITLE
[Spark] Pass catalog table to DeltaLog API call sites, part 3

### DIFF
--- a/spark/src/main/scala/io/delta/tables/DeltaTable.scala
+++ b/spark/src/main/scala/io/delta/tables/DeltaTable.scala
@@ -123,7 +123,7 @@ class DeltaTable private[tables](
    * @since 0.3.0
    */
   def history(limit: Int): DataFrame = {
-    executeHistory(deltaLog, Some(limit), table.getTableIdentifierIfExists)
+    executeHistory(deltaLog, Some(limit), table.catalogTable)
   }
 
   /**
@@ -133,7 +133,7 @@ class DeltaTable private[tables](
    * @since 0.3.0
    */
   def history(): DataFrame = {
-    executeHistory(deltaLog, tableId = table.getTableIdentifierIfExists)
+    executeHistory(deltaLog, catalogTable = table.catalogTable)
   }
 
   /**

--- a/spark/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
+++ b/spark/src/main/scala/io/delta/tables/execution/DeltaTableOperations.scala
@@ -29,8 +29,8 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.sql.{functions, Column, DataFrame}
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedRelation, UnresolvedTable}
-import org.apache.spark.sql.catalyst.analysis.UnresolvedTableImplicits._
+import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedRelation}
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.connector.catalog.Identifier
@@ -53,9 +53,9 @@ trait DeltaTableOperations extends AnalysisHelper { self: io.delta.tables.DeltaT
   protected def executeHistory(
       deltaLog: DeltaLog,
       limit: Option[Int] = None,
-      tableId: Option[TableIdentifier] = None): DataFrame = withActiveSession(sparkSession) {
+      catalogTable: Option[CatalogTable] = None): DataFrame = withActiveSession(sparkSession) {
     val history = deltaLog.history
-    sparkSession.createDataFrame(history.getHistory(limit))
+    sparkSession.createDataFrame(history.getHistory(limit, catalogTable))
   }
 
   protected def executeDetails(

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaHistoryManager.scala
@@ -40,6 +40,7 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.spark.SparkEnv
 import org.apache.spark.internal.MDC
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.{SerializableConfiguration, ThreadUtils}
 
@@ -68,12 +69,23 @@ class DeltaHistoryManager(
    * Returns the information of the latest `limit` commits made to this table in reverse
    * chronological order.
    */
+  def getHistory(
+      limitOpt: Option[Int],
+      catalogTableOpt: Option[CatalogTable]): Seq[DeltaHistory] = {
+    val snapshot = deltaLog.update(catalogTableOpt = catalogTableOpt)
+    val listStart = limitOpt
+      .map { limit => math.max(snapshot.version - limit + 1, 0) }
+      .getOrElse(getEarliestDeltaFile(deltaLog))
+    getHistory(listStart, end = Some(snapshot.version), catalogTableOpt)
+  }
+
+  /**
+   * Returns the information of the latest `limit` commits made to this table in reverse
+   * chronological order. This version does not take in a catalog table and should only be
+   * used in testing.
+   */
   def getHistory(limitOpt: Option[Int]): Seq[DeltaHistory] = {
-    val snapshot = deltaLog.update()
-    val listStart = limitOpt.map { limit =>
-      math.max(snapshot.version - limit + 1, 0)
-    }.getOrElse(getEarliestDeltaFile(deltaLog))
-    getHistory(listStart, end = Some(snapshot.version))
+    getHistory(limitOpt, catalogTableOpt = None)
   }
 
   /**
@@ -136,10 +148,12 @@ class DeltaHistoryManager(
    * chronological order. If `end` is `None`, we return all commits from start to now.
    * @param start The start of the commit range, inclusive.
    * @param end The end of the commit range, inclusive.
+   * @param catalogTableOpt the catalog table associated with the Delta table.
    */
   def getHistory(
       start: Long,
-      end: Option[Long] = None): Seq[DeltaHistory] = {
+      end: Option[Long],
+      catalogTableOpt: Option[CatalogTable] = None): Seq[DeltaHistory] = {
     val currentSnapshot = deltaLog.unsafeVolatileSnapshot
     val (snapshotNewerThanResolvedEnd, resolvedEnd) = end match {
         case Some(endInclusive) if currentSnapshot.version >= endInclusive =>
@@ -148,7 +162,7 @@ class DeltaHistoryManager(
         case _ =>
           // Either end doesn't exist or the currently cached snapshot isn't new enough to
           // satisfy it.
-          val snapshot = deltaLog.update()
+          val snapshot = deltaLog.update(catalogTableOpt = catalogTableOpt)
           val endInclusive = end.getOrElse(snapshot.version).min(snapshot.version)
           (snapshot, endInclusive)
       }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/OptimisticTransaction.scala
@@ -1407,6 +1407,7 @@ trait OptimisticTransactionImpl extends TransactionalWrite
         readSnapshot = snapshot,
         commitInfo = Some(commitInfo),
         readRowIdHighWatermark = readRowIdHighWatermark,
+        catalogTable = catalogTable,
         domainMetadata = domainMetadata,
         op = op)
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/StatisticsCollection.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.delta.DeltaColumnMapping.COLUMN_MAPPING_PHYSICAL_NAM
 import org.apache.spark.sql.delta.DeltaOperations.ComputeStats
 import org.apache.spark.sql.delta.OptimisticTransaction
 import org.apache.spark.sql.delta.actions.{AddFile, Metadata, Protocol}
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.DeletionVectorUtils
 import org.apache.spark.sql.delta.commands.DeltaCommand
 import org.apache.spark.sql.delta.metering.DeltaLogging

--- a/spark/src/test/scala/org/apache/spark/sql/delta/cdc/DeleteCDCSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/cdc/DeleteCDCSuite.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.delta.cdc
 
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.commands.cdc.CDCReader._
 import org.apache.spark.sql.delta.sources.DeltaSQLConf._

--- a/spark/src/test/scala/org/apache/spark/sql/delta/cdc/MergeCDCSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/cdc/MergeCDCSuite.scala
@@ -18,9 +18,11 @@ package org.apache.spark.sql.delta.cdc
 
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta._
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
+import org.apache.spark.sql.delta.test.DeltaTestImplicits._
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{DataFrame, QueryTest}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/cdc/UpdateCDCSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/cdc/UpdateCDCSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.delta.cdc
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.sql.delta._
 import org.apache.spark.sql.delta.actions.{AddCDCFile, AddFile, RemoveFile}
+import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.test.DeltaExcludedTestMixin
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Fix a number of code paths where we want to pass catalog table to the commit coordinator client via DeltaLog API

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Unit tests
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
