### PR TITLE
[Spark] Avoid using attributes with outdated expression IDs in internal Delta DataFrame operations

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/IdentityColumn.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/IdentityColumn.scala
@@ -138,15 +138,21 @@ object IdentityColumn extends DeltaLogging {
         if (positiveStep) max(col) else min(col)
     }
     val unresolvedExpr = to_json(array(aggregates: _*))
+
     // Resolve the collection expression by constructing a query to select the expression from a
     // table with the statsSchema and get the analyzed expression.
-    val resolvedExpr = Dataset.ofRows(spark, LocalRelation(statsDataSchema))
-      .select(unresolvedExpr).queryExecution.analyzed.expressions.head
+    val resolvedPlan = Dataset.ofRows(spark, LocalRelation(statsDataSchema))
+      .select(unresolvedExpr).queryExecution.analyzed
+
+    // We have to use the new attributes with regenerated attribute IDs, because the Analyzer
+    // doesn't guarantee that attributes IDs will stay the same
+    val newStatsDataSchema = resolvedPlan.children.head.output
+
     Some(new DeltaIdentityColumnStatsTracker(
       hadoopConf,
       path,
-      statsDataSchema,
-      resolvedExpr,
+      newStatsDataSchema,
+      resolvedPlan.expressions.head,
       identityColumnInfo
     ))
   }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/files/TransactionalWrite.scala
@@ -303,12 +303,22 @@ trait TransactionalWrite extends DeltaLogging { self: OptimisticTransactionImpl 
     (outputStatsCollectionSchema, tableStatsCollectionSchema)
   }
 
+  /**
+   * Returns a resolved `statsCollection.statsCollector` expression with `statsDataSchema`
+   * attributes re-resolved to be used for writing Delta file stats.
+   */
   protected def getStatsColExpr(
       statsDataSchema: Seq[Attribute],
-      statsCollection: StatisticsCollection): Expression = {
-    Dataset.ofRows(spark, LocalRelation(statsDataSchema))
+      statsCollection: StatisticsCollection): (Expression, Seq[Attribute]) = {
+    val resolvedPlan = Dataset.ofRows(spark, LocalRelation(statsDataSchema))
       .select(to_json(statsCollection.statsCollector))
-      .queryExecution.analyzed.expressions.head
+      .queryExecution.analyzed
+
+    // We have to use the new attributes with regenerated attribute IDs, because the Analyzer
+    // doesn't guarantee that attributes IDs will stay the same
+    val newStatsDataSchema = resolvedPlan.children.head.output
+
+    resolvedPlan.expressions.head -> newStatsDataSchema
   }
 
 
@@ -346,11 +356,12 @@ trait TransactionalWrite extends DeltaLogging { self: OptimisticTransactionImpl 
         override val statsColumnSpec = StatisticsCollection.configuredDeltaStatsColumnSpec(metadata)
         override val protocol: Protocol = newProtocol.getOrElse(snapshot.protocol)
       }
-      val statsColExpr = getStatsColExpr(outputStatsCollectionSchema, statsCollection)
+      val (statsColExpr, newOutputStatsCollectionSchema) =
+        getStatsColExpr(outputStatsCollectionSchema, statsCollection)
 
       (Some(new DeltaJobStatisticsTracker(deltaLog.newDeltaHadoopConf(),
                                           outputPath,
-                                          outputStatsCollectionSchema,
+                                          newOutputStatsCollectionSchema,
                                           statsColExpr
         )),
        Some(statsCollection))


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Avoid using attributes with outdated expression IDs in internal Delta DataFrame operations.

In this example:
```
val resolvedPlan = Dataset.ofRows(spark, LocalRelation(statsDataSchema)).select(to_json(statsCollection.statsCollector)).queryExecution.analyzed
```

the Analyzer might regenerate expression IDs (this is an implementation-specific behavior), and `statsDataSchema` may not be used along with `resolvedPlan.expressions.head`, because they will have different expression IDs associated with those expression trees. It would be correct to use `resolvedPlan.children.head.output` from that `LocalRelation`.

The issue might happen later when these attributes are passed to `DeltaJobStatisticsTracker` -> `DeltaTaskStatisticsTracker` -> `JoinedProjection.bind` along with the resolved `to_json(statsCollection.statsCollector)` expression.

The issue was found during single-pass Analyzer development, because single-pass Analyzer aggressively regenerates expression IDs, and fixed-point Analyzer preserves expression IDs for this simple DF transformation.

Context: https://issues.apache.org/jira/browse/SPARK-49834

## How was this patch tested?

Existing tests.

## Does this PR introduce _any_ user-facing changes?

No.
