### PR TITLE
[Spark] Throw user-facing exception when the value specified for delta.columnMapping.mode in DF's option causes NullPointerException

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
@@ -872,12 +872,9 @@ case object NameMapping extends DeltaColumnMappingMode {
 
 object DeltaColumnMappingMode {
   def apply(columnMappingModeString: String): DeltaColumnMappingMode = {
-    val columnMappingModeLowerCaseString = try {
-      columnMappingModeString.toLowerCase(Locale.ROOT)
-    } catch {
-      case ex: NullPointerException =>
-        throw DeltaErrors.unsupportedColumnMappingModeException(columnMappingModeString)
-    }
+    val columnMappingModeLowerCaseString =
+      Option(columnMappingModeString).map(_.toLowerCase(Locale.ROOT)).
+        getOrElse(throw DeltaErrors.unsupportedColumnMappingModeException(columnMappingModeString))
     columnMappingModeLowerCaseString match {
       case NoMapping.name => NoMapping
       case IdMapping.name => IdMapping

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
@@ -871,8 +871,14 @@ case object NameMapping extends DeltaColumnMappingMode {
 }
 
 object DeltaColumnMappingMode {
-  def apply(name: String): DeltaColumnMappingMode = {
-    name.toLowerCase(Locale.ROOT) match {
+  def apply(columnMappingModeString: String): DeltaColumnMappingMode = {
+    val columnMappingModeLowerCaseString = try {
+      columnMappingModeString.toLowerCase(Locale.ROOT)
+    } catch {
+      case ex: NullPointerException =>
+        throw DeltaErrors.unsupportedColumnMappingModeException(columnMappingModeString)
+    }
+    columnMappingModeLowerCaseString match {
       case NoMapping.name => NoMapping
       case IdMapping.name => IdMapping
       case NameMapping.name => NameMapping

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaColumnMapping.scala
@@ -873,8 +873,9 @@ case object NameMapping extends DeltaColumnMappingMode {
 object DeltaColumnMappingMode {
   def apply(columnMappingModeString: String): DeltaColumnMappingMode = {
     val columnMappingModeLowerCaseString =
-      Option(columnMappingModeString).map(_.toLowerCase(Locale.ROOT)).
-        getOrElse(throw DeltaErrors.unsupportedColumnMappingModeException(columnMappingModeString))
+      Option(columnMappingModeString)
+        .map(_.toLowerCase(Locale.ROOT))
+        .getOrElse(throw DeltaErrors.unsupportedColumnMappingModeException(columnMappingModeString))
     columnMappingModeLowerCaseString match {
       case NoMapping.name => NoMapping
       case IdMapping.name => IdMapping

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -26,7 +26,7 @@ import scala.collection.JavaConverters._
 import org.apache.spark.sql.delta.skipping.clustering.temp.{ClusterBySpec}
 import org.apache.spark.sql.delta.actions.{CommitInfo, Metadata, Protocol, TableFeatureProtocolUtils}
 import org.apache.spark.sql.delta.catalog.DeltaCatalog
-import org.apache.spark.sql.delta.commands.AlterTableDropFeatureDeltaCommand
+import org.apache.spark.sql.delta.commands.{AlterTableDropFeatureDeltaCommand, DeltaGenerateCommand}
 import org.apache.spark.sql.delta.constraints.Constraints
 import org.apache.spark.sql.delta.hooks.AutoCompactType
 import org.apache.spark.sql.delta.hooks.PostCommitHook
@@ -1685,12 +1685,22 @@ trait DeltaErrorsBase
     ex
   }
 
-  def unsupportedGenerateModeException(modeName: String): Throwable = {
-    import org.apache.spark.sql.delta.commands.DeltaGenerateCommand
-    val supportedModes = DeltaGenerateCommand.modeNameToGenerationFunc.keys.toSeq.mkString(", ")
+  private def unsupportedModeException(modeName: String, supportedModes: String): Throwable = {
     new DeltaIllegalArgumentException(
       errorClass = "DELTA_MODE_NOT_SUPPORTED",
       messageParameters = Array(modeName, supportedModes))
+  }
+
+  def unsupportedColumnMappingModeException(modeName: String): Throwable = {
+    val supportedColumnMappingModes =
+      DeltaColumnMapping.supportedModes.map(_.name).toSeq.mkString(", ")
+    unsupportedModeException(modeName, supportedColumnMappingModes)
+  }
+
+  def unsupportedGenerateModeException(modeName: String): Throwable = {
+    val supportedGenerateCommandModes =
+      DeltaGenerateCommand.modeNameToGenerationFunc.keys.toSeq.mkString(", ")
+    unsupportedModeException(modeName, supportedGenerateCommandModes)
   }
 
   def illegalUsageException(option: String, operation: String): Throwable = {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaColumnMappingSuite.scala
@@ -2093,4 +2093,17 @@ class DeltaColumnMappingSuite extends QueryTest
       }
     }
   }
+
+  test("Illegal null value specified for delta.columnMapping.mode option") {
+    withTempPath { tempPath =>
+      val ex = intercept[DeltaIllegalArgumentException] {
+        spark.range(10).write.mode("overwrite").format("delta").
+          option("delta.columnMapping.mode", null).save(tempPath.toString)
+      }
+      val supportedModes = DeltaColumnMapping.supportedModes.map(_.name).toSeq.mkString(", ")
+      assert(ex.getErrorClass === "DELTA_MODE_NOT_SUPPORTED")
+      assert(ex.getMessage.contains("Specified mode 'null' is not supported. " +
+        s"Supported modes are: $supportedModes"))
+    }
+  }
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -756,16 +756,6 @@ trait DeltaErrorsSuiteBase
     }
     {
       val e = intercept[DeltaIllegalArgumentException] {
-        throw DeltaErrors.unsupportedGenerateModeException("modeName")
-      }
-      import org.apache.spark.sql.delta.commands.DeltaGenerateCommand
-      val supportedModes = DeltaGenerateCommand.modeNameToGenerationFunc.keys.toSeq.mkString(", ")
-      checkErrorMessage(e, None, None,
-        Some(s"Specified mode 'modeName' is not supported. " +
-        s"Supported modes are: $supportedModes"))
-    }
-    {
-      val e = intercept[DeltaIllegalArgumentException] {
         throw DeltaErrors.unsupportedColumnMappingModeException("modeName")
       }
       val supportedModes = DeltaColumnMapping.supportedModes.map(_.name).toSeq.mkString(", ")
@@ -775,6 +765,16 @@ trait DeltaErrorsSuiteBase
         sqlStateOpt = Some("0AKDC"),
         errMsgOpt = Some(s"Specified mode 'modeName' is not supported. " +
           s"Supported modes are: $supportedModes"))
+    }
+    {
+      val e = intercept[DeltaIllegalArgumentException] {
+        throw DeltaErrors.unsupportedGenerateModeException("modeName")
+      }
+      import org.apache.spark.sql.delta.commands.DeltaGenerateCommand
+      val supportedModes = DeltaGenerateCommand.modeNameToGenerationFunc.keys.toSeq.mkString(", ")
+      checkErrorMessage(e, None, None,
+        Some(s"Specified mode 'modeName' is not supported. " +
+        s"Supported modes are: $supportedModes"))
     }
     {
       import org.apache.spark.sql.delta.DeltaOptions.EXCLUDE_REGEX_OPTION

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -765,6 +765,18 @@ trait DeltaErrorsSuiteBase
         s"Supported modes are: $supportedModes"))
     }
     {
+      val e = intercept[DeltaIllegalArgumentException] {
+        throw DeltaErrors.unsupportedColumnMappingModeException("modeName")
+      }
+      val supportedModes = DeltaColumnMapping.supportedModes.map(_.name).toSeq.mkString(", ")
+      checkErrorMessage(
+        e,
+        errClassOpt = Some("DELTA_MODE_NOT_SUPPORTED"),
+        sqlStateOpt = Some("0AKDC"),
+        errMsgOpt = Some(s"Specified mode 'modeName' is not supported. " +
+          s"Supported modes are: $supportedModes"))
+    }
+    {
       import org.apache.spark.sql.delta.DeltaOptions.EXCLUDE_REGEX_OPTION
       val e = intercept[DeltaIllegalArgumentException] {
         throw DeltaErrors.excludeRegexOptionException(EXCLUDE_REGEX_OPTION)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [X] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Currently, in DataFrame's `option` API, if users specified a value that causes `NullPointerException` for the `delta.columnMapping.mode`, then a `NullPointerException` exception is thrown.

This exception is rather unclear for users, so for this case, we are throwing the user-facing `DeltaIllegalArgumentException` instead.

I checked all the `DeltaConfigs`, it seems that only Column Mapping mode faces this problems, all other DeltaConfigs are

1. Accepts `null` as a valid value.
2. Throws `IllegalArgumentException`.
3. Throws an user-facing exception for null cases.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Added UT.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
Specifying `option("delta.columnMapping.mode", null)` will now throw a `DeltaIllegalArgumentException` instead of `NullPointerException`.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
