### PR TITLE
[Kernel] [Refactor] Remove superfluous engine param from ScanBuilder APIs

### DIFF
--- a/docs/source/delta-kernel-java.md
+++ b/docs/source/delta-kernel-java.md
@@ -99,14 +99,14 @@ Snapshot mySnapshot = myTable.getLatestSnapshot(myEngine);
 Now that we have a consistent snapshot view of the table, we can query more details about the table. For example, you can get the version and schema of this snapshot.
 
 ```java
-long version = mySnapshot.getVersion(myEngine);
-StructType tableSchema = mySnapshot.getSchema(myEngine);
+long version = mySnapshot.getVersion();
+StructType tableSchema = mySnapshot.getSchema();
 ```
 
 Next, to read the table data, we have to *build* a [`Scan`](https://delta-io.github.io/delta/snapshot/kernel-api/java/io/delta/kernel/Scan.html) object. In order to build a `Scan` object, create a [`ScanBuilder`](https://delta-io.github.io/delta/snapshot/kernel-api/java/io/delta/kernel/ScanBuilder.html) object which optionally allows selecting a subset of columns to read or setting a query filter. For now, ignore these optional settings.
 
 ```java
-Scan myScan = mySnapshot.getScanBuilder(myEngine).build()
+Scan myScan = mySnapshot.getScanBuilder().build()
 
 // Common information about scanning for all data files to read.
 Row scanState = myScan.getScanState(myEngine)
@@ -224,9 +224,7 @@ Predicate filter = new Predicate(
   "=",
   Arrays.asList(new Column("columnX"), Literal.ofInt(1)));
 
-Scan myFilteredScan = mySnapshot.buildScan(engine)
-  .withFilter(myEngine, filter)
-  .build()
+Scan myFilteredScan = mySnapshot.getScanBuilder().withFilter(filter).build()
 
 // Subset of the given filter that is not guaranteed to be satisfied by
 // Delta Kernel when it returns data. This filter is used by Delta Kernel
@@ -845,10 +843,7 @@ import io.delta.kernel.types.*;
 StructType readSchema = ... ;  // convert engine schema
 Predicate filterExpr = ... ;   // convert engine filter expression
 
-Scan myScan = mySnapshot.buildScan(engine)
-  .withFilter(myEngine, filterExpr)
-  .withReadSchema(myEngine, readSchema)
-  .build()
+Scan myScan = mySnapshot.getScanBuilder().withFilter(filterExpr).withReadSchema(readSchema).build();
 
 ```
 

--- a/docs/source/delta-kernel.md
+++ b/docs/source/delta-kernel.md
@@ -22,8 +22,8 @@ Here is an example of a simple table scan with a filter:
 Engine myEngine = DefaultEngine.create() ;                  // define a engine (more details below)
 Table myTable = Table.forPath("/delta/table/path");         // define what table to scan
 Snapshot mySnapshot = myTable.getLatestSnapshot(myEngine);  // define which version of table to scan
-Scan myScan = mySnapshot.getScanBuilder(myEngine)           // specify the scan details
-  .withFilters(myEngine, scanFilter)
+Scan myScan = mySnapshot.getScanBuilder()           // specify the scan details
+  .withFilters(scanFilter)
   .build();
 CloseableIterator<ColumnarBatch> physicalData =             // read the Parquet data files
   .. read from Parquet data files ...

--- a/kernel/USER_GUIDE.md
+++ b/kernel/USER_GUIDE.md
@@ -95,8 +95,8 @@ Snapshot mySnapshot = myTable.getLatestSnapshot(myEngine);
 Now that we have a consistent snapshot view of the table, we can query more details about the table. For example, you can get the version and schema of this snapshot.
 
 ```java
-long version = mySnapshot.getVersion(myEngine);
-StructType tableSchema = mySnapshot.getSchema(myEngine);
+long version = mySnapshot.getVersion();
+StructType tableSchema = mySnapshot.getSchema();
 ```
 
 Next, to read the table data, we have to *build* a [`Scan`](https://delta-io.github.io/delta/snapshot/kernel-api/java/io/delta/kernel/Scan.html) object. In order to build a `Scan` object, create a [`ScanBuilder`](https://delta-io.github.io/delta/snapshot/kernel-api/java/io/delta/kernel/ScanBuilder.html) object which optionally allows selecting a subset of columns to read or setting a query filter. For now, ignore these optional settings.
@@ -220,9 +220,7 @@ Predicate filter = new Predicate(
   "=",
   Arrays.asList(new Column("columnX"), Literal.ofInt(1)));
 
-Scan myFilteredScan = mySnapshot.buildScan(engine)
-  .withFilter(myEngine, filter)
-  .build()
+Scan myFilteredScan = mySnapshot.getScanBuilder().withFilter(filter).build()
 
 // Subset of the given filter that is not guaranteed to be satisfied by
 // Delta Kernel when it returns data. This filter is used by Delta Kernel
@@ -865,10 +863,7 @@ import io.delta.kernel.types.*;
 StructType readSchema = ... ;  // convert engine schema
 Predicate filterExpr = ... ;   // convert engine filter expression
 
-Scan myScan = mySnapshot.buildScan(engine)
-  .withFilter(myEngine, filterExpr)
-  .withReadSchema(myEngine, readSchema)
-  .build()
+Scan myScan = mySnapshot.getScanBuilder().withFilter(filterExpr).withReadSchema(readSchema).build();
 
 ```
 

--- a/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/MultiThreadedTableReader.java
+++ b/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/MultiThreadedTableReader.java
@@ -85,10 +85,10 @@ public class MultiThreadedTableReader
         Snapshot snapshot = table.getLatestSnapshot(engine);
         StructType readSchema = pruneSchema(snapshot.getSchema(), columnsOpt);
 
-        ScanBuilder scanBuilder = snapshot.getScanBuilder().withReadSchema(engine, readSchema);
+        ScanBuilder scanBuilder = snapshot.getScanBuilder().withReadSchema(readSchema);
 
         if (predicate.isPresent()) {
-            scanBuilder = scanBuilder.withFilter(engine, predicate.get());
+            scanBuilder = scanBuilder.withFilter(predicate.get());
         }
 
         return new Reader(limit)

--- a/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/SingleThreadedTableReader.java
+++ b/kernel/examples/kernel-examples/src/main/java/io/delta/kernel/examples/SingleThreadedTableReader.java
@@ -63,10 +63,10 @@ public class SingleThreadedTableReader
         Snapshot snapshot = table.getLatestSnapshot(engine);
         StructType readSchema = pruneSchema(snapshot.getSchema(), columnsOpt);
 
-        ScanBuilder scanBuilder = snapshot.getScanBuilder().withReadSchema(engine, readSchema);
+        ScanBuilder scanBuilder = snapshot.getScanBuilder().withReadSchema(readSchema);
 
         if (predicate.isPresent()) {
-            scanBuilder = scanBuilder.withFilter(engine, predicate.get());
+            scanBuilder = scanBuilder.withFilter(predicate.get());
         }
 
         return readData(readSchema, scanBuilder.build(), limit);

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/ScanBuilder.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/ScanBuilder.java
@@ -49,21 +49,19 @@ public interface ScanBuilder {
    * read from the scan files (returned by {@link Scan#getScanFiles(Engine)}) to completely filter
    * out the data that doesn't satisfy the filter.```
    *
-   * @param engine {@link Engine} instance to use in Delta Kernel.
    * @param predicate a {@link Predicate} to prune the metadata or data.
    * @return A {@link ScanBuilder} with filter applied.
    */
-  ScanBuilder withFilter(Engine engine, Predicate predicate);
+  ScanBuilder withFilter(Predicate predicate);
 
   /**
    * Apply the given <i>readSchema</i>. If the builder already has a projection applied, calling
    * this again replaces the existing projection.
    *
-   * @param engine {@link Engine} instance to use in Delta Kernel.
    * @param readSchema Subset of columns to read from the Delta table.
    * @return A {@link ScanBuilder} with projection pruning.
    */
-  ScanBuilder withReadSchema(Engine engine, StructType readSchema);
+  ScanBuilder withReadSchema(StructType readSchema);
 
   /** @return Build the {@link Scan instance} */
   Scan build();

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanBuilderImpl.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/internal/ScanBuilderImpl.java
@@ -18,7 +18,6 @@ package io.delta.kernel.internal;
 
 import io.delta.kernel.Scan;
 import io.delta.kernel.ScanBuilder;
-import io.delta.kernel.engine.Engine;
 import io.delta.kernel.expressions.Predicate;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.internal.actions.Protocol;
@@ -55,7 +54,7 @@ public class ScanBuilderImpl implements ScanBuilder {
   }
 
   @Override
-  public ScanBuilder withFilter(Engine engine, Predicate predicate) {
+  public ScanBuilder withFilter(Predicate predicate) {
     if (this.predicate.isPresent()) {
       throw new IllegalArgumentException("There already exists a filter in current builder");
     }
@@ -64,7 +63,7 @@ public class ScanBuilderImpl implements ScanBuilder {
   }
 
   @Override
-  public ScanBuilder withReadSchema(Engine engine, StructType readSchema) {
+  public ScanBuilder withReadSchema(StructType readSchema) {
     // TODO: validate the readSchema is a subset of the table schema
     this.readSchema = readSchema;
     return this;

--- a/kernel/kernel-api/src/main/java/io/delta/kernel/utils/PartitionUtils.java
+++ b/kernel/kernel-api/src/main/java/io/delta/kernel/utils/PartitionUtils.java
@@ -55,7 +55,7 @@ public class PartitionUtils {
     io.delta.kernel.internal.util.PartitionUtils.validatePredicateOnlyOnPartitionColumns(
         partitionPredicate, snapshotPartColNames);
 
-    final Scan scan = snapshot.getScanBuilder().withFilter(engine, partitionPredicate).build();
+    final Scan scan = snapshot.getScanBuilder().withFilter(partitionPredicate).build();
 
     try (CloseableIterator<FilteredColumnarBatch> columnarBatchIter = scan.getScanFiles(engine)) {
       while (columnarBatchIter.hasNext()) {

--- a/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
+++ b/kernel/kernel-defaults/src/test/scala/io/delta/kernel/defaults/utils/TestUtils.scala
@@ -197,11 +197,11 @@ trait TestUtils extends Assertions with SQLHelper {
     var scanBuilder = snapshot.getScanBuilder()
 
     if (readSchema != null) {
-      scanBuilder = scanBuilder.withReadSchema(engine, readSchema)
+      scanBuilder = scanBuilder.withReadSchema(readSchema)
     }
 
     if (filter != null) {
-      scanBuilder = scanBuilder.withFilter(engine, filter)
+      scanBuilder = scanBuilder.withFilter(filter)
     }
 
     val scan = scanBuilder.build()
@@ -265,7 +265,7 @@ trait TestUtils extends Assertions with SQLHelper {
     val scan = Table.forPath(engine, tablePath)
       .getLatestSnapshot(engine)
       .getScanBuilder()
-      .withReadSchema(engine, readSchema)
+      .withReadSchema(readSchema)
       .build()
     val scanState = scan.getScanState(engine)
 


### PR DESCRIPTION
#### Which Delta project/connector is this regarding?

- [ ] Spark
- [ ] Standalone
- [ ] Flink
- [X] Kernel
- [ ] Other (fill in here)

## Description

Remove superfluous engine param from ScanBuilder APIs

## How was this patch tested?

Refactor only.

## Does this PR introduce _any_ user-facing changes?

Removes param from public API.
