### PR TITLE
[Spark] Create DV tombstones when dropping Deletion Vectors #117451

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaOperations.scala
@@ -487,6 +487,21 @@ object DeltaOperations {
 
     override val isInPlaceFileMetadataUpdate: Option[Boolean] = Some(false)
   }
+
+  /**
+   * Recorded when dropping deletion vectors. Deletion Vector tombstones directly reference
+   * deletion vector files within the retention period. This is to protect them from deletion
+   * against oblivious writers when vacuuming.
+   */
+  object AddDeletionVectorsTombstones extends Operation("Deletion Vector Tombstones") {
+    override val parameters: Map[String, Any] = Map.empty
+
+    // This operation should only introduce RemoveFile actions.
+    override def checkAddFileWithDeletionVectorStatsAreNotTightBounds: Boolean = true
+
+    override val isInPlaceFileMetadataUpdate: Option[Boolean] = Some(false)
+  }
+
   /** Recorded when columns are added. */
   case class AddColumns(
       colsToAdd: Seq[QualifiedColTypeWithPositionForLog]) extends Operation("ADD COLUMNS") {

--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaUDF.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaUDF.scala
@@ -16,6 +16,7 @@
 
 package org.apache.spark.sql.delta
 
+import org.apache.spark.sql.delta.actions.DeletionVectorDescriptor
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.DeletedRecordCountsHistogram
 
@@ -50,6 +51,17 @@ object DeltaUDF {
       f: Array[Long] => DeletedRecordCountsHistogram): UserDefinedFunction =
     createUdfFromTemplateUnsafe(deletedRecordCountsHistogramFromArrayLongTemplate, f, udf(f))
 
+  def stringFromDeletionVectorDescriptor(
+      f: DeletionVectorDescriptor => String): UserDefinedFunction =
+    createUdfFromTemplateUnsafe(stringFromDeletionVectorDescriptorTemplate, f, udf(f))
+
+  def booleanFromDeletionVectorDescriptor(
+      f: DeletionVectorDescriptor => Boolean): UserDefinedFunction =
+    createUdfFromTemplateUnsafe(booleanFromDeletionVectorDescriptorTemplate, f, udf(f))
+
+  def booleanFromString(s: String => Boolean): UserDefinedFunction =
+    createUdfFromTemplateUnsafe(booleanFromStringTemplate, s, udf(s))
+
   def booleanFromMap(f: Map[String, String] => Boolean): UserDefinedFunction =
     createUdfFromTemplateUnsafe(booleanFromMapTemplate, f, udf(f))
 
@@ -73,6 +85,15 @@ object DeltaUDF {
   private lazy val deletedRecordCountsHistogramFromArrayLongTemplate =
     udf((_: Array[Long]) => DeletedRecordCountsHistogram(Array.empty))
       .asInstanceOf[SparkUserDefinedFunction]
+
+  private lazy val stringFromDeletionVectorDescriptorTemplate =
+    udf((_: DeletionVectorDescriptor) => "").asInstanceOf[SparkUserDefinedFunction]
+
+  private lazy val booleanFromDeletionVectorDescriptorTemplate =
+    udf((_: DeletionVectorDescriptor) => false).asInstanceOf[SparkUserDefinedFunction]
+
+  private lazy val booleanFromStringTemplate =
+    udf((_: String) => false).asInstanceOf[SparkUserDefinedFunction]
 
   private lazy val booleanFromMapTemplate =
     udf((_: Map[String, String]) => true).asInstanceOf[SparkUserDefinedFunction]

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
@@ -74,7 +74,7 @@ case class TestWriterFeaturePreDowngradeCommand(table: DeltaTableV2)
 
 case class TestUnsupportedReaderWriterFeaturePreDowngradeCommand(table: DeltaTableV2)
   extends PreDowngradeTableFeatureCommand {
-  override def removeFeatureTracesIfNeeded(): Boolean = true
+  override def removeFeatureTracesIfNeeded(spark: SparkSession): Boolean = true
 }
 
 case class TestWriterWithHistoryValidationFeaturePreDowngradeCommand(table: DeltaTableV2)

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit
 
 import scala.util.control.NonFatal
 
+import org.apache.spark.sql.delta.actions.{DeletionVectorDescriptor, RemoveFile}
 import org.apache.spark.sql.delta.catalog.DeltaTableV2
 import org.apache.spark.sql.delta.commands.{AlterTableSetPropertiesDeltaCommand, AlterTableUnsetPropertiesDeltaCommand, DeltaReorgTableCommand, DeltaReorgTableMode, DeltaReorgTableSpec}
 import org.apache.spark.sql.delta.commands.columnmapping.RemoveColumnMappingCommand
@@ -30,7 +31,10 @@ import org.apache.spark.sql.delta.metering.DeltaLogging
 import org.apache.spark.sql.delta.util.{Utils => DeltaUtils}
 import org.apache.spark.sql.util.ScalaExtensions._
 
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.analysis.ResolvedTable
+import org.apache.spark.sql.functions.{approx_count_distinct, col, not}
+
 
 /**
  * A base class for implementing a preparation command for removing table features.
@@ -45,14 +49,14 @@ sealed abstract class PreDowngradeTableFeatureCommand {
    * Returns true when it performs a cleaning action. When no action was required
    * it returns false.
    */
-  def removeFeatureTracesIfNeeded(): Boolean
+  def removeFeatureTracesIfNeeded(spark: SparkSession): Boolean
 }
 
 case class TestWriterFeaturePreDowngradeCommand(table: DeltaTableV2)
   extends PreDowngradeTableFeatureCommand
   with DeltaLogging {
   // To remove the feature we only need to remove the table property.
-  override def removeFeatureTracesIfNeeded(): Boolean = {
+  override def removeFeatureTracesIfNeeded(spark: SparkSession): Boolean = {
     // Make sure feature data/metadata exist before proceeding.
     if (TestRemovableWriterFeature.validateRemoval(table.initialSnapshot)) return false
 
@@ -62,7 +66,7 @@ case class TestWriterFeaturePreDowngradeCommand(table: DeltaTableV2)
 
     val properties = Seq(TestRemovableWriterFeature.TABLE_PROP_KEY)
     AlterTableUnsetPropertiesDeltaCommand(
-      table, properties, ifExists = true, fromDropFeatureCommand = true).run(table.spark)
+      table, properties, ifExists = true, fromDropFeatureCommand = true).run(spark)
     true
   }
 }
@@ -76,7 +80,7 @@ case class TestWriterWithHistoryValidationFeaturePreDowngradeCommand(table: Delt
     extends PreDowngradeTableFeatureCommand
     with DeltaLogging {
   // To remove the feature we only need to remove the table property.
-  override def removeFeatureTracesIfNeeded(): Boolean = {
+  override def removeFeatureTracesIfNeeded(spark: SparkSession): Boolean = {
     // Make sure feature data/metadata exist before proceeding.
     if (TestRemovableWriterWithHistoryTruncationFeature.validateRemoval(table.initialSnapshot)) {
       return false
@@ -84,7 +88,7 @@ case class TestWriterWithHistoryValidationFeaturePreDowngradeCommand(table: Delt
 
     val properties = Seq(TestRemovableWriterWithHistoryTruncationFeature.TABLE_PROP_KEY)
     AlterTableUnsetPropertiesDeltaCommand(
-      table, properties, ifExists = true, fromDropFeatureCommand = true).run(table.spark)
+      table, properties, ifExists = true, fromDropFeatureCommand = true).run(spark)
     true
   }
 }
@@ -93,7 +97,7 @@ case class TestReaderWriterFeaturePreDowngradeCommand(table: DeltaTableV2)
   extends PreDowngradeTableFeatureCommand
   with DeltaLogging {
   // To remove the feature we only need to remove the table property.
-  override def removeFeatureTracesIfNeeded(): Boolean = {
+  override def removeFeatureTracesIfNeeded(spark: SparkSession): Boolean = {
     // Make sure feature data/metadata exist before proceeding.
     if (TestRemovableReaderWriterFeature.validateRemoval(table.initialSnapshot)) return false
 
@@ -103,7 +107,7 @@ case class TestReaderWriterFeaturePreDowngradeCommand(table: DeltaTableV2)
 
     val properties = Seq(TestRemovableReaderWriterFeature.TABLE_PROP_KEY)
     AlterTableUnsetPropertiesDeltaCommand(
-      table, properties, ifExists = true, fromDropFeatureCommand = true).run(table.spark)
+      table, properties, ifExists = true, fromDropFeatureCommand = true).run(spark)
     true
   }
 }
@@ -111,12 +115,12 @@ case class TestReaderWriterFeaturePreDowngradeCommand(table: DeltaTableV2)
 case class TestLegacyWriterFeaturePreDowngradeCommand(table: DeltaTableV2)
   extends PreDowngradeTableFeatureCommand {
   /** Return true if we removed the property, false if no action was needed. */
-  override def removeFeatureTracesIfNeeded(): Boolean = {
+  override def removeFeatureTracesIfNeeded(spark: SparkSession): Boolean = {
     if (TestRemovableLegacyWriterFeature.validateRemoval(table.initialSnapshot)) return false
 
     val properties = Seq(TestRemovableLegacyWriterFeature.TABLE_PROP_KEY)
     AlterTableUnsetPropertiesDeltaCommand(
-      table, properties, ifExists = true, fromDropFeatureCommand = true).run(table.spark)
+      table, properties, ifExists = true, fromDropFeatureCommand = true).run(spark)
     true
   }
 }
@@ -124,24 +128,133 @@ case class TestLegacyWriterFeaturePreDowngradeCommand(table: DeltaTableV2)
 case class TestLegacyReaderWriterFeaturePreDowngradeCommand(table: DeltaTableV2)
   extends PreDowngradeTableFeatureCommand {
   /** Return true if we removed the property, false if no action was needed. */
-  override def removeFeatureTracesIfNeeded(): Boolean = {
+  override def removeFeatureTracesIfNeeded(spark: SparkSession): Boolean = {
     if (TestRemovableLegacyReaderWriterFeature.validateRemoval(table.initialSnapshot)) return false
 
     val properties = Seq(TestRemovableLegacyReaderWriterFeature.TABLE_PROP_KEY)
     AlterTableUnsetPropertiesDeltaCommand(
-      table, properties, ifExists = true, fromDropFeatureCommand = true).run(table.spark)
+      table, properties, ifExists = true, fromDropFeatureCommand = true).run(spark)
     true
   }
 }
 
-class DeletionVectorsRemovalMetrics(
+private[delta] class DeletionVectorsRemovalMetrics(
     val numDeletionVectorsToRemove: Long,
     val numDeletionVectorRowsToRemove: Long,
+    var dvTombstonesWithinRetentionPeriod: Long = 0L,
+    var addDVTombstonesTime: Long = 0L,
     var downgradeTimeMs: Long = 0L)
 
 case class DeletionVectorsPreDowngradeCommand(table: DeltaTableV2)
   extends PreDowngradeTableFeatureCommand
   with DeltaLogging {
+
+  /**
+   * Create RemoveFiles (tombstones) that directly reference deletion vector within the retention
+   * period. These protect the latter from accidental removal from clients that do not support
+   * deletion vectors.
+   *
+   * Note, we always create the DV tombstones even for the drop feature with history
+   * truncation implementation. This is to protect against a corner case where the user run
+   * drop feature with fastDropFeature.enabled = false and then run again with
+   * fastDropFeature.enabled = true.
+   *
+   * @param checkIfSnapshotUpdatedSinceTs The timestamp to use for updating the snapshot.
+   * @param metrics The deletion vectors removal metrics. This function only updates the DV
+   *                tombstone related metrics.
+   */
+  private def generateDVTombstones(
+      spark: SparkSession,
+      checkIfSnapshotUpdatedSinceTs: Long,
+      metrics: DeletionVectorsRemovalMetrics): Unit = {
+    import scala.jdk.CollectionConverters._
+    import org.apache.spark.sql.delta.implicits._
+
+    if (!spark.conf.get(DeltaSQLConf.FAST_DROP_FEATURE_GENERATE_DV_TOMBSTONES)) return
+
+    val startTimeNs = System.nanoTime()
+    val snapshotToUse = table.deltaLog.update(
+      checkIfUpdatedSinceTs = Some(checkIfSnapshotUpdatedSinceTs))
+
+    val deletionVectorPath = DeletionVectorDescriptor.urlEncodedPath(
+      deletionVectorCol = col("deletionVector"),
+      tablePath = table.deltaLog.dataPath)
+    val isInlineDeletionVector = DeletionVectorDescriptor.isInline(col("deletionVector"))
+
+    // SnapshotToUse.tombstones returns only the tombstones within the retention period. The
+    // default tombstone retention period is 7 days. Note, that if a RemoveFile contains
+    // DeletionVectorDescriptor, it is guaranteed it is not a DV Tombstone. Furthermore, we
+    // use distinct to deduplicate the DV references. This is because we merge DVs, and as a
+    // result, several AddFiles may point to the same DV file.
+    val removeFilesWithDVs = snapshotToUse.tombstones
+      .filter(col("deletionVector").isNotNull)
+      .filter(not(isInlineDeletionVector))
+      .select(deletionVectorPath.as("path"))
+      .distinct()
+
+    // This is a union of the DV tombstones and the regular data file tombstones without DVs (we
+    // cannot tell the difference). We use it to identify which DV tombstones are already created.
+    val filesWithoutDVs = snapshotToUse.tombstones
+      .filter(col("deletionVector").isNull)
+      .select("path")
+
+    val dvTombstonePathsToAdd = removeFilesWithDVs
+      .join(filesWithoutDVs, "path", "left_anti")
+      .as[String]
+
+    val actionsToCommit = dvTombstonePathsToAdd.toLocalIterator().asScala.map { dvPath =>
+      // Disable scala style rules to ignore warning that RemoveFile files should never be
+      // instantiated directly.
+      // scalastyle:off
+      RemoveFile(
+        path = dvPath,
+        deletionTimestamp = Some(table.deltaLog.clock.getTimeMillis()),
+        dataChange = false)
+      // scalastyle:on
+    }
+
+    // We pay some overhead here to estimate the memory required to hold the results.
+    // Above some threshold we use commitLarge. This allows to use an iterator instead of
+    // materializing results in memory. However, it comes with some disadvantages: if there is a
+    // conflict the commit is not retried.
+    // A cheaper alternative would be to use snapshot.numDeletionVectorsOpt
+    // (right before the reorg in drop feature) but this does not capture deduplication as well as
+    // any reorgs that occurred before dropping DVs.
+    // We assume 1024 bytes are required per RemoveFile.
+    val tombstonesToAddCount =
+      dvTombstonePathsToAdd.select(approx_count_distinct("path")).as[Long].first
+
+    val tombstoneCountThreshold =
+      spark.conf.get(DeltaSQLConf.FAST_DROP_FEATURE_DV_TOMBSTONE_COUNT_THRESHOLD)
+
+    if (tombstonesToAddCount > tombstoneCountThreshold) {
+      table.startTransaction(Some(snapshotToUse)).commitLarge(
+        spark,
+        nonProtocolMetadataActions = actionsToCommit,
+        op = DeltaOperations.AddDeletionVectorsTombstones,
+        newProtocolOpt = None,
+        context = Map.empty,
+        metrics = Map("dvTombstonesWithinRetentionPeriod" -> tombstonesToAddCount.toString))
+    } else {
+      table.startTransaction(Some(snapshotToUse))
+        .commit(actionsToCommit.toList, DeltaOperations.AddDeletionVectorsTombstones)
+    }
+
+    metrics.addDVTombstonesTime = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNs)
+    metrics.dvTombstonesWithinRetentionPeriod = tombstonesToAddCount
+  }
+
+  private def reorgTable(spark: SparkSession) = {
+    // Wrap `table` in a ResolvedTable that can be passed to DeltaReorgTableCommand. The catalog &
+    // table ID won't be used by DeltaReorgTableCommand.
+    import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+    val catalog = table.spark.sessionState.catalogManager.currentCatalog.asTableCatalog
+    val tableId = Seq(table.name()).asIdentifier
+
+    DeltaReorgTableCommand(target = ResolvedTable.create(catalog, tableId, table))(Nil)
+      .run(table.spark)
+    */
+  }
 
   /**
    * We first remove the table feature property to prevent any transactions from committing
@@ -152,38 +265,41 @@ case class DeletionVectorsPreDowngradeCommand(table: DeltaTableV2)
    *
    * @return Returns true if it removed DV metadata property and/or DVs. False otherwise.
    */
-  override def removeFeatureTracesIfNeeded(): Boolean = {
+  override def removeFeatureTracesIfNeeded(
+      spark: SparkSession): Boolean = {
+    val startTimeNs = table.deltaLog.clock.nanoTime()
+
     // Latest snapshot looks clean. No action is required. We may proceed
     // to the protocol downgrade phase.
-    if (DeletionVectorsTableFeature.validateRemoval(table.initialSnapshot)) return false
-
-    val startTimeNs = System.nanoTime()
-    val properties = Seq(DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.key)
-    AlterTableUnsetPropertiesDeltaCommand(
-      table, properties, ifExists = true, fromDropFeatureCommand = true).run(table.spark)
-
     val snapshot = table.update()
+    val tracesFound = !DeletionVectorsTableFeature.validateRemoval(snapshot)
+    if (tracesFound) {
+      val properties = Seq(DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.key)
+      AlterTableUnsetPropertiesDeltaCommand(
+        table, properties, ifExists = true, fromDropFeatureCommand = true).run(spark)
+
+      reorgTable(spark)
+    }
+
     val metrics = new DeletionVectorsRemovalMetrics(
       numDeletionVectorsToRemove = snapshot.numDeletionVectorsOpt.getOrElse(0L),
       numDeletionVectorRowsToRemove = snapshot.numDeletedRecordsOpt.getOrElse(0L))
 
-    // Wrap `table` in a ResolvedTable that can be passed to DeltaReorgTableCommand. The catalog &
-    // table ID won't be used by DeltaReorgTableCommand.
-    import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
-    val catalog = table.spark.sessionState.catalogManager.currentCatalog.asTableCatalog
-    val tableId = Seq(table.name()).asIdentifier
+    reorgTable(spark)
 
-    DeltaReorgTableCommand(target = ResolvedTable.create(catalog, tableId, table))(Nil)
-      .run(table.spark)
+    // Even if there no DV traces in the table we check if there are missing DV tombstones.
+    // This is to protect against an edge case where all DV traces are cleaned before invoking
+    // the drop feature command.
+    generateDVTombstones(spark, startTimeNs, metrics)
 
     metrics.downgradeTimeMs =
-      TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNs)
+      TimeUnit.NANOSECONDS.toMillis(table.deltaLog.clock.nanoTime() - startTimeNs)
 
     recordDeltaEvent(
       table.deltaLog,
       opType = "delta.deletionVectorsFeatureRemovalMetrics",
       data = metrics)
-    true
+    tracesFound
   }
 }
 
@@ -197,13 +313,13 @@ case class V2CheckpointPreDowngradeCommand(table: DeltaTableV2)
    * @return True if it changed checkpoint policy metadata property to classic.
    *         False otherwise.
    */
-  override def removeFeatureTracesIfNeeded(): Boolean = {
+  override def removeFeatureTracesIfNeeded(spark: SparkSession): Boolean = {
 
     if (V2CheckpointTableFeature.validateRemoval(table.initialSnapshot)) return false
 
     val startTimeNs = System.nanoTime()
     val properties = Map(DeltaConfigs.CHECKPOINT_POLICY.key -> CheckpointPolicy.Classic.name)
-    AlterTableSetPropertiesDeltaCommand(table, properties).run(table.spark)
+    AlterTableSetPropertiesDeltaCommand(table, properties).run(spark)
 
     recordDeltaEvent(
       table.deltaLog,
@@ -231,7 +347,7 @@ case class InCommitTimestampsPreDowngradeCommand(table: DeltaTableV2)
    * @return true if any change to the metadata (the three properties listed above) was made.
    *         False otherwise.
    */
-  override def removeFeatureTracesIfNeeded(): Boolean = {
+  override def removeFeatureTracesIfNeeded(spark: SparkSession): Boolean = {
     val startTimeNs = System.nanoTime()
     val currentMetadata = table.initialSnapshot.metadata
     val currentTableProperties = currentMetadata.configuration
@@ -283,7 +399,7 @@ case class VacuumProtocolCheckPreDowngradeCommand(table: DeltaTableV2)
    * For downgrading the [[VacuumProtocolCheckTableFeature]], we don't need remove any traces, we
    * just need to remove the feature from the [[Protocol]].
    */
-  override def removeFeatureTracesIfNeeded(): Boolean = false
+  override def removeFeatureTracesIfNeeded(spark: SparkSession): Boolean = false
 }
 
 case class CoordinatedCommitsPreDowngradeCommand(table: DeltaTableV2)
@@ -302,7 +418,7 @@ case class CoordinatedCommitsPreDowngradeCommand(table: DeltaTableV2)
    *         if there were any unbackfilled commits that were backfilled.
    *         false otherwise.
    */
-  override def removeFeatureTracesIfNeeded(): Boolean = {
+  override def removeFeatureTracesIfNeeded(spark: SparkSession): Boolean = {
     val startTimeNs = System.nanoTime()
 
     var traceRemovalNeeded = false
@@ -318,7 +434,7 @@ case class CoordinatedCommitsPreDowngradeCommand(table: DeltaTableV2)
           CoordinatedCommitsUtils.TABLE_PROPERTY_KEYS,
           ifExists = true,
           fromDropFeatureCommand = true
-        ).run(table.spark)
+        ).run(spark)
       } catch {
         case NonFatal(e) =>
           exceptionOpt = Some(e)
@@ -366,14 +482,14 @@ case class TypeWideningPreDowngradeCommand(table: DeltaTableV2)
    *
    * @return Return true if files were rewritten or metadata was removed. False otherwise.
    */
-  override def removeFeatureTracesIfNeeded(): Boolean = {
+  override def removeFeatureTracesIfNeeded(spark: SparkSession): Boolean = {
     if (TypeWideningTableFeature.validateRemoval(table.initialSnapshot)) return false
 
     val startTimeNs = System.nanoTime()
     val properties = Seq(DeltaConfigs.ENABLE_TYPE_WIDENING.key)
     AlterTableUnsetPropertiesDeltaCommand(
-      table, properties, ifExists = true, fromDropFeatureCommand = true).run(table.spark)
-    val numFilesRewritten = rewriteFilesIfNeeded()
+      table, properties, ifExists = true, fromDropFeatureCommand = true).run(spark)
+    val numFilesRewritten = rewriteFilesIfNeeded(spark)
     val metadataRemoved = removeMetadataIfNeeded()
 
     recordDeltaEvent(
@@ -393,7 +509,7 @@ case class TypeWideningPreDowngradeCommand(table: DeltaTableV2)
    * schema. These are all files not added or modified after the last type change.
    * @return Return the number of files rewritten.
    */
-  private def rewriteFilesIfNeeded(): Long = {
+  private def rewriteFilesIfNeeded(spark: SparkSession): Long = {
     if (!TypeWideningMetadata.containsTypeWideningMetadata(table.initialSnapshot.schema)) {
       return 0L
     }
@@ -401,7 +517,7 @@ case class TypeWideningPreDowngradeCommand(table: DeltaTableV2)
     // Wrap `table` in a ResolvedTable that can be passed to DeltaReorgTableCommand. The catalog &
     // table ID won't be used by DeltaReorgTableCommand.
     import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
-    val catalog = table.spark.sessionState.catalogManager.currentCatalog.asTableCatalog
+    val catalog = spark.sessionState.catalogManager.currentCatalog.asTableCatalog
     val tableId = Seq(table.name()).asIdentifier
 
     val reorg = DeltaReorgTableCommand(
@@ -409,7 +525,7 @@ case class TypeWideningPreDowngradeCommand(table: DeltaTableV2)
       reorgTableSpec = DeltaReorgTableSpec(DeltaReorgTableMode.REWRITE_TYPE_WIDENING, None)
     )(Nil)
 
-    val rows = reorg.run(table.spark)
+    val rows = reorg.run(spark)
     val metrics = rows.head.getAs[OptimizeMetrics](1)
     metrics.numFilesRemoved
   }
@@ -447,9 +563,7 @@ case class ColumnMappingPreDowngradeCommand(table: DeltaTableV2)
    * @return Returns true if it removed table property and/or has rewritten the data.
    *         False otherwise.
    */
-  override def removeFeatureTracesIfNeeded(): Boolean = {
-    val spark = table.spark
-
+  override def removeFeatureTracesIfNeeded(spark: SparkSession): Boolean = {
     // Latest snapshot looks clean. No action is required. We may proceed
     // to the protocol downgrade phase.
     if (ColumnMappingTableFeature.validateRemoval(table.initialSnapshot)) return false
@@ -476,7 +590,7 @@ case class CheckConstraintsPreDowngradeTableFeatureCommand(table: DeltaTableV2)
    * representation). Instead, we ask the user to explicitly drop the constraints before the table
    * feature can be dropped.
    */
-  override def removeFeatureTracesIfNeeded(): Boolean = {
+  override def removeFeatureTracesIfNeeded(spark: SparkSession): Boolean = {
     val checkConstraintNames = Constraints.getCheckConstraintNames(table.initialSnapshot.metadata)
     if (checkConstraintNames.isEmpty) return false
     throw DeltaErrors.cannotDropCheckConstraintFeature(checkConstraintNames)
@@ -507,13 +621,13 @@ case class CheckpointProtectionPreDowngradeCommand(table: DeltaTableV2)
    * expiration. This allows the drop process to proceed immediately after we cleanup the history
    * prior to requireCheckpointProtectionBeforeVersion.
    */
-  override def removeFeatureTracesIfNeeded(): Boolean = {
+  override def removeFeatureTracesIfNeeded(spark: SparkSession): Boolean = {
     val snapshot = table.initialSnapshot
 
     if (!historyPriorToCheckpointProtectionVersionIsTruncated(snapshot)) {
       // Add a checkpoint here to make sure we can cleanup up everything before this commit.
       // This is because metadata cleanup operations, can only clean up to the latest checkpoint.
-      createEmptyCommitAndCheckpoint(table, System.nanoTime())
+      createEmptyCommitAndCheckpoint(table, table.deltaLog.clock.nanoTime())
 
       table.deltaLog.cleanUpExpiredLogs(
         snapshot,
@@ -529,7 +643,7 @@ case class CheckpointProtectionPreDowngradeCommand(table: DeltaTableV2)
     // If history is truncated we do not need the property anymore.
     val property = DeltaConfigs.REQUIRE_CHECKPOINT_PROTECTION_BEFORE_VERSION.key
     AlterTableUnsetPropertiesDeltaCommand(
-      table, Seq(property), ifExists = true, fromDropFeatureCommand = true).run(table.spark)
+      table, Seq(property), ifExists = true, fromDropFeatureCommand = true).run(spark)
 
     // We did not do any changes that require history expiration. It is ok if the removed property
     // exists in history.

--- a/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/PreDowngradeTableFeatureCommand.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.delta.commands.optimize.OptimizeMetrics
 import org.apache.spark.sql.delta.constraints.Constraints
 import org.apache.spark.sql.delta.coordinatedcommits.CoordinatedCommitsUtils
 import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.{Utils => DeltaUtils}
 import org.apache.spark.sql.util.ScalaExtensions._
 
@@ -253,7 +254,6 @@ case class DeletionVectorsPreDowngradeCommand(table: DeltaTableV2)
 
     DeltaReorgTableCommand(target = ResolvedTable.create(catalog, tableId, table))(Nil)
       .run(table.spark)
-    */
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/TableFeature.scala
@@ -660,6 +660,14 @@ object DeletionVectorsTableFeature
     DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.fromMetaData(metadata)
   }
 
+  /**
+   * Validate whether all deletion vector traces are removed from the snapshot.
+   *
+   * Note, we do not need to validate whether DV tombstones exist. These are added in the
+   * pre-downgrade stage and always cover all DVs within the retention period. This invariant can
+   * never change unless we enable again DVs. If DVs are enabled before the protocol downgrade
+   * we will abort the operation.
+   */
   override def validateRemoval(snapshot: Snapshot): Boolean = {
     val dvsWritable = DeletionVectorUtils.deletionVectorsWritable(snapshot)
     val dvsExist = snapshot.numDeletionVectorsOpt.getOrElse(0L) > 0

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptor.scala
@@ -219,7 +219,7 @@ object DeletionVectorDescriptor {
   final val UUID_DV_MARKER: String = "u"
 
   private final val deletionVectorFileNameRegex =
-    raw"${DELETION_VECTOR_FILE_NAME_CORE}_([^.]+)\.bin".r
+    raw"${new Path(DELETION_VECTOR_FILE_NAME_CORE).toUri}_([^.]+)\.bin".r
   private final val deletionVectorFileNamePattern = deletionVectorFileNameRegex.pattern
 
   final lazy val STRUCT_TYPE: StructType =

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptor.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/DeletionVectorDescriptor.scala
@@ -21,6 +21,7 @@ import java.net.URI
 import java.util.{Base64, UUID}
 
 import org.apache.spark.sql.delta.DeltaErrors
+import org.apache.spark.sql.delta.DeltaUDF
 import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.util.{Codec, DeltaEncoder, JsonUtils}
 import com.fasterxml.jackson.annotation.JsonIgnore
@@ -32,7 +33,6 @@ import org.apache.spark.sql.{Column, Encoder}
 import org.apache.spark.sql.functions.{concat, lit, when}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
-import org.apache.spark.util.Utils
 
 /** Information about a deletion vector attached to a file action. */
 case class DeletionVectorDescriptor(
@@ -128,6 +128,10 @@ case class DeletionVectorDescriptor(
     }
   }
 
+  /** Returns the url encoded absolute path of the deletion vector. */
+  def urlEncodedPath(tablePath: Path): String =
+    SparkPath.fromPath(absolutePath(tablePath)).urlEncoded
+
   /**
    * Produce a copy of this DV, but using an absolute path.
    *
@@ -136,10 +140,9 @@ case class DeletionVectorDescriptor(
   def copyWithAbsolutePath(tableLocation: Path): DeletionVectorDescriptor = {
     storageType match {
       case UUID_DV_MARKER =>
-        val absolutePath = this.absolutePath(tableLocation)
         this.copy(
           storageType = PATH_DV_MARKER,
-          pathOrInlineDv = SparkPath.fromPath(absolutePath).urlEncoded)
+          pathOrInlineDv = urlEncodedPath(tableLocation))
       case PATH_DV_MARKER | INLINE_DV_MARKER => this.copy()
     }
   }
@@ -215,6 +218,10 @@ object DeletionVectorDescriptor {
   final val INLINE_DV_MARKER: String = "i"
   final val UUID_DV_MARKER: String = "u"
 
+  private final val deletionVectorFileNameRegex =
+    raw"${DELETION_VECTOR_FILE_NAME_CORE}_([^.]+)\.bin".r
+  private final val deletionVectorFileNamePattern = deletionVectorFileNameRegex.pattern
+
   final lazy val STRUCT_TYPE: StructType =
     Action.addFileSchema("deletionVector").dataType.asInstanceOf[StructType]
 
@@ -261,6 +268,33 @@ object DeletionVectorDescriptor {
       pathOrInlineDv = encodeData(data),
       sizeInBytes = data.length,
       cardinality = cardinality)
+
+  /**
+   * Returns whether the path points to a deletion vector file.
+   * Note, external writers are no enforced to create DV files with the same naming convertions.
+   * This function is intended for testing. */
+  private[delta] def isDeletionVectorPath(path: Path): Boolean =
+    deletionVectorFileNamePattern.matcher(path.getName).matches()
+
+  /** Only for testing. */
+  private[delta] def isDeletionVectorPath(path: String): Boolean =
+    isDeletionVectorPath(new Path(path))
+
+  /** Same as above but as a column expression. Only for testing. */
+  private[delta] def isDeletionVectorPath(pathCol: Column): Column =
+    DeltaUDF.booleanFromString(isDeletionVectorPath)(pathCol)
+
+  /** Returns a boolean column that corresponds to whether each deletion vector is inline. */
+  def isInline(dv: Column): Column =
+    DeltaUDF.booleanFromDeletionVectorDescriptor(_.isInline)(dv)
+
+  /**
+   * Returns a column with the url encoded deletion vector paths.
+   * WARNING: It throws an exception if it encounters any inline DVs. The caller is responsible
+   * for handling these separately.
+   */
+  def urlEncodedPath(deletionVectorCol: Column, tablePath: Path): Column =
+    DeltaUDF.stringFromDeletionVectorDescriptor(_.urlEncodedPath(tablePath))(deletionVectorCol)
 
   /**
    * This produces the same output as [[DeletionVectorDescriptor.uniqueId]] but as a column

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/TableFeatureSupport.scala
@@ -555,7 +555,7 @@ object DropTableFeatureUtils extends DeltaLogging {
       retryOnFailure: Boolean = false): Boolean = {
     val log = table.deltaLog
     val snapshot = log.update(checkIfUpdatedSinceTs = Some(snapshotRefreshStartTs))
-    val emptyCommitTS = System.nanoTime()
+    val emptyCommitTS = table.deltaLog.clock.nanoTime()
     log.startTransaction(table.catalogTable, Some(snapshot))
       .commit(Nil, DeltaOperations.EmptyCommit)
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/actions/actions.scala
@@ -959,6 +959,10 @@ case class RemoveFile(
   @JsonIgnore
   override def getFileSize: Long = size.getOrElse(0L)
 
+  /** Only for testing. */
+  @JsonIgnore
+  private [delta] def isDVTombstone: Boolean = DeletionVectorDescriptor.isDeletionVectorPath(new Path(path))
+
 }
 // scalastyle:on
 

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/alterDeltaTableCommands.scala
@@ -385,9 +385,9 @@ case class AlterTableDropFeatureDeltaCommand(
       // Note, for features that cannot be disabled we solely rely for correctness on
       // validateRemoval.
       val requiresHistoryValidation = removableFeature.requiresHistoryProtection
-      val startTimeNs = System.nanoTime()
+      val startTimeNs = table.deltaLog.clock.nanoTime()
       val preDowngradeMadeChanges =
-        removableFeature.preDowngradeCommand(table).removeFeatureTracesIfNeeded()
+        removableFeature.preDowngradeCommand(table).removeFeatureTracesIfNeeded(sparkSession)
       if (requiresHistoryValidation) {
         // Generate a checkpoint after the cleanup that is based on commits that do not use
         // the feature. This intends to help slow-moving tables to qualify for history truncation
@@ -483,7 +483,7 @@ case class AlterTableDropFeatureDeltaCommand(
     val deltaLog = table.deltaLog
     recordDeltaOperation(deltaLog, "delta.ddl.alter.dropFeatureWithCheckpointProtection") {
       var startTimeNs = System.nanoTime()
-      removableFeature.preDowngradeCommand(table).removeFeatureTracesIfNeeded()
+      removableFeature.preDowngradeCommand(table).removeFeatureTracesIfNeeded(sparkSession)
 
       // Create and validate the barrier checkpoints. The checkpoint are created on top of
       // empty commits. However, this is not guaranteed. Other txns might interleave the empty

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -470,7 +470,7 @@ trait DeltaSQLConfBase {
       .createWithDefaultFunction(() => SQLConf.get.getConf(DeltaSQLConf.FAST_DROP_FEATURE_ENABLED))
 
   val FAST_DROP_FEATURE_DV_TOMBSTONE_COUNT_THRESHOLD =
-    buildConf("tableFeatures.dev.fastDropFeature.DVTombstoneCountThreshold")
+    buildConf("tableFeatures.dev.fastDropFeature.dvTombstoneCountThreshold")
       .doc(
         """The maximum number of DV tombstones we are allowed store to memory when dropping
           |deletion vectors. When the resulting number of DV tombstones is higher, we use

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -450,6 +450,36 @@ trait DeltaSQLConfBase {
       .booleanConf
       .createWithDefault(false)
 
+  val FAST_DROP_FEATURE_DV_DISCOVERY_IN_VACUUM_DISABLED =
+    buildConf("tableFeatures.dev.fastDropFeature.DVDiscoveryInVacuum.disabled")
+      .internal()
+      .doc(
+        """Whether to allow DV discovery in Vacuum.
+          |This is config is only intended for testing purposes.""".stripMargin)
+      .booleanConf
+      .createWithDefault(false)
+
+  val FAST_DROP_FEATURE_GENERATE_DV_TOMBSTONES =
+    buildConf("tableFeatures.dev.fastDropFeature.generateDVTombstones.enabled")
+      .internal()
+      .doc(
+        """Whether to generate DV tombstones when dropping deletion vectors.
+          |These make sure deletion vector files won't accidentally be vacuumed by clients
+          |that do not support DVs.""".stripMargin)
+      .booleanConf
+      .createWithDefaultFunction(() => SQLConf.get.getConf(DeltaSQLConf.FAST_DROP_FEATURE_ENABLED))
+
+  val FAST_DROP_FEATURE_DV_TOMBSTONE_COUNT_THRESHOLD =
+    buildConf("tableFeatures.dev.fastDropFeature.DVTombstoneCountThreshold")
+      .doc(
+        """The maximum number of DV tombstones we are allowed store to memory when dropping
+          |deletion vectors. When the resulting number of DV tombstones is higher, we use
+          |a special commit for large outputs. This does not materialize results to memory
+          |but does not retry in case of a conflict.""".stripMargin)
+      .intConf
+      .checkValue(_ >= 0, "DVTombstoneCountThreshold must not be negative.")
+      .createWithDefault(10000)
+
   val DELTA_MAX_SNAPSHOT_LINEAGE_LENGTH =
     buildConf("maxSnapshotLineageLength")
       .internal()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

Drop feature with checkpoint protection allows dropped features to live in the table history. This has consequences in the vacuum command. This is because vacuum only reads the latest snapshot, and uses that to decide what can be deleted or not. This could lead clients that do not support past feature(s) to incorrectly vacuum auxiliary files, unless the latest snapshot can prevent this from happening using only features from the reduced protocol. The way that the table snapshot prevents deletion of files is by referencing files that were recently removed from the table (in the last 7 days) in RemoveFile actions or "tombstones".

This is problematic when a newer feature extends the functionality of these tombstones. For instance, the Deletion Vectors feature has `RemoveFile` actions that contain a reference both to the main file as well as the auxiliary Deletion Vector file. But after the downgrade, clients will not see that auxiliary DV file reference anymore, and will not preserve Deletion Vectors that were only removed from the table within the past 7 days.

This PR resolves this issue by ensuring that the auxiliary files are referenced by adding RemoveFile actions during the pre-downgrade process of Deletion Vectors.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Added new tests in `DeltaFastDropFeatureSuite`.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.