### PR TITLE
[Flink] Fix mapping between Delta's BinaryType and Flink's VarBinaryType

### DIFF
--- a/connectors/flink/src/main/java/io/delta/flink/source/internal/SchemaConverter.java
+++ b/connectors/flink/src/main/java/io/delta/flink/source/internal/SchemaConverter.java
@@ -2,7 +2,6 @@ package io.delta.flink.source.internal;
 
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
-import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.DateType;
 import org.apache.flink.table.types.logical.DecimalType;
@@ -16,6 +15,7 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 
 import io.delta.standalone.types.DataType;
@@ -64,7 +64,7 @@ public class SchemaConverter {
             case LONG:
                 return new BigIntType(nullable);
             case BINARY:
-                return new BinaryType(nullable, BinaryType.DEFAULT_LENGTH);
+                return new VarBinaryType(nullable, VarBinaryType.MAX_LENGTH);
             case BOOLEAN:
                 return new BooleanType(nullable);
             case BYTE:

--- a/connectors/flink/src/test/java/io/delta/flink/source/internal/SchemaConverterTest.java
+++ b/connectors/flink/src/test/java/io/delta/flink/source/internal/SchemaConverterTest.java
@@ -5,7 +5,6 @@ import java.util.stream.Stream;
 
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
-import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.DateType;
 import org.apache.flink.table.types.logical.DecimalType;
@@ -18,6 +17,7 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -71,7 +71,7 @@ public class SchemaConverterTest {
             Arguments.of(new io.delta.standalone.types.ByteType(), new TinyIntType()),
             Arguments.of(new io.delta.standalone.types.ShortType(), new SmallIntType()),
             Arguments.of(new io.delta.standalone.types.LongType(), new BigIntType()),
-            Arguments.of(new io.delta.standalone.types.BinaryType(), new BinaryType()),
+            Arguments.of(new io.delta.standalone.types.BinaryType(), new VarBinaryType(VarBinaryType.MAX_LENGTH)),
             Arguments.of(new io.delta.standalone.types.TimestampType(), new TimestampType()),
             Arguments.of(new io.delta.standalone.types.DateType(), new DateType()),
             Arguments.of(
@@ -163,7 +163,7 @@ public class SchemaConverterTest {
                     new io.delta.standalone.types.ShortType(),
                     true
                 ),
-                new MapType(new BinaryType(), new SmallIntType())),
+                new MapType(new VarBinaryType(VarBinaryType.MAX_LENGTH), new SmallIntType())),
             Arguments.of(
                 new io.delta.standalone.types.MapType(
                     new io.delta.standalone.types.StringType(),

--- a/connectors/flink/src/test/java/io/delta/flink/source/internal/SchemaConverterTest.java
+++ b/connectors/flink/src/test/java/io/delta/flink/source/internal/SchemaConverterTest.java
@@ -71,7 +71,9 @@ public class SchemaConverterTest {
             Arguments.of(new io.delta.standalone.types.ByteType(), new TinyIntType()),
             Arguments.of(new io.delta.standalone.types.ShortType(), new SmallIntType()),
             Arguments.of(new io.delta.standalone.types.LongType(), new BigIntType()),
-            Arguments.of(new io.delta.standalone.types.BinaryType(), new VarBinaryType(VarBinaryType.MAX_LENGTH)),
+            Arguments.of(
+                new io.delta.standalone.types.BinaryType(),
+                new VarBinaryType(VarBinaryType.MAX_LENGTH)),
             Arguments.of(new io.delta.standalone.types.TimestampType(), new TimestampType()),
             Arguments.of(new io.delta.standalone.types.DateType(), new DateType()),
             Arguments.of(


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [X] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Resolves #3977

This PR fixes a bug where the Delta-Flink connector would incorrectly map Delta's `BinaryType` (which is variable length) type to Flink's `BinaryType` (which is fixed length). Instead, this PR fixes it so that Delta's `BinaryType` is mapped to Flink's `VarBinaryType(MAX_LENGTH)`. As a comparison, Iceberg does the same [here](https://github.com/apache/iceberg/blob/8e2ffb35da2d4c5059e96cb78a30fd8c54cfbedf/flink/v1.18/flink/src/main/java/org/apache/iceberg/flink/TypeToFlinkType.java#L125).

This incorrect logic caused the behaviour seen in #3977 because:
- First, we had a source (datagen) table with Flink's BYTES (which is a synonym for VarBinaryType of MAX_LENGTH)
- Second, we had a target (delta) table. Flink created it with schema BYTES and the Delta schema had delta type `BinaryType`.
- All good so far. No problems yet.
- When we tried to `INSERT INTO <target> SELECT * FROM <source>`, the DeltaCatalog would lookup the "flink schema" of the target Delta table. It would see Delta's BinaryType and map it incorrectly to flink's BinaryType (not Flink's BYTES or VarBinaryType)
- Hence it would throw the error below

```
org.apache.flink.table.api.ValidationException: Column types of query result and sink for 'print_sink' do not match.
Cause: Incompatible types for sink column 'binary_data' at position 1.
Query schema: [id: BIGINT, binary_data: BYTES]
Sink schema: [id: BIGINT, binary_data: BINARY(1)]
```

## How was this patch tested?

Updated schema conversion tests.

New e2e test which directly tests the problematic scenario brought up in #3977.

## Does this PR introduce _any_ user-facing changes?

Yes. We fix the mapping of Delta's BinaryType to flinks VarBinaryTYpe