### PR TITLE
Kernel: Add a conversion utility to convert Iceberg schema to Delta schema

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -386,3 +386,13 @@ license, which is reproduced here as well:
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+--------------------------------------------------------------------------------
+
+This product includes code from Apache Iceberg.
+
+* io.delta.kernel.internal.util.IcebergTypeToStructType visitor implementation based on org.apache.iceberg.spark.TypeToSparkType
+
+Copyright: 2018-2024 The Apache Software Foundation
+Home page: https://iceberg.apache.org/
+License: https://www.apache.org/licenses/LICENSE-2.0

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -20,5 +20,8 @@ from the Apache Spark project (www.github.com/apache/spark)
 Apache Spark
 Copyright 2014 and onwards The Apache Software Foundation.
 
+Apache Iceberg
+Copyright 2017-2024 The Apache Software Foundation
+
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/build.sbt
+++ b/build.sbt
@@ -577,7 +577,8 @@ lazy val kernelApi = (project in file("kernel/kernel-api"))
       "com.fasterxml.jackson.core" % "jackson-core" % "2.13.5",
       "com.fasterxml.jackson.core" % "jackson-annotations" % "2.13.5",
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % "2.13.5",
-
+      "org.apache.iceberg" % "iceberg-api" % "1.6.1",
+      "org.apache.iceberg" % "iceberg-core" % "1.6.1",
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
       "junit" % "junit" % "4.13.2" % "test",
       "com.novocode" % "junit-interface" % "0.11" % "test",

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/IcebergTypeToStructType.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/IcebergTypeToStructType.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (2023) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.delta.kernel.internal.util;
+
+import io.delta.kernel.types.ArrayType;
+import io.delta.kernel.types.BinaryType;
+import io.delta.kernel.types.BooleanType;
+import io.delta.kernel.types.DataType;
+import io.delta.kernel.types.DateType;
+import io.delta.kernel.types.DecimalType;
+import io.delta.kernel.types.DoubleType;
+import io.delta.kernel.types.FieldMetadata;
+import io.delta.kernel.types.FloatType;
+import io.delta.kernel.types.IntegerType;
+import io.delta.kernel.types.LongType;
+import io.delta.kernel.types.MapType;
+import io.delta.kernel.types.StringType;
+import io.delta.kernel.types.StructField;
+import io.delta.kernel.types.StructType;
+import io.delta.kernel.types.TimestampNTZType;
+import io.delta.kernel.types.TimestampType;
+import java.util.List;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
+
+/**
+ * Schema visitor to convert Iceberg types to Delta kernel types Most code and behavior is taken
+ * from {@link org.apache.iceberg.spark.TypeToSparkType} with modifications for copying field IDs to
+ * FieldMetadata
+ */
+class IcebergTypeToStructType extends TypeUtil.SchemaVisitor<DataType> {
+  @Override
+  public DataType schema(Schema schema, DataType structType) {
+    return structType;
+  }
+
+  public DataType list(Types.ListType list, DataType elementResult) {
+    return new ArrayType(elementResult, list.isElementOptional());
+  }
+
+  @Override
+  public DataType map(Types.MapType map, DataType keyResult, DataType valueResult) {
+    return new MapType(keyResult, valueResult, map.isValueOptional());
+  }
+
+  @Override
+  public DataType struct(Types.StructType struct, List<DataType> fieldResults) {
+    List<Types.NestedField> fields = struct.fields();
+
+    List<StructField> structFields = Lists.newArrayListWithExpectedSize(fieldResults.size());
+    for (int i = 0; i < fields.size(); i++) {
+      Types.NestedField field = fields.get(i);
+      DataType type = fieldResults.get(i);
+      StructField structField =
+          new StructField(
+              field.name(),
+              type,
+              field.isOptional(),
+              FieldMetadata.builder()
+                  .putLong(ColumnMapping.COLUMN_MAPPING_ID_KEY, field.fieldId())
+                  .build());
+      // ToDo: No concept of field comments in Delta StructType?
+      structFields.add(structField);
+    }
+
+    return new StructType(structFields);
+  }
+
+  @Override
+  public DataType field(Types.NestedField field, DataType fieldResult) {
+    return fieldResult;
+  }
+
+  @Override
+  public DataType primitive(Type.PrimitiveType primitive) {
+    switch (primitive.typeId()) {
+      case BOOLEAN:
+        return BooleanType.BOOLEAN;
+      case INTEGER:
+        return IntegerType.INTEGER;
+      case LONG:
+        return LongType.LONG;
+      case FLOAT:
+        return FloatType.FLOAT;
+      case DOUBLE:
+        return DoubleType.DOUBLE;
+      case DATE:
+        return DateType.DATE;
+      case TIME:
+        throw new UnsupportedOperationException("Spark does not support time fields");
+      case TIMESTAMP:
+        Types.TimestampType ts = (Types.TimestampType) primitive;
+        if (ts.shouldAdjustToUTC()) {
+          return TimestampType.TIMESTAMP;
+        } else {
+          return TimestampNTZType.TIMESTAMP_NTZ;
+        }
+      case STRING:
+        return StringType.STRING;
+      case UUID:
+        // use String
+        return StringType.STRING;
+      case FIXED:
+        return BinaryType.BINARY;
+      case BINARY:
+        return BinaryType.BINARY;
+      case DECIMAL:
+        Types.DecimalType decimal = (Types.DecimalType) primitive;
+        return new DecimalType(decimal.precision(), decimal.scale());
+      default:
+        throw new UnsupportedOperationException(
+            "Cannot convert unknown type to Spark: " + primitive);
+    }
+  }
+}

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/SchemaUtils.java
@@ -23,6 +23,8 @@ import io.delta.kernel.internal.DeltaErrors;
 import io.delta.kernel.types.*;
 import java.util.*;
 import java.util.stream.Collectors;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.TypeUtil;
 
 /**
  * Utility methods for schema related operations such as validating the schema has no duplicate
@@ -75,6 +77,10 @@ public class SchemaUtils {
     }
 
     validateSupportedType(schema);
+  }
+
+  public static StructType icebergToDeltaSchema(Schema icebergSchema) {
+    return (StructType) TypeUtil.visit(icebergSchema, new IcebergTypeToStructType());
   }
 
   /**


### PR DESCRIPTION
This change adds a `icebergToDeltaSchema` util function to SchemaUtils which converts an Iceberg Schema to a Delta schema. 

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [ X] Kernel
- [ ] Other (fill in here)

## Description
This change adds a `icebergToDeltaSchema` util function to SchemaUtils which converts an Iceberg Schema to a Delta schema. The utility function should be a part of kernel to enable any consumers of kernel to be able to do this kind of metadata conversion.


## How was this patch tested?
Added unit tests.

## Does this PR introduce _any_ user-facing changes?
New utility API added
