### PR TITLE
[Kernel] Consolidate listing utilities code and simplify SnapshotManager log segment error case

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaErrors.java
@@ -33,6 +33,11 @@ import java.util.function.Supplier;
 public final class DeltaErrors {
   private DeltaErrors() {}
 
+  public static KernelException missingCheckpoint(String tablePath, long checkpointVersion) {
+    return new InvalidTableException(
+        tablePath, String.format("Missing checkpoint at version %s", checkpointVersion));
+  }
+
   public static KernelException versionBeforeFirstAvailableCommit(
       String tablePath, long versionToLoad, long earliestVersion) {
     String message =

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaLogActionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaLogActionUtils.java
@@ -222,22 +222,18 @@ public class DeltaLogActionUtils {
       while (fsIter.hasNext()) {
         final FileStatus fs = fsIter.next();
 
-        boolean isDesiredFileType = false;
         if (fileTypes.contains(DeltaLogFileType.COMMIT)
             && FileNames.isCommitFile(getName(fs.getPath()))) {
-          isDesiredFileType = true;
+          // Here, we do nothing (we will consume this file).
         } else if (fileTypes.contains(DeltaLogFileType.CHECKPOINT)
             && FileNames.isCheckpointFile(getName(fs.getPath()))
             && fs.getSize() > 0) {
-          // Checkpoint files of 0 size are invalid but may be ignored silently when read,
-          // hence we ignore them so that we never pick up such checkpoints.
-          isDesiredFileType = true;
+          // Checkpoint files of 0 size are invalid but may be ignored silently when read, hence we
+          // ignore them so that we never pick up such checkpoints.
+          // Here, we do nothing (we will consume this file).
         } else {
           logger.debug("Ignoring file {} as it is not of the desired type", fs.getPath());
-        }
-
-        if (!isDesiredFileType) {
-          continue;
+          continue; // Here, we continue and skip this file.
         }
 
         final long fileVersion = FileNames.getFileVersion(new Path(fs.getPath()));

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaLogActionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/DeltaLogActionUtils.java
@@ -17,6 +17,7 @@ package io.delta.kernel.internal;
 
 import static io.delta.kernel.internal.DeltaErrors.*;
 import static io.delta.kernel.internal.fs.Path.getName;
+import static io.delta.kernel.internal.util.Preconditions.checkArgument;
 
 import io.delta.kernel.data.ColumnVector;
 import io.delta.kernel.data.ColumnarBatch;
@@ -31,6 +32,7 @@ import io.delta.kernel.internal.fs.Path;
 import io.delta.kernel.internal.lang.ListUtils;
 import io.delta.kernel.internal.replay.ActionsIterator;
 import io.delta.kernel.internal.util.FileNames;
+import io.delta.kernel.internal.util.FileNames.DeltaLogFileType;
 import io.delta.kernel.types.*;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
@@ -94,14 +96,20 @@ public class DeltaLogActionUtils {
    */
   public static List<FileStatus> getCommitFilesForVersionRange(
       Engine engine, Path tablePath, long startVersion, long endVersion) {
-
     // Validate arguments
     if (startVersion < 0 || endVersion < startVersion) {
       throw invalidVersionRange(startVersion, endVersion);
     }
 
     // Get any available commit files within the version range
-    List<FileStatus> commitFiles = listCommitFiles(engine, tablePath, startVersion, endVersion);
+    final List<FileStatus> commitFiles =
+        listDeltaLogFiles(
+            engine,
+            Collections.singleton(DeltaLogFileType.COMMIT),
+            tablePath,
+            startVersion,
+            Optional.of(endVersion),
+            false /* mustBeRecreatable */);
 
     // There are no available commit files within the version range.
     // This can be due to (1) an empty directory, (2) no valid delta files in the directory,
@@ -170,6 +178,110 @@ public class DeltaLogActionUtils {
                   .withNewColumn(0, COMMIT_VERSION_STRUCT_FIELD, commitVersionVector)
                   .withNewColumn(1, COMMIT_TIMESTAMP_STRUCT_FIELD, commitTimestampVector);
             });
+  }
+
+  /**
+   * Returns the list of files of type $fileTypes in the _delta_log directory of the given
+   * $tablePath, in increasing order from $startVersion to the optional $endVersion.
+   *
+   * @throws TableNotFoundException if the table or its _delta_log does not exist
+   * @throws KernelException if mustBeRecreatable is true, endVersionOpt is present, and the
+   *     _delta_log history has been truncated so that we cannot load the desired end version
+   */
+  public static List<FileStatus> listDeltaLogFiles(
+      Engine engine,
+      Set<DeltaLogFileType> fileTypes,
+      Path tablePath,
+      long startVersion,
+      Optional<Long> endVersionOpt,
+      boolean mustBeRecreatable) {
+    checkArgument(!fileTypes.isEmpty(), "At least one file type must be provided");
+
+    endVersionOpt.ifPresent(
+        endVersion -> {
+          checkArgument(
+              endVersion >= startVersion,
+              "endVersion=%s provided is less than startVersion=%s",
+              endVersion,
+              startVersion);
+        });
+
+    final Path logPath = new Path(tablePath, "_delta_log");
+
+    logger.info(
+        "Listing log files types={} in path={} starting from {} and ending with {}",
+        fileTypes,
+        logPath,
+        startVersion,
+        endVersionOpt);
+
+    final List<FileStatus> output = new ArrayList<>();
+    final long startTimeMillis = System.currentTimeMillis();
+
+    try (CloseableIterator<FileStatus> fsIter = listLogDir(engine, tablePath, startVersion)) {
+      while (fsIter.hasNext()) {
+        final FileStatus fs = fsIter.next();
+
+        boolean isDesiredFileType = false;
+        if (fileTypes.contains(DeltaLogFileType.COMMIT)
+            && FileNames.isCommitFile(getName(fs.getPath()))) {
+          isDesiredFileType = true;
+        } else if (fileTypes.contains(DeltaLogFileType.CHECKPOINT)
+            && FileNames.isCheckpointFile(getName(fs.getPath()))
+            && fs.getSize() > 0) {
+          // Checkpoint files of 0 size are invalid but may be ignored silently when read,
+          // hence we ignore them so that we never pick up such checkpoints.
+          isDesiredFileType = true;
+        } else {
+          logger.debug("Ignoring file {} as it is not of the desired type", fs.getPath());
+        }
+
+        if (!isDesiredFileType) {
+          continue;
+        }
+
+        final long fileVersion = FileNames.getFileVersion(new Path(fs.getPath()));
+
+        if (fileVersion < startVersion) {
+          throw new RuntimeException(
+              String.format(
+                  "Listing files in %s with startVersion %s yet found file %s with version %s",
+                  logPath, startVersion, fs.getPath(), fileVersion));
+        }
+
+        if (endVersionOpt.isPresent()) {
+          final long endVersion = endVersionOpt.get();
+
+          if (fileVersion > endVersion) {
+            if (mustBeRecreatable && output.isEmpty()) {
+              final long earliestVersion =
+                  DeltaHistoryManager.getEarliestRecreatableCommit(engine, logPath);
+              throw DeltaErrors.versionBeforeFirstAvailableCommit(
+                  tablePath.toString(), endVersion, earliestVersion);
+            } else {
+              logger.debug(
+                  "Stopping listing; found file {} with version > {}=endVersion",
+                  fs.getPath(),
+                  endVersion);
+              break;
+            }
+          }
+        }
+
+        output.add(fs);
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("Unable to close resource", e);
+    }
+
+    logger.info(
+        "{}: Took {} ms to list the commit files for versions [{}, {}]",
+        tablePath,
+        System.currentTimeMillis() - startTimeMillis,
+        startVersion,
+        endVersionOpt);
+
+    return output;
   }
 
   //////////////////////
@@ -247,53 +359,10 @@ public class DeltaLogActionUtils {
           "Listing from %s",
           FileNames.listingPrefix(logPath, startVersion));
     } catch (FileNotFoundException e) {
+      // Did not find the _delta_log directory.
       throw new TableNotFoundException(tablePath.toString());
     } catch (IOException io) {
       throw new UncheckedIOException("Failed to list the files in delta log", io);
     }
-  }
-
-  /**
-   * Returns a list of delta commit files found in the _delta_log directory between startVersion and
-   * endVersion (both inclusive).
-   *
-   * @throws TableNotFoundException if the _delta_log directory does not exist
-   */
-  private static List<FileStatus> listCommitFiles(
-      Engine engine, Path tablePath, long startVersion, long endVersion) {
-
-    // TODO update to support coordinated commits; suggested to load the Snapshot at endVersion
-    //  and get the backfilled/unbackfilled commits from the LogSegment to combine with commit files
-    //  listed from [startVersion, LogSegment.checkpointVersion]
-    logger.info(
-        "{}: Listing the commit files for versions [{}, {}]", tablePath, startVersion, endVersion);
-    long startTimeMillis = System.currentTimeMillis();
-    final List<FileStatus> output = new ArrayList<>();
-    try (CloseableIterator<FileStatus> fsIter = listLogDir(engine, tablePath, startVersion)) {
-      while (fsIter.hasNext()) {
-        FileStatus fs = fsIter.next();
-        if (!FileNames.isCommitFile(getName(fs.getPath()))) {
-          logger.debug("Ignoring non-commit file {}", fs.getPath());
-          continue;
-        }
-        if (FileNames.getFileVersion(new Path(fs.getPath())) > endVersion) {
-          logger.debug(
-              "Stopping listing found file {} with version > {}=endVersion",
-              fs.getPath(),
-              endVersion);
-          break;
-        }
-        output.add(fs);
-      }
-    } catch (IOException e) {
-      throw new UncheckedIOException("Unable to close resource", e);
-    }
-    logger.info(
-        "{}: Took {} ms to list the commit files for versions [{}, {}]",
-        tablePath,
-        System.currentTimeMillis() - startTimeMillis,
-        startVersion,
-        endVersion);
-    return output;
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -438,7 +438,8 @@ public class SnapshotManager {
         // TODO: for case (a), re-load the delta log but ignore the _LAST_CHECKPOINT file.
         throw DeltaErrors.missingCheckpoint(tablePath.toString(), startCheckpointOpt.get());
       } else {
-        // No files found even when listing from 0 => empty directory => table does not exist yet.
+        // Either no files found OR no *delta* files found even when listing from 0. This means that
+        // the delta table does not exist yet.
         throw new TableNotFoundException(
             tablePath.toString(), format("No delta files found in the directory: %s", logPath));
       }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -435,6 +435,7 @@ public class SnapshotManager {
         // We either (a) determined this checkpoint version from the _LAST_CHECKPOINT file, or (b)
         // found the last complete checkpoint before our versionToLoad. In either case, we didn't
         // see the checkpoint file in the listing.
+        // TODO: for case (a), re-load the delta log but ignore the _LAST_CHECKPOINT file.
         throw DeltaErrors.missingCheckpoint(tablePath.toString(), startCheckpointOpt.get());
       } else {
         // No files found even when listing from 0 => empty directory => table does not exist yet.

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -21,7 +21,6 @@ import static io.delta.kernel.internal.TableConfig.EXPIRED_LOG_CLEANUP_ENABLED;
 import static io.delta.kernel.internal.TableConfig.LOG_RETENTION;
 import static io.delta.kernel.internal.TableFeatures.validateWriteSupportedTable;
 import static io.delta.kernel.internal.checkpoints.Checkpointer.findLastCompleteCheckpointBefore;
-import static io.delta.kernel.internal.fs.Path.getName;
 import static io.delta.kernel.internal.replay.LogReplayUtils.assertLogFilesBelongToTable;
 import static io.delta.kernel.internal.snapshot.MetadataCleanup.cleanupExpiredLogs;
 import static io.delta.kernel.internal.util.Preconditions.checkArgument;
@@ -43,8 +42,8 @@ import io.delta.kernel.internal.replay.CreateCheckpointIterator;
 import io.delta.kernel.internal.replay.LogReplay;
 import io.delta.kernel.internal.util.Clock;
 import io.delta.kernel.internal.util.FileNames;
+import io.delta.kernel.internal.util.FileNames.DeltaLogFileType;
 import io.delta.kernel.internal.util.Tuple2;
-import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
 import java.io.*;
 import java.nio.file.FileAlreadyExistsException;
@@ -266,117 +265,6 @@ public class SnapshotManager {
         });
   }
 
-  /** Get an iterator of files in the _delta_log directory starting with the startVersion. */
-  private CloseableIterator<FileStatus> listFrom(Engine engine, long startVersion)
-      throws IOException {
-    logger.debug("{}: startVersion: {}", tablePath, startVersion);
-    return wrapEngineExceptionThrowsIO(
-        () -> engine.getFileSystemClient().listFrom(FileNames.listingPrefix(logPath, startVersion)),
-        "Listing from %s",
-        FileNames.listingPrefix(logPath, startVersion));
-  }
-
-  /**
-   * Returns true if the given file name is delta log files. Delta log files can be delta commit
-   * file (e.g., 000000000.json), or checkpoint file. (e.g.,
-   * 000000001.checkpoint.00001.00003.parquet)
-   *
-   * @param fileName Name of the file (not the full path)
-   * @return Boolean Whether the file is delta log files
-   */
-  private boolean isDeltaCommitOrCheckpointFile(String fileName) {
-    return FileNames.isCheckpointFile(fileName) || FileNames.isCommitFile(fileName);
-  }
-
-  /**
-   * Returns an iterator containing a list of files found in the _delta_log directory starting with
-   * the startVersion. Returns None if no files are found or the directory is missing.
-   */
-  private Optional<CloseableIterator<FileStatus>> listFromOrNone(Engine engine, long startVersion) {
-    // LIST the directory, starting from the provided lower bound (treat missing dir as empty).
-    // NOTE: "empty/missing" is _NOT_ equivalent to "contains no useful commit files."
-    try {
-      CloseableIterator<FileStatus> results = listFrom(engine, startVersion);
-      if (results.hasNext()) {
-        return Optional.of(results);
-      } else {
-        return Optional.empty();
-      }
-    } catch (FileNotFoundException e) {
-      return Optional.empty();
-    } catch (IOException io) {
-      throw new UncheckedIOException("Failed to list the files in delta log", io);
-    }
-  }
-
-  /**
-   * Returns the delta files and checkpoint files starting from the given `startVersion`.
-   * `versionToLoad` is an optional parameter to set the max bound. It's usually used to load a
-   * table snapshot for a specific version. If no delta or checkpoint files exist below the
-   * versionToLoad and at least one delta file exists, throws an exception that the state is not
-   * reconstructable.
-   *
-   * @param startVersion the version to start. Inclusive.
-   * @param versionToLoad the optional parameter to set the max version we should return. Inclusive.
-   *     Must be >= startVersion if provided.
-   * @return Some array of files found (possibly empty, if no usable commit files are present), or
-   *     None if the listing returned no files at all.
-   */
-  protected final Optional<List<FileStatus>> listDeltaAndCheckpointFiles(
-      Engine engine, long startVersion, Optional<Long> versionToLoad) {
-    versionToLoad.ifPresent(
-        v ->
-            checkArgument(
-                v >= startVersion,
-                "versionToLoad=%s provided is less than startVersion=%s",
-                v,
-                startVersion));
-    logger.debug("startVersion: {}, versionToLoad: {}", startVersion, versionToLoad);
-
-    return listFromOrNone(engine, startVersion)
-        .map(
-            fileStatusesIter -> {
-              final List<FileStatus> output = new ArrayList<>();
-
-              while (fileStatusesIter.hasNext()) {
-                final FileStatus fileStatus = fileStatusesIter.next();
-                final String fileName = getName(fileStatus.getPath());
-
-                // Pick up all checkpoint and delta files
-                if (!isDeltaCommitOrCheckpointFile(fileName)) {
-                  continue;
-                }
-
-                // Checkpoint files of 0 size are invalid but may be ignored silently when read,
-                // hence we drop them so that we never pick up such checkpoints.
-                if (FileNames.isCheckpointFile(fileName) && fileStatus.getSize() == 0) {
-                  continue;
-                }
-                // Take files until the version we want to load
-                final boolean versionWithinRange =
-                    versionToLoad
-                        .map(v -> FileNames.getFileVersion(new Path(fileStatus.getPath())) <= v)
-                        .orElse(true);
-
-                if (!versionWithinRange) {
-                  // If we haven't taken any files yet and the first file we see is greater
-                  // than the versionToLoad then the versionToLoad is not reconstructable
-                  // from the existing logs
-                  if (output.isEmpty()) {
-                    long earliestVersion =
-                        DeltaHistoryManager.getEarliestRecreatableCommit(engine, logPath);
-                    throw DeltaErrors.versionBeforeFirstAvailableCommit(
-                        tablePath.toString(), versionToLoad.get(), earliestVersion);
-                  }
-                  break;
-                }
-                output.add(fileStatus);
-              }
-
-              return output;
-            });
-  }
-
   /**
    * Load the Snapshot for this Delta table at initialization. This method uses the `lastCheckpoint`
    * file as a hint on where to start listing the transaction log directory.
@@ -508,8 +396,15 @@ public class SnapshotManager {
             });
 
     long startTimeMillis = System.currentTimeMillis();
-    final Optional<List<FileStatus>> newFiles =
-        listDeltaAndCheckpointFiles(engine, startVersion, versionToLoad);
+    final List<FileStatus> newFiles =
+        DeltaLogActionUtils.listDeltaLogFiles(
+            engine,
+            new HashSet<>(Arrays.asList(DeltaLogFileType.COMMIT, DeltaLogFileType.CHECKPOINT)),
+            tablePath,
+            startVersion,
+            versionToLoad,
+            true /* mustBeRecreatable */);
+
     logger.info(
         "{}: Took {}ms to list the files after starting checkpoint",
         tablePath,
@@ -534,42 +429,18 @@ public class SnapshotManager {
       Engine engine,
       Optional<Long> startCheckpointOpt,
       Optional<Long> versionToLoadOpt,
-      Optional<List<FileStatus>> filesOpt) {
-    final List<FileStatus> newFiles;
-    if (filesOpt.isPresent()) {
-      newFiles = filesOpt.get();
-    } else {
-      // No files found even when listing from 0 => empty directory =>
-      // table does not exist yet.
-      if (!startCheckpointOpt.isPresent()) {
-        return Optional.empty();
-      }
-
-      // FIXME: We always write the commit and checkpoint files before updating
-      //  _last_checkpoint. If the listing came up empty, then we either encountered a
-      // list-after-put inconsistency in the underlying log store, or somebody corrupted the
-      // table by deleting files. Either way, we can't safely continue.
-      //
-      // For now, we preserve existing behavior by returning Array.empty, which will trigger a
-      // recursive call to [[getLogSegmentForVersion]] below (same as before the refactor).
-      newFiles = Collections.emptyList();
+      List<FileStatus> newFiles) {
+    if (newFiles.isEmpty()) {
+      throw new TableNotFoundException(
+          tablePath.toString(), format("No delta files found in the directory: %s", logPath));
     }
+
     logDebug(
         () ->
             format(
                 "newFiles: %s",
                 Arrays.toString(
                     newFiles.stream().map(x -> new Path(x.getPath()).getName()).toArray())));
-
-    if (newFiles.isEmpty() && !startCheckpointOpt.isPresent()) {
-      // We can't construct a snapshot because the directory contained no usable commit
-      // files... but we can't return Optional.empty either, because it was not truly empty.
-      throw new RuntimeException(format("No delta files found in the directory: %s", logPath));
-    } else if (newFiles.isEmpty()) {
-      // The directory may be deleted and recreated and we may have stale state in our
-      // DeltaLog singleton, so try listing from the first version
-      return getLogSegmentForVersion(engine, Optional.empty(), versionToLoadOpt);
-    }
 
     Tuple2<List<FileStatus>, List<FileStatus>> checkpointsAndDeltas =
         ListUtils.partition(

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/FileNames.java
@@ -29,6 +29,11 @@ public final class FileNames {
   // File name patterns and other static values //
   ////////////////////////////////////////////////
 
+  public enum DeltaLogFileType {
+    COMMIT,
+    CHECKPOINT
+  }
+
   /** Example: 00000000000000000001.json */
   private static final Pattern DELTA_FILE_PATTERN = Pattern.compile("\\d+\\.json");
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/DeltaLogActionUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/DeltaLogActionUtilsSuite.scala
@@ -16,17 +16,19 @@
 package io.delta.kernel.internal
 
 import java.io.FileNotFoundException
+import java.util.{Collections, Optional}
+
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
+
 import io.delta.kernel.exceptions.{InvalidTableException, KernelException, TableNotFoundException}
 import io.delta.kernel.internal.util.FileNames
 import io.delta.kernel.utils.FileStatus
-import org.scalatest.funsuite.AnyFunSuite
 import io.delta.kernel.internal.DeltaLogActionUtils.{getCommitFilesForVersionRange, listDeltaLogFiles, verifyDeltaVersions}
 import io.delta.kernel.internal.fs.Path
 import io.delta.kernel.test.MockFileSystemClientUtils
 
-import java.util.{Collections, HashSet, Optional}
+import org.scalatest.funsuite.AnyFunSuite
 
 class DeltaLogActionUtilsSuite extends AnyFunSuite with MockFileSystemClientUtils {
 
@@ -310,18 +312,5 @@ class DeltaLogActionUtilsSuite extends AnyFunSuite with MockFileSystemClientUtil
     assert(exMsg.contains("Cannot load table version 4 as the transaction log has been " +
       "truncated due to manual deletion or the log/checkpoint retention policy. The earliest " +
       "available version is 10"))
-  }
-
-  test("listDeltaLogFiles: throws TableNotFoundException if table not found") {
-    intercept[TableNotFoundException] {
-      listDeltaLogFiles(
-        createMockFSListFromEngine(_ => throw new FileNotFoundException()),
-        Set(FileNames.DeltaLogFileType.COMMIT, FileNames.DeltaLogFileType.CHECKPOINT).asJava,
-        dataPath,
-        0,
-        Optional.empty(),
-        false /* mustBeRecreatable */
-      )
-    }
   }
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/DeltaLogActionUtilsSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/DeltaLogActionUtilsSuite.scala
@@ -16,22 +16,23 @@
 package io.delta.kernel.internal
 
 import java.io.FileNotFoundException
-
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
-
 import io.delta.kernel.exceptions.{InvalidTableException, KernelException, TableNotFoundException}
 import io.delta.kernel.internal.util.FileNames
 import io.delta.kernel.utils.FileStatus
 import org.scalatest.funsuite.AnyFunSuite
-import io.delta.kernel.internal.DeltaLogActionUtils.{getCommitFilesForVersionRange, verifyDeltaVersions}
+import io.delta.kernel.internal.DeltaLogActionUtils.{getCommitFilesForVersionRange, listDeltaLogFiles, verifyDeltaVersions}
+import io.delta.kernel.internal.fs.Path
 import io.delta.kernel.test.MockFileSystemClientUtils
+
+import java.util.{Collections, HashSet, Optional}
 
 class DeltaLogActionUtilsSuite extends AnyFunSuite with MockFileSystemClientUtils {
 
-  //////////////////////////////////////////////////////////////////////////////////
-  // verifyDeltaVersions tests
-  //////////////////////////////////////////////////////////////////////////////////
+  ///////////////////////////////
+  // verifyDeltaVersions tests //
+  ///////////////////////////////
 
   def getCommitFiles(versions: Seq[Long]): java.util.List[FileStatus] = {
     versions
@@ -108,9 +109,9 @@ class DeltaLogActionUtilsSuite extends AnyFunSuite with MockFileSystemClientUtil
     }
   }
 
-  //////////////////////////////////////////////////////////////////////////////////
-  // getCommitFilesForVersionRange tests
-  //////////////////////////////////////////////////////////////////////////////////
+  /////////////////////////////////////////
+  // getCommitFilesForVersionRange tests //
+  /////////////////////////////////////////
 
   test("getCommitFilesForVersionRange: directory does not exist") {
     intercept[TableNotFoundException] {
@@ -240,4 +241,87 @@ class DeltaLogActionUtilsSuite extends AnyFunSuite with MockFileSystemClientUtil
     endVersion = 0,
     expectedCommitFiles = deltaFileStatuses(Seq(0))
   )
+
+  /////////////////////////////
+  // listDeltaLogFiles tests //
+  /////////////////////////////
+
+  private val checkpointsAndDeltas = singularCheckpointFileStatuses(Seq(10)) ++
+    deltaFileStatuses(Seq(10, 11, 12, 13, 14)) ++
+    Seq(FileStatus.of(s"$logPath/00000000000000000014.crc", 0, 0)) ++
+    multiCheckpointFileStatuses(Seq(14), 2) ++
+    deltaFileStatuses(Seq(15, 16, 17)) ++
+    v2CheckpointFileStatuses(Seq((17, false, 2)), "json").map(_._1)
+
+  private def extractVersions(files: Seq[FileStatus]): Seq[Long] = {
+    files.map(fs => FileNames.getFileVersion(new Path(fs.getPath)))
+  }
+
+  test("listDeltaLogFiles: no fileTypes provided") {
+    intercept[IllegalArgumentException] {
+      listDeltaLogFiles(
+        createMockFSListFromEngine(deltaFileStatuses(Seq(1, 2, 3))),
+        Collections.emptySet(), // No fileTypes provided!
+        dataPath,
+        1,
+        Optional.empty(),
+        false /* mustBeRecreatable */
+      )
+    }
+  }
+
+  test("listDeltaLogFiles: returns requested file type only") {
+    val commitFiles = listDeltaLogFiles(
+      createMockFSListFromEngine(checkpointsAndDeltas),
+      Set(FileNames.DeltaLogFileType.COMMIT).asJava,
+      dataPath,
+      10,
+      Optional.empty(),
+      false /* mustBeRecreatable */
+    ).asScala
+
+    assert(commitFiles.forall(fs => FileNames.isCommitFile(fs.getPath)))
+    assert(extractVersions(commitFiles) == Seq(10, 11, 12, 13, 14, 15, 16, 17))
+
+    val checkpointFiles = listDeltaLogFiles(
+      createMockFSListFromEngine(checkpointsAndDeltas),
+      Set(FileNames.DeltaLogFileType.CHECKPOINT).asJava,
+      dataPath,
+      10,
+      Optional.empty(),
+      false /* mustBeRecreatable */
+    ).asScala
+
+    assert(checkpointFiles.forall(fs => FileNames.isCheckpointFile(fs.getPath)))
+    assert(extractVersions(checkpointFiles) == Seq(10, 14, 14, 17))
+  }
+
+  test("listDeltaLogFiles: mustBeRecreatable") {
+    val exMsg = intercept[KernelException] {
+      listDeltaLogFiles(
+        createMockFSListFromEngine(checkpointsAndDeltas),
+        Set(FileNames.DeltaLogFileType.COMMIT, FileNames.DeltaLogFileType.CHECKPOINT).asJava,
+        dataPath,
+        0,
+        Optional.of(4),
+        true /* mustBeRecreatable */
+      )
+    }.getMessage
+    assert(exMsg.contains("Cannot load table version 4 as the transaction log has been " +
+      "truncated due to manual deletion or the log/checkpoint retention policy. The earliest " +
+      "available version is 10"))
+  }
+
+  test("listDeltaLogFiles: throws TableNotFoundException if table not found") {
+    intercept[TableNotFoundException] {
+      listDeltaLogFiles(
+        createMockFSListFromEngine(_ => throw new FileNotFoundException()),
+        Set(FileNames.DeltaLogFileType.COMMIT, FileNames.DeltaLogFileType.CHECKPOINT).asJava,
+        dataPath,
+        0,
+        Optional.empty(),
+        false /* mustBeRecreatable */
+      )
+    }
+  }
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
@@ -20,8 +20,8 @@ import java.util.{Arrays, Collections, Optional}
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 
-import io.delta.kernel.data.{ColumnarBatch, ColumnVector}
-import io.delta.kernel.exceptions.InvalidTableException
+import io.delta.kernel.data.{ColumnVector, ColumnarBatch}
+import io.delta.kernel.exceptions.{InvalidTableException, TableNotFoundException}
 import io.delta.kernel.expressions.Predicate
 import io.delta.kernel.internal.checkpoints.{CheckpointInstance, SidecarFile}
 import io.delta.kernel.internal.fs.Path
@@ -436,25 +436,27 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
   }
 
   test("getLogSegmentForVersion: empty delta log") {
-    // listDeltaAndCheckpointFiles = Optional.empty()
-    val logSegmentOpt = snapshotManager.getLogSegmentForVersion(
-      createMockFSListFromEngine(Seq.empty),
-      Optional.empty(),
-      Optional.empty()
-    )
-    assert(!logSegmentOpt.isPresent())
+    val exMsg = intercept[TableNotFoundException] {
+      snapshotManager.getLogSegmentForVersion(
+        createMockFSListFromEngine(Seq.empty),
+        Optional.empty(),
+        Optional.empty()
+      )
+    }.getMessage
+
+    assert(exMsg.contains("No delta files found in the directory"))
   }
 
   test("getLogSegmentForVersion: no delta files in the delta log") {
     // listDeltaAndCheckpointFiles = Optional.of(EmptyList)
     val files = Seq("foo", "notdelta.parquet", "foo.json", "001.checkpoint.00f.oo0.parquet")
       .map(FileStatus.of(_, 10, 10))
-    testExpectedError[RuntimeException](
+    testExpectedError[TableNotFoundException](
       files,
       expectedErrorMessageContains =
         "No delta files found in the directory: /fake/path/to/table/_delta_log"
     )
-    testExpectedError[RuntimeException](
+    testExpectedError[TableNotFoundException](
       files,
       versionToLoad = Optional.of(5),
       expectedErrorMessageContains =
@@ -848,13 +850,15 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
   }
 
   test("getLogSegmentForVersion: corrupt _last_checkpoint with empty delta log") {
-    // listDeltaAndCheckpointFiles = Optional.empty()
-    val logSegmentOpt = snapshotManager.getLogSegmentForVersion(
-      createMockFSListFromEngine(Seq.empty),
-      Optional.of(1),
-      Optional.empty()
-    )
-    assert(!logSegmentOpt.isPresent())
+    val exMsg = intercept[TableNotFoundException] {
+      snapshotManager.getLogSegmentForVersion(
+        createMockFSListFromEngine(Seq.empty),
+        Optional.of(1),
+        Optional.empty()
+      )
+    }.getMessage
+
+    assert(exMsg.contains("No delta files found in the directory"))
   }
 }
 

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/SnapshotManagerSuite.scala
@@ -850,7 +850,7 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
   }
 
   test("getLogSegmentForVersion: corrupt _last_checkpoint with empty delta log") {
-    val exMsg = intercept[TableNotFoundException] {
+    val exMsg = intercept[InvalidTableException] {
       snapshotManager.getLogSegmentForVersion(
         createMockFSListFromEngine(Seq.empty),
         Optional.of(1),
@@ -858,7 +858,7 @@ class SnapshotManagerSuite extends AnyFunSuite with MockFileSystemClientUtils {
       )
     }.getMessage
 
-    assert(exMsg.contains("No delta files found in the directory"))
+    assert(exMsg.contains("Missing checkpoint at version 1"))
   }
 }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaLogActionUtilsE2ESuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaLogActionUtilsE2ESuite.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright (2025) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.delta.kernel.defaults
 
 import java.io.File

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaLogActionUtilsE2ESuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaLogActionUtilsE2ESuite.scala
@@ -1,0 +1,50 @@
+package io.delta.kernel.defaults
+
+import java.io.File
+import java.util.Optional
+
+import scala.collection.JavaConverters._
+
+import io.delta.kernel.defaults.utils.TestUtils
+import io.delta.kernel.exceptions.TableNotFoundException
+import io.delta.kernel.internal.DeltaLogActionUtils.listDeltaLogFiles
+import io.delta.kernel.internal.fs.Path
+import io.delta.kernel.internal.util.FileNames
+
+import org.scalatest.funsuite.AnyFunSuite
+
+/** Test suite for end-to-end cases. See also the mocked unit tests in DeltaLogActionUtilsSuite. */
+class DeltaLogActionUtilsE2ESuite extends AnyFunSuite with TestUtils {
+  test("listDeltaLogFiles: throws TableNotFoundException if _delta_log does not exist") {
+    withTempDir { tableDir =>
+      intercept[TableNotFoundException] {
+        listDeltaLogFiles(
+          defaultEngine,
+          Set(FileNames.DeltaLogFileType.COMMIT, FileNames.DeltaLogFileType.CHECKPOINT).asJava,
+          new Path(tableDir.getAbsolutePath),
+          0,
+          Optional.empty(),
+          true /* mustBeRecreatable */
+        )
+      }
+    }
+  }
+
+  test("listDeltaLogFiles: returns empty list if _delta_log is empty") {
+    withTempDir { tableDir =>
+      val logDir = new File(tableDir, "_delta_log")
+      assert(logDir.mkdirs() && logDir.isDirectory && logDir.listFiles().isEmpty)
+
+      val result = listDeltaLogFiles(
+        defaultEngine,
+        Set(FileNames.DeltaLogFileType.COMMIT, FileNames.DeltaLogFileType.CHECKPOINT).asJava,
+        new Path(tableDir.getAbsolutePath),
+        0,
+        Optional.empty(),
+        true /* mustBeRecreatable */
+      )
+
+      assert(result.isEmpty)
+    }
+  }
+}

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
@@ -246,11 +246,9 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
   test("empty _delta_log folder") {
     withTempDir { dir =>
       new File(dir, "_delta_log").mkdirs()
-      val exMsg = intercept[TableNotFoundException] {
+      intercept[TableNotFoundException] {
         latestSnapshot(dir.getAbsolutePath)
-      }.getMessage
-
-      assert(exMsg.contains("No delta files found in the directory"))
+      }
     }
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
@@ -246,9 +246,11 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
   test("empty _delta_log folder") {
     withTempDir { dir =>
       new File(dir, "_delta_log").mkdirs()
-      intercept[TableNotFoundException] {
+      val exMsg = intercept[TableNotFoundException] {
         latestSnapshot(dir.getAbsolutePath)
-      }
+      }.getMessage
+
+      assert(exMsg.contains("No delta files found in the directory"))
     }
   }
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

We used to have several duplicated log directory listing utilities. This PR cleans that up so there's just one utility method.

I also got rid of the listing utility that returns an `Optional<List<FileStatus>>`. If we cannot find the `_delta_log` folder, we throw an exception. If the `_delta_log` folder is empty, we should return an empty list.

## How was this patch tested?

Just a refactor. Existing UTs.

## Does this PR introduce _any_ user-facing changes?

No.
