### PR TITLE
Fix a correctness issue around referenceless expressions being evaluated as partition filters

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/DeltaTable.scala
@@ -309,9 +309,10 @@ object DeltaTableUtils extends PredicateHelper
       partitionColumns: Seq[String],
       spark: SparkSession): Boolean = {
     val nameEquality = spark.sessionState.analyzer.resolver
-    condition.references.forall { r =>
-      partitionColumns.exists(nameEquality(r.name, _))
-    }
+    val allowReferencelessPartitionFilters = spark.sessionState.conf
+      .getConf(DeltaSQLConf.UNSAFE_ALLOW_REFERENCELESS_PARTITION_FILTERS)
+    (condition.references.nonEmpty || allowReferencelessPartitionFilters) &&
+      condition.references.forall { r => partitionColumns.exists(nameEquality(r.name, _)) }
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -1435,6 +1435,19 @@ trait DeltaSQLConfBase {
       .intConf
       .createWithDefault(32)
 
+  val UNSAFE_ALLOW_REFERENCELESS_PARTITION_FILTERS =
+    buildConf("unsafe.skipping.allowReferencelessPartitionFilters")
+      .internal()
+      .doc(
+        """Filter expressions that didn't have any references, such as rand() were incorrectly
+          |treated as a partition filter. When this flag is disabled (false), these expressions
+          |will NOT be treated as partition filters, therefore results will be correct.
+          |However, since this is a behavior change, providing a flag to return to the old behavior
+          |even though the filters will be double evaluated.
+          |""".stripMargin)
+      .booleanConf
+      .createWithDefault(false)
+
   val MDC_NUM_RANGE_IDS =
     SQLConf.buildConf("spark.databricks.io.skipping.mdc.rangeId.max")
       .internal()

--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/DataSkippingReader.scala
@@ -23,7 +23,6 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.delta.skipping.clustering.{ClusteredTableUtils, ClusteringColumnInfo}
 import org.apache.spark.sql.delta.{DeltaColumnMapping, DeltaLog, DeltaTableUtils}
-import org.apache.spark.sql.delta.ClassicColumnConversions._
 import org.apache.spark.sql.delta.actions.{AddFile, Metadata}
 import org.apache.spark.sql.delta.implicits._
 import org.apache.spark.sql.delta.metering.DeltaLogging
@@ -1175,6 +1174,22 @@ trait DataSkippingReaderBase
     dataSkippingType
   }
 
+  /** Split filters with And conditions into separate filters */
+  private def splitConjunctivePredicates(expr: Expression): Seq[Expression] = {
+    val result = new scala.collection.mutable.ArrayBuffer[Expression]
+    val stack = new scala.collection.mutable.Stack[Expression]
+    stack.push(expr)
+    while (stack.nonEmpty) {
+      stack.pop() match {
+        case And(cond1, cond2) =>
+          stack.push(cond2)
+          stack.push(cond1)
+        case other => result += other
+      }
+    }
+    result.toSeq
+  }
+
   /**
    * Gathers files that should be included in a scan based on the given predicates.
    * Statistics about the amount of data that will be read are gathered and returned.
@@ -1211,10 +1226,12 @@ trait DataSkippingReaderBase
 
     import DeltaTableUtils._
     val partitionColumns = metadata.partitionColumns
+    // Be defensive, break apart filters further if possible
+    val allFilters = filters.flatMap(splitConjunctivePredicates)
 
     // For data skipping, avoid using the filters that involve subqueries.
 
-    val (subqueryFilters, flatFilters) = filters.partition {
+    val (subqueryFilters, flatFilters) = allFilters.partition {
       case f => containsSubquery(f)
     }
 

--- a/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaTests.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/delta/stats/DataSkippingDeltaTests.scala
@@ -30,13 +30,14 @@ import org.apache.commons.io.FileUtils
 import org.apache.hadoop.fs.Path
 import org.scalatest.GivenWhenThen
 
+import org.apache.spark.sql.catalyst.plans.logical.Filter
+
 // scalastyle:off import.ordering.noEmptyLine
 import org.apache.spark.SparkConf
 import org.apache.spark.sql._
-import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, PredicateHelper}
-import org.apache.spark.sql.functions.{col, lit}
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, PredicateHelper, Rand}
+import org.apache.spark.sql.functions.{col, expr, lit}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
@@ -1726,6 +1727,70 @@ trait DataSkippingDeltaTestsBase extends DeltaExcludedBySparkVersionTestMixinShi
       )
       val data = spark.sql("select * from tbl").collect().toSeq.toString
       checkSkipping(deltaLog, hits, misses, data, false)
+    }
+  }
+
+  test("do not pushdown expressions without references as partition filters") {
+    import testImplicits._
+    withTempDir { dir =>
+      val path = dir.getCanonicalPath
+      spark.range(10000).withColumn("is_odd", 'id % 2).withColumn("is_even", ('id + 1) % 2)
+        .write.partitionBy("is_odd").format("delta").save(path)
+
+      val log = DeltaLog.forTable(spark, path)
+      val snapshot = log.update()
+      val randExpr = expr("rand() <= 0.5")
+      val partitionFilter = expr("is_odd = 1")
+      val dataFilter = expr("is_even = 1")
+      val randWithPartitionFilter = expr("rand() <= 0.5 and is_odd = 1")
+      val randWithDataFilter = expr("rand() <= 0.5 and is_even = 1")
+
+      def getDeltaScan(filters: Seq[Column]): DeltaScan = {
+        var df = spark.read.format("delta").load(path)
+        filters.foreach { col =>
+          df = df.where(col)
+        }
+        val filterExprs = df.queryExecution.analyzed.collect {
+          case Filter(condition, _) => condition
+        }
+        snapshot.filesForScan(filterExprs)
+      }
+
+      val scan = getDeltaScan(Seq(randExpr))
+      assert(scan.partitionFilters.isEmpty, "partition filters were not empty")
+      assert(scan.partitionLikeDataFilters.isEmpty, "partition-like filters were not empty")
+      assert(scan.rewrittenPartitionLikeDataFilters.isEmpty,
+        "rewritten partition-like filters were not empty")
+
+      Seq(
+        Seq(randExpr),
+        Seq(randExpr, partitionFilter),
+        Seq(randExpr, dataFilter),
+        Seq(randExpr, partitionFilter, dataFilter),
+        Seq(randWithPartitionFilter),
+        Seq(randWithDataFilter)
+      ).foreach { exprs =>
+        val scan2 = getDeltaScan(exprs)
+        assert(scan2.unusedFilters.nonEmpty, "Unused filter should contain rand")
+        assert(scan2.unusedFilters.exists(_.exists { _.isInstanceOf[Rand] }),
+          s"Unused filter should contain rand: ${scan2.unusedFilters}")
+      }
+
+      withSQLConf(DeltaSQLConf.UNSAFE_ALLOW_REFERENCELESS_PARTITION_FILTERS.key -> "true") {
+        Seq(
+          Seq(randExpr),
+          Seq(randExpr, partitionFilter),
+          Seq(randExpr, dataFilter),
+          Seq(randExpr, partitionFilter, dataFilter),
+          Seq(randWithPartitionFilter),
+          Seq(randWithDataFilter)
+        ).foreach { exprs =>
+          val scan3 = getDeltaScan(exprs)
+
+          assert(!scan3.unusedFilters.exists(_.exists { _.isInstanceOf[Rand] }),
+            s"Unused filter should not contain rand")
+        }
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
Fixes a data correctness issue, when non-deterministic expressions without any reference columns are used, such as rand() as a filter on a Delta table. These filters were being evaluated as partition filters and getting double evaluated. This caused a filter such as `rand() < 0.5` to filter ~75% of the data (due to being double evaluated) instead of just 50%.

Added a feature flag just in case for old behavior

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Added a unit test and tested the old behavior as well with a feature flag

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Filters such as rand() will not be double evaluated anymore
