### PR TITLE
[Spark] Extend streaming tests with coordinated commits (1/2)

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/coordinatedcommits/CoordinatedCommitsUtils.scala
@@ -165,7 +165,8 @@ object CoordinatedCommitsUtils extends DeltaLogging {
       protocol: Protocol,
       failIfImplUnavailable: Boolean): Option[CommitCoordinatorClient] = {
     metadata.coordinatedCommitsCoordinatorName.flatMap { commitCoordinatorStr =>
-      assert(protocol.isFeatureSupported(CoordinatedCommitsTableFeature))
+      assert(protocol.isFeatureSupported(CoordinatedCommitsTableFeature),
+        "coordinated commits table feature is not supported")
       val coordinatorConf = metadata.coordinatedCommitsCoordinatorConf
       val coordinatorOpt = CommitCoordinatorProvider.getCommitCoordinatorClientOpt(
         commitCoordinatorStr, coordinatorConf, spark)

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSQLSuite.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.delta
 
 import java.util.Date
 
+import org.apache.spark.sql.delta.DeltaTestUtils.modifyCommitTimestamp
 import org.apache.spark.sql.delta.actions.Protocol
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.DeltaTestImplicits._
@@ -226,9 +227,9 @@ class DeltaCDCSQLSuite extends DeltaCDCSuiteBase with DeltaColumnMappingTestUtil
         val deltaLog = DeltaLog.forTable(spark, TableIdentifier(tbl))
 
         val currentTime = new Date().getTime
-        modifyDeltaTimestamp(deltaLog, 0, currentTime - 100000)
-        modifyDeltaTimestamp(deltaLog, 1, currentTime)
-        modifyDeltaTimestamp(deltaLog, 2, currentTime + 100000)
+        modifyCommitTimestamp(deltaLog, 0, currentTime - 100000)
+        modifyCommitTimestamp(deltaLog, 1, currentTime)
+        modifyCommitTimestamp(deltaLog, 2, currentTime + 100000)
 
         val readDf = sql(s"SELECT * FROM table_changes('$tbl', 0, now())")
         checkCDCAnswer(

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaCDCSuite.scala
@@ -23,7 +23,7 @@ import java.util.Date
 import scala.collection.JavaConverters._
 
 // scalastyle:off import.ordering.noEmptyLine
-import org.apache.spark.sql.delta.DeltaTestUtils.BOOLEAN_DOMAIN
+import org.apache.spark.sql.delta.DeltaTestUtils.{modifyCommitTimestamp, BOOLEAN_DOMAIN}
 import org.apache.spark.sql.delta.commands.cdc.CDCReader._
 import org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsBaseSuite
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
@@ -107,16 +107,6 @@ abstract class DeltaCDCSuiteBase
       end: Boundary,
       schemaMode: Option[DeltaBatchCDFSchemaMode] = Some(BatchCDFSchemaLegacy),
       readerOptions: Map[String, String] = Map.empty): DataFrame
-
-  /** Modify timestamp for a delta commit, used to test timestamp querying */
-  def modifyDeltaTimestamp(deltaLog: DeltaLog, version: Long, time: Long): Unit = {
-    val file = new File(FileNames.unsafeDeltaFile(deltaLog.logPath, version).toUri)
-    file.setLastModified(time)
-    val crc = new File(FileNames.checksumFile(deltaLog.logPath, version).toUri)
-    if (crc.exists()) {
-      crc.setLastModified(time)
-    }
-  }
 
   /** Create table utility method */
   def ctas(srcTbl: String, dstTbl: String, disableCDC: Boolean = false): Unit = {
@@ -252,14 +242,14 @@ abstract class DeltaCDCSuiteBase
 
       // modify timestamps
       // version 0
-      modifyDeltaTimestamp(deltaLog, 0, 0)
+      modifyCommitTimestamp(deltaLog, 0, 0)
       val tsAfterV0 = dateFormat.format(new Date(1))
 
       // version 1
-      modifyDeltaTimestamp(deltaLog, 1, 1000)
+      modifyCommitTimestamp(deltaLog, 1, 1000)
       val tsAfterV1 = dateFormat.format(new Date(1001))
 
-      modifyDeltaTimestamp(deltaLog, 2, 2000)
+      modifyCommitTimestamp(deltaLog, 2, 2000)
 
       val readDf = cdcRead(
         new TablePath(tempDir.getAbsolutePath),
@@ -278,9 +268,9 @@ abstract class DeltaCDCSuiteBase
       createTblWithThreeVersions(path = Some(tempDir.getAbsolutePath))
       val deltaLog = DeltaLog.forTable(spark, tempDir.getAbsolutePath)
 
-      modifyDeltaTimestamp(deltaLog, 0, 0)
-      modifyDeltaTimestamp(deltaLog, 1, 10000)
-      modifyDeltaTimestamp(deltaLog, 2, 20000)
+      modifyCommitTimestamp(deltaLog, 0, 0)
+      modifyCommitTimestamp(deltaLog, 1, 10000)
+      modifyCommitTimestamp(deltaLog, 2, 20000)
 
       val ts0 = dateFormat.format(new Date(2000))
       val readDf = cdcRead(
@@ -299,9 +289,9 @@ abstract class DeltaCDCSuiteBase
       createTblWithThreeVersions(path = Some(tempDir.getAbsolutePath))
       val deltaLog = DeltaLog.forTable(spark, tempDir.getAbsolutePath)
 
-      modifyDeltaTimestamp(deltaLog, 0, 0)
-      modifyDeltaTimestamp(deltaLog, 1, 1000)
-      modifyDeltaTimestamp(deltaLog, 2, 2000)
+      modifyCommitTimestamp(deltaLog, 0, 0)
+      modifyCommitTimestamp(deltaLog, 1, 1000)
+      modifyCommitTimestamp(deltaLog, 2, 2000)
 
       val ts0 = dateFormat.format(new Date(0))
       val readDf = cdcRead(
@@ -320,9 +310,9 @@ abstract class DeltaCDCSuiteBase
       createTblWithThreeVersions(path = Some(tempDir.getAbsolutePath))
       val deltaLog = DeltaLog.forTable(spark, tempDir.getAbsolutePath)
 
-      modifyDeltaTimestamp(deltaLog, 0, 4000)
-      modifyDeltaTimestamp(deltaLog, 1, 8000)
-      modifyDeltaTimestamp(deltaLog, 2, 12000)
+      modifyCommitTimestamp(deltaLog, 0, 4000)
+      modifyCommitTimestamp(deltaLog, 1, 8000)
+      modifyCommitTimestamp(deltaLog, 2, 12000)
 
       val ts0 = dateFormat.format(new Date(1000))
       val ts1 = dateFormat.format(new Date(3000))
@@ -341,9 +331,9 @@ abstract class DeltaCDCSuiteBase
       createTblWithThreeVersions(path = Some(tempDir.getAbsolutePath))
       val deltaLog = DeltaLog.forTable(spark, tempDir.getAbsolutePath)
 
-      modifyDeltaTimestamp(deltaLog, 0, 0)
-      modifyDeltaTimestamp(deltaLog, 1, 4000)
-      modifyDeltaTimestamp(deltaLog, 2, 8000)
+      modifyCommitTimestamp(deltaLog, 0, 0)
+      modifyCommitTimestamp(deltaLog, 1, 4000)
+      modifyCommitTimestamp(deltaLog, 2, 8000)
 
       val ts0 = dateFormat.format(new Date(1000))
       val ts1 = dateFormat.format(new Date(3000))
@@ -363,9 +353,9 @@ abstract class DeltaCDCSuiteBase
       createTblWithThreeVersions(path = Some(tempDir.getAbsolutePath))
       val deltaLog = DeltaLog.forTable(spark, tempDir.getAbsolutePath)
 
-      modifyDeltaTimestamp(deltaLog, 0, 0)
-      modifyDeltaTimestamp(deltaLog, 1, 4000)
-      modifyDeltaTimestamp(deltaLog, 2, 8000)
+      modifyCommitTimestamp(deltaLog, 0, 0)
+      modifyCommitTimestamp(deltaLog, 1, 4000)
+      modifyCommitTimestamp(deltaLog, 2, 8000)
 
       val ts0 = dateFormat.format(new Date(3000))
       val ts1 = dateFormat.format(new Date(5000))
@@ -385,9 +375,9 @@ abstract class DeltaCDCSuiteBase
       createTblWithThreeVersions(path = Some(tempDir.getAbsolutePath))
       val deltaLog = DeltaLog.forTable(spark, tempDir.getAbsolutePath)
 
-      modifyDeltaTimestamp(deltaLog, 0, 0)
-      modifyDeltaTimestamp(deltaLog, 1, 4000)
-      modifyDeltaTimestamp(deltaLog, 2, 8000)
+      modifyCommitTimestamp(deltaLog, 0, 0)
+      modifyCommitTimestamp(deltaLog, 1, 4000)
+      modifyCommitTimestamp(deltaLog, 2, 8000)
 
       val ts0 = dateFormat.format(new Date(3000))
       val ts1 = dateFormat.format(new Date(1000))
@@ -406,9 +396,9 @@ abstract class DeltaCDCSuiteBase
       createTblWithThreeVersions(path = Some(tempDir.getAbsolutePath))
       val deltaLog = DeltaLog.forTable(spark, tempDir.getAbsolutePath)
 
-      modifyDeltaTimestamp(deltaLog, 0, 0)
-      modifyDeltaTimestamp(deltaLog, 1, 4000)
-      modifyDeltaTimestamp(deltaLog, 2, 8000)
+      modifyCommitTimestamp(deltaLog, 0, 0)
+      modifyCommitTimestamp(deltaLog, 1, 4000)
+      modifyCommitTimestamp(deltaLog, 2, 8000)
 
       val ts0 = dateFormat.format(new Date(5000))
       val ts1 = dateFormat.format(new Date(3000))
@@ -449,7 +439,7 @@ abstract class DeltaCDCSuiteBase
       // Set commit time during Daylight savings time change.
       val restoreDate = "2022-11-06 01:42:44"
       val timestamp = dateFormat.parse(s"$restoreDate -0800").getTime
-      modifyDeltaTimestamp(deltaLog, 0, timestamp)
+      modifyCommitTimestamp(deltaLog, 0, timestamp)
 
       // Verify DST is respected.
       val e = intercept[Exception] {
@@ -558,9 +548,9 @@ abstract class DeltaCDCSuiteBase
       createTblWithThreeVersions(path = Some(tempDir.getAbsolutePath))
       val deltaLog = DeltaLog.forTable(spark, tempDir.getAbsolutePath)
 
-      modifyDeltaTimestamp(deltaLog, 0, 0)
-      modifyDeltaTimestamp(deltaLog, 1, 1000)
-      modifyDeltaTimestamp(deltaLog, 2, 2000)
+      modifyCommitTimestamp(deltaLog, 0, 0)
+      modifyCommitTimestamp(deltaLog, 1, 1000)
+      modifyCommitTimestamp(deltaLog, 2, 2000)
 
       val ts0 = dateFormat.format(new Date(2000))
       val ts1 = dateFormat.format(new Date(1))
@@ -795,13 +785,13 @@ abstract class DeltaCDCSuiteBase
 
         // modify timestamps
         // version 0
-        modifyDeltaTimestamp(deltaLog, 0, 0)
+        modifyCommitTimestamp(deltaLog, 0, 0)
 
         // version 1
-        modifyDeltaTimestamp(deltaLog, 1, 1000)
+        modifyCommitTimestamp(deltaLog, 1, 1000)
 
         // version 2
-        modifyDeltaTimestamp(deltaLog, 2, 2000)
+        modifyCommitTimestamp(deltaLog, 2, 2000)
         val tsStart = dateFormat.format(new Date(3000))
         val tsEnd = dateFormat.format(new Date(4000))
 
@@ -825,13 +815,13 @@ abstract class DeltaCDCSuiteBase
 
         // modify timestamps
         // version 0
-        modifyDeltaTimestamp(deltaLog, 0, 0)
+        modifyCommitTimestamp(deltaLog, 0, 0)
 
         // version 1
-        modifyDeltaTimestamp(deltaLog, 1, 1000)
+        modifyCommitTimestamp(deltaLog, 1, 1000)
 
         // version 2
-        modifyDeltaTimestamp(deltaLog, 2, 2000)
+        modifyCommitTimestamp(deltaLog, 2, 2000)
 
         val tsStart = dateFormat.format(new Date(0))
         val tsEnd = dateFormat.format(new Date(4000))
@@ -1107,23 +1097,6 @@ class DeltaCDCScalaWithDeletionVectorsSuite extends DeltaCDCScalaSuite
 }
 
 class DeltaCDCScalaSuiteWithCoordinatedCommitsBatch10 extends DeltaCDCScalaSuite
-  with CoordinatedCommitsBaseSuite {
-
-  /** Modify timestamp for a delta commit, used to test timestamp querying */
-  override def modifyDeltaTimestamp(deltaLog: DeltaLog, version: Long, time: Long): Unit = {
-    val fileProvider = DeltaCommitFileProvider(deltaLog.snapshot)
-    val file = new File(fileProvider.deltaFile(version).toUri)
-    InCommitTimestampTestUtils.overwriteICTInDeltaFile(
-      deltaLog,
-      new Path(file.getPath),
-      Some(time))
-    file.setLastModified(time)
-    val crc = new File(FileNames.checksumFile(deltaLog.logPath, version).toUri)
-    if (crc.exists()) {
-      InCommitTimestampTestUtils.overwriteICTInCrc(deltaLog, version, Some(time))
-      crc.setLastModified(time)
-    }
-  }
-
+    with CoordinatedCommitsBaseSuite {
   override def coordinatedCommitsBackfillBatchSize: Option[Int] = Some(10)
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceLargeLogSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceLargeLogSuite.scala
@@ -23,3 +23,13 @@ class DeltaSourceLargeLogSuite extends DeltaSourceSuite {
     super.sparkConf.set(DeltaSQLConf.LOG_SIZE_IN_MEMORY_THRESHOLD.key, "0")
   }
 }
+
+class DeltaSourceLargeLogWithCoordinatedCommitsBatch1Suite
+    extends DeltaSourceLargeLogSuite {
+  override def coordinatedCommitsBackfillBatchSize: Option[Int] = Some(1)
+}
+
+class DeltaSourceLargeLogWithCoordinatedCommitsBatch100Suite
+    extends DeltaSourceLargeLogSuite {
+  override def coordinatedCommitsBackfillBatchSize: Option[Int] = Some(100)
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSuite.scala
@@ -16,14 +16,16 @@
 
 package org.apache.spark.sql.delta
 
-import java.io.{File, FileInputStream, OutputStream}
+import java.io.{File, FileInputStream, OutputStream, PrintWriter, StringWriter}
 import java.net.URI
+import java.sql.Timestamp
 import java.util.UUID
 import java.util.concurrent.TimeoutException
 
 import scala.concurrent.duration._
 import scala.language.implicitConversions
 
+import org.apache.spark.sql.delta.DeltaTestUtils.modifyCommitTimestamp
 import org.apache.spark.sql.delta.actions.{AddFile, Protocol}
 import org.apache.spark.sql.delta.sources.{DeltaSourceOffset, DeltaSQLConf}
 import org.apache.spark.sql.delta.test.DeltaSQLCommandTest
@@ -1062,7 +1064,8 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
 
   testQuietly("recreate the reservoir should fail the query") {
     withTempDir { inputDir =>
-      val deltaLog = DeltaLog.forTable(spark, new Path(inputDir.toURI))
+      val tablePath = new Path(inputDir.toURI)
+      val deltaLog = DeltaLog.forTable(spark, tablePath)
       withMetadata(deltaLog, StructType.fromDDL("value STRING"))
 
       val df = spark.readStream
@@ -1077,7 +1080,10 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         StopStream,
         AssertOnQuery { _ =>
           Utils.deleteRecursively(inputDir)
-          val deltaLog = DeltaLog.forTable(spark, new Path(inputDir.toURI))
+          if (coordinatedCommitsEnabledInTests) {
+            deleteTableFromCommitCoordinator(tablePath)
+          }
+          val deltaLog = DeltaLog.forTable(spark, tablePath)
           // All Delta tables in tests use the same tableId by default. Here we pass a new tableId
           // to simulate a new table creation in production
           withMetadata(deltaLog, StructType.fromDDL("value STRING"), tableId = Some("tableId-1234"))
@@ -1475,7 +1481,16 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
         val e = intercept[StreamingQueryException] {
           stream.processAllAvailable()
         }
-        assert(e.getCause.isInstanceOf[InvalidProtocolVersionException])
+        val cause = e.getCause
+        val sw = new StringWriter()
+        cause.printStackTrace(new PrintWriter(sw))
+        assert(
+          cause.isInstanceOf[InvalidProtocolVersionException] ||
+          // When coordinated commits are enabled, the following assertion error coming from
+          // CoordinatedCommitsUtils.getCommitCoordinatorClient may get hit
+          (cause.isInstanceOf[AssertionError] &&
+           e.getCause.getMessage.contains("coordinated commits table feature is not supported")),
+          s"Caused by: ${sw.toString}")
       } finally {
         stream.stop()
       }
@@ -1490,8 +1505,7 @@ class DeltaSourceSuite extends DeltaSourceSuiteBase
       val rangeStart = startVersion * 10
       val rangeEnd = rangeStart + 10
       spark.range(rangeStart, rangeEnd).write.format("delta").mode("append").save(location)
-      val file = new File(FileNames.unsafeDeltaFile(deltaLog.logPath, startVersion).toUri)
-      file.setLastModified(ts)
+      modifyCommitTimestamp(deltaLog, startVersion, ts)
       startVersion += 1
     }
   }
@@ -2626,4 +2640,16 @@ class MonotonicallyIncreasingTimestampFS extends RawLocalFileSystem {
 
 object MonotonicallyIncreasingTimestampFS {
   val scheme = s"MonotonicallyIncreasingTimestampFS"
+}
+
+class DeltaSourceWithCoordinatedCommitsBatch1Suite extends DeltaSourceSuite {
+  override def coordinatedCommitsBackfillBatchSize: Option[Int] = Some(1)
+}
+
+class DeltaSourceWithCoordinatedCommitsBatch10Suite extends DeltaSourceSuite {
+  override def coordinatedCommitsBackfillBatchSize: Option[Int] = Some(10)
+}
+
+class DeltaSourceWithCoordinatedCommitsBatch100Suite extends DeltaSourceSuite {
+  override def coordinatedCommitsBackfillBatchSize: Option[Int] = Some(100)
 }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.delta.actions._
 import org.apache.spark.sql.delta.commands.cdc.CDCReader
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils}
-import org.apache.spark.sql.delta.util.FileNames
+import org.apache.spark.sql.delta.util.{DeltaCommitFileProvider, FileNames}
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import io.delta.tables.{DeltaTable => IODeltaTable}
@@ -450,6 +450,29 @@ object DeltaTestUtils extends DeltaTestUtilsBase {
     // Just a more readable version of `lteq`.
     def fulfillsVersionRequirements(actual: Protocol, requirement: Protocol): Boolean =
       lteq(requirement, actual)
+  }
+
+  def modifyCommitTimestamp(deltaLog: DeltaLog, version: Long, ts: Long): Unit = {
+    val filePath = DeltaCommitFileProvider(deltaLog.update()).deltaFile(version)
+    val file = new File(filePath.toUri)
+    InCommitTimestampTestUtils.overwriteICTInDeltaFile(
+      deltaLog,
+      new Path(file.getPath),
+      Some(ts))
+    file.setLastModified(ts)
+    if (FileNames.isUnbackfilledDeltaFile(filePath)) {
+      // Also change the ICT in the backfilled file if it exists.
+      val backfilledFilePath = FileNames.unsafeDeltaFile(deltaLog.logPath, version)
+      val fs = backfilledFilePath.getFileSystem(deltaLog.newDeltaHadoopConf())
+      if (fs.exists(backfilledFilePath)) {
+        InCommitTimestampTestUtils.overwriteICTInDeltaFile(deltaLog, backfilledFilePath, Some(ts))
+      }
+    }
+    val crc = new File(FileNames.checksumFile(deltaLog.logPath, version).toUri)
+    if (crc.exists()) {
+      InCommitTimestampTestUtils.overwriteICTInCrc(deltaLog, version, Some(ts))
+      crc.setLastModified(ts)
+    }
   }
 
   def withTimeZone(zone: String)(f: => Unit): Unit = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

+ Unify the `modifyCommitTimestamp` helper functions to avoid code duplication.
+ Extend existing streaming tests to run with coordinated commits

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

Run the new tests

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No