### PR TITLE
[Kernel] Add `STARTS_WITH` expression and default impl

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/Predicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/Predicate.java
@@ -104,7 +104,7 @@ import java.util.stream.Stream;
  *   <li>Name: <code>STARTS WITH</code>
  *       <ul>
  *         <li>SQL semantic: <code>expr STARTS WITH expr</code>
- *         <li>Since version: 3.3.0
+ *         <li>Since version: 3.4.0
  *       </ul>
  * </ol>
  *

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/Predicate.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/Predicate.java
@@ -101,6 +101,11 @@ import java.util.stream.Stream;
  *         <li>SQL semantic: <code>expr1 IS NOT DISTINCT FROM expr2</code>
  *         <li>Since version: 3.3.0
  *       </ul>
+ *   <li>Name: <code>STARTS WITH</code>
+ *       <ul>
+ *         <li>SQL semantic: <code>expr STARTS WITH expr</code>
+ *         <li>Since version: 3.3.0
+ *       </ul>
  * </ol>
  *
  * @since 3.0.0

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
@@ -648,8 +648,7 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
 
     @Override
     ColumnVector visitStartsWith(final Predicate startsWith) {
-      throw new IllegalArgumentException(
-          "unexpected call for ColumnVector visitStartsWith(final Predicate startsWith)");
+      throw new IllegalArgumentException("Unexpected STARTS_WITH expression.");
     }
 
     /**

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
@@ -307,12 +307,12 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
             "Invalid number of inputs to STARTS_WITH expression. "
                 + "Example usage: STARTS_WITH(column, 'test')");
       }
-      ExpressionTransformResult leftResult = visit(startsWith.getChildren().get(0));
-      ExpressionTransformResult rightResult = visit(startsWith.getChildren().get(1));
+      ExpressionTransformResult leftResult = visit(childAt(startsWith, 0));
+      ExpressionTransformResult rightResult = visit(childAt(startsWith, 1));
       if (!(StringType.STRING.equivalent(leftResult.outputType)
           && StringType.STRING.equivalent(rightResult.outputType))) {
         throw unsupportedExpressionException(
-            startsWith, "'starts with' is only supported for string type expressions");
+            startsWith, "'STARTS_WITH' is expects STRING type inputs");
       }
       // TODO: support non literal as the second input of starts with.
       if (!(rightResult.expression instanceof Literal)) {
@@ -329,7 +329,7 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
                   right.getValue() == null
                       ? right
                       : Literal.ofString(
-                          DefaultExpressionUtils.escape(
+                          LikeExpressionEvaluator.escape(
                                   String.valueOf(right.getValue()), /*escapeChar=*/ '%')
                               .concat("%")))),
           BooleanType.BOOLEAN);

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
@@ -383,4 +383,17 @@ class DefaultExpressionUtils {
       }
     };
   }
+
+  static String escape(String pattern, char escapeChar) {
+    final int len = pattern.length();
+    final StringBuilder javaPattern = new StringBuilder(len + len);
+    for (int i = 0; i < len; i++) {
+      char c = pattern.charAt(i);
+      if (c == escapeChar) {
+        javaPattern.append('\\');
+      }
+      javaPattern.append(c);
+    }
+    return javaPattern.toString();
+  }
 }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
@@ -383,17 +383,17 @@ class DefaultExpressionUtils {
       }
     };
   }
-
-  static String escape(String pattern, char escapeChar) {
-    final int len = pattern.length();
-    final StringBuilder javaPattern = new StringBuilder(len + len);
+  /** Escapes characters escapeChar in the input String */
+  static String escape(String input, char escapeChar) {
+    final int len = input.length();
+    final StringBuilder escapedString = new StringBuilder(len + len);
     for (int i = 0; i < len; i++) {
-      char c = pattern.charAt(i);
+      char c = input.charAt(i);
       if (c == escapeChar) {
-        javaPattern.append('\\');
+        escapedString.append('\\');
       }
-      javaPattern.append(c);
+      escapedString.append(c);
     }
-    return javaPattern.toString();
+    return escapedString.toString();
   }
 }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionUtils.java
@@ -383,17 +383,4 @@ class DefaultExpressionUtils {
       }
     };
   }
-  /** Escapes characters escapeChar in the input String */
-  static String escape(String input, char escapeChar) {
-    final int len = input.length();
-    final StringBuilder escapedString = new StringBuilder(len + len);
-    for (int i = 0; i < len; i++) {
-      char c = input.charAt(i);
-      if (c == escapeChar) {
-        escapedString.append('\\');
-      }
-      escapedString.append(c);
-    }
-    return escapedString.toString();
-  }
 }

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionVisitor.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionVisitor.java
@@ -63,6 +63,8 @@ abstract class ExpressionVisitor<R> {
 
   abstract R visitLike(Predicate predicate);
 
+  abstract R visitStartsWith(Predicate predicate);
+
   final R visit(Expression expression) {
     if (expression instanceof PartitionValueExpression) {
       return visitPartitionValue((PartitionValueExpression) expression);
@@ -113,6 +115,8 @@ abstract class ExpressionVisitor<R> {
         return visitTimeAdd(expression);
       case "LIKE":
         return visitLike(new Predicate(name, children));
+      case "STARTS_WITH":
+        return visitStartsWith(new Predicate(name, children));
       default:
         throw new UnsupportedOperationException(
             String.format("Scalar expression `%s` is not supported.", name));

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/LikeExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/LikeExpressionEvaluator.java
@@ -183,4 +183,18 @@ public class LikeExpressionEvaluator {
     }
     return "(?s)" + javaPattern;
   }
+
+  /** Escapes characters escapeChar in the input String */
+  static String escape(String input, char escapeChar) {
+    final int len = input.length();
+    final StringBuilder escapedString = new StringBuilder(len + len);
+    for (int i = 0; i < len; i++) {
+      char c = input.charAt(i);
+      if (c == escapeChar) {
+        escapedString.append('\\');
+      }
+      escapedString.append(c);
+    }
+    return escapedString.toString();
+  }
 }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
@@ -615,6 +615,16 @@ class DefaultExpressionEvaluatorSuite extends AnyFunSuite with ExpressionSuiteBa
     checkBooleanVectors(new DefaultExpressionEvaluator(
       schema, startsWithExpressionAlwaysFalse, BooleanType.BOOLEAN).eval(input), allFalseVector)
 
+    val colUnicode = stringVector(Seq[String]("中文", "中", "文"))
+    val schemaUnicode = new StructType().add("col", StringType.STRING)
+    val inputUnicode = new DefaultColumnarBatch(colUnicode.getSize,
+      schemaUnicode, Array(colUnicode))
+    val startsWithExpressionUnicode = startsWith(new Column("col"), Literal.ofString("中"))
+    val expOutputVectorLiteralUnicode = booleanVector(Seq[BooleanJ](true, true, false))
+    checkBooleanVectors(new DefaultExpressionEvaluator(schemaUnicode,
+      startsWithExpressionUnicode,
+      BooleanType.BOOLEAN).eval(inputUnicode), expOutputVectorLiteralUnicode)
+
     val startsWithExpressionExpression = startsWith(new Column("col1"), new Column("col2"))
     val e = intercept[UnsupportedOperationException] {
       new DefaultExpressionEvaluator(
@@ -634,7 +644,7 @@ class DefaultExpressionEvaluatorSuite extends AnyFunSuite with ExpressionSuiteBa
         new DefaultExpressionEvaluator(
           schema, expr, BooleanType.BOOLEAN).eval(input)
       }
-      assert(e.getMessage.contains("'starts with' is only supported for string type expressions"))
+      assert(e.getMessage.contains("'STARTS_WITH' is expects STRING type inputs"))
     }
 
     checkUnsupportedTypes(BooleanType.BOOLEAN, BooleanType.BOOLEAN)

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
@@ -615,6 +615,7 @@ class DefaultExpressionEvaluatorSuite extends AnyFunSuite with ExpressionSuiteBa
     checkBooleanVectors(new DefaultExpressionEvaluator(
       schema, startsWithExpressionAlwaysFalse, BooleanType.BOOLEAN).eval(input), allFalseVector)
 
+    // scalastyle:off nonascii
     val colUnicode = stringVector(Seq[String]("中文", "中", "文"))
     val schemaUnicode = new StructType().add("col", StringType.STRING)
     val inputUnicode = new DefaultColumnarBatch(colUnicode.getSize,

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
@@ -1085,7 +1085,7 @@ class DefaultExpressionEvaluatorSuite extends AnyFunSuite with ExpressionSuiteBa
   }
 
   private def testComparator(
-                              comparator: String, left: Expression, right: Expression, expResult: BooleanJ): Unit = {
+     comparator: String, left: Expression, right: Expression, expResult: BooleanJ): Unit = {
     val expression = new Predicate(comparator, left, right)
     val batch = zeroColumnBatch(rowCount = 1)
     val outputVector = evaluator(batch.getSchema, expression, BooleanType.BOOLEAN).eval(batch)

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
@@ -1085,7 +1085,7 @@ class DefaultExpressionEvaluatorSuite extends AnyFunSuite with ExpressionSuiteBa
   }
 
   private def testComparator(
-     comparator: String, left: Expression, right: Expression, expResult: BooleanJ): Unit = {
+    comparator: String, left: Expression, right: Expression, expResult: BooleanJ): Unit = {
     val expression = new Predicate(comparator, left, right)
     val batch = zeroColumnBatch(rowCount = 1)
     val outputVector = evaluator(batch.getSchema, expression, BooleanType.BOOLEAN).eval(batch)

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/ExpressionSuiteBase.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/ExpressionSuiteBase.scala
@@ -39,7 +39,7 @@ trait ExpressionSuiteBase extends TestUtils with DefaultVectorTestUtils {
   }
 
   protected def like(
-      left: Expression, right: Expression, escape: Option[Character] = None): Predicate = {
+                      left: Expression, right: Expression, escape: Option[Character] = None): Predicate = {
     if (escape.isDefined && escape.get!=null) {
       like(List(left, right, Literal.ofString(escape.get.toString)))
     } else like(List(left, right))
@@ -47,6 +47,10 @@ trait ExpressionSuiteBase extends TestUtils with DefaultVectorTestUtils {
 
   protected def like(children: List[Expression]): Predicate = {
     new Predicate("like", children.asJava)
+  }
+
+  protected def startsWith(left: Expression, right: Expression): Predicate = {
+    new Predicate("starts_with", left, right)
   }
 
   protected def comparator(symbol: String, left: Expression, right: Expression): Predicate = {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/ExpressionSuiteBase.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/ExpressionSuiteBase.scala
@@ -39,7 +39,7 @@ trait ExpressionSuiteBase extends TestUtils with DefaultVectorTestUtils {
   }
 
   protected def like(
-                      left: Expression, right: Expression, escape: Option[Character] = None): Predicate = {
+      left: Expression, right: Expression, escape: Option[Character] = None): Predicate = {
     if (escape.isDefined && escape.get!=null) {
       like(List(left, right, Literal.ofString(escape.get.toString)))
     } else like(List(left, right))


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Initial implementation of STARTS_WITH expression following the idea mentioned in https://github.com/delta-io/delta/issues/2539#issuecomment-2195066500, i.e. transform the STARTS_WITH(a, b) with LIKE(a, b+"%"), at this moment, we only support b as literal expression.

This is 1/n for addressing https://github.com/delta-io/delta/issues/2539, the logic of data skipping will be done in the following PRs

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Added test cases in DefaultExpressionEvaluatorSuite.scala

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
