### PR TITLE
[Spark] Reorganise where deletion vectors are added to the test suites for CLONE

### DIFF
--- a/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableSQLSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/CloneTableSQLSuite.scala
@@ -31,6 +31,12 @@ import org.apache.spark.util.Utils
 class CloneTableSQLSuite extends CloneTableSuiteBase
   with DeltaColumnMappingTestUtils
 {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    disableDeletionVectors(spark.conf)
+  }
+
   // scalastyle:off argcount
   override protected def cloneTable(
       source: String,
@@ -346,7 +352,7 @@ object CloneTableSQLTestUtils {
 }
 
 class CloneTableScalaDeletionVectorSuite
-    extends CloneTableSQLSuite
+    extends CloneTableScalaSuite
     with DeltaSQLCommandTest
     with DeltaExcludedTestMixin
     with DeletionVectorsTestUtils {

--- a/spark/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/DeletionVectorsTestUtils.scala
@@ -51,6 +51,13 @@ trait DeletionVectorsTestUtils extends QueryTest with SharedSparkSession with De
     spark.conf.set(DeltaSQLConf.MERGE_USE_PERSISTENT_DELETION_VECTORS.key, merge.toString)
   }
 
+  /** Disable persistent deletion vectors in new tables and all supported DML commands. */
+  def disableDeletionVectors(conf: RuntimeConfig): Unit = {
+    conf.set(DeltaConfigs.ENABLE_DELETION_VECTORS_CREATION.defaultTablePropertyKey, false.toString)
+    conf.set(DeltaSQLConf.DELETE_USE_PERSISTENT_DELETION_VECTORS.key, false.toString)
+    conf.set(DeltaSQLConf.UPDATE_USE_PERSISTENT_DELETION_VECTORS.key, false.toString)
+  }
+
   def enableDeletionVectorsForAllSupportedOperations(spark: SparkSession): Unit =
     enableDeletionVectors(spark, delete = true, update = true)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Just some minor reorganisation of tests to ensure CLONE codepaths are tested with and without DVs as expected.

## How was this patch tested?

Test-only PR.

## Does this PR introduce _any_ user-facing changes?

No
