### PR TITLE
[3.2] Fix the consistency issue of listFrom API

### DIFF
--- a/storage-s3-dynamodb/src/main/java/io/delta/storage/BaseExternalLogStore.java
+++ b/storage-s3-dynamodb/src/main/java/io/delta/storage/BaseExternalLogStore.java
@@ -242,7 +242,9 @@ public abstract class BaseExternalLogStore extends HadoopFileSystemLogStore {
                 resolvedPath.getName(),
                 tempPath,
                 false, // not complete
-                null // no expireTime
+                null, // no expireTime
+                fs.getDefaultBlockSize(),
+                System.currentTimeMillis()
             );
 
             // Step 2.1: Create temp file T(N)
@@ -455,7 +457,7 @@ public abstract class BaseExternalLogStore extends HadoopFileSystemLogStore {
     /**
      * Returns path stripped user info.
      */
-    private Path stripUserInfo(Path path) {
+    protected Path stripUserInfo(Path path) {
         final URI uri = path.toUri();
 
         try {

--- a/storage-s3-dynamodb/src/main/java/io/delta/storage/ExternalCommitEntry.java
+++ b/storage-s3-dynamodb/src/main/java/io/delta/storage/ExternalCommitEntry.java
@@ -51,17 +51,31 @@ public final class ExternalCommitEntry {
      */
     public final Long expireTime;
 
+    /*
+     * File size
+     */
+    public final Long fileSize;
+
+    /*
+     * file modification time
+     */
+    public final Long modificationTime;
+
     public ExternalCommitEntry(
             Path tablePath,
             String fileName,
             String tempPath,
             boolean complete,
-            Long expireTime) {
+            Long expireTime,
+            Long fileSize,
+            Long modificationTime) {
         this.tablePath = tablePath;
         this.fileName = fileName;
         this.tempPath = tempPath;
         this.complete = complete;
         this.expireTime = expireTime;
+        this.fileSize = fileSize;
+        this.modificationTime = modificationTime;
     }
 
     /**
@@ -73,7 +87,9 @@ public final class ExternalCommitEntry {
             this.fileName,
             this.tempPath,
             true,
-            System.currentTimeMillis() / 1000L + expirationDelaySeconds
+            System.currentTimeMillis() / 1000L + expirationDelaySeconds,
+            this.fileSize,
+            this.modificationTime
         );
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [✖️] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
As integrated with the DynamoDBLogStore to ensure multiple writes, there are some problems working with the eventual consistent filesystem, while the listFrom API is not guaranteed to see the latest committed files. 

In this patch, put the pre-commit files in the DynamoDB as a cache. 

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
It was tested in a (pyspark) multi-writing occasion with the SwiftStack(which uses the eventual consistency). While with the original version, multiple spark session returned the 'FileNotFoundException'. With this patch it ran correctly. 

## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

