### PR TITLE
[Kernel] Enable writing to tables at version 7 when no invariants are defined in the schema

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableFeatures.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableFeatures.java
@@ -138,14 +138,14 @@ public class TableFeatures {
         throw unsupportedWriterProtocol(tablePath, minWriterVersion);
       case 7:
         for (String writerFeature : protocol.getWriterFeatures()) {
-          // For version 7, we allow 'invariants' to be present in the protocol's writerFeatures
-          // to unblock certain use cases, provided that no invariants are defined in the schema.
-          if (writerFeature.equals(INVARIANTS_FEATURE_NAME)) continue;
-          if (!SUPPORTED_WRITER_FEATURES.contains(writerFeature)) {
+          if (writerFeature.equals(INVARIANTS_FEATURE_NAME)) {
+            // For version 7, we allow 'invariants' to be present in the protocol's writerFeatures
+            // to unblock certain use cases, provided that no invariants are defined in the schema.
+            validateNoInvariants(tableSchema);
+          } else if (!SUPPORTED_WRITER_FEATURES.contains(writerFeature)) {
             throw unsupportedWriterFeature(tablePath, writerFeature);
           }
         }
-        validateNoInvariants(tableSchema);
 
         // Eventually we may have a way to declare and enforce dependencies between features.
         // By putting this check for row tracking here, it makes it easier to spot that row

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableFeatures.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TableFeatures.java
@@ -64,6 +64,8 @@ public class TableFeatures {
 
   public static final String ROW_TRACKING_FEATURE_NAME = "rowTracking";
 
+  public static final String INVARIANTS_FEATURE_NAME = "invariants";
+
   /** The minimum writer version required to support table features. */
   public static final int TABLE_FEATURES_MIN_WRITER_VERSION = 7;
 
@@ -136,10 +138,15 @@ public class TableFeatures {
         throw unsupportedWriterProtocol(tablePath, minWriterVersion);
       case 7:
         for (String writerFeature : protocol.getWriterFeatures()) {
+          // For version 7, we allow 'invariants' to be present in the protocol's writerFeatures
+          // to unblock certain use cases, provided that no invariants are defined in the schema.
+          if (writerFeature.equals(INVARIANTS_FEATURE_NAME)) continue;
           if (!SUPPORTED_WRITER_FEATURES.contains(writerFeature)) {
             throw unsupportedWriterFeature(tablePath, writerFeature);
           }
         }
+        validateNoInvariants(tableSchema);
+
         // Eventually we may have a way to declare and enforce dependencies between features.
         // By putting this check for row tracking here, it makes it easier to spot that row
         // tracking defines such a dependency that can be implicitly checked.

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableFeaturesSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/TableFeaturesSuite.scala
@@ -80,13 +80,28 @@ class TableFeaturesSuite extends AnyFunSuite {
     }
   }
 
-  Seq("invariants", "checkConstraints", "generatedColumns", "allowColumnDefaults", "changeDataFeed",
+  Seq("checkConstraints", "generatedColumns", "allowColumnDefaults", "changeDataFeed",
     "identityColumns", "deletionVectors", "timestampNtz", "v2Checkpoint", "icebergCompatV1",
-    "icebergCompatV2", "clustering",
-      "vacuumProtocolCheck").foreach { unsupportedWriterFeature =>
+    "icebergCompatV2", "clustering", "vacuumProtocolCheck").foreach { unsupportedWriterFeature =>
     test(s"validateWriteSupported: protocol 7 with $unsupportedWriterFeature") {
       checkUnsupported(createTestProtocol(minWriterVersion = 7, unsupportedWriterFeature))
     }
+  }
+
+  test("validateWriteSupported: protocol 7 with invariants, schema doesn't contain invariants") {
+    checkSupported(
+      createTestProtocol(minWriterVersion = 7, "invariants"),
+      metadata = createTestMetadata(),
+      schema = createTestSchema(includeInvariant = false)
+    )
+  }
+
+  test("validateWriteSupported: protocol 7 with invariants, schema contains invariants") {
+    checkUnsupported(
+      createTestProtocol(minWriterVersion = 7, "invariants"),
+      metadata = createTestMetadata(),
+      schema = createTestSchema(includeInvariant = true)
+    )
   }
 
   def checkSupported(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Currently, Kernel doesn't support the `invariants` feature and could not write to tables on writer version 7 if their `writerFeatures` contains `invariants`.

With this change, Kernel will allow `invariants` to be present in the `writerFeatures` for tables on writer version 7, provided the schema does not define any invariants. This unblocks Kernel from writing to such tables.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Tests are added in `TableFeaturesSuite.scala`. It also added a missing integration test in `RowTrackingSuite.scala` that was previously blocked by `invariants`.


## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.
