### PR TITLE
[Kernel] Minor SnapshotManager refactor followup

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -387,7 +387,7 @@ public class SnapshotManager {
         System.currentTimeMillis() - startTimeMillis);
 
     try {
-      return getLogSegmentForVersionHelper(startCheckpointVersionOpt, versionToLoadOpt, newFiles);
+      return constructLogSegmentFromFileList(startCheckpointVersionOpt, versionToLoadOpt, newFiles);
     } finally {
       logger.info(
           "{}: Took {}ms to construct a log segment",
@@ -400,7 +400,7 @@ public class SnapshotManager {
    * Helper function for the getLogSegmentForVersion above. Called with a provided files list, and
    * will then try to construct a new LogSegment using that.
    */
-  private LogSegment getLogSegmentForVersionHelper(
+  private LogSegment constructLogSegmentFromFileList(
       Optional<Long> startCheckpointOpt,
       Optional<Long> versionToLoadOpt,
       List<FileStatus> newFiles) {


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?
- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Followup to #4035.

Our SnapshotManager LogSegment construction logic is ... a bit messy, to say the least. This PR makes `getLogSegmentForVersion` _not_ return an Optional LogSegment.

I also start documenting some of the key steps in constructing a LogSegment. More steps, refactors, and comments will come in future PRs.

## How was this patch tested?

Mainly just a refactor. Existing UTs.

## Does this PR introduce _any_ user-facing changes?

No.
