### PR TITLE
[Spark] Protocol validation testing in time travelling

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaLog.scala
@@ -372,7 +372,15 @@ class DeltaLog private(
    * `read` and `write`.
    */
   private def protocolCheck(tableProtocol: Protocol, readOrWrite: String): Unit = {
-    val clientSupportedProtocol = Action.supportedProtocolVersion()
+    val unsupportedTestFeatures =
+      if (spark.conf.get(DeltaSQLConf.UNSUPPORTED_TESTING_FEATURES_ENABLED)) {
+        TableFeature.testUnsupportedFeatures.toSeq
+      } else {
+        Seq.empty
+      }
+
+    val clientSupportedProtocol =
+      Action.supportedProtocolVersion(featuresToExclude = unsupportedTestFeatures)
     // Depending on the operation, pull related protocol versions out of Protocol objects.
     // `getEnabledFeatures` is a pointer to pull reader/writer features out of a Protocol.
     val (clientSupportedVersions, tableRequiredVersion, getEnabledFeatures) = readOrWrite match {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
@@ -67,6 +67,11 @@ case class TestWriterFeaturePreDowngradeCommand(table: DeltaTableV2)
   }
 }
 
+case class TestUnsupportedReaderWriterFeaturePreDowngradeCommand(table: DeltaTableV2)
+  extends PreDowngradeTableFeatureCommand {
+  override def removeFeatureTracesIfNeeded(): Boolean = true
+}
+
 case class TestWriterWithHistoryValidationFeaturePreDowngradeCommand(table: DeltaTableV2)
     extends PreDowngradeTableFeatureCommand
     with DeltaLogging {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -431,6 +431,15 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(true)
 
+  val UNSUPPORTED_TESTING_FEATURES_ENABLED =
+    buildConf("tableFeatures.dev.unsupportedTableFeatures.enabled")
+      .internal()
+      .doc(
+        """When turned on, it emulates the existence of unsupported features by the client.
+          |This config is only used for testing purposes.""".stripMargin)
+      .booleanConf
+      .createWithDefault(false)
+
   val FAST_DROP_FEATURE_ENABLED =
     buildConf("tableFeatures.dev.fastDropFeature.enabled")
       .internal()

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaFastDropFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaFastDropFeatureSuite.scala
@@ -528,10 +528,10 @@ class DeltaFastDropFeatureSuite
             case "getSnapshotAt" => deltaLog.getSnapshotAt(versionBeforeRemoval)
             case "restoreToVersion" => table.restoreToVersion(versionBeforeRemoval)
             case "restoreToTS" => table.restoreToTimestamp(tsBeforeRemoval)
-            case "cloneAtVersion" => withTempDir { d =>
-              table.cloneAtVersion(versionBeforeRemoval.toInt, d.getCanonicalPath) }
+            case "cloneAtVersion" => withTempDir { d => table.cloneAtVersion(
+              versionBeforeRemoval.toInt, d.getCanonicalPath, isShallow = false) }
             case "cloneAtTS" => withTempDir { d =>
-              table.cloneAtTimestamp(tsBeforeRemoval, d.getCanonicalPath) }
+              table.cloneAtTimestamp(tsBeforeRemoval, d.getCanonicalPath, isShallow = false) }
             case "sparkVersion" => spark.read.format("delta")
               .option("versionAsOf", versionBeforeRemoval).load(dir.getCanonicalPath)
             case "sparkTS" => spark.read.format("delta")

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeltaFastDropFeatureSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeltaFastDropFeatureSuite.scala
@@ -487,7 +487,7 @@ class DeltaFastDropFeatureSuite
 
   for (timeTravelMethod <- Seq("restoreSQL", "restoreSQLTS", "selectSQL", "selectSQLTS",
                                "getSnapshotAt", "restoreToVersion", "restoreToTS",
-                               "cloneAtVersion", "cloneAtTS", "sparkVersion", "sparkTS"))
+                               "sparkVersion", "sparkTS"))
   test(s"Protocol is validated when time traveling - time-travel method: $timeTravelMethod") {
     withTempDir { dir =>
       def getTimestampForVersion(version: Long): String = {
@@ -528,10 +528,6 @@ class DeltaFastDropFeatureSuite
             case "getSnapshotAt" => deltaLog.getSnapshotAt(versionBeforeRemoval)
             case "restoreToVersion" => table.restoreToVersion(versionBeforeRemoval)
             case "restoreToTS" => table.restoreToTimestamp(tsBeforeRemoval)
-            case "cloneAtVersion" => withTempDir { d => table.cloneAtVersion(
-              versionBeforeRemoval.toInt, d.getCanonicalPath, isShallow = false) }
-            case "cloneAtTS" => withTempDir { d =>
-              table.cloneAtTimestamp(tsBeforeRemoval, d.getCanonicalPath, isShallow = false) }
             case "sparkVersion" => spark.read.format("delta")
               .option("versionAsOf", versionBeforeRemoval).load(dir.getCanonicalPath)
             case "sparkTS" => spark.read.format("delta")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Testing only PR to ensure protocol validation in time travelling works as expected.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Testing only PR.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.