### PR TITLE
[Kernel]Collect sum of added file size in Transaction metric

### DIFF
--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -341,6 +341,9 @@ public class TransactionImpl implements Transaction {
                           transactionMetrics.totalActionsCounter.increment();
                           if (!action.isNullAt(ADD_FILE_ORDINAL)) {
                             transactionMetrics.addFilesCounter.increment();
+                            AddFile addFile = new AddFile(action.getStruct(ADD_FILE_ORDINAL));
+                            transactionMetrics.addFilesSizeInBytesCounter.increment(
+                                addFile.getSize());
                           } else if (!action.isNullAt(REMOVE_FILE_ORDINAL)) {
                             transactionMetrics.removeFilesCounter.increment();
                           }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -341,9 +341,8 @@ public class TransactionImpl implements Transaction {
                           transactionMetrics.totalActionsCounter.increment();
                           if (!action.isNullAt(ADD_FILE_ORDINAL)) {
                             transactionMetrics.addFilesCounter.increment();
-                            AddFile addFile = new AddFile(action.getStruct(ADD_FILE_ORDINAL));
                             transactionMetrics.addFilesSizeInBytesCounter.increment(
-                                addFile.getSize());
+                                new AddFile(action.getStruct(ADD_FILE_ORDINAL)).getSize());
                           } else if (!action.isNullAt(REMOVE_FILE_ORDINAL)) {
                             transactionMetrics.removeFilesCounter.increment();
                           }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metrics/TransactionMetrics.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metrics/TransactionMetrics.java
@@ -36,6 +36,8 @@ public class TransactionMetrics {
   public final Counter removeFilesCounter = new Counter();
 
   public final Counter totalActionsCounter = new Counter();
+  // TODO: collect removed file's total size.
+  public final Counter addFilesSizeInBytesCounter = new Counter();
 
   /**
    * Resets the action counters (addFilesCounter, removeFilesCounter and totalActionsCounter) to 0.
@@ -45,16 +47,17 @@ public class TransactionMetrics {
    */
   public void resetActionCounters() {
     addFilesCounter.reset();
+    addFilesSizeInBytesCounter.reset();
     removeFilesCounter.reset();
     totalActionsCounter.reset();
   }
 
   public TransactionMetricsResult captureTransactionMetricsResult() {
     return new TransactionMetricsResult() {
-
       final long totalCommitDurationNs = totalCommitTimer.totalDurationNs();
       final long numCommitAttempts = commitAttemptsCounter.value();
       final long numAddFiles = addFilesCounter.value();
+      final long totalAddFilesSizeInBytes = addFilesSizeInBytesCounter.value();
       final long numRemoveFiles = removeFilesCounter.value();
       final long numTotalActions = totalActionsCounter.value();
 
@@ -82,6 +85,11 @@ public class TransactionMetrics {
       public long getNumTotalActions() {
         return numTotalActions;
       }
+
+      @Override
+      public long getTotalAddFilesSizeInBytes() {
+        return totalAddFilesSizeInBytes;
+      }
     };
   }
 
@@ -89,11 +97,12 @@ public class TransactionMetrics {
   public String toString() {
     return String.format(
         "TransactionMetrics(totalCommitTimer=%s, commitAttemptsCounter=%s, addFilesCounter=%s, "
-            + "removeFilesCounter=%s, totalActionsCounter=%s)",
+            + "removeFilesCounter=%s, totalActionsCounter=%s, totalAddFilesSizeInBytes=%s)",
         totalCommitTimer,
         commitAttemptsCounter,
         addFilesCounter,
         removeFilesCounter,
-        totalActionsCounter);
+        totalActionsCounter,
+        addFilesSizeInBytesCounter);
   }
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metrics/TransactionMetrics.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/metrics/TransactionMetrics.java
@@ -54,6 +54,7 @@ public class TransactionMetrics {
 
   public TransactionMetricsResult captureTransactionMetricsResult() {
     return new TransactionMetricsResult() {
+
       final long totalCommitDurationNs = totalCommitTimer.totalDurationNs();
       final long numCommitAttempts = commitAttemptsCounter.value();
       final long numAddFiles = addFilesCounter.value();

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/metrics/TransactionMetricsResult.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/metrics/TransactionMetricsResult.java
@@ -23,7 +23,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
   "numCommitAttempts",
   "numAddFiles",
   "numRemoveFiles",
-  "numTotalActions"
+  "numTotalActions",
+  "totalAddFilesSizeInBytes"
 })
 public interface TransactionMetricsResult {
 
@@ -50,4 +51,10 @@ public interface TransactionMetricsResult {
    *     transaction this metric may be incomplete.
    */
   long getNumTotalActions();
+
+  /**
+   * @return the sum of size of added files committed in this transaction. For a failed transaction
+   *     this metric may be incomplete.
+   */
+  long getTotalAddFilesSizeInBytes();
 }

--- a/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/metrics/MetricsReportSerializerSuite.scala
+++ b/kernel/kernel-api/src/test/scala/io/delta/kernel/internal/metrics/MetricsReportSerializerSuite.scala
@@ -117,7 +117,8 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
          |"numCommitAttempts":${transactionMetrics.getNumCommitAttempts},
          |"numAddFiles":${transactionMetrics.getNumAddFiles},
          |"numRemoveFiles":${transactionMetrics.getNumRemoveFiles},
-         |"numTotalActions":${transactionMetrics.getNumTotalActions}
+         |"numTotalActions":${transactionMetrics.getNumTotalActions},
+         |"totalAddFilesSizeInBytes":${transactionMetrics.getTotalAddFilesSizeInBytes}
          |}
          |}
          |""".stripMargin.replaceAll("\n", "")
@@ -135,6 +136,7 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
     transactionMetrics1.commitAttemptsCounter.increment(2)
     transactionMetrics1.addFilesCounter.increment(82)
     transactionMetrics1.totalActionsCounter.increment(90)
+    transactionMetrics1.addFilesSizeInBytesCounter.increment(100)
 
     val transactionReport1 = new TransactionReportImpl(
       "/table/path",
@@ -163,7 +165,8 @@ class MetricsReportSerializerSuite extends AnyFunSuite {
          |"numCommitAttempts":2,
          |"numAddFiles":82,
          |"numRemoveFiles":0,
-         |"numTotalActions":90
+         |"numTotalActions":90,
+         |"totalAddFilesSizeInBytes":100
          |}
          |}
          |""".stripMargin.replaceAll("\n", "")

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/TransactionReportSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/TransactionReportSuite.scala
@@ -100,10 +100,10 @@ class TransactionReportSuite extends AnyFunSuite with MetricsReportTestUtils {
     expectedNumTotalActions: Long = 0,
     expectedCommitVersion: Option[Long] = None,
     expectedNumAttempts: Long = 1,
+    expectedTotalAddFilesSizeInBytes: Long = 0,
     buildTransaction: (TransactionBuilder, Engine) => Transaction = (tb, e) => tb.build(e),
     engineInfo: String = "test-engine-info",
-    operation: Operation = Operation.MANUAL_UPDATE,
-    expectedTotalAddFilesSizeInBytes: Long = 0
+    operation: Operation = Operation.MANUAL_UPDATE
   ): Unit = {
     // scalastyle:on
     assert(expectException == expectedCommitVersion.isEmpty)
@@ -190,8 +190,8 @@ class TransactionReportSuite extends AnyFunSuite with MetricsReportTestUtils {
         expectedNumTotalActions = 3, // commitInfo + addFile
         expectedCommitVersion = Some(2),
         engineInfo = "foo",
-        operation = Operation.WRITE,
-        expectedTotalAddFilesSizeInBytes = 200
+        expectedTotalAddFilesSizeInBytes = 200,
+        operation = Operation.WRITE
       )
 
       // Update metadata only
@@ -255,12 +255,12 @@ class TransactionReportSuite extends AnyFunSuite with MetricsReportTestUtils {
         expectedNumAddFiles = 1,
         expectedNumTotalActions = 4, // protocol, metadata, commitInfo
         expectedCommitVersion = Some(0),
+        expectedTotalAddFilesSizeInBytes = 100,
         buildTransaction = (transBuilder, engine) => {
           transBuilder
             .withSchema(engine, new StructType().add("id", IntegerType.INTEGER))
             .build(engine)
-        },
-        expectedTotalAddFilesSizeInBytes = 100
+        }
       )
     }
   }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/TransactionReportSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/TransactionReportSuite.scala
@@ -272,16 +272,16 @@ class TransactionReportSuite extends AnyFunSuite with MetricsReportTestUtils {
       // Set up delta table with version 0
       spark.range(10).write.format("delta").mode("append").save(path)
 
-        val removeFileRow: Row = {
-          val fieldMap: Map[Integer, AnyRef] = Map(
+      val removeFileRow: Row = {
+        val fieldMap: Map[Integer, AnyRef] = Map(
           Integer.valueOf(RemoveFile.FULL_SCHEMA.indexOf("path")) -> "/path/for/remove/file",
           Integer.valueOf(RemoveFile.FULL_SCHEMA.indexOf("dataChange")) -> java.lang.Boolean.TRUE
         )
         new GenericRow(RemoveFile.FULL_SCHEMA, fieldMap.asJava)
-        }
+      }
 
-        checkTransactionReport(
-          generateCommitActions = (_, _) => CloseableIterable.inMemoryIterable(
+      checkTransactionReport(
+        generateCommitActions = (_, _) => CloseableIterable.inMemoryIterable(
           Utils.toCloseableIterator(
             Seq(SingleAction.createRemoveFileSingleAction(removeFileRow)).iterator.asJava
           )),

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/TransactionReportSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/TransactionReportSuite.scala
@@ -91,19 +91,19 @@ class TransactionReportSuite extends AnyFunSuite with MetricsReportTestUtils {
    */
   // scalastyle:off
   def checkTransactionReport(
-                              generateCommitActions: (Transaction, Engine) => CloseableIterable[Row],
-                              path: String,
-                              expectException: Boolean,
-                              expectedBaseSnapshotVersion: Long,
-                              expectedNumAddFiles: Long = 0,
-                              expectedNumRemoveFiles: Long = 0,
-                              expectedNumTotalActions: Long = 0,
-                              expectedCommitVersion: Option[Long] = None,
-                              expectedNumAttempts: Long = 1,
-                              buildTransaction: (TransactionBuilder, Engine) => Transaction = (tb, e) => tb.build(e),
-                              engineInfo: String = "test-engine-info",
-                              operation: Operation = Operation.MANUAL_UPDATE,
-                              expectedTotalAddFilesSizeInBytes: Long = 0
+    generateCommitActions: (Transaction, Engine) => CloseableIterable[Row],
+    path: String,
+    expectException: Boolean,
+    expectedBaseSnapshotVersion: Long,
+    expectedNumAddFiles: Long = 0,
+    expectedNumRemoveFiles: Long = 0,
+    expectedNumTotalActions: Long = 0,
+    expectedCommitVersion: Option[Long] = None,
+    expectedNumAttempts: Long = 1,
+    buildTransaction: (TransactionBuilder, Engine) => Transaction = (tb, e) => tb.build(e),
+    engineInfo: String = "test-engine-info",
+    operation: Operation = Operation.MANUAL_UPDATE,
+    expectedTotalAddFilesSizeInBytes: Long = 0
   ): Unit = {
     // scalastyle:on
     assert(expectException == expectedCommitVersion.isEmpty)
@@ -153,9 +153,8 @@ class TransactionReportSuite extends AnyFunSuite with MetricsReportTestUtils {
     assert(transactionReport.getTransactionMetrics.getNumTotalActions == expectedNumTotalActions)
   }
 
-  def generateAppendActions(fileStatusIter: CloseableIterator[DataFileStatus])(
-    trans: Transaction,
-    engine: Engine): CloseableIterable[Row] = {
+  def generateAppendActions(fileStatusIter: CloseableIterator[DataFileStatus])
+   (trans: Transaction, engine: Engine): CloseableIterable[Row] = {
     val transState = trans.getTransactionState(engine)
     CloseableIterable.inMemoryIterable(
       Transaction.generateAppendActions(engine, transState, fileStatusIter,
@@ -170,8 +169,8 @@ class TransactionReportSuite extends AnyFunSuite with MetricsReportTestUtils {
       // Set up delta table with version 0
       spark.range(10).write.format("delta").mode("append").save(path)
 
-        // Commit 1 AddFiles
-        checkTransactionReport(
+      // Commit 1 AddFiles
+      checkTransactionReport(
         generateCommitActions = generateAppendActions(fileStatusIter1),
         path,
         expectException = false,
@@ -180,7 +179,7 @@ class TransactionReportSuite extends AnyFunSuite with MetricsReportTestUtils {
         expectedNumTotalActions = 2, // commitInfo + addFile
           expectedCommitVersion = Some(1),
         expectedTotalAddFilesSizeInBytes = 100
-        )
+      )
 
       // Commit 2 AddFiles
       checkTransactionReport(
@@ -325,8 +324,8 @@ class TransactionReportSuite extends AnyFunSuite with MetricsReportTestUtils {
       // Set up delta table with version 0
       spark.range(10).write.format("delta").mode("append").save(path)
 
-        checkTransactionReport(
-          generateCommitActions = (trans, engine) => {
+      checkTransactionReport(
+        generateCommitActions = (trans, engine) => {
           spark.sql("ALTER TABLE delta.`" + path + "` ADD COLUMN newCol INT")
           generateAppendActions(fileStatusIter1)(trans, engine)
         },

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/TransactionReportSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/TransactionReportSuite.scala
@@ -177,7 +177,7 @@ class TransactionReportSuite extends AnyFunSuite with MetricsReportTestUtils {
         expectedBaseSnapshotVersion = 0,
         expectedNumAddFiles = 1,
         expectedNumTotalActions = 2, // commitInfo + addFile
-          expectedCommitVersion = Some(1),
+        expectedCommitVersion = Some(1),
         expectedTotalAddFilesSizeInBytes = 100
       )
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/TransactionReportSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/TransactionReportSuite.scala
@@ -158,8 +158,7 @@ class TransactionReportSuite extends AnyFunSuite with MetricsReportTestUtils {
     val transState = trans.getTransactionState(engine)
     CloseableIterable.inMemoryIterable(
       Transaction.generateAppendActions(engine, transState, fileStatusIter,
-        Transaction.getWriteContext(engine, transState, Collections.emptyMap())
-      )
+        Transaction.getWriteContext(engine, transState, Collections.emptyMap()))
     )
   }
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/TransactionReportSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/metrics/TransactionReportSuite.scala
@@ -154,7 +154,7 @@ class TransactionReportSuite extends AnyFunSuite with MetricsReportTestUtils {
   }
 
   def generateAppendActions(fileStatusIter: CloseableIterator[DataFileStatus])
-   (trans: Transaction, engine: Engine): CloseableIterable[Row] = {
+    (trans: Transaction, engine: Engine): CloseableIterable[Row] = {
     val transState = trans.getTransactionState(engine)
     CloseableIterable.inMemoryIterable(
       Transaction.generateAppendActions(engine, transState, fileStatusIter,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

#### Which Delta project/connector is this regarding?
<!--
Please add the component selected below to the beginning of the pull request title
For example: [Spark] Title of my pull request
-->

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [x] Kernel
- [ ] Other (fill in here)

## Description

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->
This PR collects the metric for added file size. Together with the added file count, they will be used further for generating CRC files 

See https://github.com/delta-io/delta/pull/4091 for e2e poc

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->
Unit test
## Does this PR introduce _any_ user-facing changes?

<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No