### PR TITLE
[Kernel] [CC Refactor #1] TableIdentifier API

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Table.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Table.java
@@ -22,6 +22,7 @@ import io.delta.kernel.exceptions.KernelException;
 import io.delta.kernel.exceptions.TableNotFoundException;
 import io.delta.kernel.internal.TableImpl;
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * Represents the Delta Lake table for a given path.
@@ -58,6 +59,24 @@ public interface Table {
   }
 
   /**
+   * Instantiate a table object for the Delta Lake table at the given path and associate it with the
+   * given {@link TableIdentifier}.
+   *
+   * <p>See {@link #forPath(Engine, String)} for more details on behavior when the table path does
+   * or does not exist.
+   *
+   * @param engine the {@link Engine} instance to use in Delta Kernel.
+   * @param path location of the table. Path is resolved to fully qualified path using the given
+   *     {@code engine}.
+   * @param tableId the {@link TableIdentifier} to associate with the {@link Table}
+   * @return an instance of {@link Table} representing the Delta table at the given path and
+   *     associated with the given {@link TableIdentifier}
+   */
+  static Table forPathWithTableId(Engine engine, String path, TableIdentifier tableId) {
+    return TableImpl.forPathWithTableId(engine, path, tableId);
+  }
+
+  /**
    * The fully qualified path of this {@link Table} instance.
    *
    * @param engine {@link Engine} instance.
@@ -65,6 +84,14 @@ public interface Table {
    * @since 3.2.0
    */
   String getPath(Engine engine);
+
+  /**
+   * The table identifier of this {@link Table} instance.
+   *
+   * @return the table identifier, or {@link Optional#empty()} if none is set.
+   * @since 3.4.0
+   */
+  Optional<TableIdentifier> getTableId();
 
   /**
    * Get the latest snapshot of the table.

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/TableIdentifierSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/TableIdentifierSuite.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright (2024) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.delta.kernel
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class TableIdentifierSuite extends AnyFunSuite {
+
+  test("TableIdentifier should throw IllegalArgumentException for null or empty namespace") {
+    assertThrows[IllegalArgumentException] {
+      new TableIdentifier(null, "table")
+    }
+    assertThrows[IllegalArgumentException] {
+      new TableIdentifier(Array(), "table")
+    }
+  }
+
+  test("TableIdentifier should throw NullPointerException for null table name") {
+    assertThrows[NullPointerException] {
+      new TableIdentifier(Array("catalog", "schema"), null)
+    }
+  }
+
+  test("TableIdentifier should return the correct namespace and name") {
+    val namespace = Array("catalog", "schema")
+    val name = "testTable"
+    val tid = new TableIdentifier(namespace, name)
+
+    assert(tid.getNamespace.sameElements(namespace))
+    assert(tid.getName == name)
+  }
+
+  test("TableIdentifiers with same namespace and name should be equal") {
+    val tid1 = new TableIdentifier(Array("catalog", "schema"), "table")
+    val tid2 = new TableIdentifier(Array("catalog", "schema"), "table")
+
+    assert(tid1 == tid2)
+    assert(tid1.hashCode == tid2.hashCode)
+  }
+
+  test("TableIdentifiers with different namespace or name should not be equal") {
+    val tid1 = new TableIdentifier(Array("catalog", "schema1"), "table1")
+    val tid2 = new TableIdentifier(Array("catalog", "schema2"), "table1")
+    val tid3 = new TableIdentifier(Array("catalog", "schema1"), "table2")
+
+    assert(tid1 != tid2)
+    assert(tid1 != tid3)
+  }
+
+  test("TableIdentifier toString") {
+    // Normal case
+    val tidNormal = new TableIdentifier(Array("catalog", "schema"), "table")
+    val expectedNormal = "TableIdentifier{catalog.schema.table}"
+    assert(tidNormal.toString == expectedNormal)
+
+    // Special case: should escape backticks
+    val tidSpecial = new TableIdentifier(Array("catalog", "sche`ma"), "tab`le")
+    val expectedSpecial = "TableIdentifier{catalog.sche``ma.tab``le}"
+    assert(tidSpecial.toString == expectedSpecial)
+  }
+}


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Note that
- TableIdentifier was added in this PR https://github.com/delta-io/delta/pull/3795
- That PR was reverted here https://github.com/delta-io/delta/pull/3900
- #3900 incorrectly didn't remove the TableIdentifier API

This PR adds back the TableIdentifier tests. It also adds the `Table::forPathWithTableId` API.

## How was this patch tested?

New UT.

## Does this PR introduce _any_ user-facing changes?

New Table API to create a Table using a path and Table Identifier.
