### PR TITLE
[Kernel] Add maxRetries to txnbuilder

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/TransactionBuilder.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/TransactionBuilder.java
@@ -83,6 +83,15 @@ public interface TransactionBuilder {
   TransactionBuilder withTableProperties(Engine engine, Map<String, String> properties);
 
   /**
+   * Set the maximum number of times to retry a transaction if a concurrent write is detected. This
+   * defaults to 200
+   *
+   * @param maxRetries The number of times to retry
+   * @return updated {@link TransactionBuilder} instance
+   */
+  TransactionBuilder withMaxRetries(int maxRetries);
+
+  /**
    * Build the transaction. Also validates the given info to ensure that a valid transaction can be
    * created.
    *

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -57,6 +57,13 @@ public class TransactionBuilderImpl implements TransactionBuilder {
   private Optional<SetTransaction> setTxnOpt = Optional.empty();
   private Optional<Map<String, String>> tableProperties = Optional.empty();
 
+  /**
+   * Number of retries for concurrent write exceptions to resolve conflicts and retry commit. In
+   * Delta-Spark, for historical reasons the number of retries is really high (10m). We are starting
+   * with a lower number by default for now. If this is not sufficient we can update it.
+   */
+  private int maxRetries = 200;
+
   public TransactionBuilderImpl(TableImpl table, String engineInfo, Operation operation) {
     this.table = table;
     this.engineInfo = engineInfo;
@@ -92,6 +99,12 @@ public class TransactionBuilderImpl implements TransactionBuilder {
   @Override
   public TransactionBuilder withTableProperties(Engine engine, Map<String, String> properties) {
     this.tableProperties = Optional.of(new HashMap<>(properties));
+    return this;
+  }
+
+  @Override
+  public TransactionBuilder withMaxRetries(int maxRetries) {
+    this.maxRetries = maxRetries;
     return this;
   }
 
@@ -161,6 +174,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
         setTxnOpt,
         shouldUpdateMetadata,
         shouldUpdateProtocol,
+        maxRetries,
         table.getClock());
   }
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -104,6 +104,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
 
   @Override
   public TransactionBuilder withMaxRetries(int maxRetries) {
+    checkArgument(maxRetries >= 0, "maxRetries must be >= 0");
     this.maxRetries = maxRetries;
     return this;
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -51,13 +51,6 @@ public class TransactionImpl implements Transaction {
   public static final int DEFAULT_READ_VERSION = 1;
   public static final int DEFAULT_WRITE_VERSION = 2;
 
-  /**
-   * Number of retries for concurrent write exceptions to resolve conflicts and retry commit. In
-   * Delta-Spark, for historical reasons the number of retries is really high (10m). We are starting
-   * with a lower number for now. If this is not sufficient we can update it.
-   */
-  private static final int NUM_TXN_RETRIES = 200;
-
   private final UUID txnId = UUID.randomUUID();
 
   private final boolean isNewTable; // the transaction is creating a new table
@@ -73,6 +66,7 @@ public class TransactionImpl implements Transaction {
   private final List<DomainMetadata> domainMetadatas = new ArrayList<>();
   private Metadata metadata;
   private boolean shouldUpdateMetadata;
+  private int maxRetries;
 
   private boolean closed; // To avoid trying to commit the same transaction again.
 
@@ -88,6 +82,7 @@ public class TransactionImpl implements Transaction {
       Optional<SetTransaction> setTxnOpt,
       boolean shouldUpdateMetadata,
       boolean shouldUpdateProtocol,
+      int maxRetries,
       Clock clock) {
     this.isNewTable = isNewTable;
     this.dataPath = dataPath;
@@ -100,6 +95,7 @@ public class TransactionImpl implements Transaction {
     this.setTxnOpt = setTxnOpt;
     this.shouldUpdateMetadata = shouldUpdateMetadata;
     this.shouldUpdateProtocol = shouldUpdateProtocol;
+    this.maxRetries = maxRetries;
     this.clock = clock;
   }
 
@@ -164,35 +160,41 @@ public class TransactionImpl implements Transaction {
         try {
           return doCommit(engine, commitAsVersion, attemptCommitInfo, dataActions);
         } catch (FileAlreadyExistsException fnfe) {
-          logger.info(
-              "Concurrent write detected when committing as version = {}. "
-                  + "Trying to resolve conflicts and retry commit.",
-              commitAsVersion);
-          TransactionRebaseState rebaseState =
-              ConflictChecker.resolveConflicts(engine, readSnapshot, commitAsVersion, this);
-          long newCommitAsVersion = rebaseState.getLatestVersion() + 1;
-          checkArgument(
-              commitAsVersion < newCommitAsVersion,
-              "New commit version %d should be greater than the previous commit "
-                  + "attempt version %d.",
-              newCommitAsVersion,
-              commitAsVersion);
-          commitAsVersion = newCommitAsVersion;
-          Optional<Long> updatedInCommitTimestamp =
-              getUpdatedInCommitTimestampAfterConflict(
-                  rebaseState.getLatestCommitTimestamp(), attemptCommitInfo.getInCommitTimestamp());
-          updateMetadataWithICTIfRequired(
-              engine, updatedInCommitTimestamp, rebaseState.getLatestVersion());
-          attemptCommitInfo.setInCommitTimestamp(updatedInCommitTimestamp);
+          if (numRetries >= maxRetries) {
+            logger.info(
+                "Concurrent write detected when committing as version = {}. ", commitAsVersion);
+          } else {
+            logger.info(
+                "Concurrent write detected when committing as version = {}. "
+                    + "Trying to resolve conflicts and retry commit.",
+                commitAsVersion);
+            TransactionRebaseState rebaseState =
+                ConflictChecker.resolveConflicts(engine, readSnapshot, commitAsVersion, this);
+            long newCommitAsVersion = rebaseState.getLatestVersion() + 1;
+            checkArgument(
+                commitAsVersion < newCommitAsVersion,
+                "New commit version %d should be greater than the previous commit "
+                    + "attempt version %d.",
+                newCommitAsVersion,
+                commitAsVersion);
+            commitAsVersion = newCommitAsVersion;
+            Optional<Long> updatedInCommitTimestamp =
+                getUpdatedInCommitTimestampAfterConflict(
+                    rebaseState.getLatestCommitTimestamp(),
+                    attemptCommitInfo.getInCommitTimestamp());
+            updateMetadataWithICTIfRequired(
+                engine, updatedInCommitTimestamp, rebaseState.getLatestVersion());
+            attemptCommitInfo.setInCommitTimestamp(updatedInCommitTimestamp);
+          }
         }
         numRetries++;
-      } while (numRetries < NUM_TXN_RETRIES);
+      } while (numRetries <= maxRetries);
     } finally {
       closed = true;
     }
 
     // we have exhausted the number of retries, give up.
-    logger.info("Exhausted maximum retries ({}) for committing transaction.", NUM_TXN_RETRIES);
+    logger.info("Exhausted maximum retries ({}) for committing transaction.", maxRetries);
     throw new ConcurrentWriteException();
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
@@ -235,7 +235,8 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
       val ex1 = intercept[ConcurrentWriteException] {
         txn1.commit(engine, emptyIterable())
       }
-      assert(ex1.getMessage.contains("Transaction has encountered a conflict and can not be committed"))
+      assert(
+        ex1.getMessage.contains("Transaction has encountered a conflict and can not be committed"))
 
       // check that we're still set to 10
       val ver2Snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
@@ -207,6 +207,42 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
     }
   }
 
+  test("Setting retries to 0 disables retries") {
+    withTempDirAndEngine { (tablePath, engine) =>
+      // Create table
+      val table = Table.forPath(engine, tablePath)
+      createTxn(engine, tablePath, isNewTable = true, testSchema, Seq.empty)
+        .commit(engine, emptyIterable())
+
+      // Create txn1 with config changes
+      val txn1 = createWriteTxnBuilder(
+        Table.forPath(engine, tablePath))
+        .withTableProperties(engine, Map(TableConfig.CHECKPOINT_INTERVAL.getKey -> "2").asJava)
+        .withMaxRetries(0)
+        .build(engine)
+
+      // Create and commit txn2
+      appendData(
+        engine,
+        tablePath,
+        data = Seq(Map.empty[String, Literal] -> dataBatches1)
+      )
+
+      val ver1Snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
+      assertMetadataProp(ver1Snapshot, TableConfig.CHECKPOINT_INTERVAL, 10)
+
+      // Try to commit txn1 but expect failure
+      val ex1 = intercept[ConcurrentWriteException] {
+        txn1.commit(engine, emptyIterable())
+      }
+      assert(ex1.getMessage.contains("Transaction has encountered a conflict and can not be committed"))
+
+      // check that we're still set to 10
+      val ver2Snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
+      assertMetadataProp(ver2Snapshot, TableConfig.CHECKPOINT_INTERVAL, 10)
+    }
+  }
+
   test("create table and configure the same properties") {
     withTempDirAndEngine { (tablePath, engine) =>
       val table = Table.forPath(engine, tablePath)

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
@@ -215,8 +215,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
         .commit(engine, emptyIterable())
 
       // Create txn1 with config changes
-      val txn1 = createWriteTxnBuilder(
-        Table.forPath(engine, tablePath))
+      val txn1 = createWriteTxnBuilder(table)
         .withTableProperties(engine, Map(TableConfig.CHECKPOINT_INTERVAL.getKey -> "2").asJava)
         .withMaxRetries(0)
         .build(engine)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

This PR allows setting the maximum number of times that kernel should retry a transaction. It does so by adding a `withMaxRetries` option to the `TransactionBuilder`.

It also refactors the commit loop code to make it a bit more clear.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

New Unit test

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes: Introduces a new public api
