### PR TITLE
[Kernel] Remove duplicate `verifyDeltaVersions` function

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -116,17 +116,12 @@ public final class DeltaErrors {
   }
 
   public static KernelException endVersionNotFound(
-      String tablePath, long endVersionRequested, Optional<Long> latestAvailableVersion) {
+      String tablePath, long endVersionRequested, long latestAvailableVersion) {
     String message =
         String.format(
             "%s: Requested table changes ending with endVersion=%d but no log file found for "
-                + "version %d%s",
-            tablePath,
-            endVersionRequested,
-            endVersionRequested,
-            latestAvailableVersion
-                .map(version -> String.format(". Latest available version is %d", version))
-                .orElse(""));
+                + "version %d. Latest available version is %d",
+            tablePath, endVersionRequested, endVersionRequested, latestAvailableVersion);
     return new KernelException(message);
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -50,7 +50,6 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import java.util.stream.LongStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,42 +75,6 @@ public class SnapshotManager {
   /////////////////
   // Public APIs //
   /////////////////
-
-  /**
-   * - Verify the versions are contiguous. - Verify the versions start with `expectedStartVersion`
-   * if it's specified. - Verify the versions end with `expectedEndVersion` if it's specified.
-   */
-  public static void verifyDeltaVersions(
-      List<Long> versions,
-      Optional<Long> expectedStartVersion,
-      Optional<Long> expectedEndVersion,
-      Path tablePath) {
-    if (!versions.isEmpty()) {
-      List<Long> contVersions =
-          LongStream.rangeClosed(versions.get(0), versions.get(versions.size() - 1))
-              .boxed()
-              .collect(Collectors.toList());
-      if (!contVersions.equals(versions)) {
-        throw new InvalidTableException(
-            tablePath.toString(),
-            String.format("Missing delta files: versions are not continuous: (%s)", versions));
-      }
-    }
-    expectedStartVersion.ifPresent(
-        v -> {
-          checkArgument(
-              !versions.isEmpty() && Objects.equals(versions.get(0), v),
-              "Did not get the first delta file version %s to compute Snapshot",
-              v);
-        });
-    expectedEndVersion.ifPresent(
-        v -> {
-          checkArgument(
-              !versions.isEmpty() && Objects.equals(versions.get(versions.size() - 1), v),
-              "Did not get the last delta file version %s to compute Snapshot",
-              v);
-        });
-  }
 
   /**
    * Construct the latest snapshot for given table.
@@ -632,18 +595,10 @@ public class SnapshotManager {
                         .map(x -> new Path(x.getPath()).getName())
                         .toArray())));
 
-    final LinkedList<Long> deltaVersionsAfterCheckpoint =
-        deltasAfterCheckpoint.stream()
-            .map(fileStatus -> FileNames.deltaVersion(new Path(fileStatus.getPath())))
-            .collect(Collectors.toCollection(LinkedList::new));
-
-    logDebug(
-        () -> format("deltaVersions: %s", Arrays.toString(deltaVersionsAfterCheckpoint.toArray())));
-
     final long newVersion =
-        deltaVersionsAfterCheckpoint.isEmpty()
+        deltasAfterCheckpoint.isEmpty()
             ? newCheckpointOpt.get().version
-            : deltaVersionsAfterCheckpoint.getLast();
+            : FileNames.deltaVersion(new Path(ListUtils.getLast(deltasAfterCheckpoint).getPath()));
 
     // There should be a delta file present for the newVersion that we are loading
     // (Even if `deltasAfterCheckpoint` is empty, `deltas` should not be)
@@ -661,11 +616,14 @@ public class SnapshotManager {
             });
 
     // We may just be getting a checkpoint file after the filtering
-    if (!deltaVersionsAfterCheckpoint.isEmpty()) {
+    if (!deltasAfterCheckpoint.isEmpty()) {
+      final long firstDeltaVersionAfterCheckpoint =
+          FileNames.deltaVersion(new Path(deltasAfterCheckpoint.get(0).getPath()));
+
       // If we have deltas after the checkpoint, the first file should be 1 greater than our
       // last checkpoint version. If no checkpoint is present, this means the first delta file
       // should be version 0.
-      if (deltaVersionsAfterCheckpoint.getFirst() != newCheckpointVersion + 1) {
+      if (firstDeltaVersionAfterCheckpoint != newCheckpointVersion + 1) {
         throw new InvalidTableException(
             tablePath.toString(),
             String.format(
@@ -676,10 +634,10 @@ public class SnapshotManager {
           "Verified delta files are contiguous from version {} to {}",
           newCheckpointVersion + 1,
           newVersion);
-      verifyDeltaVersions(
-          deltaVersionsAfterCheckpoint,
-          Optional.of(newCheckpointVersion + 1),
-          versionToLoadOpt,
+      DeltaLogActionUtils.verifyDeltaVersions(
+          deltasAfterCheckpoint,
+          newCheckpointVersion + 1 /* expected first version */,
+          versionToLoadOpt /* expected end version */,
           tablePath);
     }
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/DeltaLogActionUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/DeltaLogActionUtilsSuite.scala
@@ -27,6 +27,8 @@ import org.scalatest.funsuite.AnyFunSuite
 import io.delta.kernel.internal.DeltaLogActionUtils.{getCommitFilesForVersionRange, verifyDeltaVersions}
 import io.delta.kernel.test.MockFileSystemClientUtils
 
+import java.util.Optional
+
 class DeltaLogActionUtilsSuite extends AnyFunSuite with MockFileSystemClientUtils {
 
   //////////////////////////////////////////////////////////////////////////////////
@@ -44,14 +46,14 @@ class DeltaLogActionUtilsSuite extends AnyFunSuite with MockFileSystemClientUtil
     verifyDeltaVersions(
       getCommitFiles(Seq(1, 2, 3)),
       1,
-      3,
+      Optional.of(3),
       dataPath
     )
     // Only one version provided
     verifyDeltaVersions(
       getCommitFiles(Seq(1)),
       1,
-      1,
+      Optional.of(1),
       dataPath
     )
     // Non-contiguous versions
@@ -59,7 +61,7 @@ class DeltaLogActionUtilsSuite extends AnyFunSuite with MockFileSystemClientUtil
       verifyDeltaVersions(
         getCommitFiles(Seq(1, 3, 4)),
         1,
-        4,
+        Optional.of(4),
         dataPath
       )
     }
@@ -68,7 +70,7 @@ class DeltaLogActionUtilsSuite extends AnyFunSuite with MockFileSystemClientUtil
       verifyDeltaVersions(
         getCommitFiles(Seq(1, 2, 3)),
         0,
-        3,
+        Optional.of(3),
         dataPath
       )
     }
@@ -76,7 +78,7 @@ class DeltaLogActionUtilsSuite extends AnyFunSuite with MockFileSystemClientUtil
       verifyDeltaVersions(
         getCommitFiles(Seq(1, 2, 3)),
         1,
-        4,
+        Optional.of(4),
         dataPath
       )
     }
@@ -85,7 +87,7 @@ class DeltaLogActionUtilsSuite extends AnyFunSuite with MockFileSystemClientUtil
       verifyDeltaVersions(
         getCommitFiles(Seq()),
         1,
-        4,
+        Optional.of(4),
         dataPath
       )
     }
@@ -94,7 +96,7 @@ class DeltaLogActionUtilsSuite extends AnyFunSuite with MockFileSystemClientUtil
       verifyDeltaVersions(
         getCommitFiles(Seq(1, 1, 2)),
         1,
-        4,
+        Optional.of(4),
         dataPath
       )
     }
@@ -102,7 +104,7 @@ class DeltaLogActionUtilsSuite extends AnyFunSuite with MockFileSystemClientUtil
       verifyDeltaVersions(
         getCommitFiles(Seq(1, 4, 3, 2)),
         1,
-        2,
+        Optional.of(2),
         dataPath
       )
     }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
@@ -34,90 +34,6 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
 
-  test("verifyDeltaVersions") {
-    // empty array
-    SnapshotManager.verifyDeltaVersions(
-      Collections.emptyList(),
-      Optional.empty(),
-      Optional.empty(),
-      new Path("/path/to/table"))
-    // contiguous versions
-    SnapshotManager.verifyDeltaVersions(
-      Arrays.asList(1, 2, 3),
-      Optional.empty(),
-      Optional.empty(),
-      new Path("/path/to/table"))
-    // contiguous versions with correct `expectedStartVersion` and `expectedStartVersion`
-    SnapshotManager.verifyDeltaVersions(
-      Arrays.asList(1, 2, 3),
-      Optional.empty(),
-      Optional.of(3),
-      new Path("/path/to/table"))
-    SnapshotManager.verifyDeltaVersions(
-      Arrays.asList(1, 2, 3),
-      Optional.of(1),
-      Optional.empty(),
-      new Path("/path/to/table"))
-    SnapshotManager.verifyDeltaVersions(
-      Arrays.asList(1, 2, 3),
-      Optional.of(1),
-      Optional.of(3),
-      new Path("/path/to/table"))
-    // `expectedStartVersion` or `expectedEndVersion` doesn't match
-    intercept[IllegalArgumentException] {
-      SnapshotManager.verifyDeltaVersions(
-        Arrays.asList(1, 2),
-        Optional.of(0),
-        Optional.empty(),
-        new Path("/path/to/table"))
-    }
-    intercept[IllegalArgumentException] {
-      SnapshotManager.verifyDeltaVersions(
-        Arrays.asList(1, 2),
-        Optional.empty(),
-        Optional.of(3),
-        new Path("/path/to/table"))
-    }
-    intercept[IllegalArgumentException] {
-      SnapshotManager.verifyDeltaVersions(
-        Collections.emptyList(),
-        Optional.of(0),
-        Optional.empty(),
-        new Path("/path/to/table"))
-    }
-    intercept[IllegalArgumentException] {
-      SnapshotManager.verifyDeltaVersions(
-        Collections.emptyList(),
-        Optional.empty(),
-        Optional.of(3),
-        new Path("/path/to/table"))
-    }
-    // non contiguous versions
-    intercept[InvalidTableException] {
-      SnapshotManager.verifyDeltaVersions(
-        Arrays.asList(1, 3),
-        Optional.empty(),
-        Optional.empty(),
-        new Path("/path/to/table"))
-    }
-    // duplicates in versions
-    intercept[InvalidTableException] {
-      SnapshotManager.verifyDeltaVersions(
-        Arrays.asList(1, 2, 2, 3),
-        Optional.empty(),
-        Optional.empty(),
-        new Path("/path/to/table"))
-    }
-    // unsorted versions
-    intercept[InvalidTableException] {
-      SnapshotManager.verifyDeltaVersions(
-        Arrays.asList(3, 2, 1),
-        Optional.empty(),
-        Optional.empty(),
-        new Path("/path/to/table"))
-    }
-  }
-
   //////////////////////////////////////////////////////////////////////////////////
   // getLogSegmentForVersion tests
   //////////////////////////////////////////////////////////////////////////////////
@@ -661,17 +577,17 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
       singularCheckpointFileStatuses(Seq(10L))
     testExpectedError[InvalidTableException](
       fileList,
-      expectedErrorMessageContains = "versions are not continuous: ([11, 13])"
+      expectedErrorMessageContains = "versions are not contiguous: ([11, 13])"
     )
     testExpectedError[InvalidTableException](
       fileList,
       startCheckpoint = Optional.of(10),
-      expectedErrorMessageContains = "versions are not continuous: ([11, 13])"
+      expectedErrorMessageContains = "versions are not contiguous: ([11, 13])"
     )
     testExpectedError[InvalidTableException](
       fileList,
       versionToLoad = Optional.of(13),
-      expectedErrorMessageContains = "versions are not continuous: ([11, 13])"
+      expectedErrorMessageContains = "versions are not contiguous: ([11, 13])"
     )
   }
 
@@ -750,7 +666,7 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
     )
     testExpectedError[InvalidTableException](
       deltaFileStatuses((0L until 5L) ++ (6L until 9L)),
-      expectedErrorMessageContains = "are not continuous"
+      expectedErrorMessageContains = "are not contiguous"
     )
     // corrupt incomplete multi-part checkpoint
     val corruptedCheckpointStatuses = FileNames.checkpointFileWithParts(logPath, 10, 5).asScala

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
@@ -674,7 +674,7 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
     val e = intercept[InvalidTableException] {
       latestSnapshot(goldenTablePath("versions-not-contiguous"))
     }
-    assert(e.getMessage.contains("versions are not continuous: ([0, 2])"))
+    assert(e.getMessage.contains("versions are not contiguous: ([0, 2])"))
   }
 
   test("table protocol version greater than reader protocol version") {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Kernel had two very similar `verifyDeltaVersions` functions which verify that the input versions are contiguous.

This PR removes one of them, cleaning up the extra & unneeded tests and making minor code improvements along the way.

## How was this patch tested?

Existing UTs.

## Does this PR introduce _any_ user-facing changes?

No.
