### PR TITLE
[SPARK][SHARING][VARIANT] Create GA variant table feature

### DIFF
--- a/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala
+++ b/sharing/src/main/scala/io/delta/sharing/spark/DeltaSharingUtils.scala
@@ -45,6 +45,7 @@ object DeltaSharingUtils extends Logging {
       TimestampNTZTableFeature.name,
       TypeWideningPreviewTableFeature.name,
       TypeWideningTableFeature.name,
+      VariantTypePreviewTableFeature.name,
       VariantTypeTableFeature.name
     )
 
@@ -55,6 +56,7 @@ object DeltaSharingUtils extends Logging {
       TimestampNTZTableFeature.name,
       TypeWideningPreviewTableFeature.name,
       TypeWideningTableFeature.name,
+      VariantTypePreviewTableFeature.name,
       VariantTypeTableFeature.name
     )
 

--- a/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
+++ b/sharing/src/test/scala/io/delta/sharing/spark/TestClientForDeltaFormatSharing.scala
@@ -67,6 +67,7 @@ private[spark] class TestClientForDeltaFormatSharing(
     TimestampNTZTableFeature,
     TypeWideningPreviewTableFeature,
     TypeWideningTableFeature,
+    VariantTypePreviewTableFeature,
     VariantTypeTableFeature
   ).map(_.name)
 

--- a/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantSuite.scala
+++ b/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantSuite.scala
@@ -47,12 +47,30 @@ class DeltaVariantSuite
     deltaLog.unsafeVolatileSnapshot.protocol
   }
 
+  private def assertVariantTypeTableFeatures(
+      tableName: String,
+      expectPreviewFeature: Boolean,
+      expectStableFeature: Boolean): Unit = {
+    val features = getProtocolForTable("tbl").readerAndWriterFeatures
+    if (expectPreviewFeature) {
+      assert(features.contains(VariantTypePreviewTableFeature))
+    } else {
+      assert(!features.contains(VariantTypePreviewTableFeature))
+    }
+    if (expectStableFeature) {
+      assert(features.contains(VariantTypeTableFeature))
+    } else {
+      assert(!features.contains(VariantTypeTableFeature))
+    }
+  }
+
   test("create a new table with Variant, higher protocol and feature should be picked.") {
     withTable("tbl") {
       sql("CREATE TABLE tbl(s STRING, v VARIANT) USING DELTA")
       sql("INSERT INTO tbl (SELECT 'foo', parse_json(cast(id + 99 as string)) FROM range(1))")
       assert(spark.table("tbl").selectExpr("v::int").head == Row(99))
-      assert(getProtocolForTable("tbl").readerAndWriterFeatures.contains(VariantTypeTableFeature))
+      assertVariantTypeTableFeatures(
+        "tbl", expectPreviewFeature = true, expectStableFeature = false)
     }
   }
 
@@ -63,7 +81,10 @@ class DeltaVariantSuite
 
       val deltaLog = DeltaLog.forTable(spark, TableIdentifier("tbl"))
       assert(
-        !deltaLog.unsafeVolatileSnapshot.protocol.isFeatureSupported(VariantTypeTableFeature),
+        !deltaLog.unsafeVolatileSnapshot.protocol.isFeatureSupported(
+          VariantTypePreviewTableFeature) &&
+        !deltaLog.unsafeVolatileSnapshot.protocol.isFeatureSupported(
+          VariantTypeTableFeature),
         s"Table tbl contains VariantTypeFeature descriptor when its not supposed to"
       )
     }
@@ -102,7 +123,7 @@ class DeltaVariantSuite
         e,
         "DELTA_FEATURES_REQUIRE_MANUAL_ENABLEMENT",
         parameters = Map(
-          "unsupportedFeatures" -> VariantTypeTableFeature.name,
+          "unsupportedFeatures" -> VariantTypePreviewTableFeature.name,
           "supportedFeatures" -> currentFeatures
         )
       )
@@ -112,11 +133,28 @@ class DeltaVariantSuite
 
       assert(
         getProtocolForTable("tbl") ==
-        VariantTypeTableFeature.minProtocolVersion
-          .withFeature(VariantTypeTableFeature)
+        VariantTypePreviewTableFeature.minProtocolVersion
+          .withFeature(VariantTypePreviewTableFeature)
           .withFeature(InvariantsTableFeature)
           .withFeature(AppendOnlyTableFeature)
       )
+    }
+  }
+
+  test("variant stable and preview features can be supported simultaneously and read") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(v VARIANT) USING delta")
+      sql("INSERT INTO tbl (SELECT parse_json(cast(id + 99 as string)) FROM range(1))")
+      assert(spark.table("tbl").selectExpr("v::int").head == Row(99))
+      assertVariantTypeTableFeatures(
+        "tbl", expectPreviewFeature = true, expectStableFeature = false)
+      sql(
+        s"ALTER TABLE tbl " +
+        s"SET TBLPROPERTIES('delta.feature.variantType' = 'supported')"
+      )
+      assertVariantTypeTableFeatures(
+        "tbl", expectPreviewFeature = true, expectStableFeature = true)
+      assert(spark.table("tbl").selectExpr("v::int").head == Row(99))
     }
   }
 
@@ -267,7 +305,8 @@ class DeltaVariantSuite
         .selectExpr("tableFeatures")
         .collect()(0)
         .getAs[MutableSeq[String]](0)
-      assert(tableFeatures.find(f => f == VariantTypeTableFeature.name).nonEmpty)
+      assert(tableFeatures.find(f => f == VariantTypePreviewTableFeature.name).nonEmpty)
+      assert(tableFeatures.find(f => f == VariantTypeTableFeature.name).isEmpty)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [x] Other (sharing)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

creates the variant GA table feature. 

New variant tables are still created with the preview table feature. However, a future PR will switch this so new tables then are created with the GA table feature. At this point, we will keep the ability to read the `preview` table feature because there were no changes to the spec between preview and GA.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

added UTs

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no
