### PR TITLE
[Kernel] [Refactor] Remove superfluous engine param from Snapshot APIs

### DIFF
--- a/connectors/flink/src/main/scala/io/delta/flink/internal/KernelDeltaLogDelegator.scala
+++ b/connectors/flink/src/main/scala/io/delta/flink/internal/KernelDeltaLogDelegator.scala
@@ -83,7 +83,7 @@ class KernelDeltaLogDelegator(
       kernelSnapshotWrapper,
       hadoopConf,
       logPath,
-      kernelSnapshot.getVersion(engine), // note: engine isn't used
+      kernelSnapshot.getVersion(),
       this,
       standaloneDeltaLog
     ))

--- a/connectors/flink/src/main/scala/io/delta/flink/internal/KernelSnapshotWrapper.java
+++ b/connectors/flink/src/main/scala/io/delta/flink/internal/KernelSnapshotWrapper.java
@@ -73,9 +73,7 @@ public class KernelSnapshotWrapper implements io.delta.standalone.Snapshot {
      */
     @Override
     public long getVersion() {
-        // WARNING: getVersion in SnapshotImpl currently doesn't use the engine so we can
-        // pass null, but if this changes this code could break
-        return kernelSnapshot.getVersion(null);
+        return kernelSnapshot.getVersion();
     }
 
     /**

--- a/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/MultiThreadedTableReader.java
+++ b/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/MultiThreadedTableReader.java
@@ -83,10 +83,9 @@ public class MultiThreadedTableReader
         throws TableNotFoundException {
         Table table = Table.forPath(engine, tablePath);
         Snapshot snapshot = table.getLatestSnapshot(engine);
-        StructType readSchema = pruneSchema(snapshot.getSchema(engine), columnsOpt);
+        StructType readSchema = pruneSchema(snapshot.getSchema(), columnsOpt);
 
-        ScanBuilder scanBuilder = snapshot.getScanBuilder(engine)
-            .withReadSchema(engine, readSchema);
+        ScanBuilder scanBuilder = snapshot.getScanBuilder().withReadSchema(engine, readSchema);
 
         if (predicate.isPresent()) {
             scanBuilder = scanBuilder.withFilter(engine, predicate.get());

--- a/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/SingleThreadedTableReader.java
+++ b/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/SingleThreadedTableReader.java
@@ -61,10 +61,9 @@ public class SingleThreadedTableReader
         throws TableNotFoundException, IOException {
         Table table = Table.forPath(engine, tablePath);
         Snapshot snapshot = table.getLatestSnapshot(engine);
-        StructType readSchema = pruneSchema(snapshot.getSchema(engine), columnsOpt);
+        StructType readSchema = pruneSchema(snapshot.getSchema(), columnsOpt);
 
-        ScanBuilder scanBuilder = snapshot.getScanBuilder(engine)
-            .withReadSchema(engine, readSchema);
+        ScanBuilder scanBuilder = snapshot.getScanBuilder().withReadSchema(engine, readSchema);
 
         if (predicate.isPresent()) {
             scanBuilder = scanBuilder.withFilter(engine, predicate.get());

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/Snapshot.java
@@ -32,10 +32,9 @@ public interface Snapshot {
   /**
    * Get the version of this snapshot in the table.
    *
-   * @param engine {@link Engine} instance to use in Delta Kernel.
    * @return version of this snapshot in the Delta table
    */
-  long getVersion(Engine engine);
+  long getVersion();
 
   /**
    * Get the names of the partition columns in the Delta table at this snapshot.
@@ -43,10 +42,9 @@ public interface Snapshot {
    * <p>The partition column names are returned in the order they are defined in the Delta table
    * schema. If the table does not define any partition columns, this method returns an empty list.
    *
-   * @param engine {@link Engine} instance to use in Delta Kernel.
    * @return a list of partition column names, or an empty list if the table is not partitioned.
    */
-  List<String> getPartitionColumnNames(Engine engine);
+  List<String> getPartitionColumnNames();
 
   /**
    * Get the timestamp (in milliseconds since the Unix epoch) of the latest commit in this snapshot.
@@ -59,16 +57,14 @@ public interface Snapshot {
   /**
    * Get the schema of the table at this snapshot.
    *
-   * @param engine {@link Engine} instance to use in Delta Kernel.
    * @return Schema of the Delta table at this snapshot.
    */
-  StructType getSchema(Engine engine);
+  StructType getSchema();
 
   /**
    * Create a scan builder to construct a {@link Scan} to read data from this snapshot.
    *
-   * @param engine {@link Engine} instance to use in Delta Kernel.
    * @return an instance of {@link ScanBuilder}
    */
-  ScanBuilder getScanBuilder(Engine engine);
+  ScanBuilder getScanBuilder();
 }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanBuilderImpl.java
@@ -35,7 +35,6 @@ public class ScanBuilderImpl implements ScanBuilder {
   private final Metadata metadata;
   private final StructType snapshotSchema;
   private final LogReplay logReplay;
-  private final Engine engine;
 
   private StructType readSchema;
   private Optional<Predicate> predicate;
@@ -45,14 +44,12 @@ public class ScanBuilderImpl implements ScanBuilder {
       Protocol protocol,
       Metadata metadata,
       StructType snapshotSchema,
-      LogReplay logReplay,
-      Engine engine) {
+      LogReplay logReplay) {
     this.dataPath = dataPath;
     this.protocol = protocol;
     this.metadata = metadata;
     this.snapshotSchema = snapshotSchema;
     this.logReplay = logReplay;
-    this.engine = engine;
     this.readSchema = snapshotSchema;
     this.predicate = Optional.empty();
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/SnapshotImpl.java
@@ -73,8 +73,13 @@ public class SnapshotImpl implements Snapshot {
   /////////////////
 
   @Override
-  public long getVersion(Engine engine) {
+  public long getVersion() {
     return version;
+  }
+
+  @Override
+  public List<String> getPartitionColumnNames() {
+    return VectorUtils.toJavaList(getMetadata().getPartitionColumns());
   }
 
   /**
@@ -107,14 +112,14 @@ public class SnapshotImpl implements Snapshot {
   }
 
   @Override
-  public StructType getSchema(Engine engine) {
+  public StructType getSchema() {
     return getMetadata().getSchema();
   }
 
   @Override
-  public ScanBuilder getScanBuilder(Engine engine) {
+  public ScanBuilder getScanBuilder() {
     // TODO when we add ScanReport we will pass the SnapshotReport downstream here
-    return new ScanBuilderImpl(dataPath, protocol, metadata, getSchema(engine), logReplay, engine);
+    return new ScanBuilderImpl(dataPath, protocol, metadata, getSchema(), logReplay);
   }
 
   ///////////////////
@@ -131,10 +136,6 @@ public class SnapshotImpl implements Snapshot {
 
   public Protocol getProtocol() {
     return protocol;
-  }
-
-  public List<String> getPartitionColumnNames(Engine engine) {
-    return VectorUtils.toJavaList(getMetadata().getPartitionColumns());
   }
 
   public SnapshotReport getSnapshotReport() {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionBuilderImpl.java
@@ -128,7 +128,7 @@ public class TransactionBuilderImpl implements TransactionBuilder {
           new InitialSnapshot(table.getDataPath(), logReplay, metadata, protocol, snapshotContext);
     }
 
-    boolean isNewTable = snapshot.getVersion(engine) < 0;
+    boolean isNewTable = snapshot.getVersion() < 0;
     validate(engine, snapshot, isNewTable);
 
     boolean shouldUpdateMetadata = false;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/TransactionImpl.java
@@ -114,7 +114,7 @@ public class TransactionImpl implements Transaction {
 
   @Override
   public StructType getSchema(Engine engine) {
-    return readSnapshot.getSchema(engine);
+    return readSnapshot.getSchema();
   }
 
   public Optional<SetTransaction> getSetTxnOpt() {
@@ -166,11 +166,11 @@ public class TransactionImpl implements Transaction {
   private TransactionCommitResult commitWithRetry(
       Engine engine, CloseableIterable<Row> dataActions, TransactionMetrics transactionMetrics) {
     try {
-      long commitAsVersion = readSnapshot.getVersion(engine) + 1;
+      long commitAsVersion = readSnapshot.getVersion() + 1;
       // Generate the commit action with the inCommitTimestamp if ICT is enabled.
       CommitInfo attemptCommitInfo = generateCommitAction(engine);
       updateMetadataWithICTIfRequired(
-          engine, attemptCommitInfo.getInCommitTimestamp(), readSnapshot.getVersion(engine));
+          engine, attemptCommitInfo.getInCommitTimestamp(), readSnapshot.getVersion());
 
       // If row tracking is supported, assign base row IDs and default row commit versions to any
       // AddFile actions that do not yet have them. If the row ID high watermark changes, emit a

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ConflictChecker.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/replay/ConflictChecker.java
@@ -166,8 +166,7 @@ public class ConflictChecker {
     // against the winning transactions
     return new TransactionRebaseState(
         lastWinningVersion,
-        getLastCommitTimestamp(
-            engine, lastWinningVersion, lastWinningTxn, winningCommitInfoOpt.get()),
+        getLastCommitTimestamp(lastWinningVersion, lastWinningTxn, winningCommitInfoOpt.get()),
         updatedDataActions,
         updatedDomainMetadatas);
   }
@@ -343,8 +342,7 @@ public class ConflictChecker {
   }
 
   private List<FileStatus> getWinningCommitFiles(Engine engine) {
-    String firstWinningCommitFile =
-        deltaFile(snapshot.getLogPath(), snapshot.getVersion(engine) + 1);
+    String firstWinningCommitFile = deltaFile(snapshot.getLogPath(), snapshot.getVersion() + 1);
 
     try (CloseableIterator<FileStatus> files =
         wrapEngineExceptionThrowsIO(
@@ -374,18 +372,16 @@ public class ConflictChecker {
    * latest winning transaction commit file. For non-ICT enabled tables, this is the modification
    * time of the latest winning transaction commit file.
    *
-   * @param engine {@link Engine} instance to use
    * @param lastWinningVersion last winning version of the table
    * @param lastWinningTxn the last winning transaction commit file
    * @param winningCommitInfoOpt winning commit info
    * @return last commit timestamp of the table
    */
   private long getLastCommitTimestamp(
-      Engine engine,
       long lastWinningVersion,
       FileStatus lastWinningTxn,
       Optional<CommitInfo> winningCommitInfoOpt) {
-    if (snapshot.getVersion(engine) == -1
+    if (snapshot.getVersion() == -1
         || !IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(snapshot.getMetadata())) {
       return lastWinningTxn.getModificationTime();
     } else {

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/snapshot/SnapshotManager.java
@@ -161,10 +161,7 @@ public class SnapshotManager {
 
     // Check if writing to the given table protocol version/features is supported in Kernel
     validateWriteSupportedTable(
-        snapshot.getProtocol(),
-        snapshot.getMetadata(),
-        snapshot.getSchema(engine),
-        tablePath.toString());
+        snapshot.getProtocol(), snapshot.getMetadata(), snapshot.getSchema(), tablePath.toString());
 
     Path checkpointPath = FileNames.checkpointFileSingular(logPath, version);
 
@@ -288,8 +285,7 @@ public class SnapshotManager {
         startingFromStr);
 
     final SnapshotHint hint =
-        new SnapshotHint(
-            snapshot.getVersion(engine), snapshot.getProtocol(), snapshot.getMetadata());
+        new SnapshotHint(snapshot.getVersion(), snapshot.getProtocol(), snapshot.getMetadata());
 
     registerHint(hint);
 

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/InCommitTimestampUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/util/InCommitTimestampUtils.java
@@ -71,7 +71,7 @@ public class InCommitTimestampUtils {
     boolean isICTCurrentlyEnabled =
         IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(currentTransactionMetadata);
     boolean wasICTEnabledInReadSnapshot =
-        readSnapshot.getVersion(engine) != -1
+        readSnapshot.getVersion() != -1
             && IN_COMMIT_TIMESTAMPS_ENABLED.fromMetadata(readSnapshot.getMetadata());
     return isICTCurrentlyEnabled && !wasICTEnabledInReadSnapshot;
   }

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/utils/PartitionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/utils/PartitionUtils.java
@@ -50,14 +50,12 @@ public class PartitionUtils {
     requireNonNull(snapshot, "snapshot is null");
     requireNonNull(partitionPredicate, "partitionPredicate is null");
 
-    final Set<String> snapshotPartColNames =
-        new HashSet<>(snapshot.getPartitionColumnNames(engine));
+    final Set<String> snapshotPartColNames = new HashSet<>(snapshot.getPartitionColumnNames());
 
     io.delta.kernel.internal.util.PartitionUtils.validatePredicateOnlyOnPartitionColumns(
         partitionPredicate, snapshotPartColNames);
 
-    final Scan scan =
-        snapshot.getScanBuilder(engine).withFilter(engine, partitionPredicate).build();
+    final Scan scan = snapshot.getScanBuilder().withFilter(engine, partitionPredicate).build();
 
     try (CloseableIterator<FilteredColumnarBatch> columnarBatchIter = scan.getScanFiles(engine)) {
       while (columnarBatchIter.hasNext()) {

--- a/kernel/kernel-defaults/src/test/java/io/delta/kernel/defaults/benchmarks/BenchmarkParallelCheckpointReading.java
+++ b/kernel/kernel-defaults/src/test/java/io/delta/kernel/defaults/benchmarks/BenchmarkParallelCheckpointReading.java
@@ -114,7 +114,7 @@ public class BenchmarkParallelCheckpointReading {
     Table table = Table.forPath(engine, testTablePath);
 
     Snapshot snapshot = table.getLatestSnapshot(engine);
-    ScanBuilder scanBuilder = snapshot.getScanBuilder(engine);
+    ScanBuilder scanBuilder = snapshot.getScanBuilder();
     Scan scan = scanBuilder.build();
 
     // Scan state is not used, but get it so that we simulate the real use case.

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ActiveAddFilesLogReplayMetricsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ActiveAddFilesLogReplayMetricsSuite.scala
@@ -142,7 +142,7 @@ class ActiveAddFilesLogReplayMetricsSuite extends AnyFunSuite with TestUtils {
 
     val scanFileIter = Table.forPath(engine, tablePath)
       .getLatestSnapshot(engine)
-      .getScanBuilder(engine)
+      .getScanBuilder()
       .build()
       .getScanFiles(engine)
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/CheckpointV2ReadSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/CheckpointV2ReadSuite.scala
@@ -82,7 +82,7 @@ class CheckpointV2ReadSuite extends AnyFunSuite with TestUtils with ExpressionTe
       snapshotFromSpark.protocol.readerFeatureNames)
     assert(snapshotImpl.getProtocol.getWriterFeatures.asScala.toSet ==
       snapshotFromSpark.protocol.writerFeatureNames)
-    assert(snapshot.getVersion(defaultEngine) == snapshotFromSpark.version)
+    assert(snapshot.getVersion() == snapshotFromSpark.version)
 
     // Validate that snapshot read from most recent checkpoint. For most cases, given a checkpoint
     // interval of 2, this will be the most recent even version.
@@ -97,7 +97,7 @@ class CheckpointV2ReadSuite extends AnyFunSuite with TestUtils with ExpressionTe
 
 
     // Validate AddFiles from sidecars found against Spark connector.
-    val scan = snapshot.getScanBuilder(defaultEngine).build()
+    val scan = snapshot.getScanBuilder().build()
     val foundFiles =
       collectScanFileRows(scan).map(InternalScanFileUtils.getAddFileStatus).map(
         _.getPath.split('/').last).toSet

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableReadsSuite.scala
@@ -282,7 +282,7 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
 
     // for now we don't support timestamp type partition columns so remove from read columns
     val readCols = Table.forPath(defaultEngine, path).getLatestSnapshot(defaultEngine)
-      .getSchema(defaultEngine)
+      .getSchema()
       .withoutField("as_timestamp")
       .fields()
       .asScala
@@ -680,7 +680,7 @@ class DeltaTableReadsSuite extends AnyFunSuite with TestUtils {
   test("table protocol version greater than reader protocol version") {
     val e = intercept[Exception] {
       latestSnapshot(goldenTablePath("deltalog-invalid-protocol-version"))
-        .getScanBuilder(defaultEngine)
+        .getScanBuilder()
         .build()
     }
     assert(e.getMessage.contains("Unsupported Delta protocol reader version"))

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DeltaTableWritesSuite.scala
@@ -1060,7 +1060,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
         .commit(engine, emptyIterable())
 
       val table = Table.forPath(engine, tablePath)
-      assert(table.getLatestSnapshot(engine).getSchema(engine).equals(testSchema))
+      assert(table.getLatestSnapshot(engine).getSchema().equals(testSchema))
     }
   }
 
@@ -1112,7 +1112,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
         tableProperties = Map(TableConfig.COLUMN_MAPPING_MODE.getKey -> "id"))
         .commit(engine, emptyIterable())
 
-      val structType = table.getLatestSnapshot(engine).getSchema(engine)
+      val structType = table.getLatestSnapshot(engine).getSchema()
       assertColumnMapping(structType.get("a"), 1)
       assertColumnMapping(structType.get("b"), 2)
 
@@ -1140,7 +1140,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
         tableProperties = Map(TableConfig.COLUMN_MAPPING_MODE.getKey -> "name"))
         .commit(engine, emptyIterable())
 
-      val structType = table.getLatestSnapshot(engine).getSchema(engine)
+      val structType = table.getLatestSnapshot(engine).getSchema()
       assertColumnMapping(structType.get("a"), 1)
       assertColumnMapping(structType.get("b"), 2)
 
@@ -1167,7 +1167,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
       createTxn(engine, tablePath, isNewTable = true, schema, partCols = Seq.empty)
         .commit(engine, emptyIterable())
 
-      val structType = table.getLatestSnapshot(engine).getSchema(engine)
+      val structType = table.getLatestSnapshot(engine).getSchema()
       assert(structType.equals(schema))
 
       val ex = intercept[IllegalArgumentException] {
@@ -1203,7 +1203,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
         tableProperties = Map(TableConfig.COLUMN_MAPPING_MODE.getKey -> "name"))
         .commit(engine, emptyIterable())
 
-      val structType = table.getLatestSnapshot(engine).getSchema(engine)
+      val structType = table.getLatestSnapshot(engine).getSchema()
       assertColumnMapping(structType.get("a"), 1)
       assertColumnMapping(structType.get("b"), 2)
     }
@@ -1220,7 +1220,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
         tableProperties = Map(TableConfig.COLUMN_MAPPING_MODE.getKey -> "id"))
         .commit(engine, emptyIterable())
 
-      val structType = table.getLatestSnapshot(engine).getSchema(engine)
+      val structType = table.getLatestSnapshot(engine).getSchema()
       assertColumnMapping(structType.get("a"), 1)
       assertColumnMapping(structType.get("b"), 2)
     }
@@ -1236,7 +1236,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
       createTxn(engine, tablePath, isNewTable = true, schema, partCols = Seq.empty)
         .commit(engine, emptyIterable())
 
-      val structType = table.getLatestSnapshot(engine).getSchema(engine)
+      val structType = table.getLatestSnapshot(engine).getSchema()
       assert(structType.equals(schema))
 
       table.createTransactionBuilder(engine, testEngineInfo, Operation.WRITE)
@@ -1246,7 +1246,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
         .build(engine)
         .commit(engine, emptyIterable())
 
-      val updatedSchema = table.getLatestSnapshot(engine).getSchema(engine)
+      val updatedSchema = table.getLatestSnapshot(engine).getSchema()
       assertColumnMapping(updatedSchema.get("a"), 1, "a")
       assertColumnMapping(updatedSchema.get("b"), 2, "b")
     }
@@ -1268,7 +1268,7 @@ class DeltaTableWritesSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBa
           TableConfig.ICEBERG_COMPAT_V2_ENABLED.getKey -> "true"))
         .commit(engine, emptyIterable())
 
-      val structType = table.getLatestSnapshot(engine).getSchema(engine)
+      val structType = table.getLatestSnapshot(engine).getSchema()
       assertColumnMapping(structType.get("a"), 1)
       assertColumnMapping(structType.get("b"), 2)
       val innerStruct = structType.get("b").getDataType.asInstanceOf[StructType]

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DomainMetadataSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/DomainMetadataSuite.scala
@@ -291,7 +291,7 @@ class DomainMetadataSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase
       }
 
       // Checkpoint the table
-      val latestVersion = table.getLatestSnapshot(engine).getVersion(engine)
+      val latestVersion = table.getLatestSnapshot(engine).getVersion()
       table.checkpoint(engine, latestVersion)
 
       // Verify that only the latest domain metadata is persisted in the checkpoint
@@ -508,7 +508,7 @@ class DomainMetadataSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase
 
         // Checkpoint the table so domain metadata is distributed to both checkpoint and log files
         val table = Table.forPath(engine, tablePath)
-        val latestVersion = table.getLatestSnapshot(engine).getVersion(engine)
+        val latestVersion = table.getLatestSnapshot(engine).getVersion()
         table.checkpoint(engine, latestVersion)
 
         // Manually commit two domain metadata actions

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LogReplayEngineMetricsSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LogReplayEngineMetricsSuite.scala
@@ -76,7 +76,7 @@ class LogReplayEngineMetricsSuite extends QueryTest
       expParquetVersionsRead: Seq[Long],
       expParquetReadSetSizes: Seq[Long] = Nil): Unit = {
     engine.resetMetrics()
-    table.getLatestSnapshot(engine).getSchema(engine)
+    table.getLatestSnapshot(engine).getSchema()
 
     assertMetrics(
       engine,
@@ -93,7 +93,7 @@ class LogReplayEngineMetricsSuite extends QueryTest
       expParquetReadSetSizes: Seq[Long],
       expLastCheckpointReadCalls: Option[Int] = None): Unit = {
     engine.resetMetrics()
-    val scan = table.getLatestSnapshot(engine).getScanBuilder(engine).build()
+    val scan = table.getLatestSnapshot(engine).getScanBuilder().build()
     // get all scan files and iterate through them to trigger the metrics collection
     val scanFiles = scan.getScanFiles(engine)
     while (scanFiles.hasNext) scanFiles.next()
@@ -206,7 +206,7 @@ class LogReplayEngineMetricsSuite extends QueryTest
 
       val table = Table.forPath(tc, path)
 
-      table.getLatestSnapshot(tc).getSchema(tc)
+      table.getLatestSnapshot(tc).getSchema()
 
       // A hint is now saved at v14
 
@@ -222,7 +222,7 @@ class LogReplayEngineMetricsSuite extends QueryTest
 
       val table = Table.forPath(tc, path)
 
-      table.getLatestSnapshot(tc).getSchema(tc)
+      table.getLatestSnapshot(tc).getSchema()
 
       // A hint is now saved at v14
 
@@ -253,7 +253,7 @@ class LogReplayEngineMetricsSuite extends QueryTest
 
       val table = Table.forPath(tc, path)
 
-      table.getLatestSnapshot(tc).getSchema(tc)
+      table.getLatestSnapshot(tc).getSchema()
 
       // A hint is now saved at v3
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LogReplaySuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/LogReplaySuite.scala
@@ -87,7 +87,7 @@ class LogReplaySuite extends AnyFunSuite with TestUtils {
     test(s"missing $action should fail") {
       val path = goldenTablePath(s"deltalog-state-reconstruction-without-$action")
       val e = intercept[IllegalStateException] {
-        latestSnapshot(path).getSchema(defaultEngine)
+        latestSnapshot(path).getSchema()
       }
       assert(e.getMessage.contains(s"No $action found"))
     }
@@ -100,7 +100,7 @@ class LogReplaySuite extends AnyFunSuite with TestUtils {
     test(s"missing $action should fail missing from checkpoint") {
       val path = goldenTablePath(s"deltalog-state-reconstruction-from-checkpoint-missing-$action")
       val e = intercept[IllegalStateException] {
-        latestSnapshot(path).getSchema(defaultEngine)
+        latestSnapshot(path).getSchema()
       }
       assert(e.getMessage.contains(s"No $action found"))
     }
@@ -109,7 +109,7 @@ class LogReplaySuite extends AnyFunSuite with TestUtils {
   test("fetches the latest protocol and metadata") {
     val path = goldenTablePath("log-replay-latest-metadata-protocol")
     val snapshot = latestSnapshot(path)
-    val scanStateRow = snapshot.getScanBuilder(defaultEngine).build()
+    val scanStateRow = snapshot.getScanBuilder().build()
       .getScanState(defaultEngine)
 
     // schema is updated
@@ -126,8 +126,8 @@ class LogReplaySuite extends AnyFunSuite with TestUtils {
   test("standalone DeltaLogSuite: 'checkpoint'") {
     val path = goldenTablePath("checkpoint")
     val snapshot = latestSnapshot(path)
-    assert(snapshot.getVersion(defaultEngine) == 14)
-    val scan = snapshot.getScanBuilder(defaultEngine).build()
+    assert(snapshot.getVersion() == 14)
+    val scan = snapshot.getScanBuilder().build()
     assert(collectScanFileRows(scan).length == 1)
   }
 
@@ -144,9 +144,9 @@ class LogReplaySuite extends AnyFunSuite with TestUtils {
       expectedFiles: Array[File],
       expectedVersion: Int): Unit = {
       val snapshot = latestSnapshot(tablePath)
-      assert(snapshot.getVersion(defaultEngine) == expectedVersion)
+      assert(snapshot.getVersion() == expectedVersion)
       val scanFileRows = collectScanFileRows(
-        snapshot.getScanBuilder(defaultEngine).build())
+        snapshot.getScanBuilder().build())
       assert(scanFileRows.length == expectedFiles.length)
       val scanFilePaths = scanFileRows
         .map(InternalScanFileUtils.getAddFileStatus)
@@ -199,9 +199,9 @@ class LogReplaySuite extends AnyFunSuite with TestUtils {
     // Repartition into 2 files
     withGoldenTable("snapshot-repartitioned") { tablePath =>
       val snapshot = latestSnapshot(tablePath)
-      assert(snapshot.getVersion(defaultEngine) == 5)
+      assert(snapshot.getVersion() == 5)
       val scanFileRows = collectScanFileRows(
-        snapshot.getScanBuilder(defaultEngine).build())
+        snapshot.getScanBuilder().build())
       assert(scanFileRows.length == 2)
     }
 
@@ -216,7 +216,7 @@ class LogReplaySuite extends AnyFunSuite with TestUtils {
   test("DV cases with same path different DV keys") {
     val snapshot = latestSnapshot(goldenTablePath("log-replay-dv-key-cases"))
     val scanFileRows = collectScanFileRows(
-      snapshot.getScanBuilder(defaultEngine).build()
+      snapshot.getScanBuilder().build()
     )
     assert(scanFileRows.length == 1) // there should only be 1 add file
     val dv = InternalScanFileUtils.getDeletionVectorDescriptorFromRow(scanFileRows.head)
@@ -227,14 +227,14 @@ class LogReplaySuite extends AnyFunSuite with TestUtils {
     withGoldenTable("log-replay-special-characters-a") { path =>
       val snapshot = latestSnapshot(path)
       val scanFileRows = collectScanFileRows(
-        snapshot.getScanBuilder(defaultEngine).build()
+        snapshot.getScanBuilder().build()
       )
       assert(scanFileRows.isEmpty)
     }
     withGoldenTable("log-replay-special-characters-b") { path =>
       val snapshot = latestSnapshot(path)
       val scanFileRows = collectScanFileRows(
-        snapshot.getScanBuilder(defaultEngine).build()
+        snapshot.getScanBuilder().build()
       )
       assert(scanFileRows.length == 1)
       val addFileStatus = InternalScanFileUtils.getAddFileStatus(scanFileRows.head)
@@ -247,8 +247,8 @@ class LogReplaySuite extends AnyFunSuite with TestUtils {
   ignore("path should be canonicalized - normal characters") {
     Seq("canonicalized-paths-normal-a", "canonicalized-paths-normal-b").foreach { path =>
       val snapshot = latestSnapshot(goldenTablePath(path))
-      assert(snapshot.getVersion(defaultEngine) == 1)
-      val scanFileRows = collectScanFileRows(snapshot.getScanBuilder(defaultEngine).build())
+      assert(snapshot.getVersion() == 1)
+      val scanFileRows = collectScanFileRows(snapshot.getScanBuilder().build())
       assert(scanFileRows.isEmpty)
     }
   }
@@ -256,8 +256,8 @@ class LogReplaySuite extends AnyFunSuite with TestUtils {
   ignore("path should be canonicalized - special characters") {
     Seq("canonicalized-paths-special-a", "canonicalized-paths-special-b").foreach { path =>
       val snapshot = latestSnapshot(goldenTablePath(path))
-      assert(snapshot.getVersion(defaultEngine) == 1)
-      val scanFileRows = collectScanFileRows(snapshot.getScanBuilder(defaultEngine).build())
+      assert(snapshot.getVersion() == 1)
+      val scanFileRows = collectScanFileRows(snapshot.getScanBuilder().build())
       assert(scanFileRows.isEmpty)
     }
   }
@@ -274,7 +274,7 @@ class LogReplaySuite extends AnyFunSuite with TestUtils {
   test("delete and re-add same file in different transactions") {
     val path = goldenTablePath("delete-re-add-same-file-different-transactions")
     val snapshot = latestSnapshot(path)
-    val scan = snapshot.getScanBuilder(defaultEngine).build()
+    val scan = snapshot.getScanBuilder().build()
 
     val foundFiles = collectScanFileRows(scan).map(InternalScanFileUtils.getAddFileStatus)
 

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/RowTrackingSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/RowTrackingSuite.scala
@@ -75,9 +75,7 @@ class RowTrackingSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
     val table = TableImpl.forPath(engine, tablePath)
     val snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
 
-    val scanFileRows = collectScanFileRows(
-      snapshot.getScanBuilder(engine).build()
-    )
+    val scanFileRows = collectScanFileRows(snapshot.getScanBuilder().build())
     val sortedBaseRowIds = scanFileRows
       .map(InternalScanFileUtils.getBaseRowId)
       .map(_.orElse(-1))
@@ -93,9 +91,7 @@ class RowTrackingSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
     val table = TableImpl.forPath(engine, tablePath)
     val snapshot = table.getLatestSnapshot(engine).asInstanceOf[SnapshotImpl]
 
-    val scanFileRows = collectScanFileRows(
-      snapshot.getScanBuilder(engine).build()
-    )
+    val scanFileRows = collectScanFileRows(snapshot.getScanBuilder().build())
     val sortedAddFileDefaultRowCommitVersions = scanFileRows
       .map(InternalScanFileUtils.getDefaultRowCommitVersion)
       .map(_.orElse(-1))
@@ -189,7 +185,7 @@ class RowTrackingSuite extends DeltaTableWriteSuiteBase with ParquetSuiteBase {
 
       // Checkpoint the table
       val table = TableImpl.forPath(engine, tablePath)
-      val latestVersion = table.getLatestSnapshot(engine).getVersion(engine)
+      val latestVersion = table.getLatestSnapshot(engine).getVersion()
       table.checkpoint(engine, latestVersion)
 
       val commitVersion3 = appendData(

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/ScanSuite.scala
@@ -97,14 +97,14 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
     val snapshot = latestSnapshot(tablePath)
     hits.foreach { predicate =>
       val scanFiles = collectScanFileRows(
-        snapshot.getScanBuilder(defaultEngine)
+        snapshot.getScanBuilder()
           .withFilter(defaultEngine, predicate)
           .build())
       assert(scanFiles.nonEmpty, s"Expected hit but got miss for $predicate")
     }
     misses.foreach { predicate =>
       val scanFiles = collectScanFileRows(
-        snapshot.getScanBuilder(defaultEngine)
+        snapshot.getScanBuilder()
           .withFilter(defaultEngine, predicate)
           .build())
       assert(scanFiles.isEmpty, s"Expected miss but got hit for $predicate\n" +
@@ -121,7 +121,7 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
     val snapshot = latestSnapshot(tablePath)
     filterToNumExpFiles.foreach { case (filter, numExpFiles) =>
       val scanFiles = collectScanFileRows(
-        snapshot.getScanBuilder(defaultEngine)
+        snapshot.getScanBuilder()
           .withFilter(defaultEngine, filter)
           .build())
       assert(scanFiles.length == numExpFiles,
@@ -1010,9 +1010,7 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
           predicate: Predicate, expNumPartitions: Int, expNumFiles: Long): Unit = {
         val snapshot = latestSnapshot(tableDir.getCanonicalPath)
         val scanFiles = collectScanFileRows(
-          snapshot.getScanBuilder(defaultEngine)
-            .withFilter(defaultEngine, predicate)
-            .build())
+          snapshot.getScanBuilder().withFilter(defaultEngine, predicate).build())
         assert(scanFiles.length == expNumFiles,
           s"Expected $expNumFiles but found ${scanFiles.length} for $predicate")
 
@@ -1492,15 +1490,13 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
 
     // no filter --> don't read stats
     verifyNoStatsColumn(
-      snapshot(engineDisallowedStatsReads)
-        .getScanBuilder(engine).build()
-        .getScanFiles(engine))
+      snapshot(engineDisallowedStatsReads).getScanBuilder().build().getScanFiles(engine))
 
     // partition filter only --> don't read stats
     val partFilter = equals(new Column("part"), ofInt(1))
     verifyNoStatsColumn(
       snapshot(engineDisallowedStatsReads)
-        .getScanBuilder(engine).withFilter(engine, partFilter).build()
+        .getScanBuilder().withFilter(engine, partFilter).build()
         .getScanFiles(engine))
 
     // no eligible data skipping filter --> don't read stats
@@ -1509,7 +1505,7 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
       ofInt(1))
     verifyNoStatsColumn(
       snapshot(engineDisallowedStatsReads)
-        .getScanBuilder(engine).withFilter(engine, nonEligibleFilter).build()
+        .getScanBuilder().withFilter(engine, nonEligibleFilter).build()
         .getScanFiles(engine))
   }
 
@@ -1547,7 +1543,7 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
       val engine = engineVerifyJsonParseSchema(verifySchema(expectedCols))
       collectScanFileRows(
         Table.forPath(engine, path).getLatestSnapshot(engine)
-          .getScanBuilder(engine)
+          .getScanBuilder()
           .withFilter(engine, predicate)
           .build(),
         engine = engine)
@@ -1570,14 +1566,12 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
       }
       // No query filter
       checkStatsPresent(
-        latestSnapshot(tempDir.getCanonicalPath)
-          .getScanBuilder(defaultEngine)
-          .build()
+        latestSnapshot(tempDir.getCanonicalPath).getScanBuilder().build()
       )
       // Query filter but no valid data skipping filter
       checkStatsPresent(
         latestSnapshot(tempDir.getCanonicalPath)
-          .getScanBuilder(defaultEngine)
+          .getScanBuilder()
           .withFilter(
             defaultEngine,
             greaterThan(
@@ -1589,7 +1583,7 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
       // With valid data skipping filter present
       checkStatsPresent(
         latestSnapshot(tempDir.getCanonicalPath)
-          .getScanBuilder(defaultEngine)
+          .getScanBuilder()
           .withFilter(
             defaultEngine,
             greaterThan(
@@ -1617,7 +1611,7 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
           case Some(version) => table.getSnapshotAsOfVersion(defaultEngine, version)
           case None => table.getLatestSnapshot(defaultEngine)
         }
-        val snapshotSchema = snapshot.getSchema(defaultEngine)
+        val snapshotSchema = snapshot.getSchema()
 
         val expectedSchema = new StructType()
           .add("id", LongType.LONG, true)
@@ -1638,7 +1632,7 @@ class ScanSuite extends AnyFunSuite with TestUtils with ExpressionTestUtils with
 
         assert(snapshotSchema == expectedSchema)
 
-        val scanBuilder = snapshot.getScanBuilder(defaultEngine)
+        val scanBuilder = snapshot.getScanBuilder()
         val scan = predicate match {
           case Some(pred) => scanBuilder.withFilter(defaultEngine, pred).build()
           case None => scanBuilder.build()

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/SnapshotSuite.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/SnapshotSuite.scala
@@ -55,7 +55,7 @@ class SnapshotSuite extends AnyFunSuite with TestUtils {
 
         // Step 2: Check the partition columns
         val tablePartCols =
-          table.getLatestSnapshot(defaultEngine).getPartitionColumnNames(defaultEngine)
+          table.getLatestSnapshot(defaultEngine).getPartitionColumnNames()
 
         assert(partCols.asJava === tablePartCols)
       }

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -154,12 +154,12 @@ trait TestUtils extends Assertions with SQLHelper {
   def tableSchema(path: String): StructType = {
     Table.forPath(defaultEngine, path)
       .getLatestSnapshot(defaultEngine)
-      .getSchema(defaultEngine)
+      .getSchema()
   }
 
   def hasTableProperty(tablePath: String, propertyKey: String, expValue: String): Boolean = {
     val table = Table.forPath(defaultEngine, tablePath)
-    val schema = table.getLatestSnapshot(defaultEngine).getSchema(defaultEngine)
+    val schema = table.getLatestSnapshot(defaultEngine).getSchema()
     schema.fields().asScala.exists { field =>
       field.getMetadata.getString(propertyKey) == expValue
     }
@@ -194,7 +194,7 @@ trait TestUtils extends Assertions with SQLHelper {
 
     val result = ArrayBuffer[Row]()
 
-    var scanBuilder = snapshot.getScanBuilder(engine)
+    var scanBuilder = snapshot.getScanBuilder()
 
     if (readSchema != null) {
       scanBuilder = scanBuilder.withReadSchema(engine, readSchema)
@@ -264,7 +264,7 @@ trait TestUtils extends Assertions with SQLHelper {
     readSchema: StructType): Seq[FilteredColumnarBatch] = {
     val scan = Table.forPath(engine, tablePath)
       .getLatestSnapshot(engine)
-      .getScanBuilder(engine)
+      .getScanBuilder()
       .withReadSchema(engine, readSchema)
       .build()
     val scanState = scan.getScanState(engine)
@@ -372,25 +372,24 @@ trait TestUtils extends Assertions with SQLHelper {
     val readSchema = if (readCols == null) {
       null
     } else {
-      val schema = snapshot.getSchema(engine)
+      val schema = snapshot.getSchema()
       new StructType(readCols.map(schema.get(_)).asJava)
     }
 
     if (expectedSchema != null) {
       assert(
-        expectedSchema == snapshot.getSchema(engine),
+        expectedSchema == snapshot.getSchema(),
         s"""
            |Expected schema does not match actual schema:
            |Expected schema: $expectedSchema
-           |Actual schema: ${snapshot.getSchema(engine)}
+           |Actual schema: ${snapshot.getSchema()}
            |""".stripMargin
       )
     }
 
     expectedVersion.foreach { version =>
-      assert(version == snapshot.getVersion(defaultEngine),
-        s"Expected version $version does not match actual version" +
-          s" ${snapshot.getVersion(defaultEngine)}")
+      assert(version == snapshot.getVersion(),
+        s"Expected version $version does not match actual version ${snapshot.getVersion()}")
     }
 
     val result = readSnapshot(snapshot, readSchema, filter, expectedRemainingFilter, engine)


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Remove superfluous engine param from Snapshot APIs

## How was this patch tested?

Refactor only.

## Does this PR introduce _any_ user-facing changes?

Removes param from public API.
