### PR TITLE
Implement substring expression in delta kernel library

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/ScalarExpression.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/ScalarExpression.java
@@ -55,9 +55,15 @@ import java.util.stream.Collectors;
  *       </ul>
  *   <li>Name: <code>SUBSTRING</code>
  *       <ul>
- *         <li>Semantic: <code>SUBSTRING(colExpr, pos, len)</code>. Substring starts at pos and is
- *             of length len when str is String type or returns the slice of byte array that starts
- *             at pos in byte and is of length len when str is Binary type.
+ *         <li>Semantic: <code>SUBSTRING(colExpr, pos, len)</code>. Returns the slice of byte array
+ *             or string, that starts at pos and has the length len.
+ *             <ul>
+ *               <li>pos is 1 based. If pos is negative the start is determined by counting
+ *                   characters (or bytes for BINARY) from the end.
+ *               <li>If len is less than 1 the result is empty.
+ *               <li>If len is omitted the function returns on characters or bytes starting with
+ *                   pos.
+ *             </ul>
  *         <li>Since version: 3.4.0
  *       </ul>
  * </ol>

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/ScalarExpression.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/expressions/ScalarExpression.java
@@ -53,6 +53,13 @@ import java.util.stream.Collectors;
  *             later.
  *         <li>Since version: 3.3.0
  *       </ul>
+ *   <li>Name: <code>SUBSTRING</code>
+ *       <ul>
+ *         <li>Semantic: <code>SUBSTRING(colExpr, pos, len)</code>. Substring starts at pos and is
+ *             of length len when str is String type or returns the slice of byte array that starts
+ *             at pos in byte and is of length len when str is Binary type.
+ *         <li>Since version: 3.4.0
+ *       </ul>
  * </ol>
  *
  * @since 3.0.0

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/test/VectorTestUtils.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/test/VectorTestUtils.scala
@@ -38,6 +38,20 @@ trait VectorTestUtils {
     }
   }
 
+  protected def binaryVector(values: Seq[Array[Byte]]): ColumnVector = {
+    new ColumnVector {
+      override def getDataType: DataType = BinaryType.BINARY
+
+      override def getSize: Int = values.length
+
+      override def close(): Unit = {}
+
+      override def isNullAt(rowId: Int): Boolean = values(rowId) == null
+
+      override def getBinary(rowId: Int): Array[Byte] = values(rowId)
+    }
+  }
+
   protected def timestampVector(values: Seq[Long]): ColumnVector = {
     new ColumnVector {
       override def getDataType: DataType = TimestampType.TIMESTAMP

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
@@ -617,9 +617,8 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
 
     @Override
     ColumnVector visitSubstring(ScalarExpression subString) {
-      List<Expression> children = subString.getChildren();
       return SubstringEvaluator.eval(
-          children, children.stream().map(this::visit).collect(toList()));
+          subString.getChildren().stream().map(this::visit).collect(toList()));
     }
 
     @Override

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluator.java
@@ -287,6 +287,18 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
     }
 
     @Override
+    ExpressionTransformResult visitSubstring(ScalarExpression substring) {
+      List<ExpressionTransformResult> children =
+          substring.getChildren().stream().map(this::visit).collect(toList());
+      ScalarExpression transformedExpression =
+          SubstringEvaluator.validateAndTransform(
+              substring,
+              children.stream().map(e -> e.expression).collect(toList()),
+              children.stream().map(e -> e.outputType).collect(toList()));
+      return new ExpressionTransformResult(transformedExpression, StringType.STRING);
+    }
+
+    @Override
     ExpressionTransformResult visitLike(final Predicate like) {
       List<ExpressionTransformResult> children =
           like.getChildren().stream().map(this::visit).collect(toList());
@@ -601,6 +613,13 @@ public class DefaultExpressionEvaluator implements ExpressionEvaluator {
           return timestampColumn.getLong(rowId) + durationMicros;
         }
       };
+    }
+
+    @Override
+    ColumnVector visitSubstring(ScalarExpression subString) {
+      List<Expression> children = subString.getChildren();
+      return SubstringEvaluator.eval(
+          children, children.stream().map(this::visit).collect(toList()));
     }
 
     @Override

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionVisitor.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/ExpressionVisitor.java
@@ -61,6 +61,8 @@ abstract class ExpressionVisitor<R> {
 
   abstract R visitTimeAdd(ScalarExpression timeAdd);
 
+  abstract R visitSubstring(ScalarExpression subString);
+
   abstract R visitLike(Predicate predicate);
 
   final R visit(Expression expression) {
@@ -111,6 +113,8 @@ abstract class ExpressionVisitor<R> {
         return visitCoalesce(expression);
       case "TIMEADD":
         return visitTimeAdd(expression);
+      case "SUBSTRING":
+        return visitSubstring(expression);
       case "LIKE":
         return visitLike(new Predicate(name, children));
       default:

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/SubstringEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/SubstringEvaluator.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.defaults.internal.expressions;
+
+import static io.delta.kernel.defaults.internal.DefaultEngineErrors.unsupportedExpressionException;
+
+import io.delta.kernel.data.ColumnVector;
+import io.delta.kernel.expressions.Expression;
+import io.delta.kernel.expressions.Literal;
+import io.delta.kernel.expressions.ScalarExpression;
+import io.delta.kernel.internal.util.Utils;
+import io.delta.kernel.types.*;
+import java.util.*;
+
+/** Utility methods to evaluate {@code substring} expression. */
+public class SubstringEvaluator {
+
+  private static final Set<DataType> SUBSTRING_SUPPORTED_TYPE =
+      Collections.unmodifiableSet(
+          new HashSet<>(Arrays.asList(StringType.STRING, BinaryType.BINARY)));
+
+  static ScalarExpression validateAndTransform(
+      ScalarExpression substring,
+      List<Expression> childrenExpressions,
+      List<DataType> childrenOutputTypes) {
+    int childrenSize = substring.getChildren().size();
+    if (childrenSize < 2 || childrenSize > 3) {
+      throw unsupportedExpressionException(
+          substring,
+          "Invalid number of inputs to SUBSTRING expression. "
+              + "Example usage: SUBSTRING(column, pos), SUBSTRING(column, pos, len)");
+    }
+
+    if (!SUBSTRING_SUPPORTED_TYPE.contains(childrenOutputTypes.get(0))) {
+      throw unsupportedExpressionException(
+          substring, "Invalid type of first input of SUBSTRING: expects BINARY or STRING");
+    }
+
+    Expression posExpression = childrenExpressions.get(1);
+    if (!isIntegerLiteral(posExpression)) {
+      throw unsupportedExpressionException(
+          substring,
+          "Invalid type of second input of SUBSTRING: "
+              + "expects an integral numeric expression specifying the starting position.");
+    }
+
+    if (childrenSize == 3) {
+      Expression lengthExpression = childrenExpressions.get(2);
+      if (!isIntegerLiteral(lengthExpression)) {
+        throw unsupportedExpressionException(
+            substring, "Invalid type of third input of SUBSTRING: expects an integral numeric.");
+      }
+    }
+
+    return new ScalarExpression(substring.getName(), childrenExpressions);
+  }
+
+  static ColumnVector eval(
+      List<Expression> childrenExpressions, List<ColumnVector> childrenVectors) {
+
+    return new ColumnVector() {
+      final ColumnVector input = childrenVectors.get(0);
+      final ColumnVector positionVector = childrenVectors.get(1);
+      final Optional<ColumnVector> lengthVector =
+          childrenVectors.size() > 2 ? Optional.of(childrenVectors.get(2)) : Optional.empty();
+
+      @Override
+      public DataType getDataType() {
+        return StringType.STRING;
+      }
+
+      @Override
+      public int getSize() {
+        return input.getSize();
+      }
+
+      @Override
+      public void close() {
+        if (lengthVector.isPresent()) {
+          Utils.closeCloseables(input, positionVector, lengthVector.get());
+        } else {
+          Utils.closeCloseables(input, positionVector);
+        }
+      }
+
+      @Override
+      public boolean isNullAt(int rowId) {
+        return input.isNullAt(rowId);
+      }
+
+      @Override
+      public String getString(int rowId) {
+        if (isNullAt(rowId) || rowId < 0 || rowId >= getSize()) {
+          return null;
+        }
+
+        String inputString =
+            input.getDataType() == BinaryType.BINARY
+                ? new String(input.getBinary(rowId))
+                : input.getString(rowId);
+        int position = positionVector.getInt(rowId);
+        Optional<Integer> length = lengthVector.map(columnVector -> columnVector.getInt(rowId));
+
+        if (position > inputString.length()) {
+          return "";
+        }
+
+        int startPosition = buildStartPosition(inputString, position);
+
+        if (!length.isPresent()) {
+          return inputString.substring(Math.max(startPosition, 0));
+        }
+
+        if (length.get() < 1) {
+          return "";
+        }
+
+        int startIndex = Math.max(startPosition, 0);
+        // endIndex should be less than the length of input string, but positive.
+        // e.g. Substring("aaa", -100, 95), should be read as Substring("aaa", 0, 0)
+        int endIndex = Math.min(inputString.length(), Math.max(startPosition + length.get(), 0));
+        return inputString.substring(startIndex, endIndex);
+      }
+    };
+  }
+
+  /**
+   * Returns the index of the start position given inputString and parameter pos. The return value
+   * is not normalized, i.e. could be less than 0.
+   */
+  private static int buildStartPosition(String inputString, int pos) {
+    if (pos < 0) {
+      return inputString.length() + pos;
+    }
+    // Pos is 1 based and pos = 0 is treated as 1.
+    return Math.max(pos - 1, 0);
+  }
+
+  private static boolean isIntegerLiteral(Expression expression) {
+    if (!(expression instanceof Literal)) {
+      return false;
+    }
+    Literal literal = (Literal) expression;
+    return IntegerType.INTEGER.equals(literal.getDataType());
+  }
+
+  private SubstringEvaluator() {}
+}

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/SubstringEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/SubstringEvaluator.java
@@ -32,7 +32,7 @@ public class SubstringEvaluator {
       Collections.unmodifiableSet(
           new HashSet<>(Arrays.asList(StringType.STRING, BinaryType.BINARY)));
 
-  /** Validate and transform the {@code substring} expression. */
+  /** Validates and transforms the {@code substring} expression. */
   static ScalarExpression validateAndTransform(
       ScalarExpression substring,
       List<Expression> childrenExpressions,
@@ -70,8 +70,8 @@ public class SubstringEvaluator {
   }
 
   /**
-   * Evaluate the {@code substring} expression for given input column vector, builds a column vector
-   * with substring applied to each row.
+   * Evaluates the {@code substring} expression for given input column vector, builds a column
+   * vector with substring applied to each row.
    */
   static ColumnVector eval(List<ColumnVector> childrenVectors) {
     return new ColumnVector() {

--- a/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/SubstringEvaluator.java
+++ b/kernel/kernel-defaults/src/main/java/io/delta/kernel/defaults/internal/expressions/SubstringEvaluator.java
@@ -32,6 +32,7 @@ public class SubstringEvaluator {
       Collections.unmodifiableSet(
           new HashSet<>(Arrays.asList(StringType.STRING, BinaryType.BINARY)));
 
+  /** Validate and transform the {@code substring} expression. */
   static ScalarExpression validateAndTransform(
       ScalarExpression substring,
       List<Expression> childrenExpressions,
@@ -68,9 +69,11 @@ public class SubstringEvaluator {
     return new ScalarExpression(substring.getName(), childrenExpressions);
   }
 
-  static ColumnVector eval(
-      List<Expression> childrenExpressions, List<ColumnVector> childrenVectors) {
-
+  /**
+   * Evaluate the {@code substring} expression for given input column vector, builds a column vector
+   * with substring applied to each row.
+   */
+  static ColumnVector eval(List<ColumnVector> childrenVectors) {
     return new ColumnVector() {
       final ColumnVector input = childrenVectors.get(0);
       final ColumnVector positionVector = childrenVectors.get(1);

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/DefaultExpressionEvaluatorSuite.scala
@@ -881,6 +881,19 @@ class DefaultExpressionEvaluatorSuite extends AnyFunSuite with ExpressionSuiteBa
         Seq[String](null, "one", "two", "three", "four", null, null, "seven", "eight"))
     })
 
+    val outputVectorForEmptyInput = evaluator(
+      schema,
+      new ScalarExpression("SUBSTRING",
+        util.Arrays.asList(
+          new Column("str_col"), Literal.ofInt(1), Literal.ofInt(1))),
+      StringType.STRING
+    ).eval( new DefaultColumnarBatch(/* size= */0,
+      schema,
+      Array(
+        testColumnVector(/* size= */0, StringType.STRING),
+        testColumnVector(/* size= */0, BinaryType.BINARY))))
+    checkStringVectors(outputVectorForEmptyInput, stringVector(Seq[String]()))
+
     def checkUnsupportedColumnTypes(colType: DataType): Unit = {
       val schema = new StructType()
         .add("col1", colType)

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/ExpressionSuiteBase.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/internal/expressions/ExpressionSuiteBase.scala
@@ -38,6 +38,14 @@ trait ExpressionSuiteBase extends TestUtils with DefaultVectorTestUtils {
     new Or(left, right)
   }
 
+  protected def substring(expr: Expression, pos: Int, len: Option[Int] = None): ScalarExpression = {
+    var children = List(expr, Literal.ofInt(pos))
+    if(len.isDefined) {
+     children = children :+ Literal.ofInt(len.get)
+    }
+    new ScalarExpression("substring", children.asJava)
+  }
+
   protected def like(
       left: Expression, right: Expression, escape: Option[Character] = None): Predicate = {
     if (escape.isDefined && escape.get!=null) {
@@ -79,4 +87,22 @@ trait ExpressionSuiteBase extends TestUtils with DefaultVectorTestUtils {
       }
     }
   }
+
+  protected def checkStringVectors(actual: ColumnVector, expected: ColumnVector): Unit = {
+    assert(actual.getDataType === StringType.STRING)
+    assert(actual.getDataType === expected.getDataType)
+    assert(actual.getSize === expected.getSize)
+    Seq.range(0, actual.getSize).foreach { rowId =>
+      assert(actual.isNullAt(rowId) === expected.isNullAt(rowId))
+      if (!actual.isNullAt(rowId)) {
+        assert(
+          actual.getString(rowId) === expected.getString(rowId),
+          s"unexpected value at $rowId: " +
+            s"expected: ${expected.getString(rowId)} " +
+            s"actual: ${actual.getString(rowId)} "
+        )
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Implements substring expression. This is 2/n for addressing https://github.com/delta-io/delta/issues/2539 (i.e. data skipping of startwith depends on substring expression, see[1] for spark's code pointer), the first part is implemented in https://github.com/delta-io/delta/pull/3991.

[1]https://github.com/delta-io/delta/blob/master/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala#L557-L561

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Added e2e test cases, the expected result are generated using spark, e.g.

WITH t(x) AS 
  (SELECT null union all select "one" union all select "two" union all select "three" union all select "four" union all select null union all select null union all select "seven" union all select "eight")
select substring(x,-100,98) from t

substring(x,-100,98)
null
o
t
thr
fo
null
null
sev
eig

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No
