### PR TITLE
[Spark][TEST-ONLY] Test identity high water mark inserts when target table has no high water mark

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnIngestionSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/IdentityColumnIngestionSuite.scala
@@ -419,6 +419,42 @@ trait IdentityColumnIngestionSuiteBase extends IdentityColumnTestUtils {
     }
   }
 
+  test("Appending from a source table with a high water mark should not update" +
+    " the target table's high water mark") {
+    withSrcAndDestTables(
+      isSrcDataSubsetOfTgt = false,
+      positiveStep = true,
+      expectValidHighWaterMark = false) { (srcTblName, tgtTblName) =>
+      val tgtDeltaLog = DeltaLog.forTable(spark, TableIdentifier(tgtTblName))
+      // dataframe v2
+      spark.table(srcTblName).writeTo(tgtTblName).append()
+      assert(getHighWaterMark(tgtDeltaLog.update(), colName = "id").isEmpty,
+        "High watermark should not be set for user inserted data.")
+
+      // v1
+      spark.table(srcTblName).write.format("delta").mode("append").saveAsTable(tgtTblName)
+      assert(getHighWaterMark(tgtDeltaLog.update(), colName = "id").isEmpty,
+        "High watermark should not be set for user inserted data.")
+
+      spark.table(srcTblName).write.insertInto(tgtTblName)
+      assert(getHighWaterMark(tgtDeltaLog.update(), colName = "id").isEmpty,
+        "High watermark should not be set for user inserted data.")
+
+      // SQL
+      sql(s"INSERT INTO $tgtTblName SELECT * FROM $srcTblName")
+      assert(getHighWaterMark(tgtDeltaLog.update(), colName = "id").isEmpty,
+        "High watermark should not be set for user inserted data.")
+
+      sql(s"INSERT INTO $tgtTblName BY NAME SELECT * FROM $srcTblName")
+      assert(getHighWaterMark(tgtDeltaLog.update(), colName = "id").isEmpty,
+        "High watermark should not be set for user inserted data.")
+
+      sql(s"INSERT INTO $tgtTblName(id, value) SELECT id, value FROM $srcTblName")
+      assert(getHighWaterMark(tgtDeltaLog.update(), colName = "id").isEmpty,
+        "High watermark should not be set for user inserted data.")
+    }
+  }
+
   for {
     cdfEnabled <- DeltaTestUtils.BOOLEAN_DOMAIN
     isSrcDataSubsetOfTgt <- DeltaTestUtils.BOOLEAN_DOMAIN


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description
Test only PR. Adds some basic additional tests for inserting data into tables when the Identity Column high water mark isn't already defined. Split from the PR making identity column high water mark updates more consistent: https://github.com/delta-io/delta/pull/3989

## How was this patch tested?

New tests pass.

## Does this PR introduce _any_ user-facing changes?
No.
