### PR TITLE
[Spark] Add config for sizing snapshot partitions by file index size

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -153,8 +153,8 @@ trait DeltaSQLConfBase {
     buildConf("snapshotPartitionBytes")
       .internal()
       .doc("Number of bytes of index files to put in each partition when building a Delta Lake " +
-        "snapshot. This can be used to dynamically set the number of partitions for state" +
-        "reconstruction based on the size of the file indices.")
+        "snapshot. This can be used to dynamically set the number of partitions used for a Delta" +
+        "Lake snapshot based on the size of the file indices.")
       .bytesConf(ByteUnit.BYTE)
       .checkValue(n => n > 0, "Delta snapshot partition bytes must be positive.")
       .createOptional

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -149,6 +149,16 @@ trait DeltaSQLConfBase {
       .checkValue(n => n > 0, "Delta snapshot partition number must be positive.")
       .createOptional
 
+  val DELTA_SNAPSHOT_PARTITION_BYTES =
+    buildConf("snapshotPartitionBytes")
+      .internal()
+      .doc("Number of bytes of index files to put in each partition when building a Delta Lake " +
+        "snapshot. This can be used to dynamically set the number of partitions for state" +
+        "reconstruction based on the size of the file indices.")
+      .bytesConf(ByteUnit.BYTE)
+      .checkValue(n => n > 0, "Delta snapshot partition bytes must be positive.")
+      .createOptional
+
   val DELTA_SNAPSHOT_LOADING_MAX_RETRIES =
     buildConf("snapshotLoading.maxRetries")
       .internal()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Resolves https://github.com/delta-io/delta/issues/3351

Adds a new config that lets users set the number of partitions used for a snapshot based on the size of index files that make up the snapshot. The config is a size in bytes to divide the total size of all index files to get the number of partitions to use. This can help when simultaneously loading small and large tables, and can reduce the default 50 partitions when only doing very small things where even 50 is overkill.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
New UT

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
New optional config to size snapshot partitions