### PR TITLE
[UniForm] Allow Delta to convert Iceberg stats during UniForm conversion

### DIFF
--- a/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergStatsUtils.scala
+++ b/iceberg/src/main/scala/org/apache/spark/sql/delta/IcebergStatsUtils.scala
@@ -1,0 +1,192 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands.convert
+
+import java.lang.{Integer => JInt, Long => JLong}
+import java.nio.ByteBuffer
+
+import scala.collection.JavaConverters._
+import scala.util.control.NonFatal
+
+import org.apache.spark.sql.delta.metering.DeltaLogging
+import org.apache.spark.sql.delta.stats.DeltaStatistics._
+import org.apache.spark.sql.delta.util.JsonUtils
+import org.apache.iceberg.{DataFile, PartitionData, PartitionField, Schema, StructLike, Table}
+import org.apache.iceberg.types.{Conversions, Type => IcebergType}
+import org.apache.iceberg.types.Type.{PrimitiveType => IcebergPrimitiveType, TypeID}
+import org.apache.iceberg.types.Types.{
+  ListType => IcebergListType,
+  MapType => IcebergMapType,
+  NestedField,
+  StringType => IcebergStringType,
+  StructType => IcebergStructType
+}
+
+object IcebergStatsUtils extends DeltaLogging {
+
+  private val STATS_ALLOW_TYPES = Set[TypeID](
+    TypeID.BOOLEAN,
+    TypeID.INTEGER,
+    TypeID.LONG,
+    TypeID.FLOAT,
+    TypeID.DOUBLE,
+    TypeID.DATE,
+//    TypeID.TIME,
+//    TypeID.TIMESTAMP,
+//    TypeID.TIMESTAMP_NANO,
+    TypeID.STRING,
+//    TypeID.UUID,
+//    TypeID.FIXED,
+    TypeID.BINARY
+//    TypeID.DECIMAL
+  )
+
+  /**
+   * Convert Iceberg DataFile stats into a Json string containing Delta stats.
+   * We will abandon conversion if Iceberg DataFile has a null or empty stats for
+   * any criteria used in the conversion.
+   *
+   * @param icebergSchema            Iceberg table schema
+   * @param dataFile                 Iceberg DataFile that contains stats info
+   * @return None if stats is missing on the DataFile or error occurs during conversion
+   */
+  def icebergStatsToDelta(
+      icebergSchema: Schema,
+      dataFile: DataFile): Option[String] = {
+    try {
+      // Any empty or null fields means Iceberg has disabled column stats
+      if (dataFile.upperBounds == null ||
+        dataFile.upperBounds.isEmpty ||
+        dataFile.lowerBounds == null ||
+        dataFile.lowerBounds.isEmpty ||
+        dataFile.nullValueCounts == null ||
+        dataFile.nullValueCounts.isEmpty
+      ) {
+        return None
+      }
+      Some(icebergStatsToDelta(
+        icebergSchema,
+        dataFile.recordCount,
+        dataFile.upperBounds.asScala.toMap,
+        dataFile.lowerBounds.asScala.toMap,
+        dataFile.nullValueCounts.asScala.toMap
+      ))
+    } catch {
+      case NonFatal(e) =>
+        logError("Exception while converting Iceberg stats to Delta format", e)
+        None
+    }
+  }
+
+  /**
+   * Convert Iceberg DataFile stats into Delta stats.
+   *
+   * Iceberg stats consist of multiple maps from field_id to value. The maps include
+   * max_value, min_value and null_counts.
+   * Delta stats is a Json string.
+   *
+   **********************************************************
+   * Example:
+   **********************************************************
+   * Assume we have an Iceberg table of schema
+   * ( col1: int, field_id = 1, col2: string, field_id = 2 )
+   *
+   * The following Iceberg stats:
+   *    numRecords 100
+   *    max_value { 1 -> 200, 2 -> "max value" }
+   *    min_value { 1 -> 10, 2 -> "min value" }
+   *    null_counts { 1 -> 0, 2 -> 20 }
+   * will be converted into the following Delta style stats as a Json str
+   *
+   * {
+   *    numRecords: 100,
+   *    maxValues: {
+   *      "col1": 200,
+   *      "col2" "max value"
+   *    },
+   *    minValues: {
+   *      "col1": 10,
+   *      "col2": "min value"
+   *    },
+   *    nullCount: {
+   *      "col1": 0,
+   *      "col2": 20
+   *    }
+   * }
+   **********************************************************
+   *
+   * See also [[org.apache.spark.sql.delta.stats.StatsCollectionUtils]] for more
+   * about Delta stats.
+   *
+   * @param icebergSchema          Iceberg table schema
+   * @param numRecords             Iceberg stats of numRecords
+   * @param maxMap                 Iceberg stats of max value ( field_id -> value )
+   * @param minMap                 Iceberg stats of min value ( field_id -> value )
+   * @param nullCountMap           Iceberg stats of null count ( field_id -> value )
+   * @param logicalToPhysicalNames Delta logical to physical name mapping
+   * @return json string representing Delta stats
+   */
+  private[convert] def icebergStatsToDelta(
+      icebergSchema: Schema,
+      numRecords: Long,
+      maxMap: Map[JInt, ByteBuffer],
+      minMap: Map[JInt, ByteBuffer],
+      nullCountMap: Map[JInt, JLong]): String = {
+
+    def deserialize(ftype: IcebergType, value: Any): Any = {
+      (ftype, value) match {
+        case (_, null) => null
+        case (_: IcebergStringType, bb: ByteBuffer) =>
+          Conversions.fromByteBuffer(ftype, bb).toString
+        case (_, bb: ByteBuffer) =>
+          Conversions.fromByteBuffer(ftype, bb)
+        case _ => throw new IllegalArgumentException("unable to deserialize unknown values")
+      }
+    }
+
+    // Recursively collect stats from the given fields list and values and
+    // use the given deserializer to format the value.
+    // The result is a map of ( delta column physical name -> value )
+    def collectStats(
+        fields: java.util.List[NestedField],
+        valueMap: Map[JInt, Any],
+        deserializer: (IcebergType, Any) => Any): Map[String, Any] = {
+      fields.asScala.flatMap { field =>
+        field.`type`() match {
+          // Both Iceberg and Delta do not maintain stats for List/Map. Ignore them
+          case st: IcebergStructType =>
+            Some(field.name -> collectStats(st.fields, valueMap, deserializer))
+          case pt: IcebergPrimitiveType
+            if valueMap.contains(field.fieldId) && STATS_ALLOW_TYPES.contains(pt.typeId) =>
+            Option(deserializer(pt, valueMap(field.fieldId))).map(field.name -> _)
+          case _ => None
+        }
+      }.toMap
+    }
+
+    JsonUtils.toJson(
+      Map(
+        NUM_RECORDS -> numRecords,
+        MAX -> collectStats(icebergSchema.columns, maxMap, deserialize),
+        MIN -> collectStats(icebergSchema.columns, minMap, deserialize),
+        NULL_COUNT -> collectStats(
+          icebergSchema.columns, nullCountMap, (_: IcebergType, v: Any) => v
+        )
+      )
+    )
+  }
+}

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/CloneIcebergSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/CloneIcebergSuite.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.delta.sources.DeltaSQLConf
 import org.apache.spark.sql.delta.stats.StatisticsCollection
 import org.apache.iceberg.hadoop.HadoopTables
 
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.{AnalysisException, DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.{stringToDate, toJavaDate}
@@ -445,4 +446,17 @@ class CloneIcebergByNameSuite extends CloneIcebergSuiteBase
     }
   }
 }
+
+trait DisablingConvertIcebergStats extends CloneIcebergSuiteBase {
+  override def sparkConf: SparkConf =
+    super.sparkConf.set(DeltaSQLConf.DELTA_CONVERT_ICEBERG_STATS.key, "false")
+}
+
+class CloneIcebergByPathNoConvertStatsSuite
+  extends CloneIcebergByPathSuite
+    with DisablingConvertIcebergStats
+
+class CloneIcebergByNameNoConvertStatsSuite
+  extends CloneIcebergByNameSuite
+    with DisablingConvertIcebergStats
 

--- a/iceberg/src/test/scala/org/apache/spark/sql/delta/commands/convert/IcebergStatsUtilsSuite.scala
+++ b/iceberg/src/test/scala/org/apache/spark/sql/delta/commands/convert/IcebergStatsUtilsSuite.scala
@@ -1,0 +1,242 @@
+/*
+ * Copyright (2021) The Delta Lake Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.delta.commands.convert
+
+import java.lang.{Boolean => JBoolean, Double => JDouble, Float => JFloat, Integer => JInt, Long => JLong}
+import java.math.BigDecimal
+import java.nio.ByteBuffer
+import java.util.{List => JList, Map => JMap}
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.delta.util.JsonUtils
+import org.apache.iceberg.{DataFile, FileContent, FileFormat, PartitionData, PartitionSpec, Schema, StructLike}
+import org.apache.iceberg.transforms._
+import org.apache.iceberg.types.Conversions
+import org.apache.iceberg.types.Types._
+
+import org.apache.spark.SparkFunSuite
+
+class IcebergStatsUtilsSuite extends SparkFunSuite {
+
+  test("stats conversion from basic columns") {
+    val icebergSchema = new Schema(10, Seq[NestedField](
+      NestedField.required(1, "col_int", IntegerType.get),
+      NestedField.required(2, "col_long", LongType.get),
+      NestedField.required(3, "col_st", StringType.get),
+      NestedField.required(4, "col_boolean", BooleanType.get),
+      NestedField.required(5, "col_float", FloatType.get),
+      NestedField.required(6, "col_double", DoubleType.get),
+      NestedField.required(7, "col_date", DateType.get),
+      NestedField.required(8, "col_binary", BinaryType.get),
+      NestedField.required(9, "col_strt", StructType.of(
+        NestedField.required(10, "sc_int", IntegerType.get),
+        NestedField.required(11, "sc_int2", IntegerType.get)
+      )),
+      NestedField.required(12, "col_array",
+        ListType.ofRequired(13, IntegerType.get)),
+      NestedField.required(14, "col_map",
+        MapType.ofRequired(15, 16, IntegerType.get, StringType.get))).asJava
+    )
+
+    val minMap = Map(
+      Integer.valueOf(1) -> Conversions.toByteBuffer(IntegerType.get, JInt.valueOf(-5)),
+      Integer.valueOf(2) -> Conversions.toByteBuffer(LongType.get, JLong.valueOf(-4)),
+      Integer.valueOf(3) -> Conversions.toByteBuffer(StringType.get, "minval"),
+      Integer.valueOf(4) -> Conversions.toByteBuffer(BooleanType.get, JBoolean.FALSE),
+      Integer.valueOf(5) -> Conversions.toByteBuffer(FloatType.get, JFloat.valueOf("0.001")),
+      Integer.valueOf(6) -> Conversions.toByteBuffer(DoubleType.get, JDouble.valueOf("0.0001")),
+      Integer.valueOf(7) -> Conversions.toByteBuffer(DateType.get, JInt.valueOf(12800)),
+      Integer.valueOf(8) -> Conversions.toByteBuffer(BinaryType.get,
+        ByteBuffer.wrap(Array(1, 2, 3, 4))),
+      Integer.valueOf(10) -> Conversions.toByteBuffer(IntegerType.get, JInt.valueOf(-1)),
+      Integer.valueOf(11) -> Conversions.toByteBuffer(IntegerType.get, JInt.valueOf(-1))
+    )
+    val maxMap = Map(
+      Integer.valueOf(1) -> Conversions.toByteBuffer(IntegerType.get, JInt.valueOf(5)),
+      Integer.valueOf(2) -> Conversions.toByteBuffer(LongType.get, JLong.valueOf(4)),
+      Integer.valueOf(3) -> Conversions.toByteBuffer(StringType.get, "maxval"),
+      Integer.valueOf(4) -> Conversions.toByteBuffer(BooleanType.get, JBoolean.TRUE),
+      Integer.valueOf(5) -> Conversions.toByteBuffer(FloatType.get, JFloat.valueOf("10.001")),
+      Integer.valueOf(6) -> Conversions.toByteBuffer(DoubleType.get, JDouble.valueOf("10.0001")),
+      Integer.valueOf(7) -> Conversions.toByteBuffer(DateType.get, JInt.valueOf(13800)),
+      Integer.valueOf(8) -> Conversions.toByteBuffer(BinaryType.get,
+        ByteBuffer.wrap(Array(2, 2, 3, 4))),
+      Integer.valueOf(10) -> Conversions.toByteBuffer(IntegerType.get, JInt.valueOf(128)),
+      Integer.valueOf(11) -> Conversions.toByteBuffer(IntegerType.get, JInt.valueOf(512))
+    )
+    val nullCountMap = Map(
+      Integer.valueOf(1) -> JLong.valueOf(0),
+      Integer.valueOf(2) -> JLong.valueOf(1),
+      Integer.valueOf(3) -> JLong.valueOf(2),
+      Integer.valueOf(5) -> JLong.valueOf(3),
+      Integer.valueOf(6) -> JLong.valueOf(4),
+      Integer.valueOf(8) -> JLong.valueOf(5),
+      Integer.valueOf(10) -> JLong.valueOf(6),
+      Integer.valueOf(11) -> JLong.valueOf(7)
+    )
+
+    val deltaStats = IcebergStatsUtils.icebergStatsToDelta(
+      icebergSchema,
+      1251,
+      minMap,
+      maxMap,
+      nullCountMap
+    )
+
+    val actualStatsObj = JsonUtils.fromJson[StatsObject](deltaStats)
+    val expectedStatsObj = JsonUtils.fromJson[StatsObject](
+      """{"numRecords":1251,
+        |"maxValues":{"col_date":12800,"col_int":-5,"col_double":1.0E-4,
+        |"col_float":0.001,"col_long":-4,"col_strt":{"sc_int":-1,"sc_int2":-1},
+        |"col_boolean":false,"col_st":"minval","col_binary":"AQIDBA=="},
+        |"minValues":{"col_date":13800,"col_int":5,"col_double":10.0001,
+        |"col_float":10.001,"col_long":4,"col_strt":{"sc_int":128,"sc_int2":512},
+        |"col_boolean":true,"col_st":"maxval","col_binary":"AgIDBA=="},
+        |"nullCount":{"col_int":0,"col_double":4,"col_float":3,"col_long":1,
+        |"col_strt":{"sc_int":6,"sc_int2":7},"col_st":2,"col_binary":5}}
+        |""".stripMargin.replaceAll("\n", ""))
+    assertResult(expectedStatsObj)(actualStatsObj)
+  }
+
+  test("stats conversion from timestamp 64 and decimal is disabled") {
+    val icebergSchema = new Schema(10, Seq[NestedField](
+      NestedField.required(1, "col_ts", TimestampType.withZone),
+      NestedField.required(2, "col_tsnz", TimestampType.withoutZone),
+      NestedField.required(3, "col_decimal", DecimalType.of(10, 5))
+    ).asJava)
+    val deltaStats = IcebergStatsUtils.icebergStatsToDelta(
+      icebergSchema,
+      1251,
+      minMap = Map(
+        Integer.valueOf(1) ->
+          Conversions.toByteBuffer(TimestampType.withZone, JLong.valueOf(1734391979000000L)),
+        Integer.valueOf(2) ->
+          Conversions.toByteBuffer(TimestampType.withoutZone, JLong.valueOf(1734391979000000L)),
+        Integer.valueOf(3) ->
+          Conversions.toByteBuffer(DecimalType.of(10, 5), new BigDecimal("3.44141"))
+      ),
+      maxMap = Map(
+        Integer.valueOf(1) ->
+          Conversions.toByteBuffer(TimestampType.withZone, JLong.valueOf(1734394979000000L)),
+        Integer.valueOf(2) ->
+          Conversions.toByteBuffer(TimestampType.withoutZone, JLong.valueOf(1734394979000000L)),
+        Integer.valueOf(3) ->
+          Conversions.toByteBuffer(DecimalType.of(10, 5), new BigDecimal("9.99999"))
+      ),
+      nullCountMap = Map(
+        Integer.valueOf(1) -> JLong.valueOf(20),
+        Integer.valueOf(2) -> JLong.valueOf(10),
+        Integer.valueOf(3) -> JLong.valueOf(31)
+      )
+    )
+    assertResult(
+      JsonUtils.fromJson[StatsObject](
+        """{"numRecords":1251,"maxValues":{},"minValues":{},"nullCount":{}}"""))(
+      JsonUtils.fromJson[StatsObject](deltaStats))
+  }
+
+  test("stats conversion when value is missing or is null") {
+    val icebergSchema = new Schema(10, Seq[NestedField](
+      NestedField.required(1, "col_int", IntegerType.get),
+      NestedField.required(2, "col_long", LongType.get),
+      NestedField.required(3, "col_st", StringType.get)
+    ).asJava)
+    val deltaStats = IcebergStatsUtils.icebergStatsToDelta(
+      icebergSchema,
+      1251,
+      minMap = Map(
+        Integer.valueOf(1) -> Conversions.toByteBuffer(IntegerType.get, JInt.valueOf(-5)),
+        Integer.valueOf(2) -> Conversions.toByteBuffer(LongType.get, null),
+        Integer.valueOf(3) -> null
+      ),
+      maxMap = Map(
+        Integer.valueOf(1) -> Conversions.toByteBuffer(IntegerType.get, JInt.valueOf(5)),
+        // stats for value 2 is missing
+        Integer.valueOf(3) -> Conversions.toByteBuffer(StringType.get, "maxval"),
+        Integer.valueOf(5) -> Conversions.toByteBuffer(StringType.get, "maxval")
+      ),
+      nullCountMap = Map(
+        Integer.valueOf(1) -> JLong.valueOf(0),
+        Integer.valueOf(2) -> null,
+        Integer.valueOf(3) -> JLong.valueOf(2),
+        Integer.valueOf(5) -> JLong.valueOf(3)
+      )
+    )
+    assertResult(
+      JsonUtils.fromJson[StatsObject](
+        """{"numRecords":1251,
+          |"maxValues":{"col_int":5,"col_st":"maxval"},
+          |"minValues":{"col_int":-5},
+          |"nullCount":{"col_int":0,"col_st":2}}
+          |""".stripMargin))(
+      JsonUtils.fromJson[StatsObject](deltaStats))
+  }
+
+  test("stats conversion while DataFile misses the stats fields") {
+    val icebergSchema = new Schema(10, Seq[NestedField](
+      NestedField.required(1, "col_int", IntegerType.get),
+      NestedField.required(2, "col_long", LongType.get),
+      NestedField.required(3, "col_st", StringType.get)
+    ).asJava)
+    val expectedStats = JsonUtils.fromJson[StatsObject](
+      """{"numRecords":0,"maxValues":{"col_int":100992003},
+        |"minValues":{"col_int":100992003},"nullCount":{"col_int":2}}"""
+        .stripMargin)
+    val actualStats =
+      IcebergStatsUtils.icebergStatsToDelta(icebergSchema, DummyDataFile())
+        .map(JsonUtils.fromJson[StatsObject](_))
+        .get
+    assertResult(expectedStats)(actualStats)
+    assertResult(None)(IcebergStatsUtils.icebergStatsToDelta(icebergSchema,
+      DummyDataFile(upperBounds = null)))
+    assertResult(None)(IcebergStatsUtils.icebergStatsToDelta(icebergSchema,
+      DummyDataFile(lowerBounds = null)))
+    assertResult(None)(IcebergStatsUtils.icebergStatsToDelta(icebergSchema,
+      DummyDataFile(nullValueCounts = null)))
+  }
+}
+
+private case class StatsObject(
+    numRecords: Long,
+    maxValues: Map[String, Any],
+    minValues: Map[String, Any],
+    nullCount: Map[String, Long])
+
+private case class DummyDataFile(
+    upperBounds: JMap[JInt, ByteBuffer] =
+    Map(JInt.valueOf(1) -> ByteBuffer.wrap(Array(3, 4, 5, 6))).asJava,
+    lowerBounds: JMap[JInt, ByteBuffer] =
+    Map(JInt.valueOf(1) -> ByteBuffer.wrap(Array(3, 4, 5, 6))).asJava,
+    nullValueCounts: JMap[JInt, JLong] =
+    Map(JInt.valueOf(1) -> JLong.valueOf(2)).asJava) extends DataFile {
+  override def pos: JLong = 0L
+  override def specId: Int = 0
+  override def path: String = "dummy"
+  override def recordCount: Long = 0
+  override def fileSizeInBytes: Long = 0
+  override def content: FileContent = FileContent.DATA
+  override def format: FileFormat = FileFormat.PARQUET
+  override def partition: StructLike = null
+  override def columnSizes: JMap[JInt, JLong] = null
+  override def valueCounts: JMap[JInt, JLong] = null
+  override def nanValueCounts: JMap[JInt, JLong] = null
+  override def keyMetadata: ByteBuffer = null
+  override def splitOffsets: JList[JLong] = null
+  override def copy: DataFile = this.copy
+  override def copyWithoutStats: DataFile = this.copy
+}

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/ConvertToDeltaCommand.scala
@@ -341,7 +341,7 @@ abstract class ConvertToDeltaCommandBase(
           if (partitionSchema.isDefined) {
             throw DeltaErrors.partitionSchemaInIcebergTables
           }
-          ConvertUtils.getIcebergTable(spark, target.targetDir, None, None)
+          ConvertUtils.getIcebergTable(spark, target.targetDir, None, None, collectStats)
         case other =>
           throw DeltaErrors.convertNonParquetTablesException(tableIdentifier, other)
       }

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ConvertUtils.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/ConvertUtils.scala
@@ -71,27 +71,36 @@ trait ConvertUtilsBase extends DeltaLogging {
    * @param targetDir: the target directory of the Iceberg table.
    * @param sparkTable: the optional V2 table interface of the Iceberg table.
    * @param tableSchema: the existing converted Delta table schema (if exists) of the Iceberg table.
+   * @param collectStats: collect column stats on convert
    * @return a target Iceberg table.
    */
   def getIcebergTable(
       spark: SparkSession,
       targetDir: String,
       sparkTable: Option[Table],
-      tableSchema: Option[StructType]): ConvertTargetTable = {
+      tableSchema: Option[StructType],
+      collectStats: Boolean = true): ConvertTargetTable = {
     try {
+      val convertIcebergStats = collectStats &&
+        spark.sessionState.conf.getConf(DeltaSQLConf.DELTA_CONVERT_ICEBERG_STATS)
       val clazz = Utils.classForName(icebergSparkTableClassPath)
       if (sparkTable.isDefined) {
         val constFromTable = clazz.getConstructor(
           classOf[SparkSession],
           Utils.classForName(icebergLibTableClassPath),
-          classOf[Option[StructType]])
+          classOf[Option[StructType]],
+          java.lang.Boolean.TYPE
+        )
         val method = sparkTable.get.getClass.getMethod("table")
-        constFromTable.newInstance(spark, method.invoke(sparkTable.get), tableSchema)
+        constFromTable.newInstance(spark, method.invoke(sparkTable.get), tableSchema,
+          java.lang.Boolean.valueOf(convertIcebergStats))
       } else {
         val baseDir = getQualifiedPath(spark, new Path(targetDir)).toString
         val constFromPath = clazz.getConstructor(
-          classOf[SparkSession], classOf[String], classOf[Option[StructType]])
-        constFromPath.newInstance(spark, baseDir, tableSchema)
+          classOf[SparkSession], classOf[String], classOf[Option[StructType]],
+          java.lang.Boolean.TYPE)
+        constFromPath.newInstance(spark, baseDir, tableSchema,
+          java.lang.Boolean.valueOf(convertIcebergStats))
       }
     } catch {
       case e: ClassNotFoundException =>
@@ -215,7 +224,8 @@ trait ConvertUtilsBase extends DeltaLogging {
       path.toUri.toString
     }
 
-    AddFile(pathStrForAddFile, partition, file.length, file.modificationTime, dataChange = true)
+    AddFile(pathStrForAddFile, partition, file.length, file.modificationTime, dataChange = true,
+      stats = targetFile.stats.orNull)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/interfaces.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/commands/convert/interfaces.scala
@@ -89,8 +89,10 @@ trait ConvertTargetFileManifest extends Closeable {
  *                        table format. If none, the converter will infer partition values from the
  *                        file path, assuming the Hive directory format.
  * @param parquetSchemaDDL the Parquet schema DDL associated with the file.
+ * @param stats           Stats information extracted from the source file.
  */
 case class ConvertTargetFile(
   fileStatus: SerializableFileStatus,
   partitionValues: Option[Map[String, String]] = None,
-  parquetSchemaDDL: Option[String] = None) extends Serializable
+  parquetSchemaDDL: Option[String] = None,
+  stats: Option[String] = None) extends Serializable

--- a/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/sources/DeltaSQLConf.scala
@@ -2203,6 +2203,13 @@ trait DeltaSQLConfBase {
       .checkValue(v => v >= 1, "Must be at least 1.")
       .createWithDefault(100)
 
+  val DELTA_CONVERT_ICEBERG_STATS = buildConf("collectStats.convertIceberg")
+    .internal()
+    .doc("When enabled, attempts to convert Iceberg stats to Delta stats when cloning from " +
+      "an Iceberg source.")
+    .booleanConf
+    .createWithDefault(true)
+
   /////////////////////
   // Optimized Write
   /////////////////////


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
We allow Delta to read and convert Iceberg stats instead of collecting stats from Parquet during UniForm conversion.
## How was this patch tested?
UT & E2E
<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No