### PR TITLE
[SPARK] Allow list `timestampdiff` & `timestampadd` as generated column expressions

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/SupportedGenerationExpressions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/SupportedGenerationExpressions.scala
@@ -213,6 +213,8 @@ object SupportedGenerationExpressions {
     expression[Now]("now"),
     expression[Quarter]("quarter"),
     expression[Second]("second"),
+    expression[TimestampAdd]("timestampadd"),
+    expression[TimestampDiff]("timestampdiff"),
     expression[ParseToTimestamp]("to_timestamp"),
     expression[ParseToDate]("to_date"),
     // `gettimestamp` is not a Spark built-in class but `ParseToDate` will refer to

--- a/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/GeneratedColumnSuite.scala
@@ -1266,6 +1266,18 @@ trait GeneratedColumnSuiteBase
     }
   }
 
+  test("generation expression allows timestampdiff & timestampadd") {
+    withTableName("generation_expression_timestamp_diff_add") { tableName =>
+      createTable(
+        tableName,
+        path = None,
+        schemaString = "c1 TIMESTAMP, c2 TIMESTAMP, c3 BIGINT, c4 TIMESTAMP",
+        generatedColumns =
+          Map("c3" -> "timestampdiff(MONTH, c1, c2)", "c4" -> "timestampadd(MONTH, 1, c1)"),
+        partitionColumns = Seq.empty)
+    }
+  }
+
   test("MERGE UPDATE basic") {
     withTableName("source") { src =>
       withTableName("target") { tgt =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
It allow-lists `timestampdiff` & `timestampadd` as generated column expressions as they are deterministic.
<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->


## How was this patch tested?
New test case.
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
Previously users cannot use `timestampdiff` or `timestampadd` in generation expression. The PR allows this.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
