### PR TITLE
[Spark] Handle type widening in Delta streaming source

### DIFF
--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2310,11 +2310,15 @@
     "message" : [
       "We've detected one or more non-additive schema change(s) (<opType>) between Delta version <previousSchemaChangeVersion> and <currentSchemaChangeVersion> in the Delta streaming source.",
       "Please check if you want to manually propagate the schema change(s) to the sink table before we proceed with stream processing using the finalized schema at version <currentSchemaChangeVersion>.",
-      "Once you have fixed the schema of the sink table or have decided there is no need to fix, you can set (one of) the following SQL configurations to unblock the non-additive schema change(s) and continue stream processing.",
-      "To unblock for this particular stream just for this series of schema change(s): set `<allowCkptVerKey> = <allowCkptVerValue>`.",
-      "To unblock for this particular stream: set `<allowCkptKey> = <allowCkptValue>`",
-      "To unblock for all streams: set `<allowAllKey> = <allowAllValue>`.",
-      "Alternatively if applicable, you may replace the `<allowAllMode>` with `<opSpecificMode>` in the SQL conf to unblock stream for just this schema change type."
+      "Once you have fixed the schema of the sink table or have decided there is no need to fix, you can set the following configuration(s) to unblock the non-additive schema change(s) and continue stream processing.",
+      "",
+      "To unblock for this particular stream just for this series of schema change(s):",
+      "<unblockChangeConfs>",
+      "To unblock for this particular stream:",
+      "<unblockStreamConfs>",
+      "To unblock for all streams:",
+      "<unblockAllConfs>",
+      ""
     ],
     "sqlState" : "KD002"
   },
@@ -2324,11 +2328,16 @@
       "<wideningTypeChanges>",
       "",
       "Your streaming query contains operations that may fail or produce different results after the type change(s).",
-      "Please check if you want to update your streaming query before we proceed with stream processing using the finalized schema at <currentSchemaChangeVersion>.",
-      "Once you have updated your streaming query or have decided there is no need to update it, you can set (one of) the following SQL configurations to unblock the type change(s) and continue stream processing.",
-      "To unblock for this particular stream just for this series of type change(s): set `<allowCkptVerKey> = <allowCkptVerValue>`.",
-      "To unblock for this particular stream: set `<allowCkptKey> = <allowCkptValue>`",
-      "To unblock for all streams: set `<allowAllKey> = <allowAllValue>`."
+      "Please check if you want to update your streaming query before we proceed with stream processing using the finalized schema at version <currentSchemaChangeVersion>.",
+      "Once you have updated your streaming query or have decided there is no need to update it, you can set the following configuration to unblock the type change(s) and continue stream processing.",
+      "",
+      "To unblock for this particular stream just for this series of schema change(s):",
+      "<unblockChangeConfs>",
+      "To unblock for this particular stream:",
+      "<unblockStreamConfs>",
+      "To unblock for all streams:",
+      "<unblockAllConfs>",
+      ""
     ],
     "sqlState" : "KD002"
   },

--- a/spark/src/main/resources/error/delta-error-classes.json
+++ b/spark/src/main/resources/error/delta-error-classes.json
@@ -2309,12 +2309,26 @@
   "DELTA_STREAMING_CANNOT_CONTINUE_PROCESSING_POST_SCHEMA_EVOLUTION" : {
     "message" : [
       "We've detected one or more non-additive schema change(s) (<opType>) between Delta version <previousSchemaChangeVersion> and <currentSchemaChangeVersion> in the Delta streaming source.",
-      "Please check if you want to manually propagate the schema change(s) to the sink table before we proceed with stream processing using the finalized schema at <currentSchemaChangeVersion>.",
+      "Please check if you want to manually propagate the schema change(s) to the sink table before we proceed with stream processing using the finalized schema at version <currentSchemaChangeVersion>.",
       "Once you have fixed the schema of the sink table or have decided there is no need to fix, you can set (one of) the following SQL configurations to unblock the non-additive schema change(s) and continue stream processing.",
       "To unblock for this particular stream just for this series of schema change(s): set `<allowCkptVerKey> = <allowCkptVerValue>`.",
       "To unblock for this particular stream: set `<allowCkptKey> = <allowCkptValue>`",
       "To unblock for all streams: set `<allowAllKey> = <allowAllValue>`.",
       "Alternatively if applicable, you may replace the `<allowAllMode>` with `<opSpecificMode>` in the SQL conf to unblock stream for just this schema change type."
+    ],
+    "sqlState" : "KD002"
+  },
+  "DELTA_STREAMING_CANNOT_CONTINUE_PROCESSING_TYPE_WIDENING" : {
+    "message" : [
+      "We've detected one or more data types being widened between Delta version <previousSchemaChangeVersion> and <currentSchemaChangeVersion>:",
+      "<wideningTypeChanges>",
+      "",
+      "Your streaming query contains operations that may fail or produce different results after the type change(s).",
+      "Please check if you want to update your streaming query before we proceed with stream processing using the finalized schema at <currentSchemaChangeVersion>.",
+      "Once you have updated your streaming query or have decided there is no need to update it, you can set (one of) the following SQL configurations to unblock the type change(s) and continue stream processing.",
+      "To unblock for this particular stream just for this series of type change(s): set `<allowCkptVerKey> = <allowCkptVerValue>`.",
+      "To unblock for this particular stream: set `<allowCkptKey> = <allowCkptValue>`",
+      "To unblock for all streams: set `<allowAllKey> = <allowAllValue>`."
     ],
     "sqlState" : "KD002"
   },

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaErrors.scala
@@ -116,7 +116,7 @@ trait DocsPath {
     "tableFeatureReadRequiresWriteException",
     "tableFeatureRequiresHigherReaderProtocolVersion",
     "tableFeatureRequiresHigherWriterProtocolVersion",
-    "blockStreamingReadsWithIncompatibleColumnMappingSchemaChanges"
+    "blockStreamingReadsWithIncompatibleNonAdditiveSchemaChanges"
   )
 }
 
@@ -2943,7 +2943,7 @@ trait DeltaErrorsBase
     )
   }
 
-  def blockStreamingReadsWithIncompatibleColumnMappingSchemaChanges(
+  def blockStreamingReadsWithIncompatibleNonAdditiveSchemaChanges(
       spark: SparkSession,
       readSchema: StructType,
       incompatibleSchema: StructType,
@@ -2951,7 +2951,7 @@ trait DeltaErrorsBase
     val docLink = "/versioning.html#column-mapping"
     val enableNonAdditiveSchemaEvolution = spark.sessionState.conf.getConf(
       DeltaSQLConf.DELTA_STREAMING_ENABLE_SCHEMA_TRACKING)
-    new DeltaStreamingColumnMappingSchemaIncompatibleException(
+    new DeltaStreamingNonAdditiveSchemaIncompatibleException(
       readSchema,
       incompatibleSchema,
       generateDocsLink(spark.sparkContext.getConf, docLink),
@@ -3105,9 +3105,17 @@ trait DeltaErrorsBase
       previousSchemaChangeVersion: Long,
       currentSchemaChangeVersion: Long,
       checkpointHash: Int,
-      allowAllMode: String,
-      opTypeSpecificAllowMode: String): Throwable = {
-    val allowAllSqlConfKey = s"${DeltaSQLConf.SQL_CONF_PREFIX}.streaming.$allowAllMode"
+      sqlConfsUnblock: Seq[String]): Throwable = {
+    val unblockChangeConfs = sqlConfsUnblock.map { conf =>
+        s"""  SET $conf.ckpt_$checkpointHash = $currentSchemaChangeVersion;"""
+      }.mkString("\n")
+    val unblockStreamConfs = sqlConfsUnblock.map { conf =>
+        s"""  SET $conf.ckpt_$checkpointHash = "always";"""
+      }.mkString("\n")
+    val unblockAllConfs = sqlConfsUnblock.map { conf =>
+        s"""  SET $conf = "always";"""
+      }.mkString("\n")
+
     new DeltaRuntimeException(
       errorClass = "DELTA_STREAMING_CANNOT_CONTINUE_PROCESSING_POST_SCHEMA_EVOLUTION",
       messageParameters = Array(
@@ -3115,17 +3123,9 @@ trait DeltaErrorsBase
         previousSchemaChangeVersion.toString,
         currentSchemaChangeVersion.toString,
         currentSchemaChangeVersion.toString,
-        // Allow this stream to pass for this particular version
-        s"$allowAllSqlConfKey.ckpt_$checkpointHash",
-        currentSchemaChangeVersion.toString,
-        // Allow this stream to pass
-        s"$allowAllSqlConfKey.ckpt_$checkpointHash",
-        "always",
-        // Allow all streams to pass
-        allowAllSqlConfKey,
-        "always",
-        allowAllMode,
-        opTypeSpecificAllowMode
+        unblockChangeConfs,
+        unblockStreamConfs,
+        unblockAllConfs
       )
     )
   }
@@ -3134,12 +3134,22 @@ trait DeltaErrorsBase
       previousSchemaChangeVersion: Long,
       currentSchemaChangeVersion: Long,
       checkpointHash: Int,
-      allowAllSqlConfKey: String,
+      sqlConfsUnblock: Seq[String],
       wideningTypeChanges: Seq[TypeChange]): Throwable = {
 
     val wideningTypeChangesStr = wideningTypeChanges.map { change =>
         s"  ${SchemaUtils.prettyFieldName(change.fieldPath)}: ${change.fromType.sql} -> " +
         s"${change.toType.sql}"
+      }.mkString("\n")
+
+    val unblockChangeConfs = sqlConfsUnblock.map { conf =>
+        s"""  SET $conf.ckpt_$checkpointHash = $currentSchemaChangeVersion;"""
+      }.mkString("\n")
+    val unblockStreamConfs = sqlConfsUnblock.map { conf =>
+        s"""  SET $conf.ckpt_$checkpointHash = "always";"""
+      }.mkString("\n")
+    val unblockAllConfs = sqlConfsUnblock.map { conf =>
+        s"""  SET $conf = "always";"""
       }.mkString("\n")
 
     new DeltaRuntimeException(
@@ -3149,15 +3159,9 @@ trait DeltaErrorsBase
         currentSchemaChangeVersion.toString,
         wideningTypeChangesStr,
         currentSchemaChangeVersion.toString,
-        // Allow this stream to pass for this particular version
-        s"$allowAllSqlConfKey.ckpt_$checkpointHash",
-        currentSchemaChangeVersion.toString,
-        // Allow this stream to pass
-        s"$allowAllSqlConfKey.ckpt_$checkpointHash",
-        "always",
-        // Allow all streams to pass
-        allowAllSqlConfKey,
-        "always"
+        unblockChangeConfs,
+        unblockStreamConfs,
+        unblockAllConfs
       )
     )
   }
@@ -4019,13 +4023,13 @@ class DeltaChecksumException(
 }
 
 /**
- * Errors thrown when an operation is not supported with column mapping schema changes
- * (rename / drop column).
+ * Errors thrown when an operation is not supported with non-additive schema changes
+ * (rename / drop column, type change).
  *
  * To make compatible with existing behavior for those who accidentally has already used this
  * operation, user should always be able to use `escapeConfigName` to fall back at own risk.
  */
-class DeltaStreamingColumnMappingSchemaIncompatibleException(
+class DeltaStreamingNonAdditiveSchemaIncompatibleException(
     val readSchema: StructType,
     val incompatibleSchema: StructType,
     val docLink: String,

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TypeWidening.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TypeWidening.scala
@@ -162,4 +162,20 @@ object TypeWidening {
       case (LongType, d: DecimalType) => d.isWiderThan(LongType)
       case _ => false
     }
+
+  /**
+   * Compares `from` and `to` and returns whether the type was widened, or, for nested types,
+   * whether one of the nested fields was widened.
+   */
+  def containsWideningTypeChanges(from: DataType, to: DataType): Boolean = (from, to) match {
+    case (from: StructType, to: StructType) =>
+      TypeWideningMetadata.collectTypeChanges(from, to).nonEmpty
+    case (from: MapType, to: MapType) =>
+      containsWideningTypeChanges(from.keyType, to.keyType) ||
+        containsWideningTypeChanges(from.valueType, to.valueType)
+    case (from: ArrayType, to: ArrayType) =>
+      containsWideningTypeChanges(from.elementType, to.elementType)
+    case (from: AtomicType, to: AtomicType) =>
+      isTypeChangeSupported(from, to)
+  }
 }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TypeWideningMetadata.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TypeWideningMetadata.scala
@@ -194,7 +194,7 @@ private[delta] object TypeWideningMetadata extends DeltaLogging {
         newField
       case (_, field, _, _) => field
     }
-    changes
+    changes.toSeq
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TypeWideningMode.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TypeWideningMode.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.types.AtomicType
  * A type widening mode captures a specific set of type changes that are allowed to be applied.
  * Currently:
  *  - NoTypeWidening: No type change is allowed.
+ *  - AllTypeWidening: All supported type widening changes are allowed.
  *  - TypeEvolution(uniformIcebergCompatibleOnly = true): Type changes that are eligible to be
  *    applied automatically during schema evolution and that are supported by Iceberg are allowed.
  *  - TypeEvolution(uniformIcebergCompatibleOnly = false): Type changes that are eligible to be

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TypeWideningMode.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TypeWideningMode.scala
@@ -40,6 +40,12 @@ object TypeWideningMode {
     override def shouldWidenType(fromType: AtomicType, toType: AtomicType): Boolean = false
   }
 
+  /** All supported type widening changes are allowed. */
+  case object AllTypeWidening extends TypeWideningMode {
+    override def shouldWidenType(fromType: AtomicType, toType: AtomicType): Boolean =
+      TypeWidening.isTypeChangeSupported(fromType = fromType, toType = toType)
+  }
+
   /**
    * Type changes that are eligible to be applied automatically during schema evolution are allowed.
    * Can be restricted to only type changes supported by Iceberg.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/schema/SchemaUtils.scala
@@ -380,10 +380,8 @@ def normalizeColumnNamesInDataType(
    * As the Delta snapshots update, the schema may change as well. This method defines whether the
    * new schema of a Delta table can be used with a previously analyzed LogicalPlan. Our
    * rules are to return false if:
-   *   - Dropping any column that was present in the existing schema, if not
-   *     allowMissingColumns/allowMissingStructFields.
-   *     Note: for historical reasons, this is configured separately for top-level columns
-   *     (allowMissingColumns) and nested struct fields (allowMissingStructFields).
+   *   - Dropping any column or struct field that was present in the existing schema, if not
+   *     allowMissingColumns
    *   - Any change of datatype, unless eligible for widening. The caller specifies eligible type
    *     changes via `typeWideningMode`.
    *   - Change of partition columns. Although analyzed LogicalPlan is not changed,
@@ -406,7 +404,6 @@ def normalizeColumnNamesInDataType(
       readSchema: StructType,
       forbidTightenNullability: Boolean = false,
       allowMissingColumns: Boolean = false,
-      allowMissingStructFields: Boolean = false,
       typeWideningMode: TypeWideningMode = TypeWideningMode.NoTypeWidening,
       newPartitionColumns: Seq[String] = Seq.empty,
       oldPartitionColumns: Seq[String] = Seq.empty): Boolean = {
@@ -425,8 +422,7 @@ def normalizeColumnNamesInDataType(
           isReadCompatible(e, n,
             forbidTightenNullability,
             typeWideningMode = typeWideningMode,
-            allowMissingColumns = allowMissingStructFields,
-            allowMissingStructFields = allowMissingStructFields
+            allowMissingColumns = allowMissingColumns
           )
         case (e: ArrayType, n: ArrayType) =>
           // if existing elements are non-nullable, so should be the new element

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1224,6 +1224,22 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(false)
 
+  val DELTA_ALLOW_TYPE_WIDENING_STREAMING_SOURCE =
+    buildConf("typeWidening.allowTypeChangeStreamingDeltaSource")
+      .doc("Accept incoming widening type changes when streaming from a Delta source.")
+      .internal()
+      .booleanConf
+      .createWithDefault(true)
+
+  val DELTA_TYPE_WIDENING_BYPASS_STREAMING_TYPE_CHANGE_CHECK =
+    buildConf("typeWidening.bypassStreamingTypeChangeCheck")
+      .doc("Controls the check performed when a type change is detected when streaming from a " +
+        "Delta source. This check fails the streaming query in case a type change may impact the " +
+        "semantics of the query and requests user intervention.")
+      .internal()
+      .booleanConf
+      .createWithDefault(false)
+
   /**
    * Internal config to bypass check that prevents applying type changes that are not supported by
    * Iceberg when Uniform is enabled with Iceberg compatibility.

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2715,6 +2715,30 @@ trait DeltaErrorsSuiteBase
       assert(!e.additionalProperties("detectedDuringStreaming").toBoolean)
     }
     {
+      val e = intercept[DeltaRuntimeException] {
+        throw DeltaErrors.cannotContinueStreamingTypeWidening(
+          previousSchemaChangeVersion = 0,
+          currentSchemaChangeVersion = 1,
+          allowAllSqlConfKey = "spark.databricks.delta.streaming.allowSourceTypeWidening",
+          checkpointHash = 15,
+          wideningTypeChanges = Seq(TypeChange(None, IntegerType, LongType, Seq("a"))))
+      }
+      checkError(e,
+        "DELTA_STREAMING_CANNOT_CONTINUE_PROCESSING_TYPE_CHANGE",
+        parameters = Map(
+          "previousSchemaChangeVersion" -> "0",
+          "currentSchemaChangeVersion" -> "1",
+          "wideningTypeChanges" -> "  a: INT -> LONG",
+          "allowCkptVerKey" -> "spark.databricks.delta.streaming.allowSourceTypeWidening.ckpt_15",
+          "allowCkptVerValue" -> "1",
+          "allowCkptKey" -> "spark.databricks.delta.streaming.allowSourceTypeWidening.ckpt_15",
+          "allowCkptValue" -> "always",
+          "allowAllKey" -> "spark.databricks.delta.streaming.allowSourceTypeWidening",
+          "allowAllValue" -> "always"
+        )
+      )
+    }
+    {
       val e = intercept[DeltaUnsupportedOperationException] {
         throw DeltaErrors.blockColumnMappingAndCdcOperation(DeltaOperations.ManualUpdate)
       }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaErrorsSuite.scala
@@ -2724,11 +2724,11 @@ trait DeltaErrorsSuiteBase
           wideningTypeChanges = Seq(TypeChange(None, IntegerType, LongType, Seq("a"))))
       }
       checkError(e,
-        "DELTA_STREAMING_CANNOT_CONTINUE_PROCESSING_TYPE_CHANGE",
+        "DELTA_STREAMING_CANNOT_CONTINUE_PROCESSING_TYPE_WIDENING",
         parameters = Map(
           "previousSchemaChangeVersion" -> "0",
           "currentSchemaChangeVersion" -> "1",
-          "wideningTypeChanges" -> "  a: INT -> LONG",
+          "wideningTypeChanges" -> "  a: INT -> BIGINT",
           "allowCkptVerKey" -> "spark.databricks.delta.streaming.allowSourceTypeWidening.ckpt_15",
           "allowCkptVerValue" -> "1",
           "allowCkptKey" -> "spark.databricks.delta.streaming.allowSourceTypeWidening.ckpt_15",

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceColumnMappingSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceColumnMappingSuite.scala
@@ -54,24 +54,24 @@ trait ColumnMappingStreamingTestUtils extends StreamTest with DeltaColumnMapping
   protected def isColumnMappingSchemaIncompatibleFailure(
       t: Throwable,
       detectedDuringStreaming: Boolean): Boolean = t match {
-    case e: DeltaStreamingColumnMappingSchemaIncompatibleException =>
+    case e: DeltaStreamingNonAdditiveSchemaIncompatibleException =>
       e.additionalProperties.get("detectedDuringStreaming")
         .exists(_.toBoolean == detectedDuringStreaming)
     case _ => false
   }
 
   protected val ExpectStreamStartInCompatibleSchemaFailure =
-    ExpectFailure[DeltaStreamingColumnMappingSchemaIncompatibleException] { t =>
+    ExpectFailure[DeltaStreamingNonAdditiveSchemaIncompatibleException] { t =>
       assert(isColumnMappingSchemaIncompatibleFailure(t, detectedDuringStreaming = false))
     }
 
   protected val ExpectInStreamSchemaChangeFailure =
-    ExpectFailure[DeltaStreamingColumnMappingSchemaIncompatibleException] { t =>
+    ExpectFailure[DeltaStreamingNonAdditiveSchemaIncompatibleException] { t =>
       assert(isColumnMappingSchemaIncompatibleFailure(t, detectedDuringStreaming = true))
     }
 
   protected val ExpectGenericSchemaIncompatibleFailure =
-    ExpectFailure[DeltaStreamingColumnMappingSchemaIncompatibleException]()
+    ExpectFailure[DeltaStreamingNonAdditiveSchemaIncompatibleException]()
 
   // Failure thrown by the current DeltaSource schema change incompatible check
   protected val ExistingRetryableInStreamSchemaChangeFailure = Execute { q =>

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaSourceSchemaEvolutionSuite.scala
@@ -1959,7 +1959,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
             (s"${DeltaSQLConf.SQL_CONF_PREFIX}.streaming.$allow.ckpt_$ckptHash", ver.toString)
         )
       ).foreach { case (changeSchema, getConfKV) =>
-        testStreamFlow(changeSchema, NonAdditiveSchemaChangeTypes.SCHEMA_CHANGE_DROP, getConfKV)
+        testStreamFlow(changeSchema, schemaChangeType = "DROP COLUMN", getConfKV)
       }
     }
 
@@ -1981,7 +1981,7 @@ trait StreamingSchemaEvolutionSuiteBase extends ColumnMappingStreamingTestUtils
             (s"${DeltaSQLConf.SQL_CONF_PREFIX}.streaming.$allow.ckpt_$ckptHash", ver.toString)
         )
       ).foreach { case (changeSchema, getConfKV) =>
-        testStreamFlow(changeSchema, NonAdditiveSchemaChangeTypes.SCHEMA_CHANGE_RENAME, getConfKV)
+        testStreamFlow(changeSchema, schemaChangeType = "RENAME COLUMN", getConfKV)
       }
     }
   }

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaTestUtils.scala
@@ -282,7 +282,7 @@ trait DeltaTestUtilsBase {
   sealed trait ExpectedResult[-T]
   object ExpectedResult {
     case class Success[T](expected: T) extends ExpectedResult[T]
-    case class Failure[T](checkError: SparkThrowable => Unit) extends ExpectedResult[T]
+    case class Failure[T](checkError: SparkThrowable => Unit = _ => ()) extends ExpectedResult[T]
   }
 
   /** Utility method to check exception `e` is of type `E` or a cause of it is of type `E` */

--- a/spark/src/test/scala/org/apache/spark/sql/delta/sources/DeltaSourceMetadataEvolutionSupportSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/sources/DeltaSourceMetadataEvolutionSupportSuite.scala
@@ -1,0 +1,554 @@
+package org.apache.spark.sql.delta.sources
+
+import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaTestUtilsBase, DeltaThrowable}
+
+import org.apache.spark.{SparkConf, SparkFunSuite}
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.StructType
+
+class DeltaSourceMetadataEvolutionSupportSuite
+  extends SparkFunSuite
+    with SharedSparkSession
+    with DeltaTestUtilsBase {
+
+  protected override def sparkConf: SparkConf =
+    super.sparkConf
+      .set(DeltaSQLConf.DELTA_ALLOW_TYPE_WIDENING_STREAMING_SOURCE.key, "true")
+      .set(DeltaSQLConf.DELTA_TYPE_WIDENING_BYPASS_STREAMING_TYPE_CHANGE_CHECK.key, "false")
+
+  private def persistedMetadata(
+      schemaDDL: String,
+      physicalNames: Map[Seq[String], String]): PersistedMetadata = {
+    var schemaWithPhysicalNames = StructType.fromDDL(schemaDDL)
+    schemaWithPhysicalNames = DeltaColumnMapping.setPhysicalNames(
+      schema = schemaWithPhysicalNames,
+      physicalNames
+    )
+    schemaWithPhysicalNames = DeltaColumnMapping.assignPhysicalNames(
+      schemaWithPhysicalNames,
+      reuseLogicalName = true)
+
+    PersistedMetadata(
+      tableId = "tableId",
+      deltaCommitVersion = 0,
+      dataSchemaJson = schemaWithPhysicalNames.json,
+      partitionSchemaJson = "",
+      sourceMetadataPath = "sourceMetadataPath"
+    )
+  }
+
+  private val allUnblockConfs: Seq[String] = Seq(
+    "allowSourceColumnRename",
+    "allowSourceColumnDrop",
+    "allowSourceTypeWidening",
+    "allowSourceColumnRenameAndDrop",
+    "allowSourceColumnRenameAndTypeWidening",
+    "allowSourceColumnDropAndTypeWidening",
+    "allowSourceColumnRenameAndDropAndTypeWidening"
+  )
+
+  private def expectColumnMappingChangeBlocked(opType: String): ExpectedResult[Nothing] =
+    ExpectedResult.Failure(ex => {
+      assert(
+        ex.getErrorClass === "DELTA_STREAMING_CANNOT_CONTINUE_PROCESSING_POST_SCHEMA_EVOLUTION")
+      assert(ex.getMessageParameters.get("opType") === opType)
+    })
+
+  private def expectTypeWideningBlocked(wideningTypeChanges: Seq[String]): ExpectedResult[Nothing] =
+    ExpectedResult.Failure(ex => {
+      assert(
+        ex.getErrorClass === "DELTA_STREAMING_CANNOT_CONTINUE_PROCESSING_TYPE_WIDENING")
+      assert(
+        ex.getMessageParameters.get("wideningTypeChanges") === wideningTypeChanges.mkString("\n"))
+    })
+
+
+
+  private def expectNonWideningTypeChangeError: ExpectedResult[Nothing] =
+    ExpectedResult.Failure(ex => {
+      assert(
+        ex.getErrorClass === "DELTA_SCHEMA_CHANGED_WITH_VERSION")
+    })
+
+  private def withUnblockedChanges(unblock: Seq[String])(f: => Unit): Unit = {
+    val confs = unblock.map( conf => s"spark.databricks.delta.streaming.$conf" -> "always")
+    withSQLConf(confs: _*) {
+      f
+    }
+  }
+
+  private def testSchemaChange(
+      name: String,
+      fromDDL: String,
+      fromPhysicalNames: Map[Seq[String], String] = Map.empty,
+      toDDL: String,
+      toPhysicalNames: Map[Seq[String], String] = Map.empty,
+      expectedResult: ExpectedResult[Nothing],
+      unblock: Seq[String] = Seq.empty,
+      confs: Seq[(String, String)] = Seq.empty): Unit =
+  test(s"$name") {
+    def validate(): Unit =
+      DeltaSourceMetadataEvolutionSupport.validateIfSchemaChangeCanBeUnblockedWithSQLConf(
+        spark,
+        metadataPath = "sourceMetadataPath",
+        currentSchema = persistedMetadata(toDDL, toPhysicalNames),
+        previousSchema = persistedMetadata(fromDDL, fromPhysicalNames)
+      )
+    withSQLConf(confs: _*) {
+      expectedResult match {
+        case ExpectedResult.Success(_) => validate()
+        case ExpectedResult.Failure(checkError) =>
+          withUnblockedChanges(allUnblockConfs.filterNot(unblock.contains)) {
+            val ex = intercept[DeltaThrowable] {
+              validate()
+            }
+            checkError(ex)
+          }
+
+          // Verify that any of the unblock conf will allow the schema change to go through.
+          for (u <- unblock) {
+            withUnblockedChanges(Seq(u)) {
+              validate()
+            }
+          }
+      }
+    }
+  }
+
+  testSchemaChange(
+    name = "no schema change, use logical names",
+    fromDDL = "a int",
+    toDDL = "a int",
+    expectedResult = ExpectedResult.Success()
+  )
+
+  testSchemaChange(
+    name = "no schema change, use physical names",
+    fromDDL = "a int",
+    fromPhysicalNames = Map(Seq("a") -> "x"),
+    toDDL = "a int",
+    toPhysicalNames = Map(Seq("a") -> "x"),
+    expectedResult = ExpectedResult.Success()
+  )
+
+
+  ///////////////
+  // Rename column
+  ///////////////
+  testSchemaChange(
+    name = "column rename, use logical names",
+    fromDDL = "a int",
+    toDDL = "b int",
+    toPhysicalNames = Map(Seq("b") -> "a"),
+    expectedResult = expectColumnMappingChangeBlocked("RENAME COLUMN"),
+    unblock = Seq(
+      "allowSourceColumnRename",
+      "allowSourceColumnRenameAndDrop",
+      "allowSourceColumnRenameAndTypeWidening",
+      "allowSourceColumnRenameAndDropAndTypeWidening")
+  )
+
+  testSchemaChange(
+    name = "column rename, use physical names",
+    fromDDL = "a int",
+    fromPhysicalNames = Map(Seq("a") -> "x"),
+    toDDL = "b int",
+    toPhysicalNames = Map(Seq("b") -> "x"),
+    expectedResult = expectColumnMappingChangeBlocked("RENAME COLUMN"),
+    unblock = Seq(
+      "allowSourceColumnRename",
+      "allowSourceColumnRenameAndDrop",
+      "allowSourceColumnRenameAndTypeWidening",
+      "allowSourceColumnRenameAndDropAndTypeWidening")
+  )
+
+  testSchemaChange(
+    name = "column rename with widening type change",
+    fromDDL = "a byte",
+    fromPhysicalNames = Map(Seq("a") -> "x"),
+    toDDL = "b int",
+    toPhysicalNames = Map(Seq("b") -> "x"),
+    expectedResult = expectColumnMappingChangeBlocked("RENAME COLUMN"),
+    // We don't block the type change itself: either the user treats 'b' as a nwe column and the type
+    // change doesn't matter downstream, or 'b' is already in use in which case its type can already
+    // be arbitrary.
+    unblock = Seq(
+      "allowSourceColumnRename",
+      "allowSourceColumnRenameAndDrop",
+      "allowSourceColumnRenameAndTypeWidening",
+      "allowSourceColumnRenameAndDropAndTypeWidening")
+  )
+
+  testSchemaChange(
+    name = "column rename with non-widening type change",
+    fromDDL = "a int",
+    fromPhysicalNames = Map(Seq("a") -> "x"),
+    toDDL = "b string",
+    toPhysicalNames = Map(Seq("b") -> "x"),
+    // We don't block the type change itself: either the user treats 'b' as a nwe column and the type
+    // change doesn't matter downstream, or 'b' is already in use in which case its type can already
+    // be arbitrary.
+    expectedResult = expectColumnMappingChangeBlocked("RENAME COLUMN"),
+    unblock = Seq(
+      "allowSourceColumnRename",
+      "allowSourceColumnRenameAndDrop",
+      "allowSourceColumnRenameAndTypeWidening",
+      "allowSourceColumnRenameAndDropAndTypeWidening")
+  )
+
+  testSchemaChange(
+    name = "swap columns",
+    fromDDL = "a int, b int",
+    toDDL = "b int, a int",
+    toPhysicalNames = Map(Seq("b") -> "a", Seq("a") -> "b"),
+    expectedResult = expectColumnMappingChangeBlocked("RENAME COLUMN"),
+    unblock = Seq(
+      "allowSourceColumnRename",
+      "allowSourceColumnRenameAndDrop",
+      "allowSourceColumnRenameAndTypeWidening",
+      "allowSourceColumnRenameAndDropAndTypeWidening")
+  )
+
+  testSchemaChange(
+    name = "swap columns with widening type change",
+    fromDDL = "a byte, b byte",
+    toDDL = "b byte, a int",
+    toPhysicalNames = Map(Seq("b") -> "a", Seq("a") -> "b"),
+    expectedResult = expectColumnMappingChangeBlocked("RENAME AND TYPE WIDENING"),
+    unblock = Seq(
+      "allowSourceColumnRenameAndTypeWidening",
+      "allowSourceColumnRenameAndDropAndTypeWidening")
+  )
+
+  testSchemaChange(
+    name = "swap columns with non-widening type change",
+    fromDDL = "a int, b int",
+    toDDL = "b int, a string",
+    toPhysicalNames = Map(Seq("b") -> "a", Seq("a") -> "b"),
+    expectedResult = expectNonWideningTypeChangeError
+  )
+
+  ///////////////
+  // Drop column
+  ///////////////
+  testSchemaChange(
+    name = "drop column, use logical names",
+    fromDDL = "a int, b int",
+    toDDL = "b int",
+    expectedResult = expectColumnMappingChangeBlocked("DROP COLUMN"),
+    unblock = Seq(
+      "allowSourceColumnDrop",
+      "allowSourceColumnRenameAndDrop",
+      "allowSourceColumnDropAndTypeWidening",
+      "allowSourceColumnRenameAndDropAndTypeWidening")
+  )
+
+  testSchemaChange(
+    name = "drop column, use physical names",
+    fromDDL = "a int, b int",
+    fromPhysicalNames = Map(Seq("a") -> "x", Seq("b") -> "y"),
+    toDDL = "b int",
+    toPhysicalNames = Map(Seq("b") -> "y"),
+    expectedResult = expectColumnMappingChangeBlocked("DROP COLUMN"),
+    unblock = Seq(
+      "allowSourceColumnDrop",
+      "allowSourceColumnRenameAndDrop",
+      "allowSourceColumnDropAndTypeWidening",
+      "allowSourceColumnRenameAndDropAndTypeWidening")
+  )
+
+  testSchemaChange(
+    name = "drop column with widening type change",
+    fromDDL = "a byte, b byte",
+    fromPhysicalNames = Map(Seq("a") -> "x", Seq("b") -> "y"),
+    toDDL = "b int",
+    toPhysicalNames = Map(Seq("b") -> "y"),
+    expectedResult = expectColumnMappingChangeBlocked("DROP AND TYPE WIDENING"),
+    unblock = Seq(
+      "allowSourceColumnDropAndTypeWidening",
+      "allowSourceColumnRenameAndDropAndTypeWidening")
+  )
+
+  testSchemaChange(
+    name = "drop column with non-widening type change",
+    fromDDL = "a int, b int",
+    fromPhysicalNames = Map(Seq("a") -> "x", Seq("b") -> "y"),
+    toDDL = "b string",
+    toPhysicalNames = Map(Seq("b") -> "y"),
+    expectedResult = expectNonWideningTypeChangeError
+  )
+
+  testSchemaChange(
+    name = "drop column, swapped physical names",
+    fromDDL = "a int, b int",
+    fromPhysicalNames = Map(Seq("a") -> "b", Seq("b") -> "a"),
+    toDDL = "b int",
+    toPhysicalNames = Map(Seq("b") -> "a"),
+    expectedResult = expectColumnMappingChangeBlocked("DROP COLUMN"),
+    unblock = Seq(
+      "allowSourceColumnDrop",
+      "allowSourceColumnRenameAndDrop",
+      "allowSourceColumnDropAndTypeWidening",
+      "allowSourceColumnRenameAndDropAndTypeWidening")
+  )
+
+  testSchemaChange(
+    name = "drop column, swapped physical names with widening type change",
+    fromDDL = "a byte, b byte",
+    fromPhysicalNames = Map(Seq("a") -> "b", Seq("b") -> "a"),
+    toDDL = "b int",
+    toPhysicalNames = Map(Seq("b") -> "a"),
+    expectedResult = expectColumnMappingChangeBlocked("DROP AND TYPE WIDENING"),
+    unblock = Seq(
+      "allowSourceColumnDropAndTypeWidening",
+      "allowSourceColumnRenameAndDropAndTypeWidening")
+  )
+
+  testSchemaChange(
+    name = "drop column, swapped physical names with non-widening type change",
+    fromDDL = "a int, b int",
+    fromPhysicalNames = Map(Seq("a") -> "b", Seq("b") -> "a"),
+    toDDL = "b float",
+    toPhysicalNames = Map(Seq("b") -> "a"),
+    expectedResult = expectNonWideningTypeChangeError
+  )
+
+  ///////////////
+  // Drop and rename column
+  ///////////////
+  testSchemaChange(
+    name = "drop column, rename to other column name",
+    fromDDL = "a int, b int",
+    toDDL = "c int",
+    toPhysicalNames = Map(Seq("c") -> "b"),
+    expectedResult = expectColumnMappingChangeBlocked("RENAME AND DROP COLUMN"),
+    unblock = Seq(
+      "allowSourceColumnRenameAndDrop",
+      "allowSourceColumnRenameAndDropAndTypeWidening")
+  )
+
+  testSchemaChange(
+    name = "drop column, rename to other column name with widening type change",
+    fromDDL = "a byte, b byte",
+    toDDL = "c int",
+    toPhysicalNames = Map(Seq("c") -> "b"),
+    // We don't block the type change itself here as the column is also renamed
+    expectedResult = expectColumnMappingChangeBlocked("RENAME AND DROP COLUMN"),
+    unblock = Seq(
+      "allowSourceColumnRenameAndDrop",
+      "allowSourceColumnRenameAndDropAndTypeWidening")
+  )
+
+  testSchemaChange(
+    name = "drop column, rename to other column name with non-widening type change",
+    fromDDL = "a int, b int",
+    toDDL = "c string",
+    toPhysicalNames = Map(Seq("c") -> "b"),
+    expectedResult = expectColumnMappingChangeBlocked("RENAME AND DROP COLUMN"),
+    unblock = Seq(
+      "allowSourceColumnRenameAndDrop",
+      "allowSourceColumnRenameAndDropAndTypeWidening")
+  )
+
+  testSchemaChange(
+    name = "drop column, rename to same column name",
+    fromDDL = "a int, b int",
+    toDDL = "a int",
+    toPhysicalNames = Map(Seq("a") -> "b"),
+    expectedResult = expectColumnMappingChangeBlocked("RENAME AND DROP COLUMN"),
+    unblock = Seq(
+      "allowSourceColumnRenameAndDrop",
+      "allowSourceColumnRenameAndDropAndTypeWidening")
+  )
+
+  testSchemaChange(
+    name = "drop column, rename to same column name with widening type change",
+    fromDDL = "a byte, b byte",
+    toDDL = "a int",
+    toPhysicalNames = Map(Seq("a") -> "b"),
+    expectedResult = expectColumnMappingChangeBlocked("RENAME, DROP AND TYPE WIDENING"),
+    unblock = Seq("allowSourceColumnRenameAndDropAndTypeWidening")
+  )
+
+  testSchemaChange(
+    name = "drop column, rename to same column name with non-widening type change",
+    fromDDL = "a int, b int",
+    toDDL = "a string",
+    toPhysicalNames = Map(Seq("a") -> "b"),
+    expectedResult = expectNonWideningTypeChangeError
+  )
+
+  ///////////////
+  // Type changes
+  ///////////////
+  testSchemaChange(
+    name = "widen single column",
+    fromDDL = "a byte",
+    toDDL = "a int",
+    expectedResult = expectTypeWideningBlocked(Seq("  a: TINYINT -> INT")),
+    unblock = Seq(
+      "allowSourceTypeWidening",
+      "allowSourceColumnRenameAndTypeWidening",
+      "allowSourceColumnDropAndTypeWidening",
+      "allowSourceColumnRenameAndDropAndTypeWidening")
+  )
+
+  testSchemaChange(
+    name = "widen single column with type widening disabled in Delta source",
+    fromDDL = "a byte",
+    toDDL = "a int",
+    expectedResult = expectNonWideningTypeChangeError,
+    confs = Seq(DeltaSQLConf.DELTA_ALLOW_TYPE_WIDENING_STREAMING_SOURCE.key -> "false")
+  )
+
+  testSchemaChange(
+    name = "widen single column with type change check disabled",
+    fromDDL = "a byte",
+    toDDL = "a int",
+    expectedResult = ExpectedResult.Success(),
+    confs = Seq(DeltaSQLConf.DELTA_TYPE_WIDENING_BYPASS_STREAMING_TYPE_CHANGE_CHECK.key -> "true")
+  )
+
+  testSchemaChange(
+    name = "widen single column with both type widening and type change check disabled",
+    fromDDL = "a byte",
+    toDDL = "a int",
+    expectedResult = ExpectedResult.Success(),
+    confs = Seq(
+      DeltaSQLConf.DELTA_ALLOW_TYPE_WIDENING_STREAMING_SOURCE.key -> "false",
+      DeltaSQLConf.DELTA_TYPE_WIDENING_BYPASS_STREAMING_TYPE_CHANGE_CHECK.key -> "true"
+    )
+  )
+
+  testSchemaChange(
+    name = "narrow single column",
+    fromDDL = "a long",
+    toDDL = "a int",
+    expectedResult = expectNonWideningTypeChangeError
+  )
+
+  testSchemaChange(
+    name = "narrow single column with type change check disabled",
+    fromDDL = "a long",
+    toDDL = "a int",
+    expectedResult = ExpectedResult.Success(),
+    confs = Seq(DeltaSQLConf.DELTA_TYPE_WIDENING_BYPASS_STREAMING_TYPE_CHANGE_CHECK.key -> "true")
+  )
+
+  testSchemaChange(
+    name = "change to nullable",
+    fromDDL = "a int not null",
+    toDDL = "a int",
+    expectedResult = ExpectedResult.Success()
+  )
+  testSchemaChange(
+    name = "change to non-nullable",
+    fromDDL = "a int",
+    toDDL = "a int not null",
+    expectedResult = expectNonWideningTypeChangeError
+  )
+
+  testSchemaChange(
+    name = "widen and change to nullable",
+    fromDDL = "a byte not null",
+    toDDL = "a int",
+    expectedResult = expectTypeWideningBlocked(Seq("  a: TINYINT -> INT")),
+    unblock = Seq(
+      "allowSourceTypeWidening",
+      "allowSourceColumnRenameAndTypeWidening",
+      "allowSourceColumnDropAndTypeWidening",
+      "allowSourceColumnRenameAndDropAndTypeWidening")
+  )
+
+  testSchemaChange(
+    name = "widen change to non-nullable",
+    fromDDL = "a byte",
+    toDDL = "a int not null",
+    expectedResult = expectNonWideningTypeChangeError
+  )
+
+  testSchemaChange(
+    name = "widen map",
+    fromDDL = "a map<byte, short>",
+    toDDL = "a map<short, int>",
+    expectedResult = expectTypeWideningBlocked(Seq(
+      "  a.key: TINYINT -> SMALLINT",
+      "  a.value: SMALLINT -> INT"
+    )),
+    unblock = Seq(
+      "allowSourceTypeWidening",
+      "allowSourceColumnRenameAndTypeWidening",
+      "allowSourceColumnDropAndTypeWidening",
+      "allowSourceColumnRenameAndDropAndTypeWidening")
+  )
+
+  testSchemaChange(
+    name = "widen array",
+    fromDDL = "a array<byte>",
+    toDDL = "a array<short>",
+    expectedResult = expectTypeWideningBlocked(Seq("  a.element: TINYINT -> SMALLINT")),
+    unblock = Seq(
+      "allowSourceTypeWidening",
+      "allowSourceColumnRenameAndTypeWidening",
+      "allowSourceColumnDropAndTypeWidening",
+      "allowSourceColumnRenameAndDropAndTypeWidening")
+  )
+
+  testSchemaChange(
+    name = "widen struct",
+    fromDDL = "a struct<x: byte>",
+    toDDL = "a struct<x: short>",
+    expectedResult = expectTypeWideningBlocked(Seq("  a.x: TINYINT -> SMALLINT")),
+    unblock = Seq(
+      "allowSourceTypeWidening",
+      "allowSourceColumnRenameAndTypeWidening",
+      "allowSourceColumnDropAndTypeWidening",
+      "allowSourceColumnRenameAndDropAndTypeWidening")
+  )
+
+  testSchemaChange(
+    name = "widen struct and struct field rename",
+    fromDDL = "a struct<x: byte, y: int>",
+    toDDL = "a struct<x: short, z: int>",
+    toPhysicalNames = Map(Seq("a", "z") -> "y"),
+    expectedResult = expectColumnMappingChangeBlocked("RENAME AND TYPE WIDENING"),
+    unblock = Seq(
+      "allowSourceColumnRenameAndTypeWidening",
+      "allowSourceColumnRenameAndDropAndTypeWidening")
+  )
+
+  testSchemaChange(
+    name = "widen struct and struct field drop",
+    fromDDL = "a struct<x: byte, y: int>",
+    toDDL = "a struct<x: short>",
+    expectedResult = expectColumnMappingChangeBlocked("DROP AND TYPE WIDENING"),
+    unblock = Seq(
+      "allowSourceColumnDropAndTypeWidening",
+      "allowSourceColumnRenameAndDropAndTypeWidening")
+  )
+
+  testSchemaChange(
+    name = "widen struct and struct field rename and drop",
+    fromDDL = "a struct<x: byte, y: int, z: int>",
+    toDDL = "a struct<x: short, w: int>",
+    toPhysicalNames = Map(Seq("a", "w") -> "y"),
+    expectedResult = expectColumnMappingChangeBlocked("RENAME, DROP AND TYPE WIDENING"),
+    unblock = Seq("allowSourceColumnRenameAndDropAndTypeWidening")
+  )
+
+  test("combining individual SQL confs to unblock isn't supported") {
+    val ex = intercept[DeltaThrowable] {
+      // We're dropping a column and renaming another one. Unblocking the DROP and RENAME separately
+      // isn't supported, the user must use `allowSourceColumnRenameAndDrop` instead.
+      withUnblockedChanges(Seq("allowSourceColumnRename", "allowSourceColumnDrop")) {
+        DeltaSourceMetadataEvolutionSupport.validateIfSchemaChangeCanBeUnblockedWithSQLConf(
+          spark,
+          metadataPath = "sourceMetadataPath",
+          currentSchema = persistedMetadata("a int", Map(Seq("a") -> "b")),
+          previousSchema = persistedMetadata("a int, b int", Map.empty)
+        )
+      }
+    }
+    assert(ex.getErrorClass === "DELTA_STREAMING_CANNOT_CONTINUE_PROCESSING_POST_SCHEMA_EVOLUTION")
+  }
+}

--- a/spark/src/test/scala/org/apache/spark/sql/delta/sources/DeltaSourceMetadataEvolutionSupportSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/sources/DeltaSourceMetadataEvolutionSupportSuite.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.sql.delta.sources
 
 import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaTestUtilsBase, DeltaThrowable}
@@ -169,9 +185,9 @@ class DeltaSourceMetadataEvolutionSupportSuite
     toDDL = "b int",
     toPhysicalNames = Map(Seq("b") -> "x"),
     expectedResult = expectColumnMappingChangeBlocked("RENAME COLUMN"),
-    // We don't block the type change itself: either the user treats 'b' as a nwe column and the type
-    // change doesn't matter downstream, or 'b' is already in use in which case its type can already
-    // be arbitrary.
+    // We don't block the type change itself: either the user treats 'b' as a nwe column and the
+    // type change doesn't matter downstream, or 'b' is already in use in which case its type can
+    // already be arbitrary.
     unblock = Seq(
       "allowSourceColumnRename",
       "allowSourceColumnRenameAndDrop",
@@ -185,9 +201,9 @@ class DeltaSourceMetadataEvolutionSupportSuite
     fromPhysicalNames = Map(Seq("a") -> "x"),
     toDDL = "b string",
     toPhysicalNames = Map(Seq("b") -> "x"),
-    // We don't block the type change itself: either the user treats 'b' as a nwe column and the type
-    // change doesn't matter downstream, or 'b' is already in use in which case its type can already
-    // be arbitrary.
+    // We don't block the type change itself: either the user treats 'b' as a nwe column and the
+    // type change doesn't matter downstream, or 'b' is already in use in which case its type can
+    // already be arbitrary.
     expectedResult = expectColumnMappingChangeBlocked("RENAME COLUMN"),
     unblock = Seq(
       "allowSourceColumnRename",

--- a/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningStreamingSourceSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/typewidening/TypeWideningStreamingSourceSuite.scala
@@ -1,0 +1,476 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.typewidening
+
+import java.io.File
+
+import org.apache.spark.sql.delta._
+
+import org.apache.spark.{SparkException, SparkThrowable}
+import org.apache.spark.sql.{DataFrame, Row, SaveMode}
+import org.apache.spark.sql.functions.{col, count, lit}
+import org.apache.spark.sql.streaming.{OutputMode, StreamingQueryException, StreamTest}
+import org.apache.spark.sql.test.SQLTestUtils
+import org.apache.spark.sql.types._
+
+/**
+ * Tests covering streaming reads from a Delta table that had a column type widened.
+ */
+class TypeWideningStreamingSourceSuite extends TypeWideningStreamingSourceTests
+
+trait TypeWideningStreamingSourceTests
+  extends StreamTest
+  with SQLTestUtils
+  with TypeWideningTestMixin {
+
+  import testImplicits._
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    spark.udf.register("scala_udf", (x: Int) => x + 1)
+  }
+
+  override def afterAll(): Unit = {
+    // The scala UDF is a temporary function, no need to drop it.
+    super.afterAll()
+  }
+
+  /** Short-hand to read a data stream from the Delta table at the given location. */
+  private def readStream(
+      path: File,
+      checkpointDir: File,
+      options: Map[String, String] = Map.empty): DataFrame =
+    spark.readStream.format("delta")
+      // Type widening requires tracking schema changes.
+      .option(DeltaOptions.SCHEMA_TRACKING_LOCATION, checkpointDir.toString)
+      .options(options)
+      .load(path.getCanonicalPath)
+
+  /** Test action checking that the stream fails due to a metadata change - typ. a schema change. */
+  object ExpectMetadataEvolutionException {
+    def apply(): StreamAction =
+      ExpectFailure[DeltaRuntimeException] { ex =>
+        assert(ex.asInstanceOf[DeltaRuntimeException].getErrorClass ===
+          "DELTA_STREAMING_METADATA_EVOLUTION")
+      }
+  }
+
+  /** Test action checking that the stream fails due to a type change being blocked. */
+  object ExpectTypeChangeBlockedException {
+    def apply(): StreamAction =
+      ExpectFailure[DeltaRuntimeException] { ex =>
+        assert(ex.asInstanceOf[DeltaRuntimeException].getErrorClass ===
+          "DELTA_STREAMING_CANNOT_CONTINUE_PROCESSING_TYPE_WIDENING")
+      }
+  }
+
+  /** Test action checking that the stream fails due to an unsupported type change. */
+  object ExpectIncompatibleSchemaChangeException {
+    def apply(): StreamAction =
+      ExpectFailure[DeltaIllegalStateException] { ex =>
+        assert(ex.asInstanceOf[DeltaIllegalStateException].getErrorClass ===
+          "DELTA_SCHEMA_CHANGED_WITH_VERSION")
+      }
+  }
+
+  /**
+   * Test a streaming query with a type widening operation. Creates a Delta source with two columns
+   * `widened` and `other` of type `byte` and widens the `widened` column to `int`. The query under
+   * test is used to read from the table and checked against the expected result.
+   * @param name           Test name.
+   * @param query          Streaming query to apply on the source.
+   * @param expectedResult In case of success, checks the last batch of data written by the stream
+   *                       matches the expected result. In case of failure, the caller provides a
+   *                       check to perform on the exception.
+   * @param outputMode     Output mode of the streaming query. `Append` by default but can be
+   *                       overriden to e.g. `Complete` for aggregations.
+   */
+  private def testStreamTypeWidening(
+      name: String,
+      query: DataFrame => DataFrame,
+      partitionBy: Option[String] = None,
+      expectedResult: ExpectedResult[Seq[Row]],
+      outputMode: OutputMode = OutputMode.Append()): Unit = {
+    test(s"type change - $name") {
+      withTempDir { dir =>
+        val partitionByStr = partitionBy.map(p => s"PARTITIONED BY ($p)").getOrElse("")
+        sql(s"CREATE TABLE delta.`$dir` (widened byte, other byte) USING DELTA $partitionByStr")
+        val checkpointDir = new File(dir, "sink_checkpoint")
+
+        testStream(query(readStream(dir, checkpointDir)), outputMode)(
+          StartStream(checkpointLocation = checkpointDir.toString),
+          Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (1, 1)") },
+          Execute { _ => sql(s"ALTER TABLE delta.`$dir`ALTER COLUMN widened TYPE int") },
+          ExpectMetadataEvolutionException()
+        )
+
+        val streamActions = expectedResult match {
+          case ExpectedResult.Success(rows: Seq[Row]) =>
+            Seq(
+              Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (123456789, 2)") },
+              ProcessAllAvailable(),
+              CheckLastBatch(rows: _*)
+            )
+          case ExpectedResult.Failure(checkError) =>
+            Seq(AssertOnQuery { q =>
+              val ex = intercept[StreamingQueryException] {
+                q.processAllAvailable()
+              }
+              val cause = if (ex.getCause.getMessage.contains(
+                "Provided schema doesn't match to the schema for existing state!")) {
+                // State store schema mismatches were non-spark exception until Spark 3.5. We wrap
+                // them into a spark exception to be able to check them consistently across spark
+                // versions.
+                new SparkException(
+                  message = ex.getCause.getMessage,
+                  cause = ex,
+                  errorClass = Some("STATE_STORE_KEY_SCHEMA_NOT_COMPATIBLE"),
+                  messageParameters = Map.empty
+                )
+              } else {
+                assert(ex.getCause.isInstanceOf[SparkThrowable])
+                ex.getCause.asInstanceOf[SparkThrowable]
+              }
+              checkError(cause)
+              true
+            })
+        }
+
+        // We need to unblock the type change to let the stream make progress.
+        withSQLConf("spark.databricks.delta.streaming.allowSourceTypeWidening" -> "always") {
+          testStream(query(readStream(dir, checkpointDir)), outputMode)(
+            StartStream(checkpointLocation = checkpointDir.toString) +:
+              streamActions: _*
+          )
+        }
+      }
+    }
+  }
+
+  testStreamTypeWidening("filter",
+    query = _.where(col("widened") > 10),
+    expectedResult = ExpectedResult.Success(Seq(Row(123456789, 2)))
+  )
+
+  testStreamTypeWidening("projection",
+    query = _.withColumn("add", col("widened") + col("other")),
+    expectedResult = ExpectedResult.Success(Seq(Row(123456789, 2, 123456791)))
+  )
+
+  testStreamTypeWidening("projection partition column",
+    query = _.withColumn("add", col("widened") + col("other")),
+    partitionBy = Some("widened"),
+    expectedResult = ExpectedResult.Success(Seq(Row(123456789, 2, 123456791)))
+  )
+
+  testStreamTypeWidening("widen unused scala udf field",
+    query = _.selectExpr("scala_udf(other)"),
+    expectedResult = ExpectedResult.Success(Seq(Row(3)))
+  )
+
+  testStreamTypeWidening("widen scala udf argument",
+    query = _.selectExpr("scala_udf(widened)"),
+    expectedResult = ExpectedResult.Success(Seq(Row(123456790)))
+  )
+
+  testStreamTypeWidening("widen aggregation grouping key",
+    query = _.groupBy("widened").agg(count(col("other"))),
+    expectedResult = ExpectedResult.Failure { ex =>
+      assert(ex.getErrorClass === "STATE_STORE_KEY_SCHEMA_NOT_COMPATIBLE")
+    },
+    /*
+    expectedResult = ExpectedResult.Failure { ex =>
+      assert(
+        ex.asInstanceOf[Throwable].getMessage
+        .contains("Provided schema doesn't match to the schema for existing state"))
+    },
+     */
+    outputMode = OutputMode.Complete()
+  )
+
+  testStreamTypeWidening("widen aggregation expression",
+    query = _.groupBy("other").agg(count(col("widened"))),
+    expectedResult = ExpectedResult.Success(Seq(Row(1, 1), Row(2, 1))),
+    outputMode = OutputMode.Complete()
+  )
+
+  testStreamTypeWidening("widen aggregation expression partition column",
+    query = _.groupBy("other").agg(count(col("widened"))),
+    partitionBy = Some("widened"),
+    expectedResult = ExpectedResult.Success(Seq(Row(1, 1), Row(2, 1))),
+    outputMode = OutputMode.Complete()
+  )
+
+  testStreamTypeWidening("widen aggregation expression after projection",
+    query = _.groupBy(col("widened") + lit(1).cast(ByteType)).agg(count(col("other"))),
+    expectedResult = ExpectedResult.Failure { ex =>
+      assert(ex.getErrorClass === "STATE_STORE_KEY_SCHEMA_NOT_COMPATIBLE")
+    },
+    outputMode = OutputMode.Complete()
+  )
+
+  testStreamTypeWidening("widen limit",
+    query = _.select("widened").limit(1),
+    expectedResult = ExpectedResult.Success(Seq.empty)
+  )
+
+  test("widening type change then restore back") {
+    withTempDir { dir =>
+      sql(s"CREATE TABLE delta.`$dir` (a byte) USING DELTA")
+      val checkpointDir = new File(dir, "sink_checkpoint")
+
+      testStream(readStream(dir, checkpointDir))(
+        StartStream(checkpointLocation = checkpointDir.toString),
+        Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (1)") },
+        Execute { _ => sql(s"ALTER TABLE delta.`$dir`ALTER COLUMN a TYPE int") },
+        // Widening a column type requires restarting the stream so that the new, wider schema is
+        // used to process the batch.
+        ExpectMetadataEvolutionException()
+      )
+
+      testStream(readStream(dir, checkpointDir))(
+        StartStream(checkpointLocation = checkpointDir.toString),
+        Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (123456789)") },
+        // The type change is blocked until the user reviews it and unblocks the stream.
+        ExpectTypeChangeBlockedException()
+      )
+
+      withSQLConf("spark.databricks.delta.streaming.allowSourceTypeWidening" -> "always") {
+        testStream(readStream(dir, checkpointDir, options = Map("ignoreDeletes" -> "true")))(
+          StartStream(checkpointLocation = checkpointDir.toString),
+          ProcessAllAvailable(),
+          CheckLastBatch(123456789),
+          // Restore will narrow the type back, the schema change fails the query.
+          Execute { _ => sql(s"RESTORE delta.`$dir` VERSION AS OF 1") },
+          ExpectMetadataEvolutionException()
+        )
+      }
+
+      // Retrying doesn't allow the narrowing type change to go through.
+      withSQLConf("spark.databricks.delta.streaming.allowSourceTypeWidening" -> "always") {
+        testStream(readStream(dir, checkpointDir, options = Map("ignoreDeletes" -> "true")))(
+          StartStream(checkpointLocation = checkpointDir.toString),
+          ExpectIncompatibleSchemaChangeException()
+        )
+      }
+    }
+  }
+
+  for { (name: String, toType: DataType) <- Seq(
+    ("narrowing", ByteType),
+    ("arbitrary", StringType))
+  } {
+    test(s"$name type changes are not supported") {
+      withTempDir { dir =>
+        sql(s"CREATE TABLE delta.`$dir` (a int) USING DELTA")
+        val checkpointDir = new File(dir, "sink_checkpoint")
+
+        testStream(readStream(dir, checkpointDir, options = Map("ignoreDeletes" -> "true")))(
+          StartStream(checkpointLocation = checkpointDir.toString),
+          Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (1)") },
+          ProcessAllAvailable(),
+          Execute { _ =>
+            // Overwrite the table schema to apply an arbitrary type change.
+            spark
+              .createDataFrame(
+                sparkContext.emptyRDD[Row],
+                StructType.fromDDL(s"a ${toType.sql}"))
+              .write
+              .format("delta")
+              .mode(SaveMode.Overwrite)
+              .option("overwriteSchema", "true")
+              .save(dir.getCanonicalPath)
+          },
+          ExpectMetadataEvolutionException()
+        )
+
+        // Try to restart the stream even though the error is not retryable and it will fail again.
+        testStream(readStream(dir, checkpointDir, options = Map("ignoreDeletes" -> "true")))(
+          StartStream(checkpointLocation = checkpointDir.toString),
+          Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (2)") },
+          ExpectIncompatibleSchemaChangeException()
+        )
+      }
+    }
+  }
+
+  test("type change without schemaTrackingLocation") {
+    withTempDir { dir =>
+      sql(s"CREATE TABLE delta.`$dir` (widened byte) USING DELTA")
+      val checkpointDir = new File(dir, "sink_checkpoint")
+
+      def readWithoutSchemaTrackingLog(): DataFrame =
+        spark.readStream.format("delta").load(dir.getCanonicalPath)
+
+      testStream(readWithoutSchemaTrackingLog())(
+        StartStream(checkpointLocation = checkpointDir.toString),
+        Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (1)") },
+        ProcessAllAvailable(),
+        CheckAnswer(1)
+      )
+
+      testStream(readWithoutSchemaTrackingLog())(
+        StartStream(checkpointLocation = checkpointDir.toString),
+        Execute { _ => sql(s"ALTER TABLE delta.`$dir`ALTER COLUMN widened TYPE int") },
+        Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (123456789)") },
+        ExpectFailure[DeltaStreamingColumnMappingSchemaIncompatibleException]()
+      )
+
+      // First retry with schema log initializes it.
+      testStream(readStream(dir, checkpointDir))(
+        StartStream(checkpointLocation = checkpointDir.toString),
+        ExpectMetadataEvolutionException()
+      )
+      // Second retry updates the schema log after the type change, then fails.
+      testStream(readStream(dir, checkpointDir))(
+        StartStream(checkpointLocation = checkpointDir.toString),
+        ExpectMetadataEvolutionException()
+      )
+      // Third retry requests user action to unblock the stream.
+      testStream(readStream(dir, checkpointDir))(
+        StartStream(checkpointLocation = checkpointDir.toString),
+        ExpectTypeChangeBlockedException()
+      )
+      // Unblocking the stream goes through.
+      withSQLConf("spark.databricks.delta.streaming.allowSourceTypeWidening" -> "always") {
+        testStream(readStream(dir, checkpointDir))(
+          StartStream(checkpointLocation = checkpointDir.toString),
+          ProcessAllAvailable(),
+          CheckAnswer(123456789)
+        )
+      }
+    }
+  }
+
+  for ((name, getSqlConf: (Int => String), value) <- Seq(
+    ("unblock all", (_: Int) => "allowSourceTypeWidening", "always"),
+    ("unblock stream", (hash: Int) => s"allowSourceTypeWidening.ckpt_$hash", "always"),
+    ("unblock version", (hash: Int) => s"allowSourceTypeWidening.ckpt_$hash", "2")
+  )) {
+    test(s"unblocking stream after type change - $name") {
+      withTempDir { dir =>
+        sql(s"CREATE TABLE delta.`$dir` (widened byte, other byte) USING DELTA")
+        // Getting the checkpoint dir through the delta log to ensure the format is consistent with
+        // the path used internally to compute the hash of the checkpoint location to unblock the
+        // stream.
+        val deltaLog = DeltaLog.forTable(spark, dir.toString)
+        val checkpointDir = new File(deltaLog.dataPath.toString, "sink_checkpoint")
+
+        def readWithAgg(): DataFrame =
+          readStream(dir, checkpointDir)
+            .groupBy("other")
+            .agg(count(col("widened")))
+
+        testStream(readWithAgg(), outputMode = OutputMode.Complete())(
+          StartStream(checkpointLocation = checkpointDir.toString),
+          Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (1, 1)") },
+          Execute { _ => sql(s"ALTER TABLE delta.`$dir`ALTER COLUMN widened TYPE int") },
+          ExpectMetadataEvolutionException()
+        )
+
+        testStream(readWithAgg(), outputMode = OutputMode.Complete())(
+          StartStream(checkpointLocation = checkpointDir.toString),
+          ExpectTypeChangeBlockedException()
+        )
+
+        val checkpointHash = s"$checkpointDir/sources/0".hashCode
+
+        withSQLConf(s"spark.databricks.delta.streaming.${getSqlConf(checkpointHash)}" -> value) {
+          testStream(readWithAgg(), outputMode = OutputMode.Complete())(
+            StartStream(checkpointLocation = checkpointDir.toString),
+            Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (123456789, 1)") },
+            ProcessAllAvailable(),
+            CheckLastBatch(Row(1, 2))
+          )
+        }
+      }
+    }
+  }
+
+  test(s"overwrite schema with type change and dropped column") {
+    withTempDir { dir =>
+      sql(s"CREATE TABLE delta.`$dir` (a byte, b int) USING DELTA")
+      val checkpointDir = new File(dir, "sink_checkpoint")
+
+      testStream(readStream(dir, checkpointDir, options = Map("ignoreDeletes" -> "true")))(
+        StartStream(checkpointLocation = checkpointDir.toString),
+        Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (1, 1)") },
+        ProcessAllAvailable(),
+        Execute { _ =>
+          // Overwrite the table schema.
+          spark
+            .createDataFrame(
+              sparkContext.emptyRDD[Row],
+              StructType.fromDDL(s"a INT"))
+            .write
+            .format("delta")
+            .mode(SaveMode.Overwrite)
+            .option("overwriteSchema", "true")
+            .save(dir.getCanonicalPath)
+        },
+        ExpectMetadataEvolutionException()
+      )
+
+      testStream(readStream(dir, checkpointDir, options = Map("ignoreDeletes" -> "true")))(
+        StartStream(checkpointLocation = checkpointDir.toString),
+        ExpectFailure[DeltaRuntimeException] { ex =>
+          val conf =
+            "spark\\.databricks\\.delta\\.streaming\\.allowSourceColumnRenameAndDropAndTypeWidening"
+          checkErrorMatchPVals(
+            exception = ex.asInstanceOf[DeltaRuntimeException],
+            "DELTA_STREAMING_CANNOT_CONTINUE_PROCESSING_POST_SCHEMA_EVOLUTION",
+            parameters = Map(
+              "opType" -> "DROP AND TYPE WIDENING",
+              "previousSchemaChangeVersion" -> "0",
+              "currentSchemaChangeVersion" -> "2",
+              "allowCkptVerKey" -> (conf + "\\.ckpt_.*"),
+              "allowCkptVerValue" -> "2",
+              "allowCkptKey" -> (conf + "\\.ckpt_.*"),
+              "allowCkptValue" -> "always",
+              "allowAllKey" -> conf,
+              "allowAllValue" -> "always",
+              "allowAllMode" -> "allowSourceColumnRenameAndDropAndTypeWidening",
+              "opSpecificMode" -> "allowSourceColumnDropAndTypeWidening"
+            ))
+        }
+      )
+      // Allowing both source column drop and type widening separately is not enough to let the
+      // stream continue. Both must be unblocked using the combined config.
+      withSQLConf(
+          "spark.databricks.delta.streaming.allowSourceColumnDrop" -> "always",
+          "spark.databricks.delta.streaming.allowSourceColumnDrop" -> "always") {
+        testStream(readStream(dir, checkpointDir, options = Map("ignoreDeletes" -> "true")))(
+          StartStream(checkpointLocation = checkpointDir.toString),
+          Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (2)") },
+          ExpectFailure[DeltaRuntimeException] { ex =>
+            assert(ex.asInstanceOf[DeltaRuntimeException].getErrorClass ===
+              "DELTA_STREAMING_CANNOT_CONTINUE_PROCESSING_POST_SCHEMA_EVOLUTION")
+          }
+        )
+      }
+
+      withSQLConf("spark.databricks.delta.streaming.allowSourceColumnDropAndTypeWidening"
+          -> "always") {
+        testStream(readStream(dir, checkpointDir, options = Map("ignoreDeletes" -> "true")))(
+          StartStream(checkpointLocation = checkpointDir.toString),
+          Execute { _ => sql(s"INSERT INTO delta.`$dir` VALUES (2)") },
+          ProcessAllAvailable()
+        )
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description
Streaming reads from a Delta source currently don't allow any form of type change to be propagated: the stream fails with a non-retryable error. Type widening introduced the ability to change the type of an existing column or field in a Delta table.

This change allows widening type changes to be propagated during streaming reads from a Delta source. The same mechanism as non-additive schema changes from column mapping (Drop/Rename) is applied.
To allow widening type changes to propagate, the user must:
- Provide a schema tracking location via `.option("schemaTrackingLocation", ..)`
- Review and accept the type change by setting one of the available SQL confs (detailed in the error message)


Note that the current check for column mapping had a loophole: as long as a schema tracking location was provided, it only gated column drop/rename but allowed *any* type changes to get through. This is fixed here by properly checking and rejecting non-widening type changes.

## How was this patch tested?
- Added unit tests in `DeltaSourceMetadataEvolutionSupportSuite` covering the logic to detect and gate non-additive schema changes.
- Added test suite `TypeWideningStreamingSourceSuite` to cover stream reads from a delta source when a column is widened. 

## This PR introduces the following *user-facing* changes
When reading using a streaming query from a Delta table that had a column type widened:

### Before this change:
The stream fails with a non-retryable error:
```
[DELTA_SCHEMA_CHANGED_WITH_VERSION]
Detected schema change in version <version>:
streaming source schema: <readSchema>
data file schema: <dataSchema>
Please try restarting the query. If this issue repeats across query restarts without
making progress, you have made an incompatible schema change and need to start your
query from scratch using a new checkpoint directory.
```
Note: users could get around this by providing a schema tracking location and applying a column drop or rename to their source. This allowed *arbitrary* type changes to go through unchecked.

### After this change:
Users must provide a schema tracking location via `.option("schemaTrackingLocation")`, otherwise the stream fails with:
```
[DELTA_STREAMING_INCOMPATIBLE_SCHEMA_CHANGE_USE_SCHEMA_LOG]
Streaming read is not supported on tables with read-incompatible schema changes (e.g. rename or drop or datatype changes).
Please provide a 'schemaTrackingLocation' to enable non-additive schema evolution for Delta stream processing.
See <docLink> for more details.
Read schema: <readSchema>. Incompatible data schema: <incompatibleSchema>.
```
When a schema tracking location is provided, non-widening type changes are now properly rejected and fail with error`[DELTA_SCHEMA_CHANGED_WITH_VERSION]` 

When reading the batch that contains the type change, the stream first fail and records the tracked schema:
```
[DELTA_STREAMING_METADATA_EVOLUTION]
The schema, table configuration or protocol of your Delta table has changed during streaming.
The schema or metadata tracking log has been updated.
Please restart the stream to continue processing using the updated metadata.
Updated schema: <schema>.
Updated table configurations: <config>.
Updated table protocol: <protocol>
```
On retry, the stream fails and the user is prompted with a call to action:
```
[DELTA_STREAMING_CANNOT_CONTINUE_PROCESSING_TYPE_WIDENING]
We've detected one or more data types being widened between Delta version 2 and 3:
  col_a: INT -> BIGINT

Your streaming query contains operations that may fail or produce different results after the type change(s).
Please check if you want to update your streaming query before we proceed with stream processing using the finalized schema at version 2.
Once you have updated your streaming query or have decided there is no need to update it, you can set (one of) the following SQL configurations to unblock the type change(s) and continue stream processing.
To unblock for this particular stream just for this series of type change(s): set `spark.databricks.delta.streaming.allowSourceTypeWidening.ckpt_123456 = 2`.
To unblock for this particular stream: set `spark.databricks.delta.streaming.allowSourceTypeWidening.ckpt_123456 = always`
To unblock for all streams: set `spark.databricks.delta.streaming.allowSourceTypeWidening = always`.
```

Users can set one of the proposed config to resume processing.