### PR TITLE
[Spark] Fix NoSuchElementException in DeltaHistoryManager parallel search with empty commits

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaEncoders.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/util/DeltaEncoders.scala
@@ -116,4 +116,9 @@ private[delta] trait DeltaEncoders {
   implicit def fsPartitionSpecEncoder
     : Encoder[(SerializableFileStatus, CatalogTypes.TablePartitionSpec)]
       = _fsPartitionSpecEncoder.get
+
+  private lazy val _optionalHistoryCommitEncoder =
+    new DeltaEncoder[Option[DeltaHistoryManager.Commit]]
+  implicit def optionalHistoryCommitEncoder: Encoder[Option[DeltaHistoryManager.Commit]] =
+    _optionalHistoryCommitEncoder.get
 }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

When performing time travel operations that trigger parallel search in DeltaHistoryManager (when searching through >2000 commits), a NoSuchElementException can occur if some partitions return empty commit lists. This happens because the code attempts to call .head on potentially empty collections without proper checks.

## How was this patch tested?

UTs

## Does this PR introduce _any_ user-facing changes?

No
