### PR TITLE
[Spark] Skip non-deterministic filters to prevent incorrect file pruning in Delta queries

### DIFF
--- a/spark/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/delta/stats/PrepareDeltaScan.scala
@@ -114,20 +114,22 @@ trait PrepareDeltaScanBase extends Rule[LogicalPlan]
       limitOpt: Option[Int],
       filters: Seq[Expression],
       delta: LogicalRelation): DeltaScan = {
+    // Remove non-deterministic filters (e.g., rand() < 0.25) to prevent incorrect file pruning.
+    val deterministicFilters = filters.filter(_.deterministic)
     withStatusCode("DELTA", "Filtering files for query") {
       if (limitOpt.nonEmpty) {
         // If we trigger limit push down, the filters must be partition filters. Since
         // there are no data filters, we don't need to apply Generated Columns
         // optimization. See `DeltaTableScan` for more details.
-        return scanGenerator.filesForScan(limitOpt.get, filters)
+        return scanGenerator.filesForScan(limitOpt.get, deterministicFilters)
       }
       val filtersForScan =
         if (!GeneratedColumn.partitionFilterOptimizationEnabled(spark)) {
-          filters
+          deterministicFilters
         } else {
           val generatedPartitionFilters = GeneratedColumn.generatePartitionFilters(
-            spark, scanGenerator.snapshotToScan, filters, delta)
-          filters ++ generatedPartitionFilters
+            spark, scanGenerator.snapshotToScan, deterministicFilters, delta)
+          deterministicFilters ++ generatedPartitionFilters
         }
       scanGenerator.filesForScan(filtersForScan)
     }


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [x] Spark
- [ ] Standalone
- [ ] Flink
- [ ] Kernel
- [ ] Other (fill in here)

## Description

Currently, PrepareDeltaScan does not exclude non-deterministic filters (e.g. rand() < 0.25). So, it ends up creating a file index with these non-deterministic filters applied.

The same filters are reapplied downstream which causes them to be applied twice and the final result being unexpected.

In general, PrepareDeltaScan should not skip entire files/partitions because of non-deterministic filters.

## How was this patch tested?

Build

## Does this PR introduce _any_ user-facing changes?

No
