### PR TITLE
[VARIANT] Upgrade variantType-preview to variantType

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -2337,6 +2337,20 @@ trait DeltaSQLConfBase {
       .createWithDefault(false)
 
   ///////////
+  // VARIANT
+  ///////////////////
+  val FORCE_USE_PREVIEW_VARIANT_FEATURE = buildConf("variant.forceUsePreviewTableFeature")
+    .internal()
+    .doc(
+      """
+        | If true, creating new tables with variant columns only attaches the 'variantType-preview'
+        | table feature. Attempting to operate on existing tables created with the stable feature
+        | does not require that the preview table feature be present.
+        |""".stripMargin)
+    .booleanConf
+    .createWithDefault(false)
+
+  ///////////
   // TESTING
   ///////////
   val DELTA_POST_COMMIT_HOOK_THROW_ON_ERROR =

--- a/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantSuite.scala
+++ b/spark/src/test/scala-spark-master/org/apache/spark/sql/delta/DeltaVariantSuite.scala
@@ -23,6 +23,7 @@ import io.delta.tables.DeltaTable
 import org.apache.spark.sql.delta.actions.Protocol
 import org.apache.spark.sql.delta.actions.TableFeatureProtocolUtils
 import org.apache.spark.sql.delta.commands.optimize.OptimizeMetrics
+import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.test.{DeltaSQLCommandTest, DeltaSQLTestUtils, TestsStatistics}
 
 import org.apache.spark.{SparkException, SparkThrowable}
@@ -70,7 +71,7 @@ class DeltaVariantSuite
       sql("INSERT INTO tbl (SELECT 'foo', parse_json(cast(id + 99 as string)) FROM range(1))")
       assert(spark.table("tbl").selectExpr("v::int").head == Row(99))
       assertVariantTypeTableFeatures(
-        "tbl", expectPreviewFeature = true, expectStableFeature = false)
+        "tbl", expectPreviewFeature = false, expectStableFeature = true)
     }
   }
 
@@ -113,7 +114,7 @@ class DeltaVariantSuite
       // add table feature
       sql(
         s"ALTER TABLE tbl " +
-        s"SET TBLPROPERTIES('delta.feature.variantType-preview' = 'supported')"
+        s"SET TBLPROPERTIES('delta.feature.variantType' = 'supported')"
       )
 
       sql("ALTER TABLE tbl ADD COLUMN v VARIANT")
@@ -123,7 +124,7 @@ class DeltaVariantSuite
         e,
         "DELTA_FEATURES_REQUIRE_MANUAL_ENABLEMENT",
         parameters = Map(
-          "unsupportedFeatures" -> VariantTypePreviewTableFeature.name,
+          "unsupportedFeatures" -> VariantTypeTableFeature.name,
           "supportedFeatures" -> currentFeatures
         )
       )
@@ -133,8 +134,8 @@ class DeltaVariantSuite
 
       assert(
         getProtocolForTable("tbl") ==
-        VariantTypePreviewTableFeature.minProtocolVersion
-          .withFeature(VariantTypePreviewTableFeature)
+        VariantTypeTableFeature.minProtocolVersion
+          .withFeature(VariantTypeTableFeature)
           .withFeature(InvariantsTableFeature)
           .withFeature(AppendOnlyTableFeature)
       )
@@ -147,14 +148,133 @@ class DeltaVariantSuite
       sql("INSERT INTO tbl (SELECT parse_json(cast(id + 99 as string)) FROM range(1))")
       assert(spark.table("tbl").selectExpr("v::int").head == Row(99))
       assertVariantTypeTableFeatures(
-        "tbl", expectPreviewFeature = true, expectStableFeature = false)
+        "tbl", expectPreviewFeature = false, expectStableFeature = true)
       sql(
         s"ALTER TABLE tbl " +
-        s"SET TBLPROPERTIES('delta.feature.variantType' = 'supported')"
+        s"SET TBLPROPERTIES('delta.feature.variantType-preview' = 'supported')"
       )
       assertVariantTypeTableFeatures(
         "tbl", expectPreviewFeature = true, expectStableFeature = true)
       assert(spark.table("tbl").selectExpr("v::int").head == Row(99))
+    }
+  }
+
+  test("creating a new variant table uses only the stable table feature") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(s STRING, v VARIANT) USING DELTA")
+      sql("INSERT INTO tbl (SELECT 'foo', parse_json(cast(id + 99 as string)) FROM range(1))")
+      assert(spark.table("tbl").selectExpr("v::int").head == Row(99))
+      assertVariantTypeTableFeatures(
+        "tbl", expectPreviewFeature = false, expectStableFeature = true)
+    }
+  }
+
+  test("manually adding preview table feature does not require adding stable table feature") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(s STRING) USING delta")
+      sql(
+        s"ALTER TABLE tbl " +
+        s"SET TBLPROPERTIES('delta.feature.variantType-preview' = 'supported')"
+      )
+
+      sql("ALTER TABLE tbl ADD COLUMN v VARIANT")
+
+      sql("INSERT INTO tbl (SELECT 'foo', parse_json(cast(id + 99 as string)) FROM range(1))")
+      assert(spark.table("tbl").selectExpr("v::int").head == Row(99))
+
+      assertVariantTypeTableFeatures(
+        "tbl",
+        expectPreviewFeature = true,
+        expectStableFeature = false
+      )
+    }
+  }
+
+  test("creating table with preview feature does not add stable feature") {
+    withTable("tbl") {
+      sql(s"""CREATE TABLE tbl(v VARIANT)
+              USING delta
+              TBLPROPERTIES('delta.feature.variantType-preview' = 'supported')"""
+      )
+      sql("INSERT INTO tbl (SELECT parse_json(cast(id + 99 as string)) FROM range(1))")
+      assertVariantTypeTableFeatures(
+        "tbl",
+        expectPreviewFeature = true,
+        expectStableFeature = false
+      )
+    }
+  }
+
+  test("enabling 'FORCE_USE_PREVIEW_VARIANT_FEATURE' adds preview table feature for new table") {
+    withSQLConf(DeltaSQLConf.FORCE_USE_PREVIEW_VARIANT_FEATURE.key -> "true") {
+      withTable("tbl") {
+        sql("CREATE TABLE tbl(s STRING, v VARIANT) USING DELTA")
+        sql("INSERT INTO tbl (SELECT 'foo', parse_json(cast(id + 99 as string)) FROM range(1))")
+        assert(spark.table("tbl").selectExpr("v::int").head == Row(99))
+        assertVariantTypeTableFeatures(
+          "tbl", expectPreviewFeature = true, expectStableFeature = false)
+      }
+    }
+  }
+
+  test("enabling 'FORCE_USE_PREVIEW_VARIANT_FEATURE' and adding a variant column hints to add " +
+       " the preview table feature") {
+    withSQLConf(DeltaSQLConf.FORCE_USE_PREVIEW_VARIANT_FEATURE.key -> "true") {
+      withTable("tbl") {
+        sql("CREATE TABLE tbl(s STRING) USING delta")
+
+        val e = intercept[SparkThrowable] {
+          sql("ALTER TABLE tbl ADD COLUMN v VARIANT")
+        }
+
+        checkError(
+          e,
+          "DELTA_FEATURES_REQUIRE_MANUAL_ENABLEMENT",
+          parameters = Map(
+            "unsupportedFeatures" -> VariantTypePreviewTableFeature.name,
+            "supportedFeatures" -> DeltaLog.forTable(spark, TableIdentifier("tbl"))
+              .unsafeVolatileSnapshot
+              .protocol
+              .implicitlyAndExplicitlySupportedFeatures
+              .map(_.name)
+              .toSeq
+              .sorted
+              .mkString(", ")
+          )
+        )
+
+        sql(
+          s"ALTER TABLE tbl " +
+          s"SET TBLPROPERTIES('delta.feature.variantType-preview' = 'supported')"
+        )
+        sql("ALTER TABLE tbl ADD COLUMN v VARIANT")
+        sql("INSERT INTO tbl (SELECT 'foo', parse_json(cast(id + 99 as string)) FROM range(1))")
+        assert(spark.table("tbl").selectExpr("v::int").head == Row(99))
+
+        assertVariantTypeTableFeatures(
+          "tbl",
+          expectPreviewFeature = true,
+          expectStableFeature = false
+        )
+      }
+    }
+  }
+
+  test("enabling 'FORCE_USE_PREVIEW_VARIANT_FEATURE' on table with stable feature does not " +
+       "require adding preview feature") {
+    withTable("tbl") {
+      sql("CREATE TABLE tbl(s STRING, v VARIANT) USING DELTA")
+      sql("INSERT INTO tbl (SELECT 'foo', parse_json(cast(id + 99 as string)) FROM range(1))")
+      assert(spark.table("tbl").selectExpr("v::int").head == Row(99))
+      assertVariantTypeTableFeatures(
+        "tbl", expectPreviewFeature = false, expectStableFeature = true)
+
+      withSQLConf(DeltaSQLConf.FORCE_USE_PREVIEW_VARIANT_FEATURE.key -> "true") {
+        sql("INSERT INTO tbl (SELECT 'foo', parse_json(cast(id + 99 as string)) FROM range(1))")
+        assert(spark.table("tbl").selectExpr("v::int").count == 2)
+        assertVariantTypeTableFeatures(
+          "tbl", expectPreviewFeature = false, expectStableFeature = true)
+      }
     }
   }
 
@@ -305,8 +425,8 @@ class DeltaVariantSuite
         .selectExpr("tableFeatures")
         .collect()(0)
         .getAs[MutableSeq[String]](0)
-      assert(tableFeatures.find(f => f == VariantTypePreviewTableFeature.name).nonEmpty)
-      assert(tableFeatures.find(f => f == VariantTypeTableFeature.name).isEmpty)
+      assert(tableFeatures.find(f => f == VariantTypePreviewTableFeature.name).isEmpty)
+      assert(tableFeatures.find(f => f == VariantTypeTableFeature.name).nonEmpty)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

upgrades the variant type preview feature to GA by adding a new table feature VariantType

Note there were no changes to the spec between preview and GA, so we will continue allow reading -preview features.

New tables going forward with variants are created with the `variantType` stable table feature.

A new config `"variant.forceUsePreviewTableFeature"` is also added to revert to the old behavior (create variant tables with `variantType-preview`) if need be

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

added UTs.

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
