### PR TITLE
[Kernel] Implement AddFile class using DelegateRow

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Transaction.java
@@ -211,13 +211,13 @@ public interface Transaction {
           if (isIcebergCompatV2Enabled) {
             IcebergCompatV2Utils.validDataFileStatus(dataFileStatus);
           }
-          Row addFileRow =
+          AddFile addFileRow =
               AddFile.convertDataFileStatus(
                   tableRoot,
                   dataFileStatus,
                   ((DataWriteContextImpl) dataWriteContext).getPartitionValues(),
                   true /* dataChange */);
-          return SingleAction.createAddFileSingleAction(addFileRow);
+          return SingleAction.createAddFileSingleAction(addFileRow.toRow());
         });
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/AddFile.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/AddFile.java
@@ -19,15 +19,18 @@ import static io.delta.kernel.internal.util.InternalUtils.relativizePath;
 import static io.delta.kernel.internal.util.PartitionUtils.serializePartitionMap;
 import static java.util.stream.Collectors.toMap;
 
+import io.delta.kernel.data.MapValue;
 import io.delta.kernel.data.Row;
 import io.delta.kernel.expressions.Literal;
+import io.delta.kernel.internal.data.DelegateRow;
 import io.delta.kernel.internal.data.GenericRow;
 import io.delta.kernel.internal.fs.Path;
+import io.delta.kernel.internal.util.VectorUtils;
 import io.delta.kernel.types.*;
+import io.delta.kernel.utils.DataFileStatistics;
 import io.delta.kernel.utils.DataFileStatus;
 import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.IntStream;
 
 /** Delta log action representing an `AddFile` */
@@ -55,12 +58,15 @@ public class AddFile {
           .add(
               "tags",
               new MapType(StringType.STRING, StringType.STRING, true /* valueContainsNull */),
-              true /* nullable */);
+              true /* nullable */)
+          .add("baseRowId", LongType.LONG, true /* nullable */)
+          .add("defaultRowCommitVersion", LongType.LONG, true /* nullable */);
 
   public static final StructType SCHEMA_WITH_STATS = SCHEMA_WITHOUT_STATS.add(JSON_STATS_FIELD);
 
   /** Full schema of the {@code add} action in the Delta Log. */
   public static final StructType FULL_SCHEMA = SCHEMA_WITH_STATS;
+
   // There are more fields which are added when row-id tracking and clustering is enabled.
   // When Kernel starts supporting row-ids and clustering, we should add those fields here.
 
@@ -92,5 +98,150 @@ public class AddFile {
     }
     // any fields not present in the valueMap are considered null
     return new GenericRow(FULL_SCHEMA, valueMap);
+  }
+
+  /**
+   * The underlying {@link Row} that represents an 'AddFile' action and contains all its field
+   * values. Can be either a {@link GenericRow} or a {@link DelegateRow}.
+   */
+  private final Row row;
+
+  public AddFile(Row row) {
+    this.row = row;
+  }
+
+  public Row toRow() {
+    return row;
+  }
+
+  public String getPath() {
+    return row.getString(COL_NAME_TO_ORDINAL.get("path"));
+  }
+
+  public MapValue getPartitionValues() {
+    return row.getMap(COL_NAME_TO_ORDINAL.get("partitionValues"));
+  }
+
+  public long getSize() {
+    return row.getLong(COL_NAME_TO_ORDINAL.get("size"));
+  }
+
+  public long getModificationTime() {
+    return row.getLong(COL_NAME_TO_ORDINAL.get("modificationTime"));
+  }
+
+  public boolean getDataChange() {
+    return row.getBoolean(COL_NAME_TO_ORDINAL.get("dataChange"));
+  }
+
+  public Optional<DeletionVectorDescriptor> getDeletionVector() {
+    int ordinal = COL_NAME_TO_ORDINAL.get("deletionVector");
+    return Optional.ofNullable(
+        row.isNullAt(ordinal) ? null : DeletionVectorDescriptor.fromRow(row.getStruct(ordinal)));
+  }
+
+  public Optional<MapValue> getTags() {
+    int ordinal = COL_NAME_TO_ORDINAL.get("tags");
+    return Optional.ofNullable(row.isNullAt(ordinal) ? null : row.getMap(ordinal));
+  }
+
+  public Optional<Long> getBaseRowId() {
+    int ordinal = COL_NAME_TO_ORDINAL.get("baseRowId");
+    return Optional.ofNullable(row.isNullAt(ordinal) ? null : row.getLong(ordinal));
+  }
+
+  public Optional<Long> getDefaultRowCommitVersion() {
+    int ordinal = COL_NAME_TO_ORDINAL.get("defaultRowCommitVersion");
+    return Optional.ofNullable(row.isNullAt(ordinal) ? null : row.getLong(ordinal));
+  }
+
+  public Optional<DataFileStatistics> getStats() {
+    int ordinal = COL_NAME_TO_ORDINAL.get("stats");
+    return Optional.ofNullable(
+        row.isNullAt(ordinal)
+            ? null
+            : DataFileStatistics.deserializeFromJson(row.getString(ordinal)).orElse(null));
+  }
+
+  public Optional<Long> getNumRecords() {
+    return this.getStats().map(DataFileStatistics::getNumRecords);
+  }
+
+  /**
+   * Returns a new {@link AddFile} with the provided baseRowId. Under the hood, this is achieved by
+   * creating a new {@link DelegateRow} with the baseRowId overridden.
+   */
+  public AddFile withNewBaseRowId(long baseRowId) {
+    Map<Integer, Object> overrides =
+        Collections.singletonMap(COL_NAME_TO_ORDINAL.get("baseRowId"), baseRowId);
+    return new AddFile(new DelegateRow(row, overrides));
+  }
+
+  /**
+   * Returns a new {@link AddFile} with the provided defaultRowCommitVersion. Under the hood, this
+   * is achieved by creating a new {@link DelegateRow} with the defaultRowCommitVersion overridden.
+   */
+  public AddFile withNewDefaultRowCommitVersion(long defaultRowCommitVersion) {
+    Map<Integer, Object> overrides =
+        Collections.singletonMap(
+            COL_NAME_TO_ORDINAL.get("defaultRowCommitVersion"), defaultRowCommitVersion);
+    return new AddFile(new DelegateRow(row, overrides));
+  }
+
+  @Override
+  public String toString() {
+    // Convert the partitionValues and tags to Java Maps and make them sorted by key.
+    Map<String, String> partitionValuesJavaMap = VectorUtils.toJavaMap(getPartitionValues());
+    Map<String, String> sortedPartitionValuesJavaMap = new TreeMap<>(partitionValuesJavaMap);
+
+    Optional<Map<String, String>> tagsJavaMap = getTags().map(VectorUtils::toJavaMap);
+    Optional<Map<String, String>> sortedTagsJavaMap = tagsJavaMap.map(TreeMap::new);
+
+    StringBuilder sb = new StringBuilder();
+    sb.append("AddFile{");
+    sb.append("path='").append(getPath()).append('\'');
+    sb.append(", partitionValues=").append(sortedPartitionValuesJavaMap);
+    sb.append(", size=").append(getSize());
+    sb.append(", modificationTime=").append(getModificationTime());
+    sb.append(", dataChange=").append(getDataChange());
+    sb.append(", deletionVector=").append(getDeletionVector());
+    sb.append(", tags=").append(sortedTagsJavaMap);
+    sb.append(", baseRowId=").append(getBaseRowId());
+    sb.append(", defaultRowCommitVersion=").append(getDefaultRowCommitVersion());
+    sb.append(", stats=").append(getStats());
+    sb.append('}');
+    return sb.toString();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (!(obj instanceof AddFile)) return false;
+    AddFile other = (AddFile) obj;
+    return getSize() == other.getSize()
+        && getModificationTime() == other.getModificationTime()
+        && getDataChange() == other.getDataChange()
+        && Objects.equals(getPath(), other.getPath())
+        && Objects.equals(getPartitionValues(), other.getPartitionValues())
+        && Objects.equals(getDeletionVector(), other.getDeletionVector())
+        && Objects.equals(getTags(), other.getTags())
+        && Objects.equals(getBaseRowId(), other.getBaseRowId())
+        && Objects.equals(getDefaultRowCommitVersion(), other.getDefaultRowCommitVersion())
+        && Objects.equals(getStats(), other.getStats());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        getPath(),
+        getPartitionValues(),
+        getSize(),
+        getModificationTime(),
+        getDataChange(),
+        getDeletionVector(),
+        getTags(),
+        getBaseRowId(),
+        getDefaultRowCommitVersion(),
+        getStats());
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/AddFile.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/AddFile.java
@@ -131,56 +131,61 @@ public class AddFile extends RowBackedAction {
     return new GenericRow(FULL_SCHEMA, fieldMap);
   }
 
+  ////////////////////////////////////
+  // Constructor and Member Methods //
+  ////////////////////////////////////
+
   /** Constructs an {@link AddFile} action from the given 'AddFile' {@link Row}. */
   public AddFile(Row row) {
-    super(row);
-  }
-
-  @Override
-  protected StructType getFullSchema() {
-    return FULL_SCHEMA;
+    super(row, FULL_SCHEMA);
   }
 
   public String getPath() {
-    return (String) getValueAsObject("path");
+    return row.getString(getFieldIndex("path"));
   }
 
   public MapValue getPartitionValues() {
-    return (MapValue) getValueAsObject("partitionValues");
+    return row.getMap(getFieldIndex("partitionValues"));
   }
 
   public long getSize() {
-    return (long) getValueAsObject("size");
+    return row.getLong(getFieldIndex("size"));
   }
 
   public long getModificationTime() {
-    return (long) getValueAsObject("modificationTime");
+    return row.getLong(getFieldIndex("modificationTime"));
   }
 
   public boolean getDataChange() {
-    return (boolean) getValueAsObject("dataChange");
+    return row.getBoolean(getFieldIndex("dataChange"));
   }
 
   public Optional<DeletionVectorDescriptor> getDeletionVector() {
-    return Optional.ofNullable((Row) getValueAsObject("deletionVector"))
-        .map(DeletionVectorDescriptor::fromRow);
+    int index = getFieldIndex("deletionVector");
+    return Optional.ofNullable(
+        row.isNullAt(index) ? null : DeletionVectorDescriptor.fromRow(row.getStruct(index)));
   }
 
   public Optional<MapValue> getTags() {
-    return Optional.ofNullable((MapValue) getValueAsObject("tags"));
+    int index = getFieldIndex("tags");
+    return Optional.ofNullable(row.isNullAt(index) ? null : row.getMap(index));
   }
 
   public Optional<Long> getBaseRowId() {
-    return Optional.ofNullable((Long) getValueAsObject("baseRowId"));
+    int index = getFieldIndex("baseRowId");
+    return Optional.ofNullable(row.isNullAt(index) ? null : row.getLong(index));
   }
 
   public Optional<Long> getDefaultRowCommitVersion() {
-    return Optional.ofNullable((Long) getValueAsObject("defaultRowCommitVersion"));
+    int index = getFieldIndex("defaultRowCommitVersion");
+    return Optional.ofNullable(row.isNullAt(index) ? null : row.getLong(index));
   }
 
   public Optional<DataFileStatistics> getStats() {
-    return Optional.ofNullable((String) getValueAsObject("stats"))
-        .flatMap(DataFileStatistics::deserializeFromJson);
+    int index = getFieldIndex("stats");
+    return row.isNullAt(index)
+        ? Optional.empty()
+        : DataFileStatistics.deserializeFromJson(row.getString(index));
   }
 
   public Optional<Long> getNumRecords() {
@@ -189,13 +194,13 @@ public class AddFile extends RowBackedAction {
 
   /** Returns a new {@link AddFile} with the provided baseRowId. */
   public AddFile withNewBaseRowId(long baseRowId) {
-    return new AddFile(createRowWithOverriddenValue("baseRowId", baseRowId));
+    return new AddFile(toRowWithOverriddenValue("baseRowId", baseRowId));
   }
 
   /** Returns a new {@link AddFile} with the provided defaultRowCommitVersion. */
   public AddFile withNewDefaultRowCommitVersion(long defaultRowCommitVersion) {
     return new AddFile(
-        createRowWithOverriddenValue("defaultRowCommitVersion", defaultRowCommitVersion));
+        toRowWithOverriddenValue("defaultRowCommitVersion", defaultRowCommitVersion));
   }
 
   @Override

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/AddFile.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/AddFile.java
@@ -17,6 +17,8 @@ package io.delta.kernel.internal.actions;
 
 import static io.delta.kernel.internal.util.InternalUtils.relativizePath;
 import static io.delta.kernel.internal.util.PartitionUtils.serializePartitionMap;
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+import static io.delta.kernel.internal.util.VectorUtils.toJavaMap;
 import static java.util.stream.Collectors.toMap;
 
 import io.delta.kernel.data.MapValue;
@@ -34,7 +36,7 @@ import java.util.*;
 import java.util.stream.IntStream;
 
 /** Delta log action representing an `AddFile` */
-public class AddFile {
+public class AddFile extends RowBackedAction {
 
   /* We conditionally read this field based on the query filter */
   private static final StructField JSON_STATS_FIELD =
@@ -76,42 +78,78 @@ public class AddFile {
           .collect(toMap(i -> FULL_SCHEMA.at(i).getName(), i -> i));
 
   /**
-   * Utility to generate `AddFile` row from the given {@link DataFileStatus} and partition values.
+   * Utility to generate {@link AddFile} action instance from the given {@link DataFileStatus} and
+   * partition values.
    */
-  public static Row convertDataFileStatus(
+  public static AddFile convertDataFileStatus(
       URI tableRoot,
       DataFileStatus dataFileStatus,
       Map<String, Literal> partitionValues,
       boolean dataChange) {
     Path filePath = new Path(dataFileStatus.getPath());
-    Map<Integer, Object> valueMap = new HashMap<>();
-    valueMap.put(
-        COL_NAME_TO_ORDINAL.get("path"), relativizePath(filePath, tableRoot).toUri().toString());
-    valueMap.put(
-        COL_NAME_TO_ORDINAL.get("partitionValues"), serializePartitionMap(partitionValues));
-    valueMap.put(COL_NAME_TO_ORDINAL.get("size"), dataFileStatus.getSize());
-    valueMap.put(COL_NAME_TO_ORDINAL.get("modificationTime"), dataFileStatus.getModificationTime());
-    valueMap.put(COL_NAME_TO_ORDINAL.get("dataChange"), dataChange);
-    if (dataFileStatus.getStatistics().isPresent()) {
-      valueMap.put(
-          COL_NAME_TO_ORDINAL.get("stats"), dataFileStatus.getStatistics().get().serializeAsJson());
-    }
-    // any fields not present in the valueMap are considered null
-    return new GenericRow(FULL_SCHEMA, valueMap);
+
+    return new AddFile(
+        relativizePath(filePath, tableRoot).toUri().toString(),
+        serializePartitionMap(partitionValues),
+        dataFileStatus.getSize(),
+        dataFileStatus.getModificationTime(),
+        dataChange,
+        Optional.empty(), // deletionVector
+        Optional.empty(), // tags
+        Optional.empty(), // baseRowId
+        Optional.empty(), // defaultRowCommitVersion
+        dataFileStatus.getStatistics());
+  }
+
+  /** Constructs an {@link AddFile} action from the given 'AddFile' {@link Row}. */
+  public AddFile(Row row) {
+    super(row);
   }
 
   /**
-   * The underlying {@link Row} that represents an 'AddFile' action and contains all its field
-   * values. Can be either a {@link GenericRow} or a {@link DelegateRow}.
+   * Constructs an {@link AddFile} action from the given fields. Internally, this creates a new
+   * {@link GenericRow} with the given fields and return a new {@link AddFile} instance backed by
+   * it.
    */
-  private final Row row;
+  public AddFile(
+      String path,
+      MapValue partitionValues,
+      long size,
+      long modificationTime,
+      boolean dataChange,
+      Optional<DeletionVectorDescriptor> deletionVector,
+      Optional<MapValue> tags,
+      Optional<Long> baseRowId,
+      Optional<Long> defaultRowCommitVersion,
+      Optional<DataFileStatistics> stats) {
+    super(
+        new GenericRow(
+            FULL_SCHEMA,
+            new HashMap<Integer, Object>() {
+              {
+                // TODO - Add support for DeletionVectorDescriptor
+                checkArgument(
+                    !deletionVector.isPresent(),
+                    "DeletionVectorDescriptor currently doesn't have a way to convert to a Row");
 
-  public AddFile(Row row) {
-    this.row = row;
+                put(COL_NAME_TO_ORDINAL.get("path"), path);
+                put(COL_NAME_TO_ORDINAL.get("partitionValues"), partitionValues);
+                put(COL_NAME_TO_ORDINAL.get("size"), size);
+                put(COL_NAME_TO_ORDINAL.get("modificationTime"), modificationTime);
+                put(COL_NAME_TO_ORDINAL.get("dataChange"), dataChange);
+                tags.ifPresent(tags -> put(COL_NAME_TO_ORDINAL.get("tags"), tags));
+                baseRowId.ifPresent(id -> put(COL_NAME_TO_ORDINAL.get("baseRowId"), id));
+                defaultRowCommitVersion.ifPresent(
+                    version -> put(COL_NAME_TO_ORDINAL.get("defaultRowCommitVersion"), version));
+                stats.ifPresent(
+                    stats -> put(COL_NAME_TO_ORDINAL.get("stats"), stats.serializeAsJson()));
+              }
+            }));
   }
 
-  public Row toRow() {
-    return row;
+  @Override
+  protected StructType getFullSchema() {
+    return FULL_SCHEMA;
   }
 
   public String getPath() {
@@ -191,7 +229,7 @@ public class AddFile {
   @Override
   public String toString() {
     // Convert the partitionValues and tags to Java Maps and make them sorted by key.
-    Map<String, String> partitionValuesJavaMap = VectorUtils.toJavaMap(getPartitionValues());
+    Map<String, String> partitionValuesJavaMap = toJavaMap(getPartitionValues());
     Map<String, String> sortedPartitionValuesJavaMap = new TreeMap<>(partitionValuesJavaMap);
 
     Optional<Map<String, String>> tagsJavaMap = getTags().map(VectorUtils::toJavaMap);
@@ -218,30 +256,38 @@ public class AddFile {
     if (this == obj) return true;
     if (!(obj instanceof AddFile)) return false;
     AddFile other = (AddFile) obj;
+
+    // MapValue and DataFileStatistics don't implement equals(), so we need to convert
+    // partitionValues and tags to Java Maps, and stats to strings to compare them
     return getSize() == other.getSize()
         && getModificationTime() == other.getModificationTime()
         && getDataChange() == other.getDataChange()
         && Objects.equals(getPath(), other.getPath())
-        && Objects.equals(getPartitionValues(), other.getPartitionValues())
+        && Objects.equals(toJavaMap(getPartitionValues()), toJavaMap(other.getPartitionValues()))
         && Objects.equals(getDeletionVector(), other.getDeletionVector())
-        && Objects.equals(getTags(), other.getTags())
+        && Objects.equals(
+            getTags().map(VectorUtils::toJavaMap), other.getTags().map(VectorUtils::toJavaMap))
         && Objects.equals(getBaseRowId(), other.getBaseRowId())
         && Objects.equals(getDefaultRowCommitVersion(), other.getDefaultRowCommitVersion())
-        && Objects.equals(getStats(), other.getStats());
+        && Objects.equals(
+            getStats().map(DataFileStatistics::toString),
+            other.getStats().map(DataFileStatistics::toString));
   }
 
   @Override
   public int hashCode() {
+    // MapValue and DataFileStatistics don't implement hashCode(), so we need to convert
+    // partitionValues and tags to Java Maps, and stats to strings to compute the hash code
     return Objects.hash(
         getPath(),
-        getPartitionValues(),
+        toJavaMap(getPartitionValues()),
         getSize(),
         getModificationTime(),
         getDataChange(),
         getDeletionVector(),
-        getTags(),
+        getTags().map(VectorUtils::toJavaMap),
         getBaseRowId(),
         getDefaultRowCommitVersion(),
-        getStats());
+        getStats().map(DataFileStatistics::toString));
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/AddFile.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/AddFile.java
@@ -34,7 +34,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.TreeMap;
 
 /** Delta log action representing an `AddFile` */
 public class AddFile extends RowBackedAction {
@@ -205,22 +204,16 @@ public class AddFile extends RowBackedAction {
 
   @Override
   public String toString() {
-    // Convert the partitionValues and tags to Java Maps and make them sorted by key.
-    Map<String, String> partitionValuesJavaMap = toJavaMap(getPartitionValues());
-    Map<String, String> sortedPartitionValuesJavaMap = new TreeMap<>(partitionValuesJavaMap);
-
-    Optional<Map<String, String>> tagsJavaMap = getTags().map(VectorUtils::toJavaMap);
-    Optional<Map<String, String>> sortedTagsJavaMap = tagsJavaMap.map(TreeMap::new);
-
+    // No specific ordering is guaranteed for partitionValues and tags in the returned string
     StringBuilder sb = new StringBuilder();
     sb.append("AddFile{");
     sb.append("path='").append(getPath()).append('\'');
-    sb.append(", partitionValues=").append(sortedPartitionValuesJavaMap);
+    sb.append(", partitionValues=").append(toJavaMap(getPartitionValues()));
     sb.append(", size=").append(getSize());
     sb.append(", modificationTime=").append(getModificationTime());
     sb.append(", dataChange=").append(getDataChange());
     sb.append(", deletionVector=").append(getDeletionVector());
-    sb.append(", tags=").append(sortedTagsJavaMap);
+    sb.append(", tags=").append(getTags().map(VectorUtils::toJavaMap));
     sb.append(", baseRowId=").append(getBaseRowId());
     sb.append(", defaultRowCommitVersion=").append(getDefaultRowCommitVersion());
     sb.append(", stats=").append(getStats());

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/RemoveFile.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/RemoveFile.java
@@ -33,7 +33,11 @@ public class RemoveFile {
           .add("size", LongType.LONG, true /* nullable*/)
           .add("stats", StringType.STRING, true /* nullable */)
           .add("tags", new MapType(StringType.STRING, StringType.STRING, true), true /* nullable */)
-          .add("deletionVector", DeletionVectorDescriptor.READ_SCHEMA, true /* nullable */);
-  // There are more fields which are added when row-id tracking is enabled. When Kernel
-  // starts supporting row-ids, we should add those fields here.
+          .add("deletionVector", DeletionVectorDescriptor.READ_SCHEMA, true /* nullable */)
+          .add("baseRowId", LongType.LONG, true /* nullable */)
+          .add("defaultRowCommitVersion", LongType.LONG, true /* nullable */);
+  // TODO: Currently, Kernel doesn't create RemoveFile actions internally, nor provides APIs for
+  //  connectors to generate and commit them. Once we have the need for this, we should ensure
+  //  that the baseRowId and defaultRowCommitVersion fields of RemoveFile actions are correctly
+  //  populated to match the corresponding AddFile actions.
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/RowBackedAction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/RowBackedAction.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.actions;
+
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+
+import io.delta.kernel.data.Row;
+import io.delta.kernel.types.StructType;
+
+/**
+ * Base abstract class for Delta Log actions that are backed by a {@link Row}.This abstraction is
+ * used by actions like {@link AddFile}, where we want to avoid materializing all fields from the
+ * row when creating an action instance. For these actions, we only maintain a reference to the
+ * underlying row, and the getters retrieve values directly from it.
+ */
+public abstract class RowBackedAction {
+
+  /** The underlying {@link Row} that represents an action and contains all its field values. */
+  protected final Row row;
+
+  protected RowBackedAction(Row row) {
+    checkArgument(
+        row.getSchema().equals(getFullSchema()),
+        "Expected row schema: %s, found: %s",
+        getFullSchema(),
+        row.getSchema());
+
+    this.row = row;
+  }
+
+  /** Returns the full schema of the row that represents this action. */
+  protected abstract StructType getFullSchema();
+
+  public Row toRow() {
+    return row;
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/RowBackedAction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/RowBackedAction.java
@@ -15,7 +15,6 @@
  */
 package io.delta.kernel.internal.actions;
 
-import static io.delta.kernel.internal.util.InternalUtils.requireNonNull;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 
 import io.delta.kernel.data.Row;
@@ -28,95 +27,38 @@ import java.util.Map;
  * An abstract base class for Delta Log actions that are backed by a {@link Row}. This design is to
  * avoid materialization of all fields when creating action instances from action rows within
  * Kernel. Actions like {@link AddFile} can extend this class to maintain just a reference to the
- * underlying action row. Subclasses can:
- *
- * <ul>
- *   <li>Access field values directly from the row via {@link #getValueAsObject}
- *   <li>Create new action instances with updated fields via {@link #createRowWithOverriddenValue}
- * </ul>
+ * underlying action row.
  */
 public abstract class RowBackedAction {
 
   /** The underlying {@link Row} that represents an action and contains all its field values. */
-  private final Row row;
+  protected final Row row;
 
-  protected RowBackedAction(Row row) {
+  protected RowBackedAction(Row row, StructType expectedSchema) {
     checkArgument(
-        row.getSchema().equals(getFullSchema()),
+        row.getSchema().equals(expectedSchema),
         "Expected row schema: %s, found: %s",
-        getFullSchema(),
+        expectedSchema,
         row.getSchema());
 
     this.row = row;
   }
-
-  /** Returns the full schema of the row that represents this action. */
-  protected abstract StructType getFullSchema();
 
   /**
    * Returns the index of the field with the given name in the full schema of the row. Throws an
    * {@link IllegalArgumentException} if the field is not found.
    */
   protected int getFieldIndex(String fieldName) {
-    int index = getFullSchema().indexOf(fieldName);
-    checkArgument(index >= 0, "Field '%s' not found in schema: %s", fieldName, getFullSchema());
+    int index = row.getSchema().indexOf(fieldName);
+    checkArgument(index >= 0, "Field '%s' not found in schema: %s", fieldName, row.getSchema());
     return index;
   }
 
   /**
-   * Gets the value with the given field name from the row. The type of the Object returned depends
-   * on the data type of the field. If the field is nullable and the value is null, this method will
-   * return null. If the field is not nullable and the value is null, this method will throw an
-   * {@link IllegalArgumentException}.
-   */
-  protected Object getValueAsObject(String fieldName) {
-    StructField field = getFullSchema().get(fieldName);
-    int ordinal = getFieldIndex(fieldName);
-
-    if (!field.isNullable()) {
-      requireNonNull(row, ordinal, field.getName());
-    } else if (row.isNullAt(ordinal)) {
-      return null;
-    }
-
-    DataType dataType = field.getDataType();
-    if (dataType instanceof BooleanType) {
-      return row.getBoolean(ordinal);
-    } else if (dataType instanceof ByteType) {
-      return row.getByte(ordinal);
-    } else if (dataType instanceof ShortType) {
-      return row.getShort(ordinal);
-    } else if (dataType instanceof IntegerType) {
-      return row.getInt(ordinal);
-    } else if (dataType instanceof LongType) {
-      return row.getLong(ordinal);
-    } else if (dataType instanceof FloatType) {
-      return row.getFloat(ordinal);
-    } else if (dataType instanceof DoubleType) {
-      return row.getDouble(ordinal);
-    } else if (dataType instanceof StringType) {
-      return row.getString(ordinal);
-    } else if (dataType instanceof DecimalType) {
-      return row.getDecimal(ordinal);
-    } else if (dataType instanceof BinaryType) {
-      return row.getBinary(ordinal);
-    } else if (dataType instanceof StructType) {
-      return row.getStruct(ordinal);
-    } else if (dataType instanceof ArrayType) {
-      return row.getArray(ordinal);
-    } else if (dataType instanceof MapType) {
-      return row.getMap(ordinal);
-    } else {
-      throw new UnsupportedOperationException(
-          "Unsupported data type: " + dataType.getClass().getName());
-    }
-  }
-
-  /**
-   * Creates a new {@link Row} with the same schema and values as the row backing this action, but
+   * Returns a new {@link Row} with the same schema and values as the row backing this action, but
    * with the value of the field with the given name overridden by the given value.
    */
-  protected Row createRowWithOverriddenValue(String fieldName, Object value) {
+  protected Row toRowWithOverriddenValue(String fieldName, Object value) {
     Map<Integer, Object> overrides = Collections.singletonMap(getFieldIndex(fieldName), value);
     return new DelegateRow(row, overrides);
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/RowBackedAction.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/actions/RowBackedAction.java
@@ -15,21 +15,30 @@
  */
 package io.delta.kernel.internal.actions;
 
+import static io.delta.kernel.internal.util.InternalUtils.requireNonNull;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 
 import io.delta.kernel.data.Row;
-import io.delta.kernel.types.StructType;
+import io.delta.kernel.internal.data.DelegateRow;
+import io.delta.kernel.types.*;
+import java.util.Collections;
+import java.util.Map;
 
 /**
- * Base abstract class for Delta Log actions that are backed by a {@link Row}.This abstraction is
- * used by actions like {@link AddFile}, where we want to avoid materializing all fields from the
- * row when creating an action instance. For these actions, we only maintain a reference to the
- * underlying row, and the getters retrieve values directly from it.
+ * An abstract base class for Delta Log actions that are backed by a {@link Row}. This design is to
+ * avoid materialization of all fields when creating action instances from action rows within
+ * Kernel. Actions like {@link AddFile} can extend this class to maintain just a reference to the
+ * underlying action row. Subclasses can:
+ *
+ * <ul>
+ *   <li>Access field values directly from the row via {@link #getValueAsObject}
+ *   <li>Create new action instances with updated fields via {@link #createRowWithOverriddenValue}
+ * </ul>
  */
 public abstract class RowBackedAction {
 
   /** The underlying {@link Row} that represents an action and contains all its field values. */
-  protected final Row row;
+  private final Row row;
 
   protected RowBackedAction(Row row) {
     checkArgument(
@@ -44,7 +53,76 @@ public abstract class RowBackedAction {
   /** Returns the full schema of the row that represents this action. */
   protected abstract StructType getFullSchema();
 
-  public Row toRow() {
+  /**
+   * Returns the index of the field with the given name in the full schema of the row. Throws an
+   * {@link IllegalArgumentException} if the field is not found.
+   */
+  protected int getFieldIndex(String fieldName) {
+    int index = getFullSchema().indexOf(fieldName);
+    checkArgument(index >= 0, "Field '%s' not found in schema: %s", fieldName, getFullSchema());
+    return index;
+  }
+
+  /**
+   * Gets the value with the given field name from the row. The type of the Object returned depends
+   * on the data type of the field. If the field is nullable and the value is null, this method will
+   * return null. If the field is not nullable and the value is null, this method will throw an
+   * {@link IllegalArgumentException}.
+   */
+  protected Object getValueAsObject(String fieldName) {
+    StructField field = getFullSchema().get(fieldName);
+    int ordinal = getFieldIndex(fieldName);
+
+    if (!field.isNullable()) {
+      requireNonNull(row, ordinal, field.getName());
+    } else if (row.isNullAt(ordinal)) {
+      return null;
+    }
+
+    DataType dataType = field.getDataType();
+    if (dataType instanceof BooleanType) {
+      return row.getBoolean(ordinal);
+    } else if (dataType instanceof ByteType) {
+      return row.getByte(ordinal);
+    } else if (dataType instanceof ShortType) {
+      return row.getShort(ordinal);
+    } else if (dataType instanceof IntegerType) {
+      return row.getInt(ordinal);
+    } else if (dataType instanceof LongType) {
+      return row.getLong(ordinal);
+    } else if (dataType instanceof FloatType) {
+      return row.getFloat(ordinal);
+    } else if (dataType instanceof DoubleType) {
+      return row.getDouble(ordinal);
+    } else if (dataType instanceof StringType) {
+      return row.getString(ordinal);
+    } else if (dataType instanceof DecimalType) {
+      return row.getDecimal(ordinal);
+    } else if (dataType instanceof BinaryType) {
+      return row.getBinary(ordinal);
+    } else if (dataType instanceof StructType) {
+      return row.getStruct(ordinal);
+    } else if (dataType instanceof ArrayType) {
+      return row.getArray(ordinal);
+    } else if (dataType instanceof MapType) {
+      return row.getMap(ordinal);
+    } else {
+      throw new UnsupportedOperationException(
+          "Unsupported data type: " + dataType.getClass().getName());
+    }
+  }
+
+  /**
+   * Creates a new {@link Row} with the same schema and values as the row backing this action, but
+   * with the value of the field with the given name overridden by the given value.
+   */
+  protected Row createRowWithOverriddenValue(String fieldName, Object value) {
+    Map<Integer, Object> overrides = Collections.singletonMap(getFieldIndex(fieldName), value);
+    return new DelegateRow(row, overrides);
+  }
+
+  /** Returns the underlying {@link Row} that represents this action. */
+  public final Row toRow() {
     return row;
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/DelegateRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/DelegateRow.java
@@ -15,6 +15,8 @@
  */
 package io.delta.kernel.internal.data;
 
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
+
 import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.MapValue;
 import io.delta.kernel.data.Row;
@@ -192,21 +194,19 @@ public class DelegateRow implements Row {
 
   private void throwIfUnsafeAccess(
       int ordinal, Class<? extends DataType> expDataType, String accessType) {
+    final StructType schema = row.getSchema();
+    checkArgument(
+        ordinal >= 0 && ordinal < schema.length(),
+        "Invalid ordinal %d for schema with length %d",
+        ordinal,
+        schema.length());
 
-    DataType actualDataType = dataType(ordinal);
+    DataType actualDataType = schema.at(ordinal).getDataType();
     if (!expDataType.isAssignableFrom(actualDataType.getClass())) {
       String msg =
           String.format(
               "Fail to access a '%s' value from a field of type '%s'", accessType, actualDataType);
       throw new UnsupportedOperationException(msg);
     }
-  }
-
-  private DataType dataType(int ordinal) {
-    if (row.getSchema().length() <= ordinal) {
-      throw new IllegalArgumentException("invalid ordinal: " + ordinal);
-    }
-
-    return row.getSchema().at(ordinal).getDataType();
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/DelegateRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/DelegateRow.java
@@ -15,8 +15,6 @@
  */
 package io.delta.kernel.internal.data;
 
-import static java.util.Objects.requireNonNull;
-
 import io.delta.kernel.data.ArrayValue;
 import io.delta.kernel.data.MapValue;
 import io.delta.kernel.data.Row;
@@ -24,6 +22,7 @@ import io.delta.kernel.types.*;
 import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * This wraps an existing {@link Row} and allows overriding values for some particular ordinals.
@@ -41,8 +40,8 @@ public class DelegateRow implements Row {
   private final Map<Integer, Object> overrides;
 
   public DelegateRow(Row row, Map<Integer, Object> overrides) {
-    requireNonNull(row, "row is null");
-    requireNonNull(overrides, "map of overrides is null");
+    Objects.requireNonNull(row, "row is null");
+    Objects.requireNonNull(overrides, "map of overrides is null");
 
     if (row instanceof DelegateRow) {
       // If the row is already a delegation of another row, we merge the overrides and keep only
@@ -198,7 +197,7 @@ public class DelegateRow implements Row {
     if (!expDataType.isAssignableFrom(actualDataType.getClass())) {
       String msg =
           String.format(
-              "Trying to access a `%s` value from vector of type `%s`", accessType, actualDataType);
+              "Fail to access a '%s' value from a field of type '%s'", accessType, actualDataType);
       throw new UnsupportedOperationException(msg);
     }
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/DelegateRow.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/data/DelegateRow.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.data;
+
+import static java.util.Objects.requireNonNull;
+
+import io.delta.kernel.data.ArrayValue;
+import io.delta.kernel.data.MapValue;
+import io.delta.kernel.data.Row;
+import io.delta.kernel.types.*;
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This wraps an existing {@link Row} and allows overriding values for some particular ordinals.
+ * This enables creating a modified view of a row without mutating the original row.
+ */
+public class DelegateRow implements Row {
+
+  /** The underlying row being delegated to. */
+  private final Row row;
+
+  /**
+   * A map of ordinal-to-value overrides that takes precedence over the underlying row's data. When
+   * accessing data, this map is checked first before falling back to the underlying row.
+   */
+  private final Map<Integer, Object> overrides;
+
+  public DelegateRow(Row row, Map<Integer, Object> overrides) {
+    requireNonNull(row, "row is null");
+    requireNonNull(overrides, "map of overrides is null");
+
+    if (row instanceof DelegateRow) {
+      // If the row is already a delegation of another row, we merge the overrides and keep only
+      // one layer of delegation.
+      DelegateRow delegateRow = (DelegateRow) row;
+      this.row = delegateRow.row;
+      this.overrides = new HashMap<>(delegateRow.overrides);
+      this.overrides.putAll(overrides);
+    } else {
+      this.row = row;
+      this.overrides = new HashMap<>(overrides);
+    }
+  }
+
+  @Override
+  public StructType getSchema() {
+    return row.getSchema();
+  }
+
+  @Override
+  public boolean isNullAt(int ordinal) {
+    if (overrides.containsKey(ordinal)) {
+      return overrides.get(ordinal) == null;
+    }
+    return row.isNullAt(ordinal);
+  }
+
+  @Override
+  public boolean getBoolean(int ordinal) {
+    if (overrides.containsKey(ordinal)) {
+      throwIfUnsafeAccess(ordinal, BooleanType.class, "boolean");
+      return (boolean) overrides.get(ordinal);
+    }
+    return row.getBoolean(ordinal);
+  }
+
+  @Override
+  public byte getByte(int ordinal) {
+    if (overrides.containsKey(ordinal)) {
+      throwIfUnsafeAccess(ordinal, ByteType.class, "byte");
+      return (byte) overrides.get(ordinal);
+    }
+    return row.getByte(ordinal);
+  }
+
+  @Override
+  public short getShort(int ordinal) {
+    throwIfUnsafeAccess(ordinal, ShortType.class, "short");
+    if (overrides.containsKey(ordinal)) {
+      return (short) overrides.get(ordinal);
+    }
+    return row.getShort(ordinal);
+  }
+
+  @Override
+  public int getInt(int ordinal) {
+    if (overrides.containsKey(ordinal)) {
+      throwIfUnsafeAccess(ordinal, IntegerType.class, "integer");
+      return (int) overrides.get(ordinal);
+    }
+    return row.getInt(ordinal);
+  }
+
+  @Override
+  public long getLong(int ordinal) {
+    if (overrides.containsKey(ordinal)) {
+      throwIfUnsafeAccess(ordinal, LongType.class, "long");
+      return (long) overrides.get(ordinal);
+    }
+    return row.getLong(ordinal);
+  }
+
+  @Override
+  public float getFloat(int ordinal) {
+    if (overrides.containsKey(ordinal)) {
+      throwIfUnsafeAccess(ordinal, FloatType.class, "float");
+      return (float) overrides.get(ordinal);
+    }
+    return row.getFloat(ordinal);
+  }
+
+  @Override
+  public double getDouble(int ordinal) {
+    if (overrides.containsKey(ordinal)) {
+      throwIfUnsafeAccess(ordinal, DoubleType.class, "double");
+      return (double) overrides.get(ordinal);
+    }
+    return row.getDouble(ordinal);
+  }
+
+  @Override
+  public String getString(int ordinal) {
+    if (overrides.containsKey(ordinal)) {
+      throwIfUnsafeAccess(ordinal, StringType.class, "string");
+      return (String) overrides.get(ordinal);
+    }
+    return row.getString(ordinal);
+  }
+
+  @Override
+  public BigDecimal getDecimal(int ordinal) {
+    if (overrides.containsKey(ordinal)) {
+      throwIfUnsafeAccess(ordinal, DecimalType.class, "decimal");
+      return (BigDecimal) overrides.get(ordinal);
+    }
+    return row.getDecimal(ordinal);
+  }
+
+  @Override
+  public byte[] getBinary(int ordinal) {
+    if (overrides.containsKey(ordinal)) {
+      throwIfUnsafeAccess(ordinal, BinaryType.class, "binary");
+      return (byte[]) overrides.get(ordinal);
+    }
+    return row.getBinary(ordinal);
+  }
+
+  @Override
+  public Row getStruct(int ordinal) {
+    if (overrides.containsKey(ordinal)) {
+      throwIfUnsafeAccess(ordinal, StructType.class, "struct");
+      return (Row) overrides.get(ordinal);
+    }
+    return row.getStruct(ordinal);
+  }
+
+  @Override
+  public ArrayValue getArray(int ordinal) {
+    if (overrides.containsKey(ordinal)) {
+      // TODO: Not sufficient check, also need to check the element type. This should be revisited
+      //  together with the GenericRow.
+      throwIfUnsafeAccess(ordinal, ArrayType.class, "array");
+      return (ArrayValue) overrides.get(ordinal);
+    }
+    return row.getArray(ordinal);
+  }
+
+  @Override
+  public MapValue getMap(int ordinal) {
+    if (overrides.containsKey(ordinal)) {
+      // TODO: Not sufficient check, also need to check the element type. This should be revisited
+      //  together with the GenericRow.
+      throwIfUnsafeAccess(ordinal, MapType.class, "map");
+      return (MapValue) overrides.get(ordinal);
+    }
+    return row.getMap(ordinal);
+  }
+
+  private void throwIfUnsafeAccess(
+      int ordinal, Class<? extends DataType> expDataType, String accessType) {
+
+    DataType actualDataType = dataType(ordinal);
+    if (!expDataType.isAssignableFrom(actualDataType.getClass())) {
+      String msg =
+          String.format(
+              "Trying to access a `%s` value from vector of type `%s`", accessType, actualDataType);
+      throw new UnsupportedOperationException(msg);
+    }
+  }
+
+  private DataType dataType(int ordinal) {
+    if (row.getSchema().length() <= ordinal) {
+      throw new IllegalArgumentException("invalid ordinal: " + ordinal);
+    }
+
+    return row.getSchema().at(ordinal).getDataType();
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/types/StructType.java
@@ -87,8 +87,10 @@ public final class StructType extends DataType {
     return fields.size();
   }
 
+  /** @return the index of the field with the given name, or -1 if not found */
   public int indexOf(String fieldName) {
-    return fieldNames.indexOf(fieldName);
+    Tuple2<StructField, Integer> fieldAndOrdinal = nameToFieldAndOrdinal.get(fieldName);
+    return fieldAndOrdinal != null ? fieldAndOrdinal._2 : -1;
   }
 
   public StructField get(String fieldName) {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/utils/DataFileStatistics.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/utils/DataFileStatistics.java
@@ -19,8 +19,10 @@ import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 
 import io.delta.kernel.expressions.Column;
 import io.delta.kernel.expressions.Literal;
+import io.delta.kernel.internal.util.JsonUtils;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 
 /** Statistics about data file in a Delta Lake table. */
 public class DataFileStatistics {
@@ -100,5 +102,27 @@ public class DataFileStatistics {
     // https://github.com/delta-io/delta/pull/3342. The PR is pending on a decision.
     // For now just serialize the number of records.
     return "{\"numRecords\":" + numRecords + "}";
+  }
+
+  /**
+   * Deserialize the statistics from a JSON string. For now only the number of records is
+   * deserialized, the rest of the statistics are not supported yet.
+   *
+   * @param json Data statistics JSON string to deserialize.
+   * @return An {@link Optional} containing the deserialized {@link DataFileStatistics} if present.
+   */
+  public static Optional<DataFileStatistics> deserializeFromJson(String json) {
+    Map<String, String> keyValueMap = JsonUtils.parseJSONKeyValueMap(json);
+
+    // For now just deserialize the number of records which will be used by row tracking.
+    String numRecordsStr = keyValueMap.get("numRecords");
+    if (numRecordsStr == null) {
+      return Optional.empty();
+    }
+    long numRecords = Long.parseLong(numRecordsStr);
+    DataFileStatistics stats =
+        new DataFileStatistics(
+            numRecords, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap());
+    return Optional.of(stats);
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/utils/DataFileStatistics.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/utils/DataFileStatistics.java
@@ -114,7 +114,7 @@ public class DataFileStatistics {
   public static Optional<DataFileStatistics> deserializeFromJson(String json) {
     Map<String, String> keyValueMap = JsonUtils.parseJSONKeyValueMap(json);
 
-    // For now just deserialize the number of records which will be used by row tracking.
+    // For now just deserialize the number of records
     String numRecordsStr = keyValueMap.get("numRecords");
     if (numRecordsStr == null) {
       return Optional.empty();

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/actions/AddFileSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/actions/AddFileSuite.scala
@@ -123,14 +123,14 @@ class AddFileSuite extends AnyFunSuite {
     }
   }
 
-  test("toString() prints all fields of AddFile with partitionValues / tags in sorted order") {
+  test("toString() prints all fields of AddFile") {
     val addFileRow = generateTestAddFileRow(
       path = "test/path",
-      partitionValues = Map("b" -> "2", "a" -> "1", "c" -> "3"),
+      partitionValues = Map("col1" -> "val1"),
       size = 100L,
       modificationTime = 1234L,
       dataChange = false,
-      tags = Option(Map("tag1" -> "value1", "tag2" -> "value2")),
+      tags = Option(Map("tag1" -> "value1")),
       baseRowId = Option(12345L),
       defaultRowCommitVersion = Option(67890L),
       stats = Option("{\"numRecords\":10000}")
@@ -138,12 +138,12 @@ class AddFileSuite extends AnyFunSuite {
     val addFile = new AddFile(addFileRow)
     val expectedString = "AddFile{" +
       "path='test/path', " +
-      "partitionValues={a=1, b=2, c=3}, " +
+      "partitionValues={col1=val1}, " +
       "size=100, " +
       "modificationTime=1234, " +
       "dataChange=false, " +
       "deletionVector=Optional.empty, " +
-      "tags=Optional[{tag1=value1, tag2=value2}], " +
+      "tags=Optional[{tag1=value1}], " +
       "baseRowId=Optional[12345], " +
       "defaultRowCommitVersion=Optional[67890], " +
       "stats=Optional[{\"numRecords\":10000}]}"

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/actions/AddFileSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/actions/AddFileSuite.scala
@@ -1,0 +1,173 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.actions
+
+import io.delta.kernel.data.Row
+import io.delta.kernel.internal.data.GenericRow
+import io.delta.kernel.internal.util.VectorUtils
+import io.delta.kernel.internal.util.VectorUtils.stringStringMapValue
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.util.{HashMap => JHashMap}
+import java.util.Optional
+import scala.collection.JavaConverters._
+
+class AddFileSuite extends AnyFunSuite {
+
+  /**
+   * Generate a GenericRow representing an AddFile action with provided fields.
+   */
+  private def generateTestAddFileRow(
+      path: String = "path",
+      partitionValues: Map[String, String] = Map.empty,
+      size: Long = 10L,
+      modificationTime: Long = 20L,
+      dataChange: Boolean = true,
+      deletionVector: Option[DeletionVectorDescriptor] = Option.empty,
+      tags: Option[Map[String, String]] = Option.empty,
+      baseRowId: Option[Long] = Option.empty,
+      defaultRowCommitVersion: Option[Long] = Option.empty,
+      stats: Option[String] = Option.empty
+  ): Row = {
+    // Generate a GenericRow representing an AddFile action with provided values for testing
+    val schema = AddFile.FULL_SCHEMA
+    val nameToOrdinal: Map[String, Int] = (0 until schema.length).map { i =>
+      schema.at(i).getName -> i
+    }.toMap
+
+    val valueMap = new JHashMap[Integer, Object]()
+
+    valueMap.put(nameToOrdinal("path"), path)
+    valueMap.put(nameToOrdinal("partitionValues"), stringStringMapValue(partitionValues.asJava))
+    valueMap.put(nameToOrdinal("size"), size.asInstanceOf[java.lang.Long])
+    valueMap.put(nameToOrdinal("modificationTime"), modificationTime.asInstanceOf[java.lang.Long])
+    valueMap.put(nameToOrdinal("dataChange"), dataChange.asInstanceOf[java.lang.Boolean])
+
+    if (deletionVector.isDefined) {
+      // DeletionVectorDescriptor currently does not provide a way to convert to a Row
+      assert(false, "DeletionVectorDescriptor is not supported in AddFileSuite")
+    }
+    if (tags.isDefined) {
+      valueMap.put(nameToOrdinal("tags"), stringStringMapValue(tags.get.asJava))
+    }
+    if (baseRowId.isDefined) {
+      valueMap.put(nameToOrdinal("baseRowId"), baseRowId.get.asInstanceOf[java.lang.Long])
+    }
+    if (defaultRowCommitVersion.isDefined) {
+      valueMap.put(
+        nameToOrdinal("defaultRowCommitVersion"),
+        defaultRowCommitVersion.get.asInstanceOf[java.lang.Long]
+      )
+    }
+    if (stats.isDefined) {
+      valueMap.put(nameToOrdinal("stats"), stats.get)
+    }
+
+    new GenericRow(schema, valueMap)
+  }
+
+  test("getters can read AddFile's fields from the backing row") {
+    val addFileRow = generateTestAddFileRow(
+      path = "test/path",
+      partitionValues = Map("a" -> "1"),
+      size = 1L,
+      modificationTime = 10L,
+      dataChange = true,
+      deletionVector = Option.empty,
+      tags = Option(Map("tag1" -> "value1")),
+      baseRowId = Option(30L),
+      defaultRowCommitVersion = Option(40L),
+      stats = Option("{\"numRecords\":100}")
+    )
+
+    val addFile = new AddFile(addFileRow)
+
+    assert(addFile.getPath === "test/path")
+    assert(
+      VectorUtils.toJavaMap(addFile.getPartitionValues).asScala.equals(Map("a" -> "1"))
+    )
+    assert(addFile.getSize === 1L)
+    assert(addFile.getModificationTime === 10L)
+    assert(addFile.getDataChange === true)
+    assert(addFile.getDeletionVector === Optional.empty())
+    assert(
+      VectorUtils.toJavaMap(addFile.getTags.get()).asScala.equals(Map("tag1" -> "value1"))
+    )
+    assert(addFile.getBaseRowId === Optional.of(30L))
+    assert(addFile.getDefaultRowCommitVersion === Optional.of(40L))
+    // DataFileStatistics doesn't have an equals() override, so we need to compare the string
+    assert(addFile.getStats.get().toString === "{\"numRecords\":100}")
+    assert(addFile.getNumRecords === Optional.of(100L))
+  }
+
+  test("update a single field of an AddFile") {
+    val addFileRow = generateTestAddFileRow(baseRowId = Option(1L))
+    val addFileAction = new AddFile(addFileRow)
+
+    val updatedAddFileAction = addFileAction.withNewBaseRowId(2L)
+    assert(updatedAddFileAction.getBaseRowId === Optional.of(2L))
+
+    val updatedAddFileRow = updatedAddFileAction.toRow
+    assert(new AddFile(updatedAddFileRow).getBaseRowId === Optional.of(2L))
+  }
+
+  test("update multiple fields of an AddFile multiple times") {
+    val baseAddFileRow =
+      generateTestAddFileRow(
+        path = "test/path",
+        baseRowId = Option(0L),
+        defaultRowCommitVersion = Option(0L)
+      )
+    var addFileAction = new AddFile(baseAddFileRow)
+
+    (1L until 10L).foreach { i =>
+      addFileAction = addFileAction
+        .withNewBaseRowId(i)
+        .withNewDefaultRowCommitVersion(i * 10)
+
+      assert(addFileAction.getPath === "test/path")
+      assert(addFileAction.getBaseRowId === Optional.of(i))
+      assert(addFileAction.getDefaultRowCommitVersion === Optional.of(i * 10))
+    }
+  }
+
+  test("toString correctly prints out AddFile and with partition values / tags in sorted order") {
+    val addFileRow = generateTestAddFileRow(
+      path = "test/path",
+      partitionValues = Map("b" -> "2", "a" -> "1"),
+      size = 100L,
+      modificationTime = 1234L,
+      dataChange = true,
+      tags = Option(Map("tag1" -> "value1", "tag2" -> "value2")),
+      baseRowId = Option(12345L),
+      defaultRowCommitVersion = Option(67890L),
+      stats = Option("{\"numRecords\":10000}")
+    )
+    val addFile = new AddFile(addFileRow)
+    val expectedString = "AddFile{" +
+      "path='test/path', " +
+      "partitionValues={a=1, b=2}, " +
+      "size=100, " +
+      "modificationTime=1234, " +
+      "dataChange=true, " +
+      "deletionVector=Optional.empty, " +
+      "tags=Optional[{tag1=value1, tag2=value2}], " +
+      "baseRowId=Optional[12345], " +
+      "defaultRowCommitVersion=Optional[67890], " +
+      "stats=Optional[{\"numRecords\":10000}]}"
+    assert(addFile.toString == expectedString)
+  }
+}

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/actions/AddFileSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/actions/AddFileSuite.scala
@@ -20,7 +20,6 @@ import org.scalatest.funsuite.AnyFunSuite
 import scala.collection.JavaConverters._
 
 import io.delta.kernel.data.Row
-import io.delta.kernel.internal.actions.AddFile.createAddFileRow
 import io.delta.kernel.internal.util.VectorUtils
 import io.delta.kernel.internal.util.VectorUtils.stringStringMapValue
 import io.delta.kernel.utils.DataFileStatistics.deserializeFromJson
@@ -50,7 +49,7 @@ class AddFileSuite extends AnyFunSuite {
       case None => Optional.empty()
     }
 
-    createAddFileRow(
+    AddFile.createAddFileRow(
       path,
       stringStringMapValue(partitionValues.asJava),
       size.asInstanceOf[JLong],


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR implements the `AddFile` action class, with the help of `DelegateRow` and `RowBackedAction`, which are also newly introduced in this PR. The core changes include:

`RowBackedAction`
- A new abstract base class for Delta Log actions that are backed by a `Row`. It can be extended by actions like `AddFile`, where we want to avoid materializing of all fields from action rows when creating action instances within Kernel. 

`DelegateRow`:
- A new `Row` implementation that wraps an existing `Row` and allows overriding values for some particular ordinals.
- Currently this is used to update certain fields of an action by creating a modified view of its underlying row without mutating the original row.
- The implementation ensures we only keep one layer of delegation.

`AddFile`
- This PR implements its constructor, field getters, necessary overrides, and APIs for creating a new instance with updated fields.
- It adds two fields `baseRowId` and `defaultRowCommitVersion`, which will be used for Row Tracking later.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Unit tests were added in `AddFileSuite.scala`.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.